### PR TITLE
perf: apply clang-tidy performance fixes

### DIFF
--- a/src/achievement.cpp
+++ b/src/achievement.cpp
@@ -165,7 +165,7 @@ struct achievement_requirement {
     }
 
     bool satisifed_by( const cata_variant &v ) const {
-        int value = v.get<int>();
+        int const value = v.get<int>();
         switch( comparison ) {
             case achievement_comparison::less_equal:
                 return value <= target;
@@ -285,7 +285,7 @@ achievement_completion time_req_completed( const achievement &ach )
 
     const std::optional<achievement::time_bound> &time_req = ach.time_constraint();
 
-    time_point now = calendar::turn;
+    time_point const now = calendar::turn;
     switch( time_req->comparison() ) {
         case achievement_comparison::less_equal:
             if( now <= time_req->target() ) {
@@ -324,7 +324,7 @@ achievement_completion kill_req_completed( const achievement &ach, const kill_tr
             break;
         }
         auto& [comp, count] = pair;
-        int kill_count = m_id == mtype_id::NULL_ID() ? kt.monster_kill_count() :
+        int const kill_count = m_id == mtype_id::NULL_ID() ? kt.monster_kill_count() :
                          kt.kill_count( m_id );
         if( !ach_compare( comp, count, kill_count ) ) {
             switch( comp ) {
@@ -346,7 +346,7 @@ achievement_completion kill_req_completed( const achievement &ach, const kill_tr
             break;
         }
         auto& [comp, count] = pair;
-        int kill_count = kt.kill_count( fac_id );
+        int const kill_count = kt.kill_count( fac_id );
         if( !ach_compare( comp, count, kill_count ) ) {
             switch( comp ) {
                 case achievement_comparison::greater_equal:
@@ -372,12 +372,12 @@ achievement_completion skill_req_completed( const achievement &ach )
     if( skill_reqs.empty() ) {
         return achievement_completion::completed;
     }
-    Character &u = get_player_character();
+    Character  const&u = get_player_character();
 
     achievement_completion satisfied = achievement_completion::completed;
     for( const auto& [sk_id, pair] : skill_reqs ) {
         auto& [comp, level] = pair;
-        int skill_level = u.get_skill_level( sk_id );
+        int const skill_level = u.get_skill_level( sk_id );
         if( !ach_compare( comp, level, skill_level ) ) {
             switch( comp ) {
                 case achievement_comparison::greater_equal:
@@ -448,7 +448,7 @@ std::string achievement::kill_ui_text( achievement_completion completion,
     for( const auto& [m_id, pair] : kill_requirements() ) {
         auto& [comp, count] = pair;
         std::string cur_kills;
-        std::string mon_name = m_id == mtype_id::NULL_ID() ? count > 1 ? "monsters" : "monster" :
+        std::string const mon_name = m_id == mtype_id::NULL_ID() ? count > 1 ? "monsters" : "monster" :
                                m_id->nname( count );
         int kill_count = 0;
         std::string progress;
@@ -488,7 +488,7 @@ std::string achievement::kill_ui_text( achievement_completion completion,
             kill_status = completion;
         }
 
-        nc_color c = color_from_completion( kill_status );
+        nc_color const c = color_from_completion( kill_status );
         if( kill_status == achievement_completion::failed &&
             completion != achievement_completion::failed ) {
             cur_kills += _( " (failed)" );
@@ -498,7 +498,7 @@ std::string achievement::kill_ui_text( achievement_completion completion,
     for( const auto& [fac_id, pair] : species_kill_requirements() ) {
         auto& [comp, count] = pair;
         std::string cur_kills;
-        std::string fac_name = fac_id->name.translated( count );
+        std::string const fac_name = fac_id->name.translated( count );
         int kill_count = 0;
         std::string progress;
         bool comp_pass = false;
@@ -536,7 +536,7 @@ std::string achievement::kill_ui_text( achievement_completion completion,
             kill_status = completion;
         }
 
-        nc_color c = color_from_completion( kill_status );
+        nc_color const c = color_from_completion( kill_status );
         if( kill_status == achievement_completion::failed &&
             completion != achievement_completion::failed ) {
             cur_kills += _( " (failed)" );
@@ -549,13 +549,13 @@ std::string achievement::kill_ui_text( achievement_completion completion,
 std::string achievement::skill_ui_text() const
 {
     std::string skill_string;
-    Character &u = get_player_character();
+    Character  const&u = get_player_character();
     for( const auto& [sk_id, pair] : skill_requirements() ) {
         auto& [comp, level] = pair;
         std::string cur_skill;
         achievement_completion skill_status;
-        int sk_lvl = u.get_skill_level( sk_id );
-        bool comp_pass = ach_compare( comp, level, sk_lvl );
+        int const sk_lvl = u.get_skill_level( sk_id );
+        bool const comp_pass = ach_compare( comp, level, sk_lvl );
         switch( comp ) {
             case achievement_comparison::greater_equal:
                 skill_status = comp_pass ? achievement_completion::completed : achievement_completion::pending;
@@ -571,7 +571,7 @@ std::string achievement::skill_ui_text() const
                 skill_status = achievement_completion::completed;
                 break;
         }
-        nc_color c = color_from_completion( skill_status );
+        nc_color const c = color_from_completion( skill_status );
         if( skill_status == achievement_completion::failed ) {
             cur_skill += _( " (failed)" );
         }
@@ -585,7 +585,7 @@ std::string achievement::time_bound::time_ui_text( const achievement_completion 
 
     time_point now = calendar::turn;
 
-    nc_color c = color_from_completion( comp );
+    nc_color const c = color_from_completion( comp );
 
     auto translate_epoch = []( epoch e ) {
         switch( e ) {
@@ -600,7 +600,7 @@ std::string achievement::time_bound::time_ui_text( const achievement_completion 
         abort();
     };
 
-    std::string message = [&]() {
+    std::string const message = [&]() {
         switch( comp ) {
             case achievement_completion::pending:
                 return string_format( _( "At least %s from %s (%s remaining)" ),
@@ -739,9 +739,9 @@ void achievement::check() const
 static std::string text_for_requirement( const achievement_requirement &req,
         const cata_variant &current_value )
 {
-    bool is_satisfied = req.satisifed_by( current_value );
-    nc_color c = is_satisfied ? c_green : c_yellow;
-    int current = current_value.get<int>();
+    bool const is_satisfied = req.satisifed_by( current_value );
+    nc_color const c = is_satisfied ? c_green : c_yellow;
+    int const current = current_value.get<int>();
     int target;
     std::string result;
     if( req.comparison == achievement_comparison::anything ) {
@@ -822,14 +822,14 @@ std::string enum_to_string<achievement_completion>( achievement_completion data 
 std::string achievement_state::ui_text( const achievement *ach, const kill_tracker &kt ) const
 {
     // First: the achievement name and description
-    nc_color c = color_from_completion( completion );
+    nc_color const c = color_from_completion( completion );
     std::string result = colorize( ach->name(), c ) + "\n";
     if( !ach->description().empty() ) {
         result += "  " + colorize( ach->description(), c ) + "\n";
     }
 
     if( completion == achievement_completion::completed ) {
-        std::string message = string_format(
+        std::string const message = string_format(
                                   _( "Completed %s" ), to_string( last_state_change ) );
         result += "  " + colorize( message, c ) + "\n";
     } else {
@@ -861,7 +861,7 @@ void achievement_state::serialize( JsonOut &jsout ) const
 
 void achievement_state::deserialize( JsonIn &jsin )
 {
-    JsonObject jo = jsin.get_object();
+    JsonObject const jo = jsin.get_object();
     jo.read( "completion", completion );
     jo.read( "last_state_change", last_state_change );
 }
@@ -876,7 +876,7 @@ achievement_tracker::achievement_tracker( const achievement &a, achievements_tra
     }
 
     for( const std::unique_ptr<requirement_watcher> &watcher : watchers_ ) {
-        bool is_satisfied = watcher->is_satisfied( stats );
+        bool const is_satisfied = watcher->is_satisfied( stats );
         sorted_watchers_[is_satisfied].insert( watcher.get() );
     }
 }
@@ -889,10 +889,10 @@ void achievement_tracker::set_requirement( requirement_watcher *watcher, bool is
         assert( sorted_watchers_[0].size() + sorted_watchers_[1].size() == watchers_.size() );
     }
 
-    achievement_completion time_comp = time_req_completed( *achievement_ );
-    achievement_completion skill_comp = skill_req_completed( *achievement_ );
-    achievement_completion kill_comp = kill_req_completed( *achievement_, *tracker_->kills() );
-    bool all_clear = time_comp == achievement_completion::completed &&
+    achievement_completion const time_comp = time_req_completed( *achievement_ );
+    achievement_completion const skill_comp = skill_req_completed( *achievement_ );
+    achievement_completion const kill_comp = kill_req_completed( *achievement_, *tracker_->kills() );
+    bool const all_clear = time_comp == achievement_completion::completed &&
                      skill_comp == achievement_completion::completed && kill_comp == achievement_completion::completed;
 
     if( sorted_watchers_[false].empty() && all_clear ) {
@@ -912,7 +912,7 @@ void achievement_tracker::set_requirement( requirement_watcher *watcher, bool is
 
 bool achievement_tracker::has_failed() const
 {
-    bool failed = time_req_completed( *achievement_ ) == achievement_completion::failed ||
+    bool const failed = time_req_completed( *achievement_ ) == achievement_completion::failed ||
                   skill_req_completed( *achievement_ ) == achievement_completion::failed ||
                   kill_req_completed( *achievement_, *tracker_->kills() ) == achievement_completion::failed;
     return failed;
@@ -940,7 +940,7 @@ std::string achievement_tracker::ui_text() const
     }
 
     // First: the achievement name and description
-    nc_color c = color_from_completion( achievement_completion::pending );
+    nc_color const c = color_from_completion( achievement_completion::pending );
     std::string result = colorize( achievement_->name(), c ) + "\n";
     if( !achievement_->description().empty() ) {
         result += "  " + colorize( achievement_->description(), c ) + "\n";
@@ -1067,7 +1067,7 @@ void achievements_tracker::serialize( JsonOut &jsout ) const
 
 void achievements_tracker::deserialize( JsonIn &jsin )
 {
-    JsonObject jo = jsin.get_object();
+    JsonObject const jo = jsin.get_object();
     jo.read( "achievements_status", achievements_status_ );
 
     init_watchers();

--- a/src/achievement.cpp
+++ b/src/achievement.cpp
@@ -325,7 +325,7 @@ achievement_completion kill_req_completed( const achievement &ach, const kill_tr
         }
         auto& [comp, count] = pair;
         int const kill_count = m_id == mtype_id::NULL_ID() ? kt.monster_kill_count() :
-                         kt.kill_count( m_id );
+                               kt.kill_count( m_id );
         if( !ach_compare( comp, count, kill_count ) ) {
             switch( comp ) {
                 case achievement_comparison::greater_equal:
@@ -372,7 +372,7 @@ achievement_completion skill_req_completed( const achievement &ach )
     if( skill_reqs.empty() ) {
         return achievement_completion::completed;
     }
-    Character  const&u = get_player_character();
+    Character  const &u = get_player_character();
 
     achievement_completion satisfied = achievement_completion::completed;
     for( const auto& [sk_id, pair] : skill_reqs ) {
@@ -449,7 +449,7 @@ std::string achievement::kill_ui_text( achievement_completion completion,
         auto& [comp, count] = pair;
         std::string cur_kills;
         std::string const mon_name = m_id == mtype_id::NULL_ID() ? count > 1 ? "monsters" : "monster" :
-                               m_id->nname( count );
+                                     m_id->nname( count );
         int kill_count = 0;
         std::string progress;
         bool comp_pass = false;
@@ -549,7 +549,7 @@ std::string achievement::kill_ui_text( achievement_completion completion,
 std::string achievement::skill_ui_text() const
 {
     std::string skill_string;
-    Character  const&u = get_player_character();
+    Character  const &u = get_player_character();
     for( const auto& [sk_id, pair] : skill_requirements() ) {
         auto& [comp, level] = pair;
         std::string cur_skill;
@@ -830,7 +830,7 @@ std::string achievement_state::ui_text( const achievement *ach, const kill_track
 
     if( completion == achievement_completion::completed ) {
         std::string const message = string_format(
-                                  _( "Completed %s" ), to_string( last_state_change ) );
+                                        _( "Completed %s" ), to_string( last_state_change ) );
         result += "  " + colorize( message, c ) + "\n";
     } else {
         // Next: time constraint, kill requirements & skill requirements if any
@@ -893,7 +893,7 @@ void achievement_tracker::set_requirement( requirement_watcher *watcher, bool is
     achievement_completion const skill_comp = skill_req_completed( *achievement_ );
     achievement_completion const kill_comp = kill_req_completed( *achievement_, *tracker_->kills() );
     bool const all_clear = time_comp == achievement_completion::completed &&
-                     skill_comp == achievement_completion::completed && kill_comp == achievement_completion::completed;
+                           skill_comp == achievement_completion::completed && kill_comp == achievement_completion::completed;
 
     if( sorted_watchers_[false].empty() && all_clear ) {
         // report_achievement can result in this being deleted, so it must be
@@ -913,8 +913,8 @@ void achievement_tracker::set_requirement( requirement_watcher *watcher, bool is
 bool achievement_tracker::has_failed() const
 {
     bool const failed = time_req_completed( *achievement_ ) == achievement_completion::failed ||
-                  skill_req_completed( *achievement_ ) == achievement_completion::failed ||
-                  kill_req_completed( *achievement_, *tracker_->kills() ) == achievement_completion::failed;
+                        skill_req_completed( *achievement_ ) == achievement_completion::failed ||
+                        kill_req_completed( *achievement_, *tracker_->kills() ) == achievement_completion::failed;
     return failed;
 }
 

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -54,13 +54,13 @@ class inventory;
 
 std::vector<char> keys_bound_to( action_id act, const bool restrict_to_printable )
 {
-    input_context ctxt = get_default_mode_input_context();
+    input_context const ctxt = get_default_mode_input_context();
     return ctxt.keys_bound_to( action_ident( act ), restrict_to_printable );
 }
 
 action_id action_from_key( char ch )
 {
-    input_context ctxt = get_default_mode_input_context();
+    input_context const ctxt = get_default_mode_input_context();
     const input_event event( ch, CATA_INPUT_KEYBOARD );
     const std::string &action = ctxt.input_to_action( event );
     return look_up_action( action );
@@ -463,25 +463,25 @@ action_id look_up_action( const std::string &ident )
 // (Press X (or Y)|Try) to Z
 std::string press_x( action_id act )
 {
-    input_context ctxt = get_default_mode_input_context();
+    input_context const ctxt = get_default_mode_input_context();
     return ctxt.press_x( action_ident( act ), _( "Press " ), "", _( "Try" ) );
 }
 std::string press_x( action_id act, const std::string &key_bound, const std::string &key_unbound )
 {
-    input_context ctxt = get_default_mode_input_context();
+    input_context const ctxt = get_default_mode_input_context();
     return ctxt.press_x( action_ident( act ), key_bound, "", key_unbound );
 }
 std::string press_x( action_id act, const std::string &key_bound_pre,
                      const std::string &key_bound_suf,
                      const std::string &key_unbound )
 {
-    input_context ctxt = get_default_mode_input_context();
+    input_context const ctxt = get_default_mode_input_context();
     return ctxt.press_x( action_ident( act ), key_bound_pre, key_bound_suf, key_unbound );
 }
 std::optional<std::string> press_x_if_bound( action_id act )
 {
-    input_context ctxt = get_default_mode_input_context();
-    std::string description = action_ident( act );
+    input_context const ctxt = get_default_mode_input_context();
+    std::string const description = action_ident( act );
     if( ctxt.keys_bound_to( description ).empty() ) {
         return std::nullopt;
     }
@@ -557,12 +557,12 @@ bool can_butcher_at( const tripoint &p )
     // TODO: unify this with game::butcher
     const int factor = you.max_quality( qual_BUTCHER );
     const int factorD = you.max_quality( qual_CUT_FINE );
-    map_stack items = get_map().i_at( p );
+    map_stack const items = get_map().i_at( p );
     bool has_item = false;
     bool has_corpse = false;
 
     const inventory &crafting_inv = you.crafting_inventory();
-    for( item &items_it : items ) {
+    for( item  const&items_it : items ) {
         if( items_it.is_corpse() ) {
             if( factor != INT_MIN  || factorD != INT_MIN ) {
                 has_corpse = true;
@@ -576,7 +576,7 @@ bool can_butcher_at( const tripoint &p )
 
 bool can_move_vertical_at( const tripoint &p, int movez )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     // TODO: unify this with game::move_vertical
     if( here.has_flag( flag_SWIMMABLE, p ) && here.has_flag( TFLAG_DEEP_WATER, p ) ) {
         if( movez == -1 ) {
@@ -595,8 +595,8 @@ bool can_move_vertical_at( const tripoint &p, int movez )
 
 bool can_examine_at( const tripoint &p )
 {
-    map &here = get_map();
-    Character &u = get_player_character();
+    map  const&here = get_map();
+    Character  const&u = get_player_character();
     if( here.veh_at( p ) ) {
         return true;
     }
@@ -626,7 +626,7 @@ bool can_examine_at( const tripoint &p )
 static bool can_pickup_at( const tripoint &p )
 {
     bool veh_has_items = false;
-    map &here = get_map();
+    map  const&here = get_map();
     const optional_vpart_position vp = here.veh_at( p );
     if( vp ) {
         const int cargo_part = vp->vehicle().part_with_feature( vp->part_index(), "CARGO", false );
@@ -720,7 +720,7 @@ action_id handle_action_menu()
         action_weightings[ACTION_TOGGLE_CROUCH] = 300;
     }
 
-    map &here = get_map();
+    map  const&here = get_map();
     // Check if we're on a vehicle, if so, vehicle controls should be top.
     if( here.veh_at( g->u.pos() ) ) {
         // Make it 300 to prioritize it before examining the vehicle.
@@ -881,7 +881,7 @@ action_id handle_action_menu()
         }
 
         if( category != "back" ) {
-            std::string msg = _( "Back" );
+            std::string const msg = _( "Back" );
             entries.emplace_back( 2 * NUM_ACTIONS, true,
                                   hotkey_for_action( ACTION_ACTIONMENU ), msg + "…" );
         }
@@ -933,7 +933,7 @@ action_id handle_main_menu()
     smenu.settext( _( "MAIN MENU" ) );
     smenu.entries = entries;
     smenu.query();
-    int selection = smenu.ret;
+    int const selection = smenu.ret;
 
     if( selection < 0 || selection >= NUM_ACTIONS ) {
         return ACTION_NULL;

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -562,7 +562,7 @@ bool can_butcher_at( const tripoint &p )
     bool has_corpse = false;
 
     const inventory &crafting_inv = you.crafting_inventory();
-    for( item  const&items_it : items ) {
+    for( item  const &items_it : items ) {
         if( items_it.is_corpse() ) {
             if( factor != INT_MIN  || factorD != INT_MIN ) {
                 has_corpse = true;
@@ -576,7 +576,7 @@ bool can_butcher_at( const tripoint &p )
 
 bool can_move_vertical_at( const tripoint &p, int movez )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     // TODO: unify this with game::move_vertical
     if( here.has_flag( flag_SWIMMABLE, p ) && here.has_flag( TFLAG_DEEP_WATER, p ) ) {
         if( movez == -1 ) {
@@ -595,8 +595,8 @@ bool can_move_vertical_at( const tripoint &p, int movez )
 
 bool can_examine_at( const tripoint &p )
 {
-    map  const&here = get_map();
-    Character  const&u = get_player_character();
+    map  const &here = get_map();
+    Character  const &u = get_player_character();
     if( here.veh_at( p ) ) {
         return true;
     }
@@ -626,7 +626,7 @@ bool can_examine_at( const tripoint &p )
 static bool can_pickup_at( const tripoint &p )
 {
     bool veh_has_items = false;
-    map  const&here = get_map();
+    map  const &here = get_map();
     const optional_vpart_position vp = here.veh_at( p );
     if( vp ) {
         const int cargo_part = vp->vehicle().part_with_feature( vp->part_index(), "CARGO", false );
@@ -720,7 +720,7 @@ action_id handle_action_menu()
         action_weightings[ACTION_TOGGLE_CROUCH] = 300;
     }
 
-    map  const&here = get_map();
+    map  const &here = get_map();
     // Check if we're on a vehicle, if so, vehicle controls should be top.
     if( here.veh_at( g->u.pos() ) ) {
         // Make it 300 to prioritize it before examining the vehicle.

--- a/src/active_tile_data.cpp
+++ b/src/active_tile_data.cpp
@@ -60,7 +60,7 @@ void furn_transform::serialize( JsonOut &jsout ) const
 
 void furn_transform::deserialize( JsonIn &jsin )
 {
-    JsonObject jo = jsin.get_object();
+    JsonObject const jo = jsin.get_object();
 
     jo.read( "id", id );
     jo.read( "msg", msg );
@@ -115,23 +115,23 @@ void solar_tile::update_internal( time_point to, const tripoint_abs_ms &p, distr
     constexpr time_point zero = time_point::from_turn( 0 );
     constexpr time_duration tick_length = 10_minutes;
     constexpr int tick_turns = to_turns<int>( tick_length );
-    time_duration till_then = get_last_updated() - zero;
-    time_duration till_now = to - zero;
+    time_duration const till_then = get_last_updated() - zero;
+    time_duration const till_now = to - zero;
     // This is just for rounding to nearest tick
-    time_duration ticks_then = till_then / tick_turns;
-    time_duration ticks_now = till_now / tick_turns;
+    time_duration const ticks_then = till_then / tick_turns;
+    time_duration const ticks_now = till_now / tick_turns;
     // This is to cut down on sum_conditions
     if( ticks_then == ticks_now ) {
         return;
     }
-    time_duration rounded_then = ticks_then * tick_turns;
-    time_duration rounded_now = ticks_now * tick_turns;
+    time_duration const rounded_then = ticks_then * tick_turns;
+    time_duration const rounded_now = ticks_now * tick_turns;
 
     // TODO: Use something that doesn't calc a ton of worthless crap
-    float sunlight = sum_conditions( zero + rounded_then, zero + rounded_now,
+    float const sunlight = sum_conditions( zero + rounded_then, zero + rounded_now,
                                      p.raw() ).sunlight / default_daylight_level();
     // int64 because we can have years in here
-    std::int64_t produced = power * static_cast<std::int64_t>( sunlight ) / 1000;
+    std::int64_t const produced = power * static_cast<std::int64_t>( sunlight ) / 1000;
     grid.mod_resource( static_cast<int>( std::min( static_cast<std::int64_t>( INT_MAX ), produced ) ) );
 }
 
@@ -197,7 +197,7 @@ int battery_tile::get_resource() const
 int battery_tile::mod_resource( int amt )
 {
     // TODO: Avoid int64 math if possible
-    std::int64_t sum = static_cast<std::int64_t>( stored ) + amt;
+    std::int64_t const sum = static_cast<std::int64_t>( stored ) + amt;
     if( sum >= max_stored ) {
         stored = max_stored;
         return sum - max_stored;
@@ -213,7 +213,7 @@ int battery_tile::mod_resource( int amt )
 void charge_watcher_tile::update_internal( time_point /*to*/, const tripoint_abs_ms &p,
         distribution_grid &grid )
 {
-    int amt_stored = grid.get_resource();
+    int const amt_stored = grid.get_resource();
 
     if( amt_stored >= min_power ) {
         get_distribution_grid_tracker().get_transform_queue().add( p, transform.id, transform.msg );
@@ -307,13 +307,13 @@ void charger_tile::load( JsonObject &jo )
 void steady_consumer_tile::update_internal( time_point to, const tripoint_abs_ms &p,
         distribution_grid &grid )
 {
-    int ticks = ticks_between( get_last_updated(), to, consume_every );
+    int const ticks = ticks_between( get_last_updated(), to, consume_every );
     if( ticks == 0 ) {
         return;
     }
 
-    std::int64_t power = this->power * ticks;
-    int missing = grid.mod_resource( -power );
+    std::int64_t const power = this->power * ticks;
+    int const missing = grid.mod_resource( -power );
 
     if( missing == 0 ) {
         return;

--- a/src/active_tile_data.cpp
+++ b/src/active_tile_data.cpp
@@ -129,7 +129,7 @@ void solar_tile::update_internal( time_point to, const tripoint_abs_ms &p, distr
 
     // TODO: Use something that doesn't calc a ton of worthless crap
     float const sunlight = sum_conditions( zero + rounded_then, zero + rounded_now,
-                                     p.raw() ).sunlight / default_daylight_level();
+                                           p.raw() ).sunlight / default_daylight_level();
     // int64 because we can have years in here
     std::int64_t const produced = power * static_cast<std::int64_t>( sunlight ) / 1000;
     grid.mod_resource( static_cast<int>( std::min( static_cast<std::int64_t>( INT_MAX ), produced ) ) );

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -175,7 +175,7 @@ void aim_activity_actor::finish( player_activity &act, Character &who )
     // Fire!
     gun_mode gun = weapon->gun_current_mode();
 
-    int shots_fired = ranged::fire_gun( who, fin_trajectory.back(), gun.qty, *gun, reload_loc );
+    int const shots_fired = ranged::fire_gun( who, fin_trajectory.back(), gun.qty, *gun, reload_loc );
 
     if( shots_fired > 0 ) {
         // TODO: bionic power cost of firing should be derived from a value of the relevant weapon.
@@ -200,7 +200,7 @@ void aim_activity_actor::finish( player_activity &act, Character &who )
     aim_actor.initial_view_offset = this->initial_view_offset;
 
     // if invalid target or it's dead - reset it so a new one is acquired
-    shared_ptr_fast<Creature> last_target = who.as_player()->last_target.lock();
+    shared_ptr_fast<Creature> const last_target = who.as_player()->last_target.lock();
     if( last_target && last_target->is_dead_state() ) {
         who.as_player()->last_target.reset();
     }
@@ -238,7 +238,7 @@ std::unique_ptr<activity_actor> aim_activity_actor::deserialize( JsonIn &jsin )
 {
     aim_activity_actor actor = aim_activity_actor();
 
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
 
     data.read( "fake_weapon", actor.fake_weapon );
     data.read( "bp_cost_per_shot", actor.bp_cost_per_shot );
@@ -274,7 +274,7 @@ item *aim_activity_actor::get_weapon()
 void aim_activity_actor::restore_view()
 {
     avatar &player_character = get_avatar();
-    bool changed_z = player_character.view_offset.z != initial_view_offset.z;
+    bool const changed_z = player_character.view_offset.z != initial_view_offset.z;
     player_character.view_offset = initial_view_offset;
     if( changed_z ) {
         get_map().invalidate_map_cache( player_character.view_offset.z );
@@ -314,7 +314,7 @@ bool aim_activity_actor::load_RAS_weapon()
         }
         return true;
     };
-    item_reload_option opt = ammo_location_is_valid() ? item_reload_option( &you, weapon,
+    item_reload_option const opt = ammo_location_is_valid() ? item_reload_option( &you, weapon,
                              weapon, you.ammo_location ) : character_funcs::select_ammo( you, *gun );
     if( !opt ) {
         // Menu canceled
@@ -433,7 +433,7 @@ void dig_activity_actor::finish( player_activity &act, Character &who )
             here.spawn_item( location, itype_bone_human, rng( 5, 15 ) );
             here.furn_set( location, f_coffin_c );
         }
-        std::vector<item *> dropped = g->m.place_items( item_group_id( "allclothes" ), 50, location,
+        std::vector<item *> const dropped = g->m.place_items( item_group_id( "allclothes" ), 50, location,
                                       location, false,
                                       calendar::turn );
         g->m.place_items( item_group_id( "grave" ), 25, location, location, false, calendar::turn );
@@ -488,7 +488,7 @@ std::unique_ptr<activity_actor> dig_activity_actor::deserialize( JsonIn &jsin )
     dig_activity_actor actor( 0, tripoint_zero,
                               {}, tripoint_zero, 0, {} );
 
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
 
     data.read( "moves", actor.moves_total );
     data.read( "location", actor.location );
@@ -554,7 +554,7 @@ std::unique_ptr<activity_actor> dig_channel_activity_actor::deserialize( JsonIn 
     dig_channel_activity_actor actor( 0, tripoint_zero,
                                       {}, tripoint_zero, 0, {} );
 
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
 
     data.read( "moves", actor.moves_total );
     data.read( "location", actor.location );
@@ -587,7 +587,7 @@ bool disassemble_activity_actor::try_start_single( player_activity &act, Charact
         return false;
     }
 
-    int moves_needed = dis.time * target.count;
+    int const moves_needed = dis.time * target.count;
 
     act.moves_total = moves_needed;
     act.moves_left = moves_needed;
@@ -625,7 +625,7 @@ void disassemble_activity_actor::finish( player_activity &act, Character &who )
     }
 
     // Make a copy to avoid use-after-free
-    bool recurse = this->recursive;
+    bool const recurse = this->recursive;
 
     act.set_to_null();
 
@@ -650,7 +650,7 @@ std::unique_ptr<activity_actor> disassemble_activity_actor::deserialize( JsonIn 
 {
     disassemble_activity_actor actor;
 
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
 
     data.read( "targets", actor.targets );
     data.read( "pos", actor.pos );
@@ -671,7 +671,7 @@ act_progress_message disassemble_activity_actor::get_progress_message(
 
     if( initial_num_targets != 1 ) {
         constexpr int width = 20; // An arbitrary value
-        std::string item_name_trimmed = trim_by_length( targets.front().loc->display_name(), width );
+        std::string const item_name_trimmed = trim_by_length( targets.front().loc->display_name(), width );
 
         msg += string_format(
                    _( "\n%d out of %d, working on %-20s" ),
@@ -713,7 +713,7 @@ std::unique_ptr<activity_actor> drop_activity_actor::deserialize( JsonIn &jsin )
 {
     drop_activity_actor actor;
 
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
 
     data.read( "items", actor.items );
     data.read( "force_ground", actor.force_ground );
@@ -762,7 +762,7 @@ static hack_result hack_attempt( Character &who, const bool using_bionic )
     // only skilled supergenius never cause short circuits, but the odds are low for people
     // with moderate skills
     const int hack_stddev = 5;
-    int success = std::ceil( normal_roll( hack_level( who ), hack_stddev ) );
+    int const success = std::ceil( normal_roll( hack_level( who ), hack_stddev ) );
     if( success < 0 ) {
         who.add_msg_if_player( _( "You cause a short circuit!" ) );
         if( using_bionic ) {
@@ -812,8 +812,8 @@ hacking_activity_actor::hacking_activity_actor( use_bionic )
 
 void hacking_activity_actor::finish( player_activity &act, Character &who )
 {
-    tripoint examp = act.placement;
-    hack_type type = get_hack_type( examp );
+    tripoint const examp = act.placement;
+    hack_type const type = get_hack_type( examp );
     map &here = get_map();
     switch( hack_attempt( who, using_bionic ) ) {
         case HACK_UNABLE:
@@ -884,7 +884,7 @@ std::unique_ptr<activity_actor> hacking_activity_actor::deserialize( JsonIn &jsi
         // it was an item.
         actor.using_bionic = false;
     } else {
-        JsonObject jsobj = jsin.get_object();
+        JsonObject const jsobj = jsin.get_object();
         jsobj.read( "using_bionic", actor.using_bionic );
     }
     return actor.clone();
@@ -963,7 +963,7 @@ std::unique_ptr<activity_actor> move_items_activity_actor::deserialize( JsonIn &
 {
     move_items_activity_actor actor( {}, {}, false, tripoint_zero );
 
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
 
     data.read( "target_items", actor.target_items );
     data.read( "quantities", actor.quantities );
@@ -1044,7 +1044,7 @@ std::unique_ptr<activity_actor> pickup_activity_actor::deserialize( JsonIn &jsin
 {
     pickup_activity_actor actor( {}, std::nullopt );
 
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
 
     data.read( "target_items", actor.target_items );
     data.read( "starting_pos", actor.starting_pos );
@@ -1106,7 +1106,7 @@ std::unique_ptr<activity_actor> toggle_gate_activity_actor::deserialize( JsonIn 
 {
     toggle_gate_activity_actor actor( 0, tripoint_zero );
 
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
 
     data.read( "moves", actor.moves_total );
     data.read( "placement", actor.placement );
@@ -1147,7 +1147,7 @@ std::unique_ptr<activity_actor> stash_activity_actor::deserialize( JsonIn &jsin 
 {
     stash_activity_actor actor;
 
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
 
     data.read( "items", actor.items );
     data.read( "relpos", actor.relpos );
@@ -1193,7 +1193,7 @@ void throw_activity_actor::do_turn( player_activity &act, Character &who )
 
     if( &*target != &who.primary_weapon() ) {
         // This is to represent "implicit offhand wielding"
-        int extra_cost = who.item_handling_cost( *target, true, INVENTORY_HANDLING_PENALTY / 2 );
+        int const extra_cost = who.item_handling_cost( *target, true, INVENTORY_HANDLING_PENALTY / 2 );
         who.mod_moves( -extra_cost );
     }
 
@@ -1221,7 +1221,7 @@ std::unique_ptr<activity_actor> throw_activity_actor::deserialize( JsonIn &jsin 
 {
     throw_activity_actor actor;
 
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
 
     data.read( "target_loc", actor.target_loc );
     data.read( "blind_throw_from_pos", actor.blind_throw_from_pos );
@@ -1243,7 +1243,7 @@ std::unique_ptr<activity_actor> wash_activity_actor::deserialize( JsonIn &jsin )
 {
     wash_activity_actor actor;
 
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
 
     data.read( "targets", actor.targets );
     data.read( "moves_total", actor.moves_total );
@@ -1292,7 +1292,7 @@ void deserialize( cata::clone_ptr<activity_actor> &actor, JsonIn &jsin )
     if( jsin.test_null() ) {
         actor = nullptr;
     } else {
-        JsonObject data = jsin.get_object();
+        JsonObject const data = jsin.get_object();
         if( data.has_member( "actor_data" ) ) {
             activity_id actor_type;
             data.read( "actor_type", actor_type );

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -315,7 +315,7 @@ bool aim_activity_actor::load_RAS_weapon()
         return true;
     };
     item_reload_option const opt = ammo_location_is_valid() ? item_reload_option( &you, weapon,
-                             weapon, you.ammo_location ) : character_funcs::select_ammo( you, *gun );
+                                   weapon, you.ammo_location ) : character_funcs::select_ammo( you, *gun );
     if( !opt ) {
         // Menu canceled
         return false;
@@ -434,8 +434,8 @@ void dig_activity_actor::finish( player_activity &act, Character &who )
             here.furn_set( location, f_coffin_c );
         }
         std::vector<item *> const dropped = g->m.place_items( item_group_id( "allclothes" ), 50, location,
-                                      location, false,
-                                      calendar::turn );
+                                            location, false,
+                                            calendar::turn );
         g->m.place_items( item_group_id( "grave" ), 25, location, location, false, calendar::turn );
         g->m.place_items( item_group_id( "jewelry_front" ), 20, location, location, false, calendar::turn );
         for( item * const &it : dropped ) {

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -421,7 +421,7 @@ activity_handlers::finish_functions = {
 bool activity_handlers::resume_for_multi_activities( player &p )
 {
     if( !p.backlog.empty() ) {
-        player_activity  const&back_act = p.backlog.front();
+        player_activity  const &back_act = p.backlog.front();
         if( back_act.is_multi_type() ) {
             p.assign_activity( p.backlog.front().id() );
             p.backlog.clear();
@@ -1289,7 +1289,7 @@ void activity_handlers::butcher_finish( player_activity *act, player *p )
         int const level_cap = std::min<int>( MAX_SKILL, ( corpse->size + ( cbms.size() * 2 + 1 ) ) );
         int const size_mult = corpse->size > MS_MEDIUM ? ( corpse->size * corpse->size ) : 8;
         int const practice_amt = ( size_mult + 1 ) * ( ( time_to_cut / 150 ) + 1 ) *
-                           ( cbms.size() * cbms.size() / 2 + 1 );
+                                 ( cbms.size() * cbms.size() / 2 + 1 );
         p->practice( skill_firstaid, practice_amt, level_cap );
         add_msg( m_debug, "Experience: %d, Level cap: %d, Time to cut: %d", practice_amt, level_cap,
                  time_to_cut );
@@ -1477,7 +1477,7 @@ void activity_handlers::milk_finish( player_activity *act, player *p )
         debugmsg( "milking activity with no position of monster stored" );
         return;
     }
-    map  const&here = get_map();
+    map  const &here = get_map();
     const tripoint source_pos = here.getlocal( act->coords.at( 0 ) );
     monster *source_mon = g->critter_at<monster>( source_pos );
     if( source_mon == nullptr ) {
@@ -2111,7 +2111,7 @@ void activity_handlers::reload_finish( player_activity *act, player *p )
     }
 
     item &reloadable = *act->targets[ 0 ];
-    item  const&ammo = *act->targets[1];
+    item  const &ammo = *act->targets[1];
     std::string const ammo_name = ammo.tname();
     const int qty = act->index;
     const bool is_speedloader = ammo.has_flag( flag_SPEEDLOADER );
@@ -2196,7 +2196,7 @@ void activity_handlers::start_fire_do_turn( player_activity *act, player *p )
         }
     }
 
-    item  const&firestarter = *act->targets.front();
+    item  const &firestarter = *act->targets.front();
     if( firestarter.has_flag( flag_REQUIRES_TINDER ) ) {
         if( !here.tinder_at( act->placement ) ) {
             p->add_msg_if_player( m_info, _( "This item requires tinder to light." ) );
@@ -2388,7 +2388,7 @@ void activity_handlers::start_engines_finish( player_activity *act, player *p )
     act->set_to_null();
     // Find the vehicle by looking for a remote vehicle first, then by player relative coordinates
     vehicle *veh = g->remoteveh();
-    map  const&here = get_map();
+    map  const &here = get_map();
     if( !veh ) {
         const tripoint pos = act->placement + g->u.pos();
         veh = veh_pointer_or_null( here.veh_at( pos ) );
@@ -2560,9 +2560,9 @@ void activity_handlers::lockpicking_finish( player_activity *act, player *p )
     /** @EFFECT_DEX improves chances of successfully picking door lock, reduces chances of bad outcomes */
     /** @EFFECT_MECHANICS improves chances of successfully picking door lock, reduces chances of bad outcomes */
     int const pick_roll = 5 *
-                    ( std::pow( 1.3, p->get_skill_level( skill_mechanics ) ) +
-                      it->get_quality( qual_LOCKPICK ) - it->damage() / 2000.0 ) +
-                    p->dex_cur / 4.0;
+                          ( std::pow( 1.3, p->get_skill_level( skill_mechanics ) ) +
+                            it->get_quality( qual_LOCKPICK ) - it->damage() / 2000.0 ) +
+                          p->dex_cur / 4.0;
     int const lock_roll = rng( 1, 120 );
     if( pick_roll >= lock_roll ) {
         g->m.has_furn( act->placement ) ?
@@ -3074,7 +3074,7 @@ void activity_handlers::gunmod_add_finish( player_activity *act, player *p )
     }
 
     item &gun = *act->targets.at( 0 );
-    item  const&mod = *act->targets.at( 1 );
+    item  const &mod = *act->targets.at( 1 );
 
     // chance of success (%)
     const int roll = act->values[1];
@@ -3213,7 +3213,7 @@ void activity_handlers::travel_do_turn( player_activity *act, player *p )
                                                 ( p->global_omt_location() ) );
             waypoint = clamp( cur_omt_mid, project_bounds<coords::ms>( next_omt ) );
         }
-        map  const&here = get_map();
+        map  const &here = get_map();
         // TODO: fix point types
         tripoint centre_sub = here.getlocal( waypoint.raw() );
         if( !here.passable( centre_sub ) ) {
@@ -3284,7 +3284,7 @@ static void rod_fish( player *p, const std::vector<monster *> &fishables )
 
 void activity_handlers::fish_do_turn( player_activity *act, player *p )
 {
-    item  const&it = *act->targets.front();
+    item  const &it = *act->targets.front();
     int fish_chance = 1;
     int survival_skill = p->get_skill_level( skill_survival );
     if( it.has_flag( flag_FISH_POOR ) ) {
@@ -4169,7 +4169,7 @@ void activity_handlers::pry_nails_finish( player_activity *act, player *p )
 
 void activity_handlers::chop_tree_do_turn( player_activity *act, player * )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     sfx::play_activity_sound( "tool", "axe", sfx::get_heard_volume( here.getlocal( act->placement ) ) );
     if( calendar::once_every( 1_minutes ) ) {
         //~ Sound of a wood chopping tool at work!
@@ -4359,7 +4359,7 @@ void activity_handlers::chop_planks_finish( player_activity *act, player *p )
 
 void activity_handlers::jackhammer_do_turn( player_activity *act, player * )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     sfx::play_activity_sound( "tool", "jackhammer",
                               sfx::get_heard_volume( here.getlocal( act->placement ) ) );
     if( calendar::once_every( 1_minutes ) ) {
@@ -4472,7 +4472,7 @@ template<typename fn>
 static void cleanup_tiles( std::unordered_set<tripoint> &tiles, fn &cleanup )
 {
     auto it = tiles.begin();
-    map  const&here = get_map();
+    map  const &here = get_map();
     while( it != tiles.end() ) {
         auto current = it++;
 
@@ -4491,7 +4491,7 @@ static void perform_zone_activity_turn( player *p,
                                         const std::string &finished_msg )
 {
     const zone_manager &mgr = zone_manager::get_manager();
-    map  const&here = get_map();
+    map  const &here = get_map();
     const tripoint abspos = here.getabs( p->pos() );
     std::unordered_set<tripoint> unsorted_tiles = mgr.get_near( ztype, abspos );
 

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -421,7 +421,7 @@ activity_handlers::finish_functions = {
 bool activity_handlers::resume_for_multi_activities( player &p )
 {
     if( !p.backlog.empty() ) {
-        player_activity &back_act = p.backlog.front();
+        player_activity  const&back_act = p.backlog.front();
         if( back_act.is_multi_type() ) {
             p.assign_activity( p.backlog.front().id() );
             p.backlog.clear();
@@ -443,7 +443,7 @@ void activity_handlers::burrow_do_turn( player_activity *act, player * )
 
 void activity_handlers::burrow_finish( player_activity *act, player *p )
 {
-    tripoint pos = act->placement; // make a copy to avoid use-after-free
+    tripoint const pos = act->placement; // make a copy to avoid use-after-free
     map &here = get_map();
     act->set_to_null(); // kill activity before inflicting pain
     if( here.is_bashable( pos ) && here.has_flag( flag_SUPPORTS_ROOF, pos ) &&
@@ -1285,10 +1285,10 @@ void activity_handlers::butcher_finish( player_activity *act, player *p )
         }
         extract_or_wreck_cbms( cbms, roll, *p );
         // those lines are for XP gain with dissecting. It depends on the size of the corpse, time to dissect the corpse and the amount of bionics you would gather.
-        int time_to_cut = size_factor_in_time_to_cut( corpse->size );
-        int level_cap = std::min<int>( MAX_SKILL, ( corpse->size + ( cbms.size() * 2 + 1 ) ) );
-        int size_mult = corpse->size > MS_MEDIUM ? ( corpse->size * corpse->size ) : 8;
-        int practice_amt = ( size_mult + 1 ) * ( ( time_to_cut / 150 ) + 1 ) *
+        int const time_to_cut = size_factor_in_time_to_cut( corpse->size );
+        int const level_cap = std::min<int>( MAX_SKILL, ( corpse->size + ( cbms.size() * 2 + 1 ) ) );
+        int const size_mult = corpse->size > MS_MEDIUM ? ( corpse->size * corpse->size ) : 8;
+        int const practice_amt = ( size_mult + 1 ) * ( ( time_to_cut / 150 ) + 1 ) *
                            ( cbms.size() * cbms.size() / 2 + 1 );
         p->practice( skill_firstaid, practice_amt, level_cap );
         add_msg( m_debug, "Experience: %d, Level cap: %d, Time to cut: %d", practice_amt, level_cap,
@@ -1458,7 +1458,7 @@ void activity_handlers::shear_finish( player_activity *act, player *p )
     }
     // 22 wool staples corresponds to an average wool-producing sheep yield of 10 lbs or so
     for( int i = 0; i != 22; ++i ) {
-        item wool_staple( itype_wool_staple, calendar::turn );
+        item const wool_staple( itype_wool_staple, calendar::turn );
         here.add_item_or_charges( p->pos(), wool_staple );
     }
     source_mon->add_effect( effect_sheared, calendar::season_length() );
@@ -1477,7 +1477,7 @@ void activity_handlers::milk_finish( player_activity *act, player *p )
         debugmsg( "milking activity with no position of monster stored" );
         return;
     }
-    map &here = get_map();
+    map  const&here = get_map();
     const tripoint source_pos = here.getlocal( act->coords.at( 0 ) );
     monster *source_mon = g->critter_at<monster>( source_pos );
     if( source_mon == nullptr ) {
@@ -1632,7 +1632,7 @@ void activity_handlers::fill_liquid_do_turn( player_activity *act, player *p )
                     } else if( here.furn( source_pos ).obj().examine == &iexamine::fvat_full ) {
                         add_msg( _( "You squeeze the last drops of %s from the vat." ),
                                  liquid.type_name( 1 ) );
-                        map_stack items_here = here.i_at( source_pos );
+                        map_stack const items_here = here.i_at( source_pos );
                         if( items_here.empty() ) {
                             here.furn_set( source_pos, f_fvat_empty );
                         }
@@ -2008,7 +2008,7 @@ void activity_handlers::pulp_do_turn( player_activity *act, player *p )
     ///\EFFECT_STR increases pulping power, with diminishing returns
     float pulp_power = std::sqrt( ( p->str_cur + p->primary_weapon().damage_melee( DT_BASH ) ) *
                                   ( cut_power + 1.0f ) );
-    float pulp_effort = p->str_cur + p->primary_weapon().damage_melee( DT_BASH );
+    float const pulp_effort = p->str_cur + p->primary_weapon().damage_melee( DT_BASH );
     // Multiplier to get the chance right + some bonus for survival skill
     pulp_power *= 40 + p->get_skill_level( skill_survival ) * 5;
 
@@ -2054,7 +2054,7 @@ void activity_handlers::pulp_do_turn( player_activity *act, player *p )
                 p->practice( skill_survival, 2, 2 );
             }
 
-            float stamina_ratio = static_cast<float>( p->get_stamina() ) / p->get_stamina_max();
+            float const stamina_ratio = static_cast<float>( p->get_stamina() ) / p->get_stamina_max();
             moves += 100 / std::max( 0.25f, stamina_ratio );
             if( stamina_ratio < 0.33 || p->is_npc() ) {
                 p->moves = std::min( 0, p->moves - moves );
@@ -2111,8 +2111,8 @@ void activity_handlers::reload_finish( player_activity *act, player *p )
     }
 
     item &reloadable = *act->targets[ 0 ];
-    item &ammo = *act->targets[1];
-    std::string ammo_name = ammo.tname();
+    item  const&ammo = *act->targets[1];
+    std::string const ammo_name = ammo.tname();
     const int qty = act->index;
     const bool is_speedloader = ammo.has_flag( flag_SPEEDLOADER );
     const bool ammo_is_filthy = ammo.is_filthy();
@@ -2196,7 +2196,7 @@ void activity_handlers::start_fire_do_turn( player_activity *act, player *p )
         }
     }
 
-    item &firestarter = *act->targets.front();
+    item  const&firestarter = *act->targets.front();
     if( firestarter.has_flag( flag_REQUIRES_TINDER ) ) {
         if( !here.tinder_at( act->placement ) ) {
             p->add_msg_if_player( m_info, _( "This item requires tinder to light." ) );
@@ -2256,10 +2256,10 @@ void activity_handlers::train_finish( player_activity *act, player *p )
     const skill_id sk( act->name );
     if( sk.is_valid() ) {
         const Skill &skill = sk.obj();
-        std::string skill_name = skill.name();
-        int old_skill_level = p->get_skill_level( sk );
+        std::string const skill_name = skill.name();
+        int const old_skill_level = p->get_skill_level( sk );
         p->get_skill_level_object( sk ).train( 100, true );
-        int new_skill_level = p->get_skill_level( sk );
+        int const new_skill_level = p->get_skill_level( sk );
         if( old_skill_level != new_skill_level ) {
             add_msg( m_good, _( "You finish training %s to level %d." ),
                      skill_name, new_skill_level );
@@ -2388,7 +2388,7 @@ void activity_handlers::start_engines_finish( player_activity *act, player *p )
     act->set_to_null();
     // Find the vehicle by looking for a remote vehicle first, then by player relative coordinates
     vehicle *veh = g->remoteveh();
-    map &here = get_map();
+    map  const&here = get_map();
     if( !veh ) {
         const tripoint pos = act->placement + g->u.pos();
         veh = veh_pointer_or_null( here.veh_at( pos ) );
@@ -2546,10 +2546,10 @@ void activity_handlers::lockpicking_finish( player_activity *act, player *p )
 
     const ter_id ter_type = g->m.ter( act->placement );
     const furn_id furn_type = g->m.furn( act->placement );
-    lockpicking_open_result lr = get_lockpicking_open_result( ter_type, furn_type );
-    ter_id new_ter_type = lr.new_ter_type;
-    furn_id new_furn_type = lr.new_furn_type;
-    std::string open_message = lr.open_message;
+    lockpicking_open_result const lr = get_lockpicking_open_result( ter_type, furn_type );
+    ter_id const new_ter_type = lr.new_ter_type;
+    furn_id const new_furn_type = lr.new_furn_type;
+    std::string const open_message = lr.open_message;
 
     if( new_ter_type == t_null && new_furn_type == f_null ) {
         act->set_to_null();
@@ -2559,11 +2559,11 @@ void activity_handlers::lockpicking_finish( player_activity *act, player *p )
 
     /** @EFFECT_DEX improves chances of successfully picking door lock, reduces chances of bad outcomes */
     /** @EFFECT_MECHANICS improves chances of successfully picking door lock, reduces chances of bad outcomes */
-    int pick_roll = 5 *
+    int const pick_roll = 5 *
                     ( std::pow( 1.3, p->get_skill_level( skill_mechanics ) ) +
                       it->get_quality( qual_LOCKPICK ) - it->damage() / 2000.0 ) +
                     p->dex_cur / 4.0;
-    int lock_roll = rng( 1, 120 );
+    int const lock_roll = rng( 1, 120 );
     if( pick_roll >= lock_roll ) {
         g->m.has_furn( act->placement ) ?
         g->m.furn_set( act->placement, new_furn_type ) :
@@ -3074,7 +3074,7 @@ void activity_handlers::gunmod_add_finish( player_activity *act, player *p )
     }
 
     item &gun = *act->targets.at( 0 );
-    item &mod = *act->targets.at( 1 );
+    item  const&mod = *act->targets.at( 1 );
 
     // chance of success (%)
     const int roll = act->values[1];
@@ -3213,11 +3213,11 @@ void activity_handlers::travel_do_turn( player_activity *act, player *p )
                                                 ( p->global_omt_location() ) );
             waypoint = clamp( cur_omt_mid, project_bounds<coords::ms>( next_omt ) );
         }
-        map &here = get_map();
+        map  const&here = get_map();
         // TODO: fix point types
         tripoint centre_sub = here.getlocal( waypoint.raw() );
         if( !here.passable( centre_sub ) ) {
-            tripoint_range<tripoint> candidates = here.points_in_radius( centre_sub, 2 );
+            tripoint_range<tripoint> const candidates = here.points_in_radius( centre_sub, 2 );
             for( const tripoint &elem : candidates ) {
                 if( here.passable( elem ) ) {
                     centre_sub = elem;
@@ -3284,7 +3284,7 @@ static void rod_fish( player *p, const std::vector<monster *> &fishables )
 
 void activity_handlers::fish_do_turn( player_activity *act, player *p )
 {
-    item &it = *act->targets.front();
+    item  const&it = *act->targets.front();
     int fish_chance = 1;
     int survival_skill = p->get_skill_level( skill_survival );
     if( it.has_flag( flag_FISH_POOR ) ) {
@@ -3294,7 +3294,7 @@ void activity_handlers::fish_do_turn( player_activity *act, player *p )
         survival_skill += dice( 4, 9 );
         survival_skill *= 2;
     }
-    std::vector<monster *> fishables = g->get_fishable_monsters( act->coord_set );
+    std::vector<monster *> const fishables = g->get_fishable_monsters( act->coord_set );
     // Fish are always there, even if it dosnt seem like they are visible!
     if( fishables.empty() ) {
         fish_chance += survival_skill / 2;
@@ -3330,7 +3330,7 @@ void activity_handlers::fish_finish( player_activity *act, player *p )
 void activity_handlers::cracking_do_turn( player_activity *act, player *p )
 {
     auto cracking_tool = p->crafting_inventory().items_with( []( const item & it ) -> bool {
-        item temporary_item( it.type );
+        item const temporary_item( it.type );
         return temporary_item.has_flag( flag_SAFECRACK );
     } );
     if( cracking_tool.empty() && !p->has_bionic( bio_ears ) ) {
@@ -3574,7 +3574,7 @@ void activity_handlers::operation_do_turn( player_activity *act, player *p )
 
     const time_duration half_op_duration = difficulty * 10_minutes;
     const time_duration message_freq = difficulty * 2_minutes;
-    time_duration time_left = time_duration::from_turns( act->moves_left / 100 );
+    time_duration const time_left = time_duration::from_turns( act->moves_left / 100 );
 
     map &here = get_map();
 
@@ -3780,7 +3780,7 @@ void activity_handlers::churn_finish( player_activity *act, player *p )
 void activity_handlers::plant_seed_finish( player_activity *act, player *p )
 {
     map &here = get_map();
-    tripoint examp = here.getlocal( act->placement );
+    tripoint const examp = here.getlocal( act->placement );
     const itype_id seed_id( act->str_values[0] );
     std::list<item> used_seed;
     if( item::count_by_charges( seed_id ) ) {
@@ -3949,7 +3949,7 @@ void activity_handlers::craft_do_turn( player_activity *act, player *p )
     const recipe &rec = craft->get_making();
     const tripoint bench_pos = act->coords.front();
     // Ugly
-    bench_type bench_t = bench_type( act->values[1] );
+    bench_type const bench_t = bench_type( act->values[1] );
     const float crafting_speed = crafting_speed_multiplier( *p, *craft, bench_location{bench_t, bench_pos} );
     const int assistants = p->available_assistant_count( craft->get_making() );
     const bool is_long = act->values[0];
@@ -4013,7 +4013,7 @@ void activity_handlers::craft_do_turn( player_activity *act, player *p )
             }
         }
     } else if( craft->item_counter >= craft->get_next_failure_point() ) {
-        bool destroy = craft->handle_craft_failure( *p );
+        bool const destroy = craft->handle_craft_failure( *p );
         // If the craft needs to be destroyed, do it and stop crafting.
         if( destroy ) {
             p->add_msg_player_or_npc( _( "There is nothing left of the %s to craft from." ),
@@ -4169,7 +4169,7 @@ void activity_handlers::pry_nails_finish( player_activity *act, player *p )
 
 void activity_handlers::chop_tree_do_turn( player_activity *act, player * )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     sfx::play_activity_sound( "tool", "axe", sfx::get_heard_volume( here.getlocal( act->placement ) ) );
     if( calendar::once_every( 1_minutes ) ) {
         //~ Sound of a wood chopping tool at work!
@@ -4200,9 +4200,9 @@ void activity_handlers::chop_tree_finish( player_activity *act, player *p )
 
         for( const tripoint &elem : here.points_in_radius( pos, 1 ) ) {
             bool cantuse = false;
-            tripoint direc = elem - pos;
-            tripoint proposed_to = pos + point( 3 * direction.x, 3 * direction.y );
-            std::vector<tripoint> rough_tree_line = line_to( pos, proposed_to );
+            tripoint const direc = elem - pos;
+            tripoint const proposed_to = pos + point( 3 * direction.x, 3 * direction.y );
+            std::vector<tripoint> const rough_tree_line = line_to( pos, proposed_to );
             for( const tripoint &elem : rough_tree_line ) {
                 // Try not to drop onto a critter
                 if( g->critter_at( elem ) ) {
@@ -4210,8 +4210,8 @@ void activity_handlers::chop_tree_finish( player_activity *act, player *p )
                     break;
                 }
 
-                ter_t ter = here.ter( elem ).obj();
-                furn_t furn = here.furn( elem ).obj();
+                ter_t const ter = here.ter( elem ).obj();
+                furn_t const furn = here.furn( elem ).obj();
                 // Furniture / Terrain test
                 if( elem != pos && ( ter.bash.str_max != -1 || ( furn.id && furn.bash.str_max != -1 ) ) ) {
                     cantuse = true;
@@ -4233,7 +4233,7 @@ void activity_handlers::chop_tree_finish( player_activity *act, player *p )
     }
 
     const tripoint to = pos + 3 * direction.xy() + point( rng( -1, 1 ), rng( -1, 1 ) );
-    std::vector<tripoint> tree = line_to( pos, to, rng( 1, 8 ) );
+    std::vector<tripoint> const tree = line_to( pos, to, rng( 1, 8 ) );
     for( const tripoint &elem : tree ) {
         here.batter( elem, 300, 5 );
         here.ter_set( elem, t_trunk );
@@ -4337,8 +4337,8 @@ void activity_handlers::chop_planks_finish( player_activity *act, player *p )
     const int max_planks = 10;
     /** @EFFECT_FABRICATION increases number of planks cut from a log */
     int planks = normal_roll( 2 + p->get_skill_level( skill_id( "fabrication" ) ), 1 );
-    int wasted_planks = max_planks - planks;
-    int scraps = rng( wasted_planks, wasted_planks * 3 );
+    int const wasted_planks = max_planks - planks;
+    int const scraps = rng( wasted_planks, wasted_planks * 3 );
     planks = std::min( planks, max_planks );
 
     map &here = get_map();
@@ -4359,7 +4359,7 @@ void activity_handlers::chop_planks_finish( player_activity *act, player *p )
 
 void activity_handlers::jackhammer_do_turn( player_activity *act, player * )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     sfx::play_activity_sound( "tool", "jackhammer",
                               sfx::get_heard_volume( here.getlocal( act->placement ) ) );
     if( calendar::once_every( 1_minutes ) ) {
@@ -4472,7 +4472,7 @@ template<typename fn>
 static void cleanup_tiles( std::unordered_set<tripoint> &tiles, fn &cleanup )
 {
     auto it = tiles.begin();
-    map &here = get_map();
+    map  const&here = get_map();
     while( it != tiles.end() ) {
         auto current = it++;
 
@@ -4491,7 +4491,7 @@ static void perform_zone_activity_turn( player *p,
                                         const std::string &finished_msg )
 {
     const zone_manager &mgr = zone_manager::get_manager();
-    map &here = get_map();
+    map  const&here = get_map();
     const tripoint abspos = here.getabs( p->pos() );
     std::unordered_set<tripoint> unsorted_tiles = mgr.get_near( ztype, abspos );
 
@@ -4549,7 +4549,7 @@ void activity_handlers::fertilize_plot_do_turn( player_activity *act, player *p 
 
     const auto reject_tile = [&]( const tripoint & tile ) {
         check_fertilizer();
-        ret_val<bool> can_fert = iexamine::can_fertilize( *p, tile, fertilizer );
+        ret_val<bool> const can_fert = iexamine::can_fertilize( *p, tile, fertilizer );
         return !can_fert.success();
     };
 
@@ -4603,7 +4603,7 @@ void activity_handlers::robot_control_finish( player_activity *act, player *p )
         return;
     }
 
-    shared_ptr_fast<monster> z = act->monsters[0].lock();
+    shared_ptr_fast<monster> const z = act->monsters[0].lock();
     act->monsters.clear();
 
     if( !z || !iuse::robotcontrol_can_target( p, *z ) ) {
@@ -4677,14 +4677,14 @@ void activity_handlers::tree_communion_do_turn( player_activity *act, player *p 
     // Breadth-first search forest tiles until one reveals new overmap tiles.
     std::queue<tripoint_abs_omt> q;
     std::unordered_set<tripoint_abs_omt> seen;
-    tripoint_abs_omt loc = p->global_omt_location();
+    tripoint_abs_omt const loc = p->global_omt_location();
     q.push( loc );
     seen.insert( loc );
     const std::function<bool( const oter_id & )> filter = []( const oter_id & ter ) {
         return ter.obj().is_wooded() || ter.obj().get_name() == "field";
     };
     while( !q.empty() ) {
-        tripoint_abs_omt tpt = q.front();
+        tripoint_abs_omt const tpt = q.front();
         if( overmap_buffer.reveal( tpt, 3, filter ) ) {
             if( p->has_trait( trait_SPIRITUAL ) ) {
                 p->add_morale( MORALE_TREE_COMMUNION, 2, 30, 8_hours, 6_hours );
@@ -4740,7 +4740,7 @@ void activity_handlers::spellcasting_finish( player_activity *act, player *p )
 {
     act->set_to_null();
     const int level_override = act->get_value( 0 );
-    spell_id sp( act->name );
+    spell_id const sp( act->name );
 
     // if level is -1 then we know it's a player spell, otherwise we build it from the ground up
     spell temp_spell( sp );
@@ -4793,8 +4793,8 @@ void activity_handlers::spellcasting_finish( player_activity *act, player *p )
     }
 
     // no turning back now. it's all said and done.
-    bool success = no_fail || rng_float( 0.0f, 1.0f ) >= spell_being_cast.spell_fail( *p );
-    int exp_gained = spell_being_cast.casting_exp( *p );
+    bool const success = no_fail || rng_float( 0.0f, 1.0f ) >= spell_being_cast.spell_fail( *p );
+    int const exp_gained = spell_being_cast.casting_exp( *p );
     if( !success ) {
         p->add_msg_if_player( game_message_params{ m_bad, gmf_bypass_cooldown },
                               _( "You lose your concentration!" ) );
@@ -4818,7 +4818,7 @@ void activity_handlers::spellcasting_finish( player_activity *act, player *p )
 
     if( !no_mana ) {
         // pay the cost
-        int cost = spell_being_cast.energy_cost( *p );
+        int const cost = spell_being_cast.energy_cost( *p );
         switch( spell_being_cast.energy_source() ) {
             case mana_energy:
                 p->magic->mod_mana( *p, -cost );
@@ -4843,7 +4843,7 @@ void activity_handlers::spellcasting_finish( player_activity *act, player *p )
     if( level_override == -1 ) {
         if( !spell_being_cast.is_max_level() ) {
             // reap the reward
-            int old_level = spell_being_cast.get_level();
+            int const old_level = spell_being_cast.get_level();
             if( old_level == 0 ) {
                 spell_being_cast.gain_level();
                 p->add_msg_if_player( m_good,

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -399,7 +399,7 @@ void put_into_vehicle_or_drop( Character &c, item_drop_reason reason, const std:
 void put_into_vehicle_or_drop( Character &c, item_drop_reason reason, const std::list<item> &items,
                                const tripoint &where, bool force_ground )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     const std::optional<vpart_reference> vp = here.veh_at( where ).part_with_feature( "CARGO", false );
     if( vp && !force_ground ) {
         put_into_vehicle( c, reason, items, vp->vehicle(), vp->part_index() );
@@ -438,7 +438,7 @@ static std::list<pickup::act_item> convert_to_items( Character &p,
                 }
                 const int qty = it.count_by_charges() ? std::min<int>( it.charges, count - obtained ) : 1;
                 obtained += qty;
-                item_location loc( p, const_cast<item *>( &it ) );
+                item_location const loc( p, const_cast<item *>( &it ) );
                 res.emplace_back( loc, qty, loc.obtain_cost( p, qty ) );
             }
         } else {
@@ -485,7 +485,7 @@ std::list<act_item> reorder_for_dropping( Character &p, const drop_locations &dr
             if( iter == worn.end() ) {
                 // TODO: Use a calculated cost
                 const item_location loc( p, dit );
-                act_item act( loc, loc->count(), loc.obtain_cost( p, loc->count() ) );
+                act_item const act( loc, loc->count(), loc.obtain_cost( p, loc->count() ) );
                 worn.emplace_front( loc, loc->count(), loc.obtain_cost( p ) );
             }
         }
@@ -498,7 +498,7 @@ std::list<act_item> reorder_for_dropping( Character &p, const drop_locations &dr
     } );
 
     // Avoid tumbling to the ground. Unload cleanly.
-    units::volume dropped_inv_contents = std::accumulate( inv.begin(), inv.end(), 0_ml,
+    units::volume const dropped_inv_contents = std::accumulate( inv.begin(), inv.end(), 0_ml,
     []( units::volume acc, const act_item & ait ) {
         return acc + ait.loc->volume();
     } );
@@ -553,7 +553,7 @@ std::list<act_item> reorder_for_dropping( Character &p, const drop_locations &dr
         worn.pop_front();
         remaining_dropped_storage -= front_storage;
         while( !inv.empty() ) {
-            units::volume inventory_item_volume = inv.front().loc->volume();
+            units::volume const inventory_item_volume = inv.front().loc->volume();
             if( front_storage < inventory_item_volume ) {
                 break;
             }
@@ -700,7 +700,7 @@ void activity_on_turn_wear( player_activity &act, player &p )
     // ACT_WEAR has item_location targets, and int quantities
     while( p.moves > 0 && !act.targets.empty() ) {
         item_location target = std::move( act.targets.back() );
-        int quantity = act.values.back();
+        int const quantity = act.values.back();
         act.targets.pop_back();
         act.values.pop_back();
 
@@ -748,7 +748,7 @@ void wash_activity_actor::finish( player_activity &act, Character &who )
     for( const auto &it : targets ) {
         total_volume += it.loc->volume() * it.count / it.loc->count();
     }
-    washing_requirements required = washing_requirements_for_volume( total_volume );
+    washing_requirements const required = washing_requirements_for_volume( total_volume );
 
     const auto is_liquid_crafting_component = []( const item & it ) {
         return is_crafting_component( it ) && ( !it.count_by_charges() || it.made_of( LIQUID ) ||
@@ -899,13 +899,13 @@ static int move_cost_cart( const item &it, const tripoint &src, const tripoint &
 static int move_cost( const item &it, const tripoint &src, const tripoint &dest )
 {
     if( g->u.get_grab_type() == OBJECT_VEHICLE ) {
-        tripoint cart_position = g->u.pos() + g->u.grab_point;
+        tripoint const cart_position = g->u.pos() + g->u.grab_point;
 
         if( const std::optional<vpart_reference> vp = get_map().veh_at(
                     cart_position ).part_with_feature( "CARGO", false ) ) {
             const vehicle &veh = vp->vehicle();
-            size_t vstor = vp->part_index();
-            units::volume capacity = veh.free_volume( vstor );
+            size_t const vstor = vp->part_index();
+            units::volume const capacity = veh.free_volume( vstor );
 
             return move_cost_cart( it, src, dest, capacity );
         }
@@ -918,7 +918,7 @@ static int move_cost( const item &it, const tripoint &src, const tripoint &dest 
 // return false if it was not possible.
 static bool vehicle_activity( player &p, const tripoint &src_loc, int vpindex, char type )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     vehicle *veh = veh_pointer_or_null( here.veh_at( src_loc ) );
     if( !veh ) {
         return false;
@@ -1024,7 +1024,7 @@ static void move_item( player &p, item &it, const int quantity, const tripoint &
 std::vector<tripoint> route_adjacent( const player &p, const tripoint &dest )
 {
     auto passable_tiles = std::unordered_set<tripoint>();
-    map &here = get_map();
+    map  const&here = get_map();
 
     for( const tripoint &tp : here.points_in_radius( dest, 1 ) ) {
         if( tp != p.pos() && here.passable( tp ) && !here.obstructed_by_vehicle_rotation( dest, tp ) ) {
@@ -1057,7 +1057,7 @@ static activity_reason_info find_base_construction(
 {
     const construction &build = id.obj();
     //already done?
-    map &here = get_map();
+    map  const&here = get_map();
     const furn_id furn = here.furn( loc );
     const ter_id ter = here.ter( loc );
     if(
@@ -1192,10 +1192,10 @@ static bool are_requirements_nearby( const std::vector<tripoint> &loot_spots,
                                      const requirement_id &needed_things, player &p, const activity_id &activity_to_restore,
                                      const bool in_loot_zones, const tripoint &src_loc )
 {
-    zone_manager &mgr = zone_manager::get_manager();
+    zone_manager  const&mgr = zone_manager::get_manager();
     inventory temp_inv;
-    units::volume volume_allowed = p.volume_capacity() - p.volume_carried();
-    units::mass weight_allowed = p.weight_capacity() - p.weight_carried();
+    units::volume const volume_allowed = p.volume_capacity() - p.volume_carried();
+    units::mass const weight_allowed = p.weight_capacity() - p.weight_carried();
     static const auto check_weight_if = []( const activity_id & id ) {
         return id == ACT_MULTIPLE_FARM ||
                id == ACT_MULTIPLE_CHOP_PLANKS ||
@@ -1246,7 +1246,7 @@ static bool are_requirements_nearby( const std::vector<tripoint> &loot_spots,
             if( const std::optional<vpart_reference> vp = here.veh_at( elem ).part_with_feature( "CARGO",
                     false ) ) {
                 vehicle &src_veh = vp->vehicle();
-                int src_part = vp->part_index();
+                int const src_part = vp->part_index();
                 for( auto &it : src_veh.get_items( src_part ) ) {
                     temp_inv += it;
                 }
@@ -1258,7 +1258,7 @@ static bool are_requirements_nearby( const std::vector<tripoint> &loot_spots,
         for( const tripoint &elem : here.points_in_radius( src_loc, PICKUP_RANGE - 1 ) ) {
             const optional_vpart_position vp = here.veh_at( elem );
             if( vp ) {
-                vehicle &veh = vp->vehicle();
+                vehicle  const&veh = vp->vehicle();
                 const std::optional<vpart_reference> weldpart = vp.part_with_feature( "WELDRIG", true );
                 if( weldpart ) {
                     item welder( itype_welder, calendar::start_of_cataclysm );
@@ -1279,7 +1279,7 @@ static bool are_requirements_nearby( const std::vector<tripoint> &loot_spots,
 static bool has_skill_for_vehicle_work( const std::map<skill_id, int> &required_skills, player &p )
 {
     for( const auto &e : required_skills ) {
-        bool hasSkill = p.get_skill_level( e.first ) >= e.second;
+        bool const hasSkill = p.get_skill_level( e.first ) >= e.second;
         if( !hasSkill ) {
             return false;
         }
@@ -1292,7 +1292,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
 {
     // see activity_handlers.h cant_do_activity_reason enums
     p.invalidate_crafting_inventory();
-    zone_manager &mgr = zone_manager::get_manager();
+    zone_manager  const&mgr = zone_manager::get_manager();
     std::vector<zone_data> zones;
     map &here = get_map();
     if( act == ACT_VEHICLE_DECONSTRUCTION ||
@@ -1334,10 +1334,10 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
         }
         if( act == ACT_VEHICLE_DECONSTRUCTION ) {
             // find out if there is a vehicle part here we can remove.
-            std::vector<vehicle_part *> parts = veh->get_parts_at( src_loc, "", part_status_flag::any );
+            std::vector<vehicle_part *> const parts = veh->get_parts_at( src_loc, "", part_status_flag::any );
             for( vehicle_part *part_elem : parts ) {
                 const vpart_info &vpinfo = part_elem->info();
-                int vpindex = veh->index_of_part( part_elem, true );
+                int const vpindex = veh->index_of_part( part_elem, true );
                 // if part is not on this vehicle, or if its attached to another part that needs to be removed first.
                 if( vpindex == -1 || !veh->can_unmount( vpindex ) ) {
                     continue;
@@ -1351,7 +1351,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
                 if( !has_skill_for_vehicle_work( vpinfo.removal_skills, p ) ) {
                     continue;
                 }
-                item base( vpinfo.item );
+                item const base( vpinfo.item );
                 if( base.is_wheel() ) {
                     // no wheel removal yet
                     continue;
@@ -1379,10 +1379,10 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
             }
         } else if( act == ACT_VEHICLE_REPAIR ) {
             // find out if there is a vehicle part here we can repair.
-            std::vector<vehicle_part *> parts = veh->get_parts_at( src_loc, "", part_status_flag::any );
+            std::vector<vehicle_part *> const parts = veh->get_parts_at( src_loc, "", part_status_flag::any );
             for( vehicle_part *part_elem : parts ) {
                 const vpart_info &vpinfo = part_elem->info();
-                int vpindex = veh->index_of_part( part_elem, true );
+                int const vpindex = veh->index_of_part( part_elem, true );
                 // if part is undamaged or beyond repair - can skip it.
                 if( part_elem->is_broken() || part_elem->damage() == 0 ||
                     part_elem->info().repair_requirements().is_empty() ) {
@@ -1416,7 +1416,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
         if( !here.has_flag( "MINEABLE", src_loc ) ) {
             return activity_reason_info::fail( do_activity_reason::NO_ZONE );
         }
-        std::vector<item *> mining_inv = p.items_with( []( const item & itm ) {
+        std::vector<item *> const mining_inv = p.items_with( []( const item & itm ) {
             return ( itm.has_flag( flag_DIG_TOOL ) && !itm.type->can_use( "JACKHAMMER" ) ) ||
                    ( itm.type->can_use( "JACKHAMMER" ) && itm.ammo_sufficient() );
         } );
@@ -1430,7 +1430,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
         if( !here.has_flag( flag_FISHABLE, src_loc ) ) {
             return activity_reason_info::fail( do_activity_reason::NO_ZONE );
         }
-        std::vector<item *> rod_inv = p.items_with( []( const item & itm ) {
+        std::vector<item *> const rod_inv = p.items_with( []( const item & itm ) {
             return itm.has_flag( flag_FISH_POOR ) || itm.has_flag( flag_FISH_GOOD );
         } );
         if( rod_inv.empty() ) {
@@ -1575,7 +1575,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
                     if( seed.is_empty() ) {
                         return activity_reason_info::fail( do_activity_reason::ALREADY_DONE );
                     }
-                    std::vector<item *> seed_inv = p.items_with( []( const item & itm ) {
+                    std::vector<item *> const seed_inv = p.items_with( []( const item & itm ) {
                         return itm.is_seed();
                     } );
                     for( const auto elem : seed_inv ) {
@@ -1610,10 +1610,10 @@ static void add_basecamp_storage_to_loot_zone_list( zone_manager &mgr, const tri
         player &p, std::vector<tripoint> &loot_zone_spots, std::vector<tripoint> &combined_spots )
 {
     if( npc *const guy = dynamic_cast<npc *>( &p ) ) {
-        map &here = get_map();
+        map  const&here = get_map();
         if( guy->assigned_camp &&
             mgr.has_near( z_camp_storage, here.getabs( src_loc ), ACTIVITY_SEARCH_DISTANCE ) ) {
-            std::unordered_set<tripoint> bc_storage_set = mgr.get_near( zone_type_id( "CAMP_STORAGE" ),
+            std::unordered_set<tripoint> const bc_storage_set = mgr.get_near( zone_type_id( "CAMP_STORAGE" ),
                     here.getabs( src_loc ), ACTIVITY_SEARCH_DISTANCE );
             for( const tripoint &elem : bc_storage_set ) {
                 loot_zone_spots.push_back( here.getlocal( elem ) );
@@ -1633,7 +1633,7 @@ static std::vector<std::tuple<tripoint, itype_id, int>> requirements_map( player
     const requirement_data things_to_fetch = requirement_id( p.backlog.front().str_values[0] ).obj();
     const activity_id activity_to_restore = p.backlog.front().id();
     // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
-    requirement_id things_to_fetch_id = things_to_fetch.id();
+    requirement_id const things_to_fetch_id = things_to_fetch.id();
     std::vector<std::vector<item_comp>> req_comps = things_to_fetch.get_components();
     std::vector<std::vector<tool_comp>> tool_comps = things_to_fetch.get_tools();
     std::vector<std::vector<quality_requirement>> quality_comps = things_to_fetch.get_qualities();
@@ -1653,7 +1653,7 @@ static std::vector<std::tuple<tripoint, itype_id, int>> requirements_map( player
     std::vector<tripoint> combined_spots;
     std::map<itype_id, int> total_map;
     map &here = get_map();
-    tripoint src_loc = here.getlocal( p.backlog.front().placement );
+    tripoint const src_loc = here.getlocal( p.backlog.front().placement );
     for( const tripoint &elem : here.points_in_radius( src_loc,
             PICKUP_RANGE - 1 ) ) {
         already_there_spots.push_back( elem );
@@ -1767,14 +1767,14 @@ static std::vector<std::tuple<tripoint, itype_id, int>> requirements_map( player
             if( line_found || comp_elem.count <= 0 ) {
                 break;
             }
-            int quantity_required = comp_elem.count;
+            int const quantity_required = comp_elem.count;
             int item_quantity = 0;
             auto it = requirement_map.begin();
             int remainder = 0;
             while( it != requirement_map.end() ) {
-                tripoint pos_here = std::get<0>( *it );
-                itype_id item_here = std::get<1>( *it );
-                int quantity_here = std::get<2>( *it );
+                tripoint const pos_here = std::get<0>( *it );
+                itype_id const item_here = std::get<1>( *it );
+                int const quantity_here = std::get<2>( *it );
                 if( comp_elem.type == item_here ) {
                     item_quantity += quantity_here;
                 }
@@ -1802,9 +1802,9 @@ static std::vector<std::tuple<tripoint, itype_id, int>> requirements_map( player
                         line_found = true;
                         break;
                     }
-                    tripoint pos_here2 = std::get<0>( *it );
-                    itype_id item_here2 = std::get<1>( *it );
-                    int quantity_here2 = std::get<2>( *it );
+                    tripoint const pos_here2 = std::get<0>( *it );
+                    itype_id const item_here2 = std::get<1>( *it );
+                    int const quantity_here2 = std::get<2>( *it );
                     if( comp_elem.type == item_here2 ) {
                         if( quantity_here2 >= remainder ) {
                             final_map.push_back( std::make_tuple( pos_here2, item_here2, remainder ) );
@@ -1825,14 +1825,14 @@ static std::vector<std::tuple<tripoint, itype_id, int>> requirements_map( player
             if( line_found || comp_elem.count < -1 ) {
                 break;
             }
-            int quantity_required = std::max( 1, comp_elem.count );
+            int const quantity_required = std::max( 1, comp_elem.count );
             int item_quantity = 0;
             auto it = requirement_map.begin();
             int remainder = 0;
             while( it != requirement_map.end() ) {
-                tripoint pos_here = std::get<0>( *it );
-                itype_id item_here = std::get<1>( *it );
-                int quantity_here = std::get<2>( *it );
+                tripoint const pos_here = std::get<0>( *it );
+                itype_id const item_here = std::get<1>( *it );
+                int const quantity_here = std::get<2>( *it );
                 if( comp_elem.type == item_here ) {
                     item_quantity += quantity_here;
                 }
@@ -1860,9 +1860,9 @@ static std::vector<std::tuple<tripoint, itype_id, int>> requirements_map( player
                         line_found = true;
                         break;
                     }
-                    tripoint pos_here2 = std::get<0>( *it );
-                    itype_id item_here2 = std::get<1>( *it );
-                    int quantity_here2 = std::get<2>( *it );
+                    tripoint const pos_here2 = std::get<0>( *it );
+                    itype_id const item_here2 = std::get<1>( *it );
+                    int const quantity_here2 = std::get<2>( *it );
                     if( comp_elem.type == item_here2 ) {
                         if( quantity_here2 >= remainder ) {
                             final_map.push_back( std::make_tuple( pos_here2, item_here2, remainder ) );
@@ -1886,9 +1886,9 @@ static std::vector<std::tuple<tripoint, itype_id, int>> requirements_map( player
             const quality_id tool_qual = comp_elem.type;
             const int qual_level = comp_elem.level;
             for( auto it = requirement_map.begin(); it != requirement_map.end(); ) {
-                tripoint pos_here = std::get<0>( *it );
-                itype_id item_here = std::get<1>( *it );
-                item test_item = item( item_here, calendar::start_of_cataclysm );
+                tripoint const pos_here = std::get<0>( *it );
+                itype_id const item_here = std::get<1>( *it );
+                item const test_item = item( item_here, calendar::start_of_cataclysm );
                 if( test_item.has_quality( tool_qual, qual_level ) ) {
                     // it's just this spot that can fulfil the requirement on its own
                     final_map.push_back( std::make_tuple( pos_here, item_here, 1 ) );
@@ -1947,7 +1947,7 @@ static bool tidy_activity( player &p, const tripoint &src_loc,
 {
     auto &mgr = zone_manager::get_manager();
     map &here = get_map();
-    tripoint loot_abspos = here.getabs( src_loc );
+    tripoint const loot_abspos = here.getabs( src_loc );
     tripoint loot_src_lot;
     const auto &zone_src_set = mgr.get_near( zone_type_LOOT_UNSORTED, loot_abspos, distance );
     if( !zone_src_set.empty() ) {
@@ -2005,7 +2005,7 @@ static bool fetch_activity( player &p, const tripoint &src_loc,
     }
     const std::vector<std::tuple<tripoint, itype_id, int>> mental_map_2 = requirements_map( p,
             distance );
-    int pickup_count = 1;
+    int const pickup_count = 1;
     auto items_there = here.i_at( src_loc );
     vehicle *src_veh = nullptr;
     int src_part = 0;
@@ -2124,7 +2124,7 @@ static bool chop_plank_activity( player &p, const tripoint &src_loc )
     for( auto &i : here.i_at( src_loc ) ) {
         if( i.typeId() == itype_log ) {
             here.i_rem( src_loc, &i );
-            int moves = to_moves<int>( 20_minutes );
+            int const moves = to_moves<int>( 20_minutes );
             p.add_msg_if_player( _( "You cut the log into planks." ) );
             p.assign_activity( ACT_CHOP_PLANKS, moves, -1 );
             p.activity.placement = here.getabs( src_loc );
@@ -2218,7 +2218,7 @@ void activity_on_turn_move_loot( player_activity &act, player &p )
                 continue;
             }
 
-            bool is_adjacent_or_closer = square_dist( p.pos(), src_loc ) <= 1;
+            bool const is_adjacent_or_closer = square_dist( p.pos(), src_loc ) <= 1;
             // before we move any item, check if player is at or
             // adjacent to the loot source tile
             if( !is_adjacent_or_closer ) {
@@ -2266,7 +2266,7 @@ void activity_on_turn_move_loot( player_activity &act, player &p )
         const tripoint &src = act.placement;
         const tripoint &src_loc = here.getlocal( src );
 
-        bool is_adjacent_or_closer = square_dist( p.pos(), src_loc ) <= 1;
+        bool const is_adjacent_or_closer = square_dist( p.pos(), src_loc ) <= 1;
         // before we move any item, check if player is at or
         // adjacent to the loot source tile
         if( !is_adjacent_or_closer ) {
@@ -2394,8 +2394,8 @@ void activity_on_turn_move_loot( player_activity &act, player &p )
 
 static bool mine_activity( player &p, const tripoint &src_loc )
 {
-    map &here = get_map();
-    std::vector<item *> mining_inv = p.items_with( []( const item & itm ) {
+    map  const&here = get_map();
+    std::vector<item *> const mining_inv = p.items_with( []( const item & itm ) {
         return ( itm.has_flag( flag_DIG_TOOL ) && !itm.type->can_use( "JACKHAMMER" ) ) ||
                ( itm.type->can_use( "JACKHAMMER" ) && itm.ammo_sufficient() );
     } );
@@ -2445,11 +2445,11 @@ static bool chop_tree_activity( player &p, const tripoint &src_loc )
     if( !best_qual ) {
         return false;
     }
-    int moves = iuse::chop_moves( p, *best_qual );
+    int const moves = iuse::chop_moves( p, *best_qual );
     if( best_qual->type->can_have_charges() ) {
         p.consume_charges( *best_qual, best_qual->type->charges_to_use() );
     }
-    map &here = get_map();
+    map  const&here = get_map();
     const ter_id ter = here.ter( src_loc );
     if( here.has_flag( flag_TREE, src_loc ) ) {
         p.assign_activity( ACT_CHOP_TREE, moves, -1, p.get_item_position( best_qual ) );
@@ -2523,14 +2523,14 @@ static std::unordered_set<tripoint> generic_multi_activity_locations( player &p,
     bool dark_capable = false;
     std::unordered_set<tripoint> src_set;
 
-    zone_manager &mgr = zone_manager::get_manager();
+    zone_manager  const&mgr = zone_manager::get_manager();
     const tripoint localpos = p.pos();
     map &here = get_map();
     const tripoint abspos = here.getabs( localpos );
     if( act_id == ACT_TIDY_UP ) {
         dark_capable = true;
         tripoint unsorted_spot;
-        std::unordered_set<tripoint> unsorted_set = mgr.get_near( zone_type_LOOT_UNSORTED, abspos,
+        std::unordered_set<tripoint> const unsorted_set = mgr.get_near( zone_type_LOOT_UNSORTED, abspos,
                 ACTIVITY_SEARCH_DISTANCE );
         if( !unsorted_set.empty() ) {
             unsorted_spot = here.getlocal( random_entry( unsorted_set ) );
@@ -2560,7 +2560,7 @@ static std::unordered_set<tripoint> generic_multi_activity_locations( player &p,
                         found_one_point = true;
                         // only check for a valid path, as that is all that is needed to tidy something up.
                         if( square_dist( p.pos(), elem ) > 1 ) {
-                            std::vector<tripoint> route = route_adjacent( p, elem );
+                            std::vector<tripoint> const route = route_adjacent( p, elem );
                             if( route.empty() ) {
                                 found_route = false;
                             }
@@ -2580,7 +2580,7 @@ static std::unordered_set<tripoint> generic_multi_activity_locations( player &p,
             }
         }
     } else if( act_id != ACT_FETCH_REQUIRED ) {
-        zone_type_id zone_type = get_zone_for_act( tripoint_zero, mgr, act_id );
+        zone_type_id const zone_type = get_zone_for_act( tripoint_zero, mgr, act_id );
         src_set = mgr.get_near( zone_type_id( zone_type ), abspos, ACTIVITY_SEARCH_DISTANCE );
         // multiple construction will form a list of targets based on blueprint zones and unfinished constructions
         if( act_id == ACT_MULTIPLE_CONSTRUCTION ) {
@@ -2599,7 +2599,7 @@ static std::unordered_set<tripoint> generic_multi_activity_locations( player &p,
         // get the right zones for the items in the requirements.
         // we previously checked if the items are nearby before we set the fetch task
         // but we will check again later, to be sure nothings changed.
-        std::vector<std::tuple<tripoint, itype_id, int>> mental_map = requirements_map( p,
+        std::vector<std::tuple<tripoint, itype_id, int>> const mental_map = requirements_map( p,
                 ACTIVITY_SEARCH_DISTANCE );
         for( const auto &elem : mental_map ) {
             const tripoint &elem_point = std::get<0>( elem );
@@ -2748,7 +2748,7 @@ static requirement_check_result generic_multi_activity_check_requirement( player
                    reason == do_activity_reason::NEEDS_FISHING ) {
             std::vector<std::vector<item_comp>> requirement_comp_vector;
             std::vector<std::vector<quality_requirement>> quality_comp_vector;
-            std::vector<std::vector<tool_comp>> tool_comp_vector;
+            std::vector<std::vector<tool_comp>> const tool_comp_vector;
             if( reason == do_activity_reason::NEEDS_TILLING ) {
                 quality_comp_vector.push_back( std::vector<quality_requirement> { quality_requirement( qual_DIG, 1, 1 ) } );
             } else if( reason == do_activity_reason::NEEDS_CHOPPING ||
@@ -2770,14 +2770,14 @@ static requirement_check_result generic_multi_activity_check_requirement( player
             }
             // ok, we need a shovel/hoe/axe/etc.
             // this is an activity that only requires this one tool, so we will fetch and wield it.
-            requirement_data reqs_data = requirement_data( tool_comp_vector, quality_comp_vector,
+            requirement_data const reqs_data = requirement_data( tool_comp_vector, quality_comp_vector,
                                          requirement_comp_vector );
             const std::string ran_str = random_string( 10 );
             const requirement_id req_id( ran_str );
             requirement_data::save_requirement( reqs_data, req_id );
             what_we_need = req_id;
         }
-        bool tool_pickup = reason == do_activity_reason::NEEDS_TILLING ||
+        bool const tool_pickup = reason == do_activity_reason::NEEDS_TILLING ||
                            reason == do_activity_reason::NEEDS_PLANTING ||
                            reason == do_activity_reason::NEEDS_CHOPPING ||
                            reason == do_activity_reason::NEEDS_BUTCHERING ||
@@ -2842,7 +2842,7 @@ static bool generic_multi_activity_do( player &p, const activity_id &act_id,
 {
     // If any of the following activities return without processing
     // then they MUST return true here, to stop infinite loops.
-    zone_manager &mgr = zone_manager::get_manager();
+    zone_manager  const&mgr = zone_manager::get_manager();
 
     const do_activity_reason &reason = act_info.reason;
     const zone_data *zone = mgr.get_zone_at( src, get_zone_for_act( src_loc, mgr, act_id ) );
@@ -2860,12 +2860,12 @@ static bool generic_multi_activity_do( player &p, const activity_id &act_id,
         return false;
     } else if( reason == do_activity_reason::NEEDS_PLANTING &&
                here.has_flag_ter_or_furn( flag_PLANTABLE, src_loc ) ) {
-        std::vector<zone_data> zones = mgr.get_zones( zone_type_FARM_PLOT,
+        std::vector<zone_data> const zones = mgr.get_zones( zone_type_FARM_PLOT,
                                        here.getabs( src_loc ) );
         for( const zone_data &zone : zones ) {
             const itype_id seed =
                 dynamic_cast<const plot_options &>( zone.get_options() ).get_seed();
-            std::vector<item *> seed_inv = p.items_with( [seed]( const item & itm ) {
+            std::vector<item *> const seed_inv = p.items_with( [seed]( const item & itm ) {
                 return itm.typeId() == itype_id( seed );
             } );
             // we don't have the required seed, even though we should at this point.
@@ -2951,19 +2951,19 @@ static bool generic_multi_activity_do( player &p, const activity_id &act_id,
 
 bool generic_multi_activity_handler( player_activity &act, player &p, bool check_only )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     const tripoint abspos = here.getabs( p.pos() );
     // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
-    activity_id activity_to_restore = act.id();
+    activity_id const activity_to_restore = act.id();
     // Nuke the current activity, leaving the backlog alone
     if( !check_only ) {
         p.activity = player_activity();
     }
     // now we setup the target spots based on which activity is occurring
     // the set of target work spots - potentially after we have fetched required tools.
-    std::unordered_set<tripoint> src_set = generic_multi_activity_locations( p, activity_to_restore );
+    std::unordered_set<tripoint> const src_set = generic_multi_activity_locations( p, activity_to_restore );
     // now we have our final set of points
-    std::vector<tripoint> src_sorted = get_sorted_tiles_by_distance( abspos, src_set );
+    std::vector<tripoint> const src_sorted = get_sorted_tiles_by_distance( abspos, src_set );
     // now loop through the work-spot tiles and judge whether its worth traveling to it yet
     // or if we need to fetch something first.
     for( const tripoint &src : src_sorted ) {
@@ -2998,7 +2998,7 @@ bool generic_multi_activity_handler( player_activity &act, player &p, bool check
         }
 
         if( square_dist( p.pos(), src_loc ) > 1 ) {
-            std::vector<tripoint> route = route_adjacent( p, src_loc );
+            std::vector<tripoint> const route = route_adjacent( p, src_loc );
 
             // check if we found path to source / adjacent tile
             if( route.empty() ) {
@@ -3075,7 +3075,7 @@ static std::optional<tripoint> find_best_fire( const std::vector<tripoint> &from
             !here.clear_path( center, pt, PICKUP_RANGE, 1, 100 ) ) {
             continue;
         }
-        time_duration fire_age = fire->get_field_age();
+        time_duration const fire_age = fire->get_field_age();
         // Refuel only the best fueled fire (if it needs it)
         if( fire_age < best_fire_age ) {
             best_fire = pt;
@@ -3092,7 +3092,7 @@ static std::optional<tripoint> find_best_fire( const std::vector<tripoint> &from
 
 static inline bool has_clear_path_to_pickup_items( const tripoint &from, const tripoint &to )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     return here.has_items( to ) &&
            here.accessible_items( to ) &&
            here.clear_path( from, to, PICKUP_RANGE, 1, 100 );
@@ -3101,7 +3101,7 @@ static inline bool has_clear_path_to_pickup_items( const tripoint &from, const t
 static std::optional<tripoint> find_refuel_spot_zone( const tripoint &center )
 {
     const zone_manager &mgr = zone_manager::get_manager();
-    map &here = get_map();
+    map  const&here = get_map();
     const tripoint center_abs = here.getabs( center );
 
     const std::unordered_set<tripoint> &tiles_abs_unordered =
@@ -3158,7 +3158,7 @@ bool find_auto_consume( player &p, const consume_type type )
     }
 
     const auto ok_to_consume = [&p, type]( item & it ) -> bool {
-        item &comest = p.get_consumable_from( it );
+        item  const&comest = p.get_consumable_from( it );
         /* not food.              */
         if( comest.is_null() || comest.is_craft() || !comest.is_food() )
         {
@@ -3291,9 +3291,9 @@ void try_fuel_fire( player_activity &act, player &p, const bool starting_fire )
     }
 
     // Special case: fire containers allow burning logs, so use them as fuel if fire is contained
-    bool contained = here.has_flag_furn( TFLAG_FIRE_CONTAINER, *best_fire );
+    bool const contained = here.has_flag_furn( TFLAG_FIRE_CONTAINER, *best_fire );
     fire_data fd( 1, contained );
-    time_duration fire_age = here.get_field_age( *best_fire, fd_fire );
+    time_duration const fire_age = here.get_field_age( *best_fire, fd_fire );
 
     // Maybe TODO: - refueling in the rain could use more fuel
     // First, simulate expected burn per turn, to see if we need more fuel
@@ -3323,10 +3323,10 @@ void try_fuel_fire( player_activity &act, player &p, const bool starting_fire )
             continue;
         }
 
-        float last_fuel = fd.fuel_produced;
+        float const last_fuel = fd.fuel_produced;
         it.simulate_burn( fd );
         if( fd.fuel_produced > last_fuel ) {
-            int quantity = std::max( 1, std::min( it.charges, it.charges_per_volume( 250_ml ) ) );
+            int const quantity = std::max( 1, std::min( it.charges, it.charges_per_volume( 250_ml ) ) );
             // Note: move_item() handles messages (they're the generic "you drop x")
             move_item( p, it, quantity, *refuel_spot, *best_fire, nullptr, -1 );
             return;

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -399,7 +399,7 @@ void put_into_vehicle_or_drop( Character &c, item_drop_reason reason, const std:
 void put_into_vehicle_or_drop( Character &c, item_drop_reason reason, const std::list<item> &items,
                                const tripoint &where, bool force_ground )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     const std::optional<vpart_reference> vp = here.veh_at( where ).part_with_feature( "CARGO", false );
     if( vp && !force_ground ) {
         put_into_vehicle( c, reason, items, vp->vehicle(), vp->part_index() );
@@ -918,7 +918,7 @@ static int move_cost( const item &it, const tripoint &src, const tripoint &dest 
 // return false if it was not possible.
 static bool vehicle_activity( player &p, const tripoint &src_loc, int vpindex, char type )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     vehicle *veh = veh_pointer_or_null( here.veh_at( src_loc ) );
     if( !veh ) {
         return false;
@@ -1024,7 +1024,7 @@ static void move_item( player &p, item &it, const int quantity, const tripoint &
 std::vector<tripoint> route_adjacent( const player &p, const tripoint &dest )
 {
     auto passable_tiles = std::unordered_set<tripoint>();
-    map  const&here = get_map();
+    map  const &here = get_map();
 
     for( const tripoint &tp : here.points_in_radius( dest, 1 ) ) {
         if( tp != p.pos() && here.passable( tp ) && !here.obstructed_by_vehicle_rotation( dest, tp ) ) {
@@ -1057,7 +1057,7 @@ static activity_reason_info find_base_construction(
 {
     const construction &build = id.obj();
     //already done?
-    map  const&here = get_map();
+    map  const &here = get_map();
     const furn_id furn = here.furn( loc );
     const ter_id ter = here.ter( loc );
     if(
@@ -1192,7 +1192,7 @@ static bool are_requirements_nearby( const std::vector<tripoint> &loot_spots,
                                      const requirement_id &needed_things, player &p, const activity_id &activity_to_restore,
                                      const bool in_loot_zones, const tripoint &src_loc )
 {
-    zone_manager  const&mgr = zone_manager::get_manager();
+    zone_manager  const &mgr = zone_manager::get_manager();
     inventory temp_inv;
     units::volume const volume_allowed = p.volume_capacity() - p.volume_carried();
     units::mass const weight_allowed = p.weight_capacity() - p.weight_carried();
@@ -1258,7 +1258,7 @@ static bool are_requirements_nearby( const std::vector<tripoint> &loot_spots,
         for( const tripoint &elem : here.points_in_radius( src_loc, PICKUP_RANGE - 1 ) ) {
             const optional_vpart_position vp = here.veh_at( elem );
             if( vp ) {
-                vehicle  const&veh = vp->vehicle();
+                vehicle  const &veh = vp->vehicle();
                 const std::optional<vpart_reference> weldpart = vp.part_with_feature( "WELDRIG", true );
                 if( weldpart ) {
                     item welder( itype_welder, calendar::start_of_cataclysm );
@@ -1292,7 +1292,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
 {
     // see activity_handlers.h cant_do_activity_reason enums
     p.invalidate_crafting_inventory();
-    zone_manager  const&mgr = zone_manager::get_manager();
+    zone_manager  const &mgr = zone_manager::get_manager();
     std::vector<zone_data> zones;
     map &here = get_map();
     if( act == ACT_VEHICLE_DECONSTRUCTION ||
@@ -1610,7 +1610,7 @@ static void add_basecamp_storage_to_loot_zone_list( zone_manager &mgr, const tri
         player &p, std::vector<tripoint> &loot_zone_spots, std::vector<tripoint> &combined_spots )
 {
     if( npc *const guy = dynamic_cast<npc *>( &p ) ) {
-        map  const&here = get_map();
+        map  const &here = get_map();
         if( guy->assigned_camp &&
             mgr.has_near( z_camp_storage, here.getabs( src_loc ), ACTIVITY_SEARCH_DISTANCE ) ) {
             std::unordered_set<tripoint> const bc_storage_set = mgr.get_near( zone_type_id( "CAMP_STORAGE" ),
@@ -2394,7 +2394,7 @@ void activity_on_turn_move_loot( player_activity &act, player &p )
 
 static bool mine_activity( player &p, const tripoint &src_loc )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     std::vector<item *> const mining_inv = p.items_with( []( const item & itm ) {
         return ( itm.has_flag( flag_DIG_TOOL ) && !itm.type->can_use( "JACKHAMMER" ) ) ||
                ( itm.type->can_use( "JACKHAMMER" ) && itm.ammo_sufficient() );
@@ -2449,7 +2449,7 @@ static bool chop_tree_activity( player &p, const tripoint &src_loc )
     if( best_qual->type->can_have_charges() ) {
         p.consume_charges( *best_qual, best_qual->type->charges_to_use() );
     }
-    map  const&here = get_map();
+    map  const &here = get_map();
     const ter_id ter = here.ter( src_loc );
     if( here.has_flag( flag_TREE, src_loc ) ) {
         p.assign_activity( ACT_CHOP_TREE, moves, -1, p.get_item_position( best_qual ) );
@@ -2523,7 +2523,7 @@ static std::unordered_set<tripoint> generic_multi_activity_locations( player &p,
     bool dark_capable = false;
     std::unordered_set<tripoint> src_set;
 
-    zone_manager  const&mgr = zone_manager::get_manager();
+    zone_manager  const &mgr = zone_manager::get_manager();
     const tripoint localpos = p.pos();
     map &here = get_map();
     const tripoint abspos = here.getabs( localpos );
@@ -2771,21 +2771,21 @@ static requirement_check_result generic_multi_activity_check_requirement( player
             // ok, we need a shovel/hoe/axe/etc.
             // this is an activity that only requires this one tool, so we will fetch and wield it.
             requirement_data const reqs_data = requirement_data( tool_comp_vector, quality_comp_vector,
-                                         requirement_comp_vector );
+                                               requirement_comp_vector );
             const std::string ran_str = random_string( 10 );
             const requirement_id req_id( ran_str );
             requirement_data::save_requirement( reqs_data, req_id );
             what_we_need = req_id;
         }
         bool const tool_pickup = reason == do_activity_reason::NEEDS_TILLING ||
-                           reason == do_activity_reason::NEEDS_PLANTING ||
-                           reason == do_activity_reason::NEEDS_CHOPPING ||
-                           reason == do_activity_reason::NEEDS_BUTCHERING ||
-                           reason == do_activity_reason::NEEDS_BIG_BUTCHERING ||
-                           reason == do_activity_reason::NEEDS_TREE_CHOPPING ||
-                           reason == do_activity_reason::NEEDS_VEH_DECONST ||
-                           reason == do_activity_reason::NEEDS_VEH_REPAIR ||
-                           reason == do_activity_reason::NEEDS_MINING;
+                                 reason == do_activity_reason::NEEDS_PLANTING ||
+                                 reason == do_activity_reason::NEEDS_CHOPPING ||
+                                 reason == do_activity_reason::NEEDS_BUTCHERING ||
+                                 reason == do_activity_reason::NEEDS_BIG_BUTCHERING ||
+                                 reason == do_activity_reason::NEEDS_TREE_CHOPPING ||
+                                 reason == do_activity_reason::NEEDS_VEH_DECONST ||
+                                 reason == do_activity_reason::NEEDS_VEH_REPAIR ||
+                                 reason == do_activity_reason::NEEDS_MINING;
         // is it even worth fetching anything if there isn't enough nearby?
         if( !are_requirements_nearby( tool_pickup ? loot_zone_spots : combined_spots, what_we_need, p,
                                       act_id, tool_pickup, src_loc ) ) {
@@ -2842,7 +2842,7 @@ static bool generic_multi_activity_do( player &p, const activity_id &act_id,
 {
     // If any of the following activities return without processing
     // then they MUST return true here, to stop infinite loops.
-    zone_manager  const&mgr = zone_manager::get_manager();
+    zone_manager  const &mgr = zone_manager::get_manager();
 
     const do_activity_reason &reason = act_info.reason;
     const zone_data *zone = mgr.get_zone_at( src, get_zone_for_act( src_loc, mgr, act_id ) );
@@ -2861,7 +2861,7 @@ static bool generic_multi_activity_do( player &p, const activity_id &act_id,
     } else if( reason == do_activity_reason::NEEDS_PLANTING &&
                here.has_flag_ter_or_furn( flag_PLANTABLE, src_loc ) ) {
         std::vector<zone_data> const zones = mgr.get_zones( zone_type_FARM_PLOT,
-                                       here.getabs( src_loc ) );
+                                             here.getabs( src_loc ) );
         for( const zone_data &zone : zones ) {
             const itype_id seed =
                 dynamic_cast<const plot_options &>( zone.get_options() ).get_seed();
@@ -2951,7 +2951,7 @@ static bool generic_multi_activity_do( player &p, const activity_id &act_id,
 
 bool generic_multi_activity_handler( player_activity &act, player &p, bool check_only )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     const tripoint abspos = here.getabs( p.pos() );
     // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     activity_id const activity_to_restore = act.id();
@@ -2961,7 +2961,8 @@ bool generic_multi_activity_handler( player_activity &act, player &p, bool check
     }
     // now we setup the target spots based on which activity is occurring
     // the set of target work spots - potentially after we have fetched required tools.
-    std::unordered_set<tripoint> const src_set = generic_multi_activity_locations( p, activity_to_restore );
+    std::unordered_set<tripoint> const src_set = generic_multi_activity_locations( p,
+            activity_to_restore );
     // now we have our final set of points
     std::vector<tripoint> const src_sorted = get_sorted_tiles_by_distance( abspos, src_set );
     // now loop through the work-spot tiles and judge whether its worth traveling to it yet
@@ -3092,7 +3093,7 @@ static std::optional<tripoint> find_best_fire( const std::vector<tripoint> &from
 
 static inline bool has_clear_path_to_pickup_items( const tripoint &from, const tripoint &to )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     return here.has_items( to ) &&
            here.accessible_items( to ) &&
            here.clear_path( from, to, PICKUP_RANGE, 1, 100 );
@@ -3101,7 +3102,7 @@ static inline bool has_clear_path_to_pickup_items( const tripoint &from, const t
 static std::optional<tripoint> find_refuel_spot_zone( const tripoint &center )
 {
     const zone_manager &mgr = zone_manager::get_manager();
-    map  const&here = get_map();
+    map  const &here = get_map();
     const tripoint center_abs = here.getabs( center );
 
     const std::unordered_set<tripoint> &tiles_abs_unordered =
@@ -3158,7 +3159,7 @@ bool find_auto_consume( player &p, const consume_type type )
     }
 
     const auto ok_to_consume = [&p, type]( item & it ) -> bool {
-        item  const&comest = p.get_consumable_from( it );
+        item  const &comest = p.get_consumable_from( it );
         /* not food.              */
         if( comest.is_null() || comest.is_craft() || !comest.is_food() )
         {

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -171,7 +171,7 @@ std::string advanced_inventory::get_sortname( advanced_inv_sortby sortby )
 
 bool advanced_inventory::get_square( const std::string &action, aim_location &ret )
 {
-    for( advanced_inv_area  const&s : squares ) {
+    for( advanced_inv_area  const &s : squares ) {
         if( s.actionname == action ) {
             ret = screen_relative_location( s.id );
             return true;
@@ -534,9 +534,9 @@ int advanced_inventory::print_header( advanced_inventory_pane &pane, aim_locatio
         int const data_location = screen_relative_location( static_cast<aim_location>( i ) );
         const char *bracket = squares[data_location].can_store_in_vehicle() ? "<>" : "[]";
         bool const in_vehicle = pane.in_vehicle() && squares[data_location].id == area && sel == area &&
-                          area != AIM_ALL;
+                                area != AIM_ALL;
         bool const all_brackets = area == AIM_ALL && ( data_location >= AIM_SOUTHWEST &&
-                            data_location <= AIM_NORTHEAST );
+                                  data_location <= AIM_NORTHEAST );
         nc_color bcolor = c_red;
         nc_color kcolor = c_red;
         if( squares[data_location].canputitems( pane.get_cur_item_ptr() ) ) {
@@ -648,8 +648,8 @@ void advanced_inventory::redraw_pane( side p )
     // not where you stand, and pane is in vehicle
     // make sure the offsets are the same as the grab point
     bool const same_as_dragged = ( square.id >= AIM_SOUTHWEST && square.id <= AIM_NORTHEAST ) &&
-                           square.id != AIM_CENTER && panes[p].in_vehicle() &&
-                           square.off == squares[AIM_DRAGGED].off;
+                                 square.id != AIM_CENTER && panes[p].in_vehicle() &&
+                                 square.off == squares[AIM_DRAGGED].off;
     const advanced_inv_area &sq = same_as_dragged ? squares[AIM_DRAGGED] : square;
     bool const car = square.can_store_in_vehicle() && panes[p].in_vehicle() && sq.id != AIM_DRAGGED;
     trim_and_print( w, point( 2, 1 ), width, active ? c_green  : c_light_gray,
@@ -674,7 +674,7 @@ void advanced_inventory::redraw_pane( side p )
     if( max > 0 ) {
         int const itemcount = square.get_item_count();
         int const fmtw = 7 + ( itemcount > 99 ? 3 : itemcount > 9 ? 2 : 1 ) +
-                   ( max > 99 ? 3 : max > 9 ? 2 : 1 );
+                         ( max > 99 ? 3 : max > 9 ? 2 : 1 );
         mvwprintw( w, point( w_width / 2 - fmtw, 0 ), "< %d/%d >", itemcount, max );
     }
 
@@ -725,8 +725,8 @@ bool advanced_inventory::move_all_items( bool nested_call )
             return false;
         }
 
-        advanced_inv_area  const&sarea = squares[spane.get_area()];
-        advanced_inv_area  const&darea = squares[dpane.get_area()];
+        advanced_inv_area  const &sarea = squares[spane.get_area()];
+        advanced_inv_area  const &darea = squares[dpane.get_area()];
 
         // Check first if the destination area still have enough room for moving all.
         if( !is_processing() && sarea.volume > darea.free_volume( dpane.in_vehicle() ) &&
@@ -814,7 +814,7 @@ bool advanced_inventory::move_all_items( bool nested_call )
         return false;
     }
     advanced_inv_area &sarea = squares[spane.get_area()];
-    advanced_inv_area  const&darea = squares[dpane.get_area()];
+    advanced_inv_area  const &darea = squares[dpane.get_area()];
 
     // Make sure source and destination are different, otherwise items will disappear
     // Need to check actual position to account for dragged vehicles
@@ -1311,7 +1311,7 @@ void advanced_inventory::action_examine( advanced_inv_listitem *sitem,
     };
     if( spane.get_area() == AIM_INVENTORY || spane.get_area() == AIM_WORN ) {
         int const idx = spane.get_area() == AIM_INVENTORY ? sitem->idx :
-                  player::worn_position_to_index( sitem->idx );
+                        player::worn_position_to_index( sitem->idx );
         item_location const loc( g->u, &g->u.i_at( idx ) );
         // Setup a "return to AIM" activity. If examining the item creates a new activity
         // (e.g. reading, reloading, activating), the new activity will be put on top of
@@ -1337,7 +1337,7 @@ void advanced_inventory::action_examine( advanced_inv_listitem *sitem,
         }
         recalc = true;
     } else {
-        item  const&it = *sitem->items.front();
+        item  const &it = *sitem->items.front();
         std::vector<iteminfo> const dummy;
         std::vector<iteminfo> const item_info = it.info();
 
@@ -1718,7 +1718,7 @@ bool advanced_inventory::query_charges( aim_location destarea, const advanced_in
     // valid item is obviously required
     assert( !sitem.items.empty() );
     const item &it = *sitem.items.front();
-    advanced_inv_area  const&p = squares[destarea];
+    advanced_inv_area  const &p = squares[destarea];
     const bool by_charges = it.count_by_charges();
     const units::volume free_volume = p.free_volume( panes[dest].in_vehicle() );
     // default to move all, unless if being equipped

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -136,7 +136,7 @@ void advanced_inventory::save_settings( bool only_panes )
 
 void advanced_inventory::load_settings()
 {
-    aim_exit aim_code = static_cast<aim_exit>( save_state->exit_code );
+    aim_exit const aim_code = static_cast<aim_exit>( save_state->exit_code );
     panes[left].load_settings( save_state->saved_area, squares, aim_code == exit_re_entry );
     panes[right].load_settings( save_state->saved_area_right, squares, aim_code == exit_re_entry );
     save_state->exit_code = exit_none;
@@ -171,7 +171,7 @@ std::string advanced_inventory::get_sortname( advanced_inv_sortby sortby )
 
 bool advanced_inventory::get_square( const std::string &action, aim_location &ret )
 {
-    for( advanced_inv_area &s : squares ) {
+    for( advanced_inv_area  const&s : squares ) {
         if( s.actionname == action ) {
             ret = screen_relative_location( s.id );
             return true;
@@ -215,19 +215,19 @@ void advanced_inventory::print_items( const advanced_inventory_pane &pane, bool 
     const catacurses::window &window = pane.window;
     const auto index = pane.index;
     const int page = index / itemsPerPage;
-    bool compact = TERMX <= 100;
+    bool const compact = TERMX <= 100;
 
-    int columns = getmaxx( window );
-    std::string spaces( columns - 4, ' ' );
+    int const columns = getmaxx( window );
+    std::string const spaces( columns - 4, ' ' );
 
-    nc_color norm = active ? c_white : c_dark_gray;
+    nc_color const norm = active ? c_white : c_dark_gray;
 
     //print inventory's current and total weight + volume
     if( pane.get_area() == AIM_INVENTORY || pane.get_area() == AIM_WORN ) {
         const double weight_carried = convert_weight( g->u.weight_carried() );
         const double weight_capacity = convert_weight( g->u.weight_capacity() );
-        std::string volume_carried = format_volume( g->u.volume_carried() );
-        std::string volume_capacity = format_volume( g->u.volume_capacity() );
+        std::string const volume_carried = format_volume( g->u.volume_carried() );
+        std::string const volume_capacity = format_volume( g->u.volume_capacity() );
         // align right, so calculate formatted head length
         const std::string formatted_head = string_format( "%.1f/%.1f %s  %s/%s %s",
                                            weight_carried, weight_capacity, weight_units(),
@@ -397,7 +397,7 @@ void advanced_inventory::print_items( const advanced_inventory_pane &pane, bool 
         //print volume column
         bool it_vol_truncated = false;
         double it_vol_value = 0.0;
-        std::string it_vol = format_volume( sitem.volume, 5, &it_vol_truncated, &it_vol_value );
+        std::string const it_vol = format_volume( sitem.volume, 5, &it_vol_truncated, &it_vol_value );
         if( it_vol_truncated && it_vol_value > 0.0 ) {
             print_color = selected ? hilite( c_red ) : c_red;
         } else {
@@ -526,16 +526,16 @@ struct advanced_inv_sorter {
 int advanced_inventory::print_header( advanced_inventory_pane &pane, aim_location sel )
 {
     const catacurses::window &window = pane.window;
-    int area = pane.get_area();
-    int wwidth = getmaxx( window );
-    int ofs = wwidth - 25 - 2 - 14;
+    int const area = pane.get_area();
+    int const wwidth = getmaxx( window );
+    int const ofs = wwidth - 25 - 2 - 14;
     int min_x = wwidth;
     for( int i = 0; i < NUM_AIM_LOCATIONS; ++i ) {
-        int data_location = screen_relative_location( static_cast<aim_location>( i ) );
+        int const data_location = screen_relative_location( static_cast<aim_location>( i ) );
         const char *bracket = squares[data_location].can_store_in_vehicle() ? "<>" : "[]";
-        bool in_vehicle = pane.in_vehicle() && squares[data_location].id == area && sel == area &&
+        bool const in_vehicle = pane.in_vehicle() && squares[data_location].id == area && sel == area &&
                           area != AIM_ALL;
-        bool all_brackets = area == AIM_ALL && ( data_location >= AIM_SOUTHWEST &&
+        bool const all_brackets = area == AIM_ALL && ( data_location >= AIM_SOUTHWEST &&
                             data_location <= AIM_NORTHEAST );
         nc_color bcolor = c_red;
         nc_color kcolor = c_red;
@@ -586,7 +586,7 @@ void advanced_inventory::recalc_pane( side p )
             // Also handle the case when the other tile covers vehicle
             // or the ground below the vehicle.
             if( s.can_store_in_vehicle() && !( same && there.in_vehicle() ) ) {
-                bool do_vehicle = there.get_area() == s.id ? !there.in_vehicle() : true;
+                bool const do_vehicle = there.get_area() == s.id ? !there.in_vehicle() : true;
                 pane.add_items_from_area( s, do_vehicle );
                 alls.volume += s.volume;
                 alls.weight += s.weight;
@@ -622,7 +622,7 @@ void advanced_inventory::recalc_pane( side p )
 
 void advanced_inventory::redraw_pane( side p )
 {
-    input_context ctxt( "ADVANCED_INVENTORY" );
+    input_context const ctxt( "ADVANCED_INVENTORY" );
 
     // don't update ui if processing demands
     if( is_processing() ) {
@@ -643,15 +643,15 @@ void advanced_inventory::redraw_pane( side p )
 
     auto itm = pane.get_cur_item_ptr();
     // 2 for left border + 1 for padding between name & aim location selector
-    int width = print_header( pane, itm != nullptr ? itm->area : pane.get_area() ) - 2 - 1;
+    int const width = print_header( pane, itm != nullptr ? itm->area : pane.get_area() ) - 2 - 1;
     // only cardinals
     // not where you stand, and pane is in vehicle
     // make sure the offsets are the same as the grab point
-    bool same_as_dragged = ( square.id >= AIM_SOUTHWEST && square.id <= AIM_NORTHEAST ) &&
+    bool const same_as_dragged = ( square.id >= AIM_SOUTHWEST && square.id <= AIM_NORTHEAST ) &&
                            square.id != AIM_CENTER && panes[p].in_vehicle() &&
                            square.off == squares[AIM_DRAGGED].off;
     const advanced_inv_area &sq = same_as_dragged ? squares[AIM_DRAGGED] : square;
-    bool car = square.can_store_in_vehicle() && panes[p].in_vehicle() && sq.id != AIM_DRAGGED;
+    bool const car = square.can_store_in_vehicle() && panes[p].in_vehicle() && sq.id != AIM_DRAGGED;
     trim_and_print( w, point( 2, 1 ), width, active ? c_green  : c_light_gray,
                     car ? sq.veh->name : sq.name );
     trim_and_print( w, point( 2, 2 ), width, active ? c_light_blue : c_dark_gray, sq.desc[car] );
@@ -670,16 +670,16 @@ void advanced_inventory::redraw_pane( side p )
     draw_border( w, active ? BORDER_COLOR : c_dark_gray );
     mvwprintw( w, point( 3, 0 ), _( "< [%s] Sort: %s >" ), ctxt.get_desc( "SORT" ),
                get_sortname( pane.sortby ) );
-    int max = square.max_size;
+    int const max = square.max_size;
     if( max > 0 ) {
-        int itemcount = square.get_item_count();
-        int fmtw = 7 + ( itemcount > 99 ? 3 : itemcount > 9 ? 2 : 1 ) +
+        int const itemcount = square.get_item_count();
+        int const fmtw = 7 + ( itemcount > 99 ? 3 : itemcount > 9 ? 2 : 1 ) +
                    ( max > 99 ? 3 : max > 9 ? 2 : 1 );
         mvwprintw( w, point( w_width / 2 - fmtw, 0 ), "< %d/%d >", itemcount, max );
     }
 
-    std::string fprefix = string_format( _( "[%s] Filter" ), ctxt.get_desc( "FILTER" ) );
-    std::string fsuffix = string_format( _( "[%s] Reset" ), ctxt.get_desc( "RESET_FILTER" ) );
+    std::string const fprefix = string_format( _( "[%s] Filter" ), ctxt.get_desc( "FILTER" ) );
+    std::string const fsuffix = string_format( _( "[%s] Reset" ), ctxt.get_desc( "RESET_FILTER" ) );
     if( !filter_edit ) {
         if( !pane.filter.empty() ) {
             mvwprintw( w, point( 2, getmaxy( w ) - 1 ), "< %s: %s >", fprefix, pane.filter );
@@ -725,8 +725,8 @@ bool advanced_inventory::move_all_items( bool nested_call )
             return false;
         }
 
-        advanced_inv_area &sarea = squares[spane.get_area()];
-        advanced_inv_area &darea = squares[dpane.get_area()];
+        advanced_inv_area  const&sarea = squares[spane.get_area()];
+        advanced_inv_area  const&darea = squares[dpane.get_area()];
 
         // Check first if the destination area still have enough room for moving all.
         if( !is_processing() && sarea.volume > darea.free_volume( dpane.in_vehicle() ) &&
@@ -737,7 +737,7 @@ bool advanced_inventory::move_all_items( bool nested_call )
         // make sure that there are items to be moved
         bool done = false;
         // copy the current pane, to be restored after the move is queued
-        advanced_inventory_pane shadow = panes[src];
+        advanced_inventory_pane const shadow = panes[src];
         // here we recursively call this function with each area in order to
         // put all items in the proper destination area, with minimal fuss
         int &loc = save_state->aim_all_location;
@@ -814,7 +814,7 @@ bool advanced_inventory::move_all_items( bool nested_call )
         return false;
     }
     advanced_inv_area &sarea = squares[spane.get_area()];
-    advanced_inv_area &darea = squares[dpane.get_area()];
+    advanced_inv_area  const&darea = squares[dpane.get_area()];
 
     // Make sure source and destination are different, otherwise items will disappear
     // Need to check actual position to account for dragged vehicles
@@ -849,7 +849,7 @@ bool advanced_inventory::move_all_items( bool nested_call )
             for( size_t index = 0; index < g->u.inv.size(); ++index ) {
                 const std::list<item> &stack = g->u.inv.const_stack( index );
                 const item &it = stack.front();
-                item_location indexed_item( g->u, const_cast<item *>( &it ) );
+                item_location const indexed_item( g->u, const_cast<item *>( &it ) );
 
                 if( !spane.is_filtered( it ) ) {
                     int count;
@@ -876,7 +876,7 @@ bool advanced_inventory::move_all_items( bool nested_call )
                 }
 
                 if( !spane.is_filtered( it ) ) {
-                    item_location loc( g->u, &it );
+                    item_location const loc( g->u, &it );
                     if( it.is_favorite ) {
                         dropped_favorite.emplace_back( loc, it.count() );
                     } else {
@@ -950,7 +950,7 @@ bool advanced_inventory::move_all_items( bool nested_call )
             }
 
             if( dpane.get_area() == AIM_INVENTORY ) {
-                std::vector<pickup::pick_drop_selection> targets = pickup::optimize_pickup( target_items,
+                std::vector<pickup::pick_drop_selection> const targets = pickup::optimize_pickup( target_items,
                         quantities );
                 g->u.assign_activity( player_activity( pickup_activity_actor(
                         targets,
@@ -1180,7 +1180,7 @@ void advanced_inventory::start_activity( const aim_location destarea, const aim_
         }
 
         if( destarea == AIM_INVENTORY ) {
-            std::vector<pickup::pick_drop_selection> targets = pickup::optimize_pickup( target_items,
+            std::vector<pickup::pick_drop_selection> const targets = pickup::optimize_pickup( target_items,
                     quantities );
             g->u.assign_activity( player_activity( pickup_activity_actor(
                     targets,
@@ -1209,14 +1209,14 @@ bool advanced_inventory::action_move_item( advanced_inv_listitem *sitem,
         return false;
     }
     aim_location destarea = dpane.get_area();
-    aim_location srcarea = sitem->area;
-    bool restore_area = destarea == AIM_ALL;
+    aim_location const srcarea = sitem->area;
+    bool const restore_area = destarea == AIM_ALL;
     if( !query_destination( destarea ) ) {
         return false;
     }
     // Not necessarily equivalent to spane.in_vehicle() if using AIM_ALL
-    bool from_vehicle = sitem->from_vehicle;
-    bool to_vehicle = dpane.in_vehicle();
+    bool const from_vehicle = sitem->from_vehicle;
+    bool const to_vehicle = dpane.in_vehicle();
 
     // AIM_ALL should disable same area check and handle it with proper filtering instead.
     // This is a workaround around the lack of vehicle location info in
@@ -1256,7 +1256,7 @@ bool advanced_inventory::action_move_item( advanced_inv_listitem *sitem,
         } else {
             item *itm = &g->u.i_at( sitem->idx );
 
-            drop_locations to_move = { drop_location( item_location( g->u, itm ), amount_to_move ) };
+            drop_locations const to_move = { drop_location( item_location( g->u, itm ), amount_to_move ) };
             g->u.assign_activity( drop_activity_actor( g->u, to_move, !to_vehicle, squares[destarea].off ) );
         }
         // exit so that the activity can be carried out
@@ -1270,13 +1270,13 @@ bool advanced_inventory::action_move_item( advanced_inv_listitem *sitem,
         // worn items are never stacked, so this should check out
         assert( sitem->items.size() == 1 );
         item *itm = sitem->items.front();
-        ret_val<bool> takeoff_rv = g->u.can_takeoff( *itm );
+        ret_val<bool> const takeoff_rv = g->u.can_takeoff( *itm );
         if( !takeoff_rv.success() ) {
             add_msg( m_info, "%s", takeoff_rv.c_str() );
         } else if( destarea == AIM_INVENTORY ) {
             g->u.takeoff( *itm );
         } else {
-            drop_locations to_move = { drop_location( item_location( g->u, itm ), amount_to_move ) };
+            drop_locations const to_move = { drop_location( item_location( g->u, itm ), amount_to_move ) };
             g->u.assign_activity( drop_activity_actor( g->u, to_move, !to_vehicle, squares[destarea].off ) );
         }
         // exit so that the activity can be carried out
@@ -1310,9 +1310,9 @@ void advanced_inventory::action_examine( advanced_inv_listitem *sitem,
         return colstart + ( src == advanced_inventory::side::left ? w_width / 2 : 0 );
     };
     if( spane.get_area() == AIM_INVENTORY || spane.get_area() == AIM_WORN ) {
-        int idx = spane.get_area() == AIM_INVENTORY ? sitem->idx :
+        int const idx = spane.get_area() == AIM_INVENTORY ? sitem->idx :
                   player::worn_position_to_index( sitem->idx );
-        item_location loc( g->u, &g->u.i_at( idx ) );
+        item_location const loc( g->u, &g->u.i_at( idx ) );
         // Setup a "return to AIM" activity. If examining the item creates a new activity
         // (e.g. reading, reloading, activating), the new activity will be put on top of
         // "return to AIM". Once the new activity is finished, "return to AIM" comes back
@@ -1337,9 +1337,9 @@ void advanced_inventory::action_examine( advanced_inv_listitem *sitem,
         }
         recalc = true;
     } else {
-        item &it = *sitem->items.front();
-        std::vector<iteminfo> dummy;
-        std::vector<iteminfo> item_info = it.info();
+        item  const&it = *sitem->items.front();
+        std::vector<iteminfo> const dummy;
+        std::vector<iteminfo> const item_info = it.info();
 
         item_info_data data( it.tname(), it.type_name(), item_info, dummy );
         data.handle_scrolling = true;
@@ -1449,12 +1449,12 @@ void advanced_inventory::display()
         if( action == "CATEGORY_SELECTION" ) {
             inCategoryMode = !inCategoryMode;
         } else if( action == "ITEMS_DEFAULT" ) {
-            for( side cside : {
+            for( side const cside : {
                      left, right
                  } ) {
                 auto &pane = panes[cside];
-                int i_location = cside == left ? save_state->saved_area : save_state->saved_area_right;
-                aim_location location = static_cast<aim_location>( i_location );
+                int const i_location = cside == left ? save_state->saved_area : save_state->saved_area_right;
+                aim_location const location = static_cast<aim_location>( i_location );
                 if( pane.get_area() != location || location == AIM_ALL ) {
                     pane.recalc = true;
                 }
@@ -1487,7 +1487,7 @@ void advanced_inventory::display()
                 recalc = true;
             }
         } else if( action == "FILTER" ) {
-            std::string filter = spane.filter;
+            std::string const filter = spane.filter;
             filter_edit = true;
             if( ui ) {
                 spopup = std::make_unique<string_input_popup>();
@@ -1495,13 +1495,13 @@ void advanced_inventory::display()
                 ui->mark_resize();
             }
 
-            ime_sentry sentry;
+            ime_sentry const sentry;
 
             do {
                 if( ui ) {
                     ui_manager::redraw();
                 }
-                std::string new_filter = spopup->query_string( false );
+                std::string const new_filter = spopup->query_string( false );
                 if( spopup->canceled() ) {
                     // restore original filter
                     spane.set_filter( filter );
@@ -1592,22 +1592,22 @@ class query_destination_callback : public uilist_callback
 void query_destination_callback::draw_squares( const uilist *menu )
 {
     assert( menu->entries.size() >= 9 );
-    int ofs = -25 - 4;
+    int const ofs = -25 - 4;
     int sel = 0;
     if( menu->selected >= 0 && static_cast<size_t>( menu->selected ) < menu->entries.size() ) {
         sel = _adv_inv.screen_relative_location(
                   static_cast <aim_location>( menu->selected + 1 ) );
     }
     for( int i = 1; i < 10; i++ ) {
-        aim_location loc = _adv_inv.screen_relative_location( static_cast <aim_location>( i ) );
-        std::string key = _adv_inv.get_location_key( loc );
+        aim_location const loc = _adv_inv.screen_relative_location( static_cast <aim_location>( i ) );
+        std::string const key = _adv_inv.get_location_key( loc );
         advanced_inv_area &square = _adv_inv.get_one_square( loc );
-        bool in_vehicle = square.can_store_in_vehicle();
+        bool const in_vehicle = square.can_store_in_vehicle();
         const char *bracket = in_vehicle ? "<>" : "[]";
         // always show storage option for vehicle storage, if applicable
-        bool canputitems = menu->entries[i - 1].enabled && square.canputitems();
-        nc_color bcolor = canputitems ? sel == loc ? h_white : c_light_gray : c_dark_gray;
-        nc_color kcolor = canputitems ? sel == loc ? h_white : c_light_gray : c_dark_gray;
+        bool const canputitems = menu->entries[i - 1].enabled && square.canputitems();
+        nc_color const bcolor = canputitems ? sel == loc ? h_white : c_light_gray : c_dark_gray;
+        nc_color const kcolor = canputitems ? sel == loc ? h_white : c_light_gray : c_dark_gray;
         const point p( square.hscreen + point( ofs, 5 ) );
         mvwprintz( menu->window, p, bcolor, "%c", bracket[0] );
         wprintz( menu->window, kcolor, "%s", key );
@@ -1718,7 +1718,7 @@ bool advanced_inventory::query_charges( aim_location destarea, const advanced_in
     // valid item is obviously required
     assert( !sitem.items.empty() );
     const item &it = *sitem.items.front();
-    advanced_inv_area &p = squares[destarea];
+    advanced_inv_area  const&p = squares[destarea];
     const bool by_charges = it.count_by_charges();
     const units::volume free_volume = p.free_volume( panes[dest].in_vehicle() );
     // default to move all, unless if being equipped
@@ -1843,11 +1843,11 @@ void advanced_inventory::draw_minimap()
     };
     static const std::array<side, NUM_PANES> sides = {{left, right}};
     // get the center of the window
-    tripoint pc = {getmaxx( minimap ) / 2, getmaxy( minimap ) / 2, 0};
+    tripoint const pc = {getmaxx( minimap ) / 2, getmaxy( minimap ) / 2, 0};
     // draw the 3x3 tiles centered around player
     get_map().draw( minimap, g->u.pos() );
     for( auto s : sides ) {
-        char sym = get_minimap_sym( s );
+        char const sym = get_minimap_sym( s );
         if( sym == '\0' ) {
             continue;
         }

--- a/src/advanced_inv_area.cpp
+++ b/src/advanced_inv_area.cpp
@@ -298,7 +298,7 @@ item *advanced_inv_area::get_container( bool in_vehicle )
         } else {
             map &here = get_map();
             bool const is_in_vehicle = veh &&
-                                 ( uistate.adv_inv_container_in_vehicle || ( can_store_in_vehicle() && in_vehicle ) );
+                                       ( uistate.adv_inv_container_in_vehicle || ( can_store_in_vehicle() && in_vehicle ) );
 
             const itemstack &stacks = is_in_vehicle ?
                                       i_stacked( veh->get_items( vstor ) ) :

--- a/src/advanced_inv_area.cpp
+++ b/src/advanced_inv_area.cpp
@@ -143,7 +143,7 @@ void advanced_inv_area::init()
             canputitemsloc = can_store_in_vehicle() || here.can_put_items_ter_furn( pos );
             max_size = MAX_ITEM_IN_SQUARE;
             if( can_store_in_vehicle() ) {
-                std::string part_name = vp->info().name();
+                std::string const part_name = vp->info().name();
                 desc[1] = vp->get_label().value_or( part_name );
             }
             // get graffiti or terrain name
@@ -275,7 +275,7 @@ item *advanced_inv_area::get_container( bool in_vehicle )
             }
         } else if( uistate.adv_inv_container_location == AIM_WORN ) {
             auto &worn = g->u.worn;
-            size_t idx = static_cast<size_t>( uistate.adv_inv_container_index );
+            size_t const idx = static_cast<size_t>( uistate.adv_inv_container_index );
             if( worn.size() > idx ) {
                 auto iter = worn.begin();
                 std::advance( iter, idx );
@@ -297,7 +297,7 @@ item *advanced_inv_area::get_container( bool in_vehicle )
             }
         } else {
             map &here = get_map();
-            bool is_in_vehicle = veh &&
+            bool const is_in_vehicle = veh &&
                                  ( uistate.adv_inv_container_in_vehicle || ( can_store_in_vehicle() && in_vehicle ) );
 
             const itemstack &stacks = is_in_vehicle ?

--- a/src/advanced_inv_pane.cpp
+++ b/src/advanced_inv_pane.cpp
@@ -41,12 +41,12 @@ void advanced_inventory_pane::load_settings( int saved_area_idx,
     auto square = squares[location];
     // determine the square's vehicle/map item presence
     bool const has_veh_items = square.can_store_in_vehicle() ?
-                         !square.veh->get_items( square.vstor ).empty() : false;
+                               !square.veh->get_items( square.vstor ).empty() : false;
     bool const has_map_items = !get_map().i_at( square.pos ).empty();
     // determine based on map items and settings to show cargo
     bool const show_vehicle = is_re_enter ?
-                        save_state->in_vehicle : has_veh_items ? true :
-                        has_map_items ? false : square.can_store_in_vehicle();
+                              save_state->in_vehicle : has_veh_items ? true :
+                              has_map_items ? false : square.can_store_in_vehicle();
     set_area( square, show_vehicle );
     sortby = static_cast<advanced_inv_sortby>( save_state->sort_idx );
     index = save_state->selected_idx;

--- a/src/advanced_inv_pane.cpp
+++ b/src/advanced_inv_pane.cpp
@@ -40,11 +40,11 @@ void advanced_inventory_pane::load_settings( int saved_area_idx,
     const aim_location location = static_cast<aim_location>( i_location );
     auto square = squares[location];
     // determine the square's vehicle/map item presence
-    bool has_veh_items = square.can_store_in_vehicle() ?
+    bool const has_veh_items = square.can_store_in_vehicle() ?
                          !square.veh->get_items( square.vstor ).empty() : false;
-    bool has_map_items = !get_map().i_at( square.pos ).empty();
+    bool const has_map_items = !get_map().i_at( square.pos ).empty();
     // determine based on map items and settings to show cargo
-    bool show_vehicle = is_re_enter ?
+    bool const show_vehicle = is_re_enter ?
                         save_state->in_vehicle : has_veh_items ? true :
                         has_map_items ? false : square.can_store_in_vehicle();
     set_area( square, show_vehicle );
@@ -125,7 +125,7 @@ void advanced_inventory_pane::add_items_from_area( advanced_inv_area &square,
             if( !cont->is_container_empty() ) {
                 // filtering does not make sense for liquid in container
                 item *it = &square.get_container( in_vehicle() )->contents.front();
-                advanced_inv_listitem ait( it, 0, 1, square.id, in_vehicle() );
+                advanced_inv_listitem const ait( it, 0, 1, square.id, in_vehicle() );
                 square.volume += ait.volume;
                 square.weight += ait.weight;
                 items.push_back( ait );
@@ -133,7 +133,7 @@ void advanced_inventory_pane::add_items_from_area( advanced_inv_area &square,
             square.desc[0] = cont->tname( 1, false );
         }
     } else {
-        bool is_in_vehicle = square.can_store_in_vehicle() && ( in_vehicle() || vehicle_override );
+        bool const is_in_vehicle = square.can_store_in_vehicle() && ( in_vehicle() || vehicle_override );
         const advanced_inv_area::itemstack &stacks = is_in_vehicle ?
                 square.i_stacked( square.veh->get_items( square.vstor ) ) :
                 square.i_stacked( m.i_at( square.pos ) );

--- a/src/ammo_effect.cpp
+++ b/src/ammo_effect.cpp
@@ -65,7 +65,7 @@ int_id<ammo_effect>::int_id( const string_id<ammo_effect> &id ) : _id( id.id() )
 void ammo_effect::load( const JsonObject &jo, const std::string & )
 {
     if( jo.has_member( "aoe" ) ) {
-        JsonObject joa = jo.get_object( "aoe" );
+        JsonObject const joa = jo.get_object( "aoe" );
         optional( joa, was_loaded, "field_type", aoe_field_type_name, "fd_null" );
         optional( joa, was_loaded, "intensity_min", aoe_intensity_min, 0 );
         optional( joa, was_loaded, "intensity_max", aoe_intensity_max, 0 );
@@ -78,14 +78,14 @@ void ammo_effect::load( const JsonObject &jo, const std::string & )
         optional( joa, was_loaded, "check_sees_radius", aoe_check_sees_radius, 0 );
     }
     if( jo.has_member( "trail" ) ) {
-        JsonObject joa = jo.get_object( "trail" );
+        JsonObject const joa = jo.get_object( "trail" );
         optional( joa, was_loaded, "field_type", trail_field_type_name, "fd_null" );
         optional( joa, was_loaded, "intensity_min", trail_intensity_min, 0 );
         optional( joa, was_loaded, "intensity_max", trail_intensity_max, 0 );
         optional( joa, was_loaded, "chance", trail_chance, 100 );
     }
     if( jo.has_member( "explosion" ) ) {
-        JsonObject joe = jo.get_object( "explosion" );
+        JsonObject const joe = jo.get_object( "explosion" );
         aoe_explosion_data = load_explosion_data( joe );
     }
     optional( jo, was_loaded, "do_flashbang", do_flashbang, false );

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -65,8 +65,8 @@ class basic_animation
             long int remain = delay;
             while( remain > 0 ) {
                 // NOLINTNEXTLINE(cata-no-long): timespec uses long int
-                long int do_sleep = std::min( remain, 100'000'000L );
-                timespec to_sleep = timespec { 0, do_sleep };
+                long int const do_sleep = std::min( remain, 100'000'000L );
+                timespec const to_sleep = timespec { 0, do_sleep };
                 nanosleep( &to_sleep, nullptr );
                 inp_mngr.pump_events();
                 remain -= do_sleep;
@@ -139,10 +139,10 @@ void draw_explosion_curses( game &g, const tripoint &center, const int r,
     // TODO: Make it look different from above/below
     const tripoint p = relative_view_pos( g.u, center );
 
-    explosion_animation anim;
+    explosion_animation const anim;
 
     int frame = 0;
-    shared_ptr_fast<game::draw_callback_t> explosion_cb =
+    shared_ptr_fast<game::draw_callback_t> const explosion_cb =
     make_shared_fast<game::draw_callback_t>( [&]() {
         if( r == 0 ) {
             mvwputch( g.w_terrain, point( p.y, p.x ), col, '*' );
@@ -194,10 +194,10 @@ void draw_custom_explosion_curses( game &g,
     const tripoint topleft( center.x - getmaxx( g.w_terrain ) / 2,
                             center.y - getmaxy( g.w_terrain ) / 2, 0 );
 
-    explosion_animation anim;
+    explosion_animation const anim;
 
     auto last_layer_it = layers.begin();
-    shared_ptr_fast<game::draw_callback_t> explosion_cb =
+    shared_ptr_fast<game::draw_callback_t> const explosion_cb =
     make_shared_fast<game::draw_callback_t>( [&]() {
         for( auto it = layers.begin(); it != std::next( last_layer_it ); ++it ) {
             for( const auto &pr : *it ) {
@@ -278,10 +278,10 @@ void explosion_handler::draw_explosion( const tripoint &p, const int r, const nc
         return;
     }
 
-    explosion_animation anim;
+    explosion_animation const anim;
 
     int i = 1;
-    shared_ptr_fast<game::draw_callback_t> explosion_cb =
+    shared_ptr_fast<game::draw_callback_t> const explosion_cb =
     make_shared_fast<game::draw_callback_t>( [&]() {
         // TODO: not xpos ypos?
         tilecontext->init_explosion( p, i, exp_name );
@@ -431,11 +431,11 @@ void explosion_handler::draw_custom_explosion( const tripoint &,
         return;
     }
 
-    explosion_animation anim;
+    explosion_animation const anim;
     // We need to draw all explosions up to now
     std::map<tripoint, explosion_tile> combined_layer;
 
-    shared_ptr_fast<game::draw_callback_t> explosion_cb =
+    shared_ptr_fast<game::draw_callback_t> const explosion_cb =
     make_shared_fast<game::draw_callback_t>( [&]() {
         tilecontext->init_custom_explosion_layer( combined_layer, exp_name );
     } );
@@ -469,7 +469,7 @@ void draw_bullet_curses( map &m, const tripoint &t, const char bullet, const tri
         return;
     }
 
-    shared_ptr_fast<game::draw_callback_t> bullet_cb = make_shared_fast<game::draw_callback_t>( [&]() {
+    shared_ptr_fast<game::draw_callback_t> const bullet_cb = make_shared_fast<game::draw_callback_t>( [&]() {
         if( p != nullptr && p->z == vp.z ) {
             m.drawsq( g->w_terrain, *p, drawsq_params().center( vp ) );
         }
@@ -566,7 +566,7 @@ void game::draw_bullet( const tripoint &t, const int i,
         : bullet == '`' ? bullet_shrapnel
         : bullet_unknown;
 
-    shared_ptr_fast<draw_callback_t> bullet_cb = make_shared_fast<draw_callback_t>( [&]() {
+    shared_ptr_fast<draw_callback_t> const bullet_cb = make_shared_fast<draw_callback_t>( [&]() {
         tilecontext->init_draw_bullet( t, bullet_type, rotation );
     } );
     add_draw_callback( bullet_cb );
@@ -592,7 +592,7 @@ void hit_animation( const player &u, const tripoint &center, nc_color cColor,
     const tripoint init_pos = relative_view_pos( u, center );
     // Only show animation if initially visible
     if( init_pos.z == 0 && is_valid_in_w_terrain( init_pos.xy() ) ) {
-        shared_ptr_fast<game::draw_callback_t> hit_cb = make_shared_fast<game::draw_callback_t>( [&]() {
+        shared_ptr_fast<game::draw_callback_t> const hit_cb = make_shared_fast<game::draw_callback_t>( [&]() {
             // In case the window is resized during waiting, we always re-calculate the animation position
             const tripoint pos = relative_view_pos( u, center );
             if( pos.z == 0 && is_valid_in_w_terrain( pos.xy() ) ) {
@@ -630,7 +630,7 @@ void game::draw_hit_mon( const tripoint &p, const monster &m, const bool dead )
         return;
     }
 
-    shared_ptr_fast<draw_callback_t> hit_cb = make_shared_fast<draw_callback_t>( [&]() {
+    shared_ptr_fast<draw_callback_t> const hit_cb = make_shared_fast<draw_callback_t>( [&]() {
         tilecontext->init_draw_hit( p, m.type->id.str() );
     } );
     add_draw_callback( hit_cb );
@@ -675,7 +675,7 @@ void game::draw_hit_player( const Character &p, const int dam )
     const std::string &type = p.is_player() ? ( p.male ? player_male : player_female )
                               : p.male ? npc_male : npc_female;
 
-    shared_ptr_fast<draw_callback_t> hit_cb = make_shared_fast<draw_callback_t>( [&]() {
+    shared_ptr_fast<draw_callback_t> const hit_cb = make_shared_fast<draw_callback_t>( [&]() {
         tilecontext->init_draw_hit( p.pos(), type );
     } );
     add_draw_callback( hit_cb );
@@ -695,7 +695,7 @@ namespace
 void draw_line_curses( game &g, const tripoint &center, const std::vector<tripoint> &ret,
                        bool noreveal )
 {
-    drawsq_params params = drawsq_params().highlight( true ).center( center );
+    drawsq_params const params = drawsq_params().highlight( true ).center( center );
     for( const tripoint &p : ret ) {
         const auto critter = g.critter_at( p, true );
 
@@ -749,7 +749,7 @@ namespace
 {
 void draw_line_curses( game &g, const std::vector<tripoint> &points )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     for( const tripoint &p : points ) {
         here.drawsq( g.w_terrain, p, drawsq_params().highlight( true ) );
     }
@@ -1045,7 +1045,7 @@ bucketed_points bucket_by_distance( const tripoint &origin,
 {
     std::map<int, one_bucket> by_distance;
     for( const auto& [pt, val] : to_bucket ) {
-        int dist = trig_dist_squared( origin, pt );
+        int const dist = trig_dist_squared( origin, pt );
         by_distance[dist].emplace_back( point_with_value{ pt, val} );
     }
     bucketed_points buckets;
@@ -1073,14 +1073,14 @@ bucketed_points optimal_bucketing( const bucketed_points &buckets, size_t max_bu
         auto smallest = sizes.begin();
         size_t smallest_sum = *smallest + *( smallest + 1 );
         for( auto iter = sizes.begin() + 1; ( iter + 1 ) != sizes.end(); iter++ ) {
-            size_t sum = *iter + *( iter + 1 );
+            size_t const sum = *iter + *( iter + 1 );
             if( sum < smallest_sum ) {
                 smallest = iter;
                 smallest_sum = sum;
             }
         }
 
-        size_t distance = std::distance( sizes.begin(), smallest );
+        size_t const distance = std::distance( sizes.begin(), smallest );
         sizes[distance] += sizes[distance + 1];
         sizes.erase( smallest + 1 );
         auto left_bucket = std::next( optimal.begin(), distance );
@@ -1101,7 +1101,7 @@ static void draw_cone_aoe_curses( const tripoint &, const bucketed_points &waves
                             center.y - catacurses::getmaxy( g->w_terrain ) / 2, 0 );
 
     auto it = waves.begin();
-    shared_ptr_fast<game::draw_callback_t> wave_cb =
+    shared_ptr_fast<game::draw_callback_t> const wave_cb =
     make_shared_fast<game::draw_callback_t>( [&]() {
         // All the buckets up until now
         for( auto inner_it = waves.begin(); inner_it != std::next( it ); inner_it++ ) {
@@ -1109,7 +1109,7 @@ static void draw_cone_aoe_curses( const tripoint &, const bucketed_points &waves
                 // update tripoint in relation to top left corner of curses window
                 // mvwputch already filters out of bounds coordinates
                 const tripoint p = pr.pt - topleft;
-                int intensity = ( pr.val >= 1.0 ) + ( pr.val >= 0.5 ) + ( inner_it == it );
+                int const intensity = ( pr.val >= 1.0 ) + ( pr.val >= 0.5 ) + ( inner_it == it );
                 nc_color col;
                 switch( intensity ) {
                     case 3:
@@ -1133,7 +1133,7 @@ static void draw_cone_aoe_curses( const tripoint &, const bucketed_points &waves
     } );
     g->add_draw_callback( wave_cb );
 
-    wave_animation anim;
+    wave_animation const anim;
     for( it = waves.begin(); it != waves.end(); it++ ) {
         anim.progress();
     }
@@ -1147,10 +1147,10 @@ void draw_cone_aoe( const tripoint &origin, const std::map<tripoint, double> &ao
         return;
     }
 
-    bucketed_points buckets = bucket_by_distance( origin, aoe );
+    bucketed_points const buckets = bucket_by_distance( origin, aoe );
     // That hardcoded value could be improved... Not sure about the name
-    size_t max_bucket_count = std::min<size_t>( 10, aoe.size() );
-    bucketed_points waves = optimal_bucketing( buckets, max_bucket_count );
+    size_t const max_bucket_count = std::min<size_t>( 10, aoe.size() );
+    bucketed_points const waves = optimal_bucketing( buckets, max_bucket_count );
 
 #if defined(TILES)
     if( !use_tiles ) {
@@ -1163,9 +1163,9 @@ void draw_cone_aoe( const tripoint &origin, const std::map<tripoint, double> &ao
     one_bucket combined_layer;
     combined_layer.reserve( aoe.size() );
 
-    wave_animation anim;
+    wave_animation const anim;
 
-    shared_ptr_fast<game::draw_callback_t> wave_cb =
+    shared_ptr_fast<game::draw_callback_t> const wave_cb =
     make_shared_fast<game::draw_callback_t>( [&]() {
         tilecontext->init_draw_cone_aoe( origin, combined_layer );
     } );

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -469,7 +469,8 @@ void draw_bullet_curses( map &m, const tripoint &t, const char bullet, const tri
         return;
     }
 
-    shared_ptr_fast<game::draw_callback_t> const bullet_cb = make_shared_fast<game::draw_callback_t>( [&]() {
+    shared_ptr_fast<game::draw_callback_t> const bullet_cb =
+    make_shared_fast<game::draw_callback_t>( [&]() {
         if( p != nullptr && p->z == vp.z ) {
             m.drawsq( g->w_terrain, *p, drawsq_params().center( vp ) );
         }
@@ -592,7 +593,8 @@ void hit_animation( const player &u, const tripoint &center, nc_color cColor,
     const tripoint init_pos = relative_view_pos( u, center );
     // Only show animation if initially visible
     if( init_pos.z == 0 && is_valid_in_w_terrain( init_pos.xy() ) ) {
-        shared_ptr_fast<game::draw_callback_t> const hit_cb = make_shared_fast<game::draw_callback_t>( [&]() {
+        shared_ptr_fast<game::draw_callback_t> const hit_cb =
+        make_shared_fast<game::draw_callback_t>( [&]() {
             // In case the window is resized during waiting, we always re-calculate the animation position
             const tripoint pos = relative_view_pos( u, center );
             if( pos.z == 0 && is_valid_in_w_terrain( pos.xy() ) ) {
@@ -749,7 +751,7 @@ namespace
 {
 void draw_line_curses( game &g, const std::vector<tripoint> &points )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     for( const tripoint &p : points ) {
         here.drawsq( g.w_terrain, p, drawsq_params().highlight( true ) );
     }

--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -175,13 +175,13 @@ void draw_mid_pane( const catacurses::window &w_sort_middle,
                                worn_item_it->type_name( 1 ) ) - 1;
     std::vector<std::string> const props = clothing_properties( *worn_item_it, win_width - 3, c );
     nc_color color = c_light_gray;
-    for( std::string  const&iter : props ) {
+    for( std::string  const &iter : props ) {
         print_colored_text( w_sort_middle, point( 2, ++i ), color, c_light_gray, iter );
     }
 
     std::vector<std::string> const prot = clothing_protection( *worn_item_it, win_width - 3 );
     if( i + prot.size() < win_height ) {
-        for( std::string  const&iter : prot ) {
+        for( std::string  const &iter : prot ) {
             print_colored_text( w_sort_middle, point( 2, ++i ), color, c_light_gray, iter );
         }
     } else {
@@ -189,9 +189,10 @@ void draw_mid_pane( const catacurses::window &w_sort_middle,
     }
 
     i++;
-    std::vector<std::string> const layer_desc = foldstring( clothing_layer( *worn_item_it ), win_width );
+    std::vector<std::string> const layer_desc = foldstring( clothing_layer( *worn_item_it ),
+            win_width );
     if( i + layer_desc.size() < win_height && !clothing_layer( *worn_item_it ).empty() ) {
-        for( std::string  const&iter : layer_desc ) {
+        for( std::string  const &iter : layer_desc ) {
             mvwprintz( w_sort_middle, point( 0, ++i ), c_light_blue, iter );
         }
     }
@@ -665,7 +666,7 @@ void show_armor_layers_ui( Character &who )
                 pos++;
             }
             curr++;
-            for( layering_item_info  const&elem : items_cover_bp( who, cover ) ) {
+            for( layering_item_info  const &elem : items_cover_bp( who, cover ) ) {
                 if( curr >= rightListOffset && pos <= rightListLines ) {
                     nc_color const color = elem.penalties.color_for_stacking_badness();
                     trim_and_print( w_sort_right, point( 2, pos ), right_w - 5, color,

--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -84,13 +84,13 @@ struct item_penalties {
 item_penalties get_item_penalties( std::list<item>::const_iterator worn_item_it,
                                    const Character &c, int tabindex )
 {
-    layer_level layer = worn_item_it->get_layer();
+    layer_level const layer = worn_item_it->get_layer();
 
     std::vector<body_part> body_parts_with_stacking_penalty;
     std::vector<body_part> body_parts_with_out_of_order_penalty;
     std::vector<std::set<std::string>> lists_of_bad_items_within;
 
-    for( body_part bp : all_body_parts ) {
+    for( body_part const bp : all_body_parts ) {
         if( bp != tabindex && num_bp != tabindex ) {
             continue;
         }
@@ -173,15 +173,15 @@ void draw_mid_pane( const catacurses::window &w_sort_middle,
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     size_t i = fold_and_print( w_sort_middle, point( 1, 0 ), win_width - 1, c_white,
                                worn_item_it->type_name( 1 ) ) - 1;
-    std::vector<std::string> props = clothing_properties( *worn_item_it, win_width - 3, c );
+    std::vector<std::string> const props = clothing_properties( *worn_item_it, win_width - 3, c );
     nc_color color = c_light_gray;
-    for( std::string &iter : props ) {
+    for( std::string  const&iter : props ) {
         print_colored_text( w_sort_middle, point( 2, ++i ), color, c_light_gray, iter );
     }
 
-    std::vector<std::string> prot = clothing_protection( *worn_item_it, win_width - 3 );
+    std::vector<std::string> const prot = clothing_protection( *worn_item_it, win_width - 3 );
     if( i + prot.size() < win_height ) {
-        for( std::string &iter : prot ) {
+        for( std::string  const&iter : prot ) {
             print_colored_text( w_sort_middle, point( 2, ++i ), color, c_light_gray, iter );
         }
     } else {
@@ -189,9 +189,9 @@ void draw_mid_pane( const catacurses::window &w_sort_middle,
     }
 
     i++;
-    std::vector<std::string> layer_desc = foldstring( clothing_layer( *worn_item_it ), win_width );
+    std::vector<std::string> const layer_desc = foldstring( clothing_layer( *worn_item_it ), win_width );
     if( i + layer_desc.size() < win_height && !clothing_layer( *worn_item_it ).empty() ) {
-        for( std::string &iter : layer_desc ) {
+        for( std::string  const&iter : layer_desc ) {
             mvwprintz( w_sort_middle, point( 0, ++i ), c_light_blue, iter );
         }
     }
@@ -207,7 +207,7 @@ void draw_mid_pane( const catacurses::window &w_sort_middle,
     const item_penalties penalties = get_item_penalties( worn_item_it, c, tabindex );
 
     if( !penalties.body_parts_with_stacking_penalty.empty() ) {
-        std::string layer_description = [&]() {
+        std::string const layer_description = [&]() {
             switch( worn_item_it->get_layer() ) {
                 case PERSONAL_LAYER:
                     return _( "in your <color_light_blue>personal aura</color>" );
@@ -228,9 +228,9 @@ void draw_mid_pane( const catacurses::window &w_sort_middle,
             }
         }
         ();
-        std::string body_parts =
+        std::string const body_parts =
             body_part_names( penalties.body_parts_with_stacking_penalty );
-        std::string message =
+        std::string const message =
             string_format(
                 vgettext( "Wearing multiple items %s on your "
                           "<color_light_red>%s</color> is adding encumbrance there.",
@@ -243,7 +243,7 @@ void draw_mid_pane( const catacurses::window &w_sort_middle,
     }
 
     if( !penalties.body_parts_with_out_of_order_penalty.empty() ) {
-        std::string body_parts =
+        std::string const body_parts =
             body_part_names( penalties.body_parts_with_out_of_order_penalty );
         std::string message;
 
@@ -257,7 +257,7 @@ void draw_mid_pane( const catacurses::window &w_sort_middle,
                           body_parts
                       );
         } else {
-            std::string bad_item_name = *penalties.bad_items_within.begin();
+            std::string const bad_item_name = *penalties.bad_items_within.begin();
             message = string_format(
                           vgettext( "Wearing this outside your <color_light_blue>%s</color> "
                                     "is adding encumbrance to your <color_light_red>%s</color>.",
@@ -589,13 +589,13 @@ void show_armor_layers_ui( Character &who )
         // Left list
         const int max_drawindex = std::min( leftListSize - leftListOffset, leftListLines );
         for( int drawindex = 0; drawindex < max_drawindex; drawindex++ ) {
-            int itemindex = leftListOffset + drawindex;
+            int const itemindex = leftListOffset + drawindex;
 
             if( itemindex == leftListIndex ) {
                 mvwprintz( w_sort_left, point( 0, drawindex + 1 ), c_yellow, ">>" );
             }
 
-            std::string worn_armor_name = tmp_worn[itemindex]->tname();
+            std::string const worn_armor_name = tmp_worn[itemindex]->tname();
             item_penalties const penalties =
                 get_item_penalties( tmp_worn[itemindex], who, tabindex );
 
@@ -665,12 +665,12 @@ void show_armor_layers_ui( Character &who )
                 pos++;
             }
             curr++;
-            for( layering_item_info &elem : items_cover_bp( who, cover ) ) {
+            for( layering_item_info  const&elem : items_cover_bp( who, cover ) ) {
                 if( curr >= rightListOffset && pos <= rightListLines ) {
-                    nc_color color = elem.penalties.color_for_stacking_badness();
+                    nc_color const color = elem.penalties.color_for_stacking_badness();
                     trim_and_print( w_sort_right, point( 2, pos ), right_w - 5, color,
                                     elem.name );
-                    char plus = elem.penalties.badness() > 0 ? '+' : ' ';
+                    char const plus = elem.penalties.badness() > 0 ? '+' : ' ';
                     mvwprintz( w_sort_right, point( right_w - 4, pos ), c_light_gray, "%3d%c",
                                elem.encumber, plus );
                     pos++;
@@ -727,7 +727,7 @@ void show_armor_layers_ui( Character &who )
             }
         } else {
             // bp_*
-            body_part bp = static_cast<body_part>( tabindex );
+            body_part const bp = static_cast<body_part>( tabindex );
             for( auto it = who.worn.begin(); it != who.worn.end(); ++it ) {
                 if( it->covers( bp ) ) {
                     tmp_worn.push_back( it );
@@ -737,7 +737,7 @@ void show_armor_layers_ui( Character &who )
         leftListSize = tmp_worn.size();
 
         // Ensure leftListIndex is in bounds
-        int new_index_upper_bound = std::max( 0, leftListSize - 1 );
+        int const new_index_upper_bound = std::max( 0, leftListSize - 1 );
         leftListIndex = std::min( leftListIndex, new_index_upper_bound );
 
         ui_manager::redraw();
@@ -869,7 +869,7 @@ void show_armor_layers_ui( Character &who )
                 if( std::optional<std::list<item>::iterator> new_equip_it =
                         who.as_player()->wear_possessed( *loc.obtain( who ) ) ) {
                     // save iterator to cursor's position
-                    std::list<item>::iterator cursor_it = tmp_worn[leftListIndex];
+                    std::list<item>::iterator const cursor_it = tmp_worn[leftListIndex];
                     // reorder `worn` vector to place new item at cursor
                     who.worn.splice( cursor_it, who.worn, *new_equip_it );
                 } else if( who.is_npc() ) {

--- a/src/artifact.cpp
+++ b/src/artifact.cpp
@@ -1100,8 +1100,8 @@ void load_artifacts( const std::string &path )
     read_from_file_optional_json( path, []( JsonIn & artifact_json ) {
         artifact_json.start_array();
         while( !artifact_json.end_array() ) {
-            JsonObject jo = artifact_json.get_object();
-            std::string type = jo.get_string( "type" );
+            JsonObject const jo = artifact_json.get_object();
+            std::string const type = jo.get_string( "type" );
             if( type == "artifact_tool" ) {
                 item_controller->add_item_type( static_cast<const itype &>( it_artifact_tool( jo ) ) );
             } else if( type == "artifact_armor" ) {

--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -69,9 +69,9 @@ bool assign( const JsonObject &jo, const std::string &name, units::volume &val,
     // Object via which to report errors which differs for proportional/relative values
     JsonObject err = jo;
     err.allow_omitted_members();
-    JsonObject relative = jo.get_object( "relative" );
+    JsonObject const relative = jo.get_object( "relative" );
     relative.allow_omitted_members();
-    JsonObject proportional = jo.get_object( "proportional" );
+    JsonObject const proportional = jo.get_object( "proportional" );
     proportional.allow_omitted_members();
 
     // Do not require strict parsing for relative and proportional values as rules
@@ -138,9 +138,9 @@ bool assign( const JsonObject &jo,
     // values
     JsonObject err = jo;
     err.allow_omitted_members();
-    JsonObject relative = jo.get_object( "relative" );
+    JsonObject const relative = jo.get_object( "relative" );
     relative.allow_omitted_members();
-    JsonObject proportional = jo.get_object( "proportional" );
+    JsonObject const proportional = jo.get_object( "proportional" );
     proportional.allow_omitted_members();
 
     // Do not require strict parsing for relative and proportional values as
@@ -211,9 +211,9 @@ bool assign( const JsonObject &jo,
     // values
     JsonObject err = jo;
     err.allow_omitted_members();
-    JsonObject relative = jo.get_object( "relative" );
+    JsonObject const relative = jo.get_object( "relative" );
     relative.allow_omitted_members();
-    JsonObject proportional = jo.get_object( "proportional" );
+    JsonObject const proportional = jo.get_object( "proportional" );
     proportional.allow_omitted_members();
 
     // Do not require strict parsing for relative and proportional values as
@@ -289,9 +289,9 @@ bool assign( const JsonObject &jo,
     // values
     JsonObject err = jo;
     err.allow_omitted_members();
-    JsonObject relative = jo.get_object( "relative" );
+    JsonObject const relative = jo.get_object( "relative" );
     relative.allow_omitted_members();
-    JsonObject proportional = jo.get_object( "proportional" );
+    JsonObject const proportional = jo.get_object( "proportional" );
     proportional.allow_omitted_members();
 
     // Do not require strict parsing for relative and proportional values as
@@ -474,9 +474,9 @@ bool assign( const JsonObject &jo,
     // Object via which to report errors which differs for proportional/relative
     // values
     const JsonObject &err = jo;
-    JsonObject relative = jo.get_object( "relative" );
+    JsonObject const relative = jo.get_object( "relative" );
     relative.allow_omitted_members();
-    JsonObject proportional = jo.get_object( "proportional" );
+    JsonObject const proportional = jo.get_object( "proportional" );
     proportional.allow_omitted_members();
 
     // Currently, we load only either relative or proportional when loading

--- a/src/auto_note.cpp
+++ b/src/auto_note.cpp
@@ -155,7 +155,7 @@ auto_note_manager_gui::auto_note_manager_gui()
             continue;
         }
 
-        bool isAutoNoteEnabled = settings.has_auto_note_enabled( extra.id );
+        bool const isAutoNoteEnabled = settings.has_auto_note_enabled( extra.id );
 
         mapExtraCache.emplace( std::make_pair( extra.id, std::make_pair( extra,
                                                isAutoNoteEnabled ) ) );

--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -162,7 +162,7 @@ void user_interface::show()
             if( i >= iStartPos &&
                 i < iStartPos + ( iContentHeight > static_cast<int>( cur_rules.size() ) ?
                                   static_cast<int>( cur_rules.size() ) : iContentHeight ) ) {
-                nc_color cLineColor = cur_rules[i].bActive ? c_white : c_light_gray;
+                nc_color const cLineColor = cur_rules[i].bActive ? c_white : c_light_gray;
 
                 mvwprintz( w, point( 1, i - iStartPos ), cLineColor, "%d", i + 1 );
                 mvwprintz( w, point( 5, i - iStartPos ), cLineColor, "" );
@@ -381,7 +381,7 @@ void user_interface::show()
         return;
     }
 
-    for( tab &t : tabs ) {
+    for( tab  const&t : tabs ) {
         t.rules.get() = t.new_rules;
     }
 }
@@ -456,7 +456,7 @@ void rule::test_pattern() const
     init_windows( ui );
     ui.on_screen_resize( init_windows );
 
-    int nmatch = vMatchingItems.size();
+    int const nmatch = vMatchingItems.size();
     const std::string buf = string_format( vgettext( "%1$d item matches: %2$s",
                                            "%1$d items match: %2$s",
                                            nmatch ), nmatch, sRule );
@@ -488,7 +488,7 @@ void rule::test_pattern() const
             if( i >= iStartPos &&
                 i < iStartPos + ( iContentHeight > static_cast<int>( vMatchingItems.size() ) ?
                                   static_cast<int>( vMatchingItems.size() ) : iContentHeight ) ) {
-                nc_color cLineColor = c_white;
+                nc_color const cLineColor = c_white;
 
                 mvwprintz( w_test_rule_content, point( 0, i - iStartPos ), cLineColor, "%d", i + 1 );
                 mvwprintz( w_test_rule_content, point( 4, i - iStartPos ), cLineColor, "" );
@@ -776,7 +776,7 @@ void rule_list::serialize( JsonOut &jsout ) const
 
 void rule::deserialize( JsonIn &jsin )
 {
-    JsonObject jo = jsin.get_object();
+    JsonObject const jo = jsin.get_object();
     sRule = jo.get_string( "rule" );
     bActive = jo.get_bool( "active" );
     bExclude = jo.get_bool( "exclude" );

--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -381,7 +381,7 @@ void user_interface::show()
         return;
     }
 
-    for( tab  const&t : tabs ) {
+    for( tab  const &t : tabs ) {
         t.rules.get() = t.new_rules;
     }
 }

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -390,7 +390,7 @@ bool avatar::read( item_location loc, const bool continuous )
         add_msg( m_info, _( "Never mind." ) );
         return false;
     }
-    item  const&it = *loc;
+    item  const &it = *loc;
     if( !has_identified( it.typeId() ) ) {
         // We insta-identify the book, then try to read it
         items_identified.insert( it.typeId() );
@@ -1231,7 +1231,7 @@ bool avatar::wield( item &target )
 
     bool const worn = is_worn( target );
     int const mv = item_handling_cost( target, true,
-                                 worn ? INVENTORY_HANDLING_PENALTY / 2 : INVENTORY_HANDLING_PENALTY );
+                                       worn ? INVENTORY_HANDLING_PENALTY / 2 : INVENTORY_HANDLING_PENALTY );
 
     add_msg( m_debug, "wielding took %d moves", mv );
     moves -= mv;

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -331,7 +331,7 @@ const player *avatar::get_book_reader( const item &book, std::vector<std::string
         } else if( elem->is_blind() ) {
             reasons.push_back( string_format( _( "%s is blind." ), elem->disp_name() ) );
         } else {
-            int proj_time = time_to_read( book, *elem );
+            int const proj_time = time_to_read( book, *elem );
             if( proj_time < time_taken ) {
                 reader = elem;
                 time_taken = proj_time;
@@ -390,7 +390,7 @@ bool avatar::read( item_location loc, const bool continuous )
         add_msg( m_info, _( "Never mind." ) );
         return false;
     }
-    item &it = *loc;
+    item  const&it = *loc;
     if( !has_identified( it.typeId() ) ) {
         // We insta-identify the book, then try to read it
         items_identified.insert( it.typeId() );
@@ -653,7 +653,7 @@ bool avatar::read( item_location loc, const bool continuous )
         apply_morale.insert( elem.first );
     }
     for( Character *ch : apply_morale ) {
-        int fun = character_funcs::get_book_fun_for( *ch, it );
+        int const fun = character_funcs::get_book_fun_for( *ch, it );
         ch->add_morale( MORALE_BOOK, 0, fun * 15, decay_start + 30_minutes,
                         decay_start, false, it.type );
     }
@@ -724,7 +724,7 @@ static void skim_book_msg( const item &book, avatar &u )
         recipe_list.push_back( elem.name );
     }
     if( !recipe_list.empty() ) {
-        std::string recipe_line =
+        std::string const recipe_line =
             string_format( vgettext( "This book contains %1$zu crafting recipe: %2$s",
                                      "This book contains %1$zu crafting recipes: %2$s",
                                      recipe_list.size() ),
@@ -785,7 +785,7 @@ void avatar::do_read( item_location loc )
     for( auto &elem : learners ) {
         player *learner = elem.first;
 
-        int book_fun_for = character_funcs::get_book_fun_for( *learner, book );
+        int const book_fun_for = character_funcs::get_book_fun_for( *learner, book );
         if( book_fun_for != 0 ) {
             learner->add_morale( MORALE_BOOK, book_fun_for * 5, book_fun_for * 15, 1_hours, 30_minutes, true,
                                  book.type );
@@ -839,7 +839,7 @@ void avatar::do_read( item_location loc )
 
             skill_level.readBook( min_ex, max_ex, reading->level );
 
-            std::string skill_name = skill.obj().name();
+            std::string const skill_name = skill.obj().name();
 
             if( skill_level != originalSkillLevel ) {
                 g->events().send<event_type::gains_skill_level>(
@@ -904,7 +904,7 @@ void avatar::do_read( item_location loc )
     auto m = book.type->use_methods.find( "MA_MANUAL" );
     if( m != book.type->use_methods.end() ) {
         const matype_id style_to_learn = martial_art_learned_from( *book.type );
-        skill_id skill_used = style_to_learn->primary_skill;
+        skill_id const skill_used = style_to_learn->primary_skill;
         int difficulty = std::max( 1, style_to_learn->learn_difficulty );
         difficulty = std::max( 1, 20 + difficulty * 2 - get_skill_level( skill_used ) * 2 );
         add_msg( m_debug, _( "Chance to learn one in: %d" ), difficulty );
@@ -1000,11 +1000,11 @@ bool avatar::is_hallucination() const
 
 void avatar::disp_morale()
 {
-    int equilibrium = character_effects::calc_focus_equilibrium( *this );
+    int const equilibrium = character_effects::calc_focus_equilibrium( *this );
 
-    int fatigue_cap = character_effects::calc_morale_fatigue_cap( this->get_fatigue() );
+    int const fatigue_cap = character_effects::calc_morale_fatigue_cap( this->get_fatigue() );
 
-    int pain_penalty = has_trait( trait_CENOBITE ) ? 0 : get_perceived_pain();
+    int const pain_penalty = has_trait( trait_CENOBITE ) ? 0 : get_perceived_pain();
 
     morale->display( equilibrium, pain_penalty, fatigue_cap );
 }
@@ -1229,8 +1229,8 @@ bool avatar::wield( item &target )
     // than a skilled player with a holster.
     // There is an additional penalty when wielding items from the inventory whilst currently grabbed.
 
-    bool worn = is_worn( target );
-    int mv = item_handling_cost( target, true,
+    bool const worn = is_worn( target );
+    int const mv = item_handling_cost( target, true,
                                  worn ? INVENTORY_HANDLING_PENALTY / 2 : INVENTORY_HANDLING_PENALTY );
 
     add_msg( m_debug, "wielding took %d moves", mv );
@@ -1281,7 +1281,7 @@ bool avatar::invoke_item( item *used, const tripoint &pt )
 
     umenu.query();
 
-    int choice = umenu.ret;
+    int const choice = umenu.ret;
     if( choice < 0 || choice >= static_cast<int>( use_methods.size() ) ) {
         return false;
     }

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -614,7 +614,7 @@ void avatar_action::autoattack( avatar &you, map &m )
         return;
     }
 
-    Creature  const&best = **std::max_element( critters.begin(), critters.end(),
+    Creature  const &best = **std::max_element( critters.begin(), critters.end(),
     []( const Creature * l, const Creature * r ) {
         return rate_critter( *l ) > rate_critter( *r );
     } );
@@ -718,7 +718,7 @@ bool can_fire_turret( avatar &you, const map &m, const turret_data &turret )
 
 void avatar_action::fire_wielded_weapon( avatar &you )
 {
-    item  const&weapon = you.primary_weapon();
+    item  const &weapon = you.primary_weapon();
     if( weapon.is_gunmod() ) {
         add_msg( m_info,
                  _( "The %s must be attached to a gun, it can not be fired separately." ),
@@ -1270,7 +1270,7 @@ void avatar_action::reload_weapon( bool try_everything )
     // Reload other guns in inventory.
     // Reload misc magazines in inventory.
     avatar &u = get_avatar();
-    map  const&here = get_map();
+    map  const &here = get_map();
     std::set<itype_id> compatible_magazines;
     for( const item *gun : u.wielded_items() ) {
         const std::set<itype_id> &mags = gun->magazine_compatible();

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -154,7 +154,7 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
     }
 
     // If the player is *attempting to* move on the X axis, update facing direction of their sprite to match.
-    point new_d( dest_loc.xy() + point( -you.posx(), -you.posy() ) );
+    point const new_d( dest_loc.xy() + point( -you.posx(), -you.posy() ) );
 
     if( !tile_iso ) {
         if( new_d.x > 0 ) {
@@ -262,7 +262,7 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
         monster &critter = *mon_ptr;
         // Additional checking to make sure we won't take a swing at friendly monsters.
         Character &u = get_player_character();
-        monster_attitude att = critter.attitude( const_cast<Character *>( &u ) );
+        monster_attitude const att = critter.attitude( const_cast<Character *>( &u ) );
         if( critter.friendly == 0 &&
             !critter.has_effect( effect_pet ) && att != MATT_FRIEND ) {
             if( you.is_auto_moving() ) {
@@ -322,7 +322,7 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
     vehicle *const veh1 = veh_pointer_or_null( vp1 );
 
     bool veh_closed_door = false;
-    bool outside_vehicle = ( veh0 == nullptr || veh0 != veh1 );
+    bool const outside_vehicle = ( veh0 == nullptr || veh0 != veh1 );
     if( veh1 != nullptr ) {
         dpart = veh1->next_part_to_open( vp1->part_index(), outside_vehicle );
         veh_closed_door = dpart >= 0 && !veh1->part( dpart ).open;
@@ -342,12 +342,12 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
             return false;
         }
     }
-    bool toSwimmable = m.has_flag( flag_SWIMMABLE, dest_loc );
-    bool toDeepWater = m.has_flag( TFLAG_DEEP_WATER, dest_loc );
-    bool fromSwimmable = m.has_flag( flag_SWIMMABLE, you.pos() );
-    bool fromDeepWater = m.has_flag( TFLAG_DEEP_WATER, you.pos() );
-    bool fromBoat = veh0 != nullptr && veh0->is_in_water();
-    bool toBoat = veh1 != nullptr && veh1->is_in_water();
+    bool const toSwimmable = m.has_flag( flag_SWIMMABLE, dest_loc );
+    bool const toDeepWater = m.has_flag( TFLAG_DEEP_WATER, dest_loc );
+    bool const fromSwimmable = m.has_flag( flag_SWIMMABLE, you.pos() );
+    bool const fromDeepWater = m.has_flag( TFLAG_DEEP_WATER, you.pos() );
+    bool const fromBoat = veh0 != nullptr && veh0->is_in_water();
+    bool const toBoat = veh1 != nullptr && veh1->is_in_water();
     if( is_riding ) {
         if( !you.check_mount_will_move( dest_loc ) ) {
             if( you.is_auto_moving() ) {
@@ -461,7 +461,7 @@ bool avatar_action::ramp_move( avatar &you, map &m, const tripoint &dest_loc )
 
     // We're moving onto a tile with no support, check if it has a ramp below
     if( !m.has_floor_or_support( dest_loc ) ) {
-        tripoint below( dest_loc.xy(), dest_loc.z - 1 );
+        tripoint const below( dest_loc.xy(), dest_loc.z - 1 );
         if( m.has_flag( TFLAG_RAMP, below ) ) {
             // But we're moving onto one from above
             const tripoint dp = dest_loc - you.pos();
@@ -526,7 +526,7 @@ void avatar_action::swim( map &m, avatar &you, const tripoint &p )
         add_msg( _( "The water washes off the glowing goo!" ) );
         you.remove_effect( effect_glowing );
     }
-    int movecost = you.swim_speed();
+    int const movecost = you.swim_speed();
     you.practice( skill_swimming, you.is_underwater() ? 2 : 1 );
     if( movecost >= 500 ) {
         if( !you.is_underwater() &&
@@ -545,7 +545,7 @@ void avatar_action::swim( map &m, avatar &you, const tripoint &p )
             popup( _( "You need to breathe but you can't swim!  Get to dry land, quick!" ) );
         }
     }
-    bool diagonal = ( p.x != you.posx() && p.y != you.posy() );
+    bool const diagonal = ( p.x != you.posx() && p.y != you.posy() );
     if( you.in_vehicle ) {
         m.unboard_vehicle( you.pos() );
     }
@@ -598,7 +598,7 @@ static float rate_critter( const Creature &c )
 
 void avatar_action::autoattack( avatar &you, map &m )
 {
-    int reach = you.primary_weapon().reach_range( you );
+    int const reach = you.primary_weapon().reach_range( you );
     std::vector<Creature *> critters = ranged::targetable_creatures( you, reach );
     critters.erase( std::remove_if( critters.begin(), critters.end(), []( const Creature * c ) {
         if( !c->is_npc() ) {
@@ -614,7 +614,7 @@ void avatar_action::autoattack( avatar &you, map &m )
         return;
     }
 
-    Creature &best = **std::max_element( critters.begin(), critters.end(),
+    Creature  const&best = **std::max_element( critters.begin(), critters.end(),
     []( const Creature * l, const Creature * r ) {
         return rate_critter( *l ) > rate_critter( *r );
     } );
@@ -648,9 +648,9 @@ bool avatar_action::can_fire_weapon( avatar &you, const map &m, const item &weap
     std::vector<std::string> messages;
 
     const gun_mode &mode = weapon.gun_current_mode();
-    bool check_common = ranged::gunmode_checks_common( you, m, messages, mode );
-    bool check_weapon = ranged::gunmode_checks_weapon( you, m, messages, mode );
-    bool can_use_mode = check_common && check_weapon;
+    bool const check_common = ranged::gunmode_checks_common( you, m, messages, mode );
+    bool const check_weapon = ranged::gunmode_checks_weapon( you, m, messages, mode );
+    bool const can_use_mode = check_common && check_weapon;
     if( can_use_mode ) {
         return true;
     }
@@ -704,7 +704,7 @@ bool can_fire_turret( avatar &you, const map &m, const turret_data &turret )
     std::vector<std::string> messages;
 
     for( const std::pair<const gun_mode_id, gun_mode> &mode_map : weapon.gun_all_modes() ) {
-        bool can_use_mode = ranged::gunmode_checks_common( you, m, messages, mode_map.second );
+        bool const can_use_mode = ranged::gunmode_checks_common( you, m, messages, mode_map.second );
         if( can_use_mode ) {
             return true;
         }
@@ -718,7 +718,7 @@ bool can_fire_turret( avatar &you, const map &m, const turret_data &turret )
 
 void avatar_action::fire_wielded_weapon( avatar &you )
 {
-    item &weapon = you.primary_weapon();
+    item  const&weapon = you.primary_weapon();
     if( weapon.is_gunmod() ) {
         add_msg( m_info,
                  _( "The %s must be attached to a gun, it can not be fired separately." ),
@@ -728,7 +728,7 @@ void avatar_action::fire_wielded_weapon( avatar &you )
         return;
     } else if( weapon.ammo_data() && weapon.type->gun &&
                !weapon.ammo_types().count( weapon.ammo_data()->ammo->type ) ) {
-        std::string ammoname = weapon.ammo_current()->nname( 1 );
+        std::string const ammoname = weapon.ammo_current()->nname( 1 );
         add_msg( m_info, _( "The %s can't be fired while loaded with incompatible ammunition %s" ),
                  weapon.tname(), ammoname );
         return;
@@ -835,7 +835,7 @@ bool avatar_action::eat_here( avatar &you )
 
 void avatar_action::eat( avatar &you )
 {
-    item_location loc = game_menus::inv::consume( you );
+    item_location const loc = game_menus::inv::consume( you );
     avatar_action::eat( you, loc );
 }
 
@@ -893,8 +893,8 @@ void avatar_action::plthrow( avatar &you, item_location loc,
     // make a copy and get the original.
     // the copy is thrown and has its and the originals charges set appropiately
     // or deleted from inventory if its charges(1) or not stackable.
-    item thrown = *loc.get_item();
-    int range = you.throw_range( thrown );
+    item const thrown = *loc.get_item();
+    int const range = you.throw_range( thrown );
     if( range < 0 ) {
         add_msg( m_info, _( "You don't have that item." ) );
         return;
@@ -920,7 +920,7 @@ void avatar_action::plthrow( avatar &you, item_location loc,
     }
     // if you're wearing the item you need to be able to take it off
     if( you.is_wearing( loc->typeId() ) ) {
-        ret_val<bool> ret = you.can_takeoff( *loc );
+        ret_val<bool> const ret = you.can_takeoff( *loc );
         if( !ret.success() ) {
             add_msg( m_info, "%s", ret.c_str() );
             return;
@@ -929,7 +929,7 @@ void avatar_action::plthrow( avatar &you, item_location loc,
     // you must wield the item to throw it
     // But only if you don't have enough free hands
     const auto &wielded = you.wielded_items();
-    int required_arms = std::accumulate( wielded.begin(), wielded.end(), 0,
+    int const required_arms = std::accumulate( wielded.begin(), wielded.end(), 0,
     [&you]( int acc, const item * it ) {
         return acc + ( it->is_two_handed( you ) ? 2 : 1 );
     } );
@@ -945,7 +945,7 @@ void avatar_action::plthrow( avatar &you, item_location loc,
         loc = item_location( you, &you.primary_weapon() );
     }
 
-    throw_activity_actor actor( loc, blind_throw_from_pos );
+    throw_activity_actor const actor( loc, blind_throw_from_pos );
     you.assign_activity( actor, false );
 }
 
@@ -1074,8 +1074,8 @@ void avatar_action::wield( item_location &loc )
 
     // Can't use loc.obtain() here because that would cause things to spill.
     item to_wield = *loc.get_item();
-    item_location::type location_type = loc.where();
-    tripoint pos = loc.position();
+    item_location::type const location_type = loc.where();
+    tripoint const pos = loc.position();
     int worn_index = INT_MIN;
     if( u.is_worn( *loc.get_item() ) ) {
         auto ret = u.can_takeoff( *loc.get_item() );
@@ -1083,7 +1083,7 @@ void avatar_action::wield( item_location &loc )
             add_msg( m_info, "%s", ret.c_str() );
             return;
         }
-        int item_pos = u.get_item_position( loc.get_item() );
+        int const item_pos = u.get_item_position( loc.get_item() );
         if( item_pos != INT_MIN ) {
             worn_index = Character::worn_position_to_index( item_pos );
         }
@@ -1270,7 +1270,7 @@ void avatar_action::reload_weapon( bool try_everything )
     // Reload other guns in inventory.
     // Reload misc magazines in inventory.
     avatar &u = get_avatar();
-    map &here = get_map();
+    map  const&here = get_map();
     std::set<itype_id> compatible_magazines;
     for( const item *gun : u.wielded_items() ) {
         const std::set<itype_id> &mags = gun->magazine_compatible();
@@ -1332,7 +1332,7 @@ void avatar_action::reload_weapon( bool try_everything )
 
 void avatar_action::unload( avatar &you )
 {
-    item_location loc = g->inv_map_splice( []( const item & it ) {
+    item_location const loc = g->inv_map_splice( []( const item & it ) {
         return item_funcs::can_be_unloaded( it );
     }, _( "Unload item" ), 1, _( "You have nothing to unload." ) );
 

--- a/src/avatar_functions.cpp
+++ b/src/avatar_functions.cpp
@@ -91,7 +91,7 @@ void try_to_sleep( avatar &you, const time_duration &dur )
         webforce = true;
     }
     if( websleep || webforce ) {
-        int web = here.get_field_intensity( you.pos(), fd_web );
+        int const web = here.get_field_intensity( you.pos(), fd_web );
         if( !webforce ) {
             // At this point, it's kinda weird, but surprisingly comfy...
             if( web >= 3 ) {
@@ -369,12 +369,12 @@ void gunmod_add( avatar &you, item &gun, item &mod )
     bool no_magazines = false;
     if( !modded.magazine_integral() && !mod.type->mod->ammo_modifier.empty() ) {
         no_magazines = true;
-        for( itype_id mags : modded.magazine_compatible() ) {
-            item mag = item( mags );
+        for( itype_id const mags : modded.magazine_compatible() ) {
+            item const mag = item( mags );
             if( !no_magazines ) {
                 break;
             }
-            for( ammotype at : modded.ammo_types() ) {
+            for( ammotype const at : modded.ammo_types() ) {
                 if( mag.can_reload_with( at ) ) {
                     no_magazines = false;
                     break;
@@ -463,7 +463,7 @@ bool gunmod_remove( avatar &you, item &gun, item &mod )
         return false;
     }
 
-    item_location loc = item_location( you, &mod );
+    item_location const loc = item_location( you, &mod );
     if( mod.ammo_remaining() && !avatar_funcs::unload_item( you, loc ) ) {
         return false;
     }
@@ -525,7 +525,7 @@ std::pair<int, int> gunmod_installation_odds( const avatar &you, const item &gun
 
     for( const auto &e : mod.type->min_skills ) {
         // gain an additional chance for every level above the minimum requirement
-        skill_id sk = e.first == skill_weapon ? gun.gun_skill() : e.first;
+        skill_id const sk = e.first == skill_weapon ? gun.gun_skill() : e.first;
         chances += std::max( you.get_skill_level( sk ) - e.second, 0 );
     }
     // cap success from skill alone to 1 in 5 (~83% chance)
@@ -611,7 +611,7 @@ void use_item( avatar &you, item_location loc )
     } else if( used.type->has_use() ) {
         you.invoke_item( &used, loc.position() );
     } else if( used.has_flag( flag_SPLINT ) ) {
-        ret_val<bool> need_splint = you.can_wear( used );
+        ret_val<bool> const need_splint = you.can_wear( used );
         if( need_splint.success() ) {
             you.wear_item( used );
             loc.remove_item();
@@ -666,7 +666,7 @@ bool unload_item( avatar &you, item_location loc )
 
         bool changed = false;
         for( item *contained : it.contents.all_items_top() ) {
-            int old_charges = contained->charges;
+            int const old_charges = contained->charges;
             const bool consumed = add_or_drop_with_msg( you, *contained, true );
             changed = changed || consumed || contained->charges != old_charges;
             if( consumed ) {
@@ -849,7 +849,7 @@ std::vector<npc *> list_potential_theft_witnesses( avatar &you, const faction_id
 
 bool handle_theft_witnesses( avatar &you, const faction_id &owners )
 {
-    std::vector<npc *> witnesses = list_potential_theft_witnesses( you, owners );
+    std::vector<npc *> const witnesses = list_potential_theft_witnesses( you, owners );
     for( npc *guy : witnesses ) {
         guy->say( "<witnessed_thievery>", 7 );
     }

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -209,8 +209,8 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
     Creature *target_critter = g->critter_at( target_arg );
     map &here = get_map();
     double const target_size = target_critter != nullptr ?
-                         target_critter->ranged_target_size() :
-                         here.ranged_target_size( target_arg );
+                               target_critter->ranged_target_size() :
+                               here.ranged_target_size( target_arg );
     projectile_attack_aim const aim = projectile_attack_roll( dispersion, range, target_size );
 
     // TODO: move to-hit roll back in here

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -101,7 +101,7 @@ static void drop_or_embed_projectile( const dealt_projectile_attack &attack )
     monster *mon = dynamic_cast<monster *>( attack.hit_critter );
 
     // We can only embed in monsters
-    bool mon_there = mon != nullptr && !mon->is_dead_state();
+    bool const mon_there = mon != nullptr && !mon->is_dead_state();
     // And if we actually want to embed
     bool embed = mon_there && !proj.has_effect( ammo_effect_NO_EMBED ) &&
                  !proj.has_effect( ammo_effect_TANGLE );
@@ -208,10 +208,10 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
 
     Creature *target_critter = g->critter_at( target_arg );
     map &here = get_map();
-    double target_size = target_critter != nullptr ?
+    double const target_size = target_critter != nullptr ?
                          target_critter->ranged_target_size() :
                          here.ranged_target_size( target_arg );
-    projectile_attack_aim aim = projectile_attack_roll( dispersion, range, target_size );
+    projectile_attack_aim const aim = projectile_attack_roll( dispersion, range, target_size );
 
     // TODO: move to-hit roll back in here
 
@@ -250,12 +250,12 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
     std::vector<tripoint> trajectory;
     if( aim.missed_by_tiles >= 1.0 ) {
         // We missed enough to target a different tile
-        double dx = target_arg.x - source.x;
-        double dy = target_arg.y - source.y;
+        double const dx = target_arg.x - source.x;
+        double const dy = target_arg.y - source.y;
         units::angle rad = units::atan2( dy, dx );
 
         // cap wild misses at +/- 30 degrees
-        units::angle dispersion_angle =
+        units::angle const dispersion_angle =
             std::min( units::from_arcmin( aim.dispersion ), 30_degrees );
         rad += ( one_in( 2 ) ? 1 : -1 ) * dispersion_angle;
 
@@ -300,7 +300,7 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
     // Add the first point to the trajectory
     trajectory.insert( trajectory.begin(), source );
 
-    static emit_id muzzle_smoke( "emit_smaller_smoke_plume" );
+    static emit_id const muzzle_smoke( "emit_smaller_smoke_plume" );
     if( proj.has_effect( ammo_effect_MUZZLE_SMOKE ) ) {
         here.emit_field( trajectory.front(), muzzle_smoke );
     }
@@ -519,12 +519,12 @@ double hit_chance( const dispersion_sources &dispersion, double range, double ta
         return 1.0;
     }
 
-    double missed_by_tiles = missed_by * target_size;
+    double const missed_by_tiles = missed_by * target_size;
 
     //          T = (2*D**2 * (1 - cos V)) ** 0.5   (from iso_tangent)
     //      cos V = 1 - T**2 / (2*D**2)
-    double cosV = 1 - missed_by_tiles * missed_by_tiles / ( 2 * range * range );
-    double needed_dispersion = ( cosV < -1.0 ? M_PI : acos( cosV ) ) * 180 * 60 / M_PI;
+    double const cosV = 1 - missed_by_tiles * missed_by_tiles / ( 2 * range * range );
+    double const needed_dispersion = ( cosV < -1.0 ? M_PI : acos( cosV ) ) * 180 * 60 / M_PI;
 
     return normal_cdf( needed_dispersion, dispersion.avg(), dispersion.avg() / 2 );
 }

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -79,7 +79,7 @@ std::string base_camps::faction_decode( const std::string &full_type )
     if( full_type.size() < ( prefix_len + 2 ) ) {
         return "camp";
     }
-    int last_bar = full_type.find_last_of( '_' );
+    int const last_bar = full_type.find_last_of( '_' );
 
     return full_type.substr( prefix_len, last_bar - prefix_len );
 }
@@ -89,8 +89,8 @@ time_duration base_camps::to_workdays( const time_duration &work_time )
     if( work_time < 11_hours ) {
         return work_time;
     }
-    int work_days = work_time / 10_hours;
-    time_duration excess_time = work_time - work_days * 10_hours;
+    int const work_days = work_time / 10_hours;
+    time_duration const excess_time = work_time - work_days * 10_hours;
     return excess_time + 24_hours * work_days;
 }
 
@@ -142,7 +142,7 @@ expansion_data basecamp::parse_expansion( const std::string &terrain,
         const tripoint_abs_omt &new_pos )
 {
     expansion_data e;
-    int last_bar = terrain.find_last_of( '_' );
+    int const last_bar = terrain.find_last_of( '_' );
     e.type = terrain.substr( base_camps::prefix_len, last_bar - base_camps::prefix_len );
     e.cur_level = std::stoi( terrain.substr( last_bar + 1 ) );
     e.pos = new_pos;
@@ -224,7 +224,7 @@ std::string basecamp::om_upgrade_description( const std::string &bldg, bool trun
     comp = string_format( _( "Notes:\n%s\n\nSkills used: %s\n%s\n" ),
                           making.description, making.required_all_skills_string(), comp );
     if( !trunc ) {
-        time_duration base_time = making.batch_duration();
+        time_duration const base_time = making.batch_duration();
         comp += string_format( _( "Risk: None\nTime: %s\n" ),
                                to_string( base_camps::to_workdays( base_time ) ) );
     }
@@ -310,7 +310,7 @@ std::vector<basecamp_upgrade> basecamp::available_upgrades( point dir )
                 continue;
             }
             // skip building that have unmet requirements
-            size_t needed_requires = recp.blueprint_requires().size();
+            size_t const needed_requires = recp.blueprint_requires().size();
             size_t met_requires = 0;
             for( const auto &bp_require : recp.blueprint_requires() ) {
                 if( e_data.provides.find( bp_require.first ) == e_data.provides.end() ) {
@@ -395,7 +395,7 @@ void basecamp::add_resource( const itype_id &camp_resource )
 {
     basecamp_resource bcp_r;
     bcp_r.fake_id = camp_resource;
-    item camp_item( bcp_r.fake_id, calendar::start_of_cataclysm );
+    item const camp_item( bcp_r.fake_id, calendar::start_of_cataclysm );
     bcp_r.ammo_id = camp_item.ammo_default();
     resources.emplace_back( bcp_r );
     fuel_types.insert( bcp_r.ammo_id );
@@ -476,7 +476,7 @@ void basecamp::reset_camp_workers()
 {
     camp_workers.clear();
     for( const auto &elem : overmap_buffer.get_companion_mission_npcs() ) {
-        npc_companion_mission c_mission = elem->get_companion_mission();
+        npc_companion_mission const c_mission = elem->get_companion_mission();
         if( c_mission.position == omt_pos && c_mission.role_id == "FACTION_CAMP" ) {
             camp_workers.push_back( elem );
         }
@@ -485,7 +485,7 @@ void basecamp::reset_camp_workers()
 
 void basecamp::add_assignee( character_id id )
 {
-    npc_ptr npc_to_add = overmap_buffer.find_npc( id );
+    npc_ptr const npc_to_add = overmap_buffer.find_npc( id );
     if( !npc_to_add ) {
         debugmsg( "cant find npc to assign to basecamp, on the overmap_buffer" );
         return;
@@ -496,7 +496,7 @@ void basecamp::add_assignee( character_id id )
 
 void basecamp::remove_assignee( character_id id )
 {
-    npc_ptr npc_to_remove = overmap_buffer.find_npc( id );
+    npc_ptr const npc_to_remove = overmap_buffer.find_npc( id );
     if( !npc_to_remove ) {
         debugmsg( "cant find npc to remove from basecamp, on the overmap_buffer" );
         return;
@@ -516,8 +516,8 @@ void basecamp::validate_assignees()
             ++iter;
         }
     }
-    for( character_id elem : g->get_follower_list() ) {
-        npc_ptr npc_to_add = overmap_buffer.find_npc( elem );
+    for( character_id const elem : g->get_follower_list() ) {
+        npc_ptr const npc_to_add = overmap_buffer.find_npc( elem );
         if( !npc_to_add ) {
             continue;
         }
@@ -546,7 +546,7 @@ comp_list basecamp::get_mission_workers( const std::string &mission_id, bool con
 {
     comp_list available;
     for( const auto &elem : camp_workers ) {
-        npc_companion_mission c_mission = elem->get_companion_mission();
+        npc_companion_mission const c_mission = elem->get_companion_mission();
         if( ( c_mission.mission_id == mission_id ) ||
             ( contains && c_mission.mission_id.find( mission_id ) != std::string::npos ) ) {
             available.push_back( elem );
@@ -649,7 +649,7 @@ void basecamp::form_crafting_inventory( map &target_map )
         item camp_item( bcp_r.fake_id, calendar::start_of_cataclysm );
         camp_item.set_flag( "PSEUDO" );
         if( !bcp_r.ammo_id.is_null() ) {
-            for( basecamp_fuel &bcp_f : fuels ) {
+            for( basecamp_fuel  const&bcp_f : fuels ) {
                 if( bcp_f.ammo_id == bcp_r.ammo_id ) {
                     if( bcp_f.available > 0 ) {
                         bcp_r.available = bcp_f.available;
@@ -684,7 +684,7 @@ std::string basecamp::expansion_tab( point dir ) const
 
     const auto &e = expansions.find( dir );
     if( e != expansions.end() ) {
-        recipe_id id( base_camps::faction_encode_abs( e->second, 0 ) );
+        recipe_id const id( base_camps::faction_encode_abs( e->second, 0 ) );
         const auto e_type = expansion_types.find( id );
         if( e_type != expansion_types.end() ) {
             return e_type->second + _( "Expansion" );
@@ -723,7 +723,7 @@ bool basecamp_action_components::choose_components()
         return false;
     }
     for( const auto &it : req->get_components() ) {
-        comp_selection<item_comp> is =
+        comp_selection<item_comp> const is =
             g->u.select_item_component( it, batch_size_, base_._inv, true, filter,
                                         !base_.by_radio );
         if( is.use_from == cancel ) {
@@ -734,7 +734,7 @@ bool basecamp_action_components::choose_components()
     // this may consume pseudo-resources from fake items
     for( const auto &it : req->get_tools() ) {
         const Character *player_with_inventory = base_.by_radio ? nullptr : &get_avatar();
-        comp_selection<tool_comp> ts =
+        comp_selection<tool_comp> const ts =
             crafting::select_tool_component( it, batch_size_, base_._inv,
                                              player_with_inventory, true );
         if( ts.use_from == cancel ) {

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -649,7 +649,7 @@ void basecamp::form_crafting_inventory( map &target_map )
         item camp_item( bcp_r.fake_id, calendar::start_of_cataclysm );
         camp_item.set_flag( "PSEUDO" );
         if( !bcp_r.ammo_id.is_null() ) {
-            for( basecamp_fuel  const&bcp_f : fuels ) {
+            for( basecamp_fuel  const &bcp_f : fuels ) {
                 if( bcp_f.ammo_id == bcp_r.ammo_id ) {
                     if( bcp_f.available > 0 ) {
                         bcp_r.available = bcp_f.available;

--- a/src/behavior.cpp
+++ b/src/behavior.cpp
@@ -38,7 +38,7 @@ behavior_return node_t::tick( const oracle_t *subject ) const
         return { predicate( subject ), this };
     } else {
         assert( strategy != nullptr );
-        status_t result = predicate( subject );
+        status_t const result = predicate( subject );
         if( result == running ) {
             return strategy->evaluate( subject, children );
         } else {
@@ -54,7 +54,7 @@ std::string node_t::goal() const
 
 std::string tree::tick( const oracle_t *subject )
 {
-    behavior_return result = root->tick( subject );
+    behavior_return const result = root->tick( subject );
     active_node = result.result == running ? result.selection : nullptr;
     return goal();
 }
@@ -110,7 +110,7 @@ void node_t::load( const JsonObject &jo, const std::string & )
         optional( jo, was_loaded, "children", new_data.children );
     }
     if( jo.has_string( "strategy" ) ) {
-        std::unordered_map<std::string, const strategy_t *>::iterator new_strategy =
+        std::unordered_map<std::string, const strategy_t *>::iterator const new_strategy =
             behavior::strategy_map.find( jo.get_string( "strategy" ) );
         if( new_strategy != strategy_map.end() ) {
             strategy = new_strategy->second;

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -479,7 +479,7 @@ std::vector<std::pair<bionic_id, item>> find_reloadable_cbms( npc &who )
     std::vector<std::pair<bionic_id, item>> cbm_list;
     // Runs down full list of CBMs that qualify as weapons.
     // Need a way to make this less costly.
-    for( bionic bio : *who.my_bionics ) {
+    for( bionic const bio : *who.my_bionics ) {
         if( !bio.info().has_flag( flag_BIONIC_WEAPON ) ) {
             continue;
         }
@@ -504,7 +504,7 @@ const std::map<item, bionic_id> npc::check_toggle_cbm()
     if( free_power <= 0_J ) {
         return res;
     }
-    for( bionic &bio : *my_bionics ) {
+    for( bionic  const&bio : *my_bionics ) {
         // I'm not checking if NPC_USABLE because if it isn't it shouldn't be in them.
         if( bio.powered || !bio.info().has_flag( flag_BIONIC_WEAPON ) ||
             free_power < bio.info().power_activate ) {
@@ -535,7 +535,7 @@ void npc::check_or_use_weapon_cbm()
     }
 
     int cbm_index = 0;
-    for( bionic &bio : *my_bionics ) {
+    for( bionic  const&bio : *my_bionics ) {
         // I'm not checking if NPC_USABLE because if it isn't it shouldn't be in them.
         if( free_power >= bio.info().power_activate && bio.info().has_flag( flag_BIONIC_GUN ) ) {
             avail_active_cbms.push_back( cbm_index );
@@ -545,16 +545,16 @@ void npc::check_or_use_weapon_cbm()
 
     if( !avail_active_cbms.empty() ) {
         Creature *critter = current_target();
-        int dist = rl_dist( pos(), critter->pos() );
+        int const dist = rl_dist( pos(), critter->pos() );
         int active_index = -1;
         int best_dps = -1;
-        bool wield_gun = primary_weapon().is_gun();
+        bool const wield_gun = primary_weapon().is_gun();
         item best_cbm_active = null_item_reference();
-        for( int i : avail_active_cbms ) {
-            bionic &bio = ( *my_bionics )[ i ];
+        for( int const i : avail_active_cbms ) {
+            bionic  const&bio = ( *my_bionics )[ i ];
             const item cbm_weapon = item( bio.info().fake_item );
 
-            bool not_allowed = !rules.has_flag( ally_rule::use_guns ) ||
+            bool const not_allowed = !rules.has_flag( ally_rule::use_guns ) ||
                                ( rules.has_flag( ally_rule::use_silent ) && !cbm_weapon.is_silent() );
             if( is_player_ally() && not_allowed ) {
                 continue;
@@ -642,7 +642,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only )
         }
     };
 
-    item tmp_item;
+    item const tmp_item;
     const w_point &weatherPoint = get_weather().get_precise();
 
     map &here = get_map();
@@ -698,10 +698,10 @@ bool Character::activate_bionic( bionic &bio, bool eff_only )
     } else if( bio.id == bio_evap ) {
         add_msg_activate();
         const w_point &weatherPoint = get_weather().get_precise();
-        int humidity = get_local_humidity( weatherPoint.humidity, get_weather().weather_id,
+        int const humidity = get_local_humidity( weatherPoint.humidity, get_weather().weather_id,
                                            g->is_sheltered( g->u.pos() ) );
         // thirst units = 5 mL
-        int water_available = std::lround( humidity * 3.0 / 100.0 );
+        int const water_available = std::lround( humidity * 3.0 / 100.0 );
         if( water_available == 0 ) {
             bio.powered = false;
             add_msg_if_player( m_bad, _( "There is not enough humidity in the air for your %s to function." ),
@@ -909,7 +909,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only )
                 proj.add_effect( eff );
             }
 
-            dealt_projectile_attack dealt = projectile_attack(
+            dealt_projectile_attack const dealt = projectile_attack(
                                                 proj, pr.second, pos(), dispersion_sources{ 0 }, this );
             here.add_item_or_charges( dealt.end_point, pr.first );
         }
@@ -922,11 +922,11 @@ bool Character::activate_bionic( bionic &bio, bool eff_only )
         std::string open_message;
         if( pnt ) {
             tried_lockpick = true;
-            ter_id ter_type = g->m.ter( *pnt );
-            furn_id furn_type = g->m.furn( *pnt );
-            lockpicking_open_result lr = get_lockpicking_open_result( ter_type, furn_type );
-            ter_id new_ter_type = lr.new_ter_type;
-            furn_id new_furn_type = lr.new_furn_type;
+            ter_id const ter_type = g->m.ter( *pnt );
+            furn_id const furn_type = g->m.furn( *pnt );
+            lockpicking_open_result const lr = get_lockpicking_open_result( ter_type, furn_type );
+            ter_id const new_ter_type = lr.new_ter_type;
+            furn_id const new_furn_type = lr.new_furn_type;
             open_message = lr.open_message;
 
             if( new_ter_type != t_null || new_furn_type != f_null ) {
@@ -978,7 +978,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only )
         /* cache g->get_temperature( player location ) since it is used twice. No reason to recalc */
         const auto player_local_temp = weather.get_temperature( g->u.pos() );
         /* windpower defined in internal velocity units (=.01 mph) */
-        double windpower = 100.0f * get_local_windpower( weather.windspeed + vehwindspeed,
+        double const windpower = 100.0f * get_local_windpower( weather.windspeed + vehwindspeed,
                            cur_om_ter, pos(), weather.winddirection, g->is_sheltered( pos() ) );
         add_msg_if_player( m_info, _( "Temperature: %s." ), print_temperature( player_local_temp ) );
         add_msg_if_player( m_info, _( "Relative Humidity: %s." ),
@@ -995,11 +995,11 @@ bool Character::activate_bionic( bionic &bio, bool eff_only )
                                get_local_windchill( units::to_fahrenheit( weatherPoint.temperature ),
                                        weatherPoint.humidity,
                                        windpower / 100 ) + player_local_temp ) );
-        std::string dirstring = get_dirstring( weather.winddirection );
+        std::string const dirstring = get_dirstring( weather.winddirection );
         add_msg_if_player( m_info, _( "Wind Direction: From the %s." ), dirstring );
     } else if( bio.id == bio_remote ) {
         add_msg_activate();
-        int choice = uilist( _( "Perform which function:" ), {
+        int const choice = uilist( _( "Perform which function:" ), {
             _( "Control vehicle" ), _( "RC radio" )
         } );
         if( choice >= 0 && choice <= 1 ) {
@@ -1010,17 +1010,17 @@ bool Character::activate_bionic( bionic &bio, bool eff_only )
                 ctr = item( "radiocontrol", calendar::start_of_cataclysm );
             }
             ctr.charges = units::to_kilojoule( get_power_level() );
-            int power_use = invoke_item( &ctr );
+            int const power_use = invoke_item( &ctr );
             mod_power_level( units::from_kilojoule( -power_use ) );
             bio.powered = ctr.active;
         } else {
             bio.powered = g->remoteveh() != nullptr || !get_value( "remote_controlling" ).empty();
         }
     } else if( bio.info().is_remote_fueled ) {
-        std::vector<item *> cables = items_with( []( const item & it ) {
+        std::vector<item *> const cables = items_with( []( const item & it ) {
             return it.has_flag( flag_CABLE_SPOOL );
         } );
-        bool has_cable = !cables.empty();
+        bool const has_cable = !cables.empty();
         bool free_cable = false;
         bool success = false;
         if( !has_cable ) {
@@ -1400,7 +1400,7 @@ void Character::passive_power_gen( bionic &bio )
 itype_id Character::find_remote_fuel( bool look_only )
 {
     itype_id remote_fuel;
-    map &here = get_map();
+    map  const&here = get_map();
 
     const std::vector<item *> cables = items_with( []( const item & it ) {
         return it.active && it.has_flag( flag_CABLE_SPOOL );
@@ -1458,7 +1458,7 @@ int Character::consume_remote_fuel( int amount )
         return it.active && it.has_flag( flag_CABLE_SPOOL );
     } );
 
-    map &here = get_map();
+    map  const&here = get_map();
     for( const item *cable : cables ) {
         const std::optional<tripoint> target = cable->get_cable_target( this, pos() );
         if( target ) {
@@ -1549,7 +1549,7 @@ static bool attempt_recharge( Character &p, bionic &bio, units::energy &amount, 
                               int rate = 1 )
 {
     const bionic_data &info = bio.info();
-    units::energy power_cost = info.power_over_time * factor;
+    units::energy const power_cost = info.power_over_time * factor;
     bool recharged = false;
 
     if( power_cost > 0_kJ ) {
@@ -1599,8 +1599,8 @@ void Character::process_bionic( bionic &bio )
     }
 
     // These might be affected by environmental conditions, status effects, faulty bionics, etc.
-    int discharge_factor = 1;
-    int discharge_rate = 1;
+    int const discharge_factor = 1;
+    int const discharge_rate = 1;
 
     if( bio.charge_timer > 0 ) {
         bio.charge_timer -= discharge_rate;
@@ -1614,7 +1614,7 @@ void Character::process_bionic( bionic &bio )
             } else {
                 // Try to recharge our bionic if it is made for it
                 units::energy cost = 0_J;
-                bool recharged = attempt_recharge( *this, bio, cost, discharge_factor, discharge_rate );
+                bool const recharged = attempt_recharge( *this, bio, cost, discharge_factor, discharge_rate );
                 if( !recharged ) {
                     // No power to recharge, so deactivate
                     bio.powered = false;
@@ -1642,7 +1642,7 @@ void Character::process_bionic( bionic &bio )
         sounds::sound( pos(), 19, sounds::sound_t::activity, _( "HISISSS!" ), false, "bionic",
                        static_cast<std::string>( bio_hydraulics ) );
     } else if( bio.id == bio_nanobots ) {
-        int threshold_kcal = bio.info().kcal_trigger > 0 ? 0.85f * max_stored_kcal() +
+        int const threshold_kcal = bio.info().kcal_trigger > 0 ? 0.85f * max_stored_kcal() +
                              bio.info().kcal_trigger : 0;
         const auto can_use_bionic = [this, &bio, threshold_kcal]() -> bool {
             const bool is_kcal_sufficient = get_stored_kcal() >= threshold_kcal;
@@ -1693,7 +1693,7 @@ void Character::process_bionic( bionic &bio )
                     [this]( const bodypart_id & a, const bodypart_id & b ) {
                         return ( get_part_hp_cur( a ) - a->essential * 10 ) < ( get_part_hp_cur( b ) - b->essential * 10 );
                     } );
-                    for( bodypart_id &bpid : damaged_hp_parts ) {
+                    for( bodypart_id  const&bpid : damaged_hp_parts ) {
                         if( !can_use_bionic() ) {
                             return;
                         }
@@ -1718,7 +1718,7 @@ void Character::process_bionic( bionic &bio )
         const int pkill = get_painkiller();
         const int pain = get_pain();
         const units::energy trigger_cost = bio.info().power_trigger;
-        int max_pkill = std::min( 150, pain );
+        int const max_pkill = std::min( 150, pain );
         if( pkill < max_pkill ) {
             mod_painkiller( 1 );
             mod_power_level( -trigger_cost );
@@ -1742,10 +1742,10 @@ void Character::process_bionic( bionic &bio )
         // which is 10 mL per 5 minutes.  Humidity can modify the amount gained.
         if( calendar::once_every( 5_minutes ) ) {
             const w_point &weatherPoint = get_weather().get_precise();
-            int humidity = get_local_humidity( weatherPoint.humidity, get_weather().weather_id,
+            int const humidity = get_local_humidity( weatherPoint.humidity, get_weather().weather_id,
                                                g->is_sheltered( g->u.pos() ) );
             // in thirst units = 5 mL water
-            int water_available = std::lround( humidity * 3.0 / 100.0 );
+            int const water_available = std::lround( humidity * 3.0 / 100.0 );
             // At 50% relative humidity or more, the player will draw 10 mL
             // At 16% relative humidity or less, the bionic will give up
             if( water_available == 0 ) {
@@ -1779,7 +1779,7 @@ void Character::process_bionic( bionic &bio )
             if( bio.charge_timer > 2 ) {
                 max_rate /= 2;
             }
-            units::energy ads_recharge = std::min( max_rate, 150_kJ - bio.energy_stored );
+            units::energy const ads_recharge = std::min( max_rate, 150_kJ - bio.energy_stored );
             if( ads_recharge < get_power_level() ) {
                 mod_power_level( - ads_recharge );
                 bio.energy_stored += ads_recharge;
@@ -1829,7 +1829,7 @@ void Character::bionics_uninstall_failure( int difficulty, int success, float ad
     }
 
     add_msg( m_neutral, _( "The removal is a failure." ) );
-    std::set<body_part> bp_hurt;
+    std::set<body_part> const bp_hurt;
     switch( fail_type ) {
         case 2:
         case 3:
@@ -1860,7 +1860,7 @@ void Character::bionics_uninstall_failure( monster &installer, player &patient, 
                               adjusted_skill ) );
     const int fail_type = std::min( 5, failure_level );
 
-    bool u_see = sees( patient );
+    bool const u_see = sees( patient );
 
     if( u_see || patient.is_player() ) {
         if( fail_type <= 1 ) {
@@ -1923,7 +1923,7 @@ float Character::bionics_adjusted_skill( const skill_id &most_important_skill,
         const skill_id &least_important_skill,
         int skill_level )
 {
-    int pl_skill = bionics_pl_skill( most_important_skill, important_skill, least_important_skill,
+    int const pl_skill = bionics_pl_skill( most_important_skill, important_skill, least_important_skill,
                                      skill_level );
 
     // for chance_of_success calculation, shift skill down to a float between ~0.4 - 30
@@ -1970,7 +1970,7 @@ int bionic_manip_cos( float adjusted_skill, int bionic_difficulty )
     int chance_of_success = 0;
     // we will base chance_of_success on a ratio of skill and difficulty
     // when skill=difficulty, this gives us 1.  skill < difficulty gives a fraction.
-    float skill_difficulty_parameter = static_cast<float>( adjusted_skill /
+    float const skill_difficulty_parameter = static_cast<float>( adjusted_skill /
                                        ( 4.0 * bionic_difficulty ) );
 
     // when skill == difficulty, chance_of_success is 50%. Chance of success drops quickly below that
@@ -2033,7 +2033,7 @@ bool Character::can_uninstall_bionic( const bionic_id &b_id, player &installer, 
                          skill_mechanics,
                          skill_level );
     }
-    int chance_of_success = bionic_manip_cos( adjusted_skill, difficulty + 2 );
+    int const chance_of_success = bionic_manip_cos( adjusted_skill, difficulty + 2 );
 
     if( chance_of_success >= 100 ) {
         if( !g->u.query_yn(
@@ -2087,7 +2087,7 @@ bool Character::uninstall_bionic( const bionic_id &b_id, player &installer, bool
                                                skill_level );
     }
 
-    int chance_of_success = bionic_manip_cos( adjusted_skill, difficulty + 2 );
+    int const chance_of_success = bionic_manip_cos( adjusted_skill, difficulty + 2 );
 
     // Surgery is imminent, retract claws or blade if active
     for( bionic &bio : *installer.my_bionics ) {
@@ -2096,7 +2096,7 @@ bool Character::uninstall_bionic( const bionic_id &b_id, player &installer, bool
         }
     }
 
-    int success = chance_of_success - rng( 1, 100 );
+    int const success = chance_of_success - rng( 1, 100 );
     if( installer.has_trait( trait_DEBUG_BIONICS ) ) {
         perform_uninstall( b_id, difficulty, success, b_id->capacity, pl_skill );
         return true;
@@ -2147,7 +2147,7 @@ void Character::perform_uninstall( bionic_id bid, int difficulty, int success,
     } else {
         g->events().send<event_type::fails_to_remove_cbm>( getID(), bid );
         // for chance_of_success calculation, shift skill down to a float between ~0.4 - 30
-        float adjusted_skill = static_cast<float>( pl_skill ) - std::min( static_cast<float>( 40 ),
+        float const adjusted_skill = static_cast<float>( pl_skill ) - std::min( static_cast<float>( 40 ),
                                static_cast<float>( pl_skill ) - static_cast<float>( pl_skill ) / static_cast<float>
                                ( 10.0 ) );
         bionics_uninstall_failure( difficulty, success, adjusted_skill );
@@ -2167,9 +2167,9 @@ bool Character::uninstall_bionic( const bionic &target_cbm, monster &installer, 
     }
 
     const itype_id itemtype = target_cbm.info().itype();
-    int difficulty = itemtype.is_valid() ? itemtype->bionic->difficulty : BIONIC_NOITEM_DIFFICULTY;
-    int chance_of_success = bionic_manip_cos( adjusted_skill, difficulty + 2 );
-    int success = chance_of_success - rng( 1, 100 );
+    int const difficulty = itemtype.is_valid() ? itemtype->bionic->difficulty : BIONIC_NOITEM_DIFFICULTY;
+    int const chance_of_success = bionic_manip_cos( adjusted_skill, difficulty + 2 );
+    int const success = chance_of_success - rng( 1, 100 );
 
     const time_duration duration = difficulty * 20_minutes;
     // don't stack up the effect
@@ -2252,7 +2252,7 @@ bool Character::can_install_bionics( const itype &type, player &installer, bool 
                          skill_mechanics,
                          skill_level );
     }
-    int chance_of_success = bionic_manip_cos( adjusted_skill, difficult );
+    int const chance_of_success = bionic_manip_cos( adjusted_skill, difficult );
 
     std::vector<std::string> conflicting_muts;
     for( const trait_id &mid : bioid->canceled_mutations ) {
@@ -2310,7 +2310,7 @@ bool Character::can_install_bionics( const itype &type, player &installer, bool 
 float Character::env_surgery_bonus( int radius )
 {
     float bonus = 1.0;
-    map &here = get_map();
+    map  const&here = get_map();
     for( const tripoint &cell : here.points_in_radius( pos(), radius ) ) {
         if( here.furn( cell )->surgery_skill_multiplier ) {
             bonus = std::max( bonus, *here.furn( cell )->surgery_skill_multiplier );
@@ -2351,7 +2351,7 @@ bool Character::install_bionics( const itype &type, player &installer, bool auto
                                                skill_mechanics,
                                                skill_level );
     }
-    int chance_of_success = bionic_manip_cos( adjusted_skill, difficulty );
+    int const chance_of_success = bionic_manip_cos( adjusted_skill, difficulty );
 
     // Practice skills only if conducting manual installation
     if( !autodoc ) {
@@ -2360,7 +2360,7 @@ bool Character::install_bionics( const itype &type, player &installer, bool auto
         installer.practice( skill_mechanics, static_cast<int>( ( 100 - chance_of_success ) * 0.5 ) );
     }
 
-    int success = chance_of_success - rng( 0, 99 );
+    int const success = chance_of_success - rng( 0, 99 );
     if( installer.has_trait( trait_DEBUG_BIONICS ) ) {
         perform_install( bioid, upbioid, difficulty, success, pl_skill, "NOT_MED",
                          bioid->canceled_mutations );
@@ -2420,7 +2420,7 @@ void Character::perform_install( bionic_id bid, bionic_id upbid, int difficulty,
         g->events().send<event_type::fails_to_install_cbm>( getID(), bid );
 
         // for chance_of_success calculation, shift skill down to a float between ~0.4 - 30
-        float adjusted_skill = static_cast<float>( pl_skill ) - std::min( static_cast<float>( 40 ),
+        float const adjusted_skill = static_cast<float>( pl_skill ) - std::min( static_cast<float>( 40 ),
                                static_cast<float>( pl_skill ) - static_cast<float>( pl_skill ) / static_cast<float>
                                ( 10.0 ) );
         bionics_install_failure( installer_name, difficulty, success, adjusted_skill );
@@ -2448,7 +2448,7 @@ void Character::do_damage_for_bionic_failure( int min_damage, int max_damage )
 
     for( const bodypart_id &bp : bp_hurt ) {
         int damage = rng( min_damage, max_damage );
-        int hp = get_hp( bp );
+        int const hp = get_hp( bp );
         if( damage >= hp && ( bp == bodypart_str_id( "head" ) || bp == bodypart_str_id( "torso" ) ) ) {
             add_effect( effect_infected, 1_hours, bp->token );
             add_msg_player_or_npc( m_bad, _( "Your %s is infected." ), _( "<npcname>'s %s is infected." ),
@@ -2479,7 +2479,7 @@ void Character::bionics_install_failure( const std::string &installer,
     // this is scaled up or down by the ratio of difficulty/skill.  At high skill levels (or low
     // difficulties), only minor consequences occur.  At low skill levels, severe consequences
     // are more likely.
-    int failure_level = static_cast<int>( std::sqrt( success * 4.0 * difficulty / adjusted_skill ) );
+    int const failure_level = static_cast<int>( std::sqrt( success * 4.0 * difficulty / adjusted_skill ) );
     int fail_type = ( failure_level > 5 ? 5 : failure_level );
 
     if( installer != "NOT_MED" ) {
@@ -2513,7 +2513,7 @@ void Character::bionics_install_failure( const std::string &installer,
             // We've got all the bad bionics!
             if( valid.empty() ) {
                 if( has_max_power() ) {
-                    units::energy old_power = get_max_power_level();
+                    units::energy const old_power = get_max_power_level();
                     add_msg( m_bad, _( "%s lose power capacity!" ), disp_name() );
                     set_max_power_level( units::from_kilojoule( rng( 0,
                                          units::to_kilojoule( get_max_power_level() ) - 25 ) ) );
@@ -2659,7 +2659,7 @@ void Character::remove_bionic( const bionic_id &b )
     bionic_collection new_my_bionics;
     // any spells you should not forget due to still having a bionic installed that has it.
     std::set<spell_id> cbm_spells;
-    for( bionic &i : *my_bionics ) {
+    for( bionic  const&i : *my_bionics ) {
         if( b == i.id ) {
             continue;
         }
@@ -2861,7 +2861,7 @@ void bionic::serialize( JsonOut &json ) const
 
 void bionic::deserialize( JsonIn &jsin )
 {
-    JsonObject jo = jsin.get_object();
+    JsonObject const jo = jsin.get_object();
     id = bionic_id( jo.get_string( "id" ) );
     invlet = jo.get_int( "invlet" );
     powered = jo.get_bool( "powered" );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -479,7 +479,7 @@ std::vector<std::pair<bionic_id, item>> find_reloadable_cbms( npc &who )
     std::vector<std::pair<bionic_id, item>> cbm_list;
     // Runs down full list of CBMs that qualify as weapons.
     // Need a way to make this less costly.
-    for( bionic const bio : *who.my_bionics ) {
+    for( bionic const& bio : *who.my_bionics ) {
         if( !bio.info().has_flag( flag_BIONIC_WEAPON ) ) {
             continue;
         }

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -479,7 +479,7 @@ std::vector<std::pair<bionic_id, item>> find_reloadable_cbms( npc &who )
     std::vector<std::pair<bionic_id, item>> cbm_list;
     // Runs down full list of CBMs that qualify as weapons.
     // Need a way to make this less costly.
-    for( bionic const& bio : *who.my_bionics ) {
+    for( bionic const &bio : *who.my_bionics ) {
         if( !bio.info().has_flag( flag_BIONIC_WEAPON ) ) {
             continue;
         }
@@ -504,7 +504,7 @@ const std::map<item, bionic_id> npc::check_toggle_cbm()
     if( free_power <= 0_J ) {
         return res;
     }
-    for( bionic  const&bio : *my_bionics ) {
+    for( bionic  const &bio : *my_bionics ) {
         // I'm not checking if NPC_USABLE because if it isn't it shouldn't be in them.
         if( bio.powered || !bio.info().has_flag( flag_BIONIC_WEAPON ) ||
             free_power < bio.info().power_activate ) {
@@ -535,7 +535,7 @@ void npc::check_or_use_weapon_cbm()
     }
 
     int cbm_index = 0;
-    for( bionic  const&bio : *my_bionics ) {
+    for( bionic  const &bio : *my_bionics ) {
         // I'm not checking if NPC_USABLE because if it isn't it shouldn't be in them.
         if( free_power >= bio.info().power_activate && bio.info().has_flag( flag_BIONIC_GUN ) ) {
             avail_active_cbms.push_back( cbm_index );
@@ -551,11 +551,11 @@ void npc::check_or_use_weapon_cbm()
         bool const wield_gun = primary_weapon().is_gun();
         item best_cbm_active = null_item_reference();
         for( int const i : avail_active_cbms ) {
-            bionic  const&bio = ( *my_bionics )[ i ];
+            bionic  const &bio = ( *my_bionics )[ i ];
             const item cbm_weapon = item( bio.info().fake_item );
 
             bool const not_allowed = !rules.has_flag( ally_rule::use_guns ) ||
-                               ( rules.has_flag( ally_rule::use_silent ) && !cbm_weapon.is_silent() );
+                                     ( rules.has_flag( ally_rule::use_silent ) && !cbm_weapon.is_silent() );
             if( is_player_ally() && not_allowed ) {
                 continue;
             }
@@ -699,7 +699,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only )
         add_msg_activate();
         const w_point &weatherPoint = get_weather().get_precise();
         int const humidity = get_local_humidity( weatherPoint.humidity, get_weather().weather_id,
-                                           g->is_sheltered( g->u.pos() ) );
+                             g->is_sheltered( g->u.pos() ) );
         // thirst units = 5 mL
         int const water_available = std::lround( humidity * 3.0 / 100.0 );
         if( water_available == 0 ) {
@@ -910,7 +910,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only )
             }
 
             dealt_projectile_attack const dealt = projectile_attack(
-                                                proj, pr.second, pos(), dispersion_sources{ 0 }, this );
+                    proj, pr.second, pos(), dispersion_sources{ 0 }, this );
             here.add_item_or_charges( dealt.end_point, pr.first );
         }
 
@@ -979,7 +979,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only )
         const auto player_local_temp = weather.get_temperature( g->u.pos() );
         /* windpower defined in internal velocity units (=.01 mph) */
         double const windpower = 100.0f * get_local_windpower( weather.windspeed + vehwindspeed,
-                           cur_om_ter, pos(), weather.winddirection, g->is_sheltered( pos() ) );
+                                 cur_om_ter, pos(), weather.winddirection, g->is_sheltered( pos() ) );
         add_msg_if_player( m_info, _( "Temperature: %s." ), print_temperature( player_local_temp ) );
         add_msg_if_player( m_info, _( "Relative Humidity: %s." ),
                            print_humidity(
@@ -1400,7 +1400,7 @@ void Character::passive_power_gen( bionic &bio )
 itype_id Character::find_remote_fuel( bool look_only )
 {
     itype_id remote_fuel;
-    map  const&here = get_map();
+    map  const &here = get_map();
 
     const std::vector<item *> cables = items_with( []( const item & it ) {
         return it.active && it.has_flag( flag_CABLE_SPOOL );
@@ -1458,7 +1458,7 @@ int Character::consume_remote_fuel( int amount )
         return it.active && it.has_flag( flag_CABLE_SPOOL );
     } );
 
-    map  const&here = get_map();
+    map  const &here = get_map();
     for( const item *cable : cables ) {
         const std::optional<tripoint> target = cable->get_cable_target( this, pos() );
         if( target ) {
@@ -1643,7 +1643,7 @@ void Character::process_bionic( bionic &bio )
                        static_cast<std::string>( bio_hydraulics ) );
     } else if( bio.id == bio_nanobots ) {
         int const threshold_kcal = bio.info().kcal_trigger > 0 ? 0.85f * max_stored_kcal() +
-                             bio.info().kcal_trigger : 0;
+                                   bio.info().kcal_trigger : 0;
         const auto can_use_bionic = [this, &bio, threshold_kcal]() -> bool {
             const bool is_kcal_sufficient = get_stored_kcal() >= threshold_kcal;
             const bool is_power_sufficient = get_power_level() >= bio.info().power_trigger;
@@ -1693,7 +1693,7 @@ void Character::process_bionic( bionic &bio )
                     [this]( const bodypart_id & a, const bodypart_id & b ) {
                         return ( get_part_hp_cur( a ) - a->essential * 10 ) < ( get_part_hp_cur( b ) - b->essential * 10 );
                     } );
-                    for( bodypart_id  const&bpid : damaged_hp_parts ) {
+                    for( bodypart_id  const &bpid : damaged_hp_parts ) {
                         if( !can_use_bionic() ) {
                             return;
                         }
@@ -1743,7 +1743,7 @@ void Character::process_bionic( bionic &bio )
         if( calendar::once_every( 5_minutes ) ) {
             const w_point &weatherPoint = get_weather().get_precise();
             int const humidity = get_local_humidity( weatherPoint.humidity, get_weather().weather_id,
-                                               g->is_sheltered( g->u.pos() ) );
+                                 g->is_sheltered( g->u.pos() ) );
             // in thirst units = 5 mL water
             int const water_available = std::lround( humidity * 3.0 / 100.0 );
             // At 50% relative humidity or more, the player will draw 10 mL
@@ -1924,7 +1924,7 @@ float Character::bionics_adjusted_skill( const skill_id &most_important_skill,
         int skill_level )
 {
     int const pl_skill = bionics_pl_skill( most_important_skill, important_skill, least_important_skill,
-                                     skill_level );
+                                           skill_level );
 
     // for chance_of_success calculation, shift skill down to a float between ~0.4 - 30
     float adjusted_skill = static_cast<float>( pl_skill ) - std::min( static_cast<float>( 40 ),
@@ -1971,7 +1971,7 @@ int bionic_manip_cos( float adjusted_skill, int bionic_difficulty )
     // we will base chance_of_success on a ratio of skill and difficulty
     // when skill=difficulty, this gives us 1.  skill < difficulty gives a fraction.
     float const skill_difficulty_parameter = static_cast<float>( adjusted_skill /
-                                       ( 4.0 * bionic_difficulty ) );
+            ( 4.0 * bionic_difficulty ) );
 
     // when skill == difficulty, chance_of_success is 50%. Chance of success drops quickly below that
     // to reserve bionics for characters with the appropriate skill.  For more difficult bionics, the
@@ -2148,8 +2148,8 @@ void Character::perform_uninstall( bionic_id bid, int difficulty, int success,
         g->events().send<event_type::fails_to_remove_cbm>( getID(), bid );
         // for chance_of_success calculation, shift skill down to a float between ~0.4 - 30
         float const adjusted_skill = static_cast<float>( pl_skill ) - std::min( static_cast<float>( 40 ),
-                               static_cast<float>( pl_skill ) - static_cast<float>( pl_skill ) / static_cast<float>
-                               ( 10.0 ) );
+                                     static_cast<float>( pl_skill ) - static_cast<float>( pl_skill ) / static_cast<float>
+                                     ( 10.0 ) );
         bionics_uninstall_failure( difficulty, success, adjusted_skill );
 
     }
@@ -2167,7 +2167,8 @@ bool Character::uninstall_bionic( const bionic &target_cbm, monster &installer, 
     }
 
     const itype_id itemtype = target_cbm.info().itype();
-    int const difficulty = itemtype.is_valid() ? itemtype->bionic->difficulty : BIONIC_NOITEM_DIFFICULTY;
+    int const difficulty = itemtype.is_valid() ? itemtype->bionic->difficulty :
+                           BIONIC_NOITEM_DIFFICULTY;
     int const chance_of_success = bionic_manip_cos( adjusted_skill, difficulty + 2 );
     int const success = chance_of_success - rng( 1, 100 );
 
@@ -2310,7 +2311,7 @@ bool Character::can_install_bionics( const itype &type, player &installer, bool 
 float Character::env_surgery_bonus( int radius )
 {
     float bonus = 1.0;
-    map  const&here = get_map();
+    map  const &here = get_map();
     for( const tripoint &cell : here.points_in_radius( pos(), radius ) ) {
         if( here.furn( cell )->surgery_skill_multiplier ) {
             bonus = std::max( bonus, *here.furn( cell )->surgery_skill_multiplier );
@@ -2421,8 +2422,8 @@ void Character::perform_install( bionic_id bid, bionic_id upbid, int difficulty,
 
         // for chance_of_success calculation, shift skill down to a float between ~0.4 - 30
         float const adjusted_skill = static_cast<float>( pl_skill ) - std::min( static_cast<float>( 40 ),
-                               static_cast<float>( pl_skill ) - static_cast<float>( pl_skill ) / static_cast<float>
-                               ( 10.0 ) );
+                                     static_cast<float>( pl_skill ) - static_cast<float>( pl_skill ) / static_cast<float>
+                                     ( 10.0 ) );
         bionics_install_failure( installer_name, difficulty, success, adjusted_skill );
     }
     get_map().invalidate_map_cache( g->get_levz() );
@@ -2479,7 +2480,8 @@ void Character::bionics_install_failure( const std::string &installer,
     // this is scaled up or down by the ratio of difficulty/skill.  At high skill levels (or low
     // difficulties), only minor consequences occur.  At low skill levels, severe consequences
     // are more likely.
-    int const failure_level = static_cast<int>( std::sqrt( success * 4.0 * difficulty / adjusted_skill ) );
+    int const failure_level = static_cast<int>( std::sqrt( success * 4.0 * difficulty /
+                              adjusted_skill ) );
     int fail_type = ( failure_level > 5 ? 5 : failure_level );
 
     if( installer != "NOT_MED" ) {
@@ -2659,7 +2661,7 @@ void Character::remove_bionic( const bionic_id &b )
     bionic_collection new_my_bionics;
     // any spells you should not forget due to still having a bionic installed that has it.
     std::set<spell_id> cbm_spells;
-    for( bionic  const&i : *my_bionics ) {
+    for( bionic  const &i : *my_bionics ) {
         if( b == i.id ) {
             continue;
         }

--- a/src/bionics_ui.cpp
+++ b/src/bionics_ui.cpp
@@ -84,8 +84,8 @@ struct bionic_sort_less {
             case bionic_ui_sort_mode::INVLET:
                 return lhs->invlet < rhs->invlet;
             case bionic_ui_sort_mode::POWER: {
-                units::energy lbd_sort_power = bionic_sort_power( lbd );
-                units::energy rbd_sort_power = bionic_sort_power( rbd );
+                units::energy const lbd_sort_power = bionic_sort_power( lbd );
+                units::energy const rbd_sort_power = bionic_sort_power( rbd );
                 if( lbd_sort_power != rbd_sort_power ) {
                     return lbd_sort_power < rbd_sort_power;
                 }
@@ -187,7 +187,7 @@ char get_free_invlet( bionic_collection &bionics )
 static void draw_bionics_titlebar( const catacurses::window &window, Character *p,
                                    bionic_menu_mode mode )
 {
-    input_context ctxt( "BIONICS" );
+    input_context const ctxt( "BIONICS" );
 
     werase( window );
     std::string fuel_string;
@@ -353,8 +353,8 @@ static void draw_bionics_tabs( const catacurses::window &win, const size_t activ
     draw_tabs( win, tabs, current_mode );
 
     // Draw symbols to connect additional lines to border
-    int width = getmaxx( win );
-    int height = getmaxy( win );
+    int const width = getmaxx( win );
+    int const height = getmaxy( win );
     for( int i = 0; i < height - 1; ++i ) {
         // |
         mvwputch( win, point( 0, i ), BORDER_COLOR, LINE_XOXO );
@@ -493,7 +493,7 @@ static void draw_connectors( const catacurses::window &win, point start,
 static nc_color get_bionic_text_color( const bionic &bio, const bool isHighlightedBionic )
 {
     nc_color type = c_white;
-    bool is_power_source = bio.id->has_flag( STATIC( flag_str_id( "BIONIC_POWER_SOURCE" ) ) );
+    bool const is_power_source = bio.id->has_flag( STATIC( flag_str_id( "BIONIC_POWER_SOURCE" ) ) );
     if( bio.id->activated ) {
         if( isHighlightedBionic ) {
             if( bio.powered && !is_power_source ) {
@@ -908,7 +908,7 @@ void show_bionics_ui( Character &who )
                         if( active[i] == tmp ) {
                             tab_mode = TAB_ACTIVE;
                             cursor = static_cast<int>( i );
-                            int max_scroll_check = std::max( 0, static_cast<int>( active.size() ) - LIST_HEIGHT );
+                            int const max_scroll_check = std::max( 0, static_cast<int>( active.size() ) - LIST_HEIGHT );
                             if( static_cast<int>( i ) > max_scroll_check ) {
                                 scroll_position = max_scroll_check;
                             } else {
@@ -921,7 +921,7 @@ void show_bionics_ui( Character &who )
                         if( passive[i] == tmp ) {
                             tab_mode = TAB_PASSIVE;
                             cursor = static_cast<int>( i );
-                            int max_scroll_check = std::max( 0, static_cast<int>( passive.size() ) - LIST_HEIGHT );
+                            int const max_scroll_check = std::max( 0, static_cast<int>( passive.size() ) - LIST_HEIGHT );
                             if( static_cast<int>( i ) > max_scroll_check ) {
                                 scroll_position = max_scroll_check;
                             } else {

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -482,7 +482,7 @@ void bodypart::serialize( JsonOut &json ) const
 
 void bodypart::deserialize( JsonIn &jsin )
 {
-    JsonObject jo = jsin.get_object();
+    JsonObject const jo = jsin.get_object();
     jo.read( "id", id, true );
     jo.read( "hp_cur", hp_cur, true );
     jo.read( "hp_max", hp_max, true );

--- a/src/calendar.cpp
+++ b/src/calendar.cpp
@@ -71,7 +71,7 @@ moon_phase get_moon_phase( const time_point &p )
     const time_duration moon_phase_duration =
         calendar::season_ratio() * synodic_month;
     // Reset moon phase at start of the year
-    time_point p_year = calendar::turn_zero + time_past_new_year( p );
+    time_point const p_year = calendar::turn_zero + time_past_new_year( p );
     // Switch moon phase at noon so it stays the same all night
     const int num_middays = to_days<int>( p_year - calendar::turn_zero + 1_days / 2 );
     const time_duration nearest_midnight = num_middays * 1_days;
@@ -174,7 +174,7 @@ double current_daylight_level( const time_point &p )
                            ( calendar::season_length() );
     double modifier = 1.0;
     // For ~Boston: solstices are +/- 25% sunlight intensity from equinoxes
-    static double deviation = 0.25;
+    static double const deviation = 0.25;
 
     switch( season_of_year( p ) ) {
         case SPRING:

--- a/src/cata_libintl.cpp
+++ b/src/cata_libintl.cpp
@@ -105,31 +105,31 @@ struct PlfTStream {
                 continue;
             } else if( c >= '0' && c <= '9' ) {
                 // number
-                size_t start_pos = pos;
+                size_t const start_pos = pos;
                 while( pos < end && c >= '0' && c <= '9' ) {
                     tok.push_back( c );
                     pos++;
                     c = ( *s )[pos];
                 }
                 try {
-                    size_t ul = std::stoul( tok );
+                    size_t const ul = std::stoul( tok );
                     if( ul > std::numeric_limits<uint32_t>::max() ) {
                         throw std::out_of_range( "stoul" );
                     }
                     return PlfToken{ PlfOp::Literal, ul, start_pos, pos - start_pos };
                 } catch( const std::logic_error &err ) {
-                    std::string e = string_format( "invalid number '%s' at pos %d", tok, start_pos );
+                    std::string const e = string_format( "invalid number '%s' at pos %d", tok, start_pos );
                     throw std::runtime_error( e );
                 }
             }
-            std::string ss = s->substr( pos, end - pos );
+            std::string const ss = s->substr( pos, end - pos );
             for( const auto &t : simple_tokens ) {
                 if( string_starts_with( ss, t.first ) ) {
                     return PlfToken{ t.second, 0, pos, t.first.size() };
                 }
             }
             pos++;
-            std::string e = string_format( "unexpected character '%c' at pos %d", c, pos - 1 );
+            std::string const e = string_format( "unexpected character '%c' at pos %d", c, pos - 1 );
             throw std::runtime_error( e );
         }
         return PlfToken{ PlfOp::NumOps, 0, pos, 0 };
@@ -174,11 +174,11 @@ ParseRet plf_get_value( const PlfTStream &ts );
 
 PlfNodePtr parse_plural_rules( const std::string &s )
 {
-    PlfTStream tokstr( &s );
+    PlfTStream const tokstr( &s );
     ParseRet ret = plf_get_expr( tokstr );
     if( ret.ts.has_tokens() ) {
-        PlfToken tok = ret.ts.peek();
-        std::string e = string_format( "unexpected token at pos %d", tok.start );
+        PlfToken const tok = ret.ts.peek();
+        std::string const e = string_format( "unexpected token at pos %d", tok.start );
         throw std::runtime_error( e );
     }
     return std::move( ret.expr );
@@ -207,8 +207,8 @@ ParseRet plf_get_expr( const PlfTStream &ts )
     }
     ParseRet e2 = plf_get_expr( e1.ts.cloned().skip() );
     if( e2.ts.peek().kind != PlfOp::TerDelim ) {
-        PlfToken tok = e2.ts.peek();
-        std::string e = string_format( "expected ternary delimiter at pos %d", tok.start );
+        PlfToken const tok = e2.ts.peek();
+        std::string const e = string_format( "expected ternary delimiter at pos %d", tok.start );
         throw std::runtime_error( e );
     }
     ParseRet e3 = plf_get_expr( e2.ts.cloned().skip() );
@@ -267,13 +267,13 @@ ParseRet plf_get_mod( const PlfTStream &ts )
 
 ParseRet plf_get_value( const PlfTStream &ts )
 {
-    PlfToken next = ts.peek();
+    PlfToken const next = ts.peek();
     if( next.kind == PlfOp::BrOpen ) {
         // '(' expr ')'
         ParseRet e = plf_get_expr( ts.cloned().skip() );
         if( e.ts.peek().kind != PlfOp::BrClose ) {
-            PlfToken tok = e.ts.peek();
-            std::string e = string_format( "expected closing bracket at pos %d", tok.start );
+            PlfToken const tok = e.ts.peek();
+            std::string const e = string_format( "expected closing bracket at pos %d", tok.start );
             throw std::runtime_error( e );
         }
         return ParseRet( std::move( e.expr ), e.ts.cloned().skip() );
@@ -288,7 +288,7 @@ ParseRet plf_get_value( const PlfTStream &ts )
             0, nullptr, nullptr, nullptr, PlfOp::Variable,
         } ), ts.cloned().skip() );
     } else {
-        std::string e = string_format( "expected expression at pos %d", next.start );
+        std::string const e = string_format( "expected expression at pos %d", next.start );
         throw std::runtime_error( e );
     }
 }
@@ -297,9 +297,9 @@ size_t PlfNode::eval( size_t n ) const
 {
     switch( op ) {
         case PlfOp::Mod: {
-            size_t right = b->eval( n );
+            size_t const right = b->eval( n );
             if( right == 0 ) {
-                std::string e = string_format( "DBZ in PlfNode::eval( %d ), node='%s'", n, debug_dump() );
+                std::string const e = string_format( "DBZ in PlfNode::eval( %d ), node='%s'", n, debug_dump() );
                 throw std::runtime_error( e );
             }
             return a->eval( n ) % right;
@@ -384,7 +384,7 @@ trans_catalogue trans_catalogue::load_from_memory( std::string mo_file )
 u8 trans_catalogue::get_u8( u32 offs ) const
 {
     if( offs + 1 > buf_size() ) {
-        std::string e = string_format( "tried get_u8() at offs %#x with file size %#x", offs, buf_size() );
+        std::string const e = string_format( "tried get_u8() at offs %#x with file size %#x", offs, buf_size() );
         throw std::runtime_error( e );
     }
     return get_u8_unsafe( offs );
@@ -393,7 +393,7 @@ u8 trans_catalogue::get_u8( u32 offs ) const
 u32 trans_catalogue::get_u32( u32 offs ) const
 {
     if( offs + 4 > buf_size() ) {
-        std::string e = string_format( "tried get_u32() at offs %#x with file size %#x", offs, buf_size() );
+        std::string const e = string_format( "tried get_u32() at offs %#x with file size %#x", offs, buf_size() );
         throw std::runtime_error( e );
     }
     return get_u32_unsafe( offs );
@@ -421,17 +421,17 @@ std::string trans_catalogue::get_metadata() const
     // Since the strings are sorted in lexicographical order, this will be the first string.
     constexpr u32 METADATA_STRING_LEN = 0;
 
-    string_descr k = get_string_descr_unsafe( offs_orig_table );
+    string_descr const k = get_string_descr_unsafe( offs_orig_table );
 
     if( k.length != METADATA_STRING_LEN ) {
-        std::string e = string_format(
+        std::string const e = string_format(
                             "invalid metadata entry (expected length %#x, got %#x)",
                             METADATA_STRING_LEN, k.length
                         );
         throw std::runtime_error( e );
     }
 
-    string_descr v = get_string_descr_unsafe( offs_trans_table );
+    string_descr const v = get_string_descr_unsafe( offs_trans_table );
     return std::string( offs_to_cstr( v.offset ) );
 }
 
@@ -447,13 +447,13 @@ void trans_catalogue::process_file_header()
     constexpr u32 OFFS_ORIG_TABLE_BEGIN = 12;
     constexpr u32 OFFS_TRANS_TABLE_BEGIN = 16;
 
-    u32 magic = this->buffer.size() > 4 ? get_u32( OFFS_MAGIC_NUMBER ) : 0;
+    u32 const magic = this->buffer.size() > 4 ? get_u32( OFFS_MAGIC_NUMBER ) : 0;
     if( magic != MO_MAGIC_NUMBER_LE && magic != MO_MAGIC_NUMBER_BE ) {
         throw std::runtime_error( "not a MO file" );
     }
     this->is_little_endian = magic == MO_MAGIC_NUMBER_LE;
     if( get_u32( OFFS_REVISION ) != MO_SUPPORTED_REVISION ) {
-        std::string e = string_format(
+        std::string const e = string_format(
                             "expected revision %d, got %d",
                             MO_SUPPORTED_REVISION,
                             get_u32( OFFS_REVISION )
@@ -471,18 +471,18 @@ void trans_catalogue::check_string_terminators()
     const auto check_string = [this]( u32 offs ) {
         // Check that string with its null terminator (not included in string length)
         // does not extend beyond file boundaries.
-        string_descr s = get_string_descr( offs );
+        string_descr const s = get_string_descr( offs );
         if( s.offset + s.length + 1 > buf_size() ) {
-            std::string e = string_format(
+            std::string const e = string_format(
                                 "string_descr at offs %#x: extends beyond EOF (len:%#x offs:%#x fsize:%#x)",
                                 offs, s.length, s.offset, buf_size()
                             );
             throw std::runtime_error( e );
         }
         // Also check for existence of the null byte.
-        u8 terminator = get_u8( s.offset + s.length );
+        u8 const terminator = get_u8( s.offset + s.length );
         if( terminator != 0 ) {
-            std::string e = string_format(
+            std::string const e = string_format(
                                 "string_descr at offs %#x: missing null terminator",
                                 offs
                             );
@@ -499,7 +499,7 @@ void trans_catalogue::check_string_plurals()
 {
     // Skip metadata (the 0th entry)
     for( u32 i = 1; i < number_of_strings; i++ ) {
-        string_descr info = get_string_descr_unsafe( offs_orig_table + i * MO_STRING_DESCR_SIZE );
+        string_descr const info = get_string_descr_unsafe( offs_orig_table + i * MO_STRING_DESCR_SIZE );
 
         // Check for null byte - msgid/msgid_plural separator
         bool has_plurals = false;
@@ -515,8 +515,8 @@ void trans_catalogue::check_string_plurals()
         }
 
         // Count null bytes - each plural form is a null-terminated string (including last one)
-        u32 offs_tr = offs_trans_table + i * MO_STRING_DESCR_SIZE;
-        string_descr info_tr = get_string_descr_unsafe( offs_tr );
+        u32 const offs_tr = offs_trans_table + i * MO_STRING_DESCR_SIZE;
+        string_descr const info_tr = get_string_descr_unsafe( offs_tr );
         size_t plural_forms = 0;
         for( u32 j = info_tr.offset; j <= info_tr.offset + info_tr.length; j++ ) {
             if( get_u8_unsafe( j ) == PLF_SEPARATOR ) {
@@ -526,7 +526,7 @@ void trans_catalogue::check_string_plurals()
 
         // Number of plural forms should match the number specified in metadata
         if( plural_forms != this->plurals.num ) {
-            std::string e = string_format(
+            std::string const e = string_format(
                                 "string_descr at offs %#x: expected %d plural forms, got %d",
                                 offs_tr, this->plurals.num, plural_forms
                             );
@@ -552,7 +552,7 @@ void trans_catalogue::check_encoding( const meta_headers &headers )
             found = true;
             static const std::string expected = "Content-Type: text/plain; charset=UTF-8";
             if( entry != expected ) {
-                std::string e =
+                std::string const e =
                     string_format( "unrecognized value in Content-Type header (wrong charset?). Expected \"%s\"",
                                    expected );
                 throw std::runtime_error( e );
@@ -572,7 +572,7 @@ void trans_catalogue::check_encoding( const meta_headers &headers )
             found = true;
             static const std::string expected = "Content-Transfer-Encoding: 8bit";
             if( entry != expected ) {
-                std::string e =
+                std::string const e =
                     string_format( "unrecognized value in Content-Transfer-Encoding header.  Expected \"%s\"",
                                    expected );
                 throw std::runtime_error( e );
@@ -631,12 +631,12 @@ trans_catalogue::catalogue_plurals_info trans_catalogue::parse_plf_header(
         try {
             ret.num = std::stoul( plf_n_raw );
         } catch( const std::runtime_error &err ) {
-            std::string e = string_format( "failed to parse Plural-Forms nplurals number '%s': %s", plf_n_raw,
+            std::string const e = string_format( "failed to parse Plural-Forms nplurals number '%s': %s", plf_n_raw,
                                            err.what() );
             throw std::runtime_error( e );
         }
         if( ret.num == 0 || ret.num > MAX_PLURAL_FORMS ) {
-            std::string e = string_format( "expected at most 1-%d plural forms, got %d", MAX_PLURAL_FORMS,
+            std::string const e = string_format( "expected at most 1-%d plural forms, got %d", MAX_PLURAL_FORMS,
                                            ret.num );
             throw std::runtime_error( e );
         }
@@ -652,7 +652,7 @@ trans_catalogue::catalogue_plurals_info trans_catalogue::parse_plf_header(
         try {
             ret.expr = parse_plural_rules( plf_rules_raw );
         } catch( const std::runtime_error &err ) {
-            std::string e = string_format( "failed to parse plural forms formula: %s", err.what() );
+            std::string const e = string_format( "failed to parse plural forms formula: %s", err.what() );
             throw std::runtime_error( e );
         }
     }
@@ -666,7 +666,7 @@ trans_catalogue::trans_catalogue( std::string buffer )
     process_file_header();
     check_string_terminators();
 
-    meta_headers headers = string_split( get_metadata(), '\n' );
+    meta_headers const headers = string_split( get_metadata(), '\n' );
 
     check_encoding( headers );
     this->plurals = parse_plf_header( headers );
@@ -676,8 +676,8 @@ trans_catalogue::trans_catalogue( std::string buffer )
 
 bool trans_catalogue::check_nth_translation_has_plf( u32 n ) const
 {
-    u32 descr_offs = offs_trans_table + n * MO_STRING_DESCR_SIZE;
-    string_descr r = get_string_descr_unsafe( descr_offs );
+    u32 const descr_offs = offs_trans_table + n * MO_STRING_DESCR_SIZE;
+    string_descr const r = get_string_descr_unsafe( descr_offs );
 
     for( u32 offs = r.offset; offs < r.offset + r.length; offs++ ) {
         if( get_u8_unsafe( offs ) == PLF_SEPARATOR ) {
@@ -690,26 +690,26 @@ bool trans_catalogue::check_nth_translation_has_plf( u32 n ) const
 
 const char *trans_catalogue::get_nth_orig_string( u32 n ) const
 {
-    u32 descr_offs = offs_orig_table + n * MO_STRING_DESCR_SIZE;
-    string_descr r = get_string_descr_unsafe( descr_offs );
+    u32 const descr_offs = offs_orig_table + n * MO_STRING_DESCR_SIZE;
+    string_descr const r = get_string_descr_unsafe( descr_offs );
 
     return offs_to_cstr( r.offset );
 }
 
 const char *trans_catalogue::get_nth_translation( u32 n ) const
 {
-    u32 descr_offs = offs_trans_table + n * MO_STRING_DESCR_SIZE;
-    string_descr r = get_string_descr_unsafe( descr_offs );
+    u32 const descr_offs = offs_trans_table + n * MO_STRING_DESCR_SIZE;
+    string_descr const r = get_string_descr_unsafe( descr_offs );
 
     return offs_to_cstr( r.offset );
 }
 
 const char *trans_catalogue::get_nth_pl_translation( u32 n, size_t num ) const
 {
-    u32 descr_offs = offs_trans_table + n * MO_STRING_DESCR_SIZE;
-    string_descr r = get_string_descr_unsafe( descr_offs );
+    u32 const descr_offs = offs_trans_table + n * MO_STRING_DESCR_SIZE;
+    string_descr const r = get_string_descr_unsafe( descr_offs );
 
-    size_t plf = plurals.expr->eval( num );
+    size_t const plf = plurals.expr->eval( num );
 
     if( plf == 0 || plf >= plurals.num ) {
         return offs_to_cstr( r.offset );
@@ -755,7 +755,7 @@ void trans_library::build_string_table()
 
     for( size_t i_cat = 0; i_cat < catalogues.size(); i_cat++ ) {
         const trans_catalogue &cat = catalogues[i_cat];
-        u32 num = cat.get_num_strings();
+        u32 const num = cat.get_num_strings();
         // 0th entry is the metadata, we skip it
         strings.reserve( num - 1 );
         for( u32 i = 1; i < num; i++ ) {
@@ -767,7 +767,7 @@ void trans_library::build_string_table()
                 return strcmp( a, b ) < 0;
             } );
 
-            library_string_descr desc = { static_cast<u32>( i_cat ), i };
+            library_string_descr const desc = { static_cast<u32>( i_cat ), i };
             if( it == strings.end() ) {
                 // Not found, or all elements are greater
                 strings.push_back( desc );

--- a/src/cata_libintl.cpp
+++ b/src/cata_libintl.cpp
@@ -384,7 +384,8 @@ trans_catalogue trans_catalogue::load_from_memory( std::string mo_file )
 u8 trans_catalogue::get_u8( u32 offs ) const
 {
     if( offs + 1 > buf_size() ) {
-        std::string const e = string_format( "tried get_u8() at offs %#x with file size %#x", offs, buf_size() );
+        std::string const e = string_format( "tried get_u8() at offs %#x with file size %#x", offs,
+                                             buf_size() );
         throw std::runtime_error( e );
     }
     return get_u8_unsafe( offs );
@@ -393,7 +394,8 @@ u8 trans_catalogue::get_u8( u32 offs ) const
 u32 trans_catalogue::get_u32( u32 offs ) const
 {
     if( offs + 4 > buf_size() ) {
-        std::string const e = string_format( "tried get_u32() at offs %#x with file size %#x", offs, buf_size() );
+        std::string const e = string_format( "tried get_u32() at offs %#x with file size %#x", offs,
+                                             buf_size() );
         throw std::runtime_error( e );
     }
     return get_u32_unsafe( offs );
@@ -425,9 +427,9 @@ std::string trans_catalogue::get_metadata() const
 
     if( k.length != METADATA_STRING_LEN ) {
         std::string const e = string_format(
-                            "invalid metadata entry (expected length %#x, got %#x)",
-                            METADATA_STRING_LEN, k.length
-                        );
+                                  "invalid metadata entry (expected length %#x, got %#x)",
+                                  METADATA_STRING_LEN, k.length
+                              );
         throw std::runtime_error( e );
     }
 
@@ -454,10 +456,10 @@ void trans_catalogue::process_file_header()
     this->is_little_endian = magic == MO_MAGIC_NUMBER_LE;
     if( get_u32( OFFS_REVISION ) != MO_SUPPORTED_REVISION ) {
         std::string const e = string_format(
-                            "expected revision %d, got %d",
-                            MO_SUPPORTED_REVISION,
-                            get_u32( OFFS_REVISION )
-                        );
+                                  "expected revision %d, got %d",
+                                  MO_SUPPORTED_REVISION,
+                                  get_u32( OFFS_REVISION )
+                              );
         throw std::runtime_error( e );
     }
 
@@ -474,18 +476,18 @@ void trans_catalogue::check_string_terminators()
         string_descr const s = get_string_descr( offs );
         if( s.offset + s.length + 1 > buf_size() ) {
             std::string const e = string_format(
-                                "string_descr at offs %#x: extends beyond EOF (len:%#x offs:%#x fsize:%#x)",
-                                offs, s.length, s.offset, buf_size()
-                            );
+                                      "string_descr at offs %#x: extends beyond EOF (len:%#x offs:%#x fsize:%#x)",
+                                      offs, s.length, s.offset, buf_size()
+                                  );
             throw std::runtime_error( e );
         }
         // Also check for existence of the null byte.
         u8 const terminator = get_u8( s.offset + s.length );
         if( terminator != 0 ) {
             std::string const e = string_format(
-                                "string_descr at offs %#x: missing null terminator",
-                                offs
-                            );
+                                      "string_descr at offs %#x: missing null terminator",
+                                      offs
+                                  );
             throw std::runtime_error( e );
         }
     };
@@ -527,9 +529,9 @@ void trans_catalogue::check_string_plurals()
         // Number of plural forms should match the number specified in metadata
         if( plural_forms != this->plurals.num ) {
             std::string const e = string_format(
-                                "string_descr at offs %#x: expected %d plural forms, got %d",
-                                offs_tr, this->plurals.num, plural_forms
-                            );
+                                      "string_descr at offs %#x: expected %d plural forms, got %d",
+                                      offs_tr, this->plurals.num, plural_forms
+                                  );
             throw std::runtime_error( e );
         }
     }
@@ -631,13 +633,14 @@ trans_catalogue::catalogue_plurals_info trans_catalogue::parse_plf_header(
         try {
             ret.num = std::stoul( plf_n_raw );
         } catch( const std::runtime_error &err ) {
-            std::string const e = string_format( "failed to parse Plural-Forms nplurals number '%s': %s", plf_n_raw,
-                                           err.what() );
+            std::string const e = string_format( "failed to parse Plural-Forms nplurals number '%s': %s",
+                                                 plf_n_raw,
+                                                 err.what() );
             throw std::runtime_error( e );
         }
         if( ret.num == 0 || ret.num > MAX_PLURAL_FORMS ) {
             std::string const e = string_format( "expected at most 1-%d plural forms, got %d", MAX_PLURAL_FORMS,
-                                           ret.num );
+                                                 ret.num );
             throw std::runtime_error( e );
         }
     }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -662,7 +662,7 @@ void tileset_loader::load( const std::string &tileset_id, const bool precheck,
     }
 
     std::string json_path = tileset_root + '/' + json_conf;
-    std::string img_path = tileset_root + '/' + tileset_path;
+    std::string const img_path = tileset_root + '/' + tileset_path;
 
     dbg( DL::Info ) << "Attempting to Load JSON file " << json_path;
     std::ifstream config_file( json_path.c_str(), std::ifstream::in | std::ifstream::binary );
@@ -672,7 +672,7 @@ void tileset_loader::load( const std::string &tileset_id, const bool precheck,
     }
 
     JsonIn config_json( config_file );
-    JsonObject config = config_json.get_object();
+    JsonObject const config = config_json.get_object();
 
     // "tile_info" section must exist.
     if( !config.has_member( "tile_info" ) ) {
@@ -734,7 +734,7 @@ void tileset_loader::load( const std::string &tileset_id, const bool precheck,
                 mod_config.allow_omitted_members();
             }
         } else {
-            JsonObject mod_config = mod_config_json.get_object();
+            JsonObject const mod_config = mod_config_json.get_object();
             mark_visited( mod_config );
             load_internal( mod_config, tileset_root, img_path, pump_events );
         }
@@ -776,7 +776,7 @@ void tileset_loader::load_internal( const JsonObject &config, const std::string 
             G = -1;
             B = -1;
             if( tile_part_def.has_object( "transparency" ) ) {
-                JsonObject tra = tile_part_def.get_object( "transparency" );
+                JsonObject const tra = tile_part_def.get_object( "transparency" );
                 R = tra.get_int( "R" );
                 G = tra.get_int( "G" );
                 B = tra.get_int( "B" );
@@ -1001,9 +1001,9 @@ void tileset_loader::load_tilejson_from_file( const JsonObject &config )
         for( const std::string &t_id : ids ) {
             tile_type &curr_tile = load_tile( entry, t_id );
             curr_tile.offset = sprite_offset;
-            bool t_multi = entry.get_bool( "multitile", false );
-            bool t_rota = entry.get_bool( "rotates", t_multi );
-            int t_h3d = entry.get_int( "height_3d", 0 );
+            bool const t_multi = entry.get_bool( "multitile", false );
+            bool const t_rota = entry.get_bool( "rotates", t_multi );
+            int const t_h3d = entry.get_int( "height_3d", 0 );
             if( t_multi ) {
                 // fetch additional tiles
                 for( const JsonObject &subentry : entry.get_array( "additional_tiles" ) ) {
@@ -1056,7 +1056,7 @@ void tileset_loader::load_tile_spritelists( const JsonObject &entry,
 {
     // json array indicates rotations or variations
     if( entry.has_array( objname ) ) {
-        JsonArray g_array = entry.get_array( objname );
+        JsonArray const g_array = entry.get_array( objname );
         // int elements of array indicates rotations
         // create one variation, populate sprite_ids with list of ints
         if( g_array.test_int() ) {
@@ -1074,7 +1074,7 @@ void tileset_loader::load_tile_spritelists( const JsonObject &entry,
         else if( g_array.test_object() ) {
             for( const JsonObject &vo : g_array ) {
                 std::vector<int> v;
-                int weight = vo.get_int( "weight" );
+                int const weight = vo.get_int( "weight" );
                 // negative weight is invalid
                 if( weight < 0 ) {
                     vo.throw_error( "Invalid weight for sprite variation (<0)", objname );
@@ -1140,7 +1140,7 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
 
     {
         //set clipping to prevent drawing over stuff we shouldn't
-        SDL_Rect clipRect = {dest.x, dest.y, width, height};
+        SDL_Rect const clipRect = {dest.x, dest.y, width, height};
         printErrorIf( SDL_RenderSetClipRect( renderer.get(), &clipRect ) != 0,
                       "SDL_RenderSetClipRect failed" );
 
@@ -1253,7 +1253,7 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
                 temp_y = row + o.y;
             }
 
-            bool invis = ( temp_y < min_visible_y || temp_y > max_visible_y || temp_x < min_visible_x ||
+            bool const invis = ( temp_y < min_visible_y || temp_y > max_visible_y || temp_x < min_visible_x ||
                            temp_x > max_visible_x ) &&
                          ( has_memory_at( {temp_x, temp_y, center.z} ) || has_draw_override( {temp_x, temp_y, center.z} ) );
 
@@ -1298,7 +1298,7 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
             // Add temperature value to the overlay_strings list for every visible tile when displaying temperature
             if( g->display_overlay_state( ACTION_DISPLAY_TEMPERATURE ) && !invis ) {
                 int temp_value = get_weather().get_temperature( {temp_x, temp_y, center.z} );
-                int ctemp = units::fahrenheit_to_celsius( temp_value );
+                int const ctemp = units::fahrenheit_to_celsius( temp_value );
                 short color;
                 const short bold = 8;
                 if( ctemp > 40 ) {
@@ -1336,7 +1336,7 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
                 color_blocks.second.emplace( player_to_screen( point( temp_x, temp_y ) ), block_color );
 
                 // overlay string
-                std::string visibility_str = visibility ? "+" : "-";
+                std::string const visibility_str = visibility ? "+" : "-";
                 overlay_strings.emplace(
                     player_to_screen( point( temp_x, temp_y ) ) + point( tile_width / 4, tile_height / 4 ),
                     formatted_text( visibility_str, catacurses::black, direction::NORTH ) );
@@ -1346,11 +1346,11 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
             // color hue in the range of [0..10], 0 being white,  10 being blue
             auto draw_debug_tile = [&]( const int color_hue, const std::string & text ) {
                 if( lighting_colors.empty() ) {
-                    SDL_Color white = { 255, 255, 255, 255 };
-                    SDL_Color blue = { 0, 0, 255, 255 };
+                    SDL_Color const white = { 255, 255, 255, 255 };
+                    SDL_Color const blue = { 0, 0, 255, 255 };
                     lighting_colors = color_linear_interpolate( white, blue, 9 );
                 }
-                point tile_pos = player_to_screen( point( temp_x, temp_y ) );
+                point const tile_pos = player_to_screen( point( temp_x, temp_y ) );
 
                 // color overlay
                 SDL_Color color = lighting_colors[std::min( std::max( 0, color_hue ), 10 )];
@@ -1367,14 +1367,14 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
                 if( g->displaying_lighting_condition == 0 ) {
                     const float light = here.ambient_light_at( {temp_x, temp_y, center.z} );
                     // note: lighting will be constrained in the [1.0, 11.0] range.
-                    int intensity = static_cast<int>( std::max( 1.0, LIGHT_AMBIENT_LIT - light + 1.0 ) ) - 1;
+                    int const intensity = static_cast<int>( std::max( 1.0, LIGHT_AMBIENT_LIT - light + 1.0 ) ) - 1;
                     draw_debug_tile( intensity, string_format( "%.1f", light ) );
                 }
             }
 
             if( g->display_overlay_state( ACTION_DISPLAY_TRANSPARENCY ) ) {
                 const float tr = here.light_transparency( {temp_x, temp_y, center.z} );
-                int intensity =  tr <= LIGHT_TRANSPARENCY_SOLID ? 10 :  static_cast<int>
+                int const intensity =  tr <= LIGHT_TRANSPARENCY_SOLID ? 10 :  static_cast<int>
                                  ( ( tr - LIGHT_TRANSPARENCY_OPEN_AIR ) * 8 );
                 draw_debug_tile( intensity, string_format( "%.2f", tr ) );
             }
@@ -1388,10 +1388,10 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
                 const int &x = pos.x;
                 const int &y = pos.y;
 
-                bool in_vis_bounds = ( y >= min_visible_y && y <= max_visible_y && x >= min_visible_x &&
+                bool const in_vis_bounds = ( y >= min_visible_y && y <= max_visible_y && x >= min_visible_x &&
                                        x <= max_visible_x );
 
-                bool in_map_bounds = here.inbounds( pos );
+                bool const in_map_bounds = here.inbounds( pos );
 
                 if( ( fov_3d || z == center.z ) && in_map_bounds ) {
                     ll = ch.visibility_cache[x][y];
@@ -1422,7 +1422,7 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
                         }
                     }
 
-                    int height_3d = 0;
+                    int const height_3d = 0;
 
                     for( int i = 0; i < 4; i++ ) {
                         const tripoint np = pos + neighborhood[i];
@@ -1492,7 +1492,7 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
                     break;
                 }
                 if( p.pos.z == z ) {
-                    for( decltype( &cata_tiles::draw_furniture ) f : base_drawing_layers ) {
+                    for( decltype( &cata_tiles::draw_furniture ) const f : base_drawing_layers ) {
                         ( this->*f )( p.pos, p.ll, p.height_3d, p.invisible, center.z - p.pos.z );
                     }
                 }
@@ -1512,7 +1512,7 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
         }
 
         for( tile_render_info &p : draw_points ) {
-            for( decltype( &cata_tiles::draw_furniture ) f : final_drawing_layers ) {
+            for( decltype( &cata_tiles::draw_furniture ) const f : final_drawing_layers ) {
                 ( this->*f )( p.pos, p.ll, p.height_3d, p.invisible, 0 );
             }
         }
@@ -1549,7 +1549,7 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
     //Memorize everything the character just saw even if it wasn't displayed.
     for( int mem_y = min_visible_y; mem_y <= max_visible_y; mem_y++ ) {
         for( int mem_x = min_visible_x; mem_x <= max_visible_x; mem_x++ ) {
-            half_open_rectangle<point> already_drawn(
+            half_open_rectangle<point> const already_drawn(
                 point( min_col, min_row ), point( max_col, max_row ) );
             if( iso_mode ) {
                 // calculate the screen position according to the drawing code above (division rounded down):
@@ -1684,13 +1684,13 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
     }
 
     if( g->debug_submap_grid_overlay && !iso_mode ) {
-        point sm_start = ms_to_sm_copy( here.getabs( point( min_col, min_row ) + o ) );
-        point sm_end = ms_to_sm_copy( here.getabs( point( max_col, max_row ) + o ) );
+        point const sm_start = ms_to_sm_copy( here.getabs( point( min_col, min_row ) + o ) );
+        point const sm_end = ms_to_sm_copy( here.getabs( point( max_col, max_row ) + o ) );
 
-        bool zlevs = here.has_zlevels();
-        int mapsize = here.getmapsize();
-        tripoint mappos = here.get_abs_sub();
-        half_open_rectangle<point> maprect( mappos.xy(), mappos.xy() + point( mapsize, mapsize ) );
+        bool const zlevs = here.has_zlevels();
+        int const mapsize = here.getmapsize();
+        tripoint const mappos = here.get_abs_sub();
+        half_open_rectangle<point> const maprect( mappos.xy(), mappos.xy() + point( mapsize, mapsize ) );
 
         const auto is_map = [mappos, zlevs, maprect]( const tripoint & p ) {
             if( !maprect.contains( p.xy() ) ) {
@@ -1710,14 +1710,14 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
         constexpr int THICC = 1; // line thickness
         for( int sm_x = sm_start.x; sm_x <= sm_end.x; sm_x++ ) {
             for( int sm_y = sm_start.y; sm_y <= sm_end.y; sm_y++ ) {
-                point sm_p = point( sm_x, sm_y );
-                tripoint sm_tp = tripoint( sm_x, sm_y, center.z );
+                point const sm_p = point( sm_x, sm_y );
+                tripoint const sm_tp = tripoint( sm_x, sm_y, center.z );
                 point p1 = player_to_screen( here.getlocal( sm_to_ms_copy( sm_p ) ) );
                 point p3 = player_to_screen( here.getlocal( sm_to_ms_copy( sm_p + point_south_east ) ) );
                 p3 -= point( THICC, THICC ); // Don't draw over other lines
 
                 // Leave a small gap to indicate omt boundaries
-                point tmp = omt_to_sm_copy( sm_to_omt_copy( sm_tp ) ).xy();
+                point const tmp = omt_to_sm_copy( sm_to_omt_copy( sm_tp ) ).xy();
                 if( tmp.x == sm_tp.x ) {
                     p1.x += 2;
                 }
@@ -1880,7 +1880,7 @@ cata_tiles::find_tile_looks_like( const std::string &id, TILE_CATEGORY category,
                                          looks_like_jumps_limit - 1 );
         }
         case C_ITEM: {
-            itype_id iid = itype_id( id );
+            itype_id const iid = itype_id( id );
             if( !iid.is_valid() ) {
                 if( string_starts_with( id, "corpse_" ) ) {
                     return find_tile_looks_like(
@@ -1930,7 +1930,7 @@ bool cata_tiles::find_overlay_looks_like( const bool male, const std::string &ov
             looks_like = "mutation_" + looks_like.substr( 16 );
             continue;
         }
-        itype_id iid = itype_id( looks_like );
+        itype_id const iid = itype_id( looks_like );
         if( !iid.is_valid() ) {
             break;
         }
@@ -1951,7 +1951,7 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
     // check to make sure that we are drawing within a valid area
     // [0->width|height / tile_width|height]
 
-    half_open_rectangle<point> screen_bounds( o, o + point( screentile_width, screentile_height ) );
+    half_open_rectangle<point> const screen_bounds( o, o + point( screentile_width, screentile_height ) );
     if( !tile_iso &&
         !screen_bounds.contains( pos.xy() ) ) {
         return false;
@@ -2002,7 +2002,7 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
                 }
                 subtile = -1;
 
-                tileray face = tileray( units::from_degrees( rota ) );
+                tileray const face = tileray( units::from_degrees( rota ) );
                 sym = special_symbol( face.dir_symbol( sym ) );
                 rota = 0;
 
@@ -2162,16 +2162,16 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
         return p.x + p.y * 65536;
     };
 
-    bool has_variations = display_tile.fg.size() > 1 || display_tile.bg.size() > 1;
-    bool variations_enabled = !display_tile.animated || idle_animations.enabled();
+    bool const has_variations = display_tile.fg.size() > 1 || display_tile.bg.size() > 1;
+    bool const variations_enabled = !display_tile.animated || idle_animations.enabled();
     // with animated tiles, seed is used for stagger
-    bool seed_for_animation = has_variations && variations_enabled && display_tile.animated;
+    bool const seed_for_animation = has_variations && variations_enabled && display_tile.animated;
     bool seed_from_map_coords = false;
 
     // seed the PRNG to get a reproducible random int
     // TODO: faster solution here
     unsigned int seed = 0;
-    map &here = get_map();
+    map  const&here = get_map();
     // TODO: determine ways other than category to differentiate more types of sprites
     switch( category ) {
         case C_TERRAIN:
@@ -2190,7 +2190,7 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
             if( vp_overridden ) {
                 const vpart_id &vp_id = std::get<0>( vp_override->second );
                 if( vp_id ) {
-                    point mount = std::get<4>( vp_override->second );
+                    point const mount = std::get<4>( vp_override->second );
                     seed = simple_point_hash( mount );
                 }
             } else {
@@ -2202,7 +2202,7 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
 
             // convert vehicle 360-degree direction (0=E,45=SE, etc) to 4-way tile
             // rotation (0=N,1=W,etc)
-            tileray face = tileray( units::from_degrees( rota ) );
+            tileray const face = tileray( units::from_degrees( rota ) );
             rota = 3 - face.dir4();
 
         }
@@ -2297,7 +2297,7 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
         if( display_tile.animated ) {
             idle_animations.mark_present();
             // offset by loc_rand so that everything does not blink at the same time:
-            int frame = idle_animations.current_frame() + loc_rand;
+            int const frame = idle_animations.current_frame() + loc_rand;
             int frames_in_loop = display_tile.fg.get_weight();
             if( frames_in_loop == 1 ) {
                 frames_in_loop = display_tile.bg.get_weight();
@@ -2401,7 +2401,7 @@ bool cata_tiles::draw_sprite_at(
     destination.h = height * tile_height / tileset_ptr->get_tile_height();
 
     auto render = [&]( const int rotation, const SDL_RendererFlip flip ) {
-        int ret = sprite_tex->render_copy_ex( renderer, &destination, rotation, nullptr, flip );
+        int const ret = sprite_tex->render_copy_ex( renderer, &destination, rotation, nullptr, flip );
         if( !static_z_effect && overlay && overlay_count > 0 ) {
             overlay->set_alpha_mod( std::min( 192, ( 1 + overlay_count ) * 24 ) );
             overlay->render_copy_ex( renderer, &destination, rotation, nullptr, flip );
@@ -2557,7 +2557,7 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
     const bool overridden = override != terrain_override.end();
     bool neighborhood_overridden = overridden;
     if( !neighborhood_overridden ) {
-        for( point dir : neighborhood ) {
+        for( point const dir : neighborhood ) {
             if( terrain_override.find( p + dir ) != terrain_override.end() ) {
                 neighborhood_overridden = true;
                 break;
@@ -2729,7 +2729,7 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
     const bool overridden = override != furniture_override.end();
     bool neighborhood_overridden = overridden;
     if( !neighborhood_overridden ) {
-        for( point dir : neighborhood ) {
+        for( point const dir : neighborhood ) {
             if( furniture_override.find( p + dir ) != furniture_override.end() ) {
                 neighborhood_overridden = true;
                 break;
@@ -2803,7 +2803,7 @@ bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3
     const bool overridden = override != trap_override.end();
     bool neighborhood_overridden = overridden;
     if( !neighborhood_overridden ) {
-        for( point dir : neighborhood ) {
+        for( point const dir : neighborhood ) {
             if( trap_override.find( p + dir ) != trap_override.end() ) {
                 neighborhood_overridden = true;
                 break;
@@ -2967,12 +2967,12 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
 {
     const auto override = vpart_override.find( p );
     const bool overridden = override != vpart_override.end();
-    map &here = get_map();
+    map  const&here = get_map();
     // first memorize the actual vpart
     const optional_vpart_position vp = here.veh_at( p );
     if( vp && !invisible[0] ) {
         const vehicle &veh = vp->vehicle();
-        int veh_part = vp->part_index();
+        int const veh_part = vp->part_index();
 
         // Gets the visible part, should work fine once tileset vp_ids are updated to work with the vehicle part json ids
         // get the vpart_id
@@ -3198,7 +3198,7 @@ void cata_tiles::draw_entity_with_overlays( const Character &ch, const tripoint 
     }
     // first draw the character itself(i guess this means a tileset that
     // takes this seriously needs a naked sprite)
-    int prev_height_3d = height_3d;
+    int const prev_height_3d = height_3d;
 
     // depending on the toggle flip sprite left or right
     if( ch.facing == FD_RIGHT ) {
@@ -3208,7 +3208,7 @@ void cata_tiles::draw_entity_with_overlays( const Character &ch, const tripoint 
     }
 
     // next up, draw all the overlays
-    std::vector<std::string> overlays = ch.get_overlay_ids();
+    std::vector<std::string> const overlays = ch.get_overlay_ids();
     for( const std::string &overlay : overlays ) {
         std::string draw_id = overlay;
         if( find_overlay_looks_like( ch.male, overlay, draw_id ) ) {
@@ -3237,7 +3237,7 @@ void tileset_loader::ensure_default_item_highlight()
     }
     const Uint8 highlight_alpha = 127;
 
-    int index = ts.tile_values.size();
+    int const index = ts.tile_values.size();
 
     const SDL_Surface_Ptr surface = create_surface_32( ts.tile_width, ts.tile_height );
     assert( surface );
@@ -3577,7 +3577,7 @@ void cata_tiles::draw_cone_aoe_frame()
 {
     for( const point_with_value &pv : cone_aoe_layer ) {
         const tripoint diff = pv.pt - cone_aoe_origin;
-        int rotation = ( sgn( diff.x ) == sgn( diff.y ) ? 1 : 0 );
+        int const rotation = ( sgn( diff.x ) == sgn( diff.y ) ? 1 : 0 );
         // Should probably jsonize for flamethrower, dragon breath etc.
         static const std::array<std::string, 3> sprite_ids = {{
                 "shot_cone_weak",
@@ -3586,7 +3586,7 @@ void cata_tiles::draw_cone_aoe_frame()
             }
         };
 
-        size_t intensity = ( pv.val >= 1.0 ) + ( pv.val >= 0.5 );
+        size_t const intensity = ( pv.val >= 1.0 ) + ( pv.val >= 0.5 );
         draw_from_id_string( sprite_ids[intensity], pv.pt, 0, rotation, lit_level::LIT, false, 0 );
     }
 }
@@ -3608,7 +3608,7 @@ void cata_tiles::draw_bullet_frame()
 }
 void cata_tiles::draw_hit_frame()
 {
-    std::string hit_overlay = "animation_hit";
+    std::string const hit_overlay = "animation_hit";
 
     draw_from_id_string( hit_entity_id, C_HIT_ENTITY, empty_string, hit_pos, 0, 0,
                          lit_level::LIT, false, 0 );
@@ -3619,7 +3619,7 @@ void cata_tiles::draw_line()
     if( line_trajectory.empty() ) {
         return;
     }
-    static std::string line_overlay = "animation_line";
+    static std::string const line_overlay = "animation_line";
     if( !is_target_line || g->u.sees( line_pos ) ) {
         for( auto it = line_trajectory.begin(); it != line_trajectory.end() - 1; ++it ) {
             draw_from_id_string( line_overlay, *it, 0, 0, lit_level::LIT, false, 0 );
@@ -3667,8 +3667,8 @@ void cata_tiles::draw_sct_frame( std::multimap<point, formatted_text> &overlay_s
         int iOffsetY = 0;
 
         for( int j = 0; j < 2; ++j ) {
-            std::string sText = iter->getText( ( j == 0 ) ? "first" : "second" );
-            int FG = msgtype_to_tilecolor( iter->getMsgType( ( j == 0 ) ? "first" : "second" ),
+            std::string const sText = iter->getText( ( j == 0 ) ? "first" : "second" );
+            int const FG = msgtype_to_tilecolor( iter->getMsgType( ( j == 0 ) ? "first" : "second" ),
                                            iter->getStep() >= SCT.iMaxSteps / 2 );
 
             if( use_font ) {
@@ -3852,7 +3852,7 @@ void cata_tiles::get_rotation_and_subtile( const char val, int &rotation, int &s
 void cata_tiles::get_connect_values( const tripoint &p, int &subtile, int &rotation,
                                      const int connect_group, const std::map<tripoint, ter_id> &ter_override )
 {
-    uint8_t connections = get_map().get_known_connections( p, connect_group, ter_override );
+    uint8_t const connections = get_map().get_known_connections( p, connect_group, ter_override );
     get_rotation_and_subtile( connections, rotation, subtile );
 }
 
@@ -3978,7 +3978,7 @@ std::vector<options_manager::id_and_option> cata_tiles::build_renderer_list()
         { "opengles2", translate_marker( "opengles2" ) },
         { "software", translate_marker( "software" ) },
     };
-    int numRenderDrivers = SDL_GetNumRenderDrivers();
+    int const numRenderDrivers = SDL_GetNumRenderDrivers();
     DebugLog( DL::Info, DC::Main ) << "Number of render drivers on your system: " << numRenderDrivers;
     for( int ii = 0; ii < numRenderDrivers; ii++ ) {
         SDL_RendererInfo ri;
@@ -3999,11 +3999,11 @@ std::vector<options_manager::id_and_option> cata_tiles::build_renderer_list()
 std::vector<options_manager::id_and_option> cata_tiles::build_display_list()
 {
     std::vector<options_manager::id_and_option> display_names;
-    std::vector<options_manager::id_and_option> default_display_names = {
+    std::vector<options_manager::id_and_option> const default_display_names = {
         { "0", translate_marker( "Display 0" ) }
     };
 
-    int numdisplays = SDL_GetNumVideoDisplays();
+    int const numdisplays = SDL_GetNumVideoDisplays();
     for( int i = 0 ; i < numdisplays ; i++ ) {
         display_names.emplace_back( std::to_string( i ), std::string( SDL_GetDisplayName( i ) ) );
     }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1254,8 +1254,8 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
             }
 
             bool const invis = ( temp_y < min_visible_y || temp_y > max_visible_y || temp_x < min_visible_x ||
-                           temp_x > max_visible_x ) &&
-                         ( has_memory_at( {temp_x, temp_y, center.z} ) || has_draw_override( {temp_x, temp_y, center.z} ) );
+                                 temp_x > max_visible_x ) &&
+                               ( has_memory_at( {temp_x, temp_y, center.z} ) || has_draw_override( {temp_x, temp_y, center.z} ) );
 
 
 
@@ -1375,7 +1375,7 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
             if( g->display_overlay_state( ACTION_DISPLAY_TRANSPARENCY ) ) {
                 const float tr = here.light_transparency( {temp_x, temp_y, center.z} );
                 int const intensity =  tr <= LIGHT_TRANSPARENCY_SOLID ? 10 :  static_cast<int>
-                                 ( ( tr - LIGHT_TRANSPARENCY_OPEN_AIR ) * 8 );
+                                       ( ( tr - LIGHT_TRANSPARENCY_OPEN_AIR ) * 8 );
                 draw_debug_tile( intensity, string_format( "%.2f", tr ) );
             }
 
@@ -1389,7 +1389,7 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
                 const int &y = pos.y;
 
                 bool const in_vis_bounds = ( y >= min_visible_y && y <= max_visible_y && x >= min_visible_x &&
-                                       x <= max_visible_x );
+                                             x <= max_visible_x );
 
                 bool const in_map_bounds = here.inbounds( pos );
 
@@ -1951,7 +1951,8 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
     // check to make sure that we are drawing within a valid area
     // [0->width|height / tile_width|height]
 
-    half_open_rectangle<point> const screen_bounds( o, o + point( screentile_width, screentile_height ) );
+    half_open_rectangle<point> const screen_bounds( o, o + point( screentile_width,
+            screentile_height ) );
     if( !tile_iso &&
         !screen_bounds.contains( pos.xy() ) ) {
         return false;
@@ -2171,7 +2172,7 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
     // seed the PRNG to get a reproducible random int
     // TODO: faster solution here
     unsigned int seed = 0;
-    map  const&here = get_map();
+    map  const &here = get_map();
     // TODO: determine ways other than category to differentiate more types of sprites
     switch( category ) {
         case C_TERRAIN:
@@ -2967,7 +2968,7 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
 {
     const auto override = vpart_override.find( p );
     const bool overridden = override != vpart_override.end();
-    map  const&here = get_map();
+    map  const &here = get_map();
     // first memorize the actual vpart
     const optional_vpart_position vp = here.veh_at( p );
     if( vp && !invisible[0] ) {
@@ -3669,7 +3670,7 @@ void cata_tiles::draw_sct_frame( std::multimap<point, formatted_text> &overlay_s
         for( int j = 0; j < 2; ++j ) {
             std::string const sText = iter->getText( ( j == 0 ) ? "first" : "second" );
             int const FG = msgtype_to_tilecolor( iter->getMsgType( ( j == 0 ) ? "first" : "second" ),
-                                           iter->getStep() >= SCT.iMaxSteps / 2 );
+                                                 iter->getStep() >= SCT.iMaxSteps / 2 );
 
             if( use_font ) {
                 const auto direction = iter->getDirecton();

--- a/src/cata_utility.cpp
+++ b/src/cata_utility.cpp
@@ -91,14 +91,14 @@ double logarithmic_range( int min, int max, int pos )
     }
 
     // Normalize the pos to [0,1]
-    double range = max - min;
-    double unit_pos = ( pos - min ) / range;
+    double const range = max - min;
+    double const unit_pos = ( pos - min ) / range;
 
     // Scale and flip it to [+LOGI_CUTOFF,-LOGI_CUTOFF]
-    double scaled_pos = LOGI_CUTOFF - 2 * LOGI_CUTOFF * unit_pos;
+    double const scaled_pos = LOGI_CUTOFF - 2 * LOGI_CUTOFF * unit_pos;
 
     // Get the raw logistic value.
-    double raw_logistic = logarithmic( scaled_pos );
+    double const raw_logistic = logarithmic( scaled_pos );
 
     // Scale the output to [0,1]
     return ( raw_logistic - LOGI_MIN ) / LOGI_RANGE;
@@ -142,7 +142,7 @@ double clamp_to_width( double value, int width, int &scale, bool *out_truncated 
     } else if( scale > 0 ) {
         for( int s = 1; s <= scale; s++ ) {
             // 1 decimal separator + "s"
-            int scale_width = 1 + s;
+            int const scale_width = 1 + s;
             if( width > scale_width && value >= std::pow( 10.0, width - scale_width ) ) {
                 // above the maximum number we can fit in the width with "s" decimals
                 // show this number with one less decimal than "s"
@@ -274,7 +274,7 @@ cata_ofstream &cata_ofstream::operator=( cata_ofstream &&x )
 
 cata_ofstream &cata_ofstream::open( const std::string &path )
 {
-    std::ios_base::openmode mode = cata_ios_mode_to_std( std::ios_base::out, _mode );
+    std::ios_base::openmode const mode = cata_ios_mode_to_std( std::ios_base::out, _mode );
 
 #if defined (_MSC_VER)
     _stream = std::make_unique<std::ofstream>( utf8_to_wstr( path ), mode );
@@ -394,7 +394,7 @@ cata_ifstream &cata_ifstream::operator=( cata_ifstream &&x )
 
 cata_ifstream &cata_ifstream::open( const std::string &path )
 {
-    std::ios_base::openmode mode = cata_ios_mode_to_std( std::ios_base::in, _mode );
+    std::ios_base::openmode const mode = cata_ios_mode_to_std( std::ios_base::in, _mode );
 
 #if defined (_MSC_VER)
     _stream = std::make_unique<std::ifstream>( utf8_to_wstr( path ), mode );
@@ -493,11 +493,11 @@ ofstream_wrapper::~ofstream_wrapper()
 std::istream &safe_getline( std::istream &ins, std::string &str )
 {
     str.clear();
-    std::istream::sentry se( ins, true );
+    std::istream::sentry const se( ins, true );
     std::streambuf *sb = ins.rdbuf();
 
     while( true ) {
-        int c = sb->sbumpc();
+        int const c = sb->sbumpc();
         switch( c ) {
             case '\n':
                 return ins;
@@ -604,7 +604,7 @@ void ofstream_wrapper::close()
     }
 
     file_stream.flush();
-    bool failed = file_stream.fail();
+    bool const failed = file_stream.fail();
     file_stream.close();
     if( failed ) {
         // Remove the incomplete or otherwise faulty file (if possible).
@@ -621,18 +621,18 @@ void ofstream_wrapper::close()
 std::string obscure_message( const std::string &str, std::function<char()> f )
 {
     //~ translators: place some random 1-width characters here in your language if possible, or leave it as is
-    std::string gibberish_narrow = _( "abcdefghijklmnopqrstuvwxyz" );
-    std::string gibberish_wide =
+    std::string const gibberish_narrow = _( "abcdefghijklmnopqrstuvwxyz" );
+    std::string const gibberish_wide =
         //~ translators: place some random 2-width characters here in your language if possible, or leave it as is
         _( "に坂索トし荷測のンおク妙免イロコヤ梅棋厚れ表幌" );
-    std::wstring w_gibberish_narrow = utf8_to_wstr( gibberish_narrow );
-    std::wstring w_gibberish_wide = utf8_to_wstr( gibberish_wide );
+    std::wstring const w_gibberish_narrow = utf8_to_wstr( gibberish_narrow );
+    std::wstring const w_gibberish_wide = utf8_to_wstr( gibberish_wide );
     std::wstring w_str = utf8_to_wstr( str );
     // a trailing NULL terminator is necessary for utf8_width function
     char transformation[2] = { 0 };
     for( size_t i = 0; i < w_str.size(); ++i ) {
         transformation[0] = f();
-        std::string this_char = wstr_to_utf8( std::wstring( 1, w_str[i] ) );
+        std::string const this_char = wstr_to_utf8( std::wstring( 1, w_str[i] ) );
         if( transformation[0] == -1 ) {
             continue;
         } else if( transformation[0] == 0 ) {
@@ -718,7 +718,7 @@ holiday get_holiday_from_time( std::time_t time, bool force_refresh )
     bool success = false;
 
     std::tm local_time;
-    std::time_t current_time = time == 0 ? std::time( nullptr ) : time;
+    std::time_t const current_time = time == 0 ? std::time( nullptr ) : time;
 
     /* necessary to pass LGTM, as threadsafe version of localtime differs by platform */
 #if defined(_WIN32)

--- a/src/catacharset.cpp
+++ b/src/catacharset.cpp
@@ -148,7 +148,7 @@ int utf8_width( const char *s, const bool ignore_tags )
     const char *ptr = s;
     int w = 0;
     while( len > 0 ) {
-        uint32_t ch = UTF8_getch( &ptr, &len );
+        uint32_t const ch = UTF8_getch( &ptr, &len );
         if( ch == UNKNOWN_UNICODE ) {
             continue;
         }
@@ -169,7 +169,7 @@ int utf8_width( const utf8_wrapper &str, const bool ignore_tags )
 
 std::string left_justify( const std::string &str, const int width, const bool ignore_tags )
 {
-    int str_width = utf8_width( str, ignore_tags );
+    int const str_width = utf8_width( str, ignore_tags );
     if( str_width >= width ) {
         return str;
     } else {
@@ -179,7 +179,7 @@ std::string left_justify( const std::string &str, const int width, const bool ig
 
 std::string right_justify( const std::string &str, const int width, const bool ignore_tags )
 {
-    int str_width = utf8_width( str, ignore_tags );
+    int const str_width = utf8_width( str, ignore_tags );
     if( str_width >= width ) {
         return str;
     } else {
@@ -214,7 +214,7 @@ int cursorx_to_position( const char *line, int cursorx, int *prevpos, int maxlen
         if( utf8str[0] == 0 ) {
             break;
         }
-        uint32_t ch = UTF8_getch( &utf8str, &len );
+        uint32_t const ch = UTF8_getch( &utf8str, &len );
         int cw = mk_wcwidth( ch );
         len = ANY_LENGTH - len;
         if( len <= 0 ) {
@@ -242,7 +242,7 @@ std::string utf8_truncate( const std::string &s, size_t length )
         return s;
     }
 
-    int last_pos = cursorx_to_position( s.c_str(), length, nullptr, -1 );
+    int const last_pos = cursorx_to_position( s.c_str(), length, nullptr, -1 );
 
     return s.substr( 0, last_pos );
 }
@@ -280,19 +280,19 @@ std::string base64_encode( const std::string &str )
         return str;
     }
 
-    int input_length = str.length();
-    int output_length = 4 * ( ( input_length + 2 ) / 3 );
+    int const input_length = str.length();
+    int const output_length = 4 * ( ( input_length + 2 ) / 3 );
 
     std::string encoded_data( output_length, '\0' );
     const unsigned char *data = reinterpret_cast<const unsigned char *>( str.c_str() );
 
     for( int i = 0, j = 0; i < input_length; ) {
 
-        unsigned octet_a = i < input_length ? data[i++] : 0;
-        unsigned octet_b = i < input_length ? data[i++] : 0;
-        unsigned octet_c = i < input_length ? data[i++] : 0;
+        unsigned const octet_a = i < input_length ? data[i++] : 0;
+        unsigned const octet_b = i < input_length ? data[i++] : 0;
+        unsigned const octet_c = i < input_length ? data[i++] : 0;
 
-        unsigned triple = ( octet_a << 0x10 ) + ( octet_b << 0x08 ) + octet_c;
+        unsigned const triple = ( octet_a << 0x10 ) + ( octet_b << 0x08 ) + octet_c;
 
         encoded_data[j++] = base64_encoding_table[( triple >> 3 * 6 ) & 0x3F];
         encoded_data[j++] = base64_encoding_table[( triple >> 2 * 6 ) & 0x3F];
@@ -316,9 +316,9 @@ std::string base64_decode( const std::string &str )
 
     build_base64_decoding_table();
 
-    std::string instr = str.substr( 1 );
+    std::string const instr = str.substr( 1 );
 
-    int input_length = instr.length();
+    int const input_length = instr.length();
 
     if( input_length % 4 != 0 ) {
         return str;
@@ -338,16 +338,16 @@ std::string base64_decode( const std::string &str )
 
     for( int i = 0, j = 0; i < input_length; ) {
 
-        unsigned sextet_a = data[i] == '=' ? 0 & i++ : base64_decoding_table[static_cast<unsigned char>
+        unsigned const sextet_a = data[i] == '=' ? 0 & i++ : base64_decoding_table[static_cast<unsigned char>
                             ( data[i++] )];
-        unsigned sextet_b = data[i] == '=' ? 0 & i++ : base64_decoding_table[static_cast<unsigned char>
+        unsigned const sextet_b = data[i] == '=' ? 0 & i++ : base64_decoding_table[static_cast<unsigned char>
                             ( data[i++] )];
-        unsigned sextet_c = data[i] == '=' ? 0 & i++ : base64_decoding_table[static_cast<unsigned char>
+        unsigned const sextet_c = data[i] == '=' ? 0 & i++ : base64_decoding_table[static_cast<unsigned char>
                             ( data[i++] )];
-        unsigned sextet_d = data[i] == '=' ? 0 & i++ : base64_decoding_table[static_cast<unsigned char>
+        unsigned const sextet_d = data[i] == '=' ? 0 & i++ : base64_decoding_table[static_cast<unsigned char>
                             ( data[i++] )];
 
-        unsigned triple = ( sextet_a << 3 * 6 )
+        unsigned const triple = ( sextet_a << 3 * 6 )
                           + ( sextet_b << 2 * 6 )
                           + ( sextet_c << 1 * 6 )
                           + ( sextet_d << 0 * 6 );
@@ -389,7 +389,7 @@ std::wstring utf8_to_wstr( const std::string &str )
     strip_trailing_nulls( wstr );
     return wstr;
 #else
-    std::size_t sz = std::mbstowcs( nullptr, str.c_str(), 0 ) + 1;
+    std::size_t const sz = std::mbstowcs( nullptr, str.c_str(), 0 ) + 1;
     std::wstring wstr( sz, '\0' );
     std::mbstowcs( &wstr[0], str.c_str(), sz );
     strip_trailing_nulls( wstr );
@@ -406,7 +406,7 @@ std::string wstr_to_utf8( const std::wstring &wstr )
     strip_trailing_nulls( str );
     return str;
 #else
-    std::size_t sz = std::wcstombs( nullptr, wstr.c_str(), 0 ) + 1;
+    std::size_t const sz = std::wcstombs( nullptr, wstr.c_str(), 0 ) + 1;
     std::string str( sz, '\0' );
     std::wcstombs( &str[0], wstr.c_str(), sz );
     strip_trailing_nulls( str );
@@ -459,9 +459,9 @@ std::vector<std::string> utf8_display_split( const std::string &s )
 
 int center_text_pos( const char *text, int start_pos, int end_pos )
 {
-    int full_screen = end_pos - start_pos + 1;
-    int str_len = utf8_width( text );
-    int position = ( full_screen - str_len ) / 2;
+    int const full_screen = end_pos - start_pos + 1;
+    int const str_len = utf8_width( text );
+    int const position = ( full_screen - str_len ) / 2;
 
     if( position <= 0 ) {
         return start_pos;
@@ -477,9 +477,9 @@ int center_text_pos( const std::string &text, int start_pos, int end_pos )
 
 int center_text_pos( const utf8_wrapper &text, int start_pos, int end_pos )
 {
-    int full_screen = end_pos - start_pos + 1;
-    int str_len = text.display_width();
-    int position = ( full_screen - str_len ) / 2;
+    int const full_screen = end_pos - start_pos + 1;
+    int const str_len = text.display_width();
+    int const position = ( full_screen - str_len ) / 2;
 
     if( position <= 0 ) {
         return start_pos;

--- a/src/catacharset.cpp
+++ b/src/catacharset.cpp
@@ -338,19 +338,23 @@ std::string base64_decode( const std::string &str )
 
     for( int i = 0, j = 0; i < input_length; ) {
 
-        unsigned const sextet_a = data[i] == '=' ? 0 & i++ : base64_decoding_table[static_cast<unsigned char>
-                            ( data[i++] )];
-        unsigned const sextet_b = data[i] == '=' ? 0 & i++ : base64_decoding_table[static_cast<unsigned char>
-                            ( data[i++] )];
-        unsigned const sextet_c = data[i] == '=' ? 0 & i++ : base64_decoding_table[static_cast<unsigned char>
-                            ( data[i++] )];
-        unsigned const sextet_d = data[i] == '=' ? 0 & i++ : base64_decoding_table[static_cast<unsigned char>
-                            ( data[i++] )];
+        unsigned const sextet_a = data[i] == '=' ? 0 & i++ :
+                                  base64_decoding_table[static_cast<unsigned char>
+                                                               ( data[i++] )];
+        unsigned const sextet_b = data[i] == '=' ? 0 & i++ :
+                                  base64_decoding_table[static_cast<unsigned char>
+                                                               ( data[i++] )];
+        unsigned const sextet_c = data[i] == '=' ? 0 & i++ :
+                                  base64_decoding_table[static_cast<unsigned char>
+                                                               ( data[i++] )];
+        unsigned const sextet_d = data[i] == '=' ? 0 & i++ :
+                                  base64_decoding_table[static_cast<unsigned char>
+                                                               ( data[i++] )];
 
         unsigned const triple = ( sextet_a << 3 * 6 )
-                          + ( sextet_b << 2 * 6 )
-                          + ( sextet_c << 1 * 6 )
-                          + ( sextet_d << 0 * 6 );
+                                + ( sextet_b << 2 * 6 )
+                                + ( sextet_c << 1 * 6 )
+                                + ( sextet_d << 0 * 6 );
 
         if( j < output_length ) {
             decoded_data[j++] = ( triple >> 2 * 8 ) & 0xFF;

--- a/src/catalua.cpp
+++ b/src/catalua.cpp
@@ -129,7 +129,7 @@ std::string get_lapi_version_string()
 void startup_lua_test()
 {
     sol::state lua = make_lua_state();
-    std::string lua_startup_script = PATH_INFO::datadir() + "raw/on_game_start.lua";
+    std::string const lua_startup_script = PATH_INFO::datadir() + "raw/on_game_start.lua";
     try {
         run_lua_script( lua, lua_startup_script );
     } catch( std::runtime_error &e ) {
@@ -141,10 +141,10 @@ bool generate_lua_docs()
 {
     sol::state lua = make_lua_state();
     lua.globals()["doc_gen_func"] = lua.create_table();
-    std::string lua_doc_script = PATH_INFO::datadir() + "raw/generate_docs.lua";
+    std::string const lua_doc_script = PATH_INFO::datadir() + "raw/generate_docs.lua";
     try {
         run_lua_script( lua, lua_doc_script );
-        sol::protected_function doc_gen_func = lua["doc_gen_func"]["impl"];
+        sol::protected_function const doc_gen_func = lua["doc_gen_func"]["impl"];
         sol::protected_function_result res = doc_gen_func();
         check_func_result( res );
         std::string ret = res;
@@ -177,12 +177,12 @@ void reload_lua_code()
 
 void debug_write_lua_backtrace( std::ostream &out )
 {
-    cata::lua_state &state = *DynamicDataLoader::get_instance().lua;
-    sol::state container;
+    cata::lua_state  const&state = *DynamicDataLoader::get_instance().lua;
+    sol::state const container;
 
     luaL_traceback( container.lua_state(), state.lua.lua_state(), "=== Lua backtrace report ===", 0 );
 
-    std::string data = sol::stack::pop<std::string>( container );
+    std::string const data = sol::stack::pop<std::string>( container );
     out << data << std::endl;
 }
 
@@ -198,7 +198,7 @@ bool save_world_lua_state( const std::string &path )
     const mod_management::t_mod_list &mods = world_generator->active_world->active_mod_order;
     sol::table t = get_mod_storage_table( state );
     run_on_game_save_hooks( state );
-    bool ret = write_to_file( path, [&]( std::ostream & stream ) {
+    bool const ret = write_to_file( path, [&]( std::ostream & stream ) {
         JsonOut jsout( stream );
         jsout.start_object();
         for( const mod_id &mod : mods ) {
@@ -216,9 +216,9 @@ bool load_world_lua_state( const std::string &path )
     const mod_management::t_mod_list &mods = world_generator->active_world->active_mod_order;
     sol::table t = get_mod_storage_table( state );
 
-    bool ret = read_from_file_optional( path, [&]( std::istream & stream ) {
+    bool const ret = read_from_file_optional( path, [&]( std::istream & stream ) {
         JsonIn jsin( stream );
-        JsonObject jsobj = jsin.get_object();
+        JsonObject const jsobj = jsin.get_object();
 
         for( const mod_id &mod : mods ) {
             if( !jsobj.has_object( mod.str() ) ) {
@@ -243,7 +243,7 @@ std::unique_ptr<lua_state, lua_state_deleter> make_wrapped_state()
 
     sol::state &lua = ret->lua;
 
-    sol::table game_table = lua.create_table();
+    sol::table const game_table = lua.create_table();
     lua.globals()["game"] = game_table;
 
     return ret;
@@ -305,7 +305,7 @@ void clear_mod_being_loaded( lua_state &state )
 
 void run_mod_preload_script( lua_state &state, const mod_id &mod )
 {
-    std::string script_path = mod->path + "/" + "preload.lua";
+    std::string const script_path = mod->path + "/" + "preload.lua";
 
     if( !file_exist( script_path ) ) {
         return;
@@ -316,7 +316,7 @@ void run_mod_preload_script( lua_state &state, const mod_id &mod )
 
 void run_mod_finalize_script( lua_state &state, const mod_id &mod )
 {
-    std::string script_path = mod->path + "/" + "finalize.lua";
+    std::string const script_path = mod->path + "/" + "finalize.lua";
 
     if( !file_exist( script_path ) ) {
         return;
@@ -327,7 +327,7 @@ void run_mod_finalize_script( lua_state &state, const mod_id &mod )
 
 void run_mod_main_script( lua_state &state, const mod_id &mod )
 {
-    std::string script_path = mod->path + "/" + "main.lua";
+    std::string const script_path = mod->path + "/" + "main.lua";
 
     if( !file_exist( script_path ) ) {
         return;
@@ -340,12 +340,12 @@ template<typename... Args>
 void run_hooks( lua_state &state, std::string_view hooks_table, Args &&...args )
 {
     sol::state &lua = state.lua;
-    sol::table hooks = lua.globals()["game"]["hooks"][hooks_table];
+    sol::table const hooks = lua.globals()["game"]["hooks"][hooks_table];
     for( auto &ref : hooks ) {
         int idx = -1;
         try {
             idx = ref.first.as<int>();
-            sol::protected_function func = ref.second;
+            sol::protected_function const func = ref.second;
             sol::protected_function_result res = func( std::forward<Args>( args )... );
             check_func_result( res );
         } catch( std::runtime_error &e ) {
@@ -359,7 +359,7 @@ void reg_lua_iuse_actors( lua_state &state, Item_factory &ifactory )
 {
     sol::state &lua = state.lua;
 
-    sol::table funcs = lua.globals()["game"]["iuse_functions"];
+    sol::table const funcs = lua.globals()["game"]["iuse_functions"];
 
     for( auto &ref : funcs ) {
         std::string key;
@@ -376,7 +376,7 @@ void reg_lua_iuse_actors( lua_state &state, Item_factory &ifactory )
 
 void run_on_every_x_hooks( lua_state &state )
 {
-    std::vector<cata::on_every_x_hooks> &master_table =
+    std::vector<cata::on_every_x_hooks>  const&master_table =
         state.lua["game"]["cata_internal"]["on_every_x_hooks"];
     for( const auto &entry : master_table ) {
         if( calendar::once_every( entry.interval ) ) {

--- a/src/catalua.cpp
+++ b/src/catalua.cpp
@@ -177,7 +177,7 @@ void reload_lua_code()
 
 void debug_write_lua_backtrace( std::ostream &out )
 {
-    cata::lua_state  const&state = *DynamicDataLoader::get_instance().lua;
+    cata::lua_state  const &state = *DynamicDataLoader::get_instance().lua;
     sol::state const container;
 
     luaL_traceback( container.lua_state(), state.lua.lua_state(), "=== Lua backtrace report ===", 0 );
@@ -376,7 +376,7 @@ void reg_lua_iuse_actors( lua_state &state, Item_factory &ifactory )
 
 void run_on_every_x_hooks( lua_state &state )
 {
-    std::vector<cata::on_every_x_hooks>  const&master_table =
+    std::vector<cata::on_every_x_hooks>  const &master_table =
         state.lua["game"]["cata_internal"]["on_every_x_hooks"];
     for( const auto &entry : master_table ) {
         if( calendar::once_every( entry.interval ) ) {

--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -148,13 +148,13 @@ void cata::detail::reg_creature_family( sol::state &lua )
 
         luna::set_fx( ut, "get_effect_dur", []( const Creature & cr, const efftype_id & eff,
         sol::optional<const bodypart_str_id &> bpid ) -> time_duration {
-            body_part bp = bpid ? ( *bpid ) -> token : num_bp;
+            body_part const bp = bpid ? ( *bpid ) -> token : num_bp;
             return cr.get_effect_dur( eff, bp );
         } );
 
         luna::set_fx( ut, "get_effect_int", []( const Creature & cr, const efftype_id & eff,
         sol::optional<const bodypart_str_id &> bpid ) -> int {
-            body_part bp = bpid ? ( *bpid ) -> token : num_bp;
+            body_part const bp = bpid ? ( *bpid ) -> token : num_bp;
             return cr.get_effect_int( eff, bp );
         } );
 
@@ -164,14 +164,14 @@ void cata::detail::reg_creature_family( sol::state &lua )
                                             sol::optional<const bodypart_str_id &> bpid,
                                             sol::optional<int> intensity
         ) {
-            int eint = intensity ? *intensity : 0;
-            body_part bp = bpid ? ( *bpid ) -> token : num_bp;
+            int const eint = intensity ? *intensity : 0;
+            body_part const bp = bpid ? ( *bpid ) -> token : num_bp;
             cr.add_effect( eff, dur, bp, eint );
         } );
 
         luna::set_fx( ut, "remove_effect", []( Creature & cr, const efftype_id & eff,
         sol::optional<const bodypart_str_id &> bpid ) -> bool {
-            body_part bp = bpid ? ( *bpid ) -> token : num_bp;
+            body_part const bp = bpid ? ( *bpid ) -> token : num_bp;
             return cr.remove_effect( eff, bp );
         } );
     }
@@ -489,7 +489,7 @@ static void add_msg_lua( game_message_type t, sol::variadic_args va )
         return;
     }
 
-    std::string msg = cata::detail::fmt_lua_va( va );
+    std::string const msg = cata::detail::fmt_lua_va( va );
     add_msg( t, msg );
 }
 
@@ -570,7 +570,7 @@ void reg_enum( sol::state &lua )
 
     for( Int i = 0; i < max; ++i ) {
         E e = static_cast<E>( i );
-        std::string key = io::enum_to_string<E>( e );
+        std::string const key = io::enum_to_string<E>( e );
         luna::add_val( et, key, e );
     }
 
@@ -586,8 +586,8 @@ void cata::detail::reg_colors( sol::state &lua )
     constexpr Int max = static_cast<Int>( color_id::num_colors );
 
     for( Int i = 0; i < max; ++i ) {
-        color_id e = static_cast<color_id>( i );
-        std::string key = get_all_colors().id_to_name( e );
+        color_id const e = static_cast<color_id>( i );
+        std::string const key = get_all_colors().id_to_name( e );
         luna::add_val( et, key, e );
     }
 

--- a/src/catalua_bindings_coords.cpp
+++ b/src/catalua_bindings_coords.cpp
@@ -145,21 +145,21 @@ void cata::detail::reg_coords_library( sol::state &lua )
     luna::userlib lib = luna::begin_lib( lua, "coords" );
 
     luna::set_fx( lib, "ms_to_sm", []( const tripoint & raw ) -> std::tuple<tripoint, point> {
-        tripoint_rel_ms fine( raw );
+        tripoint_rel_ms const fine( raw );
         tripoint_rel_sm rough;
         point_sm_ms remain;
         std::tie( rough, remain ) = coords::project_remain<coords::sm>( fine );
         return std::make_pair( rough.raw(), remain.raw() );
     } );
     luna::set_fx( lib, "ms_to_omt", []( const tripoint & raw ) -> std::tuple<tripoint, point> {
-        tripoint_rel_ms fine( raw );
+        tripoint_rel_ms const fine( raw );
         tripoint_rel_omt rough;
         point_omt_ms remain;
         std::tie( rough, remain ) = coords::project_remain<coords::omt>( fine );
         return std::make_pair( rough.raw(), remain.raw() );
     } );
     luna::set_fx( lib, "ms_to_om", []( const tripoint & raw ) -> std::tuple<point, tripoint> {
-        tripoint_rel_ms fine( raw );
+        tripoint_rel_ms const fine( raw );
         point_rel_om rough;
         coords::coord_point<tripoint, coords::origin::overmap, coords::ms> remain;
         std::tie( rough, remain ) = coords::project_remain<coords::om>( fine );
@@ -168,22 +168,22 @@ void cata::detail::reg_coords_library( sol::state &lua )
 
     luna::set_fx( lib, "sm_to_ms", []( const tripoint & raw_rough,
     sol::optional<const point &> raw_remain ) -> tripoint {
-        tripoint_rel_sm rough( raw_rough );
-        point_sm_ms remain( raw_remain ? *raw_remain : point_zero );
+        tripoint_rel_sm const rough( raw_rough );
+        point_sm_ms const remain( raw_remain ? *raw_remain : point_zero );
         tripoint_rel_ms fine = coords::project_combine( rough, remain );
         return fine.raw();
     } );
     luna::set_fx( lib, "omt_to_ms", []( const tripoint & raw_rough,
     sol::optional<const point &> raw_remain ) -> tripoint {
-        tripoint_rel_omt rough( raw_rough );
-        point_omt_ms remain( raw_remain ? *raw_remain : point_zero );
+        tripoint_rel_omt const rough( raw_rough );
+        point_omt_ms const remain( raw_remain ? *raw_remain : point_zero );
         tripoint_rel_ms fine = coords::project_combine( rough, remain );
         return fine.raw();
     } );
     luna::set_fx( lib, "om_to_ms", []( const point & raw_rough,
     sol::optional<const tripoint &> raw_remain ) -> tripoint {
-        point_rel_om rough( raw_rough );
-        coords::coord_point<tripoint, coords::origin::overmap, coords::ms> remain(
+        point_rel_om const rough( raw_rough );
+        coords::coord_point<tripoint, coords::origin::overmap, coords::ms> const remain(
             raw_remain ? *raw_remain : tripoint_zero
         );
         tripoint_rel_ms fine = coords::project_combine( rough, remain );

--- a/src/catalua_console.cpp
+++ b/src/catalua_console.cpp
@@ -142,7 +142,7 @@ void show_lua_console_impl()
         werase( w_console );
         draw_border( w_console );
         std::string separator;
-        int separator_y = win_size.y - prompt_size.y - 2;
+        int const separator_y = win_size.y - prompt_size.y - 2;
         for( int i = 0; i < win_size.x - 2; i++ ) {
             separator += LINE_OXOX_S;
         }
@@ -184,11 +184,11 @@ void show_lua_console_impl()
         werase( w_log );
 
         int y_pos = log_size.y - 1;
-        int start_line = log_scroll_pos;
-        int end_line = std::min( static_cast<int>( log_folded.size() ), start_line + log_size.y );
+        int const start_line = log_scroll_pos;
+        int const end_line = std::min( static_cast<int>( log_folded.size() ), start_line + log_size.y );
         for( int log_line = start_line; log_line < end_line; log_line++ ) {
             const folded_log_msg &msg = log_folded[log_line];
-            nc_color col = get_log_level_color( msg.level );
+            nc_color const col = get_log_level_color( msg.level );
             int x_pos = 1;
             if( msg.level == LuaLogLevel::Input ) {
                 // User input is indented, and first line is highlighted
@@ -231,7 +231,7 @@ void show_lua_console_impl()
             // Close
             return;
         } else if( act == "HISTORY_UP" ) {
-            int sz = num_history_entries();
+            int const sz = num_history_entries();
             if( sz != 0 && history_cursor != 0 ) {
                 if( history_cursor == CURRENT_INPUT ) {
                     history_cursor = sz - 1;
@@ -242,7 +242,7 @@ void show_lua_console_impl()
             // Update input preview
             ui.invalidate_ui();
         } else if( act == "HISTORY_DOWN" ) {
-            int sz = num_history_entries();
+            int const sz = num_history_entries();
             if( sz != 0 && history_cursor != CURRENT_INPUT ) {
                 if( history_cursor == sz - 1 ) {
                     history_cursor = CURRENT_INPUT;
@@ -253,7 +253,7 @@ void show_lua_console_impl()
             // Update input preview
             ui.invalidate_ui();
         } else if( act == "SCROLL_UP" || act == "SCROLL_TOP" ) {
-            int limit = std::max( 0, static_cast<int>( log_folded.size() ) - log_size.y );
+            int const limit = std::max( 0, static_cast<int>( log_folded.size() ) - log_size.y );
             if( act == "SCROLL_TOP" ) {
                 log_scroll_pos = limit;
             } else {
@@ -274,7 +274,7 @@ void show_lua_console_impl()
                 create_string_editor,
                 history_cursor == CURRENT_INPUT ? current_input : get_input_history()[history_cursor]
             );
-            std::pair<bool, std::string> res = ew.query_string();
+            std::pair<bool, std::string> const res = ew.query_string();
             is_editing = false;
             history_cursor = CURRENT_INPUT;
             if( res.first ) {

--- a/src/catalua_impl.cpp
+++ b/src/catalua_impl.cpp
@@ -25,27 +25,27 @@ sol::state make_lua_state()
 
 void run_lua_script( sol::state &lua, const std::string &script_name )
 {
-    sol::load_result load_res = lua.load_file( script_name );
+    sol::load_result const load_res = lua.load_file( script_name );
 
     if( !load_res.valid() ) {
-        sol::error err = load_res;
+        sol::error const err = load_res;
         throw std::runtime_error(
             string_format( "Failed to load script %s: %s", script_name, err.what() )
         );
     }
 
-    sol::protected_function exec = load_res;
+    sol::protected_function const exec = load_res;
 
     // Sandboxing: create environment that uses globals table as fallback
     // to prevent script from accidentally (or intentionally) modifying globals table.
     // All modifications will be stored in an environment which then gets discarded.
-    sol::environment my_env( lua, sol::create, lua.globals() );
+    sol::environment const my_env( lua, sol::create, lua.globals() );
     sol::set_environment( my_env, exec );
 
-    sol::protected_function_result exec_res = exec();
+    sol::protected_function_result const exec_res = exec();
 
     if( !exec_res.valid() ) {
-        sol::error err = exec_res;
+        sol::error const err = exec_res;
         throw std::runtime_error(
             string_format( "Script runtime error in %s: %s", script_name, err.what() )
         );
@@ -60,11 +60,11 @@ void run_console_input( sol::state &lua, const std::string &chunk )
         std::string( chunk )
     );
 
-    sol::load_result load_res = lua.load( chunk, "console input" );
+    sol::load_result const load_res = lua.load( chunk, "console input" );
 
     if( !load_res.valid() ) {
         // No need to use obnoxious debugmsgs, user will see the error in log
-        sol::error err = load_res;
+        sol::error const err = load_res;
         cata::get_lua_log_instance().add(
             cata::LuaLogLevel::Error,
             string_format( "Failed to load: %s", err.what() )
@@ -72,15 +72,15 @@ void run_console_input( sol::state &lua, const std::string &chunk )
         return;
     }
 
-    sol::protected_function exec = load_res;
+    sol::protected_function const exec = load_res;
 
     // No sandboxing here, we trust console user :)
 
-    sol::protected_function_result exec_res = exec();
+    sol::protected_function_result const exec_res = exec();
 
     if( !exec_res.valid() ) {
         // No need to use obnoxious debugmsgs, user will see the error in log
-        sol::error err = exec_res;
+        sol::error const err = exec_res;
         cata::get_lua_log_instance().add(
             cata::LuaLogLevel::Error,
             string_format( "Runtime error: %s", err.what() )
@@ -89,12 +89,12 @@ void run_console_input( sol::state &lua, const std::string &chunk )
     }
 
     try {
-        sol::object retval = exec_res;
+        sol::object const retval = exec_res;
         if( retval == sol::nil ) {
             // No return - don't spam
             return;
         }
-        std::string val = lua["tostring"]( retval );
+        std::string const val = lua["tostring"]( retval );
         cata::get_lua_log_instance().add(
             cata::LuaLogLevel::Info,
             string_format( "# %s", val )
@@ -110,7 +110,7 @@ void run_console_input( sol::state &lua, const std::string &chunk )
 void check_func_result( sol::protected_function_result &res )
 {
     if( !res.valid() ) {
-        sol::error err = res;
+        sol::error const err = res;
         throw std::runtime_error(
             string_format( "Script runtime error: %s", err.what() )
         );

--- a/src/catalua_iuse_actor.cpp
+++ b/src/catalua_iuse_actor.cpp
@@ -21,7 +21,7 @@ int lua_iuse_actor::use( player &who, item &itm, bool tick, const tripoint &pos 
         try {
             sol::protected_function_result res = luafunc( who.as_character(), itm, pos );
             check_func_result( res );
-            int ret = res;
+            int const ret = res;
             return ret;
         } catch( std::runtime_error &e ) {
             debugmsg( "Failed to run iuse_function k='%s': %s", type, e.what() );

--- a/src/catalua_serde.cpp
+++ b/src/catalua_serde.cpp
@@ -33,7 +33,7 @@ void serialize_lua_table_internal( sol::table t, JsonOut &jsout, std::vector<sol
     std::vector<std::string> keys;
 
     t.for_each( [&]( sol::object key_obj, sol::object /*val_obj*/ ) {
-        std::string key = key_obj.as<std::string>();
+        std::string const key = key_obj.as<std::string>();
         keys.push_back( key );
     } );
 
@@ -41,7 +41,7 @@ void serialize_lua_table_internal( sol::table t, JsonOut &jsout, std::vector<sol
 
     for( const std::string &key : keys ) {
         jsout.member( key );
-        sol::object val = t[key];
+        sol::object const val = t[key];
 
         switch( val.get_type() ) {
             case sol::type::boolean: {
@@ -50,23 +50,23 @@ void serialize_lua_table_internal( sol::table t, JsonOut &jsout, std::vector<sol
             }
             case sol::type::number: {
                 // Horrible hack
-                sol::protected_function math_type = lua.script( "return math.type" );
+                sol::protected_function const math_type = lua.script( "return math.type" );
                 if( !math_type ) {
                     debugmsg( "Int/float serialization hack failed to acquare math.type" );
                     jsout.write_null();
                 } else {
-                    sol::protected_function_result res = math_type( val );
+                    sol::protected_function_result const res = math_type( val );
                     if( res.status() != sol::call_status::ok ) {
-                        sol::error err = res;
+                        sol::error const err = res;
                         debugmsg( "Int/float serialization hack failed to run math.type: %s", err.what() );
                         jsout.write_null();
                     } else {
-                        sol::object retval = res;
+                        sol::object const retval = res;
                         if( !retval.valid() ) {
                             debugmsg( "Int/float serialization hack returned invalid value" );
                             jsout.write_null();
                         } else {
-                            std::string mtype = res;
+                            std::string const mtype = res;
                             // There's no clear difference in JSON between int and float,
                             // so we have to be explicit to avoid subtle errors down the line
                             if( mtype == "integer" ) {
@@ -120,8 +120,8 @@ void serialize_lua_table_internal( sol::table t, JsonOut &jsout, std::vector<sol
                     jsout.write_null();
                     break;
                 }
-                sol::protected_function get_luna_type_func = table_val["get_luna_type"];
-                sol::protected_function serialize_func = table_val["serialize"];
+                sol::protected_function const get_luna_type_func = table_val["get_luna_type"];
+                sol::protected_function const serialize_func = table_val["serialize"];
 
                 if( !get_luna_type_func ) {
                     debugmsg( "Tried to serialize usertype that has not been registered through luna." );
@@ -133,14 +133,14 @@ void serialize_lua_table_internal( sol::table t, JsonOut &jsout, std::vector<sol
                     jsout.write_null();
                     break;
                 }
-                std::string kind = get_luna_type_func( val );
+                std::string const kind = get_luna_type_func( val );
                 jsout.start_object();
                 jsout.member_as_string( "type", "userdata" );
                 jsout.member_as_string( "kind", kind );
                 jsout.member( "data" );
-                sol::protected_function_result res = serialize_func( val, jsout );
+                sol::protected_function_result const res = serialize_func( val, jsout );
                 if( res.status() != sol::call_status::ok ) {
-                    sol::error err = res;
+                    sol::error const err = res;
                     debugmsg( "Failed to serialize type '%s': %s", kind, err.what() );
                 }
                 jsout.end_object();
@@ -170,47 +170,47 @@ void deserialize_lua_table( sol::table t, JsonObject &obj )
 {
     sol::state_view lua( t.lua_state() );
 
-    for( JsonMember it : obj ) {
-        std::string key = it.name();
+    for( JsonMember const it : obj ) {
+        std::string const key = it.name();
         if( it.test_bool() ) {
             t[key] = it.get_bool();
         } else if( it.test_string() ) {
             t[key] = it.get_string();
         } else if( it.test_object() ) {
-            JsonObject jo = it.get_object();
-            std::string entry_type = jo.get_member( "type" );
+            JsonObject const jo = it.get_object();
+            std::string const entry_type = jo.get_member( "type" );
             if( entry_type == "int" ) {
-                int data = jo.get_int( "data" );
+                int const data = jo.get_int( "data" );
                 t[key] = data;
             } else if( entry_type == "float" ) {
-                double data = jo.get_float( "data" );
+                double const data = jo.get_float( "data" );
                 t[key] = data;
             } else if( entry_type == "lua_table" ) {
                 JsonObject data = jo.get_object( "data" );
-                sol::table new_table = lua.create_table();
+                sol::table const new_table = lua.create_table();
                 deserialize_lua_table( new_table, data );
                 t[key] = new_table;
             } else if( entry_type == "userdata" ) {
-                std::string kind = jo.get_member( "kind" );
+                std::string const kind = jo.get_member( "kind" );
                 JsonIn &data_raw = *jo.get_raw( "data" );
                 // Horrible hack ahead
-                std::string script = string_format( "return %s.new()", kind );
-                sol::protected_function_result res = lua.script( script, "deserialize_init", sol::load_mode::any );
+                std::string const script = string_format( "return %s.new()", kind );
+                sol::protected_function_result const res = lua.script( script, "deserialize_init", sol::load_mode::any );
                 if( res.status() != sol::call_status::ok ) {
                     debugmsg( "Failed to init container for deserializable type '%s'", kind );
                 } else {
-                    sol::object obj = res;
+                    sol::object const obj = res;
                     sol::table obj_table = obj.as<sol::table>();
                     if( !obj_table ) {
                         debugmsg( "Failed to init container for deserializable type '%s'", kind );
                     } else {
-                        sol::protected_function deserialize_func = obj_table["deserialize"];
+                        sol::protected_function const deserialize_func = obj_table["deserialize"];
                         if( !deserialize_func ) {
                             debugmsg( "Failed to deserialize type '%s': not deserializable.", kind );
                         } else {
-                            sol::protected_function_result res = deserialize_func( obj, data_raw );
+                            sol::protected_function_result const res = deserialize_func( obj, data_raw );
                             if( res.status() != sol::call_status::ok ) {
-                                sol::error err = res;
+                                sol::error const err = res;
                                 debugmsg( "Failed to deserialize type '%s': %s", kind, err.what() );
                             } else {
                                 t[key] = obj;

--- a/src/catalua_serde.cpp
+++ b/src/catalua_serde.cpp
@@ -195,7 +195,8 @@ void deserialize_lua_table( sol::table t, JsonObject &obj )
                 JsonIn &data_raw = *jo.get_raw( "data" );
                 // Horrible hack ahead
                 std::string const script = string_format( "return %s.new()", kind );
-                sol::protected_function_result const res = lua.script( script, "deserialize_init", sol::load_mode::any );
+                sol::protected_function_result const res = lua.script( script, "deserialize_init",
+                        sol::load_mode::any );
                 if( res.status() != sol::call_status::ok ) {
                     debugmsg( "Failed to init container for deserializable type '%s'", kind );
                 } else {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -619,7 +619,7 @@ int Character::sight_range( int light_level ) const
      * log(LIGHT_AMBIENT_LOW / light_level) <= LIGHT_TRANSPARENCY_OPEN_AIR * distance
      * log(LIGHT_AMBIENT_LOW / light_level) * (1 / LIGHT_TRANSPARENCY_OPEN_AIR) <= distance
      */
-    int range = static_cast<int>( -std::log( get_vision_threshold( static_cast<int>
+    int const range = static_cast<int>( -std::log( get_vision_threshold( static_cast<int>
                                   ( get_map().ambient_light_at( pos() ) ) ) / static_cast<float>( light_level ) ) *
                                   ( 1.0 / LIGHT_TRANSPARENCY_OPEN_AIR ) );
 
@@ -721,7 +721,7 @@ bool Character::sight_impaired() const
 
 bool Character::has_alarm_clock() const
 {
-    map &here = get_map();
+    map  const&here = get_map();
     return ( has_item_with_flag( "ALARMCLOCK", true ) ||
              ( here.veh_at( pos() ) &&
                !empty( here.veh_at( pos() )->vehicle().get_avail_parts( "ALARMCLOCK" ) ) ) ||
@@ -730,7 +730,7 @@ bool Character::has_alarm_clock() const
 
 bool Character::has_watch() const
 {
-    map &here = get_map();
+    map  const&here = get_map();
     return ( has_item_with_flag( "WATCH", true ) ||
              ( here.veh_at( pos() ) &&
                !empty( here.veh_at( pos() )->vehicle().get_avail_parts( "WATCH" ) ) ) ||
@@ -829,7 +829,7 @@ int Character::swim_speed() const
         }
     }
     const auto usable = exclusive_flag_coverage( "ALLOWS_NATURAL_ATTACKS" );
-    float hand_bonus_mult = ( usable.test( bp_hand_l ) ? 0.5f : 0.0f ) +
+    float const hand_bonus_mult = ( usable.test( bp_hand_l ) ? 0.5f : 0.0f ) +
                             ( usable.test( bp_hand_r ) ? 0.5f : 0.0f );
 
     // base swim speed.
@@ -930,7 +930,7 @@ void Character::assign_stashed_activity()
 
 bool Character::check_outbounds_activity( const player_activity &act, bool check_only )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     if( ( act.placement != tripoint_zero && act.placement != tripoint_min &&
           !here.inbounds( here.getlocal( act.placement ) ) ) || ( !act.coords.empty() &&
                   !here.inbounds( here.getlocal( act.coords.back() ) ) ) ) {
@@ -967,8 +967,8 @@ player_activity Character::get_destination_activity() const
 
 void Character::mount_creature( monster &z )
 {
-    tripoint pnt = z.pos();
-    shared_ptr_fast<monster> mons = g->shared_from( z );
+    tripoint const pnt = z.pos();
+    shared_ptr_fast<monster> const mons = g->shared_from( z );
     if( mons == nullptr ) {
         add_msg( m_debug, "mount_creature(): monster not found in critter_tracker" );
         return;
@@ -1027,7 +1027,7 @@ bool Character::check_mount_will_move( const tripoint &dest_loc )
     }
     if( mounted_creature && mounted_creature->type->has_fear_trigger( mon_trigger::HOSTILE_CLOSE ) ) {
         for( const monster &critter : g->all_monsters() ) {
-            Attitude att = critter.attitude_to( *this );
+            Attitude const att = critter.attitude_to( *this );
             if( att == A_HOSTILE && sees( critter ) && rl_dist( pos(), critter.pos() ) <= 15 &&
                 rl_dist( dest_loc, critter.pos() ) < rl_dist( pos(), critter.pos() ) ) {
                 add_msg_if_player( _( "You fail to budge your %s!" ), mounted_creature->get_name() );
@@ -1056,7 +1056,7 @@ bool Character::check_mount_is_spooked()
         const bool saddled = mounted_creature->has_effect( effect_saddled );
         for( const monster &critter : g->all_monsters() ) {
             double chance = 1.0;
-            Attitude att = critter.attitude_to( *this );
+            Attitude const att = critter.attitude_to( *this );
             // actually too close now - horse might spook.
             if( att == A_HOSTILE && sees( critter ) && rl_dist( pos(), critter.pos() ) <= 10 ) {
                 chance += 10 - rl_dist( pos(), critter.pos() );
@@ -1399,7 +1399,7 @@ void static try_remove_crushed( Character &c )
 bool static try_remove_grab( Character &c )
 {
     int zed_number = 0;
-    map &here = get_map();
+    map  const&here = get_map();
     if( c.is_mounted() ) {
         auto mon = c.mounted_creature.get();
         if( mon->has_effect( effect_grabbed ) ) {
@@ -1591,8 +1591,8 @@ void Character::recalc_hp()
         str_boost_val = str_boost->calc_bonus( skill_total );
     }
     // Mutated toughness stacks with starting, by design.
-    float hp_mod = 1.0f + mutation_value( "hp_modifier" ) + mutation_value( "hp_modifier_secondary" );
-    float hp_adjustment = mutation_value( "hp_adjustment" ) + ( str_boost_val * 3 );
+    float const hp_mod = 1.0f + mutation_value( "hp_modifier" ) + mutation_value( "hp_modifier_secondary" );
+    float const hp_adjustment = mutation_value( "hp_adjustment" ) + ( str_boost_val * 3 );
     calc_all_parts_hp( hp_mod, hp_adjustment, get_str_base() );
 }
 
@@ -1606,10 +1606,10 @@ void Character::calc_all_parts_hp( float hp_mod, float hp_adjustment, int str_ma
             new_max *= 0.8;
         }
 
-        float max_hp_ratio = static_cast<float>( new_max ) /
+        float const max_hp_ratio = static_cast<float>( new_max ) /
                              static_cast<float>( bp.get_hp_max() );
 
-        int new_cur = std::ceil( static_cast<float>( bp.get_hp_cur() ) * max_hp_ratio );
+        int const new_cur = std::ceil( static_cast<float>( bp.get_hp_cur() ) * max_hp_ratio );
 
         bp.set_hp_max( std::max( new_max, 1 ) );
         bp.set_hp_cur( std::max( std::min( new_cur, new_max ), 0 ) );
@@ -2139,7 +2139,7 @@ Character::wear_item( const item &to_wear, bool interactive )
     const bool supertinymouse = get_size() == MS_TINY;
     last_item = to_wear.typeId();
 
-    std::list<item>::iterator position = position_to_wear_new_item( to_wear );
+    std::list<item>::iterator const position = position_to_wear_new_item( to_wear );
     std::list<item>::iterator new_item_it = worn.insert( position, to_wear );
 
     if( interactive ) {
@@ -2266,7 +2266,7 @@ int Character::i_add_to_container( const item &it, const bool unloading )
 
 item &Character::i_add( item it, bool should_stack )
 {
-    itype_id item_type_id = it.typeId();
+    itype_id const item_type_id = it.typeId();
     last_item = item_type_id;
 
     if( it.is_food() || it.is_ammo() || it.is_gun() || it.is_armor() ||
@@ -2335,7 +2335,7 @@ const item &Character::i_at( int position ) const
         return primary_weapon();
     }
     if( position < -1 ) {
-        int worn_index = worn_position_to_index( position );
+        int const worn_index = worn_position_to_index( position );
         if( static_cast<size_t>( worn_index ) < worn.size() ) {
             auto iter = worn.begin();
             std::advance( iter, worn_index );
@@ -2451,7 +2451,7 @@ std::list<item *> Character::get_dependent_worn_items( const item &it ) const
 
 void Character::drop( item_location loc, const tripoint &where )
 {
-    item &oThisItem = *loc;
+    item  const&oThisItem = *loc;
     if( is_wielding( oThisItem ) ) {
         const auto ret = can_unwield( *loc );
 
@@ -2587,7 +2587,7 @@ units::mass Character::weight_carried_reduced_by( const excluded_stacks &without
     if( weapon_it == without.end() ) {
         weaponweight = weapon.weight();
     } else {
-        int subtract_count = ( *weapon_it ).second;
+        int const subtract_count = ( *weapon_it ).second;
         if( weapon.count_by_charges() ) {
             item copy = weapon;
             copy.charges -= subtract_count;
@@ -2886,12 +2886,12 @@ ret_val<bool> Character::can_wear( const item &it, bool with_equip_change ) cons
                     }
                 }
             }
-            for( std::pair< body_part, bool > &attachment : attachments ) {
+            for( std::pair< body_part, bool >  const&attachment : attachments ) {
                 if( !attachment.second ) {
                     return ret_val<bool>::make_failure( _( "Nothing to attach the mod to!" ) );
                 }
             }
-            for( std::pair< body_part, int > &mod_part : mod_parts ) {
+            for( std::pair< body_part, int >  const&mod_part : mod_parts ) {
                 bpid = convert_bp( mod_part.first );
                 if( static_cast< body_part >( mod_part.first ) == bp_torso ) {
                     max_layer = 3;
@@ -2994,7 +2994,7 @@ Character::wear_possessed( item &to_wear, bool interactive )
     }
 
     bool was_weapon;
-    item to_wear_copy( to_wear );
+    item const to_wear_copy( to_wear );
     item &weapon = primary_weapon();
     if( &to_wear == &weapon ) {
         weapon = item();
@@ -3058,7 +3058,7 @@ bool Character::takeoff( item &it, std::list<item> *res )
         if( volume_carried() + it.volume() > volume_capacity_reduced_by( it.get_storage() ) ) {
             if( is_npc() || query_yn( _( "No room in inventory for your %s.  Drop it?" ),
                                       colorize( it.tname(), it.color_in_inventory() ) ) ) {
-                item_location loc( *this, &it );
+                item_location const loc( *this, &it );
                 drop( loc, pos() );
                 return true; // the drop activity ends up taking off the item anyway so shouldn't try to do it again here
             } else {
@@ -3156,7 +3156,7 @@ bool Character::unwield()
 ret_val<bool> Character::can_swap( const item &it ) const
 {
     if( it.has_flag( flag_POWERARMOR_MOD ) ) {
-        int max_layer = 2;
+        int const max_layer = 2;
         std::vector< std::pair< body_part, int > > mod_parts;
         body_part bp = num_bp;
         bodypart_str_id bpid;
@@ -3176,7 +3176,7 @@ ret_val<bool> Character::can_swap( const item &it ) const
                 }
             }
         }
-        for( std::pair< body_part, int > &mod_part : mod_parts ) {
+        for( std::pair< body_part, int >  const&mod_part : mod_parts ) {
             bpid = convert_bp( mod_part.first );
             if( mod_part.second >= max_layer ) {
                 return ret_val<bool>::make_failure( _( "There is no space on the opposite side!" ) );
@@ -3398,7 +3398,7 @@ int Character::rust_rate() const
     }
 
     // Stat window shows stat effects on based on current stat
-    int intel = get_int();
+    int const intel = get_int();
     /** @EFFECT_INT reduces skill rust by 10% per level above 8 */
     int ret = ( ( rate_option == "vanilla" || rate_option == "capped" ) ?
                 100 : 100 + 10 * ( intel - 8 ) );
@@ -3414,9 +3414,9 @@ int Character::rust_rate() const
 
 void Character::practice( const skill_id &id, int amount, int cap, bool suppress_warning )
 {
-    SkillLevel &level = get_skill_level_object( id );
+    SkillLevel  const&level = get_skill_level_object( id );
     const Skill &skill = id.obj();
-    std::string skill_name = skill.name();
+    std::string const skill_name = skill.name();
 
     if( !level.can_train() && !in_sleep_state() ) {
         // If leveling is disabled, don't train, don't drain focus, don't print anything
@@ -3469,9 +3469,9 @@ void Character::practice( const skill_id &id, int amount, int cap, bool suppress
         }
     }
     if( amount > 0 && level.isTraining() ) {
-        int oldLevel = get_skill_level( id );
+        int const oldLevel = get_skill_level( id );
         get_skill_level_object( id ).train( amount );
-        int newLevel = get_skill_level( id );
+        int const newLevel = get_skill_level( id );
         if( newLevel > oldLevel ) {
             g->events().send<event_type::gains_skill_level>( getID(), id, newLevel );
         }
@@ -3484,7 +3484,7 @@ void Character::practice( const skill_id &id, int amount, int cap, bool suppress
                      skill_name );
         }
 
-        int chance_to_drop = focus_pool;
+        int const chance_to_drop = focus_pool;
         focus_pool -= chance_to_drop / 100;
         // Apex Predators don't think about much other than killing.
         // They don't lose Focus when practicing combat skills.
@@ -3571,7 +3571,7 @@ void Character::apply_skill_boost()
         // For migration, reset previously applied bonus.
         // Remove after 0.E or so.
         const std::string bonus_name = boost.stat() + std::string( "_bonus" );
-        std::string previous_bonus = get_value( bonus_name );
+        std::string const previous_bonus = get_value( bonus_name );
         if( !previous_bonus.empty() ) {
             if( boost.stat() == "str" ) {
                 str_max -= atoi( previous_bonus.c_str() );
@@ -3687,7 +3687,7 @@ char_encumbrance_data Character::calc_encumbrance( const item &new_item ) const
 units::mass Character::get_weight() const
 {
     units::mass ret = 0_gram;
-    units::mass wornWeight = std::accumulate( worn.begin(), worn.end(), 0_gram,
+    units::mass const wornWeight = std::accumulate( worn.begin(), worn.end(), 0_gram,
     []( units::mass sum, const item & itm ) {
         return sum + itm.weight();
     } );
@@ -3785,7 +3785,7 @@ static void layer_item( char_encumbrance_data &vals,
         layering_encumbrance = 0;
     }
 
-    body_part_set covered_parts = it.get_covered_body_parts();
+    body_part_set const covered_parts = it.get_covered_body_parts();
     for( const body_part bp : all_body_parts ) {
         if( !covered_parts.test( bp ) ) {
             continue;
@@ -3856,7 +3856,7 @@ bool Character::in_climate_control()
     if( has_active_bionic( bio_climate ) ) {
         return true;
     }
-    map &here = get_map();
+    map  const&here = get_map();
     if( has_trait( trait_M_SKIN3 ) && here.has_flag_ter_or_furn( flag_FUNGUS, pos() ) &&
         in_sleep_state() ) {
         return true;
@@ -3894,8 +3894,8 @@ static int wind_resistance_from_item_list( const std::vector<const item *> &item
 
     for( const item *it : items ) {
         const item &i = *it;
-        int penalty = 100 - i.wind_resist();
-        int coverage = std::max( 0, i.get_coverage() - penalty );
+        int const penalty = 100 - i.wind_resist();
+        int const coverage = std::max( 0, i.get_coverage() - penalty );
         total_exposed = total_exposed * ( 100 - coverage ) / 100;
     }
 
@@ -3940,7 +3940,7 @@ int layer_details::layer( const int encumbrance )
 
     pieces.push_back( encumbrance );
 
-    int current = total;
+    int const current = total;
     if( encumbrance > max ) {
         total += max;   // *now* the old max is counted, just ignore the new max
         max = encumbrance;
@@ -4221,7 +4221,7 @@ void Character::print_health() const
     if( !is_player() ) {
         return;
     }
-    int current_health = get_healthy();
+    int const current_health = get_healthy();
     if( has_trait( trait_SELFAWARE ) ) {
         add_msg_if_player( _( "Your current health value is %d." ), current_health );
     }
@@ -4355,7 +4355,7 @@ int Character::get_thirst() const
 
 std::pair<std::string, nc_color> Character::get_thirst_description() const
 {
-    int thirst = get_thirst();
+    int const thirst = get_thirst();
     std::string hydration_string;
     nc_color hydration_color = c_white;
     if( thirst > thirst_levels::parched ) {
@@ -4384,10 +4384,10 @@ std::pair<std::string, nc_color> Character::get_thirst_description() const
 
 std::pair<std::string, nc_color> Character::get_hunger_description() const
 {
-    int total_kcal = stored_calories + stomach.get_calories();
-    int max_kcal = max_stored_kcal();
-    float days_left = static_cast<float>( total_kcal ) / bmr();
-    float days_max = static_cast<float>( max_kcal ) / bmr();
+    int const total_kcal = stored_calories + stomach.get_calories();
+    int const max_kcal = max_stored_kcal();
+    float const days_left = static_cast<float>( total_kcal ) / bmr();
+    float const days_max = static_cast<float>( max_kcal ) / bmr();
     std::string hunger_string;
     nc_color hunger_color = c_white;
     if( days_left >= days_max ) {
@@ -4419,7 +4419,7 @@ std::pair<std::string, nc_color> Character::get_hunger_description() const
 
 std::pair<std::string, nc_color> Character::get_fatigue_description() const
 {
-    int fatigue = get_fatigue();
+    int const fatigue = get_fatigue();
     std::string fatigue_string;
     nc_color fatigue_color = c_white;
     if( fatigue > fatigue_levels::exhausted ) {
@@ -4559,8 +4559,8 @@ void Character::reset_bonuses()
 
 std::string Character::get_weight_string() const
 {
-    double weight = convert_weight( bodyweight() );
-    int display_weight = static_cast<int>( std::round( weight ) );
+    double const weight = convert_weight( bodyweight() );
+    int const display_weight = static_cast<int>( std::round( weight ) );
     return std::to_string( display_weight ) + " " + weight_units();
 }
 
@@ -4577,8 +4577,8 @@ void Character::regen( int rate_multiplier )
                                    mutation_value( "pain_recovery" ) ) ) );
     }
 
-    float rest = rest_quality();
-    float heal_rate = healing_rate( rest ) * to_turns<int>( 5_minutes );
+    float const rest = rest_quality();
+    float const heal_rate = healing_rate( rest ) * to_turns<int>( 5_minutes );
     if( heal_rate > 0.0f ) {
         healall( roll_remainder( rate_multiplier * heal_rate ) );
     } else if( heal_rate < 0.0f ) {
@@ -4592,9 +4592,9 @@ void Character::regen( int rate_multiplier )
     // include healing effects
     for( int i = 0; i < num_hp_parts; i++ ) {
         const bodypart_id &bp = convert_bp( hp_to_bp( static_cast<hp_part>( i ) ) ).id();
-        float healing = healing_rate_medicine( rest, bp ) * to_turns<int>( 5_minutes );
+        float const healing = healing_rate_medicine( rest, bp ) * to_turns<int>( 5_minutes );
 
-        int healing_apply = roll_remainder( healing );
+        int const healing_apply = roll_remainder( healing );
         healed_bp( i, healing_apply );
         heal( bp, healing_apply );
         if( damage_bandaged[i] > 0 ) {
@@ -4667,7 +4667,7 @@ void Character::update_health( int external_modifiers )
     // Health tends toward healthy_mod.
     // For small differences, it changes 4 points per day
     // For large ones, up to ~40% of the difference per day
-    int health_change = effective_healthy_mod - get_healthy() + external_modifiers;
+    int const health_change = effective_healthy_mod - get_healthy() + external_modifiers;
     mod_healthy( sgn( health_change ) * std::max( 1, std::abs( health_change ) / 10 ) );
 
     // And healthy_mod decays over time.
@@ -4723,14 +4723,14 @@ void Character::update_body( const time_point &from, const time_point &to )
     for( const auto &v : vitamin::all() ) {
         const time_duration rate = vitamin_rate( v.first );
         if( rate > 0_turns ) {
-            int qty = ticks_between( from, to, rate );
+            int const qty = ticks_between( from, to, rate );
             if( qty > 0 ) {
                 vitamin_mod( v.first, 0 - qty );
             }
 
         } else if( rate < 0_turns ) {
             // mutations can result in vitamins being generated (but never accumulated)
-            int qty = ticks_between( from, to, -rate );
+            int const qty = ticks_between( from, to, -rate );
             if( qty > 0 ) {
                 vitamin_mod( v.first, qty );
             }
@@ -4742,7 +4742,7 @@ void Character::update_body( const time_point &from, const time_point &to )
 
 item *Character::best_quality_item( const quality_id &qual )
 {
-    std::vector<item *> qual_inv = items_with( [qual]( const item & itm ) {
+    std::vector<item *> const qual_inv = items_with( [qual]( const item & itm ) {
         return itm.has_quality( qual );
     } );
     item *best_qual = random_entry( qual_inv );
@@ -4769,7 +4769,7 @@ void Character::update_stomach( const time_point &from, const time_point &to )
 
     if( five_mins > 0 ) {
         // Digest nutrients in stomach
-        food_summary digested_to_body = stomach.digest( rates, five_mins );
+        food_summary const digested_to_body = stomach.digest( rates, five_mins );
         // Apply nutrients, unless this is an NPC and NO_NPC_FOOD is enabled.
         if( !npc_no_food ) {
             mod_stored_kcal( digested_to_body.nutr.kcal );
@@ -4810,13 +4810,13 @@ void Character::update_needs( int rate_multiplier )
     const bool lying = asleep || has_effect( effect_lying_down ) ||
                        activity.id() == ACT_TRY_SLEEP;
 
-    needs_rates rates = calc_needs_rates();
+    needs_rates const rates = calc_needs_rates();
 
     const bool wasnt_fatigued = get_fatigue() <= fatigue_levels::dead_tired;
     // Don't increase fatigue if sleeping or trying to sleep or if we're at the cap.
     if( get_fatigue() < 1050 && !asleep && !debug_ls ) {
         if( rates.fatigue > 0.0f ) {
-            int fatigue_roll = roll_remainder( rates.fatigue * rate_multiplier );
+            int const fatigue_roll = roll_remainder( rates.fatigue * rate_multiplier );
             mod_fatigue( fatigue_roll );
 
             // Synaptic regen bionic stops SD while awake and boosts it while sleeping
@@ -5106,8 +5106,8 @@ void Character::check_needs_extremes()
     }
 
     // Sleep deprivation kicks in if lack of sleep is avoided with stimulants or otherwise for long periods of time
-    int sleep_deprivation = get_sleep_deprivation();
-    float sleep_deprivation_pct = sleep_deprivation / static_cast<float>
+    int const sleep_deprivation = get_sleep_deprivation();
+    float const sleep_deprivation_pct = sleep_deprivation / static_cast<float>
                                   ( sleep_deprivation_levels::massive );
 
     if( sleep_deprivation >= sleep_deprivation_levels::harmless && !in_sleep_state() &&
@@ -5223,7 +5223,7 @@ void Character::update_bodytemp( const map &m, const weather_manager &weather )
     const auto player_local_temp = weather.get_temperature( pos() );
     // NOTE : visit weather.h for some details on the numbers used
     // In Celsius / 100
-    int Ctemperature = static_cast<int>( 100 * units::fahrenheit_to_celsius( player_local_temp ) );
+    int const Ctemperature = static_cast<int>( 100 * units::fahrenheit_to_celsius( player_local_temp ) );
     const w_point &weather_point = get_weather().get_precise();
     int vehwindspeed = 0;
     const optional_vpart_position vp = m.veh_at( pos() );
@@ -5231,11 +5231,11 @@ void Character::update_bodytemp( const map &m, const weather_manager &weather )
         vehwindspeed = std::abs( vp->vehicle().velocity / 100 ); // vehicle velocity in mph
     }
     const oter_id &cur_om_ter = overmap_buffer.ter( global_omt_location() );
-    bool sheltered = weather::is_sheltered( m, pos() );
-    double total_windpower = get_local_windpower( weather.windspeed + vehwindspeed, cur_om_ter,
+    bool const sheltered = weather::is_sheltered( m, pos() );
+    double const total_windpower = get_local_windpower( weather.windspeed + vehwindspeed, cur_om_ter,
                              pos(),
                              weather.winddirection, sheltered );
-    int air_humidity = get_local_humidity( weather_point.humidity, weather.weather_id,
+    int const air_humidity = get_local_humidity( weather_point.humidity, weather.weather_id,
                                            sheltered );
     // Let's cache this not to check it num_bp times
     const bool has_bark = has_trait( trait_BARK );
@@ -5306,7 +5306,7 @@ void Character::update_bodytemp( const map &m, const weather_manager &weather )
         // TODO: Port body part set id changes
         const body_part_set &covered = it.get_covered_body_parts();
         for( size_t i = 0; i < num_bp; i++ ) {
-            body_part token = static_cast<body_part>( i );
+            body_part const token = static_cast<body_part>( i );
             if( covered.test( token ) ) {
                 clothing_map[convert_bp( token )].emplace_back( &it );
             }
@@ -5347,9 +5347,9 @@ void Character::update_bodytemp( const map &m, const weather_manager &weather )
     std::map<bodypart_id, int> wind_res_per_bp_bonus = warmth::wind_resistance_from_clothing(
                 bonus_clothing_map );
     for( std::pair<const bodypart_id, int> &bp_wind_res : wind_res_per_bp ) {
-        int exposed = std::max( 0, 100 - bp_wind_res.second );
-        int exposed_bonus = std::max( 0, 100 - wind_res_per_bp_bonus.at( bp_wind_res.first ) );
-        int exposed_final = exposed * exposed_bonus / ( 100 * 100 );
+        int const exposed = std::max( 0, 100 - bp_wind_res.second );
+        int const exposed_bonus = std::max( 0, 100 - wind_res_per_bp_bonus.at( bp_wind_res.first ) );
+        int const exposed_final = exposed * exposed_bonus / ( 100 * 100 );
         bp_wind_res.second = 100 - exposed_final;
     }
     if( has_active_mutation( trait_SHELL2 ) ) {
@@ -5380,17 +5380,17 @@ void Character::update_bodytemp( const map &m, const weather_manager &weather )
                                   ( Ctemperature - ambient_norm );
 
         // Represents the fact that the body generates heat when it is cold.
-        double scaled_temperature = logarithmic_range( BODYTEMP_VERY_COLD, BODYTEMP_VERY_HOT,
+        double const scaled_temperature = logarithmic_range( BODYTEMP_VERY_COLD, BODYTEMP_VERY_HOT,
                                     temp_cur[bp->token] );
         // Produces a smooth curve between 30.0 and 60.0.
-        double homeostasis_adjustment = 30.0 * ( 1.0 + scaled_temperature );
-        int clothing_warmth_adjustment = static_cast<int>( homeostasis_adjustment * warmth_per_bp[bp] );
-        int clothing_warmth_adjusted_bonus = static_cast<int>( homeostasis_adjustment *
+        double const homeostasis_adjustment = 30.0 * ( 1.0 + scaled_temperature );
+        int const clothing_warmth_adjustment = static_cast<int>( homeostasis_adjustment * warmth_per_bp[bp] );
+        int const clothing_warmth_adjusted_bonus = static_cast<int>( homeostasis_adjustment *
                                              bonus_warmth_per_bp[bp] );
         // WINDCHILL
-        double bp_windpower = total_windpower * ( 1 - wind_res_per_bp[bp] / 100.0 );
+        double const bp_windpower = total_windpower * ( 1 - wind_res_per_bp[bp] / 100.0 );
         // Calculate windchill
-        int windchill = submerged_bp
+        int const windchill = submerged_bp
                         ? 0
                         : get_local_windchill( player_local_temp,
                                                air_humidity,
@@ -5441,7 +5441,7 @@ void Character::update_bodytemp( const map &m, const weather_manager &weather )
             bp_conv = temp_corrected_by_climate_control( bp_conv );
         }
 
-        int bonus_fire_warmth = best_fire * 500;
+        int const bonus_fire_warmth = best_fire * 500;
 
         const int comfortable_warmth = bonus_fire_warmth + lying_warmth;
         const int bonus_warmth = comfortable_warmth + mutation_heat_bonus + clothing_warmth_adjusted_bonus;
@@ -5486,7 +5486,7 @@ void Character::update_bodytemp( const map &m, const weather_manager &weather )
 
         // FINAL CALCULATION : Increments current body temperature towards convergent.
         int temp_before = temp_cur[bp->token];
-        int temp_difference = temp_before - bp_conv; // Negative if the player is warming up.
+        int const temp_difference = temp_before - bp_conv; // Negative if the player is warming up.
         int rounding_error = 0;
         // If temp_diff is small, the player cannot warm up due to rounding errors. This fixes that.
         if( temp_difference < 0 && temp_difference > -600 ) {
@@ -5501,7 +5501,7 @@ void Character::update_bodytemp( const map &m, const weather_manager &weather )
             temp_cur[bp->token] = static_cast<int>( temp_difference * change_mult )
                                   + bp_conv + rounding_error;
         }
-        int temp_after = temp_cur[bp->token];
+        int const temp_after = temp_cur[bp->token];
         // PENALTIES
         if( temp_cur[bp->token] < BODYTEMP_FREEZING ) {
             add_effect( effect_cold, 1_turns, bp->token, 3 );
@@ -5565,16 +5565,16 @@ void Character::update_bodytemp( const map &m, const weather_manager &weather )
             bp == body_part_foot_l || bp == body_part_hand_r || bp == body_part_hand_l ) {
             // Handle the frostbite timer
             // Need temps in F, windPower already in mph
-            int wetness_percentage = 100 * body_wetness[bp->token] / drench_capacity[bp->token]; // 0 - 100
+            int const wetness_percentage = 100 * body_wetness[bp->token] / drench_capacity[bp->token]; // 0 - 100
             // Warmth gives a slight buff to temperature resistance
             // Wetness gives a heavy nerf to temperature resistance
-            double adjusted_warmth = warmth_per_bp.at( bp ) - wetness_percentage;
-            int Ftemperature = static_cast<int>( player_local_temp + 0.2 * adjusted_warmth );
+            double const adjusted_warmth = warmth_per_bp.at( bp ) - wetness_percentage;
+            int const Ftemperature = static_cast<int>( player_local_temp + 0.2 * adjusted_warmth );
             // Windchill reduced by your armor
-            int FBwindPower = static_cast<int>(
+            int const FBwindPower = static_cast<int>(
                                   total_windpower * ( 1 - wind_res_per_bp[ bp ] / 100.0 ) );
 
-            int intense = get_effect_int( effect_frostbite, bp->token );
+            int const intense = get_effect_int( effect_frostbite, bp->token );
 
             // This has been broken down into 8 zones
             // Low risk zones (stops at frostnip)
@@ -5676,7 +5676,7 @@ void Character::update_bodytemp( const map &m, const weather_manager &weather )
         // Otherwise, if any other body part is BODYTEMP_VERY_COLD, or 31C
         // AND you have frostbite, then that also prevents you from sleeping
         if( in_sleep_state() ) {
-            int curr_temperature = temp_cur[bp->token];
+            int const curr_temperature = temp_cur[bp->token];
             if( bp == body_part_torso && curr_temperature <= BODYTEMP_COLD ) {
                 add_msg( m_warning, _( "Your shivering prevents you from sleeping." ) );
                 wake_up();
@@ -5711,7 +5711,7 @@ void Character::temp_equalizer( const bodypart_id &bp1, const bodypart_id &bp2 )
 {
     // Body heat is moved around.
     // If bp1 is warmer, it will lose heat
-    int diff = static_cast<int>( ( temp_cur[bp2->token] - temp_cur[bp1->token] ) * 0.001 );
+    int const diff = static_cast<int>( ( temp_cur[bp2->token] - temp_cur[bp1->token] ) * 0.001 );
     temp_cur[bp1->token] += diff;
     temp_cur[bp2->token] -= diff;
 }
@@ -5817,11 +5817,11 @@ hp_part Character::body_window( const std::string &menu_header,
 
         std::string msg;
         std::string desc;
-        bool bleeding = has_effect( effect_bleed, bp_token );
-        bool bitten = has_effect( effect_bite, bp_token );
-        bool infected = has_effect( effect_infected, bp_token );
-        bool bandaged = has_effect( effect_bandaged, bp_token );
-        bool disinfected = has_effect( effect_disinfected, bp_token );
+        bool const bleeding = has_effect( effect_bleed, bp_token );
+        bool const bitten = has_effect( effect_bite, bp_token );
+        bool const infected = has_effect( effect_infected, bp_token );
+        bool const bandaged = has_effect( effect_bandaged, bp_token );
+        bool const disinfected = has_effect( effect_disinfected, bp_token );
         const int b_power = get_effect_int( effect_bandaged, bp_token );
         const int d_power = get_effect_int( effect_disinfected, bp_token );
         int new_b_power = static_cast<int>( std::floor( bandage_power ) );
@@ -5832,7 +5832,7 @@ hp_part Character::body_window( const std::string &menu_header,
             }
 
         }
-        int new_d_power = static_cast<int>( std::floor( disinfectant_power ) );
+        int const new_d_power = static_cast<int>( std::floor( disinfectant_power ) );
 
         const auto &aligned_name = std::string( max_bp_name_len - utf8_width( e.name ), ' ' ) + e.name;
         std::string hp_str;
@@ -5854,7 +5854,7 @@ hp_part Character::body_window( const std::string &menu_header,
         } else if( precise ) {
             hp_str = string_format( "%d", current_hp );
         } else {
-            std::pair<std::string, nc_color> h_bar = get_hp_bar( current_hp, maximal_hp, false );
+            std::pair<std::string, nc_color> const h_bar = get_hp_bar( current_hp, maximal_hp, false );
             hp_str = colorize( h_bar.first, h_bar.second ) +
                      colorize( std::string( 5 - utf8_width( h_bar.first ), '.' ), c_white );
         }
@@ -6296,7 +6296,7 @@ int Character::visibility( bool, int ) const
     }
     // TODO:
     // if ( dark_clothing() && light check ...
-    int stealth_modifier = std::floor( mutation_value( "stealth_modifier" ) );
+    int const stealth_modifier = std::floor( mutation_value( "stealth_modifier" ) );
     return clamp( 100 - stealth_modifier, 40, 160 );
 }
 
@@ -6512,7 +6512,7 @@ std::string Character::extended_description() const
     const std::vector<bodypart_id> &bps = get_all_body_parts( true );
     // Find length of bp names, to align
     // accumulate looks weird here, any better function?
-    int longest = std::accumulate( bps.begin(), bps.end(), 0,
+    int const longest = std::accumulate( bps.begin(), bps.end(), 0,
     []( int m, bodypart_id bp ) {
         return std::max( m, utf8_width( body_part_name_as_heading( bp->token, 1 ) ) );
     } );
@@ -6527,8 +6527,8 @@ std::string Character::extended_description() const
         const std::string &bp_heading = body_part_name_as_heading( bp->token, 1 );
 
         const nc_color state_col = limb_color( bp, true, true, true );
-        nc_color name_color = state_col;
-        std::pair<std::string, nc_color> hp_bar = get_hp_bar( get_part_hp_cur( bp ), get_part_hp_max( bp ),
+        nc_color const name_color = state_col;
+        std::pair<std::string, nc_color> const hp_bar = get_hp_bar( get_part_hp_cur( bp ), get_part_hp_max( bp ),
                 false );
 
         ss += colorize( left_justify( bp_heading, longest ), name_color );
@@ -6573,7 +6573,7 @@ float calc_mutation_value( const std::vector<const mutation_branch *> &mutations
     float lowest = 0.0f;
     float highest = 0.0f;
     for( const mutation_branch *mut : mutations ) {
-        float val = mut->*member;
+        float const val = mut->*member;
         lowest = std::min( lowest, val );
         highest = std::max( highest, val );
     }
@@ -6662,7 +6662,7 @@ float Character::healing_rate( float at_rest_quality ) const
     } else {
         heal_rate = get_option< float >( "NPC_HEALING_RATE" );
     }
-    float awake_rate = heal_rate * mutation_value( "healing_awake" );
+    float const awake_rate = heal_rate * mutation_value( "healing_awake" );
     float final_rate = 0.0f;
     if( awake_rate > 0.0f ) {
         final_rate += awake_rate;
@@ -6686,7 +6686,7 @@ float Character::healing_rate( float at_rest_quality ) const
         return 0.0f;
     }
 
-    float primary_hp_mod = mutation_value( "hp_modifier" );
+    float const primary_hp_mod = mutation_value( "hp_modifier" );
     if( primary_hp_mod < 0.0f ) {
         // HP mod can't get below -1.0
         final_rate *= 1.0f + primary_hp_mod;
@@ -6740,7 +6740,7 @@ float Character::healing_rate_medicine( float at_rest_quality, const bodypart_id
     } else {
         rate_medicine *= 1.0f + get_healthy() / 400.0f;
     }
-    float primary_hp_mod = mutation_value( "hp_modifier" );
+    float const primary_hp_mod = mutation_value( "hp_modifier" );
     if( primary_hp_mod < 0.0f ) {
         // HP mod can't get below -1.0
         rate_medicine *= 1.0f + primary_hp_mod;
@@ -6792,7 +6792,7 @@ void Character::mod_base_age( int mod )
 
 int Character::age() const
 {
-    int years_since_cataclysm = to_turns<int>( calendar::turn - calendar::turn_zero ) /
+    int const years_since_cataclysm = to_turns<int>( calendar::turn - calendar::turn_zero ) /
                                 to_turns<int>( calendar::year_length() );
     return init_age + years_since_cataclysm;
 }
@@ -6800,7 +6800,7 @@ int Character::age() const
 std::string Character::age_string() const
 {
     //~ how old the character is in years. try to limit number of characters to fit on the screen
-    std::string unformatted = _( "%d years" );
+    std::string const unformatted = _( "%d years" );
     return string_format( unformatted, age() );
 }
 
@@ -6824,13 +6824,13 @@ std::string Character::height_string() const
     const bool metric = get_option<std::string>( "DISTANCE_UNITS" ) == "metric";
 
     if( metric ) {
-        std::string metric_string = _( "%d cm" );
+        std::string const metric_string = _( "%d cm" );
         return string_format( metric_string, height() );
     }
 
-    int total_inches = std::round( height() / 2.54 );
-    int feet = std::floor( total_inches / 12 );
-    int remainder_inches = total_inches % 12;
+    int const total_inches = std::round( height() / 2.54 );
+    int const feet = std::floor( total_inches / 12 );
+    int const remainder_inches = total_inches % 12;
     return string_format( "%d\'%d\"", feet, remainder_inches );
 }
 
@@ -7117,9 +7117,9 @@ void Character::mod_stamina( int mod )
 void Character::burn_move_stamina( int moves )
 {
     int overburden_percentage = 0;
-    units::mass current_weight = weight_carried();
+    units::mass const current_weight = weight_carried();
     // Make it at least 1 gram to avoid divide-by-zero warning
-    units::mass max_weight = std::max( weight_capacity(), 1_gram );
+    units::mass const max_weight = std::max( weight_capacity(), 1_gram );
     if( current_weight > max_weight ) {
         overburden_percentage = ( current_weight - max_weight ) * 100 / max_weight;
     }
@@ -7172,7 +7172,7 @@ void Character::update_stamina( int turns )
     float stamina_recovery = 0.0f;
     // Recover some stamina every turn.
     // max stamina modifers from mutation also affect stamina multi
-    float stamina_multiplier = 1.0f + mutation_value( stamina_regen_modifier ) +
+    float const stamina_multiplier = 1.0f + mutation_value( stamina_regen_modifier ) +
                                ( mutation_value( "max_stamina_modifier" ) - 1.0f ) +
                                bonus_from_enchantments( 1.0, enchant_vals::mod::STAMINA_REGEN );
     // But mouth encumbrance interferes, even with mutated stamina.
@@ -7244,7 +7244,7 @@ bool Character::invoke_item( item *used, const std::string &method, const tripoi
         return false;
     }
 
-    int charges_used = actually_used->type->invoke( *this->as_player(), *actually_used, pt, method );
+    int const charges_used = actually_used->type->invoke( *this->as_player(), *actually_used, pt, method );
     if( charges_used == 0 ) {
         return false;
     }
@@ -7312,7 +7312,7 @@ bool Character::dispose_item( item_location &&obj, const std::string &prompt )
                 return false;
             }
 
-            item it = *obj;
+            item const it = *obj;
             obj.remove_item();
             return !!wear_item( it );
         }
@@ -7503,7 +7503,7 @@ int Character::item_store_cost( const item &it, const item & /* container */, bo
     /** @EFFECT_STABBING decreases time taken to store a stabbing weapon */
     /** @EFFECT_CUTTING decreases time taken to store a cutting weapon */
     /** @EFFECT_BASHING decreases time taken to store a bashing weapon */
-    int lvl = get_skill_level( it.is_gun() ? it.gun_skill() : it.melee_skill() );
+    int const lvl = get_skill_level( it.is_gun() ? it.gun_skill() : it.melee_skill() );
     return item_handling_cost( it, penalties, base_cost ) / ( ( lvl + 10.0f ) / 10.0f );
 }
 
@@ -7660,7 +7660,7 @@ void Character::shout( std::string msg, bool order )
         msg = is_player() ? _( "yourself shout loudly!" ) : _( "a loud shout!" );
         shout = "default";
     }
-    int noise = get_shout_volume();
+    int const noise = get_shout_volume();
 
     // Minimum noise volume possible after all reductions.
     // Volume 1 can't be heard even by player
@@ -8049,7 +8049,7 @@ void Character::absorb_hit( const bodypart_id &bp, damage_instance &dam )
             } else if( elem.type == DT_BULLET ) {
                 elem_multi = 0.25;
             }
-            units::energy ads_cost = elem.amount * 500_J;
+            units::energy const ads_cost = elem.amount * 500_J;
             if( bio.energy_stored >= ads_cost ) {
                 dam.mult_damage( elem_multi );
                 bio.energy_stored -= ads_cost;
@@ -8065,7 +8065,7 @@ void Character::absorb_hit( const bodypart_id &bp, damage_instance &dam )
                         add_msg_if_player( m_bad, _( "Your forcefield shatters and the feedback shorts out the %s!" ),
                                            bio.info().name );
                     }
-                    int over = units::to_kilojoule( ads_cost - ( shatter_thresh - 5_kJ ) );
+                    int const over = units::to_kilojoule( ads_cost - ( shatter_thresh - 5_kJ ) );
                     bio.incapacitated_time += ( ( over / 5 ) ) * 1_turns;
                 } else {
                     add_msg_if_player( m_bad, _( "Your forcefield crackles and the %s powers down." ),
@@ -8102,7 +8102,7 @@ void Character::absorb_hit( const bodypart_id &bp, damage_instance &dam )
                 // TODO: Different fire intensity values based on damage
                 fire_data frd{ 2 };
                 destroy = armor.burn( frd );
-                int fuel = roll_remainder( frd.fuel_produced );
+                int const fuel = roll_remainder( frd.fuel_produced );
                 if( fuel > 0 ) {
                     add_effect( effect_onfire, time_duration::from_turns( fuel + 1 ), bp->token, 0, false, true );
                 }
@@ -8147,7 +8147,7 @@ void Character::absorb_hit( const bodypart_id &bp, damage_instance &dam )
         elem.amount = std::max( elem.amount, 0.0f );
     }
     map &here = get_map();
-    for( item &remain : worn_remains ) {
+    for( item  const&remain : worn_remains ) {
         here.add_item_or_charges( pos(), remain );
     }
     if( armor_destroyed ) {
@@ -8197,14 +8197,14 @@ bool Character::armor_absorb( damage_unit &du, item &armor )
     }
 
     const material_type &material = armor.get_random_material();
-    std::string damage_verb = ( du.type == DT_BASH ) ? material.bash_dmg_verb() :
+    std::string const damage_verb = ( du.type == DT_BASH ) ? material.bash_dmg_verb() :
                               material.cut_dmg_verb();
 
     const std::string pre_damage_name = armor.tname();
     const std::string pre_damage_adj = armor.get_base_material().dmg_adj( armor.damage_level( 4 ) );
 
     // add "further" if the damage adjective and verb are the same
-    std::string format_string = ( pre_damage_adj == damage_verb ) ?
+    std::string const format_string = ( pre_damage_adj == damage_verb ) ?
                                 _( "Your %1$s is %2$s further!" ) : _( "Your %1$s is %2$s!" );
     add_msg_if_player( m_bad, format_string, pre_damage_name, damage_verb );
     //item is damaged
@@ -8276,7 +8276,7 @@ void Character::on_dodge( Creature *source, int difficulty )
 
     // For adjacent attackers check for techniques usable upon successful dodge
     if( source && square_dist( pos(), source->pos() ) == 1 ) {
-        matec_id tec = pick_technique( *source, primary_weapon(), false, true, false );
+        matec_id const tec = pick_technique( *source, primary_weapon(), false, true, false );
 
         if( tec != tec_none && !is_dead_state() ) {
             if( get_stamina() < get_stamina_max() / 3 ) {
@@ -8301,8 +8301,8 @@ void Character::on_hit( Creature *source, bodypart_id bp_hit,
         return;
     }
 
-    bool u_see = g->u.sees( *this );
-    units::energy trigger_cost_base = bio_ods->power_trigger;
+    bool const u_see = g->u.sees( *this );
+    units::energy const trigger_cost_base = bio_ods->power_trigger;
     if( has_active_bionic( bio_ods ) && get_power_level() >= trigger_cost_base * 4 ) {
         if( is_player() ) {
             add_msg( m_good, _( "Your offensive defense system shocks %s in mid-attack!" ),
@@ -8312,7 +8312,7 @@ void Character::on_hit( Creature *source, bodypart_id bp_hit,
                      disp_name(),
                      source->disp_name() );
         }
-        int shock = rng( 1, 4 );
+        int const shock = rng( 1, 4 );
         mod_power_level( -shock * trigger_cost_base );
         damage_instance ods_shock_damage;
         ods_shock_damage.add_damage( DT_ELECTRIC, shock * 5 );
@@ -8321,7 +8321,7 @@ void Character::on_hit( Creature *source, bodypart_id bp_hit,
     }
     if( !wearing_something_on( bp_hit ) &&
         ( has_trait( trait_SPINES ) || has_trait( trait_QUILLS ) ) ) {
-        int spine = rng( 1, has_trait( trait_QUILLS ) ? 20 : 8 );
+        int const spine = rng( 1, has_trait( trait_QUILLS ) ? 20 : 8 );
         if( !is_player() ) {
             if( u_see ) {
                 add_msg( _( "%1$s's %2$s puncture %3$s in mid-attack!" ), name,
@@ -8347,7 +8347,7 @@ void Character::on_hit( Creature *source, bodypart_id bp_hit,
         } else {
             add_msg( m_good, _( "Your thorns scrape %s in mid-attack!" ), source->disp_name() );
         }
-        int thorn = rng( 1, 4 );
+        int const thorn = rng( 1, 4 );
         damage_instance thorn_damage;
         thorn_damage.add_damage( DT_CUT, thorn );
         // In general, critters don't have separate limbs
@@ -8432,7 +8432,7 @@ void Character::apply_damage( Creature *source, bodypart_id hurt, int dam,
     }
     if( has_effect( effect_mending, part_to_damage->token ) ) {
         effect &e = get_effect( effect_mending, part_to_damage->token );
-        float remove_mend = dam / 20.0f;
+        float const remove_mend = dam / 20.0f;
         e.mod_duration( -e.get_max_duration() * remove_mend );
     }
 
@@ -8477,7 +8477,7 @@ dealt_damage_instance Character::deal_damage( Creature *source, bodypart_id bp,
     //damage applied here
     dealt_damage_instance dealt_dams = Creature::deal_damage( source, bp, d );
     //block reduction should be by applied this point
-    int dam = dealt_dams.total_damage();
+    int const dam = dealt_dams.total_damage();
 
     // TODO: Pre or post blit hit tile onto "this"'s location here
     if( dam > 0 && g->u.sees( pos() ) ) {
@@ -8517,8 +8517,8 @@ dealt_damage_instance Character::deal_damage( Creature *source, bodypart_id bp,
     }
 
     //Acid blood effects.
-    bool u_see = g->u.sees( *this );
-    int cut_dam = dealt_dams.type_damage( DT_CUT );
+    bool const u_see = g->u.sees( *this );
+    int const cut_dam = dealt_dams.type_damage( DT_CUT );
     if( source && has_trait( trait_ACIDBLOOD ) && !one_in( 3 ) &&
         ( dam >= 4 || cut_dam > 0 ) && ( rl_dist( g->u.pos(), source->pos() ) <= 1 ) ) {
         if( is_player() ) {
@@ -8577,7 +8577,7 @@ dealt_damage_instance Character::deal_damage( Creature *source, bodypart_id bp,
                                            source->disp_name() );
                 }
             } else {
-                int prev_effect = get_effect_int( effect_grabbed );
+                int const prev_effect = get_effect_int( effect_grabbed );
                 add_effect( effect_grabbed, 2_turns, bp_torso, prev_effect + 2 );
                 source->add_effect( effect_grabbing, 2_turns );
                 add_msg_player_or_npc( m_bad, _( "You are grabbed by %s!" ), _( "<npcname> is grabbed by %s!" ),
@@ -8623,7 +8623,7 @@ int Character::reduce_healing_effect( const efftype_id &eff_id, int remove_med,
 {
     const body_part hurt_token = hurt->token;
     effect &e = get_effect( eff_id, hurt_token );
-    int intensity = e.get_intensity();
+    int const intensity = e.get_intensity();
     if( remove_med < intensity ) {
         if( eff_id == effect_bandaged ) {
             add_msg_if_player( m_bad, _( "Bandages on your %s were damaged!" ), body_part_name( hurt_token ) );
@@ -8646,7 +8646,7 @@ int Character::reduce_healing_effect( const efftype_id &eff_id, int remove_med,
 void Character::heal( const bodypart_id &healed, int dam )
 {
     if( !is_limb_broken( healed ) ) {
-        int effective_heal = std::min( dam, get_part_hp_max( healed ) - get_part_hp_cur( healed ) );
+        int const effective_heal = std::min( dam, get_part_hp_max( healed ) - get_part_hp_cur( healed ) );
         mod_part_hp_cur( healed, effective_heal );
         g->events().send<event_type::character_heals_damage>( getID(), effective_heal );
     }
@@ -8683,8 +8683,8 @@ int Character::hitall( int dam, int vary, Creature *source )
     int damage_taken = 0;
     for( int i = 0; i < num_hp_parts; i++ ) {
         const bodypart_id bp = convert_bp( hp_to_bp( static_cast<hp_part>( i ) ) ).id();
-        int ddam = vary ? dam * rng( 100 - vary, 100 ) / 100 : dam;
-        int cut = 0;
+        int const ddam = vary ? dam * rng( 100 - vary, 100 ) / 100 : dam;
+        int const cut = 0;
         auto damage = damage_instance::physical( ddam, cut, 0 );
         damage_taken += deal_damage( source, bp, damage ).total_damage();
     }
@@ -8805,10 +8805,10 @@ void Character::update_vitamins( const vitamin_id &vit )
         return; // NPCs cannot develop vitamin diseases
     }
 
-    efftype_id def = vit.obj().deficiency();
-    efftype_id exc = vit.obj().excess();
+    efftype_id const def = vit.obj().deficiency();
+    efftype_id const exc = vit.obj().excess();
 
-    int lvl = vit.obj().severity( vitamin_get( vit ) );
+    int const lvl = vit.obj().severity( vitamin_get( vit ) );
     if( lvl <= 0 ) {
         remove_effect( def );
     }
@@ -8833,7 +8833,7 @@ void Character::update_vitamins( const vitamin_id &vit )
 
 void Character::rooted_message() const
 {
-    bool wearing_shoes = is_wearing_shoes( side::LEFT ) || is_wearing_shoes( side::RIGHT );
+    bool const wearing_shoes = is_wearing_shoes( side::LEFT ) || is_wearing_shoes( side::RIGHT );
     if( ( has_trait( trait_ROOTS2 ) || has_trait( trait_ROOTS3 ) ) &&
         get_map().has_flag( flag_PLOWABLE, pos() ) &&
         !wearing_shoes ) {
@@ -8844,7 +8844,7 @@ void Character::rooted_message() const
 void Character::rooted()
 // Should average a point every two minutes or so
 {
-    double shoe_factor = footwear_factor();
+    double const shoe_factor = footwear_factor();
     if( ( has_trait( trait_ROOTS2 ) || has_trait( trait_ROOTS3 ) ) &&
         get_map().has_flag( flag_PLOWABLE, pos() ) && shoe_factor != 1.0 ) {
         if( one_in( 96 ) ) {
@@ -9274,7 +9274,7 @@ void Character::resume_backlog_activity()
 void Character::fall_asleep()
 {
     // Communicate to the player that he is using items on the floor
-    std::string item_name = is_snuggling();
+    std::string const item_name = is_snuggling();
     if( item_name == "many" ) {
         if( one_in( 15 ) ) {
             add_msg_if_player( _( "You nestle your pile of clothes for warmth." ) );
@@ -9382,14 +9382,14 @@ std::map<bodypart_id, int> Character::warmth( const std::map<bodypart_id, std::v
     for( const std::pair<const bodypart_id, std::vector<const item *>> &on_bp : clothing_map ) {
         const bodypart_id &bp = on_bp.first;
         for( const item *it : on_bp.second ) {
-            double warmth = it->get_warmth();
+            double const warmth = it->get_warmth();
             // Warmth reduced linearly with wetness
             const auto &materials = it->made_of();
-            float max_wet_resistance = std::accumulate( materials.begin(), materials.end(), 0.0f,
+            float const max_wet_resistance = std::accumulate( materials.begin(), materials.end(), 0.0f,
             []( float best, const material_id & mat ) {
                 return std::max( best, mat->warmth_when_wet() );
             } );
-            float wet_mult = 1.0f - max_wet_resistance * body_wetness[bp->token] / drench_capacity[bp->token];
+            float const wet_mult = 1.0f - max_wet_resistance * body_wetness[bp->token] / drench_capacity[bp->token];
             ret[bp] += warmth * wet_mult;
         }
         ret[bp] += get_effect_int( effect_heating_bionic, bp->token );
@@ -9469,7 +9469,7 @@ bool Character::can_use_floor_warmth() const
 
 int Character::floor_bedding_warmth( const tripoint &pos )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     const trap &trap_at_pos = here.tr_at( pos );
     const ter_id ter_at_pos = here.ter( pos );
     const furn_id furn_at_pos = here.furn( pos );
@@ -9518,12 +9518,12 @@ int Character::floor_item_warmth( const tripoint &pos )
                 false ) ) {
             vehicle *const veh = &vp->vehicle();
             const int cargo = vp->part_index();
-            vehicle_stack vehicle_items = veh->get_items( cargo );
+            vehicle_stack const vehicle_items = veh->get_items( cargo );
             warm( vehicle_items );
         }
         return item_warmth;
     }
-    map_stack floor_items = here.i_at( pos );
+    map_stack const floor_items = here.i_at( pos );
     warm( floor_items );
     return item_warmth;
 }
@@ -9534,7 +9534,7 @@ int Character::floor_warmth( const tripoint &pos ) const
     int bedding_warmth = floor_bedding_warmth( pos );
 
     // If the PC has fur, etc, that will apply too
-    int floor_mut_warmth = bodytemp_modifier_traits_floor();
+    int const floor_mut_warmth = bodytemp_modifier_traits_floor();
     // DOWN does not provide floor insulation, though.
     // Better-than-light fur or being in one's shell does.
     if( ( !( has_trait( trait_DOWN ) ) ) && ( floor_mut_warmth >= 200 ) ) {
@@ -9695,25 +9695,25 @@ std::list<item> Character::use_charges( const itype_id &what, int qty,
         if( is_mounted() && mounted_creature.get()->has_flag( MF_RIDEABLE_MECH ) &&
             mounted_creature.get()->battery_item ) {
             auto mons = mounted_creature.get();
-            int power_drain = std::min( mons->battery_item->ammo_remaining(), qty );
+            int const power_drain = std::min( mons->battery_item->ammo_remaining(), qty );
             mons->use_mech_power( -power_drain );
             qty -= std::min( qty, power_drain );
             return res;
         }
         if( has_power() && has_active_bionic( bio_ups ) ) {
-            int bio = std::min( units::to_kilojoule( get_power_level() ), qty );
+            int const bio = std::min( units::to_kilojoule( get_power_level() ), qty );
             mod_power_level( units::from_kilojoule( -bio ) );
             qty -= std::min( qty, bio );
         }
 
-        int adv = charges_of( itype_adv_UPS_off, static_cast<int>( std::ceil( qty * 0.6 ) ) );
+        int const adv = charges_of( itype_adv_UPS_off, static_cast<int>( std::ceil( qty * 0.6 ) ) );
         if( adv > 0 ) {
             std::list<item> found = use_charges( itype_adv_UPS_off, adv );
             res.splice( res.end(), found );
             qty -= std::min( qty, static_cast<int>( adv / 0.6 ) );
         }
 
-        int ups = charges_of( itype_UPS_off, qty );
+        int const ups = charges_of( itype_UPS_off, qty );
         if( ups > 0 ) {
             std::list<item> found = use_charges( itype_UPS_off, ups );
             res.splice( res.end(), found );
@@ -9949,14 +9949,14 @@ int Character::adjust_for_focus( int amount ) const
     }
     effective_focus += ( get_int() - get_option<int>( "INT_BASED_LEARNING_BASE_VALUE" ) ) *
                        get_option<int>( "INT_BASED_LEARNING_FOCUS_ADJUSTMENT" );
-    double tmp = amount * ( effective_focus / 100.0 );
+    double const tmp = amount * ( effective_focus / 100.0 );
     return roll_remainder( tmp );
 }
 
 std::set<tripoint> Character::get_path_avoid() const
 {
     std::set<tripoint> ret;
-    for( npc &guy : g->all_npcs() ) {
+    for( npc  const&guy : g->all_npcs() ) {
         if( sees( guy ) ) {
             ret.insert( guy.pos() );
         }
@@ -9975,7 +9975,7 @@ const pathfinding_settings &Character::get_pathfinding_settings() const
 float Character::power_rating() const
 {
     const item &weapon = primary_weapon();
-    int dmg = std::max( { weapon.damage_melee( DT_BASH ),
+    int const dmg = std::max( { weapon.damage_melee( DT_BASH ),
                           weapon.damage_melee( DT_CUT ),
                           weapon.damage_melee( DT_STAB )
                         } );
@@ -10011,7 +10011,7 @@ float Character::speed_rating() const
 
 item &Character::item_with_best_of_quality( const quality_id &qid )
 {
-    int maxq = max_quality( qid );
+    int const maxq = max_quality( qid );
     auto items_with_quality = items_with( [qid]( const item & it ) {
         return it.has_quality( qid );
     } );
@@ -10030,7 +10030,7 @@ int Character::run_cost( int base_cost, bool diag ) const
         movecost *= 0.7071f; // because everything here assumes 100 is base
     }
     const bool flatground = movecost < 105;
-    map &here = get_map();
+    map  const&here = get_map();
     // The "FLAT" tag includes soft surfaces, so not a good fit.
     const bool on_road = flatground && here.has_flag( "ROAD", pos() );
     const bool on_fungus = here.has_flag_ter_or_furn( "FUNGUS", pos() );
@@ -10132,7 +10132,7 @@ void Character::place_corpse()
     if( !death_drops ) {
         return;
     }
-    std::vector<item *> tmp = inv_dump();
+    std::vector<item *> const tmp = inv_dump();
     item body = item::make_corpse( mtype_id::NULL_ID(), calendar::turn, name );
     map &here = get_map();
     for( auto itm : tmp ) {
@@ -10147,7 +10147,7 @@ void Character::place_corpse()
     }
 
     // Restore amount of installed pseudo-modules of Power Storage Units
-    std::pair<int, int> storage_modules = amount_of_storage_bionics();
+    std::pair<int, int> const storage_modules = amount_of_storage_bionics();
     for( int i = 0; i < storage_modules.first; ++i ) {
         item cbm( itype_power_storage );
         cbm.faults.emplace( fault_bionic_nonsterile );
@@ -10182,7 +10182,7 @@ void Character::place_corpse( const tripoint_abs_omt &om_target )
         }
     }
 
-    std::vector<item *> tmp = inv_dump();
+    std::vector<item *> const tmp = inv_dump();
     item body = item::make_corpse( mtype_id::NULL_ID(), calendar::turn, name );
     for( auto itm : tmp ) {
         bay.add_item_or_charges( fin, *itm );
@@ -10194,7 +10194,7 @@ void Character::place_corpse( const tripoint_abs_omt &om_target )
     }
 
     // Restore amount of installed pseudo-modules of Power Storage Units
-    std::pair<int, int> storage_modules = amount_of_storage_bionics();
+    std::pair<int, int> const storage_modules = amount_of_storage_bionics();
     for( int i = 0; i < storage_modules.first; ++i ) {
         body.put_in( item( "bio_power_storage" ) );
     }
@@ -10210,7 +10210,7 @@ bool Character::sees_with_infrared( const Creature &critter ) const
         return false;
     }
 
-    map &here = get_map();
+    map  const&here = get_map();
     if( is_player() || critter.is_player() ) {
         // Players should not use map::sees
         // Likewise, players should not be "looked at" with map::sees, not to break symmetry
@@ -10238,7 +10238,7 @@ std::vector<Creature *> Character::get_hostile_creatures( int range ) const
 {
     return g->get_creatures_if( [this, range]( const Creature & critter ) -> bool {
         // Fixes circular distance range for ranged attacks
-        float dist_to_creature = std::round( rl_dist_exact( pos(), critter.pos() ) );
+        float const dist_to_creature = std::round( rl_dist_exact( pos(), critter.pos() ) );
         return this != &critter && pos() != critter.pos() && // TODO: get rid of fake npcs (pos() check)
         dist_to_creature <= range && critter.attitude_to( *this ) == A_HOSTILE
         && sees( critter );
@@ -10267,7 +10267,7 @@ bool Character::avoid_trap( const tripoint &pos, const trap &tr ) const
     /** @EFFECT_DEX increases chance to avoid traps */
 
     /** @EFFECT_DODGE increases chance to avoid traps */
-    int myroll = dice( 3, dex_cur + get_skill_level( skill_dodge ) * 1.5 );
+    int const myroll = dice( 3, dex_cur + get_skill_level( skill_dodge ) * 1.5 );
     int traproll;
     if( tr.can_see( pos, *this ) ) {
         traproll = dice( 3, tr.get_avoidance() );
@@ -10326,7 +10326,7 @@ std::vector<std::string> Character::short_description_parts() const
 {
     std::vector<std::string> result;
 
-    std::string gender = male ? _( "Male" ) : _( "Female" );
+    std::string const gender = male ? _( "Male" ) : _( "Female" );
     result.push_back( name +  ", "  + gender );
     if( is_armed() ) {
         result.push_back( _( "Wielding: " ) + primary_weapon().tname() );
@@ -10552,7 +10552,7 @@ action_id Character::get_next_auto_move_direction()
     next_expected_position.emplace( auto_move_route.front() );
     auto_move_route.erase( auto_move_route.begin() );
 
-    tripoint dp = *next_expected_position - pos();
+    tripoint const dp = *next_expected_position - pos();
 
     // Make sure the direction is just one step and that
     // all diagonal moves have 0 z component
@@ -10879,7 +10879,7 @@ int Character::impact( const int force, const tripoint &p )
     } else {
         // Slamming into terrain/furniture
         target_name = g->m.disp_name( p );
-        int hard_ground = g->m.has_flag( TFLAG_DIGGABLE, p ) ? 0 : 3;
+        int const hard_ground = g->m.has_flag( TFLAG_DIGGABLE, p ) ? 0 : 3;
         armor_eff = 0.25f; // Not much
         // Get cut by stuff
         // This isn't impalement on metal wreckage, more like flying through a closed window
@@ -11115,9 +11115,9 @@ int Character::item_reload_cost( const item &it, const item &ammo, int qty ) con
     /** @EFFECT_SHOTGUN decreases time taken to reload a shotgun */
     /** @EFFECT_LAUNCHER decreases time taken to reload a launcher */
 
-    int cost = ( it.is_gun() ? it.get_reload_time() : it.type->magazine->reload_time ) * qty;
+    int const cost = ( it.is_gun() ? it.get_reload_time() : it.type->magazine->reload_time ) * qty;
 
-    skill_id sk = it.is_gun() ? it.type->gun->skill_used : skill_gun;
+    skill_id const sk = it.is_gun() ? it.type->gun->skill_used : skill_gun;
     mv += cost / ( 1.0f + std::min( get_skill_level( sk ) * 0.1f, 1.0f ) );
 
     if( it.has_flag( "STR_RELOAD" ) ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -620,8 +620,8 @@ int Character::sight_range( int light_level ) const
      * log(LIGHT_AMBIENT_LOW / light_level) * (1 / LIGHT_TRANSPARENCY_OPEN_AIR) <= distance
      */
     int const range = static_cast<int>( -std::log( get_vision_threshold( static_cast<int>
-                                  ( get_map().ambient_light_at( pos() ) ) ) / static_cast<float>( light_level ) ) *
-                                  ( 1.0 / LIGHT_TRANSPARENCY_OPEN_AIR ) );
+                                        ( get_map().ambient_light_at( pos() ) ) ) / static_cast<float>( light_level ) ) *
+                                        ( 1.0 / LIGHT_TRANSPARENCY_OPEN_AIR ) );
 
     // Clamp to [1, sight_max].
     return clamp( range, 1, sight_max );
@@ -721,7 +721,7 @@ bool Character::sight_impaired() const
 
 bool Character::has_alarm_clock() const
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     return ( has_item_with_flag( "ALARMCLOCK", true ) ||
              ( here.veh_at( pos() ) &&
                !empty( here.veh_at( pos() )->vehicle().get_avail_parts( "ALARMCLOCK" ) ) ) ||
@@ -730,7 +730,7 @@ bool Character::has_alarm_clock() const
 
 bool Character::has_watch() const
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     return ( has_item_with_flag( "WATCH", true ) ||
              ( here.veh_at( pos() ) &&
                !empty( here.veh_at( pos() )->vehicle().get_avail_parts( "WATCH" ) ) ) ||
@@ -830,7 +830,7 @@ int Character::swim_speed() const
     }
     const auto usable = exclusive_flag_coverage( "ALLOWS_NATURAL_ATTACKS" );
     float const hand_bonus_mult = ( usable.test( bp_hand_l ) ? 0.5f : 0.0f ) +
-                            ( usable.test( bp_hand_r ) ? 0.5f : 0.0f );
+                                  ( usable.test( bp_hand_r ) ? 0.5f : 0.0f );
 
     // base swim speed.
     ret = ( 440 * mutation_value( "movecost_swim_modifier" ) ) + weight_carried() /
@@ -930,7 +930,7 @@ void Character::assign_stashed_activity()
 
 bool Character::check_outbounds_activity( const player_activity &act, bool check_only )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     if( ( act.placement != tripoint_zero && act.placement != tripoint_min &&
           !here.inbounds( here.getlocal( act.placement ) ) ) || ( !act.coords.empty() &&
                   !here.inbounds( here.getlocal( act.coords.back() ) ) ) ) {
@@ -1399,7 +1399,7 @@ void static try_remove_crushed( Character &c )
 bool static try_remove_grab( Character &c )
 {
     int zed_number = 0;
-    map  const&here = get_map();
+    map  const &here = get_map();
     if( c.is_mounted() ) {
         auto mon = c.mounted_creature.get();
         if( mon->has_effect( effect_grabbed ) ) {
@@ -1591,7 +1591,8 @@ void Character::recalc_hp()
         str_boost_val = str_boost->calc_bonus( skill_total );
     }
     // Mutated toughness stacks with starting, by design.
-    float const hp_mod = 1.0f + mutation_value( "hp_modifier" ) + mutation_value( "hp_modifier_secondary" );
+    float const hp_mod = 1.0f + mutation_value( "hp_modifier" ) +
+                         mutation_value( "hp_modifier_secondary" );
     float const hp_adjustment = mutation_value( "hp_adjustment" ) + ( str_boost_val * 3 );
     calc_all_parts_hp( hp_mod, hp_adjustment, get_str_base() );
 }
@@ -1607,7 +1608,7 @@ void Character::calc_all_parts_hp( float hp_mod, float hp_adjustment, int str_ma
         }
 
         float const max_hp_ratio = static_cast<float>( new_max ) /
-                             static_cast<float>( bp.get_hp_max() );
+                                   static_cast<float>( bp.get_hp_max() );
 
         int const new_cur = std::ceil( static_cast<float>( bp.get_hp_cur() ) * max_hp_ratio );
 
@@ -2451,7 +2452,7 @@ std::list<item *> Character::get_dependent_worn_items( const item &it ) const
 
 void Character::drop( item_location loc, const tripoint &where )
 {
-    item  const&oThisItem = *loc;
+    item  const &oThisItem = *loc;
     if( is_wielding( oThisItem ) ) {
         const auto ret = can_unwield( *loc );
 
@@ -2886,12 +2887,12 @@ ret_val<bool> Character::can_wear( const item &it, bool with_equip_change ) cons
                     }
                 }
             }
-            for( std::pair< body_part, bool >  const&attachment : attachments ) {
+            for( std::pair< body_part, bool >  const &attachment : attachments ) {
                 if( !attachment.second ) {
                     return ret_val<bool>::make_failure( _( "Nothing to attach the mod to!" ) );
                 }
             }
-            for( std::pair< body_part, int >  const&mod_part : mod_parts ) {
+            for( std::pair< body_part, int >  const &mod_part : mod_parts ) {
                 bpid = convert_bp( mod_part.first );
                 if( static_cast< body_part >( mod_part.first ) == bp_torso ) {
                     max_layer = 3;
@@ -3176,7 +3177,7 @@ ret_val<bool> Character::can_swap( const item &it ) const
                 }
             }
         }
-        for( std::pair< body_part, int >  const&mod_part : mod_parts ) {
+        for( std::pair< body_part, int >  const &mod_part : mod_parts ) {
             bpid = convert_bp( mod_part.first );
             if( mod_part.second >= max_layer ) {
                 return ret_val<bool>::make_failure( _( "There is no space on the opposite side!" ) );
@@ -3414,7 +3415,7 @@ int Character::rust_rate() const
 
 void Character::practice( const skill_id &id, int amount, int cap, bool suppress_warning )
 {
-    SkillLevel  const&level = get_skill_level_object( id );
+    SkillLevel  const &level = get_skill_level_object( id );
     const Skill &skill = id.obj();
     std::string const skill_name = skill.name();
 
@@ -3856,7 +3857,7 @@ bool Character::in_climate_control()
     if( has_active_bionic( bio_climate ) ) {
         return true;
     }
-    map  const&here = get_map();
+    map  const &here = get_map();
     if( has_trait( trait_M_SKIN3 ) && here.has_flag_ter_or_furn( flag_FUNGUS, pos() ) &&
         in_sleep_state() ) {
         return true;
@@ -5108,7 +5109,7 @@ void Character::check_needs_extremes()
     // Sleep deprivation kicks in if lack of sleep is avoided with stimulants or otherwise for long periods of time
     int const sleep_deprivation = get_sleep_deprivation();
     float const sleep_deprivation_pct = sleep_deprivation / static_cast<float>
-                                  ( sleep_deprivation_levels::massive );
+                                        ( sleep_deprivation_levels::massive );
 
     if( sleep_deprivation >= sleep_deprivation_levels::harmless && !in_sleep_state() &&
         calendar::once_every( 60_minutes ) &&
@@ -5223,7 +5224,8 @@ void Character::update_bodytemp( const map &m, const weather_manager &weather )
     const auto player_local_temp = weather.get_temperature( pos() );
     // NOTE : visit weather.h for some details on the numbers used
     // In Celsius / 100
-    int const Ctemperature = static_cast<int>( 100 * units::fahrenheit_to_celsius( player_local_temp ) );
+    int const Ctemperature = static_cast<int>( 100 * units::fahrenheit_to_celsius(
+                                 player_local_temp ) );
     const w_point &weather_point = get_weather().get_precise();
     int vehwindspeed = 0;
     const optional_vpart_position vp = m.veh_at( pos() );
@@ -5233,10 +5235,10 @@ void Character::update_bodytemp( const map &m, const weather_manager &weather )
     const oter_id &cur_om_ter = overmap_buffer.ter( global_omt_location() );
     bool const sheltered = weather::is_sheltered( m, pos() );
     double const total_windpower = get_local_windpower( weather.windspeed + vehwindspeed, cur_om_ter,
-                             pos(),
-                             weather.winddirection, sheltered );
+                                   pos(),
+                                   weather.winddirection, sheltered );
     int const air_humidity = get_local_humidity( weather_point.humidity, weather.weather_id,
-                                           sheltered );
+                             sheltered );
     // Let's cache this not to check it num_bp times
     const bool has_bark = has_trait( trait_BARK );
     const bool has_heatsink = has_bionic( bio_heatsink ) || is_wearing( itype_rm13_armor_on ) ||
@@ -5381,20 +5383,21 @@ void Character::update_bodytemp( const map &m, const weather_manager &weather )
 
         // Represents the fact that the body generates heat when it is cold.
         double const scaled_temperature = logarithmic_range( BODYTEMP_VERY_COLD, BODYTEMP_VERY_HOT,
-                                    temp_cur[bp->token] );
+                                          temp_cur[bp->token] );
         // Produces a smooth curve between 30.0 and 60.0.
         double const homeostasis_adjustment = 30.0 * ( 1.0 + scaled_temperature );
-        int const clothing_warmth_adjustment = static_cast<int>( homeostasis_adjustment * warmth_per_bp[bp] );
+        int const clothing_warmth_adjustment = static_cast<int>( homeostasis_adjustment *
+                                               warmth_per_bp[bp] );
         int const clothing_warmth_adjusted_bonus = static_cast<int>( homeostasis_adjustment *
-                                             bonus_warmth_per_bp[bp] );
+                bonus_warmth_per_bp[bp] );
         // WINDCHILL
         double const bp_windpower = total_windpower * ( 1 - wind_res_per_bp[bp] / 100.0 );
         // Calculate windchill
         int const windchill = submerged_bp
-                        ? 0
-                        : get_local_windchill( player_local_temp,
-                                               air_humidity,
-                                               bp_windpower );
+                              ? 0
+                              : get_local_windchill( player_local_temp,
+                                      air_humidity,
+                                      bp_windpower );
 
         // Convergent temperature is affected by ambient temperature,
         // clothing warmth, and body wetness.
@@ -5565,14 +5568,15 @@ void Character::update_bodytemp( const map &m, const weather_manager &weather )
             bp == body_part_foot_l || bp == body_part_hand_r || bp == body_part_hand_l ) {
             // Handle the frostbite timer
             // Need temps in F, windPower already in mph
-            int const wetness_percentage = 100 * body_wetness[bp->token] / drench_capacity[bp->token]; // 0 - 100
+            int const wetness_percentage = 100 * body_wetness[bp->token] /
+                                           drench_capacity[bp->token]; // 0 - 100
             // Warmth gives a slight buff to temperature resistance
             // Wetness gives a heavy nerf to temperature resistance
             double const adjusted_warmth = warmth_per_bp.at( bp ) - wetness_percentage;
             int const Ftemperature = static_cast<int>( player_local_temp + 0.2 * adjusted_warmth );
             // Windchill reduced by your armor
             int const FBwindPower = static_cast<int>(
-                                  total_windpower * ( 1 - wind_res_per_bp[ bp ] / 100.0 ) );
+                                        total_windpower * ( 1 - wind_res_per_bp[ bp ] / 100.0 ) );
 
             int const intense = get_effect_int( effect_frostbite, bp->token );
 
@@ -6528,7 +6532,8 @@ std::string Character::extended_description() const
 
         const nc_color state_col = limb_color( bp, true, true, true );
         nc_color const name_color = state_col;
-        std::pair<std::string, nc_color> const hp_bar = get_hp_bar( get_part_hp_cur( bp ), get_part_hp_max( bp ),
+        std::pair<std::string, nc_color> const hp_bar = get_hp_bar( get_part_hp_cur( bp ),
+                get_part_hp_max( bp ),
                 false );
 
         ss += colorize( left_justify( bp_heading, longest ), name_color );
@@ -6793,7 +6798,7 @@ void Character::mod_base_age( int mod )
 int Character::age() const
 {
     int const years_since_cataclysm = to_turns<int>( calendar::turn - calendar::turn_zero ) /
-                                to_turns<int>( calendar::year_length() );
+                                      to_turns<int>( calendar::year_length() );
     return init_age + years_since_cataclysm;
 }
 
@@ -7173,8 +7178,8 @@ void Character::update_stamina( int turns )
     // Recover some stamina every turn.
     // max stamina modifers from mutation also affect stamina multi
     float const stamina_multiplier = 1.0f + mutation_value( stamina_regen_modifier ) +
-                               ( mutation_value( "max_stamina_modifier" ) - 1.0f ) +
-                               bonus_from_enchantments( 1.0, enchant_vals::mod::STAMINA_REGEN );
+                                     ( mutation_value( "max_stamina_modifier" ) - 1.0f ) +
+                                     bonus_from_enchantments( 1.0, enchant_vals::mod::STAMINA_REGEN );
     // But mouth encumbrance interferes, even with mutated stamina.
     stamina_recovery += stamina_multiplier * std::max( 1.0f,
                         base_regen_rate - ( encumb( bp_mouth ) / 5.0f ) );
@@ -7244,7 +7249,8 @@ bool Character::invoke_item( item *used, const std::string &method, const tripoi
         return false;
     }
 
-    int const charges_used = actually_used->type->invoke( *this->as_player(), *actually_used, pt, method );
+    int const charges_used = actually_used->type->invoke( *this->as_player(), *actually_used, pt,
+                             method );
     if( charges_used == 0 ) {
         return false;
     }
@@ -8147,7 +8153,7 @@ void Character::absorb_hit( const bodypart_id &bp, damage_instance &dam )
         elem.amount = std::max( elem.amount, 0.0f );
     }
     map &here = get_map();
-    for( item  const&remain : worn_remains ) {
+    for( item  const &remain : worn_remains ) {
         here.add_item_or_charges( pos(), remain );
     }
     if( armor_destroyed ) {
@@ -8198,14 +8204,14 @@ bool Character::armor_absorb( damage_unit &du, item &armor )
 
     const material_type &material = armor.get_random_material();
     std::string const damage_verb = ( du.type == DT_BASH ) ? material.bash_dmg_verb() :
-                              material.cut_dmg_verb();
+                                    material.cut_dmg_verb();
 
     const std::string pre_damage_name = armor.tname();
     const std::string pre_damage_adj = armor.get_base_material().dmg_adj( armor.damage_level( 4 ) );
 
     // add "further" if the damage adjective and verb are the same
     std::string const format_string = ( pre_damage_adj == damage_verb ) ?
-                                _( "Your %1$s is %2$s further!" ) : _( "Your %1$s is %2$s!" );
+                                      _( "Your %1$s is %2$s further!" ) : _( "Your %1$s is %2$s!" );
     add_msg_if_player( m_bad, format_string, pre_damage_name, damage_verb );
     //item is damaged
     if( is_player() ) {
@@ -9389,7 +9395,8 @@ std::map<bodypart_id, int> Character::warmth( const std::map<bodypart_id, std::v
             []( float best, const material_id & mat ) {
                 return std::max( best, mat->warmth_when_wet() );
             } );
-            float const wet_mult = 1.0f - max_wet_resistance * body_wetness[bp->token] / drench_capacity[bp->token];
+            float const wet_mult = 1.0f - max_wet_resistance * body_wetness[bp->token] /
+                                   drench_capacity[bp->token];
             ret[bp] += warmth * wet_mult;
         }
         ret[bp] += get_effect_int( effect_heating_bionic, bp->token );
@@ -9469,7 +9476,7 @@ bool Character::can_use_floor_warmth() const
 
 int Character::floor_bedding_warmth( const tripoint &pos )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     const trap &trap_at_pos = here.tr_at( pos );
     const ter_id ter_at_pos = here.ter( pos );
     const furn_id furn_at_pos = here.furn( pos );
@@ -9956,7 +9963,7 @@ int Character::adjust_for_focus( int amount ) const
 std::set<tripoint> Character::get_path_avoid() const
 {
     std::set<tripoint> ret;
-    for( npc  const&guy : g->all_npcs() ) {
+    for( npc  const &guy : g->all_npcs() ) {
         if( sees( guy ) ) {
             ret.insert( guy.pos() );
         }
@@ -9976,9 +9983,9 @@ float Character::power_rating() const
 {
     const item &weapon = primary_weapon();
     int const dmg = std::max( { weapon.damage_melee( DT_BASH ),
-                          weapon.damage_melee( DT_CUT ),
-                          weapon.damage_melee( DT_STAB )
-                        } );
+                                weapon.damage_melee( DT_CUT ),
+                                weapon.damage_melee( DT_STAB )
+                              } );
 
     int ret = 2;
     // Small guns can be easily hidden from view
@@ -10030,7 +10037,7 @@ int Character::run_cost( int base_cost, bool diag ) const
         movecost *= 0.7071f; // because everything here assumes 100 is base
     }
     const bool flatground = movecost < 105;
-    map  const&here = get_map();
+    map  const &here = get_map();
     // The "FLAT" tag includes soft surfaces, so not a good fit.
     const bool on_road = flatground && here.has_flag( "ROAD", pos() );
     const bool on_fungus = here.has_flag_ter_or_furn( "FUNGUS", pos() );
@@ -10210,7 +10217,7 @@ bool Character::sees_with_infrared( const Creature &critter ) const
         return false;
     }
 
-    map  const&here = get_map();
+    map  const &here = get_map();
     if( is_player() || critter.is_player() ) {
         // Players should not use map::sees
         // Likewise, players should not be "looked at" with map::sees, not to break symmetry

--- a/src/character_display.cpp
+++ b/src/character_display.cpp
@@ -101,7 +101,7 @@ void character_display::print_encumbrance( const catacurses::window &win, const 
 
     // width/height excluding title & scrollbar
     const int height = getmaxy( win ) - 1;
-    bool draw_scrollbar = height < static_cast<int>( bps.size() );
+    bool const draw_scrollbar = height < static_cast<int>( bps.size() );
     const int width = getmaxx( win ) - ( draw_scrollbar ? 1 : 0 );
     // index of the first printed bodypart from `bps`
     const int firstline = clamp( line - height / 2, 0, std::max( 0,
@@ -113,7 +113,7 @@ void character_display::print_encumbrance( const catacurses::window &win, const 
      *** armor layers ui shows everything they want :-) -Davek                      ***/
     const char_encumbrance_data enc_data = ch.get_encumbrance();
     for( int i = 0; i < height; ++i ) {
-        int thisline = firstline + i;
+        int const thisline = firstline + i;
         if( thisline < 0 ) {
             continue;
         }
@@ -131,7 +131,7 @@ void character_display::print_encumbrance( const catacurses::window &win, const 
 
         // Two different highlighting schemes, highlight if the line is selected as per line being set.
         // Make the text green if this part is covered by the passed in item.
-        nc_color limb_color = thisline == line ?
+        nc_color const limb_color = thisline == line ?
                               ( highlighted ? h_green : h_light_gray ) :
                               ( highlighted ? c_green : c_light_gray );
         mvwprintz( win, point( 1, 1 + i ), limb_color, "%s", out );
@@ -675,7 +675,7 @@ static void draw_skills_tab( const catacurses::window &w_skills,
 
         if( skillslist[i].is_header ) {
             const SkillDisplayType t = SkillDisplayType::get_skill_type( aSkill->display_category() );
-            std::string type_name = t.display_string();
+            std::string const type_name = t.display_string();
             mvwprintz( w_skills, point( 0, y_pos ), c_light_gray, header_spaces );
             center_print( w_skills, y_pos, c_yellow, type_name );
         } else {
@@ -767,7 +767,7 @@ static void draw_speed_tab( const catacurses::window &w_speed,
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     mvwprintz( w_speed, point( 1, 1 ), c_light_gray, _( "Base Move Cost:" ) );
     mvwprintz( w_speed, point( 1, 2 ), c_light_gray, _( "Current Speed:" ) );
-    int newmoves = you.get_speed();
+    int const newmoves = you.get_speed();
     int pen = 0;
     unsigned int line = 3;
     if( you.weight_carried() > you.weight_capacity() ) {
@@ -827,11 +827,11 @@ static void draw_speed_tab( const catacurses::window &w_speed,
         }
     }
 
-    int quick_bonus = static_cast<int>( round( ( you.mutation_value( "speed_modifier" ) - 1 ) * 100 ) );
-    int bio_speed_bonus = 10;
+    int const quick_bonus = static_cast<int>( round( ( you.mutation_value( "speed_modifier" ) - 1 ) * 100 ) );
+    int const bio_speed_bonus = 10;
     if( quick_bonus != 0 ) {
-        std::string pen_sign = quick_bonus >= 0 ? "+" : "-";
-        nc_color pen_color = quick_bonus >= 0 ? c_green : c_red;
+        std::string const pen_sign = quick_bonus >= 0 ? "+" : "-";
+        nc_color const pen_color = quick_bonus >= 0 ? c_green : c_red;
         //~ %s: Mutations (already left-justified), %s: sign of bonus/penalty, %2d%%: speed modifier
         mvwprintz( w_speed, point( 1, line ), pen_color, pgettext( "speed bonus", "%s%s%2d%%" ),
                    left_justify( _( "Mutations" ), 20 ), pen_sign, std::abs( quick_bonus ) );
@@ -844,7 +844,7 @@ static void draw_speed_tab( const catacurses::window &w_speed,
     }
 
     for( const std::pair<const std::string, int> &speed_effect : speed_effects ) {
-        nc_color col = ( speed_effect.second > 0 ? c_green : c_red );
+        nc_color const col = ( speed_effect.second > 0 ? c_green : c_red );
         mvwprintz( w_speed, point( 1, line ), col, "%s", speed_effect.first );
         mvwprintz( w_speed, point( 21, line ), col, ( speed_effect.second > 0 ? "+" : "-" ) );
         mvwprintz( w_speed, point( std::abs( speed_effect.second ) >= 10 ? 22 : 23, line ), col, "%d%%",
@@ -852,7 +852,7 @@ static void draw_speed_tab( const catacurses::window &w_speed,
         line++;
     }
 
-    int runcost = you.run_cost( 100 );
+    int const runcost = you.run_cost( 100 );
     nc_color col = ( runcost <= 100 ? c_green : c_red );
     mvwprintz( w_speed, point( 21 + ( runcost >= 100 ? 0 : ( runcost < 10 ? 2 : 1 ) ), 1 ), col,
                "%d", runcost );
@@ -997,7 +997,7 @@ static bool handle_player_display_action( Character &you, unsigned int &line,
     }
 
     bool done = false;
-    std::string action = ctxt.handle_input();
+    std::string const action = ctxt.handle_input();
 
     if( action == "UP" ) {
         if( line > line_beg ) {
@@ -1160,8 +1160,8 @@ void character_display::disp_info( Character &ch )
 
     const std::vector<const Skill *> player_skill = Skill::get_skills_sorted_by(
     [&]( const Skill & a, const Skill & b ) {
-        skill_displayType_id type_a = a.display_category();
-        skill_displayType_id type_b = b.display_category();
+        skill_displayType_id const type_a = a.display_category();
+        skill_displayType_id const type_b = b.display_category();
 
         return localized_compare( std::make_pair( type_a, a.name() ),
                                   std::make_pair( type_b, b.name() ) );
@@ -1191,7 +1191,7 @@ void character_display::disp_info( Character &ch )
         unsigned int bionics_win_size_y = bionics_win_size_y_max;
         if( ( bionics_win_size_y_max + 1 + trait_win_size_y_max + infooffsetybottom ) > maxy ) {
             // maximum space for either window if they're both the same size
-            unsigned max_shared_y = ( maxy - infooffsetybottom - 1 ) / 2;
+            unsigned const max_shared_y = ( maxy - infooffsetybottom - 1 ) / 2;
             if( std::min( bionics_win_size_y_max, trait_win_size_y_max ) > max_shared_y ) {
                 // both are larger than the shared size
                 bionics_win_size_y = max_shared_y;
@@ -1234,10 +1234,10 @@ void character_display::disp_info( Character &ch )
 
     std::map<std::string, int> speed_effects;
     for( auto &elem : ch.get_all_effects() ) {
-        for( std::pair<const bodypart_str_id, effect> &_effect_it : elem.second ) {
-            effect &it = _effect_it.second;
-            bool reduced = ch.resists_effect( it );
-            int move_adjust = it.get_mod( "SPEED", reduced );
+        for( std::pair<const bodypart_str_id, effect>  const&_effect_it : elem.second ) {
+            effect  const&it = _effect_it.second;
+            bool const reduced = ch.resists_effect( it );
+            int const move_adjust = it.get_mod( "SPEED", reduced );
             if( move_adjust != 0 ) {
                 const std::string dis_text = it.get_speed_name();
                 speed_effects[dis_text] += move_adjust;

--- a/src/character_display.cpp
+++ b/src/character_display.cpp
@@ -132,8 +132,8 @@ void character_display::print_encumbrance( const catacurses::window &win, const 
         // Two different highlighting schemes, highlight if the line is selected as per line being set.
         // Make the text green if this part is covered by the passed in item.
         nc_color const limb_color = thisline == line ?
-                              ( highlighted ? h_green : h_light_gray ) :
-                              ( highlighted ? c_green : c_light_gray );
+                                    ( highlighted ? h_green : h_light_gray ) :
+                                    ( highlighted ? c_green : c_light_gray );
         mvwprintz( win, point( 1, 1 + i ), limb_color, "%s", out );
         // accumulated encumbrance from clothing, plus extra encumbrance from layering
         mvwprintz( win, point( 8, 1 + i ), encumb_color( e.encumbrance ), "%3d",
@@ -827,7 +827,8 @@ static void draw_speed_tab( const catacurses::window &w_speed,
         }
     }
 
-    int const quick_bonus = static_cast<int>( round( ( you.mutation_value( "speed_modifier" ) - 1 ) * 100 ) );
+    int const quick_bonus = static_cast<int>( round( ( you.mutation_value( "speed_modifier" ) - 1 ) *
+                            100 ) );
     int const bio_speed_bonus = 10;
     if( quick_bonus != 0 ) {
         std::string const pen_sign = quick_bonus >= 0 ? "+" : "-";
@@ -1234,8 +1235,8 @@ void character_display::disp_info( Character &ch )
 
     std::map<std::string, int> speed_effects;
     for( auto &elem : ch.get_all_effects() ) {
-        for( std::pair<const bodypart_str_id, effect>  const&_effect_it : elem.second ) {
-            effect  const&it = _effect_it.second;
+        for( std::pair<const bodypart_str_id, effect>  const &_effect_it : elem.second ) {
+            effect  const &it = _effect_it.second;
             bool const reduced = ch.resists_effect( it );
             int const move_adjust = it.get_mod( "SPEED", reduced );
             if( move_adjust != 0 ) {

--- a/src/character_effects.cpp
+++ b/src/character_effects.cpp
@@ -40,14 +40,14 @@ namespace character_effects
 stat_mod get_pain_penalty( const Character &ch )
 {
     stat_mod ret;
-    int pain = ch.get_perceived_pain();
+    int const pain = ch.get_perceived_pain();
     if( pain <= 0 ) {
         return ret;
     }
 
-    int stat_penalty = std::floor( std::pow( pain, 0.8f ) / 10.0f );
+    int const stat_penalty = std::floor( std::pow( pain, 0.8f ) / 10.0f );
 
-    bool ceno = ch.has_trait( trait_CENOBITE );
+    bool const ceno = ch.has_trait( trait_CENOBITE );
     if( !ceno ) {
         ret.strength = stat_penalty;
         ret.dexterity = stat_penalty;
@@ -147,7 +147,7 @@ int talk_skill( const Character &ch )
     /** @EFFECT_PER slightly increases talking skill */
 
     /** @EFFECT_SPEECH increases talking skill */
-    int ret = ch.get_int() + ch.get_per() + ch.get_skill_level( skill_id( "speech" ) ) * 3;
+    int const ret = ch.get_int() + ch.get_per() + ch.get_skill_level( skill_id( "speech" ) ) * 3;
     return ret;
 }
 

--- a/src/character_functions.cpp
+++ b/src/character_functions.cpp
@@ -164,7 +164,8 @@ float fine_detail_vision_mod( const Character &who, const tripoint &p )
     float const own_light = std::max( 1.0f, LIGHT_AMBIENT_LIT - who.active_light() - 2.0f );
 
     // Same calculation as above, but with a result 3 lower.
-    float const ambient_light = std::max( 1.0f, LIGHT_AMBIENT_LIT - get_map().ambient_light_at( p ) + 1.0f );
+    float const ambient_light = std::max( 1.0f,
+                                          LIGHT_AMBIENT_LIT - get_map().ambient_light_at( p ) + 1.0f );
 
     return std::min( own_light, ambient_light );
 }
@@ -192,8 +193,9 @@ comfort_response_t base_comfort_value( const Character &who, const tripoint &p )
     bool const plantsleep = who.has_trait( trait_CHLOROMORPH );
     bool const fungaloid_cosplay = who.has_trait( trait_M_SKIN3 );
     bool const websleep = who.has_trait( trait_WEB_WALKER );
-    bool const webforce = who.has_trait( trait_THRESH_SPIDER ) && ( who.has_trait( trait_WEB_SPINNER ) ||
-                    ( who.has_trait( trait_WEB_WEAVER ) ) );
+    bool const webforce = who.has_trait( trait_THRESH_SPIDER ) &&
+                          ( who.has_trait( trait_WEB_SPINNER ) ||
+                            ( who.has_trait( trait_WEB_WEAVER ) ) );
     bool const in_shell = who.has_active_mutation( trait_SHELL2 );
     bool const watersleep = who.has_trait( trait_WATERSLEEP );
 
@@ -664,8 +666,8 @@ std::vector<npc *> get_crafting_helpers( const Character &who, int max )
             return false;
         }
         bool const ok = !guy.in_sleep_state() && guy.is_obeying( who ) &&
-                  rl_dist( guy.pos(), who.pos() ) < PICKUP_RANGE &&
-                  get_map().clear_path( who.pos(), guy.pos(), PICKUP_RANGE, 1, 100 );
+                        rl_dist( guy.pos(), who.pos() ) < PICKUP_RANGE &&
+                        get_map().clear_path( who.pos(), guy.pos(), PICKUP_RANGE, 1, 100 );
         if( ok ) {
             n += 1;
         }

--- a/src/character_functions.cpp
+++ b/src/character_functions.cpp
@@ -161,10 +161,10 @@ float fine_detail_vision_mod( const Character &who, const tripoint &p )
     // Scale linearly as light level approaches LIGHT_AMBIENT_LIT.
     // If we're actually a source of light, assume we can direct it where we need it.
     // Therefore give a hefty bonus relative to ambient light.
-    float own_light = std::max( 1.0f, LIGHT_AMBIENT_LIT - who.active_light() - 2.0f );
+    float const own_light = std::max( 1.0f, LIGHT_AMBIENT_LIT - who.active_light() - 2.0f );
 
     // Same calculation as above, but with a result 3 lower.
-    float ambient_light = std::max( 1.0f, LIGHT_AMBIENT_LIT - get_map().ambient_light_at( p ) + 1.0f );
+    float const ambient_light = std::max( 1.0f, LIGHT_AMBIENT_LIT - get_map().ambient_light_at( p ) + 1.0f );
 
     return std::min( own_light, ambient_light );
 }
@@ -189,13 +189,13 @@ comfort_response_t base_comfort_value( const Character &who, const tripoint &p )
 
     comfort_response_t comfort_response;
 
-    bool plantsleep = who.has_trait( trait_CHLOROMORPH );
-    bool fungaloid_cosplay = who.has_trait( trait_M_SKIN3 );
-    bool websleep = who.has_trait( trait_WEB_WALKER );
-    bool webforce = who.has_trait( trait_THRESH_SPIDER ) && ( who.has_trait( trait_WEB_SPINNER ) ||
+    bool const plantsleep = who.has_trait( trait_CHLOROMORPH );
+    bool const fungaloid_cosplay = who.has_trait( trait_M_SKIN3 );
+    bool const websleep = who.has_trait( trait_WEB_WALKER );
+    bool const webforce = who.has_trait( trait_THRESH_SPIDER ) && ( who.has_trait( trait_WEB_SPINNER ) ||
                     ( who.has_trait( trait_WEB_WEAVER ) ) );
-    bool in_shell = who.has_active_mutation( trait_SHELL2 );
-    bool watersleep = who.has_trait( trait_WATERSLEEP );
+    bool const in_shell = who.has_active_mutation( trait_SHELL2 );
+    bool const watersleep = who.has_trait( trait_WATERSLEEP );
 
     map &here = get_map();
     const optional_vpart_position vp = here.veh_at( p );
@@ -204,7 +204,7 @@ comfort_response_t base_comfort_value( const Character &who, const tripoint &p )
     const ter_id ter_at_pos = tile.get_ter();
     const furn_id furn_at_pos = tile.get_furn();
 
-    int web = here.get_field_intensity( p, fd_web );
+    int const web = here.get_field_intensity( p, fd_web );
 
     // Some mutants have different comfort needs
     if( !plantsleep && !webforce ) {
@@ -319,7 +319,7 @@ int rate_sleep_spot( const Character &who, const tripoint &p )
     }
 
     int sleepy = static_cast<int>( comfort_info.level );
-    bool watersleep = who.has_trait( trait_WATERSLEEP );
+    bool const watersleep = who.has_trait( trait_WATERSLEEP );
 
     if( who.has_addiction( add_type::SLEEP ) ) {
         sleepy -= 4;
@@ -384,7 +384,7 @@ bool roll_can_sleep( Character &who )
 
     int sleepy = character_funcs::rate_sleep_spot( who, who.pos() );
     sleepy += rng( -8, 8 );
-    bool result = sleepy > 0;
+    bool const result = sleepy > 0;
 
     if( who.has_active_bionic( bio_soporific ) ) {
         if( who.bio_soporific_powered_at_last_sleep_check && !who.has_power() ) {
@@ -400,7 +400,7 @@ bool roll_can_sleep( Character &who )
 
 bool can_interface_armor( const Character &who )
 {
-    bool okay = std::any_of( who.my_bionics->begin(), who.my_bionics->end(),
+    bool const okay = std::any_of( who.my_bionics->begin(), who.my_bionics->end(),
     []( const bionic & b ) {
         return b.powered && b.info().has_flag( STATIC( flag_str_id( "BIONIC_ARMOR_INTERFACE" ) ) );
     } );
@@ -417,10 +417,10 @@ std::string fmt_wielded_weapon( const Character &who )
         std::string str = string_format( "(%d) [%s] %s", weapon.ammo_remaining(),
                                          weapon.gun_current_mode().tname(), weapon.type_name() );
         // Is either the base item or at least one auxiliary gunmod loaded (includes empty magazines)
-        bool base = weapon.ammo_capacity() > 0 && !weapon.has_flag( "RELOAD_AND_SHOOT" );
+        bool const base = weapon.ammo_capacity() > 0 && !weapon.has_flag( "RELOAD_AND_SHOOT" );
 
         const auto mods = weapon.gunmods();
-        bool aux = std::any_of( mods.begin(), mods.end(), [&]( const item * e ) {
+        bool const aux = std::any_of( mods.begin(), mods.end(), [&]( const item * e ) {
             return e->is_gun() && e->ammo_capacity() > 0 && !e->has_flag( "RELOAD_AND_SHOOT" );
         } );
 
@@ -515,7 +515,7 @@ bool try_wield_contents( Character &who, item &container, item *internal_item, b
             return elem->display_name();
         } );
         if( opts.size() > 1 ) {
-            int pos = uilist( _( "Wield what?" ), opts );
+            int const pos = uilist( _( "Wield what?" ), opts );
             if( pos < 0 ) {
                 return false;
             }
@@ -565,7 +565,7 @@ bool try_wield_contents( Character &who, item &container, item *internal_item, b
      * @EFFECT_CUTTING decreases time taken to draw cutting weapons from scabbards
      * @EFFECT_BASHING decreases time taken to draw bashing weapons from holsters
      */
-    int lvl = who.get_skill_level( weapon.is_gun() ? weapon.gun_skill() : weapon.melee_skill() );
+    int const lvl = who.get_skill_level( weapon.is_gun() ? weapon.gun_skill() : weapon.melee_skill() );
     mv += who.item_handling_cost( weapon, penalties, base_cost ) / ( ( lvl + 10.0f ) / 10.0f );
 
     who.moves -= mv;
@@ -582,9 +582,9 @@ bool try_uncanny_dodge( Character &who )
         return false;
     }
     who.mod_power_level( -trigger_cost );
-    bool is_u = who.is_avatar();
-    bool seen = is_u || get_player_character().sees( who );
-    std::optional<tripoint> adjacent = pick_safe_adjacent_tile( who );
+    bool const is_u = who.is_avatar();
+    bool const seen = is_u || get_player_character().sees( who );
+    std::optional<tripoint> const adjacent = pick_safe_adjacent_tile( who );
     if( adjacent ) {
         if( is_u ) {
             add_msg( _( "Time seems to slow down and you instinctively dodge!" ) );
@@ -663,7 +663,7 @@ std::vector<npc *> get_crafting_helpers( const Character &who, int max )
         if( max > 0 && n >= max ) {
             return false;
         }
-        bool ok = !guy.in_sleep_state() && guy.is_obeying( who ) &&
+        bool const ok = !guy.in_sleep_state() && guy.is_obeying( who ) &&
                   rl_dist( guy.pos(), who.pos() ) < PICKUP_RANGE &&
                   get_map().clear_path( who.pos(), guy.pos(), PICKUP_RANGE, 1, 100 );
         if( ok ) {
@@ -720,7 +720,7 @@ bool list_ammo( const Character &who, const item &base, std::vector<item_reload_
     }
 
     bool ammo_match_found = false;
-    int ammo_search_range = who.is_mounted() ? -1 : 1;
+    int const ammo_search_range = who.is_mounted() ? -1 : 1;
     for( const auto e : opts ) {
         for( const item_location &ammo : find_ammo_items_or_mags( who, *e, include_empty_mags,
                 ammo_search_range ) ) {
@@ -794,7 +794,7 @@ item_reload_option select_ammo( const Character &who, const item &base,
     std::vector<std::string> where;
     std::transform( opts.begin(), opts.end(),
     std::back_inserter( where ), [&]( const item_reload_option & e ) {
-        bool is_ammo_container = e.ammo->is_ammo_container();
+        bool const is_ammo_container = e.ammo->is_ammo_container();
         if( is_ammo_container || e.ammo->is_container() ) {
             if( is_ammo_container && who.is_worn( *e.ammo ) ) {
                 return e.ammo->type_name();
@@ -849,11 +849,11 @@ item_reload_option select_ammo( const Character &who, const item &base,
                 const damage_instance &dam = ammo->ammo->damage;
                 const damage_unit &du = dam.damage_units.front();
                 if( du.damage_multiplier != 1.0f ) {
-                    float dam_amt = du.amount;
+                    float const dam_amt = du.amount;
                     row += string_format( "| %-3d*%3d%% ", static_cast<int>( dam_amt ),
                                           clamp( static_cast<int>( du.damage_multiplier * 100 ), 0, 999 ) );
                 } else {
-                    float dam_amt = dam.total_damage();
+                    float const dam_amt = dam.total_damage();
                     row += string_format( "| %-8d ", static_cast<int>( dam_amt ) );
                 }
                 if( du.res_mult != 1.0f ) {
@@ -870,10 +870,10 @@ item_reload_option select_ammo( const Character &who, const item &base,
     };
 
     const ammotype base_ammotype( base.ammo_default().str() );
-    itype_id last = uistate.lastreload[ base_ammotype ];
+    itype_id const last = uistate.lastreload[ base_ammotype ];
     // We keep the last key so that pressing the key twice (for example, r-r for reload)
     // will always pick the first option on the list.
-    int last_key = inp_mngr.get_previously_pressed_key();
+    int const last_key = inp_mngr.get_previously_pressed_key();
     bool last_key_bound = false;
     // This is the entry that has out default
     int default_to = 0;
@@ -1182,14 +1182,14 @@ int ammo_count_for( const Character &who, const item &gun )
     if( !gun.is_gun() ) {
         return item::INFINITE_CHARGES;
     }
-    int ammo_drain = gun.ammo_required();
-    int energy_drain = gun.get_gun_ups_drain();
+    int const ammo_drain = gun.ammo_required();
+    int const energy_drain = gun.get_gun_ups_drain();
 
-    units::energy power = units::from_kilojoule( who.charges_of( itype_UPS ) );
+    units::energy const power = units::from_kilojoule( who.charges_of( itype_UPS ) );
     int total_ammo = gun.ammo_remaining();
     const std::vector<item_location> inv_ammo = find_ammo_items_or_mags( who, gun, true, -1 );
 
-    bool has_mag = gun.magazine_integral();
+    bool const has_mag = gun.magazine_integral();
 
     for( const item_location &it : inv_ammo ) {
         if( it->is_magazine() ) {
@@ -1223,8 +1223,8 @@ void show_skill_capped_notice( const Character &who, const skill_id &id )
     const SkillLevel &level = who.get_skill_level_object( id );
 
     const Skill &skill = id.obj();
-    std::string skill_name = skill.name();
-    int curLevel = level.level();
+    std::string const skill_name = skill.name();
+    int const curLevel = level.level();
 
     add_msg( m_info, _( "This task is too simple to train your %s beyond %d." ),
              skill_name, curLevel );

--- a/src/character_martial_arts.cpp
+++ b/src/character_martial_arts.cpp
@@ -155,7 +155,7 @@ void character_martial_arts::serialize( JsonOut &json ) const
 
 void character_martial_arts::deserialize( JsonIn &jsin )
 {
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
     data.read( "ma_styles", ma_styles );
     data.read( "keep_hands_free", keep_hands_free );
     data.read( "style_selected", style_selected );

--- a/src/character_oracle.cpp
+++ b/src/character_oracle.cpp
@@ -99,7 +99,7 @@ status_t character_oracle_t::can_take_shelter() const
 status_t character_oracle_t::has_water() const
 {
     // Check if we know about water somewhere
-    bool found_water = subject->inv.has_item_with( []( const item & cand ) {
+    bool const found_water = subject->inv.has_item_with( []( const item & cand ) {
         return cand.is_food() && cand.get_comestible()->quench > 0;
     } );
     return found_water ? running : failure;
@@ -108,7 +108,7 @@ status_t character_oracle_t::has_water() const
 status_t character_oracle_t::has_food() const
 {
     // Check if we know about food somewhere
-    bool found_food = subject->inv.has_item_with( []( const item & cand ) {
+    bool const found_food = subject->inv.has_item_with( []( const item & cand ) {
         return cand.is_food() && cand.get_comestible()->has_calories();
     } );
     return found_food ? running : failure;

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -356,8 +356,8 @@ void Character::process_one_effect( effect &it, bool is_new )
         mod = 1;
         if( is_new || it.activated( calendar::turn, "H_MOD", val, reduced, mod ) ) {
             int const bounded = bound_mod_to_vals(
-                              get_healthy_mod(), val, it.get_max_val( "H_MOD", reduced ),
-                              it.get_min_val( "H_MOD", reduced ) );
+                                    get_healthy_mod(), val, it.get_max_val( "H_MOD", reduced ),
+                                    it.get_min_val( "H_MOD", reduced ) );
             // This already applies bounds, so we pass them through.
             mod_healthy_mod( bounded, get_healthy_mod() + bounded );
         }
@@ -827,11 +827,11 @@ void Character::process_items()
     // Active item processing done, now we're recharging.
     std::vector<item *> active_worn_items;
     bool const weapon_active = weapon.has_flag( "USE_UPS" ) &&
-                         weapon.charges < weapon.type->maximum_charges();
+                               weapon.charges < weapon.type->maximum_charges();
     std::vector<size_t> active_held_items;
     int ch_UPS = 0;
     for( size_t index = 0; index < inv.size(); index++ ) {
-        item  const&it = inv.find_item( index );
+        item  const &it = inv.find_item( index );
         itype_id const identifier = it.type->get_id();
         if( identifier == itype_UPS_off ) {
             ch_UPS += it.ammo_remaining();
@@ -1046,7 +1046,7 @@ void do_pause( Character &who )
             veh = v.v;
             if( veh && veh->is_moving() && veh->player_in_control( who ) ) {
                 double const exp_temp = 1 + veh->total_mass() / 400.0_kilogram +
-                                  std::abs( veh->velocity / 3200.0 );
+                                        std::abs( veh->velocity / 3200.0 );
                 int experience = static_cast<int>( exp_temp );
                 if( exp_temp - experience > 0 && x_in_y( exp_temp - experience, 1.0 ) ) {
                     experience++;

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -113,7 +113,7 @@ void Character::recalc_speed_bonus()
             if( i.second.is_removed() ) {
                 continue;
             }
-            bool reduced = resists_effect( i.second );
+            bool const reduced = resists_effect( i.second );
             mod_speed_bonus( i.second.get_mod( "SPEED", reduced ) );
         }
     }
@@ -146,14 +146,14 @@ void Character::recalc_speed_bonus()
 
     mod_speed_bonus( get_speedydex_bonus( get_dex() ) );
 
-    float speed_modifier = Character::mutation_value( "speed_modifier" );
+    float const speed_modifier = Character::mutation_value( "speed_modifier" );
     mod_speed_mult( speed_modifier - 1 );
 
     if( has_bionic( bio_speed ) ) { // add 10% speed bonus
         mod_speed_mult( 0.1 );
     }
 
-    double ench_bonus = enchantment_cache->calc_bonus( enchant_vals::mod::SPEED, get_speed() );
+    double const ench_bonus = enchantment_cache->calc_bonus( enchant_vals::mod::SPEED, get_speed() );
     mod_speed_bonus( ench_bonus );
 }
 
@@ -327,9 +327,9 @@ void Character::process_turn()
 
 void Character::process_one_effect( effect &it, bool is_new )
 {
-    bool reduced = resists_effect( it );
+    bool const reduced = resists_effect( it );
     double mod = 1;
-    body_part bp = it.get_bp()->token;
+    body_part const bp = it.get_bp()->token;
     int val = 0;
 
     // Still hardcoded stuff, do this first since some modify their other traits
@@ -355,7 +355,7 @@ void Character::process_one_effect( effect &it, bool is_new )
     if( val != 0 ) {
         mod = 1;
         if( is_new || it.activated( calendar::turn, "H_MOD", val, reduced, mod ) ) {
-            int bounded = bound_mod_to_vals(
+            int const bounded = bound_mod_to_vals(
                               get_healthy_mod(), val, it.get_max_val( "H_MOD", reduced ),
                               it.get_min_val( "H_MOD", reduced ) );
             // This already applies bounds, so we pass them through.
@@ -444,7 +444,7 @@ void Character::process_one_effect( effect &it, bool is_new )
             }
         }
         if( is_new || it.activated( calendar::turn, "PAIN", val, reduced, mod ) ) {
-            int pain_inc = bound_mod_to_vals( get_pain(), val, it.get_max_val( "PAIN", reduced ), 0 );
+            int const pain_inc = bound_mod_to_vals( get_pain(), val, it.get_max_val( "PAIN", reduced ), 0 );
             mod_pain( pain_inc );
             if( pain_inc > 0 ) {
                 character_funcs::add_pain_msg( *this, val, bp );
@@ -730,7 +730,7 @@ void Character::reset_stats()
             if( it.is_removed() ) {
                 continue;
             }
-            bool reduced = resists_effect( it );
+            bool const reduced = resists_effect( it );
             mod_str_bonus( it.get_mod( "STR", reduced ) );
             mod_dex_bonus( it.get_mod( "DEX", reduced ) );
             mod_per_bonus( it.get_mod( "PER", reduced ) );
@@ -812,7 +812,7 @@ void Character::process_items()
         weapon = item();
     }
 
-    std::vector<item *> inv_active = inv.active_items();
+    std::vector<item *> const inv_active = inv.active_items();
     for( item *tmp_it : inv_active ) {
         if( tmp_it->process( as_player(), pos(), false ) ) {
             inv.remove_item( tmp_it );
@@ -826,13 +826,13 @@ void Character::process_items()
 
     // Active item processing done, now we're recharging.
     std::vector<item *> active_worn_items;
-    bool weapon_active = weapon.has_flag( "USE_UPS" ) &&
+    bool const weapon_active = weapon.has_flag( "USE_UPS" ) &&
                          weapon.charges < weapon.type->maximum_charges();
     std::vector<size_t> active_held_items;
     int ch_UPS = 0;
     for( size_t index = 0; index < inv.size(); index++ ) {
-        item &it = inv.find_item( index );
-        itype_id identifier = it.type->get_id();
+        item  const&it = inv.find_item( index );
+        itype_id const identifier = it.type->get_id();
         if( identifier == itype_UPS_off ) {
             ch_UPS += it.ammo_remaining();
         } else if( identifier == itype_adv_UPS_off ) {
@@ -870,7 +870,7 @@ void Character::process_items()
 
     // Load all items that use the UPS to their minimal functional charge,
     // The tool is not really useful if its charges are below charges_to_use
-    for( size_t index : active_held_items ) {
+    for( size_t const index : active_held_items ) {
         if( ch_UPS_used >= ch_UPS ) {
             break;
         }
@@ -1002,7 +1002,7 @@ void do_pause( Character &who )
     if( who.has_effect( effect_onfire ) ) {
         time_duration total_removed = 0_turns;
         time_duration total_left = 0_turns;
-        bool on_ground = who.has_effect( effect_downed );
+        bool const on_ground = who.has_effect( effect_downed );
         for( const body_part bp : all_body_parts ) {
             effect &eff = who.get_effect( effect_onfire, bp );
             if( eff.is_null() ) {
@@ -1040,12 +1040,12 @@ void do_pause( Character &who )
     }
 
     if( who.in_vehicle && one_in( 8 ) ) {
-        VehicleList vehs = here.get_vehicles();
+        VehicleList const vehs = here.get_vehicles();
         vehicle *veh = nullptr;
         for( auto &v : vehs ) {
             veh = v.v;
             if( veh && veh->is_moving() && veh->player_in_control( who ) ) {
-                double exp_temp = 1 + veh->total_mass() / 400.0_kilogram +
+                double const exp_temp = 1 + veh->total_mass() / 400.0_kilogram +
                                   std::abs( veh->velocity / 3200.0 );
                 int experience = static_cast<int>( exp_temp );
                 if( exp_temp - experience > 0 && x_in_y( exp_temp - experience, 1.0 ) ) {

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -263,13 +263,13 @@ blueprint_options::query_con_result blueprint_options::query_con()
 
 loot_options::query_loot_result loot_options::query_loot()
 {
-    int w_height = TERMY / 2;
+    int const w_height = TERMY / 2;
 
     const int w_width = TERMX / 2;
     const int w_y0 = ( TERMY > w_height ) ? ( TERMY - w_height ) / 4 : 0;
     const int w_x0 = ( TERMX > w_width ) ? ( TERMX - w_width ) / 2 : 0;
 
-    catacurses::window w_con = catacurses::newwin( w_height, w_width, point( w_x0, w_y0 ) );
+    catacurses::window const w_con = catacurses::newwin( w_height, w_width, point( w_x0, w_y0 ) );
     draw_item_filter_rules( w_con, 1, w_height - 1, item_filter_type::FILTER );
     string_input_popup()
     .title( _( "Filter:" ) )
@@ -292,7 +292,7 @@ plot_options::query_seed_result plot_options::query_seed()
     const std::unordered_set<tripoint> &zone_src_set = mgr.get_near( zone_LOOT_SEEDS,
             here.getabs( p.pos() ), 60 );
     for( const tripoint &elem : zone_src_set ) {
-        tripoint elem_loc = here.getlocal( elem );
+        tripoint const elem_loc = here.getlocal( elem );
         for( item &it : here.i_at( elem_loc ) ) {
             if( it.is_seed() ) {
                 seed_inv.push_back( &it );
@@ -302,14 +302,14 @@ plot_options::query_seed_result plot_options::query_seed()
     std::vector<seed_tuple> seed_entries = iexamine::get_seed_entries( seed_inv );
     seed_entries.emplace( seed_entries.begin(), seed_tuple( itype_id( "null" ), _( "No seed" ), 0 ) );
 
-    int seed_index = iexamine::query_seed( seed_entries );
+    int const seed_index = iexamine::query_seed( seed_entries );
 
     if( seed_index > 0 && seed_index < static_cast<int>( seed_entries.size() ) ) {
         const auto &seed_entry = seed_entries[seed_index];
         const itype_id &new_seed = std::get<0>( seed_entry );
         itype_id new_mark;
 
-        item it = item( new_seed );
+        item const it = item( new_seed );
         if( it.is_seed() ) {
             new_mark = it.type->seed->fruit_id;
         } else {
@@ -407,7 +407,7 @@ std::string plot_options::get_zone_name_suggestion() const
 {
     if( !seed.is_empty() ) {
         auto type = itype_id( seed );
-        item it = item( type );
+        item const it = item( type );
         if( it.is_seed() ) {
             return it.type->seed->plant_name.translated();
         } else {
@@ -510,7 +510,7 @@ std::optional<zone_type_id> zone_manager::query_type() const
     if( as_m.ret < 0 ) {
         return {};
     }
-    size_t index = as_m.ret;
+    size_t const index = as_m.ret;
 
     auto iter = types_vec.begin();
     std::advance( iter, index );
@@ -664,7 +664,7 @@ std::unordered_set<tripoint> zone_manager::get_point_set_loot( const tripoint &w
         int radius, bool npc_search, const faction_id &/*fac*/ ) const
 {
     std::unordered_set<tripoint> res;
-    map &here = get_map();
+    map  const&here = get_map();
     for( const tripoint elem : here.points_in_radius( here.getlocal( where ), radius ) ) {
         const zone_data *zone = get_zone_at( here.getabs( elem ) );
         // if not a LOOT zone
@@ -763,7 +763,7 @@ bool zone_manager::custom_loot_has( const tripoint &where, const item *it ) cons
         return false;
     }
     const loot_options &options = dynamic_cast<const loot_options &>( zone->get_options() );
-    std::string filter_string = options.get_mark();
+    std::string const filter_string = options.get_mark();
     auto z = item_filter_from_string( filter_string );
 
     return z( *it );
@@ -818,7 +818,7 @@ std::optional<tripoint> zone_manager::get_nearest( const zone_type_id &type, con
     int nearest_dist = range + 1;
     const std::unordered_set<tripoint> &point_set = get_point_set( type, fac );
     for( const tripoint &p : point_set ) {
-        int cur_dist = square_dist( p, where );
+        int const cur_dist = square_dist( p, where );
         if( cur_dist < nearest_dist ) {
             nearest_dist = cur_dist;
             nearest_pos = p;
@@ -830,7 +830,7 @@ std::optional<tripoint> zone_manager::get_nearest( const zone_type_id &type, con
 
     const std::unordered_set<tripoint> &vzone_set = get_vzone_set( type, fac );
     for( const tripoint &p : vzone_set ) {
-        int cur_dist = square_dist( p, where );
+        int const cur_dist = square_dist( p, where );
         if( cur_dist < nearest_dist ) {
             nearest_dist = cur_dist;
             nearest_pos = p;
@@ -977,7 +977,7 @@ void zone_manager::add( const std::string &name, const zone_type_id &type, const
 {
     zone_data new_zone = zone_data( name, type, fac, invert, enabled, start, end, options );
     //the start is a vehicle tile with cargo space
-    map &here = get_map();
+    map  const&here = get_map();
     if( const std::optional<vpart_reference> vp = here.veh_at( here.getlocal(
                 start ) ).part_with_feature( "CARGO", false ) ) {
         // TODO:Allow for loot zones on vehicles to be larger than 1x1
@@ -1066,19 +1066,19 @@ void zone_manager::rotate_zones( map &target_map, const int turns )
             ( a_end.x >= z_end.x && a_end.y >= z_end.y ) &&
             ( a_start.z == z_start.z )
           ) {
-            tripoint z_l_start3 = target_map.getlocal( z_start );
-            tripoint z_l_end3 = target_map.getlocal( z_end );
+            tripoint const z_l_start3 = target_map.getlocal( z_start );
+            tripoint const z_l_end3 = target_map.getlocal( z_end );
             // don't rotate centered squares
             if( z_l_start3.x == z_l_start3.y && z_l_end3.x == z_l_end3.y && z_l_start3.x + z_l_end3.x == 23 ) {
                 continue;
             }
-            point z_l_start = z_l_start3.xy().rotate( turns, dim );
-            point z_l_end = z_l_end3.xy().rotate( turns, dim );
-            point new_z_start = target_map.getabs( z_l_start );
-            point new_z_end = target_map.getabs( z_l_end );
-            tripoint first = tripoint( std::min( new_z_start.x, new_z_end.x ),
+            point const z_l_start = z_l_start3.xy().rotate( turns, dim );
+            point const z_l_end = z_l_end3.xy().rotate( turns, dim );
+            point const new_z_start = target_map.getabs( z_l_start );
+            point const new_z_end = target_map.getabs( z_l_end );
+            tripoint const first = tripoint( std::min( new_z_start.x, new_z_end.x ),
                                        std::min( new_z_start.y, new_z_end.y ), a_start.z );
-            tripoint second = tripoint( std::max( new_z_start.x, new_z_end.x ),
+            tripoint const second = tripoint( std::max( new_z_start.x, new_z_end.x ),
                                         std::max( new_z_start.y, new_z_end.y ), a_end.z );
             zone.set_position( std::make_pair( first, second ), false );
         }
@@ -1162,7 +1162,7 @@ void zone_data::serialize( JsonOut &json ) const
 
 void zone_data::deserialize( JsonIn &jsin )
 {
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
     data.allow_omitted_members();
     data.read( "name", name );
     data.read( "type", type );
@@ -1202,7 +1202,7 @@ void zone_data::deserialize( JsonIn &jsin )
 
 bool zone_manager::save_zones()
 {
-    std::string savefile = g->get_player_base_save_path() + ".zones.json";
+    std::string const savefile = g->get_player_base_save_path() + ".zones.json";
 
     added_vzones.clear();
     changed_vzones.clear();
@@ -1215,7 +1215,7 @@ bool zone_manager::save_zones()
 
 void zone_manager::load_zones()
 {
-    std::string savefile = g->get_player_base_save_path() + ".zones.json";
+    std::string const savefile = g->get_player_base_save_path() + ".zones.json";
 
     read_from_file_optional( savefile, [&]( std::istream & fin ) {
         JsonIn jsin( fin );

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -664,7 +664,7 @@ std::unordered_set<tripoint> zone_manager::get_point_set_loot( const tripoint &w
         int radius, bool npc_search, const faction_id &/*fac*/ ) const
 {
     std::unordered_set<tripoint> res;
-    map  const&here = get_map();
+    map  const &here = get_map();
     for( const tripoint elem : here.points_in_radius( here.getlocal( where ), radius ) ) {
         const zone_data *zone = get_zone_at( here.getabs( elem ) );
         // if not a LOOT zone
@@ -977,7 +977,7 @@ void zone_manager::add( const std::string &name, const zone_type_id &type, const
 {
     zone_data new_zone = zone_data( name, type, fac, invert, enabled, start, end, options );
     //the start is a vehicle tile with cargo space
-    map  const&here = get_map();
+    map  const &here = get_map();
     if( const std::optional<vpart_reference> vp = here.veh_at( here.getlocal(
                 start ) ).part_with_feature( "CARGO", false ) ) {
         // TODO:Allow for loot zones on vehicles to be larger than 1x1
@@ -1077,9 +1077,9 @@ void zone_manager::rotate_zones( map &target_map, const int turns )
             point const new_z_start = target_map.getabs( z_l_start );
             point const new_z_end = target_map.getabs( z_l_end );
             tripoint const first = tripoint( std::min( new_z_start.x, new_z_end.x ),
-                                       std::min( new_z_start.y, new_z_end.y ), a_start.z );
+                                             std::min( new_z_start.y, new_z_end.y ), a_start.z );
             tripoint const second = tripoint( std::max( new_z_start.x, new_z_end.x ),
-                                        std::max( new_z_start.y, new_z_end.y ), a_end.z );
+                                              std::max( new_z_start.y, new_z_end.y ), a_end.z );
             zone.set_position( std::make_pair( first, second ), false );
         }
     }

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -160,7 +160,7 @@ nc_color color_manager::get( const color_id id ) const
 
 std::string color_manager::get_name( const nc_color &color ) const
 {
-    color_id id = color_to_id( color );
+    color_id const id = color_to_id( color );
     return id_to_name( id );
 }
 
@@ -180,7 +180,7 @@ nc_color color_manager::get_random() const
 void color_manager::add_color( const color_id col, const std::string &name,
                                const nc_color &color_pair, const color_id inv_id )
 {
-    color_struct st = {color_pair, nc_color(), nc_color(), nc_color(), {{nc_color(), nc_color(), nc_color(), nc_color(), nc_color(), nc_color(), nc_color()}}, col, inv_id, name, "", "" };
+    color_struct const st = {color_pair, nc_color(), nc_color(), nc_color(), {{nc_color(), nc_color(), nc_color(), nc_color(), nc_color(), nc_color(), nc_color()}}, col, inv_id, name, "", "" };
     color_array[col] = st;
     inverted_map[color_pair] = col;
     name_map[name] = col;
@@ -212,7 +212,7 @@ nc_color color_manager::highlight_from_names( const std::string &name,
         hi_name = name + "_" + bg_name;
     }
 
-    color_id id = name_to_id( hi_name );
+    color_id const id = name_to_id( hi_name );
     return color_array[id].color;
 }
 
@@ -648,11 +648,11 @@ color_tag_parse_result get_color_from_tag( const std::string &s,
     if( s.substr( 0, 7 ) != "<color_" ) {
         return { color_tag_parse_result::non_color_tag, {} };
     }
-    size_t tag_close = s.find( '>' );
+    size_t const tag_close = s.find( '>' );
     if( tag_close == std::string::npos ) {
         return { color_tag_parse_result::non_color_tag, {} };
     }
-    std::string color_name = s.substr( 7, tag_close - 7 );
+    std::string const color_name = s.substr( 7, tag_close - 7 );
     const nc_color color = color_from_string( color_name, color_error );
     if( color != c_unset ) {
         return { color_tag_parse_result::open_color_tag, color };
@@ -968,8 +968,8 @@ void color_manager::show_gui()
 
             int i = 0;
             for( auto &iter : name_color_map ) {
-                std::string sColor = iter.first;
-                std::string sType = _( "default" );
+                std::string const sColor = iter.first;
+                std::string const sType = _( "default" );
 
                 std::string name_custom;
 
@@ -1012,7 +1012,7 @@ void color_manager::show_gui()
 
     if( bStuffChanged && query_yn( _( "Save changes?" ) ) ) {
         for( const auto &pr : name_color_map ) {
-            color_id id = name_to_id( pr.first );
+            color_id const id = name_to_id( pr.first );
             color_array[id].name_custom = pr.second.name_custom;
             color_array[id].name_invert_custom = pr.second.name_invert_custom;
         }
@@ -1068,13 +1068,13 @@ void color_manager::deserialize( JsonIn &jsin )
 {
     jsin.start_array();
     while( !jsin.end_array() ) {
-        JsonObject joColors = jsin.get_object();
+        JsonObject const joColors = jsin.get_object();
 
         const std::string name = joColors.get_string( "name" );
         const std::string name_custom = joColors.get_string( "custom" );
         const std::string name_invert_custom = joColors.get_string( "invertcustom" );
 
-        color_id id = name_to_id( name );
+        color_id const id = name_to_id( name );
         auto &entry = color_array[id];
 
         if( !name_custom.empty() ) {

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -152,7 +152,7 @@ void computer_session::use()
     // Main computer loop
     int sel = 0;
     while( true ) {
-        size_t options_size = comp.options.size();
+        size_t const options_size = comp.options.size();
 
         uilist computer_menu;
         computer_menu.text = string_format( _( "%s - Root Menu" ), comp.name );
@@ -170,7 +170,7 @@ void computer_session::use()
         }
 
         sel = computer_menu.ret;
-        computer_option current = comp.options[sel];
+        computer_option const current = comp.options[sel];
         reset_terminal();
         // Once you trip the security, you have to roll every time you want to do something
         if( current.security + comp.alerts > 0 ) {
@@ -221,7 +221,7 @@ bool computer_session::hack_attempt( player &p, int Security )
     }
 
     ///\EFFECT_COMPUTER increases chance of successful hack attempt, vs Security level
-    bool successful_attempt = ( dice( player_roll, 6 ) >= dice( Security, 6 ) );
+    bool const successful_attempt = ( dice( player_roll, 6 ) >= dice( Security, 6 ) );
     p.practice( skill_computer, successful_attempt ? ( 15 + Security * 3 ) : 7 );
     return successful_attempt;
 }
@@ -241,8 +241,8 @@ static item *pick_usb()
 
 static void remove_submap_turrets()
 {
-    map &here = get_map();
-    for( monster &critter : g->all_monsters() ) {
+    map  const&here = get_map();
+    for( monster  const&critter : g->all_monsters() ) {
         // Check 1) same overmap coords, 2) turret, 3) hostile
         if( ms_to_omt_copy( here.getabs( critter.pos() ) ) == ms_to_omt_copy( here.getabs( g->u.pos() ) ) &&
             critter.has_flag( MF_CONSOLE_DESPAWN ) &&
@@ -370,7 +370,7 @@ void computer_session::action_sample()
                 continue;
             }
             bool found_item = false;
-            item sewage( itype_sewage, calendar::turn );
+            item const sewage( itype_sewage, calendar::turn );
             for( item &elem : here.i_at( n ) ) {
                 int capa = elem.get_remaining_capacity_for_liquid( sewage );
                 if( capa <= 0 ) {
@@ -419,7 +419,7 @@ void computer_session::action_release_bionics()
 void computer_session::action_terminate()
 {
     g->events().send<event_type::terminates_subspace_specimens>();
-    map &here = get_map();
+    map  const&here = get_map();
     for( const tripoint &p : here.points_on_zlevel() ) {
         monster *const mon = g->critter_at<monster>( p );
         if( !mon ) {
@@ -462,7 +462,7 @@ void computer_session::action_cascade()
         return;
     }
     g->events().send<event_type::causes_resonance_cascade>();
-    map &here = get_map();
+    map  const&here = get_map();
     std::vector<tripoint> cascade_points;
     for( const tripoint &dest : here.points_in_radius( g->u.pos(), 10 ) ) {
         if( here.ter( dest ) == t_radio_tower ) {
@@ -533,7 +533,7 @@ void computer_session::action_map_sewer()
     const tripoint_abs_omt center = player_character.global_omt_location();
     for( int i = -60; i <= 60; i++ ) {
         for( int j = -60; j <= 60; j++ ) {
-            point offset( i, j );
+            point const offset( i, j );
             const oter_id &oter = overmap_buffer.ter( center + offset );
             if( is_ot_match( "sewer", oter, ot_match_type::type ) ||
                 is_ot_match( "sewage", oter, ot_match_type::prefix ) ) {
@@ -552,7 +552,7 @@ void computer_session::action_map_subway()
     const tripoint_abs_omt center = player_character.global_omt_location();
     for( int i = -60; i <= 60; i++ ) {
         for( int j = -60; j <= 60; j++ ) {
-            point offset( i, j );
+            point const offset( i, j );
             const oter_id &oter = overmap_buffer.ter( center + offset );
             if( is_ot_match( "subway", oter, ot_match_type::type ) ||
                 is_ot_match( "lab_train_depot", oter, ot_match_type::contains ) ) {
@@ -586,7 +586,7 @@ void computer_session::action_list_bionics()
     int more = 0;
     map &here = get_map();
     for( const tripoint &p : here.points_on_zlevel() ) {
-        for( item &elem : here.i_at( p ) ) {
+        for( item  const&elem : here.i_at( p ) ) {
             if( elem.is_bionic() ) {
                 if( static_cast<int>( names.size() ) < TERMY - 8 ) {
                     names.push_back( elem.type_name() );
@@ -777,7 +777,7 @@ void computer_session::action_blood_anal()
                     print_line( _( "Pathogen bonded to erythrocytes and leukocytes." ) );
                     if( query_bool( _( "Download data?" ) ) ) {
                         if( item *const usb = pick_usb() ) {
-                            item software( "software_blood_data", calendar::start_of_cataclysm );
+                            item const software( "software_blood_data", calendar::start_of_cataclysm );
                             usb->contents.clear_items();
                             usb->put_in( software );
                             print_line( _( "Software downloaded." ) );
@@ -815,7 +815,7 @@ void computer_session::action_data_anal()
             } else { // Success!
                 if( items.only_item().typeId() == itype_black_box ) {
                     print_line( _( "Memory Bank: Military Hexron Encryption\nPrinting Transcript\n" ) );
-                    item transcript( "black_box_transcript", calendar::turn );
+                    item const transcript( "black_box_transcript", calendar::turn );
                     here.add_item_or_charges( g->u.pos(), transcript );
                 } else {
                     print_line( _( "Memory Bank: Unencrypted\nNothing of interest.\n" ) );
@@ -1035,7 +1035,7 @@ void computer_session::action_irradiator()
                 g->u.moves -= 300;
                 for( auto it = here.i_at( dest ).begin(); it != here.i_at( dest ).end(); ++it ) {
                     // actual food processing
-                    itype_id irradiated_type( "irradiated_" + it->typeId().str() );
+                    itype_id const irradiated_type( "irradiated_" + it->typeId().str() );
                     if( !it->rotten() && irradiated_type.is_valid() ) {
                         it->convert( irradiated_type );
                     }
@@ -1106,7 +1106,7 @@ void computer_session::action_geiger()
     int sum_rads = 0;
     int peak_rad = 0;
     int tiles_counted = 0;
-    map &here = get_map();
+    map  const&here = get_map();
     print_error( _( "RADIATION MEASUREMENTS:" ) );
     for( const tripoint &dest : here.points_in_radius( g->u.pos(), 10 ) ) {
         if( here.ter( dest ) == t_rad_platform ) {
@@ -1327,7 +1327,7 @@ void computer_session::failure_alarm()
 
 void computer_session::failure_manhacks()
 {
-    int num_robots = rng( 4, 8 );
+    int const num_robots = rng( 4, 8 );
     const tripoint_range<tripoint> range =
         get_map().points_in_radius( get_player_character().pos(), 3 );
     for( int i = 0; i < num_robots; i++ ) {
@@ -1339,7 +1339,7 @@ void computer_session::failure_manhacks()
 
 void computer_session::failure_secubots()
 {
-    int num_robots = 1;
+    int const num_robots = 1;
     const tripoint_range<tripoint> range =
         get_map().points_in_radius( get_player_character().pos(), 3 );
     for( int i = 0; i < num_robots; i++ ) {
@@ -1477,7 +1477,7 @@ void computer_session::action_emerg_ref_center()
 
     const mission_type_id &mission_type = mission_type_id( "MISSION_REACH_REFUGEE_CENTER" );
     tripoint_abs_omt mission_target;
-    avatar &player_character = get_avatar();
+    avatar  const&player_character = get_avatar();
     // Check completed missions too, so people can't repeatedly get the mission.
     const std::vector<mission *> completed_missions = g->u.get_completed_missions();
     std::vector<mission *> missions = g->u.get_active_missions();
@@ -1630,7 +1630,7 @@ void computer_session::print_text( const std::string &text, Args &&... args )
 void computer_session::print_gibberish_line()
 {
     std::string gibberish;
-    int length = rng( 50, 70 );
+    int const length = rng( 50, 70 );
     for( int i = 0; i < length; i++ ) {
         switch( rng( 0, 4 ) ) {
             case 0:

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -241,8 +241,8 @@ static item *pick_usb()
 
 static void remove_submap_turrets()
 {
-    map  const&here = get_map();
-    for( monster  const&critter : g->all_monsters() ) {
+    map  const &here = get_map();
+    for( monster  const &critter : g->all_monsters() ) {
         // Check 1) same overmap coords, 2) turret, 3) hostile
         if( ms_to_omt_copy( here.getabs( critter.pos() ) ) == ms_to_omt_copy( here.getabs( g->u.pos() ) ) &&
             critter.has_flag( MF_CONSOLE_DESPAWN ) &&
@@ -419,7 +419,7 @@ void computer_session::action_release_bionics()
 void computer_session::action_terminate()
 {
     g->events().send<event_type::terminates_subspace_specimens>();
-    map  const&here = get_map();
+    map  const &here = get_map();
     for( const tripoint &p : here.points_on_zlevel() ) {
         monster *const mon = g->critter_at<monster>( p );
         if( !mon ) {
@@ -462,7 +462,7 @@ void computer_session::action_cascade()
         return;
     }
     g->events().send<event_type::causes_resonance_cascade>();
-    map  const&here = get_map();
+    map  const &here = get_map();
     std::vector<tripoint> cascade_points;
     for( const tripoint &dest : here.points_in_radius( g->u.pos(), 10 ) ) {
         if( here.ter( dest ) == t_radio_tower ) {
@@ -586,7 +586,7 @@ void computer_session::action_list_bionics()
     int more = 0;
     map &here = get_map();
     for( const tripoint &p : here.points_on_zlevel() ) {
-        for( item  const&elem : here.i_at( p ) ) {
+        for( item  const &elem : here.i_at( p ) ) {
             if( elem.is_bionic() ) {
                 if( static_cast<int>( names.size() ) < TERMY - 8 ) {
                     names.push_back( elem.type_name() );
@@ -1106,7 +1106,7 @@ void computer_session::action_geiger()
     int sum_rads = 0;
     int peak_rad = 0;
     int tiles_counted = 0;
-    map  const&here = get_map();
+    map  const &here = get_map();
     print_error( _( "RADIATION MEASUREMENTS:" ) );
     for( const tripoint &dest : here.points_in_radius( g->u.pos(), 10 ) ) {
         if( here.ter( dest ) == t_rad_platform ) {
@@ -1477,7 +1477,7 @@ void computer_session::action_emerg_ref_center()
 
     const mission_type_id &mission_type = mission_type_id( "MISSION_REACH_REFUGEE_CENTER" );
     tripoint_abs_omt mission_target;
-    avatar  const&player_character = get_avatar();
+    avatar  const &player_character = get_avatar();
     // Check completed missions too, so people can't repeatedly get the mission.
     const std::vector<mission *> completed_missions = g->u.get_completed_missions();
     std::vector<mission *> missions = g->u.get_active_missions();

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -71,13 +71,13 @@ void read_condition( const JsonObject &jo, const std::string &member_name,
         condition = null_function;
     } else if( jo.has_string( member_name ) ) {
         const std::string type = jo.get_string( member_name );
-        conditional_t<T> sub_condition( type );
+        conditional_t<T> const sub_condition( type );
         condition = [sub_condition]( const T & d ) {
             return sub_condition( d );
         };
     } else if( jo.has_object( member_name ) ) {
-        JsonObject con_obj = jo.get_object( member_name );
-        conditional_t<T> sub_condition( con_obj );
+        JsonObject const con_obj = jo.get_object( member_name );
+        conditional_t<T> const sub_condition( con_obj );
         condition = [sub_condition]( const T & d ) {
             return sub_condition( d );
         };
@@ -271,14 +271,14 @@ void conditional_t<T>::set_has_item( const JsonObject &jo, const std::string &me
 template<class T>
 void conditional_t<T>::set_has_items( const JsonObject &jo, const std::string &member, bool is_npc )
 {
-    JsonObject has_items = jo.get_object( member );
+    JsonObject const has_items = jo.get_object( member );
     if( !has_items.has_string( "item" ) || !has_items.has_int( "count" ) ) {
         condition = []( const T & ) {
             return false;
         };
     } else {
         const itype_id item_id( has_items.get_string( "item" ) );
-        int count = has_items.get_int( "count" );
+        int const count = has_items.get_int( "count" );
         condition = [item_id, count, is_npc]( const T & d ) {
             player *actor = d.alpha;
             if( is_npc ) {
@@ -297,7 +297,7 @@ void conditional_t<T>::set_has_item_category( const JsonObject &jo, const std::s
 
     size_t count = 1;
     if( jo.has_int( "count" ) ) {
-        int tcount = jo.get_int( "count" );
+        int const tcount = jo.get_int( "count" );
         if( tcount > 1 && tcount < INT_MAX ) {
             count = static_cast<size_t>( tcount );
         }
@@ -365,7 +365,7 @@ void conditional_t<T>::set_need( const JsonObject &jo, const std::string &member
         if( is_npc ) {
             actor = dynamic_cast<player *>( d.beta );
         }
-        int effective_hunger = ( actor->max_stored_kcal() - actor->get_stored_kcal() ) / 10;
+        int const effective_hunger = ( actor->max_stored_kcal() - actor->get_stored_kcal() ) / 10;
         return ( actor->get_fatigue() > amount && need == "fatigue" ) ||
                ( effective_hunger > amount && need == "hunger" ) ||
                ( actor->get_thirst() > amount && need == "thirst" );
@@ -386,7 +386,7 @@ void conditional_t<T>::set_at_om_location( const JsonObject &jo, const std::stri
         const oter_id &omt_ref = overmap_buffer.ter( omt_pos );
 
         if( location == "FACTION_CAMP_ANY" ) {
-            std::optional<basecamp *> bcp = overmap_buffer.find_camp( omt_pos.xy() );
+            std::optional<basecamp *> const bcp = overmap_buffer.find_camp( omt_pos.xy() );
             if( bcp ) {
                 return true;
             }
@@ -553,7 +553,7 @@ void conditional_t<T>::set_npc_cbm_recharge_rule( const JsonObject &jo )
 template<class T>
 void conditional_t<T>::set_npc_rule( const JsonObject &jo )
 {
-    std::string rule = jo.get_string( "npc_rule" );
+    std::string const rule = jo.get_string( "npc_rule" );
     condition = [rule]( const T & d ) {
         auto flag = ally_rule_strs.find( rule );
         if( flag != ally_rule_strs.end() ) {
@@ -566,7 +566,7 @@ void conditional_t<T>::set_npc_rule( const JsonObject &jo )
 template<class T>
 void conditional_t<T>::set_npc_override( const JsonObject &jo )
 {
-    std::string rule = jo.get_string( "npc_override" );
+    std::string const rule = jo.get_string( "npc_override" );
     condition = [rule]( const T & d ) {
         auto flag = ally_rule_strs.find( rule );
         if( flag != ally_rule_strs.end() ) {
@@ -588,7 +588,7 @@ void conditional_t<T>::set_days_since( const JsonObject &jo )
 template<class T>
 void conditional_t<T>::set_is_season( const JsonObject &jo )
 {
-    std::string season_name = jo.get_string( "is_season" );
+    std::string const season_name = jo.get_string( "is_season" );
     condition = [season_name]( const T & ) {
         const auto season = season_of_year( calendar::turn );
         return ( season == SPRING && season_name == "spring" ) ||
@@ -601,7 +601,7 @@ void conditional_t<T>::set_is_season( const JsonObject &jo )
 template<class T>
 void conditional_t<T>::set_mission_goal( const JsonObject &jo )
 {
-    std::string mission_goal_str = jo.get_string( "mission_goal" );
+    std::string const mission_goal_str = jo.get_string( "mission_goal" );
     condition = [mission_goal_str]( const T & d ) {
         mission *miss = d.beta->chatbin.mission_selected;
         if( !miss ) {
@@ -796,7 +796,7 @@ void conditional_t<T>::set_has_stolen_item( bool /*is_npc*/ )
 {
     condition = []( const T & d ) {
         player *actor = d.alpha;
-        npc &p = *d.beta;
+        npc  const&p = *d.beta;
         bool found_in_inv = false;
         for( auto &elem : actor->inv_dump() ) {
             if( elem->is_old_owner( p, true ) ) {
@@ -819,7 +819,7 @@ template<class T>
 void conditional_t<T>::set_is_outside()
 {
     condition = []( const T & d ) {
-        map &here = get_map();
+        map  const&here = get_map();
         const tripoint pos = here.getabs( d.beta->pos() );
         return !here.has_flag( TFLAG_INDOORS, pos );
     };
@@ -860,14 +860,14 @@ void conditional_t<T>::set_has_reason()
 template<class T>
 void conditional_t<T>::set_has_skill( const JsonObject &jo, const std::string &member, bool is_npc )
 {
-    JsonObject has_skill = jo.get_object( member );
+    JsonObject const has_skill = jo.get_object( member );
     if( !has_skill.has_string( "skill" ) || !has_skill.has_int( "level" ) ) {
         condition = []( const T & ) {
             return false;
         };
     } else {
         const skill_id skill( has_skill.get_string( "skill" ) );
-        int level = has_skill.get_int( "level" );
+        int const level = has_skill.get_int( "level" );
         condition = [skill, level, is_npc]( const T & d ) {
             player *actor = d.alpha;
             if( is_npc ) {
@@ -912,18 +912,18 @@ conditional_t<T>::conditional_t( const JsonObject &jo )
         std::vector<conditional_t> conditionals;
         for( const JsonValue entry : jo.get_array( type ) ) {
             if( entry.test_string() ) {
-                conditional_t<T> type_condition( entry.get_string() );
+                conditional_t<T> const type_condition( entry.get_string() );
                 conditionals.emplace_back( type_condition );
             } else {
-                JsonObject cond = entry.get_object();
-                conditional_t<T> type_condition( cond );
+                JsonObject const cond = entry.get_object();
+                conditional_t<T> const type_condition( cond );
                 conditionals.emplace_back( type_condition );
             }
         }
         return conditionals;
     };
     if( jo.has_array( "and" ) ) {
-        std::vector<conditional_t> and_conditionals = parse_array( jo, "and" );
+        std::vector<conditional_t> const and_conditionals = parse_array( jo, "and" );
         found_sub_member = true;
         condition = [and_conditionals]( const T & d ) {
             for( const auto &cond : and_conditionals ) {
@@ -934,7 +934,7 @@ conditional_t<T>::conditional_t( const JsonObject &jo )
             return true;
         };
     } else if( jo.has_array( "or" ) ) {
-        std::vector<conditional_t> or_conditionals = parse_array( jo, "or" );
+        std::vector<conditional_t> const or_conditionals = parse_array( jo, "or" );
         found_sub_member = true;
         condition = [or_conditionals]( const T & d ) {
             for( const auto &cond : or_conditionals ) {
@@ -945,7 +945,7 @@ conditional_t<T>::conditional_t( const JsonObject &jo )
             return false;
         };
     } else if( jo.has_object( "not" ) ) {
-        JsonObject cond = jo.get_object( "not" );
+        JsonObject const cond = jo.get_object( "not" );
         const conditional_t<T> sub_condition = conditional_t<T>( cond );
         found_sub_member = true;
         condition = [sub_condition]( const T & d ) {

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -796,7 +796,7 @@ void conditional_t<T>::set_has_stolen_item( bool /*is_npc*/ )
 {
     condition = []( const T & d ) {
         player *actor = d.alpha;
-        npc  const&p = *d.beta;
+        npc  const &p = *d.beta;
         bool found_in_inv = false;
         for( auto &elem : actor->inv_dump() ) {
             if( elem->is_old_owner( p, true ) ) {
@@ -819,7 +819,7 @@ template<class T>
 void conditional_t<T>::set_is_outside()
 {
     condition = []( const T & d ) {
-        map  const&here = get_map();
+        map  const &here = get_map();
         const tripoint pos = here.getabs( d.beta->pos() );
         return !here.has_flag( TFLAG_INDOORS, pos );
     };

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -498,9 +498,9 @@ std::optional<construction_id> construction_menu( const bool blueprint )
                 };
 
                 bool const pre_is_ter_or_furn = !current_con->pre_terrain.is_empty() ||
-                                          !current_con->pre_furniture.is_empty();
+                                                !current_con->pre_furniture.is_empty();
                 bool const post_is_ter_or_furn = !current_con->post_terrain.is_empty() ||
-                                           !current_con->post_furniture.is_empty();
+                                                 !current_con->post_furniture.is_empty();
 
                 // Display final product name only if more than one step.
                 // Assume single stage constructions should be clear
@@ -532,7 +532,7 @@ std::optional<construction_id> construction_menu( const bool blueprint )
                     add_line( _( "No skills required." ) );
                 } else {
                     std::string const current_line = _( "Required skills: " ) + enumerate_as_string(
-                                                   current_con->required_skills.begin(), current_con->required_skills.end(),
+                                                         current_con->required_skills.begin(), current_con->required_skills.end(),
                     []( const std::pair<skill_id, int> &skill ) {
                         nc_color col;
                         int const s_lvl = g->u.get_skill_level( skill.first );
@@ -1014,8 +1014,9 @@ void place_construction( const construction_group_str_id &group )
         }
     }
 
-    shared_ptr_fast<game::draw_callback_t> const draw_valid = make_shared_fast<game::draw_callback_t>( [&]() {
-        map  const&here = get_map();
+    shared_ptr_fast<game::draw_callback_t> const draw_valid =
+    make_shared_fast<game::draw_callback_t>( [&]() {
+        map  const &here = get_map();
         for( auto &elem : valid ) {
             here.drawsq( g->w_terrain, elem.first, drawsq_params().highlight( true ).show_items( true ) );
         }
@@ -1204,7 +1205,7 @@ inline std::array<tripoint, 4> get_orthogonal_neighbors( const tripoint &p )
 
 bool construct::check_support( const tripoint &p )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     // need two or more orthogonally adjacent supports
     if( here.impassable( p ) ) {
         return false;
@@ -1220,7 +1221,7 @@ bool construct::check_support( const tripoint &p )
 
 bool construct::check_deconstruct( const tripoint &p )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     if( here.has_furn( p.xy() ) ) {
         return here.furn( p.xy() ).obj().deconstruct.can_do;
     }
@@ -1351,7 +1352,7 @@ void construct::done_vehicle( const tripoint &p )
     }
 
     map &m = get_map();
-    avatar  const&u = get_avatar();
+    avatar  const &u = get_avatar();
 
     vehicle *veh = m.add_vehicle( vproto_id( "none" ), p, 270_degrees, 0, 0 );
 
@@ -1444,7 +1445,8 @@ void construct::done_digormine_stair( const tripoint &p, bool dig )
     tmpmap.load( tripoint( pos_sm.xy(), pos_sm.z - 1 ), false );
     const tripoint local_tmp = tmpmap.getlocal( abs_pos );
 
-    bool const dig_muts = g->u.has_trait( trait_PAINRESIST_TROGLO ) || g->u.has_trait( trait_STOCKY_TROGLO );
+    bool const dig_muts = g->u.has_trait( trait_PAINRESIST_TROGLO ) ||
+                          g->u.has_trait( trait_STOCKY_TROGLO );
 
     int const no_mut_penalty = dig_muts ? 10 : 0;
     int const mine_penalty = dig ? 0 : 10;
@@ -1518,7 +1520,8 @@ void construct::done_mine_upstair( const tripoint &p )
         return;
     }
 
-    bool const dig_muts = g->u.has_trait( trait_PAINRESIST_TROGLO ) || g->u.has_trait( trait_STOCKY_TROGLO );
+    bool const dig_muts = g->u.has_trait( trait_PAINRESIST_TROGLO ) ||
+                          g->u.has_trait( trait_STOCKY_TROGLO );
 
     int const no_mut_penalty = dig_muts ? 15 : 0;
     g->u.mod_stored_nutr( 20 + no_mut_penalty );
@@ -1782,7 +1785,7 @@ void construction::finalize()
         debugmsg( "Invalid construction category (%s) defined for construction (%s)", category, id );
     }
     requirement_data const requirements_ = std::accumulate( reqs_using.begin(), reqs_using.end(),
-                                     *requirements,
+                                           *requirements,
     []( const requirement_data & lhs, const std::pair<requirement_id, int> &rhs ) {
         return lhs + ( *rhs.first * rhs.second );
     } );

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -239,7 +239,7 @@ void finalize()
     }
     std::sort( constructions_sorted.begin(), constructions_sorted.end(),
     [&]( const construction_id & l, const construction_id & r ) -> bool {
-        lexicographic<construction> cmp;
+        lexicographic<construction> const cmp;
         return cmp( l->id, r->id );
     } );
 }
@@ -349,7 +349,7 @@ static nc_color construction_color( const construction_group_str_id &group, bool
         col = c_white;
     } else if( can_construct( group ) ) {
         const construction *con_first = nullptr;
-        std::vector<const construction *> cons = constructions_by_group( group );
+        std::vector<const construction *> const cons = constructions_by_group( group );
         const inventory &total_inv = player_character.crafting_inventory();
         for( const construction *con : cons ) {
             if( con->requirements->can_make_with_inventory( total_inv, is_crafting_component ) ) {
@@ -360,7 +360,7 @@ static nc_color construction_color( const construction_group_str_id &group, bool
         if( con_first != nullptr ) {
             col = c_white;
             for( const auto &pr : con_first->required_skills ) {
-                int s_lvl = player_character.get_skill_level( pr.first );
+                int const s_lvl = player_character.get_skill_level( pr.first );
                 if( s_lvl < pr.second ) {
                     col = c_red;
                 } else if( s_lvl < pr.second * 1.25 ) {
@@ -473,7 +473,7 @@ std::optional<construction_id> construction_menu( const bool blueprint )
             //construct the project list buffer
 
             // Print stages and their requirement.
-            std::vector<const construction *> options = constructions_by_group( current_group );
+            std::vector<const construction *> const options = constructions_by_group( current_group );
 
             construct_buffers.clear();
             current_construct_breakpoint = 0;
@@ -497,9 +497,9 @@ std::optional<construction_id> construction_menu( const bool blueprint )
                     add_folded( foldstring( line, available_window_width ) );
                 };
 
-                bool pre_is_ter_or_furn = !current_con->pre_terrain.is_empty() ||
+                bool const pre_is_ter_or_furn = !current_con->pre_terrain.is_empty() ||
                                           !current_con->pre_furniture.is_empty();
-                bool post_is_ter_or_furn = !current_con->post_terrain.is_empty() ||
+                bool const post_is_ter_or_furn = !current_con->post_terrain.is_empty() ||
                                            !current_con->post_furniture.is_empty();
 
                 // Display final product name only if more than one step.
@@ -531,11 +531,11 @@ std::optional<construction_id> construction_menu( const bool blueprint )
                 if( current_con->required_skills.empty() ) {
                     add_line( _( "No skills required." ) );
                 } else {
-                    std::string current_line = _( "Required skills: " ) + enumerate_as_string(
+                    std::string const current_line = _( "Required skills: " ) + enumerate_as_string(
                                                    current_con->required_skills.begin(), current_con->required_skills.end(),
                     []( const std::pair<skill_id, int> &skill ) {
                         nc_color col;
-                        int s_lvl = g->u.get_skill_level( skill.first );
+                        int const s_lvl = g->u.get_skill_level( skill.first );
                         if( s_lvl < skill.second ) {
                             col = c_red;
                         } else if( s_lvl < skill.second * 1.25 ) {
@@ -559,7 +559,7 @@ std::optional<construction_id> construction_menu( const bool blueprint )
                     } else {
                         require_string = current_con->pre_terrain->name();
                     }
-                    nc_color pre_color = has_pre_terrain( *current_con ) ? c_green : c_red;
+                    nc_color const pre_color = has_pre_terrain( *current_con ) ? c_green : c_red;
                     add_line( _( "Requires: " ) + colorize( require_string, pre_color ) );
                 }
                 if( !current_con->pre_note.empty() ) {
@@ -644,9 +644,9 @@ std::optional<construction_id> construction_menu( const bool blueprint )
         std::optional<point> cursor_pos;
         for( size_t i = 0; static_cast<int>( i ) < w_list_height &&
              ( i + offset ) < constructs.size(); i++ ) {
-            int current = i + offset;
+            int const current = i + offset;
             const construction_group_str_id &group = constructs[current];
-            bool highlight = ( current == select );
+            bool const highlight = ( current == select );
             const point print_from( 0, i );
             if( highlight ) {
                 cursor_pos = print_from;
@@ -919,7 +919,7 @@ std::optional<construction_id> construction_menu( const bool blueprint )
 bool player_can_build( Character &ch, const inventory &inv, const construction_group_str_id &group )
 {
     // check all with the same group to see if player can build any
-    std::vector<const construction *> cons = constructions_by_group( group );
+    std::vector<const construction *> const cons = constructions_by_group( group );
     for( const construction *con : cons ) {
         if( player_can_build( ch, inv, *con ) ) {
             return true;
@@ -946,7 +946,7 @@ bool player_can_see_to_build( Character &ch, const construction_group_str_id &gr
     if( character_funcs::can_see_fine_details( ch ) || ch.has_trait( trait_DEBUG_HS ) ) {
         return true;
     }
-    std::vector<const construction *> cons = constructions_by_group( group );
+    std::vector<const construction *> const cons = constructions_by_group( group );
     for( const construction *con : cons ) {
         if( con->dark_craftable ) {
             return true;
@@ -958,7 +958,7 @@ bool player_can_see_to_build( Character &ch, const construction_group_str_id &gr
 bool can_construct( const construction_group_str_id &group )
 {
     // check all with the same group to see if player can build any
-    std::vector<const construction *> cons = constructions_by_group( group );
+    std::vector<const construction *> const cons = constructions_by_group( group );
     for( const construction *con : cons ) {
         if( can_construct( *con ) ) {
             return true;
@@ -1014,8 +1014,8 @@ void place_construction( const construction_group_str_id &group )
         }
     }
 
-    shared_ptr_fast<game::draw_callback_t> draw_valid = make_shared_fast<game::draw_callback_t>( [&]() {
-        map &here = get_map();
+    shared_ptr_fast<game::draw_callback_t> const draw_valid = make_shared_fast<game::draw_callback_t>( [&]() {
+        map  const&here = get_map();
         for( auto &elem : valid ) {
             here.drawsq( g->w_terrain, elem.first, drawsq_params().highlight( true ).show_items( true ) );
         }
@@ -1130,7 +1130,7 @@ void complete_construction( Character &ch )
             }
         }
         if( !dump_spots.empty() ) {
-            tripoint dump_spot = random_entry( dump_spots );
+            tripoint const dump_spot = random_entry( dump_spots );
             map_stack items = here.i_at( terp );
             for( map_stack::iterator it = items.begin(); it != items.end(); ) {
                 here.add_item_or_charges( dump_spot, *it );
@@ -1204,7 +1204,7 @@ inline std::array<tripoint, 4> get_orthogonal_neighbors( const tripoint &p )
 
 bool construct::check_support( const tripoint &p )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     // need two or more orthogonally adjacent supports
     if( here.impassable( p ) ) {
         return false;
@@ -1220,7 +1220,7 @@ bool construct::check_support( const tripoint &p )
 
 bool construct::check_deconstruct( const tripoint &p )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     if( here.has_furn( p.xy() ) ) {
         return here.furn( p.xy() ).obj().deconstruct.can_do;
     }
@@ -1253,7 +1253,7 @@ bool construct::check_no_trap( const tripoint &p )
 bool construct::check_ramp_high( const tripoint &p )
 {
     if( check_up_OK( p ) && check_up_OK( p + tripoint_above ) ) {
-        for( point car_d : four_cardinal_directions ) {
+        for( point const car_d : four_cardinal_directions ) {
             // check adjacent points on the z-level above for a completed down ramp
             if( get_map().has_flag( TFLAG_RAMP_DOWN, p + car_d + tripoint_above ) ) {
                 return true;
@@ -1270,7 +1270,7 @@ bool construct::check_ramp_low( const tripoint &p )
 
 void construct::done_trunk_plank( const tripoint &/*p*/ )
 {
-    int num_logs = rng( 2, 3 );
+    int const num_logs = rng( 2, 3 );
     for( int i = 0; i < num_logs; ++i ) {
         iuse::cut_log_into_planks( g->u );
     }
@@ -1279,7 +1279,7 @@ void construct::done_trunk_plank( const tripoint &/*p*/ )
 void construct::done_grave( const tripoint &p )
 {
     map &here = get_map();
-    map_stack its = here.i_at( p );
+    map_stack const its = here.i_at( p );
     for( item it : its ) {
         if( it.is_corpse() ) {
             if( it.get_corpse_name().empty() ) {
@@ -1351,7 +1351,7 @@ void construct::done_vehicle( const tripoint &p )
     }
 
     map &m = get_map();
-    avatar &u = get_avatar();
+    avatar  const&u = get_avatar();
 
     vehicle *veh = m.add_vehicle( vproto_id( "none" ), p, 270_degrees, 0, 0 );
 
@@ -1428,7 +1428,7 @@ void construct::done_deconstruct( const tripoint &p )
 static void unroll_digging( const int numer_of_2x4s )
 {
     // refund components!
-    item rope( "rope_30" );
+    item const rope( "rope_30" );
     map &here = get_map();
     here.add_item_or_charges( g->u.pos(), rope );
     // presuming 2x4 to conserve lumber.
@@ -1444,10 +1444,10 @@ void construct::done_digormine_stair( const tripoint &p, bool dig )
     tmpmap.load( tripoint( pos_sm.xy(), pos_sm.z - 1 ), false );
     const tripoint local_tmp = tmpmap.getlocal( abs_pos );
 
-    bool dig_muts = g->u.has_trait( trait_PAINRESIST_TROGLO ) || g->u.has_trait( trait_STOCKY_TROGLO );
+    bool const dig_muts = g->u.has_trait( trait_PAINRESIST_TROGLO ) || g->u.has_trait( trait_STOCKY_TROGLO );
 
-    int no_mut_penalty = dig_muts ? 10 : 0;
-    int mine_penalty = dig ? 0 : 10;
+    int const no_mut_penalty = dig_muts ? 10 : 0;
+    int const mine_penalty = dig ? 0 : 10;
     g->u.mod_stored_nutr( 5 + mine_penalty + no_mut_penalty );
     g->u.mod_thirst( 5 + mine_penalty + no_mut_penalty );
     g->u.mod_fatigue( 10 + mine_penalty + no_mut_penalty );
@@ -1465,7 +1465,7 @@ void construct::done_digormine_stair( const tripoint &p, bool dig )
         return;
     }
 
-    bool impassable = tmpmap.impassable( local_tmp );
+    bool const impassable = tmpmap.impassable( local_tmp );
     if( !impassable ) {
         add_msg( _( "You dig into a preexisting space, and improvise a ladder." ) );
     } else if( dig ) {
@@ -1518,9 +1518,9 @@ void construct::done_mine_upstair( const tripoint &p )
         return;
     }
 
-    bool dig_muts = g->u.has_trait( trait_PAINRESIST_TROGLO ) || g->u.has_trait( trait_STOCKY_TROGLO );
+    bool const dig_muts = g->u.has_trait( trait_PAINRESIST_TROGLO ) || g->u.has_trait( trait_STOCKY_TROGLO );
 
-    int no_mut_penalty = dig_muts ? 15 : 0;
+    int const no_mut_penalty = dig_muts ? 15 : 0;
     g->u.mod_stored_nutr( 20 + no_mut_penalty );
     g->u.mod_thirst( 20 + no_mut_penalty );
     g->u.mod_fatigue( 25 + no_mut_penalty );
@@ -1618,7 +1618,7 @@ void construction::load( const JsonObject &jo, const std::string &/*src*/ )
     if( jo.has_string( "using" ) ) {
         reqs_using = { { requirement_id( jo.get_string( "using" ) ), 1} };
     } else if( jo.has_array( "using" ) ) {
-        for( JsonArray cur : jo.get_array( "using" ) ) {
+        for( JsonArray const cur : jo.get_array( "using" ) ) {
             reqs_using.emplace_back( requirement_id( cur.get_string( 0 ) ), cur.get_int( 1 ) );
         }
     }
@@ -1745,7 +1745,7 @@ void construction::check() const
     }
 
     if( !report.is_empty() ) {
-        std::string s = report.format( "construction", id.str() );
+        std::string const s = report.format( "construction", id.str() );
         debugmsg( s );
     }
 }
@@ -1781,7 +1781,7 @@ void construction::finalize()
     if( !is_valid_construction_category ) {
         debugmsg( "Invalid construction category (%s) defined for construction (%s)", category, id );
     }
-    requirement_data requirements_ = std::accumulate( reqs_using.begin(), reqs_using.end(),
+    requirement_data const requirements_ = std::accumulate( reqs_using.begin(), reqs_using.end(),
                                      *requirements,
     []( const requirement_data & lhs, const std::pair<requirement_id, int> &rhs ) {
         return lhs + ( *rhs.first * rhs.second );
@@ -1794,7 +1794,7 @@ void construction::finalize()
 int construction::print_time( const catacurses::window &w, point p, int width,
                               nc_color col ) const
 {
-    std::string text = get_time_string();
+    std::string const text = get_time_string();
     return fold_and_print( w, p, width, col, text );
 }
 
@@ -1843,7 +1843,7 @@ std::string construction::get_time_string() const
 
 std::vector<std::string> construction::get_folded_time_string( int width ) const
 {
-    std::string time_text = get_time_string();
+    std::string const time_text = get_time_string();
     std::vector<std::string> folded_time = foldstring( time_text, width );
     return folded_time;
 }

--- a/src/construction_sequence.cpp
+++ b/src/construction_sequence.cpp
@@ -36,7 +36,7 @@ void construction_sequence::check() const
         }
     }
     if( !report.is_empty() ) {
-        std::string s = report.format( "construction sequence", id.str() );
+        std::string const s = report.format( "construction sequence", id.str() );
         debugmsg( s );
     }
 }

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1034,19 +1034,19 @@ void Character::modify_stimulation( const islot_comestible &comest )
         int const hallu_duration = ( current_stim - comest.stim < 30 ) ? current_stim - 30 : comest.stim;
         add_effect( effect_visuals, hallu_duration * 30_minutes );
         std::vector<std::string> const stimboost_msg{ _( "The shadows are getting ever closer." ),
-                                                _( "You have a bad feeling about this." ),
-                                                _( "A powerful sense of dread comes over you." ),
-                                                _( "Your skin starts crawling." ),
-                                                _( "They're coming to get you." ),
-                                                _( "This might've been a bad idea…" ),
-                                                _( "You've really done it this time, haven't you?" ),
-                                                _( "You have to stay vigilant.  They're always watching…" ),
-                                                _( "mistake mistake mistake mistake mistake" ),
-                                                _( "Just gotta stay calm, and you'll make it through this." ),
-                                                _( "You're starting to feel very jumpy." ),
-                                                _( "Something is twitching at the edge of your vision." ),
-                                                _( "They know what you've done…" ),
-                                                _( "You're feeling even more paranoid than usual." ) };
+                _( "You have a bad feeling about this." ),
+                _( "A powerful sense of dread comes over you." ),
+                _( "Your skin starts crawling." ),
+                _( "They're coming to get you." ),
+                _( "This might've been a bad idea…" ),
+                _( "You've really done it this time, haven't you?" ),
+                _( "You have to stay vigilant.  They're always watching…" ),
+                _( "mistake mistake mistake mistake mistake" ),
+                _( "Just gotta stay calm, and you'll make it through this." ),
+                _( "You're starting to feel very jumpy." ),
+                _( "Something is twitching at the edge of your vision." ),
+                _( "They know what you've done…" ),
+                _( "You're feeling even more paranoid than usual." ) };
         add_msg_if_player( m_bad, random_entry_ref( stimboost_msg ) );
     }
 }
@@ -1165,8 +1165,8 @@ void Character::modify_morale( item &food, int nutr )
         mutation_category_level["URSINE"] > 40 ) {
         // Need at least 5 bear mutations for effect to show, to filter out mutations in common with other categories
         int const honey_fun = has_trait( trait_THRESH_URSINE ) ?
-                        std::min( mutation_category_level["URSINE"] / 8, 20 ) :
-                        mutation_category_level["URSINE"] / 12;
+                              std::min( mutation_category_level["URSINE"] / 8, 20 ) :
+                              mutation_category_level["URSINE"] / 12;
         if( honey_fun < 10 ) {
             add_msg_if_player( m_good, _( "You find the sweet taste of honey surprisingly palatable." ) );
         } else {

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -257,7 +257,7 @@ static int compute_default_effective_kcal( const item &comest, const Character &
     float kcal = comest.get_comestible()->default_nutrition.kcal;
 
     // Many raw foods give less calories, as your body has expends more energy digesting them.
-    bool cooked = comest.has_flag( flag_COOKED ) || extra_flags.count( flag_COOKED );
+    bool const cooked = comest.has_flag( flag_COOKED ) || extra_flags.count( flag_COOKED );
     if( comest.has_flag( flag_RAW ) && !cooked ) {
         kcal *= 0.75f;
     }
@@ -342,7 +342,7 @@ nutrients Character::compute_effective_nutrients( const item &comest ) const
     if( !comest.components.empty() && !comest.has_flag( flag_NUTRIENT_OVERRIDE ) ) {
         nutrients tally{};
         for( const item &component : comest.components ) {
-            nutrients component_value =
+            nutrients const component_value =
                 compute_effective_nutrients( component ) * component.charges;
             if( component.has_flag( flag_BYPRODUCT ) ) {
                 tally -= component_value;
@@ -368,7 +368,7 @@ std::pair<nutrients, nutrients> Character::compute_nutrient_range(
 
     // if item has components, will derive calories from that instead.
     if( comest.has_flag( flag_NUTRIENT_OVERRIDE ) ) {
-        nutrients result = compute_default_effective_nutrients( comest, *this );
+        nutrients const result = compute_default_effective_nutrients( comest, *this );
         return { result, result };
     }
 
@@ -410,13 +410,13 @@ std::pair<nutrients, nutrients> Character::compute_nutrient_range(
     }
 
     for( const std::pair<const itype_id, int> &byproduct : rec.byproducts ) {
-        item byproduct_it( byproduct.first, calendar::turn, byproduct.second );
-        nutrients byproduct_nutr = compute_default_effective_nutrients( byproduct_it, *this );
+        item const byproduct_it( byproduct.first, calendar::turn, byproduct.second );
+        nutrients const byproduct_nutr = compute_default_effective_nutrients( byproduct_it, *this );
         tally_min -= byproduct_nutr;
         tally_max -= byproduct_nutr;
     }
 
-    int charges = comest.count();
+    int const charges = comest.count();
     return { tally_min / charges, tally_max / charges };
 }
 
@@ -430,7 +430,7 @@ std::pair<nutrients, nutrients> Character::compute_nutrient_range(
         return {};
     }
 
-    item comest_it( comest, calendar::turn, 1 );
+    item const comest_it( comest, calendar::turn, 1 );
     // The default nutrients are always a possibility
     nutrients min_nutr = compute_default_effective_nutrients( comest_it, *this, extra_flags );
 
@@ -603,10 +603,10 @@ float Character::metabolic_rate_base() const
     static const std::string hunger_rate_string( "PLAYER_HUNGER_RATE" );
     static const std::string metabolism_modifier( "metabolism_modifier" );
 
-    float hunger_rate = get_option< float >( hunger_rate_string );
-    float mut_bonus = 1.0f + mutation_value( metabolism_modifier );
-    float with_mut = hunger_rate * mut_bonus;
-    float ench_bonus = bonus_from_enchantments( with_mut, enchant_vals::mod::METABOLISM );
+    float const hunger_rate = get_option< float >( hunger_rate_string );
+    float const mut_bonus = 1.0f + mutation_value( metabolism_modifier );
+    float const with_mut = hunger_rate * mut_bonus;
+    float const ench_bonus = bonus_from_enchantments( with_mut, enchant_vals::mod::METABOLISM );
 
     return std::max( 0.0f, with_mut + ench_bonus );
 }
@@ -762,7 +762,7 @@ ret_val<edible_rating> Character::will_eat( const item &food, bool interactive )
 
     const bool edible = comest->comesttype == comesttype_FOOD || food.has_flag( flag_USE_EAT_VERB );
 
-    int food_kcal = compute_effective_nutrients( food ).kcal;
+    int const food_kcal = compute_effective_nutrients( food ).kcal;
     if( food_kcal > 0 && has_effect( effect_nausea ) ) {
         add_consequence( _( "You still feel nauseous and will probably puke it all up again." ),
                          edible_rating::nausea );
@@ -807,7 +807,7 @@ ret_val<edible_rating> Character::will_eat( const item &food, bool interactive )
         }
 
         const bool eat_verb  = food.has_flag( flag_USE_EAT_VERB );
-        std::string food_tname = food.tname();
+        std::string const food_tname = food.tname();
         const nc_color food_color = food.color_in_inventory();
         if( eat_verb || comest->comesttype == comesttype_FOOD ) {
             req += string_format( _( "Eat your %s anyway?" ), colorize( food_tname, food_color ) );
@@ -881,8 +881,8 @@ bool Character::eat( item &food, bool force )
     }
     // Store the fact that the food was cold to later reapply it to the rest of the stack, to prevent rot.
     // Note: Implemented to fix display error when eating reheated food.
-    bool food_was_cold = food.has_flag( flag_COLD );
-    bool food_was_very_cold = food.has_flag( flag_VERY_COLD );
+    bool const food_was_cold = food.has_flag( flag_COLD );
+    bool const food_was_very_cold = food.has_flag( flag_VERY_COLD );
 
     if( !consume_effects( food ) ) {
         // Already consumed by using `food.type->invoke`?
@@ -1031,9 +1031,9 @@ void Character::modify_stimulation( const islot_comestible &comest )
     if( has_trait( trait_STIMBOOST ) && ( current_stim > 30 ) &&
         ( ( comest.add == add_type::CAFFEINE ) || ( comest.add == add_type::SPEED ) ||
           ( comest.add == add_type::COKE ) || ( comest.add == add_type::CRACK ) ) ) {
-        int hallu_duration = ( current_stim - comest.stim < 30 ) ? current_stim - 30 : comest.stim;
+        int const hallu_duration = ( current_stim - comest.stim < 30 ) ? current_stim - 30 : comest.stim;
         add_effect( effect_visuals, hallu_duration * 30_minutes );
-        std::vector<std::string> stimboost_msg{ _( "The shadows are getting ever closer." ),
+        std::vector<std::string> const stimboost_msg{ _( "The shadows are getting ever closer." ),
                                                 _( "You have a bad feeling about this." ),
                                                 _( "A powerful sense of dread comes over you." ),
                                                 _( "Your skin starts crawling." ),
@@ -1083,12 +1083,12 @@ void Character::modify_morale( item &food, int nutr )
             food.unset_flag( flag_COLD );
             food.unset_flag( flag_VERY_COLD );
             morale_time = 3_hours;
-            int clamped_nutr = std::max( 5, std::min( 20, nutr / 10 ) );
+            int const clamped_nutr = std::max( 5, std::min( 20, nutr / 10 ) );
             add_morale( MORALE_FOOD_HOT, clamped_nutr, 20, morale_time, morale_time / 2 );
         }
     }
 
-    std::pair<int, int> fun = fun_for( food );
+    std::pair<int, int> const fun = fun_for( food );
     if( fun.first < 0 ) {
         if( has_active_bionic( bio_taste_blocker ) &&
             get_power_level() > units::from_kilojoule( -fun.first ) ) {
@@ -1164,7 +1164,7 @@ void Character::modify_morale( item &food, int nutr )
             has_trait( trait_THRESH_URSINE ) ) &&
         mutation_category_level["URSINE"] > 40 ) {
         // Need at least 5 bear mutations for effect to show, to filter out mutations in common with other categories
-        int honey_fun = has_trait( trait_THRESH_URSINE ) ?
+        int const honey_fun = has_trait( trait_THRESH_URSINE ) ?
                         std::min( mutation_category_level["URSINE"] / 8, 20 ) :
                         mutation_category_level["URSINE"] / 12;
         if( honey_fun < 10 ) {
@@ -1202,7 +1202,7 @@ bool Character::consume_effects( item &food )
         const float rottedness = clamp( 2 * relative_rot - 2.0f, 0.1f, 1.0f );
         // ~-1 health per 1 nutrition at halfway-rotten-away, ~0 at "just got rotten"
         // But always round down
-        int h_loss = -rottedness * comest.get_default_nutr();
+        int const h_loss = -rottedness * comest.get_default_nutr();
         mod_healthy_mod( h_loss, -200 );
         add_msg( m_debug, "%d health from %0.2f%% rotten food", h_loss, rottedness );
     }
@@ -1227,7 +1227,7 @@ bool Character::consume_effects( item &food )
         add_msg_if_player( m_mixed,
                            _( "You feel as though you're going to split open!  In a good way?" ) );
         mod_pain( 5 );
-        int numslime = 1;
+        int const numslime = 1;
         for( int i = 0; i < numslime; i++ ) {
             if( monster *const slime = g->place_critter_around( mon_player_blob, pos(), 1 ) ) {
                 slime->friendly = -1;
@@ -1260,7 +1260,7 @@ bool Character::consume_effects( item &food )
         excess_kcal = 0;
     }
 
-    int excess_quench = -( get_thirst() - comest.quench );
+    int const excess_quench = -( get_thirst() - comest.quench );
     stomach.ingest( ingested );
     mod_thirst( -contained_food.type->comestible->quench );
 
@@ -1584,8 +1584,8 @@ void Character::consume( item_location loc )
                 add_msg( _( "You drop the empty %s." ), target.tname() );
                 put_into_vehicle_or_drop( *this, item_drop_reason::deliberate, { inv.remove_item( &target ) } );
             } else {
-                int quantity = inv.const_stack( inv.position_by_item( &target ) ).size();
-                char letter = target.invlet ? target.invlet : ' ';
+                int const quantity = inv.const_stack( inv.position_by_item( &target ) ).size();
+                char const letter = target.invlet ? target.invlet : ' ';
                 add_msg( m_info, _( "%c - %d empty %s" ), letter, quantity, target.tname( quantity ) );
             }
         }

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -109,8 +109,10 @@ void craft_command::execute( const tripoint &new_loc )
     map_inv.form_from_map( crafter->pos(), PICKUP_RANGE, crafter );
 
     if( has_cached_selections() ) {
-        std::vector<comp_selection<item_comp>> const missing_items = check_item_components_missing( map_inv );
-        std::vector<comp_selection<tool_comp>> const missing_tools = check_tool_components_missing( map_inv );
+        std::vector<comp_selection<item_comp>> const missing_items = check_item_components_missing(
+                                                map_inv );
+        std::vector<comp_selection<tool_comp>> const missing_tools = check_tool_components_missing(
+                                                map_inv );
 
         if( missing_items.empty() && missing_tools.empty() ) {
             // All items we used previously are still there, so we don't need to do selection.
@@ -163,9 +165,9 @@ void craft_command::execute( const tripoint &new_loc )
         tool_selections.clear();
         for( const auto &it : needs->get_tools() ) {
             comp_selection<tool_comp> const ts = crafting::select_tool_component(
-                                               it, batch_size, map_inv, crafter, true,
-                                               DEFAULT_HOTKEYS,
-                                               cost_adjustment::start_only );
+                    it, batch_size, map_inv, crafter, true,
+                    DEFAULT_HOTKEYS,
+                    cost_adjustment::start_only );
             if( ts.use_from == cancel ) {
                 return;
             }

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -80,7 +80,7 @@ void comp_selection<CompType>::serialize( JsonOut &jsout ) const
 template<typename CompType>
 void comp_selection<CompType>::deserialize( JsonIn &jsin )
 {
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
 
     std::string use_from_str;
     data.read( "use_from", use_from_str );
@@ -109,8 +109,8 @@ void craft_command::execute( const tripoint &new_loc )
     map_inv.form_from_map( crafter->pos(), PICKUP_RANGE, crafter );
 
     if( has_cached_selections() ) {
-        std::vector<comp_selection<item_comp>> missing_items = check_item_components_missing( map_inv );
-        std::vector<comp_selection<tool_comp>> missing_tools = check_tool_components_missing( map_inv );
+        std::vector<comp_selection<item_comp>> const missing_items = check_item_components_missing( map_inv );
+        std::vector<comp_selection<tool_comp>> const missing_tools = check_tool_components_missing( map_inv );
 
         if( missing_items.empty() && missing_tools.empty() ) {
             // All items we used previously are still there, so we don't need to do selection.
@@ -152,7 +152,7 @@ void craft_command::execute( const tripoint &new_loc )
         }
 
         for( const auto &it : needs->get_components() ) {
-            comp_selection<item_comp> is =
+            comp_selection<item_comp> const is =
                 crafter->select_item_component( it, batch_size, map_inv, true, filter );
             if( is.use_from == cancel ) {
                 return;
@@ -162,7 +162,7 @@ void craft_command::execute( const tripoint &new_loc )
 
         tool_selections.clear();
         for( const auto &it : needs->get_tools() ) {
-            comp_selection<tool_comp> ts = crafting::select_tool_component(
+            comp_selection<tool_comp> const ts = crafting::select_tool_component(
                                                it, batch_size, map_inv, crafter, true,
                                                DEFAULT_HOTKEYS,
                                                cost_adjustment::start_only );
@@ -292,7 +292,7 @@ std::vector<comp_selection<item_comp>> craft_command::check_item_components_miss
     const auto filter = rec->get_component_filter( flags );
 
     for( const auto &item_sel : item_selections ) {
-        itype_id type = item_sel.comp.type;
+        itype_id const type = item_sel.comp.type;
         const item_comp component = item_sel.comp;
         const int count = component.count > 0 ? component.count * batch_size : std::abs( component.count );
 
@@ -355,7 +355,7 @@ std::vector<comp_selection<tool_comp>> craft_command::check_tool_components_miss
     std::vector<comp_selection<tool_comp>> missing;
 
     for( const auto &tool_sel : tool_selections ) {
-        itype_id type = tool_sel.comp.type;
+        itype_id const type = tool_sel.comp.type;
         if( tool_sel.comp.count > 0 ) {
             const int count = tool_sel.comp.count * batch_size;
             switch( tool_sel.use_from ) {

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -136,7 +136,7 @@ float lighting_crafting_speed_multiplier( const Character &who, const recipe &re
     }
 
     const SkillLevelMap &char_skills = who.get_all_skills();
-    int skill_bonus = char_skills.exceeds_recipe_requirements( rec );
+    int const skill_bonus = char_skills.exceeds_recipe_requirements( rec );
 
     // This value whould be within [0,1]
     const float darkness =
@@ -163,7 +163,7 @@ float lighting_crafting_speed_multiplier( const Character &who, const recipe &re
 
 float morale_crafting_speed_multiplier( const Character &who, const recipe &rec )
 {
-    int morale = who.get_morale_level();
+    int const morale = who.get_morale_level();
     if( morale >= 0 ) {
         // No bonus for being happy yet
         return 1.0f;
@@ -178,7 +178,7 @@ float morale_crafting_speed_multiplier( const Character &who, const recipe &rec 
     }
 
     // Halve speed at -50 effective morale, quarter at -150
-    float morale_effect = 1.0f + ( morale_mult * morale ) / -50.0f;
+    float const morale_effect = 1.0f + ( morale_mult * morale ) / -50.0f;
 
     return 1.0f / morale_effect;
 }
@@ -209,7 +209,7 @@ float workbench_crafting_speed_multiplier( const item &craft, const bench_locati
     const units::volume &craft_volume = craft.volume();
 
     // The whole block below is so ugly because all the benches have different structs with same content
-    map &here = get_map();
+    map  const&here = get_map();
     switch( bench.type ) {
         case bench_type::hands: {
             const furn_t &f = string_id<furn_t>( "f_fake_bench_hands" ).obj();
@@ -407,7 +407,7 @@ int player::base_time_to_craft( const recipe &rec, int batch_size ) const
 int player::expected_time_to_craft( const recipe &rec, int batch_size, bool in_progress ) const
 {
     const size_t assistants = available_assistant_count( rec );
-    float modifier = crafting_speed_multiplier( *this, rec, in_progress );
+    float const modifier = crafting_speed_multiplier( *this, rec, in_progress );
     return rec.batch_time( batch_size, modifier, assistants );
 }
 
@@ -421,7 +421,7 @@ bool player::check_eligible_containers_for_crafting( const recipe &rec, int batc
     all.insert( all.end(), res.begin(), res.end() );
     all.insert( all.end(), bps.begin(), bps.end() );
 
-    map &here = get_map();
+    map  const&here = get_map();
     for( const item &prod : all ) {
         if( !prod.made_of( LIQUID ) ) {
             continue;
@@ -449,11 +449,11 @@ bool player::check_eligible_containers_for_crafting( const recipe &rec, int batc
         if( charges_to_store > 0 ) {
             if( optional_vpart_position vp = here.veh_at( pos() ) ) {
                 const itype_id &ftype = prod.typeId();
-                int fuel_cap = vp->vehicle().fuel_capacity( ftype );
-                int fuel_amnt = vp->vehicle().fuel_left( ftype );
+                int const fuel_cap = vp->vehicle().fuel_capacity( ftype );
+                int const fuel_amnt = vp->vehicle().fuel_left( ftype );
 
                 if( fuel_cap >= 0 ) {
-                    int fuel_space_left = fuel_cap - fuel_amnt;
+                    int const fuel_space_left = fuel_cap - fuel_amnt;
                     charges_to_store -= fuel_space_left;
                 }
             }
@@ -673,7 +673,7 @@ static item_location set_item_map( const tripoint &loc, item &newit )
  */
 static item_location set_item_map_or_vehicle( const player &p, const tripoint &loc, item &newit )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     if( const std::optional<vpart_reference> vp = here.veh_at( loc ).part_with_feature( "CARGO",
             false ) ) {
 
@@ -746,7 +746,7 @@ item_location player::start_craft( craft_command &command, const tripoint & )
     }
 
     bench_location bench = find_best_bench( *this, craft );
-    std::pair<bench_type, float> best_found_bench = best_bench_here( craft, bench.position,
+    std::pair<bench_type, float> const best_found_bench = best_bench_here( craft, bench.position,
             bench.type == bench_type::hands );
     if( best_found_bench.second < 1.0f ) {
         add_msg_if_player( m_info, pgettext( "in progress craft",
@@ -921,7 +921,7 @@ static void destroy_random_component( item &craft, const player &crafter )
         return;
     }
 
-    item destroyed = random_entry_removed( craft.components );
+    item const destroyed = random_entry_removed( craft.components );
 
     crafter.add_msg_player_or_npc( _( "You mess up and destroy the %s." ),
                                    _( "<npcname> messes up and destroys the %s" ), destroyed.tname() );
@@ -1058,7 +1058,7 @@ void complete_craft( player &p, item &craft, const bench_location & )
                 // but also keeps going up as difficulty goes up.
                 // Worst case is lvl 10, which will typically take
                 // 10^4/10 (1,000) minutes, or about 16 hours of crafting it to learn.
-                int difficulty = p.has_recipe( &making, p.crafting_inventory(),
+                int const difficulty = p.has_recipe( &making, p.crafting_inventory(),
                                                character_funcs::get_crafting_helpers( p ) );
                 ///\EFFECT_INT increases chance to learn recipe when crafting from a book
                 const double learning_speed =
@@ -1212,7 +1212,7 @@ bool player::can_continue_craft( item &craft )
 
         std::vector<comp_selection<item_comp>> item_selections;
         for( const auto &it : continue_reqs.get_components() ) {
-            comp_selection<item_comp> is = select_item_component( it, batch_size, map_inv, true, filter );
+            comp_selection<item_comp> const is = select_item_component( it, batch_size, map_inv, true, filter );
             if( is.use_from == cancel ) {
                 cancel_activity();
                 add_msg( _( "You stop crafting." ) );
@@ -1263,7 +1263,7 @@ bool player::can_continue_craft( item &craft )
 
         std::vector<comp_selection<tool_comp>> new_tool_selections;
         for( const std::vector<tool_comp> &alternatives : tool_reqs ) {
-            comp_selection<tool_comp> selection =
+            comp_selection<tool_comp> const selection =
                 crafting::select_tool_component( alternatives, batch_size, map_inv, this, true, DEFAULT_HOTKEYS,
                                                  cost_adjustment::continue_only );
             if( selection.use_from == cancel ) {
@@ -1292,7 +1292,7 @@ const requirement_data *player::select_requirements(
     for( const requirement_data *req : alternatives ) {
         // Write with a large width and then just re-join the lines, because
         // uilist does its own wrapping and we want to rely on that.
-        std::vector<std::string> component_lines =
+        std::vector<std::string> const component_lines =
             req->get_folded_components_list( TERMX - 4, c_light_gray, inv, filter, batch, "",
                                              requirement_display_flags::no_unavailable );
         menu.addentry_desc( "", join( component_lines, "\n" ) );
@@ -1322,11 +1322,11 @@ comp_selection<item_comp> player::select_item_component( const std::vector<item_
     comp_selection<item_comp> selected;
 
     for( const auto &component : components ) {
-        itype_id type = component.type;
-        int count = ( component.count > 0 ) ? component.count * batch : std::abs( component.count );
+        itype_id const type = component.type;
+        int const count = ( component.count > 0 ) ? component.count * batch : std::abs( component.count );
 
         if( item::count_by_charges( type ) && count > 0 ) {
-            int map_charges = map_inv.charges_of( type, INT_MAX, filter );
+            int const map_charges = map_inv.charges_of( type, INT_MAX, filter );
 
             // If map has infinite charges, just use them
             if( map_charges == item::INFINITE_CHARGES ) {
@@ -1335,7 +1335,7 @@ comp_selection<item_comp> player::select_item_component( const std::vector<item_
                 return selected;
             }
             if( player_inv ) {
-                int player_charges = charges_of( type, INT_MAX, filter );
+                int const player_charges = charges_of( type, INT_MAX, filter );
                 bool found = false;
                 if( player_charges >= count ) {
                     player_has.push_back( component );
@@ -1407,7 +1407,7 @@ comp_selection<item_comp> player::select_item_component( const std::vector<item_
         uilist cmenu;
         // Populate options with the names of the items
         for( auto &map_ha : map_has ) { // Index 0-(map_has.size()-1)
-            std::string tmpStr = string_format( _( "%s (%d/%d nearby)" ),
+            std::string const tmpStr = string_format( _( "%s (%d/%d nearby)" ),
                                                 item::nname( map_ha.type ),
                                                 ( map_ha.count * batch ),
                                                 item::count_by_charges( map_ha.type ) ?
@@ -1416,7 +1416,7 @@ comp_selection<item_comp> player::select_item_component( const std::vector<item_
             cmenu.addentry( tmpStr );
         }
         for( auto &player_ha : player_has ) { // Index map_has.size()-(map_has.size()+player_has.size()-1)
-            std::string tmpStr = string_format( _( "%s (%d/%d on person)" ),
+            std::string const tmpStr = string_format( _( "%s (%d/%d on person)" ),
                                                 item::nname( player_ha.type ),
                                                 ( player_ha.count * batch ),
                                                 item::count_by_charges( player_ha.type ) ?
@@ -1426,12 +1426,12 @@ comp_selection<item_comp> player::select_item_component( const std::vector<item_
         }
         for( auto &component : mixed ) {
             // Index player_has.size()-(map_has.size()+player_has.size()+mixed.size()-1)
-            int available = item::count_by_charges( component.type ) ?
+            int const available = item::count_by_charges( component.type ) ?
                             map_inv.charges_of( component.type, INT_MAX, filter ) +
                             charges_of( component.type, INT_MAX, filter ) :
                             map_inv.amount_of( component.type, false, INT_MAX, filter ) +
                             amount_of( component.type, false, INT_MAX, filter );
-            std::string tmpStr = string_format( _( "%s (%d/%d nearby & on person)" ),
+            std::string const tmpStr = string_format( _( "%s (%d/%d nearby & on person)" ),
                                                 item::nname( component.type ),
                                                 component.count * batch,
                                                 available );
@@ -1526,7 +1526,7 @@ std::list<item> player::consume_items( map &m, const comp_selection<item_comp> &
         return ret;
     }
 
-    item_comp selected_comp = is.comp;
+    item_comp const selected_comp = is.comp;
 
     const tripoint &loc = origin;
     const bool by_charges = item::count_by_charges( selected_comp.type ) && selected_comp.count > 0;
@@ -1620,29 +1620,29 @@ find_tool_component( const Character *player_with_inv, const std::vector<tool_co
         return std::make_pair( INT_MAX, INT_MAX );
     };
 
-    bool found_nocharge = false;
+    bool const found_nocharge = false;
     // Use charges of any tools that require charges used
     for( auto it = tools.begin(); it != tools.end() && !found_nocharge; ++it ) {
-        itype_id type = it->type;
+        itype_id const type = it->type;
         if( it->count > 0 ) {
             const std::pair<int, int> &expected_count = calc_charges( *it );
             const int count = expected_count.first;
             const int ideal = expected_count.second;
             if( player_with_inv ) {
                 if( player_with_inv->has_charges( type, count ) ) {
-                    int total_charges = player_with_inv->charges_of( type );
-                    comp_selection<tool_comp> sel( use_from_player, *it );
+                    int const total_charges = player_with_inv->charges_of( type );
+                    comp_selection<tool_comp> const sel( use_from_player, *it );
                     available_tools.emplace_back( sel, total_charges, ideal );
                 }
             }
             if( map_inv.has_charges( type, count ) ) {
-                int total_charges = map_inv.charges_of( type );
-                comp_selection<tool_comp> sel( use_from_map, *it );
+                int const total_charges = map_inv.charges_of( type );
+                comp_selection<tool_comp> const sel( use_from_map, *it );
                 available_tools.emplace_back( sel, total_charges, ideal );
             }
         } else if( ( player_with_inv && player_with_inv->has_amount( type, 1 ) )
                    || map_inv.has_tools( type, 1 ) ) {
-            comp_selection<tool_comp> sel( use_from_none, *it );
+            comp_selection<tool_comp> const sel( use_from_none, *it );
             available_tools.emplace_back( sel, 0, 0 );
         }
     }
@@ -1704,12 +1704,12 @@ query_tool_selection( const std::vector<avail_tool_comp> &available_tools,
             const char *format = tool.comp.use_from == use_from_map
                                  ? _( "%s (%d/%d charges nearby)" )
                                  : _( "%s (%d/%d charges on person)" );
-            std::string str = string_format( format,
+            std::string const str = string_format( format,
                                              item::nname( comp_type ), tool.ideal,
                                              tool.charges );
             tmenu.addentry( str );
         } else {
-            std::string str = tool.comp.use_from == use_from_map
+            std::string const str = tool.comp.use_from == use_from_map
                               ? item::nname( comp_type ) + _( " (nearby)" )
                               : item::nname( comp_type );
             tmenu.addentry( str );
@@ -1736,9 +1736,9 @@ select_tool_component( const std::vector<tool_comp> &tools, int batch, const inv
                        const std::string &hotkeys,
                        cost_adjustment adjustment )
 {
-    std::vector<avail_tool_comp> options = find_tool_component( player_with_inv, tools, batch, map_inv,
+    std::vector<avail_tool_comp> const options = find_tool_component( player_with_inv, tools, batch, map_inv,
                                            adjustment );
-    bool is_npc = player_with_inv ? player_with_inv->is_npc() : false;
+    bool const is_npc = player_with_inv ? player_with_inv->is_npc() : false;
     return query_tool_selection( options, hotkeys, can_cancel, is_npc );
 }
 
@@ -1768,14 +1768,14 @@ bool player::craft_consume_tools( item &craft, int mulitplier, bool start_craft 
     }
 
     const auto calc_charges = [&craft, &start_craft, &mulitplier]( int charges ) {
-        int ret = charges;
+        int const ret = charges;
 
         if( charges <= 0 ) {
             return ret;
         }
 
         // Account for batch size
-        int full_cost = charges * craft.charges;
+        int const full_cost = charges * craft.charges;
 
         if( start_craft ) {
             return crafting::charges_for_starting( full_cost );
@@ -1793,7 +1793,7 @@ bool player::craft_consume_tools( item &craft, int mulitplier, bool start_craft 
     map_inv.form_from_map( pos(), PICKUP_RANGE, this );
 
     for( const comp_selection<tool_comp> &tool_sel : cached_tool_selections ) {
-        itype_id type = tool_sel.comp.type;
+        itype_id const type = tool_sel.comp.type;
         if( tool_sel.comp.count > 0 ) {
             const int count = calc_charges( tool_sel.comp.count );
             switch( tool_sel.use_from ) {
@@ -1899,14 +1899,14 @@ ret_val<bool> crafting::can_disassemble( const Character &who, const item &obj,
     }
 
     // refuse to disassemble items containing monsters/pets
-    std::string monster = obj.get_var( "contained_name" );
+    std::string const monster = obj.get_var( "contained_name" );
     if( !monster.empty() ) {
         return ret_val<bool>::make_failure( _( "You must remove the %s before you can disassemble this." ),
                                             monster );
     }
 
     if( obj.count_by_charges() ) {
-        int batch_size = r.disassembly_batch_size();
+        int const batch_size = r.disassembly_batch_size();
         if( obj.charges < batch_size ) {
             auto msg = vgettext( "You need at least %d charge of %s.",
                                  "You need at least %d charges of %s.", batch_size );
@@ -1982,7 +1982,7 @@ static disass_prompt_result prompt_disassemble_in_seq( avatar &you, const item &
         }
     }
 
-    int batch_size = r.disassembly_batch_size();
+    int const batch_size = r.disassembly_batch_size();
 
     if( interactive && get_option<bool>( "QUERY_DISASSEMBLE" ) ) {
         std::string msg;
@@ -2055,7 +2055,7 @@ static bool prompt_disassemble_single( avatar &you, item_location target, bool i
     loc.loc = target;
     loc.count = res.batches ? *res.batches : 1;
 
-    tripoint_abs_ms pos_abs( get_map().getabs( you.pos() ) );
+    tripoint_abs_ms const pos_abs( get_map().getabs( you.pos() ) );
 
     you.assign_activity( disassemble_activity_actor( {{ loc }}, pos_abs, false ) );
 
@@ -2064,7 +2064,7 @@ static bool prompt_disassemble_single( avatar &you, item_location target, bool i
 
 bool crafting::disassemble( avatar &you )
 {
-    item_location target = game_menus::inv::disassemble( you );
+    item_location const target = game_menus::inv::disassemble( you );
     return prompt_disassemble_single( you, target, false );
 }
 
@@ -2077,7 +2077,7 @@ bool crafting::disassemble_all( avatar &you, bool recursively )
 {
     std::vector<iuse_location> targets;
 
-    tripoint pos = you.pos();
+    tripoint const pos = you.pos();
 
     for( item &itm : get_map().i_at( pos ) ) {
         disass_prompt_result res = prompt_disassemble_in_seq( you, itm, false, true );
@@ -2090,7 +2090,7 @@ bool crafting::disassemble_all( avatar &you, bool recursively )
     }
 
     if( !targets.empty() ) {
-        tripoint_abs_ms pos_abs( get_map().getabs( you.pos() ) );
+        tripoint_abs_ms const pos_abs( get_map().getabs( you.pos() ) );
 
         you.assign_activity( disassemble_activity_actor( std::move( targets ), pos_abs, recursively ) );
         return true;
@@ -2112,7 +2112,7 @@ void crafting::complete_disassemble( Character &who, iuse_location target, const
     // has been removed.
     item dis_item = org_item;
 
-    float component_success_chance = std::min( std::pow( 0.8, dis_item.damage_level( 4 ) ), 1.0 );
+    float const component_success_chance = std::min( std::pow( 0.8, dis_item.damage_level( 4 ) ), 1.0 );
 
     add_msg( _( "You disassemble the %s into its components." ), dis_item.tname() );
     // Remove any batteries, ammo and mods first
@@ -2120,7 +2120,7 @@ void crafting::complete_disassemble( Character &who, iuse_location target, const
     remove_radio_mod( dis_item, *who.as_player() );
 
     if( org_item.count_by_charges() ) {
-        int batch_size = dis.disassembly_batch_size();
+        int const batch_size = dis.disassembly_batch_size();
         org_item.charges -= batch_size * target.count;
     }
     // remove the item, except when it's counted by charges and still has some
@@ -2141,10 +2141,10 @@ void crafting::complete_disassemble( Character &who, iuse_location target, const
 
     // Sides on dice is 16 plus your current intelligence
     ///\EFFECT_INT increases success rate for disassembling items
-    int skill_sides = 16 + who.int_cur;
+    int const skill_sides = 16 + who.int_cur;
 
-    int diff_dice = dis.difficulty;
-    int diff_sides = 24; // 16 + 8 (default intelligence)
+    int const diff_dice = dis.difficulty;
+    int const diff_sides = 24; // 16 + 8 (default intelligence)
 
     // disassembly only nets a bit of practice
     if( dis.skill_used ) {
@@ -2302,7 +2302,7 @@ static std::pair<bench_type, float> best_bench_here( const item &craft, const tr
     bench_type best_type = bench_type::ground;
     float best_mult = workbench_crafting_speed_multiplier( craft, bench_location{bench_type::ground, loc} );
     if( can_lift ) {
-        float hands_mult = workbench_crafting_speed_multiplier( craft, bench_location{bench_type::hands, loc} );
+        float const hands_mult = workbench_crafting_speed_multiplier( craft, bench_location{bench_type::hands, loc} );
         if( hands_mult > best_mult ) {
             best_type = bench_type::hands;
             best_mult = hands_mult;
@@ -2310,7 +2310,7 @@ static std::pair<bench_type, float> best_bench_here( const item &craft, const tr
     }
 
     if( g->m.furn( loc ).obj().workbench ) {
-        float furn_mult = workbench_crafting_speed_multiplier( craft, bench_location{bench_type::furniture, loc} );
+        float const furn_mult = workbench_crafting_speed_multiplier( craft, bench_location{bench_type::furniture, loc} );
         if( furn_mult > best_mult ) {
             best_type = bench_type::furniture;
             best_mult = furn_mult;
@@ -2319,7 +2319,7 @@ static std::pair<bench_type, float> best_bench_here( const item &craft, const tr
 
     if( const std::optional<vpart_reference> vp = g->m.veh_at(
                 loc ).part_with_feature( "WORKBENCH", true ) ) {
-        float veh_mult = workbench_crafting_speed_multiplier( craft, bench_location{bench_type::vehicle, loc} );
+        float const veh_mult = workbench_crafting_speed_multiplier( craft, bench_location{bench_type::vehicle, loc} );
         if( veh_mult > best_mult ) {
             best_type = bench_type::vehicle;
             best_mult = veh_mult;
@@ -2330,8 +2330,8 @@ static std::pair<bench_type, float> best_bench_here( const item &craft, const tr
 
 bench_location find_best_bench( const player &p, const item &craft )
 {
-    bool can_lift = p.can_wield( craft ).success() && p.weight_capacity() >= craft.weight();
-    std::pair<bench_type, float> bench_here = best_bench_here( craft, p.pos(), can_lift );
+    bool const can_lift = p.can_wield( craft ).success() && p.weight_capacity() >= craft.weight();
+    std::pair<bench_type, float> const bench_here = best_bench_here( craft, p.pos(), can_lift );
     bench_type best_type = bench_here.first;
     float best_bench_multi = bench_here.second;
     tripoint best_loc = p.pos();
@@ -2372,8 +2372,8 @@ std::set<itype_id> get_books_for_recipe( const Character &c, const inventory &cr
     std::set<itype_id> book_ids;
     const int skill_level = c.get_skill_level( r->skill_used );
     for( auto &book_lvl : r->booksets ) {
-        itype_id book_id = book_lvl.first;
-        int required_skill_level = book_lvl.second;
+        itype_id const book_id = book_lvl.first;
+        int const required_skill_level = book_lvl.second;
         if( skill_level >= required_skill_level && crafting_inv.amount_of( book_id ) > 0 ) {
             book_ids.insert( book_id );
         }

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -209,7 +209,7 @@ float workbench_crafting_speed_multiplier( const item &craft, const bench_locati
     const units::volume &craft_volume = craft.volume();
 
     // The whole block below is so ugly because all the benches have different structs with same content
-    map  const&here = get_map();
+    map  const &here = get_map();
     switch( bench.type ) {
         case bench_type::hands: {
             const furn_t &f = string_id<furn_t>( "f_fake_bench_hands" ).obj();
@@ -421,7 +421,7 @@ bool player::check_eligible_containers_for_crafting( const recipe &rec, int batc
     all.insert( all.end(), res.begin(), res.end() );
     all.insert( all.end(), bps.begin(), bps.end() );
 
-    map  const&here = get_map();
+    map  const &here = get_map();
     for( const item &prod : all ) {
         if( !prod.made_of( LIQUID ) ) {
             continue;
@@ -673,7 +673,7 @@ static item_location set_item_map( const tripoint &loc, item &newit )
  */
 static item_location set_item_map_or_vehicle( const player &p, const tripoint &loc, item &newit )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     if( const std::optional<vpart_reference> vp = here.veh_at( loc ).part_with_feature( "CARGO",
             false ) ) {
 
@@ -1059,7 +1059,7 @@ void complete_craft( player &p, item &craft, const bench_location & )
                 // Worst case is lvl 10, which will typically take
                 // 10^4/10 (1,000) minutes, or about 16 hours of crafting it to learn.
                 int const difficulty = p.has_recipe( &making, p.crafting_inventory(),
-                                               character_funcs::get_crafting_helpers( p ) );
+                                                     character_funcs::get_crafting_helpers( p ) );
                 ///\EFFECT_INT increases chance to learn recipe when crafting from a book
                 const double learning_speed =
                     std::max( p.get_skill_level( making.skill_used ), 1 ) *
@@ -1408,33 +1408,33 @@ comp_selection<item_comp> player::select_item_component( const std::vector<item_
         // Populate options with the names of the items
         for( auto &map_ha : map_has ) { // Index 0-(map_has.size()-1)
             std::string const tmpStr = string_format( _( "%s (%d/%d nearby)" ),
-                                                item::nname( map_ha.type ),
-                                                ( map_ha.count * batch ),
-                                                item::count_by_charges( map_ha.type ) ?
-                                                map_inv.charges_of( map_ha.type, INT_MAX, filter ) :
-                                                map_inv.amount_of( map_ha.type, false, INT_MAX, filter ) );
+                                       item::nname( map_ha.type ),
+                                       ( map_ha.count * batch ),
+                                       item::count_by_charges( map_ha.type ) ?
+                                       map_inv.charges_of( map_ha.type, INT_MAX, filter ) :
+                                       map_inv.amount_of( map_ha.type, false, INT_MAX, filter ) );
             cmenu.addentry( tmpStr );
         }
         for( auto &player_ha : player_has ) { // Index map_has.size()-(map_has.size()+player_has.size()-1)
             std::string const tmpStr = string_format( _( "%s (%d/%d on person)" ),
-                                                item::nname( player_ha.type ),
-                                                ( player_ha.count * batch ),
-                                                item::count_by_charges( player_ha.type ) ?
-                                                charges_of( player_ha.type, INT_MAX, filter ) :
-                                                amount_of( player_ha.type, false, INT_MAX, filter ) );
+                                       item::nname( player_ha.type ),
+                                       ( player_ha.count * batch ),
+                                       item::count_by_charges( player_ha.type ) ?
+                                       charges_of( player_ha.type, INT_MAX, filter ) :
+                                       amount_of( player_ha.type, false, INT_MAX, filter ) );
             cmenu.addentry( tmpStr );
         }
         for( auto &component : mixed ) {
             // Index player_has.size()-(map_has.size()+player_has.size()+mixed.size()-1)
             int const available = item::count_by_charges( component.type ) ?
-                            map_inv.charges_of( component.type, INT_MAX, filter ) +
-                            charges_of( component.type, INT_MAX, filter ) :
-                            map_inv.amount_of( component.type, false, INT_MAX, filter ) +
-                            amount_of( component.type, false, INT_MAX, filter );
+                                  map_inv.charges_of( component.type, INT_MAX, filter ) +
+                                  charges_of( component.type, INT_MAX, filter ) :
+                                  map_inv.amount_of( component.type, false, INT_MAX, filter ) +
+                                  amount_of( component.type, false, INT_MAX, filter );
             std::string const tmpStr = string_format( _( "%s (%d/%d nearby & on person)" ),
-                                                item::nname( component.type ),
-                                                component.count * batch,
-                                                available );
+                                       item::nname( component.type ),
+                                       component.count * batch,
+                                       available );
             cmenu.addentry( tmpStr );
         }
 
@@ -1705,13 +1705,13 @@ query_tool_selection( const std::vector<avail_tool_comp> &available_tools,
                                  ? _( "%s (%d/%d charges nearby)" )
                                  : _( "%s (%d/%d charges on person)" );
             std::string const str = string_format( format,
-                                             item::nname( comp_type ), tool.ideal,
-                                             tool.charges );
+                                                   item::nname( comp_type ), tool.ideal,
+                                                   tool.charges );
             tmenu.addentry( str );
         } else {
             std::string const str = tool.comp.use_from == use_from_map
-                              ? item::nname( comp_type ) + _( " (nearby)" )
-                              : item::nname( comp_type );
+                                    ? item::nname( comp_type ) + _( " (nearby)" )
+                                    : item::nname( comp_type );
             tmenu.addentry( str );
         }
     }
@@ -1736,8 +1736,9 @@ select_tool_component( const std::vector<tool_comp> &tools, int batch, const inv
                        const std::string &hotkeys,
                        cost_adjustment adjustment )
 {
-    std::vector<avail_tool_comp> const options = find_tool_component( player_with_inv, tools, batch, map_inv,
-                                           adjustment );
+    std::vector<avail_tool_comp> const options = find_tool_component( player_with_inv, tools, batch,
+            map_inv,
+            adjustment );
     bool const is_npc = player_with_inv ? player_with_inv->is_npc() : false;
     return query_tool_selection( options, hotkeys, can_cancel, is_npc );
 }

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -180,8 +180,8 @@ const recipe *select_crafting_recipe( int &batch_size )
         }
         std::vector<iteminfo> const info = item_info_cache.dummy.info( count );
         item_info_data const data( item_info_cache.dummy.tname( count ),
-                             item_info_cache.dummy.type_name( count ),
-                             info, {}, scroll_pos );
+                                   item_info_cache.dummy.type_name( count ),
+                                   info, {}, scroll_pos );
         return data;
     };
 

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -106,7 +106,7 @@ void load_recipe_category( const JsonObject &jsobj )
 
 static std::string get_subcat_unprefixed( const std::string &cat, const std::string &prefixed_name )
 {
-    std::string prefix = "CSC_" + get_cat_unprefixed( cat ) + "_";
+    std::string const prefix = "CSC_" + get_cat_unprefixed( cat ) + "_";
 
     if( prefixed_name.find( prefix ) == 0 ) {
         return prefixed_name.substr( prefix.size(), prefixed_name.size() - prefix.size() );
@@ -178,8 +178,8 @@ const recipe *select_crafting_recipe( int &batch_size )
             item_info_scroll = 0;
             item_info_scroll_popup = 0;
         }
-        std::vector<iteminfo> info = item_info_cache.dummy.info( count );
-        item_info_data data( item_info_cache.dummy.tname( count ),
+        std::vector<iteminfo> const info = item_info_cache.dummy.info( count );
+        item_info_data const data( item_info_cache.dummy.tname( count ),
                              item_info_cache.dummy.type_name( count ),
                              info, {}, scroll_pos );
         return data;
@@ -388,12 +388,12 @@ const recipe *select_crafting_recipe( int &batch_size )
         mvwputch( w_data, point( width - 1, dataHeight - 1 ), BORDER_COLOR, LINE_XOOX ); // _|
 
         std::optional<point> cursor_pos;
-        int recmax = current.size();
+        int const recmax = current.size();
 
         // Draw recipes with scroll list
         // get subset to draw
         calcStartPos( recipe_scroll_window_min, line, dataLines, recmax );
-        int recipe_scroll_window_max = std::min( recmax, recipe_scroll_window_min + dataLines );
+        int const recipe_scroll_window_max = std::min( recmax, recipe_scroll_window_min + dataLines );
 
         for( int i = recipe_scroll_window_min; i < recipe_scroll_window_max; ++i ) {
             std::string tmp_name = current[i]->result_name();
@@ -411,7 +411,7 @@ const recipe *select_crafting_recipe( int &batch_size )
 
         const int count = batch ? line + 1 : 1; // batch size
         if( !current.empty() ) {
-            int pane = FULL_SCREEN_WIDTH - 30 - 1;
+            int const pane = FULL_SCREEN_WIDTH - 30 - 1;
             nc_color col = available[line].color();
 
             const auto &req = current[line]->simple_requirements();
@@ -439,7 +439,7 @@ const recipe *select_crafting_recipe( int &batch_size )
                 auto books_with_recipe = show_unavailable
                                          ? crafting::get_books_for_recipe( current[line] )
                                          : crafting::get_books_for_recipe( u, crafting_inv, current[line] );
-                std::string enumerated_books =
+                std::string const enumerated_books =
                     enumerate_as_string( books_with_recipe.begin(), books_with_recipe.end(),
                 []( itype_id type_id ) {
                     return colorize( item::nname( type_id ), c_cyan );
@@ -770,7 +770,7 @@ const recipe *select_crafting_recipe( int &batch_size )
                 display_mode = 0;
             }
         } else if( action == "LEFT" ) {
-            std::string start = subtab.cur();
+            std::string const start = subtab.cur();
             do {
                 subtab.prev();
             } while( subtab.cur() != start && shown_recipes.empty_category( tab.cur(),
@@ -786,7 +786,7 @@ const recipe *select_crafting_recipe( int &batch_size )
             subtab = list_circularizer<std::string>( craft_subcat_list[tab.cur()] );
             recalc = true;
         } else if( action == "RIGHT" ) {
-            std::string start = subtab.cur();
+            std::string const start = subtab.cur();
             do {
                 subtab.next();
             } while( subtab.cur() != start && shown_recipes.empty_category( tab.cur(),
@@ -834,7 +834,7 @@ const recipe *select_crafting_recipe( int &batch_size )
                 std::string example;
                 std::string description;
             };
-            std::vector<SearchPrefix> prefixes = {
+            std::vector<SearchPrefix> const prefixes = {
                 { 'q', _( "metal sawing" ), _( "<color_cyan>quality</color> of resulting item" ) },
                 //~ Example result description search term
                 { 'd', _( "reach attack" ), _( "<color_cyan>full description</color> of resulting item (slow)" ) },
@@ -849,7 +849,7 @@ const recipe *select_crafting_recipe( int &batch_size )
             for( const auto &prefix : prefixes ) {
                 max_example_length = std::max( max_example_length, utf8_width( prefix.example ) );
             }
-            std::string spaces( max_example_length, ' ' );
+            std::string const spaces( max_example_length, ' ' );
 
             std::string description =
                 _( "The default is to search result names.  Some single-character prefixes "
@@ -859,7 +859,7 @@ const recipe *select_crafting_recipe( int &batch_size )
                    "<color_white>Examples:</color>\n" );
 
             {
-                std::string example_name = _( "shirt" );
+                std::string const example_name = _( "shirt" );
                 auto padding = max_example_length - utf8_width( example_name );
                 description += string_format(
                                    _( "  <color_white>%s</color>%.*s    %s\n" ),
@@ -939,7 +939,7 @@ const recipe *select_crafting_recipe( int &batch_size )
                 recalc = true;
                 continue;
             }
-            std::string recipe_name = peek_related_recipe( current[line], shown_recipes );
+            std::string const recipe_name = peek_related_recipe( current[line], shown_recipes );
             if( recipe_name.empty() ) {
                 keepline = true;
             } else {
@@ -1035,7 +1035,7 @@ int related_menu_fill( uilist &rmenu,
 
         // we have different recipes with the same names
         // list only one of them as we show and filter by name only
-        std::string recipe_name = p.second;
+        std::string const recipe_name = p.second;
         if( recipe_name == recipe_name_prev ) {
             continue;
         }
@@ -1063,9 +1063,9 @@ int related_menu_fill( uilist &rmenu,
                 std::string prev_item_name;
                 // 2nd pass: add defferent recipes
                 for( size_t recipe_n = 0; recipe_n < current_part.size(); recipe_n++ ) {
-                    std::string cur_item_name = current_part[recipe_n]->result_name();
+                    std::string const cur_item_name = current_part[recipe_n]->result_name();
                     if( cur_item_name != prev_item_name ) {
-                        std::string sym = recipe_n == current_part.size() - 1 ? "└ " : "├ ";
+                        std::string const sym = recipe_n == current_part.size() - 1 ? "└ " : "├ ";
                         rmenu.addentry( ++np_last, true, -1, sym + cur_item_name );
                     }
                     prev_item_name = cur_item_name;
@@ -1149,7 +1149,7 @@ static void draw_recipe_subtabs( const catacurses::window &w, const std::string 
                                  const recipe_subset &available_recipes, TAB_MODE mode )
 {
     werase( w );
-    int width = getmaxx( w );
+    int const width = getmaxx( w );
     for( int i = 0; i < width; i++ ) {
         if( i == 0 ) {
             mvwputch( w, point( i, 2 ), BORDER_COLOR, LINE_XXXO ); // |-
@@ -1170,9 +1170,9 @@ static void draw_recipe_subtabs( const catacurses::window &w, const std::string 
             // Draw the tabs on each other
             int pos_x = 2;
             // Step between tabs, two for tabs border
-            int tab_step = 3;
+            int const tab_step = 3;
             for( const auto &stt : craft_subcat_list[tab] ) {
-                bool empty = available_recipes.empty_category( tab, stt != "CSC_ALL" ? stt : "" );
+                bool const empty = available_recipes.empty_category( tab, stt != "CSC_ALL" ? stt : "" );
                 draw_subtab( w, pos_x, normalized_names[stt], subtab == stt, true, empty );
                 pos_x += utf8_width( normalized_names[stt] ) + tab_step;
             }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -224,7 +224,7 @@ bool Creature::sees( const Creature &critter ) const
         return ch == nullptr || !ch->is_invisible();
     };
 
-    map  const&here = get_map();
+    map  const &here = get_map();
     const Character *ch = critter.as_character();
     const int wanted_range = rl_dist( pos(), critter.pos() );
     // Can always see adjacent monsters on the same level, unless they're through a vehicle wall.
@@ -283,7 +283,7 @@ bool Creature::sees( const tripoint &t, bool is_avatar, int range_mod ) const
         return false;
     }
 
-    map  const&here = get_map();
+    map  const &here = get_map();
     const int range_cur = sight_range( here.ambient_light_at( t ) );
     const int range_day = sight_range( default_daylight_level() );
     const int range_night = sight_range( 0 );
@@ -337,7 +337,7 @@ static bool overlaps_vehicle( const std::set<tripoint> &veh_area, const tripoint
 Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area )
 {
     Creature *target = nullptr;
-    player  const&u = g->u; // Could easily protect something that isn't the player
+    player  const &u = g->u; // Could easily protect something that isn't the player
     constexpr int hostile_adj = 2; // Priority bonus for hostile targets
     const int iff_dist = ( range + area ) * 3 / 2 + 6; // iff check triggers at this distance
     // iff safety margin (degrees). less accuracy, more paranoia
@@ -349,7 +349,7 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
     bool area_iff = false;      // Need to check distance from target to player
     bool angle_iff = true;      // Need to check if player is in a cone between us and target
     int const pldist = rl_dist( pos(), g->u.pos() );
-    map  const&here = get_map();
+    map  const &here = get_map();
     vehicle *in_veh = is_fake() ? veh_pointer_or_null( here.veh_at( pos() ) ) : nullptr;
     if( pldist < iff_dist && sees( g->u ) ) {
         area_iff = area > 0;

--- a/src/creature_tracker.cpp
+++ b/src/creature_tracker.cpp
@@ -56,7 +56,7 @@ shared_ptr_fast<monster> Creature_tracker::from_temporary_id( const int id )
 bool Creature_tracker::add( shared_ptr_fast<monster> critter_ptr )
 {
     assert( critter_ptr );
-    monster  const&critter = *critter_ptr;
+    monster  const &critter = *critter_ptr;
 
     if( critter.type->id.is_null() ) { // Don't want to spawn null monsters o.O
         return false;
@@ -94,7 +94,7 @@ bool Creature_tracker::add( shared_ptr_fast<monster> critter_ptr )
 void Creature_tracker::add_to_faction_map( shared_ptr_fast<monster> critter_ptr )
 {
     assert( critter_ptr );
-    monster  const&critter = *critter_ptr;
+    monster  const &critter = *critter_ptr;
 
     // Only 1 faction per mon at the moment.
     if( critter.friendly == 0 ) {

--- a/src/creature_tracker.cpp
+++ b/src/creature_tracker.cpp
@@ -56,7 +56,7 @@ shared_ptr_fast<monster> Creature_tracker::from_temporary_id( const int id )
 bool Creature_tracker::add( shared_ptr_fast<monster> critter_ptr )
 {
     assert( critter_ptr );
-    monster &critter = *critter_ptr;
+    monster  const&critter = *critter_ptr;
 
     if( critter.type->id.is_null() ) { // Don't want to spawn null monsters o.O
         return false;
@@ -94,7 +94,7 @@ bool Creature_tracker::add( shared_ptr_fast<monster> critter_ptr )
 void Creature_tracker::add_to_faction_map( shared_ptr_fast<monster> critter_ptr )
 {
     assert( critter_ptr );
-    monster &critter = *critter_ptr;
+    monster  const&critter = *critter_ptr;
 
     // Only 1 faction per mon at the moment.
     if( critter.friendly == 0 ) {
@@ -238,7 +238,7 @@ void Creature_tracker::swap_positions( monster &first, monster &second )
     }
     // implied: (first_ptr != second_ptr) or (first_ptr == nullptr && second_ptr == nullptr)
 
-    tripoint temp = second.pos();
+    tripoint const temp = second.pos();
     second.spawn( first.pos() );
     first.spawn( temp );
 

--- a/src/cursesport.cpp
+++ b/src/cursesport.cpp
@@ -128,7 +128,7 @@ void catacurses::wborder( const window &win_, chtype ls, chtype rs, chtype ts, c
     }
     int i = 0;
     int j = 0;
-    point old = win->cursor; // methods below move the cursor, save the value!
+    point const old = win->cursor; // methods below move the cursor, save the value!
 
     const chtype border_ls = ls ? ls : LINE_XOXO;
     const chtype border_rs = rs ? rs : LINE_XOXO;
@@ -496,7 +496,7 @@ void catacurses::wattron( const window &win_, const nc_color &attrs )
         return;
     }
 
-    int pairNumber = attrs.to_color_pair_index();
+    int const pairNumber = attrs.to_color_pair_index();
     win->FG = cata_cursesport::colorpairs[pairNumber].FG;
     win->BG = cata_cursesport::colorpairs[pairNumber].BG;
     if( attrs.is_bold() ) {

--- a/src/damage.cpp
+++ b/src/damage.cpp
@@ -41,7 +41,7 @@ damage_instance::damage_instance( damage_type dt, float amt, float arpen, float 
 void damage_instance::add_damage( damage_type dt, float amt, float arpen, float arpen_mult,
                                   float dmg_mult )
 {
-    damage_unit du( dt, amt, arpen, arpen_mult, dmg_mult );
+    damage_unit const du( dt, amt, arpen, arpen_mult, dmg_mult );
     add( du );
 }
 
@@ -146,7 +146,7 @@ void damage_instance::deserialize( JsonIn &jsin )
 {
     // TODO: Clean up
     if( jsin.test_object() ) {
-        JsonObject jo = jsin.get_object();
+        JsonObject const jo = jsin.get_object();
         *this = load_damage_instance( jo );
     } else if( jsin.test_array() ) {
         *this = load_damage_instance( jsin.get_array() );
@@ -192,7 +192,7 @@ resistances::resistances( const item &armor, bool to_self )
     // Armors protect, but all items can resist
     if( to_self || armor.is_armor() ) {
         for( int i = 0; i < NUM_DT; i++ ) {
-            damage_type dt = static_cast<damage_type>( i );
+            damage_type const dt = static_cast<damage_type>( i );
             set_resist( dt, armor.damage_resist( dt, to_self ) );
         }
     }
@@ -272,9 +272,9 @@ std::string name_by_dt( const damage_type &dt )
 
 const skill_id &skill_by_dt( damage_type dt )
 {
-    static skill_id skill_bashing( "bashing" );
-    static skill_id skill_cutting( "cutting" );
-    static skill_id skill_stabbing( "stabbing" );
+    static skill_id const skill_bashing( "bashing" );
+    static skill_id const skill_cutting( "cutting" );
+    static skill_id const skill_stabbing( "stabbing" );
 
     switch( dt ) {
         case DT_BASH:
@@ -293,19 +293,19 @@ const skill_id &skill_by_dt( damage_type dt )
 
 static damage_unit load_damage_unit( const JsonObject &curr )
 {
-    damage_type dt = dt_by_name( curr.get_string( "damage_type" ) );
+    damage_type const dt = dt_by_name( curr.get_string( "damage_type" ) );
     if( dt == DT_NULL ) {
         curr.throw_error( "Invalid damage type" );
     }
 
-    float amount = curr.get_float( "amount", 0 );
-    float arpen = curr.get_float( "armor_penetration", 0 );
-    float armor_mul = curr.get_float( "armor_multiplier", 1.0f );
-    float damage_mul = curr.get_float( "damage_multiplier", 1.0f );
+    float const amount = curr.get_float( "amount", 0 );
+    float const arpen = curr.get_float( "armor_penetration", 0 );
+    float const armor_mul = curr.get_float( "armor_multiplier", 1.0f );
+    float const damage_mul = curr.get_float( "damage_multiplier", 1.0f );
 
     // Legacy
-    float unc_armor_mul = curr.get_float( "constant_armor_multiplier", 1.0f );
-    float unc_damage_mul = curr.get_float( "constant_damage_multiplier", 1.0f );
+    float const unc_armor_mul = curr.get_float( "constant_armor_multiplier", 1.0f );
+    float const unc_damage_mul = curr.get_float( "constant_damage_multiplier", 1.0f );
 
     return damage_unit( dt, amount, arpen, armor_mul * unc_armor_mul, damage_mul * unc_damage_mul );
 }
@@ -391,15 +391,15 @@ damage_instance load_damage_instance_inherit( const JsonArray &jarr, const damag
 std::array<float, NUM_DT> load_damage_array( const JsonObject &jo )
 {
     std::array<float, NUM_DT> ret;
-    float init_val = jo.get_float( "all", 0.0f );
+    float const init_val = jo.get_float( "all", 0.0f );
 
-    float phys = jo.get_float( "physical", init_val );
+    float const phys = jo.get_float( "physical", init_val );
     ret[ DT_BASH ] = jo.get_float( "bash", phys );
     ret[ DT_CUT ] = jo.get_float( "cut", phys );
     ret[ DT_STAB ] = jo.get_float( "stab", phys );
     ret[ DT_BULLET ] = jo.get_float( "bullet", phys );
 
-    float non_phys = jo.get_float( "non_physical", init_val );
+    float const non_phys = jo.get_float( "non_physical", init_val );
     ret[ DT_BIOLOGICAL ] = jo.get_float( "biological", non_phys );
     ret[ DT_ACID ] = jo.get_float( "acid", non_phys );
     ret[ DT_HEAT ] = jo.get_float( "heat", non_phys );

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -182,11 +182,11 @@ static void debug_error_prompt(
         return;
     }
 
-    std::string formatted_report = [&]() {
+    std::string const formatted_report = [&]() {
         const char *repetition_string =
             _( "Excessive error repetition detected.  Please file a bug report at https://github.com/cataclysmbnteam/Cataclysm-BN/issues" );
         // try to prepend repetition string if we are forcing the display. Right now that's the only reason for this prompt to display.
-        std::string pre = force ? string_format(
+        std::string const pre = force ? string_format(
                               "            %s\n",
                               repetition_string
                           ) : "";
@@ -203,7 +203,7 @@ static void debug_error_prompt(
     ();
 
 #if defined(BACKTRACE)
-    std::string backtrace_instructions =
+    std::string const backtrace_instructions =
         string_format(
             _( "See %s for a full stack backtrace" ),
             PATH_INFO::debug()
@@ -404,7 +404,7 @@ void realDebugmsg( const char *filename, const char *line, const char *funcname,
     }
 
     // Show excessive repetition prompt once per excessive set
-    bool excess_repetition = rep_folder.repeat_count == repetition_folder::repetition_threshold;
+    bool const excess_repetition = rep_folder.repeat_count == repetition_folder::repetition_threshold;
 
     if( buffering_debugmsgs ) {
         buffered_prompts().push_back( {filename, line, funcname, text, false } );
@@ -589,7 +589,7 @@ std::ostream &DebugFile::get_file()
 
 void DebugFile::init( DebugOutput output_mode, const std::string &filename )
 {
-    std::shared_ptr<std::ostringstream> str_buffer = std::dynamic_pointer_cast<std::ostringstream>
+    std::shared_ptr<std::ostringstream> const str_buffer = std::dynamic_pointer_cast<std::ostringstream>
             ( file );
 
     switch( output_mode ) {
@@ -757,8 +757,8 @@ static std::optional<uintptr_t> debug_compute_load_offset(
     // things (e.g. dladdr1 in GNU libdl) but this approach might
     // perhaps be more portable and adds no link-time dependencies.
 
-    uintptr_t offset_within_symbol = std::stoull( offset_within_symbol_s, nullptr, 0 );
-    std::string string_sought = " " + symbol;
+    uintptr_t const offset_within_symbol = std::stoull( offset_within_symbol_s, nullptr, 0 );
+    std::string const string_sought = " " + symbol;
 
     // We need to try calling nm in two different ways, because one
     // works for executables and the other for libraries.
@@ -1000,7 +1000,7 @@ void debug_write_backtrace( std::ostream &out )
     // BACKTRACE is not supported under CYGWIN!
     ( void ) out;
 #   else
-    int count = backtrace( bt, bt_cnt );
+    int const count = backtrace( bt, bt_cnt );
     char **funcNames = backtrace_symbols( bt, count );
     for( int i = 0; i < count; ++i ) {
         out << "\n    " << funcNames[i];
@@ -1028,7 +1028,7 @@ void debug_write_backtrace( std::ostream &out )
         std::ostringstream cmd;
         cmd.imbue( std::locale::classic() );
         cmd << "addr2line -i -e " << binary << " -f -C" << std::hex;
-        for( uintptr_t address : addresses ) {
+        for( uintptr_t const address : addresses ) {
             cmd << " 0x" << ( address - load_offset );
         }
         cmd << " 2>&1";
@@ -1097,8 +1097,8 @@ void debug_write_backtrace( std::ostream &out )
 
             if( symbolNameEnd < offsetEnd && offsetEnd < funcNameEnd ) {
                 const auto offsetStart = symbolNameEnd + 1;
-                std::string symbol_name( symbolNameStart, symbolNameEnd );
-                std::string offset_within_symbol( offsetStart, offsetEnd );
+                std::string const symbol_name( symbolNameStart, symbolNameEnd );
+                std::string const offset_within_symbol( offsetStart, offsetEnd );
 
                 std::optional<uintptr_t> offset =
                     debug_compute_load_offset( binary_name, symbol_name, offset_within_symbol,
@@ -1195,11 +1195,11 @@ detail::DebugLogGuard detail::realDebugLog( DL lev, DC cl, const char *filename,
 #if defined(BACKTRACE)
         // Push the first retrieved value back by a second so it won't match.
         static time_t next_backtrace = time( nullptr ) - 1;
-        time_t now = time( nullptr );
+        time_t const now = time( nullptr );
         if( lev == DL::Error && now >= next_backtrace ) {
             out << "(error message will follow backtrace)";
             debug_write_backtrace( out );
-            time_t after = time( nullptr );
+            time_t const after = time( nullptr );
             // Cool down for 60s between backtrace emissions.
             next_backtrace = after + 60;
             out << "Backtrace emission took " << after - now << " seconds." << std::endl;
@@ -1261,7 +1261,7 @@ static std::string shell_exec( const std::string &command )
     std::vector<char> buffer( 512 );
     std::string output;
     try {
-        std::unique_ptr<FILE, decltype( &pclose )> pipe( popen( command.c_str(), "r" ), pclose );
+        std::unique_ptr<FILE, decltype( &pclose )> const pipe( popen( command.c_str(), "r" ), pclose );
         if( pipe ) {
             while( fgets( buffer.data(), buffer.size(), pipe.get() ) != nullptr ) {
                 output += buffer.data();
@@ -1541,7 +1541,7 @@ std::string game_info::game_report()
     }
     std::stringstream report;
 
-    std::string lang = get_option<std::string>( "USE_LANG" );
+    std::string const lang = get_option<std::string>( "USE_LANG" );
     std::string lang_translated;
     for( const language_info &info : list_available_languages() ) {
         if( lang == info.id ) {

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -187,9 +187,9 @@ static void debug_error_prompt(
             _( "Excessive error repetition detected.  Please file a bug report at https://github.com/cataclysmbnteam/Cataclysm-BN/issues" );
         // try to prepend repetition string if we are forcing the display. Right now that's the only reason for this prompt to display.
         std::string const pre = force ? string_format(
-                              "            %s\n",
-                              repetition_string
-                          ) : "";
+                                    "            %s\n",
+                                    repetition_string
+                                ) : "";
         return string_format(
                    "%s"
                    " DEBUG    : %s\n\n"

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -257,7 +257,7 @@ static int info_uilist( bool display_all_entries = true )
 
 static int vehicle_uilist()
 {
-    std::vector<uilist_entry> uilist_initializer = {
+    std::vector<uilist_entry> const uilist_initializer = {
         { uilist_entry( DEBUG_VEHICLE_BATTERY_CHARGE, true, 'b', _( "Change [b]attery charge" ) ) },
         { uilist_entry( DEBUG_VEHICLE_EXPORT_JSON, true, 'j', _( "Export [j]son template" ) ) },
     };
@@ -495,7 +495,7 @@ static Character &pick_character( Character &preselected )
     auto iter = std::find_if( locations.begin(), locations.end(), [&preselected]( const tripoint & p ) {
         return p == preselected.pos();
     } );
-    size_t preselect_index = iter != locations.end() ? std::distance( locations.begin(), iter ) : 0;
+    size_t const preselect_index = iter != locations.end() ? std::distance( locations.begin(), iter ) : 0;
 
     pointmenu_cb callback( locations );
     charmenu.callback = &callback;
@@ -602,7 +602,7 @@ void character_edit_menu( Character &c )
         menu_entries.emplace_back( edit_character::attitude, true, 'A',  _( "Set [A]ttitude" ) );
         menu_entries.emplace_back( edit_character::opinion, true, 'O',  _( "Set [O]pinion" ) );
     }
-    uilist nmenu( nmenu_label, menu_entries );
+    uilist const nmenu( nmenu_label, menu_entries );
     switch( nmenu.ret ) {
         case edit_character::pick: {
             Character &other = pick_character( c );
@@ -668,7 +668,7 @@ void character_edit_menu( Character &c )
             if( !loc ) {
                 break;
             }
-            item &to_wear = *loc;
+            item  const&to_wear = *loc;
             if( to_wear.is_armor() ) {
                 p.on_item_wear( to_wear );
                 p.worn.push_back( to_wear );
@@ -757,10 +757,10 @@ void character_edit_menu( Character &c )
             }
             break;
         case edit_character::morale: {
-            int current_morale_level = p.get_morale_level();
+            int const current_morale_level = p.get_morale_level();
             int value;
             if( query_int( value, _( "Set the morale to?  Currently: %d" ), current_morale_level ) ) {
-                int morale_level_delta = value - current_morale_level;
+                int const morale_level_delta = value - current_morale_level;
                 p.add_morale( MORALE_PERM_DEBUG, morale_level_delta );
                 p.apply_persistent_morale();
             }
@@ -1037,8 +1037,8 @@ void character_edit_menu( Character &c )
             attitudes_ui.text = _( "Choose new attitude" );
             std::vector<npc_attitude> attitudes;
             for( int i = NPCATT_NULL; i < NPCATT_END; i++ ) {
-                npc_attitude att_id = static_cast<npc_attitude>( i );
-                std::string att_name = npc_attitude_name( att_id );
+                npc_attitude const att_id = static_cast<npc_attitude>( i );
+                std::string const att_name = npc_attitude_name( att_id );
                 attitudes.push_back( att_id );
                 if( att_name == _( "Unknown attitude" ) ) {
                     continue;
@@ -1114,7 +1114,7 @@ void character_edit_menu( Character &c )
                 uile.enabled = !sp->is_max_level();
                 uiles.emplace_back( uile );
             }
-            int action = uilist( _( "Debug level spell:" ), uiles );
+            int const action = uilist( _( "Debug level spell:" ), uiles );
             if( action < 0 ) {
                 break;
             }
@@ -1189,7 +1189,7 @@ void mission_debug::edit( player &who )
 
 void mission_debug::edit_npc( npc &who )
 {
-    npc_chatbin &bin = who.chatbin;
+    npc_chatbin  const&bin = who.chatbin;
     std::vector<mission *> all_missions;
 
     uilist mmenu;
@@ -1251,7 +1251,7 @@ void mission_debug::edit_player()
 static bool remove_from_vec( std::vector<mission *> &vec, mission *m )
 {
     auto iter = std::remove( vec.begin(), vec.end(), m );
-    bool ret = iter != vec.end();
+    bool const ret = iter != vec.end();
     vec.erase( iter, vec.end() );
     return ret;
 }
@@ -1383,8 +1383,8 @@ void benchmark( const int max_difference, bench_kind kind )
 
 void debug()
 {
-    bool debug_menu_has_hotkey = hotkey_for_action( ACTION_DEBUG, false ) != -1;
-    int action = debug_menu_uilist( debug_menu_has_hotkey );
+    bool const debug_menu_has_hotkey = hotkey_for_action( ACTION_DEBUG, false ) != -1;
+    int const action = debug_menu_uilist( debug_menu_has_hotkey );
     avatar &u = g->u;
     map &m = g->m;
     switch( action ) {
@@ -1414,7 +1414,7 @@ void debug()
         break;
 
         case DEBUG_SPAWN_NPC: {
-            shared_ptr_fast<npc> temp = make_shared_fast<npc>();
+            shared_ptr_fast<npc> const temp = make_shared_fast<npc>();
             temp->randomize();
             temp->spawn_at_precise( { g->get_levx(), g->get_levy() }, u.pos() + point( -4, -4 ) );
             overmap_buffer.insert_npc( temp );
@@ -1466,7 +1466,7 @@ void debug()
                 _( "NPCs are NOT going to spawn." ),
                 g->num_creatures() );
             for( const npc &guy : g->all_npcs() ) {
-                tripoint t = guy.global_sm_location();
+                tripoint const t = guy.global_sm_location();
                 add_msg( m_info, _( "%s: map ( %d:%d ) pos ( %d:%d )" ), guy.name, t.x,
                          t.y, guy.posx(), guy.posy() );
             }
@@ -1506,7 +1506,7 @@ void debug()
             const tripoint_range<tripoint> points = get_map().points_in_rectangle(
                     first.position.value(), second.position.value() );
 
-            std::vector<Creature *> creatures = g->get_creatures_if(
+            std::vector<Creature *> const creatures = g->get_creatures_if(
             [&points]( const Creature & critter ) -> bool {
                 return !critter.is_avatar() && points.is_point_inside( critter.pos() );
             } );
@@ -1555,7 +1555,7 @@ void debug()
                 if( veh_menu.ret >= 0 && veh_menu.ret < static_cast<int>( veh_strings.size() ) ) {
                     // Didn't cancel
                     const vproto_id &selected_opt = veh_strings[veh_menu.ret].second;
-                    tripoint dest = u.pos();
+                    tripoint const dest = u.pos();
                     uilist veh_cond_menu;
                     veh_cond_menu.text = _( "Vehicle condition" );
                     veh_cond_menu.addentry( 0, true, MENU_AUTOASSIGN, _( "Light damage" ) );
@@ -1580,7 +1580,7 @@ void debug()
 
         case DEBUG_SPAWN_ARTIFACT:
             if( const std::optional<tripoint> center = g->look_around( true ) ) {
-                artifact_natural_property prop = static_cast<artifact_natural_property>( rng( ARTPROP_NULL + 1,
+                artifact_natural_property const prop = static_cast<artifact_natural_property>( rng( ARTPROP_NULL + 1,
                                                  ARTPROP_MAX - 1 ) );
                 m.create_anomaly( *center, prop );
                 m.spawn_natural_artifact( *center, prop );
@@ -1646,7 +1646,7 @@ void debug()
                                       _( "Disable speed forcing" ) : _( "Keep normal wind speed" ) );
             int count = 1;
             for( int speed = 0; speed <= 100; speed += 10 ) {
-                std::string speedstring = std::to_string( speed ) + " " + velocity_units( VU_WIND );
+                std::string const speedstring = std::to_string( speed ) + " " + velocity_units( VU_WIND );
                 wind_speed_menu.addentry( count, true, MENU_AUTOASSIGN, speedstring );
                 count += 1;
             }
@@ -1751,7 +1751,7 @@ void debug()
 #if defined(TILES)
             const auto &sounds_to_draw = sounds::get_monster_sounds();
 
-            shared_ptr_fast<game::draw_callback_t> sound_cb = make_shared_fast<game::draw_callback_t>( [&]() {
+            shared_ptr_fast<game::draw_callback_t> const sound_cb = make_shared_fast<game::draw_callback_t>( [&]() {
                 const point offset {
                     u.view_offset.xy() + point( POSX - u.posx(), POSY - u.posy() )
                 };
@@ -1859,7 +1859,7 @@ void debug()
                                   _( "Set season to?  (0 = spring)" ) );
                         if( calendar::eternal_season() ) {
                             // Can't use season_of_year because it checks for eternal
-                            season_type new_initial_season = static_cast<season_type>(
+                            season_type const new_initial_season = static_cast<season_type>(
                                                                  to_turn<int>( calendar::turn ) / to_turns<int>( calendar::season_length() ) % 4
                                                              );
                             season_of_year( calendar::before_time_starts );
@@ -1954,7 +1954,7 @@ void debug()
                 mx_menu.addentry( -1, true, -1, extra );
             }
             mx_menu.query();
-            int mx_choice = mx_menu.ret;
+            int const mx_choice = mx_menu.ret;
             if( mx_choice >= 0 && mx_choice < static_cast<int>( mx_str.size() ) ) {
                 const tripoint_abs_omt where_omt( ui::omap::choose_point() );
                 if( where_omt != overmap::invalid_tripoint ) {
@@ -2053,7 +2053,7 @@ void debug()
             std::string popup_msg = _( "Report written to debug.log" );
 #if defined(TILES)
             // copy to clipboard
-            int clipboard_result = SDL_SetClipboardText( report.c_str() );
+            int const clipboard_result = SDL_SetClipboardText( report.c_str() );
             printErrorIf( clipboard_result != 0, "Error while copying the game report to the clipboard." );
             if( clipboard_result == 0 ) {
                 popup_msg += _( " and to the clipboard." );

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -495,7 +495,8 @@ static Character &pick_character( Character &preselected )
     auto iter = std::find_if( locations.begin(), locations.end(), [&preselected]( const tripoint & p ) {
         return p == preselected.pos();
     } );
-    size_t const preselect_index = iter != locations.end() ? std::distance( locations.begin(), iter ) : 0;
+    size_t const preselect_index = iter != locations.end() ? std::distance( locations.begin(),
+                                   iter ) : 0;
 
     pointmenu_cb callback( locations );
     charmenu.callback = &callback;
@@ -668,7 +669,7 @@ void character_edit_menu( Character &c )
             if( !loc ) {
                 break;
             }
-            item  const&to_wear = *loc;
+            item  const &to_wear = *loc;
             if( to_wear.is_armor() ) {
                 p.on_item_wear( to_wear );
                 p.worn.push_back( to_wear );
@@ -1189,7 +1190,7 @@ void mission_debug::edit( player &who )
 
 void mission_debug::edit_npc( npc &who )
 {
-    npc_chatbin  const&bin = who.chatbin;
+    npc_chatbin  const &bin = who.chatbin;
     std::vector<mission *> all_missions;
 
     uilist mmenu;
@@ -1580,8 +1581,9 @@ void debug()
 
         case DEBUG_SPAWN_ARTIFACT:
             if( const std::optional<tripoint> center = g->look_around( true ) ) {
-                artifact_natural_property const prop = static_cast<artifact_natural_property>( rng( ARTPROP_NULL + 1,
-                                                 ARTPROP_MAX - 1 ) );
+                artifact_natural_property const prop = static_cast<artifact_natural_property>( rng(
+                        ARTPROP_NULL + 1,
+                        ARTPROP_MAX - 1 ) );
                 m.create_anomaly( *center, prop );
                 m.spawn_natural_artifact( *center, prop );
             }
@@ -1751,7 +1753,8 @@ void debug()
 #if defined(TILES)
             const auto &sounds_to_draw = sounds::get_monster_sounds();
 
-            shared_ptr_fast<game::draw_callback_t> const sound_cb = make_shared_fast<game::draw_callback_t>( [&]() {
+            shared_ptr_fast<game::draw_callback_t> const sound_cb =
+            make_shared_fast<game::draw_callback_t>( [&]() {
                 const point offset {
                     u.view_offset.xy() + point( POSX - u.posx(), POSY - u.posy() )
                 };
@@ -1860,8 +1863,8 @@ void debug()
                         if( calendar::eternal_season() ) {
                             // Can't use season_of_year because it checks for eternal
                             season_type const new_initial_season = static_cast<season_type>(
-                                                                 to_turn<int>( calendar::turn ) / to_turns<int>( calendar::season_length() ) % 4
-                                                             );
+                                    to_turn<int>( calendar::turn ) / to_turns<int>( calendar::season_length() ) % 4
+                                                                   );
                             season_of_year( calendar::before_time_starts );
                             calendar::set_calendar_config( {
                                 calendar::config.start_of_cataclysm(),

--- a/src/dependency_tree.cpp
+++ b/src/dependency_tree.cpp
@@ -97,10 +97,10 @@ void dependency_node::inherit_errors()
 
         // add check errors
         if( !check->errors().empty() ) {
-            std::map<node_error_type, std::vector<std::string > > cerrors = check->errors();
+            std::map<node_error_type, std::vector<std::string > > const cerrors = check->errors();
             for( auto &cerror : cerrors ) {
-                std::vector<std::string> node_errors = cerror.second;
-                node_error_type error_type = cerror.first;
+                std::vector<std::string> const node_errors = cerror.second;
+                node_error_type const error_type = cerror.first;
                 std::vector<std::string> cur_errors = all_errors[error_type];
                 for( auto &node_error : node_errors ) {
                     if( std::find( cur_errors.begin(), cur_errors.end(), node_error ) ==
@@ -127,7 +127,7 @@ std::vector<mod_id> dependency_node::get_dependencies_as_strings() const
 {
     std::vector<mod_id> ret;
 
-    std::vector<dependency_node *> as_nodes = get_dependencies_as_nodes();
+    std::vector<dependency_node *> const as_nodes = get_dependencies_as_nodes();
 
     ret.reserve( as_nodes.size() );
 
@@ -188,7 +188,7 @@ std::vector<mod_id> dependency_node::get_dependents_as_strings() const
 {
     std::vector<mod_id> ret;
 
-    std::vector<dependency_node *> as_nodes = get_dependents_as_nodes();
+    std::vector<dependency_node *> const as_nodes = get_dependents_as_nodes();
 
     ret.reserve( as_nodes.size() );
 
@@ -273,7 +273,7 @@ void dependency_tree::build_connections(
             dependency_node *knode = &iter->second;
 
             // apply parents list
-            std::vector<mod_id> vnode_parents = elem.second;
+            std::vector<mod_id> const vnode_parents = elem.second;
             for( auto &vnode_parent : vnode_parents ) {
                 const auto iter = master_node_map.find( vnode_parent );
                 if( iter != master_node_map.end() ) {
@@ -393,7 +393,7 @@ void dependency_tree::check_for_strongly_connected_components()
         }
     }
 
-    for( std::vector<dependency_node *> &list : strongly_connected_components ) {
+    for( std::vector<dependency_node *>  const&list : strongly_connected_components ) {
         if( list.size() <= 1 ) {
             continue;
         }
@@ -470,7 +470,7 @@ void dependency_tree::check_for_conflicting_dependencies()
             for( const dependency_node *this_dep_conf : both ) {
                 //~ Single entry in list of conflicting dependencies, both %s are mod ids.
                 //~ Example of final string: "[aftershock] with [classic-zombies]"
-                std::string msg = string_format( _( "[%1$s] with [%2$s]" ), this_dep->key, this_dep_conf->key );
+                std::string const msg = string_format( _( "[%1$s] with [%2$s]" ), this_dep->key, this_dep_conf->key );
                 this_node->all_errors[node_error_type::conflicting_deps].push_back( msg );
             }
         }

--- a/src/dependency_tree.cpp
+++ b/src/dependency_tree.cpp
@@ -393,7 +393,7 @@ void dependency_tree::check_for_strongly_connected_components()
         }
     }
 
-    for( std::vector<dependency_node *>  const&list : strongly_connected_components ) {
+    for( std::vector<dependency_node *>  const &list : strongly_connected_components ) {
         if( list.size() <= 1 ) {
             continue;
         }
@@ -470,7 +470,8 @@ void dependency_tree::check_for_conflicting_dependencies()
             for( const dependency_node *this_dep_conf : both ) {
                 //~ Single entry in list of conflicting dependencies, both %s are mod ids.
                 //~ Example of final string: "[aftershock] with [classic-zombies]"
-                std::string const msg = string_format( _( "[%1$s] with [%2$s]" ), this_dep->key, this_dep_conf->key );
+                std::string const msg = string_format( _( "[%1$s] with [%2$s]" ), this_dep->key,
+                                                       this_dep_conf->key );
                 this_node->all_errors[node_error_type::conflicting_deps].push_back( msg );
             }
         }

--- a/src/descriptions.cpp
+++ b/src/descriptions.cpp
@@ -149,7 +149,7 @@ void game::extended_description( const tripoint &p )
                 break;
         }
 
-        std::string signage = m.get_signage( p );
+        std::string const signage = m.get_signage( p );
         if( !signage.empty() ) {
             // NOLINTNEXTLINE(cata-text-style): the question mark does not end a sentence
             desc += u.has_trait( trait_ILLITERATE ) ? _( "\nSign: ???" ) : string_format( _( "\nSign: %s" ),
@@ -179,14 +179,14 @@ std::string map_data_common_t::extended_description() const
     std::stringstream ss;
     ss << "<header>" << string_format( _( "That is a %s." ), name() ) << "</header>" << '\n';
     ss << description << std::endl;
-    bool has_any_harvest = std::any_of( harvest_by_season.begin(), harvest_by_season.end(),
+    bool const has_any_harvest = std::any_of( harvest_by_season.begin(), harvest_by_season.end(),
     []( const harvest_id & hv ) {
         return !hv.obj().empty();
     } );
 
     if( has_any_harvest ) {
         ss << "--" << std::endl;
-        int player_skill = get_avatar().get_skill_level( skill_survival );
+        int const player_skill = get_avatar().get_skill_level( skill_survival );
         ss << _( "You could harvest the following things from it:" ) << std::endl;
         // Group them by identical ids to avoid repeating same blocks of data
         // First, invert the mapping: season->id to id->seasons
@@ -243,7 +243,7 @@ std::string map_data_common_t::extended_description() const
     if( debug_vision() ) {
         ss << "Bash: " << bash.str_min << "-" << bash.str_max << "\n";
         if( bash.ranged ) {
-            static std::string indent = "    ";
+            static std::string const indent = "    ";
             ss << "Ranged: " << "\n";
             ss << indent << "Reduction:" << bash.ranged->reduction.min << "-" << bash.ranged->reduction.max;
             if( bash.ranged->reduction_laser ) {

--- a/src/dialogue_win.cpp
+++ b/src/dialogue_win.cpp
@@ -13,10 +13,10 @@
 
 void dialogue_window::resize_dialogue( ui_adaptor &ui )
 {
-    int win_beginy = TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 4 : 0;
-    int win_beginx = TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 4 : 0;
-    int maxy = win_beginy ? TERMY - 2 * win_beginy : FULL_SCREEN_HEIGHT;
-    int maxx = win_beginx ? TERMX - 2 * win_beginx : FULL_SCREEN_WIDTH;
+    int const win_beginy = TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 4 : 0;
+    int const win_beginx = TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 4 : 0;
+    int const maxy = win_beginy ? TERMY - 2 * win_beginy : FULL_SCREEN_HEIGHT;
+    int const maxx = win_beginx ? TERMX - 2 * win_beginx : FULL_SCREEN_WIDTH;
     d_win = catacurses::newwin( maxy, maxx, point( win_beginx, win_beginy ) );
     ui.position_from_window( d_win );
     curr_page = 0;
@@ -29,8 +29,8 @@ void dialogue_window::resize_dialogue( ui_adaptor &ui )
 void dialogue_window::print_header( const std::string &name )
 {
     draw_border( d_win );
-    int win_midx = getmaxx( d_win ) / 2;
-    int winy = getmaxy( d_win );
+    int const win_midx = getmaxx( d_win ) / 2;
+    int const winy = getmaxy( d_win );
     mvwvline( d_win, point( win_midx + 1, 1 ), LINE_XOXO, winy - 1 );
     mvwputch( d_win, point( win_midx + 1, 0 ), BORDER_COLOR, LINE_OXXX );
     mvwputch( d_win, point( win_midx + 1, winy - 1 ), BORDER_COLOR, LINE_XXOX );
@@ -48,7 +48,7 @@ void dialogue_window::clear_window_texts()
 
 void dialogue_window::add_to_history( const std::string &msg )
 {
-    size_t idx = history.size();
+    size_t const idx = history.size();
     history.push_back( msg );
     cache_msg( msg, idx );
 }
@@ -61,7 +61,7 @@ void dialogue_window::print_history()
     int curline = getmaxy( d_win ) - 2;
     int curindex = draw_cache.size() - 1;
     // Highligh last message
-    size_t msg_to_highlight = history.size() - 1;
+    size_t const msg_to_highlight = history.size() - 1;
     // Print at line 2 and below, line 1 contains the header, line 0 the border
     while( curindex >= 0 && curline >= 2 ) {
         const std::pair<std::string, size_t> &msg = draw_cache[curindex];
@@ -86,7 +86,7 @@ static std::vector<page> split_to_pages( const std::vector<talk_data> &responses
 {
     page this_page;
     std::vector<page> ret;
-    int fold_width = page_w - 3;
+    int const fold_width = page_w - 3;
     int this_h = 0;
     for( const talk_data &resp : responses ) {
         // Assemble single entry for printing

--- a/src/diary.cpp
+++ b/src/diary.cpp
@@ -298,9 +298,9 @@ void diary::kill_changes()
             add_to_change_list( _( "Kills:" ) );
             for( const std::pair<const string_id<mtype>, int> &elem : curr_page->kills ) {
                 const mtype &m = elem.first.obj();
-                nc_color color = m.color;
-                std::string symbol = m.sym;
-                std::string nname = m.nname( elem.second );
+                nc_color const color = m.color;
+                std::string const symbol = m.sym;
+                std::string const nname = m.nname( elem.second );
                 add_to_change_list( string_format( "%4d ", elem.second ) + colorize( symbol,
                                     color ) + " " + colorize( nname, c_light_gray ), m.get_description() );
             }
@@ -321,9 +321,9 @@ void diary::kill_changes()
             bool flag = true;
             for( const std::pair<const string_id<mtype>, int> &elem : curr_page->kills ) {
                 const mtype &m = elem.first.obj();
-                nc_color color = m.color;
-                std::string symbol = m.sym;
-                std::string nname = m.nname( elem.second );
+                nc_color const color = m.color;
+                std::string const symbol = m.sym;
+                std::string const nname = m.nname( elem.second );
                 int kills = elem.second;
                 if( prev_page->kills.count( elem.first ) > 0 ) {
                     const int prev_kills = prev_page->kills[elem.first];
@@ -393,7 +393,7 @@ void diary::skill_changes()
             for( const std::pair<const string_id<Skill>, int> &elem : curr_page->skill_levels ) {
 
                 if( elem.second > 0 ) {
-                    Skill s = elem.first.obj();
+                    Skill const s = elem.first.obj();
                     add_to_change_list( string_format( "<color_light_blue>%s: %d</color>", s.name(), elem.second ),
                                         s.description() );
                 }
@@ -410,7 +410,7 @@ void diary::skill_changes()
                         add_to_change_list( _( "Skills:" ) );
                         flag = false;
                     }
-                    Skill s = elem.first.obj();
+                    Skill const s = elem.first.obj();
                     add_to_change_list( string_format( _( "<color_light_blue>%s: %d -> %d</color>" ), s.name(),
                                                        prev_page->skill_levels[elem.first], elem.second ), s.description() );
                 }
@@ -650,11 +650,11 @@ std::vector<std::string> diary::get_head_text()
         //~ %1$d is the current page number, %2$d is the number of pages in total
         std::vector<std::string> head_text = { string_format( _( "Entry: %1$d/%2$d" ), opened_page + 1, pages.size() ) };
 
-        std::string complete_time_text = to_string( get_page_ptr()->turn ); // get complete time
+        std::string const complete_time_text = to_string( get_page_ptr()->turn ); // get complete time
         std::string day_and_time_text = complete_time_text.substr( complete_time_text.find_last_of( ',' ) +
                                         2 );
         day_and_time_text[0] = std::toupper( day_and_time_text[0] );
-        std::string year_and_season_text = complete_time_text.substr( 0,
+        std::string const year_and_season_text = complete_time_text.substr( 0,
                                            complete_time_text.find_last_of( ',' ) + 1 );
 
         head_text.insert( head_text.end(), year_and_season_text );
@@ -671,7 +671,7 @@ std::vector<std::string> diary::get_head_text()
 
 void diary::death_entry()
 {
-    bool last_time = query_yn( _( "Open your diary for the last time?" ) );
+    bool const last_time = query_yn( _( "Open your diary for the last time?" ) );
     if( last_time ) {
         show_diary_ui( this );
     }
@@ -712,8 +712,8 @@ void diary::new_page()
     }
     page->known_martial_arts = u->martial_arts_data->get_known_styles();
     page->bionics = u->get_bionics();
-    for( Skill &elem : Skill::skills ) {
-        int level = u->get_skill_level_object( elem.ident() ).level();
+    for( Skill  const&elem : Skill::skills ) {
+        int const level = u->get_skill_level_object( elem.ident() ).level();
         page->skill_levels.insert( { elem.ident(), level } );
     }
     page->max_power_level = u->get_max_power_level();
@@ -759,8 +759,8 @@ void diary::export_to_md( bool last_export )
 
 bool diary::store()
 {
-    std::string name = base64_encode( get_avatar().get_save_id() + "_diary" );
-    std::string path = g->get_world_base_save_path() + "/" + name + ".json";
+    std::string const name = base64_encode( get_avatar().get_save_id() + "_diary" );
+    std::string const path = g->get_world_base_save_path() + "/" + name + ".json";
     const bool is_writen = write_to_file( path, [&]( std::ostream & fout ) {
         serialize( fout );
     }, _( "diary data" ) );
@@ -809,8 +809,8 @@ void diary::serialize( JsonOut &jsout )
 
 void diary::load()
 {
-    std::string name = base64_encode( get_avatar().get_save_id() + "_diary" );
-    std::string path = g->get_world_base_save_path() + "/" + name + ".json";
+    std::string const name = base64_encode( get_avatar().get_save_id() + "_diary" );
+    std::string const path = g->get_world_base_save_path() + "/" + name + ".json";
     if( file_exist( path ) ) {
         read_from_file( path, [&]( std::istream & fin ) {
             deserialize( fin );
@@ -827,11 +827,11 @@ void diary::deserialize( std::istream &fin )
 void diary::deserialize( JsonIn &jsin )
 {
     try {
-        JsonObject data = jsin.get_object();
+        JsonObject const data = jsin.get_object();
 
         data.read( "owner", owner );
         pages.clear();
-        for( JsonObject elem : data.get_array( "pages" ) ) {
+        for( JsonObject const elem : data.get_array( "pages" ) ) {
             std::unique_ptr<diary_page> page( new diary_page() );
             page->m_text = elem.get_string( "text" );
             elem.read( "turn", page->turn );

--- a/src/diary.cpp
+++ b/src/diary.cpp
@@ -655,7 +655,7 @@ std::vector<std::string> diary::get_head_text()
                                         2 );
         day_and_time_text[0] = std::toupper( day_and_time_text[0] );
         std::string const year_and_season_text = complete_time_text.substr( 0,
-                                           complete_time_text.find_last_of( ',' ) + 1 );
+                complete_time_text.find_last_of( ',' ) + 1 );
 
         head_text.insert( head_text.end(), year_and_season_text );
         head_text.insert( head_text.end(), day_and_time_text );
@@ -712,7 +712,7 @@ void diary::new_page()
     }
     page->known_martial_arts = u->martial_arts_data->get_known_styles();
     page->bionics = u->get_bionics();
-    for( Skill  const&elem : Skill::skills ) {
+    for( Skill  const &elem : Skill::skills ) {
         int const level = u->get_skill_level_object( elem.ident() ).level();
         page->skill_levels.insert( { elem.ident(), level } );
     }

--- a/src/diary_ui.cpp
+++ b/src/diary_ui.cpp
@@ -191,9 +191,9 @@ void diary::show_diary_ui( diary *c_diary )
     ui_diary.on_screen_resize( [&]( ui_adaptor & ui ) {
         const std::pair<point, point> beg_and_max = diary_window_position();
         point const beg = ( uis_padding() != 0 ) ? point( uis_padding() + MAX_DAIRY_UI_WIDTH / 4 - 3,
-                    beg_and_max.first.y - 1 ) : beg_and_max.first + point( uis_padding() - 3, -1 );
+                          beg_and_max.first.y - 1 ) : beg_and_max.first + point( uis_padding() - 3, -1 );
         point const max = point( TERMX - beg.x - 5,
-                           beg_and_max.second.y ) - point( uis_padding(), 0 );
+                                 beg_and_max.second.y ) - point( uis_padding(), 0 );
         const int midx = max.x / 2;
 
         w_changes = catacurses::newwin( max.y - 3, midx - 1, beg + point_south );
@@ -265,11 +265,11 @@ void diary::show_diary_ui( diary *c_diary )
         draw_border( w_desc );
         center_print( w_desc, 0, c_light_gray, string_format( _( "%s's Diary" ), c_diary->owner ) );
         std::string const desc = string_format( _( "%s, %s, %s, %s" ),
-                                          ctxt.get_desc( "NEW_PAGE", _( "New page" ), input_context::allow_all_keys ),
-                                          ctxt.get_desc( "CONFIRM", _( "Edit text" ), input_context::allow_all_keys ),
-                                          ctxt.get_desc( "DELETE PAGE", _( "Delete page" ), input_context::allow_all_keys ),
-                                          ctxt.get_desc( "EXPORT_DIARY", _( "Export diary" ), input_context::allow_all_keys )
-                                        );
+                                                ctxt.get_desc( "NEW_PAGE", _( "New page" ), input_context::allow_all_keys ),
+                                                ctxt.get_desc( "CONFIRM", _( "Edit text" ), input_context::allow_all_keys ),
+                                                ctxt.get_desc( "DELETE PAGE", _( "Delete page" ), input_context::allow_all_keys ),
+                                                ctxt.get_desc( "EXPORT_DIARY", _( "Export diary" ), input_context::allow_all_keys )
+                                              );
         center_print( w_desc, 1, c_white, desc );
 
         wnoutrefresh( w_desc );

--- a/src/diary_ui.cpp
+++ b/src/diary_ui.cpp
@@ -80,9 +80,9 @@ void print_list_scrollable( catacurses::window *win, std::string text, int *sele
                             int entries_per_page, int xoffset, int width, bool active, bool border,
                             const report_color_error color_error )
 {
-    int border_space = border ? 1 : 0;
+    int const border_space = border ? 1 : 0;
     // -1 on the left for scroll bar and another -1 on the right reserved for cursor
-    std::vector<std::string> list = foldstring( text, width - 2 - border_space * 2 );
+    std::vector<std::string> const list = foldstring( text, width - 2 - border_space * 2 );
     print_list_scrollable( win, list, selection, entries_per_page, xoffset, width, active, border,
                            color_error );
 }
@@ -163,7 +163,7 @@ static int uis_padding()
 
 void diary::show_diary_ui( diary *c_diary )
 {
-    catacurses::window w_diary;
+    catacurses::window const w_diary;
     catacurses::window w_pages; // pages window, left of diary
     catacurses::window w_text; // right part of diary
     catacurses::window w_changes; // left part of diary
@@ -190,9 +190,9 @@ void diary::show_diary_ui( diary *c_diary )
     ui_adaptor ui_diary;
     ui_diary.on_screen_resize( [&]( ui_adaptor & ui ) {
         const std::pair<point, point> beg_and_max = diary_window_position();
-        point beg = ( uis_padding() != 0 ) ? point( uis_padding() + MAX_DAIRY_UI_WIDTH / 4 - 3,
+        point const beg = ( uis_padding() != 0 ) ? point( uis_padding() + MAX_DAIRY_UI_WIDTH / 4 - 3,
                     beg_and_max.first.y - 1 ) : beg_and_max.first + point( uis_padding() - 3, -1 );
-        point max = point( TERMX - beg.x - 5,
+        point const max = point( TERMX - beg.x - 5,
                            beg_and_max.second.y ) - point( uis_padding(), 0 );
         const int midx = max.x / 2;
 
@@ -228,8 +228,8 @@ void diary::show_diary_ui( diary *c_diary )
     ui_adaptor ui_pages;
     ui_pages.on_screen_resize( [&]( ui_adaptor & ui ) {
         const std::pair<point, point> beg_and_max = diary_window_position();
-        point beg = beg_and_max.first;
-        point max = beg_and_max.second;
+        point const beg = beg_and_max.first;
+        point const max = beg_and_max.second;
 
         w_pages = catacurses::newwin( max.y + 5,
                                       ( uis_padding() != 0 ) ? MAX_DAIRY_UI_WIDTH / 4 - 7 : beg.x - 7, point( uis_padding(),
@@ -252,7 +252,7 @@ void diary::show_diary_ui( diary *c_diary )
     ui_adaptor ui_desc;
     ui_desc.on_screen_resize( [&]( ui_adaptor & ui ) {
         const std::pair<point, point> beg_and_max = diary_window_position();
-        point beg = beg_and_max.first;
+        point const beg = beg_and_max.first;
 
         w_desc = catacurses::newwin( 3, TERMX - uis_padding() * 2, point( uis_padding(), beg.y - 6 ) );
 
@@ -264,7 +264,7 @@ void diary::show_diary_ui( diary *c_diary )
 
         draw_border( w_desc );
         center_print( w_desc, 0, c_light_gray, string_format( _( "%s's Diary" ), c_diary->owner ) );
-        std::string desc = string_format( _( "%s, %s, %s, %s" ),
+        std::string const desc = string_format( _( "%s, %s, %s, %s" ),
                                           ctxt.get_desc( "NEW_PAGE", _( "New page" ), input_context::allow_all_keys ),
                                           ctxt.get_desc( "CONFIRM", _( "Edit text" ), input_context::allow_all_keys ),
                                           ctxt.get_desc( "DELETE PAGE", _( "Delete page" ), input_context::allow_all_keys ),
@@ -278,8 +278,8 @@ void diary::show_diary_ui( diary *c_diary )
     ui_adaptor ui_info;
     ui_info.on_screen_resize( [&]( ui_adaptor & ui ) {
         const std::pair<point, point> beg_and_max = diary_window_position();
-        point beg = beg_and_max.first;
-        point max = beg_and_max.second;
+        point const beg = beg_and_max.first;
+        point const max = beg_and_max.second;
 
         w_info = catacurses::newwin( ( TERMY - beg.y - max.y - 2 ) > 7 ? 7 : TERMY - beg.y - max.y - 2,
                                      TERMX - uis_padding() * 2, point( uis_padding(), beg.y + max.y + 2 ) );

--- a/src/distraction_manager.cpp
+++ b/src/distraction_manager.cpp
@@ -216,7 +216,7 @@ void distraction_manager_gui::load()
     }
 
     std::ifstream distr;
-    std::string file = PATH_INFO::distraction();
+    std::string const file = PATH_INFO::distraction();
 
     distr.open( file.c_str(), std::ifstream::in | std::ifstream::binary );
 
@@ -252,7 +252,7 @@ void distraction_manager_gui::deserialize( JsonIn &jsin )
 {
     jsin.start_array();
     while( !jsin.end_array() ) {
-        JsonObject jo = jsin.get_object();
+        JsonObject const jo = jsin.get_object();
 
         if( !jo.has_string( "Distraction Type" ) ) {
             continue;

--- a/src/distribution_grid.cpp
+++ b/src/distribution_grid.cpp
@@ -76,7 +76,7 @@ int distribution_grid::mod_resource( int amt, bool recurse )
         for( const tile_location &loc : c.second ) {
             battery_tile *battery = active_tiles::furn_at<battery_tile>( loc.absolute );
             if( battery != nullptr ) {
-                int amt_before_battery = amt;
+                int const amt_before_battery = amt;
                 amt = battery->mod_resource( amt );
                 if( cached_amount_here ) {
                     cached_amount_here = *cached_amount_here + amt_before_battery - amt;
@@ -190,13 +190,13 @@ distribution_grid &distribution_grid_tracker::make_distribution_grid_at(
     assert( !overmap_positions.empty() );
     std::vector<tripoint_abs_sm> submap_positions;
     for( const tripoint_abs_omt &omp : overmap_positions ) {
-        tripoint_abs_sm tp = project_to<coords::sm>( omp );
+        tripoint_abs_sm const tp = project_to<coords::sm>( omp );
         submap_positions.emplace_back( tp + point_zero );
         submap_positions.emplace_back( tp + point_east );
         submap_positions.emplace_back( tp + point_south );
         submap_positions.emplace_back( tp + point_south_east );
     }
-    shared_ptr_fast<distribution_grid> dist_grid = make_shared_fast<distribution_grid>
+    shared_ptr_fast<distribution_grid> const dist_grid = make_shared_fast<distribution_grid>
             ( submap_positions, mb );
     for( const tripoint_abs_sm &smp : submap_positions ) {
         shared_ptr_fast<distribution_grid> &old_grid = parent_distribution_grids[smp];
@@ -225,9 +225,9 @@ void distribution_grid_tracker::on_saved()
         world_generator->active_world == nullptr ) {
         return;
     }
-    tripoint_abs_sm min_bounds( bounds.p_min, -OVERMAP_DEPTH );
-    tripoint_abs_sm max_bounds( bounds.p_max, OVERMAP_HEIGHT );
-    tripoint_range<tripoint_abs_sm> bounds_range( min_bounds, max_bounds );
+    tripoint_abs_sm const min_bounds( bounds.p_min, -OVERMAP_DEPTH );
+    tripoint_abs_sm const max_bounds( bounds.p_max, OVERMAP_HEIGHT );
+    tripoint_range<tripoint_abs_sm> const bounds_range( min_bounds, max_bounds );
     // Remove all grids that are no longer in the bounds
     for( auto iter = parent_distribution_grids.begin(); iter != parent_distribution_grids.end(); ) {
         if( !bounds_range.is_point_inside( iter->first ) ) {
@@ -246,7 +246,7 @@ void distribution_grid_tracker::on_saved()
 
 void distribution_grid_tracker::on_changed( const tripoint_abs_ms &p )
 {
-    tripoint_abs_sm sm_pos = project_to<coords::sm>( p );
+    tripoint_abs_sm const sm_pos = project_to<coords::sm>( p );
     // TODO: If not in bounds, just drop the grid, rebuild lazily
     if( parent_distribution_grids.count( sm_pos ) > 0 ||
         bounds.contains( sm_pos.xy() ) ) {
@@ -262,7 +262,7 @@ void distribution_grid_tracker::on_options_changed()
 
 distribution_grid &distribution_grid_tracker::grid_at( const tripoint_abs_ms &p )
 {
-    tripoint_abs_sm sm_pos = project_to<coords::sm>( p );
+    tripoint_abs_sm const sm_pos = project_to<coords::sm>( p );
     auto iter = parent_distribution_grids.find( sm_pos );
     if( iter != parent_distribution_grids.end() ) {
         return *iter->second;
@@ -280,7 +280,7 @@ const distribution_grid &distribution_grid_tracker::grid_at( const tripoint_abs_
 
 std::uintptr_t distribution_grid_tracker::debug_grid_id( const tripoint_abs_omt &omp ) const
 {
-    tripoint_abs_sm sm_pos = project_to<coords::sm>( omp );
+    tripoint_abs_sm const sm_pos = project_to<coords::sm>( omp );
     auto iter = parent_distribution_grids.find( sm_pos );
     if( iter != parent_distribution_grids.end() ) {
         distribution_grid *ret = iter->second.get();
@@ -362,7 +362,7 @@ void distribution_grid_tracker::load( half_open_rectangle<point_abs_sm> area )
 
 void distribution_grid_tracker::load( const map &m )
 {
-    point_abs_sm p_min( m.get_abs_sub().xy() );
-    point_abs_sm p_max( p_min + point( m.getmapsize(), m.getmapsize() ) );
+    point_abs_sm const p_min( m.get_abs_sub().xy() );
+    point_abs_sm const p_max( p_min + point( m.getmapsize(), m.getmapsize() ) );
     load( half_open_rectangle<point_abs_sm>( p_min, p_max ) );
 }

--- a/src/drawing_primitives.cpp
+++ b/src/drawing_primitives.cpp
@@ -11,7 +11,7 @@
 
 void draw_line( std::function<void( point )>set, point p1, point p2 )
 {
-    std::vector<point> line = line_to( p1, p2, 0 );
+    std::vector<point> const line = line_to( p1, p2, 0 );
     for( auto &i : line ) {
         set( i );
     }

--- a/src/drop_token.cpp
+++ b/src/drop_token.cpp
@@ -16,7 +16,7 @@ void item_drop_token::serialize( JsonOut &jsout ) const
 
 void item_drop_token::deserialize( JsonIn &jsin )
 {
-    JsonObject jo = jsin.get_object();
+    JsonObject const jo = jsin.get_object();
     jo.read( "turn", turn );
     jo.read( "drop_number", drop_number );
     jo.read( "parent_number", parent_number );
@@ -52,7 +52,7 @@ void drop_token_provider::serialize( JsonOut &jsout ) const
 
 void drop_token_provider::deserialize( JsonIn &jsin )
 {
-    JsonObject jo = jsin.get_object();
+    JsonObject const jo = jsin.get_object();
     jo.read( "last_turn", last_turn );
     jo.read( "last_drop", last_drop );
 }

--- a/src/dump.cpp
+++ b/src/dump.cpp
@@ -116,7 +116,7 @@ bool game::dump_stats( const std::string &what, dump_mode mode,
             rows.push_back( r );
         };
 
-        body_part bp = opts.empty() ? num_bp : get_body_part_token( opts.front() );
+        body_part const bp = opts.empty() ? num_bp : get_body_part_token( opts.front() );
 
         for( const itype *e : item_controller->all() ) {
             if( e->armor ) {
@@ -154,7 +154,7 @@ bool game::dump_stats( const std::string &what, dump_mode mode,
         };
 
         for( const itype *e : item_controller->all() ) {
-            item food( e, calendar::turn, item::solitary_tag {} );
+            item const food( e, calendar::turn, item::solitary_tag {} );
 
             if( food.is_food() && g->u.can_eat( food ).success() ) {
                 dump( food );
@@ -279,8 +279,8 @@ bool game::dump_stats( const std::string &what, dump_mode mode,
             "Aerodynamics coeff", "Rolling coeff", "Static Drag", "Offroad %"
         };
         auto dump = [&rows]( const vproto_id & obj ) {
-            vehicle veh_empty( obj, 0, 0 );
-            vehicle veh_fueled( obj, 100, 0 );
+            vehicle const veh_empty( obj, 0, 0 );
+            vehicle const veh_fueled( obj, 100, 0 );
 
             std::vector<std::string> r;
             r.push_back( veh_empty.name );
@@ -308,7 +308,7 @@ bool game::dump_stats( const std::string &what, dump_mode mode,
             std::vector<std::string> r;
             r.push_back( obj.name() );
             r.push_back( obj.location );
-            int w = std::ceil( to_gram( item( obj.item ).weight() ) / 1000.0 );
+            int const w = std::ceil( to_gram( item( obj.item ).weight() ) / 1000.0 );
             r.push_back( std::to_string( w ) );
             r.push_back( std::to_string( obj.size / units::legacy_volume_factor ) );
             rows.push_back( r );

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -109,7 +109,7 @@ void edit_json( SAVEOBJ &it )
 {
     int tmret = -1;
     std::string save1 = serialize( it );
-    std::string osave1 = save1;
+    std::string const osave1 = save1;
     std::vector<std::string> fs1 = fld_string( save1, TERMX - 10 );
     do {
         uilist tm;
@@ -125,7 +125,7 @@ void edit_json( SAVEOBJ &it )
             } catch( const std::exception &err ) {
                 popup( "Error on deserialization: %s", err.what() );
             }
-            std::string save2 = serialize( it );
+            std::string const save2 = serialize( it );
             std::vector<std::string> fs2 = fld_string( save2, TERMX - 10 );
 
             tm.addentry( -1, false, -2, "== Reloaded: =====================" );
@@ -141,7 +141,7 @@ void edit_json( SAVEOBJ &it )
             fs2.clear();
         } else if( tmret == 1 ) {
             string_input_popup popup;
-            std::string ret = popup
+            std::string const ret = popup
                               .text( save1 )
                               .query_string();
             if( popup.confirmed() ) {
@@ -231,7 +231,7 @@ void editmap_hilight::draw( editmap &em, bool update )
                 }
                 const field &t_field = here.field_at( p );
                 if( t_field.field_count() > 0 ) {
-                    field_type_id t_ftype = t_field.displayed_field_type();
+                    field_type_id const t_ftype = t_field.displayed_field_type();
                     const field_entry *t_fld = t_field.find_field( t_ftype );
                     if( t_fld != nullptr ) {
                         t_col = t_fld->color();
@@ -241,7 +241,7 @@ void editmap_hilight::draw( editmap &em, bool update )
                 if( blink_interval[ cur_blink ] ) {
                     t_col = getbg( t_col );
                 }
-                tripoint scrpos = em.pos2screen( p );
+                tripoint const scrpos = em.pos2screen( p );
                 mvwputch( g->w_terrain, scrpos.xy(), t_col, t_sym );
             }
         }
@@ -339,7 +339,7 @@ shared_ptr_fast<ui_adaptor> editmap::create_or_get_ui_adaptor()
 
 std::optional<tripoint> editmap::edit()
 {
-    restore_on_out_of_scope<tripoint> view_offset_prev( g->u.view_offset );
+    restore_on_out_of_scope<tripoint> const view_offset_prev( g->u.view_offset );
     target = g->u.pos() + g->u.view_offset;
     input_context ctxt( "EDITMAP" );
     ctxt.set_iso( true );
@@ -367,13 +367,13 @@ std::optional<tripoint> editmap::edit()
     uberdraw = uistate.editmap_nsa_viewmode;
     blink = true;
 
-    shared_ptr_fast<game::draw_callback_t> editmap_cb = draw_cb_container().create_or_get();
-    shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
-    on_out_of_scope invalidate_current_ui( [this]() {
+    shared_ptr_fast<game::draw_callback_t> const editmap_cb = draw_cb_container().create_or_get();
+    shared_ptr_fast<ui_adaptor> const current_ui = create_or_get_ui_adaptor();
+    on_out_of_scope const invalidate_current_ui( [this]() {
         do_ui_invalidation();
     } );
-    restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
-    restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
+    restore_on_out_of_scope<std::string> const info_txt_prev( info_txt_curr );
+    restore_on_out_of_scope<std::string> const info_title_prev( info_title_curr );
 
     do {
         if( target_list.empty() ) {
@@ -448,9 +448,9 @@ std::optional<tripoint> editmap::edit()
 
 void editmap::uber_draw_ter( const catacurses::window &w, map *m )
 {
-    tripoint center = target;
-    tripoint start = center.xy() + tripoint( -getmaxx( w ) / 2, -getmaxy( w ) / 2, target.z );
-    tripoint end = center.xy() + tripoint( getmaxx( w ) / 2, getmaxy( w ) / 2, target.z );
+    tripoint const center = target;
+    tripoint const start = center.xy() + tripoint( -getmaxx( w ) / 2, -getmaxy( w ) / 2, target.z );
+    tripoint const end = center.xy() + tripoint( getmaxx( w ) / 2, getmaxy( w ) / 2, target.z );
     /*
         // pending filter options
         bool draw_furn=true;
@@ -459,14 +459,14 @@ void editmap::uber_draw_ter( const catacurses::window &w, map *m )
         bool draw_fld=true;
         bool draw_veh=true;
     */
-    bool game_map = m == &get_map() || w == g->w_terrain;
+    bool const game_map = m == &get_map() || w == g->w_terrain;
     const int msize = MAPSIZE_X;
     if( refresh_mplans ) {
         hilights["mplan"].points.clear();
     }
-    drawsq_params params = drawsq_params().center( center );
+    drawsq_params const params = drawsq_params().center( center );
     for( const tripoint &p : tripoint_range<tripoint>( start, end ) ) {
-        int sym = game_map ? '%' : ' ';
+        int const sym = game_map ? '%' : ' ';
         if( p.x >= 0 && p.x < msize && p.y >= 0 && p.y < msize ) {
             if( game_map ) {
                 Creature *critter = g->critter_at( p );
@@ -573,7 +573,7 @@ void editmap::draw_main_ui_overlay()
                     }
                     const field &t_field = here.field_at( p );
                     if( t_field.field_count() > 0 ) {
-                        field_type_id t_ftype = t_field.displayed_field_type();
+                        field_type_id const t_ftype = t_field.displayed_field_type();
                         const field_entry *t_fld = t_field.find_field( t_ftype );
                         if( t_fld != nullptr ) {
                             t_col = t_fld->color();
@@ -581,7 +581,7 @@ void editmap::draw_main_ui_overlay()
                         }
                     }
                     t_col = altblink ? green_background( t_col ) : cyan_background( t_col );
-                    tripoint scrpos = pos2screen( p );
+                    tripoint const scrpos = pos2screen( p );
                     mvwputch( g->w_terrain, scrpos.xy(), t_col, t_sym );
                 }
 #ifdef TILES
@@ -643,8 +643,8 @@ void editmap::draw_main_ui_overlay()
                         char part_mod = 0;
                         const vpart_id &vp_id = veh.part_id_string( veh_part, false, part_mod );
                         const std::optional<vpart_reference> cargopart = vp.part_with_feature( "CARGO", true );
-                        bool draw_highlight = cargopart && !veh.get_items( cargopart->part_index() ).empty();
-                        units::angle veh_dir = veh.face.dir();
+                        bool const draw_highlight = cargopart && !veh.get_items( cargopart->part_index() ).empty();
+                        units::angle const veh_dir = veh.face.dir();
                         g->draw_vpart_override( map_p, vp_id, part_mod, veh_dir, draw_highlight, vp->mount() );
                     } else {
                         g->draw_vpart_override( map_p, vpart_id::NULL_ID(), 0, 0_degrees, false,
@@ -682,7 +682,7 @@ void editmap::draw_main_ui_overlay()
 #endif
             hilights["mapgentgt"].draw( *this, true );
             tmpmap.reset_vehicle_cache( );
-            drawsq_params params = drawsq_params().center( tripoint( SEEX - 1, SEEY - 1, target.z ) );
+            drawsq_params const params = drawsq_params().center( tripoint( SEEX - 1, SEEY - 1, target.z ) );
             for( const tripoint &p : tmpmap.points_on_zlevel() ) {
                 tmpmap.drawsq( g->w_terrain, p, params );
             }
@@ -697,7 +697,7 @@ void editmap::update_view_with_help( const std::string &txt, const std::string &
     // updating info
     werase( w_info );
 
-    Character &player_character = get_player_character();
+    Character  const&player_character = get_player_character();
     map &here = get_map();
 
     const optional_vpart_position vp = here.veh_at( target );
@@ -747,8 +747,8 @@ void editmap::update_view_with_help( const std::string &txt, const std::string &
                map_cache.seen_cache[target.x][target.y],
                map_cache.camera_cache[target.x][target.y]
              );
-    map::apparent_light_info al = map::apparent_light_helper( map_cache, target );
-    int apparent_light = static_cast<int>(
+    map::apparent_light_info const al = map::apparent_light_helper( map_cache, target );
+    int const apparent_light = static_cast<int>(
                              here.apparent_light_at( target, here.get_visibility_variables_cache() ) );
     mvwprintw( w_info, point( 1, off++ ), _( "outside: %d obstructed: %d floor: %d" ),
                static_cast<int>( here.is_outside( target ) ),
@@ -1121,13 +1121,13 @@ void editmap::edit_feature()
     int current_feature = emenu.selected = feature<T_id>( target ).to_i();
     emenu.entries[current_feature].text_color = c_green;
 
-    shared_ptr_fast<game::draw_callback_t> editmap_cb = draw_cb_container().create_or_get();
-    shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
-    on_out_of_scope invalidate_current_ui( [this]() {
+    shared_ptr_fast<game::draw_callback_t> const editmap_cb = draw_cb_container().create_or_get();
+    shared_ptr_fast<ui_adaptor> const current_ui = create_or_get_ui_adaptor();
+    on_out_of_scope const invalidate_current_ui( [this]() {
         do_ui_invalidation();
     } );
-    restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
-    restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
+    restore_on_out_of_scope<std::string> const info_txt_prev( info_txt_curr );
+    restore_on_out_of_scope<std::string> const info_title_prev( info_title_curr );
 
     blink = true;
     bool quit = false;
@@ -1141,7 +1141,7 @@ void editmap::edit_feature()
             draw_target_override = nullptr;
         }
 
-        input_context ctxt( emenu.input_category );
+        input_context const ctxt( emenu.input_category );
         info_txt_curr = string_format( pgettext( "keybinding descriptions", "%s, %s, %s, %s, %s" ),
                                        ctxt.describe_key_and_name( "CONFIRM" ),
                                        ctxt.describe_key_and_name( "CONFIRM_QUIT" ),
@@ -1238,13 +1238,13 @@ void editmap::edit_fld()
     };
     fmenu.allow_additional = true;
 
-    shared_ptr_fast<game::draw_callback_t> editmap_cb = draw_cb_container().create_or_get();
-    shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
-    on_out_of_scope invalidate_current_ui( [this]() {
+    shared_ptr_fast<game::draw_callback_t> const editmap_cb = draw_cb_container().create_or_get();
+    shared_ptr_fast<ui_adaptor> const current_ui = create_or_get_ui_adaptor();
+    on_out_of_scope const invalidate_current_ui( [this]() {
         do_ui_invalidation();
     } );
-    restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
-    restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
+    restore_on_out_of_scope<std::string> const info_txt_prev( info_txt_curr );
+    restore_on_out_of_scope<std::string> const info_title_prev( info_title_curr );
     map &here = get_map();
 
     blink = true;
@@ -1258,7 +1258,7 @@ void editmap::edit_fld()
             draw_target_override = nullptr;
         }
 
-        input_context ctxt( fmenu.input_category );
+        input_context const ctxt( fmenu.input_category );
         // \u00A0 is the non-breaking space
         info_txt_curr = string_format( pgettext( "keybinding descriptions",
                                        "%s, %s, [%s,%s]\u00A0intensity, %s, %s, %s" ),
@@ -1284,7 +1284,7 @@ void editmap::edit_fld()
             const field_type &ftype = idx.obj();
             int fsel_intensity = field_intensity;
             if( fmenu.ret > 0 ) {
-                shared_ptr_fast<ui_adaptor> fmenu_ui = fmenu.create_or_get_ui_adaptor();
+                shared_ptr_fast<ui_adaptor> const fmenu_ui = fmenu.create_or_get_ui_adaptor();
 
                 uilist femenu;
                 femenu.w_width_setup = width;
@@ -1356,15 +1356,15 @@ void editmap::edit_fld()
             sel_field_intensity = 0;
         } else if( fmenu.ret == UILIST_ADDITIONAL ) {
             if( fmenu.ret_act == "EDITMAP_TAB" ) {
-                int sel_tmp = fmenu.selected;
-                int ret = select_shape( editshape, 0 );
+                int const sel_tmp = fmenu.selected;
+                int const ret = select_shape( editshape, 0 );
                 if( ret > 0 ) {
                     setup_fmenu( fmenu );
                 }
                 fmenu.selected = sel_tmp;
             } else if( fmenu.ret_act == "EDITMAP_MOVE" ) {
-                int sel_tmp = fmenu.selected;
-                int ret = select_shape( editshape, 1 );
+                int const sel_tmp = fmenu.selected;
+                int const ret = select_shape( editshape, 1 );
                 if( ret > 0 ) {
                     setup_fmenu( fmenu );
                 }
@@ -1411,15 +1411,15 @@ void editmap::edit_itm()
     };
     ilmenu.allow_additional = true;
 
-    shared_ptr_fast<game::draw_callback_t> editmap_cb = draw_cb_container().create_or_get();
-    shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
-    on_out_of_scope invalidate_current_ui( [this]() {
+    shared_ptr_fast<game::draw_callback_t> const editmap_cb = draw_cb_container().create_or_get();
+    shared_ptr_fast<ui_adaptor> const current_ui = create_or_get_ui_adaptor();
+    on_out_of_scope const invalidate_current_ui( [this]() {
         do_ui_invalidation();
     } );
-    restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
-    restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
+    restore_on_out_of_scope<std::string> const info_txt_prev( info_txt_curr );
+    restore_on_out_of_scope<std::string> const info_title_prev( info_title_curr );
 
-    shared_ptr_fast<ui_adaptor> ilmenu_ui = ilmenu.create_or_get_ui_adaptor();
+    shared_ptr_fast<ui_adaptor> const ilmenu_ui = ilmenu.create_or_get_ui_adaptor();
 
     do {
         info_txt_curr.clear();
@@ -1454,7 +1454,7 @@ void editmap::edit_itm()
             };
             imenu.allow_additional = true;
 
-            shared_ptr_fast<ui_adaptor> imenu_ui = imenu.create_or_get_ui_adaptor();
+            shared_ptr_fast<ui_adaptor> const imenu_ui = imenu.create_or_get_ui_adaptor();
 
             do {
                 imenu.query();
@@ -1472,7 +1472,7 @@ void editmap::edit_itm()
                             break;
                     }
                     string_input_popup popup;
-                    int retval = popup
+                    int const retval = popup
                                  .title( "set:" )
                                  .width( 20 )
                                  .text( std::to_string( intval ) )
@@ -1537,8 +1537,8 @@ void editmap::recalc_target( shapetype shape )
     target_list.clear();
     switch( shape ) {
         case editmap_circle: {
-            int radius = rl_dist( origin, target );
-            map &here = get_map();
+            int const radius = rl_dist( origin, target );
+            map  const&here = get_map();
             for( const tripoint &p : here.points_in_radius( origin, radius ) ) {
                 if( rl_dist( p, origin ) <= radius ) {
                     if( editmap_boundaries.contains( p ) ) {
@@ -1608,7 +1608,7 @@ static int limited_shift( int var, int &shift, int min, int max )
 bool editmap::move_target( const std::string &action, int moveorigin )
 {
     tripoint mp;
-    bool move_origin = moveorigin == 1 ? true :
+    bool const move_origin = moveorigin == 1 ? true :
                        moveorigin == 0 ? false : moveall;
     if( eget_direction( mp, action ) ) {
         target.x = limited_shift( target.x, mp.x, 0, MAPSIZE_X );
@@ -1627,9 +1627,9 @@ bool editmap::move_target( const std::string &action, int moveorigin )
  */
 int editmap::select_shape( shapetype shape, int mode )
 {
-    tripoint orig = target;
-    tripoint origor = origin;
-    shapetype origshape = editshape;
+    tripoint const orig = target;
+    tripoint const origor = origin;
+    shapetype const origshape = editshape;
     editshape = shape;
     input_context ctxt( "EDITMAP_SHAPE" );
     ctxt.set_iso( true );
@@ -1658,13 +1658,13 @@ int editmap::select_shape( shapetype shape, int mode )
     }
     altblink = moveall;
 
-    shared_ptr_fast<game::draw_callback_t> editmap_cb = draw_cb_container().create_or_get();
-    shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
-    on_out_of_scope invalidate_current_ui( [this]() {
+    shared_ptr_fast<game::draw_callback_t> const editmap_cb = draw_cb_container().create_or_get();
+    shared_ptr_fast<ui_adaptor> const current_ui = create_or_get_ui_adaptor();
+    on_out_of_scope const invalidate_current_ui( [this]() {
         do_ui_invalidation();
     } );
-    restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
-    restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
+    restore_on_out_of_scope<std::string> const info_txt_prev( info_txt_curr );
+    restore_on_out_of_scope<std::string> const info_title_prev( info_title_curr );
 
     do {
         if( moveall ) {
@@ -1707,11 +1707,11 @@ int editmap::select_shape( shapetype shape, int mode )
                 };
                 smenu.allow_additional = true;
 
-                on_out_of_scope invalidate_current_ui_2( [this]() {
+                on_out_of_scope const invalidate_current_ui_2( [this]() {
                     do_ui_invalidation();
                 } );
-                restore_on_out_of_scope<std::string> info_txt_prev_2( info_txt_curr );
-                restore_on_out_of_scope<std::string> info_title_prev_2( info_title_curr );
+                restore_on_out_of_scope<std::string> const info_txt_prev_2( info_txt_curr );
+                restore_on_out_of_scope<std::string> const info_title_prev_2( info_title_curr );
 
                 do {
                     info_txt_curr.clear();
@@ -1738,7 +1738,7 @@ int editmap::select_shape( shapetype shape, int mode )
             target = origin;
             update = true;
         } else if( action == "SWAP" ) {
-            tripoint tmporigin = origin;
+            tripoint const tmporigin = origin;
             origin = target;
             target = tmporigin;
             update = true;
@@ -1825,14 +1825,14 @@ void editmap::mapgen_preview( const real_coords &tc, uilist &gmenu )
     };
     gpmenu.allow_additional = true;
 
-    shared_ptr_fast<game::draw_callback_t> editmap_cb = draw_cb_container().create_or_get();
-    shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
-    on_out_of_scope invalidate_current_ui( [this]() {
+    shared_ptr_fast<game::draw_callback_t> const editmap_cb = draw_cb_container().create_or_get();
+    shared_ptr_fast<ui_adaptor> const current_ui = create_or_get_ui_adaptor();
+    on_out_of_scope const invalidate_current_ui( [this]() {
         do_ui_invalidation();
     } );
-    restore_on_out_of_scope<tinymap *> tinymap_ptr_prev( tmpmap_ptr );
-    restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
-    restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
+    restore_on_out_of_scope<tinymap *> const tinymap_ptr_prev( tmpmap_ptr );
+    restore_on_out_of_scope<std::string> const info_txt_prev( info_txt_curr );
+    restore_on_out_of_scope<std::string> const info_title_prev( info_title_curr );
     map &here = get_map();
 
     int lastsel = gmenu.selected;
@@ -1853,7 +1853,7 @@ void editmap::mapgen_preview( const real_coords &tc, uilist &gmenu )
         } else {
             tmpmap_ptr = nullptr;
         }
-        input_context ctxt( gpmenu.input_category );
+        input_context const ctxt( gpmenu.input_category );
         // \u00A0 is the non-breaking space
         info_txt_curr = string_format( pgettext( "keybinding descriptions",
                                        "[%s,%s]\u00A0prev/next oter type, [%s,%s]\u00A0select, %s, %s" ),
@@ -1990,7 +1990,7 @@ bool editmap::mapgen_veh_destroy( const tripoint_abs_omt &omt_tgt, vehicle *car_
             submap *destsm = target_bay.get_submap_at_grid( { x, y, target.z } );
             for( auto &z : destsm->vehicles ) {
                 if( z.get() == car_target ) {
-                    std::unique_ptr<vehicle> old_veh = target_bay.detach_vehicle( z.get() );
+                    std::unique_ptr<vehicle> const old_veh = target_bay.detach_vehicle( z.get() );
                     here.reset_vehicle_cache( );
                     here.clear_vehicle_list( omt_tgt.z() );
                     //Rebuild vehicle_list?
@@ -2016,15 +2016,15 @@ void editmap::mapgen_retarget()
     // Needed for timeout to be useful
     ctxt.register_action( "ANY_INPUT" );
     std::string action;
-    tripoint origm = target;
+    tripoint const origm = target;
 
-    shared_ptr_fast<game::draw_callback_t> editmap_cb = draw_cb_container().create_or_get();
-    shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
-    on_out_of_scope invalidate_current_ui( [this]() {
+    shared_ptr_fast<game::draw_callback_t> const editmap_cb = draw_cb_container().create_or_get();
+    shared_ptr_fast<ui_adaptor> const current_ui = create_or_get_ui_adaptor();
+    on_out_of_scope const invalidate_current_ui( [this]() {
         do_ui_invalidation();
     } );
-    restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
-    restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
+    restore_on_out_of_scope<std::string> const info_txt_prev( info_txt_curr );
+    restore_on_out_of_scope<std::string> const info_title_prev( info_title_curr );
 
     blink = true;
     do {
@@ -2037,8 +2037,8 @@ void editmap::mapgen_retarget()
         ui_manager::redraw();
         action = ctxt.handle_input( get_option<int>( "BLINK_SPEED" ) );
         if( const std::optional<tripoint> vec = ctxt.get_direction( action ) ) {
-            point vec_ms = omt_to_ms_copy( vec->xy() );
-            tripoint ptarget = target + vec_ms;
+            point const vec_ms = omt_to_ms_copy( vec->xy() );
+            tripoint const ptarget = target + vec_ms;
             if( editmap_boundaries.contains( ptarget ) &&
                 editmap_boundaries.contains( ptarget + point( SEEX, SEEY ) ) ) {
                 target = ptarget;
@@ -2091,19 +2091,19 @@ void editmap::edit_mapgen()
     }
     real_coords tc;
 
-    shared_ptr_fast<game::draw_callback_t> editmap_cb = draw_cb_container().create_or_get();
-    shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
-    on_out_of_scope invalidate_current_ui( [this]() {
+    shared_ptr_fast<game::draw_callback_t> const editmap_cb = draw_cb_container().create_or_get();
+    shared_ptr_fast<ui_adaptor> const current_ui = create_or_get_ui_adaptor();
+    on_out_of_scope const invalidate_current_ui( [this]() {
         do_ui_invalidation();
     } );
-    restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
-    restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
-    map &here = get_map();
+    restore_on_out_of_scope<std::string> const info_txt_prev( info_txt_curr );
+    restore_on_out_of_scope<std::string> const info_title_prev( info_title_curr );
+    map  const&here = get_map();
 
     do {
         tc.fromabs( here.getabs( target.xy() ) );
-        point omt_lpos = here.getlocal( tc.begin_om_pos() );
-        tripoint om_ltarget = omt_lpos + tripoint( -1 + SEEX, -1 + SEEY, target.z );
+        point const omt_lpos = here.getlocal( tc.begin_om_pos() );
+        tripoint const om_ltarget = omt_lpos + tripoint( -1 + SEEX, -1 + SEEY, target.z );
 
         if( target.x != om_ltarget.x || target.y != om_ltarget.y ) {
             target = om_ltarget;
@@ -2121,7 +2121,7 @@ void editmap::edit_mapgen()
 
         blink = true;
 
-        input_context ctxt( gmenu.input_category );
+        input_context const ctxt( gmenu.input_category );
         info_txt_curr = string_format( pgettext( "keybinding descriptions", "%s, %s, %s" ),
                                        ctxt.describe_key_and_name( "EDITMAP_MOVE" ),
                                        ctxt.describe_key_and_name( "CONFIRM" ),
@@ -2133,7 +2133,7 @@ void editmap::edit_mapgen()
 
         if( gmenu.ret >= 0 ) {
             blink = false;
-            shared_ptr_fast<ui_adaptor> gmenu_ui = gmenu.create_or_get_ui_adaptor();
+            shared_ptr_fast<ui_adaptor> const gmenu_ui = gmenu.create_or_get_ui_adaptor();
             mapgen_preview( tc, gmenu );
             blink = true;
         } else if( gmenu.ret == UILIST_ADDITIONAL ) {

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -142,8 +142,8 @@ void edit_json( SAVEOBJ &it )
         } else if( tmret == 1 ) {
             string_input_popup popup;
             std::string const ret = popup
-                              .text( save1 )
-                              .query_string();
+                                    .text( save1 )
+                                    .query_string();
             if( popup.confirmed() ) {
                 fs1 = fld_string( ret, TERMX - 10 );
                 save1 = ret;
@@ -697,7 +697,7 @@ void editmap::update_view_with_help( const std::string &txt, const std::string &
     // updating info
     werase( w_info );
 
-    Character  const&player_character = get_player_character();
+    Character  const &player_character = get_player_character();
     map &here = get_map();
 
     const optional_vpart_position vp = here.veh_at( target );
@@ -749,7 +749,7 @@ void editmap::update_view_with_help( const std::string &txt, const std::string &
              );
     map::apparent_light_info const al = map::apparent_light_helper( map_cache, target );
     int const apparent_light = static_cast<int>(
-                             here.apparent_light_at( target, here.get_visibility_variables_cache() ) );
+                                   here.apparent_light_at( target, here.get_visibility_variables_cache() ) );
     mvwprintw( w_info, point( 1, off++ ), _( "outside: %d obstructed: %d floor: %d" ),
                static_cast<int>( here.is_outside( target ) ),
                static_cast<int>( al.obstructed ),
@@ -1473,10 +1473,10 @@ void editmap::edit_itm()
                     }
                     string_input_popup popup;
                     int const retval = popup
-                                 .title( "set:" )
-                                 .width( 20 )
-                                 .text( std::to_string( intval ) )
-                                 .query_int();
+                                       .title( "set:" )
+                                       .width( 20 )
+                                       .text( std::to_string( intval ) )
+                                       .query_int();
                     if( popup.confirmed() ) {
                         switch( imenu.ret ) {
                             case imenu_bday:
@@ -1538,7 +1538,7 @@ void editmap::recalc_target( shapetype shape )
     switch( shape ) {
         case editmap_circle: {
             int const radius = rl_dist( origin, target );
-            map  const&here = get_map();
+            map  const &here = get_map();
             for( const tripoint &p : here.points_in_radius( origin, radius ) ) {
                 if( rl_dist( p, origin ) <= radius ) {
                     if( editmap_boundaries.contains( p ) ) {
@@ -1609,7 +1609,7 @@ bool editmap::move_target( const std::string &action, int moveorigin )
 {
     tripoint mp;
     bool const move_origin = moveorigin == 1 ? true :
-                       moveorigin == 0 ? false : moveall;
+                             moveorigin == 0 ? false : moveall;
     if( eget_direction( mp, action ) ) {
         target.x = limited_shift( target.x, mp.x, 0, MAPSIZE_X );
         target.y = limited_shift( target.y, mp.y, 0, MAPSIZE_Y );
@@ -2098,7 +2098,7 @@ void editmap::edit_mapgen()
     } );
     restore_on_out_of_scope<std::string> const info_txt_prev( info_txt_curr );
     restore_on_out_of_scope<std::string> const info_title_prev( info_title_curr );
-    map  const&here = get_map();
+    map  const &here = get_map();
 
     do {
         tc.fromabs( here.getabs( target.xy() ) );

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -974,7 +974,7 @@ int effect::get_avg_mod( std::string arg, bool reduced ) const
 int effect::get_amount( std::string arg, bool reduced ) const
 {
     int const intensity_capped = eff_type->max_effective_intensity > 0 ? std::min(
-                               eff_type->max_effective_intensity, intensity ) : intensity;
+                                     eff_type->max_effective_intensity, intensity ) : intensity;
     auto &mod_data = eff_type->mod_data;
     double ret = 0;
     auto found = mod_data.find( std::make_tuple( "base_mods", reduced, arg, "amount" ) );

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -79,9 +79,9 @@ void weed_msg( player &p )
 {
     const time_duration howhigh = p.get_effect_dur( effect_weed_high );
     ///\EFFECT_INT changes messages when smoking weed
-    int smarts = p.get_int();
+    int const smarts = p.get_int();
     if( howhigh > 12_minutes && one_in( 7 ) ) {
-        int msg = rng( 0, 5 );
+        int const msg = rng( 0, 5 );
         switch( msg ) {
             case 0:
                 // Freakazoid
@@ -140,7 +140,7 @@ void weed_msg( player &p )
                 return;
         }
     } else if( howhigh > 10_minutes && one_in( 5 ) ) {
-        int msg = rng( 0, 5 );
+        int const msg = rng( 0, 5 );
         switch( msg ) {
             case 0:
                 // Bob Marley
@@ -189,7 +189,7 @@ void weed_msg( player &p )
                 return;
         }
     } else if( howhigh > 5_minutes && one_in( 3 ) ) {
-        int msg = rng( 0, 5 );
+        int const msg = rng( 0, 5 );
         switch( msg ) {
             case 0:
                 // Cheech and Chong
@@ -232,7 +232,7 @@ static void extract_effect(
     double val = 0;
     double reduced_val = 0;
     if( j.has_member( mod_type ) ) {
-        JsonArray jsarr = j.get_array( mod_type );
+        JsonArray const jsarr = j.get_array( mod_type );
         val = jsarr.get_float( 0 );
         // If a second value exists use it, else reduced_val = val.
         if( jsarr.size() >= 2 ) {
@@ -253,7 +253,7 @@ static void extract_effect(
 bool effect_type::load_mod_data( const JsonObject &jo, const std::string &member )
 {
     if( jo.has_object( member ) ) {
-        JsonObject j = jo.get_object( member );
+        JsonObject const j = jo.get_object( member );
 
         // Stats first
         //                          json field                  type key    arg key
@@ -506,7 +506,7 @@ morale_type effect_type::get_morale_type() const
 bool effect_type::load_miss_msgs( const JsonObject &jo, const std::string &member )
 {
     if( jo.has_array( member ) ) {
-        for( JsonArray inner : jo.get_array( member ) ) {
+        for( JsonArray const inner : jo.get_array( member ) ) {
             miss_msgs.push_back( std::make_pair( inner.get_string( 0 ), inner.get_int( 1 ) ) );
         }
         return true;
@@ -516,9 +516,9 @@ bool effect_type::load_miss_msgs( const JsonObject &jo, const std::string &membe
 bool effect_type::load_decay_msgs( const JsonObject &jo, const std::string &member )
 {
     if( jo.has_array( member ) ) {
-        for( JsonArray inner : jo.get_array( member ) ) {
-            std::string msg = inner.get_string( 0 );
-            std::string r = inner.get_string( 1 );
+        for( JsonArray const inner : jo.get_array( member ) ) {
+            std::string const msg = inner.get_string( 0 );
+            std::string const r = inner.get_string( 1 );
             game_message_type rate = m_neutral;
             if( r == "good" ) {
                 rate = m_good;
@@ -874,7 +874,7 @@ int effect::set_intensity( int val, bool alert )
                  eff_type->decay_msgs[ val - 1 ].first.c_str() );
     }
 
-    int old_intensity = intensity;
+    int const old_intensity = intensity;
     intensity = val;
     if( old_intensity != intensity ) {
         add_msg( m_debug, "%s intensity %d->%d", get_id().c_str(), old_intensity, intensity );
@@ -973,7 +973,7 @@ int effect::get_avg_mod( std::string arg, bool reduced ) const
 
 int effect::get_amount( std::string arg, bool reduced ) const
 {
-    int intensity_capped = eff_type->max_effective_intensity > 0 ? std::min(
+    int const intensity_capped = eff_type->max_effective_intensity > 0 ? std::min(
                                eff_type->max_effective_intensity, intensity ) : intensity;
     auto &mod_data = eff_type->mod_data;
     double ret = 0;
@@ -1293,7 +1293,7 @@ void load_effect_type( const JsonObject &jo )
     new_etype.part_descs = jo.get_bool( "part_descs", false );
 
     if( jo.has_member( "rating" ) ) {
-        std::string r = jo.get_string( "rating" );
+        std::string const r = jo.get_string( "rating" );
         if( r == "good" ) {
             new_etype.rating = e_good;
         } else if( r == "neutral" ) {
@@ -1375,7 +1375,7 @@ void load_effect_type( const JsonObject &jo )
     new_etype.mod_data.end(), []( decltype( *new_etype.mod_data.begin() ) & pr ) {
         return std::get<2>( pr.first ) == "MORALE";
     } );
-    bool has_morale_effect = morale_effect != new_etype.mod_data.end();
+    bool const has_morale_effect = morale_effect != new_etype.mod_data.end();
     if( new_etype.morale && !has_morale_effect ) {
         jo.throw_error( "Morale type set, but no MORALE base/scaling effect", "morale" );
     } else if( !new_etype.morale && has_morale_effect ) {
@@ -1394,8 +1394,8 @@ void load_effect_type( const JsonObject &jo )
             auto reduced = new_etype.mod_data.find( reduced_tuple );
             auto non_reduced_tuple = std::make_tuple( cur_mod, false, "MORALE", "amount" );
             auto non_reduced = new_etype.mod_data.find( non_reduced_tuple );
-            bool has_reduced = reduced != new_etype.mod_data.end();
-            bool has_non_reduced = non_reduced != new_etype.mod_data.end();
+            bool const has_reduced = reduced != new_etype.mod_data.end();
+            bool const has_non_reduced = non_reduced != new_etype.mod_data.end();
             if( ( has_reduced && has_non_reduced && reduced->second != non_reduced->second )
                 || has_reduced != has_non_reduced ) {
                 jo.throw_error( "MORALE doesn't support different amounts for resisted effects yet",
@@ -1443,7 +1443,7 @@ void effect::serialize( JsonOut &json ) const
 }
 void effect::deserialize( JsonIn &jsin )
 {
-    JsonObject jo = jsin.get_object();
+    JsonObject const jo = jsin.get_object();
     const efftype_id id( jo.get_string( "eff_type" ) );
     eff_type = &id.obj();
     jo.read( "duration", duration );

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -154,7 +154,7 @@ static event::fields_type
 get_fields_helper( event_type type, std::integer_sequence<int, I...> )
 {
     event::fields_type result;
-    bool discard[] = {
+    bool const discard[] = {
         ( get_fields_if_match<static_cast<event_type>( I )>( type, result ), true )...
     };
     ( void ) discard;

--- a/src/event_statistics.cpp
+++ b/src/event_statistics.cpp
@@ -183,7 +183,7 @@ struct value_constraint {
     }
 
     void deserialize( JsonIn &jsin ) {
-        JsonObject jo = jsin.get_object();
+        JsonObject const jo = jsin.get_object();
         int equals_int;
         if( jo.read( "equals", equals_int, false ) ) {
             equals_ = cata_variant::make<cata_variant_type::int_>( equals_int );
@@ -217,7 +217,7 @@ struct value_constraint {
                 return;
             }
 
-            cata_variant_type stat_type = ( *equals_statistic_ )->type();
+            cata_variant_type const stat_type = ( *equals_statistic_ )->type();
             if( stat_type != input_type ) {
                 debugmsg( "constraint for event_transformation %s matches statistic %s of "
                           "different type.  Statistic has type %s but value compared with it has "
@@ -248,7 +248,7 @@ struct new_field {
     std::string input_field;
 
     void deserialize( JsonIn &jsin ) {
-        JsonObject jo = jsin.get_object();
+        JsonObject const jo = jsin.get_object();
         if( jo.size() != 1 ) {
             jo.throw_error( "new field specifications must have exactly one entry" );
         }
@@ -433,7 +433,7 @@ struct event_transformation_impl : public event_transformation::impl {
                                      stats_tracker &stats ) const {
         EventVector result = { input_data };
         for( const std::pair<std::string, new_field> &p : new_fields_ ) {
-            EventVector before_this_pass = std::move( result );
+            EventVector const before_this_pass = std::move( result );
             result.clear();
             for( const cata::event::data_type &data : before_this_pass ) {
                 EventVector from_this_event = p.second.transform( data, p.first );
@@ -470,9 +470,9 @@ struct event_transformation_impl : public event_transformation::impl {
         event_multiset result;
 
         for( const std::pair<const cata::event::data_type, int> &p : input ) {
-            cata::event::data_type event_data = p.first;
-            EventVector transformed = match_and_transform( event_data, stats );
-            for( cata::event::data_type &d : transformed ) {
+            cata::event::data_type const event_data = p.first;
+            EventVector const transformed = match_and_transform( event_data, stats );
+            for( cata::event::data_type  const&d : transformed ) {
                 result.add( { d, p.second } );
             }
         }
@@ -532,7 +532,7 @@ struct event_transformation_impl : public event_transformation::impl {
         void event_added( const cata::event &e, stats_tracker &stats ) override {
             EventVector transformed = transformation_->match_and_transform( e.data(), stats );
             for( cata::event::data_type &d : transformed ) {
-                cata::event new_event( e.type(), e.time(), std::move( d ) );
+                cata::event const new_event( e.type(), e.time(), std::move( d ) );
                 data_.add( new_event );
                 stats.transformed_set_changed( transformation_->id_, new_event );
             }
@@ -631,7 +631,7 @@ struct event_statistic_count : event_statistic::impl {
     cata::clone_ptr<event_source> source;
 
     cata_variant value( stats_tracker &stats ) const override {
-        int count = source->get( stats ).count();
+        int const count = source->get( stats ).count();
         return cata_variant::make<cata_variant_type::int_>( count );
     }
 
@@ -684,7 +684,7 @@ struct event_statistic_total : event_statistic::impl {
     std::string field;
 
     cata_variant value( stats_tracker &stats ) const override {
-        int total = source->get( stats ).total( field );
+        int const total = source->get( stats ).total( field );
         return cata_variant::make<cata_variant_type::int_>( total );
     }
 
@@ -746,7 +746,7 @@ struct event_statistic_maximum : event_statistic::impl {
     std::string field;
 
     cata_variant value( stats_tracker &stats ) const override {
-        int maximum = source->get( stats ).maximum( field );
+        int const maximum = source->get( stats ).maximum( field );
         return cata_variant::make<cata_variant_type::int_>( maximum );
     }
 
@@ -811,7 +811,7 @@ struct event_statistic_minimum : event_statistic::impl {
     std::string field;
 
     cata_variant value( stats_tracker &stats ) const override {
-        int minimum = source->get( stats ).minimum( field );
+        int const minimum = source->get( stats ).minimum( field );
         return cata_variant::make<cata_variant_type::int_>( minimum );
     }
 
@@ -1025,8 +1025,8 @@ monotonically event_statistic::monotonicity() const
 
 std::string score::description( stats_tracker &stats ) const
 {
-    cata_variant val = value( stats );
-    std::string value_string = value( stats ).get_string();
+    cata_variant const val = value( stats );
+    std::string const value_string = value( stats ).get_string();
     std::string desc;
     if( val.type() == cata_variant_type::int_ ) {
         desc = stat_->description().translated( val.get<int>() );

--- a/src/event_statistics.cpp
+++ b/src/event_statistics.cpp
@@ -472,7 +472,7 @@ struct event_transformation_impl : public event_transformation::impl {
         for( const std::pair<const cata::event::data_type, int> &p : input ) {
             cata::event::data_type const event_data = p.first;
             EventVector const transformed = match_and_transform( event_data, stats );
-            for( cata::event::data_type  const&d : transformed ) {
+            for( cata::event::data_type  const &d : transformed ) {
                 result.add( { d, p.second } );
             }
         }

--- a/src/examine_item_menu.cpp
+++ b/src/examine_item_menu.cpp
@@ -58,10 +58,10 @@ bool run(
 
     int info_area_scroll_pos = 0;
     constexpr int info_area_scroll_step = 3;
-    temperature_flag temperature = rot::temperature_flag_for_location( get_map(), item_location( you,
+    temperature_flag const temperature = rot::temperature_flag_for_location( get_map(), item_location( you,
                                    &itm ) );
-    std::vector<iteminfo> item_info_vals = itm.info( temperature );
-    std::vector<iteminfo> dummy_compare;
+    std::vector<iteminfo> const item_info_vals = itm.info( temperature );
+    std::vector<iteminfo> const dummy_compare;
     item_info_data data( itm.tname(), itm.type_name(), item_info_vals, dummy_compare,
                          info_area_scroll_pos );
 
@@ -96,8 +96,8 @@ bool run(
         ctxt.register_action( act );
 
         std::string bound_key = ctxt.key_bound_to( act );
-        int bound_key_i = bound_key.size() == 1 ? bound_key[0] : '?';
-        std::string act_name = ctxt.get_action_name( act );
+        int const bound_key_i = bound_key.size() == 1 ? bound_key[0] : '?';
+        std::string const act_name = ctxt.get_action_name( act );
         action_list.addentry( actions.size(), true, bound_key_i, act_name );
 
         auto &list_entry = action_list.entries.back();
@@ -225,12 +225,12 @@ bool run(
     }
 
     int selected_action = 0;
-    int num_actions = static_cast<int>( actions.size() );
+    int const num_actions = static_cast<int>( actions.size() );
 
     std::unique_ptr<ui_adaptor> ui = std::make_unique<ui_adaptor>();
     ui->on_screen_resize( [&]( ui_adaptor & ui ) {
-        int width = func_width();
-        int pos_x = func_pos_x();
+        int const width = func_width();
+        int const pos_x = func_pos_x();
         w_info = catacurses::newwin( TERMY, width, point( pos_x, 0 ) );
         ui.position_from_window( w_info );
     } );
@@ -277,7 +277,7 @@ bool run(
             selected_action = ( selected_action + 1 + num_actions ) % num_actions;
             action_list.set_selected( selected_action );
         } else {
-            for( action_entry &entry : actions ) {
+            for( action_entry  const&entry : actions ) {
                 if( entry.action == action ) {
                     ret_val = entry.on_select();
                     exit = true;

--- a/src/examine_item_menu.cpp
+++ b/src/examine_item_menu.cpp
@@ -58,8 +58,9 @@ bool run(
 
     int info_area_scroll_pos = 0;
     constexpr int info_area_scroll_step = 3;
-    temperature_flag const temperature = rot::temperature_flag_for_location( get_map(), item_location( you,
-                                   &itm ) );
+    temperature_flag const temperature = rot::temperature_flag_for_location( get_map(),
+                                         item_location( you,
+                                                 &itm ) );
     std::vector<iteminfo> const item_info_vals = itm.info( temperature );
     std::vector<iteminfo> const dummy_compare;
     item_info_data data( itm.tname(), itm.type_name(), item_info_vals, dummy_compare,
@@ -277,7 +278,7 @@ bool run(
             selected_action = ( selected_action + 1 + num_actions ) % num_actions;
             action_list.set_selected( selected_action );
         } else {
-            for( action_entry  const&entry : actions ) {
+            for( action_entry  const &entry : actions ) {
                 if( entry.action == action ) {
                     ret_val = entry.on_select();
                     exit = true;

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -132,10 +132,10 @@ explosion_data load_explosion_data( const JsonObject &jo )
         jo.read( "fragment", ret.fragment );
     } else {
         // Legacy
-        float power = jo.get_float( "power" );
+        float const power = jo.get_float( "power" );
         ret.damage = power * explosion_handler::power_to_dmg_mult;
         // Don't reuse old formula, it gave way too big blasts
-        float distance_factor = jo.get_float( "distance_factor", 0.8f );
+        float const distance_factor = jo.get_float( "distance_factor", 0.8f );
         ret.radius = explosion_handler::blast_radius_from_legacy( power, distance_factor );
         if( jo.has_int( "shrapnel" ) ) {
             ret.fragment = explosion_handler::shrapnel_from_legacy( power, ret.radius );
@@ -428,7 +428,7 @@ class ExplosionProcess
 
 void ExplosionProcess::fill_maps()
 {
-    map &here = get_map();
+    map  const&here = get_map();
 
     const int shrapnel_range = shrapnel.has_value() ? shrapnel.value().range : 0;
     const int aoe_radius = std::max( blast_radius, shrapnel_range );
@@ -496,7 +496,7 @@ inline bool ExplosionProcess::is_occluded( const tripoint from, const tripoint t
         return false;
     }
 
-    map &here = get_map();
+    map  const&here = get_map();
     tripoint last_position = from;
 
     std::vector<tripoint> line_of_movement = line_to( from, to );
@@ -610,7 +610,7 @@ void ExplosionProcess::project_shrapnel( const tripoint position )
         const auto bps = critter->get_all_body_parts( true );
         // Humans get hit in all body parts
         if( critter->is_player() ) {
-            for( bodypart_id bp : bps ) {
+            for( bodypart_id const bp : bps ) {
                 if( Character::bp_to_hp( bp->token ) == num_hp_parts ) {
                     continue;
                 }
@@ -619,14 +619,14 @@ void ExplosionProcess::project_shrapnel( const tripoint position )
                 // Halve damage to be closer to what monsters take
                 damage_instance half_impact = fragment.impact;
                 half_impact.mult_damage( 0.5f );
-                dealt_damage_instance dealt = critter->deal_damage( emitter.value_or( nullptr ), bp,
+                dealt_damage_instance const dealt = critter->deal_damage( emitter.value_or( nullptr ), bp,
                                               fragment.impact );
                 if( dealt.total_damage() > 0 ) {
                     damage_taken += dealt.total_damage();
                 }
             }
         } else {
-            dealt_damage_instance dealt = critter->deal_damage( emitter.value_or( nullptr ), bps[0],
+            dealt_damage_instance const dealt = critter->deal_damage( emitter.value_or( nullptr ), bps[0],
                                           fragment.impact );
             if( dealt.total_damage() > 0 ) {
                 damage_taken += dealt.total_damage();
@@ -777,7 +777,7 @@ void ExplosionProcess::blast_tile( const tripoint position, const int rl_distanc
                                             blast_power / ExplosionConstants::MULTIBASH_COUNT;
             assert( blast_force_decay > 0 );
             while( terrain_blast_force > 0 ) {
-                bash_params bash{
+                bash_params const bash{
                     static_cast<int>( terrain_blast_force ),
                     true,
                     false,
@@ -941,9 +941,9 @@ void ExplosionProcess::move_entity( const tripoint position,
         for( int step = 0; step <= intermediate_steps; step++ ) {
             const float progress = static_cast<float>( step ) / static_cast<float>( intermediate_steps );
             const float cur_distance_travelled = distance_to_travel * progress;
-            rl_vec2d new_position_vec = datum.position +
+            rl_vec2d const new_position_vec = datum.position +
                                         rl_vec2d( cur_distance_travelled, 0.0 ).rotated( datum.angle );
-            tripoint maybe_new_position = tripoint( static_cast<int>( new_position_vec.x ),
+            tripoint const maybe_new_position = tripoint( static_cast<int>( new_position_vec.x ),
                                                     static_cast<int>( new_position_vec.y ),
                                                     position.z );
             if( !here.inbounds( maybe_new_position ) ||
@@ -971,7 +971,7 @@ void ExplosionProcess::move_entity( const tripoint position,
             std::get<Creature *>( cur_target )->setpos( new_position );
         } else {
             item *target = std::get<safe_reference<item>>( cur_target ).get();
-            item copy = *target;
+            item const copy = *target;
 
             if( !copy.is_null() ) {
                 here.i_rem( position, target );
@@ -1023,7 +1023,7 @@ void ExplosionProcess::run()
     // We need to temporary disable it because
     //   larger explosions may end up filling
     //   the texture pool, causing a crash
-    bool disable_minimap = is_animated() && pixel_minimap_option;
+    bool const disable_minimap = is_animated() && pixel_minimap_option;
     if( disable_minimap ) {
         g->toggle_pixel_minimap();
     }
@@ -1066,11 +1066,11 @@ void ExplosionProcess::run()
 
     for( const auto &position : recombination_targets ) {
         std::vector<item> storage;
-        for( item &it : here.i_at( position ) ) {
+        for( item  const&it : here.i_at( position ) ) {
             storage.push_back( it );
         }
         here.i_clear( position );
-        for( item &it : storage ) {
+        for( item  const&it : storage ) {
             here.add_item_or_charges( position, it );
         }
     }
@@ -1114,7 +1114,7 @@ static std::map<const Creature *, int> legacy_shrapnel( const tripoint &src,
 
     map &here = get_map();
 
-    diagonal_blocks( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = here.access_cache(
+    diagonal_blocks const( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = here.access_cache(
                 src.z ).vehicle_obstructed_cache;
 
     // TODO: Calculate range based on max effective range for projectiles.
@@ -1151,7 +1151,7 @@ static std::map<const Creature *, int> legacy_shrapnel( const tripoint &src,
             auto bps = critter->get_all_body_parts( true );
             // Humans get hit in all body parts
             if( critter->is_player() ) {
-                for( bodypart_id bp : bps ) {
+                for( bodypart_id const bp : bps ) {
                     // TODO: This shouldn't be needed, get_bps should do it
                     if( Character::bp_to_hp( bp->token ) == num_hp_parts ) {
                         continue;
@@ -1161,13 +1161,13 @@ static std::map<const Creature *, int> legacy_shrapnel( const tripoint &src,
                     // Halve damage to be closer to what monsters take
                     damage_instance half_impact = proj.impact;
                     half_impact.mult_damage( 0.5f );
-                    dealt_damage_instance dealt = critter->deal_damage( source, bp, proj.impact );
+                    dealt_damage_instance const dealt = critter->deal_damage( source, bp, proj.impact );
                     if( dealt.total_damage() > 0 ) {
                         damage_taken += dealt.total_damage();
                     }
                 }
             } else {
-                dealt_damage_instance dealt = critter->deal_damage( source, bps[0], proj.impact );
+                dealt_damage_instance const dealt = critter->deal_damage( source, bps[0], proj.impact );
                 if( dealt.total_damage() > 0 ) {
                     damage_taken += dealt.total_damage();
                 }
@@ -1175,7 +1175,7 @@ static std::map<const Creature *, int> legacy_shrapnel( const tripoint &src,
             damaged[critter] = damage_taken;
         }
         if( here.impassable( target ) ) {
-            int damage = proj.impact.total_damage();
+            int const damage = proj.impact.total_damage();
             if( optional_vpart_position vp = here.veh_at( target ) ) {
                 vp->vehicle().damage( vp->part_index(), damage / 100 );
             } else {
@@ -1225,7 +1225,7 @@ static std::map<const Creature *, int> legacy_shrapnel( const tripoint &src,
     } );
 
     int animated_explosion_range = 0.0f;
-    std::map<const Creature *, int> blasted;
+    std::map<const Creature *, int> const blasted;
 
     int i = 0;
     for( const dist_point_pair &pair : blast_map ) {
@@ -1328,7 +1328,7 @@ static std::map<const Creature *, int> legacy_blast( const tripoint &p, const fl
 
         // Iterate over all neighbors. Bash all of them, propagate to some
         for( size_t i = 0; i < max_index; i++ ) {
-            tripoint dest( pt + tripoint( x_offset[i], y_offset[i], z_offset[i] ) );
+            tripoint const dest( pt + tripoint( x_offset[i], y_offset[i], z_offset[i] ) );
             if( closed.count( dest ) != 0 || !here.inbounds( dest ) ||
                 here.obstructed_by_vehicle_rotation( pt, dest ) ) {
                 continue;
@@ -1370,13 +1370,13 @@ static std::map<const Creature *, int> legacy_blast( const tripoint &p, const fl
             continue;
         }
 
-        float percentage = obstacle_blast_percentage( radius, dist_map.at( pt ) );
+        float const percentage = obstacle_blast_percentage( radius, dist_map.at( pt ) );
         if( percentage > 0.0f ) {
             static const std::array<nc_color, 3> colors = { {
                     c_red, c_yellow, c_white
                 }
             };
-            size_t color_index = ( power > 30 ? 1 : 0 ) + ( percentage > 0.5f ? 1 : 0 );
+            size_t const color_index = ( power > 30 ? 1 : 0 ) + ( percentage > 0.5f ? 1 : 0 );
 
             explosion_colors[pt] = colors[color_index];
         }
@@ -1508,12 +1508,12 @@ void explosion_funcs::regular( const queued_explosion &qe )
     std::function<bool( const Creature & )> predicate ) {
         if( predicate( *pr.first ) && g->u.sees( *pr.first ) ) {
             const Creature *critter = pr.first;
-            bool blasted = damaged_by_blast.find( critter ) != damaged_by_blast.end();
-            bool shredded = damaged_by_shrapnel.find( critter ) != damaged_by_shrapnel.end();
-            std::string cause_description = ( blasted && shredded ) ? _( "the explosion and shrapnel" ) :
+            bool const blasted = damaged_by_blast.find( critter ) != damaged_by_blast.end();
+            bool const shredded = damaged_by_shrapnel.find( critter ) != damaged_by_shrapnel.end();
+            std::string const cause_description = ( blasted && shredded ) ? _( "the explosion and shrapnel" ) :
                                             blasted ? _( "the explosion" ) :
                                             _( "the shrapnel" );
-            std::string damage_description = ( pr.second > 0 ) ?
+            std::string const damage_description = ( pr.second > 0 ) ?
                                              string_format( _( "taking %d damage" ), pr.second ) :
                                              _( "but takes no damage" );
             if( critter->is_player() ) {
@@ -1561,7 +1561,7 @@ void flashbang( const tripoint &p, bool player_immune, const std::string &exp_na
 void explosion_funcs::flashbang( const queued_explosion &qe )
 {
     const tripoint &p = qe.pos;
-    map &here = get_map();
+    map  const&here = get_map();
 
     draw_explosion( p, 8, c_white, qe.graphics_name );
     int dist = rl_dist( g->u.pos(), p );
@@ -1629,7 +1629,7 @@ void explosion_funcs::shockwave( const queued_explosion &qe )
                    false,
                    "misc", "shockwave" );
 
-    for( monster &critter : g->all_monsters() ) {
+    for( monster  const&critter : g->all_monsters() ) {
         if( critter.posz() != p.z ) {
             continue;
         }
@@ -1639,7 +1639,7 @@ void explosion_funcs::shockwave( const queued_explosion &qe )
         }
     }
     // TODO: combine the two loops and the case for g->u using all_creatures()
-    for( npc &guy : g->all_npcs() ) {
+    for( npc  const&guy : g->all_npcs() ) {
         if( guy.posz() != p.z ) {
             continue;
         }
@@ -1683,7 +1683,7 @@ void emp_blast( const tripoint &p )
     // TODO: More terrain effects.
     if( here.ter( p ) == t_card_science || here.ter( p ) == t_card_military ||
         here.ter( p ) == t_card_industrial ) {
-        int rn = rng( 1, 100 );
+        int const rn = rng( 1, 100 );
         if( rn > 92 || rn < 40 ) {
             if( sight ) {
                 add_msg( _( "The card reader is rendered non-functional." ) );
@@ -1696,7 +1696,7 @@ void emp_blast( const tripoint &p )
             }
             for( int i = -3; i <= 3; i++ ) {
                 for( int j = -3; j <= 3; j++ ) {
-                    tripoint p2 = p + tripoint( i, j, 0 );
+                    tripoint const p2 = p + tripoint( i, j, 0 );
                     if( here.ter( p2 ) == t_door_metal_locked ) {
                         here.ter_set( p2, t_floor );
                     }
@@ -1741,7 +1741,7 @@ void emp_blast( const tripoint &p )
                 if( sight ) {
                     add_msg( _( "The EMP blast fries the %s!" ), critter.name() );
                 }
-                int dam = dice( 10, 10 );
+                int const dam = dice( 10, 10 );
                 critter.apply_damage( nullptr, bodypart_id( "torso" ), dam );
                 critter.check_dead_state();
                 if( !critter.is_dead() && one_in( 6 ) ) {
@@ -1755,7 +1755,7 @@ void emp_blast( const tripoint &p )
                 }
                 critter.add_effect( effect_emp, 3_minutes );
             } else if( critter.has_effect( effect_emp ) ) {
-                int dam = dice( 3, 5 );
+                int const dam = dice( 3, 5 );
                 if( sight ) {
                     add_msg( m_good, _( "The %s's disabled electrical field reverses polarity!" ),
                              critter.name() );
@@ -1772,7 +1772,7 @@ void emp_blast( const tripoint &p )
     if( u.pos() == p ) {
         if( u.get_power_level() > 0_kJ ) {
             add_msg( m_bad, _( "The EMP blast drains your power." ) );
-            int max_drain = ( u.get_power_level() > 1000_kJ ? 1000 : units::to_kilojoule(
+            int const max_drain = ( u.get_power_level() > 1000_kJ ? 1000 : units::to_kilojoule(
                                   u.get_power_level() ) );
             u.mod_power_level( units::from_kilojoule( -rng( 1 + max_drain / 3, max_drain ) ) );
         }
@@ -1816,10 +1816,10 @@ void explosion_funcs::resonance_cascade( const queued_explosion &qe )
     constexpr half_open_rectangle<point> map_bounds( point_zero, point( MAPSIZE_X, MAPSIZE_Y ) );
     constexpr point cascade_reach( 8, 8 );
 
-    point start = clamp( p.xy() - cascade_reach, map_bounds );
-    point end = clamp( p.xy() + cascade_reach, map_bounds );
+    point const start = clamp( p.xy() - cascade_reach, map_bounds );
+    point const end = clamp( p.xy() + cascade_reach, map_bounds );
 
-    std::vector<int> rolls;
+    std::vector<int> const rolls;
 
     tripoint dest = p;
     for( dest.y = start.y; dest.y < end.y; dest.y++ ) {
@@ -1874,7 +1874,7 @@ void explosion_funcs::resonance_cascade( const queued_explosion &qe )
                 case 13:
                 case 14:
                 case 15: {
-                    MonsterGroupResult spawn_details = MonsterGroupManager::GetResultFromGroup( GROUP_NETHER );
+                    MonsterGroupResult const spawn_details = MonsterGroupManager::GetResultFromGroup( GROUP_NETHER );
                     g->place_critter_at( spawn_details.name, dest );
                     break;
                 }
@@ -1900,9 +1900,9 @@ void explosion_funcs::resonance_cascade( const queued_explosion &qe )
 
 projectile shrapnel_from_legacy( int power, float blast_radius )
 {
-    int range = 2 * blast_radius;
+    int const range = 2 * blast_radius;
     // Damage approximately equal to blast damage at epicenter
-    int damage = power * power_to_dmg_mult;
+    int const damage = power * power_to_dmg_mult;
     projectile proj;
     proj.speed = 1000;
     proj.range = range;
@@ -1926,7 +1926,7 @@ explosion_queue &get_explosion_queue()
 void explosion_queue::execute()
 {
     while( !elems.empty() ) {
-        queued_explosion exp = std::move( elems.front() );
+        queued_explosion const exp = std::move( elems.front() );
         elems.pop_front();
         switch( exp.type ) {
             case ExplosionType::Regular:

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -428,7 +428,7 @@ class ExplosionProcess
 
 void ExplosionProcess::fill_maps()
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
 
     const int shrapnel_range = shrapnel.has_value() ? shrapnel.value().range : 0;
     const int aoe_radius = std::max( blast_radius, shrapnel_range );
@@ -496,7 +496,7 @@ inline bool ExplosionProcess::is_occluded( const tripoint from, const tripoint t
         return false;
     }
 
-    map  const&here = get_map();
+    map  const &here = get_map();
     tripoint last_position = from;
 
     std::vector<tripoint> line_of_movement = line_to( from, to );
@@ -620,14 +620,14 @@ void ExplosionProcess::project_shrapnel( const tripoint position )
                 damage_instance half_impact = fragment.impact;
                 half_impact.mult_damage( 0.5f );
                 dealt_damage_instance const dealt = critter->deal_damage( emitter.value_or( nullptr ), bp,
-                                              fragment.impact );
+                                                    fragment.impact );
                 if( dealt.total_damage() > 0 ) {
                     damage_taken += dealt.total_damage();
                 }
             }
         } else {
             dealt_damage_instance const dealt = critter->deal_damage( emitter.value_or( nullptr ), bps[0],
-                                          fragment.impact );
+                                                fragment.impact );
             if( dealt.total_damage() > 0 ) {
                 damage_taken += dealt.total_damage();
             }
@@ -942,10 +942,10 @@ void ExplosionProcess::move_entity( const tripoint position,
             const float progress = static_cast<float>( step ) / static_cast<float>( intermediate_steps );
             const float cur_distance_travelled = distance_to_travel * progress;
             rl_vec2d const new_position_vec = datum.position +
-                                        rl_vec2d( cur_distance_travelled, 0.0 ).rotated( datum.angle );
+                                              rl_vec2d( cur_distance_travelled, 0.0 ).rotated( datum.angle );
             tripoint const maybe_new_position = tripoint( static_cast<int>( new_position_vec.x ),
-                                                    static_cast<int>( new_position_vec.y ),
-                                                    position.z );
+                                                static_cast<int>( new_position_vec.y ),
+                                                position.z );
             if( !here.inbounds( maybe_new_position ) ||
                 here.impassable( maybe_new_position ) ||
                 ( is_mob && maybe_new_position != position && g->critter_at( maybe_new_position ) ) ||
@@ -1066,11 +1066,11 @@ void ExplosionProcess::run()
 
     for( const auto &position : recombination_targets ) {
         std::vector<item> storage;
-        for( item  const&it : here.i_at( position ) ) {
+        for( item  const &it : here.i_at( position ) ) {
             storage.push_back( it );
         }
         here.i_clear( position );
-        for( item  const&it : storage ) {
+        for( item  const &it : storage ) {
             here.add_item_or_charges( position, it );
         }
     }
@@ -1511,11 +1511,11 @@ void explosion_funcs::regular( const queued_explosion &qe )
             bool const blasted = damaged_by_blast.find( critter ) != damaged_by_blast.end();
             bool const shredded = damaged_by_shrapnel.find( critter ) != damaged_by_shrapnel.end();
             std::string const cause_description = ( blasted && shredded ) ? _( "the explosion and shrapnel" ) :
-                                            blasted ? _( "the explosion" ) :
-                                            _( "the shrapnel" );
+                                                  blasted ? _( "the explosion" ) :
+                                                  _( "the shrapnel" );
             std::string const damage_description = ( pr.second > 0 ) ?
-                                             string_format( _( "taking %d damage" ), pr.second ) :
-                                             _( "but takes no damage" );
+                                                   string_format( _( "taking %d damage" ), pr.second ) :
+                                                   _( "but takes no damage" );
             if( critter->is_player() ) {
                 add_msg( _( "You are hit by %s, %s." ),
                          cause_description, damage_description );
@@ -1561,7 +1561,7 @@ void flashbang( const tripoint &p, bool player_immune, const std::string &exp_na
 void explosion_funcs::flashbang( const queued_explosion &qe )
 {
     const tripoint &p = qe.pos;
-    map  const&here = get_map();
+    map  const &here = get_map();
 
     draw_explosion( p, 8, c_white, qe.graphics_name );
     int dist = rl_dist( g->u.pos(), p );
@@ -1629,7 +1629,7 @@ void explosion_funcs::shockwave( const queued_explosion &qe )
                    false,
                    "misc", "shockwave" );
 
-    for( monster  const&critter : g->all_monsters() ) {
+    for( monster  const &critter : g->all_monsters() ) {
         if( critter.posz() != p.z ) {
             continue;
         }
@@ -1639,7 +1639,7 @@ void explosion_funcs::shockwave( const queued_explosion &qe )
         }
     }
     // TODO: combine the two loops and the case for g->u using all_creatures()
-    for( npc  const&guy : g->all_npcs() ) {
+    for( npc  const &guy : g->all_npcs() ) {
         if( guy.posz() != p.z ) {
             continue;
         }
@@ -1773,7 +1773,7 @@ void emp_blast( const tripoint &p )
         if( u.get_power_level() > 0_kJ ) {
             add_msg( m_bad, _( "The EMP blast drains your power." ) );
             int const max_drain = ( u.get_power_level() > 1000_kJ ? 1000 : units::to_kilojoule(
-                                  u.get_power_level() ) );
+                                        u.get_power_level() ) );
             u.mod_power_level( units::from_kilojoule( -rng( 1 + max_drain / 3, max_drain ) ) );
         }
         // TODO: More effects?

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -61,7 +61,7 @@ faction::faction( const faction_template &templ )
 
 void faction_template::load( const JsonObject &jsobj )
 {
-    faction_template fac( jsobj );
+    faction_template const fac( jsobj );
     npc_factions::all_templates.emplace_back( fac );
 }
 
@@ -84,7 +84,7 @@ void faction_template::reset()
 void faction_template::load_relations( const JsonObject &jsobj )
 {
     for( const JsonMember fac : jsobj.get_object( "relations" ) ) {
-        JsonObject rel_jo = fac.get_object();
+        JsonObject const rel_jo = fac.get_object();
         std::bitset<npc_factions::rel_types> fac_relation( 0 );
         for( const auto &rel_flag : npc_factions::relation_strs ) {
             fac_relation.set( rel_flag.second, rel_jo.get_bool( rel_flag.first, false ) );
@@ -293,7 +293,7 @@ std::string fac_wealth_text( int val, int size )
 std::string faction::food_supply_text()
 {
     //Convert to how many days you can support the population
-    int val = food_supply / ( size * 288 );
+    int const val = food_supply / ( size * 288 );
     if( val >= 30 ) {
         return pgettext( "Faction food", "Overflowing" );
     }
@@ -311,7 +311,7 @@ std::string faction::food_supply_text()
 
 nc_color faction::food_supply_color()
 {
-    int val = food_supply / ( size * 288 );
+    int const val = food_supply / ( size * 288 );
     if( val >= 30 ) {
         return c_green;
     } else if( val >= 14 ) {
@@ -466,7 +466,7 @@ const faction &string_id<faction>::obj() const
     if( ptr ) {
         return *ptr;
     } else {
-        static faction null_fac;
+        static faction const null_fac;
         return null_fac;
     }
 }
@@ -481,24 +481,24 @@ void basecamp::faction_display( const catacurses::window &fac_w, const int width
 {
     int y = 2;
     const nc_color col = c_white;
-    Character &player_character = get_player_character();
+    Character  const&player_character = get_player_character();
     const tripoint_abs_omt player_abspos = player_character.global_omt_location();
-    tripoint_abs_omt camp_pos = camp_omt_pos();
-    std::string direction = direction_name( direction_from( player_abspos, camp_pos ) );
+    tripoint_abs_omt const camp_pos = camp_omt_pos();
+    std::string const direction = direction_name( direction_from( player_abspos, camp_pos ) );
     mvwprintz( fac_w, point( width, ++y ), c_light_gray, _( "Press enter to rename this camp" ) );
     if( direction != "center" ) {
         mvwprintz( fac_w, point( width, ++y ), c_light_gray, _( "Direction: to the " ) + direction );
     }
     mvwprintz( fac_w, point( width, ++y ), col, _( "Location: %s" ), camp_pos.to_string() );
     faction *yours = player_character.get_faction();
-    std::string food_text = string_format( _( "Food Supply: %s %d calories" ),
+    std::string const food_text = string_format( _( "Food Supply: %s %d calories" ),
                                            yours->food_supply_text(), yours->food_supply );
-    nc_color food_col = yours->food_supply_color();
+    nc_color const food_col = yours->food_supply_color();
     mvwprintz( fac_w, point( width, ++y ), food_col, food_text );
-    std::string bldg = next_upgrade( base_camps::base_dir, 1 );
-    std::string bldg_full = _( "Next Upgrade: " ) + bldg;
+    std::string const bldg = next_upgrade( base_camps::base_dir, 1 );
+    std::string const bldg_full = _( "Next Upgrade: " ) + bldg;
     mvwprintz( fac_w, point( width, ++y ), col, bldg_full );
-    std::string requirements = om_upgrade_description( bldg, true );
+    std::string const requirements = om_upgrade_description( bldg, true );
     fold_and_print( fac_w, point( width, ++y ), getmaxx( fac_w ) - width - 2, col, requirements );
 }
 
@@ -517,7 +517,7 @@ int npc::faction_display( const catacurses::window &fac_w, const int width ) con
     int retval = 0;
     int y = 2;
     const nc_color col = c_white;
-    Character &player_character = get_player_character();
+    Character  const&player_character = get_player_character();
     const tripoint_abs_omt player_abspos = player_character.global_omt_location();
 
     //get NPC followers, status, direction, location, needs, weapon, etc.
@@ -537,13 +537,13 @@ int npc::faction_display( const catacurses::window &fac_w, const int width ) con
             }
             mission_string = _( "Current Mission: " ) + dest_string;
         } else {
-            npc_companion_mission c_mission = get_companion_mission();
+            npc_companion_mission const c_mission = get_companion_mission();
             mission_string = _( "Current Mission: " ) +
                              get_mission_action_string( c_mission.mission_id );
         }
     }
     fold_and_print( fac_w, point( width, ++y ), getmaxx( fac_w ) - width - 2, col, mission_string );
-    tripoint_abs_omt guy_abspos = global_omt_location();
+    tripoint_abs_omt const guy_abspos = global_omt_location();
     basecamp *temp_camp = nullptr;
     if( assigned_camp ) {
         std::optional<basecamp *> bcp = overmap_buffer.find_camp( ( *assigned_camp ).xy() );
@@ -552,7 +552,7 @@ int npc::faction_display( const catacurses::window &fac_w, const int width ) con
         }
     }
     const bool is_stationed = assigned_camp && temp_camp;
-    std::string direction = direction_name( direction_from( player_abspos, guy_abspos ) );
+    std::string const direction = direction_name( direction_from( player_abspos, guy_abspos ) );
     if( direction != "center" ) {
         mvwprintz( fac_w, point( width, ++y ), col, _( "Direction: to the " ) + direction );
     } else {
@@ -566,8 +566,8 @@ int npc::faction_display( const catacurses::window &fac_w, const int width ) con
     }
     std::string can_see;
     nc_color see_color;
-    bool u_has_radio = g->u.has_item_with_flag( "TWO_WAY_RADIO", true );
-    bool guy_has_radio = has_item_with_flag( "TWO_WAY_RADIO", true );
+    bool const u_has_radio = g->u.has_item_with_flag( "TWO_WAY_RADIO", true );
+    bool const guy_has_radio = has_item_with_flag( "TWO_WAY_RADIO", true );
     // is the NPC even in the same area as the player?
     if( rl_dist( player_abspos, global_omt_location() ) > 3 ||
         ( rl_dist( g->u.pos(), pos() ) > SEEX * 2 || !g->u.sees( pos() ) ) ) {
@@ -655,7 +655,7 @@ int npc::faction_display( const catacurses::window &fac_w, const int width ) con
                _( "Thirst: " ) + ( thirst_pair.first.empty() ? nominal : thirst_pair.first ) );
     mvwprintz( fac_w, point( width, ++y ), fatigue_pair.second,
                _( "Fatigue: " ) + ( fatigue_pair.first.empty() ? nominal : fatigue_pair.first ) );
-    int lines = fold_and_print( fac_w, point( width, ++y ), getmaxx( fac_w ) - width - 2, c_white,
+    int const lines = fold_and_print( fac_w, point( width, ++y ), getmaxx( fac_w ) - width - 2, c_white,
                                 _( "Wielding: " ) + primary_weapon().tname() );
     y += lines;
 
@@ -669,14 +669,14 @@ int npc::faction_display( const catacurses::window &fac_w, const int width ) con
     std::vector<std::string> skill_strs;
     for( size_t i = 0; i < skillslist.size() && count < 3; i++ ) {
         if( !skillslist[ i ]->is_combat_skill() ) {
-            std::string skill_str = string_format( "%s: %d", skillslist[i]->name(),
+            std::string const skill_str = string_format( "%s: %d", skillslist[i]->name(),
                                                    get_skill_level( skillslist[i]->ident() ) );
             skill_strs.push_back( skill_str );
             count += 1;
         }
     }
-    std::string best_three_noncombat = _( "Best other skills: " );
-    std::string best_skill_text = string_format( _( "Best combat skill: %s: %d" ),
+    std::string const best_three_noncombat = _( "Best other skills: " );
+    std::string const best_skill_text = string_format( _( "Best combat skill: %s: %d" ),
                                   best_skill().obj().name(), best_skill_level() );
     mvwprintz( fac_w, point( width, ++y ), col, best_skill_text );
     mvwprintz( fac_w, point( width, ++y ), col, best_three_noncombat + skill_strs[0] );
@@ -792,7 +792,7 @@ void faction_manager::display() const
                                         followers[i]->disp_name() );
                     }
                     if( guy ) {
-                        int retval = guy->faction_display( w_missions, 31 );
+                        int const retval = guy->faction_display( w_missions, 31 );
                         if( retval == 2 ) {
                             radio_interactable = true;
                         } else if( retval == 1 ) {
@@ -838,7 +838,7 @@ void faction_manager::display() const
         // create a list of NPCs, visible and the ones on overmapbuffer
         followers.clear();
         for( auto &elem : g->get_follower_list() ) {
-            shared_ptr_fast<npc> npc_to_get = overmap_buffer.find_npc( elem );
+            shared_ptr_fast<npc> const npc_to_get = overmap_buffer.find_npc( elem );
             if( !npc_to_get ) {
                 continue;
             }
@@ -858,7 +858,7 @@ void faction_manager::display() const
         camp = nullptr;
         // create a list of faction camps
         camps.clear();
-        for( tripoint_abs_omt elem : g->u.camps ) {
+        for( tripoint_abs_omt const elem : g->u.camps ) {
             std::optional<basecamp *> p = overmap_buffer.find_camp( elem.xy() );
             if( !p ) {
                 continue;

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -481,7 +481,7 @@ void basecamp::faction_display( const catacurses::window &fac_w, const int width
 {
     int y = 2;
     const nc_color col = c_white;
-    Character  const&player_character = get_player_character();
+    Character  const &player_character = get_player_character();
     const tripoint_abs_omt player_abspos = player_character.global_omt_location();
     tripoint_abs_omt const camp_pos = camp_omt_pos();
     std::string const direction = direction_name( direction_from( player_abspos, camp_pos ) );
@@ -492,7 +492,7 @@ void basecamp::faction_display( const catacurses::window &fac_w, const int width
     mvwprintz( fac_w, point( width, ++y ), col, _( "Location: %s" ), camp_pos.to_string() );
     faction *yours = player_character.get_faction();
     std::string const food_text = string_format( _( "Food Supply: %s %d calories" ),
-                                           yours->food_supply_text(), yours->food_supply );
+                                  yours->food_supply_text(), yours->food_supply );
     nc_color const food_col = yours->food_supply_color();
     mvwprintz( fac_w, point( width, ++y ), food_col, food_text );
     std::string const bldg = next_upgrade( base_camps::base_dir, 1 );
@@ -517,7 +517,7 @@ int npc::faction_display( const catacurses::window &fac_w, const int width ) con
     int retval = 0;
     int y = 2;
     const nc_color col = c_white;
-    Character  const&player_character = get_player_character();
+    Character  const &player_character = get_player_character();
     const tripoint_abs_omt player_abspos = player_character.global_omt_location();
 
     //get NPC followers, status, direction, location, needs, weapon, etc.
@@ -656,7 +656,7 @@ int npc::faction_display( const catacurses::window &fac_w, const int width ) con
     mvwprintz( fac_w, point( width, ++y ), fatigue_pair.second,
                _( "Fatigue: " ) + ( fatigue_pair.first.empty() ? nominal : fatigue_pair.first ) );
     int const lines = fold_and_print( fac_w, point( width, ++y ), getmaxx( fac_w ) - width - 2, c_white,
-                                _( "Wielding: " ) + primary_weapon().tname() );
+                                      _( "Wielding: " ) + primary_weapon().tname() );
     y += lines;
 
     const auto skillslist = Skill::get_skills_sorted_by( [&]( const Skill & a, const Skill & b ) {
@@ -670,14 +670,14 @@ int npc::faction_display( const catacurses::window &fac_w, const int width ) con
     for( size_t i = 0; i < skillslist.size() && count < 3; i++ ) {
         if( !skillslist[ i ]->is_combat_skill() ) {
             std::string const skill_str = string_format( "%s: %d", skillslist[i]->name(),
-                                                   get_skill_level( skillslist[i]->ident() ) );
+                                          get_skill_level( skillslist[i]->ident() ) );
             skill_strs.push_back( skill_str );
             count += 1;
         }
     }
     std::string const best_three_noncombat = _( "Best other skills: " );
     std::string const best_skill_text = string_format( _( "Best combat skill: %s: %d" ),
-                                  best_skill().obj().name(), best_skill_level() );
+                                        best_skill().obj().name(), best_skill_level() );
     mvwprintz( fac_w, point( width, ++y ), col, best_skill_text );
     mvwprintz( fac_w, point( width, ++y ), col, best_three_noncombat + skill_strs[0] );
     mvwprintz( fac_w, point( width + 20, ++y ), col, skill_strs[1] );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -497,7 +497,7 @@ static bool update_time_fixed( std::string &entry, const comp_list &npc_list,
 {
     bool avail = false;
     for( auto &comp : npc_list ) {
-        time_duration elapsed = calendar::turn - comp->companion_mission_time;
+        time_duration const elapsed = calendar::turn - comp->companion_mission_time;
         entry = entry + " " +  comp->name + " [" + to_string( elapsed ) + "/" +
                 to_string( duration ) + "]\n";
         avail |= elapsed >= duration;
@@ -509,7 +509,7 @@ static bool update_time_fixed( std::string &entry, const comp_list &npc_list,
 static std::optional<basecamp *> get_basecamp( npc &p, const std::string &camp_type = "default" )
 {
 
-    tripoint_abs_omt omt_pos = p.global_omt_location();
+    tripoint_abs_omt const omt_pos = p.global_omt_location();
     std::optional<basecamp *> bcp = overmap_buffer.find_camp( omt_pos.xy() );
     if( bcp ) {
         return bcp;
@@ -563,7 +563,7 @@ void talk_function::start_camp( npc &p )
         return;
     }
 
-    std::vector<std::pair<std::string, tripoint_abs_omt>> om_region =
+    std::vector<std::pair<std::string, tripoint_abs_omt>> const om_region =
                 om_building_region( omt_pos, 1 );
     int near_fields = 0;
     for( const auto &om_near : om_region ) {
@@ -572,7 +572,7 @@ void talk_function::start_camp( npc &p )
             near_fields += 1;
         }
     }
-    std::vector<std::pair<std::string, tripoint_abs_omt>> om_region_ext =
+    std::vector<std::pair<std::string, tripoint_abs_omt>> const om_region_ext =
                 om_building_region( omt_pos, 3 );
     int forests = 0;
     int waters = 0;
@@ -626,7 +626,7 @@ void talk_function::recover_camp( npc &p )
 
 void talk_function::remove_overseer( npc &p )
 {
-    size_t suffix = p.name.find( _( ", Camp Manager" ) );
+    size_t const suffix = p.name.find( _( ", Camp Manager" ) );
     if( suffix != std::string::npos ) {
         p.name = p.name.substr( 0, suffix );
     }
@@ -683,7 +683,7 @@ void basecamp::add_available_recipes( mission_data &mission_key, point dir,
         const std::string &title_e = dir_abbr + recipe_data.second;
         const std::string &entry = craft_description( recipe_data.first );
         const recipe &recp = recipe_data.first.obj();
-        bool craftable = recp.deduped_requirements().can_make_with_inventory(
+        bool const craftable = recp.deduped_requirements().can_make_with_inventory(
                              _inv, recp.get_component_filter() );
         mission_key.add_start( id, title_e, dir, entry, craftable );
     }
@@ -692,7 +692,7 @@ void basecamp::add_available_recipes( mission_data &mission_key, point dir,
 void basecamp::get_available_missions_by_dir( mission_data &mission_key, point dir )
 {
     std::string entry;
-    std::string gather_bldg = "null";
+    std::string const gather_bldg = "null";
 
     const std::string dir_id = base_camps::all_directions.at( dir ).id;
     const std::string dir_abbr = base_camps::all_directions.at( dir ).bracket_abbr.translated();
@@ -700,11 +700,11 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, point d
 
     if( dir != base_camps::base_dir ) {
         // return legacy workers
-        comp_list npc_list = get_mission_workers( "_faction_upgrade_exp_" + dir_id );
+        comp_list const npc_list = get_mission_workers( "_faction_upgrade_exp_" + dir_id );
         if( !npc_list.empty() ) {
             const base_camps::miss_data &miss_info = base_camps::miss_info[ "_faction_upgrade_exp_" ];
             entry = miss_info.action.translated();
-            bool avail = update_time_left( entry, npc_list );
+            bool const avail = update_time_left( entry, npc_list );
             mission_key.add_return( "Recover Ally, " + dir_id + " Expansion",
                                     _( "Recover Ally, " ) + dir_abbr + _( " Expansion" ), dir,
                                     entry, avail );
@@ -712,7 +712,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, point d
         // Generate upgrade missions for expansions
         for( const basecamp_upgrade &upgrade : available_upgrades( dir ) ) {
             const base_camps::miss_data &miss_info = base_camps::miss_info[ "_faction_upgrade_exp_" ];
-            comp_list npc_list = get_mission_workers( upgrade.bldg + "_faction_upgrade_exp_" +
+            comp_list const npc_list = get_mission_workers( upgrade.bldg + "_faction_upgrade_exp_" +
                                  dir_id );
             if( npc_list.empty() ) {
                 entry = om_upgrade_description( upgrade.bldg );
@@ -721,7 +721,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, point d
                                        upgrade.avail );
             } else {
                 entry = miss_info.action.translated();
-                bool avail = update_time_left( entry, npc_list );
+                bool const avail = update_time_left( entry, npc_list );
                 mission_key.add_return( "Recover Ally, " + dir_id + " Expansion" + upgrade.bldg,
                                         _( "Recover Ally, " ) + dir_abbr + _( " Expansion" ) +
                                         " " + upgrade.name, dir, entry, avail );
@@ -730,7 +730,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, point d
     }
 
     if( has_provides( "gathering", dir ) ) {
-        comp_list npc_list = get_mission_workers( "_faction_camp_gathering" );
+        comp_list const npc_list = get_mission_workers( "_faction_camp_gathering" );
         const base_camps::miss_data &miss_info = base_camps::miss_info[ "_faction_camp_gathering" ];
         entry = string_format( _( "Notes:\n"
                                   "Send a companion to gather materials for the next camp "
@@ -747,13 +747,13 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, point d
                                entry, npc_list.size() < 3 );
         if( !npc_list.empty() ) {
             entry = miss_info.action.translated();
-            bool avail = update_time_fixed( entry, npc_list, 3_hours );
+            bool const avail = update_time_fixed( entry, npc_list, 3_hours );
             mission_key.add_return( miss_info.ret_miss_id, miss_info.ret_desc.translated(),
                                     dir, entry, avail );
         }
     }
     if( has_provides( "firewood", dir ) ) {
-        comp_list npc_list = get_mission_workers( "_faction_camp_firewood" );
+        comp_list const npc_list = get_mission_workers( "_faction_camp_firewood" );
         const base_camps::miss_data &miss_info = base_camps::miss_info[ "_faction_camp_firewood" ];
         entry = string_format( _( "Notes:\n"
                                   "Send a companion to gather light brush and heavy sticks.\n\n"
@@ -770,13 +770,13 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, point d
                                entry, npc_list.size() < 3 );
         if( !npc_list.empty() ) {
             entry = miss_info.action.translated();
-            bool avail = update_time_fixed( entry, npc_list, 3_hours );
+            bool const avail = update_time_fixed( entry, npc_list, 3_hours );
             mission_key.add_return( miss_info.ret_miss_id, miss_info.ret_desc.translated(),
                                     std::nullopt, entry, avail );
         }
     }
     if( has_provides( "sorting", dir ) ) {
-        comp_list npc_list = get_mission_workers( "_faction_camp_menial" );
+        comp_list const npc_list = get_mission_workers( "_faction_camp_menial" );
         const base_camps::miss_data &miss_info = base_camps::miss_info[ "_faction_camp_menial" ];
         entry = string_format( _( "Notes:\n"
                                   "Send a companion to do low level chores and sort "
@@ -793,14 +793,14 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, point d
                                entry, npc_list.empty() );
         if( !npc_list.empty() ) {
             entry = miss_info.action.translated();
-            bool avail = update_time_left( entry, npc_list );
+            bool const avail = update_time_left( entry, npc_list );
             mission_key.add_return( miss_info.ret_miss_id, miss_info.ret_desc.translated(),
                                     std::nullopt, entry, avail );
         }
     }
 
     if( has_provides( "logging", dir ) ) {
-        comp_list npc_list = get_mission_workers( "_faction_camp_cut_log" );
+        comp_list const npc_list = get_mission_workers( "_faction_camp_cut_log" );
         const base_camps::miss_data &miss_info = base_camps::miss_info[ "_faction_camp_cut_log" ];
         entry = string_format( _( "Notes:\n"
                                   "Send a companion to a nearby forest to cut logs.\n\n"
@@ -819,14 +819,14 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, point d
                                entry, npc_list.empty() );
         if( !npc_list.empty() ) {
             entry = miss_info.action.translated();
-            bool avail = update_time_left( entry, npc_list );
+            bool const avail = update_time_left( entry, npc_list );
             mission_key.add_return( miss_info.ret_miss_id, miss_info.ret_desc.translated(),
                                     std::nullopt, entry, avail );
         }
     }
 
     if( has_provides( "logging", dir ) ) {
-        comp_list npc_list = get_mission_workers( "_faction_camp_clearcut" );
+        comp_list const npc_list = get_mission_workers( "_faction_camp_clearcut" );
         const base_camps::miss_data &miss_info = base_camps::miss_info[ "_faction_camp_clearcut" ];
         entry = string_format( _( "Notes:\n"
                                   "Send a companion to a clear a nearby forest.\n\n"
@@ -845,14 +845,14 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, point d
                                entry, npc_list.empty() );
         if( !npc_list.empty() ) {
             entry = miss_info.action.translated();
-            bool avail = update_time_left( entry, npc_list );
+            bool const avail = update_time_left( entry, npc_list );
             mission_key.add_return( miss_info.ret_miss_id, miss_info.ret_desc.translated(),
                                     std::nullopt, entry, avail );
         }
     }
 
     if( has_provides( "relaying", dir ) ) {
-        comp_list npc_list = get_mission_workers( "_faction_camp_hide_site" );
+        comp_list const npc_list = get_mission_workers( "_faction_camp_hide_site" );
         const base_camps::miss_data &miss_info = base_camps::miss_info[ "_faction_camp_hide_site" ];
         entry = string_format( _( "Notes:\n"
                                   "Send a companion to build an improvised shelter and stock it "
@@ -870,14 +870,14 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, point d
                                entry, npc_list.empty() );
         if( !npc_list.empty() ) {
             entry = miss_info.action.translated();
-            bool avail = update_time_left( entry, npc_list );
+            bool const avail = update_time_left( entry, npc_list );
             mission_key.add_return( miss_info.ret_miss_id, miss_info.ret_desc.translated(),
                                     std::nullopt, entry, avail );
         }
     }
 
     if( has_provides( "relaying", dir ) ) {
-        comp_list npc_list = get_mission_workers( "_faction_camp_hide_trans" );
+        comp_list const npc_list = get_mission_workers( "_faction_camp_hide_trans" );
         const base_camps::miss_data &miss_info = base_camps::miss_info[ "_faction_camp_hide_trans" ];
         entry = string_format( _( "Notes:\n"
                                   "Push gear out to a hide site or bring gear back from one.\n\n"
@@ -896,14 +896,14 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, point d
                                npc_list.empty() );
         if( !npc_list.empty() ) {
             entry = miss_info.action.translated();
-            bool avail = update_time_left( entry, npc_list );
+            bool const avail = update_time_left( entry, npc_list );
             mission_key.add_return( miss_info.ret_miss_id, miss_info.ret_desc.translated(),
                                     std::nullopt, entry, avail );
         }
     }
 
     if( has_provides( "foraging", dir ) ) {
-        comp_list npc_list = get_mission_workers( "_faction_camp_foraging" );
+        comp_list const npc_list = get_mission_workers( "_faction_camp_foraging" );
         const base_camps::miss_data &miss_info = base_camps::miss_info[ "_faction_camp_foraging" ];
         entry = string_format( _( "Notes:\n"
                                   "Send a companion to forage for edible plants.\n\n"
@@ -920,14 +920,14 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, point d
                                entry, npc_list.size() < 3 );
         if( !npc_list.empty() ) {
             entry = miss_info.action.translated();
-            bool avail = update_time_fixed( entry, npc_list, 4_hours );
+            bool const avail = update_time_fixed( entry, npc_list, 4_hours );
             mission_key.add_return( miss_info.ret_miss_id, miss_info.ret_desc.translated(),
                                     dir, entry, avail );
         }
     }
 
     if( has_provides( "trapping", dir ) ) {
-        comp_list npc_list = get_mission_workers( "_faction_camp_trapping" );
+        comp_list const npc_list = get_mission_workers( "_faction_camp_trapping" );
         const base_camps::miss_data &miss_info = base_camps::miss_info[ "_faction_camp_trapping" ];
         entry = string_format( _( "Notes:\n"
                                   "Send a companion to set traps for small game.\n\n"
@@ -943,14 +943,14 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, point d
                                entry, npc_list.size() < 2 );
         if( !npc_list.empty() ) {
             entry = miss_info.action.translated();
-            bool avail = update_time_fixed( entry, npc_list, 6_hours );
+            bool const avail = update_time_fixed( entry, npc_list, 6_hours );
             mission_key.add_return( miss_info.ret_miss_id, miss_info.ret_desc.translated(),
                                     dir, entry, avail );
         }
     }
 
     if( has_provides( "hunting", dir ) ) {
-        comp_list npc_list = get_mission_workers( "_faction_camp_hunting" );
+        comp_list const npc_list = get_mission_workers( "_faction_camp_hunting" );
         const base_camps::miss_data &miss_info = base_camps::miss_info[ "_faction_camp_hunting" ];
         entry = string_format( _( "Notes:\n"
                                   "Send a companion to hunt large animals.\n\n"
@@ -966,14 +966,14 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, point d
                                entry, npc_list.empty() );
         if( !npc_list.empty() ) {
             entry = miss_info.action.translated();
-            bool avail = update_time_fixed( entry, npc_list, 6_hours );
+            bool const avail = update_time_fixed( entry, npc_list, 6_hours );
             mission_key.add_return( miss_info.ret_miss_id, miss_info.ret_desc.translated(),
                                     dir, entry, avail );
         }
     }
 
     if( has_provides( "walls", dir ) ) {
-        comp_list npc_list = get_mission_workers( "_faction_camp_om_fortifications" );
+        comp_list const npc_list = get_mission_workers( "_faction_camp_om_fortifications" );
         const base_camps::miss_data &miss_info =
             base_camps::miss_info[ "_faction_camp_om_fortifications" ];
         entry = om_upgrade_description( "faction_wall_level_N_0" );
@@ -984,28 +984,28 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, point d
                                npc_list.empty() );
         if( !npc_list.empty() ) {
             entry = miss_info.action.translated();
-            bool avail = update_time_left( entry, npc_list );
+            bool const avail = update_time_left( entry, npc_list );
             mission_key.add_return( miss_info.ret_miss_id, miss_info.ret_desc.translated(),
                                     std::nullopt, entry, avail );
         }
     }
 
     if( has_provides( "recruiting", dir ) ) {
-        comp_list npc_list = get_mission_workers( "_faction_camp_recruit_0" );
+        comp_list const npc_list = get_mission_workers( "_faction_camp_recruit_0" );
         const base_camps::miss_data &miss_info = base_camps::miss_info[ "_faction_camp_recruit_0" ];
         entry = recruit_description( npc_list.size() );
         mission_key.add_start( miss_info.miss_id, miss_info.desc.translated(), dir, entry,
                                npc_list.empty() );
         if( !npc_list.empty() ) {
             entry = miss_info.action.translated();
-            bool avail = update_time_left( entry, npc_list );
+            bool const avail = update_time_left( entry, npc_list );
             mission_key.add_return( miss_info.ret_miss_id, miss_info.ret_desc.translated(),
                                     std::nullopt, entry, avail );
         }
     }
 
     if( has_provides( "scouting", dir ) ) {
-        comp_list npc_list = get_mission_workers( "_faction_camp_scout_0" );
+        comp_list const npc_list = get_mission_workers( "_faction_camp_scout_0" );
         const base_camps::miss_data &miss_info = base_camps::miss_info[ "_faction_camp_scout_0" ];
         entry = string_format( _( "Notes:\n"
                                   "Send a companion out into the great unknown.  High survival "
@@ -1024,14 +1024,14 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, point d
                                entry, npc_list.size() < 3 );
         if( !npc_list.empty() ) {
             entry = miss_info.action.translated();
-            bool avail = update_time_left( entry, npc_list );
+            bool const avail = update_time_left( entry, npc_list );
             mission_key.add_return( miss_info.ret_miss_id,  miss_info.ret_desc.translated(),
                                     std::nullopt, entry, avail );
         }
     }
 
     if( has_provides( "patrolling", dir ) ) {
-        comp_list npc_list = get_mission_workers( "_faction_camp_combat_0" );
+        comp_list const npc_list = get_mission_workers( "_faction_camp_combat_0" );
         const base_camps::miss_data &miss_info = base_camps::miss_info[ "_faction_camp_combat_0" ];
         entry = string_format( _( "Notes:\n"
                                   "Send a companion to purge the wasteland.  Their goal is to "
@@ -1052,14 +1052,14 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, point d
                                entry, npc_list.size() < 3 );
         if( !npc_list.empty() ) {
             entry = miss_info.action.translated();
-            bool avail = update_time_left( entry, npc_list );
+            bool const avail = update_time_left( entry, npc_list );
             mission_key.add_return( miss_info.ret_miss_id, miss_info.ret_desc.translated(),
                                     std::nullopt, entry, avail );
         }
     }
 
     if( has_provides( "dismantling", dir ) ) {
-        comp_list npc_list = get_mission_workers( "_faction_exp_chop_shop_" + dir_id );
+        comp_list const npc_list = get_mission_workers( "_faction_exp_chop_shop_" + dir_id );
         const base_camps::miss_data &miss_info = base_camps::miss_info[ "_faction_exp_chop_shop_" ];
         entry = _( "Notes:\n"
                    "Have a companion attempt to completely dissemble a vehicle into "
@@ -1075,36 +1075,36 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, point d
                                npc_list.empty() );
         if( !npc_list.empty() ) {
             entry = miss_info.action.translated();
-            bool avail = update_time_left( entry, npc_list );
+            bool const avail = update_time_left( entry, npc_list );
             mission_key.add_return( dir_id + miss_info.ret_miss_id,
                                     dir_abbr + miss_info.ret_desc, dir, entry, avail );
         }
     }
 
-    std::map<recipe_id, translation> craft_recipes = recipe_deck( dir );
+    std::map<recipe_id, translation> const craft_recipes = recipe_deck( dir );
     if( has_provides( "kitchen", dir ) ) {
-        comp_list npc_list = get_mission_workers( "_faction_exp_kitchen_cooking_" + dir_id );
+        comp_list const npc_list = get_mission_workers( "_faction_exp_kitchen_cooking_" + dir_id );
         const base_camps::miss_data &miss_info =
             base_camps::miss_info[ "_faction_exp_kitchen_cooking_" ];
         if( npc_list.empty() ) {
             add_available_recipes( mission_key, dir, craft_recipes );
         } else {
             entry = miss_info.action.translated();
-            bool avail = update_time_left( entry, npc_list );
+            bool const avail = update_time_left( entry, npc_list );
             mission_key.add_return( dir_id + miss_info.ret_miss_id,
                                     dir_abbr + miss_info.ret_desc, dir, entry, avail );
         }
     }
 
     if( has_provides( "blacksmith", dir ) ) {
-        comp_list npc_list = get_mission_workers( "_faction_exp_blacksmith_crafting_" + dir_id );
+        comp_list const npc_list = get_mission_workers( "_faction_exp_blacksmith_crafting_" + dir_id );
         const base_camps::miss_data &miss_info =
             base_camps::miss_info[ "_faction_exp_blacksmith_crafting_" ];
         if( npc_list.empty() ) {
             add_available_recipes( mission_key, dir, craft_recipes );
         } else {
             entry = miss_info.action.translated();
-            bool avail = update_time_left( entry, npc_list );
+            bool const avail = update_time_left( entry, npc_list );
             mission_key.add_return( dir_id + miss_info.ret_miss_id,
                                     dir_abbr + miss_info.ret_desc, dir, entry, avail );
         }
@@ -1112,7 +1112,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, point d
 
     if( has_provides( "farming", dir ) ) {
         size_t plots = 0;
-        comp_list npc_list = get_mission_workers( "_faction_exp_plow_" + dir_id );
+        comp_list const npc_list = get_mission_workers( "_faction_exp_plow_" + dir_id );
         const base_camps::miss_data &miss_info = base_camps::miss_info[ "_faction_exp_plow_" ];
         if( npc_list.empty() ) {
             entry = _( "Notes:\n"
@@ -1131,14 +1131,14 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, point d
                                    entry, plots > 0 );
         } else {
             entry = miss_info.action.translated();
-            bool avail = update_time_left( entry, npc_list );
+            bool const avail = update_time_left( entry, npc_list );
             mission_key.add_return( dir_id + miss_info.ret_miss_id,
                                     dir_abbr + miss_info.ret_desc, dir, entry, avail );
         }
     }
     if( has_provides( "farming", dir ) ) {
         size_t plots = 0;
-        comp_list npc_list = get_mission_workers( "_faction_exp_plant_" + dir_id );
+        comp_list const npc_list = get_mission_workers( "_faction_exp_plant_" + dir_id );
         const base_camps::miss_data &miss_info = base_camps::miss_info[ "_faction_exp_plant_" ];
         if( npc_list.empty() ) {
             entry = _( "Notes:\n"
@@ -1160,14 +1160,14 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, point d
                                    plots > 0 && warm_enough_to_plant( omt_trg ) );
         } else {
             entry = miss_info.action.translated();
-            bool avail = update_time_left( entry, npc_list );
+            bool const avail = update_time_left( entry, npc_list );
             mission_key.add_return( dir_id + miss_info.ret_miss_id,
                                     dir_abbr + miss_info.ret_desc, dir, entry, avail );
         }
     }
     if( has_provides( "farming", dir ) ) {
         size_t plots = 0;
-        comp_list npc_list = get_mission_workers( "_faction_exp_harvest_" + dir_id );
+        comp_list const npc_list = get_mission_workers( "_faction_exp_harvest_" + dir_id );
         const base_camps::miss_data &miss_info = base_camps::miss_info[ "_faction_exp_harvest_" ];
         if( npc_list.empty() ) {
             entry = _( "Notes:\n"
@@ -1186,21 +1186,21 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, point d
                                    plots > 0 );
         } else {
             entry = miss_info.action.translated();
-            bool avail = update_time_left( entry, npc_list );
+            bool const avail = update_time_left( entry, npc_list );
             mission_key.add_return( dir_id + miss_info.ret_miss_id,
                                     dir_abbr + miss_info.ret_desc, dir, entry, avail );
         }
     }
 
     if( has_provides( "reseeding", dir ) ) {
-        comp_list npc_list = get_mission_workers( "_faction_exp_farm_crafting_" + dir_id );
+        comp_list const npc_list = get_mission_workers( "_faction_exp_farm_crafting_" + dir_id );
         const base_camps::miss_data &miss_info =
             base_camps::miss_info[ "_faction_exp_farm_crafting_" ];
         if( npc_list.empty() ) {
             add_available_recipes( mission_key, dir, craft_recipes );
         } else {
             entry = miss_info.action.translated();
-            bool avail = update_time_left( entry, npc_list );
+            bool const avail = update_time_left( entry, npc_list );
             mission_key.add_return( dir_id + miss_info.ret_miss_id,
                                     dir_abbr + miss_info.ret_desc, dir, entry, avail );
         }
@@ -1211,7 +1211,7 @@ void basecamp::get_available_missions( mission_data &mission_key )
 {
     std::string entry;
 
-    point base_dir = base_camps::base_dir;
+    point const base_dir = base_camps::base_dir;
     const base_camps::direction_data &base_data = base_camps::all_directions.at( base_dir );
     const std::string base_dir_id = base_data.id;
     const std::string base_dir_abbr = base_data.bracket_abbr.translated();
@@ -1220,18 +1220,18 @@ void basecamp::get_available_missions( mission_data &mission_key )
 
     // Handling for the central tile
     // return legacy workers
-    comp_list legacy_npc_list = get_mission_workers( "_faction_upgrade_camp" );
+    comp_list const legacy_npc_list = get_mission_workers( "_faction_upgrade_camp" );
     if( !legacy_npc_list.empty() ) {
         const base_camps::miss_data &miss_info = base_camps::miss_info[ "_faction_upgrade_camp" ];
         entry = miss_info.action.translated();
-        bool avail = update_time_left( entry, legacy_npc_list );
+        bool const avail = update_time_left( entry, legacy_npc_list );
         mission_key.add_return( miss_info.ret_miss_id, miss_info.ret_desc.translated(),
                                 base_camps::base_dir, entry, avail );
     }
     for( const basecamp_upgrade &upgrade : available_upgrades( base_camps::base_dir ) ) {
         gather_bldg = upgrade.bldg;
         const base_camps::miss_data &miss_info = base_camps::miss_info[ "_faction_upgrade_camp" ];
-        comp_list npc_list = get_mission_workers( upgrade.bldg + "_faction_upgrade_camp" );
+        comp_list const npc_list = get_mission_workers( upgrade.bldg + "_faction_upgrade_camp" );
         if( npc_list.empty() && !upgrade.in_progress ) {
             entry = om_upgrade_description( upgrade.bldg );
             mission_key.add_start( miss_info.miss_id + upgrade.bldg,
@@ -1239,7 +1239,7 @@ void basecamp::get_available_missions( mission_data &mission_key )
                                    entry, upgrade.avail );
         } else if( !npc_list.empty() && upgrade.in_progress ) {
             entry = miss_info.action.translated();
-            bool avail = update_time_left( entry, npc_list );
+            bool const avail = update_time_left( entry, npc_list );
             mission_key.add_return( miss_info.ret_miss_id + upgrade.bldg,
                                     miss_info.ret_desc + " " + upgrade.name, base_camps::base_dir,
                                     entry, avail );
@@ -1247,21 +1247,21 @@ void basecamp::get_available_missions( mission_data &mission_key )
     }
 
     // Missions that belong exclusively to the central tile
-    comp_list npc_list = get_mission_workers( "_faction_camp_crafting_" + base_dir_id );
+    comp_list const npc_list = get_mission_workers( "_faction_camp_crafting_" + base_dir_id );
     const base_camps::miss_data &miss_info = base_camps::miss_info[ "_faction_camp_crafting_" ];
     //This handles all crafting by the base, regardless of level
     if( npc_list.empty() ) {
-        std::map<recipe_id, translation> craft_recipes = recipe_deck( base_camps::base_dir );
+        std::map<recipe_id, translation> const craft_recipes = recipe_deck( base_camps::base_dir );
         add_available_recipes( mission_key, base_camps::base_dir, craft_recipes );
     } else {
         entry = miss_info.action.translated();
-        bool avail = update_time_left( entry, npc_list );
+        bool const avail = update_time_left( entry, npc_list );
         mission_key.add_return( base_dir_id + miss_info.ret_miss_id,
                                 base_dir_abbr + miss_info.ret_desc, base_camps::base_dir, entry,
                                 avail );
     }
     if( can_expand() ) {
-        comp_list npc_list = get_mission_workers( "_faction_camp_expansion" );
+        comp_list const npc_list = get_mission_workers( "_faction_camp_expansion" );
         const base_camps::miss_data &miss_info = base_camps::miss_info[ "_faction_camp_expansion" ];
         entry = string_format( _( "Notes:\n"
                                   "Your base has become large enough to support an expansion.  "
@@ -1285,7 +1285,7 @@ void basecamp::get_available_missions( mission_data &mission_key )
                                base_camps::base_dir, entry, npc_list.empty() );
         if( !npc_list.empty() ) {
             entry = miss_info.action.translated();
-            bool avail = update_time_left( entry, npc_list );
+            bool const avail = update_time_left( entry, npc_list );
             mission_key.add_return( miss_info.ret_miss_id, miss_info.ret_desc.translated(),
                                     base_camps::base_dir, entry, avail );
         }
@@ -1327,7 +1327,7 @@ void basecamp::get_available_missions( mission_data &mission_key )
     get_available_missions_by_dir( mission_key, base_camps::base_dir );
 
     // Loop over expansions
-    for( point dir : directions ) {
+    for( point const dir : directions ) {
         get_available_missions_by_dir( mission_key, dir );
     }
 
@@ -1342,7 +1342,7 @@ void basecamp::get_available_missions( mission_data &mission_key )
                                   "companion who cannot otherwise be recovered.\n\n"
                                   "Companions must be on missions for at least 24 hours before "
                                   "emergency recall becomes available." ) );
-        bool avail = update_time_fixed( entry, camp_workers, 24_hours );
+        bool const avail = update_time_fixed( entry, camp_workers, 24_hours );
         mission_key.add_return( miss_info.ret_miss_id, miss_info.ret_desc.translated(),
                                 base_camps::base_dir, entry, avail );
     }
@@ -1351,7 +1351,7 @@ void basecamp::get_available_missions( mission_data &mission_key )
 bool basecamp::handle_mission( const std::string &miss_id,
                                const std::optional<point> &opt_miss_dir )
 {
-    point miss_dir = opt_miss_dir ? *opt_miss_dir : base_camps::base_dir;
+    point const miss_dir = opt_miss_dir ? *opt_miss_dir : base_camps::base_dir;
 
     if( miss_id == "Distribute Food" ) {
         distribute_food();
@@ -1490,7 +1490,7 @@ bool basecamp::handle_mission( const std::string &miss_id,
         upgrade_return( miss_dir, "_faction_upgrade_exp_" + miss_dir_id );
     } else {
         const std::string search_str = "Recover Ally, " + miss_dir_id + " Expansion";
-        size_t search_len = search_str.size();
+        size_t const search_len = search_str.size();
         if( miss_id.size() > search_len && miss_id.substr( 0, search_len ) == search_str ) {
             const std::string bldg = miss_id.substr( search_len );
             upgrade_return( miss_dir, bldg + "_faction_upgrade_exp_" + miss_dir_id, bldg );
@@ -1594,14 +1594,14 @@ void basecamp::start_upgrade( const std::string &bldg, point dir,
     //Stop upgrade if you don't have materials
     if( making.deduped_requirements().can_make_with_inventory(
             _inv, making.get_component_filter() ) ) {
-        bool must_feed = bldg != "faction_base_camp_1";
+        bool const must_feed = bldg != "faction_base_camp_1";
 
         basecamp_action_components components( making, 1, *this );
         if( !components.choose_components() ) {
             return;
         }
 
-        time_duration work_days = base_camps::to_workdays( making.batch_duration() );
+        time_duration const work_days = base_camps::to_workdays( making.batch_duration() );
         npc_ptr comp = nullptr;
         if( making.required_skills.empty() ) {
             if( making.skill_used.is_valid() ) {
@@ -1629,15 +1629,15 @@ void basecamp::start_upgrade( const std::string &bldg, point dir,
 void basecamp::abandon_camp()
 {
     validate_assignees();
-    for( npc_ptr &guy : overmap_buffer.get_companion_mission_npcs( 10 ) ) {
-        npc_companion_mission c_mission = guy->get_companion_mission();
+    for( npc_ptr  const&guy : overmap_buffer.get_companion_mission_npcs( 10 ) ) {
+        npc_companion_mission const c_mission = guy->get_companion_mission();
         if( c_mission.role_id != base_camps::id ) {
             continue;
         }
         const std::string return_msg = _( "responds to the emergency recall…" );
         finish_return( *guy, false, return_msg, "menial", 0, true );
     }
-    for( npc_ptr &guy : get_npcs_assigned() ) {
+    for( npc_ptr  const&guy : get_npcs_assigned() ) {
         talk_function::stop_guard( *guy );
     }
     overmap_buffer.remove_camp( *this );
@@ -1708,7 +1708,7 @@ void basecamp::worker_assignment_ui()
         // create a list of npcs stationed at this camp
         followers.clear();
         for( const character_id &elem : g->get_follower_list() ) {
-            shared_ptr_fast<npc> npc_to_get = overmap_buffer.find_npc( elem );
+            shared_ptr_fast<npc> const npc_to_get = overmap_buffer.find_npc( elem );
             if( !npc_to_get || !npc_to_get->is_following() ) {
                 continue;
             }
@@ -1795,9 +1795,9 @@ void basecamp::job_assignment_ui()
                 int start_y = 3;
                 if( cur_npc ) {
                     if( cur_npc->has_job() ) {
-                        for( activity_id &elem : cur_npc->job.get_prioritised_vector() ) {
+                        for( activity_id  const&elem : cur_npc->job.get_prioritised_vector() ) {
                             const int priority = cur_npc->job.get_priority_of_job( elem );
-                            player_activity test_act = player_activity( elem );
+                            player_activity const test_act = player_activity( elem );
                             mvwprintz( w_jobs, point( 46, start_y ), c_light_gray, string_format( _( "%s : %s" ),
                                        test_act.get_verb(), std::to_string( priority ) ) );
                             start_y++;
@@ -1855,7 +1855,7 @@ void basecamp::job_assignment_ui()
                     smenu.addentry( count, true, 'C', _( "Clear all priorities" ) );
                     count++;
                     for( const activity_id &elem : job_vec ) {
-                        player_activity test_act = player_activity( elem );
+                        player_activity const test_act = player_activity( elem );
                         const int priority = cur_npc->job.get_priority_of_job( elem );
                         smenu.addentry( count, true, MENU_AUTOASSIGN, string_format( _( "%s : %s" ), test_act.get_verb(),
                                         std::to_string( priority ) ) );
@@ -1867,8 +1867,8 @@ void basecamp::job_assignment_ui()
                     } else if( smenu.ret == 0 ) {
                         cur_npc->job.clear_all_priorities();
                     } else if( smenu.ret > 0 && smenu.ret <= static_cast<int>( job_vec.size() ) ) {
-                        activity_id sel_job = job_vec[smenu.ret - 1];
-                        player_activity test_act = player_activity( sel_job );
+                        activity_id const sel_job = job_vec[smenu.ret - 1];
+                        player_activity const test_act = player_activity( sel_job );
                         const std::string formatted = string_format( _( "Priority for %s " ), test_act.get_verb() );
                         const int amount = string_input_popup()
                                            .title( formatted )
@@ -1893,7 +1893,7 @@ void basecamp::start_menial_labor()
         popup( _( "You don't have enough food stored to feed your companion." ) );
         return;
     }
-    shared_ptr_fast<npc> comp = talk_function::companion_choose();
+    shared_ptr_fast<npc> const comp = talk_function::companion_choose();
     if( comp == nullptr ) {
         return;
     }
@@ -1905,19 +1905,19 @@ void basecamp::start_menial_labor()
 
 void basecamp::start_cut_logs()
 {
-    std::vector<std::string> log_sources = { "forest", "forest_thick", "forest_water" };
+    std::vector<std::string> const log_sources = { "forest", "forest_thick", "forest_water" };
     popup( _( "Forests and swamps are the only valid cutting locations." ) );
-    tripoint_abs_omt forest = om_target_tile( omt_pos, 1, 50, log_sources );
+    tripoint_abs_omt const forest = om_target_tile( omt_pos, 1, 50, log_sources );
     if( forest != tripoint_abs_omt( -999, -999, -999 ) ) {
         standard_npc sample_npc( "Temp" );
         sample_npc.set_fake( true );
-        int tree_est = om_cutdown_trees_est( forest, 50 );
-        int tree_young_est = om_harvest_ter_est( sample_npc, forest,
+        int const tree_est = om_cutdown_trees_est( forest, 50 );
+        int const tree_young_est = om_harvest_ter_est( sample_npc, forest,
                              ter_id( "t_tree_young" ), 50 );
-        int dist = rl_dist( forest.xy(), omt_pos.xy() );
+        int const dist = rl_dist( forest.xy(), omt_pos.xy() );
         //Very roughly what the player does + 6 hours for prep, clean up, breaks
-        time_duration chop_time = 6_hours + 1_hours * tree_est + 7_minutes * tree_young_est;
-        int haul_items = 2 * tree_est + 3 * tree_young_est;
+        time_duration const chop_time = 6_hours + 1_hours * tree_est + 7_minutes * tree_young_est;
+        int const haul_items = 2 * tree_est + 3 * tree_young_est;
         time_duration travel_time = companion_travel_time_calc( forest, omt_pos, 0_minutes,
                                     2, haul_items );
         time_duration work_time = travel_time + chop_time;
@@ -1926,13 +1926,13 @@ void basecamp::start_cut_logs()
             return;
         }
 
-        npc_ptr comp = start_mission( "_faction_camp_cut_log", work_time, true,
+        npc_ptr const comp = start_mission( "_faction_camp_cut_log", work_time, true,
                                       _( "departs to cut logs…" ), false, {},
                                       skill_fabrication, 2 );
         if( comp != nullptr ) {
             om_cutdown_trees_logs( forest, 50 );
             om_harvest_ter( *comp, forest, ter_id( "t_tree_young" ), 50 );
-            mass_volume harvest = om_harvest_itm( comp, forest, 95 );
+            mass_volume const harvest = om_harvest_itm( comp, forest, 95 );
             // recalculate trips based on actual load and capacity
             travel_time = companion_travel_time_calc( forest, omt_pos, 0_minutes, 2,
                           harvest.count );
@@ -1952,26 +1952,26 @@ void basecamp::start_cut_logs()
 
 void basecamp::start_clearcut()
 {
-    std::vector<std::string> log_sources = { "forest", "forest_thick" };
+    std::vector<std::string> const log_sources = { "forest", "forest_thick" };
     popup( _( "Forests are the only valid cutting locations." ) );
-    tripoint_abs_omt forest = om_target_tile( omt_pos, 1, 50, log_sources );
+    tripoint_abs_omt const forest = om_target_tile( omt_pos, 1, 50, log_sources );
     if( forest != tripoint_abs_omt( -999, -999, -999 ) ) {
         standard_npc sample_npc( "Temp" );
         sample_npc.set_fake( true );
-        int tree_est = om_cutdown_trees_est( forest, 95 );
-        int tree_young_est = om_harvest_ter_est( sample_npc, forest,
+        int const tree_est = om_cutdown_trees_est( forest, 95 );
+        int const tree_young_est = om_harvest_ter_est( sample_npc, forest,
                              ter_id( "t_tree_young" ), 95 );
-        int dist = rl_dist( forest.xy(), omt_pos.xy() );
+        int const dist = rl_dist( forest.xy(), omt_pos.xy() );
         //Very roughly what the player does + 6 hours for prep, clean up, breaks
-        time_duration chop_time = 6_hours + 1_hours * tree_est + 7_minutes * tree_young_est;
-        time_duration travel_time = companion_travel_time_calc( forest, omt_pos, 0_minutes, 2 );
-        time_duration work_time = travel_time + chop_time;
+        time_duration const chop_time = 6_hours + 1_hours * tree_est + 7_minutes * tree_young_est;
+        time_duration const travel_time = companion_travel_time_calc( forest, omt_pos, 0_minutes, 2 );
+        time_duration const work_time = travel_time + chop_time;
         if( !query_yn( _( "Trip Estimate:\n%s" ), camp_trip_description( work_time,
                        chop_time, travel_time, dist, 2, time_to_food( work_time ) ) ) ) {
             return;
         }
 
-        npc_ptr comp = start_mission( "_faction_camp_clearcut", work_time,
+        npc_ptr const comp = start_mission( "_faction_camp_clearcut", work_time,
                                       true, _( "departs to clear a forest…" ), false, {},
                                       skill_fabrication, 1 );
         if( comp != nullptr ) {
@@ -1987,33 +1987,33 @@ void basecamp::start_clearcut()
 
 void basecamp::start_setup_hide_site()
 {
-    std::vector<std::string> hide_locations = { "forest", "forest_thick", "forest_water",
+    std::vector<std::string> const hide_locations = { "forest", "forest_thick", "forest_water",
                                                 "field"
                                               };
     popup( _( "Forests, swamps, and fields are valid hide site locations." ) );
-    tripoint_abs_omt forest = om_target_tile( omt_pos, 10, 90, hide_locations, true, true,
+    tripoint_abs_omt const forest = om_target_tile( omt_pos, 10, 90, hide_locations, true, true,
                               omt_pos, true );
     if( forest != tripoint_abs_omt( -999, -999, -999 ) ) {
-        int dist = rl_dist( forest.xy(), omt_pos.xy() );
+        int const dist = rl_dist( forest.xy(), omt_pos.xy() );
         inventory tgt_inv = g->u.inv;
-        std::vector<item *> pos_inv = tgt_inv.items_with( []( const item & itm ) {
+        std::vector<item *> const pos_inv = tgt_inv.items_with( []( const item & itm ) {
             return !itm.can_revive();
         } );
         if( !pos_inv.empty() ) {
-            std::vector<item *> losing_equipment = give_equipment( pos_inv,
+            std::vector<item *> const losing_equipment = give_equipment( pos_inv,
                                                    _( "Do you wish to give your companion "
                                                            "additional items?" ) );
             int trips = om_carry_weight_to_trips( losing_equipment );
             int haulage = trips <= 2 ? 0 : losing_equipment.size();
-            time_duration build_time = 6_hours;
-            time_duration travel_time = companion_travel_time_calc( forest, omt_pos, 0_minutes,
+            time_duration const build_time = 6_hours;
+            time_duration const travel_time = companion_travel_time_calc( forest, omt_pos, 0_minutes,
                                         2, haulage );
             time_duration work_time = travel_time + build_time;
             if( !query_yn( _( "Trip Estimate:\n%s" ), camp_trip_description( work_time,
                            build_time, travel_time, dist, trips, time_to_food( work_time ) ) ) ) {
                 return;
             }
-            npc_ptr comp = start_mission( "_faction_camp_hide_site", work_time, true,
+            npc_ptr const comp = start_mission( "_faction_camp_hide_site", work_time, true,
                                           _( "departs to build a hide site…" ), false, {},
                                           skill_survival, 3 );
             if( comp != nullptr ) {
@@ -2032,14 +2032,14 @@ void basecamp::start_setup_hide_site()
 
 void basecamp::start_relay_hide_site()
 {
-    std::vector<std::string> hide_locations = { "faction_hide_site_0" };
+    std::vector<std::string> const hide_locations = { "faction_hide_site_0" };
     popup( _( "You must select an existing hide site." ) );
-    tripoint_abs_omt forest = om_target_tile( omt_pos, 10, 90, hide_locations, true, true,
+    tripoint_abs_omt const forest = om_target_tile( omt_pos, 10, 90, hide_locations, true, true,
                               omt_pos, true );
     if( forest != tripoint_abs_omt( -999, -999, -999 ) ) {
-        int dist = rl_dist( forest.xy(), omt_pos.xy() );
+        int const dist = rl_dist( forest.xy(), omt_pos.xy() );
         inventory tgt_inv = g->u.inv;
-        std::vector<item *> pos_inv = tgt_inv.items_with( []( const item & itm ) {
+        std::vector<item *> const pos_inv = tgt_inv.items_with( []( const item & itm ) {
             return !itm.can_revive();
         } );
         std::vector<item *> losing_equipment;
@@ -2063,10 +2063,10 @@ void basecamp::start_relay_hide_site()
             //Only get charged the greater trips since return is free for both
             int trips = std::max( om_carry_weight_to_trips( gaining_equipment ),
                                   om_carry_weight_to_trips( losing_equipment ) );
-            int haulage = trips <= 2 ? 0 : std::max( gaining_equipment.size(),
+            int const haulage = trips <= 2 ? 0 : std::max( gaining_equipment.size(),
                           losing_equipment.size() );
-            time_duration build_time = 6_hours;
-            time_duration travel_time = companion_travel_time_calc( forest, omt_pos, 0_minutes,
+            time_duration const build_time = 6_hours;
+            time_duration const travel_time = companion_travel_time_calc( forest, omt_pos, 0_minutes,
                                         trips, haulage );
             time_duration work_time = travel_time + build_time;
             if( !query_yn( _( "Trip Estimate:\n%s" ), camp_trip_description( work_time, build_time,
@@ -2074,14 +2074,14 @@ void basecamp::start_relay_hide_site()
                 return;
             }
 
-            npc_ptr comp = start_mission( "_faction_camp_hide_trans", work_time, true,
+            npc_ptr const comp = start_mission( "_faction_camp_hide_trans", work_time, true,
                                           _( "departs for the hide site…" ), false, {},
                                           skill_survival, 3 );
             if( comp != nullptr ) {
                 // recalculate trips based on actual load
                 trips = std::max( om_carry_weight_to_trips( gaining_equipment, comp ),
                                   om_carry_weight_to_trips( losing_equipment, comp ) );
-                int haulage = trips <= 2 ? 0 : std::max( gaining_equipment.size(),
+                int const haulage = trips <= 2 ? 0 : std::max( gaining_equipment.size(),
                               losing_equipment.size() );
                 work_time = companion_travel_time_calc( forest, omt_pos, 0_minutes, trips,
                                                         haulage ) + build_time;
@@ -2096,7 +2096,7 @@ void basecamp::start_relay_hide_site()
 
 void basecamp::start_fortifications( std::string &bldg_exp )
 {
-    std::vector<std::string> allowed_locations = {
+    std::vector<std::string> const allowed_locations = {
         "forest", "forest_thick", "forest_water", "field"
     };
     popup( _( "Select a start and end point.  Line must be straight.  Fields, forests, and "
@@ -2108,15 +2108,15 @@ void basecamp::start_fortifications( std::string &bldg_exp )
     if( start != tripoint_abs_omt( -999, -999, -999 ) &&
         stop != tripoint_abs_omt( -999, -999, -999 ) ) {
         const recipe &making = recipe_id( bldg_exp ).obj();
-        bool change_x = ( start.x() != stop.x() );
-        bool change_y = ( start.y() != stop.y() );
+        bool const change_x = ( start.x() != stop.x() );
+        bool const change_y = ( start.y() != stop.y() );
         if( change_x && change_y ) {
             popup( "Construction line must be straight!" );
             return;
         }
         if( bldg_exp == "faction_wall_level_N_1" ) {
-            std::vector<tripoint_abs_omt> tmp_line = line_to( stop, start );
-            int line_count = tmp_line.size();
+            std::vector<tripoint_abs_omt> const tmp_line = line_to( stop, start );
+            int const line_count = tmp_line.size();
             int yes_count = 0;
             for( auto elem : tmp_line ) {
                 if( std::find( fortifications.begin(), fortifications.end(), elem ) != fortifications.end() ) {
@@ -2162,8 +2162,8 @@ void basecamp::start_fortifications( std::string &bldg_exp )
             dist += rl_dist( fort_om.xy(), omt_pos.xy() );
             travel_time += companion_travel_time_calc( fort_om, omt_pos, 0_minutes, 2 );
         }
-        time_duration total_time = base_camps::to_workdays( travel_time + build_time );
-        int need_food = time_to_food( total_time );
+        time_duration const total_time = base_camps::to_workdays( travel_time + build_time );
+        int const need_food = time_to_food( total_time );
         if( !query_yn( _( "Trip Estimate:\n%s" ), camp_trip_description( total_time, build_time,
                        travel_time, dist, trips, need_food ) ) ) {
             return;
@@ -2179,7 +2179,7 @@ void basecamp::start_fortifications( std::string &bldg_exp )
             return;
         }
 
-        npc_ptr comp = start_mission( "_faction_camp_om_fortifications", total_time, true,
+        npc_ptr const comp = start_mission( "_faction_camp_om_fortifications", total_time, true,
                                       _( "begins constructing fortifications…" ), false, {},
                                       making.required_skills );
         if( comp != nullptr ) {
@@ -2196,19 +2196,19 @@ void basecamp::start_combat_mission( const std::string &miss )
 {
     popup( _( "Select checkpoints until you reach maximum range or select the last point again "
               "to end." ) );
-    tripoint_abs_omt start = omt_pos;
-    std::vector<tripoint_abs_omt> scout_points = om_companion_path( start, 90, true );
+    tripoint_abs_omt const start = omt_pos;
+    std::vector<tripoint_abs_omt> const scout_points = om_companion_path( start, 90, true );
     if( scout_points.empty() ) {
         return;
     }
-    int dist = scout_points.size();
-    int trips = 2;
-    time_duration travel_time = companion_travel_time_calc( scout_points, 0_minutes, trips );
+    int const dist = scout_points.size();
+    int const trips = 2;
+    time_duration const travel_time = companion_travel_time_calc( scout_points, 0_minutes, trips );
     if( !query_yn( _( "Trip Estimate:\n%s" ), camp_trip_description( 0_hours, 0_hours,
                    travel_time, dist, trips, time_to_food( travel_time ) ) ) ) {
         return;
     }
-    npc_ptr comp = start_mission( miss, travel_time, true, _( "departs on patrol…" ),
+    npc_ptr const comp = start_mission( miss, travel_time, true, _( "departs on patrol…" ),
                                   false, {}, skill_survival, 3 );
     if( comp != nullptr ) {
         comp->companion_mission_points = scout_points;
@@ -2241,7 +2241,7 @@ void basecamp::start_crafting( const std::string &cur_id, point cur_dir,
 
         int batch_size = 1;
         string_input_popup popup_input;
-        int batch_max = recipe_batch_max( making );
+        int const batch_max = recipe_batch_max( making );
         const std::string title = string_format( _( "Batch crafting %s [MAX: %d]: " ),
                                   making.result_name(), batch_max );
         popup_input.title( title ).edit( batch_size );
@@ -2259,8 +2259,8 @@ void basecamp::start_crafting( const std::string &cur_id, point cur_dir,
             return;
         }
 
-        time_duration work_days = base_camps::to_workdays( making.batch_duration( batch_size ) );
-        npc_ptr comp = start_mission( miss_id + cur_dir_id, work_days, true,
+        time_duration const work_days = base_camps::to_workdays( making.batch_duration( batch_size ) );
+        npc_ptr const comp = start_mission( miss_id + cur_dir_id, work_days, true,
                                       _( "begins to work…" ), false, {},
                                       making.required_skills );
         if( comp != nullptr ) {
@@ -2305,8 +2305,8 @@ static std::pair<size_t, std::string> farm_action( const tripoint_abs_omt &omt_t
     //farm_map is what the area actually looks like
     tinymap farm_map;
     farm_map.load( project_to<coords::sm>( omt_tgt ), false );
-    tripoint mapmin = tripoint( 0, 0, omt_tgt.z() );
-    tripoint mapmax = tripoint( 2 * SEEX - 1, 2 * SEEY - 1, omt_tgt.z() );
+    tripoint const mapmin = tripoint( 0, 0, omt_tgt.z() );
+    tripoint const mapmax = tripoint( 2 * SEEX - 1, 2 * SEEY - 1, omt_tgt.z() );
     bool done_planting = false;
     map &here = get_map();
     for( const tripoint &pos : farm_map.points_in_rectangle( mapmin, mapmax ) ) {
@@ -2357,11 +2357,11 @@ static std::pair<size_t, std::string> farm_action( const tripoint_abs_omt &omt_t
                     if( seed != items.end() && farm_valid_seed( *seed ) ) {
                         plots_cnt += 1;
                         if( comp ) {
-                            int skillLevel = comp->get_skill_level( skill_survival );
+                            int const skillLevel = comp->get_skill_level( skill_survival );
                             ///\EFFECT_SURVIVAL increases number of plants harvested from a seed
                             int plant_cnt = rng( skillLevel / 2, skillLevel );
                             plant_cnt = std::min( std::max( plant_cnt, 1 ), 9 );
-                            int seed_cnt = std::max( 1, rng( plant_cnt / 4, plant_cnt / 2 ) );
+                            int const seed_cnt = std::max( 1, rng( plant_cnt / 4, plant_cnt / 2 ) );
                             for( auto &i : iexamine::get_harvest_items( *seed->type, plant_cnt,
                                     seed_cnt, true ) ) {
                                 here.add_item_or_charges( g->u.pos(), i );
@@ -2401,8 +2401,8 @@ static std::pair<size_t, std::string> farm_action( const tripoint_abs_omt &omt_t
 void basecamp::start_farm_op( point dir, const tripoint_abs_omt &omt_tgt, farm_ops op )
 {
     const std::string &dir_id = base_camps::all_directions.at( dir ).id;
-    std::pair<size_t, std::string> farm_data = farm_action( omt_tgt, op );
-    size_t plots_cnt = farm_data.first;
+    std::pair<size_t, std::string> const farm_data = farm_action( omt_tgt, op );
+    size_t const plots_cnt = farm_data.first;
     if( !plots_cnt ) {
         return;
     }
@@ -2415,18 +2415,18 @@ void basecamp::start_farm_op( point dir, const tripoint_abs_omt &omt_tgt, farm_o
                            _( "begins to harvest the field…" ), false, {}, skill_survival, 1 );
             break;
         case farm_ops::plant: {
-            std::vector<item *> seed_inv = _inv.items_with( farm_valid_seed );
+            std::vector<item *> const seed_inv = _inv.items_with( farm_valid_seed );
             if( seed_inv.empty() ) {
                 popup( _( "You have no additional seeds to give your companions…" ) );
                 return;
             }
-            std::vector<item *> plant_these = give_equipment( seed_inv,
+            std::vector<item *> const plant_these = give_equipment( seed_inv,
                                               _( "Which seeds do you wish to have planted?" ) );
             size_t seed_cnt = 0;
             for( item *seeds : plant_these ) {
                 seed_cnt += seeds->count();
             }
-            size_t plots_seeded = std::min( seed_cnt, plots_cnt );
+            size_t const plots_seeded = std::min( seed_cnt, plots_cnt );
             if( !seed_cnt ) {
                 return;
             }
@@ -2459,7 +2459,7 @@ bool basecamp::start_garage_chop( point dir, const tripoint_abs_omt &omt_tgt )
     }
 
     const std::string dir_id = base_camps::all_directions.at( dir ).id;
-    npc_ptr comp = start_mission( "_faction_exp_chop_shop_" + dir_id, 5_days, true,
+    npc_ptr const comp = start_mission( "_faction_exp_chop_shop_" + dir_id, 5_days, true,
                                   _( "begins working in the garage…" ), false, {},
                                   skill_mechanics, 2 );
     if( comp == nullptr ) {
@@ -2467,14 +2467,14 @@ bool basecamp::start_garage_chop( point dir, const tripoint_abs_omt &omt_tgt )
     }
     // FIXME: use ranges, do this sensibly
     //Chopping up the car!
-    int skillLevel = comp->get_skill_level( skill_mechanics );
+    int const skillLevel = comp->get_skill_level( skill_mechanics );
     for( int prt = 0; prt < car->part_count(); prt++ ) {
         vehicle_stack contents = car->get_items( prt );
         for( auto iter = contents.begin(); iter != contents.end(); ) {
             comp->companion_mission_inv.add_item( *iter );
             iter = contents.erase( iter );
         }
-        bool broken = car->part( prt ).is_broken();
+        bool const broken = car->part( prt ).is_broken();
         bool skill_break = false;
         bool skill_destroy = false;
 
@@ -2526,7 +2526,7 @@ void basecamp::finish_return( npc &comp, const bool fixed_time, const std::strin
 {
     popup( "%s %s", comp.name, return_msg );
     // this is the time the mission was expected to take, or did take for fixed time missions
-    time_duration reserve_time = comp.companion_mission_time_ret - comp.companion_mission_time;
+    time_duration const reserve_time = comp.companion_mission_time_ret - comp.companion_mission_time;
     time_duration mission_time = reserve_time;
     if( !fixed_time ) {
         mission_time = calendar::turn - comp.companion_mission_time;
@@ -2537,11 +2537,11 @@ void basecamp::finish_return( npc &comp, const bool fixed_time, const std::strin
 
     // companions subtracted food when they started the mission, but didn't mod their hunger for
     // that food.  so add it back in.
-    int need_food = time_to_food( mission_time - reserve_time );
+    int const need_food = time_to_food( mission_time - reserve_time );
     if( camp_food_supply() < need_food ) {
         popup( _( "Your companion seems disappointed that your pantry is empty…" ) );
     }
-    int avail_food = std::min( need_food, camp_food_supply() ) + time_to_food( reserve_time );
+    int const avail_food = std::min( need_food, camp_food_supply() ) + time_to_food( reserve_time );
     // movng all the logic from talk_function::companion return here instead of polluting
     // mission_companion
     comp.reset_companion_mission();
@@ -2613,8 +2613,8 @@ bool basecamp::upgrade_return( point dir, const std::string &miss,
     const tripoint_abs_omt upos = e->second.pos;
     const recipe &making = recipe_id( bldg ).obj();
 
-    time_duration work_days = base_camps::to_workdays( making.batch_duration() );
-    npc_ptr comp = companion_choose_return( miss, work_days );
+    time_duration const work_days = base_camps::to_workdays( making.batch_duration() );
+    npc_ptr const comp = companion_choose_return( miss, work_days );
 
     if( comp == nullptr ) {
         return false;
@@ -2638,7 +2638,7 @@ bool basecamp::upgrade_return( point dir, const std::string &miss,
 bool basecamp::menial_return()
 {
     const std::string msg = _( "returns from doing the dirty work to keep the camp running…" );
-    npc_ptr comp = mission_return( "_faction_camp_menial", 3_hours, true, msg, "menial", 2 );
+    npc_ptr const comp = mission_return( "_faction_camp_menial", 3_hours, true, msg, "menial", 2 );
     if( comp == nullptr ) {
         return false;
     }
@@ -2648,7 +2648,7 @@ bool basecamp::menial_return()
 
 bool basecamp::gathering_return( const std::string &task, time_duration min_time )
 {
-    npc_ptr comp = companion_choose_return( task, min_time );
+    npc_ptr const comp = companion_choose_return( task, min_time );
     if( comp == nullptr ) {
         return false;
     }
@@ -2681,7 +2681,7 @@ bool basecamp::gathering_return( const std::string &task, time_duration min_time
         checks_per_cycle = 2;
     }
 
-    time_duration mission_time = calendar::turn - comp->companion_mission_time;
+    time_duration const mission_time = calendar::turn - comp->companion_mission_time;
     if( one_in( danger ) && !survive_random_encounter( *comp, task_description, favor, threat ) ) {
         return false;
     }
@@ -2723,7 +2723,7 @@ bool basecamp::gathering_return( const std::string &task, time_duration min_time
 
 void basecamp::fortifications_return()
 {
-    npc_ptr comp = companion_choose_return( "_faction_camp_om_fortifications", 3_hours );
+    npc_ptr const comp = companion_choose_return( "_faction_camp_om_fortifications", 3_hours );
     if( comp != nullptr ) {
         std::string build_n = "faction_wall_level_N_0";
         std::string build_e = "faction_wall_level_E_0";
@@ -2737,7 +2737,7 @@ void basecamp::fortifications_return()
         }
         std::string build_first = build_e;
         std::string build_second = build_w;
-        bool build_dir_NS = comp->companion_mission_points[0].y() !=
+        bool const build_dir_NS = comp->companion_mission_points[0].y() !=
                             comp->companion_mission_points[1].y();
         if( build_dir_NS ) {
             build_first = build_s;
@@ -2756,7 +2756,7 @@ void basecamp::fortifications_return()
                 run_mapgen_update_func( build_second, build_point[pt] );
             }
             if( comp->companion_mission_role_id == "faction_wall_level_N_0" ) {
-                tripoint_abs_omt fort_point = build_point[pt];
+                tripoint_abs_omt const fort_point = build_point[pt];
                 fortifications.push_back( fort_point );
             }
         }
@@ -2769,7 +2769,7 @@ void basecamp::recruit_return( const std::string &task, int score )
 {
     const std::string msg = _( "returns from searching for recruits with "
                                "a bit more experience…" );
-    npc_ptr comp = mission_return( task, 4_days, true, msg, "recruiting", 2 );
+    npc_ptr const comp = mission_return( task, 4_days, true, msg, "recruiting", 2 );
     if( comp == nullptr ) {
         return;
     }
@@ -2880,17 +2880,17 @@ void basecamp::recruit_return( const std::string &task, int score )
 
 void basecamp::combat_mission_return( const std::string &miss )
 {
-    npc_ptr comp = companion_choose_return( miss, 3_hours );
+    npc_ptr const comp = companion_choose_return( miss, 3_hours );
     if( comp != nullptr ) {
-        bool patrolling = miss == "_faction_camp_combat_0";
+        bool const patrolling = miss == "_faction_camp_combat_0";
         comp_list patrol;
-        npc_ptr guy = overmap_buffer.find_npc( comp->getID() );
+        npc_ptr const guy = overmap_buffer.find_npc( comp->getID() );
         if( guy ) {
             patrol.push_back( guy );
         }
         for( auto pt : comp->companion_mission_points ) {
             const oter_id &omt_ref = overmap_buffer.ter( pt );
-            int swim = comp->get_skill_level( skill_swimming );
+            int const swim = comp->get_skill_level( skill_swimming );
             if( is_river( omt_ref ) && swim < 2 ) {
                 if( swim == 0 ) {
                     popup( _( "Your companion hit a river and didn't know how to swim…" ) );
@@ -2901,7 +2901,7 @@ void basecamp::combat_mission_return( const std::string &miss )
                 break;
             }
             comp->death_drops = false;
-            bool outcome = talk_function::companion_om_combat_check( patrol, pt, patrolling );
+            bool const outcome = talk_function::companion_om_combat_check( patrol, pt, patrolling );
             comp->death_drops = true;
             if( outcome ) {
                 overmap_buffer.reveal( pt, 2 );
@@ -2920,7 +2920,7 @@ void basecamp::combat_mission_return( const std::string &miss )
 
 bool basecamp::survey_return()
 {
-    npc_ptr comp = companion_choose_return( "_faction_camp_expansion", 3_hours );
+    npc_ptr const comp = companion_choose_return( "_faction_camp_expansion", 3_hours );
     if( comp == nullptr ) {
         return false;
     }
@@ -2931,7 +2931,7 @@ bool basecamp::survey_return()
         return false;
     }
 
-    int dist = rl_dist( where.xy(), omt_pos.xy() );
+    int const dist = rl_dist( where.xy(), omt_pos.xy() );
     if( dist != 1 ) {
         popup( _( "You must select a tile within %d range of the camp" ), 1 );
         return false;
@@ -2973,7 +2973,7 @@ bool basecamp::survey_return()
 bool basecamp::farm_return( const std::string &task, const tripoint_abs_omt &omt_tgt, farm_ops op )
 {
     const std::string msg = _( "returns from working your fields…" );
-    npc_ptr comp = companion_choose_return( task, 15_minutes );
+    npc_ptr const comp = companion_choose_return( task, 15_minutes );
     if( comp == nullptr ) {
         return false;
     }
@@ -3009,7 +3009,7 @@ void talk_function::draw_camp_tabs( const catacurses::window &win,
     int tab_space = 1;
     int tab_x = 0;
     for( auto &t : tabs ) {
-        bool tab_empty = entries[tab_x + 1].empty();
+        bool const tab_empty = entries[tab_x + 1].empty();
         draw_subtab( win, tab_space, t, tab_x == cur_tab, false, tab_empty );
         tab_space += tab_step + utf8_width( t );
         tab_x++;
@@ -3044,10 +3044,10 @@ int basecamp::recipe_batch_max( const recipe &making ) const
     const int max_checks = 9;
     for( size_t batch_size = 1000; batch_size > 0; batch_size /= 10 ) {
         for( int iter = 0; iter < max_checks; iter++ ) {
-            time_duration work_days = base_camps::to_workdays( making.batch_duration(
+            time_duration const work_days = base_camps::to_workdays( making.batch_duration(
                                           max_batch + batch_size ) );
-            int food_req = time_to_food( work_days );
-            bool can_make = making.deduped_requirements().can_make_with_inventory(
+            int const food_req = time_to_food( work_days );
+            bool const can_make = making.deduped_requirements().can_make_with_inventory(
                                 _inv, making.get_component_filter(), max_batch + batch_size );
             if( can_make && camp_food_supply() > food_req ) {
                 max_batch += batch_size;
@@ -3140,8 +3140,8 @@ int om_harvest_furn( npc &comp, const tripoint &omt_tgt, const furn_id &f, int c
     target_bay.load( tripoint( omt_tgt.x * 2, omt_tgt.y * 2, omt_tgt.z ), false );
     int harvested = 0;
     int total = 0;
-    tripoint mapmin = tripoint( 0, 0, omt_tgt.z );
-    tripoint mapmax = tripoint( 2 * SEEX - 1, 2 * SEEY - 1, omt_tgt.z );
+    tripoint const mapmin = tripoint( 0, 0, omt_tgt.z );
+    tripoint const mapmax = tripoint( 2 * SEEX - 1, 2 * SEEY - 1, omt_tgt.z );
     for( const tripoint &p : target_bay.points_in_rectangle( mapmin, mapmax ) ) {
         if( target_bay.furn( p ) == f && x_in_y( chance, 100 ) ) {
             total++;
@@ -3183,8 +3183,8 @@ int om_harvest_ter( npc &comp, const tripoint_abs_omt &omt_tgt, const ter_id &t,
     target_bay.load( project_to<coords::sm>( omt_tgt ), false );
     int harvested = 0;
     int total = 0;
-    tripoint mapmin = tripoint( 0, 0, omt_tgt.z() );
-    tripoint mapmax = tripoint( 2 * SEEX - 1, 2 * SEEY - 1, omt_tgt.z() );
+    tripoint const mapmin = tripoint( 0, 0, omt_tgt.z() );
+    tripoint const mapmax = tripoint( 2 * SEEX - 1, 2 * SEEY - 1, omt_tgt.z() );
     for( const tripoint &p : target_bay.points_in_rectangle( mapmin, mapmax ) ) {
         if( target_bay.ter( p ) == t && x_in_y( chance, 100 ) ) {
             total++;
@@ -3227,20 +3227,20 @@ int om_cutdown_trees( const tripoint_abs_omt &omt_tgt, int chance, bool estimate
     target_bay.load( project_to<coords::sm>( omt_tgt ), false );
     int harvested = 0;
     int total = 0;
-    tripoint mapmin = tripoint( 0, 0, omt_tgt.z() );
-    tripoint mapmax = tripoint( 2 * SEEX - 1, 2 * SEEY - 1, omt_tgt.z() );
+    tripoint const mapmin = tripoint( 0, 0, omt_tgt.z() );
+    tripoint const mapmax = tripoint( 2 * SEEX - 1, 2 * SEEY - 1, omt_tgt.z() );
     for( const tripoint &p : target_bay.points_in_rectangle( mapmin, mapmax ) ) {
         if( target_bay.ter( p ).obj().has_flag( flag_TREE ) && rng( 0, 100 ) < chance ) {
             total++;
             if( estimate ) {
                 continue;
             }
-            tripoint delta{
+            tripoint const delta{
                 3 * ( 2 * rng( 0, 1 ) - 1 ) + rng( -1, 1 ),
                 3 * rng( -1, 1 ) + rng( -1, 1 ),
                 omt_tgt.z()
             };
-            std::vector<tripoint> tree = line_to( p, p + delta, rng( 1, 8 ) );
+            std::vector<tripoint> const tree = line_to( p, p + delta, rng( 1, 8 ) );
             for( auto &elem : tree ) {
                 target_bay.destroy( elem );
                 target_bay.ter_set( elem, t_trunk );
@@ -3279,8 +3279,8 @@ mass_volume om_harvest_itm( npc_ptr comp, const tripoint_abs_omt &omt_tgt, int c
     units::volume total_v = 0_ml;
     int total_num = 0;
     int harvested_num = 0;
-    tripoint mapmin = tripoint( 0, 0, omt_tgt.z() );
-    tripoint mapmax = tripoint( 2 * SEEX - 1, 2 * SEEY - 1, omt_tgt.z() );
+    tripoint const mapmin = tripoint( 0, 0, omt_tgt.z() );
+    tripoint const mapmax = tripoint( 2 * SEEX - 1, 2 * SEEY - 1, omt_tgt.z() );
     for( const tripoint &p : target_bay.points_in_rectangle( mapmin, mapmax ) ) {
         for( const item &i : target_bay.i_at( p ) ) {
             total_m += i.weight( true );
@@ -3322,7 +3322,7 @@ tripoint_abs_omt om_target_tile( const tripoint_abs_omt &omt_pos, int min_range,
         popup( _( "Select a location between  %d and  %d tiles away." ), min_range, range );
     }
 
-    std::vector<std::string> bounce_locations = { "faction_hide_site_0" };
+    std::vector<std::string> const bounce_locations = { "faction_hide_site_0" };
 
     tripoint_abs_omt where;
     om_range_mark( omt_pos, range );
@@ -3338,7 +3338,7 @@ tripoint_abs_omt om_target_tile( const tripoint_abs_omt &omt_pos, int min_range,
     if( where == overmap::invalid_tripoint ) {
         return tripoint_abs_omt( -999, -999, -999 );
     }
-    int dist = rl_dist( where.xy(), omt_pos.xy() );
+    int const dist = rl_dist( where.xy(), omt_pos.xy() );
     if( dist > range || dist < min_range ) {
         popup( _( "You must select a target between %d and %d range from the base.  Range: %d" ),
                min_range, range, dist );
@@ -3419,7 +3419,7 @@ void om_range_mark( const tripoint_abs_omt &origin, int range, bool add_notes,
 void om_line_mark( const tripoint_abs_omt &origin, const tripoint_abs_omt &dest, bool add_notes,
                    const std::string &message )
 {
-    std::vector<tripoint_abs_omt> note_pts = line_to( origin, dest );
+    std::vector<tripoint_abs_omt> const note_pts = line_to( origin, dest );
 
     for( auto pt : note_pts ) {
         if( add_notes ) {
@@ -3468,7 +3468,7 @@ bool om_set_hide_site( npc &comp, const tripoint_abs_omt &omt_tgt,
 time_duration companion_travel_time_calc( const tripoint_abs_omt &omt_pos,
         const tripoint_abs_omt &omt_tgt, time_duration work, int trips, int haulage )
 {
-    std::vector<tripoint_abs_omt> journey = line_to( omt_pos, omt_tgt );
+    std::vector<tripoint_abs_omt> const journey = line_to( omt_pos, omt_tgt );
     return companion_travel_time_calc( journey, work, trips, haulage );
 }
 
@@ -3478,7 +3478,7 @@ time_duration companion_travel_time_calc( const std::vector<tripoint_abs_omt> &j
     int one_way = 0;
     for( auto &om : journey ) {
         const oter_id &omt_ref = overmap_buffer.ter( om );
-        std::string om_id = omt_ref.id().c_str();
+        std::string const om_id = omt_ref.id().c_str();
         //Player walks 1 om is roughly 30 seconds
         if( om_id == "field" ) {
             one_way += 30 + 30 * haulage;
@@ -3501,8 +3501,8 @@ time_duration companion_travel_time_calc( const std::vector<tripoint_abs_omt> &j
 int om_carry_weight_to_trips( units::mass mass, units::volume volume,
                               units::mass carry_mass, units::volume carry_volume )
 {
-    int trips_m = 1 + mass / carry_mass;
-    int trips_v = 1 + volume / carry_volume;
+    int const trips_m = 1 + mass / carry_mass;
+    int const trips_v = 1 + volume / carry_volume;
     // return the number of round trips
     return 2 * std::max( trips_m, trips_v );
 }
@@ -3515,9 +3515,9 @@ int om_carry_weight_to_trips( const std::vector<item *> &itms, npc_ptr comp )
         total_m += i->weight( true );
         total_v += i->volume( true );
     }
-    units::mass max_m = comp ? comp->weight_capacity() - comp->weight_carried() : 30_kilogram;
+    units::mass const max_m = comp ? comp->weight_capacity() - comp->weight_carried() : 30_kilogram;
     //Assume an additional pack will be carried in addition to normal gear
-    units::volume sack_v = item( itype_id( "makeshift_sling" ) ).get_storage();
+    units::volume const sack_v = item( itype_id( "makeshift_sling" ) ).get_storage();
     units::volume max_v = comp ? comp->volume_capacity() - comp->volume_carried() : sack_v;
     max_v += sack_v;
     return om_carry_weight_to_trips( total_m, total_v, max_m, max_v );
@@ -3531,7 +3531,7 @@ std::vector<tripoint_abs_omt> om_companion_path( const tripoint_abs_omt &start, 
     int range = range_start;
     int def_range = range_start;
     while( range > 3 ) {
-        tripoint_abs_omt spt = om_target_tile( last, 0, range, {}, false, true, last, false );
+        tripoint_abs_omt const spt = om_target_tile( last, 0, range, {}, false, true, last, false );
         if( spt == tripoint_abs_omt( -999, -999, -999 ) ) {
             scout_points.clear();
             return scout_points;
@@ -3626,7 +3626,7 @@ std::vector<std::pair<std::string, tripoint_abs_omt>> talk_function::om_building
     std::vector<std::pair<std::string, tripoint_abs_omt>> om_camp_region;
     for( const tripoint_abs_omt &omt_near_pos : points_in_radius( omt_pos, range ) ) {
         const oter_id &omt_rnear = overmap_buffer.ter( omt_near_pos );
-        std::string om_rnear_id = omt_rnear.id().c_str();
+        std::string const om_rnear_id = omt_rnear.id().c_str();
         if( !purge || ( om_rnear_id.find( "faction_base_" ) != std::string::npos &&
                         om_rnear_id.find( "faction_base_camp" ) == std::string::npos ) ) {
             om_camp_region.push_back( std::make_pair( om_rnear_id, omt_near_pos ) );
@@ -3650,7 +3650,7 @@ std::string camp_trip_description( const time_duration &total_time,
 {
     std::string entry = "\n";
     //A square is roughly 3 m
-    int dist_m = distance * SEEX * 2 * 3;
+    int const dist_m = distance * SEEX * 2 * 3;
     if( dist_m > 1000 ) {
         entry += string_format( _( ">Distance:%15.2f (km)\n" ), dist_m / 1000.0 );
         entry += string_format( _( ">One Way: %15d (trips)\n" ), trips );
@@ -3673,7 +3673,7 @@ std::string basecamp::craft_description( const recipe_id &itm )
     const recipe &making = itm.obj();
 
     std::vector<std::string> component_print_buffer;
-    int pane = FULL_SCREEN_WIDTH;
+    int const pane = FULL_SCREEN_WIDTH;
     const requirement_data &req = making.simple_requirements();
     auto tools = req.get_folded_tools_list( pane, c_white, _inv, 1 );
     auto comps = req.get_folded_components_list( pane, c_white, _inv,
@@ -3749,7 +3749,7 @@ std::string basecamp::recruit_description( int npc_count )
     int sexpansions;
     int sfaction;
     int sbonus;
-    int total = recruit_evaluation( sbase, sexpansions, sfaction, sbonus );
+    int const total = recruit_evaluation( sbase, sexpansions, sfaction, sbonus );
     std::string desc = string_format( _( "Notes:\n"
                                          "Recruiting additional followers is very dangerous and "
                                          "expensive.  The outcome is heavily dependent on the "
@@ -3802,7 +3802,7 @@ std::string basecamp::gathering_description( const std::string &bldg )
 std::string basecamp::farm_description( const tripoint_abs_omt &farm_pos, size_t &plots_count,
                                         farm_ops operation )
 {
-    std::pair<size_t, std::string> farm_data = farm_action( farm_pos, operation );
+    std::pair<size_t, std::string> const farm_data = farm_action( farm_pos, operation );
     std::string entry;
     plots_count = farm_data.first;
     switch( operation ) {
@@ -3834,10 +3834,10 @@ std::string camp_car_description( vehicle *car )
                                 static_cast<int>( 100 * pt.health_percent() ) );
         entry += string_format( _( ">Fuel:    %s\n" ), right_justify( item::nname( vp.fuel_type ), 25 ) );
     }
-    std::map<itype_id, int> fuels = car->fuels_left();
+    std::map<itype_id, int> const fuels = car->fuels_left();
     entry += _( "----  Fuel Storage & Battery   ----\n" );
     for( auto &fuel : fuels ) {
-        std::string fuel_entry = string_format( "%d/%d", car->fuel_left( fuel.first ),
+        std::string const fuel_entry = string_format( "%d/%d", car->fuel_left( fuel.first ),
                                                 car->fuel_capacity( fuel.first ) );
         entry += string_format( ">%s:%s\n", item( fuel.first ).tname(),
                                 right_justify( fuel_entry, 33 - utf8_width( item( fuel.first ).tname() ) ) );
@@ -4036,8 +4036,8 @@ void apply_camp_ownership( const tripoint &camp_pos, int radius )
 bool survive_random_encounter( npc &comp, std::string &situation, int favor, int threat )
 {
     popup( _( "While %s, a silent specter approaches %s…" ), situation, comp.name );
-    int skill_1 = comp.get_skill_level( skill_survival );
-    int skill_2 = comp.get_skill_level( skill_speech );
+    int const skill_1 = comp.get_skill_level( skill_survival );
+    int const skill_2 = comp.get_skill_level( skill_speech );
     if( skill_1 + favor > rng( 0, 10 ) ) {
         popup( _( "%s notices the antlered horror and slips away before it gets too close." ),
                comp.name );
@@ -4050,13 +4050,13 @@ bool survive_random_encounter( npc &comp, std::string &situation, int favor, int
         talk_function::companion_skill_trainer( comp, "recruiting", 10_minutes, 10 - favor );
     } else {
         popup( _( "%s didn't detect the ambush until it was too late!" ), comp.name );
-        int skill = comp.get_skill_level( skill_melee ) +
+        int const skill = comp.get_skill_level( skill_melee ) +
                     0.5 * comp.get_skill_level( skill_survival ) +
                     comp.get_skill_level( skill_bashing ) +
                     comp.get_skill_level( skill_cutting ) +
                     comp.get_skill_level( skill_stabbing ) +
                     comp.get_skill_level( skill_unarmed ) + comp.get_skill_level( skill_dodge );
-        int monsters = rng( 0, threat );
+        int const monsters = rng( 0, threat );
         if( skill * rng( 8, 12 ) > ( monsters * rng( 8, 12 ) ) ) {
             if( one_in( 2 ) ) {
                 popup( _( "The bull moose charged %s from the tree line…" ), comp.name );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -684,7 +684,7 @@ void basecamp::add_available_recipes( mission_data &mission_key, point dir,
         const std::string &entry = craft_description( recipe_data.first );
         const recipe &recp = recipe_data.first.obj();
         bool const craftable = recp.deduped_requirements().can_make_with_inventory(
-                             _inv, recp.get_component_filter() );
+                                   _inv, recp.get_component_filter() );
         mission_key.add_start( id, title_e, dir, entry, craftable );
     }
 }
@@ -713,7 +713,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, point d
         for( const basecamp_upgrade &upgrade : available_upgrades( dir ) ) {
             const base_camps::miss_data &miss_info = base_camps::miss_info[ "_faction_upgrade_exp_" ];
             comp_list const npc_list = get_mission_workers( upgrade.bldg + "_faction_upgrade_exp_" +
-                                 dir_id );
+                                       dir_id );
             if( npc_list.empty() ) {
                 entry = om_upgrade_description( upgrade.bldg );
                 mission_key.add_start( dir_id + miss_info.miss_id + upgrade.bldg,
@@ -1629,7 +1629,7 @@ void basecamp::start_upgrade( const std::string &bldg, point dir,
 void basecamp::abandon_camp()
 {
     validate_assignees();
-    for( npc_ptr  const&guy : overmap_buffer.get_companion_mission_npcs( 10 ) ) {
+    for( npc_ptr  const &guy : overmap_buffer.get_companion_mission_npcs( 10 ) ) {
         npc_companion_mission const c_mission = guy->get_companion_mission();
         if( c_mission.role_id != base_camps::id ) {
             continue;
@@ -1637,7 +1637,7 @@ void basecamp::abandon_camp()
         const std::string return_msg = _( "responds to the emergency recall…" );
         finish_return( *guy, false, return_msg, "menial", 0, true );
     }
-    for( npc_ptr  const&guy : get_npcs_assigned() ) {
+    for( npc_ptr  const &guy : get_npcs_assigned() ) {
         talk_function::stop_guard( *guy );
     }
     overmap_buffer.remove_camp( *this );
@@ -1795,7 +1795,7 @@ void basecamp::job_assignment_ui()
                 int start_y = 3;
                 if( cur_npc ) {
                     if( cur_npc->has_job() ) {
-                        for( activity_id  const&elem : cur_npc->job.get_prioritised_vector() ) {
+                        for( activity_id  const &elem : cur_npc->job.get_prioritised_vector() ) {
                             const int priority = cur_npc->job.get_priority_of_job( elem );
                             player_activity const test_act = player_activity( elem );
                             mvwprintz( w_jobs, point( 46, start_y ), c_light_gray, string_format( _( "%s : %s" ),
@@ -1913,7 +1913,7 @@ void basecamp::start_cut_logs()
         sample_npc.set_fake( true );
         int const tree_est = om_cutdown_trees_est( forest, 50 );
         int const tree_young_est = om_harvest_ter_est( sample_npc, forest,
-                             ter_id( "t_tree_young" ), 50 );
+                                   ter_id( "t_tree_young" ), 50 );
         int const dist = rl_dist( forest.xy(), omt_pos.xy() );
         //Very roughly what the player does + 6 hours for prep, clean up, breaks
         time_duration const chop_time = 6_hours + 1_hours * tree_est + 7_minutes * tree_young_est;
@@ -1927,8 +1927,8 @@ void basecamp::start_cut_logs()
         }
 
         npc_ptr const comp = start_mission( "_faction_camp_cut_log", work_time, true,
-                                      _( "departs to cut logs…" ), false, {},
-                                      skill_fabrication, 2 );
+                                            _( "departs to cut logs…" ), false, {},
+                                            skill_fabrication, 2 );
         if( comp != nullptr ) {
             om_cutdown_trees_logs( forest, 50 );
             om_harvest_ter( *comp, forest, ter_id( "t_tree_young" ), 50 );
@@ -1960,7 +1960,7 @@ void basecamp::start_clearcut()
         sample_npc.set_fake( true );
         int const tree_est = om_cutdown_trees_est( forest, 95 );
         int const tree_young_est = om_harvest_ter_est( sample_npc, forest,
-                             ter_id( "t_tree_young" ), 95 );
+                                   ter_id( "t_tree_young" ), 95 );
         int const dist = rl_dist( forest.xy(), omt_pos.xy() );
         //Very roughly what the player does + 6 hours for prep, clean up, breaks
         time_duration const chop_time = 6_hours + 1_hours * tree_est + 7_minutes * tree_young_est;
@@ -1972,8 +1972,8 @@ void basecamp::start_clearcut()
         }
 
         npc_ptr const comp = start_mission( "_faction_camp_clearcut", work_time,
-                                      true, _( "departs to clear a forest…" ), false, {},
-                                      skill_fabrication, 1 );
+                                            true, _( "departs to clear a forest…" ), false, {},
+                                            skill_fabrication, 1 );
         if( comp != nullptr ) {
             om_cutdown_trees_trunks( forest, 95 );
             om_harvest_ter_break( *comp, forest, ter_id( "t_tree_young" ), 95 );
@@ -1988,11 +1988,11 @@ void basecamp::start_clearcut()
 void basecamp::start_setup_hide_site()
 {
     std::vector<std::string> const hide_locations = { "forest", "forest_thick", "forest_water",
-                                                "field"
-                                              };
+                                                      "field"
+                                                    };
     popup( _( "Forests, swamps, and fields are valid hide site locations." ) );
     tripoint_abs_omt const forest = om_target_tile( omt_pos, 10, 90, hide_locations, true, true,
-                              omt_pos, true );
+                                    omt_pos, true );
     if( forest != tripoint_abs_omt( -999, -999, -999 ) ) {
         int const dist = rl_dist( forest.xy(), omt_pos.xy() );
         inventory tgt_inv = g->u.inv;
@@ -2001,21 +2001,21 @@ void basecamp::start_setup_hide_site()
         } );
         if( !pos_inv.empty() ) {
             std::vector<item *> const losing_equipment = give_equipment( pos_inv,
-                                                   _( "Do you wish to give your companion "
-                                                           "additional items?" ) );
+                    _( "Do you wish to give your companion "
+                       "additional items?" ) );
             int trips = om_carry_weight_to_trips( losing_equipment );
             int haulage = trips <= 2 ? 0 : losing_equipment.size();
             time_duration const build_time = 6_hours;
             time_duration const travel_time = companion_travel_time_calc( forest, omt_pos, 0_minutes,
-                                        2, haulage );
+                                              2, haulage );
             time_duration work_time = travel_time + build_time;
             if( !query_yn( _( "Trip Estimate:\n%s" ), camp_trip_description( work_time,
                            build_time, travel_time, dist, trips, time_to_food( work_time ) ) ) ) {
                 return;
             }
             npc_ptr const comp = start_mission( "_faction_camp_hide_site", work_time, true,
-                                          _( "departs to build a hide site…" ), false, {},
-                                          skill_survival, 3 );
+                                                _( "departs to build a hide site…" ), false, {},
+                                                skill_survival, 3 );
             if( comp != nullptr ) {
                 trips = om_carry_weight_to_trips( losing_equipment, comp );
                 haulage = trips <= 2 ? 0 : losing_equipment.size();
@@ -2035,7 +2035,7 @@ void basecamp::start_relay_hide_site()
     std::vector<std::string> const hide_locations = { "faction_hide_site_0" };
     popup( _( "You must select an existing hide site." ) );
     tripoint_abs_omt const forest = om_target_tile( omt_pos, 10, 90, hide_locations, true, true,
-                              omt_pos, true );
+                                    omt_pos, true );
     if( forest != tripoint_abs_omt( -999, -999, -999 ) ) {
         int const dist = rl_dist( forest.xy(), omt_pos.xy() );
         inventory tgt_inv = g->u.inv;
@@ -2064,10 +2064,10 @@ void basecamp::start_relay_hide_site()
             int trips = std::max( om_carry_weight_to_trips( gaining_equipment ),
                                   om_carry_weight_to_trips( losing_equipment ) );
             int const haulage = trips <= 2 ? 0 : std::max( gaining_equipment.size(),
-                          losing_equipment.size() );
+                                losing_equipment.size() );
             time_duration const build_time = 6_hours;
             time_duration const travel_time = companion_travel_time_calc( forest, omt_pos, 0_minutes,
-                                        trips, haulage );
+                                              trips, haulage );
             time_duration work_time = travel_time + build_time;
             if( !query_yn( _( "Trip Estimate:\n%s" ), camp_trip_description( work_time, build_time,
                            travel_time, dist, trips, time_to_food( work_time ) ) ) ) {
@@ -2075,14 +2075,14 @@ void basecamp::start_relay_hide_site()
             }
 
             npc_ptr const comp = start_mission( "_faction_camp_hide_trans", work_time, true,
-                                          _( "departs for the hide site…" ), false, {},
-                                          skill_survival, 3 );
+                                                _( "departs for the hide site…" ), false, {},
+                                                skill_survival, 3 );
             if( comp != nullptr ) {
                 // recalculate trips based on actual load
                 trips = std::max( om_carry_weight_to_trips( gaining_equipment, comp ),
                                   om_carry_weight_to_trips( losing_equipment, comp ) );
                 int const haulage = trips <= 2 ? 0 : std::max( gaining_equipment.size(),
-                              losing_equipment.size() );
+                                    losing_equipment.size() );
                 work_time = companion_travel_time_calc( forest, omt_pos, 0_minutes, trips,
                                                         haulage ) + build_time;
                 comp->companion_mission_time_ret = calendar::turn + work_time;
@@ -2180,8 +2180,8 @@ void basecamp::start_fortifications( std::string &bldg_exp )
         }
 
         npc_ptr const comp = start_mission( "_faction_camp_om_fortifications", total_time, true,
-                                      _( "begins constructing fortifications…" ), false, {},
-                                      making.required_skills );
+                                            _( "begins constructing fortifications…" ), false, {},
+                                            making.required_skills );
         if( comp != nullptr ) {
             components.consume_components();
             comp->companion_mission_role_id = bldg_exp;
@@ -2209,7 +2209,7 @@ void basecamp::start_combat_mission( const std::string &miss )
         return;
     }
     npc_ptr const comp = start_mission( miss, travel_time, true, _( "departs on patrol…" ),
-                                  false, {}, skill_survival, 3 );
+                                        false, {}, skill_survival, 3 );
     if( comp != nullptr ) {
         comp->companion_mission_points = scout_points;
     }
@@ -2261,8 +2261,8 @@ void basecamp::start_crafting( const std::string &cur_id, point cur_dir,
 
         time_duration const work_days = base_camps::to_workdays( making.batch_duration( batch_size ) );
         npc_ptr const comp = start_mission( miss_id + cur_dir_id, work_days, true,
-                                      _( "begins to work…" ), false, {},
-                                      making.required_skills );
+                                            _( "begins to work…" ), false, {},
+                                            making.required_skills );
         if( comp != nullptr ) {
             components.consume_components();
             for( const item &results : making.create_results( batch_size ) ) {
@@ -2421,7 +2421,7 @@ void basecamp::start_farm_op( point dir, const tripoint_abs_omt &omt_tgt, farm_o
                 return;
             }
             std::vector<item *> const plant_these = give_equipment( seed_inv,
-                                              _( "Which seeds do you wish to have planted?" ) );
+                                                    _( "Which seeds do you wish to have planted?" ) );
             size_t seed_cnt = 0;
             for( item *seeds : plant_these ) {
                 seed_cnt += seeds->count();
@@ -2460,8 +2460,8 @@ bool basecamp::start_garage_chop( point dir, const tripoint_abs_omt &omt_tgt )
 
     const std::string dir_id = base_camps::all_directions.at( dir ).id;
     npc_ptr const comp = start_mission( "_faction_exp_chop_shop_" + dir_id, 5_days, true,
-                                  _( "begins working in the garage…" ), false, {},
-                                  skill_mechanics, 2 );
+                                        _( "begins working in the garage…" ), false, {},
+                                        skill_mechanics, 2 );
     if( comp == nullptr ) {
         return false;
     }
@@ -2738,7 +2738,7 @@ void basecamp::fortifications_return()
         std::string build_first = build_e;
         std::string build_second = build_w;
         bool const build_dir_NS = comp->companion_mission_points[0].y() !=
-                            comp->companion_mission_points[1].y();
+                                  comp->companion_mission_points[1].y();
         if( build_dir_NS ) {
             build_first = build_s;
             build_second = build_n;
@@ -3045,10 +3045,10 @@ int basecamp::recipe_batch_max( const recipe &making ) const
     for( size_t batch_size = 1000; batch_size > 0; batch_size /= 10 ) {
         for( int iter = 0; iter < max_checks; iter++ ) {
             time_duration const work_days = base_camps::to_workdays( making.batch_duration(
-                                          max_batch + batch_size ) );
+                                                max_batch + batch_size ) );
             int const food_req = time_to_food( work_days );
             bool const can_make = making.deduped_requirements().can_make_with_inventory(
-                                _inv, making.get_component_filter(), max_batch + batch_size );
+                                      _inv, making.get_component_filter(), max_batch + batch_size );
             if( can_make && camp_food_supply() > food_req ) {
                 max_batch += batch_size;
             } else {
@@ -3838,7 +3838,7 @@ std::string camp_car_description( vehicle *car )
     entry += _( "----  Fuel Storage & Battery   ----\n" );
     for( auto &fuel : fuels ) {
         std::string const fuel_entry = string_format( "%d/%d", car->fuel_left( fuel.first ),
-                                                car->fuel_capacity( fuel.first ) );
+                                       car->fuel_capacity( fuel.first ) );
         entry += string_format( ">%s:%s\n", item( fuel.first ).tname(),
                                 right_justify( fuel_entry, 33 - utf8_width( item( fuel.first ).tname() ) ) );
     }
@@ -4051,11 +4051,11 @@ bool survive_random_encounter( npc &comp, std::string &situation, int favor, int
     } else {
         popup( _( "%s didn't detect the ambush until it was too late!" ), comp.name );
         int const skill = comp.get_skill_level( skill_melee ) +
-                    0.5 * comp.get_skill_level( skill_survival ) +
-                    comp.get_skill_level( skill_bashing ) +
-                    comp.get_skill_level( skill_cutting ) +
-                    comp.get_skill_level( skill_stabbing ) +
-                    comp.get_skill_level( skill_unarmed ) + comp.get_skill_level( skill_dodge );
+                          0.5 * comp.get_skill_level( skill_survival ) +
+                          comp.get_skill_level( skill_bashing ) +
+                          comp.get_skill_level( skill_cutting ) +
+                          comp.get_skill_level( skill_stabbing ) +
+                          comp.get_skill_level( skill_unarmed ) + comp.get_skill_level( skill_dodge );
         int const monsters = rng( 0, threat );
         if( skill * rng( 8, 12 ) > ( monsters * rng( 8, 12 ) ) ) {
             if( one_in( 2 ) ) {

--- a/src/fault.cpp
+++ b/src/fault.cpp
@@ -57,7 +57,7 @@ void fault::load_fault( const JsonObject &jo )
         if( jo_method.has_string( "requirements" ) ) {
             mandatory( jo_method, false, "requirements", m.requirements );
         } else {
-            JsonObject jo_req = jo_method.get_object( "requirements" );
+            JsonObject const jo_req = jo_method.get_object( "requirements" );
             m.requirements = requirement_id( m.id );
             requirement_data::load_requirement( jo_req, m.requirements );
         }

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -201,7 +201,7 @@ bool field::add_field( const field_type_id &field_type_to_add, const int new_int
         if( it->first->stacking_type == fields::stacking_type::intensity ) {
             it->second.set_field_intensity( it->second.get_field_intensity() + new_intensity );
         } else {
-            time_duration half_life = field_type_to_add->half_life;
+            time_duration const half_life = field_type_to_add->half_life;
             if( new_age < half_life ) {
                 it->second.mod_field_age( new_age - half_life );
             }

--- a/src/field_type.cpp
+++ b/src/field_type.cpp
@@ -142,7 +142,8 @@ void field_type::load( const JsonObject &jo, const std::string & )
     optional( jo, was_loaded, "legacy_enum_id", legacy_enum_id, -1 );
     for( const JsonObject jao : jo.get_array( "intensity_levels" ) ) {
         field_intensity_level intensity_level;
-        field_intensity_level const fallback_intensity_level = !intensity_levels.empty() ? intensity_levels.back()
+        field_intensity_level const fallback_intensity_level = !intensity_levels.empty() ?
+                intensity_levels.back()
                 : intensity_level;
         optional( jao, was_loaded, "name", intensity_level.name, fallback_intensity_level.name );
         optional( jao, was_loaded, "sym", intensity_level.symbol, unicode_codepoint_from_symbol_reader,

--- a/src/field_type.cpp
+++ b/src/field_type.cpp
@@ -142,7 +142,7 @@ void field_type::load( const JsonObject &jo, const std::string & )
     optional( jo, was_loaded, "legacy_enum_id", legacy_enum_id, -1 );
     for( const JsonObject jao : jo.get_array( "intensity_levels" ) ) {
         field_intensity_level intensity_level;
-        field_intensity_level fallback_intensity_level = !intensity_levels.empty() ? intensity_levels.back()
+        field_intensity_level const fallback_intensity_level = !intensity_levels.empty() ? intensity_levels.back()
                 : intensity_level;
         optional( jao, was_loaded, "name", intensity_level.name, fallback_intensity_level.name );
         optional( jao, was_loaded, "sym", intensity_level.symbol, unicode_codepoint_from_symbol_reader,
@@ -219,7 +219,7 @@ void field_type::load( const JsonObject &jo, const std::string & )
     }
 
     if( jo.has_object( "npc_complain" ) ) {
-        JsonObject joc = jo.get_object( "npc_complain" );
+        JsonObject const joc = jo.get_object( "npc_complain" );
         int chance;
         std::string issue;
         time_duration duration;
@@ -231,11 +231,11 @@ void field_type::load( const JsonObject &jo, const std::string & )
         npc_complain_data = std::make_tuple( chance, issue, duration, speech );
     }
 
-    JsonObject jid = jo.get_object( "immunity_data" );
+    JsonObject const jid = jo.get_object( "immunity_data" );
     for( const std::string id : jid.get_array( "traits" ) ) {
         immunity_data_traits.emplace_back( id );
     }
-    for( JsonArray jao : jid.get_array( "body_part_env_resistance" ) ) {
+    for( JsonArray const jao : jid.get_array( "body_part_env_resistance" ) ) {
         immunity_data_body_part_env_resistance.emplace_back( std::make_pair( get_body_part_token(
                     jao.get_string( 0 ) ), jao.get_int( 1 ) ) );
     }

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -75,7 +75,7 @@ bool file_exist( const std::string &path )
 bool file_exist( const std::string &path )
 {
     struct stat buffer;
-    bool success = stat( path.c_str(), &buffer ) == 0;
+    bool const success = stat( path.c_str(), &buffer ) == 0;
     return success && S_ISREG( buffer.st_mode );
 }
 #endif
@@ -207,7 +207,7 @@ bool is_directory_stat( const std::string &full_path )
     int stat_ret = _wstat( utf8_to_wstr( full_path ).c_str(), &result );
 #else
     struct stat result;
-    int stat_ret = stat( full_path.c_str(), &result );
+    int const stat_ret = stat( full_path.c_str(), &result );
 #endif
     if( stat_ret != 0 ) {
         const auto e_str = strerror( errno );
@@ -440,7 +440,7 @@ bool copy_file( const std::string &source_path, const std::string &dest_path )
     if( !source_stream.is_open() ) {
         return false;
     }
-    bool res = write_to_file( dest_path, [&]( std::ostream & dest_stream ) {
+    bool const res = write_to_file( dest_path, [&]( std::ostream & dest_stream ) {
         dest_stream << source_stream->rdbuf();
     }, nullptr );
     return res && !source_stream.fail();

--- a/src/font_loader.cpp
+++ b/src/font_loader.cpp
@@ -12,7 +12,7 @@ void font_loader::load_throws( const std::string &path )
     try {
         cata_ifstream stream = std::move( cata_ifstream().mode( cata_ios_mode::binary ).open( path ) );
         JsonIn json( *stream );
-        JsonObject config = json.get_object();
+        JsonObject const config = json.get_object();
         if( config.has_string( "typeface" ) ) {
             typeface.emplace_back( config.get_string( "typeface" ) );
         } else {
@@ -52,7 +52,7 @@ void font_loader::load()
         }
     }
     if( try_user ) {
-        font_loader copy = *this;
+        font_loader const copy = *this;
         try {
             load_throws( user_fontconfig );
             return;

--- a/src/fungal_effects.cpp
+++ b/src/fungal_effects.cpp
@@ -127,7 +127,7 @@ void fungal_effects::marlossify( const tripoint &p )
         return;
     }
     for( int i = 0; i < 25; i++ ) {
-        bool is_fungi = m.has_flag_ter( flag_FUNGUS, p );
+        bool const is_fungi = m.has_flag_ter( flag_FUNGUS, p );
         spread_fungus( p );
         if( is_fungi ) {
             return;
@@ -224,7 +224,7 @@ void fungal_effects::spread_fungus_one_tile( const tripoint &p, const int growth
 void fungal_effects::spread_fungus( const tripoint &p )
 {
     int growth = 1;
-    map &here = get_map();
+    map  const&here = get_map();
     for( const tripoint &tmp : here.points_in_radius( p, 1 ) ) {
         if( tmp == p ) {
             continue;

--- a/src/fungal_effects.cpp
+++ b/src/fungal_effects.cpp
@@ -224,7 +224,7 @@ void fungal_effects::spread_fungus_one_tile( const tripoint &p, const int growth
 void fungal_effects::spread_fungus( const tripoint &p )
 {
     int growth = 1;
-    map  const&here = get_map();
+    map  const &here = get_map();
     for( const tripoint &tmp : here.points_in_radius( p, 1 ) ) {
         if( tmp == p ) {
             continue;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -431,10 +431,10 @@ void game::reload_tileset( [[maybe_unused]] std::function<void( std::string )> o
 {
 #if defined(TILES)
     // Disable UIs below to avoid accessing the tile context during loading.
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
+    ui_adaptor const ui( ui_adaptor::disable_uis_below {} );
     try {
         tilecontext->reinit();
-        std::vector<mod_id> dummy;
+        std::vector<mod_id> const dummy;
         tilecontext->load_tileset(
             get_option<std::string>( "TILES" ),
             world_generator->active_world ? world_generator->active_world->active_mod_order : dummy,
@@ -571,7 +571,7 @@ bool game::start_game()
 
     init_autosave();
 
-    background_pane background;
+    background_pane const background;
     static_popup popup;
     popup.message( "%s", _( "Please wait as we build your world" ) );
     ui_manager::redraw();
@@ -667,7 +667,7 @@ bool game::start_game()
     // Make sure that no monsters are near the player
     // This can happen in lab starts
     if( !spawn_near ) {
-        for( monster &critter : all_monsters() ) {
+        for( monster  const&critter : all_monsters() ) {
             if( rl_dist( critter.pos(), u.pos() ) <= 5 ||
                 m.clear_path( critter.pos(), u.pos(), 40, 1, 100 ) ) {
                 remove_zombie( critter );
@@ -695,8 +695,8 @@ bool game::start_game()
         start_loc.handle_heli_crash( u );
         bool success = false;
         for( auto v : m.get_vehicles() ) {
-            std::string name = v.v->type.str();
-            std::string search = std::string( "helicopter" );
+            std::string const name = v.v->type.str();
+            std::string const search = std::string( "helicopter" );
             if( name.find( search ) != std::string::npos ) {
                 for( const vpart_reference &vp : v.v->get_any_parts( VPFLAG_CONTROLS ) ) {
                     const tripoint pos = vp.pos();
@@ -754,8 +754,8 @@ bool game::start_game()
         mission->assign( u );
     }
     g->events().send<event_type::game_start>( u.getID() );
-    for( Skill &elem : Skill::skills ) {
-        int level = u.get_skill_level_object( elem.ident() ).level();
+    for( Skill  const&elem : Skill::skills ) {
+        int const level = u.get_skill_level_object( elem.ident() ).level();
         if( level > 0 ) {
             g->events().send<event_type::gains_skill_level>( u.getID(), elem.ident(), level );
         }
@@ -769,7 +769,7 @@ vehicle *game::place_vehicle_nearby(
 {
     std::vector<std::string> search_types = omt_search_types;
     if( search_types.empty() ) {
-        vehicle veh( id );
+        vehicle const veh( id );
         if( veh.can_float() ) {
             search_types.push_back( "river" );
             search_types.push_back( "lake" );
@@ -897,7 +897,7 @@ void game::create_starting_npcs()
         return; //There is already an NPC in this starting location
     }
 
-    shared_ptr_fast<npc> tmp = make_shared_fast<npc>();
+    shared_ptr_fast<npc> const tmp = make_shared_fast<npc>();
     tmp->randomize( one_in( 2 ) ? NC_DOCTOR : NC_NONE );
     tmp->spawn_at_precise( { get_levx(), get_levy() }, u.pos() - point_south_east );
     overmap_buffer.insert_npc( tmp );
@@ -933,7 +933,7 @@ static std::string generate_memorial_filename( const std::string &char_name )
 
     // Add a timestamp for uniqueness.
     char buffer[suffix_len] {};
-    std::time_t t = std::time( nullptr );
+    std::time_t const t = std::time( nullptr );
     std::strftime( buffer, suffix_len, "%Y-%m-%d-%H-%M-%S", std::localtime( &t ) );
     memorial_file_path << buffer;
 
@@ -1052,7 +1052,7 @@ bool game::cleanup_at_end()
         const int iOffsetX = TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0;
         const int iOffsetY = TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0;
 
-        catacurses::window w_rip = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
+        catacurses::window const w_rip = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
                                    point( iOffsetX, iOffsetY ) );
         draw_border( w_rip );
 
@@ -1130,8 +1130,8 @@ bool game::cleanup_at_end()
                    c_light_gray,
                    sTemp );
 
-        int iStartX = FULL_SCREEN_WIDTH / 2 - ( ( iMaxWidth - 4 ) / 2 );
-        std::string sLastWords = string_input_popup()
+        int const iStartX = FULL_SCREEN_WIDTH / 2 - ( ( iMaxWidth - 4 ) / 2 );
+        std::string const sLastWords = string_input_popup()
                                  .window( w_rip, point( iStartX, iNameLine ), iStartX + iMaxWidth - 4 - 1 )
                                  .max_length( iMaxWidth - 4 - 1 )
                                  .query_string();
@@ -1139,13 +1139,13 @@ bool game::cleanup_at_end()
         const bool is_suicide = uquit == QUIT_SUICIDE;
         events().send<event_type::game_over>( is_suicide, sLastWords );
         // Struck the save_player_data here to forestall Weirdness
-        std::string char_filename = generate_memorial_filename( u.name );
+        std::string const char_filename = generate_memorial_filename( u.name );
         move_save_to_graveyard( char_filename );
         write_memorial_file( char_filename, sLastWords );
         memorial().clear();
         std::vector<std::string> characters = list_active_saves();
         // remove current player from the active characters list, as they are dead
-        std::vector<std::string>::iterator curchar = std::find( characters.begin(),
+        std::vector<std::string>::iterator const curchar = std::find( characters.begin(),
                 characters.end(), u.get_save_id() );
         if( curchar != characters.end() ) {
             characters.erase( curchar );
@@ -1157,7 +1157,7 @@ bool game::cleanup_at_end()
 
             if( get_option<std::string>( "WORLD_END" ) == "query" ) {
                 bool decided = false;
-                std::string buffer = _( "Warning: NPC interactions and some other global flags "
+                std::string const buffer = _( "Warning: NPC interactions and some other global flags "
                                         "will not all reset when starting a new character in an "
                                         "already-played world.  This can lead to some strange "
                                         "behavior.\n\n"
@@ -1252,12 +1252,12 @@ void game::calc_driving_offset( vehicle *veh )
     }
     const int g_light_level = static_cast<int>( light_level( u.posz() ) );
     const int light_sight_range = u.sight_range( g_light_level );
-    int sight = std::max( veh_lumi( *veh ), light_sight_range );
+    int const sight = std::max( veh_lumi( *veh ), light_sight_range );
 
     // The maximal offset will leave at least this many tiles
     // between the PC and the edge of the main window.
     static const int border_range = 2;
-    point max_offset( ( getmaxx( w_terrain ) + 1 ) / 2 - border_range - 1,
+    point const max_offset( ( getmaxx( w_terrain ) + 1 ) / 2 - border_range - 1,
                       ( getmaxy( w_terrain ) + 1 ) / 2 - border_range - 1 );
 
     // velocity at or below this results in no offset at all
@@ -1564,7 +1564,7 @@ bool game::do_turn()
             }
 
             // Avoid redrawing the main UI every time due to invalidation
-            ui_adaptor dummy( ui_adaptor::disable_uis_below {} );
+            ui_adaptor const dummy( ui_adaptor::disable_uis_below {} );
             wait_popup = std::make_unique<static_popup>();
             wait_popup->on_top( true ).wait_message( "%s", wait_message );
             ui_manager::redraw();
@@ -1614,8 +1614,8 @@ void game::process_voluntary_act_interrupt()
         return;
     }
 
-    bool has_activity = u.activity && u.activity.moves_left > 0;
-    bool is_travelling = u.has_destination() && !u.omt_path.empty();
+    bool const has_activity = u.activity && u.activity.moves_left > 0;
+    bool const is_travelling = u.has_destination() && !u.omt_path.empty();
 
     if( !has_activity && !is_travelling ) {
         // Nohing to interrupt
@@ -1625,7 +1625,7 @@ void game::process_voluntary_act_interrupt()
     // Key poll may be quite expensive, so limit it to 10 times per second.
     static auto last_poll = std::chrono::steady_clock::now();
     auto now = std::chrono::steady_clock::now();
-    int64_t difference = std::chrono::duration_cast<std::chrono::milliseconds>
+    int64_t const difference = std::chrono::duration_cast<std::chrono::milliseconds>
                          ( now - last_poll ).count();
 
     if( difference > 100 ) {
@@ -1804,7 +1804,7 @@ int get_heat_radiation( const tripoint &location, bool direct )
     // Stored as intensity-distance pairs
     int temp_mod = 0;
     int best_fire = 0;
-    Character &player_character = get_avatar();
+    Character  const&player_character = get_avatar();
     map &here = get_map();
     // Convert it to an int id once, instead of 139 times per turn
     const field_type_id fd_fire_int = fd_fire.id();
@@ -1813,7 +1813,7 @@ int get_heat_radiation( const tripoint &location, bool direct )
 
         maptile mt = here.maptile_at( dest );
 
-        int ffire = maptile_field_intensity( mt, fd_fire_int );
+        int const ffire = maptile_field_intensity( mt, fd_fire_int );
         if( ffire > 0 ) {
             heat_intensity = ffire;
         } else  {
@@ -1861,7 +1861,7 @@ int get_convection_temperature( const tripoint &location )
 
 int game::assign_mission_id()
 {
-    int ret = next_mission_id;
+    int const ret = next_mission_id;
     next_mission_id++;
     return ret;
 }
@@ -1956,7 +1956,7 @@ void game::validate_camps()
         overmap_buffer.add_camp( camp );
         m.remove_submap_camp( u.pos() );
     } else if( camp.camp_omt_pos() != tripoint_abs_omt() ) {
-        std::string camp_name = _( "Faction Camp" );
+        std::string const camp_name = _( "Faction Camp" );
         camp.set_name( camp_name );
         overmap_buffer.add_camp( camp );
         m.remove_submap_camp( u.pos() );
@@ -2449,14 +2449,14 @@ void game::win_screen()
     std::string msg = _( "You managed to close the portal and end the invasion!" );
     msg += '\n';
     if( u.is_dead_state() ) {
-        translation t = translation::to_translation( "win_game",
+        translation const t = translation::to_translation( "win_game",
                         "Unfortunately, you had to sacrifice your life to achieve this." );
         msg += colorize( t, c_red ) + '\n';
         memorial().add(
             pgettext( "memorial_male", "Sacrificed his life to close the portal." ),
             pgettext( "memorial_female", "Sacrificed her life to close the portal." ) );
     } else {
-        translation t = translation::to_translation( "win_game", "You managed to survive the ordeal." );
+        translation const t = translation::to_translation( "win_game", "You managed to survive the ordeal." );
         msg += colorize( t, c_green ) + '\n';
         memorial().add(
             pgettext( "memorial_male", "Safely closed the portal." ),
@@ -2539,7 +2539,7 @@ bool game::load( const std::string &world )
 
 bool game::load( const save_t &name )
 {
-    background_pane background;
+    background_pane const background;
     static_popup popup;
     popup.message( "%s", _( "Please wait…\nLoading the save…" ) );
     ui_manager::redraw();
@@ -2632,7 +2632,7 @@ bool game::load( const save_t &name )
 void game::reset_npc_dispositions()
 {
     for( auto elem : follower_ids ) {
-        shared_ptr_fast<npc> npc_to_get = overmap_buffer.find_npc( elem );
+        shared_ptr_fast<npc> const npc_to_get = overmap_buffer.find_npc( elem );
         if( !npc_to_get )  {
             continue;
         }
@@ -2659,7 +2659,7 @@ void game::reset_npc_dispositions()
 //Saves all factions and missions and npcs.
 bool game::save_factions_missions_npcs()
 {
-    std::string masterfile = get_world_base_save_path() + "/" + SAVE_MASTER;
+    std::string const masterfile = get_world_base_save_path() + "/" + SAVE_MASTER;
     return write_to_file( masterfile, [&]( std::ostream & fout ) {
         serialize_master( fout );
     }, _( "factions data" ) );
@@ -2667,7 +2667,7 @@ bool game::save_factions_missions_npcs()
 
 bool game::save_artifacts()
 {
-    std::string artfilename = get_world_base_save_path() + "/" + SAVE_ARTIFACTS;
+    std::string const artfilename = get_world_base_save_path() + "/" + SAVE_ARTIFACTS;
     return ::save_artifacts( artfilename );
 }
 
@@ -2803,7 +2803,7 @@ void game::write_memorial_file( const std::string &filename, std::string sLastWo
         return;
     }
 
-    std::string path = memorial_active_world_dir + filename + ".txt";
+    std::string const path = memorial_active_world_dir + filename + ".txt";
 
     write_to_file( path, [&]( std::ostream & fout ) {
         memorial().write( fout, sLastWords );
@@ -2814,7 +2814,7 @@ void game::disp_NPC_epilogues()
 {
     // TODO: This search needs to be expanded to all NPCs
     for( auto elem : follower_ids ) {
-        shared_ptr_fast<npc> guy = overmap_buffer.find_npc( elem );
+        shared_ptr_fast<npc> const guy = overmap_buffer.find_npc( elem );
         if( !guy ) {
             continue;
         }
@@ -2988,7 +2988,7 @@ shared_ptr_fast<ui_adaptor> game::create_or_get_main_ui_adaptor()
 
 void game::invalidate_main_ui_adaptor() const
 {
-    shared_ptr_fast<ui_adaptor> ui = main_ui_adaptor.lock();
+    shared_ptr_fast<ui_adaptor> const ui = main_ui_adaptor.lock();
     if( ui ) {
         ui->invalidate_ui();
     }
@@ -2996,7 +2996,7 @@ void game::invalidate_main_ui_adaptor() const
 
 void game::mark_main_ui_adaptor_resize() const
 {
-    shared_ptr_fast<ui_adaptor> ui = main_ui_adaptor.lock();
+    shared_ptr_fast<ui_adaptor> const ui = main_ui_adaptor.lock();
     if( ui ) {
         ui->mark_resize();
     }
@@ -3112,7 +3112,7 @@ void game::draw()
     werase( w_terrain );
     draw_ter();
     for( auto it = draw_callbacks.begin(); it != draw_callbacks.end(); ) {
-        shared_ptr_fast<draw_callback_t> cb = it->lock();
+        shared_ptr_fast<draw_callback_t> const cb = it->lock();
         if( cb ) {
             ( *cb )();
             ++it;
@@ -3133,7 +3133,7 @@ void game::draw_panels( bool force_draw )
     auto &mgr = panel_manager::get_manager();
     int y = 0;
     const bool sidebar_right = get_option<std::string>( "SIDEBAR_POSITION" ) == "right";
-    int spacer = get_option<bool>( "SIDEBAR_SPACERS" ) ? 1 : 0;
+    int const spacer = get_option<bool>( "SIDEBAR_SPACERS" ) ? 1 : 0;
     int log_height = 0;
     for( const window_panel &panel : mgr.get_current_layout() ) {
         if( panel.get_height() != -2 && panel.toggle && panel.render() ) {
@@ -3255,14 +3255,14 @@ void game::draw_ter( const tripoint &center, const bool looking, const bool draw
         draw_footsteps( w_terrain, tripoint( -center.x, -center.y, center.z ) + point( POSX, POSY ) );
     }
 
-    for( Creature &critter : all_creatures() ) {
+    for( Creature  const&critter : all_creatures() ) {
         draw_critter( critter, center );
     }
 
     if( !destination_preview.empty() && u.view_offset.z == 0 ) {
         // Draw auto-move preview trail
         const tripoint &final_destination = destination_preview.back();
-        tripoint line_center = u.pos() + u.view_offset;
+        tripoint const line_center = u.pos() + u.view_offset;
         draw_line( final_destination, line_center, destination_preview, true );
         mvwputch( w_terrain, final_destination.xy() - u.view_offset.xy() + point( POSX - u.posx(),
                   POSY - u.posy() ), c_white, 'X' );
@@ -3286,8 +3286,8 @@ std::optional<tripoint> game::get_veh_dir_indicator_location( bool next ) const
         return std::nullopt;
     }
     vehicle *const veh = &vp->vehicle();
-    rl_vec2d face = next ? veh->dir_vec() : veh->face_vec();
-    float r = 10.0;
+    rl_vec2d const face = next ? veh->dir_vec() : veh->face_vec();
+    float const r = 10.0;
     return tripoint( static_cast<int>( r * face.x ), static_cast<int>( r * face.y ), u.pos().z );
 }
 
@@ -3315,7 +3315,7 @@ void game::draw_minimap()
         for( int j = -2; j <= 2; j++ ) {
             const point_abs_omt om( curs2 + point( i, j ) );
             nc_color ter_color;
-            tripoint_abs_omt omp( om, get_levz() );
+            tripoint_abs_omt const omp( om, get_levz() );
             std::string ter_sym;
             const bool seen = overmap_buffer.seen( omp );
             const bool vehicle_here = overmap_buffer.has_vehicle( omp );
@@ -3329,7 +3329,7 @@ void game::draw_minimap()
                 int symbolIndex = note_text.find( ':' );
                 int colorIndex = note_text.find( ';' );
 
-                bool symbolFirst = symbolIndex < colorIndex;
+                bool const symbolFirst = symbolIndex < colorIndex;
 
                 if( colorIndex > -1 && symbolIndex > -1 ) {
                     if( symbolFirst ) {
@@ -3370,7 +3370,7 @@ void game::draw_minimap()
                         colorStart = symbolIndex + 1;
                     }
 
-                    std::string sym = note_text.substr( colorStart, colorIndex - colorStart );
+                    std::string const sym = note_text.substr( colorStart, colorIndex - colorStart );
 
                     if( sym.length() == 2 ) {
                         if( sym == "br" ) {
@@ -3381,7 +3381,7 @@ void game::draw_minimap()
                             ter_color = c_dark_gray;
                         }
                     } else {
-                        char colorID = sym.c_str()[0];
+                        char const colorID = sym.c_str()[0];
                         if( colorID == 'r' ) {
                             ter_color = c_light_red;
                         } else if( colorID == 'R' ) {
@@ -3441,7 +3441,7 @@ void game::draw_minimap()
 
     // Print arrow to mission if we have one!
     if( !drew_mission ) {
-        double slope = curs2.x() != targ.x() ?
+        double const slope = curs2.x() != targ.x() ?
                        static_cast<double>( targ.y() - curs2.y() ) / ( targ.x() - curs2.x() ) : 4;
 
         if( curs2.x() == targ.x() || std::fabs( slope ) > 3.5 ) { // Vertical slope
@@ -3587,7 +3587,7 @@ character_id game::assign_npc_id()
 
 Creature *game::is_hostile_nearby()
 {
-    int distance = ( get_option<int>( "SAFEMODEPROXIMITY" ) <= 0 ) ? MAX_VIEW_DISTANCE :
+    int const distance = ( get_option<int>( "SAFEMODEPROXIMITY" ) <= 0 ) ? MAX_VIEW_DISTANCE :
                    get_option<int>( "SAFEMODEPROXIMITY" );
     return is_hostile_within( distance );
 }
@@ -3720,7 +3720,7 @@ void game::mon_info( const catacurses::window &w, int hor_padding )
     //for the alignment of the 1,2,3 rows on the right edge
     xcoords[2] -= utf8_width( _( "East:" ) ) - utf8_width( _( "NE:" ) );
     for( int i = 0; i < 8; i++ ) {
-        nc_color c = unique_types[i].empty() && unique_mons[i].empty() ? c_dark_gray
+        nc_color const c = unique_types[i].empty() && unique_mons[i].empty() ? c_dark_gray
                      : ( dangerous[i] ? c_light_red : c_light_gray );
         mvwprintz( w, point( xcoords[i] + hor_padding, ycoords[i] + startrow ), c, dir_labels[i] );
     }
@@ -3730,7 +3730,7 @@ void game::mon_info( const catacurses::window &w, int hor_padding )
         point pr( xcoords[i] + widths[i] + 1, ycoords[i] + startrow );
 
         // The list of symbols needs a space on each end.
-        int symroom = ( width / 3 ) - widths[i] - 2;
+        int const symroom = ( width / 3 ) - widths[i] - 2;
         const int typeshere_npc = unique_types[i].size();
         const int typeshere_mon = unique_mons[i].size();
         const int typeshere = typeshere_mon + typeshere_npc;
@@ -3795,7 +3795,7 @@ void game::mon_info( const catacurses::window &w, int hor_padding )
     // Print monster names, starting with those at location 8 (nearby).
     for( int j = 8; j >= 0 && pr.y < maxheight; j-- ) {
         // Separate names by some number of spaces (more for local monsters).
-        int namesep = ( j == 8 ? 2 : 1 );
+        int const namesep = ( j == 8 ? 2 : 1 );
         for( const std::pair<const mtype *, int> &mon : mons_at[j] ) {
             const mtype *const type = mon.first;
             const int count = mon.second;
@@ -3997,7 +3997,7 @@ void game::mon_info_update( )
     if( newseen > mostseen ) {
         if( newseen - mostseen == 1 ) {
             if( !new_seen_mon.empty() ) {
-                monster &critter = *new_seen_mon.back();
+                monster  const&critter = *new_seen_mon.back();
                 cancel_activity_or_ignore_query( distraction_type::hostile_spotted_far,
                                                  string_format( _( "%s spotted!" ), critter.name() ) );
                 if( u.has_trait( trait_id( "M_DEFENDER" ) ) && critter.type->in_species( PLANT ) ) {
@@ -4044,7 +4044,7 @@ void game::cleanup_dead()
 {
     // Dead monsters need to stay in the tracker until everything else that needs to die does so
     // This is because dying monsters can still interact with other dying monsters (@ref Creature::killer)
-    bool monster_is_dead = critter_tracker->kill_marked_for_death();
+    bool const monster_is_dead = critter_tracker->kill_marked_for_death();
 
     bool npc_is_dead = false;
     // can't use all_npcs as that does not include dead ones
@@ -4082,7 +4082,7 @@ void game::monmove()
     for( monster &critter : all_monsters() ) {
         // Critters in impassable tiles get pushed away, unless it's not impassable for them
         if( !critter.is_dead() && m.impassable( critter.pos() ) && !critter.can_move_to( critter.pos() ) ) {
-            std::string msg = string_format( "%s can't move to its location!  %s  %s", critter.name(),
+            std::string const msg = string_format( "%s can't move to its location!  %s  %s", critter.name(),
                                              critter.pos().to_string(), m.tername( critter.pos() ) );
             dbg( DL::Error ) << msg;
             add_msg( m_debug, msg );
@@ -4170,7 +4170,7 @@ void game::monmove()
         while( !guy.is_dead() && guy.moves > 0 && turns < 10 &&
                ( !guy.in_sleep_state() || guy.activity.id() == ACT_OPERATION )
              ) {
-            int moves = guy.moves;
+            int const moves = guy.moves;
             guy.move();
             if( moves == guy.moves ) {
                 // Count every time we exit npc::move() without spending any moves.
@@ -4282,7 +4282,7 @@ void game::knockback( std::vector<tripoint> &traj, int stun, int dam_mult,
     }
     std::size_t force_remaining = traj.size();
     if( monster *const targ = critter_at<monster>( tp, true ) ) {
-        tripoint start_pos = targ->pos();
+        tripoint const start_pos = targ->pos();
 
         if( stun > 0 ) {
             targ->add_effect( effect_stunned, 1_turns * stun );
@@ -4347,7 +4347,7 @@ void game::knockback( std::vector<tripoint> &traj, int stun, int dam_mult,
             }
         }
     } else if( npc *const targ = critter_at<npc>( tp ) ) {
-        tripoint start_pos = targ->pos();
+        tripoint const start_pos = targ->pos();
 
         if( stun > 0 ) {
             targ->add_effect( effect_stunned, 1_turns * stun );
@@ -4364,7 +4364,7 @@ void game::knockback( std::vector<tripoint> &traj, int stun, int dam_mult,
                         add_msg( _( "%s was stunned!" ), targ->name );
                     }
 
-                    std::array<bodypart_id, 8> bps = {{
+                    std::array<bodypart_id, 8> const bps = {{
                             bodypart_id( "head" ),
                             bodypart_id( "arm_l" ), bodypart_id( "arm_r" ),
                             bodypart_id( "hand_l" ), bodypart_id( "hand_r" ),
@@ -4420,7 +4420,7 @@ void game::knockback( std::vector<tripoint> &traj, int stun, int dam_mult,
             }
         }
     } else if( u.pos() == tp ) {
-        tripoint start_pos = u.pos();
+        tripoint const start_pos = u.pos();
 
         if( stun > 0 ) {
             u.add_effect( effect_stunned, 1_turns * stun );
@@ -4447,7 +4447,7 @@ void game::knockback( std::vector<tripoint> &traj, int stun, int dam_mult,
                                  force_remaining );
                     }
                     u.add_effect( effect_stunned, 1_turns * force_remaining );
-                    std::array<bodypart_id, 8> bps = {{
+                    std::array<bodypart_id, 8> const bps = {{
                             bodypart_id( "head" ),
                             bodypart_id( "arm_l" ), bodypart_id( "arm_r" ),
                             bodypart_id( "hand_l" ), bodypart_id( "hand_r" ),
@@ -4750,7 +4750,7 @@ void game::clear_zombies()
 bool game::spawn_hallucination( const tripoint &p )
 {
     if( one_in( 100 ) ) {
-        shared_ptr_fast<npc> tmp = make_shared_fast<npc>();
+        shared_ptr_fast<npc> const tmp = make_shared_fast<npc>();
         tmp->randomize( NC_HALLU );
         tmp->spawn_at_precise( { get_levx(), get_levy() }, p );
         if( !critter_at( p, true ) ) {
@@ -4795,7 +4795,7 @@ bool game::swap_critters( Creature &a, Creature &b )
     // Simplify by "sorting" the arguments
     // Only the first argument can be u
     // If swapping player/npc with a monster, monster is second
-    bool a_first = a.is_player() ||
+    bool const a_first = a.is_player() ||
                    ( a.is_npc() && !b.is_player() );
     Creature &first  = a_first ? a : b;
     Creature &second = a_first ? b : a;
@@ -4827,7 +4827,7 @@ bool game::swap_critters( Creature &a, Creature &b )
         m.unboard_vehicle( other_npc->pos() );
     }
 
-    tripoint temp = second.pos();
+    tripoint const temp = second.pos();
     second.setpos( first.pos() );
 
     if( first.is_player() ) {
@@ -4867,7 +4867,7 @@ bool game::revive_corpse( const tripoint &p, item &it )
         debugmsg( "Tried to revive a non-corpse." );
         return false;
     }
-    shared_ptr_fast<monster> newmon_ptr = make_shared_fast<monster>
+    shared_ptr_fast<monster> const newmon_ptr = make_shared_fast<monster>
                                           ( it.get_mtype()->id );
     monster &critter = *newmon_ptr;
     critter.init_from_item( it );
@@ -4907,7 +4907,7 @@ void static delete_cyborg_item( map &m, const tripoint &couch_pos, item *cyborg 
     if( const std::optional<vpart_reference> vp = get_map().veh_at( couch_pos ).part_with_feature(
                 flag_AUTODOC_COUCH, false ) ) {
         auto dest_veh = &vp->vehicle();
-        int dest_part = vp->part_index();
+        int const dest_part = vp->part_index();
 
         for( item &it : dest_veh->get_items( dest_part ) ) {
             if( &it == cyborg ) {
@@ -4924,15 +4924,15 @@ void static delete_cyborg_item( map &m, const tripoint &couch_pos, item *cyborg 
 
 void game::save_cyborg( item *cyborg, const tripoint &couch_pos, player &installer )
 {
-    int assist_bonus = installer.get_effect_int( effect_assisted );
+    int const assist_bonus = installer.get_effect_int( effect_assisted );
 
-    float adjusted_skill = installer.bionics_adjusted_skill( skill_firstaid,
+    float const adjusted_skill = installer.bionics_adjusted_skill( skill_firstaid,
                            skill_computer,
                            skill_electronics,
                            -1 );
 
-    int damage = cyborg->damage();
-    int dmg_lvl = cyborg->damage_level( 4 );
+    int const damage = cyborg->damage();
+    int const dmg_lvl = cyborg->damage_level( 4 );
     int difficulty = 12;
 
     if( damage != 0 ) {
@@ -4944,8 +4944,8 @@ void game::save_cyborg( item *cyborg, const tripoint &couch_pos, player &install
         difficulty += dmg_lvl;
     }
 
-    int chance_of_success = bionic_manip_cos( adjusted_skill + assist_bonus, difficulty );
-    int success = chance_of_success - rng( 1, 100 );
+    int const chance_of_success = bionic_manip_cos( adjusted_skill + assist_bonus, difficulty );
+    int const success = chance_of_success - rng( 1, 100 );
 
     if( !g->u.query_yn(
             _( "WARNING: %i percent chance of SEVERE damage to all body parts!  Continue anyway?" ),
@@ -4960,7 +4960,7 @@ void game::save_cyborg( item *cyborg, const tripoint &couch_pos, player &install
         delete_cyborg_item( g->m, couch_pos, cyborg );
 
         const string_id<npc_template> npc_cyborg( "cyborg_rescued" );
-        shared_ptr_fast<npc> tmp = make_shared_fast<npc>();
+        shared_ptr_fast<npc> const tmp = make_shared_fast<npc>();
         tmp->load_npc_template( npc_cyborg );
         tmp->spawn_at_precise( { get_levx(), get_levy() }, couch_pos );
         overmap_buffer.insert_npc( tmp );
@@ -5161,7 +5161,7 @@ void game::moving_vehicle_dismount( const tripoint &dest_loc )
         debugmsg( "Need somewhere to dismount towards." );
         return;
     }
-    tileray ray( dest_loc.xy() + point( -u.posx(), -u.posy() ) );
+    tileray const ray( dest_loc.xy() + point( -u.posx(), -u.posy() ) );
     // TODO:: make dir() const correct!
     const units::angle d = ray.dir();
     add_msg( _( "You dive from the %s." ), veh->name );
@@ -5328,7 +5328,7 @@ bool game::npc_menu( npc &who )
         u.mod_moves( -200 );
     } else if( choice == push ) {
         // TODO: Make NPCs protest when displaced onto dangerous crap
-        tripoint oldpos = who.pos();
+        tripoint const oldpos = who.pos();
         who.move_away_from( u.pos(), true );
         u.mod_moves( -20 );
         if( oldpos != who.pos() ) {
@@ -5365,7 +5365,7 @@ bool game::npc_menu( npc &who )
             return false;
         }
         item &used = *loc;
-        bool did_use = u.invoke_item( &used, heal_string, who.pos() );
+        bool const did_use = u.invoke_item( &used, heal_string, who.pos() );
         if( did_use ) {
             // Note: exiting a body part selection menu counts as use here
             u.mod_moves( -300 );
@@ -5489,7 +5489,7 @@ void game::examine( const tripoint &examp )
         if( mon != nullptr ) {
             if( mon->battery_item && mon->has_effect( effect_pet ) ) {
                 const itype &type = *mon->type->mech_battery;
-                int max_charge = type.magazine->capacity;
+                int const max_charge = type.magazine->capacity;
                 float charge_percent;
                 if( mon->battery_item ) {
                     charge_percent = static_cast<float>( mon->battery_item->ammo_remaining() ) / max_charge * 100;
@@ -5640,7 +5640,7 @@ void game::pickup()
 void game::pickup( const tripoint &p )
 {
     // Highlight target
-    shared_ptr_fast<game::draw_callback_t> hilite_cb = make_shared_fast<game::draw_callback_t>( [&]() {
+    shared_ptr_fast<game::draw_callback_t> const hilite_cb = make_shared_fast<game::draw_callback_t>( [&]() {
         m.drawsq( w_terrain, p, drawsq_params().highlight( true ) );
     } );
     add_draw_callback( hilite_cb );
@@ -5683,7 +5683,7 @@ void game::peek()
 void game::peek( const tripoint &p )
 {
     u.moves -= 200;
-    tripoint prev = u.pos();
+    tripoint const prev = u.pos();
     u.setpos( p );
     tripoint center = p;
     const look_around_result result = look_around( /*show_window=*/true, center, center, false, false,
@@ -5691,7 +5691,7 @@ void game::peek( const tripoint &p )
     u.setpos( prev );
 
     if( result.peek_action && *result.peek_action == PA_BLIND_THROW ) {
-        item_location loc;
+        item_location const loc;
         avatar_action::plthrow( u, loc, p );
     }
     m.invalidate_map_cache( p.z );
@@ -5882,7 +5882,7 @@ void game::print_terrain_info( const tripoint &lp, const catacurses::window &w_l
         return ret;
     };
 
-    std::string tile = string_format( "(%s) %s", area_name, fmt_tile_info( lp ) );
+    std::string const tile = string_format( "(%s) %s", area_name, fmt_tile_info( lp ) );
 
     if( m.impassable( lp ) ) {
         lines = fold_and_print( w_look, point( column, line ), max_width, c_light_gray,
@@ -5899,7 +5899,7 @@ void game::print_terrain_info( const tripoint &lp, const catacurses::window &w_l
         wprintz( w_look, ll.second, ll.first );
     }
 
-    std::string signage = m.get_signage( lp );
+    std::string const signage = m.get_signage( lp );
     if( !signage.empty() ) {
         trim_and_print( w_look, point( column, ++lines ), max_width, c_dark_gray,
                         // NOLINTNEXTLINE(cata-text-style): the question mark does not end a sentence
@@ -5908,8 +5908,8 @@ void game::print_terrain_info( const tripoint &lp, const catacurses::window &w_l
 
     if( m.has_zlevels() && lp.z > -OVERMAP_DEPTH && !m.has_floor( lp ) ) {
         // Print info about stuff below
-        tripoint below( lp.xy(), lp.z - 1 );
-        std::string tile_below = fmt_tile_info( below );
+        tripoint const below( lp.xy(), lp.z - 1 );
+        std::string const tile_below = fmt_tile_info( below );
 
         if( !m.has_floor_or_support( lp ) ) {
             fold_and_print( w_look, point( column, ++lines ), max_width, c_dark_gray,
@@ -5922,7 +5922,7 @@ void game::print_terrain_info( const tripoint &lp, const catacurses::window &w_l
         }
     }
 
-    int map_features = fold_and_print( w_look, point( column, ++lines ), max_width, c_dark_gray,
+    int const map_features = fold_and_print( w_look, point( column, ++lines ), max_width, c_dark_gray,
                                        m.features( lp ) );
     fold_and_print( w_look, point( column, ++lines ), max_width, c_light_gray, _( "Coverage: %d%%" ),
                     m.coverage( lp ) );
@@ -5940,7 +5940,7 @@ void game::print_fields_info( const tripoint &lp, const catacurses::window &w_lo
         if( fld.first.obj().has_fire && ( m.has_flag( TFLAG_FIRE_CONTAINER, lp ) ||
                                           m.ter( lp ) == t_pit_shallow || m.ter( lp ) == t_pit ) ) {
             const int max_width = getmaxx( w_look ) - column - 2;
-            int lines = fold_and_print( w_look, point( column, ++line ), max_width, cur.color(),
+            int const lines = fold_and_print( w_look, point( column, ++line ), max_width, cur.color(),
                                         get_fire_fuel_string( lp ) ) - 1;
             line += lines;
         } else {
@@ -5972,7 +5972,7 @@ void game::print_trap_info( const tripoint &lp, const catacurses::window &w_look
 void game::print_creature_info( const Creature *creature, const catacurses::window &w_look,
                                 const int column, int &line, const int last_line )
 {
-    int vLines = last_line - line;
+    int const vLines = last_line - line;
     if( creature != nullptr && ( u.sees( *creature ) || creature == &u ) ) {
         line = creature->print_info( w_look, ++line, vLines, column );
     }
@@ -6199,7 +6199,7 @@ void game::zones_manager()
             zones = mgr.get_zones();
         } else {
             const tripoint &u_abs_pos = m.getabs( u.pos() );
-            for( zone_manager::ref_zone_data &ref : mgr.get_zones() ) {
+            for( zone_manager::ref_zone_data  const&ref : mgr.get_zones() ) {
                 const tripoint &zone_abs_pos = ref.get().get_center_point();
                 if( u_abs_pos.z == zone_abs_pos.z && rl_dist( u_abs_pos, zone_abs_pos ) <= 50 ) {
                     zones.emplace_back( ref );
@@ -6239,20 +6239,20 @@ void game::zones_manager()
     std::optional<tripoint> zone_start;
     std::optional<tripoint> zone_end;
     bool zone_blink = false;
-    bool zone_cursor = false;
+    bool const zone_cursor = false;
     shared_ptr_fast<draw_callback_t> zone_cb = create_zone_callback(
                 zone_start, zone_end, zone_blink, zone_cursor );
     add_draw_callback( zone_cb );
 
     auto query_position =
     [&]() -> std::optional<std::pair<tripoint, tripoint>> {
-        on_out_of_scope invalidate_current_ui( [&]()
+        on_out_of_scope const invalidate_current_ui( [&]()
         {
             ui.mark_resize();
         } );
-        restore_on_out_of_scope<bool> show_prev( show );
-        restore_on_out_of_scope<std::optional<tripoint>> zone_start_prev( zone_start );
-        restore_on_out_of_scope<std::optional<tripoint>> zone_end_prev( zone_end );
+        restore_on_out_of_scope<bool> const show_prev( show );
+        restore_on_out_of_scope<std::optional<tripoint>> const zone_start_prev( zone_start );
+        restore_on_out_of_scope<std::optional<tripoint>> const zone_end_prev( zone_end );
         show = false;
         zone_start = std::nullopt;
         zone_end = std::nullopt;
@@ -6273,12 +6273,12 @@ void game::zones_manager()
             const look_around_result second = look_around( /*show_window=*/false, center, *first.position,
                     true, true, false );
             if( second.position ) {
-                tripoint first_abs = m.getabs( tripoint( std::min( first.position->x,
+                tripoint const first_abs = m.getabs( tripoint( std::min( first.position->x,
                                                second.position->x ),
                                                std::min( first.position->y, second.position->y ),
                                                std::min( first.position->z,
                                                        second.position->z ) ) );
-                tripoint second_abs = m.getabs( tripoint( std::max( first.position->x,
+                tripoint const second_abs = m.getabs( tripoint( std::max( first.position->x,
                                                 second.position->x ),
                                                 std::max( first.position->y, second.position->y ),
                                                 std::max( first.position->z,
@@ -6311,7 +6311,7 @@ void game::zones_manager()
 
             int iNum = 0;
 
-            tripoint player_absolute_pos = m.getabs( u.pos() );
+            tripoint const player_absolute_pos = m.getabs( u.pos() );
 
             //Display saved zones
             for( auto &i : zones ) {
@@ -6334,7 +6334,7 @@ void game::zones_manager()
                     mvwprintz( w_zones, point( 20, iNum - start_index ), colorLine,
                                mgr.get_name_from_type( zone.get_type() ) );
 
-                    tripoint center = zone.get_center_point();
+                    tripoint const center = zone.get_center_point();
 
                     //Draw direction + distance
                     mvwprintz( w_zones, point( 32, iNum - start_index ), colorLine, "%*d %s",
@@ -6467,12 +6467,12 @@ void game::zones_manager()
                         break;
                     }
                     case 5: {
-                        on_out_of_scope invalidate_current_ui( [&]() {
+                        on_out_of_scope const invalidate_current_ui( [&]() {
                             ui.mark_resize();
                         } );
-                        restore_on_out_of_scope<bool> show_prev( show );
-                        restore_on_out_of_scope<std::optional<tripoint>> zone_start_prev( zone_start );
-                        restore_on_out_of_scope<std::optional<tripoint>> zone_end_prev( zone_end );
+                        restore_on_out_of_scope<bool> const show_prev( show );
+                        restore_on_out_of_scope<std::optional<tripoint>> const zone_start_prev( zone_start );
+                        restore_on_out_of_scope<std::optional<tripoint>> const zone_end_prev( zone_end );
                         show = false;
                         zone_start = std::nullopt;
                         zone_end = std::nullopt;
@@ -6525,9 +6525,9 @@ void game::zones_manager()
 
             } else if( action == "SHOW_ZONE_ON_MAP" ) {
                 //show zone position on overmap;
-                tripoint_abs_omt player_overmap_position = u.global_omt_location();
+                tripoint_abs_omt const player_overmap_position = u.global_omt_location();
                 // TODO: fix point types
-                tripoint_abs_omt zone_overmap( ms_to_omt_copy( zones[active_index].get().get_center_point() ) );
+                tripoint_abs_omt const zone_overmap( ms_to_omt_copy( zones[active_index].get().get_center_point() ) );
 
                 ui::omap::display_zones( player_overmap_position, zone_overmap, active_index );
             } else if( action == "ENABLE_ZONE" ) {
@@ -6599,7 +6599,7 @@ void game::pre_print_all_tile_info( const tripoint &lp, const catacurses::window
 std::optional<tripoint> game::look_around( bool force_3d )
 {
     tripoint center = u.pos() + u.view_offset;
-    look_around_result result = look_around( /*show_window=*/true, center, center, false, false,
+    look_around_result const result = look_around( /*show_window=*/true, center, center, false, false,
                                 false, false, tripoint_zero, force_3d );
     return result.position;
 }
@@ -6619,7 +6619,7 @@ look_around_result game::look_around( bool show_window, tripoint &center,
     int &ly = lp.y;
     int &lz = lp.z;
 
-    int soffset = get_option<int>( "FAST_SCROLL_OFFSET" );
+    int const soffset = get_option<int>( "FAST_SCROLL_OFFSET" );
     bool fast_scroll = false;
 
     std::unique_ptr<ui_adaptor> ui;
@@ -6627,7 +6627,7 @@ look_around_result game::look_around( bool show_window, tripoint &center,
     if( show_window ) {
         ui = std::make_unique<ui_adaptor>();
         ui->on_screen_resize( [&]( ui_adaptor & ui ) {
-            int panel_width = panel_manager::get_manager().get_current_layout().begin()->get_width();
+            int const panel_width = panel_manager::get_manager().get_current_layout().begin()->get_width();
             int height = pixel_minimap_option ? TERMY - getmaxy( w_pixel_minimap ) : TERMY;
 
             // If particularly small, base height on panel width irrespective of other elements.
@@ -6636,9 +6636,9 @@ look_around_result game::look_around( bool show_window, tripoint &center,
                 height = panel_width / 2;
             }
 
-            int la_y = 0;
+            int const la_y = 0;
             int la_x = TERMX - panel_width;
-            std::string position = get_option<std::string>( "LOOKAROUND_POSITION" );
+            std::string const position = get_option<std::string>( "LOOKAROUND_POSITION" );
             if( position == "left" ) {
                 if( get_option<std::string>( "SIDEBAR_POSITION" ) == "right" ) {
                     la_x = panel_manager::get_manager().get_width_left();
@@ -6646,8 +6646,8 @@ look_around_result game::look_around( bool show_window, tripoint &center,
                     la_x = panel_manager::get_manager().get_width_left() - panel_width;
                 }
             }
-            int la_h = height;
-            int la_w = panel_width;
+            int const la_h = height;
+            int const la_w = panel_width;
             w_info = catacurses::newwin( la_h, la_w, point( la_x, la_y ) );
 
             ui.position_from_window( w_info );
@@ -6715,14 +6715,14 @@ look_around_result game::look_around( bool show_window, tripoint &center,
 
             center_print( w_info, 0, c_white, string_format( _( "< <color_green>Look Around</color> >" ) ) );
 
-            std::string extended_descr_text = string_format( _( "%s - %s" ),
+            std::string const extended_descr_text = string_format( _( "%s - %s" ),
                                               ctxt.get_desc( "EXTENDED_DESCRIPTION" ),
                                               ctxt.get_action_name( "EXTENDED_DESCRIPTION" ) );
-            std::string fast_scroll_text = string_format( _( "%s - %s" ),
+            std::string const fast_scroll_text = string_format( _( "%s - %s" ),
                                            ctxt.get_desc( "TOGGLE_FAST_SCROLL" ),
                                            ctxt.get_action_name( "TOGGLE_FAST_SCROLL" ) );
 #if defined(TILES)
-            std::string pixel_minimap_text = string_format( _( "%s - %s" ),
+            std::string const pixel_minimap_text = string_format( _( "%s - %s" ),
                                              ctxt.get_desc( "toggle_pixel_minimap" ),
                                              ctxt.get_action_name( "toggle_pixel_minimap" ) );
 #endif // TILES
@@ -6750,7 +6750,7 @@ look_around_result game::look_around( bool show_window, tripoint &center,
     std::optional<tripoint> zone_start;
     std::optional<tripoint> zone_end;
     bool zone_blink = false;
-    bool zone_cursor = true;
+    bool const zone_cursor = true;
     shared_ptr_fast<draw_callback_t> zone_cb = create_zone_callback( zone_start, zone_end, zone_blink,
             zone_cursor, is_moving_zone );
     add_draw_callback( zone_cb );
@@ -6958,11 +6958,11 @@ std::vector<map_item_stack> game::find_nearby_items( int iRadius )
         return ret;
     }
 
-    int range = fov_3d ? ( fov_3d_z_range * 2 ) + 1 : 1;
-    int center_z = u.pos().z;
+    int const range = fov_3d ? ( fov_3d_z_range * 2 ) + 1 : 1;
+    int const center_z = u.pos().z;
 
     for( int i = 1; i <= range; i++ ) {
-        int z = i % 2 ? center_z - i / 2 : center_z + i / 2;
+        int const z = i % 2 ? center_z - i / 2 : center_z + i / 2;
         for( auto &points_p_it : closest_points_first( {u.pos().xy(), z}, iRadius ) ) {
             if( points_p_it.y >= u.posy() - iRadius && points_p_it.y <= u.posy() + iRadius &&
                 u.sees( points_p_it ) &&
@@ -6993,7 +6993,7 @@ std::vector<map_item_stack> game::find_nearby_items( int iRadius )
 void draw_trail( const tripoint &start, const tripoint &end, const bool bDrawX )
 {
     std::vector<tripoint> pts;
-    tripoint center = g->u.pos() + g->u.view_offset;
+    tripoint const center = g->u.pos() + g->u.view_offset;
     if( start != end ) {
         //Draw trail
         pts = line_to( start, end, 0, 0 );
@@ -7034,11 +7034,11 @@ static void centerlistview( const tripoint &active_item_position, int ui_width )
             u.view_offset.x = active_item_position.x;
             u.view_offset.y = active_item_position.y;
         } else {
-            point pos( active_item_position.xy() + point( POSX, POSY ) );
+            point const pos( active_item_position.xy() + point( POSX, POSY ) );
 
             // item/monster list UI is on the right, so get the difference between its width
             // and the width of the sidebar on the right (if any)
-            int sidebar_right_adjusted = ui_width - panel_manager::get_manager().get_width_right();
+            int const sidebar_right_adjusted = ui_width - panel_manager::get_manager().get_width_right();
             // if and only if that difference is greater than zero, use that as offset
             int right_offset = sidebar_right_adjusted > 0 ? sidebar_right_adjusted : 0;
 
@@ -7046,7 +7046,7 @@ static void centerlistview( const tripoint &active_item_position, int ui_width )
             // This lets us account for possible differences in terrain width between
             // the normal sidebar and the list-all-whatever display.
             to_map_font_dim_width( right_offset );
-            int terrain_width = TERRAIN_WINDOW_WIDTH - right_offset;
+            int const terrain_width = TERRAIN_WINDOW_WIDTH - right_offset;
 
             if( pos.x < 0 ) {
                 u.view_offset.x = pos.x;
@@ -7143,12 +7143,12 @@ bool game::take_screenshot( const std::string &path ) const
 bool game::take_screenshot() const
 {
     // check that the current '<world>/screenshots' directory exists
-    std::string map_directory = get_world_base_save_path() + "/screenshots/";
+    std::string const map_directory = get_world_base_save_path() + "/screenshots/";
     assure_dir_exist( map_directory );
 
     // build file name: <map_dir>/screenshots/[<character_name>]_<date>.png
     // Date format is a somewhat ISO-8601 compliant GMT time date (except for some characters that wouldn't pass on most file systems like ':').
-    std::time_t time = std::time( nullptr );
+    std::time_t const time = std::time( nullptr );
     std::stringstream date_buffer;
     date_buffer << std::put_time( std::gmtime( &time ), "%F_%H-%M-%S_%z" );
     const std::string tmp_file_name = string_format( "[%s]_%s.png", get_player_character().get_name(),
@@ -7231,9 +7231,9 @@ void game::reset_item_list_state( const catacurses::window &window, int height,
     tokens.emplace_back( _( "<F>ilter" ) );
     tokens.emplace_back( _( "<+/->Priority" ) );
 
-    int gaps = tokens.size() + 1;
+    int const gaps = tokens.size() + 1;
     letters = 0;
-    int n = tokens.size();
+    int const n = tokens.size();
     for( int i = 0; i < n; i++ ) {
         letters += utf8_width( tokens[i] ) - 2; //length ignores < >
     }
@@ -7488,11 +7488,11 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
             werase( w_item_info );
 
             if( iItemNum > 0 && activeItem ) {
-                item_location loc( map_cursor( u.pos() + activeItem->example_item_pos ),
+                item_location const loc( map_cursor( u.pos() + activeItem->example_item_pos ),
                                    const_cast<item *>( activeItem->example ) );
-                temperature_flag temperature = rot::temperature_flag_for_location( m, loc );
-                std::vector<iteminfo> this_item = activeItem->example->info( temperature );
-                std::vector<iteminfo> item_info_dummy;
+                temperature_flag const temperature = rot::temperature_flag_for_location( m, loc );
+                std::vector<iteminfo> const this_item = activeItem->example->info( temperature );
+                std::vector<iteminfo> const item_info_dummy;
 
                 item_info_data dummy( "", "", this_item, item_info_dummy, iScrollPos );
                 dummy.without_getch = true;
@@ -7526,7 +7526,7 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
     std::optional<tripoint> trail_start;
     std::optional<tripoint> trail_end;
     bool trail_end_x = false;
-    shared_ptr_fast<draw_callback_t> trail_cb = create_trail_callback( trail_start, trail_end,
+    shared_ptr_fast<draw_callback_t> const trail_cb = create_trail_callback( trail_start, trail_end,
             trail_end_x );
     add_draw_callback( trail_cb );
 
@@ -7554,12 +7554,12 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
             uistate.list_item_filter_active = false;
             addcategory = !sort_radius;
         } else if( action == "EXAMINE" && !filtered_items.empty() && activeItem ) {
-            std::vector<iteminfo> dummy;
+            std::vector<iteminfo> const dummy;
             const item *example_item = activeItem->example;
             // TODO: const_item_location
-            item_location loc = item_location( u, const_cast<item *>( example_item ) );
-            temperature_flag temperature = rot::temperature_flag_for_location( m, loc );
-            std::vector<iteminfo> this_item = example_item->info( temperature );
+            item_location const loc = item_location( u, const_cast<item *>( example_item ) );
+            temperature_flag const temperature = rot::temperature_flag_for_location( m, loc );
+            std::vector<iteminfo> const this_item = example_item->info( temperature );
 
             item_info_data info_data( example_item->tname(), example_item->type_name(), this_item, dummy );
             info_data.handle_scrolling = true;
@@ -7846,7 +7846,7 @@ game::vmenu_ret game::list_monsters( const std::vector<Creature *> &monster_list
                 // given the currently selected monster iActive. get the selected row
                 int iSelPos = iActive;
                 for( auto &ia : mSortCategory ) {
-                    int index = ia.first;
+                    int const index = ia.first;
                     if( index <= iSelPos ) {
                         ++iSelPos;
                     } else {
@@ -7987,7 +7987,7 @@ game::vmenu_ret game::list_monsters( const std::vector<Creature *> &monster_list
     std::optional<tripoint> trail_start;
     std::optional<tripoint> trail_end;
     bool trail_end_x = false;
-    shared_ptr_fast<draw_callback_t> trail_cb = create_trail_callback( trail_start, trail_end,
+    shared_ptr_fast<draw_callback_t> const trail_cb = create_trail_callback( trail_start, trail_end,
             trail_end_x );
     add_draw_callback( trail_cb );
 
@@ -8207,8 +8207,8 @@ static void butcher_submenu( const std::vector<map_stack::iterator> &corpses, in
         return to_string_clipped( time_duration::from_turns( time_to_cut / 100 ) );
     };
     auto info_on_action = [&]( butcher_type type ) {
-        int corpse_index = corpse == -1 ? 0 : corpse;
-        butchery_setup setup = consider_butchery( *corpses[corpse_index], you, type );
+        int const corpse_index = corpse == -1 ? 0 : corpse;
+        butchery_setup const setup = consider_butchery( *corpses[corpse_index], you, type );
         std::string out;
         for( const std::string &problem : setup.problems ) {
             out += "\n" + colorize( problem, c_red );
@@ -8546,7 +8546,7 @@ void game::butcher()
                     break;
                 case MULTIBUTCHER:
                     butcher_submenu( corpses );
-                    for( map_stack::iterator &it : corpses ) {
+                    for( map_stack::iterator  const&it : corpses ) {
                         u.activity.targets.emplace_back( map_cursor( u.pos() ), &*it );
                     }
                     break;
@@ -8723,7 +8723,7 @@ bool game::is_dangerous_tile( const tripoint &dest_loc ) const
 
 bool game::prompt_dangerous_tile( const tripoint &dest_loc ) const
 {
-    std::vector<std::string> harmful_stuff = get_dangerous_tile( dest_loc );
+    std::vector<std::string> const harmful_stuff = get_dangerous_tile( dest_loc );
 
     if( !harmful_stuff.empty() &&
         !query_yn( _( "Really step into %s?" ), enumerate_as_string( harmful_stuff ) ) ) {
@@ -8893,7 +8893,7 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp )
     u.set_underwater( false );
 
     if( !shifting_furniture && !pushing && is_dangerous_tile( dest_loc ) ) {
-        std::vector<std::string> harmful_stuff = get_dangerous_tile( dest_loc );
+        std::vector<std::string> const harmful_stuff = get_dangerous_tile( dest_loc );
         const auto dangerous_terrain_opt = get_option<std::string>( "DANGEROUS_TERRAIN_WARNING_PROMPT" );
         const auto harmful_text = enumerate_as_string( harmful_stuff );
         const auto warn_msg = [&]( const char *const msg ) {
@@ -8937,7 +8937,7 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp )
     } else if( mcost == 0 ) {
         return false;
     }
-    bool diag = trigdist && u.posx() != dest_loc.x && u.posy() != dest_loc.y;
+    bool const diag = trigdist && u.posx() != dest_loc.x && u.posy() != dest_loc.y;
     const int previous_moves = u.moves;
     if( u.is_mounted() ) {
         auto crit = u.mounted_creature.get();
@@ -9086,8 +9086,8 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp )
     }
 
     tripoint oldpos = u.pos();
-    point submap_shift = place_player( dest_loc );
-    point ms_shift = sm_to_ms_copy( submap_shift );
+    point const submap_shift = place_player( dest_loc );
+    point const ms_shift = sm_to_ms_copy( submap_shift );
     oldpos = oldpos - ms_shift;
 
     if( pulling ) {
@@ -9115,7 +9115,7 @@ point game::place_player( const tripoint &dest_loc )
     if( const std::optional<std::string> label = vp1.get_label() ) {
         add_msg( m_info, _( "Label here: %s" ), *label );
     }
-    std::string signage = m.get_signage( dest_loc );
+    std::string const signage = m.get_signage( dest_loc );
     if( !signage.empty() ) {
         if( !u.has_trait( trait_ILLITERATE ) ) {
             add_msg( m_info, _( "The sign says: %s" ), signage );
@@ -9355,9 +9355,9 @@ point game::place_player( const tripoint &dest_loc )
                 std::vector<item> items;
                 for( auto &tmpitem : m.i_at( u.pos() ) ) {
 
-                    std::string next_tname = tmpitem.tname();
-                    std::string next_dname = tmpitem.display_name();
-                    bool by_charges = tmpitem.count_by_charges();
+                    std::string const next_tname = tmpitem.tname();
+                    std::string const next_dname = tmpitem.display_name();
+                    bool const by_charges = tmpitem.count_by_charges();
                     bool got_it = false;
                     for( size_t i = 0; i < names.size(); ++i ) {
                         if( by_charges && next_tname == names[i] ) {
@@ -9394,7 +9394,7 @@ point game::place_player( const tripoint &dest_loc )
                 int and_the_rest = 0;
                 for( size_t i = 0; i < names.size(); ++i ) {
                     //~ number of items: "<number> <item>"
-                    std::string fmt = vgettext( "%1$d %2$s", "%1$d %2$s", counts[i] );
+                    std::string const fmt = vgettext( "%1$d %2$s", "%1$d %2$s", counts[i] );
                     names[i] = string_format( fmt, counts[i], names[i] );
                     // Skip the first two.
                     if( i > 1 ) {
@@ -9502,7 +9502,7 @@ bool game::phasing_move( const tripoint &dest_loc, const bool via_ramp )
         dest.y += d.y;
     }
 
-    units::energy power_cost = bio_probability_travel->power_activate;
+    units::energy const power_cost = bio_probability_travel->power_activate;
 
     if( tunneldist != 0 ) {
         // -1 because power_cost for the first tile was already taken up by the bionic's activation
@@ -9545,7 +9545,7 @@ bool game::grabbed_furn_move( const tripoint &dp )
 {
     // Furniture: pull, push, or standing still and nudging object around.
     // Can push furniture out of reach.
-    tripoint fpos = u.pos() + u.grab_point;
+    tripoint const fpos = u.pos() + u.grab_point;
     // supposed position of grabbed furniture
     if( !m.has_furn( fpos ) ) {
         // Where did it go? We're grabbing thin air so reset.
@@ -9558,7 +9558,7 @@ bool game::grabbed_furn_move( const tripoint &dp )
     const bool pulling_furniture = dp == -u.grab_point;
     const bool shifting_furniture = !pushing_furniture && !pulling_furniture;
 
-    tripoint fdest = fpos + dp; // intended destination of furniture.
+    tripoint const fdest = fpos + dp; // intended destination of furniture.
     // Check floor: floorless tiles don't need to be flat and have no traps
     const bool has_floor = m.has_floor( fdest );
     // Unfortunately, game::is_empty fails for tiles we're standing on,
@@ -9592,7 +9592,7 @@ bool game::grabbed_furn_move( const tripoint &dp )
                              m.furn( fpos ).obj().has_flag( "SEALED" );
 
     const int fire_intensity = m.get_field_intensity( fpos, fd_fire );
-    time_duration fire_age = m.get_field_age( fpos, fd_fire );
+    time_duration const fire_age = m.get_field_age( fpos, fd_fire );
 
     int str_req = furntype.move_str_req;
     // Factor in weight of items contained in the furniture.
@@ -9630,7 +9630,7 @@ bool game::grabbed_furn_move( const tripoint &dp )
     u.moves -= str_req * 10;
     // Additional penalty if we can't comfortably move it.
     if( str_req > adjusted_str ) {
-        int move_penalty = std::pow( str_req, 2.0 ) + 100.0;
+        int const move_penalty = std::pow( str_req, 2.0 ) + 100.0;
         if( move_penalty <= 1000 ) {
             if( adjusted_str >= str_req - 3 ) {
                 u.moves -= std::max( 3000, move_penalty * 10 );
@@ -9699,7 +9699,7 @@ bool game::grabbed_furn_move( const tripoint &dp )
 
     if( shifting_furniture ) {
         // We didn't move
-        tripoint d_sum = u.grab_point + dp;
+        tripoint const d_sum = u.grab_point + dp;
         if( std::abs( d_sum.x ) < 2 && std::abs( d_sum.y ) < 2 ) {
             u.grab_point = d_sum; // furniture moved relative to us
         } else { // we pushed furniture out of reach
@@ -9822,7 +9822,7 @@ void game::fling_creature( Creature *c, const units::angle &dir, float flvel, bo
         c->set_underwater( false );
         // TODO: Check whenever it is actually in the viewport
         // or maybe even just redraw the changed tiles
-        bool seen = is_u || u.sees( *c ); // To avoid redrawing when not seen
+        bool const seen = is_u || u.sees( *c ); // To avoid redrawing when not seen
         if( force_next ) {
             pt = next_forced;
             force_next = false;
@@ -9934,7 +9934,7 @@ void game::fling_creature( Creature *c, const units::angle &dir, float flvel, bo
                 force = std::max( force / 2 - 5, 0 );
             }
             if( force > 0 ) {
-                int dmg = c->impact( force, c->pos() );
+                int const dmg = c->impact( force, c->pos() );
                 // TODO: Make landing damage the floor
                 m.bash( c->pos(), dmg / 4, false, false, false );
             }
@@ -9987,7 +9987,7 @@ static std::optional<tripoint> point_selection_menu( const std::vector<tripoint>
 
 static std::optional<tripoint> find_empty_spot_nearby( const tripoint &pos )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     for( const tripoint &p : here.points_in_radius( pos, 1 ) ) {
         if( p == pos ) {
             continue;
@@ -10224,7 +10224,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
                 critter.has_effect( effect_tied ) ) {
                 continue;
             }
-            int turns = critter.turns_to_reach( to.xy() );
+            int const turns = critter.turns_to_reach( to.xy() );
             if( turns < 10 && coming_to_stairs.size() < 8 && critter.will_reach( to.xy() )
                 && !slippedpast ) {
                 critter.staircount = 10 + turns;
@@ -10251,7 +10251,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
     }
 
     if( m.has_zlevels() && std::abs( movez ) == 1 ) {
-        bool ladder = m.has_flag( "DIFFICULT_Z", u.pos() );
+        bool const ladder = m.has_flag( "DIFFICULT_Z", u.pos() );
         for( monster &critter : all_monsters() ) {
             if( ladder && !critter.climbs() ) {
                 continue;
@@ -10304,7 +10304,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
             npc *guy = g->critter_at<npc>( u.pos(), true );
             if( guy ) {
                 crit_name = guy->get_name();
-                tripoint old_pos = guy->pos();
+                tripoint const old_pos = guy->pos();
                 if( !guy->is_enemy() ) {
                     guy->move_away_from( u.pos(), true );
                     if( old_pos != guy->pos() ) {
@@ -10455,8 +10455,8 @@ std::optional<tripoint> game::find_or_make_stairs( map &mp, const int z_after, b
 {
     const int omtilesz = SEEX * 2;
     real_coords rc( m.getabs( point( u.posx(), u.posy() ) ) );
-    tripoint omtile_align_start( m.getlocal( rc.begin_om_pos() ), z_after );
-    tripoint omtile_align_end( omtile_align_start + point( -1 + omtilesz, -1 + omtilesz ) );
+    tripoint const omtile_align_start( m.getlocal( rc.begin_om_pos() ), z_after );
+    tripoint const omtile_align_end( omtile_align_start + point( -1 + omtilesz, -1 + omtilesz ) );
 
     // Try to find the stairs.
     std::optional<tripoint> stairs;
@@ -10489,9 +10489,9 @@ std::optional<tripoint> game::find_or_make_stairs( map &mp, const int z_after, b
         if( Creature *blocking_creature = critter_at( stairs.value() ) ) {
             npc *guy = dynamic_cast<npc *>( blocking_creature );
             monster *mon = dynamic_cast<monster *>( blocking_creature );
-            bool would_move = ( guy && !guy->is_enemy() ) || ( mon && mon->friendly == -1 );
-            bool can_displace = find_empty_spot_nearby( *stairs ).has_value();
-            std::string cr_name = blocking_creature->get_name();
+            bool const would_move = ( guy && !guy->is_enemy() ) || ( mon && mon->friendly == -1 );
+            bool const can_displace = find_empty_spot_nearby( *stairs ).has_value();
+            std::string const cr_name = blocking_creature->get_name();
             std::string msg;
             if( guy ) {
                 //~ %s is the name of hostile NPC
@@ -10717,10 +10717,10 @@ point game::update_map( int &x, int &y )
 
     // this handles loading/unloading submaps that have scrolled on or off the viewport
     // NOLINTNEXTLINE(cata-use-named-point-constants)
-    inclusive_rectangle<point> size_1( point( -1, -1 ), point( 1, 1 ) );
+    inclusive_rectangle<point> const size_1( point( -1, -1 ), point( 1, 1 ) );
     point remaining_shift = shift;
     while( remaining_shift != point_zero ) {
-        point this_shift = clamp( remaining_shift, size_1 );
+        point const this_shift = clamp( remaining_shift, size_1 );
         m.shift( this_shift );
         remaining_shift -= this_shift;
     }
@@ -10797,8 +10797,8 @@ void game::update_overmap_seen()
             continue;
         }
         // If circular distances are enabled, scale overmap distances by the diagonality of the sight line.
-        point abs_delta = delta.raw().abs();
-        int max_delta = std::max( abs_delta.x, abs_delta.y );
+        point const abs_delta = delta.raw().abs();
+        int const max_delta = std::max( abs_delta.x, abs_delta.y );
         const float multiplier = trigdist ? std::sqrt( h_squared ) / max_delta : 1;
         const std::vector<tripoint_abs_omt> line = line_to( ompos, p );
         float sight_points = dist;
@@ -10882,7 +10882,7 @@ void game::update_stair_monsters()
 
     // Attempt to spawn zombies.
     for( size_t i = 0; i < coming_to_stairs.size(); i++ ) {
-        point mpos( stairx[si], stairy[si] );
+        point const mpos( stairx[si], stairy[si] );
         monster &critter = coming_to_stairs[i];
         const tripoint dest {
             mpos, g->get_levz()
@@ -10957,11 +10957,11 @@ void game::update_stair_monsters()
                 tries++;
                 push.x = rng( -1, 1 );
                 push.y = rng( -1, 1 );
-                point ipos( mpos + push );
-                tripoint pos( ipos, get_levz() );
+                point const ipos( mpos + push );
+                tripoint const pos( ipos, get_levz() );
                 if( ( push.x != 0 || push.y != 0 ) && !critter_at( pos ) &&
                     critter.can_move_to( pos ) ) {
-                    bool resiststhrow = ( u.is_throw_immune() ) ||
+                    bool const resiststhrow = ( u.is_throw_immune() ) ||
                                         ( u.has_trait( trait_LEG_TENT_BRACE ) );
                     if( resiststhrow && one_in( player_throw_resist_chance ) ) {
                         u.moves -= 25; // small charge for avoiding the push altogether
@@ -11015,8 +11015,8 @@ void game::update_stair_monsters()
                 tries++;
                 push2.x = rng( -1, 1 );
                 push2.y = rng( -1, 1 );
-                point ipos2( mpos + push2 );
-                tripoint pos( ipos2, get_levz() );
+                point const ipos2( mpos + push2 );
+                tripoint const pos( ipos2, get_levz() );
                 if( ( push2.x == 0 && push2.y == 0 ) || ( ( ipos2.x == u.posx() ) && ( ipos2.y == u.posy() ) ) ) {
                     continue;
                 }
@@ -11132,7 +11132,7 @@ void game::perhaps_add_random_npc()
         }
         counter += 1;
     }
-    shared_ptr_fast<npc> tmp = make_shared_fast<npc>();
+    shared_ptr_fast<npc> const tmp = make_shared_fast<npc>();
     tmp->randomize();
     std::string new_fac_id = "solo_";
     new_fac_id += tmp->name;
@@ -11143,7 +11143,7 @@ void game::perhaps_add_random_npc()
     // adds the npc to the correct overmap.
     // Only spawn random NPCs on z-level 0
     // TODO: fix point types
-    tripoint submap_spawn = omt_to_sm_copy( spawn_point.raw() );
+    tripoint const submap_spawn = omt_to_sm_copy( spawn_point.raw() );
     tmp->spawn_at_sm( tripoint( submap_spawn.xy(), 0 ) );
     overmap_buffer.insert_npc( tmp );
     tmp->form_opinion( u );
@@ -11176,12 +11176,12 @@ void game::display_scent()
         display_toggle_overlay( ACTION_DISPLAY_SCENT );
     } else {
         int div;
-        bool got_value = query_int( div, _( "Set the Scent Map sensitivity to (0 to cancel)?" ) );
+        bool const got_value = query_int( div, _( "Set the Scent Map sensitivity to (0 to cancel)?" ) );
         if( !got_value || div < 1 ) {
             add_msg( _( "Never mind." ) );
             return;
         }
-        shared_ptr_fast<game::draw_callback_t> scent_cb = make_shared_fast<game::draw_callback_t>( [&]() {
+        shared_ptr_fast<game::draw_callback_t> const scent_cb = make_shared_fast<game::draw_callback_t>( [&]() {
             scent.draw( w_terrain, div * 2, u.pos() + u.view_offset );
         } );
         g->add_draw_callback( scent_cb );
@@ -11273,7 +11273,7 @@ void game::display_lighting()
             return;
         }
         uilist lighting_menu;
-        std::vector<std::string> lighting_menu_strings{
+        std::vector<std::string> const lighting_menu_strings{
             "Global lighting conditions"
         };
 
@@ -11324,7 +11324,7 @@ void game::quicksave()
     ui_manager::redraw();
     refresh_display();
 
-    time_t now = time( nullptr ); //timestamp for start of saving procedure
+    time_t const now = time( nullptr ); //timestamp for start of saving procedure
 
     //perform save
     save();
@@ -11475,7 +11475,7 @@ void game::process_artifact( item &it, player &p )
 
             case AEP_SMOKE:
                 if( one_in( 10 ) ) {
-                    tripoint pt( p.posx() + rng( -1, 1 ),
+                    tripoint const pt( p.posx() + rng( -1, 1 ),
                                  p.posy() + rng( -1, 1 ),
                                  p.posz() );
                     m.add_field( pt, fd_smoke, rng( 1, 3 ) );
@@ -11577,7 +11577,7 @@ bool check_art_charge_req( item &it )
     const bool worn = p.is_worn( it );
     const bool wielded = ( &it == &p.primary_weapon() );
     const bool heldweapon = ( wielded && !it.is_armor() ); //don't charge wielded clothes
-    map &here = get_map();
+    map  const&here = get_map();
     switch( it.type->artifact->charge_req ) {
         case( ACR_NULL ):
         case( NUM_ACRS ):
@@ -11871,7 +11871,7 @@ void game::add_artifact_dreams( )
 {
     //If player is sleeping, get a dream from a carried artifact
     //Don't need to check that player is sleeping here, that's done before calling
-    std::vector<item *> art_items = u.items_with( []( const item & it ) -> bool {
+    std::vector<item *> const art_items = u.items_with( []( const item & it ) -> bool {
         return it.is_artifact();
     } );
     std::vector<item *>      valid_arts;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -667,7 +667,7 @@ bool game::start_game()
     // Make sure that no monsters are near the player
     // This can happen in lab starts
     if( !spawn_near ) {
-        for( monster  const&critter : all_monsters() ) {
+        for( monster  const &critter : all_monsters() ) {
             if( rl_dist( critter.pos(), u.pos() ) <= 5 ||
                 m.clear_path( critter.pos(), u.pos(), 40, 1, 100 ) ) {
                 remove_zombie( critter );
@@ -754,7 +754,7 @@ bool game::start_game()
         mission->assign( u );
     }
     g->events().send<event_type::game_start>( u.getID() );
-    for( Skill  const&elem : Skill::skills ) {
+    for( Skill  const &elem : Skill::skills ) {
         int const level = u.get_skill_level_object( elem.ident() ).level();
         if( level > 0 ) {
             g->events().send<event_type::gains_skill_level>( u.getID(), elem.ident(), level );
@@ -1053,7 +1053,7 @@ bool game::cleanup_at_end()
         const int iOffsetY = TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0;
 
         catacurses::window const w_rip = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
-                                   point( iOffsetX, iOffsetY ) );
+                                         point( iOffsetX, iOffsetY ) );
         draw_border( w_rip );
 
         sfx::do_player_death_hurt( g->u, true );
@@ -1132,9 +1132,9 @@ bool game::cleanup_at_end()
 
         int const iStartX = FULL_SCREEN_WIDTH / 2 - ( ( iMaxWidth - 4 ) / 2 );
         std::string const sLastWords = string_input_popup()
-                                 .window( w_rip, point( iStartX, iNameLine ), iStartX + iMaxWidth - 4 - 1 )
-                                 .max_length( iMaxWidth - 4 - 1 )
-                                 .query_string();
+                                       .window( w_rip, point( iStartX, iNameLine ), iStartX + iMaxWidth - 4 - 1 )
+                                       .max_length( iMaxWidth - 4 - 1 )
+                                       .query_string();
         death_screen();
         const bool is_suicide = uquit == QUIT_SUICIDE;
         events().send<event_type::game_over>( is_suicide, sLastWords );
@@ -1158,11 +1158,11 @@ bool game::cleanup_at_end()
             if( get_option<std::string>( "WORLD_END" ) == "query" ) {
                 bool decided = false;
                 std::string const buffer = _( "Warning: NPC interactions and some other global flags "
-                                        "will not all reset when starting a new character in an "
-                                        "already-played world.  This can lead to some strange "
-                                        "behavior.\n\n"
-                                        "Are you sure you wish to keep this world?"
-                                      );
+                                              "will not all reset when starting a new character in an "
+                                              "already-played world.  This can lead to some strange "
+                                              "behavior.\n\n"
+                                              "Are you sure you wish to keep this world?"
+                                            );
 
                 while( !decided ) {
                     uilist smenu;
@@ -1258,7 +1258,7 @@ void game::calc_driving_offset( vehicle *veh )
     // between the PC and the edge of the main window.
     static const int border_range = 2;
     point const max_offset( ( getmaxx( w_terrain ) + 1 ) / 2 - border_range - 1,
-                      ( getmaxy( w_terrain ) + 1 ) / 2 - border_range - 1 );
+                            ( getmaxy( w_terrain ) + 1 ) / 2 - border_range - 1 );
 
     // velocity at or below this results in no offset at all
     static const float min_offset_vel = 1 * vehicles::vmiph_per_tile;
@@ -1626,7 +1626,7 @@ void game::process_voluntary_act_interrupt()
     static auto last_poll = std::chrono::steady_clock::now();
     auto now = std::chrono::steady_clock::now();
     int64_t const difference = std::chrono::duration_cast<std::chrono::milliseconds>
-                         ( now - last_poll ).count();
+                               ( now - last_poll ).count();
 
     if( difference > 100 ) {
         handle_key_blocking_activity();
@@ -1804,7 +1804,7 @@ int get_heat_radiation( const tripoint &location, bool direct )
     // Stored as intensity-distance pairs
     int temp_mod = 0;
     int best_fire = 0;
-    Character  const&player_character = get_avatar();
+    Character  const &player_character = get_avatar();
     map &here = get_map();
     // Convert it to an int id once, instead of 139 times per turn
     const field_type_id fd_fire_int = fd_fire.id();
@@ -2450,13 +2450,14 @@ void game::win_screen()
     msg += '\n';
     if( u.is_dead_state() ) {
         translation const t = translation::to_translation( "win_game",
-                        "Unfortunately, you had to sacrifice your life to achieve this." );
+                              "Unfortunately, you had to sacrifice your life to achieve this." );
         msg += colorize( t, c_red ) + '\n';
         memorial().add(
             pgettext( "memorial_male", "Sacrificed his life to close the portal." ),
             pgettext( "memorial_female", "Sacrificed her life to close the portal." ) );
     } else {
-        translation const t = translation::to_translation( "win_game", "You managed to survive the ordeal." );
+        translation const t = translation::to_translation( "win_game",
+                              "You managed to survive the ordeal." );
         msg += colorize( t, c_green ) + '\n';
         memorial().add(
             pgettext( "memorial_male", "Safely closed the portal." ),
@@ -3255,7 +3256,7 @@ void game::draw_ter( const tripoint &center, const bool looking, const bool draw
         draw_footsteps( w_terrain, tripoint( -center.x, -center.y, center.z ) + point( POSX, POSY ) );
     }
 
-    for( Creature  const&critter : all_creatures() ) {
+    for( Creature  const &critter : all_creatures() ) {
         draw_critter( critter, center );
     }
 
@@ -3442,7 +3443,7 @@ void game::draw_minimap()
     // Print arrow to mission if we have one!
     if( !drew_mission ) {
         double const slope = curs2.x() != targ.x() ?
-                       static_cast<double>( targ.y() - curs2.y() ) / ( targ.x() - curs2.x() ) : 4;
+                             static_cast<double>( targ.y() - curs2.y() ) / ( targ.x() - curs2.x() ) : 4;
 
         if( curs2.x() == targ.x() || std::fabs( slope ) > 3.5 ) { // Vertical slope
             if( targ.y() > curs2.y() ) {
@@ -3588,7 +3589,7 @@ character_id game::assign_npc_id()
 Creature *game::is_hostile_nearby()
 {
     int const distance = ( get_option<int>( "SAFEMODEPROXIMITY" ) <= 0 ) ? MAX_VIEW_DISTANCE :
-                   get_option<int>( "SAFEMODEPROXIMITY" );
+                         get_option<int>( "SAFEMODEPROXIMITY" );
     return is_hostile_within( distance );
 }
 
@@ -3721,7 +3722,7 @@ void game::mon_info( const catacurses::window &w, int hor_padding )
     xcoords[2] -= utf8_width( _( "East:" ) ) - utf8_width( _( "NE:" ) );
     for( int i = 0; i < 8; i++ ) {
         nc_color const c = unique_types[i].empty() && unique_mons[i].empty() ? c_dark_gray
-                     : ( dangerous[i] ? c_light_red : c_light_gray );
+                           : ( dangerous[i] ? c_light_red : c_light_gray );
         mvwprintz( w, point( xcoords[i] + hor_padding, ycoords[i] + startrow ), c, dir_labels[i] );
     }
 
@@ -3997,7 +3998,7 @@ void game::mon_info_update( )
     if( newseen > mostseen ) {
         if( newseen - mostseen == 1 ) {
             if( !new_seen_mon.empty() ) {
-                monster  const&critter = *new_seen_mon.back();
+                monster  const &critter = *new_seen_mon.back();
                 cancel_activity_or_ignore_query( distraction_type::hostile_spotted_far,
                                                  string_format( _( "%s spotted!" ), critter.name() ) );
                 if( u.has_trait( trait_id( "M_DEFENDER" ) ) && critter.type->in_species( PLANT ) ) {
@@ -4083,7 +4084,7 @@ void game::monmove()
         // Critters in impassable tiles get pushed away, unless it's not impassable for them
         if( !critter.is_dead() && m.impassable( critter.pos() ) && !critter.can_move_to( critter.pos() ) ) {
             std::string const msg = string_format( "%s can't move to its location!  %s  %s", critter.name(),
-                                             critter.pos().to_string(), m.tername( critter.pos() ) );
+                                                   critter.pos().to_string(), m.tername( critter.pos() ) );
             dbg( DL::Error ) << msg;
             add_msg( m_debug, msg );
             bool okay = false;
@@ -4796,7 +4797,7 @@ bool game::swap_critters( Creature &a, Creature &b )
     // Only the first argument can be u
     // If swapping player/npc with a monster, monster is second
     bool const a_first = a.is_player() ||
-                   ( a.is_npc() && !b.is_player() );
+                         ( a.is_npc() && !b.is_player() );
     Creature &first  = a_first ? a : b;
     Creature &second = a_first ? b : a;
     // Possible options:
@@ -4868,7 +4869,7 @@ bool game::revive_corpse( const tripoint &p, item &it )
         return false;
     }
     shared_ptr_fast<monster> const newmon_ptr = make_shared_fast<monster>
-                                          ( it.get_mtype()->id );
+            ( it.get_mtype()->id );
     monster &critter = *newmon_ptr;
     critter.init_from_item( it );
     if( critter.get_hp() < 1 ) {
@@ -4927,9 +4928,9 @@ void game::save_cyborg( item *cyborg, const tripoint &couch_pos, player &install
     int const assist_bonus = installer.get_effect_int( effect_assisted );
 
     float const adjusted_skill = installer.bionics_adjusted_skill( skill_firstaid,
-                           skill_computer,
-                           skill_electronics,
-                           -1 );
+                                 skill_computer,
+                                 skill_electronics,
+                                 -1 );
 
     int const damage = cyborg->damage();
     int const dmg_lvl = cyborg->damage_level( 4 );
@@ -5640,7 +5641,8 @@ void game::pickup()
 void game::pickup( const tripoint &p )
 {
     // Highlight target
-    shared_ptr_fast<game::draw_callback_t> const hilite_cb = make_shared_fast<game::draw_callback_t>( [&]() {
+    shared_ptr_fast<game::draw_callback_t> const hilite_cb =
+    make_shared_fast<game::draw_callback_t>( [&]() {
         m.drawsq( w_terrain, p, drawsq_params().highlight( true ) );
     } );
     add_draw_callback( hilite_cb );
@@ -5923,7 +5925,7 @@ void game::print_terrain_info( const tripoint &lp, const catacurses::window &w_l
     }
 
     int const map_features = fold_and_print( w_look, point( column, ++lines ), max_width, c_dark_gray,
-                                       m.features( lp ) );
+                             m.features( lp ) );
     fold_and_print( w_look, point( column, ++lines ), max_width, c_light_gray, _( "Coverage: %d%%" ),
                     m.coverage( lp ) );
     if( line < lines ) {
@@ -5941,7 +5943,7 @@ void game::print_fields_info( const tripoint &lp, const catacurses::window &w_lo
                                           m.ter( lp ) == t_pit_shallow || m.ter( lp ) == t_pit ) ) {
             const int max_width = getmaxx( w_look ) - column - 2;
             int const lines = fold_and_print( w_look, point( column, ++line ), max_width, cur.color(),
-                                        get_fire_fuel_string( lp ) ) - 1;
+                                              get_fire_fuel_string( lp ) ) - 1;
             line += lines;
         } else {
             mvwprintz( w_look, point( column, ++line ), cur.color(), cur.name() );
@@ -6199,7 +6201,7 @@ void game::zones_manager()
             zones = mgr.get_zones();
         } else {
             const tripoint &u_abs_pos = m.getabs( u.pos() );
-            for( zone_manager::ref_zone_data  const&ref : mgr.get_zones() ) {
+            for( zone_manager::ref_zone_data  const &ref : mgr.get_zones() ) {
                 const tripoint &zone_abs_pos = ref.get().get_center_point();
                 if( u_abs_pos.z == zone_abs_pos.z && rl_dist( u_abs_pos, zone_abs_pos ) <= 50 ) {
                     zones.emplace_back( ref );
@@ -6274,15 +6276,15 @@ void game::zones_manager()
                     true, true, false );
             if( second.position ) {
                 tripoint const first_abs = m.getabs( tripoint( std::min( first.position->x,
-                                               second.position->x ),
-                                               std::min( first.position->y, second.position->y ),
-                                               std::min( first.position->z,
-                                                       second.position->z ) ) );
+                                                     second.position->x ),
+                                                     std::min( first.position->y, second.position->y ),
+                                                     std::min( first.position->z,
+                                                             second.position->z ) ) );
                 tripoint const second_abs = m.getabs( tripoint( std::max( first.position->x,
-                                                second.position->x ),
-                                                std::max( first.position->y, second.position->y ),
-                                                std::max( first.position->z,
-                                                        second.position->z ) ) );
+                                                      second.position->x ),
+                                                      std::max( first.position->y, second.position->y ),
+                                                      std::max( first.position->z,
+                                                              second.position->z ) ) );
                 return std::pair<tripoint, tripoint>( first_abs, second_abs );
             }
         }
@@ -6527,7 +6529,8 @@ void game::zones_manager()
                 //show zone position on overmap;
                 tripoint_abs_omt const player_overmap_position = u.global_omt_location();
                 // TODO: fix point types
-                tripoint_abs_omt const zone_overmap( ms_to_omt_copy( zones[active_index].get().get_center_point() ) );
+                tripoint_abs_omt const zone_overmap( ms_to_omt_copy(
+                        zones[active_index].get().get_center_point() ) );
 
                 ui::omap::display_zones( player_overmap_position, zone_overmap, active_index );
             } else if( action == "ENABLE_ZONE" ) {
@@ -6600,7 +6603,7 @@ std::optional<tripoint> game::look_around( bool force_3d )
 {
     tripoint center = u.pos() + u.view_offset;
     look_around_result const result = look_around( /*show_window=*/true, center, center, false, false,
-                                false, false, tripoint_zero, force_3d );
+                                      false, false, tripoint_zero, force_3d );
     return result.position;
 }
 
@@ -6716,15 +6719,15 @@ look_around_result game::look_around( bool show_window, tripoint &center,
             center_print( w_info, 0, c_white, string_format( _( "< <color_green>Look Around</color> >" ) ) );
 
             std::string const extended_descr_text = string_format( _( "%s - %s" ),
-                                              ctxt.get_desc( "EXTENDED_DESCRIPTION" ),
-                                              ctxt.get_action_name( "EXTENDED_DESCRIPTION" ) );
+                                                    ctxt.get_desc( "EXTENDED_DESCRIPTION" ),
+                                                    ctxt.get_action_name( "EXTENDED_DESCRIPTION" ) );
             std::string const fast_scroll_text = string_format( _( "%s - %s" ),
-                                           ctxt.get_desc( "TOGGLE_FAST_SCROLL" ),
-                                           ctxt.get_action_name( "TOGGLE_FAST_SCROLL" ) );
+                                                 ctxt.get_desc( "TOGGLE_FAST_SCROLL" ),
+                                                 ctxt.get_action_name( "TOGGLE_FAST_SCROLL" ) );
 #if defined(TILES)
             std::string const pixel_minimap_text = string_format( _( "%s - %s" ),
-                                             ctxt.get_desc( "toggle_pixel_minimap" ),
-                                             ctxt.get_action_name( "toggle_pixel_minimap" ) );
+                                                   ctxt.get_desc( "toggle_pixel_minimap" ),
+                                                   ctxt.get_action_name( "toggle_pixel_minimap" ) );
 #endif // TILES
 
             center_print( w_info, getmaxy( w_info ) - 2, c_light_gray, extended_descr_text );
@@ -7489,7 +7492,7 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
 
             if( iItemNum > 0 && activeItem ) {
                 item_location const loc( map_cursor( u.pos() + activeItem->example_item_pos ),
-                                   const_cast<item *>( activeItem->example ) );
+                                         const_cast<item *>( activeItem->example ) );
                 temperature_flag const temperature = rot::temperature_flag_for_location( m, loc );
                 std::vector<iteminfo> const this_item = activeItem->example->info( temperature );
                 std::vector<iteminfo> const item_info_dummy;
@@ -8546,7 +8549,7 @@ void game::butcher()
                     break;
                 case MULTIBUTCHER:
                     butcher_submenu( corpses );
-                    for( map_stack::iterator  const&it : corpses ) {
+                    for( map_stack::iterator  const &it : corpses ) {
                         u.activity.targets.emplace_back( map_cursor( u.pos() ), &*it );
                     }
                     break;
@@ -9987,7 +9990,7 @@ static std::optional<tripoint> point_selection_menu( const std::vector<tripoint>
 
 static std::optional<tripoint> find_empty_spot_nearby( const tripoint &pos )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     for( const tripoint &p : here.points_in_radius( pos, 1 ) ) {
         if( p == pos ) {
             continue;
@@ -10962,7 +10965,7 @@ void game::update_stair_monsters()
                 if( ( push.x != 0 || push.y != 0 ) && !critter_at( pos ) &&
                     critter.can_move_to( pos ) ) {
                     bool const resiststhrow = ( u.is_throw_immune() ) ||
-                                        ( u.has_trait( trait_LEG_TENT_BRACE ) );
+                                              ( u.has_trait( trait_LEG_TENT_BRACE ) );
                     if( resiststhrow && one_in( player_throw_resist_chance ) ) {
                         u.moves -= 25; // small charge for avoiding the push altogether
                         add_msg( _( "The %s fails to push you back!" ),
@@ -11181,7 +11184,8 @@ void game::display_scent()
             add_msg( _( "Never mind." ) );
             return;
         }
-        shared_ptr_fast<game::draw_callback_t> const scent_cb = make_shared_fast<game::draw_callback_t>( [&]() {
+        shared_ptr_fast<game::draw_callback_t> const scent_cb =
+        make_shared_fast<game::draw_callback_t>( [&]() {
             scent.draw( w_terrain, div * 2, u.pos() + u.view_offset );
         } );
         g->add_draw_callback( scent_cb );
@@ -11476,8 +11480,8 @@ void game::process_artifact( item &it, player &p )
             case AEP_SMOKE:
                 if( one_in( 10 ) ) {
                     tripoint const pt( p.posx() + rng( -1, 1 ),
-                                 p.posy() + rng( -1, 1 ),
-                                 p.posz() );
+                                       p.posy() + rng( -1, 1 ),
+                                       p.posz() );
                     m.add_field( pt, fd_smoke, rng( 1, 3 ) );
                 }
                 break;
@@ -11577,7 +11581,7 @@ bool check_art_charge_req( item &it )
     const bool worn = p.is_worn( it );
     const bool wielded = ( &it == &p.primary_weapon() );
     const bool heldweapon = ( wielded && !it.is_armor() ); //don't charge wielded clothes
-    map  const&here = get_map();
+    map  const &here = get_map();
     switch( it.type->artifact->charge_req ) {
         case( ACR_NULL ):
         case( NUM_ACRS ):

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -589,9 +589,9 @@ class comestible_inventory_preset : public inventory_selector_preset
                         cbm_name = _( "Furnace" );
                         break;
                     case rechargeable_cbm::other:
-                        std::vector<bionic_id> bids = p.get_bionic_fueled_with( get_consumable_item( loc ) );
+                        std::vector<bionic_id> const bids = p.get_bionic_fueled_with( get_consumable_item( loc ) );
                         if( !bids.empty() ) {
-                            bionic_id bid = p.get_most_efficient_bionic( bids );
+                            bionic_id const bid = p.get_most_efficient_bionic( bids );
                             cbm_name = bid->name.translated();
                         }
                         break;
@@ -642,10 +642,10 @@ class comestible_inventory_preset : public inventory_selector_preset
         }
 
         bool sort_compare( const inventory_entry &lhs, const inventory_entry &rhs ) const override {
-            time_duration time_a = get_time_left( lhs.any_item() );
-            time_duration time_b = get_time_left( rhs.any_item() );
-            int order_a = get_order( lhs.any_item(), time_a );
-            int order_b = get_order( rhs.any_item(), time_b );
+            time_duration const time_a = get_time_left( lhs.any_item() );
+            time_duration const time_b = get_time_left( rhs.any_item() );
+            int const order_a = get_order( lhs.any_item(), time_a );
+            int const order_b = get_order( rhs.any_item(), time_b );
 
             return order_a < order_b
                    || ( order_a == order_b && time_a < time_b )
@@ -713,7 +713,7 @@ class comestible_inventory_preset : public inventory_selector_preset
                 return _( "soon!" );
             }
 
-            time_duration time_left = get_time_left( loc );
+            time_duration const time_left = get_time_left( loc );
             return to_string_approx( time_left );
         }
 
@@ -1581,7 +1581,7 @@ iuse_locations game_menus::inv::multiwash( Character &ch, int water, int cleanse
         for( const auto &it : items ) {
             total_volume += it.first->volume() * it.second / it.first->count();
         }
-        washing_requirements required = washing_requirements_for_volume( total_volume );
+        washing_requirements const required = washing_requirements_for_volume( total_volume );
         auto to_string = []( int val ) -> std::string {
             if( val == INT_MAX )
             {
@@ -1651,12 +1651,12 @@ void game_menus::inv::compare( const item &l, const item &r )
     ctxt.register_action( "PAGE_UP" );
     ctxt.register_action( "PAGE_DOWN" );
 
-    std::vector<iteminfo> lhs_info = l.info();
-    std::vector<iteminfo> rhs_info = r.info();
-    std::string lhs_tname = l.tname();
-    std::string rhs_tname = r.tname();
-    std::string lhs_type_name = l.type_name();
-    std::string rhs_type_name = r.type_name();
+    std::vector<iteminfo> const lhs_info = l.info();
+    std::vector<iteminfo> const rhs_info = r.info();
+    std::string const lhs_tname = l.tname();
+    std::string const rhs_tname = r.tname();
+    std::string const lhs_type_name = l.type_name();
+    std::string const rhs_type_name = r.type_name();
 
     int lhs_scroll_pos = 0;
     int rhs_scroll_pos = 0;
@@ -1713,7 +1713,7 @@ void game_menus::inv::reassign_letter( Character &who, item &it, int invlet )
 
     if( !invlet || inv_chars.valid( invlet ) ) {
         const auto iter = who.inv.assigned_invlet.find( it.invlet );
-        bool found = iter != who.inv.assigned_invlet.end();
+        bool const found = iter != who.inv.assigned_invlet.end();
         if( found ) {
             who.inv.assigned_invlet.erase( iter );
         }
@@ -1812,7 +1812,7 @@ static item_location autodoc_internal( player &u, player &patient,
         }
     }
 
-    std::vector<const item *> install_programs = patient.crafting_inventory().items_with( [](
+    std::vector<const item *> const install_programs = patient.crafting_inventory().items_with( [](
                 const item & it ) -> bool { return it.has_flag( "BIONIC_INSTALLATION_DATA" ); } );
 
     if( !install_programs.empty() ) {
@@ -1927,7 +1927,7 @@ class bionic_install_preset: public inventory_selector_preset
             int chance_of_failure = 100;
             player &installer = p;
 
-            std::vector<const item *> install_programs = p.crafting_inventory().items_with( [loc](
+            std::vector<const item *> const install_programs = p.crafting_inventory().items_with( [loc](
                         const item & it ) -> bool { return it.typeId() == loc.get_item()->type->bionic->installation_data; } );
 
             const bool has_install_program = !install_programs.empty();

--- a/src/gamemode_defense.cpp
+++ b/src/gamemode_defense.cpp
@@ -223,7 +223,7 @@ void defense_game::init_constructions()
 
 void defense_game::init_map()
 {
-    background_pane background;
+    background_pane const background;
     static_popup popup;
     popup.message( _( "Please wait as the map generates [%2d%%]" ), 0 );
     ui_manager::redraw();
@@ -232,7 +232,7 @@ void defense_game::init_map()
     auto &starting_om = overmap_buffer.get( point_abs_om() );
     for( int x = 0; x < OMAPX; x++ ) {
         for( int y = 0; y < OMAPY; y++ ) {
-            tripoint_om_omt p( x, y, 0 );
+            tripoint_om_omt const p( x, y, 0 );
             starting_om.ter_set( p, oter_id( "field" ) );
             starting_om.seen( p ) = true;
         }
@@ -275,7 +275,7 @@ void defense_game::init_map()
         for( int j = 0; j <= MAPSIZE * 2; j += 2 ) {
             int mx = 100 - MAPSIZE + i;
             int my = 100 - MAPSIZE + j;
-            int percent = 100 * ( ( j / 2 + MAPSIZE * ( i / 2 ) ) ) /
+            int const percent = 100 * ( ( j / 2 + MAPSIZE * ( i / 2 ) ) ) /
                           ( ( MAPSIZE ) * ( MAPSIZE + 1 ) );
             if( percent >= old_percent + 1 ) {
                 popup.message( _( "Please wait as the map generates [%2d%%]" ), percent );
@@ -296,7 +296,7 @@ void defense_game::init_map()
     }
 
     // For this mode assume we always want overmap zero.
-    tripoint_abs_omt abs_defloc_pos = project_combine( point_abs_om(), defloc_pos );
+    tripoint_abs_omt const abs_defloc_pos = project_combine( point_abs_om(), defloc_pos );
     g->load_map( project_to<coords::sm>( abs_defloc_pos ) );
     Character &player_character = get_player_character();
     player_character.setx( SEEX );
@@ -468,7 +468,7 @@ void defense_game::init_to_style( defense_style new_style )
 
 void defense_game::setup()
 {
-    background_pane bg_pane;
+    background_pane const bg_pane;
 
     catacurses::window w;
 
@@ -482,7 +482,7 @@ void defense_game::setup()
     ui.mark_resize();
 
     int selection = 1;
-    int selection_max = 20;
+    int const selection_max = 20;
 
     ui.on_redraw( [&]( const ui_adaptor & ) {
         refresh_setup( w, selection );
@@ -878,7 +878,7 @@ void defense_game::caravan()
 
     signed total_price = 0;
 
-    background_pane bg_pane;
+    background_pane const bg_pane;
 
     catacurses::window w;
     ui_adaptor ui;
@@ -976,8 +976,8 @@ void defense_game::caravan()
         } else if( action == "RIGHT" ) {
             if( current_window == 1 && !items[category_selected].empty() ) {
                 item_count[category_selected][item_selected]++;
-                itype_id tmp_itm = items[category_selected][item_selected];
-                int item_price = item( tmp_itm, calendar::start_of_cataclysm ).price( false );
+                itype_id const tmp_itm = items[category_selected][item_selected];
+                int const item_price = item( tmp_itm, calendar::start_of_cataclysm ).price( false );
                 total_price += caravan_price( g->u, item_price );
                 if( category_selected == CARAVAN_CART ) { // Find the item in its category
                     for( int i = 1; i < NUM_CARAVAN_CATEGORIES; i++ ) {
@@ -1005,8 +1005,8 @@ void defense_game::caravan()
             if( current_window == 1 && !items[category_selected].empty() &&
                 item_count[category_selected][item_selected] > 0 ) {
                 item_count[category_selected][item_selected]--;
-                itype_id tmp_itm = items[category_selected][item_selected];
-                int item_price = item( tmp_itm, calendar::start_of_cataclysm ).price( false );
+                itype_id const tmp_itm = items[category_selected][item_selected];
+                int const item_price = item( tmp_itm, calendar::start_of_cataclysm ).price( false );
                 total_price -= caravan_price( g->u, item_price );
                 if( category_selected == CARAVAN_CART ) { // Find the item in its category
                     for( int i = 1; i < NUM_CARAVAN_CATEGORIES; i++ ) {
@@ -1147,10 +1147,10 @@ std::vector<itype_id> caravan_items( caravan_category cat )
             return ret;
     }
 
-    item_group::ItemList item_list = item_group::items_from( item_group_id( group_id ) );
+    item_group::ItemList const item_list = item_group::items_from( item_group_id( group_id ) );
 
     for( auto &it : item_list ) {
-        itype_id item_type = it.typeId();
+        itype_id const item_type = it.typeId();
         ret.emplace_back( item_type );
         // Add the default magazine types for each gun.
         if( it.is_gun() && !it.magazine_integral() ) {
@@ -1247,7 +1247,7 @@ void draw_caravan_items( const catacurses::window &w, std::vector<itype_id> *ite
     }
     // THEN print it--if item_selected is valid
     if( item_selected < static_cast<int>( items->size() ) ) {
-        item tmp( ( *items )[item_selected], calendar::start_of_cataclysm );
+        item const tmp( ( *items )[item_selected], calendar::start_of_cataclysm );
         fold_and_print( w, point( 1, 12 ), 38, c_white, tmp.info_string( iteminfo_query::no_text ) );
     }
     // Next, clear the item list on the right
@@ -1261,8 +1261,8 @@ void draw_caravan_items( const catacurses::window &w, std::vector<itype_id> *ite
                    item::nname( ( *items )[i], ( *counts )[i] ) );
         wprintz( w, c_white, " x %2d", ( *counts )[i] );
         if( ( *counts )[i] > 0 ) {
-            int item_price = item( ( *items )[i], calendar::start_of_cataclysm ).price( false );
-            int price = caravan_price( g->u, item_price * ( *counts )[i] );
+            int const item_price = item( ( *items )[i], calendar::start_of_cataclysm ).price( false );
+            int const price = caravan_price( g->u, item_price * ( *counts )[i] );
             wprintz( w, ( price > g->u.cash ? c_red : c_green ), " (%s)", format_money( price ) );
         }
     }
@@ -1302,7 +1302,7 @@ void defense_game::spawn_wave()
         }
         const mtype &type = random_entry( valid ).obj();
         if( themed_wave ) {
-            int num = diff / type.difficulty;
+            int const num = diff / type.difficulty;
             if( num >= SPECIAL_WAVE_MIN ) {
                 // TODO: Do we want a special message here?
                 for( int i = 0; i < num; i++ ) {

--- a/src/gamemode_defense.cpp
+++ b/src/gamemode_defense.cpp
@@ -276,7 +276,7 @@ void defense_game::init_map()
             int mx = 100 - MAPSIZE + i;
             int my = 100 - MAPSIZE + j;
             int const percent = 100 * ( ( j / 2 + MAPSIZE * ( i / 2 ) ) ) /
-                          ( ( MAPSIZE ) * ( MAPSIZE + 1 ) );
+                                ( ( MAPSIZE ) * ( MAPSIZE + 1 ) );
             if( percent >= old_percent + 1 ) {
                 popup.message( _( "Please wait as the map generates [%2d%%]" ), percent );
                 ui_manager::redraw();

--- a/src/gamemode_tutorial.cpp
+++ b/src/gamemode_tutorial.cpp
@@ -258,7 +258,7 @@ void tutorial_game::post_action( action_id act )
             if( g->u.has_amount( itype_grenade_act, 1 ) ) {
                 add_message( tut_lesson::LESSON_ACT_GRENADE );
             }
-            map  const&here = get_map();
+            map  const &here = get_map();
             for( const tripoint &dest : here.points_in_radius( g->u.pos(), 1 ) ) {
                 if( here.tr_at( dest ).id == trap_str_id( "tr_bubblewrap" ) ) {
                     add_message( tut_lesson::LESSON_ACT_BUBBLEWRAP );

--- a/src/gamemode_tutorial.cpp
+++ b/src/gamemode_tutorial.cpp
@@ -135,7 +135,7 @@ bool tutorial_game::init()
     auto &starting_om = overmap_buffer.get( point_abs_om() );
     for( int i = 0; i < OMAPX; i++ ) {
         for( int j = 0; j < OMAPY; j++ ) {
-            tripoint_om_omt p( i, j, 0 );
+            tripoint_om_omt const p( i, j, 0 );
             starting_om.ter_set( p + tripoint_below, rock );
             // Start with the overmap revealed
             starting_om.seen( p ) = true;
@@ -258,7 +258,7 @@ void tutorial_game::post_action( action_id act )
             if( g->u.has_amount( itype_grenade_act, 1 ) ) {
                 add_message( tut_lesson::LESSON_ACT_GRENADE );
             }
-            map &here = get_map();
+            map  const&here = get_map();
             for( const tripoint &dest : here.points_in_radius( g->u.pos(), 1 ) ) {
                 if( here.tr_at( dest ).id == trap_str_id( "tr_bubblewrap" ) ) {
                     add_message( tut_lesson::LESSON_ACT_BUBBLEWRAP );
@@ -278,7 +278,7 @@ void tutorial_game::post_action( action_id act )
             break;
 
         case ACTION_WEAR: {
-            item it( g->u.last_item, calendar::start_of_cataclysm );
+            item const it( g->u.last_item, calendar::start_of_cataclysm );
             if( it.is_armor() ) {
                 if( it.get_coverage() >= 2 || it.get_thickness() >= 2 ) {
                     add_message( tut_lesson::LESSON_WORE_ARMOR );
@@ -303,7 +303,7 @@ void tutorial_game::post_action( action_id act )
             add_message( tut_lesson::LESSON_INTERACT );
         /* fallthrough */
         case ACTION_PICKUP: {
-            item it( g->u.last_item, calendar::start_of_cataclysm );
+            item const it( g->u.last_item, calendar::start_of_cataclysm );
             if( it.is_armor() ) {
                 add_message( tut_lesson::LESSON_GOT_ARMOR );
             } else if( it.is_gun() ) {

--- a/src/gates.cpp
+++ b/src/gates.cpp
@@ -88,7 +88,7 @@ void gate_data::load( const JsonObject &jo, const std::string & )
     mandatory( jo, was_loaded, "walls", walls, string_id_reader<ter_t> {} );
 
     if( !was_loaded || jo.has_member( "messages" ) ) {
-        JsonObject messages_obj = jo.get_object( "messages" );
+        JsonObject const messages_obj = jo.get_object( "messages" );
 
         optional( messages_obj, was_loaded, "pull", pull_message );
         optional( messages_obj, was_loaded, "open", open_message );
@@ -180,14 +180,14 @@ void gates::toggle_gate( const tripoint &pos )
     bool fail = false;
 
     map &here = get_map();
-    for( point wall_offset : four_adjacent_offsets ) {
+    for( point const wall_offset : four_adjacent_offsets ) {
         const tripoint wall_pos = pos + wall_offset;
 
         if( !gate.is_suitable_wall( wall_pos ) ) {
             continue;
         }
 
-        for( point gate_offset : four_adjacent_offsets ) {
+        for( point const gate_offset : four_adjacent_offsets ) {
             const tripoint gate_pos = wall_pos + gate_offset;
 
             if( gate_pos == pos ) {

--- a/src/generic_factory.cpp
+++ b/src/generic_factory.cpp
@@ -27,7 +27,7 @@ bool unicode_codepoint_from_symbol_reader( const JsonObject &jo,
             sym_as_string = string_from_int( sym_as_int );
         }
     }
-    uint32_t sym_as_codepoint = UTF8_getch( sym_as_string );
+    uint32_t const sym_as_codepoint = UTF8_getch( sym_as_string );
     if( mk_wcwidth( sym_as_codepoint ) != 1 ) {
         jo.throw_error( member_name + " must be exactly one console cell wide", member_name );
     }

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -153,7 +153,7 @@ bool game::grabbed_veh_move( const tripoint &dp )
     //vehicle movement: strength check. very strong humans can move about 2,000 kg in a wheelbarrow.
     // int str_req = grabbed_vehicle->total_mass() / 100_kilogram; //strength required to move vehicle.
     // for smaller vehicles, offroad_str_req_cap sanity-checks our results.
-    int str_req = std::min( get_vehicle_str_requirement( grabbed_vehicle ),
+    int const str_req = std::min( get_vehicle_str_requirement( grabbed_vehicle ),
                             offroad_str_req_cap( grabbed_vehicle ) );
     int str = u.get_str();
     if( u.is_mounted() ) {
@@ -250,9 +250,9 @@ bool game::grabbed_veh_move( const tripoint &dp )
         return false;
     }
 
-    for( int p : grabbed_vehicle->wheelcache ) {
+    for( int const p : grabbed_vehicle->wheelcache ) {
         if( one_in( 2 ) ) {
-            tripoint wheel_p = grabbed_vehicle->global_part_pos3( grabbed_part );
+            tripoint const wheel_p = grabbed_vehicle->global_part_pos3( grabbed_part );
             grabbed_vehicle->handle_trap( wheel_p, p );
         }
     }

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -154,7 +154,7 @@ bool game::grabbed_veh_move( const tripoint &dp )
     // int str_req = grabbed_vehicle->total_mass() / 100_kilogram; //strength required to move vehicle.
     // for smaller vehicles, offroad_str_req_cap sanity-checks our results.
     int const str_req = std::min( get_vehicle_str_requirement( grabbed_vehicle ),
-                            offroad_str_req_cap( grabbed_vehicle ) );
+                                  offroad_str_req_cap( grabbed_vehicle ) );
     int str = u.get_str();
     if( u.is_mounted() ) {
         auto mons = u.mounted_creature.get();

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -165,7 +165,7 @@ class user_turn
                 return 0;
             }
             auto now = std::chrono::steady_clock::now();
-            std::chrono::milliseconds elapsed_ms =
+            std::chrono::milliseconds const elapsed_ms =
                 std::chrono::duration_cast<std::chrono::milliseconds>( now - user_turn_start );
             return elapsed_ms.count() / ( 10.0 * turn_duration );
         }
@@ -186,8 +186,8 @@ static bool init_weather_anim( const weather_type_id &wtype, weather_printable &
 
 static void generate_weather_anim_frame( const weather_type_id &wtype, weather_printable &wPrint )
 {
-    map &m = get_map();
-    avatar &u = get_avatar();
+    map  const&m = get_map();
+    avatar  const&u = get_avatar();
 
     const visibility_variables &cache = m.get_visibility_variables_cache();
     const level_cache &map_cache = m.get_cache_ref( u.posz() );
@@ -284,7 +284,7 @@ input_context game::get_player_input( std::string &action )
     weather_printable wPrint;
     bool animate_weather = false;
     bool animate_sct = false;
-    bool do_animations = [&]() {
+    bool const do_animations = [&]() {
         if( get_option<bool>( "ANIMATIONS" ) ) {
             const bool weather_has_anim = init_weather_anim( get_weather().weather_id, wPrint );
 
@@ -307,7 +307,7 @@ input_context game::get_player_input( std::string &action )
     if( do_animations ) {
         ctxt.set_timeout( 125 );
 
-        shared_ptr_fast<game::draw_callback_t> animation_cb =
+        shared_ptr_fast<game::draw_callback_t> const animation_cb =
         make_shared_fast<game::draw_callback_t>( [&]() {
             if( animate_weather ) {
                 draw_weather( wPrint );
@@ -335,7 +335,7 @@ input_context game::get_player_input( std::string &action )
                     const direction oCurDir = iter->getDirecton();
                     const int width = utf8_width( iter->getText() );
                     for( int i = 0; i < width; ++i ) {
-                        tripoint tmp( iter->getPosX() + i, iter->getPosY(), get_levz() );
+                        tripoint const tmp( iter->getPosX() + i, iter->getPosY(), get_levz() );
                         const Creature *critter = critter_at( tmp, true );
 
                         if( critter != nullptr && u.sees( *critter ) ) {
@@ -401,7 +401,7 @@ inline static void rcdrive( point d )
 {
     player &u = g->u;
     map &here = get_map();
-    std::string car_location_string = u.get_value( "remote_controlling" );
+    std::string const car_location_string = u.get_value( "remote_controlling" );
 
     if( car_location_string.empty() ) {
         u.add_msg_if_player( m_warning, _( "No radio car connected." ) );
@@ -433,7 +433,7 @@ inline static void rcdrive( point d )
                        _( "sound of a collision with an obstacle." ), true, "misc", "rc_car_hits_obstacle" );
         return;
     } else if( !here.add_item_or_charges( dest, *rc_car ).is_null() ) {
-        tripoint src( c );
+        tripoint const src( c );
         //~ Sound of moving a remote controlled car
         sounds::sound( src, 6, sounds::sound_t::movement, _( "zzz…" ), true, "misc", "rc_car_drives" );
         u.moves -= 50;
@@ -455,7 +455,7 @@ static void pldrive( const tripoint &p )
     vehicle *veh = g->remoteveh();
     bool remote = true;
     int part = -1;
-    map &here = get_map();
+    map  const&here = get_map();
     if( !veh ) {
         if( const optional_vpart_position vp = here.veh_at( u.pos() ) ) {
             veh = &vp->vehicle();
@@ -531,10 +531,10 @@ static void open()
 
     if( const optional_vpart_position vp = here.veh_at( openp ) ) {
         vehicle *const veh = &vp->vehicle();
-        int openable = veh->next_part_to_open( vp->part_index() );
+        int const openable = veh->next_part_to_open( vp->part_index() );
         if( openable >= 0 ) {
             const vehicle *player_veh = veh_pointer_or_null( here.veh_at( u.pos() ) );
-            bool outside = !player_veh || player_veh != veh;
+            bool const outside = !player_veh || player_veh != veh;
             if( !outside ) {
                 if( !veh->handle_potential_theft( get_avatar() ) ) {
                     u.moves += 100;
@@ -547,7 +547,7 @@ static void open()
                 // If there is, we open everything on tile. This means opening a closed,
                 // curtained door from outside is possible, but it will magically open the
                 // curtains as well.
-                int outside_openable = veh->next_part_to_open( vp->part_index(), true );
+                int const outside_openable = veh->next_part_to_open( vp->part_index(), true );
                 if( outside_openable == -1 ) {
                     const std::string name = veh->part_info( openable ).name();
                     add_msg( m_info, _( "That %s can only opened from the inside." ), name );
@@ -573,7 +573,7 @@ static void open()
         return;
     }
 
-    bool didit = here.open_door( openp, !here.is_outside( u.pos() ) );
+    bool const didit = here.open_door( openp, !here.is_outside( u.pos() ) );
 
     if( !didit ) {
         const ter_str_id tid = here.ter( openp ).id();
@@ -655,7 +655,7 @@ static void grab()
 static void haul()
 {
     player &u = g->u;
-    map &here = get_map();
+    map  const&here = get_map();
 
     if( u.is_hauling() ) {
         u.stop_hauling();
@@ -730,7 +730,7 @@ static void smash()
             crit->use_mech_power( -3 );
         }
     }
-    for( std::pair<const field_type_id, field_entry> &fd_to_smsh : here.field_at( smashp ) ) {
+    for( std::pair<const field_type_id, field_entry>  const&fd_to_smsh : here.field_at( smashp ) ) {
         const map_bash_info &bash_info = fd_to_smsh.first->bash_info;
         if( bash_info.str_min == -1 ) {
             continue;
@@ -831,8 +831,8 @@ static void smash()
                 }
 
                 if( to_safety ) {
-                    tripoint oldpos = u.pos();
-                    tripoint newpos = u.pos() + *to_safety;
+                    tripoint const oldpos = u.pos();
+                    tripoint const newpos = u.pos() + *to_safety;
                     // game::walk_move will return true even if you don't move
                     if( g->walk_move( newpos ) && u.pos() != oldpos ) {
                         break;
@@ -875,7 +875,7 @@ static void wait()
     uilist as_m;
     player &u = g->u;
     bool setting_alarm = false;
-    map &here = get_map();
+    map  const&here = get_map();
 
     if( u.controlling_vehicle && ( here.veh_at( u.pos() )->vehicle().velocity ||
                                    here.veh_at( u.pos() )->vehicle().cruise_velocity ) ) {
@@ -884,7 +884,7 @@ static void wait()
     }
 
     if( u.has_alarm_clock() ) {
-        int alarm_query = try_set_alarm();
+        int const alarm_query = try_set_alarm();
         if( alarm_query == UILIST_CANCEL ) {
             return;
         }
@@ -968,7 +968,7 @@ static void wait()
 
     time_duration time_to_wait;
     if( as_m.ret == 13 ) {
-        int minutes = string_input_popup()
+        int const minutes = string_input_popup()
                       .title( _( "How long?  (in minutes)" ) )
                       .identifier( "wait_duration" )
                       .query_int();
@@ -1003,7 +1003,7 @@ static void wait()
             actType = ACT_WAIT;
         }
 
-        player_activity new_act( actType, 100 * ( to_turns<int>( time_to_wait ) ), 0 );
+        player_activity const new_act( actType, 100 * ( to_turns<int>( time_to_wait ) ), 0 );
 
         u.assign_activity( new_act, false );
     }
@@ -1101,7 +1101,7 @@ static void sleep()
     }
     if( u.has_alarm_clock() ) {
         /* Reuse menu to ask player whether they want to set an alarm. */
-        bool can_hibernate = u.get_kcal_percent() > 0.95 && u.has_active_mutation( trait_HIBERNATE );
+        bool const can_hibernate = u.get_kcal_percent() > 0.95 && u.has_active_mutation( trait_HIBERNATE );
 
         as_m.reset();
         as_m.text = can_hibernate ?
@@ -1371,14 +1371,14 @@ static void fire()
             }
         }
         if( !options.empty() ) {
-            int sel = uilist( _( "Draw what?" ), options );
+            int const sel = uilist( _( "Draw what?" ), options );
             if( sel >= 0 ) {
                 actions[sel]();
             }
         }
     }
 
-    item &weapon = u.primary_weapon();
+    item  const&weapon = u.primary_weapon();
     if( weapon.is_gun() && !weapon.gun_current_mode().melee() ) {
         avatar_action::fire_wielded_weapon( u );
     } else if( weapon.reach_range( u ) > 1 ) {
@@ -1423,7 +1423,7 @@ static void cast_spell()
 {
     player &u = g->u;
 
-    std::vector<spell_id> spells = u.magic->spells();
+    std::vector<spell_id> const spells = u.magic->spells();
 
     if( spells.empty() ) {
         add_msg( game_message_params{ m_bad, gmf_bypass_cooldown },
@@ -1432,8 +1432,8 @@ static void cast_spell()
     }
 
     bool can_cast_spells = false;
-    for( spell_id sp : spells ) {
-        spell temp_spell = u.magic->get_spell( sp );
+    for( spell_id const sp : spells ) {
+        spell const temp_spell = u.magic->get_spell( sp );
         if( temp_spell.can_cast( u ) ) {
             can_cast_spells = true;
         }
@@ -1549,7 +1549,7 @@ bool game::handle_action()
     }
 
     const optional_vpart_position vp = m.veh_at( u.pos() );
-    bool veh_ctrl = !u.is_dead_state() &&
+    bool const veh_ctrl = !u.is_dead_state() &&
                     ( ( vp && vp->vehicle().player_in_control( u ) ) || remoteveh() != nullptr );
 
     // If performing an action with right mouse button, co-ordinates
@@ -1679,9 +1679,9 @@ bool game::handle_action()
     // This has no action unless we're in a special game mode.
     gamemode->pre_action( act );
 
-    int soffset = get_option<int>( "MOVE_VIEW_OFFSET" );
+    int const soffset = get_option<int>( "MOVE_VIEW_OFFSET" );
 
-    int before_action_moves = u.moves;
+    int const before_action_moves = u.moves;
 
     // These actions are allowed while deathcam is active. Registered in game::get_player_input
     if( uquit == QUIT_WATCH || !u.is_dead_state() ) {
@@ -1794,7 +1794,7 @@ bool game::handle_action()
                     point dest_delta = get_delta_from_movement_action( act, iso_rotate::yes );
                     if( auto_travel_mode && !u.is_auto_moving() ) {
                         for( int i = 0; i < SEEX; i++ ) {
-                            tripoint auto_travel_destination( u.posx() + dest_delta.x * ( SEEX - i ),
+                            tripoint const auto_travel_destination( u.posx() + dest_delta.x * ( SEEX - i ),
                                                               u.posy() + dest_delta.y * ( SEEX - i ),
                                                               u.posz() );
                             destination_preview = m.route( u.pos(),
@@ -2078,7 +2078,7 @@ bool game::handle_action()
                 break;
 
             case ACTION_THROW: {
-                item_location loc;
+                item_location const loc;
                 avatar_action::plthrow( g->u, loc );
                 break;
             }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -186,8 +186,8 @@ static bool init_weather_anim( const weather_type_id &wtype, weather_printable &
 
 static void generate_weather_anim_frame( const weather_type_id &wtype, weather_printable &wPrint )
 {
-    map  const&m = get_map();
-    avatar  const&u = get_avatar();
+    map  const &m = get_map();
+    avatar  const &u = get_avatar();
 
     const visibility_variables &cache = m.get_visibility_variables_cache();
     const level_cache &map_cache = m.get_cache_ref( u.posz() );
@@ -455,7 +455,7 @@ static void pldrive( const tripoint &p )
     vehicle *veh = g->remoteveh();
     bool remote = true;
     int part = -1;
-    map  const&here = get_map();
+    map  const &here = get_map();
     if( !veh ) {
         if( const optional_vpart_position vp = here.veh_at( u.pos() ) ) {
             veh = &vp->vehicle();
@@ -655,7 +655,7 @@ static void grab()
 static void haul()
 {
     player &u = g->u;
-    map  const&here = get_map();
+    map  const &here = get_map();
 
     if( u.is_hauling() ) {
         u.stop_hauling();
@@ -730,7 +730,7 @@ static void smash()
             crit->use_mech_power( -3 );
         }
     }
-    for( std::pair<const field_type_id, field_entry>  const&fd_to_smsh : here.field_at( smashp ) ) {
+    for( std::pair<const field_type_id, field_entry>  const &fd_to_smsh : here.field_at( smashp ) ) {
         const map_bash_info &bash_info = fd_to_smsh.first->bash_info;
         if( bash_info.str_min == -1 ) {
             continue;
@@ -875,7 +875,7 @@ static void wait()
     uilist as_m;
     player &u = g->u;
     bool setting_alarm = false;
-    map  const&here = get_map();
+    map  const &here = get_map();
 
     if( u.controlling_vehicle && ( here.veh_at( u.pos() )->vehicle().velocity ||
                                    here.veh_at( u.pos() )->vehicle().cruise_velocity ) ) {
@@ -969,9 +969,9 @@ static void wait()
     time_duration time_to_wait;
     if( as_m.ret == 13 ) {
         int const minutes = string_input_popup()
-                      .title( _( "How long?  (in minutes)" ) )
-                      .identifier( "wait_duration" )
-                      .query_int();
+                            .title( _( "How long?  (in minutes)" ) )
+                            .identifier( "wait_duration" )
+                            .query_int();
         time_to_wait = minutes * 1_minutes;
     } else {
 
@@ -1378,7 +1378,7 @@ static void fire()
         }
     }
 
-    item  const&weapon = u.primary_weapon();
+    item  const &weapon = u.primary_weapon();
     if( weapon.is_gun() && !weapon.gun_current_mode().melee() ) {
         avatar_action::fire_wielded_weapon( u );
     } else if( weapon.reach_range( u ) > 1 ) {
@@ -1550,7 +1550,7 @@ bool game::handle_action()
 
     const optional_vpart_position vp = m.veh_at( u.pos() );
     bool const veh_ctrl = !u.is_dead_state() &&
-                    ( ( vp && vp->vehicle().player_in_control( u ) ) || remoteveh() != nullptr );
+                          ( ( vp && vp->vehicle().player_in_control( u ) ) || remoteveh() != nullptr );
 
     // If performing an action with right mouse button, co-ordinates
     // of location clicked.
@@ -1795,8 +1795,8 @@ bool game::handle_action()
                     if( auto_travel_mode && !u.is_auto_moving() ) {
                         for( int i = 0; i < SEEX; i++ ) {
                             tripoint const auto_travel_destination( u.posx() + dest_delta.x * ( SEEX - i ),
-                                                              u.posy() + dest_delta.y * ( SEEX - i ),
-                                                              u.posz() );
+                                                                    u.posy() + dest_delta.y * ( SEEX - i ),
+                                                                    u.posz() );
                             destination_preview = m.route( u.pos(),
                                                            auto_travel_destination,
                                                            u.get_pathfinding_settings(),

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -221,7 +221,7 @@ static bool get_liquid_target( item &liquid, item *const source, const int radiu
     for( const auto &e : here.points_in_radius( g->u.pos(), 1 ) ) {
         auto veh = veh_pointer_or_null( here.veh_at( e ) );
         if( veh ) {
-            vehicle_part_range vpr = veh->get_all_parts();
+            vehicle_part_range const vpr = veh->get_all_parts();
             if( veh && std::any_of( vpr.begin(), vpr.end(), [&liquid]( const vpart_reference & pt ) {
             return pt.part().can_reload( liquid );
             } ) ) {

--- a/src/harvest.cpp
+++ b/src/harvest.cpp
@@ -211,8 +211,8 @@ std::string harvest_list::describe( int at_skill ) const
             max_f = en.max;
         }
         // TODO: Avoid repetition here by making a common harvest drop function
-        int max_drops = std::min<int>( en.max, std::round( std::max( 0.0f, max_f ) ) );
-        int min_drops = std::max<int>( 0.0f, std::round( std::min( min_f, max_f ) ) );
+        int const max_drops = std::min<int>( en.max, std::round( std::max( 0.0f, max_f ) ) );
+        int const min_drops = std::max<int>( 0.0f, std::round( std::min( min_f, max_f ) ) );
         if( max_drops <= 0 ) {
             return std::string();
         }

--- a/src/help.cpp
+++ b/src/help.cpp
@@ -44,12 +44,12 @@ void help::deserialize( JsonIn &jsin )
 {
     hotkeys.clear();
 
-    std::string note_colors = get_note_colors();
-    std::string dir_grid = get_dir_grid();
+    std::string const note_colors = get_note_colors();
+    std::string const dir_grid = get_dir_grid();
 
     jsin.start_array();
     while( !jsin.end_array() ) {
-        JsonObject jo = jsin.get_object();
+        JsonObject const jo = jsin.get_object();
 
         std::vector<std::string> messages;
         jo.read( "messages", messages );
@@ -65,7 +65,7 @@ void help::deserialize( JsonIn &jsin )
         }
 
         jo.get_string( "type" ); // Mark as visited
-        std::string name = jo.get_string( "name" );
+        std::string const name = jo.get_string( "name" );
         help_texts[jo.get_int( "order" )] = std::make_pair( name, messages );
         hotkeys.push_back( get_hotkeys( name ) );
     }
@@ -91,8 +91,8 @@ std::string help::get_dir_grid()
     for( auto dir : movearray ) {
         std::vector<char> keys = keys_bound_to( dir );
         for( size_t i = 0; i < 2; i++ ) {
-            std::string what = "<" + action_ident( dir ) + string_format( "_%d>", i );
-            std::string with = i < keys.size()
+            std::string const what = "<" + action_ident( dir ) + string_format( "_%d>", i );
+            std::string const with = i < keys.size()
                                ? string_format( "<color_light_blue>%s</color>", keys[i] )
                                : "<color_red>?</color>";
             movement = replace_all( movement, what, with );
@@ -106,14 +106,14 @@ void help::draw_menu( const catacurses::window &win )
 {
     werase( win );
     // NOLINTNEXTLINE(cata-use-named-point-constants)
-    int y = fold_and_print( win, point( 1, 0 ), getmaxx( win ) - 2, c_white,
+    int const y = fold_and_print( win, point( 1, 0 ), getmaxx( win ) - 2, c_white,
                             _( "Please press one of the following for help on that topic:\n"
                                "Press ESC to return to the game." ) ) + 1;
 
-    size_t half_size = help_texts.size() / 2 + 1;
+    size_t const half_size = help_texts.size() / 2 + 1;
     int second_column = divide_round_up( getmaxx( win ), 2 );
     for( size_t i = 0; i < help_texts.size(); i++ ) {
-        std::string cat_name = _( help_texts[i].first );
+        std::string const cat_name = _( help_texts[i].first );
         if( i < half_size ) {
             second_column = std::max( second_column, utf8_width( cat_name ) + 4 );
         }
@@ -173,7 +173,7 @@ void help::display_help()
         ui_manager::redraw();
 
         action = ctxt.handle_input();
-        std::string sInput = ctxt.get_raw_input().text;
+        std::string const sInput = ctxt.get_raw_input().text;
         for( size_t i = 0; i < hotkeys.size(); ++i ) {
             for( const std::string &hotkey : hotkeys[i] ) {
                 if( sInput == hotkey ) {
@@ -184,9 +184,9 @@ void help::display_help()
                         std::string line_proc = _( line );
                         size_t pos = line_proc.find( "<press_", 0, 7 );
                         while( pos != std::string::npos ) {
-                            size_t pos2 = line_proc.find( ">", pos, 1 );
+                            size_t const pos2 = line_proc.find( ">", pos, 1 );
 
-                            std::string action = line_proc.substr( pos + 7, pos2 - pos - 7 );
+                            std::string const action = line_proc.substr( pos + 7, pos2 - pos - 7 );
                             auto replace = "<color_light_blue>" + press_x( look_up_action( action ), "", "" ) + "</color>";
 
                             if( replace.empty() ) {

--- a/src/help.cpp
+++ b/src/help.cpp
@@ -93,8 +93,8 @@ std::string help::get_dir_grid()
         for( size_t i = 0; i < 2; i++ ) {
             std::string const what = "<" + action_ident( dir ) + string_format( "_%d>", i );
             std::string const with = i < keys.size()
-                               ? string_format( "<color_light_blue>%s</color>", keys[i] )
-                               : "<color_red>?</color>";
+                                     ? string_format( "<color_light_blue>%s</color>", keys[i] )
+                                     : "<color_red>?</color>";
             movement = replace_all( movement, what, with );
         }
     }
@@ -107,8 +107,8 @@ void help::draw_menu( const catacurses::window &win )
     werase( win );
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     int const y = fold_and_print( win, point( 1, 0 ), getmaxx( win ) - 2, c_white,
-                            _( "Please press one of the following for help on that topic:\n"
-                               "Press ESC to return to the game." ) ) + 1;
+                                  _( "Please press one of the following for help on that topic:\n"
+                                     "Press ESC to return to the game." ) ) + 1;
 
     size_t const half_size = help_texts.size() / 2 + 1;
     int second_column = divide_round_up( getmaxx( win ), 2 );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -372,7 +372,7 @@ void iexamine::gaspump( player &p, const tripoint &examp )
                 ///\EFFECT_DEX decreases amount of gas spilled from a pump
                 const int qty = rng( 1, max_spill_charges * 8.0 / std::max( 1, p.get_dex() ) );
 
-                item spill = item_it->split( qty );
+                item const spill = item_it->split( qty );
                 if( spill.is_null() ) {
                     here.add_item_or_charges( p.pos(), *item_it );
                     items.erase( item_it );
@@ -559,7 +559,7 @@ class atm_menu
 
         //!Deposit money from cash card into bank account.
         bool do_deposit_money() {
-            int money = u.charges_of( itype_cash_card );
+            int const money = u.charges_of( itype_cash_card );
 
             if( !money ) {
                 popup( _( "You can only deposit money from charged cash cards!" ) );
@@ -587,7 +587,7 @@ class atm_menu
         bool do_withdraw_money() {
             //We may want to use visit_items here but that's fairly heavy.
             //For now, just check weapon if we didn't find it in the inventory.
-            int pos = u.inv.position_by_type( itype_cash_card );
+            int const pos = u.inv.position_by_type( itype_cash_card );
             item *dst;
             if( pos == INT_MIN ) {
                 dst = &u.primary_weapon();
@@ -764,7 +764,7 @@ void iexamine::vending( player &p, const tripoint &examp )
         if( cur_pos < num_items - cur_pos ) {
             page_beg = std::max( 0, cur_pos - lines_above );
         } else {
-            int page_end = std::min( num_items, cur_pos + lines_below );
+            int const page_end = std::min( num_items, cur_pos + lines_below );
             page_beg = std::max( 0, page_end - list_lines );
         }
 
@@ -888,10 +888,10 @@ void iexamine::elevator( player &p, const tripoint &examp )
     if( !query_yn( _( "Use the %s?" ), here.tername( examp ) ) ) {
         return;
     }
-    int movez = ( examp.z < 0 ? 2 : -2 );
+    int const movez = ( examp.z < 0 ? 2 : -2 );
 
-    tripoint original_floor_omt = ms_to_omt_copy( here.getabs( examp ) );
-    tripoint new_floor_omt = original_floor_omt + tripoint( point_zero, movez );
+    tripoint const original_floor_omt = ms_to_omt_copy( here.getabs( examp ) );
+    tripoint const new_floor_omt = original_floor_omt + tripoint( point_zero, movez );
 
 
     // first find critters in the destination elevator and move them out of the way
@@ -899,7 +899,7 @@ void iexamine::elevator( player &p, const tripoint &examp )
         if( critter.is_player() ) {
             continue;
         } else if( here.has_flag( flag_ELEVATOR, critter.pos() ) ) {
-            tripoint critter_omt = ms_to_omt_copy( here.getabs( critter.pos() ) );
+            tripoint const critter_omt = ms_to_omt_copy( here.getabs( critter.pos() ) );
             if( critter_omt == new_floor_omt ) {
                 for( const tripoint &candidate : closest_points_first( critter.pos(), 10 ) ) {
                     if( !here.has_flag( flag_ELEVATOR, candidate ) &&
@@ -935,7 +935,7 @@ void iexamine::elevator( player &p, const tripoint &examp )
     for( const tripoint &pos : closest_points_first( p.pos(), 10 ) ) {
         if( here.has_flag( flag_ELEVATOR, pos ) ) {
             map_stack items = here.i_at( pos );
-            tripoint dest = first_elevator_tile( pos + tripoint( 0, 0, movez ) );
+            tripoint const dest = first_elevator_tile( pos + tripoint( 0, 0, movez ) );
             move_item( items, pos, dest );
         }
     }
@@ -948,7 +948,7 @@ void iexamine::elevator( player &p, const tripoint &examp )
         if( critter.is_player() ) {
             continue;
         } else if( here.has_flag( flag_ELEVATOR, critter.pos() ) ) {
-            tripoint critter_omt = ms_to_omt_copy( here.getabs( critter.pos() ) );
+            tripoint const critter_omt = ms_to_omt_copy( here.getabs( critter.pos() ) );
 
             if( critter_omt == original_floor_omt ) {
                 for( const tripoint &candidate : closest_points_first( p.pos(), 10 ) ) {
@@ -1025,7 +1025,7 @@ void iexamine::cardreader( player &p, const tripoint &examp )
 {
     bool open = false;
     map &here = get_map();
-    itype_id card_type = ( here.ter( examp ) == t_card_science ? itype_id_science :
+    itype_id const card_type = ( here.ter( examp ) == t_card_science ? itype_id_science :
                            here.ter( examp ) == t_card_military ? itype_id_military :
                            itype_id_industrial );
     if( p.has_amount( card_type, 1 ) && query_yn( _( "Swipe your ID card?" ) ) ) {
@@ -1036,7 +1036,7 @@ void iexamine::cardreader( player &p, const tripoint &examp )
                 open = true;
             }
         }
-        for( monster &critter : g->all_monsters() ) {
+        for( monster  const&critter : g->all_monsters() ) {
             // Check 1) same overmap coords, 2) turret, 3) hostile
             if( ms_to_omt_copy( here.getabs( critter.pos() ) ) == ms_to_omt_copy( here.getabs( examp ) ) &&
                 critter.has_flag( MF_ID_CARD_DESPAWN ) &&
@@ -1058,7 +1058,7 @@ void iexamine::cardreader( player &p, const tripoint &examp )
 
 void iexamine::cardreader_robofac( player &p, const tripoint &examp )
 {
-    itype_id card_type = itype_id_science;
+    itype_id const card_type = itype_id_science;
     if( p.has_amount( card_type, 1 ) && query_yn( _( "Swipe your ID card?" ) ) ) {
         p.mod_moves( -100 );
         p.use_amount( card_type, 1 );
@@ -1219,7 +1219,7 @@ void iexamine::bars( player &p, const tripoint &examp )
         none( p, examp );
         return;
     }
-    map &here = get_map();
+    map  const&here = get_map();
     if( ( ( p.encumb( bp_torso ) ) >= 10 ) && ( ( p.encumb( bp_head ) ) >= 10 ) &&
         ( p.encumb( bp_foot_l ) >= 10 ||
           p.encumb( bp_foot_r ) >= 10 ) ) { // Most likely places for rigid gear that would catch on the bars.
@@ -1355,7 +1355,7 @@ void iexamine::pit_covered( player &p, const tripoint &examp )
     }
 
     map &here = get_map();
-    item plank( "2x4", calendar::turn );
+    item const plank( "2x4", calendar::turn );
     add_msg( _( "You remove the plank." ) );
     here.add_item_or_charges( p.pos(), plank );
 
@@ -1420,7 +1420,7 @@ void iexamine::slot_machine( player &p, const tripoint & )
 void iexamine::safe( player &p, const tripoint &examp )
 {
     auto cracking_tool = p.crafting_inventory().items_with( []( const item & it ) -> bool {
-        item temporary_item( it.type );
+        item const temporary_item( it.type );
         return temporary_item.has_flag( flag_SAFECRACK );
     } );
 
@@ -1547,7 +1547,7 @@ void iexamine::locked_object( player &p, const tripoint &examp )
 {
     map &here = get_map();
 
-    safe_reference<item> prying_tool = find_best_prying_tool( p );
+    safe_reference<item> const prying_tool = find_best_prying_tool( p );
     if( prying_tool ) {
         apply_prying_tool( p, prying_tool.get(), examp );
         return;
@@ -1555,7 +1555,7 @@ void iexamine::locked_object( player &p, const tripoint &examp )
 
     // if the furniture/terrain is also lockpickable
     if( here.has_flag_ter_or_furn( "LOCKED", examp ) ) {
-        safe_reference<item> lock_picking_tool = find_best_lock_picking_tool( p );
+        safe_reference<item> const lock_picking_tool = find_best_lock_picking_tool( p );
         if( lock_picking_tool ) {
             apply_lock_picking_tool( p, lock_picking_tool.get(), examp );
         } else {
@@ -1576,7 +1576,7 @@ void iexamine::locked_object_pickable( player &p, const tripoint &examp )
 {
     map &here = get_map();
 
-    safe_reference<item> lock_picking_tool = find_best_lock_picking_tool( p );
+    safe_reference<item> const lock_picking_tool = find_best_lock_picking_tool( p );
     if( lock_picking_tool ) {
         apply_lock_picking_tool( p, lock_picking_tool.get(), examp );
         return;
@@ -1589,9 +1589,9 @@ void iexamine::locked_object_pickable( player &p, const tripoint &examp )
 void iexamine::bulletin_board( player &p, const tripoint &examp )
 {
     g->validate_camps();
-    map &here = get_map();
+    map  const&here = get_map();
     // TODO: fix point types
-    point_abs_omt omt( ms_to_omt_copy( here.getabs( examp.xy() ) ) );
+    point_abs_omt const omt( ms_to_omt_copy( here.getabs( examp.xy() ) ) );
     std::optional<basecamp *> bcp = overmap_buffer.find_camp( omt );
     if( bcp ) {
         basecamp *temp_camp = *bcp;
@@ -1627,7 +1627,7 @@ void iexamine::fault( player &, const tripoint & )
  */
 void iexamine::notify( player &, const tripoint &pos )
 {
-    std::string message = g->m.has_furn( pos ) ?
+    std::string const message = g->m.has_furn( pos ) ?
                           g->m.furn( pos ).obj().message :
                           g->m.ter( pos ).obj().message;
     if( !message.empty() ) {
@@ -1784,7 +1784,7 @@ void iexamine::fswitch( player &p, const tripoint &examp )
         none( p, examp );
         return;
     }
-    ter_id terid = here.ter( examp );
+    ter_id const terid = here.ter( examp );
     p.moves -= to_moves<int>( 1_seconds );
     tripoint tmp;
     tmp.z = examp.z;
@@ -1895,7 +1895,7 @@ static bool drink_nectar( player &p )
  */
 static void handle_harvest( player &p, const std::string &itemid, bool force_drop )
 {
-    item harvest = item( itemid );
+    item const harvest = item( itemid );
     if( !force_drop && p.can_pick_volume( harvest ) &&
         p.can_pick_weight( harvest, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) ) {
         p.i_add( harvest );
@@ -1941,7 +1941,7 @@ void iexamine::flower_poppy( player &p, const tripoint &examp )
         return;
     }
 
-    int resist = p.get_env_resist( bodypart_id( "mouth" ) );
+    int const resist = p.get_env_resist( bodypart_id( "mouth" ) );
 
     if( resist < 10 ) {
         // Can't smell the flowers with a gas mask on!
@@ -2009,7 +2009,7 @@ void iexamine::flower_dahlia( player &p, const tripoint &examp )
     }
 
     map &here = get_map();
-    bool can_get_root = p.has_quality( qual_DIG ) || p.has_trait( trait_BURROW );
+    bool const can_get_root = p.has_quality( qual_DIG ) || p.has_trait( trait_BURROW );
     if( can_get_root ) {
         if( !query_yn( _( "Pick %s?" ), here.furnname( examp ) ) ) {
             none( p, examp );
@@ -2064,12 +2064,12 @@ static bool harvest_common( player &p, const tripoint &examp, bool furn, bool ne
         return false;
     }
 
-    int lev = p.get_skill_level( skill_survival );
+    int const lev = p.get_skill_level( skill_survival );
     bool got_anything = false;
     for( const auto &entry : harvest ) {
-        float min_num = entry.base_num.first + lev * entry.scale_num.first;
-        float max_num = entry.base_num.second + lev * entry.scale_num.second;
-        int roll = std::min<int>( entry.max, std::round( rng_float( min_num, max_num ) ) );
+        float const min_num = entry.base_num.first + lev * entry.scale_num.first;
+        float const max_num = entry.base_num.second + lev * entry.scale_num.second;
+        int const roll = std::min<int>( entry.max, std::round( rng_float( min_num, max_num ) ) );
         if( roll >= 1 ) {
             got_anything = true;
             for( int i = 0; i < roll; i++ ) {
@@ -2090,7 +2090,7 @@ static bool harvest_common( player &p, const tripoint &examp, bool furn, bool ne
 
 void iexamine::harvest_furn_nectar( player &p, const tripoint &examp )
 {
-    bool auto_forage = get_option<bool>( "AUTO_FEATURES" ) &&
+    bool const auto_forage = get_option<bool>( "AUTO_FEATURES" ) &&
                        get_option<std::string>( "AUTO_FORAGING" ) == "both";
     if( harvest_common( p, examp, true, true, auto_forage ) ) {
         get_map().furn_set( examp, f_null );
@@ -2099,7 +2099,7 @@ void iexamine::harvest_furn_nectar( player &p, const tripoint &examp )
 
 void iexamine::harvest_furn( player &p, const tripoint &examp )
 {
-    bool auto_forage = get_option<bool>( "AUTO_FEATURES" ) &&
+    bool const auto_forage = get_option<bool>( "AUTO_FEATURES" ) &&
                        get_option<std::string>( "AUTO_FORAGING" ) == "both";
     if( harvest_common( p, examp, true, false, auto_forage ) ) {
         get_map().furn_set( examp, f_null );
@@ -2108,7 +2108,7 @@ void iexamine::harvest_furn( player &p, const tripoint &examp )
 
 void iexamine::harvest_ter_nectar( player &p, const tripoint &examp )
 {
-    bool auto_forage = get_option<bool>( "AUTO_FEATURES" ) &&
+    bool const auto_forage = get_option<bool>( "AUTO_FEATURES" ) &&
                        ( get_option<std::string>( "AUTO_FORAGING" ) == "both" ||
                          get_option<std::string>( "AUTO_FORAGING" ) == "bushes" ||
                          get_option<std::string>( "AUTO_FORAGING" ) == "trees" );
@@ -2120,7 +2120,7 @@ void iexamine::harvest_ter_nectar( player &p, const tripoint &examp )
 
 void iexamine::harvest_ter( player &p, const tripoint &examp )
 {
-    bool auto_forage = get_option<bool>( "AUTO_FEATURES" ) &&
+    bool const auto_forage = get_option<bool>( "AUTO_FEATURES" ) &&
                        ( get_option<std::string>( "AUTO_FORAGING" ) == "both" ||
                          get_option<std::string>( "AUTO_FORAGING" ) == "trees" );
     if( harvest_common( p, examp, false, false, auto_forage ) ) {
@@ -2144,7 +2144,7 @@ void iexamine::flower_marloss( player &p, const tripoint &examp )
         add_msg( m_info, _( "This flower is still alive, despite the harsh conditions…" ) );
     }
     map &here = get_map();
-    item nectar( "nectar" );
+    item const nectar( "nectar" );
     if( can_drink_nectar( p, nectar ) ) {
         if( !query_yn( _( "You feel out of place as you explore the %s. Drink?" ),
                        here.furnname( examp ) ) ) {
@@ -2192,8 +2192,8 @@ void iexamine::egg_sack_generic( player &p, const tripoint &examp,
             }
         }
     }
-    int roll = rng( 4, 20 );
-    bool drop_eggs = monster_count >= 1;
+    int const roll = rng( 4, 20 );
+    bool const drop_eggs = monster_count >= 1;
     for( int i = 0; i < roll; i++ ) {
         handle_harvest( p, "spider_egg", drop_eggs );
     }
@@ -2268,9 +2268,9 @@ int iexamine::query_seed( const std::vector<seed_tuple> &seed_entries )
     int count = 0;
     for( const auto &entry : seed_entries ) {
         const std::string &seed_name = std::get<1>( entry );
-        int seed_count = std::get<2>( entry );
+        int const seed_count = std::get<2>( entry );
 
-        std::string format = seed_count > 0 ? "%s (%d)" : "%s";
+        std::string const format = seed_count > 0 ? "%s (%d)" : "%s";
 
         smenu.addentry( count++, true, MENU_AUTOASSIGN, format.c_str(),
                         seed_name, seed_count );
@@ -2312,7 +2312,7 @@ void iexamine::dirtmound( player &p, const tripoint &examp )
         add_msg(m_info, _("It is too dark to plant anything now."));
         return;
     }*/
-    std::vector<item *> seed_inv = p.items_with( []( const item & itm ) {
+    std::vector<item *> const seed_inv = p.items_with( []( const item & itm ) {
         return itm.is_seed();
     } );
     if( seed_inv.empty() ) {
@@ -2326,7 +2326,7 @@ void iexamine::dirtmound( player &p, const tripoint &examp )
 
     auto seed_entries = get_seed_entries( seed_inv );
 
-    int seed_index = query_seed( seed_entries );
+    int const seed_index = query_seed( seed_entries );
 
     // Did we cancel?
     if( seed_index < 0 || seed_index >= static_cast<int>( seed_entries.size() ) ) {
@@ -2435,7 +2435,7 @@ void iexamine::harvest_plant( player &p, const tripoint &examp, bool from_activi
         const itype &type = *seed->type;
         here.i_clear( examp );
 
-        int skillLevel = p.get_skill_level( skill_survival );
+        int const skillLevel = p.get_skill_level( skill_survival );
         ///\EFFECT_SURVIVAL increases number of plants harvested from a seed
         int plant_count = rng( skillLevel / 2, skillLevel );
         plant_count *= here.furn( examp )->plant->harvest_multiplier;
@@ -2478,7 +2478,7 @@ ret_val<bool> iexamine::can_fertilize( player &p, const tripoint &tile,
 
 void iexamine::fertilize_plant( player &p, const tripoint &tile, const itype_id &fertilizer )
 {
-    ret_val<bool> can_fert = can_fertilize( p, tile, fertilizer );
+    ret_val<bool> const can_fert = can_fertilize( p, tile, fertilizer );
     if( !can_fert.success() ) {
         debugmsg( can_fert.str() );
         return;
@@ -2521,7 +2521,7 @@ void iexamine::fertilize_plant( player &p, const tripoint &tile, const itype_id 
 
 itype_id iexamine::choose_fertilizer( player &p, const std::string &pname, bool ask_player )
 {
-    std::vector<const item *> f_inv = p.all_items_with_flag( flag_FERTILIZER );
+    std::vector<const item *> const f_inv = p.all_items_with_flag( flag_FERTILIZER );
     if( f_inv.empty() ) {
         add_msg( m_info, _( "You have no fertilizer for the %s." ), pname );
         return itype_id();
@@ -2578,7 +2578,7 @@ void iexamine::aggie_plant( player &p, const tripoint &examp )
             add_msg( m_info, _( "This %s has already been fertilized." ), pname );
             return;
         }
-        itype_id fertilizer = choose_fertilizer( p, pname, true /*ask player for confirmation */ );
+        itype_id const fertilizer = choose_fertilizer( p, pname, true /*ask player for confirmation */ );
 
         if( !fertilizer.is_empty() ) {
             fertilize_plant( p, examp, fertilizer );
@@ -2590,7 +2590,7 @@ void iexamine::aggie_plant( player &p, const tripoint &examp )
 void iexamine::kiln_empty( player &p, const tripoint &examp )
 {
     map &here = get_map();
-    furn_id cur_kiln_type = here.furn( examp );
+    furn_id const cur_kiln_type = here.furn( examp );
     furn_id next_kiln_type = f_null;
     if( cur_kiln_type == f_kiln_empty ) {
         next_kiln_type = f_kiln_full;
@@ -2626,7 +2626,7 @@ void iexamine::kiln_empty( player &p, const tripoint &examp )
 
     ///\EFFECT_FABRICATION decreases loss when firing a kiln
     const int skill = p.get_skill_level( skill_fabrication );
-    int loss = 60 - 2 *
+    int const loss = 60 - 2 *
                skill; // We can afford to be inefficient - logs and skeletons are cheap, charcoal isn't
 
     // Burn stuff that should get charred, leave out the rest
@@ -2635,8 +2635,8 @@ void iexamine::kiln_empty( player &p, const tripoint &examp )
         total_volume += i.volume();
     }
 
-    units::volume char_volume = ( 100 - loss ) * total_volume / 100;
-    int char_charges = itype_unfinished_charcoal->charges_per_volume( char_volume );
+    units::volume const char_volume = ( 100 - loss ) * total_volume / 100;
+    int const char_charges = itype_unfinished_charcoal->charges_per_volume( char_volume );
     if( char_charges < 1 ) {
         add_msg( _( "The batch in this kiln is too small to yield any charcoal." ) );
         return;
@@ -2665,7 +2665,7 @@ void iexamine::kiln_empty( player &p, const tripoint &examp )
 void iexamine::kiln_full( player &, const tripoint &examp )
 {
     map &here = get_map();
-    furn_id cur_kiln_type = here.furn( examp );
+    furn_id const cur_kiln_type = here.furn( examp );
     furn_id next_kiln_type = f_null;
     if( cur_kiln_type == f_kiln_full ) {
         next_kiln_type = f_kiln_empty;
@@ -2687,8 +2687,8 @@ void iexamine::kiln_full( player &, const tripoint &examp )
     const time_duration firing_time = 6_hours; // 5 days in real life
     const time_duration time_left = firing_time - items.only_item().age();
     if( time_left > 0_turns ) {
-        int hours = to_hours<int>( time_left );
-        int minutes = to_minutes<int>( time_left ) + 1;
+        int const hours = to_hours<int>( time_left );
+        int const minutes = to_minutes<int>( time_left ) + 1;
         if( minutes > 60 ) {
             add_msg( vgettext( "It will finish burning in about %d hour.",
                                "It will finish burning in about %d hours.",
@@ -2722,7 +2722,7 @@ void iexamine::kiln_full( player &, const tripoint &examp )
 void iexamine::arcfurnace_empty( player &p, const tripoint &examp )
 {
     map &here = get_map();
-    furn_id cur_arcfurnace_type = here.furn( examp );
+    furn_id const cur_arcfurnace_type = here.furn( examp );
     furn_id next_arcfurnace_type = f_null;
     if( cur_arcfurnace_type == f_arcfurnace_empty ) {
         next_arcfurnace_type = f_arcfurnace_full;
@@ -2756,7 +2756,7 @@ void iexamine::arcfurnace_empty( player &p, const tripoint &examp )
 
     ///\EFFECT_FABRICATION decreases loss when firing a furnace
     const int skill = p.get_skill_level( skill_fabrication );
-    int loss = 60 - 2 *
+    int const loss = 60 - 2 *
                skill; // Inefficency is still fine, coal and limestone is abundant
 
     // Burn stuff that should get charred, leave out the rest
@@ -2765,8 +2765,8 @@ void iexamine::arcfurnace_empty( player &p, const tripoint &examp )
         total_volume += i.volume();
     }
 
-    units::volume char_volume = ( 100 - loss ) * total_volume / 100;
-    int char_charges = itype_unfinished_cac2->charges_per_volume( char_volume );
+    units::volume const char_volume = ( 100 - loss ) * total_volume / 100;
+    int const char_charges = itype_unfinished_cac2->charges_per_volume( char_volume );
     if( char_charges < 1 ) {
         add_msg( _( "The batch in this furance is too small to yield usable calcium carbide." ) );
         return;
@@ -2795,7 +2795,7 @@ void iexamine::arcfurnace_empty( player &p, const tripoint &examp )
 void iexamine::arcfurnace_full( player &, const tripoint &examp )
 {
     map &here = get_map();
-    furn_id cur_arcfurnace_type = here.furn( examp );
+    furn_id const cur_arcfurnace_type = here.furn( examp );
     furn_id next_arcfurnace_type = f_null;
     if( cur_arcfurnace_type == f_arcfurnace_full ) {
         next_arcfurnace_type = f_arcfurnace_empty;
@@ -2815,8 +2815,8 @@ void iexamine::arcfurnace_full( player &, const tripoint &examp )
     const time_duration firing_time = 2_hours; // Arc furnaces work really fast in reality
     const time_duration time_left = firing_time - items.only_item().age();
     if( time_left > 0_turns ) {
-        int hours = to_hours<int>( time_left );
-        int minutes = to_minutes<int>( time_left ) + 1;
+        int const hours = to_hours<int>( time_left );
+        int const minutes = to_minutes<int>( time_left ) + 1;
         if( minutes > 60 ) {
             add_msg( vgettext( "It will finish burning in about %d hour.",
                                "It will finish burning in about %d hours.",
@@ -2850,7 +2850,7 @@ void iexamine::arcfurnace_full( player &, const tripoint &examp )
 
 void iexamine::autoclave_empty( player &p, const tripoint & )
 {
-    item_location bionic = game_menus::inv::sterilize_cbm( p );
+    item_location const bionic = game_menus::inv::sterilize_cbm( p );
     if( bionic ) {
         avatar_funcs::mend_item( *p.as_avatar(), item_location( bionic ) );
     } else {
@@ -2861,7 +2861,7 @@ void iexamine::autoclave_empty( player &p, const tripoint & )
 void iexamine::autoclave_full( player &, const tripoint &examp )
 {
     map &here = get_map();
-    furn_id cur_autoclave_type = here.furn( examp );
+    furn_id const cur_autoclave_type = here.furn( examp );
     furn_id next_autoclave_type = f_null;
     if( cur_autoclave_type == furn_id( "f_autoclave_full" ) ) {
         next_autoclave_type = furn_id( "f_autoclave" );
@@ -2872,11 +2872,11 @@ void iexamine::autoclave_full( player &, const tripoint &examp )
     }
 
     map_stack items = here.i_at( examp );
-    bool cbms = std::all_of( items.begin(), items.end(), []( const item & i ) {
+    bool const cbms = std::all_of( items.begin(), items.end(), []( const item & i ) {
         return i.is_bionic();
     } );
 
-    bool cbms_not_packed = std::all_of( items.begin(), items.end(), []( const item & i ) {
+    bool const cbms_not_packed = std::all_of( items.begin(), items.end(), []( const item & i ) {
         return i.is_bionic() && i.has_flag( flag_NO_PACKED );
     } );
 
@@ -3074,7 +3074,7 @@ void iexamine::fvat_empty( player &p, const tripoint &examp )
         brew_type = b_types[b_index];
         brew_nname = item::nname( brew_type );
     } else {
-        item &brew = here.i_at( examp ).only_item();
+        item  const&brew = here.i_at( examp ).only_item();
         brew_type = brew.typeId();
         brew_nname = item::nname( brew_type );
         charges_on_ground = brew.charges;
@@ -3109,7 +3109,7 @@ void iexamine::fvat_empty( player &p, const tripoint &examp )
     }
     if( to_deposit ) {
         item brew( brew_type, calendar::start_of_cataclysm );
-        int charges_held = p.charges_of( brew_type );
+        int const charges_held = p.charges_of( brew_type );
         brew.charges = charges_on_ground;
         for( int i = 0; i < charges_held && !vat_full; i++ ) {
             p.use_charges( brew_type, 1 );
@@ -3163,7 +3163,7 @@ void iexamine::fvat_full( player &p, const tripoint &examp )
         return;
     }
 
-    item &brew_i = *items_here.begin();
+    item  const&brew_i = *items_here.begin();
     // Does the vat contain unfermented brew, or already fermented booze?
     // TODO: Allow "recursive brewing" to continue without player having to check on it
     if( brew_i.is_brewable() ) {
@@ -3173,7 +3173,7 @@ void iexamine::fvat_full( player &p, const tripoint &examp )
         const time_duration brew_time = brew_i.brewing_time();
         const time_duration progress = brew_i.age();
         if( progress < brew_time ) {
-            int hours = to_hours<int>( brew_time - progress );
+            int const hours = to_hours<int>( brew_time - progress );
             if( hours < 1 ) {
                 add_msg( _( "It will finish brewing in less than an hour." ) );
             } else {
@@ -3190,7 +3190,7 @@ void iexamine::fvat_full( player &p, const tripoint &examp )
             here.i_clear( examp );
             for( const auto &result : results ) {
                 // TODO: Different age based on settings
-                item booze( result, brew_i.birthday(), brew_i.charges );
+                item const booze( result, brew_i.birthday(), brew_i.charges );
                 here.add_item( examp, booze );
                 if( booze.made_of( LIQUID ) ) {
                     add_msg( _( "The %s is now ready for bottling." ), booze.tname() );
@@ -3258,7 +3258,7 @@ void iexamine::keg( player &p, const tripoint &examp )
     none( p, examp );
     map &here = get_map();
     const auto keg_name = here.name( examp );
-    units::volume keg_cap = get_keg_capacity( examp );
+    units::volume const keg_cap = get_keg_capacity( examp );
 
     const bool has_container_with_liquid = map_cursor( examp ).has_item_with( []( const item & it ) {
         return !it.is_container_empty() && it.can_unload_liquid();
@@ -3314,8 +3314,8 @@ void iexamine::keg( player &p, const tripoint &examp )
         displace_items_except_one_liquid( examp );
 
         //Store liquid chosen in the keg
-        itype_id drink_type = drink_types[ drink_index ];
-        int charges_held = p.charges_of( drink_type );
+        itype_id const drink_type = drink_types[ drink_index ];
+        int const charges_held = p.charges_of( drink_type );
         item drink( drink_type, calendar::start_of_cataclysm );
         drink.set_relative_rot( drink_rot[ drink_index ] );
         drink.charges = 0;
@@ -3387,7 +3387,7 @@ void iexamine::keg( player &p, const tripoint &examp )
                     add_msg( _( "The %s is completely full." ), keg_name );
                     return;
                 }
-                int charges_held = p.charges_of( drink.typeId() );
+                int const charges_held = p.charges_of( drink.typeId() );
                 if( charges_held < 1 ) {
                     add_msg( m_info, _( "You don't have any %1$s to fill the %2$s with." ),
                              drink_nname, keg_name );
@@ -3455,7 +3455,7 @@ static void pick_plant( player &p, const tripoint &examp,
                         const itype_id &itemType, ter_id new_ter, bool seeds = false )
 {
     map &here = get_map();
-    bool auto_forage = get_option<bool>( "AUTO_FEATURES" ) &&
+    bool const auto_forage = get_option<bool>( "AUTO_FEATURES" ) &&
                        get_option<std::string>( "AUTO_FORAGING" ) != "off";
     if( p.is_player() && !auto_forage &&
         !query_yn( _( "Harvest the %s?" ), here.tername( examp ) ) ) {
@@ -3466,7 +3466,7 @@ static void pick_plant( player &p, const tripoint &examp,
     const int survival = p.get_skill_level( skill_survival );
     p.practice( skill_survival, 6 );
 
-    int plantBase = rng( 2, 5 );
+    int const plantBase = rng( 2, 5 );
     ///\EFFECT_SURVIVAL increases number of plants harvested
     int plantCount = rng( plantBase, plantBase + survival / 2 );
     plantCount = std::min( plantCount, 12 );
@@ -3600,7 +3600,7 @@ void iexamine::tree_maple_tapped( player &p, const tripoint &examp )
                 return;
             }
 
-            item tree_spile( "tree_spile" );
+            item const tree_spile( "tree_spile" );
             add_msg( _( "You remove the %s." ), tree_spile.tname( 1 ) );
             here.add_item_or_charges( p.pos(), tree_spile );
 
@@ -3715,12 +3715,12 @@ void iexamine::recycle_compactor( player &, const tripoint &examp )
         choose_metal.addentry( m.name() );
     }
     choose_metal.query();
-    int m_idx = choose_metal.ret;
+    int const m_idx = choose_metal.ret;
     if( m_idx < 0 || m_idx >= static_cast<int>( metals.size() ) ) {
         add_msg( _( "Never mind." ) );
         return;
     }
-    material_type m = metals.at( m_idx );
+    material_type const m = metals.at( m_idx );
 
     map &here = get_map();
     // check inputs and tally total mass
@@ -3769,7 +3769,7 @@ void iexamine::recycle_compactor( player &, const tripoint &examp )
                                                it.tname( amount ) ) );
     }
     choose_output.query();
-    int o_idx = choose_output.ret;
+    int const o_idx = choose_output.ret;
     if( o_idx < 0 || o_idx >= static_cast<int>( m.compacts_into().size() ) ) {
         add_msg( _( "Never mind." ) );
         return;
@@ -3781,14 +3781,14 @@ void iexamine::recycle_compactor( player &, const tripoint &examp )
     }
 
     // produce outputs
-    double recover_factor = rng( 6, 9 ) / 10.0;
+    double const recover_factor = rng( 6, 9 ) / 10.0;
     sum_weight = sum_weight * recover_factor;
     sounds::sound( examp, 80, sounds::sound_t::combat, _( "Ka-klunk!" ), true, "tool", "compactor" );
     bool out_desired = false;
     bool out_any = false;
     for( auto it = m.compacts_into().begin() + o_idx; it != m.compacts_into().end(); ++it ) {
         const units::mass ow = item( *it, calendar::start_of_cataclysm, item::solitary_tag{} ).weight();
-        int count = sum_weight / ow;
+        int const count = sum_weight / ow;
         sum_weight -= count * ow;
         if( count > 0 ) {
             here.spawn_item( examp, *it, count, 1, calendar::turn );
@@ -3823,7 +3823,7 @@ void iexamine::trap( player &p, const tripoint &examp )
         return;
     }
     const int possible = tr.get_difficulty();
-    bool seen = tr.can_see( examp, p );
+    bool const seen = tr.can_see( examp, p );
     if( tr.loadid == tr_unfinished_construction || here.partial_con_at( examp ) ) {
         partial_con *pc = here.partial_con_at( examp );
         if( pc ) {
@@ -3931,7 +3931,7 @@ void iexamine::reload_furniture( player &p, const tripoint &examp )
         return;
     }
 
-    map_stack items_here = here.i_at( examp );
+    map_stack const items_here = here.i_at( examp );
     std::vector<std::string> ammo_names;
     std::vector<itype> ammo_filtered;
     int ammo_index = 0;
@@ -4012,7 +4012,7 @@ void iexamine::reload_furniture( player &p, const tripoint &examp )
         }
     }
     if( amount != 0 ) {
-        item it( cur_ammo->get_id(), calendar::turn, amount );
+        item const it( cur_ammo->get_id(), calendar::turn, amount );
         here.add_item( examp, it );
     }
 
@@ -4181,9 +4181,9 @@ void iexamine::curtains( player &p, const tripoint &examp )
 
 void iexamine::sign( player &p, const tripoint &examp )
 {
-    map &here = get_map();
-    std::string existing_signage = here.get_signage( examp );
-    bool previous_signage_exists = !existing_signage.empty();
+    map  const&here = get_map();
+    std::string const existing_signage = here.get_signage( examp );
+    bool const previous_signage_exists = !existing_signage.empty();
 
     // Display existing message, or lack thereof.
     if( p.has_trait( trait_ILLITERATE ) ) {
@@ -4196,7 +4196,7 @@ void iexamine::sign( player &p, const tripoint &examp )
 
     // Allow chance to modify message.
     std::vector<tool_comp> tools;
-    std::vector<const item *> filter = p.crafting_inventory().items_with( []( const item & it ) {
+    std::vector<const item *> const filter = p.crafting_inventory().items_with( []( const item & it ) {
         return it.has_flag( flag_WRITE_MESSAGE ) && it.charges > 0;
     } );
     tools.reserve( filter.size() );
@@ -4206,19 +4206,19 @@ void iexamine::sign( player &p, const tripoint &examp )
 
     if( !tools.empty() ) {
         // Different messages if the sign already has writing associated with it.
-        std::string query_message = previous_signage_exists ?
+        std::string const query_message = previous_signage_exists ?
                                     _( "Overwrite the existing message on the sign?" ) :
                                     _( "Add a message to the sign?" );
-        std::string ignore_message = _( "You leave the sign alone." );
+        std::string const ignore_message = _( "You leave the sign alone." );
         if( query_yn( query_message ) ) {
-            std::string signage = string_input_popup()
+            std::string const signage = string_input_popup()
                                   .title( _( "Write what?" ) )
                                   .identifier( "signage" )
                                   .query_string();
             if( signage.empty() ) {
                 p.add_msg_if_player( m_neutral, ignore_message );
             } else {
-                std::string spray_painted_message = previous_signage_exists ?
+                std::string const spray_painted_message = previous_signage_exists ?
                                                     _( "You overwrite the previous message on the sign with your graffiti." ) :
                                                     _( "You graffiti a message onto the sign." );
                 here.set_signage( examp, signage );
@@ -4235,7 +4235,7 @@ void iexamine::sign( player &p, const tripoint &examp )
 static int getNearPumpCount( const tripoint &p )
 {
     int result = 0;
-    map &here = get_map();
+    map  const&here = get_map();
     for( const tripoint &tmp : here.points_in_radius( p, 12 ) ) {
         const auto t = here.ter( tmp );
         if( t == ter_str_id( "t_gas_pump" ) || t == ter_str_id( "t_gas_pump_a" ) ) {
@@ -4297,11 +4297,11 @@ static int findBestGasDiscount( player &p )
     int discount = 0;
 
     for( size_t i = 0; i < p.inv.size(); i++ ) {
-        item &it = p.inv.find_item( i );
+        item  const&it = p.inv.find_item( i );
 
         if( it.has_flag( "GAS_DISCOUNT" ) ) {
 
-            int q = getGasDiscountCardQuality( it );
+            int const q = getGasDiscountCardQuality( it );
             if( q > discount ) {
                 discount = q;
             }
@@ -4356,7 +4356,7 @@ static int getGasPricePerLiter( int discount )
 
 std::optional<tripoint> iexamine::getGasPumpByNumber( const tripoint &p, int number )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     int k = 0;
     for( const tripoint &tmp : here.points_in_radius( p, 12 ) ) {
         const auto t = here.ter( tmp );
@@ -4379,7 +4379,7 @@ bool iexamine::toPumpFuel( const tripoint &src, const tripoint &dst, int units )
 
             item_it->charges -= units;
 
-            item liq_d( item_it->type, calendar::turn, units );
+            item const liq_d( item_it->type, calendar::turn, units );
 
             const auto backup_pump = here.ter( dst );
             here.ter_set( dst, ter_str_id::NULL_ID() );
@@ -4404,7 +4404,7 @@ static int fromPumpFuel( const tripoint &dst, const tripoint &src )
     for( auto item_it = items.begin(); item_it != items.end(); ++item_it ) {
         if( item_it->made_of( LIQUID ) ) {
             // how much do we have in the pump?
-            item liq_d( item_it->type, calendar::turn, item_it->charges );
+            item const liq_d( item_it->type, calendar::turn, item_it->charges );
 
             // add the charges to the destination
             const auto backup_tank = here.ter( dst );
@@ -4413,7 +4413,7 @@ static int fromPumpFuel( const tripoint &dst, const tripoint &src )
             here.ter_set( dst, backup_tank );
 
             // remove the liquid from the pump
-            int amount = item_it->charges;
+            int const amount = item_it->charges;
             items.erase( item_it );
             return amount;
         }
@@ -4450,7 +4450,7 @@ void iexamine::pay_gas( player &p, const tripoint &examp )
         popup( _( "You're illiterate, and can't read the screen." ) );
     }
 
-    int pumpCount = getNearPumpCount( examp );
+    int const pumpCount = getNearPumpCount( examp );
     if( pumpCount == 0 ) {
         popup( str_to_illiterate_str( _( "Failure!  No gas pumps found!" ) ) );
         return;
@@ -4474,12 +4474,12 @@ void iexamine::pay_gas( player &p, const tripoint &examp )
         uistate.ags_pay_gas_selected_pump = 0;
     }
 
-    int discount = findBestGasDiscount( p );
-    std::string discountName = getGasDiscountName( discount );
+    int const discount = findBestGasDiscount( p );
+    std::string const discountName = getGasDiscountName( discount );
 
-    int pricePerUnit = getGasPricePerLiter( discount );
+    int const pricePerUnit = getGasPricePerLiter( discount );
 
-    bool can_hack = ( !p.has_trait( trait_ILLITERATE ) &&
+    bool const can_hack = ( !p.has_trait( trait_ILLITERATE ) &&
                       ( ( p.has_charges( itype_electrohack, 25 ) ) ||
                         ( p.has_bionic( bio_fingerhack ) && p.get_power_level() > 24_kJ ) ) );
 
@@ -4491,7 +4491,7 @@ void iexamine::pay_gas( player &p, const tripoint &examp )
     amenu.addentry( buy_gas, true, 'b', str_to_illiterate_str( _( "Buy gas." ) ) );
     amenu.addentry( refund, true, 'r', str_to_illiterate_str( _( "Refund cash." ) ) );
 
-    std::string gaspumpselected = str_to_illiterate_str( _( "Current gas pump: " ) ) +
+    std::string const gaspumpselected = str_to_illiterate_str( _( "Current gas pump: " ) ) +
                                   std::to_string( uistate.ags_pay_gas_selected_pump + 1 );
     amenu.addentry( 0, false, -1, gaspumpselected );
     amenu.addentry( choose_pump, true, 'p', str_to_illiterate_str( _( "Choose a gas pump." ) ) );
@@ -4540,9 +4540,9 @@ void iexamine::pay_gas( player &p, const tripoint &examp )
             return;
         }
 
-        int maximum_liters = std::min( money / pricePerUnit, tankGasUnits / 1000 );
+        int const maximum_liters = std::min( money / pricePerUnit, tankGasUnits / 1000 );
 
-        std::string popupmsg = string_format(
+        std::string const popupmsg = string_format(
                                    _( "How many liters of gasoline to buy?  Max: %d L.  (0 to cancel)" ), maximum_liters );
         int liters = string_input_popup()
                      .title( popupmsg )
@@ -4566,7 +4566,7 @@ void iexamine::pay_gas( player &p, const tripoint &examp )
         sounds::sound( p.pos(), 6, sounds::sound_t::activity, _( "Glug Glug Glug" ), true, "tool",
                        "gaspump" );
 
-        int cost = liters * pricePerUnit;
+        int const cost = liters * pricePerUnit;
         money -= cost;
         p.use_charges( itype_cash_card, cost );
 
@@ -4591,7 +4591,7 @@ void iexamine::pay_gas( player &p, const tripoint &examp )
         // Okay, we have a cash card. Now we need to know what's left in the pump.
         const std::optional<tripoint> pGasPump = getGasPumpByNumber( examp,
                 uistate.ags_pay_gas_selected_pump );
-        int amount = pGasPump ? fromPumpFuel( pTank, *pGasPump ) : 0;
+        int const amount = pGasPump ? fromPumpFuel( pTank, *pGasPump ) : 0;
         if( amount >= 0 ) {
             sounds::sound( p.pos(), 6, sounds::sound_t::activity, _( "Glug Glug Glug" ), true, "tool",
                            "gaspump" );
@@ -4624,7 +4624,7 @@ void iexamine::ledge( player &p, const tripoint &examp )
     map &here = get_map();
     switch( cmenu.ret ) {
         case ledge_action::jump_over: {
-            tripoint dest( p.posx() + 2 * sgn( examp.x - p.posx() ), p.posy() + 2 * sgn( examp.y - p.posy() ),
+            tripoint const dest( p.posx() + 2 * sgn( examp.x - p.posx() ), p.posy() + 2 * sgn( examp.y - p.posy() ),
                            p.posz() );
             if( p.get_str() < 4 ) {
                 add_msg( m_warning, _( "You are too weak to jump over an obstacle." ) );
@@ -4750,7 +4750,7 @@ void iexamine::ledge( player &p, const tripoint &examp )
                 p.add_msg_if_player( _( "There is nothing for your to attach your web to!" ) );
             } else {
                 for( int i = 1; i < success_range; i++ ) {
-                    tripoint dest( p.posx() + i * sgn( examp.x - p.posx() ), p.posy() + i * sgn( examp.y - p.posy() ),
+                    tripoint const dest( p.posx() + i * sgn( examp.x - p.posx() ), p.posy() + i * sgn( examp.y - p.posy() ),
                                    p.posz() );
 
                     g->m.ter_set( dest, t_web_bridge );
@@ -4788,7 +4788,7 @@ static player &player_on_couch( player &p, const tripoint &autodoc_loc, player &
 static Character &operator_present( Character &p, const tripoint &autodoc_loc,
                                     Character &null_patient )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     for( const auto &loc : here.points_in_radius( autodoc_loc, 1 ) ) {
         if( !here.has_flag_furn_or_vpart( flag_AUTODOC_COUCH, loc ) ) {
             if( p.pos() == loc ) {
@@ -4820,7 +4820,7 @@ static item &cyborg_on_couch( const tripoint &couch_pos, item &null_cyborg )
     if( const std::optional<vpart_reference> vp = get_map().veh_at( couch_pos ).part_with_feature(
                 flag_AUTODOC_COUCH, false ) ) {
         auto dest_veh = &vp->vehicle();
-        int dest_part = vp->part_index();
+        int const dest_part = vp->part_index();
         for( item &it : dest_veh->get_items( dest_part ) ) {
             if( it.typeId() == itype_bot_broken_cyborg || it.typeId() == itype_bot_prototype_cyborg ) {
                 return it;
@@ -4837,7 +4837,7 @@ static item &cyborg_on_couch( const tripoint &couch_pos, item &null_cyborg )
 
 static player &best_installer( player &p, player &null_player, int difficulty )
 {
-    float player_skill = p.bionics_adjusted_skill( skill_firstaid,
+    float const player_skill = p.bionics_adjusted_skill( skill_firstaid,
                          skill_computer,
                          skill_electronics );
 
@@ -4858,12 +4858,12 @@ static player &best_installer( player &p, player &null_player, int difficulty )
     const std::pair<float, int> &rhs ) {
         return rhs.first < lhs.first;
     } );
-    int player_cos = bionic_manip_cos( player_skill, difficulty );
+    int const player_cos = bionic_manip_cos( player_skill, difficulty );
     for( size_t i = 0; i < g->allies().size() ; i ++ ) {
         if( ally_skills[ i ].first > player_skill ) {
             const npc *e = g->allies()[ ally_skills[ i ].second ];
             player &ally = *g->critter_by_id<player>( e->getID() );
-            int ally_cos = bionic_manip_cos( ally_skills[ i ].first, difficulty );
+            int const ally_cos = bionic_manip_cos( ally_skills[ i ].first, difficulty );
             if( e->has_effect( effect_sleep ) ) {
                 if( !g->u.query_yn(
                         //~ %1$s is the name of the ally
@@ -4948,7 +4948,7 @@ void iexamine::autodoc( player &p, const tripoint &examp )
                     for( size_t i = 0; i < 6; i++ ) {
                         choice_names.push_back( _( "C0RR#PTED?D#TA" ) );
                     }
-                    int choice_index = uilist( _( "Choose bionic to uninstall" ), choice_names );
+                    int const choice_index = uilist( _( "Choose bionic to uninstall" ), choice_names );
                     if( choice_index == 0 ) {
                         g->save_cyborg( &cyborg, couch_pos, p );
                     } else {
@@ -4999,8 +4999,8 @@ void iexamine::autodoc( player &p, const tripoint &examp )
     if( const std::optional<vpart_reference> vp = get_map().veh_at( examp ).part_with_feature(
                 flag_AUTODOC, false ) ) {
         auto dest_veh = &vp->vehicle();
-        int dest_part = vp->part_index();
-        for( item &it : dest_veh->get_items( dest_part ) ) {
+        int const dest_part = vp->part_index();
+        for( item  const&it : dest_veh->get_items( dest_part ) ) {
             if( it.typeId() == itype_arm_splint ) {
                 arm_splints.push_back( it );
             }
@@ -5034,7 +5034,7 @@ void iexamine::autodoc( player &p, const tripoint &examp )
         needs_anesthesia = false;
     } else {
         const inventory &crafting_inv = p.crafting_inventory();
-        std::vector<const item *> a_filter = crafting_inv.items_with( []( const item & it ) {
+        std::vector<const item *> const a_filter = crafting_inv.items_with( []( const item & it ) {
             return it.has_quality( qual_ANESTHESIA );
         } );
         for( const item *anesthesia_item : a_filter ) {
@@ -5166,7 +5166,7 @@ void iexamine::autodoc( player &p, const tripoint &examp )
             for( int i = 0; i < num_hp_parts; i++ ) {
                 const bodypart_id &part = convert_bp( player::hp_to_bp( static_cast<hp_part>( i ) ) ).id();
                 const bool broken = patient.is_limb_broken( part );
-                effect &existing_effect = patient.get_effect( effect_mending, part->token );
+                effect  const&existing_effect = patient.get_effect( effect_mending, part->token );
                 // Skip part if not broken or already healed 50%
                 if( !broken || ( !existing_effect.is_null() &&
                                  existing_effect.get_duration() >
@@ -5260,7 +5260,7 @@ void iexamine::autodoc( player &p, const tripoint &examp )
                     patient.add_effect( effect_disinfected, 1_turns, bp_healed->token );
                     effect &e = patient.get_effect( effect_disinfected, bp_healed->token );
                     e.set_duration( e.get_int_dur_factor() * disinfectant_intensity );
-                    hp_part target_part = player::bp_to_hp( bp_healed->token );
+                    hp_part const target_part = player::bp_to_hp( bp_healed->token );
                     patient.damage_disinfected[target_part] =
                         patient.get_part_hp_max( bp_healed ) - patient.get_part_hp_cur( bp_healed );
 
@@ -5391,7 +5391,7 @@ static void mill_activate( player &p, const tripoint &examp )
 static void smoker_activate( player &p, const tripoint &examp )
 {
     map &here = get_map();
-    furn_id cur_smoker_type = here.furn( examp );
+    furn_id const cur_smoker_type = here.furn( examp );
     furn_id next_smoker_type = f_null;
     const bool portable = here.furn( examp ) == furn_str_id( "f_metal_smoking_rack" ) ||
                           here.furn( examp ) == furn_str_id( "f_metal_smoking_rack_active" );
@@ -5458,7 +5458,7 @@ static void smoker_activate( player &p, const tripoint &examp )
         return;
     }
 
-    int char_charges = get_charcoal_charges( food_volume );
+    int const char_charges = get_charcoal_charges( food_volume );
 
     if( count_charges_in_list( charcoal->type, here.i_at( examp ) ) < char_charges ) {
         add_msg( _( "There is not enough charcoal in the rack to smoke this much food." ) );
@@ -5541,7 +5541,7 @@ void iexamine::mill_finalize( player &, const tripoint &examp, const time_point 
 static void smoker_finalize( player &, const tripoint &examp, const time_point &start_time )
 {
     map &here = get_map();
-    furn_id cur_smoker_type = here.furn( examp );
+    furn_id const cur_smoker_type = here.furn( examp );
     furn_id next_smoker_type = f_null;
     if( cur_smoker_type == f_smoking_rack_active ) {
         next_smoker_type = f_smoking_rack;
@@ -5573,7 +5573,7 @@ static void smoker_finalize( player &, const tripoint &examp, const time_point &
                 result.set_relative_rot( it.get_relative_rot() );
                 result.unset_flag( flag_PROCESSING_RESULT );
 
-                recipe rec;
+                recipe const rec;
                 result.inherit_flags( it, rec );
                 if( !result.has_flag( flag_NUTRIENT_OVERRIDE ) ) {
                     // If the item has "cooks_like" it will be replaced by that item as a component.
@@ -5610,7 +5610,7 @@ static void smoker_load_food( player &p, const tripoint &examp,
     inv.remove_items_with( []( const item & it ) {
         return it.rotten();
     } );
-    std::vector<const item *> filtered = p.crafting_inventory().items_with( []( const item & it ) {
+    std::vector<const item *> const filtered = p.crafting_inventory().items_with( []( const item & it ) {
         return it.has_flag( flag_SMOKABLE );
     } );
 
@@ -5662,7 +5662,7 @@ static void smoker_load_food( player &p, const tripoint &examp,
     // ... then ask how many to put it
     const std::string popupmsg = string_format( _( "Insert how many %s into the rack?" ),
                                  item::nname( what->typeId(), count ) );
-    int amount = string_input_popup()
+    int const amount = string_input_popup()
                  .title( popupmsg )
                  .width( 20 )
                  .text( std::to_string( max_count ) )
@@ -5690,9 +5690,9 @@ static void smoker_load_food( player &p, const tripoint &examp,
         return it.rotten();
     } );
 
-    comp_selection<item_comp> selected = p.select_item_component( comps, 1, inv, true,
+    comp_selection<item_comp> const selected = p.select_item_component( comps, 1, inv, true,
                                          is_non_rotten_crafting_component );
-    std::list<item> moved = p.consume_items( selected, 1, is_non_rotten_crafting_component );
+    std::list<item> const moved = p.consume_items( selected, 1, is_non_rotten_crafting_component );
 
     for( const item &m : moved ) {
         here.add_item( examp, m );
@@ -5718,7 +5718,7 @@ static void mill_load_food( player &p, const tripoint &examp,
     inv.remove_items_with( []( const item & it ) {
         return it.rotten();
     } );
-    std::vector<const item *> filtered = p.crafting_inventory().items_with( []( const item & it ) {
+    std::vector<const item *> const filtered = p.crafting_inventory().items_with( []( const item & it ) {
         return static_cast<bool>( it.type->milling_data );
     } );
 
@@ -5770,7 +5770,7 @@ static void mill_load_food( player &p, const tripoint &examp,
     // ... then ask how many to put it
     const std::string popupmsg = string_format( _( "Insert how many %s into the mill?" ),
                                  item::nname( what->typeId(), count ) );
-    int amount = string_input_popup()
+    int const amount = string_input_popup()
                  .title( popupmsg )
                  .width( 20 )
                  .text( std::to_string( max_count ) )
@@ -5798,9 +5798,9 @@ static void mill_load_food( player &p, const tripoint &examp,
         return it.rotten();
     } );
 
-    comp_selection<item_comp> selected = p.select_item_component( comps, 1, inv, true,
+    comp_selection<item_comp> const selected = p.select_item_component( comps, 1, inv, true,
                                          is_non_rotten_crafting_component );
-    std::list<item> moved = p.consume_items( selected, 1, is_non_rotten_crafting_component );
+    std::list<item> const moved = p.consume_items( selected, 1, is_non_rotten_crafting_component );
     for( const item &m : moved ) {
         here.add_item( examp, m );
         p.mod_moves( -p.item_handling_cost( m ) );
@@ -5812,7 +5812,7 @@ static void mill_load_food( player &p, const tripoint &examp,
 
 void iexamine::on_smoke_out( const tripoint &examp, const time_point &start_time )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     if( here.furn( examp ) == furn_str_id( "f_smoking_rack_active" ) ||
         here.furn( examp ) == furn_str_id( "f_metal_smoking_rack_active" ) ) {
         smoker_finalize( g->u, examp, start_time );
@@ -6232,7 +6232,7 @@ void iexamine::dimensional_portal( player &p, const tripoint &examp )
     menu.text = _( "What to do with the portal:" );
     menu.desc_enabled = true;
 
-    std::vector<const item *> nukes = p.all_items_with_flag( flag_CLOSES_PORTAL );
+    std::vector<const item *> const nukes = p.all_items_with_flag( flag_CLOSES_PORTAL );
     menu.addentry_desc( 0, !nukes.empty(), 'e', _( "Close from here" ),
                         _( "Requires a nuclear explosive" ) );
     menu.addentry_desc( 1, true, 'Q', _( "Sacrifice yourself" ),
@@ -6268,12 +6268,12 @@ void iexamine::dimensional_portal( player &p, const tripoint &examp )
 
 void iexamine::check_power( player &, const tripoint &examp )
 {
-    tripoint_abs_ms abspos( g->m.getabs( examp ) );
+    tripoint_abs_ms const abspos( g->m.getabs( examp ) );
     battery_tile *battery = active_tiles::furn_at<battery_tile>( abspos );
     if( battery != nullptr ) {
         add_msg( m_info, _( "This battery stores %d kJ of electric power." ), battery->get_resource() );
     }
-    int amt = get_distribution_grid_tracker().grid_at( abspos ).get_resource();
+    int const amt = get_distribution_grid_tracker().grid_at( abspos ).get_resource();
     add_msg( m_info, _( "This electric grid stores %d kJ of electric power." ), amt );
 }
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -5934,7 +5934,7 @@ void iexamine::quern_examine( player &p, const tripoint &examp )
                     }
                     mill_list[it] += it.count();
                 }
-                for( auto it_mill : mill_list ) {
+                for( const auto& it_mill : mill_list ) {
                     pop += "-> " + item::nname( it_mill.first.typeId(),
                                                 it_mill.first.count() ) + ( ( it_mill.second > 1 ) ? " (" + std::to_string(
                                                             it_mill.second ) + ")\n" : "\n" );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1026,8 +1026,8 @@ void iexamine::cardreader( player &p, const tripoint &examp )
     bool open = false;
     map &here = get_map();
     itype_id const card_type = ( here.ter( examp ) == t_card_science ? itype_id_science :
-                           here.ter( examp ) == t_card_military ? itype_id_military :
-                           itype_id_industrial );
+                                 here.ter( examp ) == t_card_military ? itype_id_military :
+                                 itype_id_industrial );
     if( p.has_amount( card_type, 1 ) && query_yn( _( "Swipe your ID card?" ) ) ) {
         p.mod_moves( -to_turns<int>( 1_seconds ) );
         for( const tripoint &tmp : here.points_in_radius( examp, 3 ) ) {
@@ -1036,7 +1036,7 @@ void iexamine::cardreader( player &p, const tripoint &examp )
                 open = true;
             }
         }
-        for( monster  const&critter : g->all_monsters() ) {
+        for( monster  const &critter : g->all_monsters() ) {
             // Check 1) same overmap coords, 2) turret, 3) hostile
             if( ms_to_omt_copy( here.getabs( critter.pos() ) ) == ms_to_omt_copy( here.getabs( examp ) ) &&
                 critter.has_flag( MF_ID_CARD_DESPAWN ) &&
@@ -1219,7 +1219,7 @@ void iexamine::bars( player &p, const tripoint &examp )
         none( p, examp );
         return;
     }
-    map  const&here = get_map();
+    map  const &here = get_map();
     if( ( ( p.encumb( bp_torso ) ) >= 10 ) && ( ( p.encumb( bp_head ) ) >= 10 ) &&
         ( p.encumb( bp_foot_l ) >= 10 ||
           p.encumb( bp_foot_r ) >= 10 ) ) { // Most likely places for rigid gear that would catch on the bars.
@@ -1589,7 +1589,7 @@ void iexamine::locked_object_pickable( player &p, const tripoint &examp )
 void iexamine::bulletin_board( player &p, const tripoint &examp )
 {
     g->validate_camps();
-    map  const&here = get_map();
+    map  const &here = get_map();
     // TODO: fix point types
     point_abs_omt const omt( ms_to_omt_copy( here.getabs( examp.xy() ) ) );
     std::optional<basecamp *> bcp = overmap_buffer.find_camp( omt );
@@ -1628,8 +1628,8 @@ void iexamine::fault( player &, const tripoint & )
 void iexamine::notify( player &, const tripoint &pos )
 {
     std::string const message = g->m.has_furn( pos ) ?
-                          g->m.furn( pos ).obj().message :
-                          g->m.ter( pos ).obj().message;
+                                g->m.furn( pos ).obj().message :
+                                g->m.ter( pos ).obj().message;
     if( !message.empty() ) {
         popup( _( message ) );
     }
@@ -2091,7 +2091,7 @@ static bool harvest_common( player &p, const tripoint &examp, bool furn, bool ne
 void iexamine::harvest_furn_nectar( player &p, const tripoint &examp )
 {
     bool const auto_forage = get_option<bool>( "AUTO_FEATURES" ) &&
-                       get_option<std::string>( "AUTO_FORAGING" ) == "both";
+                             get_option<std::string>( "AUTO_FORAGING" ) == "both";
     if( harvest_common( p, examp, true, true, auto_forage ) ) {
         get_map().furn_set( examp, f_null );
     }
@@ -2100,7 +2100,7 @@ void iexamine::harvest_furn_nectar( player &p, const tripoint &examp )
 void iexamine::harvest_furn( player &p, const tripoint &examp )
 {
     bool const auto_forage = get_option<bool>( "AUTO_FEATURES" ) &&
-                       get_option<std::string>( "AUTO_FORAGING" ) == "both";
+                             get_option<std::string>( "AUTO_FORAGING" ) == "both";
     if( harvest_common( p, examp, true, false, auto_forage ) ) {
         get_map().furn_set( examp, f_null );
     }
@@ -2109,9 +2109,9 @@ void iexamine::harvest_furn( player &p, const tripoint &examp )
 void iexamine::harvest_ter_nectar( player &p, const tripoint &examp )
 {
     bool const auto_forage = get_option<bool>( "AUTO_FEATURES" ) &&
-                       ( get_option<std::string>( "AUTO_FORAGING" ) == "both" ||
-                         get_option<std::string>( "AUTO_FORAGING" ) == "bushes" ||
-                         get_option<std::string>( "AUTO_FORAGING" ) == "trees" );
+                             ( get_option<std::string>( "AUTO_FORAGING" ) == "both" ||
+                               get_option<std::string>( "AUTO_FORAGING" ) == "bushes" ||
+                               get_option<std::string>( "AUTO_FORAGING" ) == "trees" );
     if( harvest_common( p, examp, false, true, auto_forage ) ) {
         map &here = get_map();
         here.ter_set( examp, here.get_ter_transforms_into( examp ) );
@@ -2121,8 +2121,8 @@ void iexamine::harvest_ter_nectar( player &p, const tripoint &examp )
 void iexamine::harvest_ter( player &p, const tripoint &examp )
 {
     bool const auto_forage = get_option<bool>( "AUTO_FEATURES" ) &&
-                       ( get_option<std::string>( "AUTO_FORAGING" ) == "both" ||
-                         get_option<std::string>( "AUTO_FORAGING" ) == "trees" );
+                             ( get_option<std::string>( "AUTO_FORAGING" ) == "both" ||
+                               get_option<std::string>( "AUTO_FORAGING" ) == "trees" );
     if( harvest_common( p, examp, false, false, auto_forage ) ) {
         map &here = get_map();
         here.ter_set( examp, here.get_ter_transforms_into( examp ) );
@@ -2627,7 +2627,7 @@ void iexamine::kiln_empty( player &p, const tripoint &examp )
     ///\EFFECT_FABRICATION decreases loss when firing a kiln
     const int skill = p.get_skill_level( skill_fabrication );
     int const loss = 60 - 2 *
-               skill; // We can afford to be inefficient - logs and skeletons are cheap, charcoal isn't
+                     skill; // We can afford to be inefficient - logs and skeletons are cheap, charcoal isn't
 
     // Burn stuff that should get charred, leave out the rest
     units::volume total_volume = 0_ml;
@@ -2757,7 +2757,7 @@ void iexamine::arcfurnace_empty( player &p, const tripoint &examp )
     ///\EFFECT_FABRICATION decreases loss when firing a furnace
     const int skill = p.get_skill_level( skill_fabrication );
     int const loss = 60 - 2 *
-               skill; // Inefficency is still fine, coal and limestone is abundant
+                     skill; // Inefficency is still fine, coal and limestone is abundant
 
     // Burn stuff that should get charred, leave out the rest
     units::volume total_volume = 0_ml;
@@ -3074,7 +3074,7 @@ void iexamine::fvat_empty( player &p, const tripoint &examp )
         brew_type = b_types[b_index];
         brew_nname = item::nname( brew_type );
     } else {
-        item  const&brew = here.i_at( examp ).only_item();
+        item  const &brew = here.i_at( examp ).only_item();
         brew_type = brew.typeId();
         brew_nname = item::nname( brew_type );
         charges_on_ground = brew.charges;
@@ -3163,7 +3163,7 @@ void iexamine::fvat_full( player &p, const tripoint &examp )
         return;
     }
 
-    item  const&brew_i = *items_here.begin();
+    item  const &brew_i = *items_here.begin();
     // Does the vat contain unfermented brew, or already fermented booze?
     // TODO: Allow "recursive brewing" to continue without player having to check on it
     if( brew_i.is_brewable() ) {
@@ -3456,7 +3456,7 @@ static void pick_plant( player &p, const tripoint &examp,
 {
     map &here = get_map();
     bool const auto_forage = get_option<bool>( "AUTO_FEATURES" ) &&
-                       get_option<std::string>( "AUTO_FORAGING" ) != "off";
+                             get_option<std::string>( "AUTO_FORAGING" ) != "off";
     if( p.is_player() && !auto_forage &&
         !query_yn( _( "Harvest the %s?" ), here.tername( examp ) ) ) {
         iexamine::none( p, examp );
@@ -4181,7 +4181,7 @@ void iexamine::curtains( player &p, const tripoint &examp )
 
 void iexamine::sign( player &p, const tripoint &examp )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     std::string const existing_signage = here.get_signage( examp );
     bool const previous_signage_exists = !existing_signage.empty();
 
@@ -4207,20 +4207,20 @@ void iexamine::sign( player &p, const tripoint &examp )
     if( !tools.empty() ) {
         // Different messages if the sign already has writing associated with it.
         std::string const query_message = previous_signage_exists ?
-                                    _( "Overwrite the existing message on the sign?" ) :
-                                    _( "Add a message to the sign?" );
+                                          _( "Overwrite the existing message on the sign?" ) :
+                                          _( "Add a message to the sign?" );
         std::string const ignore_message = _( "You leave the sign alone." );
         if( query_yn( query_message ) ) {
             std::string const signage = string_input_popup()
-                                  .title( _( "Write what?" ) )
-                                  .identifier( "signage" )
-                                  .query_string();
+                                        .title( _( "Write what?" ) )
+                                        .identifier( "signage" )
+                                        .query_string();
             if( signage.empty() ) {
                 p.add_msg_if_player( m_neutral, ignore_message );
             } else {
                 std::string const spray_painted_message = previous_signage_exists ?
-                                                    _( "You overwrite the previous message on the sign with your graffiti." ) :
-                                                    _( "You graffiti a message onto the sign." );
+                        _( "You overwrite the previous message on the sign with your graffiti." ) :
+                        _( "You graffiti a message onto the sign." );
                 here.set_signage( examp, signage );
                 p.add_msg_if_player( m_info, spray_painted_message );
                 p.mod_moves( - 20 * signage.length() );
@@ -4235,7 +4235,7 @@ void iexamine::sign( player &p, const tripoint &examp )
 static int getNearPumpCount( const tripoint &p )
 {
     int result = 0;
-    map  const&here = get_map();
+    map  const &here = get_map();
     for( const tripoint &tmp : here.points_in_radius( p, 12 ) ) {
         const auto t = here.ter( tmp );
         if( t == ter_str_id( "t_gas_pump" ) || t == ter_str_id( "t_gas_pump_a" ) ) {
@@ -4297,7 +4297,7 @@ static int findBestGasDiscount( player &p )
     int discount = 0;
 
     for( size_t i = 0; i < p.inv.size(); i++ ) {
-        item  const&it = p.inv.find_item( i );
+        item  const &it = p.inv.find_item( i );
 
         if( it.has_flag( "GAS_DISCOUNT" ) ) {
 
@@ -4356,7 +4356,7 @@ static int getGasPricePerLiter( int discount )
 
 std::optional<tripoint> iexamine::getGasPumpByNumber( const tripoint &p, int number )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     int k = 0;
     for( const tripoint &tmp : here.points_in_radius( p, 12 ) ) {
         const auto t = here.ter( tmp );
@@ -4480,8 +4480,8 @@ void iexamine::pay_gas( player &p, const tripoint &examp )
     int const pricePerUnit = getGasPricePerLiter( discount );
 
     bool const can_hack = ( !p.has_trait( trait_ILLITERATE ) &&
-                      ( ( p.has_charges( itype_electrohack, 25 ) ) ||
-                        ( p.has_bionic( bio_fingerhack ) && p.get_power_level() > 24_kJ ) ) );
+                            ( ( p.has_charges( itype_electrohack, 25 ) ) ||
+                              ( p.has_bionic( bio_fingerhack ) && p.get_power_level() > 24_kJ ) ) );
 
     uilist amenu;
     amenu.selected = 1;
@@ -4492,7 +4492,7 @@ void iexamine::pay_gas( player &p, const tripoint &examp )
     amenu.addentry( refund, true, 'r', str_to_illiterate_str( _( "Refund cash." ) ) );
 
     std::string const gaspumpselected = str_to_illiterate_str( _( "Current gas pump: " ) ) +
-                                  std::to_string( uistate.ags_pay_gas_selected_pump + 1 );
+                                        std::to_string( uistate.ags_pay_gas_selected_pump + 1 );
     amenu.addentry( 0, false, -1, gaspumpselected );
     amenu.addentry( choose_pump, true, 'p', str_to_illiterate_str( _( "Choose a gas pump." ) ) );
 
@@ -4543,7 +4543,7 @@ void iexamine::pay_gas( player &p, const tripoint &examp )
         int const maximum_liters = std::min( money / pricePerUnit, tankGasUnits / 1000 );
 
         std::string const popupmsg = string_format(
-                                   _( "How many liters of gasoline to buy?  Max: %d L.  (0 to cancel)" ), maximum_liters );
+                                         _( "How many liters of gasoline to buy?  Max: %d L.  (0 to cancel)" ), maximum_liters );
         int liters = string_input_popup()
                      .title( popupmsg )
                      .width( 20 )
@@ -4624,8 +4624,9 @@ void iexamine::ledge( player &p, const tripoint &examp )
     map &here = get_map();
     switch( cmenu.ret ) {
         case ledge_action::jump_over: {
-            tripoint const dest( p.posx() + 2 * sgn( examp.x - p.posx() ), p.posy() + 2 * sgn( examp.y - p.posy() ),
-                           p.posz() );
+            tripoint const dest( p.posx() + 2 * sgn( examp.x - p.posx() ),
+                                 p.posy() + 2 * sgn( examp.y - p.posy() ),
+                                 p.posz() );
             if( p.get_str() < 4 ) {
                 add_msg( m_warning, _( "You are too weak to jump over an obstacle." ) );
             } else if( 100 * p.weight_carried() / p.weight_capacity() > 25 ) {
@@ -4750,8 +4751,9 @@ void iexamine::ledge( player &p, const tripoint &examp )
                 p.add_msg_if_player( _( "There is nothing for your to attach your web to!" ) );
             } else {
                 for( int i = 1; i < success_range; i++ ) {
-                    tripoint const dest( p.posx() + i * sgn( examp.x - p.posx() ), p.posy() + i * sgn( examp.y - p.posy() ),
-                                   p.posz() );
+                    tripoint const dest( p.posx() + i * sgn( examp.x - p.posx() ),
+                                         p.posy() + i * sgn( examp.y - p.posy() ),
+                                         p.posz() );
 
                     g->m.ter_set( dest, t_web_bridge );
                 }
@@ -4788,7 +4790,7 @@ static player &player_on_couch( player &p, const tripoint &autodoc_loc, player &
 static Character &operator_present( Character &p, const tripoint &autodoc_loc,
                                     Character &null_patient )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     for( const auto &loc : here.points_in_radius( autodoc_loc, 1 ) ) {
         if( !here.has_flag_furn_or_vpart( flag_AUTODOC_COUCH, loc ) ) {
             if( p.pos() == loc ) {
@@ -4838,8 +4840,8 @@ static item &cyborg_on_couch( const tripoint &couch_pos, item &null_cyborg )
 static player &best_installer( player &p, player &null_player, int difficulty )
 {
     float const player_skill = p.bionics_adjusted_skill( skill_firstaid,
-                         skill_computer,
-                         skill_electronics );
+                               skill_computer,
+                               skill_electronics );
 
     std::vector< std::pair<float, int>> ally_skills;
     ally_skills.reserve( g->allies().size() );
@@ -5000,7 +5002,7 @@ void iexamine::autodoc( player &p, const tripoint &examp )
                 flag_AUTODOC, false ) ) {
         auto dest_veh = &vp->vehicle();
         int const dest_part = vp->part_index();
-        for( item  const&it : dest_veh->get_items( dest_part ) ) {
+        for( item  const &it : dest_veh->get_items( dest_part ) ) {
             if( it.typeId() == itype_arm_splint ) {
                 arm_splints.push_back( it );
             }
@@ -5166,7 +5168,7 @@ void iexamine::autodoc( player &p, const tripoint &examp )
             for( int i = 0; i < num_hp_parts; i++ ) {
                 const bodypart_id &part = convert_bp( player::hp_to_bp( static_cast<hp_part>( i ) ) ).id();
                 const bool broken = patient.is_limb_broken( part );
-                effect  const&existing_effect = patient.get_effect( effect_mending, part->token );
+                effect  const &existing_effect = patient.get_effect( effect_mending, part->token );
                 // Skip part if not broken or already healed 50%
                 if( !broken || ( !existing_effect.is_null() &&
                                  existing_effect.get_duration() >
@@ -5610,7 +5612,8 @@ static void smoker_load_food( player &p, const tripoint &examp,
     inv.remove_items_with( []( const item & it ) {
         return it.rotten();
     } );
-    std::vector<const item *> const filtered = p.crafting_inventory().items_with( []( const item & it ) {
+    std::vector<const item *> const filtered = p.crafting_inventory().items_with( [](
+    const item & it ) {
         return it.has_flag( flag_SMOKABLE );
     } );
 
@@ -5663,11 +5666,11 @@ static void smoker_load_food( player &p, const tripoint &examp,
     const std::string popupmsg = string_format( _( "Insert how many %s into the rack?" ),
                                  item::nname( what->typeId(), count ) );
     int const amount = string_input_popup()
-                 .title( popupmsg )
-                 .width( 20 )
-                 .text( std::to_string( max_count ) )
-                 .only_digits( true )
-                 .query_int();
+                       .title( popupmsg )
+                       .width( 20 )
+                       .text( std::to_string( max_count ) )
+                       .only_digits( true )
+                       .query_int();
 
     if( amount == 0 ) {
         add_msg( m_info, _( "Never mind." ) );
@@ -5691,7 +5694,7 @@ static void smoker_load_food( player &p, const tripoint &examp,
     } );
 
     comp_selection<item_comp> const selected = p.select_item_component( comps, 1, inv, true,
-                                         is_non_rotten_crafting_component );
+            is_non_rotten_crafting_component );
     std::list<item> const moved = p.consume_items( selected, 1, is_non_rotten_crafting_component );
 
     for( const item &m : moved ) {
@@ -5718,7 +5721,8 @@ static void mill_load_food( player &p, const tripoint &examp,
     inv.remove_items_with( []( const item & it ) {
         return it.rotten();
     } );
-    std::vector<const item *> const filtered = p.crafting_inventory().items_with( []( const item & it ) {
+    std::vector<const item *> const filtered = p.crafting_inventory().items_with( [](
+    const item & it ) {
         return static_cast<bool>( it.type->milling_data );
     } );
 
@@ -5771,11 +5775,11 @@ static void mill_load_food( player &p, const tripoint &examp,
     const std::string popupmsg = string_format( _( "Insert how many %s into the mill?" ),
                                  item::nname( what->typeId(), count ) );
     int const amount = string_input_popup()
-                 .title( popupmsg )
-                 .width( 20 )
-                 .text( std::to_string( max_count ) )
-                 .only_digits( true )
-                 .query_int();
+                       .title( popupmsg )
+                       .width( 20 )
+                       .text( std::to_string( max_count ) )
+                       .only_digits( true )
+                       .query_int();
 
     if( amount == 0 ) {
         add_msg( m_info, _( "Never mind." ) );
@@ -5799,7 +5803,7 @@ static void mill_load_food( player &p, const tripoint &examp,
     } );
 
     comp_selection<item_comp> const selected = p.select_item_component( comps, 1, inv, true,
-                                         is_non_rotten_crafting_component );
+            is_non_rotten_crafting_component );
     std::list<item> const moved = p.consume_items( selected, 1, is_non_rotten_crafting_component );
     for( const item &m : moved ) {
         here.add_item( examp, m );
@@ -5812,7 +5816,7 @@ static void mill_load_food( player &p, const tripoint &examp,
 
 void iexamine::on_smoke_out( const tripoint &examp, const time_point &start_time )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     if( here.furn( examp ) == furn_str_id( "f_smoking_rack_active" ) ||
         here.furn( examp ) == furn_str_id( "f_metal_smoking_rack_active" ) ) {
         smoker_finalize( g->u, examp, start_time );
@@ -5934,7 +5938,7 @@ void iexamine::quern_examine( player &p, const tripoint &examp )
                     }
                     mill_list[it] += it.count();
                 }
-                for( const auto& it_mill : mill_list ) {
+                for( const auto &it_mill : mill_list ) {
                     pop += "-> " + item::nname( it_mill.first.typeId(),
                                                 it_mill.first.count() ) + ( ( it_mill.second > 1 ) ? " (" + std::to_string(
                                                             it_mill.second ) + ")\n" : "\n" );

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -166,9 +166,9 @@ void DynamicDataLoader::load_deferred( deferred_json &data )
                 debugmsg( "JSON source location has null path, data may load incorrectly" );
             } else {
                 try {
-                    shared_ptr_fast<std::istream> stream = get_cached_stream( *it->first.path );
+                    shared_ptr_fast<std::istream> const stream = get_cached_stream( *it->first.path );
                     JsonIn jsin( *stream, it->first );
-                    JsonObject jo = jsin.get_object();
+                    JsonObject const jo = jsin.get_object();
                     load_object( jo, it->second );
                 } catch( const JsonError &err ) {
                     debugmsg( "(json-error)\n%s", err.what() );
@@ -184,7 +184,7 @@ void DynamicDataLoader::load_deferred( deferred_json &data )
                     debugmsg( "JSON source location has null path when reporting circular dependency" );
                 } else {
                     try {
-                        shared_ptr_fast<std::istream> stream = get_cached_stream( *it->first.path );
+                        shared_ptr_fast<std::istream> const stream = get_cached_stream( *it->first.path );
                         JsonIn jsin( *stream, elem.first );
                         jsin.error( "JSON contains circular dependency, this object is discarded" );
                     } catch( const JsonError &err ) {
@@ -477,7 +477,7 @@ void DynamicDataLoader::load_data_from_path( const std::string &path, const std:
     // get a list of all files in the directory
     str_vec files = get_files_from_path( ".json", path, true, true );
     if( files.empty() ) {
-        std::ifstream tmp( path.c_str(), std::ios::in );
+        std::ifstream const tmp( path.c_str(), std::ios::in );
         if( tmp ) {
             // path is actually a file, don't checking the extension,
             // assume we want to load this file anyway
@@ -642,7 +642,7 @@ void DynamicDataLoader::finalize_loaded_data( loading_ui &ui )
     assert( !finalized && "Can't finalize the data twice." );
     assert( !stream_cache && "Expected stream cache to be null before finalization" );
 
-    on_out_of_scope reset_stream_cache( [this]() {
+    on_out_of_scope const reset_stream_cache( [this]() {
         stream_cache.reset();
     } );
     stream_cache = std::make_unique<cached_streams>();
@@ -1033,7 +1033,7 @@ bool init::check_mods_for_errors( loading_ui &ui, const std::vector<mod_id> &opt
             std::cerr << "Error loading data: " << err.what() << std::endl;
         }
 
-        std::string world_name = world_generator->active_world->world_name;
+        std::string const world_name = world_generator->active_world->world_name;
         world_generator->delete_world( world_name, true );
 
         // TODO: Why would we need these calls?

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -608,8 +608,10 @@ void input_context::clear_conflicting_keybindings( const input_event &event )
     for( std::vector<std::string>::const_iterator registered_action = registered_actions.begin();
          registered_action != registered_actions.end();
          ++registered_action ) {
-        input_manager::t_actions::iterator const default_action = default_actions.find( *registered_action );
-        input_manager::t_actions::iterator const category_action = category_actions.find( *registered_action );
+        input_manager::t_actions::iterator const default_action = default_actions.find(
+                    *registered_action );
+        input_manager::t_actions::iterator const category_action = category_actions.find(
+                    *registered_action );
         if( default_action != default_actions.end() ) {
             std::vector<input_event> &events = default_action->second.input_events;
             events.erase( std::remove( events.begin(), events.end(), event ), events.end() );

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -111,8 +111,8 @@ input_manager inp_mngr;
 void input_manager::init()
 {
     std::map<char, action_id> keymap;
-    std::string keymap_file_loaded_from;
-    std::set<action_id> unbound_keymap;
+    std::string const keymap_file_loaded_from;
+    std::set<action_id> const unbound_keymap;
     init_keycode_mapping();
     reset_timeout();
 
@@ -198,7 +198,7 @@ void input_manager::load( const std::string &file_name, bool is_user_preferences
     jsin.start_array();
     while( !jsin.end_array() ) {
         // JSON object representing the action
-        JsonObject action = jsin.get_object();
+        JsonObject const action = jsin.get_object();
 
         const std::string type = action.get_string( "type", "keybinding" );
         if( type != "keybinding" ) {
@@ -220,7 +220,7 @@ void input_manager::load( const std::string &file_name, bool is_user_preferences
 
         t_input_event_list events;
         for( const JsonObject keybinding : action.get_array( "bindings" ) ) {
-            std::string input_method = keybinding.get_string( "input_method" );
+            std::string const input_method = keybinding.get_string( "input_method" );
             input_event new_event;
             if( input_method == "keyboard" ) {
                 new_event.type = CATA_INPUT_KEYBOARD;
@@ -283,7 +283,7 @@ void input_manager::save()
 
                 jsout.member( "id", action.first );
                 jsout.member( "category", a->first );
-                bool is_user_created = action.second.is_user_created;
+                bool const is_user_created = action.second.is_user_created;
                 if( is_user_created ) {
                     jsout.member( "is_user_created", is_user_created );
                 }
@@ -342,7 +342,7 @@ void input_manager::init_keycode_mapping()
     // Between space and tilde, all keys more or less map
     // to themselves(see ASCII table)
     for( char c = char_key_beg; c <= char_key_end; c++ ) {
-        std::string name( 1, c );
+        std::string const name( 1, c );
         add_keycode_pair( c, name );
     }
 
@@ -550,7 +550,7 @@ void input_manager::remove_input_for_action(
     const t_action_contexts::iterator action_context = action_contexts.find( context );
     if( action_context != action_contexts.end() ) {
         t_actions &actions = action_context->second;
-        t_actions::iterator action = actions.find( action_descriptor );
+        t_actions::iterator const action = actions.find( action_descriptor );
         if( action != actions.end() ) {
             if( action->second.is_user_created ) {
                 // Since this is a user created hotkey, remove it so that the
@@ -608,8 +608,8 @@ void input_context::clear_conflicting_keybindings( const input_event &event )
     for( std::vector<std::string>::const_iterator registered_action = registered_actions.begin();
          registered_action != registered_actions.end();
          ++registered_action ) {
-        input_manager::t_actions::iterator default_action = default_actions.find( *registered_action );
-        input_manager::t_actions::iterator category_action = category_actions.find( *registered_action );
+        input_manager::t_actions::iterator const default_action = default_actions.find( *registered_action );
+        input_manager::t_actions::iterator const category_action = category_actions.find( *registered_action );
         if( default_action != default_actions.end() ) {
             std::vector<input_event> &events = default_action->second.input_events;
             events.erase( std::remove( events.begin(), events.end(), event ), events.end() );
@@ -1022,9 +1022,9 @@ action_id input_context::display_menu( const bool permit_execute_action )
     size_t legwidth = 0;
     string_input_popup spopup;
     const auto recalc_size = [&]( ui_adaptor & ui ) {
-        int maxwidth = std::max( FULL_SCREEN_WIDTH, TERMX );
+        int const maxwidth = std::max( FULL_SCREEN_WIDTH, TERMX );
         width = min( 80, maxwidth );
-        int maxheight = std::max( FULL_SCREEN_HEIGHT, TERMY );
+        int const maxheight = std::max( FULL_SCREEN_HEIGHT, TERMY );
         height = min( maxheight, static_cast<int>( hotkeys.size() ) + LEGEND_HEIGHT + BORDER_SPACE );
 
         w_help = catacurses::newwin( height - 2, width - 2,
@@ -1130,7 +1130,7 @@ action_id input_context::display_menu( const bool permit_execute_action )
     ui.on_redraw( redraw );
 
     // do not switch IME mode now, but restore previous mode on return
-    ime_sentry sentry( ime_sentry::keep );
+    ime_sentry const sentry( ime_sentry::keep );
     while( true ) {
         ui_manager::redraw();
 
@@ -1176,7 +1176,7 @@ action_id input_context::display_menu( const bool permit_execute_action )
             // Check if this entry is local or global.
             bool is_local = false;
             const action_attributes &actions = inp_mngr.get_action_attributes( action_id, category, &is_local );
-            bool is_empty = actions.input_events.empty();
+            bool const is_empty = actions.input_events.empty();
             const std::string name = get_action_name( action_id );
 
             // We don't want to completely delete a global context entry.

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -73,8 +73,8 @@ invlet_favorites::invlet_favorites( const std::unordered_map<itype_id, std::stri
             continue;
         }
         invlets_by_id.insert( p );
-        for( char invlet : p.second ) {
-            uint8_t invlet_u = invlet;
+        for( char const invlet : p.second ) {
+            uint8_t const invlet_u = invlet;
             if( !ids_by_invlet[invlet_u].is_empty() ) {
                 debugmsg( "Duplicate invlet: %s and %s both mapped to %c",
                           ids_by_invlet[invlet_u].str(), p.first.str(), invlet );
@@ -90,27 +90,27 @@ void invlet_favorites::set( char invlet, const itype_id &id )
         return;
     }
     erase( invlet );
-    uint8_t invlet_u = invlet;
+    uint8_t const invlet_u = invlet;
     ids_by_invlet[invlet_u] = id;
     invlets_by_id[id].push_back( invlet );
 }
 
 void invlet_favorites::erase( char invlet )
 {
-    uint8_t invlet_u = invlet;
+    uint8_t const invlet_u = invlet;
     const itype_id &id = ids_by_invlet[invlet_u];
     if( id.is_empty() ) {
         return;
     }
     std::string &invlets = invlets_by_id[id];
-    std::string::iterator it = std::find( invlets.begin(), invlets.end(), invlet );
+    std::string::iterator const it = std::find( invlets.begin(), invlets.end(), invlet );
     invlets.erase( it );
     ids_by_invlet[invlet_u] = itype_id();
 }
 
 bool invlet_favorites::contains( char invlet, const itype_id &id ) const
 {
-    uint8_t invlet_u = invlet;
+    uint8_t const invlet_u = invlet;
     return ids_by_invlet[invlet_u] == id;
 }
 
@@ -291,7 +291,7 @@ item &inventory::add_item( item newit, bool keep_invlet, bool assign_invlet, boo
     if( should_stack ) {
         // See if we can't stack this item.
         for( auto &elem : items ) {
-            std::list<item>::iterator it_ref = elem.begin();
+            std::list<item>::iterator const it_ref = elem.begin();
             if( it_ref->stacks_with( newit ) ) {
                 if( it_ref->merge_charges( newit ) ) {
                     return *it_ref;
@@ -329,7 +329,7 @@ void inventory::build_items_type_cache()
 {
     items_type_cache.clear();
     for( auto &elem : items ) {
-        itype_id type = elem.front().typeId();
+        itype_id const type = elem.front().typeId();
         items_type_cache[type].push_back( &elem );
     }
     items_type_cached = true;
@@ -343,7 +343,7 @@ item &inventory::add_item_by_items_type_cache( item newit, bool keep_invlet, boo
         debugmsg( "Tried to add item to inventory using cache without building the items_type_cache." );
         build_items_type_cache();
     }
-    itype_id type = newit.typeId();
+    itype_id const type = newit.typeId();
     if( should_stack ) {
         // See if we can't stack this item.
         for( auto &elem : items_type_cache[type] ) {
@@ -498,7 +498,7 @@ void inventory::form_from_map( map &m, const tripoint &origin, int range, const 
         m.reachable_flood_steps( reachable_pts, origin, range, 1, 100 );
     } else {
         // Fill reachable points with points_in_radius
-        tripoint_range<tripoint> in_radius = m.points_in_radius( origin, range );
+        tripoint_range<tripoint> const in_radius = m.points_in_radius( origin, range );
         for( const tripoint &p : in_radius ) {
             reachable_pts.emplace_back( p );
         }
@@ -533,7 +533,7 @@ void inventory::form_from_map( map &m, std::vector<tripoint> pts, const Characte
             }
         }
         if( m.has_items( p ) && m.accessible_items( p ) ) {
-            bool allow_liquids = m.has_flag_ter_or_furn( "LIQUIDCONT", p );
+            bool const allow_liquids = m.has_flag_ter_or_furn( "LIQUIDCONT", p );
             for( auto &i : m.i_at( p ) ) {
                 // if it's *the* player requesting this from from map inventory
                 // then don't allow items owned by another faction to be factored into recipe components etc.
@@ -552,7 +552,7 @@ void inventory::form_from_map( map &m, std::vector<tripoint> pts, const Characte
             add_item_by_items_type_cache( fire );
         }
         // Handle any water from infinite map sources.
-        item water = m.water_from( p );
+        item const water = m.water_from( p );
         if( !water.is_null() ) {
             add_item_by_items_type_cache( water );
         }
@@ -738,7 +738,7 @@ item inventory::remove_item( const int position )
             items_type_cached = false;
             if( iter->size() > 1 ) {
                 std::list<item>::iterator stack_member = iter->begin();
-                char invlet = stack_member->invlet;
+                char const invlet = stack_member->invlet;
                 ++stack_member;
                 stack_member->invlet = invlet;
             }
@@ -919,7 +919,7 @@ int inventory::worst_item_value( npc *p ) const
     int worst = 99999;
     for( const auto &elem : items ) {
         const item &it = elem.front();
-        int val = p->value( it );
+        int const val = p->value( it );
         if( val < worst ) {
             worst = val;
         }
@@ -946,7 +946,7 @@ item *inventory::most_appropriate_painkiller( int pain )
     item *ret = &null_item_reference();
     for( auto &elem : items ) {
         int diff = 9999;
-        itype_id type = elem.front().typeId();
+        itype_id const type = elem.front().typeId();
         if( type == itype_aspirin ) {
             diff = std::abs( pain - 15 );
         } else if( type == itype_codeine ) {
@@ -1156,7 +1156,7 @@ void inventory::assign_empty_invlet( item &it, const Character &p, const bool fo
     }
 
     invlets_bitset cur_inv = p.allocated_invlets();
-    itype_id target_type = it.typeId();
+    itype_id const target_type = it.typeId();
     for( auto iter : assigned_invlet ) {
         if( iter.second == target_type && !cur_inv[iter.first] ) {
             it.invlet = iter.first;
@@ -1167,7 +1167,7 @@ void inventory::assign_empty_invlet( item &it, const Character &p, const bool fo
         // XXX YUCK I don't know how else to get the keybindings
         // FIXME: Find a better way to get bound keys
         avatar &u = g->u;
-        inventory_selector selector( u );
+        inventory_selector const selector( u );
 
         std::vector<char> binds = selector.all_bound_keys();
 
@@ -1231,7 +1231,7 @@ void inventory::update_invlet( item &newit, bool assign_invlet )
 
     // Remove letters that have been assigned to other items in the inventory
     if( newit.invlet ) {
-        char tmp_invlet = newit.invlet;
+        char const tmp_invlet = newit.invlet;
         newit.invlet = '\0';
         if( g->u.invlet_to_item( tmp_invlet ) == nullptr ) {
             newit.invlet = tmp_invlet;

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -1146,7 +1146,7 @@ void inventory_selector::add_entry( inventory_column &target_column,
 
     is_empty = false;
     inventory_entry const entry( locations, custom_category,
-                           preset.get_denial( locations.front() ).empty() );
+                                 preset.get_denial( locations.front() ).empty() );
 
     target_column.add_entry( entry );
 
@@ -1659,7 +1659,7 @@ void inventory_selector::draw_footer( const catacurses::window &w ) const
         int filter_offset = 0;
         if( has_available_choices() || !filter.empty() ) {
             std::string const text = string_format( filter.empty() ? _( "[%s] Filter" ) : _( "[%s] Filter: " ),
-                                              ctxt.get_desc( "INVENTORY_FILTER" ) );
+                                                    ctxt.get_desc( "INVENTORY_FILTER" ) );
             filter_offset = utf8_width( text + filter ) + 6;
 
             mvwprintz( w, point( 2, getmaxy( w ) - border ), c_light_gray, "< " );

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -644,7 +644,7 @@ void inventory_column::set_stack_favorite( const item_location &location, bool f
     std::list<item *> to_favorite;
 
     if( location.where() == item_location::type::character ) {
-        int position = g->u.get_item_position( selected_item );
+        int const position = g->u.get_item_position( selected_item );
 
         if( position < 0 ) {
             g->u.i_at( position ).set_favorite( !selected_item->is_favorite ); // worn/wielded
@@ -883,7 +883,7 @@ void inventory_column::draw( const catacurses::window &win, point pos ) const
 
         int x1 = pos.x + get_entry_indent( entry );
         int x2 = pos.x + std::max( static_cast<int>( reserved_width - get_cells_width() ), 0 );
-        int yy = pos.y + line;
+        int const yy = pos.y + line;
 
         const bool selected = active && is_selected( entry );
 
@@ -918,7 +918,7 @@ void inventory_column::draw( const catacurses::window &win, point pos ) const
             x2 += cells[cell_index].current_width;
 
             size_t text_width = utf8_width( entry_cell_cache.text[cell_index], true );
-            size_t text_gap = cell_index > 0 ? std::max( cells[cell_index].gap(), min_cell_gap ) : 0;
+            size_t const text_gap = cell_index > 0 ? std::max( cells[cell_index].gap(), min_cell_gap ) : 0;
             size_t available_width = x2 - x1 - text_gap;
 
             if( text_width > available_width ) {
@@ -1027,7 +1027,7 @@ void selection_column::prepare_paging( const std::string &filter )
 
 void selection_column::on_change( const inventory_entry &entry )
 {
-    inventory_entry my_entry( entry, &*selected_cat );
+    inventory_entry const my_entry( entry, &*selected_cat );
 
     auto iter = std::find( entries.begin(), entries.end(), my_entry );
 
@@ -1145,12 +1145,12 @@ void inventory_selector::add_entry( inventory_column &target_column,
     }
 
     is_empty = false;
-    inventory_entry entry( locations, custom_category,
+    inventory_entry const entry( locations, custom_category,
                            preset.get_denial( locations.front() ).empty() );
 
     target_column.add_entry( entry );
 
-    shared_ptr_fast<ui_adaptor> current_ui = ui.lock();
+    shared_ptr_fast<ui_adaptor> const current_ui = ui.lock();
     if( current_ui ) {
         current_ui->mark_resize();
     }
@@ -1522,7 +1522,7 @@ void inventory_selector::resize_window( int width, int height )
     if( spopup ) {
         spopup->window( w_inv, point( 4, getmaxy( w_inv ) - 1 ), ( getmaxx( w_inv ) / 2 ) - 4 );
     }
-    shared_ptr_fast<ui_adaptor> current_ui = ui.lock();
+    shared_ptr_fast<ui_adaptor> const current_ui = ui.lock();
     if( current_ui ) {
         current_ui->position_from_window( w_inv );
     }
@@ -1548,12 +1548,12 @@ void inventory_selector::set_filter()
     spopup->max_length( 256 )
     .text( filter );
 
-    shared_ptr_fast<ui_adaptor> current_ui = ui.lock();
+    shared_ptr_fast<ui_adaptor> const current_ui = ui.lock();
     if( current_ui ) {
         current_ui->mark_resize();
     }
 
-    ime_sentry sentry;
+    ime_sentry const sentry;
 
     do {
         ui_manager::redraw();
@@ -1580,7 +1580,7 @@ void inventory_selector::set_filter( const std::string &str )
     for( const auto elem : columns ) {
         elem->set_filter( filter );
     }
-    shared_ptr_fast<ui_adaptor> current_ui = ui.lock();
+    shared_ptr_fast<ui_adaptor> const current_ui = ui.lock();
     if( current_ui ) {
         current_ui->mark_resize();
     }
@@ -1607,7 +1607,7 @@ void inventory_selector::draw_columns( const catacurses::window &w ) const
                                    ? free_space % ( columns.size() - 1 ) : 0;
 
     size_t x = border + 1;
-    size_t y = get_header_height() + border + 1;
+    size_t const y = get_header_height() + border + 1;
     size_t active_x = 0;
 
     for( const auto &elem : columns ) {
@@ -1658,7 +1658,7 @@ void inventory_selector::draw_footer( const catacurses::window &w ) const
     } else {
         int filter_offset = 0;
         if( has_available_choices() || !filter.empty() ) {
-            std::string text = string_format( filter.empty() ? _( "[%s] Filter" ) : _( "[%s] Filter: " ),
+            std::string const text = string_format( filter.empty() ? _( "[%s] Filter" ) : _( "[%s] Filter: " ),
                                               ctxt.get_desc( "INVENTORY_FILTER" ) );
             filter_offset = utf8_width( text + filter ) + 6;
 
@@ -1882,7 +1882,7 @@ const navigation_mode_data &inventory_selector::get_navigation_data( navigation_
 std::string inventory_selector::action_bound_to_key( char key ) const
 {
     for( const std::string &action_descriptor : ctxt.get_registered_actions_copy() ) {
-        for( char bound_key : ctxt.keys_bound_to( action_descriptor ) ) {
+        for( char const bound_key : ctxt.keys_bound_to( action_descriptor ) ) {
             if( key == bound_key ) {
                 return action_descriptor;
             }
@@ -1903,7 +1903,7 @@ std::vector<char> inventory_selector::all_bound_keys() const
 
 item_location inventory_pick_selector::execute()
 {
-    shared_ptr_fast<ui_adaptor> ui = create_or_get_ui_adaptor();
+    shared_ptr_fast<ui_adaptor> const ui = create_or_get_ui_adaptor();
     while( true ) {
         ui_manager::redraw();
 
@@ -1960,7 +1960,7 @@ inventory_compare_selector::inventory_compare_selector( player &p ) :
 
 std::pair<const item *, const item *> inventory_compare_selector::execute()
 {
-    shared_ptr_fast<ui_adaptor> ui = create_or_get_ui_adaptor();
+    shared_ptr_fast<ui_adaptor> const ui = create_or_get_ui_adaptor();
     while( true ) {
         ui_manager::redraw();
 
@@ -2037,7 +2037,7 @@ inventory_iuse_selector::inventory_iuse_selector(
 
 std::list<iuse_location> inventory_iuse_selector::execute()
 {
-    shared_ptr_fast<ui_adaptor> ui = create_or_get_ui_adaptor();
+    shared_ptr_fast<ui_adaptor> const ui = create_or_get_ui_adaptor();
 
     int count = 0;
     while( true ) {
@@ -2174,7 +2174,7 @@ void inventory_drop_selector::process_selected( int &count,
 
 drop_locations inventory_drop_selector::execute()
 {
-    shared_ptr_fast<ui_adaptor> ui = create_or_get_ui_adaptor();
+    shared_ptr_fast<ui_adaptor> const ui = create_or_get_ui_adaptor();
     this->keep_open = false;
 
     // if we favorited an item, we exited this function and entered it again
@@ -2288,7 +2288,7 @@ drop_locations inventory_drop_selector::execute()
     drop_locations dropped_pos_and_qty;
 
     for( const std::pair<const item *const, int>  &drop_pair : dropping ) {
-        item_location loc( u, const_cast<item *>( drop_pair.first ) );
+        item_location const loc( u, const_cast<item *>( drop_pair.first ) );
         // Note: drop_location here contains location of first item in stack,
         // and amount of items to be dropped from the stack.
         dropped_pos_and_qty.emplace_back( loc, drop_pair.second );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8940,7 +8940,7 @@ uint64_t item::make_component_hash() const
     }
 
     std::string concatenated_ids;
-    for( std::string const id : id_set ) {
+    for( std::string const& id : id_set ) {
         concatenated_ids += id;
     }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -388,7 +388,8 @@ item::item( const itype *type, time_point turn, int qty ) : type( type ), bday( 
     }
 
     if( has_flag( flag_NANOFAB_TEMPLATE ) ) {
-        itype_id const nanofab_recipe = item_group::item_from( item_group_id( "nanofab_recipes" ) ).typeId();
+        itype_id const nanofab_recipe = item_group::item_from(
+                                            item_group_id( "nanofab_recipes" ) ).typeId();
         set_var( "NANOFAB_ITEM_ID", nanofab_recipe.str() );
     }
 
@@ -483,7 +484,7 @@ item::item( const recipe *rec, int qty, std::list<item> items, std::vector<item_
         }
     }
 
-    for( item  const&component : components ) {
+    for( item  const &component : components ) {
         for( const std::string &f : component.item_tags ) {
             if( json_flag::get( f ).craft_inherit() ) {
                 set_flag( f );
@@ -1125,7 +1126,7 @@ static std::string get_freshness_description( const item &food_item )
     if( time_left > shelf_life ) {
         time_left = shelf_life;
     }
-    avatar  const&you = get_avatar();
+    avatar  const &you = get_avatar();
     if( food_item.is_fresh() ) {
         // Fresh food is assumed to be obviously so regardless of skill.
         if( you.can_estimate_rot() ) {
@@ -1354,7 +1355,7 @@ double item::effective_dps( const player &guy, const monster &mon ) const
     double total_moves = ( hit_trials - num_all_hits ) * moves_per_attack;
     double total_damage = 0.0;
     double const num_crits = std::min( num_low_hits * crit_chance + num_high_hits * double_crit_chance,
-                                 num_all_hits );
+                                       num_all_hits );
     // critical hits are counted separately
     double const num_hits = num_all_hits - num_crits;
     // sum average damage past armor and return the number of moves required to achieve
@@ -1556,7 +1557,7 @@ void item::basic_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
         // Display any minimal stat or skill requirements for the item
         std::vector<std::string> req;
         if( get_min_str() > 0 ) {
-            avatar  const&viewer = get_avatar();
+            avatar  const &viewer = get_avatar();
             if( has_flag( flag_STR_DRAW ) && ranged::get_str_draw_penalty( *this, viewer ) < 1.0f ) {
                 if( ranged::get_str_draw_penalty( *this, viewer ) < 0.5f ) {
                     req.push_back( string_format( _( "%s %d <color_magenta>(Can't use!)</color>" ), _( "strength" ),
@@ -1656,7 +1657,7 @@ void item::med_info( const item *med_item, std::vector<iteminfo> &info, const it
 
     if( med_com->stim != 0 && parts->test( iteminfo_parts::MED_STIMULATION ) ) {
         std::string const name = string_format( "%s <stat>%s</stat>", _( "Stimulation:" ),
-                                          med_com->stim > 0 ? _( "Upper" ) : _( "Downer" ) );
+                                                med_com->stim > 0 ? _( "Upper" ) : _( "Downer" ) );
         info.push_back( iteminfo( "MED", name ) );
     }
 
@@ -1687,7 +1688,7 @@ void item::food_info( const item *food_item, std::vector<iteminfo> &info,
     }
 
     bool const show_nutr = parts->test( iteminfo_parts::FOOD_NUTRITION ) ||
-                     parts->test( iteminfo_parts::FOOD_VITAMINS );
+                           parts->test( iteminfo_parts::FOOD_VITAMINS );
     if( min_nutr != max_nutr && show_nutr ) {
         info.emplace_back(
             "FOOD", _( "Nutrition will <color_cyan>vary with chosen ingredients</color>." ) );
@@ -2023,7 +2024,7 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
     const std::string space = "  ";
     const islot_gun &gun = *mod->type->gun;
     const Skill &skill = *mod->gun_skill();
-    avatar  const&viewer = get_avatar();
+    avatar  const &viewer = get_avatar();
 
     // many statistics are dependent upon loaded ammo
     // if item is unloaded (or is RELOAD_AND_SHOOT) shows approximate stats using default ammo
@@ -2347,7 +2348,7 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
         std::map<gunmod_location, int> const mod_locations = get_mod_locations();
 
         int iternum = 0;
-        for( std::pair<const gunmod_location, int>  const&elem : mod_locations ) {
+        for( std::pair<const gunmod_location, int>  const &elem : mod_locations ) {
             if( iternum != 0 ) {
                 mod_str += "; ";
             }
@@ -2375,7 +2376,7 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
     if( mod->casings_count() && parts->test( iteminfo_parts::DESCRIPTION_GUN_CASINGS ) ) {
         insert_separation_line( info );
         std::string const tmp = vgettext( "Contains <stat>%i</stat> casing",
-                                    "Contains <stat>%i</stat> casings", mod->casings_count() );
+                                          "Contains <stat>%i</stat> casings", mod->casings_count() );
         info.emplace_back( "DESCRIPTION", string_format( tmp, mod->casings_count() ) );
     }
 }
@@ -2447,7 +2448,7 @@ void item::gunmod_info( std::vector<iteminfo> &info, const iteminfo_query *parts
         std::map<gunmod_location, int> const mod_locations = mod.add_mod;
 
         int iternum = 0;
-        for( std::pair<const gunmod_location, int>  const&elem : mod_locations ) {
+        for( std::pair<const gunmod_location, int>  const &elem : mod_locations ) {
             if( iternum != 0 ) {
                 mod_loc_str += "; ";
             }
@@ -2556,7 +2557,7 @@ void item::armor_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
         return;
     }
 
-    avatar  const&you = get_avatar();
+    avatar  const &you = get_avatar();
     int const encumbrance = get_encumber( you );
     const sizing sizing_level = get_sizing( you, encumbrance != 0 );
     const std::string space = "  ";
@@ -2764,7 +2765,7 @@ void item::armor_fit_info( std::vector<iteminfo> &info, const iteminfo_query *pa
         return;
     }
 
-    avatar  const&you = get_avatar();
+    avatar  const &you = get_avatar();
     int const encumbrance = get_encumber( you );
     const sizing sizing_level = get_sizing( you, encumbrance != 0 );
 
@@ -2878,7 +2879,7 @@ void item::armor_fit_info( std::vector<iteminfo> &info, const iteminfo_query *pa
                         break;
                 }
                 std::string const info_str = string_format( _( "* This clothing <info>can be "
-                                                      "refitted</info>%s." ), resize_str );
+                                             "refitted</info>%s." ), resize_str );
                 info.push_back( iteminfo( "DESCRIPTION", info_str ) );
             }
         } else {
@@ -2921,7 +2922,7 @@ void item::book_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
         return;
     }
 
-    Character  const&character = get_player_character();
+    Character  const &character = get_player_character();
 
     insert_separation_line( info );
     const islot_book &book = *type->book;
@@ -3007,8 +3008,8 @@ void item::book_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
     if( book.chapters > 0 && parts->test( iteminfo_parts::BOOK_NUMUNREADCHAPTERS ) ) {
         const int unread = get_remaining_chapters( you );
         std::string const fmt = vgettext( "This book has <num> <info>unread chapter</info>.",
-                                    "This book has <num> <info>unread chapters</info>.",
-                                    unread );
+                                          "This book has <num> <info>unread chapters</info>.",
+                                          unread );
         info.push_back( iteminfo( "BOOK", "", fmt, iteminfo::no_flags, unread ) );
     }
 
@@ -3958,7 +3959,7 @@ void item::final_info( std::vector<iteminfo> &info, const iteminfo_query &parts_
                     std::back_inserter( result_names ),
                 [&crafting_inv]( const recipe * r ) {
                     bool const can_make = r->deduped_requirements().can_make_with_inventory(
-                                        crafting_inv, r->get_component_filter() );
+                                              crafting_inv, r->get_component_filter() );
                     return std::make_pair( r->result_name(), can_make );
                 } );
                 std::sort( result_names.begin(), result_names.end(), localized_compare );
@@ -4243,9 +4244,9 @@ nc_color item::color_in_inventory( const player &p ) const
         for( const ammotype &at : ammo_types() ) {
             // get_ammo finds uncontained ammo, find_ammo finds ammo in magazines
             bool const has_ammo = !character_funcs::get_ammo_items( p, at ).empty() ||
-                            !character_funcs::find_ammo_items_or_mags( p, *this, false, -1 ).empty();
+                                  !character_funcs::find_ammo_items_or_mags( p, *this, false, -1 ).empty();
             bool const has_mag = magazine_integral() ||
-                           !character_funcs::find_ammo_items_or_mags( p, *this, true, -1 ).empty();
+                                 !character_funcs::find_ammo_items_or_mags( p, *this, true, -1 ).empty();
             if( has_ammo && has_mag ) {
                 ret = c_green;
                 break;
@@ -4351,7 +4352,7 @@ void item::on_wear( Character &p )
                     }
                 }
             }
-            for( std::pair< body_part, int >  const&mod_part : mod_parts ) {
+            for( std::pair< body_part, int >  const &mod_part : mod_parts ) {
                 bpid = convert_bp( mod_part.first );
                 if( bpid->part_side == side::LEFT && mod_part.second > lhs ) {
                     add_msg( _( "left" ) );
@@ -4690,7 +4691,7 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
         maintext = label( quantity );
     }
 
-    avatar  const&you = get_avatar();
+    avatar  const &you = get_avatar();
     std::string tagtext;
     if( is_food() ) {
         if( has_flag( flag_HIDDEN_POISON ) && you.get_skill_level( skill_survival ) >= 3 ) {
@@ -4859,7 +4860,7 @@ std::string item::display_name( unsigned int quantity ) const
             sidetxt = string_format( " (%s)", _( "right" ) );
             break;
     }
-    avatar  const&you = get_avatar();
+    avatar  const &you = get_avatar();
     int amount = 0;
     int max_amount = 0;
     bool const has_item = is_container() && contents.num_item_stacks() == 1;
@@ -5206,7 +5207,8 @@ int item::lift_strength() const
 int item::attack_cost() const
 {
     int const base = 65 + ( volume() / 62.5_ml + weight() / 60_gram ) / count();
-    int const bonus = bonus_from_enchantments_wielded( base, enchant_vals::mod::ITEM_ATTACK_COST, true );
+    int const bonus = bonus_from_enchantments_wielded( base, enchant_vals::mod::ITEM_ATTACK_COST,
+                      true );
     return std::max( 0, base + bonus );
 }
 
@@ -5734,8 +5736,8 @@ time_duration item::minimum_freshness_duration( temperature_flag temperature ) c
     time_duration const remaining_rot = type->comestible->spoils - rot;
     // Has to be in int64 or it will overflow for long lasting food
     unsigned long long const duration = to_turns<unsigned long long>( remaining_rot )
-                                  * to_turns<unsigned long long>( 1_hours )
-                                  / rot_per_hour;
+                                        * to_turns<unsigned long long>( 1_hours )
+                                        / rot_per_hour;
     if( duration > to_turns<unsigned long long>( calendar::INDEFINITELY_LONG_DURATION ) ) {
         return calendar::INDEFINITELY_LONG_DURATION;
     }
@@ -8068,8 +8070,8 @@ void item_reload_option::qty( int val )
 {
     bool const ammo_in_container = ammo->is_ammo_container();
     bool const ammo_in_liquid_container = ammo->is_watertight_container();
-    item  const&ammo_obj = ( ammo_in_container || ammo_in_liquid_container ) ?
-                     ammo->contents.front() : *ammo;
+    item  const &ammo_obj = ( ammo_in_container || ammo_in_liquid_container ) ?
+                            ammo->contents.front() : *ammo;
 
     if( ( ammo_in_container && !ammo_obj.is_ammo() ) ||
         ( ammo_in_liquid_container && !ammo_obj.made_of( LIQUID ) ) ) {
@@ -8197,7 +8199,7 @@ bool item::reload( player &u, item_location loc, int qty )
         if( magazine_current() ) {
             //~ %1$s: magazine name, %2$s: weapon name
             std::string const prompt = string_format( pgettext( "magazine", "Eject %1$s from %2$s?" ),
-                                                magazine_current()->tname(), tname() );
+                                       magazine_current()->tname(), tname() );
 
             // eject magazine to player inventory and try to dispose of it from there
             item &mag = u.i_add( *magazine_current() );
@@ -8940,7 +8942,7 @@ uint64_t item::make_component_hash() const
     }
 
     std::string concatenated_ids;
-    for( std::string const& id : id_set ) {
+    for( std::string const &id : id_set ) {
         concatenated_ids += id;
     }
 
@@ -9022,8 +9024,8 @@ bool item::process_rot( const bool seals, const tripoint &pos,
         const unsigned int seed = g->get_seed();
         // It's a modifier, so we need to subtract 0_f
         units::temperature const local_mod = units::from_fahrenheit( g->new_game
-                                       ? 0
-                                       : get_map().get_temperature( pos ) ) - 0_f;
+                                             ? 0
+                                             : get_map().get_temperature( pos ) ) - 0_f;
 
         // Process the past of this item since the last time it was processed
         while( now - time > 1_hours ) {
@@ -9042,11 +9044,13 @@ bool item::process_rot( const bool seals, const tripoint &pos,
                 env_temperature_raw = units::from_fahrenheit( AVERAGE_ANNUAL_TEMPERATURE ) + local_mod;
             }
 
-            units::temperature const env_temperature_clipped = clip_by_temperature_flag( env_temperature_raw, flag );
+            units::temperature const env_temperature_clipped = clip_by_temperature_flag( env_temperature_raw,
+                    flag );
 
             // Lookup table is in F
-            int const final_temperature_in_fahrenheit = static_cast<int>( std::round( units::to_fahrenheit<float>
-                                                  ( env_temperature_clipped ) ) );
+            int const final_temperature_in_fahrenheit = static_cast<int>( std::round(
+                        units::to_fahrenheit<float>
+                        ( env_temperature_clipped ) ) );
 
             // Calculate item rot
             rot += calc_rot( time, final_temperature_in_fahrenheit );
@@ -9062,8 +9066,9 @@ bool item::process_rot( const bool seals, const tripoint &pos,
     // Remaining <1 h from above
     // and items that are held near the player
     if( now - time > smallest_interval ) {
-        int const final_temperature_in_fahrenheit = static_cast<int>( std::round( units::to_fahrenheit<float>
-                                              ( temp ) ) );
+        int const final_temperature_in_fahrenheit = static_cast<int>( std::round(
+                    units::to_fahrenheit<float>
+                    ( temp ) ) );
 
         rot += calc_rot( now, final_temperature_in_fahrenheit );
         last_rot_check = now;
@@ -9186,7 +9191,7 @@ bool item::process_corpse( player *carrier, const tripoint &pos )
 
 bool item::process_fake_mill( player * /*carrier*/, const tripoint &pos )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     if( here.furn( pos ) != furn_str_id( "f_wind_mill_active" ) &&
         here.furn( pos ) != furn_str_id( "f_water_mill_active" ) ) {
         item_counter = 0;
@@ -9203,7 +9208,7 @@ bool item::process_fake_mill( player * /*carrier*/, const tripoint &pos )
 
 bool item::process_fake_smoke( player * /*carrier*/, const tripoint &pos )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     if( here.furn( pos ) != furn_str_id( "f_smoking_rack_active" ) &&
         here.furn( pos ) != furn_str_id( "f_metal_smoking_rack_active" ) ) {
         item_counter = 0;
@@ -9316,7 +9321,7 @@ bool item::process_extinguish( player *carrier, const tripoint &pos )
         default:
             break;
     }
-    map  const&here = get_map();
+    map  const &here = get_map();
     if( in_inv && !in_veh && here.has_flag( flag_DEEP_WATER, pos ) ) {
         extinguish = true;
         submerged = true;
@@ -9374,7 +9379,7 @@ std::optional<tripoint> item::get_cable_target( Character *p, const tripoint &po
     if( state != "pay_out_cable" && state != "cable_charger_link" ) {
         return std::nullopt;
     }
-    map  const&here = get_map();
+    map  const &here = get_map();
     const optional_vpart_position vp_pos = here.veh_at( pos );
     if( vp_pos ) {
         const std::optional<vpart_reference> seat = vp_pos.part_with_feature( "BOARDABLE", true );
@@ -9383,7 +9388,8 @@ std::optional<tripoint> item::get_cable_target( Character *p, const tripoint &po
         }
     }
 
-    tripoint const source( get_var( "source_x", 0 ), get_var( "source_y", 0 ), get_var( "source_z", 0 ) );
+    tripoint const source( get_var( "source_x", 0 ), get_var( "source_y", 0 ), get_var( "source_z",
+                           0 ) );
 
     return here.getlocal( source );
 }
@@ -9421,7 +9427,7 @@ bool item::process_cable( player *carrier, const tripoint &pos )
     if( !source ) {
         return false;
     }
-    map  const&here = get_map();
+    map  const &here = get_map();
     if( !here.veh_at( *source ) || ( source->z != g->get_levz() && !here.has_zlevels() ) ) {
         if( carrier->has_item( *this ) ) {
             carrier->add_msg_if_player( m_bad, _( "You notice the cable has come loose!" ) );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -318,7 +318,7 @@ light_emission nolight = {0, 0, 0};
 // the returned pointer is always valid, it's never cleared by the @ref Item_factory.
 static const itype *nullitem()
 {
-    static itype nullitem_m;
+    static itype const nullitem_m;
     return &nullitem_m;
 }
 
@@ -388,7 +388,7 @@ item::item( const itype *type, time_point turn, int qty ) : type( type ), bday( 
     }
 
     if( has_flag( flag_NANOFAB_TEMPLATE ) ) {
-        itype_id nanofab_recipe = item_group::item_from( item_group_id( "nanofab_recipes" ) ).typeId();
+        itype_id const nanofab_recipe = item_group::item_from( item_group_id( "nanofab_recipes" ) ).typeId();
         set_var( "NANOFAB_ITEM_ID", nanofab_recipe.str() );
     }
 
@@ -483,7 +483,7 @@ item::item( const recipe *rec, int qty, std::list<item> items, std::vector<item_
         }
     }
 
-    for( item &component : components ) {
+    for( item  const&component : components ) {
         for( const std::string &f : component.item_tags ) {
             if( json_flag::get( f ).craft_inherit() ) {
                 set_flag( f );
@@ -514,7 +514,7 @@ item item::make_corpse( const mtype_id &mt, time_point turn, const std::string &
         debugmsg( "tried to make a corpse with an invalid mtype id" );
     }
 
-    std::string corpse_type = mt == mtype_id::NULL_ID() ? "corpse_generic_human" : "corpse";
+    std::string const corpse_type = mt == mtype_id::NULL_ID() ? "corpse_generic_human" : "corpse";
 
     item result( corpse_type, turn );
     result.corpse = &mt.obj();
@@ -599,7 +599,7 @@ item &item::ammo_set( const itype_id &ammo, int qty )
 
             // else try to add a magazine using default ammo count property if set
         } else if( !magazine_default().is_null() ) {
-            item mag( magazine_default() );
+            item const mag( magazine_default() );
             if( mag.type->magazine->count > 0 ) {
                 qty = mag.type->magazine->count;
             } else {
@@ -875,7 +875,7 @@ int item::charges_per_volume( const units::volume &vol ) const
         // dimension
         return vol * static_cast<int64_t>( type->stack_size ) / type->volume;
     } else {
-        units::volume my_volume = volume();
+        units::volume const my_volume = volume();
         if( my_volume == 0_ml ) {
             debugmsg( "Item '%s' with zero volume", tname() );
             return INFINITE_CHARGES;
@@ -933,9 +933,9 @@ bool item::stacks_with( const item &rhs, bool check_components, bool skip_type_c
     if( goes_bad() && rhs.goes_bad() ) {
         // Stack items that fall into the same "bucket" of freshness.
         // Distant buckets are larger than near ones.
-        std::pair<int, clipped_unit> my_clipped_time_to_rot =
+        std::pair<int, clipped_unit> const my_clipped_time_to_rot =
             clipped_time( get_shelf_life() - rot );
-        std::pair<int, clipped_unit> other_clipped_time_to_rot =
+        std::pair<int, clipped_unit> const other_clipped_time_to_rot =
             clipped_time( rhs.get_shelf_life() - rhs.rot );
         if( my_clipped_time_to_rot != other_clipped_time_to_rot ) {
             return false;
@@ -1125,7 +1125,7 @@ static std::string get_freshness_description( const item &food_item )
     if( time_left > shelf_life ) {
         time_left = shelf_life;
     }
-    avatar &you = get_avatar();
+    avatar  const&you = get_avatar();
     if( food_item.is_fresh() ) {
         // Fresh food is assumed to be obviously so regardless of skill.
         if( you.can_estimate_rot() ) {
@@ -1330,11 +1330,11 @@ double item::effective_dps( const player &guy, const monster &mon ) const
     const float mon_dodge = mon.get_dodge();
     float base_hit = guy.get_dex() / 4.0f + guy.get_hit_weapon( *this );
     base_hit *= std::max( 0.25f, 1.0f - guy.encumb( bp_torso ) / 100.0f );
-    float mon_defense = mon_dodge + mon.size_melee_penalty() / 5.0;
+    float const mon_defense = mon_dodge + mon.size_melee_penalty() / 5.0;
     constexpr double hit_trials = 10000.0;
     const int rng_mean = std::max( std::min( static_cast<int>( base_hit - mon_defense ), 20 ),
                                    -20 ) + 20;
-    double num_all_hits = hits_by_accuracy[ rng_mean ];
+    double const num_all_hits = hits_by_accuracy[ rng_mean ];
     /* critical hits have two chances to occur: triple critical hits happen much less frequently,
      * and double critical hits can only occur if a hit roll is more than 1.5 * monster dodge.
      * Not the hit roll used to determine the attack, another one.
@@ -1344,19 +1344,19 @@ double item::effective_dps( const player &guy, const monster &mon ) const
      */
     const int rng_high_mean = std::max( std::min( static_cast<int>( base_hit - 1.5 * mon_dodge ),
                                         20 ), -20 ) + 20;
-    double num_high_hits = hits_by_accuracy[ rng_high_mean ] * num_all_hits / hit_trials;
-    double double_crit_chance = guy.crit_chance( 4, 0, *this );
-    double crit_chance = guy.crit_chance( 0, 0, *this );
-    double num_low_hits = std::max( 0.0, num_all_hits - num_high_hits );
+    double const num_high_hits = hits_by_accuracy[ rng_high_mean ] * num_all_hits / hit_trials;
+    double const double_crit_chance = guy.crit_chance( 4, 0, *this );
+    double const crit_chance = guy.crit_chance( 0, 0, *this );
+    double const num_low_hits = std::max( 0.0, num_all_hits - num_high_hits );
 
-    double moves_per_attack = guy.attack_cost( *this );
+    double const moves_per_attack = guy.attack_cost( *this );
     // attacks that miss do no damage but take time
     double total_moves = ( hit_trials - num_all_hits ) * moves_per_attack;
     double total_damage = 0.0;
-    double num_crits = std::min( num_low_hits * crit_chance + num_high_hits * double_crit_chance,
+    double const num_crits = std::min( num_low_hits * crit_chance + num_high_hits * double_crit_chance,
                                  num_all_hits );
     // critical hits are counted separately
-    double num_hits = num_all_hits - num_crits;
+    double const num_hits = num_all_hits - num_crits;
     // sum average damage past armor and return the number of moves required to achieve
     // that damage
     const auto calc_effective_damage = [ &, moves_per_attack]( const double num_strikes,
@@ -1376,7 +1376,7 @@ double item::effective_dps( const player &guy, const monster &mon ) const
                 dealt_dams.dealt_dams[ dmg_unit.type ] += cur_damage;
             }
         }
-        double damage_per_hit = dealt_dams.total_damage();
+        double const damage_per_hit = dealt_dams.total_damage();
         subtotal_damage = damage_per_hit * num_strikes;
         double subtotal_moves = moves_per_attack * num_strikes;
 
@@ -1398,7 +1398,7 @@ double item::effective_dps( const player &guy, const monster &mon ) const
                     rs_dealt_dams.dealt_dams[ dmg_unit.type ] += cur_damage;
                 }
             }
-            double rs_damage_per_hit = rs_dealt_dams.total_damage();
+            double const rs_damage_per_hit = rs_dealt_dams.total_damage();
             subtotal_moves *= 0.5;
             subtotal_damage *= 0.5;
             subtotal_moves += moves_per_attack * num_strikes * 0.33;
@@ -1406,10 +1406,10 @@ double item::effective_dps( const player &guy, const monster &mon ) const
         }
         return std::make_pair( subtotal_moves, subtotal_damage );
     };
-    std::pair<double, double> crit_summary = calc_effective_damage( num_crits, true, guy, mon );
+    std::pair<double, double> const crit_summary = calc_effective_damage( num_crits, true, guy, mon );
     total_moves += crit_summary.first;
     total_damage += crit_summary.second;
-    std::pair<double, double> summary = calc_effective_damage( num_hits, false, guy, mon );
+    std::pair<double, double> const summary = calc_effective_damage( num_hits, false, guy, mon );
     total_moves += summary.first;
     total_damage += summary.second;
     return total_damage * to_moves<double>( 1_seconds ) / total_moves;
@@ -1437,7 +1437,7 @@ std::map<std::string, double> item::dps( const bool for_display, const bool for_
             ( comp_mon.second.evaluate != for_calc ) ) {
             continue;
         }
-        monster test_mon = monster( comp_mon.second.mon_id );
+        monster const test_mon = monster( comp_mon.second.mon_id );
         results[ comp_mon.first.translated() ] = effective_dps( guy, test_mon );
     }
     return results;
@@ -1556,7 +1556,7 @@ void item::basic_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
         // Display any minimal stat or skill requirements for the item
         std::vector<std::string> req;
         if( get_min_str() > 0 ) {
-            avatar &viewer = get_avatar();
+            avatar  const&viewer = get_avatar();
             if( has_flag( flag_STR_DRAW ) && ranged::get_str_draw_penalty( *this, viewer ) < 1.0f ) {
                 if( ranged::get_str_draw_penalty( *this, viewer ) < 0.5f ) {
                     req.push_back( string_format( _( "%s %d <color_magenta>(Can't use!)</color>" ), _( "strength" ),
@@ -1655,7 +1655,7 @@ void item::med_info( const item *med_item, std::vector<iteminfo> &info, const it
     }
 
     if( med_com->stim != 0 && parts->test( iteminfo_parts::MED_STIMULATION ) ) {
-        std::string name = string_format( "%s <stat>%s</stat>", _( "Stimulation:" ),
+        std::string const name = string_format( "%s <stat>%s</stat>", _( "Stimulation:" ),
                                           med_com->stim > 0 ? _( "Upper" ) : _( "Downer" ) );
         info.push_back( iteminfo( "MED", name ) );
     }
@@ -1686,7 +1686,7 @@ void item::food_info( const item *food_item, std::vector<iteminfo> &info,
             you.compute_nutrient_range( *food_item, recipe_id( recipe_exemplar ) );
     }
 
-    bool show_nutr = parts->test( iteminfo_parts::FOOD_NUTRITION ) ||
+    bool const show_nutr = parts->test( iteminfo_parts::FOOD_NUTRITION ) ||
                      parts->test( iteminfo_parts::FOOD_VITAMINS );
     if( min_nutr != max_nutr && show_nutr ) {
         info.emplace_back(
@@ -1844,8 +1844,8 @@ void item::food_info( const item *food_item, std::vector<iteminfo> &info,
             }
 
             if( print_freshness_duration ) {
-                time_duration remaining_fresh = food_item->minimum_freshness_duration( temperature );
-                std::string time_string = to_string_clipped( remaining_fresh );
+                time_duration const remaining_fresh = food_item->minimum_freshness_duration( temperature );
+                std::string const time_string = to_string_clipped( remaining_fresh );
                 info.emplace_back( "DESCRIPTION", string_format( temperature_description, time_string ) );
             } else {
                 info.emplace_back( "DESCRIPTION", temperature_description );
@@ -1921,11 +1921,11 @@ void item::ammo_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
 
     const islot_ammo &ammo = *ammo_data()->ammo;
     if( !ammo.damage.empty() || ammo.force_stat_display ) {
-        bool has_flat_dmg = !ammo.damage.empty() && ammo.damage.damage_units.front().amount > 0;
-        bool display_flat_dmg = parts->test( iteminfo_parts::AMMO_DAMAGE_VALUE );
+        bool const has_flat_dmg = !ammo.damage.empty() && ammo.damage.damage_units.front().amount > 0;
+        bool const display_flat_dmg = parts->test( iteminfo_parts::AMMO_DAMAGE_VALUE );
         // TODO: Multiple units
-        bool has_dmg_multiplier = ammo.damage.damage_units.front().damage_multiplier != 1.0;
-        bool display_dmg_multiplier = parts->test( iteminfo_parts::AMMO_DAMAGE_PROPORTIONAL );
+        bool const has_dmg_multiplier = ammo.damage.damage_units.front().damage_multiplier != 1.0;
+        bool const display_dmg_multiplier = parts->test( iteminfo_parts::AMMO_DAMAGE_PROPORTIONAL );
         bool didnt_print_dmg = false;
         if( has_flat_dmg && has_dmg_multiplier
             && has_dmg_multiplier && display_dmg_multiplier ) {
@@ -1951,10 +1951,10 @@ void item::ammo_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
         const std::string &maybe_space = didnt_print_dmg ? no_space : space;
 
         // TODO: Deduplicate with damage display
-        bool has_flat_arpen = get_ranged_pierce( ammo ) != 0;
-        bool display_flat_arpen = parts->test( iteminfo_parts::AMMO_DAMAGE_AP );
-        bool has_armor_mult = get_ranged_armor_mult( ammo ) != 1.0;
-        bool display_armor_mult = parts->test( iteminfo_parts::AMMO_DAMAGE_AP_PROPORTIONAL );
+        bool const has_flat_arpen = get_ranged_pierce( ammo ) != 0;
+        bool const display_flat_arpen = parts->test( iteminfo_parts::AMMO_DAMAGE_AP );
+        bool const has_armor_mult = get_ranged_armor_mult( ammo ) != 1.0;
+        bool const display_armor_mult = parts->test( iteminfo_parts::AMMO_DAMAGE_AP_PROPORTIONAL );
         if( has_flat_arpen && display_flat_arpen
             && has_armor_mult && display_armor_mult ) {
             info.emplace_back( "AMMO", maybe_space + _( "Armor-pierce: " ), "",
@@ -2023,7 +2023,7 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
     const std::string space = "  ";
     const islot_gun &gun = *mod->type->gun;
     const Skill &skill = *mod->gun_skill();
-    avatar &viewer = get_avatar();
+    avatar  const&viewer = get_avatar();
 
     // many statistics are dependent upon loaded ammo
     // if item is unloaded (or is RELOAD_AND_SHOOT) shows approximate stats using default ammo
@@ -2071,7 +2071,7 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
         // ammo_damage, sum_of_damage, and ammo_mult not shown so don't need to translate.
         if( parts->test( iteminfo_parts::GUN_DAMAGE_LOADEDAMMO ) ) {
             assert( curammo ); // Appease clang-tidy
-            damage_instance ammo_dam = curammo->ammo->damage;
+            damage_instance const ammo_dam = curammo->ammo->damage;
             info.push_back( iteminfo( "GUN", "ammo_damage", "",
                                       iteminfo::no_newline | iteminfo::no_name |
                                       iteminfo::show_plus, ammo_du.amount ) );
@@ -2086,7 +2086,7 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
     }
     info.back().bNewLine = true;
     avatar &you = get_avatar();
-    int max_gun_range = loaded_mod->gun_range( &you );
+    int const max_gun_range = loaded_mod->gun_range( &you );
     if( max_gun_range > 0 && parts->test( iteminfo_parts::GUN_MAX_RANGE ) ) {
         info.emplace_back( "GUN", _( "Maximum range: " ), "<num>", iteminfo::no_flags,
                            max_gun_range );
@@ -2099,7 +2099,7 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
     }
     if( mod->ammo_required() ) {
         assert( curammo ); // Appease clang-tidy
-        int ammo_pierce = get_ranged_pierce( *curammo->ammo );
+        int const ammo_pierce = get_ranged_pierce( *curammo->ammo );
         // ammo_armor_pierce and sum_of_armor_pierce don't need to translate.
         if( parts->test( iteminfo_parts::GUN_ARMORPIERCE_LOADEDAMMO ) ) {
             info.push_back( iteminfo( "GUN", "ammo_armor_pierce", "",
@@ -2161,7 +2161,7 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
                                   mod->gun_dispersion( false, false ) ) );
     }
     if( mod->ammo_required() ) {
-        int ammo_dispersion = curammo->ammo->dispersion;
+        int const ammo_dispersion = curammo->ammo->dispersion;
         // ammo_dispersion and sum_of_dispersion don't need to translate.
         if( parts->test( iteminfo_parts::GUN_DISPERSION_LOADEDAMMO ) ) {
             info.push_back( iteminfo( "GUN", "ammo_dispersion", "",
@@ -2181,9 +2181,9 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
     info.back().bNewLine = true;
 
     // if effective sight dispersion differs from actual sight dispersion display both
-    int act_disp = mod->sight_dispersion();
-    int eff_disp = ranged::effective_dispersion( you, act_disp );
-    int adj_disp = eff_disp - act_disp;
+    int const act_disp = mod->sight_dispersion();
+    int const eff_disp = ranged::effective_dispersion( you, act_disp );
+    int const adj_disp = eff_disp - act_disp;
 
     if( parts->test( iteminfo_parts::GUN_DISPERSION_SIGHT ) ) {
         info.push_back( iteminfo( "GUN", _( "Sight dispersion: " ), "",
@@ -2200,7 +2200,7 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
         }
     }
 
-    bool bipod = mod->has_flag( flag_BIPOD );
+    bool const bipod = mod->has_flag( flag_BIPOD );
 
     if( loaded_mod->gun_recoil() ) {
         if( parts->test( iteminfo_parts::GUN_RECOIL_PERCENTAGE ) ) {
@@ -2306,11 +2306,11 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
             // distinct tag per aim type.
             const std::string tag = "GUN_" + type.name;
             info.emplace_back( tag, string_format( "<info>%s</info>", type.name ) );
-            int max_dispersion = ranged::get_weapon_dispersion( you, *loaded_mod ).max();
-            int range = range_with_even_chance_of_good_hit( max_dispersion + type.threshold );
+            int const max_dispersion = ranged::get_weapon_dispersion( you, *loaded_mod ).max();
+            int const range = range_with_even_chance_of_good_hit( max_dispersion + type.threshold );
             info.emplace_back( tag, _( "Even chance of good hit at range: " ),
                                _( "<num>" ), iteminfo::no_flags, range );
-            int aim_mv = ranged::gun_engagement_moves( you, *mod, type.threshold );
+            int const aim_mv = ranged::gun_engagement_moves( you, *mod, type.threshold );
             info.emplace_back( tag, _( "Time to reach aim level: " ), _( "<num> moves " ),
                                iteminfo::lower_is_better, aim_mv );
         }
@@ -2344,10 +2344,10 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
 
         std::string mod_str = _( "<bold>Mods</bold>: " );
 
-        std::map<gunmod_location, int> mod_locations = get_mod_locations();
+        std::map<gunmod_location, int> const mod_locations = get_mod_locations();
 
         int iternum = 0;
-        for( std::pair<const gunmod_location, int> &elem : mod_locations ) {
+        for( std::pair<const gunmod_location, int>  const&elem : mod_locations ) {
             if( iternum != 0 ) {
                 mod_str += "; ";
             }
@@ -2374,7 +2374,7 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
 
     if( mod->casings_count() && parts->test( iteminfo_parts::DESCRIPTION_GUN_CASINGS ) ) {
         insert_separation_line( info );
-        std::string tmp = vgettext( "Contains <stat>%i</stat> casing",
+        std::string const tmp = vgettext( "Contains <stat>%i</stat> casing",
                                     "Contains <stat>%i</stat> casings", mod->casings_count() );
         info.emplace_back( "DESCRIPTION", string_format( tmp, mod->casings_count() ) );
     }
@@ -2411,12 +2411,12 @@ void item::gunmod_info( std::vector<iteminfo> &info, const iteminfo_query *parts
         info.push_back( iteminfo( "GUNMOD", _( "Aim speed: " ), "",
                                   iteminfo::lower_is_better, mod.aim_speed ) );
     }
-    int total_damage = static_cast<int>( mod.damage.total_damage() );
+    int const total_damage = static_cast<int>( mod.damage.total_damage() );
     if( total_damage != 0 && parts->test( iteminfo_parts::GUNMOD_DAMAGE ) ) {
         info.push_back( iteminfo( "GUNMOD", _( "Damage: " ), "", iteminfo::show_plus,
                                   total_damage ) );
     }
-    int pierce = get_ranged_pierce( mod );
+    int const pierce = get_ranged_pierce( mod );
     if( get_ranged_pierce( mod ) != 0 && parts->test( iteminfo_parts::GUNMOD_ARMORPIERCE ) ) {
         info.push_back( iteminfo( "GUNMOD", _( "Armor-pierce: " ), "", iteminfo::show_plus,
                                   pierce ) );
@@ -2444,10 +2444,10 @@ void item::gunmod_info( std::vector<iteminfo> &info, const iteminfo_query *parts
 
         std::string mod_loc_str = _( "<bold>Adds mod locations: </bold> " );
 
-        std::map<gunmod_location, int> mod_locations = mod.add_mod;
+        std::map<gunmod_location, int> const mod_locations = mod.add_mod;
 
         int iternum = 0;
-        for( std::pair<const gunmod_location, int> &elem : mod_locations ) {
+        for( std::pair<const gunmod_location, int>  const&elem : mod_locations ) {
             if( iternum != 0 ) {
                 mod_loc_str += "; ";
             }
@@ -2556,12 +2556,12 @@ void item::armor_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
         return;
     }
 
-    avatar &you = get_avatar();
-    int encumbrance = get_encumber( you );
+    avatar  const&you = get_avatar();
+    int const encumbrance = get_encumber( you );
     const sizing sizing_level = get_sizing( you, encumbrance != 0 );
     const std::string space = "  ";
-    body_part_set covered_parts = get_covered_body_parts();
-    bool covers_anything = covered_parts.any();
+    body_part_set const covered_parts = get_covered_body_parts();
+    bool const covers_anything = covered_parts.any();
 
     if( parts->test( iteminfo_parts::ARMOR_BODYPARTS ) ) {
         insert_separation_line( info );
@@ -2764,8 +2764,8 @@ void item::armor_fit_info( std::vector<iteminfo> &info, const iteminfo_query *pa
         return;
     }
 
-    avatar &you = get_avatar();
-    int encumbrance = get_encumber( you );
+    avatar  const&you = get_avatar();
+    int const encumbrance = get_encumber( you );
     const sizing sizing_level = get_sizing( you, encumbrance != 0 );
 
     if( has_flag( flag_HELMET_COMPAT ) &&
@@ -2855,7 +2855,7 @@ void item::armor_fit_info( std::vector<iteminfo> &info, const iteminfo_query *pa
                         break;
                 }
                 if( !resize_str.empty() ) {
-                    std::string info_str = string_format( _( "* This clothing %s." ), resize_str );
+                    std::string const info_str = string_format( _( "* This clothing %s." ), resize_str );
                     info.push_back( iteminfo( "DESCRIPTION", info_str ) );
                 }
             } else {
@@ -2877,7 +2877,7 @@ void item::armor_fit_info( std::vector<iteminfo> &info, const iteminfo_query *pa
                     default:
                         break;
                 }
-                std::string info_str = string_format( _( "* This clothing <info>can be "
+                std::string const info_str = string_format( _( "* This clothing <info>can be "
                                                       "refitted</info>%s." ), resize_str );
                 info.push_back( iteminfo( "DESCRIPTION", info_str ) );
             }
@@ -2921,7 +2921,7 @@ void item::book_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
         return;
     }
 
-    Character &character = get_player_character();
+    Character  const&character = get_player_character();
 
     insert_separation_line( info );
     const islot_book &book = *type->book;
@@ -3006,7 +3006,7 @@ void item::book_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
 
     if( book.chapters > 0 && parts->test( iteminfo_parts::BOOK_NUMUNREADCHAPTERS ) ) {
         const int unread = get_remaining_chapters( you );
-        std::string fmt = vgettext( "This book has <num> <info>unread chapter</info>.",
+        std::string const fmt = vgettext( "This book has <num> <info>unread chapter</info>.",
                                     "This book has <num> <info>unread chapters</info>.",
                                     unread );
         info.push_back( iteminfo( "BOOK", "", fmt, iteminfo::no_flags, unread ) );
@@ -3033,7 +3033,7 @@ void item::book_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
     }
 
     if( !recipe_list.empty() && parts->test( iteminfo_parts::DESCRIPTION_BOOK_RECIPES ) ) {
-        std::string recipe_line =
+        std::string const recipe_line =
             string_format( vgettext( "This book contains %1$d crafting recipe: %2$s",
                                      "This book contains %1$d crafting recipes: %2$s",
                                      recipe_list.size() ),
@@ -3126,7 +3126,7 @@ void item::tool_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
         }
     } else if( ammo_capacity() != 0 && parts->test( iteminfo_parts::TOOL_CAPACITY ) ) {
         std::string tmp;
-        bool bionic_tool = has_flag( flag_USES_BIONIC_POWER );
+        bool const bionic_tool = has_flag( flag_USES_BIONIC_POWER );
         if( !ammo_types().empty() ) {
             //~ "%s" is ammunition type. This types can't be plural.
             tmp = vgettext( "Maximum <num> charge of %s.", "Maximum <num> charges of %s.",
@@ -3161,7 +3161,7 @@ void item::component_info( std::vector<iteminfo> &info, const iteminfo_query *pa
                                   _( components_to_string() ) ) ) );
     } else if( get_var( "bionics_scanned_by", -1 ) == get_avatar().getID().get_value() ) {
         // TODO: Extract into a more proper place (function in namespace)
-        std::string bionics_string = enumerate_as_string( components.begin(), components.end(),
+        std::string const bionics_string = enumerate_as_string( components.begin(), components.end(),
         []( const item & entry ) -> std::string {
             return entry.is_bionic() ? entry.display_name() : "";
         }, enumeration_conjunction::none );
@@ -3420,9 +3420,9 @@ void item::combat_info( std::vector<iteminfo> &info, const iteminfo_query *parts
 {
     const std::string space = "  ";
 
-    int dmg_bash = damage_melee( DT_BASH );
-    int dmg_cut  = damage_melee( DT_CUT );
-    int dmg_stab = damage_melee( DT_STAB );
+    int const dmg_bash = damage_melee( DT_BASH );
+    int const dmg_cut  = damage_melee( DT_CUT );
+    int const dmg_stab = damage_melee( DT_STAB );
     if( parts->test( iteminfo_parts::BASE_DAMAGE ) ) {
         insert_separation_line( info );
         std::string sep;
@@ -3510,7 +3510,7 @@ void item::combat_info( std::vector<iteminfo> &info, const iteminfo_query *parts
         you.roll_all_damage( false, non_crit, true, *this );
         damage_instance crit;
         you.roll_all_damage( true, crit, true, *this );
-        int attack_cost = you.attack_cost( *this );
+        int const attack_cost = you.attack_cost( *this );
         insert_separation_line( info );
         if( parts->test( iteminfo_parts::DESCRIPTION_MELEEDMG ) ) {
             info.push_back( iteminfo( "DESCRIPTION", _( "<bold>Average melee damage</bold>:" ) ) );
@@ -3598,7 +3598,7 @@ void item::contents_info( std::vector<iteminfo> &info, const iteminfo_query *par
             const translation &description = contents_item->type->description;
 
             if( contents_item->made_of( LIQUID ) ) {
-                units::volume contents_volume = contents_item->volume() * batch;
+                units::volume const contents_volume = contents_item->volume() * batch;
                 int converted_volume_scale = 0;
                 const double converted_volume =
                     round_up( convert_volume( contents_volume.value(),
@@ -3882,8 +3882,8 @@ void item::final_info( std::vector<iteminfo> &info, const iteminfo_query &parts_
         }
     }
 
-    std::map<std::string, std::string>::const_iterator item_note = item_vars.find( "item_note" );
-    std::map<std::string, std::string>::const_iterator item_note_tool =
+    std::map<std::string, std::string>::const_iterator const item_note = item_vars.find( "item_note" );
+    std::map<std::string, std::string>::const_iterator const item_note_tool =
         item_vars.find( "item_note_tool" );
 
     if( item_note != item_vars.end() && parts->test( iteminfo_parts::DESCRIPTION_NOTES ) ) {
@@ -3930,7 +3930,7 @@ void item::final_info( std::vector<iteminfo> &info, const iteminfo_query &parts_
 
     // Recipes using this item as an ingredient
     if( parts->test( iteminfo_parts::DESCRIPTION_APPLICABLE_RECIPES ) ) {
-        itype_id tid = contents.empty() ? typeId() : contents.front().typeId();
+        itype_id const tid = contents.empty() ? typeId() : contents.front().typeId();
         const inventory &crafting_inv = you.crafting_inventory();
 
         const recipe_subset available_recipe_subset = you.get_available_recipes( crafting_inv, nullptr,
@@ -3957,7 +3957,7 @@ void item::final_info( std::vector<iteminfo> &info, const iteminfo_query &parts_
                     item_recipes.begin(), item_recipes.end(),
                     std::back_inserter( result_names ),
                 [&crafting_inv]( const recipe * r ) {
-                    bool can_make = r->deduped_requirements().can_make_with_inventory(
+                    bool const can_make = r->deduped_requirements().can_make_with_inventory(
                                         crafting_inv, r->get_component_filter() );
                     return std::make_pair( r->result_name(), can_make );
                 } );
@@ -4091,7 +4091,7 @@ std::string item::info_string() const
 std::string item::info_string( const iteminfo_query &parts, int batch,
                                temperature_flag temperature ) const
 {
-    std::vector<iteminfo> item_info = info( parts, batch, temperature );
+    std::vector<iteminfo> const item_info = info( parts, batch, temperature );
     return format_item_info( item_info, {} );
 }
 
@@ -4101,7 +4101,7 @@ std::map<gunmod_location, int> item::get_mod_locations() const
 
     for( const item *mod : gunmods() ) {
         if( !mod->type->gunmod->add_mod.empty() ) {
-            std::map<gunmod_location, int> add_locations = mod->type->gunmod->add_mod;
+            std::map<gunmod_location, int> const add_locations = mod->type->gunmod->add_mod;
 
             for( const std::pair<const gunmod_location, int> &add_location : add_locations ) {
                 mod_locations[add_location.first] += add_location.second;
@@ -4242,9 +4242,9 @@ nc_color item::color_in_inventory( const player &p ) const
         // Gun with integrated mag counts as both
         for( const ammotype &at : ammo_types() ) {
             // get_ammo finds uncontained ammo, find_ammo finds ammo in magazines
-            bool has_ammo = !character_funcs::get_ammo_items( p, at ).empty() ||
+            bool const has_ammo = !character_funcs::get_ammo_items( p, at ).empty() ||
                             !character_funcs::find_ammo_items_or_mags( p, *this, false, -1 ).empty();
-            bool has_mag = magazine_integral() ||
+            bool const has_mag = magazine_integral() ||
                            !character_funcs::find_ammo_items_or_mags( p, *this, true, -1 ).empty();
             if( has_ammo && has_mag ) {
                 ret = c_green;
@@ -4258,10 +4258,10 @@ nc_color item::color_in_inventory( const player &p ) const
         // Likewise, ammo is green if you have guns that use it
         // ltred if you have the gun but no mags
         // Gun with integrated mag counts as both
-        bool has_gun = p.has_item_with( [this]( const item & i ) {
+        bool const has_gun = p.has_item_with( [this]( const item & i ) {
             return i.is_gun() && i.ammo_types().count( ammo_type() );
         } );
-        bool has_mag = p.has_item_with( [this]( const item & i ) {
+        bool const has_mag = p.has_item_with( [this]( const item & i ) {
             return ( i.is_gun() && i.magazine_integral() && i.ammo_types().count( ammo_type() ) ) ||
                    ( i.is_magazine() && i.ammo_types().count( ammo_type() ) );
         } );
@@ -4273,10 +4273,10 @@ nc_color item::color_in_inventory( const player &p ) const
     } else if( is_magazine() ) {
         // Magazines are green if you have guns and ammo for them
         // ltred if you have one but not the other
-        bool has_gun = p.has_item_with( [this]( const item & it ) {
+        bool const has_gun = p.has_item_with( [this]( const item & it ) {
             return it.is_gun() && it.magazine_compatible().count( typeId() ) > 0;
         } );
-        bool has_ammo = !character_funcs::find_ammo_items_or_mags( p, *this, false, -1 ).empty();
+        bool const has_ammo = !character_funcs::find_ammo_items_or_mags( p, *this, false, -1 ).empty();
         if( has_gun && has_ammo ) {
             ret = c_green;
         } else if( has_gun || has_ammo ) {
@@ -4351,7 +4351,7 @@ void item::on_wear( Character &p )
                     }
                 }
             }
-            for( std::pair< body_part, int > &mod_part : mod_parts ) {
+            for( std::pair< body_part, int >  const&mod_part : mod_parts ) {
                 bpid = convert_bp( mod_part.first );
                 if( bpid->part_side == side::LEFT && mod_part.second > lhs ) {
                     add_msg( _( "left" ) );
@@ -4390,7 +4390,7 @@ void item::on_wear( Character &p )
             debugmsg( "iuse_actor type descriptor and actual type mismatch" );
             return;
         }
-        std::string transform_flag = actor->dependencies;
+        std::string const transform_flag = actor->dependencies;
         for( const auto &elem : p.worn ) {
             if( elem.has_flag( transform_flag ) && elem.active != active ) {
                 transform = true;
@@ -4448,7 +4448,7 @@ void item::on_wield( player &p, int mv )
             d /= std::max( p.get_skill_level( melee_skill() ), 1 );
         }
 
-        int penalty = get_var( "volume", volume() / units::legacy_volume_factor ) * d;
+        int const penalty = get_var( "volume", volume() / units::legacy_volume_factor ) * d;
         p.moves -= penalty;
         mv += penalty;
     }
@@ -4573,7 +4573,7 @@ void item::on_damage( int qty, damage_type )
 
 std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int truncate ) const
 {
-    int dirt_level = get_var( "dirt", 0 ) / 2000;
+    int const dirt_level = get_var( "dirt", 0 ) / 2000;
     std::string dirt_symbol;
     // TODO: MATERIALS put this in json
 
@@ -4690,7 +4690,7 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
         maintext = label( quantity );
     }
 
-    avatar &you = get_avatar();
+    avatar  const&you = get_avatar();
     std::string tagtext;
     if( is_food() ) {
         if( has_flag( flag_HIDDEN_POISON ) && you.get_skill_level( skill_survival ) >= 3 ) {
@@ -4859,12 +4859,12 @@ std::string item::display_name( unsigned int quantity ) const
             sidetxt = string_format( " (%s)", _( "right" ) );
             break;
     }
-    avatar &you = get_avatar();
+    avatar  const&you = get_avatar();
     int amount = 0;
     int max_amount = 0;
-    bool has_item = is_container() && contents.num_item_stacks() == 1;
-    bool has_ammo = is_ammo_container() && contents.num_item_stacks() == 1;
-    bool contains = has_item || has_ammo;
+    bool const has_item = is_container() && contents.num_item_stacks() == 1;
+    bool const has_ammo = is_ammo_container() && contents.num_item_stacks() == 1;
+    bool const contains = has_item || has_ammo;
     bool show_amt = false;
     // We should handle infinite charges properly in all cases.
     if( contains ) {
@@ -4919,9 +4919,9 @@ std::string item::display_name( unsigned int quantity ) const
     // HACK: This is a hack to prevent possible crashing when displaying maps as items during character creation
     if( is_map() && calendar::turn != calendar::turn_zero ) {
         // TODO: fix point types
-        tripoint map_pos_omt =
+        tripoint const map_pos_omt =
             get_var( "reveal_map_center_omt", you.global_omt_location().raw() );
-        tripoint_abs_sm map_pos =
+        tripoint_abs_sm const map_pos =
             project_to<coords::sm>( tripoint_abs_omt( map_pos_omt ) );
         const city *c = overmap_buffer.closest_city( map_pos ).city;
         if( c != nullptr ) {
@@ -5000,7 +5000,7 @@ units::mass item::weight( bool include_contents, bool integral ) const
     }
 
     units::mass ret;
-    std::string local_str_mass = integral ? get_var( "integral_weight" ) : get_var( "weight" );
+    std::string const local_str_mass = integral ? get_var( "integral_weight" ) : get_var( "weight" );
     if( local_str_mass.empty() ) {
         ret = integral ? type->integral_weight : type->weight;
     } else {
@@ -5039,7 +5039,7 @@ units::mass item::weight( bool include_contents, bool integral ) const
 
     } else if( magazine_integral() && !is_magazine() ) {
         if( ammo_current() == itype_plut_cell ) {
-            units::mass w = ( *ammo_types().begin() )->default_ammotype()->weight;
+            units::mass const w = ( *ammo_types().begin() )->default_ammotype()->weight;
             ret += ammo_remaining() * w / PLUTONIUM_CHARGES;
         } else if( ammo_data() ) {
             ret += ammo_remaining() * ammo_data()->weight;
@@ -5155,7 +5155,7 @@ units::volume item::volume( bool integral ) const
     }
 
     if( count_by_charges() || made_of( LIQUID ) ) {
-        units::quantity<int64_t, units::volume_in_milliliter_tag> num = ret * static_cast<int64_t>
+        units::quantity<int64_t, units::volume_in_milliliter_tag> const num = ret * static_cast<int64_t>
                 ( charges );
         if( type->stack_size <= 0 ) {
             debugmsg( "Item type %s has invalid stack_size %d", typeId().str(), type->stack_size );
@@ -5205,8 +5205,8 @@ int item::lift_strength() const
 
 int item::attack_cost() const
 {
-    int base = 65 + ( volume() / 62.5_ml + weight() / 60_gram ) / count();
-    int bonus = bonus_from_enchantments_wielded( base, enchant_vals::mod::ITEM_ATTACK_COST, true );
+    int const base = 65 + ( volume() / 62.5_ml + weight() / 60_gram ) / count();
+    int const bonus = bonus_from_enchantments_wielded( base, enchant_vals::mod::ITEM_ATTACK_COST, true );
     return std::max( 0, base + bonus );
 }
 
@@ -5271,8 +5271,8 @@ damage_instance item::base_damage_melee() const
     // TODO: Caching
     damage_instance ret;
     for( size_t i = DT_NULL + 1; i < NUM_DT; i++ ) {
-        damage_type dt = static_cast<damage_type>( i );
-        int dam = damage_melee( dt );
+        damage_type const dt = static_cast<damage_type>( i );
+        int const dam = damage_melee( dt );
         if( dam > 0 ) {
             ret.add_damage( dt, dam );
         }
@@ -5396,7 +5396,7 @@ int64_t item::get_property_int64_t( const std::string &prop, int64_t def ) const
     const auto it = type->properties.find( prop );
     if( it != type->properties.end() ) {
         char *e = nullptr;
-        int64_t r = std::strtoll( it->second.c_str(), &e, 10 );
+        int64_t const r = std::strtoll( it->second.c_str(), &e, 10 );
         if( !it->second.empty() && *e == '\0' ) {
             return r;
         }
@@ -5695,11 +5695,11 @@ time_duration item::calc_rot( time_point time, int temp ) const
     // positive = food was produced some time before calendar::start and/or bad storage
     // negative = food was stored in good conditions before calendar::start
     if( last_rot_check <= calendar::start_of_cataclysm ) {
-        time_duration spoil_variation = get_shelf_life() * 0.2f;
+        time_duration const spoil_variation = get_shelf_life() * 0.2f;
         added_rot += rng( -spoil_variation, spoil_variation );
     }
 
-    time_duration time_delta = time - last_rot_check;
+    time_duration const time_delta = time - last_rot_check;
     added_rot += factor * time_delta / 1_hours * get_hourly_rotpoints_at_temp( temp ) * 1_turns;
     return added_rot;
 }
@@ -5724,16 +5724,16 @@ static int temperature_flag_to_highest_temperature( temperature_flag temperature
 
 time_duration item::minimum_freshness_duration( temperature_flag temperature ) const
 {
-    int temperature_f = temperature_flag_to_highest_temperature( temperature );
-    unsigned long long rot_per_hour = get_hourly_rotpoints_at_temp( temperature_f );
+    int const temperature_f = temperature_flag_to_highest_temperature( temperature );
+    unsigned long long const rot_per_hour = get_hourly_rotpoints_at_temp( temperature_f );
 
     if( rot_per_hour <= 0 || !type->comestible ) {
         return calendar::INDEFINITELY_LONG_DURATION;
     }
 
-    time_duration remaining_rot = type->comestible->spoils - rot;
+    time_duration const remaining_rot = type->comestible->spoils - rot;
     // Has to be in int64 or it will overflow for long lasting food
-    unsigned long long duration = to_turns<unsigned long long>( remaining_rot )
+    unsigned long long const duration = to_turns<unsigned long long>( remaining_rot )
                                   * to_turns<unsigned long long>( 1_hours )
                                   / rot_per_hour;
     if( duration > to_turns<unsigned long long>( calendar::INDEFINITELY_LONG_DURATION ) ) {
@@ -5761,7 +5761,7 @@ units::volume item::get_storage() const
         return is_pet_armor() ? type->pet_armor->storage : 0_ml;
     }
     units::volume storage = t->storage;
-    float mod = get_clothing_mod_val( clothing_mod_type_storage );
+    float const mod = get_clothing_mod_val( clothing_mod_type_storage );
     storage += std::lround( mod ) * units::legacy_volume_factor;
 
     return storage;
@@ -5792,9 +5792,9 @@ int item::get_env_resist( int override_base_resist ) const
         return is_pet_armor() ? type->pet_armor->env_resist : 0;
     }
     // modify if item is a gas mask and has filter
-    int resist_base = t->env_resist;
-    int resist_filter = get_var( "overwrite_env_resist", 0 );
-    int resist = std::max( { resist_base, resist_filter, override_base_resist } );
+    int const resist_base = t->env_resist;
+    int const resist_filter = get_var( "overwrite_env_resist", 0 );
+    int const resist = std::max( { resist_base, resist_filter, override_base_resist } );
 
     return std::lround( resist * get_relative_health() );
 }
@@ -6003,7 +6003,7 @@ bool item::ready_to_revive( const tripoint &pos ) const
     if( damage_level( 4 ) > 0 ) {
         age_in_hours /= ( damage_level( 4 ) + 1 );
     }
-    int rez_factor = 48 - age_in_hours;
+    int const rez_factor = 48 - age_in_hours;
     if( age_in_hours > 6 && ( rez_factor <= 0 || one_in( rez_factor ) ) ) {
         // If we're a special revival zombie, wait to get up until the player is nearby.
         const bool isReviveSpecial = has_flag( flag_REVIVE_SPECIAL );
@@ -6060,7 +6060,7 @@ int item::bash_resist( bool to_self ) const
     }
 
     float resist = 0;
-    float mod = get_clothing_mod_val( clothing_mod_type_bash );
+    float const mod = get_clothing_mod_val( clothing_mod_type_bash );
     int eff_thickness = 1;
 
     // base resistance
@@ -6089,7 +6089,7 @@ int item::cut_resist( bool to_self ) const
 
     const int base_thickness = get_thickness();
     float resist = 0;
-    float mod = get_clothing_mod_val( clothing_mod_type_cut );
+    float const mod = get_clothing_mod_val( clothing_mod_type_cut );
     int eff_thickness = 1;
 
     // base resistance
@@ -6128,7 +6128,7 @@ int item::bullet_resist( bool to_self ) const
 
     const int base_thickness = get_thickness();
     float resist = 0;
-    float mod = get_clothing_mod_val( clothing_mod_type_bullet );
+    float const mod = get_clothing_mod_val( clothing_mod_type_bullet );
     int eff_thickness = 1;
 
     // base resistance
@@ -6157,7 +6157,7 @@ int item::acid_resist( bool to_self, int base_env_resist ) const
     }
 
     float resist = 0.0;
-    float mod = get_clothing_mod_val( clothing_mod_type_acid );
+    float const mod = get_clothing_mod_val( clothing_mod_type_acid );
     if( is_null() ) {
         return 0.0;
     }
@@ -6191,7 +6191,7 @@ int item::fire_resist( bool to_self, int base_env_resist ) const
     }
 
     float resist = 0.0;
-    float mod = get_clothing_mod_val( clothing_mod_type_fire );
+    float const mod = get_clothing_mod_val( clothing_mod_type_fire );
     if( is_null() ) {
         return 0.0;
     }
@@ -6381,7 +6381,7 @@ std::string item::durability_indicator( bool include_intact ) const
 
 const std::set<itype_id> &item::repaired_with() const
 {
-    static std::set<itype_id> no_repair;
+    static std::set<itype_id> const no_repair;
     return has_flag( flag_NO_REPAIR )  ? no_repair : type->repair;
 }
 
@@ -6722,7 +6722,7 @@ const islot_armor *item::find_armor_data() const
 
 bool item::is_pet_armor( bool on_pet ) const
 {
-    bool is_worn = on_pet && !get_var( "pet_armor", "" ).empty();
+    bool const is_worn = on_pet && !get_var( "pet_armor", "" ).empty();
     return has_flag( flag_IS_PET_ARMOR ) && ( is_worn || !on_pet );
 }
 
@@ -6804,7 +6804,7 @@ bool item::is_irremovable() const
 
 int item::wind_resist() const
 {
-    std::vector<const material_type *> materials = made_of_types();
+    std::vector<const material_type *> const materials = made_of_types();
     if( materials.empty() ) {
         debugmsg( "Called item::wind_resist on an item (%s [%s]) made of nothing!", tname(), typeId() );
         return 99;
@@ -6855,7 +6855,7 @@ bool item::has_explosion_data() const
 
 struct fuel_explosion item::get_explosion_data()
 {
-    static struct fuel_explosion null_data;
+    static struct fuel_explosion const null_data;
     return has_explosion_data() ? type->fuel->explosion_data : null_data;
 }
 
@@ -6879,7 +6879,7 @@ bool item::can_unload_liquid() const
     }
 
     const item &cts = contents.front();
-    bool cts_is_frozen_liquid = cts.made_of( LIQUID ) && cts.made_of( SOLID );
+    bool const cts_is_frozen_liquid = cts.made_of( LIQUID ) && cts.made_of( SOLID );
     return is_bucket() || !cts_is_frozen_liquid;
 }
 
@@ -7152,7 +7152,7 @@ std::vector<std::pair<const recipe *, int>> item::get_available_recipes( const p
         // Capture the index one past the delimiter, i.e. start of target string.
         size_t first_string_index = recipes.find_first_of( ',' ) + 1;
         while( first_string_index != std::string::npos ) {
-            size_t next_string_index = recipes.find_first_of( ',', first_string_index );
+            size_t const next_string_index = recipes.find_first_of( ',', first_string_index );
             if( next_string_index == std::string::npos ) {
                 break;
             }
@@ -7202,8 +7202,8 @@ bool item::operator<( const item &other ) const
             }
             return me->charges < rhs->charges;
         } else {
-            std::string n1 = me_type->nname( 1 );
-            std::string n2 = rhs_type->nname( 1 );
+            std::string const n1 = me_type->nname( 1 );
+            std::string const n2 = rhs_type->nname( 1 );
             return localized_compare( n1, n2 );
         }
     }
@@ -7251,7 +7251,7 @@ int item::gun_dispersion( bool with_ammo, bool with_scaling ) const
     for( const item *mod : gunmods() ) {
         dispersion_sum += mod->type->gunmod->dispersion;
     }
-    int dispPerDamage = get_option< int >( "DISPERSION_PER_GUN_DAMAGE" );
+    int const dispPerDamage = get_option< int >( "DISPERSION_PER_GUN_DAMAGE" );
     dispersion_sum += damage_level( 4 ) * dispPerDamage;
     dispersion_sum = std::max( dispersion_sum, 0 );
     if( with_ammo && ammo_data() ) {
@@ -7264,7 +7264,7 @@ int item::gun_dispersion( bool with_ammo, bool with_scaling ) const
     // Dividing dispersion by 15 temporarily as a gross adjustment,
     // will bake that adjustment into individual gun definitions in the future.
     // Absolute minimum gun dispersion is 1.
-    double divider = get_option< float >( "GUN_DISPERSION_DIVIDER" );
+    double const divider = get_option< float >( "GUN_DISPERSION_DIVIDER" );
     dispersion_sum = std::max( static_cast<int>( std::round( dispersion_sum / divider ) ), 1 );
 
     return dispersion_sum;
@@ -7304,7 +7304,7 @@ damage_instance item::gun_damage( bool with_ammo ) const
         ret.add( ammo_data()->ammo->damage );
     }
 
-    int item_damage = damage_level( 4 );
+    int const item_damage = damage_level( 4 );
     if( item_damage > 0 ) {
         // TODO: This isn't a good solution for multi-damage guns/ammos
         for( damage_unit &du : ret ) {
@@ -7406,7 +7406,7 @@ int item::ammo_remaining() const
     if( is_tool() || is_gun() ) {
         // includes auxiliary gunmods
         if( has_flag( flag_USES_BIONIC_POWER ) ) {
-            int power = units::to_kilojoule( get_avatar().get_power_level() );
+            int const power = units::to_kilojoule( get_avatar().get_power_level() );
             return power;
         }
         return charges;
@@ -7598,7 +7598,7 @@ const std::set<ammotype> &item::ammo_types( bool conversion ) const
         return type->magazine->type;
     }
 
-    static std::set<ammotype> atypes = {};
+    static std::set<ammotype> const atypes = {};
     return atypes;
 }
 
@@ -7719,7 +7719,7 @@ std::set<itype_id> item::magazine_compatible( bool conversion ) const
         if( !m->type->mod->magazine_adaptor.empty() ) {
             for( const ammotype &atype : ammo_types( conversion ) ) {
                 if( m->type->mod->magazine_adaptor.count( atype ) ) {
-                    std::set<itype_id> magazines_for_atype = m->type->mod->magazine_adaptor.find( atype )->second;
+                    std::set<itype_id> const magazines_for_atype = m->type->mod->magazine_adaptor.find( atype )->second;
                     mags.insert( magazines_for_atype.begin(), magazines_for_atype.end() );
                 }
             }
@@ -7729,7 +7729,7 @@ std::set<itype_id> item::magazine_compatible( bool conversion ) const
 
     for( const ammotype &atype : ammo_types( conversion ) ) {
         if( type->magazines.count( atype ) ) {
-            std::set<itype_id> magazines_for_atype = type->magazines.find( atype )->second;
+            std::set<itype_id> const magazines_for_atype = type->magazines.find( atype )->second;
             mags.insert( magazines_for_atype.begin(), magazines_for_atype.end() );
         }
     }
@@ -8066,9 +8066,9 @@ int item_reload_option::moves() const
 
 void item_reload_option::qty( int val )
 {
-    bool ammo_in_container = ammo->is_ammo_container();
-    bool ammo_in_liquid_container = ammo->is_watertight_container();
-    item &ammo_obj = ( ammo_in_container || ammo_in_liquid_container ) ?
+    bool const ammo_in_container = ammo->is_ammo_container();
+    bool const ammo_in_liquid_container = ammo->is_watertight_container();
+    item  const&ammo_obj = ( ammo_in_container || ammo_in_liquid_container ) ?
                      ammo->contents.front() : *ammo;
 
     if( ( ammo_in_container && !ammo_obj.is_ammo() ) ||
@@ -8092,8 +8092,8 @@ void item_reload_option::qty( int val )
         }
     }
 
-    bool ammo_by_charges = ammo_obj.is_ammo() || ammo_in_liquid_container;
-    int available_ammo = ammo_by_charges ? ammo_obj.charges : ammo_obj.ammo_remaining();
+    bool const ammo_by_charges = ammo_obj.is_ammo() || ammo_in_liquid_container;
+    int const available_ammo = ammo_by_charges ? ammo_obj.charges : ammo_obj.ammo_remaining();
     // constrain by available ammo, target capacity and other external factors (max_qty)
     // @ref max_qty is currently set when reloading ammo belts and limits to available linkages
     qty_ = std::min( { val, available_ammo, remaining_capacity, max_qty } );
@@ -8196,7 +8196,7 @@ bool item::reload( player &u, item_location loc, int qty )
         // if we already have a magazine loaded prompt to eject it
         if( magazine_current() ) {
             //~ %1$s: magazine name, %2$s: weapon name
-            std::string prompt = string_format( pgettext( "magazine", "Eject %1$s from %2$s?" ),
+            std::string const prompt = string_format( pgettext( "magazine", "Eject %1$s from %2$s?" ),
                                                 magazine_current()->tname(), tname() );
 
             // eject magazine to player inventory and try to dispose of it from there
@@ -8265,7 +8265,7 @@ float item::simulate_burn( fire_data &frd ) const
             smoke_added += bd.smoke;
             burn_added += bd.burn;
         } else {
-            double volume_burn_rate = to_liter( bd.volume_per_turn ) / to_liter( vol );
+            double const volume_burn_rate = to_liter( bd.volume_per_turn ) / to_liter( vol );
             time_added += bd.fuel * volume_burn_rate;
             smoke_added += bd.smoke * volume_burn_rate;
             burn_added += bd.burn * volume_burn_rate;
@@ -8286,7 +8286,7 @@ float item::simulate_burn( fire_data &frd ) const
     }
 
     if( count_by_charges() ) {
-        int stack_burnt = rng( type->stack_size / 2, type->stack_size );
+        int const stack_burnt = rng( type->stack_size / 2, type->stack_size );
         time_added *= stack_burnt;
         smoke_added *= stack_burnt;
         burn_added *= stack_burnt;
@@ -8299,7 +8299,7 @@ float item::simulate_burn( fire_data &frd ) const
 
 bool item::burn( fire_data &frd )
 {
-    float burn_added = simulate_burn( frd );
+    float const burn_added = simulate_burn( frd );
 
     if( burn_added <= 0 ) {
         return false;
@@ -8360,7 +8360,7 @@ bool item::flammable( int threshold ) const
     }
 
     volume_per_turn /= mats.size();
-    units::volume vol = base_volume();
+    units::volume const vol = base_volume();
     if( volume_per_turn > 0_ml && volume_per_turn < vol ) {
         flammability = flammability * volume_per_turn / vol;
     } else {
@@ -8513,7 +8513,7 @@ bool item::use_amount( const itype_id &it, int &quantity, std::list<item> &used,
                        const std::function<bool( const item & )> &filter )
 {
     // Remember quantity so that we can unseal self
-    int old_quantity = quantity;
+    int const old_quantity = quantity;
     std::vector<item *> removed_items;
     // First, check contents
     visit_items(
@@ -8646,7 +8646,7 @@ bool item::use_charges( const itype_id &what, int &qty, std::list<item> &used,
 
         if( e->is_tool() ) {
             if( e->typeId() == what ) {
-                int n = std::min( e->ammo_remaining(), qty );
+                int const n = std::min( e->ammo_remaining(), qty );
                 qty -= n;
 
                 used.push_back( item( *e ).ammo_set( e->ammo_current(), n ) );
@@ -8658,7 +8658,7 @@ bool item::use_charges( const itype_id &what, int &qty, std::list<item> &used,
             if( e->typeId() == what ) {
 
                 // if can supply excess charges split required off leaving remainder in-situ
-                item obj = e->split( qty );
+                item const obj = e->split( qty );
                 if( parent ) {
                     parent->on_contents_changed();
                 }
@@ -8710,7 +8710,7 @@ const item_category &item::get_category() const
         return contents.front().get_category();
     }
 
-    static item_category null_category;
+    static item_category const null_category;
     return type->category_force.is_valid() ? type->category_force.obj() : null_category;
 }
 
@@ -8940,11 +8940,11 @@ uint64_t item::make_component_hash() const
     }
 
     std::string concatenated_ids;
-    for( std::string id : id_set ) {
+    for( std::string const id : id_set ) {
         concatenated_ids += id;
     }
 
-    std::hash<std::string> hasher;
+    std::hash<std::string> const hasher;
     return hasher( concatenated_ids );
 }
 
@@ -9007,13 +9007,13 @@ bool item::process_rot( const bool seals, const tripoint &pos,
 
     // process rot at most once every 100_turns (10 min)
     // note we're also gated by item::processing_speed
-    time_duration smallest_interval = 10_minutes;
+    time_duration const smallest_interval = 10_minutes;
 
     units::temperature temp = units::from_fahrenheit( weather.get_temperature( pos ) );
     temp = clip_by_temperature_flag( temp, flag );
 
     time_point time = last_rot_check;
-    item_internal::scoped_goes_bad_cache _cache( this );
+    item_internal::scoped_goes_bad_cache const _cache( this );
 
     if( now - time > 1_hours ) {
         // This code is for items that were left out of reality bubble for long time
@@ -9021,31 +9021,31 @@ bool item::process_rot( const bool seals, const tripoint &pos,
         const weather_generator &wgen = weather.get_cur_weather_gen();
         const unsigned int seed = g->get_seed();
         // It's a modifier, so we need to subtract 0_f
-        units::temperature local_mod = units::from_fahrenheit( g->new_game
+        units::temperature const local_mod = units::from_fahrenheit( g->new_game
                                        ? 0
                                        : get_map().get_temperature( pos ) ) - 0_f;
 
         // Process the past of this item since the last time it was processed
         while( now - time > 1_hours ) {
             // Get the environment temperature
-            time_duration time_delta = std::min( 1_hours, now - 1_hours - time );
+            time_duration const time_delta = std::min( 1_hours, now - 1_hours - time );
             time += time_delta;
 
             //Use weather if above ground, use map temp if below
             units::temperature env_temperature_raw;
             if( pos.z >= 0 ) {
-                tripoint_abs_ms location = tripoint_abs_ms( get_map().getabs( pos ) );
-                units::temperature weather_temperature = wgen.get_weather_temperature( location, time,
+                tripoint_abs_ms const location = tripoint_abs_ms( get_map().getabs( pos ) );
+                units::temperature const weather_temperature = wgen.get_weather_temperature( location, time,
                         calendar::config, seed );
                 env_temperature_raw = weather_temperature + local_mod;
             } else {
                 env_temperature_raw = units::from_fahrenheit( AVERAGE_ANNUAL_TEMPERATURE ) + local_mod;
             }
 
-            units::temperature env_temperature_clipped = clip_by_temperature_flag( env_temperature_raw, flag );
+            units::temperature const env_temperature_clipped = clip_by_temperature_flag( env_temperature_raw, flag );
 
             // Lookup table is in F
-            int final_temperature_in_fahrenheit = static_cast<int>( std::round( units::to_fahrenheit<float>
+            int const final_temperature_in_fahrenheit = static_cast<int>( std::round( units::to_fahrenheit<float>
                                                   ( env_temperature_clipped ) ) );
 
             // Calculate item rot
@@ -9062,7 +9062,7 @@ bool item::process_rot( const bool seals, const tripoint &pos,
     // Remaining <1 h from above
     // and items that are held near the player
     if( now - time > smallest_interval ) {
-        int final_temperature_in_fahrenheit = static_cast<int>( std::round( units::to_fahrenheit<float>
+        int const final_temperature_in_fahrenheit = static_cast<int>( std::round( units::to_fahrenheit<float>
                                               ( temp ) ) );
 
         rot += calc_rot( now, final_temperature_in_fahrenheit );
@@ -9186,7 +9186,7 @@ bool item::process_corpse( player *carrier, const tripoint &pos )
 
 bool item::process_fake_mill( player * /*carrier*/, const tripoint &pos )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     if( here.furn( pos ) != furn_str_id( "f_wind_mill_active" ) &&
         here.furn( pos ) != furn_str_id( "f_water_mill_active" ) ) {
         item_counter = 0;
@@ -9203,7 +9203,7 @@ bool item::process_fake_mill( player * /*carrier*/, const tripoint &pos )
 
 bool item::process_fake_smoke( player * /*carrier*/, const tripoint &pos )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     if( here.furn( pos ) != furn_str_id( "f_smoking_rack_active" ) &&
         here.furn( pos ) != furn_str_id( "f_metal_smoking_rack_active" ) ) {
         item_counter = 0;
@@ -9297,12 +9297,12 @@ bool item::process_extinguish( player *carrier, const tripoint &pos )
 {
     // checks for water
     bool extinguish = false;
-    bool in_inv = carrier != nullptr && carrier->has_item( *this );
+    bool const in_inv = carrier != nullptr && carrier->has_item( *this );
     bool submerged = false;
     bool precipitation = false;
     bool windtoostrong = false;
-    bool in_veh = carrier != nullptr && carrier->in_vehicle;
-    int windpower = get_weather().windspeed;
+    bool const in_veh = carrier != nullptr && carrier->in_vehicle;
+    int const windpower = get_weather().windspeed;
     switch( get_weather().weather_id->precip ) {
         case precip_class::very_light:
             precipitation = one_in( 100 );
@@ -9316,7 +9316,7 @@ bool item::process_extinguish( player *carrier, const tripoint &pos )
         default:
             break;
     }
-    map &here = get_map();
+    map  const&here = get_map();
     if( in_inv && !in_veh && here.has_flag( flag_DEEP_WATER, pos ) ) {
         extinguish = true;
         submerged = true;
@@ -9374,7 +9374,7 @@ std::optional<tripoint> item::get_cable_target( Character *p, const tripoint &po
     if( state != "pay_out_cable" && state != "cable_charger_link" ) {
         return std::nullopt;
     }
-    map &here = get_map();
+    map  const&here = get_map();
     const optional_vpart_position vp_pos = here.veh_at( pos );
     if( vp_pos ) {
         const std::optional<vpart_reference> seat = vp_pos.part_with_feature( "BOARDABLE", true );
@@ -9383,7 +9383,7 @@ std::optional<tripoint> item::get_cable_target( Character *p, const tripoint &po
         }
     }
 
-    tripoint source( get_var( "source_x", 0 ), get_var( "source_y", 0 ), get_var( "source_z", 0 ) );
+    tripoint const source( get_var( "source_x", 0 ), get_var( "source_y", 0 ), get_var( "source_z", 0 ) );
 
     return here.getlocal( source );
 }
@@ -9394,7 +9394,7 @@ bool item::process_cable( player *carrier, const tripoint &pos )
         //reset_cable( carrier );
         return false;
     }
-    std::string state = get_var( "state" );
+    std::string const state = get_var( "state" );
     if( state == "solar_pack_link" || state == "solar_pack" ) {
         if( !carrier->has_item( *this ) || !carrier->worn_with_flag( "SOLARPACK_ON" ) ) {
             carrier->add_msg_if_player( m_bad, _( "You notice the cable has come loose!" ) );
@@ -9421,7 +9421,7 @@ bool item::process_cable( player *carrier, const tripoint &pos )
     if( !source ) {
         return false;
     }
-    map &here = get_map();
+    map  const&here = get_map();
     if( !here.veh_at( *source ) || ( source->z != g->get_levz() && !here.has_zlevels() ) ) {
         if( carrier->has_item( *this ) ) {
             carrier->add_msg_if_player( m_bad, _( "You notice the cable has come loose!" ) );
@@ -9430,8 +9430,8 @@ bool item::process_cable( player *carrier, const tripoint &pos )
         return false;
     }
 
-    int distance = rl_dist( pos, *source );
-    int max_charges = type->maximum_charges();
+    int const distance = rl_dist( pos, *source );
+    int const max_charges = type->maximum_charges();
     charges = max_charges - distance;
 
     if( charges < 1 ) {
@@ -9446,7 +9446,7 @@ bool item::process_cable( player *carrier, const tripoint &pos )
 
 void item::reset_cable( player *p )
 {
-    int max_charges = type->maximum_charges();
+    int const max_charges = type->maximum_charges();
 
     set_var( "state", "attach_first" );
     erase_var( "source_x" );
@@ -9468,7 +9468,7 @@ bool item::process_UPS( player *carrier, const tripoint & /*pos*/ )
         active = false;
         return false;
     }
-    bool has_connected_cable = carrier->has_item_with( []( const item & it ) {
+    bool const has_connected_cable = carrier->has_item_with( []( const item & it ) {
         return it.active && it.has_flag( flag_CABLE_SPOOL ) && ( it.get_var( "state" ) == "UPS_link" ||
                 it.get_var( "state" ) == "UPS" );
     } );
@@ -9509,7 +9509,7 @@ bool item::process_tool( player *carrier, const tripoint &pos )
                 return false;
             } else {
                 bool active = false;
-                std::string transform_flag = actor->dependencies;
+                std::string const transform_flag = actor->dependencies;
                 for( const auto &elem : carrier->worn ) {
                     if( elem.active && elem.has_flag( transform_flag ) ) {
                         active = true;
@@ -9573,7 +9573,7 @@ bool item::process_tool( player *carrier, const tripoint &pos )
                 debugmsg( "iuse_actor type descriptor and actual type mismatch." );
                 return false;
             }
-            std::string transformed_flag = actor->flag;
+            std::string const transformed_flag = actor->flag;
             for( auto &elem : carrier->worn ) {
                 if( elem.active && elem.has_flag( transformed_flag ) ) {
                     if( !elem.type->can_use( "set_transformed" ) ) {

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -31,7 +31,7 @@ size_t item_contents::num_item_stacks() const
 
 bool item_contents::spill_contents( const tripoint &pos )
 {
-    for( item  const&it : items ) {
+    for( item  const &it : items ) {
         get_map().add_item_or_charges( pos, it );
     }
 

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -31,7 +31,7 @@ size_t item_contents::num_item_stacks() const
 
 bool item_contents::spill_contents( const tripoint &pos )
 {
-    for( item &it : items ) {
+    for( item  const&it : items ) {
         get_map().add_item_or_charges( pos, it );
     }
 
@@ -43,7 +43,7 @@ void item_contents::handle_liquid_or_spill( Character &guy )
 {
     for( auto iter = items.begin(); iter != items.end(); ) {
         if( iter->made_of( LIQUID ) ) {
-            item liquid( *iter );
+            item const liquid( *iter );
             iter = items.erase( iter );
             liquid_handler::handle_all_liquid( liquid, 1 );
         } else {

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -693,7 +693,7 @@ void Item_factory::finalize_item_blacklist()
             return r.result() == candidate->first;
         } );
     }
-    for( vproto_id  const&vid : vehicle_prototype::get_all() ) {
+    for( vproto_id  const &vid : vehicle_prototype::get_all() ) {
         vehicle_prototype &prototype = const_cast<vehicle_prototype &>( vid.obj() );
         for( vehicle_item_spawn &vis : prototype.item_spawns ) {
             auto &vec = vis.item_ids;
@@ -751,7 +751,7 @@ void Item_factory::finalize_item_blacklist()
             }
         }
     }
-    for( vproto_id  const&vid : vehicle_prototype::get_all() ) {
+    for( vproto_id  const &vid : vehicle_prototype::get_all() ) {
         vehicle_prototype &prototype = const_cast<vehicle_prototype &>( vid.obj() );
         for( vehicle_item_spawn &vis : prototype.item_spawns ) {
             for( itype_id &type_to_spawn : vis.item_ids ) {
@@ -3187,7 +3187,7 @@ item_category_id calc_category( const itype &obj )
 std::vector<item_group_id> Item_factory::get_all_group_names()
 {
     std::vector<item_group_id> rval;
-    for( GroupMap::value_type  const&group_pair : m_template_groups ) {
+    for( GroupMap::value_type  const &group_pair : m_template_groups ) {
         rval.push_back( item_group_id( group_pair.first ) );
     }
     return rval;

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -115,7 +115,7 @@ static void assign( const JsonObject &jo, const std::string &name,
         return;
     }
     mods.clear();
-    for( JsonArray curr : jo.get_array( name ) ) {
+    for( JsonArray const curr : jo.get_array( name ) ) {
         mods.emplace( gun_mode_id( curr.get_string( 0 ) ), gun_modifier_data( curr.get_string( 1 ),
                       curr.get_int( 2 ), curr.size() >= 4 ? curr.get_tags( 3 ) : std::set<std::string>() ) );
     }
@@ -186,7 +186,7 @@ void Item_factory::finalize_pre( itype &obj )
     }
 
     if( obj.mod ) {
-        std::string func = obj.gunmod ? "GUNMOD_ATTACH" : "TOOLMOD_ATTACH";
+        std::string const func = obj.gunmod ? "GUNMOD_ATTACH" : "TOOLMOD_ATTACH";
         emplace_usage( obj.use_methods, func );
     } else if( obj.gun ) {
         const std::string func = "detach_gunmods";
@@ -450,7 +450,7 @@ void Item_factory::finalize_pre( itype &obj )
         }
 
         if( obj.gun->handling < 0 ) {
-            bool burst_only = std::all_of( obj.gun->modes.begin(), obj.gun->modes.end(),
+            bool const burst_only = std::all_of( obj.gun->modes.begin(), obj.gun->modes.end(),
             []( const std::pair<gun_mode_id, gun_modifier_data> &pr ) {
                 return pr.second.qty() > 1 || pr.second.flags().count( "MELEE" ) > 0;
             } );
@@ -494,7 +494,7 @@ void Item_factory::finalize_pre( itype &obj )
             for( const auto &v : vitamin::all() ) {
                 if( !vitamins.count( v.first ) ) {
                     for( const auto &m : mat ) {
-                        double amount = m->vitamin( v.first ) * healthy / mat.size();
+                        double const amount = m->vitamin( v.first ) * healthy / mat.size();
                         vitamins[v.first] += std::ceil( amount );
                     }
                 }
@@ -693,7 +693,7 @@ void Item_factory::finalize_item_blacklist()
             return r.result() == candidate->first;
         } );
     }
-    for( vproto_id &vid : vehicle_prototype::get_all() ) {
+    for( vproto_id  const&vid : vehicle_prototype::get_all() ) {
         vehicle_prototype &prototype = const_cast<vehicle_prototype &>( vid.obj() );
         for( vehicle_item_spawn &vis : prototype.item_spawns ) {
             auto &vec = vis.item_ids;
@@ -751,11 +751,11 @@ void Item_factory::finalize_item_blacklist()
             }
         }
     }
-    for( vproto_id &vid : vehicle_prototype::get_all() ) {
+    for( vproto_id  const&vid : vehicle_prototype::get_all() ) {
         vehicle_prototype &prototype = const_cast<vehicle_prototype &>( vid.obj() );
         for( vehicle_item_spawn &vis : prototype.item_spawns ) {
             for( itype_id &type_to_spawn : vis.item_ids ) {
-                std::map<itype_id, migration>::iterator replacement =
+                std::map<itype_id, migration>::iterator const replacement =
                     migrations.find( type_to_spawn );
                 if( replacement != migrations.end() ) {
                     type_to_spawn = replacement->second.replace;
@@ -830,7 +830,7 @@ void Item_factory::add_iuse( const std::string &type, const use_function_pointer
 
 void Item_factory::add_actor( std::unique_ptr<iuse_actor> ptr )
 {
-    std::string type = ptr->type;
+    std::string const type = ptr->type;
     iuse_function_list[ type ] = use_function( std::move( ptr ) );
 }
 
@@ -1564,7 +1564,7 @@ const itype *Item_factory::find_template( const itype_id &id ) const
 
 Item_spawn_data *Item_factory::get_group( const item_group_id &item_group_id )
 {
-    GroupMap::iterator group_iter = m_template_groups.find( item_group_id );
+    GroupMap::iterator const group_iter = m_template_groups.find( item_group_id );
     if( group_iter != m_template_groups.end() ) {
         return group_iter->second.get();
     }
@@ -1592,7 +1592,7 @@ void Item_factory::load_slot_optional( cata::value_ptr<SlotType> &slotptr, const
     if( !jo.has_member( member ) ) {
         return;
     }
-    JsonObject slotjo = jo.get_object( member );
+    JsonObject const slotjo = jo.get_object( member );
     load_slot( slotptr, slotjo, src );
 }
 
@@ -1757,7 +1757,7 @@ void Item_factory::load( islot_fuel &slot, const JsonObject &jo, const std::stri
     }
     if( jo.has_member( "explosion_data" ) ) {
         slot.has_explode_data = true;
-        JsonObject jo_ed = jo.get_object( "explosion_data" );
+        JsonObject const jo_ed = jo.get_object( "explosion_data" );
         slot.explosion_data.explosion_chance_hot = jo_ed.get_int( "chance_hot" );
         slot.explosion_data.explosion_chance_cold = jo_ed.get_int( "chance_cold" );
         slot.explosion_data.explosion_factor = jo_ed.get_float( "factor" );
@@ -1817,7 +1817,7 @@ void Item_factory::load( islot_gun &slot, const JsonObject &jo, const std::strin
 
     if( jo.has_array( "valid_mod_locations" ) ) {
         slot.valid_mod_locations.clear();
-        for( JsonArray curr : jo.get_array( "valid_mod_locations" ) ) {
+        for( JsonArray const curr : jo.get_array( "valid_mod_locations" ) ) {
             slot.valid_mod_locations.emplace( curr.get_string( 0 ), curr.get_int( 1 ) );
         }
     }
@@ -1959,8 +1959,8 @@ void Item_factory::load( islot_mod &slot, const JsonObject &jo, const std::strin
     if( !mags.empty() ) {
         slot.magazine_adaptor.clear();
     }
-    for( JsonArray arr : mags ) {
-        ammotype ammo( arr.get_string( 0 ) ); // an ammo type (e.g. 9mm)
+    for( JsonArray const arr : mags ) {
+        ammotype const ammo( arr.get_string( 0 ) ); // an ammo type (e.g. 9mm)
         // compatible magazines for this ammo type
         for( const std::string line : arr.get_array( 1 ) ) {
             slot.magazine_adaptor[ ammo ].insert( itype_id( line ) );
@@ -2019,8 +2019,8 @@ void Item_factory::load( islot_comestible &slot, const JsonObject &jo, const std
 {
     const bool strict = is_strict_enabled( src );
 
-    JsonObject relative = jo.get_object( "relative" );
-    JsonObject proportional = jo.get_object( "proportional" );
+    JsonObject const relative = jo.get_object( "relative" );
+    JsonObject const proportional = jo.get_object( "proportional" );
     relative.allow_omitted_members();
     proportional.allow_omitted_members();
 
@@ -2067,7 +2067,7 @@ void Item_factory::load( islot_comestible &slot, const JsonObject &jo, const std
 
     bool is_not_boring = false;
     if( jo.has_member( "primary_material" ) ) {
-        std::string mat = jo.get_string( "primary_material" );
+        std::string const mat = jo.get_string( "primary_material" );
         is_not_boring = is_not_boring || mat == "junk";
     }
     if( jo.has_member( "material" ) ) {
@@ -2111,8 +2111,8 @@ void Item_factory::load( islot_comestible &slot, const JsonObject &jo, const std
 
     // any specification of vitamins suppresses use of material defaults @see Item_factory::finalize
     if( jo.has_array( "vitamins" ) ) {
-        for( JsonArray pair : jo.get_array( "vitamins" ) ) {
-            vitamin_id vit( pair.get_string( 0 ) );
+        for( JsonArray const pair : jo.get_array( "vitamins" ) ) {
+            vitamin_id const vit( pair.get_string( 0 ) );
             slot.default_nutrition.vitamins[ vit ] = pair.get_int( 1 );
         }
 
@@ -2123,8 +2123,8 @@ void Item_factory::load( islot_comestible &slot, const JsonObject &jo, const std
                 slot.default_nutrition.vitamins[ v.first ] += relative.get_int( "vitamins" );
             }
         } else if( relative.has_array( "vitamins" ) ) {
-            for( JsonArray pair : relative.get_array( "vitamins" ) ) {
-                vitamin_id vit( pair.get_string( 0 ) );
+            for( JsonArray const pair : relative.get_array( "vitamins" ) ) {
+                vitamin_id const vit( pair.get_string( 0 ) );
                 slot.default_nutrition.vitamins[ vit ] += pair.get_int( 1 );
             }
         }
@@ -2216,7 +2216,7 @@ void Item_factory::load( islot_gunmod &slot, const JsonObject &jo, const std::st
     assign( jo, "min_str_required_mod", slot.min_str_required_mod );
     if( jo.has_array( "add_mod" ) ) {
         slot.add_mod.clear();
-        for( JsonArray curr : jo.get_array( "add_mod" ) ) {
+        for( JsonArray const curr : jo.get_array( "add_mod" ) ) {
             slot.add_mod.emplace( curr.get_string( 0 ), curr.get_int( 1 ) );
         }
     }
@@ -2502,8 +2502,8 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
         def.magazine_default.clear();
         def.magazines.clear();
 
-        for( JsonArray arr : jo.get_array( "magazines" ) ) {
-            ammotype ammo( arr.get_string( 0 ) ); // an ammo type (e.g. 9mm)
+        for( JsonArray const arr : jo.get_array( "magazines" ) ) {
+            ammotype const ammo( arr.get_string( 0 ) ); // an ammo type (e.g. 9mm)
             JsonArray compat = arr.get_array( 1 ); // compatible magazines for this ammo type
 
             // the first magazine for this ammo type is the default
@@ -2519,7 +2519,7 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
     if( !jarr.empty() ) {
         def.min_skills.clear();
     }
-    for( JsonArray cur : jarr ) {
+    for( JsonArray const cur : jarr ) {
         const auto sk = skill_id( cur.get_string( 0 ) );
         if( !sk.is_valid() ) {
             jo.throw_error( string_format( "invalid skill: %s", sk.c_str() ), "min_skills" );
@@ -2528,7 +2528,7 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
     }
 
     if( jo.has_member( "explosion" ) ) {
-        JsonObject je = jo.get_object( "explosion" );
+        JsonObject const je = jo.get_object( "explosion" );
         def.explosion = load_explosion_data( je );
     }
 
@@ -2540,12 +2540,12 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
         set_qualities_from_json( jo, "qualities", def );
     } else {
         if( jo.has_object( "extend" ) ) {
-            JsonObject tmp = jo.get_object( "extend" );
+            JsonObject const tmp = jo.get_object( "extend" );
             tmp.allow_omitted_members();
             extend_qualities_from_json( tmp, "qualities", def );
         }
         if( jo.has_object( "delete" ) ) {
-            JsonObject tmp = jo.get_object( "delete" );
+            JsonObject const tmp = jo.get_object( "delete" );
             tmp.allow_omitted_members();
             delete_qualities_from_json( tmp, "qualities", def );
         }
@@ -2567,7 +2567,7 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
 
     } else if( jo.has_object( "countdown_action" ) ) {
         auto tmp = jo.get_object( "countdown_action" );
-        use_function fun = usage_from_object( tmp ).second;
+        use_function const fun = usage_from_object( tmp ).second;
         if( fun ) {
             def.countdown_action = fun;
         }
@@ -2578,7 +2578,7 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
 
     } else if( jo.has_object( "drop_action" ) ) {
         auto tmp = jo.get_object( "drop_action" );
-        use_function fun = usage_from_object( tmp ).second;
+        use_function const fun = usage_from_object( tmp ).second;
         if( fun ) {
             def.drop_action = fun;
         }
@@ -2618,7 +2618,7 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
     if( jo.has_member( "gunmod_data" ) ) {
         // use the same JsonObject for the two load_slot calls to avoid
         // warnings about unvisited Json members
-        JsonObject jo_gunmod = jo.get_object( "gunmod_data" );
+        JsonObject const jo_gunmod = jo.get_object( "gunmod_data" );
         load_slot( def.gunmod, jo_gunmod, src );
         load_slot( def.mod, jo_gunmod, src );
     }
@@ -2722,7 +2722,7 @@ void Item_factory::set_qualities_from_json( const JsonObject &jo, const std::str
 void Item_factory::extend_qualities_from_json( const JsonObject &jo, const std::string &member,
         itype &def )
 {
-    for( JsonArray curr : jo.get_array( member ) ) {
+    for( JsonArray const curr : jo.get_array( member ) ) {
         def.qualities[quality_id( curr.get_string( 0 ) )] = curr.get_int( 1 );
     }
 }
@@ -2730,7 +2730,7 @@ void Item_factory::extend_qualities_from_json( const JsonObject &jo, const std::
 void Item_factory::delete_qualities_from_json( const JsonObject &jo, const std::string &member,
         itype &def )
 {
-    for( JsonArray curr : jo.get_array( member ) ) {
+    for( JsonArray const curr : jo.get_array( member ) ) {
         const auto iter = def.qualities.find( quality_id( curr.get_string( 0 ) ) );
         if( iter != def.qualities.end() && iter->second == curr.get_int( 1 ) ) {
             def.qualities.erase( iter );
@@ -2911,7 +2911,7 @@ bool Item_factory::load_string( std::vector<std::string> &vec, const JsonObject 
 void Item_factory::add_entry( Item_group &ig, const JsonObject &obj )
 {
     std::unique_ptr<Item_group> gptr;
-    int probability = obj.get_int( "prob", 100 );
+    int const probability = obj.get_int( "prob", 100 );
     JsonArray jarr;
     if( obj.has_member( "collection" ) ) {
         gptr = std::make_unique<Item_group>( Item_group::G_COLLECTION, probability, ig.with_ammo,
@@ -2995,10 +2995,10 @@ void Item_factory::load_item_group( const JsonObject &jsobj, const item_group_id
     if( subtype == "old" ) {
         for( const JsonValue entry : jsobj.get_array( "items" ) ) {
             if( entry.test_object() ) {
-                JsonObject subobj = entry.get_object();
+                JsonObject const subobj = entry.get_object();
                 add_entry( *ig, subobj );
             } else {
-                JsonArray pair = entry.get_array();
+                JsonArray const pair = entry.get_array();
                 ig->add_item_entry( itype_id( pair.get_string( 0 ) ), pair.get_int( 1 ) );
             }
         }
@@ -3015,10 +3015,10 @@ void Item_factory::load_item_group( const JsonObject &jsobj, const item_group_id
             if( entry.test_string() ) {
                 ig->add_item_entry( itype_id( entry.get_string() ), 100 );
             } else if( entry.test_array() ) {
-                JsonArray subitem = entry.get_array();
+                JsonArray const subitem = entry.get_array();
                 ig->add_item_entry( itype_id( subitem.get_string( 0 ) ), subitem.get_int( 1 ) );
             } else {
-                JsonObject subobj = entry.get_object();
+                JsonObject const subobj = entry.get_object();
                 add_entry( *ig, subobj );
             }
         }
@@ -3028,10 +3028,10 @@ void Item_factory::load_item_group( const JsonObject &jsobj, const item_group_id
             if( entry.test_string() ) {
                 ig->add_group_entry( item_group_id( entry.get_string() ), 100 );
             } else if( entry.test_array() ) {
-                JsonArray subitem = entry.get_array();
+                JsonArray const subitem = entry.get_array();
                 ig->add_group_entry( item_group_id( subitem.get_string( 0 ) ), subitem.get_int( 1 ) );
             } else {
-                JsonObject subobj = entry.get_object();
+                JsonObject const subobj = entry.get_object();
                 add_entry( *ig, subobj );
             }
         }
@@ -3049,11 +3049,11 @@ void Item_factory::set_use_methods_from_json( const JsonObject &jo, const std::s
     if( jo.has_array( member ) ) {
         for( const JsonValue entry : jo.get_array( member ) ) {
             if( entry.test_string() ) {
-                std::string type = entry.get_string();
+                std::string const type = entry.get_string();
                 emplace_usage( use_methods, type );
             } else if( entry.test_object() ) {
                 auto obj = entry.get_object();
-                std::pair<std::string, use_function> fun = usage_from_object( obj );
+                std::pair<std::string, use_function> const fun = usage_from_object( obj );
                 if( fun.second ) {
                     use_methods.insert( fun );
                 }
@@ -3063,11 +3063,11 @@ void Item_factory::set_use_methods_from_json( const JsonObject &jo, const std::s
         }
     } else {
         if( jo.has_string( member ) ) {
-            std::string type = jo.get_string( member );
+            std::string const type = jo.get_string( member );
             emplace_usage( use_methods, type );
         } else if( jo.has_object( member ) ) {
             auto obj = jo.get_object( member );
-            std::pair<std::string, use_function> fun = usage_from_object( obj );
+            std::pair<std::string, use_function> const fun = usage_from_object( obj );
             if( fun.second ) {
                 use_methods.insert( fun );
             }
@@ -3177,7 +3177,7 @@ item_category_id calc_category( const itype &obj )
         return item_category_id( "bionics" );
     }
 
-    bool weap = std::any_of( obj.melee.begin(), obj.melee.end(), []( int qty ) {
+    bool const weap = std::any_of( obj.melee.begin(), obj.melee.end(), []( int qty ) {
         return qty > MELEE_STAT;
     } );
 
@@ -3187,7 +3187,7 @@ item_category_id calc_category( const itype &obj )
 std::vector<item_group_id> Item_factory::get_all_group_names()
 {
     std::vector<item_group_id> rval;
-    for( GroupMap::value_type &group_pair : m_template_groups ) {
+    for( GroupMap::value_type  const&group_pair : m_template_groups ) {
         rval.push_back( item_group_id( group_pair.first ) );
     }
     return rval;

--- a/src/item_functions.cpp
+++ b/src/item_functions.cpp
@@ -48,9 +48,9 @@ int shots_remaining( const Character &who, const item &it )
         return 0;
     }
 
-    int ammo_drain = it.ammo_required();
-    int energy_drain = it.get_gun_ups_drain();
-    int power = who.charges_of( itype_UPS );
+    int const ammo_drain = it.ammo_required();
+    int const energy_drain = it.get_gun_ups_drain();
+    int const power = who.charges_of( itype_UPS );
 
     if( ammo_drain > 0 && energy_drain > 0 ) {
         // Both UPS and ammo, lower is limiting.

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -344,9 +344,9 @@ void Item_modifier::modify( item &new_item ) const
 
     if( new_item.is_tool() || new_item.is_gun() || new_item.is_magazine() ) {
         bool const spawn_ammo = rng( 0, 99 ) < with_ammo && new_item.ammo_remaining() == 0 && ch == -1 &&
-                          ( !new_item.is_tool() || new_item.type->tool->rand_charges.empty() );
+                                ( !new_item.is_tool() || new_item.type->tool->rand_charges.empty() );
         bool const spawn_mag  = rng( 0, 99 ) < with_magazine && !new_item.magazine_integral() &&
-                          !new_item.magazine_current();
+                                !new_item.magazine_current();
 
         if( spawn_mag ) {
             new_item.put_in( item( new_item.magazine_default(), new_item.birthday() ) );

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -246,7 +246,7 @@ void Item_modifier::modify( item &new_item ) const
     // no need for dirt if it's a bow
     if( new_item.is_gun() && !new_item.has_flag( flag_PRIMITIVE_RANGED_WEAPON ) &&
         !new_item.has_flag( flag_NON_FOULING ) ) {
-        int random_dirt = rng( dirt.first, dirt.second );
+        int const random_dirt = rng( dirt.first, dirt.second );
         // if gun RNG is dirty, must add dirt fault to allow cleaning
         if( random_dirt > 0 ) {
             new_item.set_var( "dirt", random_dirt );
@@ -343,9 +343,9 @@ void Item_modifier::modify( item &new_item ) const
     }
 
     if( new_item.is_tool() || new_item.is_gun() || new_item.is_magazine() ) {
-        bool spawn_ammo = rng( 0, 99 ) < with_ammo && new_item.ammo_remaining() == 0 && ch == -1 &&
+        bool const spawn_ammo = rng( 0, 99 ) < with_ammo && new_item.ammo_remaining() == 0 && ch == -1 &&
                           ( !new_item.is_tool() || new_item.type->tool->rand_charges.empty() );
-        bool spawn_mag  = rng( 0, 99 ) < with_magazine && !new_item.magazine_integral() &&
+        bool const spawn_mag  = rng( 0, 99 ) < with_magazine && !new_item.magazine_integral() &&
                           !new_item.magazine_current();
 
         if( spawn_mag ) {
@@ -368,7 +368,7 @@ void Item_modifier::modify( item &new_item ) const
     }
 
     if( contents != nullptr ) {
-        Item_spawn_data::ItemList contentitems = contents->create( new_item.birthday() );
+        Item_spawn_data::ItemList const contentitems = contents->create( new_item.birthday() );
         for( const item &it : contentitems ) {
             new_item.put_in( it );
         }
@@ -565,7 +565,7 @@ std::set<const itype *> Item_group::every_item() const
 {
     std::set<const itype *> result;
     for( const auto &spawn_data : items ) {
-        std::set<const itype *> these_items = spawn_data->every_item();
+        std::set<const itype *> const these_items = spawn_data->every_item();
         result.insert( these_items.begin(), these_items.end() );
     }
     return result;
@@ -654,7 +654,7 @@ item_group_id item_group::load_item_group( const JsonValue &value,
     } else if( value.test_object() ) {
         const item_group_id group = get_unique_group_id();
 
-        JsonObject jo = value.get_object();
+        JsonObject const jo = value.get_object();
         const std::string subtype = jo.get_string( "subtype", default_subtype );
         item_controller->load_item_group( jo, group, subtype );
 
@@ -662,7 +662,7 @@ item_group_id item_group::load_item_group( const JsonValue &value,
     } else if( value.test_array() ) {
         const item_group_id group = get_unique_group_id();
 
-        JsonArray jarr = value.get_array();
+        JsonArray const jarr = value.get_array();
         // load_item_group needs a bool, invalid subtypes are unexpected and most likely errors
         // from the caller of this function.
         if( default_subtype != "collection" && default_subtype != "distribution" ) {

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -204,7 +204,7 @@ class item_location::impl::item_on_map : public item_location::impl
         item_location obtain( Character &ch, int qty ) override {
             ch.moves -= obtain_cost( ch, qty );
 
-            item obj = target()->split( qty );
+            item const obj = target()->split( qty );
             if( !obj.is_null() ) {
                 return item_location( ch, &ch.i_add( obj, should_stack ) );
             } else {
@@ -332,7 +332,7 @@ class item_location::impl::item_on_person : public item_location::impl
                 return item_location( ch, target() );
             }
 
-            item obj = target()->split( qty );
+            item const obj = target()->split( qty );
             if( !obj.is_null() ) {
                 return item_location( ch, &ch.i_add( obj, should_stack ) );
             } else {
@@ -447,7 +447,7 @@ class item_location::impl::item_on_vehicle : public item_location::impl
         }
 
         std::string describe( const Character *ch ) const override {
-            vpart_position part_pos( cur.veh, cur.part );
+            vpart_position const part_pos( cur.veh, cur.part );
             std::string res;
             if( auto label = part_pos.get_label() ) {
                 res = colorize( *label, c_light_blue ) + " ";
@@ -466,7 +466,7 @@ class item_location::impl::item_on_vehicle : public item_location::impl
         item_location obtain( Character &ch, int qty ) override {
             ch.moves -= obtain_cost( ch, qty );
 
-            item obj = target()->split( qty );
+            item const obj = target()->split( qty );
             if( !obj.is_null() ) {
                 return item_location( ch, &ch.i_add( obj, should_stack ) );
             } else {
@@ -586,7 +586,7 @@ class item_location::impl::item_in_container : public item_location::impl
         item_location obtain( Character &ch, int qty ) override {
             ch.mod_moves( -obtain_cost( ch, qty ) );
 
-            item obj = target()->split( qty );
+            item const obj = target()->split( qty );
             if( !obj.is_null() ) {
                 return item_location( ch, &ch.i_add( obj, should_stack ) );
             } else {
@@ -703,7 +703,7 @@ void item_location::deserialize( JsonIn &js )
 
     } else if( type == "vehicle" ) {
         vehicle *const veh = veh_pointer_or_null( get_map().veh_at( pos ) );
-        int part = obj.get_int( "part" );
+        int const part = obj.get_int( "part" );
         if( veh && part >= 0 && part < veh->part_count() ) {
             ptr.reset( new impl::item_on_vehicle( vehicle_cursor( *veh, part ), idx ) );
         }

--- a/src/item_search.cpp
+++ b/src/item_search.cpp
@@ -95,7 +95,7 @@ std::function<bool( const item & )> item_filter_from_string( const std::string &
 
 std::pair<std::string, std::string> get_both( const std::string &a )
 {
-    size_t split_mark = a.find( ';' );
+    size_t const split_mark = a.find( ';' );
     return std::make_pair( a.substr( 0, split_mark - 1 ),
                            a.substr( split_mark + 1 ) );
 }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1765,7 +1765,7 @@ static bool good_fishing_spot( tripoint pos )
 {
     std::unordered_set<tripoint> fishable_locations = g->get_fishable_locations( 60, pos );
     std::vector<monster *> const fishables = g->get_fishable_monsters( fishable_locations );
-    map  const&here = get_map();
+    map  const &here = get_map();
     // isolated little body of water with no definite fish population
     // TODO: fix point types
     const oter_id &cur_omt =
@@ -2638,7 +2638,7 @@ static digging_moves_and_byproducts dig_pit_moves_and_byproducts( player *p, ite
     // And now determine the moves...
     int const dig_minutes = deep ? deep_pit_time : shallow_pit_time;
     int const moves = to_moves<int>( std::max( 10_minutes,
-                                         time_duration::from_minutes( dig_minutes * attr ) / quality ) );
+                                     time_duration::from_minutes( dig_minutes * attr ) / quality ) );
 
     ter_id result_terrain;
     if( channel ) {
@@ -3340,9 +3340,9 @@ int iuse::geiger( player *p, item *it, bool t, const tripoint &pos )
             return it->type->charges_to_use();
         }
         std::string const description = rads > 50 ? _( "buzzing" ) :
-                                  rads > 25 ? _( "rapid clicking" ) : _( "clicking" );
+                                        rads > 25 ? _( "rapid clicking" ) : _( "clicking" );
         std::string const sound_var = rads > 50 ? _( "geiger_high" ) :
-                                rads > 25 ? _( "geiger_medium" ) : _( "geiger_low" );
+                                      rads > 25 ? _( "geiger_medium" ) : _( "geiger_low" );
 
         sounds::sound( pos, 6, sounds::sound_t::alarm, description, true, "tool", sound_var );
         if( !p->can_hear( pos, 6 ) ) {
@@ -3394,7 +3394,7 @@ int iuse::geiger( player *p, item *it, bool t, const tripoint &pos )
                 break;
             }
             if( npc *const person_ = g->critter_at<npc>( pnt ) ) {
-                npc  const&person = *person_;
+                npc  const &person = *person_;
                 p->add_msg_if_player( m_info, _( "%s's radiation level: %d mSv (%d mSv from items)" ),
                                       person.name, person.get_rad(),
                                       person.leak_level( "RADIOACTIVE" ) );
@@ -3966,8 +3966,9 @@ int iuse::tazer( player *p, item *it, bool, const tripoint &pos )
     } else {
         // TODO: Maybe - Execute an attack and maybe zap something other than torso
         // Maybe, because it's torso (heart) that fails when zapped with electricity
-        int const dam = target->deal_damage( p, bodypart_id( "torso" ), damage_instance( DT_ELECTRIC, rng( 5,
-                                       25 ) ) ).total_damage();
+        int const dam = target->deal_damage( p, bodypart_id( "torso" ), damage_instance( DT_ELECTRIC,
+                                             rng( 5,
+                                                     25 ) ) ).total_damage();
         if( dam > 0 ) {
             p->add_msg_player_or_npc( m_good,
                                       _( "You shock %s!" ),
@@ -5062,7 +5063,7 @@ int iuse::mop( player *p, item *it, bool, const tripoint & )
                 return true;
             }
         }
-        field  const&fld = g->m.field_at( pnt );
+        field  const &fld = g->m.field_at( pnt );
         for( field_type_id const fid : to_check ) {
             if( fld.find_field_c( fid ) ) {
                 return true;
@@ -5467,10 +5468,10 @@ int iuse::handle_ground_graffiti( player &p, item *it, const std::string &prefix
 {
     string_input_popup popup;
     std::string const message = popup
-                          .description( prefix + " " + _( "(To delete, clear the text and confirm)" ) )
-                          .text( g->m.has_graffiti_at( where ) ? g->m.graffiti_at( where ) : std::string() )
-                          .identifier( "graffiti" )
-                          .query_string();
+                                .description( prefix + " " + _( "(To delete, clear the text and confirm)" ) )
+                                .text( g->m.has_graffiti_at( where ) ? g->m.graffiti_at( where ) : std::string() )
+                                .identifier( "graffiti" )
+                                .query_string();
     if( popup.canceled() ) {
         return 0;
     }
@@ -5786,7 +5787,7 @@ int iuse::gun_clean( player *p, item *, bool, const tripoint & )
         p->add_msg_if_player( m_info, _( "You do not have that item!" ) );
         return 0;
     }
-    item  const&fix = *loc;
+    item  const &fix = *loc;
     if( !fix.is_firearm() ) {
         p->add_msg_if_player( m_info, _( "That isn't a firearm!" ) );
         return 0;
@@ -6047,7 +6048,8 @@ int iuse::robotcontrol( player *p, item *it, bool, const tripoint & )
 
             /** @EFFECT_INT speeds up hacking preperation */
             /** @EFFECT_COMPUTER speeds up hacking preperation */
-            int const move_cost = std::max( 100, 1000 - p->int_cur * 10 - p->get_skill_level( skill_computer ) * 10 );
+            int const move_cost = std::max( 100,
+                                            1000 - p->int_cur * 10 - p->get_skill_level( skill_computer ) * 10 );
             player_activity act( ACT_ROBOT_CONTROL, move_cost );
             act.monsters.emplace_back( z );
 
@@ -6921,7 +6923,7 @@ static object_names_collection enumerate_objects_around_point( const tripoint &p
         std::unordered_set<tripoint> &ignored_points,
         std::unordered_set<const vehicle *> &vehicles_recorded )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     const tripoint_range<tripoint> bounds =
         here.points_in_radius( bounds_center_point, bounds_radius );
     const tripoint_range<tripoint> points_in_radius = here.points_in_radius( point, radius );
@@ -6944,7 +6946,7 @@ static object_names_collection enumerate_objects_around_point( const tripoint &p
             continue; // disallow photos with not visible objects
         }
         units::volume const volume_to_search = point_around_figure == bounds_center_point ? 0_ml :
-                                         min_visible_volume;
+                                               min_visible_volume;
 
         std::string furn_desc = colorized_feature_description_at( point_around_figure, item_found,
                                 volume_to_search );
@@ -7075,7 +7077,7 @@ static extended_photo_def photo_def_for_camera_point( const tripoint &aim_point,
 
     std::string const timestamp = to_string( time_point( calendar::turn ) );
     int const dist = rl_dist( camera_pos, aim_point );
-    map  const&here = get_map();
+    map  const &here = get_map();
     const tripoint_range<tripoint> bounds = here.points_in_radius( aim_point, 2 );
     extended_photo_def photo;
     bool need_store_weather = false;
@@ -7145,7 +7147,8 @@ static extended_photo_def photo_def_for_camera_point( const tripoint &aim_point,
             figure_effects = effects_description_for_creature( creature, pose, pronoun_sex );
             description_figures_appearance[ figure_name ] = figure_appearance;
 
-            object_names_collection const obj_collection = enumerate_objects_around_point( current, 1, aim_point, 2,
+            object_names_collection const obj_collection = enumerate_objects_around_point( current, 1,
+                    aim_point, 2,
                     camera_pos, min_visible_volume, true,
                     ignored_points, vehicles_recorded );
             std::string figure_text = pose + obj_collection.figure_text;
@@ -7192,7 +7195,7 @@ static extended_photo_def photo_def_for_camera_point( const tripoint &aim_point,
 
     if( !description_figures_status.empty() ) {
         std::string const names = enumerate_as_string( description_figures_status.begin(),
-                            description_figures_status.end(),
+                                  description_figures_status.end(),
         []( const std::pair<std::string, std::string> &it ) {
             return colorize( it.first, c_light_blue );
         } );
@@ -7253,28 +7256,30 @@ static extended_photo_def photo_def_for_camera_point( const tripoint &aim_point,
 
     if( !obj_coll.items.empty() ) {
         std::string const obj_list = enumerate_as_string( obj_coll.items.begin(), obj_coll.items.end(),
-                               format_object_pair_article );
+                                     format_object_pair_article );
         photo_text += "\n\n" + string_format( vgettext( "There is something lying on the ground: %s.",
                                               "There are some things lying on the ground: %s.", num_of( obj_coll.items ) ),
                                               obj_list );
     }
     if( !obj_coll.furniture.empty() ) {
-        std::string const obj_list = enumerate_as_string( obj_coll.furniture.begin(), obj_coll.furniture.end(),
-                               format_object_pair_article );
+        std::string const obj_list = enumerate_as_string( obj_coll.furniture.begin(),
+                                     obj_coll.furniture.end(),
+                                     format_object_pair_article );
         photo_text += "\n\n" + string_format( vgettext( "Something is visible in the background: %s.",
                                               "Some objects are visible in the background: %s.", num_of( obj_coll.furniture ) ),
                                               obj_list );
     }
     if( !obj_coll.vehicles.empty() ) {
-        std::string const obj_list = enumerate_as_string( obj_coll.vehicles.begin(), obj_coll.vehicles.end(),
-                               format_object_pair_no_article );
+        std::string const obj_list = enumerate_as_string( obj_coll.vehicles.begin(),
+                                     obj_coll.vehicles.end(),
+                                     format_object_pair_no_article );
         photo_text += "\n\n" + string_format( vgettext( "There is %s parked in the background.",
                                               "There are %s parked in the background.", num_of( obj_coll.vehicles ) ),
                                               obj_list );
     }
     if( !obj_coll.terrain.empty() ) {
         std::string const obj_list = enumerate_as_string( obj_coll.terrain.begin(), obj_coll.terrain.end(),
-                               format_object_pair_article );
+                                     format_object_pair_article );
         photo_text += "\n\n" + string_format( vgettext( "There is %s in the background.",
                                               "There are %s in the background.", num_of( obj_coll.terrain ) ),
                                               obj_list );
@@ -7461,7 +7466,7 @@ int iuse::camera( player *p, item *it, bool, const tripoint & )
 
     // CAMERA_NPC_PHOTOS is old save variable
     bool const found_extended_photos = !it->get_var( "CAMERA_NPC_PHOTOS" ).empty() ||
-                                 !it->get_var( "CAMERA_EXTENDED_PHOTOS" ).empty();
+                                       !it->get_var( "CAMERA_EXTENDED_PHOTOS" ).empty();
     bool const found_monster_photos = !it->get_var( "CAMERA_MONSTER_PHOTOS" ).empty();
 
     uilist amenu;
@@ -7537,7 +7542,7 @@ int iuse::camera( player *p, item *it, bool, const tripoint & )
                 }
 
                 if( mon ) {
-                    monster  const&z = *mon;
+                    monster  const &z = *mon;
 
                     // shoot past small monsters and hallucinations
                     if( trajectory_point != aim_point && ( z.type->size <= MS_SMALL || z.is_hallucination() ||
@@ -7850,7 +7855,7 @@ int iuse::foodperson( player *p, item *it, bool t, const tripoint &pos )
     }
 
     time_duration const shift = time_duration::from_turns( it->magazine_current()->ammo_remaining() *
-                          it->type->tool->turns_per_charge );
+                                it->type->tool->turns_per_charge );
 
     p->add_msg_if_player( m_info, _( "Your HUD lights-up: \"Your shift ends in %s\"." ),
                           to_string( shift ) );
@@ -7905,7 +7910,7 @@ int iuse::radiocar( player *p, item *it, bool, const tripoint & )
                 p->add_msg_if_player( m_info, _( "You do not have that item!" ) );
                 return 0;
             }
-            item  const&put = *loc;
+            item  const &put = *loc;
 
             if( put.has_flag( "RADIOCARITEM" ) && ( put.volume() <= 1250_ml ||
                                                     ( put.weight() <= 2_kilogram ) ) ) {
@@ -8136,7 +8141,8 @@ static bool hackveh( player &p, item &it, vehicle &veh )
     /** @EFFECT_INT increases chance of bypassing vehicle security system */
 
     /** @EFFECT_COMPUTER increases chance of bypassing vehicle security system */
-    int const roll = dice( p.get_skill_level( skill_computer ) + 2, p.int_cur ) - ( advanced ? 50 : 25 );
+    int const roll = dice( p.get_skill_level( skill_computer ) + 2,
+                           p.int_cur ) - ( advanced ? 50 : 25 );
     int effort = 0;
     bool success = false;
     if( roll < -20 ) { // Really bad rolls will trigger the alarm before you know it exists
@@ -8480,7 +8486,7 @@ int iuse::multicooker( player *p, item *it, bool t, const tripoint &pos )
         }
 
         if( mc_take == choice ) {
-            item  const&dish = *dish_it;
+            item  const &dish = *dish_it;
             const std::string dish_name = dish.tname( dish.charges, false );
             if( dish.made_of( LIQUID ) ) {
                 if( !p->check_eligible_containers_for_crafting( *recipe_id( it->get_var( "RECIPE" ) ), 1 ) ) {
@@ -8562,7 +8568,7 @@ int iuse::multicooker( player *p, item *it, bool t, const tripoint &pos )
                     return 0;
                 }
 
-                for( const auto& component : reqs->get_components() ) {
+                for( const auto &component : reqs->get_components() ) {
                     p->consume_items( component, 1, filter );
                 }
 
@@ -8700,8 +8706,8 @@ int iuse::tow_attach( player *p, item *it, bool, const tripoint & )
     } else {
         const auto confirm_source_vehicle = []( player * p, item * it, const bool detach_if_missing ) {
             tripoint const source_global( it->get_var( "source_x", 0 ),
-                                    it->get_var( "source_y", 0 ),
-                                    it->get_var( "source_z", 0 ) );
+                                          it->get_var( "source_y", 0 ),
+                                          it->get_var( "source_z", 0 ) );
             tripoint const source_local = g->m.getlocal( source_global );
             const optional_vpart_position source_vp = g->m.veh_at( source_local );
             vehicle *const source_veh = veh_pointer_or_null( source_vp );
@@ -8874,8 +8880,8 @@ int iuse::cable_attach( player *p, item *it, bool, const tripoint & )
     } else {
         const auto confirm_source_vehicle = []( player * p, item * it, const bool detach_if_missing ) {
             tripoint const source_global( it->get_var( "source_x", 0 ),
-                                    it->get_var( "source_y", 0 ),
-                                    it->get_var( "source_z", 0 ) );
+                                          it->get_var( "source_y", 0 ),
+                                          it->get_var( "source_z", 0 ) );
             tripoint const source_local = g->m.getlocal( source_global );
             const optional_vpart_position source_vp = g->m.veh_at( source_local );
             vehicle *const source_veh = veh_pointer_or_null( source_vp );
@@ -8987,8 +8993,8 @@ int iuse::cable_attach( player *p, item *it, bool, const tripoint & )
             return 0;
         } else {
             tripoint const source_global( it->get_var( "source_x", 0 ),
-                                    it->get_var( "source_y", 0 ),
-                                    it->get_var( "source_z", 0 ) );
+                                          it->get_var( "source_y", 0 ),
+                                          it->get_var( "source_z", 0 ) );
             const vpart_id vpid( it->typeId().str() );
 
             point vcoords = source_vp->mount();
@@ -9072,7 +9078,7 @@ int iuse::weather_tool( player *p, item *it, bool, const tripoint & )
     /* Possibly used twice. Worth spending the time to precalculate. */
     const auto player_local_temp = weather.get_temperature( p->pos() );
 
-    map  const&here = get_map();
+    map  const &here = get_map();
     if( it->typeId() == itype_weather_reader ) {
         p->add_msg_if_player( m_neutral, _( "The %s's monitor slowly outputs the data…" ),
                               it->tname() );
@@ -9428,15 +9434,15 @@ int wash_items( player *p, bool soft_items, bool hard_items )
         return it.made_of( LIQUID ) || it.contents_made_of( LIQUID );
     };
     int const available_water = std::max(
-                              crafting_inv.charges_of( itype_water, INT_MAX, is_liquid ),
-                              crafting_inv.charges_of( itype_water_clean, INT_MAX, is_liquid )
-                          );
+                                    crafting_inv.charges_of( itype_water, INT_MAX, is_liquid ),
+                                    crafting_inv.charges_of( itype_water_clean, INT_MAX, is_liquid )
+                                );
     int const available_cleanser = std::max( crafting_inv.charges_of( itype_soap ),
-                                       crafting_inv.charges_of( itype_detergent ) );
+                                   crafting_inv.charges_of( itype_detergent ) );
 
     iuse_locations const to_clean = game_menus::inv::multiwash( *p, available_water, available_cleanser,
-                              soft_items,
-                              hard_items );
+                                    soft_items,
+                                    hard_items );
 
     if( to_clean.empty() ) {
         return 0;
@@ -9449,7 +9455,7 @@ int wash_items( player *p, bool soft_items, bool hard_items )
             p->add_msg_if_player( m_info, _( "Never mind." ) );
             return 0;
         }
-        item  const&i = *iloc.loc;
+        item  const &i = *iloc.loc;
         total_volume += i.volume() * iloc.count / i.count();
     }
 
@@ -9682,8 +9688,10 @@ int iuse::report_grid_charge( player *p, item *, bool, const tripoint &pos )
 
 int iuse::report_grid_connections( player *p, item *, bool, const tripoint &pos )
 {
-    tripoint_abs_omt const pos_abs = project_to<coords::omt>( tripoint_abs_ms( get_map().getabs( pos ) ) );
-    std::vector<tripoint_rel_omt> const connections = overmap_buffer.electric_grid_connectivity_at( pos_abs );
+    tripoint_abs_omt const pos_abs = project_to<coords::omt>( tripoint_abs_ms( get_map().getabs(
+                                         pos ) ) );
+    std::vector<tripoint_rel_omt> const connections = overmap_buffer.electric_grid_connectivity_at(
+                pos_abs );
 
     std::vector<std::string> connection_names;
     for( const tripoint_rel_omt &delta : connections ) {
@@ -9705,7 +9713,8 @@ int iuse::report_grid_connections( player *p, item *, bool, const tripoint &pos 
 
 int iuse::modify_grid_connections( player *p, item *it, bool, const tripoint &pos )
 {
-    tripoint_abs_omt const pos_abs = project_to<coords::omt>( tripoint_abs_ms( get_map().getabs( pos ) ) );
+    tripoint_abs_omt const pos_abs = project_to<coords::omt>( tripoint_abs_ms( get_map().getabs(
+                                         pos ) ) );
     std::vector<tripoint_rel_omt> connections = overmap_buffer.electric_grid_connectivity_at( pos_abs );
 
     uilist ui;
@@ -9731,12 +9740,14 @@ int iuse::modify_grid_connections( player *p, item *it, bool, const tripoint &po
     }
 
     size_t const ret = static_cast<size_t>( ui.ret );
-    tripoint_abs_omt const destination_pos_abs = pos_abs + tripoint_rel_omt( six_cardinal_directions[ret] );
+    tripoint_abs_omt const destination_pos_abs = pos_abs + tripoint_rel_omt(
+                six_cardinal_directions[ret] );
     if( connection_present[ret] ) {
         overmap_buffer.remove_grid_connection( pos_abs, destination_pos_abs );
     } else {
         std::set<tripoint_abs_omt> const lhs_locations = overmap_buffer.electric_grid_at( pos_abs );
-        std::set<tripoint_abs_omt> const rhs_locations = overmap_buffer.electric_grid_at( destination_pos_abs );
+        std::set<tripoint_abs_omt> const rhs_locations = overmap_buffer.electric_grid_at(
+                    destination_pos_abs );
         int cost_mult;
         if( lhs_locations == rhs_locations ) {
             cost_mult = 0;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8562,7 +8562,7 @@ int iuse::multicooker( player *p, item *it, bool t, const tripoint &pos )
                     return 0;
                 }
 
-                for( auto component : reqs->get_components() ) {
+                for( const auto& component : reqs->get_components() ) {
                     p->consume_items( component, 1, filter );
                 }
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -536,7 +536,7 @@ int iuse::alcohol_strong( player *p, item *it, bool, const tripoint & )
  */
 int iuse::smoking( player *p, item *it, bool, const tripoint & )
 {
-    bool hasFire = ( p->has_charges( itype_fire, 1 ) );
+    bool const hasFire = ( p->has_charges( itype_fire, 1 ) );
 
     // make sure we're not already smoking something
     if( !check_litcig( *p ) ) {
@@ -851,7 +851,7 @@ int iuse::meth( player *p, item *it, bool, const tripoint & )
     if( duration > 0_turns ) {
         // meth actually inhibits hunger, weaker characters benefit more
         /** @EFFECT_STR_MAX >4 experiences less hunger benefit from meth */
-        int hungerpen = ( p->str_max < 5 ? 35 : 40 - ( 2 * p->str_max ) );
+        int const hungerpen = ( p->str_max < 5 ? 35 : 40 - ( 2 * p->str_max ) );
         if( hungerpen > 0 ) {
             p->mod_stored_kcal( 10 * hungerpen );
         }
@@ -866,7 +866,7 @@ int iuse::vaccine( player *p, item *it, bool, const tripoint & )
     p->add_msg_if_player( m_good, _( "You feel tough." ) );
     p->mod_healthy_mod( 200, 200 );
     p->mod_pain( 3 );
-    item syringe( "syringe", it->birthday() );
+    item const syringe( "syringe", it->birthday() );
     p->i_add( syringe );
     return it->type->charges_to_use();
 }
@@ -1045,7 +1045,7 @@ int iuse::blech( player *p, item *it, bool, const tripoint & )
                                        p->has_trait( trait_ACIDBLOOD ) ) ) {
         p->add_msg_if_player( m_bad, _( "Blech, that tastes gross!" ) );
         //reverse the harmful values of drinking this acid.
-        double multiplier = -1;
+        double const multiplier = -1;
         p->mod_stored_kcal( 10 * p->nutrition_for( *it ) * multiplier );
         p->mod_thirst( -it->get_comestible()->quench * multiplier + 20 );
         p->mod_healthy_mod( it->get_comestible()->healthy * multiplier,
@@ -1136,7 +1136,7 @@ static void do_purify( player &p )
 
 int iuse::purifier( player *p, item *it, bool, const tripoint & )
 {
-    mutagen_attempt checks =
+    mutagen_attempt const checks =
         mutagen_common_checks( *p, *it, false, mutagen_technique::consumed_purifier );
     if( !checks.allowed ) {
         return checks.charges_used;
@@ -1148,7 +1148,7 @@ int iuse::purifier( player *p, item *it, bool, const tripoint & )
 
 int iuse::purify_iv( player *p, item *it, bool, const tripoint & )
 {
-    mutagen_attempt checks =
+    mutagen_attempt const checks =
         mutagen_common_checks( *p, *it, false, mutagen_technique::injected_purifier );
     if( !checks.allowed ) {
         return checks.charges_used;
@@ -1190,7 +1190,7 @@ int iuse::purify_iv( player *p, item *it, bool, const tripoint & )
 
 int iuse::purify_smart( player *p, item *it, bool, const tripoint & )
 {
-    mutagen_attempt checks =
+    mutagen_attempt const checks =
         mutagen_common_checks( *p, *it, false, mutagen_technique::injected_smart_purifier );
     if( !checks.allowed ) {
         return checks.charges_used;
@@ -1212,7 +1212,7 @@ int iuse::purify_smart( player *p, item *it, bool, const tripoint & )
         return 0;
     }
 
-    int mutation_index = uilist( _( "Choose a mutation to purify" ), valid_names );
+    int const mutation_index = uilist( _( "Choose a mutation to purify" ), valid_names );
     if( mutation_index < 0 ) {
         return 0;
     }
@@ -1233,7 +1233,7 @@ int iuse::purify_smart( player *p, item *it, bool, const tripoint & )
 
     p->mod_pain( 3 );
 
-    item syringe( "syringe", it->birthday() );
+    item const syringe( "syringe", it->birthday() );
     p->i_add( syringe );
     return it->type->charges_to_use();
 }
@@ -1247,7 +1247,7 @@ static void spawn_spores( const player &p )
         if( here.impassable( dest ) ) {
             continue;
         }
-        float dist = rl_dist( dest, p.pos() );
+        float const dist = rl_dist( dest, p.pos() );
         if( x_in_y( 1, dist ) ) {
             fe.marlossify( dest );
         }
@@ -1286,7 +1286,7 @@ static void marloss_common( player &p, item &it, const trait_id &current_color )
         return;
     }
 
-    int marloss_count = std::count_if( mycus_colors.begin(), mycus_colors.end(),
+    int const marloss_count = std::count_if( mycus_colors.begin(), mycus_colors.end(),
     [&p]( const std::pair<trait_id, add_type> &pr ) {
         return p.has_trait( pr.first );
     } );
@@ -1302,7 +1302,7 @@ static void marloss_common( player &p, item &it, const trait_id &current_color )
      * 8 - Vomit
      * 9-12 - Give Marloss mutation
      */
-    int effect = rng( 1, 12 );
+    int const effect = rng( 1, 12 );
     if( effect <= 3 ) {
         p.add_msg_if_player( _( "It tastes extremely strange!" ) );
         p.mutate();
@@ -1683,7 +1683,7 @@ int iuse::radio_mod( player *p, item *, bool, const tripoint & )
     }
     item &modded = *loc;
 
-    int choice = uilist( _( "Which signal should activate the item?" ), {
+    int const choice = uilist( _( "Which signal should activate the item?" ), {
         _( "\"Red\"" ), _( "\"Blue\"" ), _( "\"Green\"" )
     } );
 
@@ -1764,13 +1764,13 @@ int iuse::remove_all_mods( player *p, item *, bool, const tripoint & )
 static bool good_fishing_spot( tripoint pos )
 {
     std::unordered_set<tripoint> fishable_locations = g->get_fishable_locations( 60, pos );
-    std::vector<monster *> fishables = g->get_fishable_monsters( fishable_locations );
-    map &here = get_map();
+    std::vector<monster *> const fishables = g->get_fishable_monsters( fishable_locations );
+    map  const&here = get_map();
     // isolated little body of water with no definite fish population
     // TODO: fix point types
     const oter_id &cur_omt =
         overmap_buffer.ter( tripoint_abs_omt( ms_to_omt_copy( here.getabs( pos ) ) ) );
-    std::string om_id = cur_omt.id().c_str();
+    std::string const om_id = cur_omt.id().c_str();
     if( fishables.empty() && !g->m.has_flag( "CURRENT", pos ) &&
         om_id.find( "river_" ) == std::string::npos && !cur_omt->is_lake() && !cur_omt->is_lake_shore() ) {
         g->u.add_msg_if_player( m_info, _( "You doubt you will have much luck catching fish here" ) );
@@ -1903,7 +1903,7 @@ int iuse::fish_trap( player *p, item *it, bool t, const tripoint &pos )
 
             //get the fishables around the trap's spot
             std::unordered_set<tripoint> fishable_locations = g->get_fishable_locations( 60, pos );
-            std::vector<monster *> fishables = g->get_fishable_monsters( fishable_locations );
+            std::vector<monster *> const fishables = g->get_fishable_monsters( fishable_locations );
             for( int i = 0; i < fishes; i++ ) {
                 p->practice( skill_survival, rng( 3, 10 ) );
                 if( !fishables.empty() ) {
@@ -2177,7 +2177,7 @@ int iuse::directional_antenna( player *p, item *it, bool, const tripoint & )
     // Report direction.
     // TODO: fix point types
     const tripoint_abs_sm player_pos( p->global_sm_location() );
-    direction angle = direction_from( player_pos.xy(), tref.abs_sm_pos );
+    direction const angle = direction_from( player_pos.xy(), tref.abs_sm_pos );
     add_msg( _( "The signal seems strongest to the %s." ), direction_name( angle ) );
     return it->type->charges_to_use();
 }
@@ -2197,8 +2197,8 @@ int iuse::radio_on( player *p, item *it, bool t, const tripoint &pos )
             }
 
             message = obscure_message( message, [&]()->int {
-                int signal_roll = dice( 10, tref.signal_strength * 3 );
-                int static_roll = dice( 10, 100 );
+                int const signal_roll = dice( 10, tref.signal_strength * 3 );
+                int const static_roll = dice( 10, 100 );
                 if( static_roll > signal_roll )
                 {
                     if( static_roll < signal_roll * 1.1 && one_in( 4 ) ) {
@@ -2213,7 +2213,7 @@ int iuse::radio_on( player *p, item *it, bool t, const tripoint &pos )
             } );
 
             std::vector<std::string> segments = foldstring( message, RADIO_PER_TURN );
-            int index = to_turn<int>( calendar::turn ) % segments.size();
+            int const index = to_turn<int>( calendar::turn ) % segments.size();
             message = string_format( _( "radio: %s" ), segments[index] );
         }
         sounds::ambient_sound( pos, 6, sounds::sound_t::electronic_speech, message );
@@ -2344,7 +2344,7 @@ int iuse::note_bionics( player *p, item *it, bool t, const tripoint &pos )
             corpse.set_var( "bionics_scanned_by", p->getID().get_value() );
             if( !cbms.empty() ) {
                 corpse.set_flag( "CBM_SCANNED" );
-                std::string bionics_string =
+                std::string const bionics_string =
                     enumerate_as_string( cbms.begin(), cbms.end(),
                 []( const item * entry ) -> std::string {
                     return entry->display_name();
@@ -2636,8 +2636,8 @@ static digging_moves_and_byproducts dig_pit_moves_and_byproducts( player *p, ite
     const double attr = 10 / std::max( 1, p->str_cur );
 
     // And now determine the moves...
-    int dig_minutes = deep ? deep_pit_time : shallow_pit_time;
-    int moves = to_moves<int>( std::max( 10_minutes,
+    int const dig_minutes = deep ? deep_pit_time : shallow_pit_time;
+    int const moves = to_moves<int>( std::max( 10_minutes,
                                          time_duration::from_minutes( dig_minutes * attr ) / quality ) );
 
     ter_id result_terrain;
@@ -2757,10 +2757,10 @@ int iuse::dig_channel( player *p, item *it, bool t, const tripoint & )
     }
     const tripoint dig_point = p->pos();
 
-    tripoint north = dig_point + point_north;
-    tripoint south = dig_point + point_south;
-    tripoint west = dig_point + point_west;
-    tripoint east = dig_point + point_east;
+    tripoint const north = dig_point + point_north;
+    tripoint const south = dig_point + point_south;
+    tripoint const west = dig_point + point_west;
+    tripoint const east = dig_point + point_east;
 
     const bool can_dig_here = g->m.has_flag( flag_DIGGABLE, dig_point ) &&
                               !g->m.has_furn( dig_point ) &&
@@ -2907,7 +2907,7 @@ int iuse::clear_rubble( player *p, item *it, bool, const tripoint & )
     }
 
     int moves = to_moves<int>( 30_seconds );
-    int bonus = std::max( it->get_quality( quality_id( "DIG" ) ) - 1, 1 );
+    int const bonus = std::max( it->get_quality( quality_id( "DIG" ) ) - 1, 1 );
 
     const std::vector<npc *> helpers = character_funcs::get_crafting_helpers( *p, 3 );
     for( const npc *np : helpers ) {
@@ -2915,7 +2915,7 @@ int iuse::clear_rubble( player *p, item *it, bool, const tripoint & )
     }
     moves = moves * ( 10 - helpers.size() ) / 10;
 
-    player_activity act( ACT_CLEAR_RUBBLE, moves / bonus, bonus );
+    player_activity const act( ACT_CLEAR_RUBBLE, moves / bonus, bonus );
     p->assign_activity( act );
     p->activity.placement = pnt;
     return it->type->charges_to_use();
@@ -3339,9 +3339,9 @@ int iuse::geiger( player *p, item *it, bool t, const tripoint &pos )
         if( rads == 0 ) {
             return it->type->charges_to_use();
         }
-        std::string description = rads > 50 ? _( "buzzing" ) :
+        std::string const description = rads > 50 ? _( "buzzing" ) :
                                   rads > 25 ? _( "rapid clicking" ) : _( "clicking" );
-        std::string sound_var = rads > 50 ? _( "geiger_high" ) :
+        std::string const sound_var = rads > 50 ? _( "geiger_high" ) :
                                 rads > 25 ? _( "geiger_medium" ) : _( "geiger_low" );
 
         sounds::sound( pos, 6, sounds::sound_t::alarm, description, true, "tool", sound_var );
@@ -3373,7 +3373,7 @@ int iuse::geiger( player *p, item *it, bool t, const tripoint &pos )
         return 0;
     }
 
-    int ch = uilist( _( "Geiger counter:" ), {
+    int const ch = uilist( _( "Geiger counter:" ), {
         _( "Scan yourself or other person" ), _( "Scan the ground" ), _( "Turn continuous scan on" )
     } );
     switch( ch ) {
@@ -3394,7 +3394,7 @@ int iuse::geiger( player *p, item *it, bool t, const tripoint &pos )
                 break;
             }
             if( npc *const person_ = g->critter_at<npc>( pnt ) ) {
-                npc &person = *person_;
+                npc  const&person = *person_;
                 p->add_msg_if_player( m_info, _( "%s's radiation level: %d mSv (%d mSv from items)" ),
                                       person.name, person.get_rad(),
                                       person.leak_level( "RADIOACTIVE" ) );
@@ -3533,8 +3533,8 @@ int iuse::granade_act( player *p, item *it, bool t, const tripoint &pos )
                               it->tname() );
         return 0;
     } else { // When that timer runs down...
-        int explosion_radius = 3;
-        int effect_roll = rng( 1, 5 );
+        int const explosion_radius = 3;
+        int const effect_roll = rng( 1, 5 );
         auto buff_stat = [&]( int &current_stat, int modify_by ) {
             auto modified_stat = current_stat + modify_by;
             current_stat = std::max( current_stat, std::min( 15, modified_stat ) );
@@ -3667,7 +3667,7 @@ int iuse::granade_act( player *p, item *it, bool t, const tripoint &pos )
 int iuse::c4( player *p, item *it, bool, const tripoint & )
 {
     int time;
-    bool got_value = query_int( time, _( "Set the timer to (0 to cancel)?" ) );
+    bool const got_value = query_int( time, _( "Set the timer to (0 to cancel)?" ) );
     if( !got_value || time <= 0 ) {
         p->add_msg_if_player( _( "Never mind." ) );
         return 0;
@@ -3704,10 +3704,10 @@ int iuse::grenade_inc_act( player *p, item *it, bool t, const tripoint &pos )
         p->add_msg_if_player( m_info, _( "You've already released the handle, try throwing it instead." ) );
         return 0;
     } else {  // blow up
-        int num_flames = rng( 3, 5 );
+        int const num_flames = rng( 3, 5 );
         for( int current_flame = 0; current_flame < num_flames; current_flame++ ) {
-            tripoint dest( pos + point( rng( -5, 5 ), rng( -5, 5 ) ) );
-            std::vector<tripoint> flames = line_to( pos, dest, 0, 0 );
+            tripoint const dest( pos + point( rng( -5, 5 ), rng( -5, 5 ) ) );
+            std::vector<tripoint> const flames = line_to( pos, dest, 0, 0 );
             for( auto &flame : flames ) {
                 g->m.add_field( flame, fd_fire, rng( 0, 2 ) );
             }
@@ -3788,7 +3788,7 @@ int iuse::firecracker_pack( player *p, item *it, bool, const tripoint & )
 
 int iuse::firecracker_pack_act( player *, item *it, bool, const tripoint &pos )
 {
-    time_duration timer = it->age();
+    time_duration const timer = it->age();
     if( timer < 2_turns ) {
         sounds::sound( pos, 0, sounds::sound_t::alarm, _( "ssss…" ), true, "misc", "lit_fuse" );
         it->inc_damage();
@@ -3846,7 +3846,7 @@ int iuse::firecracker_act( player *p, item *it, bool t, const tripoint &pos )
 int iuse::mininuke( player *p, item *it, bool, const tripoint & )
 {
     int time;
-    bool got_value = query_int( time, _( "Set the timer to ___ turns (0 to cancel)?" ) );
+    bool const got_value = query_int( time, _( "Set the timer to ___ turns (0 to cancel)?" ) );
     if( !got_value || time <= 0 ) {
         p->add_msg_if_player( _( "Never mind." ) );
         return 0;
@@ -3914,7 +3914,7 @@ int iuse::portal( player *p, item *it, bool, const tripoint & )
         p->add_msg_if_player( m_info, _( "You cannot do that while mounted." ) );
         return 0;
     }
-    tripoint t( p->posx() + rng( -2, 2 ), p->posy() + rng( -2, 2 ), p->posz() );
+    tripoint const t( p->posx() + rng( -2, 2 ), p->posy() + rng( -2, 2 ), p->posz() );
     g->m.trap_set( t, tr_portal );
     return it->type->charges_to_use();
 }
@@ -3954,7 +3954,7 @@ int iuse::tazer( player *p, item *it, bool, const tripoint &pos )
 
     /** @EFFECT_DEX slightly increases chance of successfully using tazer */
     /** @EFFECT_MELEE increases chance of successfully using a tazer */
-    int numdice = 3 + ( p->dex_cur / 2.5 ) + p->get_skill_level( skill_melee ) * 2;
+    int const numdice = 3 + ( p->dex_cur / 2.5 ) + p->get_skill_level( skill_melee ) * 2;
     p->moves -= to_moves<int>( 1_seconds );
 
     /** @EFFECT_DODGE increases chance of dodging a tazer attack */
@@ -3966,7 +3966,7 @@ int iuse::tazer( player *p, item *it, bool, const tripoint &pos )
     } else {
         // TODO: Maybe - Execute an attack and maybe zap something other than torso
         // Maybe, because it's torso (heart) that fails when zapped with electricity
-        int dam = target->deal_damage( p, bodypart_id( "torso" ), damage_instance( DT_ELECTRIC, rng( 5,
+        int const dam = target->deal_damage( p, bodypart_id( "torso" ), damage_instance( DT_ELECTRIC, rng( 5,
                                        25 ) ) ).total_damage();
         if( dam > 0 ) {
             p->add_msg_player_or_npc( m_good,
@@ -4005,7 +4005,7 @@ int iuse::tazer2( player *p, item *it, bool b, const tripoint &pos )
 
 int iuse::shocktonfa_off( player *p, item *it, bool t, const tripoint &pos )
 {
-    int choice = uilist( _( "tactical tonfa" ), {
+    int const choice = uilist( _( "tactical tonfa" ), {
         _( "Zap something" ), _( "Turn on light" )
     } );
 
@@ -4036,7 +4036,7 @@ int iuse::shocktonfa_on( player *p, item *it, bool t, const tripoint &pos )
             p->add_msg_if_player( m_info, _( "Your tactical tonfa is out of power." ) );
             it->convert( itype_shocktonfa_off ).active = false;
         } else {
-            int choice = uilist( _( "tactical tonfa" ), {
+            int const choice = uilist( _( "tactical tonfa" ), {
                 _( "Zap something" ), _( "Turn off light" )
             } );
 
@@ -4094,7 +4094,7 @@ static std::string get_music_description()
         return _( "some bass-heavy post-glam speed polka." );
     }
 
-    size_t i = static_cast<size_t>( rng( 0, descriptions.size() * 2 ) );
+    size_t const i = static_cast<size_t>( rng( 0, descriptions.size() * 2 ) );
     if( i < descriptions.size() ) {
         return _( descriptions[i] );
     }
@@ -4421,7 +4421,7 @@ int iuse::hand_crank( player *p, item *it, bool, const tripoint & )
     if( magazine && magazine->has_flag( "RECHARGE" ) ) {
         // 1600 minutes. It shouldn't ever run this long, but it's an upper bound.
         // expectation is it runs until the player is too tired.
-        int moves = to_moves<int>( 1600_minutes );
+        int const moves = to_moves<int>( 1600_minutes );
         if( it->ammo_capacity() > it->ammo_remaining() ) {
             p->add_msg_if_player( _( "You start cranking the %s to charge its %s." ), it->tname(),
                                   it->magazine_current()->tname() );
@@ -4464,7 +4464,7 @@ int iuse::vibe( player *p, item *it, bool, const tripoint & )
         p->add_msg_if_player( m_info, _( "*Your* batteries are dead." ) );
         return 0;
     } else {
-        int moves = to_moves<int>( 20_minutes );
+        int const moves = to_moves<int>( 20_minutes );
         if( it->ammo_remaining() > 0 ) {
             p->add_msg_if_player( _( "You fire up your %s and start getting the tension out." ),
                                   it->tname() );
@@ -4515,7 +4515,7 @@ int iuse::dog_whistle( player *p, item *it, bool, const tripoint & )
     p->add_msg_if_player( _( "You blow your dog whistle." ) );
     for( monster &critter : g->all_monsters() ) {
         if( critter.friendly != 0 && critter.has_flag( MF_DOGFOOD ) ) {
-            bool u_see = g->u.sees( critter );
+            bool const u_see = g->u.sees( critter );
             if( critter.has_effect( effect_docile ) ) {
                 if( u_see ) {
                     p->add_msg_if_player( _( "Your %s looks ready to attack." ), critter.name() );
@@ -4587,7 +4587,7 @@ int iuse::blood_draw( player *p, item *it, bool, const tripoint & )
     }
 
     if( acid_blood ) {
-        item acid( "acid", calendar::turn );
+        item const acid( "acid", calendar::turn );
         it->put_in( acid );
         if( one_in( 3 ) ) {
             if( it->inc_damage( DT_ACID ) ) {
@@ -4885,7 +4885,7 @@ int iuse::oxytorch( player *p, item *it, bool, const tripoint & )
     }
 
     const int charges = turns * it->ammo_required();
-    int moves = to_moves<int>( time_duration::from_turns( turns ) );
+    int const moves = to_moves<int>( time_duration::from_turns( turns ) );
 
     if( charges > it->ammo_remaining() ) {
         p->add_msg_if_player( m_info, _( "Your torch doesn't have enough acetylene to cut that." ) );
@@ -5062,16 +5062,16 @@ int iuse::mop( player *p, item *it, bool, const tripoint & )
                 return true;
             }
         }
-        field &fld = g->m.field_at( pnt );
-        for( field_type_id fid : to_check ) {
+        field  const&fld = g->m.field_at( pnt );
+        for( field_type_id const fid : to_check ) {
             if( fld.find_field_c( fid ) ) {
                 return true;
             }
         }
         if( const optional_vpart_position vp = g->m.veh_at( pnt ) ) {
             vehicle *const veh = &vp->vehicle();
-            std::vector<int> parts_here = veh->parts_at_relative( vp->mount(), true );
-            for( int elem : parts_here ) {
+            std::vector<int> const parts_here = veh->parts_at_relative( vp->mount(), true );
+            for( int const elem : parts_here ) {
                 if( veh->part( elem ).blood > 0 ) {
                     return true;
                 }
@@ -5149,14 +5149,14 @@ int iuse::artifact( player *p, item *it, bool, const tripoint & )
             case AEA_STORM: {
                 sounds::sound( p->pos(), 10, sounds::sound_t::combat, _( "Ka-BOOM!" ), true, "environment",
                                "thunder_near" );
-                int num_bolts = rng( 2, 4 );
+                int const num_bolts = rng( 2, 4 );
                 for( int j = 0; j < num_bolts; j++ ) {
                     point dir;
                     while( dir.x == 0 && dir.y == 0 ) {
                         dir.x = rng( -1, 1 );
                         dir.y = rng( -1, 1 );
                     }
-                    int dist = rng( 4, 12 );
+                    int const dist = rng( 4, 12 );
                     point bolt( p->posx(), p->posy() );
                     for( int n = 0; n < dist; n++ ) {
                         bolt.x += dir.x;
@@ -5220,7 +5220,7 @@ int iuse::artifact( player *p, item *it, bool, const tripoint & )
 
             case AEA_FATIGUE: {
                 p->add_msg_if_player( m_warning, _( "The fabric of space seems to decay." ) );
-                point p2{ rng( p->posx() - 3, p->posx() + 3 ), rng( p->posy() - 3, p->posy() + 3 ) };
+                point const p2{ rng( p->posx() - 3, p->posx() + 3 ), rng( p->posy() - 3, p->posy() + 3 ) };
                 g->m.add_field( {p2, p->posz()}, fd_fatigue, rng( 1, 2 ) );
             }
             break;
@@ -5270,7 +5270,7 @@ int iuse::artifact( player *p, item *it, bool, const tripoint & )
                 break;
 
             case AEA_BUGS: {
-                int roll = rng( 1, 10 );
+                int const roll = rng( 1, 10 );
                 mtype_id bug = mtype_id::NULL_ID();
                 int num = 0;
                 if( roll <= 4 ) {
@@ -5348,7 +5348,7 @@ int iuse::artifact( player *p, item *it, bool, const tripoint & )
 
             case AEA_FIRESTORM: {
                 p->add_msg_if_player( m_bad, _( "Fire rains down around you!" ) );
-                std::vector<tripoint> ps = closest_points_first( p->pos(), 3 );
+                std::vector<tripoint> const ps = closest_points_first( p->pos(), 3 );
                 for( auto p_it : ps ) {
                     if( !one_in( 3 ) ) {
                         g->m.add_field( p_it, fd_fire, 1 + rng( 0, 1 ) * rng( 0, 1 ), 3_minutes );
@@ -5398,7 +5398,7 @@ int iuse::artifact( player *p, item *it, bool, const tripoint & )
                 break;
 
             case AEA_SHADOWS: {
-                int num_shadows = rng( 4, 8 );
+                int const num_shadows = rng( 4, 8 );
                 int num_spawned = 0;
                 for( int j = 0; j < num_shadows; j++ ) {
                     for( int tries = 0; tries < 10; ++tries ) {
@@ -5466,7 +5466,7 @@ int iuse::handle_ground_graffiti( player &p, item *it, const std::string &prefix
                                   const tripoint &where )
 {
     string_input_popup popup;
-    std::string message = popup
+    std::string const message = popup
                           .description( prefix + " " + _( "(To delete, clear the text and confirm)" ) )
                           .text( g->m.has_graffiti_at( where ) ? g->m.graffiti_at( where ) : std::string() )
                           .identifier( "graffiti" )
@@ -5475,7 +5475,7 @@ int iuse::handle_ground_graffiti( player &p, item *it, const std::string &prefix
         return 0;
     }
 
-    bool grave = g->m.ter( where ) == t_grave_new;
+    bool const grave = g->m.ter( where ) == t_grave_new;
     int move_cost;
     if( message.empty() ) {
         if( g->m.has_graffiti_at( where ) ) {
@@ -5518,9 +5518,9 @@ int iuse::towel_common( player *p, item *it, bool t )
         // wet towels only as they are active items.
         return 0;
     }
-    bool slime = p->has_effect( effect_slimed );
-    bool boom = p->has_effect( effect_boomered );
-    bool glow = p->has_effect( effect_glowing );
+    bool const slime = p->has_effect( effect_slimed );
+    bool const boom = p->has_effect( effect_boomered );
+    bool const glow = p->has_effect( effect_glowing );
     int mult = slime + boom + glow; // cleaning off more than one at once makes it take longer
     bool towelUsed = false;
     const std::string name = it ? it->tname() : _( "towel" );
@@ -5643,7 +5643,7 @@ int iuse::adrenaline_injector( player *p, item *it, bool, const tripoint & )
     p->add_msg_player_or_npc( _( "You inject yourself with adrenaline." ),
                               _( "<npcname> injects themselves with adrenaline." ) );
 
-    item syringe( "syringe", it->birthday() );
+    item const syringe( "syringe", it->birthday() );
     p->i_add( syringe );
     if( p->has_effect( effect_adrenaline ) ) {
         p->add_msg_if_player( m_bad, _( "Your heart spasms!" ) );
@@ -5786,7 +5786,7 @@ int iuse::gun_clean( player *p, item *, bool, const tripoint & )
         p->add_msg_if_player( m_info, _( "You do not have that item!" ) );
         return 0;
     }
-    item &fix = *loc;
+    item  const&fix = *loc;
     if( !fix.is_firearm() ) {
         p->add_msg_if_player( m_info, _( "That isn't a firearm!" ) );
         return 0;
@@ -6002,7 +6002,7 @@ int iuse::robotcontrol( player *p, item *it, bool, const tripoint & )
         return 0;
     }
 
-    int choice = uilist( _( "Welcome to hackPRO!:" ), {
+    int const choice = uilist( _( "Welcome to hackPRO!:" ), {
         _( "Prepare IFF protocol override" ),
         _( "Set friendly robots to passive mode" ),
         _( "Set friendly robots to combat mode" )
@@ -6042,12 +6042,12 @@ int iuse::robotcontrol( player *p, item *it, bool, const tripoint & )
                 return it->type->charges_to_use();
             }
             const size_t mondex = pick_robot.ret;
-            shared_ptr_fast< monster > z = mons[mondex];
+            shared_ptr_fast< monster > const z = mons[mondex];
             p->add_msg_if_player( _( "You start reprogramming the %s into an ally." ), z->name() );
 
             /** @EFFECT_INT speeds up hacking preperation */
             /** @EFFECT_COMPUTER speeds up hacking preperation */
-            int move_cost = std::max( 100, 1000 - p->int_cur * 10 - p->get_skill_level( skill_computer ) * 10 );
+            int const move_cost = std::max( 100, 1000 - p->int_cur * 10 - p->get_skill_level( skill_computer ) * 10 );
             player_activity act( ACT_ROBOT_CONTROL, move_cost );
             act.monsters.emplace_back( z );
 
@@ -6174,7 +6174,7 @@ static bool einkpc_download_memory_card( player &p, item &eink, item &mc )
     if( mc.get_var( "MC_PHOTOS", 0 ) > 0 ) {
         something_downloaded = true;
 
-        int new_photos = mc.get_var( "MC_PHOTOS", 0 );
+        int const new_photos = mc.get_var( "MC_PHOTOS", 0 );
         mc.erase_var( "MC_PHOTOS" );
 
         p.add_msg_if_player( m_good, vgettext( "You download %d new photo into internal memory.",
@@ -6187,7 +6187,7 @@ static bool einkpc_download_memory_card( player &p, item &eink, item &mc )
     if( mc.get_var( "MC_MUSIC", 0 ) > 0 ) {
         something_downloaded = true;
 
-        int new_songs = mc.get_var( "MC_MUSIC", 0 );
+        int const new_songs = mc.get_var( "MC_MUSIC", 0 );
         mc.erase_var( "MC_MUSIC" );
 
         p.add_msg_if_player( m_good, vgettext( "You download %d new song into internal memory.",
@@ -6672,7 +6672,7 @@ struct extended_photo_def : public JsonDeserializer, public JsonSerializer {
 
     extended_photo_def() = default;
     void deserialize( JsonIn &jsin ) override {
-        JsonObject obj = jsin.get_object();
+        JsonObject const obj = jsin.get_object();
         quality = obj.get_int( "quality" );
         name = obj.get_string( "name" );
         description = obj.get_string( "description" );
@@ -6711,14 +6711,14 @@ static std::string colorized_field_description_at( const tripoint &point )
 
 static std::string colorized_item_name( const item &item )
 {
-    nc_color color = item.color_in_inventory();
-    std::string damtext = item.damage() != 0 ? item.durability_indicator() : "";
+    nc_color const color = item.color_in_inventory();
+    std::string const damtext = item.damage() != 0 ? item.durability_indicator() : "";
     return damtext + colorize( item.tname( 1, false ), color );
 }
 
 static std::string colorized_item_description( const item &item )
 {
-    iteminfo_query query = iteminfo_query(
+    iteminfo_query const query = iteminfo_query(
     std::vector<iteminfo_parts> {
         iteminfo_parts::DESCRIPTION,
         iteminfo_parts::DESCRIPTION_NOTES,
@@ -6730,7 +6730,7 @@ static std::string colorized_item_description( const item &item )
 static item get_top_item_at_point( const tripoint &point,
                                    const units::volume &min_visible_volume )
 {
-    map_stack items = g->m.i_at( point );
+    map_stack const items = g->m.i_at( point );
     // iterate from topmost item down to ground
     for( const item &it : items ) {
         if( it.volume() > min_visible_volume ) {
@@ -6782,7 +6782,7 @@ static std::string colorized_feature_description_at( const tripoint &center_poin
     const furn_id furn = g->m.furn( center_point );
     if( furn != f_null && furn.is_valid() ) {
         std::string furn_str = colorize( furn->name(), c_yellow );
-        std::string sign_message = g->m.get_signage( center_point );
+        std::string const sign_message = g->m.get_signage( center_point );
         if( !sign_message.empty() ) {
             furn_str += string_format( _( " with message \"%s\"" ), sign_message );
         }
@@ -6877,14 +6877,14 @@ static std::string effects_description_for_creature( Creature *const creature, s
             }
         }
         if( creature->has_effect( effect_sad ) ) {
-            int intensity = creature->get_effect_int( effect_sad );
+            int const intensity = creature->get_effect_int( effect_sad );
             if( intensity > 500 && intensity <= 950 ) {
                 figure_effects += pronoun_sex + pgettext( "Someone", " looks <color_blue>sad</color>. " );
             } else if( intensity > 950 ) {
                 figure_effects += pronoun_sex + pgettext( "Someone", " looks <color_blue>depressed</color>. " );
             }
         }
-        float pain = creature->get_pain() / 10.f;
+        float const pain = creature->get_pain() / 10.f;
         if( pain > 3 ) {
             figure_effects += pronoun_sex + pgettext( "Someone", " is writhing in <color_red>pain</color>. " );
         }
@@ -6921,11 +6921,11 @@ static object_names_collection enumerate_objects_around_point( const tripoint &p
         std::unordered_set<tripoint> &ignored_points,
         std::unordered_set<const vehicle *> &vehicles_recorded )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     const tripoint_range<tripoint> bounds =
         here.points_in_radius( bounds_center_point, bounds_radius );
     const tripoint_range<tripoint> points_in_radius = here.points_in_radius( point, radius );
-    int dist = rl_dist( camera_pos, point );
+    int const dist = rl_dist( camera_pos, point );
 
     bool item_found = false;
     std::unordered_set<const vehicle *> local_vehicles_recorded( vehicles_recorded );
@@ -6943,7 +6943,7 @@ static object_names_collection enumerate_objects_around_point( const tripoint &p
               !( point_around_figure == point && create_figure_desc ) ) ) {
             continue; // disallow photos with not visible objects
         }
-        units::volume volume_to_search = point_around_figure == bounds_center_point ? 0_ml :
+        units::volume const volume_to_search = point_around_figure == bounds_center_point ? 0_ml :
                                          min_visible_volume;
 
         std::string furn_desc = colorized_feature_description_at( point_around_figure, item_found,
@@ -7028,7 +7028,7 @@ static object_names_collection enumerate_objects_around_point( const tripoint &p
     if( create_figure_desc ) {
         std::vector<std::string> objects_combined_desc;
         int objects_combined_num = 0;
-        std::unordered_map<std::string, int> vecs_to_retrieve[4] = {
+        std::unordered_map<std::string, int> const vecs_to_retrieve[4] = {
             ret_obj.furniture, ret_obj.vehicles, ret_obj.items, ret_obj.terrain
         };
 
@@ -7052,7 +7052,7 @@ static object_names_collection enumerate_objects_around_point( const tripoint &p
         }
         if( !objects_combined_desc.empty() ) {
             // store objects to description_figures_status
-            std::string objects_text = enumerate_as_string( objects_combined_desc );
+            std::string const objects_text = enumerate_as_string( objects_combined_desc );
             ret_obj.obj_nearby_text = string_format( vgettext( "Nearby is %s.", "Nearby are %s.",
                                       objects_combined_num ), objects_text );
         }
@@ -7073,9 +7073,9 @@ static extended_photo_def photo_def_for_camera_point( const tripoint &aim_point,
     std::unordered_map<std::string, std::string> description_figures_appearance;
     std::vector<std::pair<std::string, std::string>> description_figures_status;
 
-    std::string timestamp = to_string( time_point( calendar::turn ) );
-    int dist = rl_dist( camera_pos, aim_point );
-    map &here = get_map();
+    std::string const timestamp = to_string( time_point( calendar::turn ) );
+    int const dist = rl_dist( camera_pos, aim_point );
+    map  const&here = get_map();
     const tripoint_range<tripoint> bounds = here.points_in_radius( aim_point, 2 );
     extended_photo_def photo;
     bool need_store_weather = false;
@@ -7145,7 +7145,7 @@ static extended_photo_def photo_def_for_camera_point( const tripoint &aim_point,
             figure_effects = effects_description_for_creature( creature, pose, pronoun_sex );
             description_figures_appearance[ figure_name ] = figure_appearance;
 
-            object_names_collection obj_collection = enumerate_objects_around_point( current, 1, aim_point, 2,
+            object_names_collection const obj_collection = enumerate_objects_around_point( current, 1, aim_point, 2,
                     camera_pos, min_visible_volume, true,
                     ignored_points, vehicles_recorded );
             std::string figure_text = pose + obj_collection.figure_text;
@@ -7191,7 +7191,7 @@ static extended_photo_def photo_def_for_camera_point( const tripoint &aim_point,
     const furn_id furn_aim = g->m.furn( aim_point );
 
     if( !description_figures_status.empty() ) {
-        std::string names = enumerate_as_string( description_figures_status.begin(),
+        std::string const names = enumerate_as_string( description_figures_status.begin(),
                             description_figures_status.end(),
         []( const std::pair<std::string, std::string> &it ) {
             return colorize( it.first, c_light_blue );
@@ -7252,28 +7252,28 @@ static extended_photo_def photo_def_for_camera_point( const tripoint &aim_point,
     };
 
     if( !obj_coll.items.empty() ) {
-        std::string obj_list = enumerate_as_string( obj_coll.items.begin(), obj_coll.items.end(),
+        std::string const obj_list = enumerate_as_string( obj_coll.items.begin(), obj_coll.items.end(),
                                format_object_pair_article );
         photo_text += "\n\n" + string_format( vgettext( "There is something lying on the ground: %s.",
                                               "There are some things lying on the ground: %s.", num_of( obj_coll.items ) ),
                                               obj_list );
     }
     if( !obj_coll.furniture.empty() ) {
-        std::string obj_list = enumerate_as_string( obj_coll.furniture.begin(), obj_coll.furniture.end(),
+        std::string const obj_list = enumerate_as_string( obj_coll.furniture.begin(), obj_coll.furniture.end(),
                                format_object_pair_article );
         photo_text += "\n\n" + string_format( vgettext( "Something is visible in the background: %s.",
                                               "Some objects are visible in the background: %s.", num_of( obj_coll.furniture ) ),
                                               obj_list );
     }
     if( !obj_coll.vehicles.empty() ) {
-        std::string obj_list = enumerate_as_string( obj_coll.vehicles.begin(), obj_coll.vehicles.end(),
+        std::string const obj_list = enumerate_as_string( obj_coll.vehicles.begin(), obj_coll.vehicles.end(),
                                format_object_pair_no_article );
         photo_text += "\n\n" + string_format( vgettext( "There is %s parked in the background.",
                                               "There are %s parked in the background.", num_of( obj_coll.vehicles ) ),
                                               obj_list );
     }
     if( !obj_coll.terrain.empty() ) {
-        std::string obj_list = enumerate_as_string( obj_coll.terrain.begin(), obj_coll.terrain.end(),
+        std::string const obj_list = enumerate_as_string( obj_coll.terrain.begin(), obj_coll.terrain.end(),
                                format_object_pair_article );
         photo_text += "\n\n" + string_format( vgettext( "There is %s in the background.",
                                               "There are %s in the background.", num_of( obj_coll.terrain ) ),
@@ -7430,7 +7430,7 @@ static bool show_photo_selection( player &p, item &it, const std::string &var_na
     for( const extended_photo_def &extended_photo : extended_photos ) {
         std::string menu_str = extended_photo.name;
 
-        size_t index = menu_str.find( p.name );
+        size_t const index = menu_str.find( p.name );
         if( index != std::string::npos ) {
             menu_str.replace( index, p.name.length(), _( "You" ) );
         }
@@ -7460,9 +7460,9 @@ int iuse::camera( player *p, item *it, bool, const tripoint & )
     enum {c_shot, c_photos, c_monsters, c_upload};
 
     // CAMERA_NPC_PHOTOS is old save variable
-    bool found_extended_photos = !it->get_var( "CAMERA_NPC_PHOTOS" ).empty() ||
+    bool const found_extended_photos = !it->get_var( "CAMERA_NPC_PHOTOS" ).empty() ||
                                  !it->get_var( "CAMERA_EXTENDED_PHOTOS" ).empty();
-    bool found_monster_photos = !it->get_var( "CAMERA_MONSTER_PHOTOS" ).empty();
+    bool const found_monster_photos = !it->get_var( "CAMERA_MONSTER_PHOTOS" ).empty();
 
     uilist amenu;
     amenu.text = _( "What to do with camera?" );
@@ -7522,9 +7522,9 @@ int iuse::camera( player *p, item *it, bool, const tripoint & )
             monster *const mon = g->critter_at<monster>( trajectory_point, true );
             player *const guy = g->critter_at<player>( trajectory_point );
             if( mon || guy || trajectory_point == aim_point ) {
-                int dist = rl_dist( p->pos(), trajectory_point );
+                int const dist = rl_dist( p->pos(), trajectory_point );
 
-                int camera_bonus = it->has_flag( "CAMERA_PRO" ) ? 10 : 0;
+                int const camera_bonus = it->has_flag( "CAMERA_PRO" ) ? 10 : 0;
                 int photo_quality = 20 - rng( dist, dist * 2 ) * 2 + rng( camera_bonus / 2, camera_bonus );
                 if( photo_quality > 5 ) {
                     photo_quality = 5;
@@ -7537,7 +7537,7 @@ int iuse::camera( player *p, item *it, bool, const tripoint & )
                 }
 
                 if( mon ) {
-                    monster &z = *mon;
+                    monster  const&z = *mon;
 
                     // shoot past small monsters and hallucinations
                     if( trajectory_point != aim_point && ( z.type->size <= MS_SMALL || z.is_hallucination() ||
@@ -7849,7 +7849,7 @@ int iuse::foodperson( player *p, item *it, bool t, const tripoint &pos )
         return it->type->charges_to_use();
     }
 
-    time_duration shift = time_duration::from_turns( it->magazine_current()->ammo_remaining() *
+    time_duration const shift = time_duration::from_turns( it->magazine_current()->ammo_remaining() *
                           it->type->tool->turns_per_charge );
 
     p->add_msg_if_player( m_info, _( "Your HUD lights-up: \"Your shift ends in %s\"." ),
@@ -7905,7 +7905,7 @@ int iuse::radiocar( player *p, item *it, bool, const tripoint & )
                 p->add_msg_if_player( m_info, _( "You do not have that item!" ) );
                 return 0;
             }
-            item &put = *loc;
+            item  const&put = *loc;
 
             if( put.has_flag( "RADIOCARITEM" ) && ( put.volume() <= 1250_ml ||
                                                     ( put.weight() <= 2_kilogram ) ) ) {
@@ -7947,7 +7947,7 @@ int iuse::radiocaron( player *p, item *it, bool t, const tripoint &pos )
         return 0;
     }
 
-    int choice = uilist( _( "What to do with activated RC car?" ), {
+    int const choice = uilist( _( "What to do with activated RC car?" ), {
         _( "Turn off" )
     } );
 
@@ -7974,7 +7974,7 @@ static void emit_radio_signal( player &p, const std::string &signal )
         if( it.has_flag( "RADIO_ACTIVATION" ) && it.has_flag( signal ) )
         {
             sounds::sound( p.pos(), 6, sounds::sound_t::alarm, _( "beep" ), true, "misc", "beep" );
-            bool invoke_proc = it.has_flag( "RADIO_INVOKE_PROC" );
+            bool const invoke_proc = it.has_flag( "RADIO_INVOKE_PROC" );
             // Invoke to transform item
             it.type->invoke( p, it, loc );
             if( invoke_proc ) {
@@ -7985,8 +7985,8 @@ static void emit_radio_signal( player &p, const std::string &signal )
         return VisitResponse::NEXT;
     };
 
-    int z_min = g->m.has_zlevels() ? -OVERMAP_DEPTH : 0;
-    int z_max = g->m.has_zlevels() ? OVERMAP_HEIGHT : 0;
+    int const z_min = g->m.has_zlevels() ? -OVERMAP_DEPTH : 0;
+    int const z_max = g->m.has_zlevels() ? OVERMAP_HEIGHT : 0;
     for( int zlev = z_min; zlev <= z_max; zlev++ ) {
         for( tripoint loc : g->m.points_on_zlevel( zlev ) ) {
             // Items on ground
@@ -8049,7 +8049,7 @@ int iuse::radiocontrol( player *p, item *it, bool t, const tripoint & )
         car_action = _( "Stop controlling RC car" );
     }
 
-    int choice = uilist( _( "What to do with radio control?" ), {
+    int const choice = uilist( _( "What to do with radio control?" ), {
         car_action,
         _( "Press red button" ), _( "Press blue button" ), _( "Press green button" )
     } );
@@ -8062,9 +8062,9 @@ int iuse::radiocontrol( player *p, item *it, bool t, const tripoint & )
             p->remove_value( "remote_controlling" );
         } else {
             std::vector<std::pair<tripoint, item *>> rc_pairs;
-            for( tripoint pt : g->m.points_on_zlevel( p->posz() ) ) {
+            for( tripoint const pt : g->m.points_on_zlevel( p->posz() ) ) {
                 map_cursor mc( pt );
-                std::vector<item *> rc_items_here = mc.items_with( [&]( const item & it ) {
+                std::vector<item *> const rc_items_here = mc.items_with( [&]( const item & it ) {
                     return it.has_flag( "RADIO_CONTROLLED" );
                 } );
                 for( item *it : rc_items_here ) {
@@ -8136,7 +8136,7 @@ static bool hackveh( player &p, item &it, vehicle &veh )
     /** @EFFECT_INT increases chance of bypassing vehicle security system */
 
     /** @EFFECT_COMPUTER increases chance of bypassing vehicle security system */
-    int roll = dice( p.get_skill_level( skill_computer ) + 2, p.int_cur ) - ( advanced ? 50 : 25 );
+    int const roll = dice( p.get_skill_level( skill_computer ) + 2, p.int_cur ) - ( advanced ? 50 : 25 );
     int effort = 0;
     bool success = false;
     if( roll < -20 ) { // Really bad rolls will trigger the alarm before you know it exists
@@ -8242,8 +8242,8 @@ int iuse::remoteveh( player *p, item *it, bool t, const tripoint &pos )
         return it->type->charges_to_use();
     }
 
-    bool controlling = it->active && remote != nullptr;
-    int choice = uilist( _( "What to do with remote vehicle control:" ), {
+    bool const controlling = it->active && remote != nullptr;
+    int const choice = uilist( _( "What to do with remote vehicle control:" ), {
         controlling ? _( "Stop controlling the vehicle." ) : _( "Take control of a vehicle." ),
         _( "Execute one vehicle action" )
     } );
@@ -8258,7 +8258,7 @@ int iuse::remoteveh( player *p, item *it, bool t, const tripoint &pos )
         return 0;
     }
 
-    point p2( g->u.view_offset.xy() );
+    point const p2( g->u.view_offset.xy() );
 
     vehicle *veh = pickveh( pos, choice == 0 );
 
@@ -8379,7 +8379,7 @@ int iuse::multicooker( player *p, item *it, bool t, const tripoint &pos )
         }
 
         if( cooktime <= 0 ) {
-            item meal( it->get_var( "DISH" ) );
+            item const meal( it->get_var( "DISH" ) );
 
             it->active = false;
             it->erase_var( "DISH" );
@@ -8463,7 +8463,7 @@ int iuse::multicooker( player *p, item *it, bool t, const tripoint &pos )
         }
 
         menu.query();
-        int choice = menu.ret;
+        int const choice = menu.ret;
 
         if( choice < 0 ) {
             return 0;
@@ -8480,7 +8480,7 @@ int iuse::multicooker( player *p, item *it, bool t, const tripoint &pos )
         }
 
         if( mc_take == choice ) {
-            item &dish = *dish_it;
+            item  const&dish = *dish_it;
             const std::string dish_name = dish.tname( dish.charges, false );
             if( dish.made_of( LIQUID ) ) {
                 if( !p->check_eligible_containers_for_crafting( *recipe_id( it->get_var( "RECIPE" ) ), 1 ) ) {
@@ -8531,7 +8531,7 @@ int iuse::multicooker( player *p, item *it, bool t, const tripoint &pos )
 
             dmenu.query();
 
-            int choice = dmenu.ret;
+            int const choice = dmenu.ret;
 
             if( choice < 0 ) {
                 return 0;
@@ -8657,7 +8657,7 @@ int iuse::multicooker( player *p, item *it, bool t, const tripoint &pos )
 
 int iuse::tow_attach( player *p, item *it, bool, const tripoint & )
 {
-    std::string initial_state = it->get_var( "state", "attach_first" );
+    std::string const initial_state = it->get_var( "state", "attach_first" );
     if( !p ) {
         return 0;
     }
@@ -8699,10 +8699,10 @@ int iuse::tow_attach( player *p, item *it, bool, const tripoint & )
         }
     } else {
         const auto confirm_source_vehicle = []( player * p, item * it, const bool detach_if_missing ) {
-            tripoint source_global( it->get_var( "source_x", 0 ),
+            tripoint const source_global( it->get_var( "source_x", 0 ),
                                     it->get_var( "source_y", 0 ),
                                     it->get_var( "source_z", 0 ) );
-            tripoint source_local = g->m.getlocal( source_global );
+            tripoint const source_local = g->m.getlocal( source_global );
             const optional_vpart_position source_vp = g->m.veh_at( source_local );
             vehicle *const source_veh = veh_pointer_or_null( source_vp );
             if( detach_if_missing && source_veh == nullptr ) {
@@ -8721,7 +8721,7 @@ int iuse::tow_attach( player *p, item *it, bool, const tripoint & )
         kmenu.addentry( 1, paying_out, -1, _( "Attach loose end to vehicle" ) );
 
         kmenu.query();
-        int choice = kmenu.ret;
+        int const choice = kmenu.ret;
 
         if( choice < 0 ) {
             return 0; // we did nothing.
@@ -8764,10 +8764,10 @@ int iuse::tow_attach( player *p, item *it, bool, const tripoint & )
             }
             const vpart_id vpid( it->typeId().str() );
             point vcoords = source_vp->mount();
-            vehicle_part source_part( vpid, vcoords, item( *it ) );
+            vehicle_part const source_part( vpid, vcoords, item( *it ) );
             source_veh->install_part( vcoords, source_part );
             vcoords = target_vp->mount();
-            vehicle_part target_part( vpid, vcoords, item( *it ) );
+            vehicle_part const target_part( vpid, vcoords, item( *it ) );
             target_veh->install_part( vcoords, target_part );
 
             if( p->has_item( *it ) ) {
@@ -8784,7 +8784,7 @@ int iuse::tow_attach( player *p, item *it, bool, const tripoint & )
 
 int iuse::cable_attach( player *p, item *it, bool, const tripoint & )
 {
-    std::string initial_state = it->get_var( "state", "attach_first" );
+    std::string const initial_state = it->get_var( "state", "attach_first" );
     const bool has_bio_cable = !p->get_remote_fueled_bionic().is_empty();
     const bool has_solar_pack = p->worn_with_flag( "SOLARPACK" );
     const bool has_solar_pack_on = p->worn_with_flag( "SOLARPACK_ON" );
@@ -8826,7 +8826,7 @@ int iuse::cable_attach( player *p, item *it, bool, const tripoint & )
                 kmenu.addentry( 3, true, -1, _( "Attach cable to UPS" ) );
             }
             kmenu.query();
-            int choice = kmenu.ret;
+            int const choice = kmenu.ret;
 
             if( choice < 0 ) {
                 return 0; // we did nothing.
@@ -8873,10 +8873,10 @@ int iuse::cable_attach( player *p, item *it, bool, const tripoint & )
         }
     } else {
         const auto confirm_source_vehicle = []( player * p, item * it, const bool detach_if_missing ) {
-            tripoint source_global( it->get_var( "source_x", 0 ),
+            tripoint const source_global( it->get_var( "source_x", 0 ),
                                     it->get_var( "source_y", 0 ),
                                     it->get_var( "source_z", 0 ) );
-            tripoint source_local = g->m.getlocal( source_global );
+            tripoint const source_local = g->m.getlocal( source_global );
             const optional_vpart_position source_vp = g->m.veh_at( source_local );
             vehicle *const source_veh = veh_pointer_or_null( source_vp );
             if( detach_if_missing && source_veh == nullptr ) {
@@ -8892,7 +8892,7 @@ int iuse::cable_attach( player *p, item *it, bool, const tripoint & )
         const bool cable_cbm = initial_state == "cable_charger";
         const bool solar_pack = initial_state == "solar_pack";
         const bool UPS = initial_state == "UPS";
-        bool loose_ends = paying_out || cable_cbm || solar_pack || UPS;
+        bool const loose_ends = paying_out || cable_cbm || solar_pack || UPS;
         uilist kmenu;
         kmenu.text = _( "Using cable:" );
         kmenu.addentry( 0, true, -1, _( "Detach and re-spool the cable" ) );
@@ -8909,7 +8909,7 @@ int iuse::cable_attach( player *p, item *it, bool, const tripoint & )
             }
         }
         kmenu.query();
-        int choice = kmenu.ret;
+        int const choice = kmenu.ret;
 
         if( choice < 0 ) {
             return 0; // we did nothing.
@@ -8986,7 +8986,7 @@ int iuse::cable_attach( player *p, item *it, bool, const tripoint & )
             p->add_msg_if_player( m_good, _( "You are now plugged to the vehicle." ) );
             return 0;
         } else {
-            tripoint source_global( it->get_var( "source_x", 0 ),
+            tripoint const source_global( it->get_var( "source_x", 0 ),
                                     it->get_var( "source_y", 0 ),
                                     it->get_var( "source_z", 0 ) );
             const vpart_id vpid( it->typeId().str() );
@@ -9072,7 +9072,7 @@ int iuse::weather_tool( player *p, item *it, bool, const tripoint & )
     /* Possibly used twice. Worth spending the time to precalculate. */
     const auto player_local_temp = weather.get_temperature( p->pos() );
 
-    map &here = get_map();
+    map  const&here = get_map();
     if( it->typeId() == itype_weather_reader ) {
         p->add_msg_if_player( m_neutral, _( "The %s's monitor slowly outputs the data…" ),
                               it->tname() );
@@ -9138,7 +9138,7 @@ int iuse::weather_tool( player *p, item *it, bool, const tripoint & )
                                      weatherPoint.humidity,
                                      windpower / 100 ) +
                 player_local_temp ) );
-        std::string dirstring = get_dirstring( weather.winddirection );
+        std::string const dirstring = get_dirstring( weather.winddirection );
         p->add_msg_if_player( m_neutral, _( "Wind Direction: From the %s." ), dirstring );
     }
 
@@ -9192,7 +9192,7 @@ int iuse::capture_monster_veh( player *p, item *it, bool, const tripoint &pos )
 
 bool item::release_monster( const tripoint &target, const int radius )
 {
-    shared_ptr_fast<monster> new_monster = make_shared_fast<monster>();
+    shared_ptr_fast<monster> const new_monster = make_shared_fast<monster>();
     try {
         ::deserialize( *new_monster, get_var( "contained_json", "" ) );
     } catch( const std::exception &e ) {
@@ -9297,7 +9297,7 @@ int iuse::capture_monster_act( player *p, item *it, bool, const tripoint &pos )
                 return 0;
             }
             // TODO: replace this with some kind of melee check.
-            int chance = f.hp_percentage() / 10;
+            int const chance = f.hp_percentage() / 10;
             // A weaker monster is easier to capture.
             // If the monster is friendly, then put it in the item
             // without checking if it rolled a success.
@@ -9347,9 +9347,9 @@ int iuse::ladder( player *p, item *, bool, const tripoint & )
 
 washing_requirements washing_requirements_for_volume( const units::volume &vol )
 {
-    int water = divide_round_up( vol, 125_ml );
-    int cleanser = divide_round_up( vol, 1_liter );
-    int time = to_moves<int>( 10_seconds * ( vol / 250_ml ) );
+    int const water = divide_round_up( vol, 125_ml );
+    int const cleanser = divide_round_up( vol, 1_liter );
+    int const time = to_moves<int>( 10_seconds * ( vol / 250_ml ) );
     return { water, cleanser, time };
 }
 
@@ -9427,14 +9427,14 @@ int wash_items( player *p, bool soft_items, bool hard_items )
     auto is_liquid = []( const item & it ) {
         return it.made_of( LIQUID ) || it.contents_made_of( LIQUID );
     };
-    int available_water = std::max(
+    int const available_water = std::max(
                               crafting_inv.charges_of( itype_water, INT_MAX, is_liquid ),
                               crafting_inv.charges_of( itype_water_clean, INT_MAX, is_liquid )
                           );
-    int available_cleanser = std::max( crafting_inv.charges_of( itype_soap ),
+    int const available_cleanser = std::max( crafting_inv.charges_of( itype_soap ),
                                        crafting_inv.charges_of( itype_detergent ) );
 
-    iuse_locations to_clean = game_menus::inv::multiwash( *p, available_water, available_cleanser,
+    iuse_locations const to_clean = game_menus::inv::multiwash( *p, available_water, available_cleanser,
                               soft_items,
                               hard_items );
 
@@ -9449,7 +9449,7 @@ int wash_items( player *p, bool soft_items, bool hard_items )
             p->add_msg_if_player( m_info, _( "Never mind." ) );
             return 0;
         }
-        item &i = *iloc.loc;
+        item  const&i = *iloc.loc;
         total_volume += i.volume() * iloc.count / i.count();
     }
 
@@ -9548,7 +9548,7 @@ int iuse::craft( player *p, item *it, bool, const tripoint &pos )
     }
 
     if( !where ) {
-        map_cursor mc = map_cursor( pos );
+        map_cursor const mc = map_cursor( pos );
         if( mc.has_item( *it ) ) {
             where = item_location( map_cursor( pos ), it );
         } else {
@@ -9648,7 +9648,7 @@ int iuse::magic_8_ball( player *p, item *it, bool, const tripoint & )
     };
 
     p->add_msg_if_player( m_info, _( "You ask the %s, then flip it." ), it->tname() );
-    int rn = rng( 0, tab.size() - 1 );
+    int const rn = rng( 0, tab.size() - 1 );
     auto color = ( rn >= BALL8_BAD ? m_bad : rn >= BALL8_UNK ? m_info : m_good );
     p->add_msg_if_player( color, _( "The %s says: %s" ), it->tname(), _( tab[rn] ) );
     return 0;
@@ -9671,10 +9671,10 @@ int iuse::toggle_heats_food( player *p, item *it, bool, const tripoint & )
 
 int iuse::report_grid_charge( player *p, item *, bool, const tripoint &pos )
 {
-    tripoint_abs_ms pos_abs( get_map().getabs( pos ) );
+    tripoint_abs_ms const pos_abs( get_map().getabs( pos ) );
     const distribution_grid &gr = get_distribution_grid_tracker().grid_at( pos_abs );
 
-    int amt = gr.get_resource();
+    int const amt = gr.get_resource();
     p->add_msg_if_player( _( "This electric grid stores %d kJ of electric power." ), amt );
 
     return 0;
@@ -9682,8 +9682,8 @@ int iuse::report_grid_charge( player *p, item *, bool, const tripoint &pos )
 
 int iuse::report_grid_connections( player *p, item *, bool, const tripoint &pos )
 {
-    tripoint_abs_omt pos_abs = project_to<coords::omt>( tripoint_abs_ms( get_map().getabs( pos ) ) );
-    std::vector<tripoint_rel_omt> connections = overmap_buffer.electric_grid_connectivity_at( pos_abs );
+    tripoint_abs_omt const pos_abs = project_to<coords::omt>( tripoint_abs_ms( get_map().getabs( pos ) ) );
+    std::vector<tripoint_rel_omt> const connections = overmap_buffer.electric_grid_connectivity_at( pos_abs );
 
     std::vector<std::string> connection_names;
     for( const tripoint_rel_omt &delta : connections ) {
@@ -9705,7 +9705,7 @@ int iuse::report_grid_connections( player *p, item *, bool, const tripoint &pos 
 
 int iuse::modify_grid_connections( player *p, item *it, bool, const tripoint &pos )
 {
-    tripoint_abs_omt pos_abs = project_to<coords::omt>( tripoint_abs_ms( get_map().getabs( pos ) ) );
+    tripoint_abs_omt const pos_abs = project_to<coords::omt>( tripoint_abs_ms( get_map().getabs( pos ) ) );
     std::vector<tripoint_rel_omt> connections = overmap_buffer.electric_grid_connectivity_at( pos_abs );
 
     uilist ui;
@@ -9715,13 +9715,13 @@ int iuse::modify_grid_connections( player *p, item *it, bool, const tripoint &po
         const tripoint &delta = six_cardinal_directions[i];
         connection_present[i] = std::count( connections.begin(), connections.end(),
                                             tripoint_rel_omt( delta ) );
-        std::string name = direction_name( direction_from( delta ) );
-        int i_int = static_cast<int>( i );
+        std::string const name = direction_name( direction_from( delta ) );
+        int const i_int = static_cast<int>( i );
         const char *format = connection_present[i]
                              ? _( "Remove connection in direction: %s" )
                              : _( "Add connection in direction: %s" );
-        int new_z = pos.z + delta.z;
-        bool enabled = new_z >= -10 && new_z <= 10;
+        int const new_z = pos.z + delta.z;
+        bool const enabled = new_z >= -10 && new_z <= 10;
         ui.addentry( i_int, enabled, i_int, format, name.c_str() );
     }
 
@@ -9730,13 +9730,13 @@ int iuse::modify_grid_connections( player *p, item *it, bool, const tripoint &po
         return 0;
     }
 
-    size_t ret = static_cast<size_t>( ui.ret );
-    tripoint_abs_omt destination_pos_abs = pos_abs + tripoint_rel_omt( six_cardinal_directions[ret] );
+    size_t const ret = static_cast<size_t>( ui.ret );
+    tripoint_abs_omt const destination_pos_abs = pos_abs + tripoint_rel_omt( six_cardinal_directions[ret] );
     if( connection_present[ret] ) {
         overmap_buffer.remove_grid_connection( pos_abs, destination_pos_abs );
     } else {
-        std::set<tripoint_abs_omt> lhs_locations = overmap_buffer.electric_grid_at( pos_abs );
-        std::set<tripoint_abs_omt> rhs_locations = overmap_buffer.electric_grid_at( destination_pos_abs );
+        std::set<tripoint_abs_omt> const lhs_locations = overmap_buffer.electric_grid_at( pos_abs );
+        std::set<tripoint_abs_omt> const rhs_locations = overmap_buffer.electric_grid_at( destination_pos_abs );
         int cost_mult;
         if( lhs_locations == rhs_locations ) {
             cost_mult = 0;
@@ -9790,7 +9790,7 @@ int iuse::modify_grid_connections( player *p, item *it, bool, const tripoint &po
         }
         p->invalidate_crafting_inventory();
 
-        bool success = overmap_buffer.add_grid_connection( pos_abs, destination_pos_abs );
+        bool const success = overmap_buffer.add_grid_connection( pos_abs, destination_pos_abs );
         if( success ) {
             return it->type->charges_to_use();
         }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -265,7 +265,7 @@ int iuse_transform::use( player &p, item &it, bool t, const tripoint &pos ) cons
         p.moves -= moves;
     }
 
-    item obj_copy( it );
+    item const obj_copy( it );
     item *obj;
     // defined here to allow making a new item assigned to the pointer
     item obj_it;
@@ -324,7 +324,7 @@ ret_val<bool> iuse_transform::can_use( const Character &p, const item &, bool,
     if( unmet_reqs.empty() ) {
         return ret_val<bool>::make_success();
     }
-    std::string unmet_reqs_string = enumerate_as_string( unmet_reqs.begin(), unmet_reqs.end(),
+    std::string const unmet_reqs_string = enumerate_as_string( unmet_reqs.begin(), unmet_reqs.end(),
     [&]( const std::pair<quality_id, int> &unmet_req ) {
         return string_format( "%s %d", unmet_req.first.obj().name, unmet_req.second );
     } );
@@ -351,7 +351,7 @@ void iuse_transform::finalize( const itype_id & )
             debugmsg( "Invalid transform container: %s", container.c_str() );
         }
 
-        item dummy( target );
+        item const dummy( target );
         if( ammo_qty > 1 && !dummy.count_by_charges() ) {
             debugmsg( "Transform target with container must be an item with charges, got non-charged: %s",
                       target.c_str() );
@@ -501,7 +501,7 @@ std::unique_ptr<iuse_actor> explosion_iuse::clone() const
 // They must also be passable.
 static std::vector<tripoint> points_for_gas_cloud( const tripoint &center, int radius )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     std::vector<tripoint> result;
     for( const auto &p : closest_points_first( center, radius ) ) {
         if( here.impassable( p ) ) {
@@ -585,7 +585,7 @@ void explosion_iuse::trigger_explosion( const tripoint &pos, Creature *source ) 
     }
     map &here = get_map();
     if( fields_radius >= 0 && fields_type.id() ) {
-        std::vector<tripoint> gas_sources = points_for_gas_cloud( pos, fields_radius );
+        std::vector<tripoint> const gas_sources = points_for_gas_cloud( pos, fields_radius );
         for( auto &gas_source : gas_sources ) {
             const int field_intensity = rng( fields_min_intensity, fields_max_intensity );
             here.add_field( gas_source, fields_type, field_intensity, 1_turns );
@@ -754,7 +754,7 @@ void consume_drug_iuse::load( const JsonObject &obj )
     obj.read( "fields_produced", fields_produced );
     obj.read( "moves", moves );
 
-    for( JsonArray vit : obj.get_array( "vitamins" ) ) {
+    for( JsonArray const vit : obj.get_array( "vitamins" ) ) {
         auto lo = vit.get_int( 1 );
         auto hi = vit.size() >= 3 ? vit.get_int( 2 ) : lo;
         vitamins.emplace( vitamin_id( vit.get_string( 0 ) ), std::make_pair( lo, hi ) );
@@ -1012,8 +1012,8 @@ void place_monster_iuse::load( const JsonObject &obj )
     obj.read( "place_randomly", place_randomly );
     obj.read( "is_pet", is_pet );
     if( obj.has_array( "skills" ) ) {
-        JsonArray skills_ja = obj.get_array( "skills" );
-        for( JsonValue s : skills_ja ) {
+        JsonArray const skills_ja = obj.get_array( "skills" );
+        for( JsonValue const s : skills_ja ) {
             skills.emplace( skill_id( s.get_string() ) );
         }
     }
@@ -1021,7 +1021,7 @@ void place_monster_iuse::load( const JsonObject &obj )
 
 int place_monster_iuse::use( player &p, item &it, bool, const tripoint & ) const
 {
-    shared_ptr_fast<monster> newmon_ptr = make_shared_fast<monster>( mtypeid );
+    shared_ptr_fast<monster> const newmon_ptr = make_shared_fast<monster>( mtypeid );
     monster &newmon = *newmon_ptr;
     newmon.init_from_item( it );
     if( place_randomly ) {
@@ -1166,7 +1166,7 @@ int pick_lock_actor::use( player &p, item &it, bool, const tripoint &t ) const
         }
         const ter_id ter = here.ter( pnt );
         const furn_id furn = here.furn( pnt );
-        lockpicking_open_result result = get_lockpicking_open_result( ter, furn );
+        lockpicking_open_result const result = get_lockpicking_open_result( ter, furn );
         const bool is_allowed = result.new_ter_type || result.new_furn_type;
         return is_allowed;
     };
@@ -1246,7 +1246,7 @@ void deploy_furn_actor::info( const item &, std::vector<iteminfo> &dump ) const
                            string_format( _( "Can be <info>activated</info> to deploy as furniture (<stat>%s</stat>)." ),
                                           furn_name ) );
     } else {
-        std::string furn_usages = enumerate_as_string( can_function_as, enumeration_conjunction::or_ );
+        std::string const furn_usages = enumerate_as_string( can_function_as, enumeration_conjunction::or_ );
         dump.emplace_back( "DESCRIPTION",
                            string_format(
                                _( "Can be <info>activated</info> to deploy as furniture (<stat>%s</stat>), which can then be used as %s." ),
@@ -1326,7 +1326,7 @@ void reveal_map_actor::load( const JsonObject &obj )
             ter = entry.get_string();
             ter_match_type = ot_match_type::contains;
         } else {
-            JsonObject jo = entry.get_object();
+            JsonObject const jo = entry.get_object();
             ter = jo.get_string( "om_terrain" );
             ter_match_type = jo.get_enum_value<ot_match_type>( "om_terrain_match_type",
                              ot_match_type::contains );
@@ -1490,14 +1490,14 @@ int firestarter_actor::use( player &p, item &it, bool t, const tripoint &spos ) 
     }
 
     tripoint pos = spos;
-    float light = light_mod( p.pos() );
+    float const light = light_mod( p.pos() );
     if( !prep_firestarter_use( p, pos ) ) {
         return 0;
     }
 
-    double skill_level = p.get_skill_level( skill_survival );
+    double const skill_level = p.get_skill_level( skill_survival );
     /** @EFFECT_SURVIVAL speeds up fire starting */
-    float moves_modifier = std::pow( 0.8, std::min( 5.0, skill_level ) );
+    float const moves_modifier = std::pow( 0.8, std::min( 5.0, skill_level ) );
     const int moves_base = moves_cost_by_fuel( pos );
     const double moves_per_turn = to_moves<double>( 1_turns );
     const int min_moves = std::min<int>(
@@ -1568,7 +1568,7 @@ static const units::volume minimal_volume_to_cut = 250_ml;
 
 int salvage_actor::time_to_cut_up( const item &it ) const
 {
-    int count = it.volume() / minimal_volume_to_cut;
+    int const count = it.volume() / minimal_volume_to_cut;
     return moves_per_part * count;
 }
 
@@ -1598,7 +1598,7 @@ bool salvage_actor::valid_to_cut_up( const item &it ) const
 // This is the former valid_to_cut_up with all the messages and queries
 bool salvage_actor::try_to_cut_up( player &p, item &it ) const
 {
-    int pos = p.get_item_position( &it );
+    int const pos = p.get_item_position( &it );
 
     if( it.is_null() ) {
         add_msg( m_info, _( "You do not have that item." ) );
@@ -1653,9 +1653,9 @@ int salvage_actor::cut_up( player &p, item &it, item_location &cut ) const
     int count = cut.get_item()->volume() / minimal_volume_to_cut;
     // Chance of us losing a material component to entropy.
     /** @EFFECT_FABRICATION reduces chance of losing components when cutting items up */
-    int entropy_threshold = std::max( 5, 10 - p.get_skill_level( skill_fabrication ) );
+    int const entropy_threshold = std::max( 5, 10 - p.get_skill_level( skill_fabrication ) );
     // What material components can we get back?
-    std::vector<material_id> cut_material_components = cut.get_item()->made_of();
+    std::vector<material_id> const cut_material_components = cut.get_item()->made_of();
     // What materials do we salvage (ids and counts).
     std::map<itype_id, int> materials_salvaged;
 
@@ -1688,7 +1688,7 @@ int salvage_actor::cut_up( player &p, item &it, item_location &cut ) const
     // chance of losing more components if the item is damaged.
     // If the item being cut is not damaged, no additional losses will be incurred.
     if( count > 0 && cut.get_item()->damage() > 0 ) {
-        float component_success_chance = std::min( std::pow( 0.8, cut.get_item()->damage_level( 4 ) ),
+        float const component_success_chance = std::min( std::pow( 0.8, cut.get_item()->damage_level( 4 ) ),
                                          1.0 );
         for( int i = count; i > 0; i-- ) {
             if( component_success_chance < rng_float( 0, 1 ) ) {
@@ -1708,8 +1708,8 @@ int salvage_actor::cut_up( player &p, item &it, item_location &cut ) const
     add_msg( m_info, _( "You try to salvage materials from the %s." ),
              cut.get_item()->tname() );
 
-    item_location::type cut_type = cut.where();
-    tripoint pos = cut.position();
+    item_location::type const cut_type = cut.where();
+    tripoint const pos = cut.position();
 
     // Clean up before removing the item.
     remove_ammo( *cut.get_item(), p );
@@ -1720,8 +1720,8 @@ int salvage_actor::cut_up( player &p, item &it, item_location &cut ) const
 
     map &here = get_map();
     for( const auto &salvaged : materials_salvaged ) {
-        itype_id mat_name = salvaged.first;
-        int amount = salvaged.second;
+        itype_id const mat_name = salvaged.first;
+        int const amount = salvaged.second;
         item result( mat_name, calendar::turn );
         if( amount > 0 ) {
             add_msg( m_good, vgettext( "Salvaged %1$i %2$s.", "Salvaged %1$i %2$s.", amount ),
@@ -1812,7 +1812,7 @@ bool inscribe_actor::item_inscription( item &tool, item &cut ) const
     }
 
     const bool hasnote = cut.has_var( carving );
-    std::string messageprefix = ( hasnote ? _( "(To delete, clear the text and confirm)\n" ) : "" ) +
+    std::string const messageprefix = ( hasnote ? _( "(To delete, clear the text and confirm)\n" ) : "" ) +
                                 //~ %1$s: gerund (e.g. carved), %2$s: item name
                                 string_format( pgettext( "carving", "%1$s on the %2$s is: " ),
                                         gerund, cut.type_name() );
@@ -1919,7 +1919,7 @@ bool cauterize_actor::cauterize_effect( player &p, item &it, bool force )
 {
     // TODO: Make this less hacky
     static const heal_actor dummy = prepare_dummy();
-    hp_part hpart = dummy.use_healing_item( p, p, it, force );
+    hp_part const hpart = dummy.use_healing_item( p, p, it, force );
     if( hpart != num_hp_parts ) {
         p.add_msg_if_player( m_neutral, _( "You cauterize yourself." ) );
         if( !( p.has_trait( trait_NOPAIN ) ) ) {
@@ -1949,7 +1949,7 @@ int cauterize_actor::use( player &p, item &it, bool t, const tripoint & ) const
         p.add_msg_if_player( m_info, _( "You cannot do that while mounted." ) );
         return 0;
     }
-    bool has_disease = p.has_effect( effect_bite ) || p.has_effect( effect_bleed );
+    bool const has_disease = p.has_effect( effect_bite ) || p.has_effect( effect_bleed );
     bool did_cauterize = false;
 
     if( has_disease ) {
@@ -2030,10 +2030,10 @@ int enzlave_actor::use( player &p, item &it, bool t, const tripoint & ) const
         p.add_msg_if_player( m_info, _( "You cannot do that while mounted." ) );
         return 0;
     }
-    map_stack items = get_map().i_at( point( p.posx(), p.posy() ) );
+    map_stack const items = get_map().i_at( point( p.posx(), p.posy() ) );
     std::vector<const item *> corpses;
 
-    for( item &corpse_candidate : items ) {
+    for( item  const&corpse_candidate : items ) {
         const mtype *mt = corpse_candidate.get_mtype();
         if( corpse_candidate.is_corpse() && mt->in_species( ZOMBIE ) &&
             mt->made_of( material_id( "flesh" ) ) &&
@@ -2090,8 +2090,8 @@ int enzlave_actor::use( player &p, item &it, bool t, const tripoint & ) const
         /** @EFFECT_SURVIVAL decreases moral penalty and duration for enzlavement */
         int moraleMalus = -50 * ( 5.0 / p.get_skill_level( skill_survival ) );
         int maxMalus = -250 * ( 5.0 / p.get_skill_level( skill_survival ) );
-        time_duration duration = 30_minutes * ( 5.0 / p.get_skill_level( skill_survival ) );
-        time_duration decayDelay = 3_minutes * ( 5.0 / p.get_skill_level( skill_survival ) );
+        time_duration const duration = 30_minutes * ( 5.0 / p.get_skill_level( skill_survival ) );
+        time_duration const decayDelay = 3_minutes * ( 5.0 / p.get_skill_level( skill_survival ) );
 
         if( p.has_trait( trait_PACIFIST ) ) {
             moraleMalus *= 5;
@@ -2114,7 +2114,7 @@ int enzlave_actor::use( player &p, item &it, bool t, const tripoint & ) const
     // Speed range is 20 - 120 (for humanoids, dogs get way faster)
     // This gives us a difficulty ranging roughly from 10 - 40, with up to +25 for corpse damage.
     // An average zombie with an undamaged corpse is 0 + 8 + 14 = 22.
-    int difficulty = ( body->damage_level( 4 ) * 5 ) + ( mt->hp / 10 ) + ( mt->speed / 5 );
+    int const difficulty = ( body->damage_level( 4 ) * 5 ) + ( mt->hp / 10 ) + ( mt->speed / 5 );
     // 0 - 30
     /** @EFFECT_DEX increases chance of success for enzlavement */
 
@@ -2125,7 +2125,7 @@ int enzlave_actor::use( player &p, item &it, bool t, const tripoint & ) const
                  ( p.dex_cur / 2 );
     skills *= 2;
 
-    int success = rng( 0, skills ) - rng( 0, difficulty );
+    int const success = rng( 0, skills ) - rng( 0, difficulty );
 
     /** @EFFECT_FIRSTAID speeds up enzlavement */
     const int moves = difficulty * to_moves<int>( 12_seconds ) / p.get_skill_level( skill_firstaid );
@@ -2600,7 +2600,7 @@ int cast_spell_actor::use( player &p, item &it, bool, const tripoint & ) const
         return 0;
     }
 
-    spell casting = spell( spell_id( item_spell ) );
+    spell const casting = spell( spell_id( item_spell ) );
 
     player_activity cast_spell( ACT_SPELLCASTING, casting.casting_time( p ) );
     // [0] this is used as a spell level override for items casting spells
@@ -2730,7 +2730,7 @@ int holster_actor::use( player &p, item &it, bool, const tripoint & ) const
     std::vector<std::string> opts;
 
     if( static_cast<int>( it.contents.num_item_stacks() ) < multi ) {
-        std::string prompt = holster_prompt.empty() ? _( "Holster item" ) : _( holster_prompt );
+        std::string const prompt = holster_prompt.empty() ? _( "Holster item" ) : _( holster_prompt );
         opts.push_back( prompt );
         pos = -1;
     }
@@ -2792,7 +2792,7 @@ int holster_actor::use( player &p, item &it, bool, const tripoint & ) const
 
 void holster_actor::info( const item &, std::vector<iteminfo> &dump ) const
 {
-    std::string message = vgettext( "Can be activated to store a suitable item.",
+    std::string const message = vgettext( "Can be activated to store a suitable item.",
                                     "Can be activated to store suitable items.", multi );
     dump.emplace_back( "DESCRIPTION", message );
     dump.emplace_back( "TOOL", _( "Num items: " ), "<num>", iteminfo::no_flags, multi );
@@ -2901,7 +2901,7 @@ bool bandolier_actor::reload( player &p, item &obj ) const
 
     // add or stack the ammo dependent upon existing contents
     if( obj.contents.empty() ) {
-        item put = sel.ammo->split( sel.qty() );
+        item const put = sel.ammo->split( sel.qty() );
         if( !put.is_null() ) {
             obj.put_in( put );
         } else {
@@ -3395,7 +3395,7 @@ repair_item_actor::repair_type repair_item_actor::default_action( const item &fi
         return RT_REFIT;
     }
 
-    Character &player_character = get_player_character();
+    Character  const&player_character = get_player_character();
     const bool smol = player_character.get_size() == MS_TINY;
 
     const bool is_undersized = fix.has_flag( flag_UNDERSIZE );
@@ -3461,7 +3461,7 @@ repair_item_actor::attempt_hint repair_item_actor::repair( player &pl, item &too
     const auto action = default_action( *fix, current_skill_level );
     const auto chance = repair_chance( pl, *fix, action );
     int practice_amount = repair_recipe_difficulty( pl, *fix, true ) / 2 + 1;
-    float roll_value = rng_float( 0.0, 1.0 );
+    float const roll_value = rng_float( 0.0, 1.0 );
     enum roll_result {
         SUCCESS,
         FAILURE,
@@ -3615,7 +3615,7 @@ void heal_actor::load( const JsonObject &obj )
     torso_power = obj.get_float( "torso_power", 1.5f * limb_power );
 
     limb_scaling = obj.get_float( "limb_scaling", 0.25f * limb_power );
-    double scaling_ratio = limb_power < 0.0001f ? 0.0 :
+    double const scaling_ratio = limb_power < 0.0001f ? 0.0 :
                            static_cast<double>( limb_scaling / limb_power );
     head_scaling = obj.get_float( "head_scaling", scaling_ratio * head_power );
     torso_scaling = obj.get_float( "torso_scaling", scaling_ratio * torso_power );
@@ -3635,7 +3635,7 @@ void heal_actor::load( const JsonObject &obj )
     if( obj.has_string( "used_up_item" ) ) {
         obj.read( "used_up_item", used_up_item_id, true );
     } else if( obj.has_object( "used_up_item" ) ) {
-        JsonObject u = obj.get_object( "used_up_item" );
+        JsonObject const u = obj.get_object( "used_up_item" );
         u.read( "id", used_up_item_id, true );
         used_up_item_quantity = u.get_int( "quantity", used_up_item_quantity );
         used_up_item_charges = u.get_int( "charges", used_up_item_charges );
@@ -3767,7 +3767,7 @@ int heal_actor::finish_using( player &healer, player &patient, item &it, hp_part
 
     const body_part bp_healed = player::hp_to_bp( healed );
 
-    Character &player_character = get_player_character();
+    Character  const&player_character = get_player_character();
     const bool u_see = healer.is_player() || patient.is_player() ||
                        player_character.sees( healer ) || player_character.sees( patient );
     const bool player_healing_player = healer.is_player() && patient.is_player();
@@ -3850,7 +3850,7 @@ int heal_actor::finish_using( player &healer, player &patient, item &it, hp_part
 
     // apply healing over time effects
     if( bandages_power > 0 ) {
-        int bandages_intensity = get_bandaged_level( healer );
+        int const bandages_intensity = get_bandaged_level( healer );
         patient.add_effect( effect_bandaged, 1_turns, bp_healed );
         effect &e = patient.get_effect( effect_bandaged, bp_healed );
         e.set_duration( e.get_int_dur_factor() * bandages_intensity );
@@ -3858,7 +3858,7 @@ int heal_actor::finish_using( player &healer, player &patient, item &it, hp_part
         practice_amount += 2 * bandages_intensity;
     }
     if( disinfectant_power > 0 ) {
-        int disinfectant_intensity = get_disinfected_level( healer );
+        int const disinfectant_intensity = get_disinfected_level( healer );
         patient.add_effect( effect_disinfected, 1_turns, bp_healed );
         effect &e = patient.get_effect( effect_disinfected, bp_healed );
         e.set_duration( e.get_int_dur_factor() * disinfectant_intensity );
@@ -3888,7 +3888,7 @@ static hp_part pick_part_to_heal(
                          /** @EFFECT_FIRSTAID increases precision when using first aid on someone else */
                          ( healer.get_skill_level( skill_firstaid ) * 4 + healer.per_cur >= 20 );
     while( true ) {
-        hp_part healed_part = patient.body_window( menu_header, force, precise,
+        hp_part const healed_part = patient.body_window( menu_header, force, precise,
                               limb_power, head_bonus, torso_bonus,
                               bleed_chance, bite_chance, infect_chance, bandage_power, disinfectant_power );
         if( healed_part == num_hp_parts ) {
@@ -4005,7 +4005,7 @@ void heal_actor::info( const item &, std::vector<iteminfo> &dump ) const
         dump.emplace_back( "HEAL", _( "<bold>Healing effects</bold> " ) );
     }
 
-    Character &player_character = get_player_character();
+    Character  const&player_character = get_player_character();
     if( head_power > 0 || torso_power > 0 || limb_power > 0 ) {
         dump.emplace_back( "HEAL", _( "Base healing: " ) );
         dump.emplace_back( "HEAL_BASE", _( "Head: " ), "", iteminfo::no_newline, head_power );
@@ -4080,7 +4080,7 @@ void place_trap_actor::load( const JsonObject &obj )
     assign( obj, "needs_neighbor_terrain", needs_neighbor_terrain );
     assign( obj, "bury_question", bury_question );
     if( !bury_question.empty() ) {
-        JsonObject buried_json = obj.get_object( "bury" );
+        JsonObject const buried_json = obj.get_object( "bury" );
         buried_data.load( buried_json );
     }
     unburied_data.load( obj );
@@ -4094,7 +4094,7 @@ std::unique_ptr<iuse_actor> place_trap_actor::clone() const
 
 static bool is_solid_neighbor( const tripoint &pos, point offset )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     const tripoint a = pos + offset;
     const tripoint b = pos - offset;
     return here.move_cost( a ) != 2 && here.move_cost( b ) != 2;
@@ -4102,7 +4102,7 @@ static bool is_solid_neighbor( const tripoint &pos, point offset )
 
 static bool has_neighbor( const tripoint &pos, const ter_id &terrain_id )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     for( const tripoint &t : here.points_in_radius( pos, 1, 0 ) ) {
         if( here.ter( t ) == terrain_id ) {
             return true;
@@ -4118,7 +4118,7 @@ bool place_trap_actor::is_allowed( player &p, const tripoint &pos, const std::st
                              name );
         return false;
     }
-    map &here = get_map();
+    map  const&here = get_map();
     if( here.move_cost( pos ) != 2 ) {
         p.add_msg_if_player( m_info, _( "You can't place a %s there." ), name );
         return false;
@@ -4181,8 +4181,8 @@ int place_trap_actor::use( player &p, item &it, bool, const tripoint & ) const
         return 0;
     }
 
-    map &here = get_map();
-    int distance_to_trap_center = unburied_data.trap.obj().get_trap_radius() +
+    map  const&here = get_map();
+    int const distance_to_trap_center = unburied_data.trap.obj().get_trap_radius() +
                                   outer_layer_trap.obj().get_trap_radius() + 1;
     if( unburied_data.trap.obj().get_trap_radius() > 0 ) {
         // Math correction for multi-tile traps
@@ -4528,16 +4528,16 @@ void mutagen_actor::load( const JsonObject &obj )
 
 int mutagen_actor::use( player &p, item &it, bool, const tripoint & ) const
 {
-    mutagen_attempt checks =
+    mutagen_attempt const checks =
         mutagen_common_checks( p, it, false, mutagen_technique::consumed_mutagen );
 
     if( !checks.allowed ) {
         return checks.charges_used;
     }
 
-    bool no_category = mutation_category == "ANY";
-    bool balanced = get_option<bool>( "BALANCED_MUTATIONS" );
-    int accumulated_mutagen = p.get_effect_int( effect_accumulated_mutagen );
+    bool const no_category = mutation_category == "ANY";
+    bool const balanced = get_option<bool>( "BALANCED_MUTATIONS" );
+    int const accumulated_mutagen = p.get_effect_int( effect_accumulated_mutagen );
     if( balanced && !is_strong && is_weak && accumulated_mutagen < 2 && no_category && !p.query_yn(
             _( "Looking at it just makes you tired.  It probably won't work.  Do you want to try anyway?" )
         ) ) {
@@ -4570,7 +4570,7 @@ int mutagen_actor::use( player &p, item &it, bool, const tripoint & ) const
         p.add_effect( effect_downed, 20_turns, num_bp, 0 );
     }
 
-    int mut_count = 1 + ( is_strong ? one_in( 3 ) : 0 );
+    int const mut_count = 1 + ( is_strong ? one_in( 3 ) : 0 );
 
     for( int i = 0; i < mut_count; i++ ) {
         p.mutate_category( m_category.id );
@@ -4596,7 +4596,7 @@ void mutagen_iv_actor::load( const JsonObject &obj )
 
 int mutagen_iv_actor::use( player &p, item &it, bool, const tripoint & ) const
 {
-    mutagen_attempt checks =
+    mutagen_attempt const checks =
         mutagen_common_checks( p, it, false, mutagen_technique::injected_mutagen );
 
     if( !checks.allowed ) {
@@ -4677,7 +4677,7 @@ void deploy_tent_actor::load( const JsonObject &obj )
 
 int deploy_tent_actor::use( player &p, item &it, bool, const tripoint & ) const
 {
-    int diam = 2 * radius + 1;
+    int const diam = 2 * radius + 1;
     if( p.is_mounted() ) {
         p.add_msg_if_player( _( "You cannot do that while mounted." ) );
         return 0;
@@ -4733,7 +4733,7 @@ int deploy_tent_actor::use( player &p, item &it, bool, const tripoint & ) const
 
 bool deploy_tent_actor::check_intact( const tripoint &center ) const
 {
-    map &here = get_map();
+    map  const&here = get_map();
     for( const tripoint &dest : here.points_in_radius( center, radius ) ) {
         const furn_id fid = here.furn( dest );
         if( dest == center && floor_center ) {
@@ -4768,7 +4768,7 @@ int weigh_self_actor::use( player &p, item &, bool, const tripoint & ) const
         return 0;
     }
     // this is a weight, either in kgs or in lbs.
-    double weight = convert_weight( p.get_weight() );
+    double const weight = convert_weight( p.get_weight() );
     if( weight > convert_weight( max_weight ) ) {
         popup( _( "ERROR: Max weight of %.0f %s exceeded" ), convert_weight( max_weight ), weight_units() );
     } else {
@@ -5040,7 +5040,7 @@ void change_scent_iuse::load( const JsonObject &obj )
         obj.throw_error( "Invalid scent type id.", "scent_typeid" );
     }
     if( obj.has_array( "effects" ) ) {
-        for( JsonObject e : obj.get_array( "effects" ) ) {
+        for( JsonObject const e : obj.get_array( "effects" ) ) {
             effects.push_back( load_effect_data( e ) );
         }
     }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -501,7 +501,7 @@ std::unique_ptr<iuse_actor> explosion_iuse::clone() const
 // They must also be passable.
 static std::vector<tripoint> points_for_gas_cloud( const tripoint &center, int radius )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     std::vector<tripoint> result;
     for( const auto &p : closest_points_first( center, radius ) ) {
         if( here.impassable( p ) ) {
@@ -1246,7 +1246,8 @@ void deploy_furn_actor::info( const item &, std::vector<iteminfo> &dump ) const
                            string_format( _( "Can be <info>activated</info> to deploy as furniture (<stat>%s</stat>)." ),
                                           furn_name ) );
     } else {
-        std::string const furn_usages = enumerate_as_string( can_function_as, enumeration_conjunction::or_ );
+        std::string const furn_usages = enumerate_as_string( can_function_as,
+                                        enumeration_conjunction::or_ );
         dump.emplace_back( "DESCRIPTION",
                            string_format(
                                _( "Can be <info>activated</info> to deploy as furniture (<stat>%s</stat>), which can then be used as %s." ),
@@ -1689,7 +1690,7 @@ int salvage_actor::cut_up( player &p, item &it, item_location &cut ) const
     // If the item being cut is not damaged, no additional losses will be incurred.
     if( count > 0 && cut.get_item()->damage() > 0 ) {
         float const component_success_chance = std::min( std::pow( 0.8, cut.get_item()->damage_level( 4 ) ),
-                                         1.0 );
+                                               1.0 );
         for( int i = count; i > 0; i-- ) {
             if( component_success_chance < rng_float( 0, 1 ) ) {
                 count--;
@@ -1812,10 +1813,11 @@ bool inscribe_actor::item_inscription( item &tool, item &cut ) const
     }
 
     const bool hasnote = cut.has_var( carving );
-    std::string const messageprefix = ( hasnote ? _( "(To delete, clear the text and confirm)\n" ) : "" ) +
-                                //~ %1$s: gerund (e.g. carved), %2$s: item name
-                                string_format( pgettext( "carving", "%1$s on the %2$s is: " ),
-                                        gerund, cut.type_name() );
+    std::string const messageprefix = ( hasnote ? _( "(To delete, clear the text and confirm)\n" ) :
+                                        "" ) +
+                                      //~ %1$s: gerund (e.g. carved), %2$s: item name
+                                      string_format( pgettext( "carving", "%1$s on the %2$s is: " ),
+                                              gerund, cut.type_name() );
 
     string_input_popup popup;
     popup.title( string_format( _( "%s what?" ), verb ) )
@@ -2033,7 +2035,7 @@ int enzlave_actor::use( player &p, item &it, bool t, const tripoint & ) const
     map_stack const items = get_map().i_at( point( p.posx(), p.posy() ) );
     std::vector<const item *> corpses;
 
-    for( item  const&corpse_candidate : items ) {
+    for( item  const &corpse_candidate : items ) {
         const mtype *mt = corpse_candidate.get_mtype();
         if( corpse_candidate.is_corpse() && mt->in_species( ZOMBIE ) &&
             mt->made_of( material_id( "flesh" ) ) &&
@@ -2793,7 +2795,7 @@ int holster_actor::use( player &p, item &it, bool, const tripoint & ) const
 void holster_actor::info( const item &, std::vector<iteminfo> &dump ) const
 {
     std::string const message = vgettext( "Can be activated to store a suitable item.",
-                                    "Can be activated to store suitable items.", multi );
+                                          "Can be activated to store suitable items.", multi );
     dump.emplace_back( "DESCRIPTION", message );
     dump.emplace_back( "TOOL", _( "Num items: " ), "<num>", iteminfo::no_flags, multi );
     dump.emplace_back( "TOOL", _( "Item volume: Min: " ),
@@ -3395,7 +3397,7 @@ repair_item_actor::repair_type repair_item_actor::default_action( const item &fi
         return RT_REFIT;
     }
 
-    Character  const&player_character = get_player_character();
+    Character  const &player_character = get_player_character();
     const bool smol = player_character.get_size() == MS_TINY;
 
     const bool is_undersized = fix.has_flag( flag_UNDERSIZE );
@@ -3616,7 +3618,7 @@ void heal_actor::load( const JsonObject &obj )
 
     limb_scaling = obj.get_float( "limb_scaling", 0.25f * limb_power );
     double const scaling_ratio = limb_power < 0.0001f ? 0.0 :
-                           static_cast<double>( limb_scaling / limb_power );
+                                 static_cast<double>( limb_scaling / limb_power );
     head_scaling = obj.get_float( "head_scaling", scaling_ratio * head_power );
     torso_scaling = obj.get_float( "torso_scaling", scaling_ratio * torso_power );
 
@@ -3767,7 +3769,7 @@ int heal_actor::finish_using( player &healer, player &patient, item &it, hp_part
 
     const body_part bp_healed = player::hp_to_bp( healed );
 
-    Character  const&player_character = get_player_character();
+    Character  const &player_character = get_player_character();
     const bool u_see = healer.is_player() || patient.is_player() ||
                        player_character.sees( healer ) || player_character.sees( patient );
     const bool player_healing_player = healer.is_player() && patient.is_player();
@@ -3889,8 +3891,8 @@ static hp_part pick_part_to_heal(
                          ( healer.get_skill_level( skill_firstaid ) * 4 + healer.per_cur >= 20 );
     while( true ) {
         hp_part const healed_part = patient.body_window( menu_header, force, precise,
-                              limb_power, head_bonus, torso_bonus,
-                              bleed_chance, bite_chance, infect_chance, bandage_power, disinfectant_power );
+                                    limb_power, head_bonus, torso_bonus,
+                                    bleed_chance, bite_chance, infect_chance, bandage_power, disinfectant_power );
         if( healed_part == num_hp_parts ) {
             return num_hp_parts;
         }
@@ -4005,7 +4007,7 @@ void heal_actor::info( const item &, std::vector<iteminfo> &dump ) const
         dump.emplace_back( "HEAL", _( "<bold>Healing effects</bold> " ) );
     }
 
-    Character  const&player_character = get_player_character();
+    Character  const &player_character = get_player_character();
     if( head_power > 0 || torso_power > 0 || limb_power > 0 ) {
         dump.emplace_back( "HEAL", _( "Base healing: " ) );
         dump.emplace_back( "HEAL_BASE", _( "Head: " ), "", iteminfo::no_newline, head_power );
@@ -4094,7 +4096,7 @@ std::unique_ptr<iuse_actor> place_trap_actor::clone() const
 
 static bool is_solid_neighbor( const tripoint &pos, point offset )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     const tripoint a = pos + offset;
     const tripoint b = pos - offset;
     return here.move_cost( a ) != 2 && here.move_cost( b ) != 2;
@@ -4102,7 +4104,7 @@ static bool is_solid_neighbor( const tripoint &pos, point offset )
 
 static bool has_neighbor( const tripoint &pos, const ter_id &terrain_id )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     for( const tripoint &t : here.points_in_radius( pos, 1, 0 ) ) {
         if( here.ter( t ) == terrain_id ) {
             return true;
@@ -4118,7 +4120,7 @@ bool place_trap_actor::is_allowed( player &p, const tripoint &pos, const std::st
                              name );
         return false;
     }
-    map  const&here = get_map();
+    map  const &here = get_map();
     if( here.move_cost( pos ) != 2 ) {
         p.add_msg_if_player( m_info, _( "You can't place a %s there." ), name );
         return false;
@@ -4181,9 +4183,9 @@ int place_trap_actor::use( player &p, item &it, bool, const tripoint & ) const
         return 0;
     }
 
-    map  const&here = get_map();
+    map  const &here = get_map();
     int const distance_to_trap_center = unburied_data.trap.obj().get_trap_radius() +
-                                  outer_layer_trap.obj().get_trap_radius() + 1;
+                                        outer_layer_trap.obj().get_trap_radius() + 1;
     if( unburied_data.trap.obj().get_trap_radius() > 0 ) {
         // Math correction for multi-tile traps
         pos.x = ( pos.x - p.posx() ) * distance_to_trap_center + p.posx();
@@ -4733,7 +4735,7 @@ int deploy_tent_actor::use( player &p, item &it, bool, const tripoint & ) const
 
 bool deploy_tent_actor::check_intact( const tripoint &center ) const
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     for( const tripoint &dest : here.points_in_radius( center, radius ) ) {
         const furn_id fid = here.furn( dest );
         if( dest == center && floor_center ) {

--- a/src/iuse_software.cpp
+++ b/src/iuse_software.cpp
@@ -24,8 +24,8 @@ bool play_videogame( const std::string &function_name,
         return true; // generic game
     }
     if( function_name == "robot_finds_kitten" ) {
-        robot_finds_kitten findkitten;
-        bool foundkitten = findkitten.ret;
+        robot_finds_kitten const findkitten;
+        bool const foundkitten = findkitten.ret;
         if( foundkitten ) {
             end_message = _( "You found kitten!" );
             score = 30;
@@ -34,7 +34,7 @@ bool play_videogame( const std::string &function_name,
         return foundkitten;
     } else if( function_name == "snake_game" ) {
         snake_game sg;
-        int iScore = sg.start_game();
+        int const iScore = sg.start_game();
 
         if( iScore >= 10000 ) {
             score = 30;
@@ -47,7 +47,7 @@ bool play_videogame( const std::string &function_name,
         return true;
     } else if( function_name == "sokoban_game" ) {
         sokoban_game sg;
-        int iScore = sg.start_game();
+        int const iScore = sg.start_game();
 
         if( iScore >= 5000 ) {
             score = 30;
@@ -65,7 +65,7 @@ bool play_videogame( const std::string &function_name,
         return true;
     } else if( function_name == "lightson_game" ) {
         lightson_game lg;
-        int iScore = lg.start_game();
+        int const iScore = lg.start_game();
         score = std::min( 15, iScore * 3 );
 
         return true;

--- a/src/iuse_software_kitten.cpp
+++ b/src/iuse_software_kitten.cpp
@@ -16,7 +16,7 @@ static constexpr int KITTEN = 1;
 
 std::string robot_finds_kitten::getmessage( int idx ) const
 {
-    std::string rfimessages[MAXMESSAGES] = {
+    std::string const rfimessages[MAXMESSAGES] = {
         _( "\"I pity the fool who mistakes me for kitten!\", sez Mr. T." ),
         _( "That's just an old tin can." ),
         _( "It's an altar to the horse god." ),
@@ -230,7 +230,7 @@ std::string robot_finds_kitten::getmessage( int idx ) const
 robot_finds_kitten::robot_finds_kitten()
 {
     ret = false;
-    char ktile[83] =
+    char const ktile[83] =
         "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!#&()*+./:;=?![]{|}y";
     int used_messages[MAXMESSAGES];
 
@@ -326,7 +326,7 @@ robot_finds_kitten::robot_finds_kitten()
 
 void robot_finds_kitten::show() const
 {
-    input_context ctxt( "IUSE_SOFTWARE_KITTEN" );
+    input_context const ctxt( "IUSE_SOFTWARE_KITTEN" );
 
     draw_border( bkatwin );
     wnoutrefresh( bkatwin );

--- a/src/iuse_software_lightson.cpp
+++ b/src/iuse_software_lightson.cpp
@@ -66,9 +66,9 @@ void lightson_game::draw_level()
     draw_border( w );
     for( int i = 0; i < level_size.y; i++ ) {
         for( int j = 0; j < level_size.x; j++ ) {
-            point current = point( j, i );
-            bool selected = position == current;
-            bool on = get_value_at( current );
+            point const current = point( j, i );
+            bool const selected = position == current;
+            bool const on = get_value_at( current );
             const nc_color fg = on ? c_white : c_dark_gray;
             const char symbol = on ? '#' : '-';
             mvwputch( w, current + point_south_east, selected ? hilite( c_white ) : fg, symbol );
@@ -190,7 +190,7 @@ int lightson_game::start_game()
             new_level();
         }
         ui_manager::redraw();
-        std::string action = ctxt.handle_input();
+        std::string const action = ctxt.handle_input();
         if( const std::optional<tripoint> vec = ctxt.get_direction( action ) ) {
             position.y = clamp( position.y + vec->y, 0, level_size.y - 1 );
             position.x = clamp( position.x + vec->x, 0, level_size.x - 1 );

--- a/src/iuse_software_minesweeper.cpp
+++ b/src/iuse_software_minesweeper.cpp
@@ -104,7 +104,7 @@ void minesweeper_game::new_level()
     for( int y = 0; y < level.y; y++ ) {
         for( int x = 0; x < level.x; x++ ) {
             if( mLevel[y][x] == bomb ) {
-                for( point p : closest_points_first( {x, y}, 1 ) ) {
+                for( point const p : closest_points_first( {x, y}, 1 ) ) {
                     if( p.x >= 0 && p.x < level.x && p.y >= 0 && p.y < level.y ) {
                         if( mLevel[p.y][p.x] != bomb ) {
                             mLevel[p.y][p.x]++;
@@ -262,7 +262,7 @@ int minesweeper_game::start_game()
             mLevelReveal[pt.y][pt.x] = seen;
 
             if( mLevel[pt.y][pt.x] == 0 ) {
-                for( point p : closest_points_first( pt, 1 ) ) {
+                for( point const p : closest_points_first( pt, 1 ) ) {
                     if( p.x >= 0 && p.x < level.x && p.y >= 0 && p.y < level.y ) {
                         if( mLevelReveal[p.y][p.x] != seen ) {
                             rec_reveal( p );

--- a/src/iuse_software_snake.cpp
+++ b/src/iuse_software_snake.cpp
@@ -30,7 +30,7 @@ void snake_game::print_header( const catacurses::window &w_snake, bool show_shor
 {
     draw_border( w_snake, BORDER_COLOR, _( "S N A K E" ), c_white );
     if( show_shortcut ) {
-        std::string shortcut = _( "<q>uit" );
+        std::string const shortcut = _( "<q>uit" );
         shortcut_print( w_snake, point( FULL_SCREEN_WIDTH - utf8_width( shortcut ) - 2, 0 ),
                         c_white, c_light_green, shortcut );
     }
@@ -42,7 +42,7 @@ void snake_game::snake_over( const catacurses::window &w_snake, int iScore )
     print_header( w_snake, false );
 
     // Body of dead snake
-    size_t body_length = 3;
+    size_t const body_length = 3;
     for( size_t i = 1; i <= body_length; i++ ) {
         for( size_t j = 0; j <= 1; j++ ) {
             mvwprintz( w_snake, point( 4 + j * 65, i ), c_green, "|   |" );

--- a/src/iuse_software_sokoban.cpp
+++ b/src/iuse_software_sokoban.cpp
@@ -327,7 +327,7 @@ int sokoban_game::start_game()
                 if( vUndo[vUndo.size() - 1].sTileOld == "$" ||
                     vUndo[vUndo.size() - 1].sTileOld == "*" ) {
                     mLevel[pl.y][pl.x] = mLevel[pl.y][pl.x] == "." ? "*" : "$";
-                    point np = pl + dir;
+                    point const np = pl + dir;
                     mLevel[np.y][np.x] = mLevel[np.y][np.x] == "*" ?
                                          "." : " ";
 
@@ -359,14 +359,14 @@ int sokoban_game::start_game()
 
         if( bMoved ) {
             //check if we can move the player
-            std::string sMoveTo = mLevel[pl.y + dir.y][pl.x + dir.x];
+            std::string const sMoveTo = mLevel[pl.y + dir.y][pl.x + dir.x];
             bool bMovePlayer = false;
 
             if( sMoveTo != "#" ) {
                 if( sMoveTo == "$" || sMoveTo == "*" ) {
                     //Check if we can move the package
-                    point p_pack = pl + dir * 2;
-                    std::string sMovePackTo = mLevel[p_pack.y][p_pack.x];
+                    point const p_pack = pl + dir * 2;
+                    std::string const sMovePackTo = mLevel[p_pack.y][p_pack.x];
                     if( sMovePackTo == "." || sMovePackTo == " " ) {
                         //move both
                         bMovePlayer = true;

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -85,8 +85,8 @@ JsonObject::JsonObject( JsonIn &j )
     // cache the position of the value for each member
     jsin->start_object();
     while( !jsin->end_object() ) {
-        std::string n = jsin->get_member_name();
-        int p = jsin->tell();
+        std::string const n = jsin->get_member_name();
+        int const p = jsin->tell();
         if( positions.count( n ) > 0 ) {
             j.error( "duplicate entry in json object" );
         }
@@ -308,7 +308,7 @@ void JsonValue::show_warning( std::string err ) const
 
 JsonIn *JsonObject::get_raw( const std::string &name ) const
 {
-    int pos = verify_position( name );
+    int const pos = verify_position( name );
     mark_visited( name );
     jsin->seek( pos );
     return jsin;
@@ -338,7 +338,7 @@ bool JsonObject::get_bool( const std::string &name ) const
 
 bool JsonObject::get_bool( const std::string &name, const bool fallback ) const
 {
-    int pos = verify_position( name, false );
+    int const pos = verify_position( name, false );
     if( !pos ) {
         return fallback;
     }
@@ -354,7 +354,7 @@ int JsonObject::get_int( const std::string &name ) const
 
 int JsonObject::get_int( const std::string &name, const int fallback ) const
 {
-    int pos = verify_position( name, false );
+    int const pos = verify_position( name, false );
     if( !pos ) {
         return fallback;
     }
@@ -370,7 +370,7 @@ double JsonObject::get_float( const std::string &name ) const
 
 double JsonObject::get_float( const std::string &name, const double fallback ) const
 {
-    int pos = verify_position( name, false );
+    int const pos = verify_position( name, false );
     if( !pos ) {
         return fallback;
     }
@@ -386,7 +386,7 @@ std::string JsonObject::get_string( const std::string &name ) const
 
 std::string JsonObject::get_string( const std::string &name, const std::string &fallback ) const
 {
-    int pos = verify_position( name, false );
+    int const pos = verify_position( name, false );
     if( !pos ) {
         return fallback;
     }
@@ -399,7 +399,7 @@ std::string JsonObject::get_string( const std::string &name, const std::string &
 
 JsonArray JsonObject::get_array( const std::string &name ) const
 {
-    int pos = verify_position( name, false );
+    int const pos = verify_position( name, false );
     if( !pos ) {
         return JsonArray();
     }
@@ -428,7 +428,7 @@ std::vector<std::string> JsonObject::get_string_array( const std::string &name )
 
 JsonObject JsonObject::get_object( const std::string &name ) const
 {
-    int pos = verify_position( name, false );
+    int const pos = verify_position( name, false );
     if( !pos ) {
         return JsonObject();
     }
@@ -441,7 +441,7 @@ JsonObject JsonObject::get_object( const std::string &name ) const
 
 bool JsonObject::has_null( const std::string &name ) const
 {
-    int pos = verify_position( name, false );
+    int const pos = verify_position( name, false );
     if( !pos ) {
         return false;
     }
@@ -452,7 +452,7 @@ bool JsonObject::has_null( const std::string &name ) const
 
 bool JsonObject::has_bool( const std::string &name ) const
 {
-    int pos = verify_position( name, false );
+    int const pos = verify_position( name, false );
     if( !pos ) {
         return false;
     }
@@ -462,7 +462,7 @@ bool JsonObject::has_bool( const std::string &name ) const
 
 bool JsonObject::has_number( const std::string &name ) const
 {
-    int pos = verify_position( name, false );
+    int const pos = verify_position( name, false );
     if( !pos ) {
         return false;
     }
@@ -472,7 +472,7 @@ bool JsonObject::has_number( const std::string &name ) const
 
 bool JsonObject::has_string( const std::string &name ) const
 {
-    int pos = verify_position( name, false );
+    int const pos = verify_position( name, false );
     if( !pos ) {
         return false;
     }
@@ -482,7 +482,7 @@ bool JsonObject::has_string( const std::string &name ) const
 
 bool JsonObject::has_array( const std::string &name ) const
 {
-    int pos = verify_position( name, false );
+    int const pos = verify_position( name, false );
     if( !pos ) {
         return false;
     }
@@ -492,7 +492,7 @@ bool JsonObject::has_array( const std::string &name ) const
 
 bool JsonObject::has_object( const std::string &name ) const
 {
-    int pos = verify_position( name, false );
+    int const pos = verify_position( name, false );
     if( !pos ) {
         return false;
     }
@@ -846,7 +846,7 @@ void JsonIn::skip_member()
 void JsonIn::skip_separator()
 {
     eat_whitespace();
-    signed char ch = peek();
+    signed char const ch = peek();
     if( ch == ',' ) {
         if( ate_separator ) {
             error( "duplicate comma" );
@@ -918,7 +918,7 @@ void JsonIn::skip_string()
 void JsonIn::skip_value()
 {
     eat_whitespace();
-    char ch = peek();
+    char const ch = peek();
     // it's either a string '"'
     if( ch == '"' ) {
         skip_string();
@@ -1256,7 +1256,7 @@ int JsonIn::get_int()
 {
     static_assert( sizeof( int ) <= sizeof( int64_t ),
                    "JsonIn::get_int() assumed sizeof( int ) <= sizeof( int64_t )" );
-    number_sci_notation n = get_any_int();
+    number_sci_notation const n = get_any_int();
     if( !n.negative && n.number > static_cast<uint64_t>( std::numeric_limits<int>::max() ) ) {
         error( "Found a number greater than " + std::to_string( std::numeric_limits<int>::max() ) +
                " which is unsupported in this context." );
@@ -1282,7 +1282,7 @@ int JsonIn::get_int()
 
 unsigned int JsonIn::get_uint()
 {
-    number_sci_notation n = get_any_int();
+    number_sci_notation const n = get_any_int();
     if( n.number > std::numeric_limits<unsigned int>::max() ) {
         error( "Found a number greater than " +
                std::to_string( std::numeric_limits<unsigned int>::max() ) +
@@ -1296,7 +1296,7 @@ unsigned int JsonIn::get_uint()
 
 int64_t JsonIn::get_int64()
 {
-    number_sci_notation n = get_any_int();
+    number_sci_notation const n = get_any_int();
     if( !n.negative && n.number > static_cast<uint64_t>( std::numeric_limits<int64_t>::max() ) ) {
         error( "Signed integers greater than " +
                std::to_string( std::numeric_limits<int64_t>::max() ) + " not supported." );
@@ -1322,7 +1322,7 @@ int64_t JsonIn::get_int64()
 
 uint64_t JsonIn::get_uint64()
 {
-    number_sci_notation n = get_any_int();
+    number_sci_notation const n = get_any_int();
     if( n.negative ) {
         error( "Unsigned integers cannot have a negative sign." );
     }
@@ -1331,7 +1331,7 @@ uint64_t JsonIn::get_uint64()
 
 double JsonIn::get_float()
 {
-    number_sci_notation n = get_any_number();
+    number_sci_notation const n = get_any_number();
     return n.number * std::pow( 10.0f, n.exp ) * ( n.negative ? -1.f : 1.f );
 }
 
@@ -1811,7 +1811,7 @@ std::string JsonIn::line_number( int offset_modifier )
                 return "file=" + name + ",line=???";
         }
     } // else stream is fine
-    int pos = tell();
+    int const pos = tell();
     int line = 1;
     int offset = 1;
     char ch;
@@ -1867,7 +1867,7 @@ void JsonIn::error( const std::string &message, int offset )
     // Seek to eof after throwing to avoid continue reading from the incorrect
     // location. The calling code of json error methods is supposed to restore
     // the stream location if it wishes to recover from the error.
-    on_out_of_scope seek_to_eof( [this]() {
+    on_out_of_scope const seek_to_eof( [this]() {
         stream->seekg( 0, std::istream::end );
     } );
     std::ostringstream err;
@@ -1875,7 +1875,7 @@ void JsonIn::error( const std::string &message, int offset )
     // also print surrounding few lines of context, if not too large
     err << "\n\n";
     stream->seekg( offset, std::istream::cur );
-    size_t pos = tell();
+    size_t const pos = tell();
     rewind( 3, 240 );
     size_t startpos = tell();
     std::string buffer( pos - startpos, '\0' );
@@ -2018,7 +2018,7 @@ std::string JsonIn::substr( size_t pos, size_t len )
     std::string ret;
     if( len == std::string::npos ) {
         stream->seekg( 0, std::istream::end );
-        size_t end = tell();
+        size_t const end = tell();
         len = end - pos;
     }
     ret.resize( len );
@@ -2171,7 +2171,7 @@ void JsonOut::write( const std::string &val )
     }
     stream->put( '"' );
     for( const auto &i : val ) {
-        unsigned char ch = i;
+        unsigned char const ch = i;
         if( ch == '"' ) {
             stream->write( "\\\"", 2 );
         } else if( ch == '\\' ) {
@@ -2193,7 +2193,7 @@ void JsonOut::write( const std::string &val )
             // convert to "\uxxxx" unicode escape
             stream->write( "\\u00", 4 );
             stream->put( ( ch < 0x10 ) ? '0' : '1' );
-            char remainder = ch & 0x0F;
+            char const remainder = ch & 0x0F;
             if( remainder < 0x0A ) {
                 stream->put( '0' + remainder );
             } else {
@@ -2213,10 +2213,10 @@ void JsonOut::write( const std::bitset<N> &b )
     if( need_separator ) {
         write_separator();
     }
-    std::string converted = b.to_string();
+    std::string const converted = b.to_string();
     stream->put( '"' );
     for( auto &i : converted ) {
-        unsigned char ch = i;
+        unsigned char const ch = i;
         stream->put( ch );
     }
     stream->put( '"' );

--- a/src/json_source_location.cpp
+++ b/src/json_source_location.cpp
@@ -8,7 +8,7 @@ void throw_error_at_json_loc( const json_source_location &loc, const std::string
     if( !loc.path ) {
         throw JsonError( string_format( "Json error: (unknown pos): %s", message ) );
     }
-    shared_ptr_fast<std::istream> stream = DynamicDataLoader::get_instance().get_cached_stream(
+    shared_ptr_fast<std::istream> const stream = DynamicDataLoader::get_instance().get_cached_stream(
             *loc.path );
     if( !stream ) {
         throw JsonError( string_format( "Json error: (%s:%d): %s", *loc.path, loc.offset, message ) );

--- a/src/json_source_location.cpp
+++ b/src/json_source_location.cpp
@@ -9,7 +9,7 @@ void throw_error_at_json_loc( const json_source_location &loc, const std::string
         throw JsonError( string_format( "Json error: (unknown pos): %s", message ) );
     }
     shared_ptr_fast<std::istream> const stream = DynamicDataLoader::get_instance().get_cached_stream(
-            *loc.path );
+                *loc.path );
     if( !stream ) {
         throw JsonError( string_format( "Json error: (%s:%d): %s", *loc.path, loc.offset, message ) );
     }

--- a/src/kill_tracker.cpp
+++ b/src/kill_tracker.cpp
@@ -120,21 +120,21 @@ void kill_tracker::notify( const cata::event &e )
 {
     switch( e.type() ) {
         case event_type::character_kills_monster: {
-            character_id killer = e.get<character_id>( "killer" );
+            character_id const killer = e.get<character_id>( "killer" );
             if( killer != get_avatar().getID() ) {
                 // TODO: add a kill counter for npcs?
                 break;
             }
-            mtype_id victim_type = e.get<mtype_id>( "victim_type" );
+            mtype_id const victim_type = e.get<mtype_id>( "victim_type" );
             kills[victim_type]++;
             break;
         }
         case event_type::character_kills_character: {
-            character_id killer = e.get<character_id>( "killer" );
+            character_id const killer = e.get<character_id>( "killer" );
             if( killer != get_avatar().getID() ) {
                 break;
             }
-            std::string victim_name = e.get<cata_variant_type::string>( "victim_name" );
+            std::string const victim_name = e.get<cata_variant_type::string>( "victim_name" );
             npc_kills.push_back( victim_name );
             break;
         }

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -127,7 +127,7 @@ std::string to_valid_language( const std::string &lang )
     }
     const size_t p = lang.find( '_' );
     if( p != std::string::npos ) {
-        std::string lang2 = lang.substr( 0, p );
+        std::string const lang2 = lang.substr( 0, p );
         for( const language_info &info : lang_options ) {
             if( string_starts_with( lang2, info.id ) ) {
                 return info.id;
@@ -215,7 +215,7 @@ static std::vector<language_info> load_languages( const std::string &filepath )
             throw std::runtime_error( string_format( "File '%s' not found", filepath ) );
         }
         JsonIn json( stream );
-        JsonArray arr = json.get_array();
+        JsonArray const arr = json.get_array();
         for( const JsonObject &obj : arr ) {
             language_info info;
             info.id = obj.get_string( "id" );
@@ -285,7 +285,7 @@ bool init_language_system()
         lang_options = { fallback_language };
     }
 
-    std::string lang = getSystemUILang();
+    std::string const lang = getSystemUILang();
     if( lang.empty() ) {
         system_language = nullptr;
         dbg( DL::Warn ) << "Failed to detect system UI language.";
@@ -343,7 +343,7 @@ void update_global_locale()
         dbg( DL::Warn ) << "Error while setlocale(LC_ALL, '.1252').";
     }
 #else // _WIN32
-    std::string lang = ::get_option<std::string>( "USE_LANG" );
+    std::string const lang = ::get_option<std::string>( "USE_LANG" );
 
     bool set_user = false;
     if( lang.empty() ) {
@@ -389,7 +389,7 @@ std::vector<std::string> get_lang_path_substring( const std::string &lang_id )
     } else {
         // Id with dialect specified ('en_US', 'fr_FR', etc.)
         // First try loading exact resource, then try dialect-agnostic resource.
-        std::string lang_only = lang_id.substr( 0, p );
+        std::string const lang_only = lang_id.substr( 0, p );
         ret.push_back( lang_id );
         ret.push_back( lang_only );
     }
@@ -399,9 +399,9 @@ std::vector<std::string> get_lang_path_substring( const std::string &lang_id )
 bool translations_exists_for_lang( const std::string &lang_id )
 {
 
-    std::vector<std::string> opts = get_lang_path_substring( lang_id );
+    std::vector<std::string> const opts = get_lang_path_substring( lang_id );
     for( const std::string &s : opts ) {
-        std::string path = PATH_INFO::base_path() + "lang/mo/" + s + "/LC_MESSAGES/cataclysm-bn.mo";
+        std::string const path = PATH_INFO::base_path() + "lang/mo/" + s + "/LC_MESSAGES/cataclysm-bn.mo";
         if( file_exist( path ) ) {
             return true;
         }
@@ -468,9 +468,9 @@ static void set_library( trans_library lib )
 static void add_cat_if_exists( std::vector<trans_catalogue> &list, const std::string &lang_id,
                                const std::string &path_start, const std::string &path_end )
 {
-    std::vector<std::string> opts = get_lang_path_substring( lang_id );
+    std::vector<std::string> const opts = get_lang_path_substring( lang_id );
     for( const std::string &s : opts ) {
-        std::string path = path_start + s + path_end;
+        std::string const path = path_start + s + path_end;
         if( !file_exist( path ) ) {
             continue;
         }
@@ -569,7 +569,7 @@ void translatable_mod_info::update()
     if( list.empty() ) {
         return;
     }
-    trans_library lib = trans_library::create( std::move( list ) );
+    trans_library const lib = trans_library::create( std::move( list ) );
 
     name_tr = lib.get( name_raw.c_str() );
     description_tr = lib.get( description_raw.c_str() );

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -111,10 +111,10 @@ bool map::build_transparency_cache( const int zlev )
         return false;
     }
 
-    std::set<tripoint> vehicles_processed;
+    std::set<tripoint> const vehicles_processed;
 
     // if true, all submaps are invalid (can use batch init)
-    bool rebuild_all = map_cache.transparency_cache_dirty.all();
+    bool const rebuild_all = map_cache.transparency_cache_dirty.all();
 
     if( rebuild_all ) {
         // Default to just barely not transparent.
@@ -169,7 +169,7 @@ bool map::build_transparency_cache( const int zlev )
             };
 
             if( cur_submap->is_uniform ) {
-                float value = calc_transp( sm_offset );
+                float const value = calc_transp( sm_offset );
                 // if rebuild_all==true all values were already set to LIGHT_TRANSPARENCY_OPEN_AIR
                 if( !rebuild_all || value != LIGHT_TRANSPARENCY_OPEN_AIR ) {
                     for( int sx = 0; sx < SEEX; ++sx ) {
@@ -220,7 +220,7 @@ bool map::build_vision_transparency_cache( const Character &player )
         }
 
         int i = 0;
-        for( point adjacent : eight_adjacent_offsets ) {
+        for( point const adjacent : eight_adjacent_offsets ) {
             vision_transparency_cache[i] = VISION_ADJUST_NONE;
 
             // If we're crouching behind an obstacle, we can't see past it.
@@ -364,7 +364,7 @@ void map::build_sunlight_cache( int pzlev )
         // Replace this with a calculated shift based on time of day and date.
         // At first compress the angle such that it takes no more than one tile of shift per level.
         // To exceed that, we'll have to handle casting light from the side instead of the top.
-        point offset;
+        point const offset;
         const level_cache &prev_map_cache = get_cache_ref( zlev + 1 );
         const auto &prev_lm = prev_map_cache.lm;
         const auto &prev_transparency_cache = prev_map_cache.transparency_cache;
@@ -393,9 +393,9 @@ void map::build_sunlight_cache( int pzlev )
             for( int y = 0; y < MAPSIZE_Y; ++y ) {
                 // Check center, then four adjacent cardinals.
                 for( int i = 0; i < 5; ++i ) {
-                    int prev_x = x + offset.x + cardinals[i].x;
-                    int prev_y = y + offset.y + cardinals[i].y;
-                    bool inbounds = prev_x >= 0 && prev_x < MAPSIZE_X &&
+                    int const prev_x = x + offset.x + cardinals[i].x;
+                    int const prev_y = y + offset.y + cardinals[i].y;
+                    bool const inbounds = prev_x >= 0 && prev_x < MAPSIZE_X &&
                                     prev_y >= 0 && prev_y < MAPSIZE_Y;
 
                     if( !inbounds ) {
@@ -439,7 +439,7 @@ void map::generate_lightmap( const int zlev )
     auto &sm = map_cache.sm;
     auto &outside_cache = map_cache.outside_cache;
     auto &prev_floor_cache = get_cache( clamp( zlev + 1, -OVERMAP_DEPTH, OVERMAP_DEPTH ) ).floor_cache;
-    bool top_floor = zlev == OVERMAP_DEPTH;
+    bool const top_floor = zlev == OVERMAP_DEPTH;
     std::memset( lm, 0, sizeof( lm ) );
     std::memset( sm, 0, sizeof( sm ) );
 
@@ -490,7 +490,7 @@ void map::generate_lightmap( const int zlev )
                     if( !outside_cache[p.x][p.y] || ( !top_floor && prev_floor_cache[p.x][p.y] ) ) {
                         // Apply light sources for external/internal divide
                         for( int i = 0; i < 4; ++i ) {
-                            point neighbour = p.xy() + point( dir_x[i], dir_y[i] );
+                            point const neighbour = p.xy() + point( dir_x[i], dir_y[i] );
                             if( lightmap_boundaries.contains( neighbour )
                                 && outside_cache[neighbour.x][neighbour.y] &&
                                 ( top_floor || !prev_floor_cache[neighbour.x][neighbour.y] )
@@ -538,7 +538,7 @@ void map::generate_lightmap( const int zlev )
         }
     }
 
-    for( monster &critter : g->all_monsters() ) {
+    for( monster  const&critter : g->all_monsters() ) {
         if( critter.is_hallucination() ) {
             continue;
         }
@@ -557,7 +557,7 @@ void map::generate_lightmap( const int zlev )
     }
 
     // Apply any vehicle light sources
-    VehicleList vehs = get_vehicles();
+    VehicleList const vehs = get_vehicles();
     for( auto &vv : vehs ) {
         vehicle *v = vv.v;
 
@@ -577,7 +577,7 @@ void map::generate_lightmap( const int zlev )
 
         for( const auto pt : lights ) {
             const auto &vp = pt->info();
-            tripoint src = v->global_part_pos3( *pt );
+            tripoint const src = v->global_part_pos3( *pt );
 
             if( !inbounds( src ) ) {
                 continue;
@@ -853,7 +853,7 @@ static inline int fast_rl_dist( tripoint to )
         return square_dist( tripoint_zero, to );
     }
 
-    int val = to.x * to.x + to.y * to.y + to.z * to.z;
+    int const val = to.x * to.x + to.y * to.y + to.z * to.z;
 
     if( val < 2 ) {
         return val;
@@ -862,7 +862,7 @@ static inline int fast_rl_dist( tripoint to )
     int a = start;
 
     for( int i = 0; i < iterations; i++ ) {
-        int b = val / a;
+        int const b = val / a;
         a = ( a + b ) / 2;
     }
 
@@ -938,7 +938,7 @@ void cast_zlight_segment(
         cata::unreachable();
     };
 
-    int radius = 60 - offset_distance;
+    int const radius = 60 - offset_distance;
 
     constexpr int min_z = -OVERMAP_DEPTH;
     constexpr int max_z = OVERMAP_HEIGHT;
@@ -953,7 +953,7 @@ void cast_zlight_segment(
 
         int z_start = z_skip != -1 ? z_skip : std::max( 0,
                       static_cast<int>( std::ceil( ( ( distance - 0.5f ) * start_major ) - 0.5f ) ) );
-        int z_limit = std::min( distance,
+        int const z_limit = std::min( distance,
                                 static_cast<int>( std::ceil( ( ( distance + 0.5f ) * end_major ) + 0.5f ) ) - 1 );
 
         for( delta.z = z_start; delta.z <= std::min( fov_3d_z_range, z_limit ); delta.z++ ) {
@@ -965,10 +965,10 @@ void cast_zlight_segment(
 
             const int z_index = current.z + OVERMAP_DEPTH;
 
-            int x_start = x_skip != -1 ? x_skip : std::max( 0,
+            int const x_start = x_skip != -1 ? x_skip : std::max( 0,
                           static_cast<int>( std::ceil( ( ( distance - 0.5f ) * start_minor ) - 0.5f ) ) );
 
-            int x_limit = std::min( distance,
+            int const x_limit = std::min( distance,
                                     static_cast<int>( std::ceil( ( ( distance + 0.5f ) * end_minor ) + 0.5f ) ) - 1 );
 
             for( delta.x = x_start; delta.x <= x_limit; delta.x++ ) {
@@ -1238,7 +1238,7 @@ void castLight( Out( &output_cache )[MAPSIZE_X][MAPSIZE_Y],
         cata::unreachable();
     };
 
-    int radius = 60 - offsetDistance;
+    int const radius = 60 - offsetDistance;
     if( start < end ) {
         return;
     }
@@ -1253,12 +1253,12 @@ void castLight( Out( &output_cache )[MAPSIZE_X][MAPSIZE_Y],
         delta.x = std::ceil( std::max( static_cast<float>( -distance ),
                                        ( ( -distance - 0.5f ) * start ) - 0.5f ) );
         //And a limit so that the commented end > trailingEdge is never true
-        int x_limit = std::floor( std::min( 0.0f,
+        int const x_limit = std::floor( std::min( 0.0f,
                                             ( ( -distance + 0.5f ) * end ) - 0.5f ) ) + 1;
 
         int last_dist = -1;
         for( ; delta.x <= x_limit; delta.x++ ) {
-            point current( offset.x + delta.x * xx + delta.y * xy, offset.y + delta.x * yx + delta.y * yy );
+            point const current( offset.x + delta.x * xx + delta.y * xy, offset.y + delta.x * yx + delta.y * yy );
 
             if( !( current.x >= 0 && current.y >= 0 && current.x < MAPSIZE_X &&
                    current.y < MAPSIZE_Y ) /* || start < leadingEdge */ ) {
@@ -1299,7 +1299,7 @@ void castLight( Out( &output_cache )[MAPSIZE_X][MAPSIZE_Y],
             if( new_transparency == current_transparency ) {
                 continue;
             }
-            float trailingEdge = ( delta.x - 0.5f ) / ( delta.y + 0.5f );
+            float const trailingEdge = ( delta.x - 0.5f ) / ( delta.y + 0.5f );
             // Only cast recursively if previous span was not opaque.
             if( check( current_transparency, last_intensity ) ) {
                 //Are we moving off a fast path?
@@ -1389,9 +1389,9 @@ void castLightWithLookup( Out( &output_cache )[MAPSIZE_X][MAPSIZE_Y],
     //Find the first tile
     point delta;
     delta.y = -row;
-    float away = start - ( -row + 0.5f ) / ( -row - 0.5f );
+    float const away = start - ( -row + 0.5f ) / ( -row - 0.5f );
     delta.x = -row + std::max( static_cast<int>( std::ceil( away * ( -row - 0.5f ) ) ), 0 );
-    point first( offset.x + delta.x * xx + delta.y * xy, offset.y + delta.x * yx + delta.y * yy );
+    point const first( offset.x + delta.x * xx + delta.y * xy, offset.y + delta.x * yx + delta.y * yy );
 
     if( cumulative_transparency == LIGHT_TRANSPARENCY_OPEN_AIR && first.x >= 0 && first.y >= 0 &&
         first.x < MAPSIZE_X && first.y < MAPSIZE_Y ) {
@@ -1471,7 +1471,7 @@ void map::apply_vision_transparency_cache( const tripoint &center, int target_z,
     diagonal_blocks( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = map_cache.vehicle_obscured_cache;
 
     int i = 0;
-    for( point adjacent : eight_adjacent_offsets ) {
+    for( point const adjacent : eight_adjacent_offsets ) {
         const tripoint p = center + adjacent;
         if( !inbounds( p ) ) {
             continue;
@@ -1510,7 +1510,7 @@ void map::restore_vision_transparency_cache( const tripoint &center, int target_
     diagonal_blocks( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = map_cache.vehicle_obscured_cache;
 
     int i = 0;
-    for( point adjacent : eight_adjacent_offsets ) {
+    for( point const adjacent : eight_adjacent_offsets ) {
         const tripoint p = center + adjacent;
         if( !inbounds( p ) ) {
             continue;
@@ -1591,10 +1591,10 @@ template void castLightAllWithLookup<float, four_quadrants, sight_calc, sight_ch
 void map::build_seen_cache( const tripoint &origin, const int target_z )
 {
     auto &map_cache = get_cache( target_z );
-    float ( &transparency_cache )[MAPSIZE_X][MAPSIZE_Y] = map_cache.transparency_cache;
+    float  const( &transparency_cache )[MAPSIZE_X][MAPSIZE_Y] = map_cache.transparency_cache;
     float ( &seen_cache )[MAPSIZE_X][MAPSIZE_Y] = map_cache.seen_cache;
     float ( &camera_cache )[MAPSIZE_X][MAPSIZE_Y] = map_cache.camera_cache;
-    diagonal_blocks( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = map_cache.vehicle_obscured_cache;
+    diagonal_blocks const( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = map_cache.vehicle_obscured_cache;
 
     constexpr float light_transparency_solid = LIGHT_TRANSPARENCY_SOLID;
     constexpr int map_dimensions = MAPSIZE_X * MAPSIZE_Y;
@@ -1680,8 +1680,8 @@ void map::build_seen_cache( const tripoint &origin, const int target_z )
         }
     }
 
-    for( int mirror : mirrors ) {
-        bool is_camera = veh->part_info( mirror ).has_flag( "CAMERA" );
+    for( int const mirror : mirrors ) {
+        bool const is_camera = veh->part_info( mirror ).has_flag( "CAMERA" );
         if( is_camera && cam_control < 0 ) {
             continue; // Player not at camera control, so cameras don't work
         }
@@ -1751,9 +1751,9 @@ void map::apply_light_source( const tripoint &p, float luminance )
     auto &cache = get_cache( p.z );
     four_quadrants( &lm )[MAPSIZE_X][MAPSIZE_Y] = cache.lm;
     float ( &sm )[MAPSIZE_X][MAPSIZE_Y] = cache.sm;
-    float ( &transparency_cache )[MAPSIZE_X][MAPSIZE_Y] = cache.transparency_cache;
-    float ( &light_source_buffer )[MAPSIZE_X][MAPSIZE_Y] = cache.light_source_buffer;
-    diagonal_blocks( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = cache.vehicle_obscured_cache;
+    float  const( &transparency_cache )[MAPSIZE_X][MAPSIZE_Y] = cache.transparency_cache;
+    float  const( &light_source_buffer )[MAPSIZE_X][MAPSIZE_Y] = cache.light_source_buffer;
+    diagonal_blocks const( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = cache.vehicle_obscured_cache;
 
     const point p2( p.xy() );
 
@@ -1785,10 +1785,10 @@ void map::apply_light_source( const tripoint &p, float luminance )
            sy
     */
     const int peer_inbounds = LIGHTMAP_CACHE_X - 1;
-    bool north = ( p2.y != 0 && light_source_buffer[p2.x][p2.y - 1] < luminance );
-    bool south = ( p2.y != peer_inbounds && light_source_buffer[p2.x][p2.y + 1] < luminance );
-    bool east = ( p2.x != peer_inbounds && light_source_buffer[p2.x + 1][p2.y] < luminance );
-    bool west = ( p2.x != 0 && light_source_buffer[p2.x - 1][p2.y] < luminance );
+    bool const north = ( p2.y != 0 && light_source_buffer[p2.x][p2.y - 1] < luminance );
+    bool const south = ( p2.y != peer_inbounds && light_source_buffer[p2.x][p2.y + 1] < luminance );
+    bool const east = ( p2.x != peer_inbounds && light_source_buffer[p2.x + 1][p2.y] < luminance );
+    bool const west = ( p2.x != 0 && light_source_buffer[p2.x - 1][p2.y] < luminance );
 
     if( north ) {
         castLightWithLookup < 1, 0, 0, -1, float, four_quadrants, light_calc, light_check,
@@ -1833,8 +1833,8 @@ void map::apply_directional_light( const tripoint &p, int direction, float lumin
 
     auto &cache = get_cache( p.z );
     four_quadrants( &lm )[MAPSIZE_X][MAPSIZE_Y] = cache.lm;
-    float ( &transparency_cache )[MAPSIZE_X][MAPSIZE_Y] = cache.transparency_cache;
-    diagonal_blocks( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = cache.vehicle_obscured_cache;
+    float  const( &transparency_cache )[MAPSIZE_X][MAPSIZE_Y] = cache.transparency_cache;
+    diagonal_blocks const( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = cache.vehicle_obscured_cache;
 
     if( direction == 90 ) {
         castLightWithLookup < 1, 0, 0, -1, float, four_quadrants, light_calc, light_check,
@@ -1881,10 +1881,10 @@ void map::apply_light_arc( const tripoint &p, units::angle angle, float luminanc
     // Normalize (should work with negative values too)
     const units::angle wangle = wideangle / 2.0;
 
-    units::angle nangle = fmod( angle, 360_degrees );
+    units::angle const nangle = fmod( angle, 360_degrees );
 
     tripoint end;
-    int range = LIGHT_RANGE( luminance );
+    int const range = LIGHT_RANGE( luminance );
     calc_ray_end( nangle, range, p, end );
     apply_light_ray( lit, p, end, luminance );
 
@@ -1902,7 +1902,7 @@ void map::apply_light_arc( const tripoint &p, units::angle angle, float luminanc
     // NOLINTNEXTLINE(clang-analyzer-security.FloatLoopCounter)
     for( units::angle ao = wstep; ao <= wangle; ao += wstep ) {
         if( trigdist ) {
-            double fdist = ( ao * M_PI_2 ) / wangle;
+            double const fdist = ( ao * M_PI_2 ) / wangle;
             end.x = static_cast<int>(
                         p.x + ( static_cast<double>( range ) - fdist * 2.0 ) * cos( nangle + ao ) );
             end.y = static_cast<int>(
@@ -1926,11 +1926,11 @@ void map::apply_light_arc( const tripoint &p, units::angle angle, float luminanc
 void map::apply_light_ray( bool lit[LIGHTMAP_CACHE_X][LIGHTMAP_CACHE_Y],
                            const tripoint &s, const tripoint &e, float luminance )
 {
-    point a( std::abs( e.x - s.x ) * 2, std::abs( e.y - s.y ) * 2 );
-    point d( ( s.x < e.x ) ? 1 : -1, ( s.y < e.y ) ? 1 : -1 );
+    point const a( std::abs( e.x - s.x ) * 2, std::abs( e.y - s.y ) * 2 );
+    point const d( ( s.x < e.x ) ? 1 : -1, ( s.y < e.y ) ? 1 : -1 );
     point p( s.xy() );
 
-    quadrant quad = quadrant_from_x_y( d.x, d.y );
+    quadrant const quad = quadrant_from_x_y( d.x, d.y );
 
     // TODO: Invert that z comparison when it's sane
     if( s.z != e.z || ( s.x == e.x && s.y == e.y ) ) {
@@ -1958,13 +1958,13 @@ void map::apply_light_ray( bool lit[LIGHTMAP_CACHE_X][LIGHTMAP_CACHE_Y],
 
             // TODO: clamp coordinates to map bounds before this method is called.
             if( lightmap_boundaries.contains( p ) ) {
-                float current_transparency = transparency_cache[p.x][p.y];
-                bool is_opaque = ( current_transparency == LIGHT_TRANSPARENCY_SOLID );
+                float const current_transparency = transparency_cache[p.x][p.y];
+                bool const is_opaque = ( current_transparency == LIGHT_TRANSPARENCY_SOLID );
                 if( !lit[p.x][p.y] ) {
                     // Multiple rays will pass through the same squares so we need to record that
                     lit[p.x][p.y] = true;
-                    float lm_val = luminance / ( fastexp( transparency * distance ) * distance );
-                    quadrant q = is_opaque ? quad : quadrant::default_;
+                    float const lm_val = luminance / ( fastexp( transparency * distance ) * distance );
+                    quadrant const q = is_opaque ? quad : quadrant::default_;
                     lm[p.x][p.y][q] = std::max( lm[p.x][p.y][q], lm_val );
                 }
                 if( is_opaque ) {
@@ -1990,13 +1990,13 @@ void map::apply_light_ray( bool lit[LIGHTMAP_CACHE_X][LIGHTMAP_CACHE_Y],
             t += a.x;
 
             if( lightmap_boundaries.contains( p ) ) {
-                float current_transparency = transparency_cache[p.x][p.y];
-                bool is_opaque = ( current_transparency == LIGHT_TRANSPARENCY_SOLID );
+                float const current_transparency = transparency_cache[p.x][p.y];
+                bool const is_opaque = ( current_transparency == LIGHT_TRANSPARENCY_SOLID );
                 if( !lit[p.x][p.y] ) {
                     // Multiple rays will pass through the same squares so we need to record that
                     lit[p.x][p.y] = true;
-                    float lm_val = luminance / ( fastexp( transparency * distance ) * distance );
-                    quadrant q = is_opaque ? quad : quadrant::default_;
+                    float const lm_val = luminance / ( fastexp( transparency * distance ) * distance );
+                    quadrant const q = is_opaque ? quad : quadrant::default_;
                     lm[p.x][p.y][q] = std::max( lm[p.x][p.y][q], lm_val );
                 }
                 if( is_opaque ) {

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -396,7 +396,7 @@ void map::build_sunlight_cache( int pzlev )
                     int const prev_x = x + offset.x + cardinals[i].x;
                     int const prev_y = y + offset.y + cardinals[i].y;
                     bool const inbounds = prev_x >= 0 && prev_x < MAPSIZE_X &&
-                                    prev_y >= 0 && prev_y < MAPSIZE_Y;
+                                          prev_y >= 0 && prev_y < MAPSIZE_Y;
 
                     if( !inbounds ) {
                         continue;
@@ -538,7 +538,7 @@ void map::generate_lightmap( const int zlev )
         }
     }
 
-    for( monster  const&critter : g->all_monsters() ) {
+    for( monster  const &critter : g->all_monsters() ) {
         if( critter.is_hallucination() ) {
             continue;
         }
@@ -954,7 +954,7 @@ void cast_zlight_segment(
         int z_start = z_skip != -1 ? z_skip : std::max( 0,
                       static_cast<int>( std::ceil( ( ( distance - 0.5f ) * start_major ) - 0.5f ) ) );
         int const z_limit = std::min( distance,
-                                static_cast<int>( std::ceil( ( ( distance + 0.5f ) * end_major ) + 0.5f ) ) - 1 );
+                                      static_cast<int>( std::ceil( ( ( distance + 0.5f ) * end_major ) + 0.5f ) ) - 1 );
 
         for( delta.z = z_start; delta.z <= std::min( fov_3d_z_range, z_limit ); delta.z++ ) {
 
@@ -966,10 +966,10 @@ void cast_zlight_segment(
             const int z_index = current.z + OVERMAP_DEPTH;
 
             int const x_start = x_skip != -1 ? x_skip : std::max( 0,
-                          static_cast<int>( std::ceil( ( ( distance - 0.5f ) * start_minor ) - 0.5f ) ) );
+                                static_cast<int>( std::ceil( ( ( distance - 0.5f ) * start_minor ) - 0.5f ) ) );
 
             int const x_limit = std::min( distance,
-                                    static_cast<int>( std::ceil( ( ( distance + 0.5f ) * end_minor ) + 0.5f ) ) - 1 );
+                                          static_cast<int>( std::ceil( ( ( distance + 0.5f ) * end_minor ) + 0.5f ) ) - 1 );
 
             for( delta.x = x_start; delta.x <= x_limit; delta.x++ ) {
                 current.x = offset.x + delta.x * xx + delta.y * xy + delta.z * xz;
@@ -1254,11 +1254,12 @@ void castLight( Out( &output_cache )[MAPSIZE_X][MAPSIZE_Y],
                                        ( ( -distance - 0.5f ) * start ) - 0.5f ) );
         //And a limit so that the commented end > trailingEdge is never true
         int const x_limit = std::floor( std::min( 0.0f,
-                                            ( ( -distance + 0.5f ) * end ) - 0.5f ) ) + 1;
+                                        ( ( -distance + 0.5f ) * end ) - 0.5f ) ) + 1;
 
         int last_dist = -1;
         for( ; delta.x <= x_limit; delta.x++ ) {
-            point const current( offset.x + delta.x * xx + delta.y * xy, offset.y + delta.x * yx + delta.y * yy );
+            point const current( offset.x + delta.x * xx + delta.y * xy,
+                                 offset.y + delta.x * yx + delta.y * yy );
 
             if( !( current.x >= 0 && current.y >= 0 && current.x < MAPSIZE_X &&
                    current.y < MAPSIZE_Y ) /* || start < leadingEdge */ ) {

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -327,7 +327,7 @@ units::angle atan2( point p )
 unsigned make_xyz( const tripoint &p )
 {
     static constexpr double sixteenth_arc = M_PI / 8;
-    int vertical_position = ( ( p.z > 0 ) ? 2u : ( p.z < 0 ) ? 1u : 0u ) * 9u;
+    int const vertical_position = ( ( p.z > 0 ) ? 2u : ( p.z < 0 ) ? 1u : 0u ) * 9u;
     if( p.xy() == point_zero ) {
         return vertical_position;
     }
@@ -336,7 +336,7 @@ unsigned make_xyz( const tripoint &p )
     // You can read 'octant' as being "number of 22.5 degree sections away from due south".
     // FIXME: atan2 normally takes arguments in ( y, x ) order.  This is
     // passing ( x, y ).
-    int octant = atan2( p.x, p.y ) / sixteenth_arc;
+    int const octant = atan2( p.x, p.y ) / sixteenth_arc;
     switch( octant ) {
         case 0:
             return direction::SOUTH + vertical_position;
@@ -372,9 +372,9 @@ static std::tuple<double, double, double> slope_of( const std::vector<tripoint> 
 {
     assert( !line.empty() && line.front() != line.back() );
     const double len = trig_dist( line.front(), line.back() );
-    double normDx = ( line.back().x - line.front().x ) / len;
-    double normDy = ( line.back().y - line.front().y ) / len;
-    double normDz = ( line.back().z - line.front().z ) / len;
+    double const normDx = ( line.back().x - line.front().x ) / len;
+    double const normDy = ( line.back().y - line.front().y ) / len;
+    double const normDz = ( line.back().z - line.front().z ) / len;
     // slope of <x, y, z>
     return std::make_tuple( normDx, normDy, normDz );
 }
@@ -537,7 +537,7 @@ std::string direction_name_short( const direction dir )
 
 std::string direction_suffix( const tripoint &p, const tripoint &q )
 {
-    int dist = square_dist( p, q );
+    int const dist = square_dist( p, q );
     if( dist <= 0 ) {
         return std::string();
     }
@@ -589,8 +589,8 @@ std::vector<tripoint> squares_closer_to( const tripoint &from, const tripoint &t
 // and the two squares flanking it.
 std::vector<point> squares_in_direction( point p1, point p2 )
 {
-    int junk = 0;
-    point center_square = line_to( p1, p2, junk )[0];
+    int const junk = 0;
+    point const center_square = line_to( p1, p2, junk )[0];
     std::vector<point> adjacent_squares;
     adjacent_squares.reserve( 3 );
     adjacent_squares.push_back( center_square );

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -271,7 +271,7 @@ void spell_type::load( const JsonObject &jo, const std::string & )
     mandatory( jo, was_loaded, "valid_targets", valid_targets, trigger_reader );
 
     if( jo.has_array( "extra_effects" ) ) {
-        for( JsonObject fake_spell_obj : jo.get_array( "extra_effects" ) ) {
+        for( JsonObject const fake_spell_obj : jo.get_array( "extra_effects" ) ) {
             fake_spell temp;
             temp.load( fake_spell_obj );
             additional_spells.emplace_back( temp );
@@ -403,7 +403,7 @@ void spell_type::check_consistency()
                           sp_t.effect_str );
             }
         }
-        std::set<spell_id> spell_effect_list;
+        std::set<spell_id> const spell_effect_list;
         if( spell_infinite_loop_check( spell_effect_list, sp_t.id ) ) {
             debugmsg( "ERROR: %s has infinite loop in extra_effects", sp_t.id.c_str() );
         }
@@ -956,7 +956,7 @@ bool spell::is_valid_target( const Creature &caster, const tripoint &p ) const
 {
     bool valid = false;
     if( Creature *const cr = g->critter_at<Creature>( p ) ) {
-        Creature::Attitude cr_att = cr->attitude_to( caster );
+        Creature::Attitude const cr_att = cr->attitude_to( caster );
         valid = valid || ( cr_att != Creature::A_FRIENDLY && is_valid_target( target_hostile ) );
         valid = valid || ( cr_att == Creature::A_FRIENDLY && is_valid_target( target_ally ) &&
                            p != caster.pos() );
@@ -1090,9 +1090,9 @@ int spell::casting_exp( const Character &guy ) const
 std::string spell::enumerate_targets() const
 {
     std::vector<std::string> all_valid_targets;
-    int last_target = static_cast<int>( valid_target::_LAST );
+    int const last_target = static_cast<int>( valid_target::_LAST );
     for( int i = 0; i < last_target; ++i ) {
-        valid_target t = static_cast<valid_target>( i );
+        valid_target const t = static_cast<valid_target>( i );
         if( is_valid_target( t ) && t != target_none ) {
             all_valid_targets.emplace_back( io::enum_to_string( t ) );
         }
@@ -1188,7 +1188,7 @@ void spell::cast_all_effects( Creature &source, const tripoint &target ) const
                 return;
             }
             const int rand_spell = rng( 0, type->additional_spells.size() - 1 );
-            spell sp = ( iter + rand_spell )->get_spell( get_level() );
+            spell const sp = ( iter + rand_spell )->get_spell( get_level() );
             const bool _self = ( iter + rand_spell )->self;
 
             // This spell flag makes it so the message of the spell that's cast using this spell will be sent.
@@ -1212,7 +1212,7 @@ void spell::cast_all_effects( Creature &source, const tripoint &target ) const
         // first call the effect of the main spell
         cast_spell_effect( source, target );
         for( const fake_spell &extra_spell : type->additional_spells ) {
-            spell sp = extra_spell.get_spell( get_level() );
+            spell const sp = extra_spell.get_spell( get_level() );
             if( sp.has_flag( RANDOM_TARGET ) ) {
                 if( const std::optional<tripoint> new_target = sp.random_valid_target( source,
                         extra_spell.self ? source.pos() : target ) ) {
@@ -1275,13 +1275,13 @@ void known_magic::serialize( JsonOut &json ) const
 
 void known_magic::deserialize( JsonIn &jsin )
 {
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
     data.read( "mana", mana );
 
-    for( JsonObject jo : data.get_array( "spellbook" ) ) {
+    for( JsonObject const jo : data.get_array( "spellbook" ) ) {
         std::string id = jo.get_string( "id" );
         spell_id sp = spell_id( id );
-        int xp = jo.get_int( "xp" );
+        int const xp = jo.get_int( "xp" );
         if( !sp.is_valid() ) {
             debugmsg( "Skipping spell with invalid id: %s", sp.c_str() );
         } else if( knows_spell( sp ) ) {
@@ -1431,12 +1431,12 @@ void known_magic::mod_mana( const Character &guy, int add_mana )
 
 int known_magic::max_mana( const Character &guy ) const
 {
-    float int_bonus = ( ( 0.2f + guy.get_int() * 0.1f ) - 1.0f ) * mana_base;
-    float mut_mul = guy.mutation_value( "mana_multiplier" );
-    float mut_add = guy.mutation_value( "mana_modifier" );
-    int natural_cap = std::max( 0.0f, ( ( mana_base + int_bonus ) * mut_mul ) + mut_add );
+    float const int_bonus = ( ( 0.2f + guy.get_int() * 0.1f ) - 1.0f ) * mana_base;
+    float const mut_mul = guy.mutation_value( "mana_multiplier" );
+    float const mut_add = guy.mutation_value( "mana_modifier" );
+    int const natural_cap = std::max( 0.0f, ( ( mana_base + int_bonus ) * mut_mul ) + mut_add );
 
-    int ench_bonus = guy.bonus_from_enchantments( natural_cap, enchant_vals::mod::MANA_CAP, true );
+    int const ench_bonus = guy.bonus_from_enchantments( natural_cap, enchant_vals::mod::MANA_CAP, true );
 
     return std::max( 0, natural_cap + ench_bonus );
 }
@@ -1444,12 +1444,12 @@ int known_magic::max_mana( const Character &guy ) const
 double known_magic::mana_regen_rate( const Character &guy ) const
 {
     // mana should replenish in 8 hours.
-    double full_replenish = to_turns<double>( 8_hours );
-    double capacity = max_mana( guy );
-    double mut_mul = guy.mutation_value( "mana_regen_multiplier" );
-    double natural_regen = std::max( 0.0, capacity * mut_mul / full_replenish );
+    double const full_replenish = to_turns<double>( 8_hours );
+    double const capacity = max_mana( guy );
+    double const mut_mul = guy.mutation_value( "mana_regen_multiplier" );
+    double const natural_regen = std::max( 0.0, capacity * mut_mul / full_replenish );
 
-    double ench_bonus = guy.bonus_from_enchantments( natural_regen, enchant_vals::mod::MANA_REGEN );
+    double const ench_bonus = guy.bonus_from_enchantments( natural_regen, enchant_vals::mod::MANA_REGEN );
 
     return std::max( 0.0, natural_regen + ench_bonus );
 }
@@ -1471,7 +1471,7 @@ std::vector<spell_id> known_magic::spells() const
 // does the Character have enough energy (of the type of the spell) to cast the spell?
 bool known_magic::has_enough_energy( const Character &guy, spell &sp ) const
 {
-    int cost = sp.energy_cost( guy );
+    int const cost = sp.energy_cost( guy );
     switch( sp.energy_source() ) {
         case mana_energy:
             return available_mana() >= cost;
@@ -1563,7 +1563,7 @@ class spellcasting_callback : public uilist_callback
             for( int i = 1; i < menu->w_height - 1; i++ ) {
                 mvwputch( menu->window, point( menu->w_width - menu->pad_right, i ), c_magenta, LINE_XOXO );
             }
-            std::string ignore_string = casting_ignore ? _( "Ignore Distractions" ) :
+            std::string const ignore_string = casting_ignore ? _( "Ignore Distractions" ) :
                                         _( "Popup Distractions" );
             mvwprintz( menu->window, point( menu->w_width - menu->pad_right + 2, 0 ),
                        casting_ignore ? c_red : c_light_green, string_format( "%s %s", "[I]", ignore_string ) );
@@ -1640,7 +1640,7 @@ void spellcasting_callback::draw_spell_info( const spell &sp, const uilist *menu
     const std::string fx = sp.effect();
     int line = 1;
     nc_color gray = c_light_gray;
-    nc_color light_green = c_light_green;
+    nc_color const light_green = c_light_green;
     nc_color yellow = c_yellow;
 
     print_colored_text( w_menu, point( h_col1, line++ ), yellow, yellow,
@@ -2058,7 +2058,7 @@ void fake_spell::serialize( JsonOut &json ) const
 
 void fake_spell::deserialize( JsonIn &jsin )
 {
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
     load( data );
 }
 
@@ -2066,7 +2066,7 @@ spell fake_spell::get_spell( int min_level_override ) const
 {
     spell sp( id );
     // the max level this spell will be. can be optionally limited
-    int spell_limiter = max_level ? std::min( *max_level, sp.get_max_level() ) : sp.get_max_level();
+    int const spell_limiter = max_level ? std::min( *max_level, sp.get_max_level() ) : sp.get_max_level();
     // level is the minimum level the fake_spell will output
     min_level_override = std::max( min_level_override, level );
     if( min_level_override > spell_limiter ) {
@@ -2074,7 +2074,7 @@ spell fake_spell::get_spell( int min_level_override ) const
         min_level_override = spell_limiter;
     }
     // the "level" of the fake spell is the goal, but needs to be clamped to min and max
-    int level_of_spell = clamp( level, min_level_override,  std::min( sp.get_max_level(),
+    int const level_of_spell = clamp( level, min_level_override,  std::min( sp.get_max_level(),
                                 spell_limiter ) );
     if( level > spell_limiter ) {
         debugmsg( "ERROR: fake spell %s has higher min_level than max_level", id.c_str() );
@@ -2101,16 +2101,16 @@ void spell_events::notify( const cata::event &e )
 {
     switch( e.type() ) {
         case event_type::player_levels_spell: {
-            spell_id sid = e.get<spell_id>( "spell" );
-            int slvl = e.get<int>( "new_level" );
+            spell_id const sid = e.get<spell_id>( "spell" );
+            int const slvl = e.get<int>( "new_level" );
             spell_type spell_cast = spell_factory.obj( sid );
             for( std::map<std::string, int>::iterator it = spell_cast.learn_spells.begin();
                  it != spell_cast.learn_spells.end(); ++it ) {
                 std::string learn_spell_id = it->first;
-                int learn_at_level = it->second;
+                int const learn_at_level = it->second;
                 if( learn_at_level == slvl ) {
                     g->u.magic->learn_spell( learn_spell_id, g->u );
-                    spell_type spell_learned = spell_factory.obj( spell_id( learn_spell_id ) );
+                    spell_type const spell_learned = spell_factory.obj( spell_id( learn_spell_id ) );
                     add_msg(
                         _( "Your experience and knowledge in creating and manipulating magical energies to cast %s have opened your eyes to new possibilities, you can now cast %s." ),
                         spell_cast.name,

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1261,7 +1261,7 @@ void known_magic::serialize( JsonOut &json ) const
 
     json.member( "spellbook" );
     json.start_array();
-    for( const auto& pair : spellbook ) {
+    for( const auto &pair : spellbook ) {
         json.start_object();
         json.member( "id", pair.second.id() );
         json.member( "xp", pair.second.xp() );
@@ -1436,7 +1436,8 @@ int known_magic::max_mana( const Character &guy ) const
     float const mut_add = guy.mutation_value( "mana_modifier" );
     int const natural_cap = std::max( 0.0f, ( ( mana_base + int_bonus ) * mut_mul ) + mut_add );
 
-    int const ench_bonus = guy.bonus_from_enchantments( natural_cap, enchant_vals::mod::MANA_CAP, true );
+    int const ench_bonus = guy.bonus_from_enchantments( natural_cap, enchant_vals::mod::MANA_CAP,
+                           true );
 
     return std::max( 0, natural_cap + ench_bonus );
 }
@@ -1449,7 +1450,8 @@ double known_magic::mana_regen_rate( const Character &guy ) const
     double const mut_mul = guy.mutation_value( "mana_regen_multiplier" );
     double const natural_regen = std::max( 0.0, capacity * mut_mul / full_replenish );
 
-    double const ench_bonus = guy.bonus_from_enchantments( natural_regen, enchant_vals::mod::MANA_REGEN );
+    double const ench_bonus = guy.bonus_from_enchantments( natural_regen,
+                              enchant_vals::mod::MANA_REGEN );
 
     return std::max( 0.0, natural_regen + ench_bonus );
 }
@@ -1462,7 +1464,7 @@ void known_magic::update_mana( const Character &guy, double turns )
 std::vector<spell_id> known_magic::spells() const
 {
     std::vector<spell_id> spell_ids;
-    for( const auto& pair : spellbook ) {
+    for( const auto &pair : spellbook ) {
         spell_ids.emplace_back( pair.first );
     }
     return spell_ids;
@@ -1564,7 +1566,7 @@ class spellcasting_callback : public uilist_callback
                 mvwputch( menu->window, point( menu->w_width - menu->pad_right, i ), c_magenta, LINE_XOXO );
             }
             std::string const ignore_string = casting_ignore ? _( "Ignore Distractions" ) :
-                                        _( "Popup Distractions" );
+                                              _( "Popup Distractions" );
             mvwprintz( menu->window, point( menu->w_width - menu->pad_right + 2, 0 ),
                        casting_ignore ? c_red : c_light_green, string_format( "%s %s", "[I]", ignore_string ) );
             const std::string assign_letter = _( "Assign Hotkey [=]" );
@@ -2066,7 +2068,8 @@ spell fake_spell::get_spell( int min_level_override ) const
 {
     spell sp( id );
     // the max level this spell will be. can be optionally limited
-    int const spell_limiter = max_level ? std::min( *max_level, sp.get_max_level() ) : sp.get_max_level();
+    int const spell_limiter = max_level ? std::min( *max_level,
+                              sp.get_max_level() ) : sp.get_max_level();
     // level is the minimum level the fake_spell will output
     min_level_override = std::max( min_level_override, level );
     if( min_level_override > spell_limiter ) {
@@ -2075,7 +2078,7 @@ spell fake_spell::get_spell( int min_level_override ) const
     }
     // the "level" of the fake spell is the goal, but needs to be clamped to min and max
     int const level_of_spell = clamp( level, min_level_override,  std::min( sp.get_max_level(),
-                                spell_limiter ) );
+                                      spell_limiter ) );
     if( level > spell_limiter ) {
         debugmsg( "ERROR: fake spell %s has higher min_level than max_level", id.c_str() );
         return sp;

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1261,7 +1261,7 @@ void known_magic::serialize( JsonOut &json ) const
 
     json.member( "spellbook" );
     json.start_array();
-    for( auto pair : spellbook ) {
+    for( const auto& pair : spellbook ) {
         json.start_object();
         json.member( "id", pair.second.id() );
         json.member( "xp", pair.second.xp() );
@@ -1462,7 +1462,7 @@ void known_magic::update_mana( const Character &guy, double turns )
 std::vector<spell_id> known_magic::spells() const
 {
     std::vector<spell_id> spell_ids;
-    for( auto pair : spellbook ) {
+    for( const auto& pair : spellbook ) {
         spell_ids.emplace_back( pair.first );
     }
     return spell_ids;

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -212,9 +212,9 @@ void enchantment::load( const JsonObject &jo, const std::string & )
     jo.read( "emitter", emitter );
 
     if( jo.has_object( "intermittent_activation" ) ) {
-        JsonObject jobj = jo.get_object( "intermittent_activation" );
+        JsonObject const jobj = jo.get_object( "intermittent_activation" );
         for( const JsonObject effect_obj : jobj.get_array( "effects" ) ) {
-            time_duration freq = read_from_json_string<time_duration>( *effect_obj.get_raw( "frequency" ),
+            time_duration const freq = read_from_json_string<time_duration>( *effect_obj.get_raw( "frequency" ),
                                  time_duration::units );
             if( effect_obj.has_array( "spell_effects" ) ) {
                 for( const JsonObject fake_spell_obj : effect_obj.get_array( "spell_effects" ) ) {
@@ -224,7 +224,7 @@ void enchantment::load( const JsonObject &jo, const std::string & )
                 }
             } else if( effect_obj.has_object( "spell_effects" ) ) {
                 fake_spell fake;
-                JsonObject fake_spell_obj = effect_obj.get_object( "spell_effects" );
+                JsonObject const fake_spell_obj = effect_obj.get_object( "spell_effects" );
                 fake.load( fake_spell_obj );
                 add_activation( freq, fake );
             }
@@ -235,7 +235,7 @@ void enchantment::load( const JsonObject &jo, const std::string & )
     active_conditions.second = io::string_to_enum<condition>( jo.get_string( "condition",
                                "ALWAYS" ) );
 
-    for( JsonObject jsobj : jo.get_array( "ench_effects" ) ) {
+    for( JsonObject const jsobj : jo.get_array( "ench_effects" ) ) {
         ench_effects.emplace( efftype_id( jsobj.get_string( "effect" ) ), jsobj.get_int( "intensity" ) );
     }
 
@@ -243,8 +243,8 @@ void enchantment::load( const JsonObject &jo, const std::string & )
 
     if( jo.has_array( "values" ) ) {
         for( const JsonObject value_obj : jo.get_array( "values" ) ) {
-            std::string value_raw = value_obj.get_string( "value" );
-            std::string value_new = migrate_ench_vals_enums( value_raw );
+            std::string const value_raw = value_obj.get_string( "value" );
+            std::string const value_new = migrate_ench_vals_enums( value_raw );
             if( json_report_strict && value_new != value_raw ) {
                 value_obj.show_warning(
                     string_format( "%s has been renamed to %s", value_raw, value_new ), "value" );
@@ -335,7 +335,7 @@ void enchantment::serialize( JsonOut &jsout ) const
     jsout.member( "values" );
     jsout.start_array();
     for( int value = 0; value < static_cast<int>( enchant_vals::mod::NUM_MOD ); value++ ) {
-        enchant_vals::mod enum_value = static_cast<enchant_vals::mod>( value );
+        enchant_vals::mod const enum_value = static_cast<enchant_vals::mod>( value );
         if( get_value_add( enum_value ) == 0 && get_value_multiply( enum_value ) == 0.0 ) {
             continue;
         }
@@ -434,8 +434,8 @@ double enchantment::calc_bonus( enchant_vals::mod value, double base, bool round
         default:
             break;
     }
-    double add = use_add ? get_value_add( value ) : 0.0;
-    double mul = get_value_multiply( value );
+    double const add = use_add ? get_value_add( value ) : 0.0;
+    double const mul = get_value_multiply( value );
     double ret = add + base * mul;
     if( round ) {
         ret = trunc( ret );

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -215,7 +215,7 @@ void enchantment::load( const JsonObject &jo, const std::string & )
         JsonObject const jobj = jo.get_object( "intermittent_activation" );
         for( const JsonObject effect_obj : jobj.get_array( "effects" ) ) {
             time_duration const freq = read_from_json_string<time_duration>( *effect_obj.get_raw( "frequency" ),
-                                 time_duration::units );
+                                       time_duration::units );
             if( effect_obj.has_array( "spell_effects" ) ) {
                 for( const JsonObject fake_spell_obj : effect_obj.get_array( "spell_effects" ) ) {
                     fake_spell fake;

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -87,7 +87,7 @@ struct line_iterable {
 // Orientation of point C relative to line AB
 static int side_of( point a, point b, point c )
 {
-    int cross = ( ( b.x - a.x ) * ( c.y - a.y ) - ( b.y - a.y ) * ( c.x - a.x ) );
+    int const cross = ( ( b.x - a.x ) * ( c.y - a.y ) - ( b.y - a.y ) * ( c.x - a.x ) );
     return ( cross > 0 ) - ( cross < 0 );
 }
 // Tests if point c is between or on lines (a0, a0 + d) and (a1, a1 + d)
@@ -114,7 +114,7 @@ static void build_line( spell_detail::line_iterable line, const tripoint &source
 
 void spell_effect::teleport_random( const spell &sp, Creature &caster, const tripoint & )
 {
-    bool safe = !sp.has_flag( spell_flag::UNSAFE_TELEPORT );
+    bool const safe = !sp.has_flag( spell_flag::UNSAFE_TELEPORT );
     const int min_distance = sp.range();
     const int max_distance = sp.range() + sp.aoe();
     if( min_distance > max_distance || min_distance < 0 || max_distance < 0 ) {
@@ -164,7 +164,7 @@ static bool in_spell_aoe( const tripoint &start, const tripoint &end, const int 
     if( ignore_walls ) {
         return true;
     }
-    map &here = get_map();
+    map  const&here = get_map();
     const std::vector<tripoint> trajectory = line_to( start, end );
     tripoint last_point = start;
     for( const tripoint &pt : trajectory ) {
@@ -206,9 +206,9 @@ std::set<tripoint> spell_effect::spell_effect_cone( const spell &sp, const tripo
         calc_ray_end( angle, range, source, potential );
         end_points.emplace( potential );
     }
-    map &here = get_map();
+    map  const&here = get_map();
     for( const tripoint &ep : end_points ) {
-        std::vector<tripoint> trajectory = line_to( source, ep );
+        std::vector<tripoint> const trajectory = line_to( source, ep );
         tripoint last_point = source;
         for( const tripoint &tp : trajectory ) {
             if( ignore_walls || ( !here.obstructed_by_vehicle_rotation( tp, last_point ) &&
@@ -231,7 +231,7 @@ static bool test_always_true( const tripoint &, const tripoint & )
 }
 static bool test_passable( const tripoint &p, const tripoint &prev )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     return ( !here.obstructed_by_vehicle_rotation( prev, p ) && ( here.passable( p ) ||
              here.has_flag( "THIN_OBSTACLE", p ) ) );
 }
@@ -264,7 +264,7 @@ std::set<tripoint> spell_effect::spell_effect_line( const spell &, const tripoin
     }
 
     // is delta aligned with, cw, or ccw of primary axis
-    int delta_side = spell_detail::side_of( point_zero, axis_delta, delta );
+    int const delta_side = spell_detail::side_of( point_zero, axis_delta, delta );
 
     bool ( *test )( const tripoint &,
                     const tripoint & ) = ignore_walls ? test_always_true : test_passable;
@@ -287,7 +287,7 @@ std::set<tripoint> spell_effect::spell_effect_line( const spell &, const tripoin
     if( delta_side == 0 ) { // delta is already axis aligned, only need straight lines
         // cw leg
         point prev_point;
-        for( point p : line_to( point_zero, unit_cw_perp_axis * cw_len ) ) {
+        for( point const p : line_to( point_zero, unit_cw_perp_axis * cw_len ) ) {
             base_line.reset( p );
             if( !test( source + p, source + prev_point ) ) {
                 break;
@@ -298,7 +298,7 @@ std::set<tripoint> spell_effect::spell_effect_line( const spell &, const tripoin
         }
         // ccw leg
         prev_point = point_zero;
-        for( point p : line_to( point_zero, unit_cw_perp_axis * -ccw_len ) ) {
+        for( point const p : line_to( point_zero, unit_cw_perp_axis * -ccw_len ) ) {
             base_line.reset( p );
             if( !test( source + p, source + prev_point ) ) {
                 break;
@@ -310,7 +310,7 @@ std::set<tripoint> spell_effect::spell_effect_line( const spell &, const tripoin
     } else if( delta_side == 1 ) { // delta is cw of primary axis
         // ccw leg is behind perp axis
         point prev_point;
-        for( point p : line_to( point_zero, unit_cw_perp_axis * -ccw_len ) ) {
+        for( point const p : line_to( point_zero, unit_cw_perp_axis * -ccw_len ) ) {
             base_line.reset( p );
 
             // forward until in
@@ -325,7 +325,7 @@ std::set<tripoint> spell_effect::spell_effect_line( const spell &, const tripoin
         }
         prev_point = point_zero;
         // cw leg is before perp axis
-        for( point p : line_to( point_zero, unit_cw_perp_axis * cw_len ) ) {
+        for( point const p : line_to( point_zero, unit_cw_perp_axis * cw_len ) ) {
             base_line.reset( p );
 
             // move back
@@ -342,7 +342,7 @@ std::set<tripoint> spell_effect::spell_effect_line( const spell &, const tripoin
     } else if( delta_side == -1 ) { // delta is ccw of primary axis
         // ccw leg is before perp axis
         point prev_point;
-        for( point p : line_to( point_zero, unit_cw_perp_axis * -ccw_len ) ) {
+        for( point const p : line_to( point_zero, unit_cw_perp_axis * -ccw_len ) ) {
             base_line.reset( p );
 
             // move back
@@ -358,7 +358,7 @@ std::set<tripoint> spell_effect::spell_effect_line( const spell &, const tripoin
         }
         prev_point = point_zero;
         // cw leg is behind perp axis
-        for( point p : line_to( point_zero, unit_cw_perp_axis * cw_len ) ) {
+        for( point const p : line_to( point_zero, unit_cw_perp_axis * cw_len ) ) {
             base_line.reset( p );
 
             // forward until in
@@ -431,13 +431,13 @@ static void add_effect_to_target( const tripoint &target, const spell &sp )
 {
     Creature *const critter = g->critter_at<Creature>( target );
     Character *const guy = g->critter_at<Character>( target );
-    efftype_id spell_effect( sp.effect_data() );
+    efftype_id const spell_effect( sp.effect_data() );
 
     // TODO: migrate duration from moves to time_duration
     const int dur_turns = sp.duration() / 100;
     // Ensure permanent effect has at last 1 second of duration,
     // so it won't be instantly removed as expired.
-    time_duration dur_td = ( spell_effect->is_permanent() && dur_turns == 0 )
+    time_duration const dur_td = ( spell_effect->is_permanent() && dur_turns == 0 )
                            ? 1_seconds
                            : 1_turns * dur_turns;
 
@@ -499,7 +499,7 @@ void spell_effect::projectile_attack( const spell &sp, Creature &caster,
 {
     std::vector<tripoint> trajectory = line_to( caster.pos(), target );
     tripoint prev_point = caster.pos();
-    map &here = get_map();
+    map  const&here = get_map();
     for( std::vector<tripoint>::iterator iter = trajectory.begin(); iter != trajectory.end(); iter++ ) {
         if( ( here.impassable( *iter ) && !here.has_flag( "THIN_OBSTACLE", *iter ) ) ||
             here.obstructed_by_vehicle_rotation( prev_point, *iter ) ) {
@@ -554,7 +554,7 @@ bool area_expander::enqueue( const tripoint &from, const tripoint &to, float cos
 {
     if( contains( to ) ) {
         // We will modify existing node if its cost is lower.
-        int index = area_search[to];
+        int const index = area_search[to];
         node &node = area[index];
         if( cost < node.cost ) {
             node.from = from;
@@ -562,7 +562,7 @@ bool area_expander::enqueue( const tripoint &from, const tripoint &to, float cos
         }
         return false;
     }
-    int index = area.size();
+    int const index = area.size();
     area.push_back( {to, from, cost} );
     frontier.push( index );
     area_search[to] = index;
@@ -580,22 +580,22 @@ int area_expander::run( const tripoint &center )
     // Number of nodes expanded.
     int expanded = 0;
 
-    map &here = get_map();
+    map  const&here = get_map();
 
     while( !frontier.empty() ) {
-        int best_index = frontier.top();
+        int const best_index = frontier.top();
         frontier.pop();
-        node &best = area[best_index];
+        node  const&best = area[best_index];
 
         for( size_t i = 0; i < 8; i++ ) {
-            tripoint pt = best.position + point( x_offset[ i ], y_offset[ i ] );
+            tripoint const pt = best.position + point( x_offset[ i ], y_offset[ i ] );
 
             if( ( here.impassable( pt ) && !here.has_flag( "THIN_OBSTACLE", pt ) ) ||
                 here.obstructed_by_vehicle_rotation( best.position, pt ) ) {
                 continue;
             }
 
-            float center_range = static_cast<float>( rl_dist( center, pt ) );
+            float const center_range = static_cast<float>( rl_dist( center, pt ) );
             if( max_range > 0 && center_range > max_range ) {
                 continue;
             }
@@ -604,7 +604,7 @@ int area_expander::run( const tripoint &center )
                 continue;
             }
 
-            float delta_range = trig_dist( best.position, pt );
+            float const delta_range = trig_dist( best.position, pt );
 
             if( enqueue( best.position, pt, best.cost + delta_range ) ) {
                 expanded++;
@@ -644,13 +644,13 @@ static void spell_move( const spell &sp, const Creature &caster,
     }
 
     // Moving creatures
-    bool can_target_creature = sp.is_valid_effect_target( target_self ) ||
+    bool const can_target_creature = sp.is_valid_effect_target( target_self ) ||
                                sp.is_valid_effect_target( target_ally ) ||
                                sp.is_valid_effect_target( target_hostile );
 
     if( can_target_creature ) {
         if( Creature *victim = g->critter_at<Creature>( from ) ) {
-            Creature::Attitude cr_att = victim->attitude_to( get_avatar() );
+            Creature::Attitude const cr_att = victim->attitude_to( get_avatar() );
             bool valid = cr_att != Creature::A_FRIENDLY && sp.is_valid_effect_target( target_hostile );
             valid |= cr_att == Creature::A_FRIENDLY && sp.is_valid_effect_target( target_ally );
             valid |= victim == &caster && sp.is_valid_effect_target( target_self );
@@ -678,7 +678,7 @@ static void spell_move( const spell &sp, const Creature &caster,
         }
         auto &src_field = here.field_at( from );
         if( field_entry *entry = src_field.find_field( fid ) ) {
-            int intensity = entry->get_field_intensity();
+            int const intensity = entry->get_field_intensity();
             here.remove_field( from, fid );
             here.set_field_intensity( to, fid, intensity );
         }
@@ -911,7 +911,7 @@ void spell_effect::none( const spell &sp, Creature &, const tripoint & )
 void spell_effect::transform_blast( const spell &sp, Creature &caster,
                                     const tripoint &target )
 {
-    ter_furn_transform_id transform( sp.effect_data() );
+    ter_furn_transform_id const transform( sp.effect_data() );
     const std::set<tripoint> area = spell_effect_blast( sp, caster.pos(), target, sp.aoe(), true );
     for( const tripoint &location : area ) {
         if( one_in( sp.damage() ) ) {

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -164,7 +164,7 @@ static bool in_spell_aoe( const tripoint &start, const tripoint &end, const int 
     if( ignore_walls ) {
         return true;
     }
-    map  const&here = get_map();
+    map  const &here = get_map();
     const std::vector<tripoint> trajectory = line_to( start, end );
     tripoint last_point = start;
     for( const tripoint &pt : trajectory ) {
@@ -206,7 +206,7 @@ std::set<tripoint> spell_effect::spell_effect_cone( const spell &sp, const tripo
         calc_ray_end( angle, range, source, potential );
         end_points.emplace( potential );
     }
-    map  const&here = get_map();
+    map  const &here = get_map();
     for( const tripoint &ep : end_points ) {
         std::vector<tripoint> const trajectory = line_to( source, ep );
         tripoint last_point = source;
@@ -231,7 +231,7 @@ static bool test_always_true( const tripoint &, const tripoint & )
 }
 static bool test_passable( const tripoint &p, const tripoint &prev )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     return ( !here.obstructed_by_vehicle_rotation( prev, p ) && ( here.passable( p ) ||
              here.has_flag( "THIN_OBSTACLE", p ) ) );
 }
@@ -438,8 +438,8 @@ static void add_effect_to_target( const tripoint &target, const spell &sp )
     // Ensure permanent effect has at last 1 second of duration,
     // so it won't be instantly removed as expired.
     time_duration const dur_td = ( spell_effect->is_permanent() && dur_turns == 0 )
-                           ? 1_seconds
-                           : 1_turns * dur_turns;
+                                 ? 1_seconds
+                                 : 1_turns * dur_turns;
 
     bool bodypart_effected = false;
 
@@ -499,7 +499,7 @@ void spell_effect::projectile_attack( const spell &sp, Creature &caster,
 {
     std::vector<tripoint> trajectory = line_to( caster.pos(), target );
     tripoint prev_point = caster.pos();
-    map  const&here = get_map();
+    map  const &here = get_map();
     for( std::vector<tripoint>::iterator iter = trajectory.begin(); iter != trajectory.end(); iter++ ) {
         if( ( here.impassable( *iter ) && !here.has_flag( "THIN_OBSTACLE", *iter ) ) ||
             here.obstructed_by_vehicle_rotation( prev_point, *iter ) ) {
@@ -580,12 +580,12 @@ int area_expander::run( const tripoint &center )
     // Number of nodes expanded.
     int expanded = 0;
 
-    map  const&here = get_map();
+    map  const &here = get_map();
 
     while( !frontier.empty() ) {
         int const best_index = frontier.top();
         frontier.pop();
-        node  const&best = area[best_index];
+        node  const &best = area[best_index];
 
         for( size_t i = 0; i < 8; i++ ) {
             tripoint const pt = best.position + point( x_offset[ i ], y_offset[ i ] );
@@ -645,8 +645,8 @@ static void spell_move( const spell &sp, const Creature &caster,
 
     // Moving creatures
     bool const can_target_creature = sp.is_valid_effect_target( target_self ) ||
-                               sp.is_valid_effect_target( target_ally ) ||
-                               sp.is_valid_effect_target( target_hostile );
+                                     sp.is_valid_effect_target( target_ally ) ||
+                                     sp.is_valid_effect_target( target_hostile );
 
     if( can_target_creature ) {
         if( Creature *victim = g->critter_at<Creature>( from ) ) {

--- a/src/magic_teleporter_list.cpp
+++ b/src/magic_teleporter_list.cpp
@@ -85,7 +85,7 @@ bool teleporter_list::place_avatar_overmap( Character &you, const tripoint_abs_o
     if( !global_dest ) {
         return false;
     }
-    tripoint local_dest = omt_dest.getlocal( *global_dest ) + point( 60, 60 );
+    tripoint const local_dest = omt_dest.getlocal( *global_dest ) + point( 60, 60 );
     you.add_effect( efftype_id( "ignore_fall_damage" ), 1_seconds, num_bp, 0, true );
     g->place_player_overmap( omt_pt );
     g->place_player( local_dest );
@@ -134,7 +134,7 @@ void teleporter_list::serialize( JsonOut &json ) const
 
     json.member( "known_teleporters" );
     json.start_array();
-    for( std::pair<tripoint_abs_omt, std::string> pair : known_teleporters ) {
+    for( std::pair<tripoint_abs_omt, std::string> const pair : known_teleporters ) {
         json.start_object();
         json.member( "position", pair.first );
         json.member( "name", pair.second );
@@ -147,9 +147,9 @@ void teleporter_list::serialize( JsonOut &json ) const
 
 void teleporter_list::deserialize( JsonIn &jsin )
 {
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
 
-    for( JsonObject jo : data.get_array( "known_teleporters" ) ) {
+    for( JsonObject const jo : data.get_array( "known_teleporters" ) ) {
         tripoint_abs_omt temp_pos;
         jo.read( "position", temp_pos );
         std::string name;
@@ -175,11 +175,11 @@ class teleporter_callback : public uilist_callback
                 mvwputch( menu->window, point( start_x, i ), c_magenta, LINE_XOXO );
             }
             if( entnum >= 0 && static_cast<size_t>( entnum ) < index_pairs.size() ) {
-                avatar &player_character = get_avatar();
+                avatar  const&player_character = get_avatar();
                 overmap_ui::draw_overmap_chunk( menu->window, player_character, index_pairs[entnum],
                                                 point( start_x + 1, 1 ),
                                                 29, 21 );
-                int dist = rl_dist( player_character.global_omt_location(), index_pairs[entnum] );
+                int const dist = rl_dist( player_character.global_omt_location(), index_pairs[entnum] );
                 mvwprintz( menu->window, point( start_x + 2, 1 ), c_white,
                            string_format( _( "Distance: %d %s" ), dist,
                                           index_pairs[entnum].to_string() ) );

--- a/src/magic_teleporter_list.cpp
+++ b/src/magic_teleporter_list.cpp
@@ -175,7 +175,7 @@ class teleporter_callback : public uilist_callback
                 mvwputch( menu->window, point( start_x, i ), c_magenta, LINE_XOXO );
             }
             if( entnum >= 0 && static_cast<size_t>( entnum ) < index_pairs.size() ) {
-                avatar  const&player_character = get_avatar();
+                avatar  const &player_character = get_avatar();
                 overmap_ui::draw_overmap_chunk( menu->window, player_character, index_pairs[entnum],
                                                 point( start_x + 1, 1 ),
                                                 29, 21 );

--- a/src/magic_ter_fur_transform.cpp
+++ b/src/magic_ter_fur_transform.cpp
@@ -66,7 +66,7 @@ static void load_transform_results( const JsonObject &jsi, const std::string &js
     }
     for( const JsonValue entry : jsi.get_array( json_key ) ) {
         if( entry.test_array() ) {
-            JsonArray inner = entry.get_array();
+            JsonArray const inner = entry.get_array();
             list.add( T( inner.get_string( 0 ) ), inner.get_int( 1 ) );
         } else {
             list.add( T( entry.get_string() ), 1 );
@@ -90,7 +90,7 @@ void ter_furn_transform::load( const JsonObject &jo, const std::string & )
     optional( jo, was_loaded, "fail_message", fail_message, "" );
 
     if( jo.has_member( "terrain" ) ) {
-        for( JsonObject ter_obj : jo.get_array( "terrain" ) ) {
+        for( JsonObject const ter_obj : jo.get_array( "terrain" ) ) {
             ter_furn_data<ter_str_id> cur_results = ter_furn_data<ter_str_id>();
             cur_results.load( ter_obj );
 
@@ -105,7 +105,7 @@ void ter_furn_transform::load( const JsonObject &jo, const std::string & )
     }
 
     if( jo.has_member( "furniture" ) ) {
-        for( JsonObject furn_obj : jo.get_array( "furniture" ) ) {
+        for( JsonObject const furn_obj : jo.get_array( "furniture" ) ) {
             ter_furn_data<furn_str_id> cur_results = ter_furn_data<furn_str_id>();
             cur_results.load( furn_obj );
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -601,11 +601,11 @@ int main( int argc, char *argv[] )
 
     if( !dir_exist( PATH_INFO::datadir() ) ) {
         std::string const msg = string_format(
-                              "Can't find directory \"%s\"\n"
-                              "Please ensure the current working directory is correct.\n"
-                              "Perhaps you meant to start \"cataclysm-launcher\"?\n",
-                              PATH_INFO::datadir().c_str()
-                          );
+                                    "Can't find directory \"%s\"\n"
+                                    "Please ensure the current working directory is correct.\n"
+                                    "Perhaps you meant to start \"cataclysm-launcher\"?\n",
+                                    PATH_INFO::datadir().c_str()
+                                );
         report_fatal_error( msg );
         exit( 1 );
     }
@@ -613,19 +613,19 @@ int main( int argc, char *argv[] )
     const auto check_dir_good = []( const std::string & dir ) {
         if( !assure_dir_exist( dir ) ) {
             std::string const msg = string_format(
-                                  "Can't open or create \"%s\"\n"
-                                  "Please ensure you have write permission.\n",
-                                  dir.c_str()
-                              );
+                                        "Can't open or create \"%s\"\n"
+                                        "Please ensure you have write permission.\n",
+                                        dir.c_str()
+                                    );
             report_fatal_error( msg );
             exit( 1 );
         }
         if( !can_write_to_dir( dir ) ) {
             std::string const msg = string_format(
-                                  "Can't write to \"%s\"\n"
-                                  "Please ensure you have write permission and free storage space.\n",
-                                  dir.c_str()
-                              );
+                                        "Can't write to \"%s\"\n"
+                                        "Please ensure you have write permission and free storage space.\n",
+                                        dir.c_str()
+                                    );
             report_fatal_error( msg );
             exit( 1 );
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -555,7 +555,7 @@ int main( int argc, char *argv[] )
                     if( !strcmp( argv[0], arg_handler.flag ) ) {
                         argc--;
                         argv++;
-                        int args_consumed = arg_handler.handler( argc, const_cast<const char **>( argv ) );
+                        int const args_consumed = arg_handler.handler( argc, const_cast<const char **>( argv ) );
                         if( args_consumed < 0 ) {
                             cata_printf( "Failed parsing parameter '%s'\n", *( argv - 1 ) );
                             exit( 1 );
@@ -580,7 +580,7 @@ int main( int argc, char *argv[] )
                 if( !strcmp( saved_argv[0], arg_handler.flag ) ) {
                     --saved_argc;
                     ++saved_argv;
-                    int args_consumed = arg_handler.handler( saved_argc, saved_argv );
+                    int const args_consumed = arg_handler.handler( saved_argc, saved_argv );
                     if( args_consumed < 0 ) {
                         cata_printf( "Failed parsing parameter '%s'\n", *( argv - 1 ) );
                         exit( 1 );
@@ -600,7 +600,7 @@ int main( int argc, char *argv[] )
     }
 
     if( !dir_exist( PATH_INFO::datadir() ) ) {
-        std::string msg = string_format(
+        std::string const msg = string_format(
                               "Can't find directory \"%s\"\n"
                               "Please ensure the current working directory is correct.\n"
                               "Perhaps you meant to start \"cataclysm-launcher\"?\n",
@@ -612,7 +612,7 @@ int main( int argc, char *argv[] )
 
     const auto check_dir_good = []( const std::string & dir ) {
         if( !assure_dir_exist( dir ) ) {
-            std::string msg = string_format(
+            std::string const msg = string_format(
                                   "Can't open or create \"%s\"\n"
                                   "Please ensure you have write permission.\n",
                                   dir.c_str()
@@ -621,7 +621,7 @@ int main( int argc, char *argv[] )
             exit( 1 );
         }
         if( !can_write_to_dir( dir ) ) {
-            std::string msg = string_format(
+            std::string const msg = string_format(
                                   "Can't write to \"%s\"\n"
                                   "Please ensure you have write permission and free storage space.\n",
                                   dir.c_str()
@@ -759,7 +759,7 @@ int main( int argc, char *argv[] )
             }
         }
 
-        shared_ptr_fast<ui_adaptor> ui = g->create_or_get_main_ui_adaptor();
+        shared_ptr_fast<ui_adaptor> const ui = g->create_or_get_main_ui_adaptor();
         while( !g->do_turn() );
     }
 

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -105,7 +105,7 @@ static int utf8_width_notags( const char *s )
     int w = 0;
     bool inside_tag = false;
     while( len > 0 ) {
-        uint32_t ch = UTF8_getch( &ptr, &len );
+        uint32_t const ch = UTF8_getch( &ptr, &len );
         if( ch == UNKNOWN_UNICODE ) {
             continue;
         }
@@ -136,17 +136,17 @@ std::vector<int> main_menu::print_menu_items( const catacurses::window &w_in,
         }
         ret.push_back( utf8_width_notags( text.c_str() ) );
 
-        std::string temp = shortcut_text( iSel == i ? hilite( c_yellow ) : c_yellow, vItems[i] );
+        std::string const temp = shortcut_text( iSel == i ? hilite( c_yellow ) : c_yellow, vItems[i] );
         text += string_format( "[%s]", colorize( temp,
                                iSel == i ? hilite( c_light_gray ) : c_light_gray ) );
     }
 
-    int text_width = utf8_width_notags( text.c_str() );
+    int const text_width = utf8_width_notags( text.c_str() );
     if( text_width > getmaxx( w_in ) ) {
         offset.y -= std::ceil( text_width / getmaxx( w_in ) );
     }
 
-    std::vector<std::string> menu_txt = foldstring( text, getmaxx( w_in ), ']' );
+    std::vector<std::string> const menu_txt = foldstring( text, getmaxx( w_in ), ']' );
 
     int y_off = 0;
     int sel_opt = 0;
@@ -161,7 +161,7 @@ std::vector<int> main_menu::print_menu_items( const catacurses::window &w_in,
             if( tmp_chars.at( x ) == "[" ) {
                 for( int x2 = x; static_cast<size_t>( x2 ) < tmp_chars.size(); x2++ ) {
                     if( tmp_chars.at( x2 ) == "]" ) {
-                        inclusive_rectangle<point> rec( win_offset + offset + point( x, y_off ),
+                        inclusive_rectangle<point> const rec( win_offset + offset + point( x, y_off ),
                                                         win_offset + offset + point( x2, y_off ) );
                         main_menu_button_map.emplace_back( rec, sel_opt++ );
                         break;
@@ -180,7 +180,7 @@ void main_menu::display_sub_menu( int sel, const point &bottom_left, int sel_lin
     main_menu_sub_button_map.clear();
     std::vector<std::string> sub_opts;
     int xlen = 0;
-    main_menu_opts sel_o = static_cast<main_menu_opts>( sel );
+    main_menu_opts const sel_o = static_cast<main_menu_opts>( sel );
     switch( sel_o ) {
         case main_menu_opts::CREDITS:
             display_text( mmenu_credits, _( "Credits" ), sel_line );
@@ -191,9 +191,9 @@ void main_menu::display_sub_menu( int sel, const point &bottom_left, int sel_lin
             return;
         case main_menu_opts::SETTINGS:
             for( int i = 0; static_cast<size_t>( i ) < vSettingsSubItems.size(); ++i ) {
-                nc_color clr = i == sel2 ? hilite( c_yellow ) : c_yellow;
+                nc_color const clr = i == sel2 ? hilite( c_yellow ) : c_yellow;
                 sub_opts.push_back( shortcut_text( clr, vSettingsSubItems[i] ) );
-                int len = utf8_width( shortcut_text( clr, vSettingsSubItems[i] ), true );
+                int const len = utf8_width( shortcut_text( clr, vSettingsSubItems[i] ), true );
                 if( len > xlen ) {
                     xlen = len;
                 }
@@ -201,9 +201,9 @@ void main_menu::display_sub_menu( int sel, const point &bottom_left, int sel_lin
             break;
         case main_menu_opts::NEWCHAR:
             for( int i = 0; static_cast<size_t>( i ) < vNewGameSubItems.size(); i++ ) {
-                nc_color clr = i == sel2 ? hilite( c_yellow ) : c_yellow;
+                nc_color const clr = i == sel2 ? hilite( c_yellow ) : c_yellow;
                 sub_opts.push_back( shortcut_text( clr, vNewGameSubItems[i] ) );
-                int len = utf8_width( shortcut_text( clr, vNewGameSubItems[i] ), true );
+                int const len = utf8_width( shortcut_text( clr, vNewGameSubItems[i] ), true );
                 if( len > xlen ) {
                     xlen = len;
                 }
@@ -219,7 +219,7 @@ void main_menu::display_sub_menu( int sel, const point &bottom_left, int sel_lin
             std::vector<std::string> all_worldnames = world_generator->all_worldnames();
             for( int i = 0; static_cast<size_t>( i ) < all_worldnames.size(); i++ ) {
                 WORLDPTR world = world_generator->get_world( all_worldnames[i] );
-                int savegames_count = world->world_saves.size();
+                int const savegames_count = world->world_saves.size();
                 nc_color clr = c_white;
                 std::string txt = all_worldnames[i];
                 if( world->needs_lua() && !cata::has_lua() ) {
@@ -233,7 +233,7 @@ void main_menu::display_sub_menu( int sel, const point &bottom_left, int sel_lin
                 }
                 sub_opts.push_back( colorize( string_format( "%s (%d)", txt, savegames_count ),
                                               ( sel2 == i + ( extra_opt ? 1 : 0 ) ) ? hilite( clr ) : clr ) );
-                int len = utf8_width( sub_opts.back(), true );
+                int const len = utf8_width( sub_opts.back(), true );
                 if( len > xlen ) {
                     xlen = len;
                 }
@@ -251,16 +251,16 @@ void main_menu::display_sub_menu( int sel, const point &bottom_left, int sel_lin
     }
 
     const point top_left( bottom_left + point( 0, -( sub_opts.size() + 1 ) ) );
-    catacurses::window w_sub = catacurses::newwin( sub_opts.size() + 2, xlen + 4, top_left );
+    catacurses::window const w_sub = catacurses::newwin( sub_opts.size() + 2, xlen + 4, top_left );
     werase( w_sub );
     draw_border( w_sub, c_light_gray );
     for( int y = 0; static_cast<size_t>( y ) < sub_opts.size(); y++ ) {
         std::string opt = ( sel2 == y ? "» " : "  " ) + sub_opts[y];
-        int padding = ( xlen + 2 ) - utf8_width( opt, true );
+        int const padding = ( xlen + 2 ) - utf8_width( opt, true );
         opt.append( padding, ' ' );
-        nc_color clr = sel2 == y ? hilite( c_light_gray ) : c_light_gray;
+        nc_color const clr = sel2 == y ? hilite( c_light_gray ) : c_light_gray;
         trim_and_print( w_sub, point( 1, y + 1 ), xlen + 2, clr, opt );
-        inclusive_rectangle<point> rec( top_left + point( 1, y + 1 ), top_left + point( xlen + 2, y + 1 ) );
+        inclusive_rectangle<point> const rec( top_left + point( 1, y + 1 ), top_left + point( xlen + 2, y + 1 ) );
         main_menu_sub_button_map.emplace_back( rec, std::pair<int, int> { sel, y } );
     }
     wnoutrefresh( w_sub );
@@ -275,8 +275,8 @@ void main_menu::print_menu( const catacurses::window &w_open, int iSel, const po
     werase( w_open );
 
     // Define window size
-    int window_width = getmaxx( w_open );
-    int window_height = getmaxy( w_open );
+    int const window_width = getmaxx( w_open );
+    int const window_height = getmaxy( w_open );
 
     // Draw horizontal line
     for( int i = 1; i < window_width - 1; ++i ) {
@@ -326,7 +326,7 @@ void main_menu::print_menu( const catacurses::window &w_open, int iSel, const po
     if( mmenu_title.size() > 1 ) {
         for( const std::string &i_title : mmenu_title ) {
             nc_color cur_color = c_white;
-            nc_color base_color = c_white;
+            nc_color const base_color = c_white;
             print_colored_text( w_open, point( iOffsetX, iLine++ ), cur_color, base_color, i_title );
         }
     } else {
@@ -526,18 +526,18 @@ void main_menu::display_text( const std::string &text, const std::string &title,
     const int b_height = FULL_SCREEN_HEIGHT - clamp( ( FULL_SCREEN_HEIGHT - w_open_height ) + 4, 0, 4 );
     const int vert_off = clamp( ( w_open_height - FULL_SCREEN_HEIGHT ) / 2, getbegy( w_open ), TERMY );
 
-    catacurses::window w_border = catacurses::newwin( b_height, FULL_SCREEN_WIDTH,
+    catacurses::window const w_border = catacurses::newwin( b_height, FULL_SCREEN_WIDTH,
                                   point( clamp( ( TERMX - FULL_SCREEN_WIDTH ) / 2, 0, TERMX ), vert_off ) );
 
-    catacurses::window w_text = catacurses::newwin( b_height - 2, FULL_SCREEN_WIDTH - 2,
+    catacurses::window const w_text = catacurses::newwin( b_height - 2, FULL_SCREEN_WIDTH - 2,
                                 point( 1 + clamp( ( TERMX - FULL_SCREEN_WIDTH ) / 2, 0, TERMX ), 1 + vert_off ) );
 
     draw_border( w_border, BORDER_COLOR, title );
 
-    int width = FULL_SCREEN_WIDTH - 2;
-    int height = b_height - 2;
+    int const width = FULL_SCREEN_WIDTH - 2;
+    int const height = b_height - 2;
     const auto vFolded = foldstring( text, width );
-    int iLines = vFolded.size();
+    int const iLines = vFolded.size();
 
     fold_and_print_from( w_text, point_zero, width, selected, c_light_gray, text );
 
@@ -629,7 +629,7 @@ bool main_menu::opening_screen()
         sel2 = world_generator->get_world_index( world_generator->last_world_name );
     }
 
-    background_pane background;
+    background_pane const background;
 
     ui_adaptor ui;
     ui.on_redraw( [&]( const ui_adaptor & ) {
@@ -648,7 +648,7 @@ bool main_menu::opening_screen()
         // Since this is an index for a mutable array, it should always be regenerated instead of modified.
         const size_t last_world_pos = world_generator->get_world_index( world_generator->last_world_name );
         std::string action = ctxt.handle_input();
-        input_event sInput = ctxt.get_raw_input();
+        input_event const sInput = ctxt.get_raw_input();
 
         // check automatic menu shortcuts
         for( int i = 0; static_cast<size_t>( i ) < vMenuHotkeys.size(); ++i ) {
@@ -714,8 +714,8 @@ bool main_menu::opening_screen()
                    action == "PAGE_UP" || action == "PAGE_DOWN" ||
                    action == "SCROLL_UP" || action == "SCROLL_DOWN" ) {
             int max_item_count = 0;
-            int min_item_val = 0;
-            main_menu_opts opt = static_cast<main_menu_opts>( sel1 );
+            int const min_item_val = 0;
+            main_menu_opts const opt = static_cast<main_menu_opts>( sel1 );
             switch( opt ) {
                 case main_menu_opts::MOTD:
                 case main_menu_opts::CREDITS:
@@ -724,7 +724,7 @@ bool main_menu::opening_screen()
                             sel_line--;
                         }
                     } else if( action == "DOWN" || action == "PAGE_DOWN" || action == "SCROLL_DOWN" ) {
-                        int effective_height = sel_line + FULL_SCREEN_HEIGHT - 2;
+                        int const effective_height = sel_line + FULL_SCREEN_HEIGHT - 2;
                         if( ( opt == main_menu_opts::CREDITS && effective_height < mmenu_credits_len ) ||
                             ( opt == main_menu_opts::MOTD && effective_height < mmenu_motd_len ) ) {
                             sel_line++;
@@ -848,7 +848,7 @@ bool main_menu::new_character_tab()
                 return false;
             }
 
-            std::string res = query_popup()
+            std::string const res = query_popup()
                               .context( "LOAD_DELETE_CANCEL" ).default_color( c_light_gray )
                               .message( _( "What to do with template \"%s\"?" ), templates[opt_val] )
                               .option( "LOAD" ).option( "DELETE" ).option( "CANCEL" ).cursor( 0 )
@@ -888,8 +888,8 @@ bool main_menu::new_character_tab()
         world = world_generator->make_new_world( special_game_type::DEFENSE );
     } else {
         // Pick a world, suppressing prompts if it's "play now" mode.
-        bool empty_only = sel2 == 3 || sel2 == 4;
-        bool show_prompt = !empty_only;
+        bool const empty_only = sel2 == 3 || sel2 == 4;
+        bool const show_prompt = !empty_only;
         world = world_generator->pick_world( show_prompt, empty_only );
     }
 
@@ -905,7 +905,7 @@ bool main_menu::new_character_tab()
     }
 
     if( g->gamemode ) {
-        bool success = g->gamemode->init();
+        bool const success = g->gamemode->init();
         if( success ) {
             cleanup.cancel();
         }
@@ -1031,7 +1031,7 @@ void main_menu::world_tab( const std::string &worldname )
         mmenu.entries.emplace_back( static_cast<int>( i ), true, vWorldHotkeys[i], vWorldSubItems[i] );
     }
     mmenu.query();
-    int opt_val = mmenu.ret;
+    int const opt_val = mmenu.ret;
     if( opt_val < 0 || static_cast<size_t>( opt_val ) >= vWorldSubItems.size() ) {
         return;
     }

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -162,7 +162,7 @@ std::vector<int> main_menu::print_menu_items( const catacurses::window &w_in,
                 for( int x2 = x; static_cast<size_t>( x2 ) < tmp_chars.size(); x2++ ) {
                     if( tmp_chars.at( x2 ) == "]" ) {
                         inclusive_rectangle<point> const rec( win_offset + offset + point( x, y_off ),
-                                                        win_offset + offset + point( x2, y_off ) );
+                                                              win_offset + offset + point( x2, y_off ) );
                         main_menu_button_map.emplace_back( rec, sel_opt++ );
                         break;
                     }
@@ -260,7 +260,8 @@ void main_menu::display_sub_menu( int sel, const point &bottom_left, int sel_lin
         opt.append( padding, ' ' );
         nc_color const clr = sel2 == y ? hilite( c_light_gray ) : c_light_gray;
         trim_and_print( w_sub, point( 1, y + 1 ), xlen + 2, clr, opt );
-        inclusive_rectangle<point> const rec( top_left + point( 1, y + 1 ), top_left + point( xlen + 2, y + 1 ) );
+        inclusive_rectangle<point> const rec( top_left + point( 1, y + 1 ), top_left + point( xlen + 2,
+                                              y + 1 ) );
         main_menu_sub_button_map.emplace_back( rec, std::pair<int, int> { sel, y } );
     }
     wnoutrefresh( w_sub );
@@ -527,10 +528,10 @@ void main_menu::display_text( const std::string &text, const std::string &title,
     const int vert_off = clamp( ( w_open_height - FULL_SCREEN_HEIGHT ) / 2, getbegy( w_open ), TERMY );
 
     catacurses::window const w_border = catacurses::newwin( b_height, FULL_SCREEN_WIDTH,
-                                  point( clamp( ( TERMX - FULL_SCREEN_WIDTH ) / 2, 0, TERMX ), vert_off ) );
+                                        point( clamp( ( TERMX - FULL_SCREEN_WIDTH ) / 2, 0, TERMX ), vert_off ) );
 
     catacurses::window const w_text = catacurses::newwin( b_height - 2, FULL_SCREEN_WIDTH - 2,
-                                point( 1 + clamp( ( TERMX - FULL_SCREEN_WIDTH ) / 2, 0, TERMX ), 1 + vert_off ) );
+                                      point( 1 + clamp( ( TERMX - FULL_SCREEN_WIDTH ) / 2, 0, TERMX ), 1 + vert_off ) );
 
     draw_border( w_border, BORDER_COLOR, title );
 
@@ -849,10 +850,10 @@ bool main_menu::new_character_tab()
             }
 
             std::string const res = query_popup()
-                              .context( "LOAD_DELETE_CANCEL" ).default_color( c_light_gray )
-                              .message( _( "What to do with template \"%s\"?" ), templates[opt_val] )
-                              .option( "LOAD" ).option( "DELETE" ).option( "CANCEL" ).cursor( 0 )
-                              .query().action;
+                                    .context( "LOAD_DELETE_CANCEL" ).default_color( c_light_gray )
+                                    .message( _( "What to do with template \"%s\"?" ), templates[opt_val] )
+                                    .option( "LOAD" ).option( "DELETE" ).option( "CANCEL" ).cursor( 0 )
+                                    .query().action;
             if( res == "DELETE" &&
                 query_yn( _( "Are you sure you want to delete %s?" ), templates[opt_val] ) ) {
                 const auto path = PATH_INFO::templatedir() + templates[opt_val] + ".template";

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -474,10 +474,10 @@ void map::vehmove()
 {
     // give vehicles movement points
     VehicleList vehicle_list;
-    int minz = zlevels ? -OVERMAP_DEPTH : abs_sub.z;
-    int maxz = zlevels ? OVERMAP_HEIGHT : abs_sub.z;
+    int const minz = zlevels ? -OVERMAP_DEPTH : abs_sub.z;
+    int const maxz = zlevels ? OVERMAP_HEIGHT : abs_sub.z;
     for( int zlev = minz; zlev <= maxz; ++zlev ) {
-        level_cache &cache = get_cache( zlev );
+        level_cache  const&cache = get_cache( zlev );
         for( vehicle *veh : cache.vehicle_list ) {
             veh->gain_moves();
             veh->slow_leak();
@@ -510,7 +510,7 @@ void map::vehmove()
     // The bool tracks whether the vehicles is on the map or not.
     std::map<vehicle *, bool> connected_vehicles;
     for( int zlev = minz; zlev <= maxz; ++zlev ) {
-        level_cache &cache = get_cache( zlev );
+        level_cache  const&cache = get_cache( zlev );
         vehicle::enumerate_vehicles( connected_vehicles, cache.vehicle_list );
     }
     for( std::pair<vehicle *const, bool> &veh_pair : connected_vehicles ) {
@@ -550,8 +550,8 @@ bool map::vehproceed( VehicleList &vehicle_list )
     }
 
     // confirm that veh_in_active_range is still correct for each z-level
-    int minz = zlevels ? -OVERMAP_DEPTH : abs_sub.z;
-    int maxz = zlevels ? OVERMAP_HEIGHT : abs_sub.z;
+    int const minz = zlevels ? -OVERMAP_DEPTH : abs_sub.z;
+    int const maxz = zlevels ? OVERMAP_HEIGHT : abs_sub.z;
     for( int zlev = minz; zlev <= maxz; ++zlev ) {
         level_cache &cache = get_cache( zlev );
 
@@ -612,7 +612,7 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &fac
     veh.precalc_mounts( 1, veh.skidding ? veh.turn_dir : facing.dir(), veh.pivot_point() );
 
     // cancel out any movement of the vehicle due only to a change in pivot
-    tripoint dp1 = dp - veh.pivot_displacement();
+    tripoint const dp1 = dp - veh.pivot_displacement();
 
     if( !vertical ) {
         veh.adjust_zlevel( 1, dp1 );
@@ -666,7 +666,7 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &fac
                 continue;
             }
 
-            point collision_point = veh.part( coll.part ).mount;
+            point const collision_point = veh.part( coll.part ).mount;
             const int coll_dmg = coll.imp;
             // Shock damage, if the target part is a rotor treat as an aimed hit.
             if( veh.part_info( coll.part ).rotor_diameter() > 0 ) {
@@ -732,7 +732,7 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &fac
         }
     }
 
-    Character &player_character = get_player_character();
+    Character  const&player_character = get_player_character();
     const bool seen = sees_veh( player_character, veh, false );
 
     if( can_move || ( vertical && veh.is_falling ) ) {
@@ -846,51 +846,51 @@ float map::vehicle_vehicle_collision( vehicle &veh, vehicle &veh2,
     if( !vertical ) {
         // For reference, a cargo truck weighs ~25300, a bicycle 690,
         //  and 38mph is 3800 'velocity'
-        rl_vec2d velo_veh1 = veh.velo_vec();
-        rl_vec2d velo_veh2 = veh2.velo_vec();
+        rl_vec2d const velo_veh1 = veh.velo_vec();
+        rl_vec2d const velo_veh2 = veh2.velo_vec();
         const float m1 = to_kilogram( veh.total_mass() );
         const float m2 = to_kilogram( veh2.total_mass() );
         //Energy of vehicle1 and vehicle2 before collision
-        float E = 0.5 * m1 * velo_veh1.magnitude() * velo_veh1.magnitude() +
+        float const E = 0.5 * m1 * velo_veh1.magnitude() * velo_veh1.magnitude() +
                   0.5 * m2 * velo_veh2.magnitude() * velo_veh2.magnitude();
 
         // Collision_axis
-        point cof1 = veh .rotated_center_of_mass();
-        point cof2 = veh2.rotated_center_of_mass();
-        int &x_cof1 = cof1.x;
-        int &y_cof1 = cof1.y;
-        int &x_cof2 = cof2.x;
-        int &y_cof2 = cof2.y;
+        point const cof1 = veh .rotated_center_of_mass();
+        point const cof2 = veh2.rotated_center_of_mass();
+        int  const&x_cof1 = cof1.x;
+        int  const&y_cof1 = cof1.y;
+        int  const&x_cof2 = cof2.x;
+        int  const&y_cof2 = cof2.y;
         rl_vec2d collision_axis_y;
 
         collision_axis_y.x = ( veh.global_pos3().x + x_cof1 ) - ( veh2.global_pos3().x + x_cof2 );
         collision_axis_y.y = ( veh.global_pos3().y + y_cof1 ) - ( veh2.global_pos3().y + y_cof2 );
         collision_axis_y = collision_axis_y.normalized();
-        rl_vec2d collision_axis_x = collision_axis_y.rotated( M_PI / 2 );
+        rl_vec2d const collision_axis_x = collision_axis_y.rotated( M_PI / 2 );
         // imp? & delta? & final? reworked:
         // newvel1 =( vel1 * ( mass1 - mass2 ) + ( 2 * mass2 * vel2 ) ) / ( mass1 + mass2 )
         // as per http://en.wikipedia.org/wiki/Elastic_collision
         //velocity of veh1 before collision in the direction of collision_axis_y
-        float vel1_y = collision_axis_y.dot_product( velo_veh1 );
-        float vel1_x = collision_axis_x.dot_product( velo_veh1 );
+        float const vel1_y = collision_axis_y.dot_product( velo_veh1 );
+        float const vel1_x = collision_axis_x.dot_product( velo_veh1 );
         //velocity of veh2 before collision in the direction of collision_axis_y
-        float vel2_y = collision_axis_y.dot_product( velo_veh2 );
-        float vel2_x = collision_axis_x.dot_product( velo_veh2 );
+        float const vel2_y = collision_axis_y.dot_product( velo_veh2 );
+        float const vel2_x = collision_axis_x.dot_product( velo_veh2 );
         // e = 0 -> inelastic collision
         // e = 1 -> elastic collision
-        float e = get_collision_factor( vel1_y / 100 - vel2_y / 100 );
+        float const e = get_collision_factor( vel1_y / 100 - vel2_y / 100 );
 
         // Velocity after collision
         // vel1_x_a = vel1_x, because in x-direction we have no transmission of force
-        float vel1_x_a = vel1_x;
-        float vel2_x_a = vel2_x;
+        float const vel1_x_a = vel1_x;
+        float const vel2_x_a = vel2_x;
         // Transmission of force only in direction of collision_axix_y
         // Equation: partially elastic collision
-        float vel1_y_a = ( m2 * vel2_y * ( 1 + e ) + vel1_y * ( m1 - m2 * e ) ) / ( m1 + m2 );
-        float vel2_y_a = ( m1 * vel1_y * ( 1 + e ) + vel2_y * ( m2 - m1 * e ) ) / ( m1 + m2 );
+        float const vel1_y_a = ( m2 * vel2_y * ( 1 + e ) + vel1_y * ( m1 - m2 * e ) ) / ( m1 + m2 );
+        float const vel2_y_a = ( m1 * vel1_y * ( 1 + e ) + vel2_y * ( m2 - m1 * e ) ) / ( m1 + m2 );
         // Add both components; Note: collision_axis is normalized
-        rl_vec2d final1 = collision_axis_y * vel1_y_a + collision_axis_x * vel1_x_a;
-        rl_vec2d final2 = collision_axis_y * vel2_y_a + collision_axis_x * vel2_x_a;
+        rl_vec2d const final1 = collision_axis_y * vel1_y_a + collision_axis_x * vel1_x_a;
+        rl_vec2d const final2 = collision_axis_y * vel2_y_a + collision_axis_x * vel2_x_a;
 
         veh.move.init( final1.as_point() );
         if( final1.dot_product( veh.face_vec() ) < 0 ) {
@@ -918,9 +918,9 @@ float map::vehicle_vehicle_collision( vehicle &veh, vehicle &veh2,
         veh2.of_turn = avg_of_turn * 1.1;
 
         //Energy after collision
-        float E_a = 0.5 * m1 * final1.magnitude() * final1.magnitude() +
+        float const E_a = 0.5 * m1 * final1.magnitude() * final1.magnitude() +
                     0.5 * m2 * final2.magnitude() * final2.magnitude();
-        float d_E = E - E_a;  //Lost energy at collision -> deformation energy
+        float const d_E = E - E_a;  //Lost energy at collision -> deformation energy
         dmg = std::abs( d_E / 1000 / 2000 );  //adjust to balance damage
     } else {
         const float m1 = to_kilogram( veh.total_mass() );
@@ -930,8 +930,8 @@ float map::vehicle_vehicle_collision( vehicle &veh, vehicle &veh2,
         veh.vertical_velocity = 0;
     }
 
-    float dmg_veh1 = dmg * 0.5;
-    float dmg_veh2 = dmg * 0.5;
+    float const dmg_veh1 = dmg * 0.5;
+    float const dmg_veh2 = dmg * 0.5;
 
     int coll_parts_cnt = 0; //quantity of colliding parts between veh1 and veh2
     for( const auto &veh_veh_coll : collisions ) {
@@ -1184,7 +1184,7 @@ bool map::displace_vehicle( vehicle &veh, const tripoint &dp )
 {
     const tripoint src = veh.global_pos3();
 
-    tripoint dst = src + dp;
+    tripoint const dst = src + dp;
 
     if( !inbounds( src ) ) {
         add_msg( m_debug, "map::displace_vehicle: coordinates out of bounds %d,%d,%d->%d,%d,%d",
@@ -1267,10 +1267,10 @@ bool map::displace_vehicle( vehicle &veh, const tripoint &dp )
             }
             const vehicle_part &veh_part = veh.part( prt );
 
-            tripoint next_pos = veh_part.precalc[1];
+            tripoint const next_pos = veh_part.precalc[1];
 
             // Place passenger on the new part location
-            tripoint psgp( dst + next_pos );
+            tripoint const psgp( dst + next_pos );
             // someone is in the way so try again
             if( g->critter_at( psgp ) ) {
                 complete = false;
@@ -1334,7 +1334,7 @@ bool map::displace_vehicle( vehicle &veh, const tripoint &dp )
     //global positions of vehicle loot zones have changed.
     veh.zones_dirty = true;
 
-    for( int vsmz : smzs ) {
+    for( int const vsmz : smzs ) {
         on_vehicle_moved( dst.z + vsmz );
     }
     return true;
@@ -1360,7 +1360,7 @@ bool map::displace_water( const tripoint &p )
                     || has_flag( TFLAG_DEEP_WATER, temp ) ) {
                     continue;
                 }
-                ter_id ter0 = ter( temp );
+                ter_id const ter0 = ter( temp );
                 if( ter0 == t_water_sh ||
                     ter0 == t_water_dp || ter0 == t_water_moving_sh || ter0 == t_water_moving_dp ) {
                     continue;
@@ -1484,7 +1484,7 @@ void map::furn_set( const tripoint &p, const furn_id &new_furniture,
 
     // Make sure the furniture falls if it needs to
     support_dirty( p );
-    tripoint above( p.xy(), p.z + 1 );
+    tripoint const above( p.xy(), p.z + 1 );
     // Make sure that if we supported something and no longer do so, it falls down
     support_dirty( above );
 
@@ -1512,7 +1512,7 @@ bool map::can_move_furniture( const tripoint &pos, player *p )
         return false;
     }
     const furn_t &furniture_type = furn( pos ).obj();
-    int required_str = furniture_type.move_str_req;
+    int const required_str = furniture_type.move_str_req;
 
     // Object can not be moved (or nothing there)
     if( required_str < 0 ) {
@@ -1598,7 +1598,7 @@ uint8_t map::get_known_connections( const tripoint &p, int connect_group,
 
     // populate connection information
     for( int i = 0; i < 4; ++i ) {
-        tripoint neighbour = p + offsets[i];
+        tripoint const neighbour = p + offsets[i];
         if( !inbounds( neighbour ) ) {
             continue;
         }
@@ -1763,7 +1763,7 @@ bool map::ter_set( const tripoint &p, const ter_id &new_terrain )
     // TODO: Limit to changes that affect move cost, traps and stairs
     set_pathfinding_cache_dirty( p.z );
 
-    tripoint above( p.xy(), p.z + 1 );
+    tripoint const above( p.xy(), p.z + 1 );
     // Make sure that if we supported something and no longer do so, it falls down
     support_dirty( above );
 
@@ -1908,7 +1908,7 @@ int map::combined_movecost( const tripoint &from, const tripoint &to,
     const int cost2 = move_cost( to, ignored_vehicle );
     // Multiply cost depending on the number of differing axes
     // 0 if all axes are equal, 100% if only 1 differs, 141% for 2, 200% for 3
-    size_t match = trigdist ? ( from.x != to.x ) + ( from.y != to.y ) + ( from.z != to.z ) : 1;
+    size_t const match = trigdist ? ( from.x != to.x ) + ( from.y != to.y ) + ( from.z != to.z ) : 1;
     if( flying || from.z == to.z ) {
         return ( cost1 + cost2 + modifier ) * mults[match] / 2;
     }
@@ -1978,7 +1978,7 @@ bool map::valid_move( const tripoint &from, const tripoint &to,
         // Can't move from up to down
         if( std::abs( from.x - to.x ) == 1 || std::abs( from.y - to.y ) == 1 ) {
             // Break the move into two - vertical then horizontal
-            tripoint midpoint( down_p.xy(), up_p.z );
+            tripoint const midpoint( down_p.xy(), up_p.z );
             return valid_move( down_p, midpoint, bash, flying, via_ramp ) &&
                    valid_move( midpoint, up_p, bash, flying, via_ramp );
         }
@@ -2083,7 +2083,7 @@ bool map::has_floor( const tripoint &p ) const
 
 bool map::floor_between( const tripoint &first, const tripoint &second ) const
 {
-    int diff = std::abs( first.z - second.z );
+    int const diff = std::abs( first.z - second.z );
     if( diff == 0 ) { //There's never a floor between two tiles on the same level
         return false;
     }
@@ -2091,7 +2091,7 @@ bool map::floor_between( const tripoint &first, const tripoint &second ) const
         debugmsg( "map::floor_between should only be called on tiles that are exactly 1 z level apart" );
         return true;
     }
-    int upper = std::max( first.z, second.z );
+    int const upper = std::max( first.z, second.z );
     if( first.xy() == second.xy() ) {
         return has_floor( tripoint( first.xy(), upper ) );
     }
@@ -2164,7 +2164,7 @@ void map::drop_furniture( const tripoint &p )
             return SS_FLOOR;
         }
 
-        tripoint below_dest( pt.xy(), pt.z - 1 );
+        tripoint const below_dest( pt.xy(), pt.z - 1 );
         if( supports_above( below_dest ) ) {
             return SS_GOOD_SUPPORT;
         }
@@ -2231,7 +2231,7 @@ void map::drop_furniture( const tripoint &p )
     }
 
     // TODO: Balance this.
-    int dmg = weight * ( p.z - current.z );
+    int const dmg = weight * ( p.z - current.z );
 
     if( last_state == SS_FLOOR ) {
         // Bash the same tile twice - once for furniture, once for the floor
@@ -2239,12 +2239,12 @@ void map::drop_furniture( const tripoint &p )
         bash( current, dmg, false, false, true );
     } else if( last_state == SS_BAD_SUPPORT || last_state == SS_GOOD_SUPPORT ) {
         bash( current, dmg, false, false, false );
-        tripoint below( current.xy(), current.z - 1 );
+        tripoint const below( current.xy(), current.z - 1 );
         bash( below, dmg, false, false, false );
     } else if( last_state == SS_CREATURE ) {
         const std::string &furn_name = frn_obj.name();
         bash( current, dmg, false, false, false );
-        tripoint below( current.xy(), current.z - 1 );
+        tripoint const below( current.xy(), current.z - 1 );
         Creature *critter = g->critter_at( below );
         if( critter == nullptr ) {
             debugmsg( "drop_furniture couldn't find creature at %d,%d,%d",
@@ -2363,7 +2363,7 @@ void map::process_falling()
         add_msg( m_debug, "Checking %d tiles for falling objects",
                  support_cache_dirty.size() );
         // We want the cache to stay constant, but falling can change it
-        std::set<tripoint> last_cache = std::move( support_cache_dirty );
+        std::set<tripoint> const last_cache = std::move( support_cache_dirty );
         support_cache_dirty.clear();
         for( const tripoint &p : last_cache ) {
             drop_everything( p );
@@ -2496,7 +2496,7 @@ int map::bash_rating_internal( const int str, const furn_t &furniture,
         return 10;
     }
 
-    int ret = ( 10 * ( str - bash_min ) ) / ( bash_max - bash_min );
+    int const ret = ( 10 * ( str - bash_min ) ) / ( bash_max - bash_min );
     // Round up to 1, so that desperate NPCs can try to bash down walls
     return std::max( ret, 1 );
 }
@@ -2882,13 +2882,13 @@ bool map::mop_spills( const tripoint &p )
         fd_slime,
         fd_sludge
     };
-    for( field_type_id fid : to_check ) {
+    for( field_type_id const fid : to_check ) {
         retval |= fld.remove_field( fid );
     }
 
     if( const optional_vpart_position vp = veh_at( p ) ) {
         vehicle *const veh = &vp->vehicle();
-        std::vector<int> parts_here = veh->parts_at_relative( vp->mount(), true );
+        std::vector<int> const parts_here = veh->parts_at_relative( vp->mount(), true );
         for( auto &elem : parts_here ) {
             if( veh->part( elem ).blood > 0 ) {
                 veh->part( elem ).blood = 0;
@@ -3113,7 +3113,7 @@ void map::smash_items( const tripoint &p, const int power, const std::string &ca
         }
 
         // Active explosives arbitrarily get double the destroy threshold
-        bool is_active_explosive = it->active && it->type->get_use( "explosion" ) != nullptr;
+        bool const is_active_explosive = it->active && it->type->get_use( "explosion" ) != nullptr;
         if( is_active_explosive && it->charges == 0 ) {
             it++;
             continue;
@@ -3144,7 +3144,7 @@ void map::smash_items( const tripoint &p, const int power, const std::string &ca
             }
         } else {
             const field_type_id type_blood = it->is_corpse() ? it->get_mtype()->bloodType() : fd_null;
-            float roll = rng_float( 0.0, destroy_chance );
+            float const roll = rng_float( 0.0, destroy_chance );
             if( roll >= destroy_threshold ) {
                 item_was_destroyed = true;
             } else if( roll >= pulp_threshold ) {
@@ -3260,8 +3260,8 @@ static bool furn_is_supported( const map &m, const tripoint &p )
 
 static int get_sound_volume( const map_bash_info &bash )
 {
-    int smin = bash.str_min;
-    int smax = bash.str_max;
+    int const smin = bash.str_min;
+    int const smax = bash.str_max;
     // TODO: Consider setting this in finalize instead of calculating here
     return bash.sound_vol.value_or( std::min( static_cast<int>( smin * 1.5 ), smax ) );
 }
@@ -3295,7 +3295,7 @@ bash_results map::bash_ter_success( const tripoint &p, const bash_params &params
         ter_set( p, t_open_air );
         propagate_suspension_check( p );
     } else {
-        tripoint below( p.xy(), p.z - 1 );
+        tripoint const below( p.xy(), p.z - 1 );
         const ter_t &ter_below = ter( below ).obj();
         // Only setting the flag here because we want drops and sounds in correct order
         follow_below |= zlevels && bash.bash_below && ter_below.roof;
@@ -3307,7 +3307,7 @@ bash_results map::bash_ter_success( const tripoint &p, const bash_params &params
 
     if( !bash.sound.empty() && !params.silent ) {
         static const std::string soundfxid = "smash_success";
-        int sound_volume = get_sound_volume( bash );
+        int const sound_volume = get_sound_volume( bash );
         sounds::sound( p, sound_volume, sounds::sound_t::combat, bash.sound, false,
                        soundfxid, soundfxvariant );
     }
@@ -3365,7 +3365,7 @@ bash_results map::bash_ter_success( const tripoint &p, const bash_params &params
                     params_copy.do_recurse = false;
                     // TODO: Unwrap the calls, don't recurse
                     // TODO: Don't bash furn
-                    bash_results results_sub = bash_ter_furn( p, params_copy );
+                    bash_results const results_sub = bash_ter_furn( p, params_copy );
                     result |= results_sub;
                     if( !results_sub.success ) {
                         // Blocked, as in "the roof was too strong to bash"
@@ -3483,7 +3483,7 @@ bash_results map::bash_furn_success( const tripoint &p, const bash_params &param
 
     if( !bash.sound.empty() && !params.silent ) {
         static const std::string soundfxid = "smash_success";
-        int sound_volume = get_sound_volume( bash );
+        int const sound_volume = get_sound_volume( bash );
         sounds::sound( p, sound_volume, sounds::sound_t::combat, bash.sound, false,
                        soundfxid, soundfxvariant );
     }
@@ -3524,7 +3524,7 @@ bash_results map::bash_ter_furn( const tripoint &p, const bash_params &params )
         } else if( !bash->ter_set && zlevels ) {
             // HACK: A hack for destroy && !bash_floor
             // We have to check what would we create and cancel if it is what we have now
-            tripoint below( p.xy(), p.z - 1 );
+            tripoint const below( p.xy(), p.z - 1 );
             const auto roof = get_roof( below, false );
             if( roof == ter( p ) ) {
                 smash_ter = false;
@@ -3584,7 +3584,7 @@ bash_results map::bash_ter_furn( const tripoint &p, const bash_params &params )
         }
 
         if( bash->str_min_supported != -1 || bash->str_max_supported != -1 ) {
-            tripoint below( p.xy(), p.z - 1 );
+            tripoint const below( p.xy(), p.z - 1 );
             if( !zlevels || has_flag( TFLAG_SUPPORTS_ROOF, below ) ) {
                 if( bash->str_min_supported != -1 ) {
                     smin = bash->str_min_supported;
@@ -3602,7 +3602,7 @@ bash_results map::bash_ter_furn( const tripoint &p, const bash_params &params )
     }
 
     if( !result.success ) {
-        int sound_volume = bash->sound_fail_vol.value_or( 12 );
+        int const sound_volume = bash->sound_fail_vol.value_or( 12 );
 
         result.did_bash = true;
         if( !params.silent ) {
@@ -3624,7 +3624,7 @@ bash_results map::bash( const tripoint &p, const int str,
                         bool silent, bool destroy, bool bash_floor,
                         const vehicle *bashing_vehicle )
 {
-    bash_params bsh{
+    bash_params const bsh{
         str, silent, destroy, bash_floor, static_cast<float>( rng_float( 0, 1.0f ) ), false, true
     };
     bash_results result;
@@ -3738,7 +3738,7 @@ void map::destroy( const tripoint &p, const bool silent )
 
     // If we were destroying a floor, allow destroying floors
     // If we were destroying something unpassable, destroy only that
-    bool was_impassable = impassable( p );
+    bool const was_impassable = impassable( p );
     int count = 0;
     while( count <= 25
            && bash( p, 999, silent, true ).success
@@ -3844,7 +3844,7 @@ void map::shoot( const tripoint &p, projectile &proj, const bool hit_items )
         dam = vp->vehicle().damage( vp->part_index(), dam, inc ? DT_HEAT : DT_STAB, hit_items );
     }
 
-    ter_id terrain = ter( p );
+    ter_id const terrain = ter( p );
     ter_t ter = terrain.obj();
 
     if( ter.bash.ranged ) {
@@ -3856,7 +3856,7 @@ void map::shoot( const tripoint &p, projectile &proj, const bool hit_items )
         } else {
             dam -= rng( ri.reduction.min, ri.reduction.max );
             if( dam > ri.destroy_threshold ) {
-                bash_params params{0, false, true, hit_items, 1.0, false};
+                bash_params const params{0, false, true, hit_items, 1.0, false};
                 bash_ter_success( p, params );
             }
             if( dam <= 0 && is_transparent( p ) && get_avatar().sees( p ) ) {
@@ -3998,7 +3998,7 @@ bool map::open_door( const tripoint &p, const bool inside, const bool check_only
 
             if( ( you.has_trait( trait_id( "SCHIZOPHRENIC" ) ) || you.has_artifact_with( AEP_SCHIZO ) )
                 && one_in( 50 ) && !ter.has_flag( "TRANSPARENT" ) ) {
-                tripoint mp = p + -2 * you.pos().xy() + tripoint( 2 * p.x, 2 * p.y, p.z );
+                tripoint const mp = p + -2 * you.pos().xy() + tripoint( 2 * p.x, 2 * p.y, p.z );
                 g->spawn_hallucination( mp );
             }
         }
@@ -4024,7 +4024,7 @@ bool map::open_door( const tripoint &p, const bool inside, const bool check_only
 
         return true;
     } else if( const optional_vpart_position vp = veh_at( p ) ) {
-        int openable = vp->vehicle().next_part_to_open( vp->part_index(), true );
+        int const openable = vp->vehicle().next_part_to_open( vp->part_index(), true );
         if( openable >= 0 ) {
             if( you.is_mounted() ) {
                 auto mon = you.mounted_creature.get();
@@ -4183,7 +4183,7 @@ void map::adjust_radiation( const tripoint &p, const int delta )
     point l;
     submap *const current_submap = get_submap_at( p, l );
 
-    int current_radiation = current_submap->get_radiation( l );
+    int const current_radiation = current_submap->get_radiation( l );
     current_submap->set_radiation( l, current_radiation + delta );
 }
 
@@ -4238,7 +4238,7 @@ map_stack::iterator map::i_rem( const tripoint &p, map_stack::const_iterator it 
 void map::i_rem( const tripoint &p, item *it )
 {
     map_stack map_items = i_at( p );
-    map_stack::const_iterator iter = map_items.get_iterator_from_pointer( it );
+    map_stack::const_iterator const iter = map_items.get_iterator_from_pointer( it );
     if( iter != map_items.end() ) {
         i_rem( p, iter );
     }
@@ -4249,7 +4249,7 @@ void map::i_clear( const tripoint &p )
     point l;
     submap *const current_submap = get_submap_at( p, l );
 
-    for( item &it : current_submap->get_items( l ) ) {
+    for( item  const&it : current_submap->get_items( l ) ) {
         // remove from the active items cache (if it isn't there does nothing)
         current_submap->active_items.remove( &it );
     }
@@ -4553,8 +4553,8 @@ void map::make_active( item_location &loc )
     }
     point l;
     submap *const current_submap = get_submap_at( loc.position(), l );
-    cata::colony<item> &item_stack = current_submap->get_items( l );
-    cata::colony<item>::iterator iter = item_stack.get_iterator_from_pointer( target );
+    cata::colony<item>  const&item_stack = current_submap->get_items( l );
+    cata::colony<item>::iterator const iter = item_stack.get_iterator_from_pointer( target );
 
     if( current_submap->active_items.empty() ) {
         submaps_with_active_items.insert( tripoint( abs_sub.x + loc.position().x / SEEX,
@@ -4676,10 +4676,10 @@ std::vector<tripoint> map::check_submap_active_item_consistency()
     for( int z = -OVERMAP_DEPTH; z < OVERMAP_HEIGHT; ++z ) {
         for( int x = 0; x < MAPSIZE; ++x ) {
             for( int y = 0; y < MAPSIZE; ++y ) {
-                tripoint p( x, y, z );
+                tripoint const p( x, y, z );
                 submap *s = get_submap_at_grid( p );
-                bool has_active_items = !s->active_items.get().empty();
-                bool map_has_active_items = submaps_with_active_items.count( p + abs_sub.xy() );
+                bool const has_active_items = !s->active_items.get().empty();
+                bool const map_has_active_items = submaps_with_active_items.count( p + abs_sub.xy() );
                 if( has_active_items != map_has_active_items ) {
                     result.push_back( p + abs_sub.xy() );
                 }
@@ -4687,8 +4687,8 @@ std::vector<tripoint> map::check_submap_active_item_consistency()
         }
     }
     for( const tripoint &p : submaps_with_active_items ) {
-        tripoint rel = p - abs_sub.xy();
-        half_open_rectangle<point> map( point_zero, point( MAPSIZE, MAPSIZE ) );
+        tripoint const rel = p - abs_sub.xy();
+        half_open_rectangle<point> const map( point_zero, point( MAPSIZE, MAPSIZE ) );
         if( !map.contains( rel.xy() ) ) {
             result.push_back( p );
         }
@@ -4701,10 +4701,10 @@ void map::process_items()
     const int minz = zlevels ? -OVERMAP_DEPTH : abs_sub.z;
     const int maxz = zlevels ? OVERMAP_HEIGHT : abs_sub.z;
     for( int gz = minz; gz <= maxz; ++gz ) {
-        level_cache &cache = access_cache( gz );
+        level_cache  const&cache = access_cache( gz );
         std::set<tripoint> submaps_with_vehicles;
         for( vehicle *this_vehicle : cache.vehicle_list ) {
-            tripoint pos = this_vehicle->global_pos3();
+            tripoint const pos = this_vehicle->global_pos3();
             submaps_with_vehicles.emplace( pos.x / SEEX, pos.y / SEEY, pos.z );
         }
         for( const tripoint &pos : submaps_with_vehicles ) {
@@ -4753,7 +4753,7 @@ void map::process_items_in_submap( submap &current_submap, const tripoint &gridp
         }
 
         const tripoint map_location = tripoint( grid_offset + active_item_ref.location, gridp.z );
-        temperature_flag flag = temperature_flag_at_point( *this, map_location );
+        temperature_flag const flag = temperature_flag_at_point( *this, map_location );
         map_stack items = i_at( map_location );
         process_map_items( items, active_item_ref.item_ref, map_location, flag );
     }
@@ -4919,7 +4919,7 @@ std::list<item> map::use_amount_square( const tripoint &p, const itype_id &type,
 {
     std::list<item> ret;
     // Handle infinite map sources.
-    item water = water_from( p );
+    item const water = water_from( p );
     if( water.typeId() == type ) {
         ret.push_back( water );
         quantity = 0;
@@ -5002,7 +5002,7 @@ static void use_charges_from_furn( const furn_t &f, const itype_id &type, int &q
             const tripoint_abs_ms abspos( m->getabs( p ) );
             auto &grid = get_distribution_grid_tracker().grid_at( abspos );
             item furn_item( itt.get_id(), calendar::start_of_cataclysm, grid.get_resource() );
-            int initial_quantity = quantity;
+            int const initial_quantity = quantity;
             if( filter( furn_item ) ) {
                 furn_item.use_charges( type, quantity, ret, p );
                 // That quantity math thing is atrocious. Punishment for the int& "argument".
@@ -5399,7 +5399,7 @@ void map::remove_trap( const tripoint &p )
     point l;
     submap *const current_submap = get_submap_at( p, l );
 
-    trap_id tid = current_submap->get_trap( l );
+    trap_id const tid = current_submap->get_trap( l );
     if( tid != tr_null ) {
         if( g != nullptr && this == &get_map() ) {
             g->u.add_known_trap( p, tr_null.obj() );
@@ -5475,7 +5475,7 @@ int map::set_field_intensity( const tripoint &p, const field_type_id &type,
 {
     field_entry *field_ptr = get_field( p, type );
     if( field_ptr != nullptr ) {
-        int adj = ( isoffset ? field_ptr->get_field_intensity() : 0 ) + new_intensity;
+        int const adj = ( isoffset ? field_ptr->get_field_intensity() : 0 ) + new_intensity;
         if( adj > 0 ) {
             field_ptr->set_field_intensity( adj );
             return adj;
@@ -5717,7 +5717,7 @@ basecamp map::hoist_submap_camp( const tripoint &p )
 
 void map::add_camp( const tripoint_abs_omt &omt_pos, const std::string &name )
 {
-    basecamp temp_camp = basecamp( name, omt_pos );
+    basecamp const temp_camp = basecamp( name, omt_pos );
     overmap_buffer.add_camp( temp_camp );
     g->u.camps.insert( omt_pos );
     g->validate_camps();
@@ -5746,8 +5746,8 @@ void map::update_visibility_cache( const int zlev )
     int sm_squares_seen[MAPSIZE][MAPSIZE];
     std::memset( sm_squares_seen, 0, sizeof( sm_squares_seen ) );
 
-    int min_z = fov_3d ? -OVERMAP_DEPTH : zlev;
-    int max_z = fov_3d ? OVERMAP_HEIGHT : zlev;
+    int const min_z = fov_3d ? -OVERMAP_DEPTH : zlev;
+    int const max_z = fov_3d ? OVERMAP_HEIGHT : zlev;
 
     for( int z = min_z; z <= max_z; z++ ) {
 
@@ -5759,7 +5759,7 @@ void map::update_visibility_cache( const int zlev )
         int &y = p.y;
         for( x = 0; x < MAPSIZE_X; x++ ) {
             for( y = 0; y < MAPSIZE_Y; y++ ) {
-                lit_level ll = apparent_light_at( p, visibility_variables_cache );
+                lit_level const ll = apparent_light_at( p, visibility_variables_cache );
                 visibility_cache[x][y] = ll;
                 if( z == zlev ) {
                     sm_squares_seen[ x / SEEX ][ y / SEEY ] += ( ll == lit_level::BRIGHT || ll == lit_level::LIT );
@@ -5822,7 +5822,7 @@ visibility_type map::get_visibility( const lit_level ll,
 static bool has_memory_at( const tripoint &p )
 {
     if( g->u.should_show_map_memory() ) {
-        int t = g->u.get_memorized_symbol( g->m.getabs( p ) );
+        int const t = g->u.get_memorized_symbol( g->m.getabs( p ) );
         return t != 0;
     }
     return false;
@@ -5850,8 +5850,8 @@ void map::draw( const catacurses::window &w, const tripoint &center )
 
     const auto &visibility_cache = get_cache_ref( center.z ).visibility_cache;
 
-    int wnd_h = getmaxy( w );
-    int wnd_w = getmaxx( w );
+    int const wnd_h = getmaxy( w );
+    int const wnd_w = getmaxx( w );
     const tripoint offs = center - tripoint( wnd_w / 2, wnd_h / 2, 0 );
 
     // Map memory should be at least the size of the view range
@@ -5881,7 +5881,7 @@ void map::draw( const catacurses::window &w, const tripoint &center )
     };
 
     const auto draw_vision_effect = [&]( const visibility_type vis ) -> bool {
-        int sym = '#';
+        int const sym = '#';
         nc_color col;
         switch( vis )
         {
@@ -5937,7 +5937,7 @@ void map::draw( const catacurses::window &w, const tripoint &center )
     }
 
     // Memorize off-screen tiles
-    half_open_rectangle<point> display( offs.xy(), offs.xy() + point( wnd_w, wnd_h ) );
+    half_open_rectangle<point> const display( offs.xy(), offs.xy() + point( wnd_w, wnd_h ) );
     drawsq_params mm_params = drawsq_params().memorize( true ).output( false );
     for( int y = 0; y < MAPSIZE_Y; y++ ) {
         for( int x = 0; x < MAPSIZE_X; x++ ) {
@@ -5989,7 +5989,7 @@ void map::drawsq( const catacurses::window &w, const tripoint &p,
         return;
     }
 
-    tripoint below( p.xy(), p.z - 1 );
+    tripoint const below( p.xy(), p.z - 1 );
     const maptile tile_below = maptile_at( below );
     draw_from_above( w, below, tile_below, params );
 }
@@ -6291,7 +6291,7 @@ bool map::sees( const tripoint &F, const tripoint &T, const int range,
         min.x << 16 | min.y << 8 | ( min.z + OVERMAP_DEPTH ),
         max.x << 16 | max.y << 8 | ( max.z + OVERMAP_DEPTH )
     );
-    char cached = skew_vision_cache.get( key, -1 );
+    char const cached = skew_vision_cache.get( key, -1 );
     if( cached >= 0 ) {
         return cached > 0;
     }
@@ -6360,7 +6360,7 @@ int map::obstacle_coverage( const tripoint &loc1, const tripoint &loc2 ) const
         return 0;
     }
     const point a( std::abs( loc1.x - loc2.x ) * 2, std::abs( loc1.y - loc2.y ) * 2 );
-    int offset = std::min( a.x, a.y ) - ( std::max( a.x, a.y ) / 2 );
+    int const offset = std::min( a.x, a.y ) - ( std::max( a.x, a.y ) / 2 );
     tripoint obstaclepos;
     bresenham( loc2, loc1, offset, 0, [&obstaclepos]( const tripoint & new_point ) {
         // Only adjacent tile between you and enemy is checked for cover.
@@ -6453,37 +6453,37 @@ void map::reachable_flood_steps( std::vector<tripoint> &reachable_pts, const tri
         // set initial cost for grid point
         tripoint origin_relative = tp - f;
         origin_relative += origin_offset;
-        int ndx = origin_relative.x + origin_relative.y * grid_dim;
+        int const ndx = origin_relative.x + origin_relative.y * grid_dim;
         t_grid[ ndx ] = initial_visit_distance;
     }
 
     auto gen_neighbors = []( const pq_item & elem, int grid_dim, pq_item * neighbors ) {
         // Up to 8 neighbors
-        int new_cost = elem.dist + 1;
+        int const new_cost = elem.dist + 1;
         // *INDENT-OFF*
-        int ox[8] = {
+        int const ox[8] = {
             -1, 0, 1,
             -1,    1,
             -1, 0, 1
         };
-        int oy[8] = {
+        int const oy[8] = {
             -1, -1, -1,
             0,      0,
             1,  1,  1
         };
         // *INDENT-ON*
 
-        point e( elem.ndx % grid_dim, elem.ndx / grid_dim );
+        point const e( elem.ndx % grid_dim, elem.ndx / grid_dim );
         for( int i = 0; i < 8; ++i ) {
-            point n( e + point( ox[i], oy[i] ) );
+            point const n( e + point( ox[i], oy[i] ) );
 
-            int ndx = n.x + n.y * grid_dim;
+            int const ndx = n.x + n.y * grid_dim;
             neighbors[i] = { new_cost, ndx };
         }
     };
 
     PQ_type pq( pq_item_comp{} );
-    pq_item first_item{ 0, range + range * grid_dim };
+    pq_item const first_item{ 0, range + range * grid_dim };
     pq.push( first_item );
     pq_item neighbor_elems[8];
 
@@ -6495,7 +6495,7 @@ void map::reachable_flood_steps( std::vector<tripoint> &reachable_pts, const tri
             t_grid[ item.ndx ] = item.dist;
             if( item.dist + 1 < range ) {
                 gen_neighbors( item, grid_dim, neighbor_elems );
-                for( pq_item neighbor_elem : neighbor_elems ) {
+                for( pq_item const neighbor_elem : neighbor_elems ) {
                     pq.push( neighbor_elem );
                 }
             }
@@ -6508,8 +6508,8 @@ void map::reachable_flood_steps( std::vector<tripoint> &reachable_pts, const tri
                 // set self and neighbors to 1
                 for( int dy = -1; dy <= 1; ++dy ) {
                     for( int dx = -1; dx <= 1; ++dx ) {
-                        int tx = dx + x;
-                        int ty = dy + y;
+                        int const tx = dx + x;
+                        int const ty = dy + y;
 
                         if( tx >= 0 && tx < grid_dim && ty >= 0 && ty < grid_dim ) {
                             o_grid[ tx + ty * grid_dim ] = 1;
@@ -6524,7 +6524,7 @@ void map::reachable_flood_steps( std::vector<tripoint> &reachable_pts, const tri
     for( int y = 0, ndx = 0; y < grid_dim; ++y ) {
         for( int x = 0; x < grid_dim; ++x, ++ndx ) {
             if( o_grid[ ndx ] ) {
-                tripoint t = f - origin_offset + tripoint{ x, y, 0 };
+                tripoint const t = f - origin_offset + tripoint{ x, y, 0 };
                 reachable_pts.push_back( t );
             }
         }
@@ -6627,13 +6627,13 @@ bool map::obstructed_by_vehicle_rotation( const tripoint &from, const tripoint &
 
     if( from.z != to.z ) {
         //Split it into two checks, one for each z level
-        tripoint flattened = {from.xy(), to.z};
+        tripoint const flattened = {from.xy(), to.z};
         if( obstructed_by_vehicle_rotation( flattened, to ) ) {
             return true;
         }
     }
 
-    point delta = to.xy() - from.xy();
+    point const delta = to.xy() - from.xy();
 
     auto cache = get_cache( from.z ).vehicle_obstructed_cache;
 
@@ -6664,13 +6664,13 @@ bool map::obscured_by_vehicle_rotation( const tripoint &from, const tripoint &to
 
     if( from.z != to.z ) {
         //Split it into two checks, one for each z level
-        tripoint flattened = {from.xy(), to.z};
+        tripoint const flattened = {from.xy(), to.z};
         if( obscured_by_vehicle_rotation( flattened, to ) ) {
             return true;
         }
     }
 
-    point delta = to.xy() - from.xy();
+    point const delta = to.xy() - from.xy();
 
     auto cache = get_cache( from.z ).vehicle_obscured_cache;
 
@@ -6804,7 +6804,7 @@ template<int SIZE, int MULTIPLIER>
 void shift_bitset_cache( std::bitset<SIZE *SIZE> &cache, point s )
 {
     // sx shifts by MULTIPLIER rows, sy shifts by MULTIPLIER columns.
-    int shift_amount = s.x * MULTIPLIER + s.y * SIZE * MULTIPLIER;
+    int const shift_amount = s.x * MULTIPLIER + s.y * SIZE * MULTIPLIER;
     if( shift_amount > 0 ) {
         cache >>= static_cast<size_t>( shift_amount );
     } else if( shift_amount < 0 ) {
@@ -6817,7 +6817,7 @@ void shift_bitset_cache( std::bitset<SIZE *SIZE> &cache, point s )
     }
     const size_t x_offset = s.x > 0 ? SIZE - MULTIPLIER : 0;
     for( size_t y = 0; y < SIZE; ++y ) {
-        size_t y_offset = y * SIZE;
+        size_t const y_offset = y * SIZE;
         for( size_t x = 0; x < MULTIPLIER; ++x ) {
             cache.reset( y_offset + x_offset + x );
         }
@@ -6833,10 +6833,10 @@ shift_bitset_cache<MAPSIZE, 1>( std::bitset<MAPSIZE *MAPSIZE> &cache, point s );
 static inline void shift_tripoint_set( std::set<tripoint> &set, point offset,
                                        const half_open_rectangle<point> &boundaries )
 {
-    std::set<tripoint> old_set = std::move( set );
+    std::set<tripoint> const old_set = std::move( set );
     set.clear();
     for( const tripoint &pt : old_set ) {
-        tripoint new_pt = pt + offset;
+        tripoint const new_pt = pt + offset;
         if( boundaries.contains( new_pt.xy() ) ) {
             set.insert( new_pt );
         }
@@ -6860,8 +6860,8 @@ static inline void shift_tripoint_map( std::map<tripoint, T> &map, point offset,
 void map::shift_vehicle_z( vehicle &veh, int z_shift )
 {
 
-    tripoint src = veh.global_pos3();
-    tripoint dst = src + tripoint_above * z_shift;
+    tripoint const src = veh.global_pos3();
+    tripoint const dst = src + tripoint_above * z_shift;
 
     submap *src_submap = get_submap_at( src );
     submap *dst_submap = get_submap_at( dst );
@@ -7059,7 +7059,7 @@ void map::vertical_shift( const int newz )
         return;
     }
 
-    tripoint trp = get_abs_sub();
+    tripoint const trp = get_abs_sub();
     set_abs_sub( tripoint( trp.xy(), newz ) );
 
     // TODO: Remove the function when it's safe
@@ -7246,14 +7246,14 @@ void map::rotten_item_spawn( const item &item, const tripoint &pnt )
         return;
     }
     const auto &comest = item.get_comestible();
-    mongroup_id mgroup = comest->rot_spawn;
+    mongroup_id const mgroup = comest->rot_spawn;
     if( !mgroup ) {
         return;
     }
     const int chance = static_cast<int>( comest->rot_spawn_chance *
                                          get_option<float>( "CARRION_SPAWNRATE" ) );
     if( rng( 0, 100 ) < chance ) {
-        MonsterGroupResult spawn_details = MonsterGroupManager::GetResultFromGroup( mgroup );
+        MonsterGroupResult const spawn_details = MonsterGroupManager::GetResultFromGroup( mgroup );
         add_spawn( spawn_details.name, 1, pnt, false );
         if( g->u.sees( pnt ) ) {
             if( item.is_seed() ) {
@@ -7296,7 +7296,7 @@ void map::grow_plant( const tripoint &p )
     }
     // Can't use item_stack::only_item() since there might be fertilizer
     map_stack items = i_at( p );
-    map_stack::iterator seed = std::find_if( items.begin(), items.end(), []( const item & it ) {
+    map_stack::iterator const seed = std::find_if( items.begin(), items.end(), []( const item & it ) {
         return it.is_seed();
     } );
 
@@ -7319,7 +7319,7 @@ void map::grow_plant( const tripoint &p )
             }
 
             // Remove fertilizer if any
-            map_stack::iterator fertilizer = std::find_if( items.begin(), items.end(), []( const item & it ) {
+            map_stack::iterator const fertilizer = std::find_if( items.begin(), items.end(), []( const item & it ) {
                 return it.has_flag( "FERTILIZER" );
             } );
             if( fertilizer != items.end() ) {
@@ -7334,7 +7334,7 @@ void map::grow_plant( const tripoint &p )
             }
 
             // Remove fertilizer if any
-            map_stack::iterator fertilizer = std::find_if( items.begin(), items.end(), []( const item & it ) {
+            map_stack::iterator const fertilizer = std::find_if( items.begin(), items.end(), []( const item & it ) {
                 return it.has_flag( "FERTILIZER" );
             } );
             if( fertilizer != items.end() ) {
@@ -7410,12 +7410,12 @@ void map::produce_sap( const tripoint &p, const time_duration &time_since_last_a
 
         const time_point last_actualize = calendar::turn - time_since_last_actualize;
         const time_duration last_actualize_tof = time_past_new_year( last_actualize );
-        bool last_producing = (
+        bool const last_producing = (
                                   last_actualize_tof >= late_winter_start ||
                                   last_actualize_tof < early_spring_end
                               );
         const time_duration current_tof = time_past_new_year( calendar::turn );
-        bool current_producing = (
+        bool const current_producing = (
                                      current_tof >= late_winter_start ||
                                      current_tof < early_spring_end
                                  );
@@ -7565,7 +7565,7 @@ void map::actualize( const tripoint &grid )
             }
             // plants contain a seed item which must not be removed under any circumstances
             if( !furn.has_flag( "DONT_REMOVE_ROTTEN" ) ) {
-                temperature_flag temperature = temperature_flag_at_point( *this, pnt );
+                temperature_flag const temperature = temperature_flag_at_point( *this, pnt );
                 remove_rotten_items( tmpsub->get_items( { x, y } ), pnt, temperature );
             }
 
@@ -7613,7 +7613,7 @@ void map::add_roofs( const tripoint &grid )
         return;
     }
 
-    bool check_roof = grid.z > -OVERMAP_DEPTH;
+    bool const check_roof = grid.z > -OVERMAP_DEPTH;
 
     submap *const sub_below = check_roof ? get_submap_at_grid( grid + tripoint_below ) : nullptr;
 
@@ -7700,9 +7700,9 @@ void map::spawn_monsters_submap_group( const tripoint &gp, mongroup &group, bool
 
     for( int x = 0; x < SEEX; ++x ) {
         for( int y = 0; y < SEEY; ++y ) {
-            int fx = x + SEEX * gp.x;
-            int fy = y + SEEY * gp.y;
-            tripoint fp{ fx, fy, gp.z };
+            int const fx = x + SEEX * gp.x;
+            int const fy = y + SEEY * gp.y;
+            tripoint const fp{ fx, fy, gp.z };
             if( g->critter_at( fp ) != nullptr ) {
                 continue; // there is already some creature
             }
@@ -7741,7 +7741,7 @@ void map::spawn_monsters_submap_group( const tripoint &gp, mongroup &group, bool
     if( pop ) {
         // Populate the group from its population variable.
         for( int m = 0; m < pop; m++ ) {
-            MonsterGroupResult spawn_details = MonsterGroupManager::GetResultFromGroup( group.type, &pop );
+            MonsterGroupResult const spawn_details = MonsterGroupManager::GetResultFromGroup( group.type, &pop );
             if( !spawn_details.name ) {
                 continue;
             }
@@ -7988,8 +7988,8 @@ bool map::has_graffiti_at( const tripoint &p ) const
 
 int map::determine_wall_corner( const tripoint &p ) const
 {
-    int test_connect_group = ter( p ).obj().connect_group;
-    uint8_t connections = get_known_connections( p, test_connect_group );
+    int const test_connect_group = ter( p ).obj().connect_group;
+    uint8_t const connections = get_known_connections( p, test_connect_group );
     // The bits in connections are SEWN, whereas the characters in LINE_
     // constants are NESW, so we want values in 8 | 2 | 1 | 4 order.
     switch( connections ) {
@@ -8066,7 +8066,7 @@ void map::build_outside_cache( const int zlev )
 
             for( int sx = 0; sx < SEEX; ++sx ) {
                 for( int sy = 0; sy < SEEY; ++sy ) {
-                    point sp( sx, sy );
+                    point const sp( sx, sy );
                     if( cur_submap->get_ter( sp ).obj().has_flag( TFLAG_INDOORS ) ||
                         cur_submap->get_furn( sp ).obj().has_flag( TFLAG_INDOORS ) ) {
                         const int x = sx + smx * SEEX;
@@ -8110,8 +8110,8 @@ void map::build_obstacle_cache( const tripoint &start, const tripoint &end,
             for( int sx = 0; sx < SEEX; ++sx ) {
                 for( int sy = 0; sy < SEEY; ++sy ) {
                     const point sp( sx, sy );
-                    int ter_move = cur_submap->get_ter( sp ).obj().movecost;
-                    int furn_move = cur_submap->get_furn( sp ).obj().movecost;
+                    int const ter_move = cur_submap->get_ter( sp ).obj().movecost;
+                    int const furn_move = cur_submap->get_furn( sp ).obj().movecost;
                     const int x = sx + smx * SEEX;
                     const int y = sy + smy * SEEY;
                     if( ter_move == 0 || furn_move < 0 || ter_move + furn_move == 0 ) {
@@ -8123,12 +8123,12 @@ void map::build_obstacle_cache( const tripoint &start, const tripoint &end,
             }
         }
     }
-    VehicleList vehs = get_vehicles( start, end );
+    VehicleList const vehs = get_vehicles( start, end );
     const inclusive_cuboid<tripoint> bounds( start, end );
     // Cache all the vehicle stuff in one loop
     for( auto &v : vehs ) {
         for( const vpart_reference &vp : v.v->get_all_parts() ) {
-            tripoint p = v.pos + vp.part().precalc[0];
+            tripoint const p = v.pos + vp.part().precalc[0];
             if( p.z != start.z ) {
                 break;
             }
@@ -8155,7 +8155,7 @@ bool map::build_floor_cache( const int zlev )
     std::uninitialized_fill_n(
         &floor_cache[0][0], ( MAPSIZE_X ) * ( MAPSIZE_Y ), true );
 
-    bool lowest_z_lev = zlev <= -OVERMAP_DEPTH;
+    bool const lowest_z_lev = zlev <= -OVERMAP_DEPTH;
     for( int smx = 0; smx < my_MAPSIZE; ++smx ) {
         for( int smy = 0; smy < my_MAPSIZE; ++smy ) {
             const submap *cur_submap = get_submap_at_grid( { smx, smy, zlev } );
@@ -8173,7 +8173,7 @@ bool map::build_floor_cache( const int zlev )
 
             for( int sx = 0; sx < SEEX; ++sx ) {
                 for( int sy = 0; sy < SEEY; ++sy ) {
-                    point sp( sx, sy );
+                    point const sp( sx, sy );
                     const ter_t &terrain = cur_submap->get_ter( sp ).obj();
                     if( terrain.has_flag( TFLAG_NO_FLOOR ) ) {
                         if( below_submap && ( below_submap->get_furn( sp ).obj().has_flag( TFLAG_SUN_ROOF_ABOVE ) ) ) {
@@ -8221,10 +8221,10 @@ void map::update_suspension_cache( const int &z )
 
                 for( int sx = 0; sx < SEEX; ++sx ) {
                     for( int sy = 0; sy < SEEY; ++sy ) {
-                        point sp( sx, sy );
+                        point const sp( sx, sy );
                         const ter_t &terrain = cur_submap->get_ter( sp ).obj();
                         if( terrain.has_flag( TFLAG_SUSPENDED ) ) {
-                            tripoint loc( coords::project_combine( point_om_sm( point( smx, smy ) ), point_sm_ms( sp ) ).raw(),
+                            tripoint const loc( coords::project_combine( point_om_sm( point( smx, smy ) ), point_sm_ms( sp ) ).raw(),
                                           z );
                             suspension_cache.emplace_back( getabs( loc ).xy() );
                         }
@@ -8279,7 +8279,7 @@ static void vehicle_caching_internal( level_cache &zch, const vpart_reference &v
     bool vehicle_is_opaque = vp.has_feature( VPFLAG_OPAQUE ) && !vp.part().is_broken();
 
     if( vehicle_is_opaque ) {
-        int dpart = v->part_with_feature( part, VPFLAG_OPENABLE, true );
+        int const dpart = v->part_with_feature( part, VPFLAG_OPENABLE, true );
         if( dpart < 0 || !v->part( dpart ).open ) {
             transparency_cache[part_pos.x][part_pos.y] = LIGHT_TRANSPARENCY_SOLID;
         } else {
@@ -8343,7 +8343,7 @@ static void vehicle_caching_internal_above( level_cache &zch_above, const vpart_
 
 void map::do_vehicle_caching( int z )
 {
-    level_cache &ch = get_cache( z );
+    level_cache  const&ch = get_cache( z );
     for( vehicle *v : ch.vehicle_list ) {
         for( const vpart_reference &vp : v->get_all_parts() ) {
             const tripoint &part_pos = v->global_part_pos3( vp.part() );
@@ -8371,7 +8371,7 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
         update_suspension_cache( z );
         seen_cache_dirty |= ( build_floor_cache( z ) && affects_seen_cache );
         seen_cache_dirty |= get_cache( z ).seen_cache_dirty && affects_seen_cache;
-        diagonal_blocks fill = {false, false};
+        diagonal_blocks const fill = {false, false};
         std::uninitialized_fill_n( &( get_cache( z ).vehicle_obscured_cache[0][0] ), MAPSIZE_X * MAPSIZE_Y,
                                    fill );
         std::uninitialized_fill_n( &( get_cache( z ).vehicle_obstructed_cache[0][0] ),
@@ -8726,7 +8726,7 @@ void map::scent_blockers( std::array<std::array<char, MAPSIZE_X>, MAPSIZE_Y> &sc
 
     auto vehs = get_vehicles();
     for( auto &wrapped_veh : vehs ) {
-        vehicle &veh = *( wrapped_veh.v );
+        vehicle  const&veh = *( wrapped_veh.v );
         for( const vpart_reference &vp : veh.get_any_parts( VPFLAG_OBSTACLE ) ) {
             const tripoint part_pos = vp.pos();
             if( local_bounds.contains( part_pos.xy() ) && scent_transfer[part_pos.x][part_pos.y] == 5 ) {
@@ -8812,7 +8812,7 @@ std::list<item_location> map::get_active_items_in_radius( const tripoint &center
         const point sm_offset( submap_loc.x * SEEX, submap_loc.y * SEEY );
 
         submap *sm = get_submap_at_grid( submap_loc );
-        std::vector<item_reference> items = type == special_item_type::none ? sm->active_items.get() :
+        std::vector<item_reference> const items = type == special_item_type::none ? sm->active_items.get() :
                                             sm->active_items.get_special( type );
         for( const auto &elem : items ) {
             const tripoint pos( sm_offset + elem.location, submap_loc.z );
@@ -8919,7 +8919,7 @@ level_cache::level_cache()
     std::fill_n( &outside_cache[0][0], map_dimensions, false );
     std::fill_n( &floor_cache[0][0], map_dimensions, false );
     std::fill_n( &transparency_cache[0][0], map_dimensions, 0.0f );
-    diagonal_blocks fill = {false, false};
+    diagonal_blocks const fill = {false, false};
     std::fill_n( &vehicle_obscured_cache[0][0], map_dimensions, fill );
     std::fill_n( &vehicle_obstructed_cache[0][0], map_dimensions, fill );
     std::fill_n( &seen_cache[0][0], map_dimensions, 0.0f );
@@ -9025,7 +9025,7 @@ void map::update_pathfinding_cache( int zlev ) const
 
                     pf_special cur_value = PF_NORMAL;
 
-                    maptile tile( cur_submap, point( sx, sy ) );
+                    maptile const tile( cur_submap, point( sx, sy ) );
 
                     const auto &terrain = tile.get_ter_t();
                     const auto &furniture = tile.get_furn_t();
@@ -9122,7 +9122,7 @@ bool map::is_cornerfloor( const tripoint &p ) const
     }
     if( !impassable_adjacent.empty() ) {
         //to check if a floor is a corner we first search if any of its diagonal adjacent points is impassable
-        std::set< tripoint> diagonals = { p + tripoint_north_east, p + tripoint_north_west, p + tripoint_south_east, p + tripoint_south_west };
+        std::set< tripoint> const diagonals = { p + tripoint_north_east, p + tripoint_north_west, p + tripoint_south_east, p + tripoint_south_west };
         for( const tripoint &impassable_diagonal : diagonals ) {
             if( impassable_adjacent.count( impassable_diagonal ) != 0 ) {
                 //for every impassable diagonal found, we check if that diagonal terrain has at least two impassable neighbors that also neighbor point p

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -477,7 +477,7 @@ void map::vehmove()
     int const minz = zlevels ? -OVERMAP_DEPTH : abs_sub.z;
     int const maxz = zlevels ? OVERMAP_HEIGHT : abs_sub.z;
     for( int zlev = minz; zlev <= maxz; ++zlev ) {
-        level_cache  const&cache = get_cache( zlev );
+        level_cache  const &cache = get_cache( zlev );
         for( vehicle *veh : cache.vehicle_list ) {
             veh->gain_moves();
             veh->slow_leak();
@@ -510,7 +510,7 @@ void map::vehmove()
     // The bool tracks whether the vehicles is on the map or not.
     std::map<vehicle *, bool> connected_vehicles;
     for( int zlev = minz; zlev <= maxz; ++zlev ) {
-        level_cache  const&cache = get_cache( zlev );
+        level_cache  const &cache = get_cache( zlev );
         vehicle::enumerate_vehicles( connected_vehicles, cache.vehicle_list );
     }
     for( std::pair<vehicle *const, bool> &veh_pair : connected_vehicles ) {
@@ -732,7 +732,7 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &fac
         }
     }
 
-    Character  const&player_character = get_player_character();
+    Character  const &player_character = get_player_character();
     const bool seen = sees_veh( player_character, veh, false );
 
     if( can_move || ( vertical && veh.is_falling ) ) {
@@ -852,15 +852,15 @@ float map::vehicle_vehicle_collision( vehicle &veh, vehicle &veh2,
         const float m2 = to_kilogram( veh2.total_mass() );
         //Energy of vehicle1 and vehicle2 before collision
         float const E = 0.5 * m1 * velo_veh1.magnitude() * velo_veh1.magnitude() +
-                  0.5 * m2 * velo_veh2.magnitude() * velo_veh2.magnitude();
+                        0.5 * m2 * velo_veh2.magnitude() * velo_veh2.magnitude();
 
         // Collision_axis
         point const cof1 = veh .rotated_center_of_mass();
         point const cof2 = veh2.rotated_center_of_mass();
-        int  const&x_cof1 = cof1.x;
-        int  const&y_cof1 = cof1.y;
-        int  const&x_cof2 = cof2.x;
-        int  const&y_cof2 = cof2.y;
+        int  const &x_cof1 = cof1.x;
+        int  const &y_cof1 = cof1.y;
+        int  const &x_cof2 = cof2.x;
+        int  const &y_cof2 = cof2.y;
         rl_vec2d collision_axis_y;
 
         collision_axis_y.x = ( veh.global_pos3().x + x_cof1 ) - ( veh2.global_pos3().x + x_cof2 );
@@ -919,7 +919,7 @@ float map::vehicle_vehicle_collision( vehicle &veh, vehicle &veh2,
 
         //Energy after collision
         float const E_a = 0.5 * m1 * final1.magnitude() * final1.magnitude() +
-                    0.5 * m2 * final2.magnitude() * final2.magnitude();
+                          0.5 * m2 * final2.magnitude() * final2.magnitude();
         float const d_E = E - E_a;  //Lost energy at collision -> deformation energy
         dmg = std::abs( d_E / 1000 / 2000 );  //adjust to balance damage
     } else {
@@ -4249,7 +4249,7 @@ void map::i_clear( const tripoint &p )
     point l;
     submap *const current_submap = get_submap_at( p, l );
 
-    for( item  const&it : current_submap->get_items( l ) ) {
+    for( item  const &it : current_submap->get_items( l ) ) {
         // remove from the active items cache (if it isn't there does nothing)
         current_submap->active_items.remove( &it );
     }
@@ -4553,7 +4553,7 @@ void map::make_active( item_location &loc )
     }
     point l;
     submap *const current_submap = get_submap_at( loc.position(), l );
-    cata::colony<item>  const&item_stack = current_submap->get_items( l );
+    cata::colony<item>  const &item_stack = current_submap->get_items( l );
     cata::colony<item>::iterator const iter = item_stack.get_iterator_from_pointer( target );
 
     if( current_submap->active_items.empty() ) {
@@ -4701,7 +4701,7 @@ void map::process_items()
     const int minz = zlevels ? -OVERMAP_DEPTH : abs_sub.z;
     const int maxz = zlevels ? OVERMAP_HEIGHT : abs_sub.z;
     for( int gz = minz; gz <= maxz; ++gz ) {
-        level_cache  const&cache = access_cache( gz );
+        level_cache  const &cache = access_cache( gz );
         std::set<tripoint> submaps_with_vehicles;
         for( vehicle *this_vehicle : cache.vehicle_list ) {
             tripoint const pos = this_vehicle->global_pos3();
@@ -7319,7 +7319,8 @@ void map::grow_plant( const tripoint &p )
             }
 
             // Remove fertilizer if any
-            map_stack::iterator const fertilizer = std::find_if( items.begin(), items.end(), []( const item & it ) {
+            map_stack::iterator const fertilizer = std::find_if( items.begin(),
+            items.end(), []( const item & it ) {
                 return it.has_flag( "FERTILIZER" );
             } );
             if( fertilizer != items.end() ) {
@@ -7334,7 +7335,8 @@ void map::grow_plant( const tripoint &p )
             }
 
             // Remove fertilizer if any
-            map_stack::iterator const fertilizer = std::find_if( items.begin(), items.end(), []( const item & it ) {
+            map_stack::iterator const fertilizer = std::find_if( items.begin(),
+            items.end(), []( const item & it ) {
                 return it.has_flag( "FERTILIZER" );
             } );
             if( fertilizer != items.end() ) {
@@ -7411,14 +7413,14 @@ void map::produce_sap( const tripoint &p, const time_duration &time_since_last_a
         const time_point last_actualize = calendar::turn - time_since_last_actualize;
         const time_duration last_actualize_tof = time_past_new_year( last_actualize );
         bool const last_producing = (
-                                  last_actualize_tof >= late_winter_start ||
-                                  last_actualize_tof < early_spring_end
-                              );
+                                        last_actualize_tof >= late_winter_start ||
+                                        last_actualize_tof < early_spring_end
+                                    );
         const time_duration current_tof = time_past_new_year( calendar::turn );
         bool const current_producing = (
-                                     current_tof >= late_winter_start ||
-                                     current_tof < early_spring_end
-                                 );
+                                           current_tof >= late_winter_start ||
+                                           current_tof < early_spring_end
+                                       );
 
         const time_duration non_producing_length = 3.25 * calendar::season_length();
 
@@ -7741,7 +7743,8 @@ void map::spawn_monsters_submap_group( const tripoint &gp, mongroup &group, bool
     if( pop ) {
         // Populate the group from its population variable.
         for( int m = 0; m < pop; m++ ) {
-            MonsterGroupResult const spawn_details = MonsterGroupManager::GetResultFromGroup( group.type, &pop );
+            MonsterGroupResult const spawn_details = MonsterGroupManager::GetResultFromGroup( group.type,
+                    &pop );
             if( !spawn_details.name ) {
                 continue;
             }
@@ -8224,8 +8227,9 @@ void map::update_suspension_cache( const int &z )
                         point const sp( sx, sy );
                         const ter_t &terrain = cur_submap->get_ter( sp ).obj();
                         if( terrain.has_flag( TFLAG_SUSPENDED ) ) {
-                            tripoint const loc( coords::project_combine( point_om_sm( point( smx, smy ) ), point_sm_ms( sp ) ).raw(),
-                                          z );
+                            tripoint const loc( coords::project_combine( point_om_sm( point( smx, smy ) ),
+                                                point_sm_ms( sp ) ).raw(),
+                                                z );
                             suspension_cache.emplace_back( getabs( loc ).xy() );
                         }
                     }
@@ -8343,7 +8347,7 @@ static void vehicle_caching_internal_above( level_cache &zch_above, const vpart_
 
 void map::do_vehicle_caching( int z )
 {
-    level_cache  const&ch = get_cache( z );
+    level_cache  const &ch = get_cache( z );
     for( vehicle *v : ch.vehicle_list ) {
         for( const vpart_reference &vp : v->get_all_parts() ) {
             const tripoint &part_pos = v->global_part_pos3( vp.part() );
@@ -8726,7 +8730,7 @@ void map::scent_blockers( std::array<std::array<char, MAPSIZE_X>, MAPSIZE_Y> &sc
 
     auto vehs = get_vehicles();
     for( auto &wrapped_veh : vehs ) {
-        vehicle  const&veh = *( wrapped_veh.v );
+        vehicle  const &veh = *( wrapped_veh.v );
         for( const vpart_reference &vp : veh.get_any_parts( VPFLAG_OBSTACLE ) ) {
             const tripoint part_pos = vp.pos();
             if( local_bounds.contains( part_pos.xy() ) && scent_transfer[part_pos.x][part_pos.y] == 5 ) {
@@ -8813,7 +8817,7 @@ std::list<item_location> map::get_active_items_in_radius( const tripoint &center
 
         submap *sm = get_submap_at_grid( submap_loc );
         std::vector<item_reference> const items = type == special_item_type::none ? sm->active_items.get() :
-                                            sm->active_items.get_special( type );
+                sm->active_items.get_special( type );
         for( const auto &elem : items ) {
             const tripoint pos( sm_offset + elem.location, submap_loc.z );
 

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -335,7 +335,7 @@ static bool mx_house_spider( map &m, const tripoint &loc )
 
 static bool mx_helicopter( map &m, const tripoint &abs_sub )
 {
-    point c{ rng( 6, SEEX * 2 - 7 ), rng( 6, SEEY * 2 - 7 ) };
+    point const c{ rng( 6, SEEX * 2 - 7 ), rng( 6, SEEY * 2 - 7 ) };
 
     for( int x = 0; x < SEEX * 2; x++ ) {
         for( int y = 0; y < SEEY * 2; y++ ) {
@@ -376,7 +376,7 @@ static bool mx_helicopter( map &m, const tripoint &abs_sub )
         }
     }
 
-    units::angle dir1 = random_direction();
+    units::angle const dir1 = random_direction();
 
     auto crashed_hull = vgroup_id( "crashed_helicopters" )->pick();
 
@@ -386,24 +386,24 @@ static bool mx_helicopter( map &m, const tripoint &abs_sub )
     veh->turn( dir1 );
 
     // Get the bounding box, centered on mount(0,0)
-    bounding_box bbox = veh->get_bounding_box();
+    bounding_box const bbox = veh->get_bounding_box();
     // Move the wreckage forward/backward half it's length so that it spawns more over the center of the debris area
-    int x_length = std::abs( bbox.p2.x - bbox.p1.x );
-    int y_length = std::abs( bbox.p2.y - bbox.p1.y );
+    int const x_length = std::abs( bbox.p2.x - bbox.p1.x );
+    int const y_length = std::abs( bbox.p2.y - bbox.p1.y );
 
     // cont.
-    int x_offset = veh->dir_vec().x * x_length / 2;
-    int y_offset = veh->dir_vec().y * y_length / 2;
+    int const x_offset = veh->dir_vec().x * x_length / 2;
+    int const y_offset = veh->dir_vec().y * y_length / 2;
 
-    int x_min = std::abs( bbox.p1.x ) + 0;
-    int y_min = std::abs( bbox.p1.y ) + 0;
+    int const x_min = std::abs( bbox.p1.x ) + 0;
+    int const y_min = std::abs( bbox.p1.y ) + 0;
 
-    int x_max = SEEX * 2 - bbox.p2.x - 1;
-    int y_max = SEEY * 2 - bbox.p2.y - 1;
+    int const x_max = SEEX * 2 - bbox.p2.x - 1;
+    int const y_max = SEEY * 2 - bbox.p2.y - 1;
 
     // Clamp x1 & y1 such that no parts of the vehicle extend over the border of the submap.
-    int x1 = clamp( c.x + x_offset, x_min, x_max );
-    int y1 = clamp( c.y + y_offset, y_min, y_max );
+    int const x1 = clamp( c.x + x_offset, x_min, x_max );
+    int const y1 = clamp( c.y + y_offset, y_min, y_max );
 
     vehicle *wreckage = m.add_vehicle(
                             crashed_hull, tripoint( x1, y1, abs_sub.z ), dir1, rng( 1, 33 ), 1 );
@@ -507,7 +507,7 @@ static bool mx_helicopter( map &m, const tripoint &abs_sub )
 
 static bool mx_military( map &m, const tripoint & )
 {
-    int num_bodies = dice( 2, 6 );
+    int const num_bodies = dice( 2, 6 );
     for( int i = 0; i < num_bodies; i++ ) {
         if( const auto p = random_point( m, [&m]( const tripoint & n ) {
         return m.passable( n );
@@ -527,9 +527,9 @@ static bool mx_military( map &m, const tripoint & )
         }
 
     }
-    int num_monsters = rng( 0, 3 );
+    int const num_monsters = rng( 0, 3 );
     for( int i = 0; i < num_monsters; i++ ) {
-        point m2{ rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ) };
+        point const m2{ rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ) };
         m.place_spawns( GROUP_NETHER_CAPTURED, 1, m2, m2, 1, true );
     }
     m.place_spawns( GROUP_MAYBE_MIL, 2, point_zero, point( SEEX * 2 - 1, SEEY * 2 - 1 ),
@@ -542,7 +542,7 @@ static bool mx_military( map &m, const tripoint & )
 
 static bool mx_science( map &m, const tripoint & )
 {
-    int num_bodies = dice( 2, 5 );
+    int const num_bodies = dice( 2, 5 );
     for( int i = 0; i < num_bodies; i++ ) {
         if( const auto p = random_point( m, [&m]( const tripoint & n ) {
         return m.passable( n );
@@ -555,9 +555,9 @@ static bool mx_science( map &m, const tripoint & )
             }
         }
     }
-    int num_monsters = rng( 0, 3 );
+    int const num_monsters = rng( 0, 3 );
     for( int i = 0; i < num_monsters; i++ ) {
-        point m2{ rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ) };
+        point const m2{ rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ) };
         m.place_spawns( GROUP_NETHER_CAPTURED, 1, m2, m2, 1, true );
     }
     m.place_items( item_group_id( "rare" ), 45, point_zero, point( SEEX * 2 - 1, SEEY * 2 - 1 ), true,
@@ -569,8 +569,8 @@ static bool mx_science( map &m, const tripoint & )
 static bool mx_collegekids( map &m, const tripoint & )
 {
     //college kids that got into trouble
-    int num_bodies = dice( 2, 6 );
-    int type = dice( 1, 10 );
+    int const num_bodies = dice( 2, 6 );
+    int const type = dice( 1, 10 );
 
     for( int i = 0; i < num_bodies; i++ ) {
         if( const auto p = random_point( m, [&m]( const tripoint & n ) {
@@ -592,9 +592,9 @@ static bool mx_collegekids( map &m, const tripoint & )
             }
         }
     }
-    int num_monsters = rng( 0, 3 );
+    int const num_monsters = rng( 0, 3 );
     for( int i = 0; i < num_monsters; i++ ) {
-        point m2{ rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ) };
+        point const m2{ rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ) };
         m.place_spawns( GROUP_NETHER_CAPTURED, 1, m2, m2, 1, true );
     }
 
@@ -701,7 +701,7 @@ static bool mx_roadblock( map &m, const tripoint &abs_sub )
         m.ter_set( point( 14, 8 ), t_plut_generator );
         line_furn( &m, f_sandbag_wall, point( 12, 9 ), point( 15, 9 ) );
 
-        int num_bodies = dice( 2, 5 );
+        int const num_bodies = dice( 2, 5 );
         for( int i = 0; i < num_bodies; i++ ) {
             if( const auto p = random_point( m, [&m]( const tripoint & n ) {
             return m.passable( n );
@@ -709,7 +709,7 @@ static bool mx_roadblock( map &m, const tripoint &abs_sub )
                 m.place_items( item_group_id( "map_extra_military" ), 100, *p, *p, true,
                                calendar::start_of_cataclysm );
 
-                int splatter_range = rng( 1, 3 );
+                int const splatter_range = rng( 1, 3 );
                 for( int j = 0; j <= splatter_range; j++ ) {
                     m.add_field( *p + point( -j * 1, j * 1 ), fd_blood, 1, 0_turns );
                 }
@@ -746,7 +746,7 @@ static bool mx_roadblock( map &m, const tripoint &abs_sub )
         m.ter_set( point( 8, 11 ), t_plut_generator );
         line_furn( &m, f_sandbag_wall, point( 6, 12 ), point( 9, 12 ) );
 
-        int num_bodies = dice( 1, 6 );
+        int const num_bodies = dice( 1, 6 );
         for( int i = 0; i < num_bodies; i++ ) {
             if( const auto p = random_point( m, [&m]( const tripoint & n ) {
             return m.passable( n );
@@ -754,7 +754,7 @@ static bool mx_roadblock( map &m, const tripoint &abs_sub )
                 m.place_items( item_group_id( "map_extra_police" ), 100, *p, *p, true,
                                calendar::start_of_cataclysm );
 
-                int splatter_range = rng( 1, 3 );
+                int const splatter_range = rng( 1, 3 );
                 for( int j = 0; j <= splatter_range; j++ ) {
                     m.add_field( *p + point( j * 1, -j * 1 ), fd_blood, 1, 0_turns );
                 }
@@ -871,10 +871,10 @@ static bool mx_drugdeal( map &m, const tripoint &abs_sub )
             drugtype = itype_heroin;
             break;
     }
-    int num_bodies_a = dice( 3, 3 );
-    int num_bodies_b = dice( 3, 3 );
-    bool north_south = one_in( 2 );
-    bool a_has_drugs = one_in( 2 );
+    int const num_bodies_a = dice( 3, 3 );
+    int const num_bodies_b = dice( 3, 3 );
+    bool const north_south = one_in( 2 );
+    bool const a_has_drugs = one_in( 2 );
 
     for( int i = 0; i < num_bodies_a; i++ ) {
         point p;
@@ -909,7 +909,7 @@ static bool mx_drugdeal( map &m, const tripoint &abs_sub )
             } else {
                 m.place_items( item_group_id( "map_extra_drugdeal" ), 100, p, p, true,
                                calendar::start_of_cataclysm );
-                int splatter_range = rng( 1, 3 );
+                int const splatter_range = rng( 1, 3 );
                 for( int j = 0; j <= splatter_range; j++ ) {
                     m.add_field( p + tripoint( j * offset.x, j * offset.y, abs_sub.z ), fd_blood, 1, 0_turns );
                 }
@@ -941,7 +941,7 @@ static bool mx_drugdeal( map &m, const tripoint &abs_sub )
             } else {
                 m.place_items( item_group_id( "map_extra_drugdeal" ), 100, p2, p2, true,
                                calendar::start_of_cataclysm );
-                int splatter_range = rng( 1, 3 );
+                int const splatter_range = rng( 1, 3 );
                 for( int j = 0; j <= splatter_range; j++ ) {
                     m.add_field( p2 + tripoint( j * offset2.x, j * offset2.y, abs_sub.z ), fd_blood, 1, 0_turns );
                 }
@@ -956,9 +956,9 @@ static bool mx_drugdeal( map &m, const tripoint &abs_sub )
             }
         }
     }
-    int num_monsters = rng( 0, 3 );
+    int const num_monsters = rng( 0, 3 );
     for( int i = 0; i < num_monsters; i++ ) {
-        point m2{ rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ) };
+        point const m2{ rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ) };
         m.place_spawns( GROUP_NETHER_CAPTURED, 1, m2, m2, 1, true );
     }
 
@@ -967,7 +967,7 @@ static bool mx_drugdeal( map &m, const tripoint &abs_sub )
 
 static bool mx_supplydrop( map &m, const tripoint &/*abs_sub*/ )
 {
-    int num_crates = rng( 1, 5 );
+    int const num_crates = rng( 1, 5 );
     for( int i = 0; i < num_crates; i++ ) {
         const auto p = random_point( m, [&m]( const tripoint & n ) {
             return m.passable( n );
@@ -1038,7 +1038,7 @@ static bool mx_portal( map &m, const tripoint &abs_sub )
     m.trap_set( *portal_pos, tr_portal );
 
     // We'll make between 0 and 4 attempts to spawn monsters here.
-    int num_monsters = rng( 0, 4 );
+    int const num_monsters = rng( 0, 4 );
     for( int i = 0; i < num_monsters; i++ ) {
         // Get a random location from our points that is not the portal location, does not have the
         // NO_FLOOR flag, and isn't currently occupied by a creature.
@@ -1145,13 +1145,13 @@ static bool mx_minefield( map &m_orig, const tripoint &abs_sub )
         //50% chance to spawn a dead soldier with a trail of blood
         if( one_in( 2 ) ) {
             m.add_splatter_trail( fd_blood, { 17, 6, abs_sub.z }, { 19, 3, abs_sub.z } );
-            item body = item::make_corpse();
+            item const body = item::make_corpse();
             m.put_items_from_loc( item_group_id( "mon_zombie_soldier_death_drops" ), { 17, 5, abs_sub.z } );
             m.add_item_or_charges( { 17, 5, abs_sub.z }, body );
         }
 
         //33% chance to spawn empty magazines used by soldiers
-        std::vector<point> empty_magazines_locations = line_to( point( 15, 5 ), point( 20, 5 ) );
+        std::vector<point> const empty_magazines_locations = line_to( point( 15, 5 ), point( 20, 5 ) );
         for( auto &i : empty_magazines_locations ) {
             if( one_in( 3 ) ) {
                 m.spawn_item( { i, abs_sub.z }, itype_stanag30 );
@@ -1161,7 +1161,7 @@ static bool mx_minefield( map &m_orig, const tripoint &abs_sub )
         //Horizontal line of barbed wire fence
         line( &m, t_fence_barbed, point( 3, 9 ), point( SEEX * 2 - 4, 9 ) );
 
-        std::vector<point> barbed_wire = line_to( point( 3, 9 ), point( SEEX * 2 - 4, 9 ) );
+        std::vector<point> const barbed_wire = line_to( point( 3, 9 ), point( SEEX * 2 - 4, 9 ) );
         for( auto &i : barbed_wire ) {
             //10% chance to spawn corpses of bloody people/zombies on every tile of barbed wire fence
             if( one_in( 10 ) ) {
@@ -1221,7 +1221,7 @@ static bool mx_minefield( map &m_orig, const tripoint &abs_sub )
         //Section of barbed wire fence
         line( &m, t_fence_barbed, point( 3, 13 ), point( SEEX * 2 - 4, 13 ) );
 
-        std::vector<point> barbed_wire = line_to( point( 3, 13 ), point( SEEX * 2 - 4, 13 ) );
+        std::vector<point> const barbed_wire = line_to( point( 3, 13 ), point( SEEX * 2 - 4, 13 ) );
         for( auto &i : barbed_wire ) {
             //10% chance to spawn corpses of bloody people/zombies on every tile of barbed wire fence
             if( one_in( 10 ) ) {
@@ -1241,7 +1241,7 @@ static bool mx_minefield( map &m_orig, const tripoint &abs_sub )
                     m.add_field( { loc.xy(), abs_sub.z }, fd_gibs_flesh, rng( 1, 3 ) );
                 }
             }
-            item body = item::make_corpse();
+            item const body = item::make_corpse();
             m.put_items_from_loc( item_group_id( "mon_zombie_soldier_death_drops" ), { 11, 21, abs_sub.z } );
             m.add_item_or_charges( { 11, 21, abs_sub.z }, body );
         }
@@ -1261,7 +1261,7 @@ static bool mx_minefield( map &m_orig, const tripoint &abs_sub )
         }
 
         //33% chance to spawn empty magazines used by soldiers
-        std::vector<point> empty_magazines_locations = line_to( point( 5, 16 ), point( 18, 16 ) );
+        std::vector<point> const empty_magazines_locations = line_to( point( 5, 16 ), point( 18, 16 ) );
         for( auto &i : empty_magazines_locations ) {
             if( one_in( 3 ) ) {
                 m.spawn_item( { i, abs_sub.z }, itype_stanag30 );
@@ -1341,7 +1341,7 @@ static bool mx_minefield( map &m_orig, const tripoint &abs_sub )
         //33% chance for a crazy maniac ramming the tent with some unfortunate inside
         if( one_in( 3 ) ) {
             //Blood and gore
-            std::vector<point> blood_track = line_to( point( 1, 6 ), point( 8, 6 ) );
+            std::vector<point> const blood_track = line_to( point( 1, 6 ), point( 8, 6 ) );
             for( auto &i : blood_track ) {
                 m.add_field( { i, abs_sub.z }, fd_blood, 1 );
             }
@@ -1358,7 +1358,7 @@ static bool mx_minefield( map &m_orig, const tripoint &abs_sub )
             line_furn( &m, f_null, point( 10, 7 ), point( 10, 8 ) );
 
             //Spill sand from damaged sandbags
-            std::vector<point> sandbag_positions = squares_in_direction( point( 10, 7 ), point( 11, 8 ) );
+            std::vector<point> const sandbag_positions = squares_in_direction( point( 10, 7 ), point( 11, 8 ) );
             for( auto &i : sandbag_positions ) {
                 m.spawn_item( { i, abs_sub.z }, itype_bag_canvas, rng( 5, 13 ) );
                 m.spawn_item( { i, abs_sub.z }, itype_material_sand, rng( 3, 8 ) );
@@ -1375,7 +1375,7 @@ static bool mx_minefield( map &m_orig, const tripoint &abs_sub )
             }
 
             //33% chance to spawn empty magazines used by soldiers
-            std::vector<point> empty_magazines_locations = line_to( point( 9, 3 ), point( 9, 13 ) );
+            std::vector<point> const empty_magazines_locations = line_to( point( 9, 3 ), point( 9, 13 ) );
             for( auto &i : empty_magazines_locations ) {
                 if( one_in( 3 ) ) {
                     m.spawn_item( { i, abs_sub.z }, itype_stanag30 );
@@ -1407,14 +1407,14 @@ static bool mx_minefield( map &m_orig, const tripoint &abs_sub )
         }
 
         //33% chance to spawn empty magazines used by soldiers
-        std::vector<point> empty_magazines_locations = line_to( point( 9, 16 ), point( 9, 20 ) );
+        std::vector<point> const empty_magazines_locations = line_to( point( 9, 16 ), point( 9, 20 ) );
         for( auto &i : empty_magazines_locations ) {
             if( one_in( 3 ) ) {
                 m.spawn_item( { i, abs_sub.z }, itype_stanag30 );
             }
         }
 
-        std::vector<point> barbed_wire = line_to( point( 12, 3 ), point( 12, 20 ) );
+        std::vector<point> const barbed_wire = line_to( point( 12, 3 ), point( 12, 20 ) );
         for( auto &i : barbed_wire ) {
             //10% chance to spawn corpses of bloody people/zombies on every tile of barbed wire fence
             if( one_in( 10 ) ) {
@@ -1477,7 +1477,7 @@ static bool mx_minefield( map &m_orig, const tripoint &abs_sub )
         //50% chance to spawn a soldier killed by gunfire, and a trail of blood
         if( one_in( 2 ) ) {
             m.add_splatter_trail( fd_blood, { 14, 5, abs_sub.z }, { 17, 5, abs_sub.z } );
-            item body = item::make_corpse();
+            item const body = item::make_corpse();
             m.put_items_from_loc( item_group_id( "mon_zombie_soldier_death_drops" ), { 15, 5, abs_sub.z } );
             m.add_item_or_charges( { 15, 5, abs_sub.z }, body );
         }
@@ -1490,7 +1490,7 @@ static bool mx_minefield( map &m_orig, const tripoint &abs_sub )
         }
 
         //33% chance to spawn empty magazines used by soldiers
-        std::vector<point> empty_magazines_locations = line_to( point( 15, 2 ), point( 15, 8 ) );
+        std::vector<point> const empty_magazines_locations = line_to( point( 15, 2 ), point( 15, 8 ) );
         for( auto &i : empty_magazines_locations ) {
             if( one_in( 3 ) ) {
                 m.spawn_item( { i, abs_sub.z }, itype_stanag30 );
@@ -1521,7 +1521,7 @@ static bool mx_minefield( map &m_orig, const tripoint &abs_sub )
             m.spawn_item( { 23, 11, abs_sub.z }, itype_hatchet );
 
             //Spawn chopped soldier corpse
-            item body = item::make_corpse();
+            item const body = item::make_corpse();
             m.put_items_from_loc( item_group_id( "mon_zombie_soldier_death_drops" ), { 23, 12, abs_sub.z } );
             m.add_item_or_charges( { 23, 12, abs_sub.z }, body );
             m.add_field( { 23, 12, abs_sub.z }, fd_gibs_flesh, rng( 1, 3 ) );
@@ -1607,9 +1607,9 @@ static bool mx_minefield( map &m_orig, const tripoint &abs_sub )
 
 static bool mx_crater( map &m, const tripoint &abs_sub )
 {
-    int size = rng( 2, 6 );
-    int size_squared = size * size;
-    point p{ rng( size, SEEX * 2 - 1 - size ), rng( size, SEEY * 2 - 1 - size ) };
+    int const size = rng( 2, 6 );
+    int const size_squared = size * size;
+    point const p{ rng( size, SEEX * 2 - 1 - size ), rng( size, SEEY * 2 - 1 - size ) };
     for( int i = p.x - size; i <= p.x + size; i++ ) {
         for( int j = p.y - size; j <= p.y + size; j++ ) {
             //If we're using circular distances, make circular craters
@@ -1633,7 +1633,7 @@ static void place_fumarole( map &m, point p1, point p2, std::set<point> &ignited
     // Tracks points nearby for ignition after the lava is placed
     //std::set<point> ignited;
 
-    std::vector<point> fumarole = line_to( p1, p2, 0 );
+    std::vector<point> const fumarole = line_to( p1, p2, 0 );
     for( auto &i : fumarole ) {
         m.ter_set( i, t_lava );
 
@@ -1687,8 +1687,8 @@ static bool mx_portal_in( map &m, const tripoint &abs_sub )
         case 3: {
             m.add_field( portal_location, fd_fatigue, 3 );
             for( int i = 0; i < rng( 1, 10 ); i++ ) {
-                tripoint end_location = { rng( 0, SEEX * 2 - 1 ), rng( 0, SEEY * 2 - 1 ), abs_sub.z };
-                std::vector<tripoint> failure = line_to( portal_location, end_location );
+                tripoint const end_location = { rng( 0, SEEX * 2 - 1 ), rng( 0, SEEY * 2 - 1 ), abs_sub.z };
+                std::vector<tripoint> const failure = line_to( portal_location, end_location );
                 for( auto &i : failure ) {
                     m.ter_set( { i.xy(), abs_sub.z }, t_pit );
                 }
@@ -1713,8 +1713,8 @@ static bool mx_portal_in( map &m, const tripoint &abs_sub )
         //Lava seams originating from the portal
         case 5: {
             if( abs_sub.z <= 0 ) {
-                point p1{ rng( 0, SEEX - 3 ), rng( 0, SEEY - 3 ) };
-                point p2{ rng( SEEX, SEEX * 2 - 3 ), rng( SEEY, SEEY * 2 - 3 ) };
+                point const p1{ rng( 0, SEEX - 3 ), rng( 0, SEEY - 3 ) };
+                point const p2{ rng( SEEX, SEEX * 2 - 3 ), rng( SEEY, SEEY * 2 - 3 ) };
                 // Pick a random cardinal direction to also spawn lava in
                 // This will make the lava a single connected line, not just on diagonals
                 static const std::array<direction, 4> possibilities = { { direction::EAST, direction::WEST, direction::NORTH, direction::SOUTH } };
@@ -1771,7 +1771,7 @@ static bool mx_portal_in( map &m, const tripoint &abs_sub )
         //Anomaly caused by the portal and spawned an artifact
         case 7: {
             m.add_field( portal_location, fd_fatigue, 3 );
-            artifact_natural_property prop =
+            artifact_natural_property const prop =
                 static_cast<artifact_natural_property>( rng( ARTPROP_NULL + 1, ARTPROP_MAX - 1 ) );
             m.create_anomaly( portal_location, prop );
             m.spawn_natural_artifact( p + tripoint{ rng( -1, 1 ), rng( -1, 1 ), abs_sub.z }, prop );
@@ -1805,9 +1805,9 @@ static bool mx_spider( map &m, const tripoint &abs_sub )
         for( int j = 0; j < SEEY * 2; j++ ) {
             const tripoint location( i, j, abs_sub.z );
 
-            bool should_web_flat = m.has_flag_ter( flag_FLAT, location ) && !one_in( 3 );
-            bool should_web_shrub = m.has_flag_ter( flag_SHRUB, location ) && !one_in( 4 );
-            bool should_web_tree = m.has_flag_ter( flag_TREE, location ) && !one_in( 4 );
+            bool const should_web_flat = m.has_flag_ter( flag_FLAT, location ) && !one_in( 3 );
+            bool const should_web_shrub = m.has_flag_ter( flag_SHRUB, location ) && !one_in( 4 );
+            bool const should_web_tree = m.has_flag_ter( flag_TREE, location ) && !one_in( 4 );
 
             if( should_web_flat || should_web_shrub || should_web_tree ) {
                 m.add_field( location, fd_web, rng( 1, 3 ), 0_turns );
@@ -1908,7 +1908,7 @@ static bool mx_clearcut( map &m, const tripoint &abs_sub )
 
     // This map extra converts all trees and young trees in the area to stumps.
 
-    ter_id stump( "t_stump" );
+    ter_id const stump( "t_stump" );
 
     bool did_something = false;
 
@@ -2068,12 +2068,12 @@ static void burned_ground_parser( map &m, const tripoint &loc )
     const ter_id tid = m.ter( loc );
     const ter_t &tr = tid.obj();
 
-    VehicleList vehs = m.get_vehicles();
+    VehicleList const vehs = m.get_vehicles();
     std::vector<vehicle *> vehicles;
     std::vector<tripoint> points;
     for( wrapped_vehicle vehicle : vehs ) {
         vehicles.push_back( vehicle.v );
-        std::set<tripoint> occupied = vehicle.v->get_points();
+        std::set<tripoint> const occupied = vehicle.v->get_points();
         for( const tripoint &t : occupied ) {
             points.push_back( t );
         }
@@ -2199,12 +2199,12 @@ static bool mx_burned_ground( map &m, const tripoint &abs_sub )
             burned_ground_parser( m, loc );
         }
     }
-    VehicleList vehs = m.get_vehicles();
+    VehicleList const vehs = m.get_vehicles();
     std::vector<vehicle *> vehicles;
     std::vector<tripoint> points;
     for( wrapped_vehicle vehicle : vehs ) {
         vehicles.push_back( vehicle.v );
-        std::set<tripoint> occupied = vehicle.v->get_points();
+        std::set<tripoint> const occupied = vehicle.v->get_points();
         for( const tripoint &t : occupied ) {
             points.push_back( t );
         }
@@ -2587,7 +2587,7 @@ static bool mx_mayhem( map &m, const tripoint &abs_sub )
                 }
 
                 const int max_wolves = rng( 1, 3 );
-                item body = item::make_corpse( mon_wolf );
+                item const body = item::make_corpse( mon_wolf );
                 if( one_in( 2 ) ) { //...from the north
                     for( int i = 0; i < max_wolves; i++ ) {
                         const auto &loc = m.points_in_radius( { 12, 12, abs_sub.z }, 3 );
@@ -2679,7 +2679,7 @@ static bool mx_casings( map &m, const tripoint &abs_sub )
             //Spawn casings and blood trail along the direction of movement
             const tripoint from = { rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ), abs_sub.z };
             const tripoint to = { rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ), abs_sub.z };
-            std::vector<tripoint> casings = line_to( from, to );
+            std::vector<tripoint> const casings = line_to( from, to );
             for( auto &i : casings ) {
                 if( one_in( 2 ) ) {
                     m.spawn_items( { i.xy(), abs_sub.z }, items );
@@ -2836,7 +2836,7 @@ static bool mx_grave( map &m, const tripoint &abs_sub )
             //Pets' corpses
             const std::vector<mtype_id> pets = MonsterGroupManager::GetMonstersFromGroup( GROUP_PETS );
             const mtype_id &pet = random_entry_ref( pets );
-            item body = item::make_corpse( pet, calendar::start_of_cataclysm );
+            item const body = item::make_corpse( pet, calendar::start_of_cataclysm );
             m.add_item_or_charges( corpse_location, body );
         }
         //5% chance to spawn easter egg grave(s)
@@ -3068,7 +3068,7 @@ void debug_spawn_test()
 {
     uilist mx_menu;
     std::vector<std::string> mx_names;
-    for( std::pair<const std::string, map_extras> &region_extra :
+    for( std::pair<const std::string, map_extras>  const&region_extra :
          region_settings_map["default"].region_extras ) {
         mx_menu.addentry( -1, true, -1, region_extra.first );
         mx_names.push_back( region_extra.first );
@@ -3098,12 +3098,12 @@ void debug_spawn_test()
         }
 
         std::multimap<int, std::string> sorted_results;
-        for( std::pair<const std::string, int> &e : results ) {
+        for( std::pair<const std::string, int>  const&e : results ) {
             sorted_results.insert( std::pair<int, std::string>( e.second, e.first ) );
         }
         uilist results_menu;
         results_menu.text = _( "Result of 32400 selections:" );
-        for( std::pair<const int, std::string> &r : sorted_results ) {
+        for( std::pair<const int, std::string>  const&r : sorted_results ) {
             results_menu.entries.emplace_back( static_cast<int>( results_menu.entries.size() ), true, -2,
                                                string_format( "%d x %s", r.first, r.second ) );
         }
@@ -3118,7 +3118,7 @@ void map_extra::load( const JsonObject &jo, const std::string & )
     mandatory( jo, was_loaded, "name", _name );
     mandatory( jo, was_loaded, "description", _description );
     if( jo.has_object( "generator" ) ) {
-        JsonObject jg = jo.get_object( "generator" );
+        JsonObject const jg = jo.get_object( "generator" );
         generator_method = jg.get_enum_value<map_extra_method>( "generator_method",
                            map_extra_method::null );
         mandatory( jg, was_loaded, "generator_id", generator_id );

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -3068,7 +3068,7 @@ void debug_spawn_test()
 {
     uilist mx_menu;
     std::vector<std::string> mx_names;
-    for( std::pair<const std::string, map_extras>  const&region_extra :
+    for( std::pair<const std::string, map_extras>  const &region_extra :
          region_settings_map["default"].region_extras ) {
         mx_menu.addentry( -1, true, -1, region_extra.first );
         mx_names.push_back( region_extra.first );
@@ -3098,12 +3098,12 @@ void debug_spawn_test()
         }
 
         std::multimap<int, std::string> sorted_results;
-        for( std::pair<const std::string, int>  const&e : results ) {
+        for( std::pair<const std::string, int>  const &e : results ) {
             sorted_results.insert( std::pair<int, std::string>( e.second, e.first ) );
         }
         uilist results_menu;
         results_menu.text = _( "Result of 32400 selections:" );
-        for( std::pair<const int, std::string>  const&r : sorted_results ) {
+        for( std::pair<const int, std::string>  const &r : sorted_results ) {
             results_menu.entries.emplace_back( static_cast<int>( results_menu.entries.size() ), true, -2,
                                                string_format( "%d x %s", r.first, r.second ) );
         }

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -95,15 +95,15 @@ static const trait_id trait_WEB_WALKER( "WEB_WALKER" );
 
 void map::create_burnproducts( const tripoint &p, const item &fuel, const units::mass &burned_mass )
 {
-    std::vector<material_id> all_mats = fuel.made_of();
+    std::vector<material_id> const all_mats = fuel.made_of();
     if( all_mats.empty() ) {
         return;
     }
     // Items that are multiple materials are assumed to be equal parts each.
     const units::mass by_weight = burned_mass / all_mats.size();
-    for( material_id &mat : all_mats ) {
+    for( material_id  const&mat : all_mats ) {
         for( auto &bp : mat->burn_products() ) {
-            itype_id id = bp.first;
+            itype_id const id = bp.first;
             // Spawning the same item as the one that was just burned is pointless
             // and leads to infinite recursion.
             if( fuel.typeId() == id ) {
@@ -210,7 +210,7 @@ std::array<std::pair<tripoint, maptile>, 8> map::get_neighbors( const tripoint &
 
 bool map::gas_can_spread_to( field_entry &cur, const tripoint &src, const tripoint &dst )
 {
-    maptile dst_tile = maptile_at( dst );
+    maptile const dst_tile = maptile_at( dst );
     const field_entry *tmpfld = dst_tile.get_field().find_field( cur.get_field_type() );
     // Candidates are existing weaker fields or navigable/flagged tiles with no field.
     if( tmpfld == nullptr || tmpfld->get_field_intensity() < cur.get_field_intensity() ) {
@@ -251,7 +251,7 @@ void map::gas_spread_to( field_entry &cur, maptile &dst, const tripoint &p )
 void map::spread_gas( field_entry &cur, const tripoint &p, int percent_spread,
                       const time_duration &outdoor_age_speedup, scent_block &sblk )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     // TODO: fix point types
     const oter_id &cur_om_ter =
         overmap_buffer.ter( tripoint_abs_omt( ms_to_omt_copy( here.getabs( p ) ) ) );
@@ -382,7 +382,7 @@ void map::create_hot_air( const tripoint &p, int intensity )
     }
 
     for( int counter = 0; counter < 5; counter++ ) {
-        tripoint dst( p + point( rng( -1, 1 ), rng( -1, 1 ) ) );
+        tripoint const dst( p + point( rng( -1, 1 ), rng( -1, 1 ) ) );
         add_field( dst, hot_air, 1 );
     }
 }
@@ -486,7 +486,7 @@ void map::process_fields_in_submap( submap *const current_submap,
                 if( cur_fd_type_id == fd_acid ) {
                     // Try to fall by a z-level
                     if( zlevels && p.z > -OVERMAP_DEPTH ) {
-                        tripoint dst{ p.xy(), p.z - 1 };
+                        tripoint const dst{ p.xy(), p.z - 1 };
                         if( valid_move( p, dst, true, true ) ) {
                             field_entry *acid_there = field_at( dst ).find_field( fd_acid );
                             if( acid_there == nullptr ) {
@@ -554,14 +554,14 @@ void map::process_fields_in_submap( submap *const current_submap,
 
                         fire_data frd( cur.get_field_intensity(), !can_spread );
                         // The highest # of items this fire can remove in one turn
-                        int max_consume = cur.get_field_intensity() * 2;
+                        int const max_consume = cur.get_field_intensity() * 2;
 
                         for( auto fuel = items_here.begin(); fuel != items_here.end() && consumed < max_consume; ) {
                             // `item::burn` modifies the charges in order to simulate some of them getting
                             // destroyed by the fire, this changes the item weight, but may not actually
                             // destroy it. We need to spawn products anyway.
                             const units::mass old_weight = fuel->weight( false );
-                            bool destroyed = fuel->burn( frd );
+                            bool const destroyed = fuel->burn( frd );
                             // If the item is considered destroyed, it may have negative charge count,
                             // see `item::burn?. This in turn means `item::weight` returns a negative value,
                             // which we can not use, so only call `weight` when it's still an existing item.
@@ -646,7 +646,7 @@ void map::process_fields_in_submap( submap *const current_submap,
 
                     if( ter.has_flag( TFLAG_NO_FLOOR ) && zlevels && p.z > -OVERMAP_DEPTH ) {
                         // We're hanging in the air - let's fall down
-                        tripoint dst{ p.xy(), p.z - 1 };
+                        tripoint const dst{ p.xy(), p.z - 1 };
                         if( valid_move( p, dst, true, true ) ) {
                             maptile dst_tile = maptile_at_internal( dst );
                             field_entry *fire_there = dst_tile.find_field( fd_fire );
@@ -721,7 +721,7 @@ void map::process_fields_in_submap( submap *const current_submap,
                             // if there is more fire there, make it bigger and give it some fuel.
                             // This is how big fires spend their excess age:
                             // making other fires bigger. Flashpoint.
-                            size_t end_it = static_cast<size_t>( rng( 0, neighs.size() - 1 ) );
+                            size_t const end_it = static_cast<size_t>( rng( 0, neighs.size() - 1 ) );
                             for( size_t i = ( end_it + 1 ) % neighs.size(), count = 0;
                                  count != neighs.size() && cur.get_field_age() < 0_turns;
                                  i = ( i + 1 ) % neighs.size(), count++ ) {
@@ -792,7 +792,7 @@ void map::process_fields_in_submap( submap *const current_submap,
                                 continue;
                             }
 
-                            tripoint &dst_p = neighs[i].first;
+                            tripoint  const&dst_p = neighs[i].first;
                             maptile &dst = neighs[i].second;
                             // No bounds checking here: we'll treat the invalid neighbors as valid.
                             // We're using the map tile wrapper, so we can treat invalid tiles as sentinels.
@@ -874,7 +874,7 @@ void map::process_fields_in_submap( submap *const current_submap,
 
                 // Apply radiation
                 if( cur.extra_radiation_max() > 0 ) {
-                    int extra_radiation = rng( cur.extra_radiation_min(), cur.extra_radiation_max() );
+                    int const extra_radiation = rng( cur.extra_radiation_min(), cur.extra_radiation_max() );
                     adjust_radiation( p, extra_radiation );
                 }
 
@@ -944,9 +944,9 @@ void map::process_fields_in_submap( submap *const current_submap,
                             }
                             // Spread to adjacent space, then
                             if( valid.empty() ) {
-                                tripoint dst( p + point( rng( -1, 1 ), rng( -1, 1 ) ) );
+                                tripoint const dst( p + point( rng( -1, 1 ), rng( -1, 1 ) ) );
                                 field_entry *elec = get_field( dst ).find_field( fd_electricity );
-                                bool pass = passable( dst ) && !obstructed_by_vehicle_rotation( p, dst );
+                                bool const pass = passable( dst ) && !obstructed_by_vehicle_rotation( p, dst );
                                 if( pass && elec != nullptr &&
                                     elec->get_field_intensity() < 3 ) {
                                     elec->set_field_intensity( elec->get_field_intensity() + 1 );
@@ -965,11 +965,11 @@ void map::process_fields_in_submap( submap *const current_submap,
                     }
                 }
 
-                int monster_spawn_chance = cur.monster_spawn_chance();
+                int const monster_spawn_chance = cur.monster_spawn_chance();
                 int monster_spawn_count = cur.monster_spawn_count();
                 if( monster_spawn_count > 0 && monster_spawn_chance > 0 && one_in( monster_spawn_chance ) ) {
                     for( ; monster_spawn_count > 0; monster_spawn_count-- ) {
-                        MonsterGroupResult spawn_details = MonsterGroupManager::GetResultFromGroup(
+                        MonsterGroupResult const spawn_details = MonsterGroupManager::GetResultFromGroup(
                                                                cur.monster_spawn_group(), &monster_spawn_count );
                         if( !spawn_details.name ) {
                             continue;
@@ -1001,7 +1001,7 @@ void map::process_fields_in_submap( submap *const current_submap,
                                 }
                             }
                             if( !valid.empty() ) {
-                                tripoint newp = random_entry( valid );
+                                tripoint const newp = random_entry( valid );
                                 add_item_or_charges( newp, tmp );
                                 if( g->u.pos() == newp ) {
                                     add_msg( m_bad, _( "A %s hits you!" ), tmp.tname() );
@@ -1037,7 +1037,7 @@ void map::process_fields_in_submap( submap *const current_submap,
                         }
                     } else {
                         cur.set_field_intensity( 3 );
-                        int num_bolts = rng( 3, 6 );
+                        int const num_bolts = rng( 3, 6 );
                         for( int i = 0; i < num_bolts; i++ ) {
                             int xdir = 0;
                             int ydir = 0;
@@ -1045,7 +1045,7 @@ void map::process_fields_in_submap( submap *const current_submap,
                                 xdir = rng( -1, 1 );
                                 ydir = rng( -1, 1 );
                             }
-                            int dist = rng( 4, 12 );
+                            int const dist = rng( 4, 12 );
                             int boltx = p.x;
                             int bolty = p.y;
                             for( int n = 0; n < dist; n++ ) {
@@ -1125,9 +1125,9 @@ void map::process_fields_in_submap( submap *const current_submap,
                             rl_dist( p, g->u.pos() ) < 10 &&
                             clear_path( p, g->u.pos(), 10, 1, 100 ) ) {
 
-                            std::vector<point> candidate_positions =
+                            std::vector<point> const candidate_positions =
                                 squares_in_direction( p.xy(), point( g->u.posx(), g->u.posy() ) );
-                            for( point candidate_position : candidate_positions ) {
+                            for( point const candidate_position : candidate_positions ) {
                                 field &target_field = get_field( tripoint( candidate_position, p.z ) );
                                 // Only shift if there are no bees already there.
                                 // TODO: Figure out a way to merge bee fields without allowing
@@ -1147,7 +1147,7 @@ void map::process_fields_in_submap( submap *const current_submap,
                 }
                 if( cur_fd_type_id == fd_incendiary ) {
                     // Needed for variable scope
-                    tripoint dst( p + point( rng( -1, 1 ), rng( -1, 1 ) ) );
+                    tripoint const dst( p + point( rng( -1, 1 ), rng( -1, 1 ) ) );
                     if( has_flag( TFLAG_FLAMMABLE, dst ) ||
                         has_flag( TFLAG_FLAMMABLE_ASH, dst ) ||
                         has_flag( TFLAG_FLAMMABLE_HARD, dst ) ) {
@@ -1501,7 +1501,7 @@ void map::player_in_field( player &u )
                 const int intensity = cur.get_field_intensity();
                 // Bees will try to sting you in random body parts, up to 8 times.
                 for( int i = 0; i < rng( 1, 7 ); i++ ) {
-                    bodypart_id bp = u.get_random_body_part();
+                    bodypart_id const bp = u.get_random_body_part();
                     int sum_cover = 0;
                     for( const item &i : u.worn ) {
                         if( i.covers( bp->token ) ) {
@@ -1966,10 +1966,10 @@ void map::propagate_field( const tripoint &center, const field_type_id &type, in
             open.pop();
         }
 
-        int increment = std::max<int>( 1, amount / gas_front.size() );
+        int const increment = std::max<int>( 1, amount / gas_front.size() );
 
         while( !gas_front.empty() ) {
-            gas_blast gp = random_entry_removed( gas_front );
+            gas_blast const gp = random_entry_removed( gas_front );
             closed.insert( gp.second );
             const int cur_intensity = get_field_intensity( gp.second, type );
             if( cur_intensity < max_intensity ) {
@@ -1987,7 +1987,7 @@ void map::propagate_field( const tripoint &center, const field_type_id &type, in
             static const std::array<int, 8> x_offset = {{ -1, 1,  0, 0,  1, -1, -1, 1  }};
             static const std::array<int, 8> y_offset = {{  0, 0, -1, 1, -1,  1, -1, 1  }};
             for( size_t i = 0; i < 8; i++ ) {
-                tripoint pt = gp.second + point( x_offset[ i ], y_offset[ i ] );
+                tripoint const pt = gp.second + point( x_offset[ i ], y_offset[ i ] );
                 if( closed.count( pt ) > 0 ) {
                     continue;
                 }

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -101,7 +101,7 @@ void map::create_burnproducts( const tripoint &p, const item &fuel, const units:
     }
     // Items that are multiple materials are assumed to be equal parts each.
     const units::mass by_weight = burned_mass / all_mats.size();
-    for( material_id  const&mat : all_mats ) {
+    for( material_id  const &mat : all_mats ) {
         for( auto &bp : mat->burn_products() ) {
             itype_id const id = bp.first;
             // Spawning the same item as the one that was just burned is pointless
@@ -251,7 +251,7 @@ void map::gas_spread_to( field_entry &cur, maptile &dst, const tripoint &p )
 void map::spread_gas( field_entry &cur, const tripoint &p, int percent_spread,
                       const time_duration &outdoor_age_speedup, scent_block &sblk )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     // TODO: fix point types
     const oter_id &cur_om_ter =
         overmap_buffer.ter( tripoint_abs_omt( ms_to_omt_copy( here.getabs( p ) ) ) );
@@ -792,7 +792,7 @@ void map::process_fields_in_submap( submap *const current_submap,
                                 continue;
                             }
 
-                            tripoint  const&dst_p = neighs[i].first;
+                            tripoint  const &dst_p = neighs[i].first;
                             maptile &dst = neighs[i].second;
                             // No bounds checking here: we'll treat the invalid neighbors as valid.
                             // We're using the map tile wrapper, so we can treat invalid tiles as sentinels.
@@ -970,7 +970,7 @@ void map::process_fields_in_submap( submap *const current_submap,
                 if( monster_spawn_count > 0 && monster_spawn_chance > 0 && one_in( monster_spawn_chance ) ) {
                     for( ; monster_spawn_count > 0; monster_spawn_count-- ) {
                         MonsterGroupResult const spawn_details = MonsterGroupManager::GetResultFromGroup(
-                                                               cur.monster_spawn_group(), &monster_spawn_count );
+                                    cur.monster_spawn_group(), &monster_spawn_count );
                         if( !spawn_details.name ) {
                             continue;
                         }

--- a/src/map_item_stack.cpp
+++ b/src/map_item_stack.cpp
@@ -86,7 +86,7 @@ int list_filter_high_priority( std::vector<map_item_stack> &stack, const std::st
         }
     }
 
-    int id = stack.size();
+    int const id = stack.size();
     for( auto &elem : tempstack ) {
         stack.push_back( elem );
     }
@@ -108,7 +108,7 @@ int list_filter_low_priority( std::vector<map_item_stack> &stack, const int star
         }
     }
 
-    int id = stack.size();
+    int const id = stack.size();
     for( auto &elem : tempstack ) {
         stack.push_back( elem );
     }

--- a/src/map_memory.cpp
+++ b/src/map_memory.cpp
@@ -72,7 +72,7 @@ map_memory::map_memory()
 
 const memorized_terrain_tile &map_memory::get_tile( const tripoint &pos )
 {
-    coord_pair p( pos );
+    coord_pair const p( pos );
     const mm_submap &sm = get_submap( p.sm );
     return sm.tile( p.loc );
 }
@@ -86,8 +86,8 @@ bool map_memory::has_memory_for_autodrive( const tripoint &pos )
     //       To work around it, we check for whether map memory has any data associated with the tile
     //       and then assume it's up to date, which works in 99% cases.
     //       Oh, and we don't want to use get_tile() and get_symbol() to avoid looking up the mm_submap twice.
-    coord_pair p( pos );
-    shared_ptr_fast<mm_submap> sm = fetch_submap( p.sm );
+    coord_pair const p( pos );
+    shared_ptr_fast<mm_submap> const sm = fetch_submap( p.sm );
     return sm->tile( p.loc ) != mm_submap::default_tile ||
            sm->symbol( p.loc ) != mm_submap::default_symbol;
 }
@@ -95,28 +95,28 @@ bool map_memory::has_memory_for_autodrive( const tripoint &pos )
 void map_memory::memorize_tile( const tripoint &pos, const std::string &ter,
                                 const int subtile, const int rotation )
 {
-    coord_pair p( pos );
+    coord_pair const p( pos );
     mm_submap &sm = get_submap( p.sm );
     sm.set_tile( p.loc, memorized_terrain_tile{ ter, subtile, rotation } );
 }
 
 int map_memory::get_symbol( const tripoint &pos )
 {
-    coord_pair p( pos );
+    coord_pair const p( pos );
     const mm_submap &sm = get_submap( p.sm );
     return sm.symbol( p.loc );
 }
 
 void map_memory::memorize_symbol( const tripoint &pos, const int symbol )
 {
-    coord_pair p( pos );
+    coord_pair const p( pos );
     mm_submap &sm = get_submap( p.sm );
     sm.set_symbol( p.loc, symbol );
 }
 
 void map_memory::clear_memorized_tile( const tripoint &pos )
 {
-    coord_pair p( pos );
+    coord_pair const p( pos );
     mm_submap &sm = get_submap( p.sm );
     sm.set_symbol( p.loc, mm_submap::default_symbol );
     sm.set_tile( p.loc, mm_submap::default_tile );
@@ -127,16 +127,16 @@ bool map_memory::prepare_region( const tripoint &p1, const tripoint &p2 )
     assert( p1.z == p2.z );
     assert( p1.x <= p2.x && p1.y <= p2.y );
 
-    tripoint sm_p1 = coord_pair( p1 ).sm - point_south_east;
-    tripoint sm_p2 = coord_pair( p2 ).sm + point_south_east;
+    tripoint const sm_p1 = coord_pair( p1 ).sm - point_south_east;
+    tripoint const sm_p2 = coord_pair( p2 ).sm + point_south_east;
 
-    tripoint sm_pos = sm_p1;
-    point sm_size = sm_p2.xy() - sm_p1.xy();
+    tripoint const sm_pos = sm_p1;
+    point const sm_size = sm_p2.xy() - sm_p1.xy();
 
-    bool z_levels = get_map().has_zlevels();
+    bool const z_levels = get_map().has_zlevels();
 
     if( sm_pos.z == cache_pos.z || z_levels ) {
-        inclusive_rectangle<point> rect( cache_pos.xy(), cache_pos.xy() + cache_size );
+        inclusive_rectangle<point> const rect( cache_pos.xy(), cache_pos.xy() + cache_size );
         if( rect.contains( sm_p1.xy() ) && rect.contains( sm_p2.xy() ) ) {
             return false;
         }
@@ -145,8 +145,8 @@ bool map_memory::prepare_region( const tripoint &p1, const tripoint &p2 )
     dbg( DL::Info ) << "Preparing memory map for area: pos: " << sm_pos << " size: " << sm_size;
 
 
-    int minz = z_levels ? -OVERMAP_DEPTH : p1.z;
-    int maxz = z_levels ? OVERMAP_HEIGHT : p1.z;
+    int const minz = z_levels ? -OVERMAP_DEPTH : p1.z;
+    int const maxz = z_levels ? OVERMAP_HEIGHT : p1.z;
 
     cache_pos = sm_pos;
     cache_size = sm_size;
@@ -182,14 +182,14 @@ shared_ptr_fast<mm_submap> map_memory::allocate_submap( const tripoint &sm_pos )
     // Since all save/load operations are done on regions of submaps,
     // we need to allocate the whole region at once.
     shared_ptr_fast<mm_submap> ret;
-    tripoint reg = reg_coord_pair( sm_pos ).reg;
+    tripoint const reg = reg_coord_pair( sm_pos ).reg;
 
     dbg( DL::Info ) << "Allocated mm_region " << reg << " [" << mmr_to_sm_copy( reg ) << "]";
 
     for( size_t y = 0; y < MM_REG_SIZE; y++ ) {
         for( size_t x = 0; x < MM_REG_SIZE; x++ ) {
-            tripoint pos = mmr_to_sm_copy( reg ) + tripoint( x, y, 0 );
-            shared_ptr_fast<mm_submap> sm = make_shared_fast<mm_submap>();
+            tripoint const pos = mmr_to_sm_copy( reg ) + tripoint( x, y, 0 );
+            shared_ptr_fast<mm_submap> const sm = make_shared_fast<mm_submap>();
             if( pos == sm_pos ) {
                 ret = sm;
             }
@@ -236,7 +236,7 @@ shared_ptr_fast<mm_submap> map_memory::load_submap( const tripoint &sm_pos )
     }
 
     const std::string dirname = find_mm_dir();
-    reg_coord_pair p( sm_pos );
+    reg_coord_pair const p( sm_pos );
     const std::string path = find_region_path( dirname, p.reg );
 
     if( !dir_exist( dirname ) ) {
@@ -266,8 +266,8 @@ shared_ptr_fast<mm_submap> map_memory::load_submap( const tripoint &sm_pos )
 
     for( size_t y = 0; y < MM_REG_SIZE; y++ ) {
         for( size_t x = 0; x < MM_REG_SIZE; x++ ) {
-            tripoint pos = mmr_to_sm_copy( p.reg ) + tripoint( x, y, 0 );
-            shared_ptr_fast<mm_submap> &sm = mmr.submaps[x][y];
+            tripoint const pos = mmr_to_sm_copy( p.reg ) + tripoint( x, y, 0 );
+            shared_ptr_fast<mm_submap>  const&sm = mmr.submaps[x][y];
             if( pos == sm_pos ) {
                 ret = sm;
             }
@@ -286,7 +286,7 @@ mm_submap &map_memory::get_submap( const tripoint &sm_pos )
     // First, try fetching from cache.
     // If it's not in cache (or cache is absent), go the long way.
     if( cache_pos != tripoint_min ) {
-        int zoffset = get_map().has_zlevels()
+        int const zoffset = get_map().has_zlevels()
                       ? ( sm_pos.z + OVERMAP_DEPTH ) * cache_size.y * cache_size.x
                       : 0;
         const point idx = ( sm_pos - cache_pos ).xy();
@@ -318,8 +318,8 @@ void map_memory::load( const tripoint &pos )
         return;
     }
 
-    coord_pair p( pos );
-    tripoint start = p.sm - tripoint( MM_SIZE / 2, MM_SIZE / 2, 0 );
+    coord_pair const p( pos );
+    tripoint const start = p.sm - tripoint( MM_SIZE / 2, MM_SIZE / 2, 0 );
     dbg( DL::Info ) << "[LOAD] Loading memory map around " << p.sm << ". Loading submaps within "
                     << start << "->" << start + tripoint( MM_SIZE, MM_SIZE, 0 );
     for( int dy = 0; dy < MM_SIZE; dy++ ) {
@@ -332,7 +332,7 @@ void map_memory::load( const tripoint &pos )
 
 bool map_memory::save( const tripoint &pos )
 {
-    tripoint sm_center = coord_pair( pos ).sm;
+    tripoint const sm_center = coord_pair( pos ).sm;
     const std::string dirname = find_mm_dir();
     assure_dir_exist( dirname );
 
@@ -350,7 +350,7 @@ bool map_memory::save( const tripoint &pos )
     submaps.clear();
 
     constexpr point MM_HSIZE_P = point( MM_SIZE / 2, MM_SIZE / 2 );
-    half_open_rectangle<point> rect_keep( sm_center.xy() - MM_HSIZE_P, sm_center.xy() + MM_HSIZE_P );
+    half_open_rectangle<point> const rect_keep( sm_center.xy() - MM_HSIZE_P, sm_center.xy() + MM_HSIZE_P );
 
     dbg( DL::Info ) << "[SAVE] Saving memory map around " << sm_center << ". Keeping submaps within "
                     << rect_keep.p_min << "->" << rect_keep.p_max;
@@ -377,8 +377,8 @@ bool map_memory::save( const tripoint &pos )
             const bool res = write_to_file( path, writer, descr.c_str() );
             result = result & res;
         }
-        tripoint regp_sm = mmr_to_sm_copy( regp );
-        half_open_rectangle<point> rect_reg(
+        tripoint const regp_sm = mmr_to_sm_copy( regp );
+        half_open_rectangle<point> const rect_reg(
             regp_sm.xy(),
             regp_sm.xy() + point( MM_REG_SIZE, MM_REG_SIZE )
         );
@@ -387,8 +387,8 @@ bool map_memory::save( const tripoint &pos )
             // Put submaps back
             for( size_t y = 0; y < MM_REG_SIZE; y++ ) {
                 for( size_t x = 0; x < MM_REG_SIZE; x++ ) {
-                    tripoint p = regp_sm + tripoint( x, y, 0 );
-                    shared_ptr_fast<mm_submap> &sm = reg.submaps[x][y];
+                    tripoint const p = regp_sm + tripoint( x, y, 0 );
+                    shared_ptr_fast<mm_submap>  const&sm = reg.submaps[x][y];
                     submaps.insert( std::make_pair( p, sm ) );
                 }
             }

--- a/src/map_memory.cpp
+++ b/src/map_memory.cpp
@@ -267,7 +267,7 @@ shared_ptr_fast<mm_submap> map_memory::load_submap( const tripoint &sm_pos )
     for( size_t y = 0; y < MM_REG_SIZE; y++ ) {
         for( size_t x = 0; x < MM_REG_SIZE; x++ ) {
             tripoint const pos = mmr_to_sm_copy( p.reg ) + tripoint( x, y, 0 );
-            shared_ptr_fast<mm_submap>  const&sm = mmr.submaps[x][y];
+            shared_ptr_fast<mm_submap>  const &sm = mmr.submaps[x][y];
             if( pos == sm_pos ) {
                 ret = sm;
             }
@@ -287,8 +287,8 @@ mm_submap &map_memory::get_submap( const tripoint &sm_pos )
     // If it's not in cache (or cache is absent), go the long way.
     if( cache_pos != tripoint_min ) {
         int const zoffset = get_map().has_zlevels()
-                      ? ( sm_pos.z + OVERMAP_DEPTH ) * cache_size.y * cache_size.x
-                      : 0;
+                            ? ( sm_pos.z + OVERMAP_DEPTH ) * cache_size.y * cache_size.x
+                            : 0;
         const point idx = ( sm_pos - cache_pos ).xy();
         if( idx.x > 0 && idx.y > 0 && idx.x < cache_size.x && idx.y < cache_size.y ) {
             return *cached[idx.y * cache_size.x + idx.x + zoffset];
@@ -350,7 +350,8 @@ bool map_memory::save( const tripoint &pos )
     submaps.clear();
 
     constexpr point MM_HSIZE_P = point( MM_SIZE / 2, MM_SIZE / 2 );
-    half_open_rectangle<point> const rect_keep( sm_center.xy() - MM_HSIZE_P, sm_center.xy() + MM_HSIZE_P );
+    half_open_rectangle<point> const rect_keep( sm_center.xy() - MM_HSIZE_P,
+            sm_center.xy() + MM_HSIZE_P );
 
     dbg( DL::Info ) << "[SAVE] Saving memory map around " << sm_center << ". Keeping submaps within "
                     << rect_keep.p_min << "->" << rect_keep.p_max;
@@ -388,7 +389,7 @@ bool map_memory::save( const tripoint &pos )
             for( size_t y = 0; y < MM_REG_SIZE; y++ ) {
                 for( size_t x = 0; x < MM_REG_SIZE; x++ ) {
                     tripoint const p = regp_sm + tripoint( x, y, 0 );
-                    shared_ptr_fast<mm_submap>  const&sm = reg.submaps[x][y];
+                    shared_ptr_fast<mm_submap>  const &sm = reg.submaps[x][y];
                     submaps.insert( std::make_pair( p, sm ) );
                 }
             }

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -62,7 +62,7 @@ bool mapbuffer::add_submap( const tripoint &p, submap *sm )
 {
     // FIXME: get rid of this overload and make submap ownership semantics sane.
     std::unique_ptr<submap> temp( sm );
-    bool result = add_submap( p, temp );
+    bool const result = add_submap( p, temp );
     if( !result ) {
         // NOLINTNEXTLINE( bugprone-unused-return-value )
         temp.release();
@@ -100,9 +100,9 @@ void mapbuffer::save( bool delete_after_save )
     assure_dir_exist( g->get_world_base_save_path() + "/maps" );
 
     int num_saved_submaps = 0;
-    int num_total_submaps = submaps.size();
+    int const num_total_submaps = submaps.size();
 
-    map &here = get_map();
+    map  const&here = get_map();
     const tripoint map_origin = sm_to_omt_copy( here.get_abs_sub() );
     const bool map_has_zlevels = g != nullptr && here.has_zlevels();
 
@@ -281,12 +281,12 @@ void mapbuffer::deserialize( JsonIn &jsin )
         jsin.start_object();
         int version = 0;
         while( !jsin.end_object() ) {
-            std::string submap_member_name = jsin.get_member_name();
+            std::string const submap_member_name = jsin.get_member_name();
             if( submap_member_name == "version" ) {
                 version = jsin.get_int();
             } else if( submap_member_name == "coordinates" ) {
                 jsin.start_array();
-                tripoint loc{ jsin.get_int(), jsin.get_int(), jsin.get_int() };
+                tripoint const loc{ jsin.get_int(), jsin.get_int(), jsin.get_int() };
                 jsin.end_array();
                 submap_coordinates = loc;
             } else {

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -102,7 +102,7 @@ void mapbuffer::save( bool delete_after_save )
     int num_saved_submaps = 0;
     int const num_total_submaps = submaps.size();
 
-    map  const&here = get_map();
+    map  const &here = get_map();
     const tripoint map_origin = sm_to_omt_copy( here.get_abs_sub() );
     const bool map_has_zlevels = g != nullptr && here.has_zlevels();
 

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -210,7 +210,7 @@ static const std::unordered_map<std::string, ter_connects> ter_connects_map = { 
 
 void ranged_bash_info::deserialize( JsonIn &jsin )
 {
-    JsonObject jo = jsin.get_object();
+    JsonObject const jo = jsin.get_object();
 
     assign( jo, "reduction", reduction );
     assign( jo, "reduction_laser", reduction_laser );
@@ -243,7 +243,7 @@ map_bash_info::map_bash_info() : str_min( -1 ), str_max( -1 ),
 
 void map_bash_info::deserialize( JsonIn &jsin )
 {
-    JsonObject jo = jsin.get_object();
+    JsonObject const jo = jsin.get_object();
 
     assign( jo, "str_min", str_min );
     assign( jo, "str_max", str_max );
@@ -345,7 +345,7 @@ bool map_deconstruct_info::load( const JsonObject &jsobj, const std::string &mem
     if( !jsobj.has_object( member ) ) {
         return false;
     }
-    JsonObject j = jsobj.get_object( member );
+    JsonObject const j = jsobj.get_object( member );
     furn_set = furn_str_id( j.get_string( "furn_set", "f_null" ) );
 
     if( !is_furniture ) {
@@ -363,7 +363,7 @@ furn_workbench_info::furn_workbench_info() : multiplier( 1.0f ), allowed_mass( u
 
 void furn_workbench_info::deserialize( JsonIn &jsin )
 {
-    JsonObject j = jsin.get_object();
+    JsonObject const j = jsin.get_object();
 
     assign( j, "multiplier", multiplier );
     assign( j, "mass", allowed_mass );
@@ -375,7 +375,7 @@ plant_data::plant_data() : transform( furn_str_id::NULL_ID() ), base( furn_str_i
 
 void plant_data::deserialize( JsonIn &jsin )
 {
-    JsonObject j = jsin.get_object();
+    JsonObject const j = jsin.get_object();
 
     assign( j, "transform", transform );
     assign( j, "base", base );
@@ -397,7 +397,7 @@ bool pry_result::load( const JsonObject &jsobj, const std::string &member,
         return false;
     }
 
-    JsonObject j = jsobj.get_object( member );
+    JsonObject const j = jsobj.get_object( member );
     pry_quality = j.get_int( "pry_quality", -1 );
     pry_bonus_mult = j.get_int( "pry_bonus_mult", 1 );
     difficulty = j.get_int( "difficulty", 1 );
@@ -1292,7 +1292,7 @@ void map_data_common_t::load( const JsonObject &jo, const std::string &src )
     }
 
     if( jo.has_array( "harvest_by_season" ) ) {
-        for( JsonObject harvest_jo : jo.get_array( "harvest_by_season" ) ) {
+        for( JsonObject const harvest_jo : jo.get_array( "harvest_by_season" ) ) {
             auto season_strings = harvest_jo.get_tags( "seasons" );
             std::set<season_type> seasons;
             std::transform( season_strings.begin(), season_strings.end(), std::inserter( seasons,
@@ -1311,7 +1311,7 @@ void map_data_common_t::load( const JsonObject &jo, const std::string &src )
                                 "harvest_by_season" );
             }
 
-            for( season_type s : seasons ) {
+            for( season_type const s : seasons ) {
                 harvest_by_season[ s ] = hl;
             }
         }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -131,8 +131,8 @@ void map::generate( const tripoint &p, const time_point &when )
     }
     // x, and y are submap coordinates, convert to overmap terrain coordinates
     // TODO: fix point types
-    tripoint_abs_omt abs_omt( sm_to_omt_copy( p ) );
-    oter_id terrain_type = overmap_buffer.ter( abs_omt );
+    tripoint_abs_omt const abs_omt( sm_to_omt_copy( p ) );
+    oter_id const terrain_type = overmap_buffer.ter( abs_omt );
 
     // This attempts to scale density of zombies inversely with distance from the nearest city.
     // In other words, make city centers dense and perimeters sparse.
@@ -180,7 +180,7 @@ void map::generate( const tripoint &p, const time_point &when )
     if( spawns.group && x_in_y( odds_after_density, 100 ) ) {
         int pop = spawn_count * rng( spawns.population.min, spawns.population.max );
         for( ; pop > 0; pop-- ) {
-            MonsterGroupResult spawn_details = MonsterGroupManager::GetResultFromGroup( spawns.group, &pop );
+            MonsterGroupResult const spawn_details = MonsterGroupManager::GetResultFromGroup( spawns.group, &pop );
             if( !spawn_details.name ) {
                 continue;
             }
@@ -377,7 +377,7 @@ void calculate_mapgen_weights()   // TODO: rename as it runs jsonfunction setup 
     oter_mapgen.setup();
     // Not really calculate weights, but let's keep it here for now
     for( auto &pr : nested_mapgen ) {
-        for( weighted_object<int, std::shared_ptr<mapgen_function_json_nested>> &ptr : pr.second ) {
+        for( weighted_object<int, std::shared_ptr<mapgen_function_json_nested>>  const&ptr : pr.second ) {
             ptr.obj->setup();
             inp_mngr.pump_events();
         }
@@ -436,7 +436,7 @@ static void set_mapgen_defer( const JsonObject &jsi, const std::string &member,
 std::shared_ptr<mapgen_function>
 load_mapgen_function( const JsonObject &jio, point offset, point total )
 {
-    int mgweight = jio.get_int( "weight", 1000 );
+    int const mgweight = jio.get_int( "weight", 1000 );
     if( mgweight <= 0 || jio.get_bool( "disabled", false ) ) {
         jio.allow_omitted_members();
         return nullptr; // nothing
@@ -449,7 +449,7 @@ load_mapgen_function( const JsonObject &jio, point offset, point total )
             jio.throw_error( "function does not exist", "name" );
         }
     } else if( mgtype == "json" ) {
-        JsonObject jo = jio.get_object( "object" );
+        JsonObject const jo = jio.get_object( "object" );
         const json_source_location jsrc = jo.get_source_location();
         jo.allow_omitted_members();
         return std::make_shared<mapgen_function_json>(
@@ -462,7 +462,7 @@ load_mapgen_function( const JsonObject &jio, point offset, point total )
 void load_and_add_mapgen_function( const JsonObject &jio, const std::string &id_base,
                                    point offset, point total )
 {
-    std::shared_ptr<mapgen_function> f = load_mapgen_function( jio, offset, total );
+    std::shared_ptr<mapgen_function> const f = load_mapgen_function( jio, offset, total );
     if( f ) {
         oter_mapgen.add( id_base, f );
     }
@@ -473,8 +473,8 @@ static void load_nested_mapgen( const JsonObject &jio, const std::string &id_bas
     const std::string mgtype = jio.get_string( "method" );
     if( mgtype == "json" ) {
         if( jio.has_object( "object" ) ) {
-            int weight = jio.get_int( "weight", 1000 );
-            JsonObject jo = jio.get_object( "object" );
+            int const weight = jio.get_int( "weight", 1000 );
+            JsonObject const jo = jio.get_object( "object" );
             const json_source_location jsrc = jo.get_source_location();
             jo.allow_omitted_members();
             nested_mapgen[id_base].add( std::make_shared<mapgen_function_json_nested>( jsrc ), weight );
@@ -492,7 +492,7 @@ static void load_update_mapgen( const JsonObject &jio, const std::string &id_bas
     const std::string mgtype = jio.get_string( "method" );
     if( mgtype == "json" ) {
         if( jio.has_object( "object" ) ) {
-            JsonObject jo = jio.get_object( "object" );
+            JsonObject const jo = jio.get_object( "object" );
             const json_source_location jsrc = jo.get_source_location();
             jo.allow_omitted_members();
             update_mapgen[id_base].push_back(
@@ -516,11 +516,11 @@ void load_mapgen( const JsonObject &jo )
     static constexpr point point_one( 1, 1 );
 
     if( jo.has_array( "om_terrain" ) ) {
-        JsonArray ja = jo.get_array( "om_terrain" );
+        JsonArray const ja = jo.get_array( "om_terrain" );
         if( ja.test_array() ) {
             point offset;
-            point total( ja.get_array( 0 ).size(), ja.size() );
-            for( JsonArray row_items : ja ) {
+            point const total( ja.get_array( 0 ).size(), ja.size() );
+            for( JsonArray const row_items : ja ) {
                 for( const std::string mapgenid : row_items ) {
                     load_and_add_mapgen_function( jo, mapgenid, offset, total );
                     offset.x++;
@@ -579,7 +579,7 @@ size_t mapgen_function_json_base::calc_index( point p ) const
 static bool common_check_bounds( const jmapgen_int &x, const jmapgen_int &y,
                                  point mapgensize, const JsonObject &jso )
 {
-    half_open_rectangle<point> bounds( point_zero, mapgensize );
+    half_open_rectangle<point> const bounds( point_zero, mapgensize );
     if( !bounds.contains( point( x.val, y.val ) ) ) {
         return false;
     }
@@ -640,7 +640,7 @@ jmapgen_int::jmapgen_int( point p ) : val( p.x ), valmax( p.y ) {}
 jmapgen_int::jmapgen_int( const JsonObject &jo, const std::string &tag )
 {
     if( jo.has_array( tag ) ) {
-        JsonArray sparray = jo.get_array( tag );
+        JsonArray const sparray = jo.get_array( tag );
         if( sparray.size() < 1 || sparray.size() > 2 ) {
             jo.throw_error( "invalid data: must be an array of 1 or 2 values", tag );
         }
@@ -661,7 +661,7 @@ jmapgen_int::jmapgen_int( const JsonObject &jo, const std::string &tag, int def_
     , valmax( def_valmax )
 {
     if( jo.has_array( tag ) ) {
-        JsonArray sparray = jo.get_array( tag );
+        JsonArray const sparray = jo.get_array( tag );
         if( sparray.size() > 2 ) {
             jo.throw_error( "invalid data: must be an array of 1 or 2 values", tag );
         }
@@ -790,7 +790,7 @@ void mapgen_function_json_base::setup_setmap( const JsonArray &parray )
         pjo.read( "rotation", tmp_rotation );
         pjo.read( "fuel", tmp_fuel );
         pjo.read( "status", tmp_status );
-        jmapgen_setmap tmp( tmp_x, tmp_y, tmp_x2, tmp_y2,
+        jmapgen_setmap const tmp( tmp_x, tmp_y, tmp_x2, tmp_y2,
                             static_cast<jmapgen_setmap_op>( tmpop + setmap_optype ), tmp_i,
                             tmp_chance, tmp_repeat, tmp_rotation, tmp_fuel, tmp_status );
 
@@ -893,7 +893,7 @@ class jmapgen_npc : public jmapgen_piece
                 set_mapgen_defer( jsi, "class", "unknown npc class" );
             }
             if( jsi.has_string( "add_trait" ) ) {
-                std::string new_trait = jsi.get_string( "add_trait" );
+                std::string const new_trait = jsi.get_string( "add_trait" );
                 traits.emplace_back( new_trait );
             } else if( jsi.has_array( "add_trait" ) ) {
                 for( const std::string new_trait : jsi.get_array( "add_trait" ) ) {
@@ -902,7 +902,7 @@ class jmapgen_npc : public jmapgen_piece
             }
         }
         void apply( mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y ) const override {
-            character_id npc_id = dat.m.place_npc( point( x.get(), y.get() ), npc_class );
+            character_id const npc_id = dat.m.place_npc( point( x.get(), y.get() ), npc_class );
             if( dat.mission() && target ) {
                 dat.mission()->set_target_npc_id( npc_id );
             }
@@ -964,7 +964,7 @@ class jmapgen_sign : public jmapgen_piece
                 signtext = _( signtext );
 
                 std::string cityname = "illegible city name";
-                tripoint abs_sub = dat.m.get_abs_sub();
+                tripoint const abs_sub = dat.m.get_abs_sub();
                 // TODO: fix point types
                 const city *c = overmap_buffer.closest_city( tripoint_abs_sm( abs_sub ) ).city;
                 if( c != nullptr ) {
@@ -1016,7 +1016,7 @@ class jmapgen_graffiti : public jmapgen_piece
                 graffiti = _( graffiti );
 
                 std::string cityname = "illegible city name";
-                tripoint abs_sub = dat.m.get_abs_sub();
+                tripoint const abs_sub = dat.m.get_abs_sub();
                 // TODO: fix point types
                 const city *c = overmap_buffer.closest_city( tripoint_abs_sm( abs_sub ) ).city;
                 if( c != nullptr ) {
@@ -1049,7 +1049,7 @@ class jmapgen_vending_machine : public jmapgen_piece
             }
         }
         void apply( mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y ) const override {
-            point r{ x.get(), y.get() };
+            point const r{ x.get(), y.get() };
             dat.m.furn_set( r, f_null );
             dat.m.place_vending( r, item_group, reinforced );
         }
@@ -1166,7 +1166,7 @@ class jmapgen_item_group : public jmapgen_piece
         item_group_id group_id;
         jmapgen_int chance;
         jmapgen_item_group( const JsonObject &jsi ) : chance( jsi, "chance", 1, 1 ) {
-            JsonValue group = jsi.get_member( "item" );
+            JsonValue const group = jsi.get_member( "item" );
             group_id = item_group::load_item_group( group, "collection" );
             repeat = jmapgen_int( jsi, "repeat", 1, 1 );
         }
@@ -1290,7 +1290,7 @@ class jmapgen_monster : public jmapgen_piece
                     mtype_id id;
                     int weight = 100;
                     if( entry.test_array() ) {
-                        JsonArray inner = entry.get_array();
+                        JsonArray const inner = entry.get_array();
                         id = mtype_id( inner.get_string( 0 ) );
                         weight = inner.get_int( 1 );
                     } else {
@@ -1303,7 +1303,7 @@ class jmapgen_monster : public jmapgen_piece
                     ids.add( id, weight );
                 }
             } else {
-                mtype_id id = mtype_id( jsi.get_string( "monster" ) );
+                mtype_id const id = mtype_id( jsi.get_string( "monster" ) );
                 if( !id.is_valid() ) {
                     set_mapgen_defer( jsi, "monster", "no such monster" );
                     return;
@@ -1313,13 +1313,13 @@ class jmapgen_monster : public jmapgen_piece
         }
         void apply( mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y ) const override {
 
-            int raw_odds = chance.get();
+            int const raw_odds = chance.get();
 
             // Handle spawn density: Increase odds, but don't let the odds of absence go below half the odds at density 1.
             // Instead, apply a multipler to the number of monsters for really high densities.
             // For example, a 50% chance at spawn density 4 becomes a 75% chance of ~2.7 monsters.
             int odds_after_density = raw_odds * get_option<float>( "SPAWN_DENSITY" );
-            int max_odds = ( 100 + raw_odds ) / 2;
+            int const max_odds = ( 100 + raw_odds ) / 2;
             float density_multiplier = 1;
             if( odds_after_density > max_odds ) {
                 density_multiplier = 1.0f * odds_after_density / max_odds;
@@ -1345,7 +1345,7 @@ class jmapgen_monster : public jmapgen_piece
             }
 
             if( m_id != mongroup_id::NULL_ID() ) {
-                MonsterGroupResult spawn_details = MonsterGroupManager::GetResultFromGroup( m_id );
+                MonsterGroupResult const spawn_details = MonsterGroupManager::GetResultFromGroup( m_id );
                 dat.m.add_spawn( spawn_details.name, spawn_count * pack_size.get(),
                 { x.get(), y.get(), dat.m.get_abs_sub().z },
                 friendly, -1, mission_id, name );
@@ -1432,7 +1432,7 @@ class jmapgen_spawn_item : public jmapgen_piece
 
             // 100% chance = exactly 1 item, otherwise scale by item spawn rate.
             const float spawn_rate = get_option<float>( "ITEM_SPAWNRATE" );
-            int spawn_count = ( c == 100 ) ? 1 : roll_remainder( c * spawn_rate / 100.0f );
+            int const spawn_count = ( c == 100 ) ? 1 : roll_remainder( c * spawn_rate / 100.0f );
             for( int i = 0; i < spawn_count; i++ ) {
                 dat.m.spawn_item( point( x.get(), y.get() ), type, amount.get() );
             }
@@ -1573,12 +1573,12 @@ class jmapgen_computer : public jmapgen_piece
             security = jsi.get_int( "security", 0 );
             target = jsi.get_bool( "target", false );
             if( jsi.has_array( "options" ) ) {
-                for( JsonObject jo : jsi.get_array( "options" ) ) {
+                for( JsonObject const jo : jsi.get_array( "options" ) ) {
                     options.emplace_back( computer_option::from_json( jo ) );
                 }
             }
             if( jsi.has_array( "failures" ) ) {
-                for( JsonObject jo : jsi.get_array( "failures" ) ) {
+                for( JsonObject const jo : jsi.get_array( "failures" ) ) {
                     failures.emplace_back( computer_failure::from_json( jo ) );
                 }
             }
@@ -1626,18 +1626,18 @@ class jmapgen_sealed_item : public jmapgen_piece
             : furniture( jsi.get_string( "furniture" ) )
             , chance( jsi, "chance", 100, 100 ) {
             if( jsi.has_object( "item" ) ) {
-                JsonObject item_obj = jsi.get_object( "item" );
+                JsonObject const item_obj = jsi.get_object( "item" );
                 item_spawner = jmapgen_spawn_item( item_obj );
             }
             if( jsi.has_object( "items" ) ) {
-                JsonObject items_obj = jsi.get_object( "items" );
+                JsonObject const items_obj = jsi.get_object( "items" );
                 item_group_spawner = jmapgen_item_group( items_obj );
             }
         }
 
         void check( const std::string &oter_name ) const override {
             const furn_t &furn = furniture.obj();
-            std::string summary = string_format(
+            std::string const summary = string_format(
                                       "sealed_item special in json mapgen for overmap terrain %s using furniture %s",
                                       oter_name, furn.id.str() );
 
@@ -1662,13 +1662,13 @@ class jmapgen_sealed_item : public jmapgen_piece
                 }
 
                 if( item_spawner ) {
-                    int count = item_spawner->amount.get();
+                    int const count = item_spawner->amount.get();
                     if( count != 1 ) {
                         debugmsg( "%s (with flag PLANT) spawns %d items; it should spawn exactly "
                                   "one.", summary, count );
                         return;
                     }
-                    int item_chance = item_spawner->chance.get();
+                    int const item_chance = item_spawner->chance.get();
                     if( item_chance != 100 ) {
                         debugmsg( "%s (with flag PLANT) spawns an item (%s) with probability %d%%; "
                                   "it should always spawn.  You can move the \"chance\" up to the "
@@ -1684,7 +1684,7 @@ class jmapgen_sealed_item : public jmapgen_piece
                 }
 
                 if( item_group_spawner ) {
-                    int ig_chance = item_group_spawner->chance.get();
+                    int const ig_chance = item_group_spawner->chance.get();
                     if( ig_chance != 100 ) {
                         debugmsg( "%s (with flag PLANT) spawns item group %s with chance %d.  "
                                   "It should have chance 100.  You can move the \"chance\" up to the "
@@ -1692,7 +1692,7 @@ class jmapgen_sealed_item : public jmapgen_piece
                                   summary, item_group_spawner->group_id.str(), ig_chance );
                         return;
                     }
-                    item_group_id group_id = item_group_spawner->group_id;
+                    item_group_id const group_id = item_group_spawner->group_id;
                     for( const itype *type : item_group::every_possible_item_from( group_id ) ) {
                         if( !type->seed ) {
                             debugmsg( "%s (with flag PLANT) spawns item group %s which can "
@@ -1786,7 +1786,7 @@ static void load_weighted_entries( const JsonObject &jsi, const std::string &jso
 {
     for( const JsonValue entry : jsi.get_array( json_key ) ) {
         if( entry.test_array() ) {
-            JsonArray inner = entry.get_array();
+            JsonArray const inner = entry.get_array();
             list.add( inner.get_string( 0 ), inner.get_int( 1 ) );
         } else {
             list.add( entry.get_string(), 100 );
@@ -1811,8 +1811,8 @@ class jmapgen_nested : public jmapgen_piece
                 std::set<oter_str_id> above;
             public:
                 neighborhood_check( const JsonObject &jsi ) {
-                    for( om_direction::type dir : om_direction::all ) {
-                        int index = static_cast<int>( dir );
+                    for( om_direction::type const dir : om_direction::all ) {
+                        int const index = static_cast<int>( dir );
                         neighbors[index] = jsi.get_tags<oter_str_id>( om_direction::id( dir ) );
                         has_any |= !neighbors[index].empty();
 
@@ -1827,8 +1827,8 @@ class jmapgen_nested : public jmapgen_piece
                     }
 
                     bool all_directions_match  = true;
-                    for( om_direction::type dir : om_direction::all ) {
-                        int index = static_cast<int>( dir );
+                    for( om_direction::type const dir : om_direction::all ) {
+                        int const index = static_cast<int>( dir );
                         const std::set<oter_str_id> &allowed_neighbors = neighbors[index];
 
                         if( allowed_neighbors.empty() ) {
@@ -1930,7 +1930,7 @@ void jmapgen_objects::add( const jmapgen_place &place,
 template<typename PieceType>
 void jmapgen_objects::load_objects( JsonArray parray )
 {
-    for( JsonObject jsi : parray ) {
+    for( JsonObject const jsi : parray ) {
         jmapgen_place where( jsi );
         where.offset( m_offset );
 
@@ -1945,7 +1945,7 @@ void jmapgen_objects::load_objects( JsonArray parray )
 template<>
 void jmapgen_objects::load_objects<jmapgen_loot>( JsonArray parray )
 {
-    for( JsonObject jsi : parray ) {
+    for( JsonObject const jsi : parray ) {
         jmapgen_place where( jsi );
         where.offset( m_offset );
 
@@ -2000,7 +2000,7 @@ void load_place_mapings( const JsonValue &value, mapgen_palette::placing_map::ma
     if( value.test_object() ) {
         load_place_mapings<PieceType>( value.get_object(), vect );
     } else {
-        for( JsonObject jo : value.get_array() ) {
+        for( JsonObject const jo : value.get_array() ) {
             load_place_mapings<PieceType>( jo, vect );
             jo.allow_omitted_members();
         }
@@ -2060,7 +2060,7 @@ void load_place_mapings_alternatively( const JsonValue &value,
                     entry.throw_error( err.what() );
                 }
             } else if( entry.test_object() ) {
-                JsonObject jsi = entry.get_object();
+                JsonObject const jsi = entry.get_object();
                 alter->alternatives.emplace_back( jsi );
             } else if( entry.test_array() ) {
                 // If this is an array, it means it is an entry followed by a desired total count of instances.
@@ -2077,7 +2077,7 @@ void load_place_mapings_alternatively( const JsonValue &value,
                         piece_and_count_jarr.throw_error( err.what() );
                     }
                 } else if( piece_and_count_jarr.test_object() ) {
-                    JsonObject jsi = piece_and_count_jarr.next_object();
+                    JsonObject const jsi = piece_and_count_jarr.next_object();
                     alter->alternatives.emplace_back( jsi );
                 } else {
                     piece_and_count_jarr.throw_error( "First entry must be a string or object." );
@@ -2085,7 +2085,7 @@ void load_place_mapings_alternatively( const JsonValue &value,
 
                 if( piece_and_count_jarr.test_int() ) {
                     // We already emplaced the first instance, so do one less.
-                    int repeat = std::max( 0, piece_and_count_jarr.next_int() - 1 );
+                    int const repeat = std::max( 0, piece_and_count_jarr.next_int() - 1 );
                     PieceType piece_to_repeat = alter->alternatives.back();
                     for( int i = 0; i < repeat; i++ ) {
                         alter->alternatives.emplace_back( piece_to_repeat );
@@ -2127,7 +2127,7 @@ void mapgen_palette::load_place_mapings( const JsonObject &jo, const std::string
     if( jo.has_object( "mapping" ) ) {
         for( const JsonMember member : jo.get_object( "mapping" ) ) {
             const map_key key( member );
-            JsonObject sub = member.get_object();
+            JsonObject const sub = member.get_object();
             sub.allow_omitted_members();
             if( !sub.has_member( member_name ) ) {
                 continue;
@@ -2170,7 +2170,7 @@ static bool check_furn( const furn_id &id, const std::string &context )
 
 void mapgen_palette::check()
 {
-    std::string context = "palette " + id;
+    std::string const context = "palette " + id;
     for( const std::pair<const map_key, furn_id> &p : format_furniture ) {
         if( check_furn( p.second, context ) ) {
             return;
@@ -2191,7 +2191,7 @@ mapgen_palette mapgen_palette::load_temp( const JsonObject &jo, const std::strin
 
 void mapgen_palette::load( const JsonObject &jo, const std::string &src )
 {
-    mapgen_palette ret = load_internal( jo, src, true, false );
+    mapgen_palette const ret = load_internal( jo, src, true, false );
     if( ret.id.empty() ) {
         jo.throw_error( "Named palette needs an id" );
     }
@@ -2212,7 +2212,7 @@ const mapgen_palette &mapgen_palette::get( const palette_id &id )
     }
 
     debugmsg( "Requested palette with unknown id %s", id.c_str() );
-    static mapgen_palette dummy;
+    static mapgen_palette const dummy;
     return dummy;
 }
 
@@ -2353,7 +2353,7 @@ bool mapgen_function_json_nested::setup_internal( const JsonObject &jo )
 {
     // Mandatory - nested mapgen must be explicitly sized
     if( jo.has_array( "mapgensize" ) ) {
-        JsonArray jarr = jo.get_array( "mapgensize" );
+        JsonArray const jarr = jo.get_array( "mapgensize" );
         mapgensize = point( jarr.get_int( 0 ), jarr.get_int( 1 ) );
         if( mapgensize.x == 0 || mapgensize.x != mapgensize.y ) {
             // Non-square sizes not implemented yet
@@ -2399,10 +2399,10 @@ void mapgen_function_json_base::setup_common()
         debugmsg( "null json source location path" );
         return;
     }
-    shared_ptr_fast<std::istream> stream = DynamicDataLoader::get_instance().get_cached_stream(
+    shared_ptr_fast<std::istream> const stream = DynamicDataLoader::get_instance().get_cached_stream(
             *jsrcloc->path );
     JsonIn jsin( *stream, *jsrcloc );
-    JsonObject jo = jsin.get_object();
+    JsonObject const jo = jsin.get_object();
     mapgen_defer::defer = false;
     if( !setup_common( jo ) ) {
         jsin.error( "format: no terrain map" );
@@ -2418,8 +2418,8 @@ bool mapgen_function_json_base::setup_common( const JsonObject &jo )
 {
     bool fallback_terrain_exists = setup_internal( jo );
     JsonArray parray;
-    JsonArray sparray;
-    JsonObject pjo;
+    JsonArray const sparray;
+    JsonObject const pjo;
 
     format.resize( static_cast<size_t>( mapgensize.x * mapgensize.y ) );
     // just like mapf::basic_bind("stuff",blargle("foo", etc) ), only json input and faster when applying
@@ -2438,7 +2438,7 @@ bool mapgen_function_json_base::setup_common( const JsonObject &jo )
         // mandatory: mapgensize rows of mapgensize character lines, each of which must have a
         // matching key in "terrain", unless fill_ter is set
         // "rows:" [ "aaaajustlikeinmapgen.cpp", "this.must!be!exactly.24!", "and_must_match_terrain_", .... ]
-        point expected_dim = mapgensize + m_offset;
+        point const expected_dim = mapgensize + m_offset;
         assert( expected_dim.x >= 0 );
         assert( expected_dim.y >= 0 );
 
@@ -2503,7 +2503,7 @@ bool mapgen_function_json_base::setup_common( const JsonObject &jo )
                     format[ calc_index( p ) ].furn = iter_furn->second;
                 }
                 if( has_placing ) {
-                    jmapgen_place where( p );
+                    jmapgen_place const where( p );
                     for( auto &what : fpi->second ) {
                         objects.add( where, what );
                     }
@@ -2583,7 +2583,7 @@ void mapgen_function_json_base::check_common( const std::string &oter_name ) con
             setmap.op != JMAPGEN_SETMAP_SQUARE_FURN ) {
             continue;
         }
-        furn_id id( setmap.val.get() );
+        furn_id const id( setmap.val.get() );
         if( check_furn( id, "oter " + oter_name ) ) {
             return;
         }
@@ -2760,7 +2760,7 @@ void mapgen_function_json_base::formatted_set_incredibly_simple( map &m, point o
 {
     for( int y = 0; y < mapgensize.y; y++ ) {
         for( int x = 0; x < mapgensize.x; x++ ) {
-            point p( x, y );
+            point const p( x, y );
             const size_t index = calc_index( p );
             const ter_furn_id &tdata = format[index];
             const point map_pos = p + offset;
@@ -2965,7 +2965,7 @@ void map::draw_office_tower( mapgendata &dat )
 {
     const oter_id &terrain_type = dat.terrain_type();
     const auto place_office_chairs = [&]() {
-        int num_chairs = rng( 0, 6 );
+        int const num_chairs = rng( 0, 6 );
         for( int i = 0; i < num_chairs; i++ ) {
             add_vehicle( vproto_id( "swivel_chair" ), point( rng( 6, 16 ), rng( 6, 16 ) ),
                          0_degrees, -1, -1, false );
@@ -3557,7 +3557,7 @@ void map::draw_lab( mapgendata &dat )
     bool central_lab = false;
     bool tower_lab = false;
 
-    point p2;
+    point const p2;
 
     int lw = 0;
     int rw = 0;
@@ -3577,7 +3577,7 @@ void map::draw_lab( mapgendata &dat )
         tower_lab = is_ot_match( "tower_lab", terrain_type, ot_match_type::prefix );
 
         if( ice_lab ) {
-            int temperature = -20 + 30 * ( dat.zlevel() );
+            int const temperature = -20 + 30 * ( dat.zlevel() );
             set_temperature( p2, temperature );
             set_temperature( p2 + point( SEEX, 0 ), temperature );
             set_temperature( p2 + point( 0, SEEY ), temperature );
@@ -3725,16 +3725,16 @@ void map::draw_lab( mapgendata &dat )
                     // Rotated maps cannot handle borders and have to be caught in code.
                     // We determine if a border isn't handled by checking the east-facing
                     // border space where the door normally is -- it should be a wall or door.
-                    tripoint east_border( 23, 11, abs_sub.z );
+                    tripoint const east_border( 23, 11, abs_sub.z );
                     if( !has_flag_ter( "WALL", east_border ) &&
                         !has_flag_ter( "DOOR", east_border ) ) {
                         // TODO: create a ter_reset function that does ter_set,
                         // furn_set, and i_clear?
-                        ter_id lw_type = tower_lab ? t_reinforced_glass : t_concrete_wall;
-                        ter_id tw_type = tower_lab ? t_reinforced_glass : t_concrete_wall;
-                        ter_id rw_type = tower_lab && rw == 2 ? t_reinforced_glass :
+                        ter_id const lw_type = tower_lab ? t_reinforced_glass : t_concrete_wall;
+                        ter_id const tw_type = tower_lab ? t_reinforced_glass : t_concrete_wall;
+                        ter_id const rw_type = tower_lab && rw == 2 ? t_reinforced_glass :
                                          t_concrete_wall;
-                        ter_id bw_type = tower_lab && bw == 2 ? t_reinforced_glass :
+                        ter_id const bw_type = tower_lab && bw == 2 ? t_reinforced_glass :
                                          t_concrete_wall;
                         for( int i = 0; i < SEEX * 2; i++ ) {
                             ter_set( point( 23, i ), rw_type );
@@ -4108,7 +4108,7 @@ void map::draw_lab( mapgendata &dat )
                 // toxic gas leaks and smoke-filled rooms.
                 case 3:
                 case 4: {
-                    bool is_toxic = one_in( 3 );
+                    bool const is_toxic = one_in( 3 );
                     for( int i = 0; i < SEEX * 2; i++ ) {
                         for( int j = 0; j < SEEY * 2; j++ ) {
                             if( one_in( 200 ) && ( t_thconc_floor == ter( point( i, j ) ) ||
@@ -4125,8 +4125,8 @@ void map::draw_lab( mapgendata &dat )
                 }
                 // portal with an artifact effect.
                 case 5: {
-                    tripoint center( rng( 6, SEEX * 2 - 7 ), rng( 6, SEEY * 2 - 7 ), abs_sub.z );
-                    std::vector<artifact_natural_property> valid_props = {
+                    tripoint const center( rng( 6, SEEX * 2 - 7 ), rng( 6, SEEY * 2 - 7 ), abs_sub.z );
+                    std::vector<artifact_natural_property> const valid_props = {
                         ARTPROP_BREATHING,
                         ARTPROP_CRACKLING,
                         ARTPROP_WARM,
@@ -4150,7 +4150,7 @@ void map::draw_lab( mapgendata &dat )
                 }
                 // radioactive accident.
                 case 6: {
-                    tripoint center( rng( 6, SEEX * 2 - 7 ), rng( 6, SEEY * 2 - 7 ), abs_sub.z );
+                    tripoint const center( rng( 6, SEEX * 2 - 7 ), rng( 6, SEEY * 2 - 7 ), abs_sub.z );
                     if( has_flag_ter( "WALL", center.xy() ) ) {
                         // just skip it, we don't want to risk embedding radiation out of sight.
                         break;
@@ -4183,8 +4183,8 @@ void map::draw_lab( mapgendata &dat )
                                   center.xy() + point_west, 1, true );
 
                     // damaged mininuke/plut thrown past edge of rubble so the player can see it.
-                    int marker_x = center.x - 2 + 4 * rng( 0, 1 );
-                    int marker_y = center.y + rng( -2, 2 );
+                    int const marker_x = center.x - 2 + 4 * rng( 0, 1 );
+                    int const marker_y = center.y + rng( -2, 2 );
                     if( one_in( 4 ) ) {
                         spawn_item(
                             point( marker_x, marker_y ), "mininuke", 1, 1, calendar::start_of_cataclysm, rng( 2, 4 )
@@ -4214,7 +4214,7 @@ void map::draw_lab( mapgendata &dat )
                             }
                         }
                     }
-                    tripoint center( rng( 6, SEEX * 2 - 7 ), rng( 6, SEEY * 2 - 7 ), abs_sub.z );
+                    tripoint const center( rng( 6, SEEX * 2 - 7 ), rng( 6, SEEY * 2 - 7 ), abs_sub.z );
 
                     // Make a portal surrounded by more dense fungal stuff and a fungaloid.
                     draw_rough_circle( [this]( point  p ) {
@@ -4252,7 +4252,7 @@ void map::draw_lab( mapgendata &dat )
         tower_lab = is_ot_match( "tower_lab", terrain_type, ot_match_type::prefix );
 
         if( ice_lab ) {
-            int temperature = -20 + 30 * dat.zlevel();
+            int const temperature = -20 + 30 * dat.zlevel();
             set_temperature( p2, temperature );
             set_temperature( p2 + point( SEEX, 0 ), temperature );
             set_temperature( p2 + point( 0, SEEY ), temperature );
@@ -4270,13 +4270,13 @@ void map::draw_lab( mapgendata &dat )
             // Rotated maps cannot handle borders and have to be caught in code.
             // We determine if a border isn't handled by checking the east-facing
             // border space where the door normally is -- it should be a wall or door.
-            tripoint east_border( 23, 11, abs_sub.z );
+            tripoint const east_border( 23, 11, abs_sub.z );
             if( !has_flag_ter( "WALL", east_border ) && !has_flag_ter( "DOOR", east_border ) ) {
                 // TODO: create a ter_reset function that does ter_set, furn_set, and i_clear?
-                ter_id lw_type = tower_lab ? t_reinforced_glass : t_concrete_wall;
-                ter_id tw_type = tower_lab ? t_reinforced_glass : t_concrete_wall;
-                ter_id rw_type = tower_lab && rw == 2 ? t_reinforced_glass : t_concrete_wall;
-                ter_id bw_type = tower_lab && bw == 2 ? t_reinforced_glass : t_concrete_wall;
+                ter_id const lw_type = tower_lab ? t_reinforced_glass : t_concrete_wall;
+                ter_id const tw_type = tower_lab ? t_reinforced_glass : t_concrete_wall;
+                ter_id const rw_type = tower_lab && rw == 2 ? t_reinforced_glass : t_concrete_wall;
+                ter_id const bw_type = tower_lab && bw == 2 ? t_reinforced_glass : t_concrete_wall;
                 for( int i = 0; i < SEEX * 2; i++ ) {
                     ter_set( point( 23, i ), rw_type );
                     furn_set( point( 23, i ), f_null );
@@ -4636,7 +4636,7 @@ void map::draw_mine( mapgendata &dat )
 
             case 1: {
                 // Toxic gas
-                point gas_vent_location( rng( 9, 14 ), rng( 9, 14 ) );
+                point const gas_vent_location( rng( 9, 14 ), rng( 9, 14 ) );
                 ter_set( point( gas_vent_location ), t_rock );
                 add_field( { gas_vent_location, abs_sub.z }, fd_gas_vent, 2 );
             }
@@ -4644,14 +4644,14 @@ void map::draw_mine( mapgendata &dat )
 
             case 2: {
                 // Lava
-                point start_location( rng( 6, SEEX ), rng( 6, SEEY ) );
-                point end_location( rng( SEEX + 1, SEEX * 2 - 7 ), rng( SEEY + 1, SEEY * 2 - 7 ) );
+                point const start_location( rng( 6, SEEX ), rng( 6, SEEY ) );
+                point const end_location( rng( SEEX + 1, SEEX * 2 - 7 ), rng( SEEY + 1, SEEY * 2 - 7 ) );
                 const int num = rng( 2, 4 );
                 for( int i = 0; i < num; i++ ) {
-                    int lx1 = start_location.x + rng( -1, 1 );
-                    int lx2 = end_location.x + rng( -1, 1 );
-                    int ly1 = start_location.y + rng( -1, 1 );
-                    int ly2 = end_location.y + rng( -1, 1 );
+                    int const lx1 = start_location.x + rng( -1, 1 );
+                    int const lx2 = end_location.x + rng( -1, 1 );
+                    int const ly1 = start_location.y + rng( -1, 1 );
+                    int const ly2 = end_location.y + rng( -1, 1 );
                     line( this, t_lava, point( lx1, ly1 ), point( lx2, ly2 ) );
                 }
                 for( const tripoint &ore : points_in_rectangle( tripoint( start_location, abs_sub.z ),
@@ -4666,7 +4666,7 @@ void map::draw_mine( mapgendata &dat )
 
             case 3: {
                 // Wrecked equipment
-                point wreck_location( rng( 9, 14 ), rng( 9, 14 ) );
+                point const wreck_location( rng( 9, 14 ), rng( 9, 14 ) );
                 for( int i = wreck_location.x - 3; i < wreck_location.x + 3; i++ ) {
                     for( int j = wreck_location.y - 3; j < wreck_location.y + 3; j++ ) {
                         if( !one_in( 4 ) ) {
@@ -4850,7 +4850,7 @@ void map::draw_mine( mapgendata &dat )
         // The Thing dog
         const int num_bodies = rng( 4, 8 );
         for( int i = 0; i < num_bodies; i++ ) {
-            point p3( rng( 4, SEEX * 2 - 5 ), rng( 4, SEEX * 2 - 5 ) );
+            point const p3( rng( 4, SEEX * 2 - 5 ), rng( 4, SEEX * 2 - 5 ) );
             add_item( p3, item::make_corpse() );
             place_items( item_group_id( "mon_zombie_miner_death_drops" ), 60, p3,
                          p3, false, calendar::start_of_cataclysm );
@@ -4937,13 +4937,13 @@ void map::draw_triffid( mapgendata &dat )
         do {
             node_built[node] = true;
             step++;
-            point node2( 1 + 6 * ( node % 4 ), 1 + 6 * static_cast<int>( node / 4 ) );
+            point const node2( 1 + 6 * ( node % 4 ), 1 + 6 * static_cast<int>( node / 4 ) );
             // Clear a 4x4 dirt square
             square( this, t_dirt, node2, node2 + point( 3, 3 ) );
             // Spawn a monster in there
             if( step > 2 ) { // First couple of chambers are safe
-                int monrng = rng( 1, 25 );
-                point spawn( node2 + point{ rng( 0, 3 ), rng( 0, 3 ) } );
+                int const monrng = rng( 1, 25 );
+                point const spawn( node2 + point{ rng( 0, 3 ), rng( 0, 3 ) } );
                 if( monrng <= 24 ) {
                     place_spawns( GROUP_TRIFFID_OUTER, 1, node2,
                                   node2 + point( 3, 3 ), 1, true );
@@ -5051,7 +5051,7 @@ void map::draw_triffid( mapgendata &dat )
                         chance_south++;
                     }
                 }
-                int roll = rng( 0, chance_west + chance_east + chance_north + chance_south );
+                int const roll = rng( 0, chance_west + chance_east + chance_north + chance_south );
                 if( roll < chance_west && x > 0 ) {
                     x--;
                 } else if( roll < chance_west + chance_east && x < EAST_EDGE ) {
@@ -5197,7 +5197,7 @@ void map::draw_connections( mapgendata &dat )
     if( terrain_type->has_flag( has_sidewalk ) ) {
         for( int dir = 4; dir < 8; dir++ ) { // NE SE SW NW
             bool n_roads_nesw[4] = {};
-            int n_num_dirs = terrain_type_to_nesw_array( oter_id( dat.t_nesw[dir] ), n_roads_nesw );
+            int const n_num_dirs = terrain_type_to_nesw_array( oter_id( dat.t_nesw[dir] ), n_roads_nesw );
             // only handle diagonal neighbors
             if( n_num_dirs == 2 &&
                 n_roads_nesw[( ( dir - 4 ) + 3 ) % 4] &&
@@ -5249,9 +5249,9 @@ void map::place_spawns( const mongroup_id &group, const int chance,
         spawn_density = get_option< float >( "SPAWN_DENSITY" );
     }
 
-    float multiplier = density * spawn_density;
+    float const multiplier = density * spawn_density;
     // Only spawn 1 creature if individual flag set, else scale by density
-    float thenum = individual ? 1 : ( multiplier * rng_float( 10.0f, 50.0f ) );
+    float const thenum = individual ? 1 : ( multiplier * rng_float( 10.0f, 50.0f ) );
     int num = roll_remainder( thenum );
 
     // GetResultFromGroup decrements num
@@ -5267,7 +5267,7 @@ void map::place_spawns( const mongroup_id &group, const int chance,
         } while( impassable( p ) && tries > 0 );
 
         // Pick a monster type
-        MonsterGroupResult spawn_details = MonsterGroupManager::GetResultFromGroup( group, &num );
+        MonsterGroupResult const spawn_details = MonsterGroupManager::GetResultFromGroup( group, &num );
 
         add_spawn( spawn_details.name, spawn_details.pack_size, { p, abs_sub.z },
                    friendly, -1, mission_id, name );
@@ -5320,7 +5320,7 @@ character_id map::place_npc( point p, const string_id<npc_template> &type, bool 
     if( !force && !get_option<bool>( "STATIC_NPC" ) ) {
         return character_id(); //Do not generate an npc.
     }
-    shared_ptr_fast<npc> temp = make_shared_fast<npc>();
+    shared_ptr_fast<npc> const temp = make_shared_fast<npc>();
     temp->load_npc_template( type );
     temp->spawn_at_precise( { abs_sub.xy() }, { p, abs_sub.z } );
     temp->toggle_trait( trait_NPC_STATIC_NPC );
@@ -5369,7 +5369,7 @@ std::vector<item *> map::place_items( const item_group_id &loc, const int chance
     }
 
     const float spawn_rate = get_option<float>( "ITEM_SPAWNRATE" );
-    int spawn_count = roll_remainder( chance * spawn_rate / 100.0f );
+    int const spawn_count = roll_remainder( chance * spawn_rate / 100.0f );
     for( int i = 0; i < spawn_count; i++ ) {
         // Might contain one item or several that belong together like guns & their ammo
         int tries = 0;
@@ -5430,7 +5430,7 @@ void map::add_spawn( const mtype_id &type, int count, const tripoint &p, bool fr
     if( MonsterGroupManager::monster_is_blacklisted( type ) ) {
         return;
     }
-    spawn_point tmp( type, count, offset, faction_id, mission_id, friendly, name );
+    spawn_point const tmp( type, count, offset, faction_id, mission_id, friendly, name );
     place_on_submap->spawns.push_back( tmp );
 }
 
@@ -5686,7 +5686,7 @@ void map::rotate( int turns, const bool setpos_safe )
             // OK, this is ugly: we remove the NPC from the whole map
             // Then we place it back from scratch
             // It could be rewritten to utilize the fact that rotation shouldn't cross overmaps
-            shared_ptr_fast<npc> npc_ptr = overmap_buffer.remove_npc( np.getID() );
+            shared_ptr_fast<npc> const npc_ptr = overmap_buffer.remove_npc( np.getID() );
             np.spawn_at_precise( { abs_sub.xy() }, { new_pos, abs_sub.z } );
             overmap_buffer.insert_npc( npc_ptr );
         }
@@ -5714,7 +5714,7 @@ void map::rotate( int turns, const bool setpos_safe )
     // Then rotate them and recalculate vehicle positions.
     for( int j = 0; j < 2; ++j ) {
         for( int i = 0; i < 2; ++i ) {
-            point p( i, j );
+            point const p( i, j );
             auto sm = get_submap_at_grid( p );
 
             sm->rotate( turns );
@@ -5788,7 +5788,7 @@ void science_room( map *m, point p1, point p2, int z, int rotate )
     int height = p2.y - p1.y;
     int width  = p2.x - p1.x;
     if( rotate % 2 == 1 ) { // Swap width & height if we're a lateral room
-        int tmp = height;
+        int const tmp = height;
         height  = width;
         width   = tmp;
     }
@@ -5797,7 +5797,7 @@ void science_room( map *m, point p1, point p2, int z, int rotate )
             m->ter_set( point( i, j ), t_thconc_floor );
         }
     }
-    int area = height * width;
+    int const area = height * width;
     std::vector<room_type> valid_rooms;
     if( height < 5 && width < 5 ) {
         valid_rooms.push_back( room_closet );
@@ -5836,7 +5836,7 @@ void science_room( map *m, point p1, point p2, int z, int rotate )
             break;
         case room_lobby:
             if( rotate % 2 == 0 ) { // Vertical
-                int desk = p1.y + rng( static_cast<int>( height / 2 ) - static_cast<int>( height / 4 ),
+                int const desk = p1.y + rng( static_cast<int>( height / 2 ) - static_cast<int>( height / 4 ),
                                        static_cast<int>( height / 2 ) + 1 );
                 for( int x = p1.x + static_cast<int>( width / 4 ); x < p2.x - static_cast<int>( width / 4 ); x++ ) {
                     m->furn_set( point( x, desk ), f_counter );
@@ -5852,7 +5852,7 @@ void science_room( map *m, point p1, point p2, int z, int rotate )
                                  point( static_cast<int>( ( p1.x + p2.x ) / 2 ), desk ),
                                  point( static_cast<int>( ( p1.x + p2.x ) / 2 ), desk ), 1, true );
             } else {
-                int desk = p1.x + rng( static_cast<int>( height / 2 ) - static_cast<int>( height / 4 ),
+                int const desk = p1.x + rng( static_cast<int>( height / 2 ) - static_cast<int>( height / 4 ),
                                        static_cast<int>( height / 2 ) + 1 );
                 for( int y = p1.y + static_cast<int>( width / 4 ); y < p2.y - static_cast<int>( width / 4 ); y++ ) {
                     m->furn_set( point( desk, y ), f_counter );
@@ -5996,7 +5996,7 @@ void science_room( map *m, point p1, point p2, int z, int rotate )
         case room_bionics:
             if( rotate % 2 == 0 ) {
                 int biox = p1.x + 2;
-                int bioy = static_cast<int>( ( p1.y + p2.y ) / 2 );
+                int const bioy = static_cast<int>( ( p1.y + p2.y ) / 2 );
                 mapf::formatted_set_simple( m, point( biox - 1, bioy - 1 ),
                                             "---\n"
                                             "|c|\n"
@@ -6037,7 +6037,7 @@ void science_room( map *m, point p1, point p2, int z, int rotate )
                     _( "ERROR!  Access denied!  Unauthorized access will be met with lethal force!" ) );
             } else {
                 int bioy = p1.y + 2;
-                int biox = static_cast<int>( ( p1.x + p2.x ) / 2 );
+                int const biox = static_cast<int>( ( p1.x + p2.x ) / 2 );
                 mapf::formatted_set_simple( m, point( biox - 1, bioy - 1 ),
                                             "|-|\n"
                                             "|c=\n"
@@ -6126,8 +6126,8 @@ void science_room( map *m, point p1, point p2, int z, int rotate )
             break;
         case room_split:
             if( rotate % 2 == 0 ) {
-                int w1 = static_cast<int>( ( p1.x + p2.x ) / 2 ) - 2;
-                int w2 = static_cast<int>( ( p1.x + p2.x ) / 2 ) + 2;
+                int const w1 = static_cast<int>( ( p1.x + p2.x ) / 2 ) - 2;
+                int const w2 = static_cast<int>( ( p1.x + p2.x ) / 2 ) + 2;
                 for( int y = p1.y; y <= p2.y; y++ ) {
                     m->ter_set( point( w1, y ), t_concrete_wall );
                     m->ter_set( point( w2, y ), t_concrete_wall );
@@ -6137,8 +6137,8 @@ void science_room( map *m, point p1, point p2, int z, int rotate )
                 science_room( m, p1, point( w1 - 1, p2.y ), z, 1 );
                 science_room( m, point( w2 + 1, p1.y ), p2, z, 3 );
             } else {
-                int w1 = static_cast<int>( ( p1.y + p2.y ) / 2 ) - 2;
-                int w2 = static_cast<int>( ( p1.y + p2.y ) / 2 ) + 2;
+                int const w1 = static_cast<int>( ( p1.y + p2.y ) / 2 ) - 2;
+                int const w2 = static_cast<int>( ( p1.y + p2.y ) / 2 ) + 2;
                 for( int x = p1.x; x <= p2.x; x++ ) {
                     m->ter_set( point( x, w1 ), t_concrete_wall );
                     m->ter_set( point( x, w2 ), t_concrete_wall );
@@ -6157,7 +6157,7 @@ void science_room( map *m, point p1, point p2, int z, int rotate )
 void map::create_anomaly( const tripoint &cp, artifact_natural_property prop, bool create_rubble )
 {
     // TODO: Z
-    point c( cp.xy() );
+    point const c( cp.xy() );
     if( create_rubble ) {
         rough_circle( this, t_dirt, c, 11 );
         rough_circle_furn( this, f_rubble, c, 5 );
@@ -6409,7 +6409,7 @@ bool update_mapgen_function_json::update_map( mapgendata &md, point offset,
             const mapgendata &md;
             const int rotation;
     };
-    rotation_guard rot( md );
+    rotation_guard const rot( md );
 
     for( auto &elem : setmap_points ) {
         if( verify && elem.has_vehicle_collision( md, offset ) ) {
@@ -6496,7 +6496,7 @@ std::pair<std::map<ter_id, int>, std::map<furn_id, int>> get_changed_ids_from_up
 
     ::fake_map fake_map( f_null, t_dirt, tr_null, fake_map_z );
 
-    oter_id any = oter_id( "field" );
+    oter_id const any = oter_id( "field" );
     // just need a variable here, it doesn't need to be valid
     const regional_settings dummy_settings;
 
@@ -6505,12 +6505,12 @@ std::pair<std::map<ter_id, int>, std::map<furn_id, int>> get_changed_ids_from_up
 
     if( update_function->second[0]->update_map( fake_md ) ) {
         for( const tripoint &pos : fake_map.points_on_zlevel( fake_map_z ) ) {
-            ter_id ter_at_pos = fake_map.ter( pos );
+            ter_id const ter_at_pos = fake_map.ter( pos );
             if( ter_at_pos != t_dirt ) {
                 terrains[ter_at_pos] += 1;
             }
             if( fake_map.has_furn( pos ) ) {
-                furn_id furn_at_pos = fake_map.furn( pos );
+                furn_id const furn_at_pos = fake_map.furn( pos );
                 furnitures[furn_at_pos] += 1;
             }
         }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -180,7 +180,8 @@ void map::generate( const tripoint &p, const time_point &when )
     if( spawns.group && x_in_y( odds_after_density, 100 ) ) {
         int pop = spawn_count * rng( spawns.population.min, spawns.population.max );
         for( ; pop > 0; pop-- ) {
-            MonsterGroupResult const spawn_details = MonsterGroupManager::GetResultFromGroup( spawns.group, &pop );
+            MonsterGroupResult const spawn_details = MonsterGroupManager::GetResultFromGroup( spawns.group,
+                    &pop );
             if( !spawn_details.name ) {
                 continue;
             }
@@ -377,7 +378,7 @@ void calculate_mapgen_weights()   // TODO: rename as it runs jsonfunction setup 
     oter_mapgen.setup();
     // Not really calculate weights, but let's keep it here for now
     for( auto &pr : nested_mapgen ) {
-        for( weighted_object<int, std::shared_ptr<mapgen_function_json_nested>>  const&ptr : pr.second ) {
+        for( weighted_object<int, std::shared_ptr<mapgen_function_json_nested>>  const &ptr : pr.second ) {
             ptr.obj->setup();
             inp_mngr.pump_events();
         }
@@ -791,8 +792,8 @@ void mapgen_function_json_base::setup_setmap( const JsonArray &parray )
         pjo.read( "fuel", tmp_fuel );
         pjo.read( "status", tmp_status );
         jmapgen_setmap const tmp( tmp_x, tmp_y, tmp_x2, tmp_y2,
-                            static_cast<jmapgen_setmap_op>( tmpop + setmap_optype ), tmp_i,
-                            tmp_chance, tmp_repeat, tmp_rotation, tmp_fuel, tmp_status );
+                                  static_cast<jmapgen_setmap_op>( tmpop + setmap_optype ), tmp_i,
+                                  tmp_chance, tmp_repeat, tmp_rotation, tmp_fuel, tmp_status );
 
         setmap_points.push_back( tmp );
         tmpval.clear();
@@ -1638,8 +1639,8 @@ class jmapgen_sealed_item : public jmapgen_piece
         void check( const std::string &oter_name ) const override {
             const furn_t &furn = furniture.obj();
             std::string const summary = string_format(
-                                      "sealed_item special in json mapgen for overmap terrain %s using furniture %s",
-                                      oter_name, furn.id.str() );
+                                            "sealed_item special in json mapgen for overmap terrain %s using furniture %s",
+                                            oter_name, furn.id.str() );
 
             if( !furniture.is_valid() ) {
                 debugmsg( "%s which is not valid furniture", summary );
@@ -2400,7 +2401,7 @@ void mapgen_function_json_base::setup_common()
         return;
     }
     shared_ptr_fast<std::istream> const stream = DynamicDataLoader::get_instance().get_cached_stream(
-            *jsrcloc->path );
+                *jsrcloc->path );
     JsonIn jsin( *stream, *jsrcloc );
     JsonObject const jo = jsin.get_object();
     mapgen_defer::defer = false;
@@ -3733,9 +3734,9 @@ void map::draw_lab( mapgendata &dat )
                         ter_id const lw_type = tower_lab ? t_reinforced_glass : t_concrete_wall;
                         ter_id const tw_type = tower_lab ? t_reinforced_glass : t_concrete_wall;
                         ter_id const rw_type = tower_lab && rw == 2 ? t_reinforced_glass :
-                                         t_concrete_wall;
+                                               t_concrete_wall;
                         ter_id const bw_type = tower_lab && bw == 2 ? t_reinforced_glass :
-                                         t_concrete_wall;
+                                               t_concrete_wall;
                         for( int i = 0; i < SEEX * 2; i++ ) {
                             ter_set( point( 23, i ), rw_type );
                             furn_set( point( 23, i ), f_null );
@@ -5837,7 +5838,7 @@ void science_room( map *m, point p1, point p2, int z, int rotate )
         case room_lobby:
             if( rotate % 2 == 0 ) { // Vertical
                 int const desk = p1.y + rng( static_cast<int>( height / 2 ) - static_cast<int>( height / 4 ),
-                                       static_cast<int>( height / 2 ) + 1 );
+                                             static_cast<int>( height / 2 ) + 1 );
                 for( int x = p1.x + static_cast<int>( width / 4 ); x < p2.x - static_cast<int>( width / 4 ); x++ ) {
                     m->furn_set( point( x, desk ), f_counter );
                 }
@@ -5853,7 +5854,7 @@ void science_room( map *m, point p1, point p2, int z, int rotate )
                                  point( static_cast<int>( ( p1.x + p2.x ) / 2 ), desk ), 1, true );
             } else {
                 int const desk = p1.x + rng( static_cast<int>( height / 2 ) - static_cast<int>( height / 4 ),
-                                       static_cast<int>( height / 2 ) + 1 );
+                                             static_cast<int>( height / 2 ) + 1 );
                 for( int y = p1.y + static_cast<int>( width / 4 ); y < p2.y - static_cast<int>( width / 4 ); y++ ) {
                     m->furn_set( point( desk, y ), f_counter );
                 }

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -2845,7 +2845,7 @@ void mapgen_lake_shore( mapgendata &dat )
     bool did_extend_adjacent_terrain = false;
     if( !dat.region.overmap_lake.shore_extendable_overmap_terrain.empty() ) {
         std::map<oter_id, int> adjacent_type_count;
-        for( oter_id  const&adjacent : dat.t_nesw ) {
+        for( oter_id  const &adjacent : dat.t_nesw ) {
             // Define the terrain we'll look for a match on.
             oter_id match = adjacent;
 
@@ -3213,7 +3213,7 @@ void mapgen_lake_shore( mapgendata &dat )
 
     const auto fill_deep_water = [&]( point  starting_point ) {
         std::vector<point> const water_points = ff::point_flood_fill_4_connected( starting_point, visited,
-                                          should_fill );
+                                                should_fill );
         for( auto &wp : water_points ) {
             m->ter_set( wp, t_water_dp );
             m->furn_set( wp, f_null );

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -256,11 +256,11 @@ void mapgen_field( mapgendata &dat )
                                );
 
     // one dominant plant type ( for boosted_vegetation == true )
-    ter_furn_id altbush = dat.region.field_coverage.pick( true );
+    ter_furn_id const altbush = dat.region.field_coverage.pick( true );
 
     for( int i = 0; i < SEEX * 2; i++ ) {
         for( int j = 0; j < SEEY * 2; j++ ) {
-            point p( i, j );
+            point const p( i, j );
             // default is
             m->ter_set( p, dat.groundcover() );
             // yay, a shrub ( or tombstone )
@@ -287,7 +287,7 @@ void mapgen_hive( mapgendata &dat )
     // Start with a basic forest pattern
     for( int i = 0; i < SEEX * 2; i++ ) {
         for( int j = 0; j < SEEY * 2; j++ ) {
-            int rn = rng( 0, 14 );
+            int const rn = rng( 0, 14 );
             if( rn > 13 ) {
                 m->ter_set( point( i, j ), t_tree );
             } else if( rn > 11 ) {
@@ -326,8 +326,8 @@ void mapgen_hive( mapgendata &dat )
                 m->ter_set( point( i + 1, j + 2 ), t_floor_wax );
 
                 // Up to two of these get skipped; an entrance to the cell
-                int skip1 = rng( 0, SEEX * 2 - 1 );
-                int skip2 = rng( 0, SEEY * 2 - 1 );
+                int const skip1 = rng( 0, SEEX * 2 - 1 );
+                int const skip2 = rng( 0, SEEY * 2 - 1 );
 
                 m->ter_set( point( i - 1, j - 4 ), t_wax );
                 m->ter_set( point( i, j - 4 ), t_wax );
@@ -487,7 +487,7 @@ void nesw_array_rotate( T *array, size_t len, size_t dist )
 static void coord_rotate_cw( int &x, int &y, int rot )
 {
     for( ; rot--; ) {
-        int temp = y;
+        int const temp = y;
         y = x;
         x = ( SEEY * 2 - 1 ) - temp;
     }
@@ -519,9 +519,9 @@ void mapgen_road( mapgendata &dat )
 
     // which of the cardinal directions get roads?
     bool roads_nesw[4] = {};
-    int num_dirs = terrain_type_to_nesw_array( dat.terrain_type(), roads_nesw );
+    int const num_dirs = terrain_type_to_nesw_array( dat.terrain_type(), roads_nesw );
     // if this is a dead end, extend past the middle of the tile
-    int dead_end_extension = ( num_dirs == 1 ? 8 : 0 );
+    int const dead_end_extension = ( num_dirs == 1 ? 8 : 0 );
 
     // which way should our roads curve, based on neighbor roads?
     int curvedir_nesw[4] = {};
@@ -534,7 +534,7 @@ void mapgen_road( mapgendata &dat )
         // n_* contain details about the neighbor being considered
         bool n_roads_nesw[4] = {};
         // TODO: figure out how to call this function without creating a new oter_id object
-        int n_num_dirs = terrain_type_to_nesw_array( dat.t_nesw[dir], n_roads_nesw );
+        int const n_num_dirs = terrain_type_to_nesw_array( dat.t_nesw[dir], n_roads_nesw );
         // if 2-way neighbor has a road facing us
         if( n_num_dirs == 2 && n_roads_nesw[( dir + 2 ) % 4] ) {
             // curve towards the direction the neighbor turns
@@ -834,7 +834,7 @@ void mapgen_road( mapgendata &dat )
     }
 
     // add some items
-    bool plaza = ( plaza_dir > -1 );
+    bool const plaza = ( plaza_dir > -1 );
     m->place_items( item_group_id( plaza ? "trash" : "road" ), 5, point_zero, point( SEEX * 2 - 1,
                     SEEX * 2 - 1 ), plaza,
                     dat.when() );
@@ -1280,7 +1280,7 @@ void mapgen_sewer_tee( mapgendata &dat )
 void mapgen_sewer_four_way( mapgendata &dat )
 {
     map *const m = &dat.m;
-    int rn = rng( 0, 3 );
+    int const rn = rng( 0, 3 );
     for( int i = 0; i < SEEX * 2; i++ ) {
         for( int j = 0; j < SEEY * 2; j++ ) {
             if( ( i < SEEX - 2 || i > SEEX + 1 ) && ( j < SEEY - 2 || j > SEEY + 1 ) ) {
@@ -1341,7 +1341,7 @@ void mapgen_railroad( mapgendata &dat )
     dat.fill_groundcover();
     // which of the cardinal directions get railroads?
     bool railroads_nesw[4] = {};
-    int num_dirs = terrain_type_to_nesw_array( dat.terrain_type(), railroads_nesw );
+    int const num_dirs = terrain_type_to_nesw_array( dat.terrain_type(), railroads_nesw );
     // which way should our railroads curve, based on neighbor railroads?
     int curvedir_nesw[4] = {};
     for( int dir = 0; dir < 4; dir++ ) { // N E S W
@@ -1351,7 +1351,7 @@ void mapgen_railroad( mapgendata &dat )
         // n_* contain details about the neighbor being considered
         bool n_railroads_nesw[4] = {};
         // TODO: figure out how to call this function without creating a new oter_id object
-        int n_num_dirs = terrain_type_to_nesw_array( dat.t_nesw[dir], n_railroads_nesw );
+        int const n_num_dirs = terrain_type_to_nesw_array( dat.t_nesw[dir], n_railroads_nesw );
         // if 2-way neighbor has a railroad facing us
         if( n_num_dirs == 2 && n_railroads_nesw[( dir + 2 ) % 4] ) {
             // curve towards the direction the neighbor turns
@@ -1691,12 +1691,12 @@ void mapgen_river_curved_not( mapgendata &dat )
     fill_background( m, t_water_moving_dp );
     // this is not_ne, so deep on all sides except ne corner, which is shallow
     // shallow is 20,0, 23,4
-    int north_edge = rng( 16, 18 );
-    int east_edge = rng( 4, 8 );
+    int const north_edge = rng( 16, 18 );
+    int const east_edge = rng( 4, 8 );
 
     for( int x = north_edge; x < SEEX * 2; x++ ) {
         for( int y = 0; y < east_edge; y++ ) {
-            int circle_edge = ( ( SEEX * 2 - x ) * ( SEEX * 2 - x ) ) + ( y * y );
+            int const circle_edge = ( ( SEEX * 2 - x ) * ( SEEX * 2 - x ) ) + ( y * y );
             if( circle_edge <= 8 ) {
                 m->ter_set( point( x, y ), grass_or_dirt() );
             }
@@ -1726,7 +1726,7 @@ void mapgen_river_straight( mapgendata &dat )
 
     for( int x = 0; x < SEEX * 2; x++ ) {
         int ground_edge = rng( 1, 3 );
-        int shallow_edge = rng( 4, 6 );
+        int const shallow_edge = rng( 4, 6 );
         line( m, grass_or_dirt(), point( x, 0 ), point( x, ground_edge ) );
         if( one_in( 25 ) ) {
             m->ter_set( point( x, ++ground_edge ), clay_or_sand() );
@@ -1752,7 +1752,7 @@ void mapgen_river_curved( mapgendata &dat )
     // NE corner deep, other corners are shallow.  do 2 passes: one x, one y
     for( int x = 0; x < SEEX * 2; x++ ) {
         int ground_edge = rng( 1, 3 );
-        int shallow_edge = rng( 4, 6 );
+        int const shallow_edge = rng( 4, 6 );
         line( m, grass_or_dirt(), point( x, 0 ), point( x, ground_edge ) );
         if( one_in( 25 ) ) {
             m->ter_set( point( x, ++ground_edge ), clay_or_sand() );
@@ -1761,7 +1761,7 @@ void mapgen_river_curved( mapgendata &dat )
     }
     for( int y = 0; y < SEEY * 2; y++ ) {
         int ground_edge = rng( 19, 21 );
-        int shallow_edge = rng( 16, 18 );
+        int const shallow_edge = rng( 16, 18 );
         line( m, grass_or_dirt(), point( ground_edge, y ), point( SEEX * 2 - 1, y ) );
         if( one_in( 25 ) ) {
             m->ter_set( point( --ground_edge, y ), clay_or_sand() );
@@ -1835,9 +1835,9 @@ void mapgen_cavern( mapgendata &dat )
     }
 
     // Number of pillars
-    int rn = rng( 0, 2 ) * rng( 0, 3 ) + rng( 0, 1 );
+    int const rn = rng( 0, 2 ) * rng( 0, 3 ) + rng( 0, 1 );
     for( int n = 0; n < rn; n++ ) {
-        point p{ rng( 5, SEEX * 2 - 6 ), rng( 5, SEEY * 2 - 6 ) };
+        point const p{ rng( 5, SEEX * 2 - 6 ), rng( 5, SEEY * 2 - 6 ) };
         for( int i = p.x - 1; i <= p.x + 1; i++ ) {
             for( int j = p.y - 1; j <= p.y + 1; j++ ) {
                 m->ter_set( point( i, j ), t_rock );
@@ -2280,10 +2280,10 @@ static void mapgen_ants_generic( mapgendata &dat )
             }
         }
     }
-    int rn = rng( 10, 20 );
+    int const rn = rng( 10, 20 );
     point p;
     for( int n = 0; n < rn; n++ ) {
-        int cw = rng( 1, 8 );
+        int const cw = rng( 1, 8 );
         do {
             p.x = rng( 1 + cw, SEEX * 2 - 2 - cw );
             p.y = rng( 1 + cw, SEEY * 2 - 2 - cw );
@@ -2659,7 +2659,7 @@ void mapgen_forest( mapgendata &dat )
     // terrain dependent furniture.
     for( int x = 0; x < SEEX * 2; x++ ) {
         for( int y = 0; y < SEEY * 2; y++ ) {
-            point p( x, y );
+            point const p( x, y );
             const ter_furn_id feature = get_blended_feature( p );
             ter_or_furn_set( m, p, feature );
             set_terrain_dependent_furniture( feature.ter, p );
@@ -2689,7 +2689,7 @@ void mapgen_forest_trail_straight( mapgendata &dat )
                     dat.region.forest_trail.trail_width_offset_max );
     };
 
-    point center( SEEX + center_offset(), SEEY + center_offset() );
+    point const center( SEEX + center_offset(), SEEY + center_offset() );
 
     for( int i = 0; i < SEEX * 2; i++ ) {
         for( int j = 0; j < SEEY * 2; j++ ) {
@@ -2725,7 +2725,7 @@ void mapgen_forest_trail_curved( mapgendata &dat )
                     dat.region.forest_trail.trail_width_offset_max );
     };
 
-    point center( SEEX + center_offset(), SEEY + center_offset() );
+    point const center( SEEX + center_offset(), SEEY + center_offset() );
 
     for( int i = 0; i < SEEX * 2; i++ ) {
         for( int j = 0; j < SEEY * 2; j++ ) {
@@ -2769,7 +2769,7 @@ void mapgen_forest_trail_tee( mapgendata &dat )
                     dat.region.forest_trail.trail_width_offset_max );
     };
 
-    point center( SEEX + center_offset(), SEEY + center_offset() );
+    point const center( SEEX + center_offset(), SEEY + center_offset() );
 
     for( int i = 0; i < SEEX * 2; i++ ) {
         for( int j = 0; j < SEEY * 2; j++ ) {
@@ -2812,7 +2812,7 @@ void mapgen_forest_trail_four_way( mapgendata &dat )
                     dat.region.forest_trail.trail_width_offset_max );
     };
 
-    point center( SEEX + center_offset(), SEEY + center_offset() );
+    point const center( SEEX + center_offset(), SEEY + center_offset() );
 
     for( int i = 0; i < SEEX * 2; i++ ) {
         for( int j = 0; j < SEEY * 2; j++ ) {
@@ -2845,7 +2845,7 @@ void mapgen_lake_shore( mapgendata &dat )
     bool did_extend_adjacent_terrain = false;
     if( !dat.region.overmap_lake.shore_extendable_overmap_terrain.empty() ) {
         std::map<oter_id, int> adjacent_type_count;
-        for( oter_id &adjacent : dat.t_nesw ) {
+        for( oter_id  const&adjacent : dat.t_nesw ) {
             // Define the terrain we'll look for a match on.
             oter_id match = adjacent;
 
@@ -3162,9 +3162,9 @@ void mapgen_lake_shore( mapgendata &dat )
     // It buffers the points a bit for a thicker line. It also clears any furniture that might
     // be in the location as a result of our extending adjacent mapgen.
     const auto draw_shallow_water = [&]( point  from, point  to ) {
-        std::vector<point> points = line_to( from, to );
+        std::vector<point> const points = line_to( from, to );
         for( auto &p : points ) {
-            for( point bp : closest_points_first( p, 1 ) ) {
+            for( point const bp : closest_points_first( p, 1 ) ) {
                 if( !map_boundaries.contains( bp ) ) {
                     continue;
                 }
@@ -3212,7 +3212,7 @@ void mapgen_lake_shore( mapgendata &dat )
     };
 
     const auto fill_deep_water = [&]( point  starting_point ) {
-        std::vector<point> water_points = ff::point_flood_fill_4_connected( starting_point, visited,
+        std::vector<point> const water_points = ff::point_flood_fill_4_connected( starting_point, visited,
                                           should_fill );
         for( auto &wp : water_points ) {
             m->ter_set( wp, t_water_dp );
@@ -3245,19 +3245,19 @@ void mapgen_lake_shore( mapgendata &dat )
 
 void mremove_trap( map *m, point p )
 {
-    tripoint actual_location( p, m->get_abs_sub().z );
+    tripoint const actual_location( p, m->get_abs_sub().z );
     m->remove_trap( actual_location );
 }
 
 void mtrap_set( map *m, point p, trap_id type )
 {
-    tripoint actual_location( p, m->get_abs_sub().z );
+    tripoint const actual_location( p, m->get_abs_sub().z );
     m->trap_set( actual_location, type );
 }
 
 void madd_field( map *m, point p, field_type_id type, int intensity )
 {
-    tripoint actual_location( p, m->get_abs_sub().z );
+    tripoint const actual_location( p, m->get_abs_sub().z );
     m->add_field( actual_location, type, intensity, 0_turns );
 }
 

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -1001,7 +1001,7 @@ bool character_martial_arts::can_leg_block( const Character &owner ) const
     const martialart &ma = style_selected.obj();
     ///\EFFECT_UNARMED increases ability to perform leg block
     int const unarmed_skill = owner.has_active_bionic( bio_cqb ) ? 5 : owner.get_skill_level(
-                            skill_unarmed );
+                                  skill_unarmed );
 
     // Success conditions.
     if( owner.get_working_leg_count() >= 1 ) {
@@ -1020,7 +1020,7 @@ bool character_martial_arts::can_arm_block( const Character &owner ) const
     const martialart &ma = style_selected.obj();
     ///\EFFECT_UNARMED increases ability to perform arm block
     int const unarmed_skill = owner.has_active_bionic( bio_cqb ) ? 5 : owner.get_skill_level(
-                            skill_unarmed );
+                                  skill_unarmed );
 
     // Success conditions.
     if( !owner.is_limb_broken( bodypart_id( "arm_l" ) ) ||
@@ -1553,8 +1553,8 @@ bool ma_style_callback::key( const input_context &ctxt, const input_event &event
                                      itp->weapon_category.end(), cat_check ) ) {
                         // If so, add it to the categories it applies to.
                         std::string const weaponname = wielded ? colorize( item::nname( weap_id ) + _( " [wielded]" ),
-                                                 c_light_cyan ) :
-                                                 carried ? colorize( item::nname( weap_id ), c_yellow ) : item::nname( weap_id );
+                                                       c_light_cyan ) :
+                                                       carried ? colorize( item::nname( weap_id ), c_yellow ) : item::nname( weap_id );
                         weapons_by_category[cat].push_back( weaponname );
                     }
                 }
@@ -1569,7 +1569,7 @@ bool ma_style_callback::key( const input_context &ctxt, const input_event &event
                 std::sort( list.second.begin(), list.second.end(), localized_compare );
                 // If item factory somehow manages to crap out and it has no translation/name, use the ID.
                 std::string const cat_name = list.first.is_valid() ? list.first->name().translated()
-                                       : colorize( "ID: " + std::string( list.first ), c_red );
+                                             : colorize( "ID: " + std::string( list.first ), c_red );
                 buffer += std::string( "<header>" ) + cat_name + ": " +
                           std::string( "</header>" );
                 buffer += enumerate_as_string( list.second ) + std::string( "\n" );
@@ -1584,8 +1584,8 @@ bool ma_style_callback::key( const input_context &ctxt, const input_event &event
                         return it.typeId() == weap_id;
                     } );
                     std::string const weaponname = wielded ? colorize( item::nname( wid ) + _( " [wielded]" ),
-                                             c_light_cyan ) :
-                                             carried ? colorize( item::nname( wid ), c_yellow ) : item::nname( wid );
+                                                   c_light_cyan ) :
+                                                   carried ? colorize( item::nname( wid ), c_yellow ) : item::nname( wid );
                     weapons.push_back( weaponname );
                 }
                 // Sorting alphabetically makes it easier to find a specific weapon

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -121,7 +121,7 @@ class ma_skill_reader : public generic_typed_reader<ma_skill_reader>
 {
     public:
         std::pair<skill_id, int> get_next( JsonIn &jin ) const {
-            JsonObject jo = jin.get_object();
+            JsonObject const jo = jin.get_object();
             return std::pair<skill_id, int>( skill_id( jo.get_string( "name" ) ), jo.get_int( "level" ) );
         }
         template<typename C>
@@ -139,8 +139,8 @@ class ma_weapon_damage_reader : public generic_typed_reader<ma_weapon_damage_rea
         std::map<std::string, damage_type> dt_map = get_dt_map();
 
         std::pair<damage_type, int> get_next( JsonIn &jin ) const {
-            JsonObject jo = jin.get_object();
-            std::string type = jo.get_string( "type" );
+            JsonObject const jo = jin.get_object();
+            std::string const type = jo.get_string( "type" );
             const auto iter = get_dt_map().find( type );
             if( iter == get_dt_map().end() ) {
                 jo.throw_error( "Invalid damage type" );
@@ -150,8 +150,8 @@ class ma_weapon_damage_reader : public generic_typed_reader<ma_weapon_damage_rea
         }
         template<typename C>
         void erase_next( JsonIn &jin, C &container ) const {
-            JsonObject jo = jin.get_object();
-            std::string type = jo.get_string( "type" );
+            JsonObject const jo = jin.get_object();
+            std::string const type = jo.get_string( "type" );
             const auto iter = get_dt_map().find( type );
             if( iter == get_dt_map().end() ) {
                 jo.throw_error( "Invalid damage type" );
@@ -184,7 +184,7 @@ void ma_technique::load( const JsonObject &jo, const std::string &src )
     optional( jo, was_loaded, "description", description, "" );
 
     if( jo.has_member( "messages" ) ) {
-        JsonArray jsarr = jo.get_array( "messages" );
+        JsonArray const jsarr = jo.get_array( "messages" );
         avatar_message = jsarr.get_string( 0 );
         npc_message = jsarr.get_string( 1 );
     }
@@ -287,7 +287,7 @@ class ma_buff_reader : public generic_typed_reader<ma_buff_reader>
             if( jin.test_string() ) {
                 return mabuff_id( jin.get_string() );
             }
-            JsonObject jsobj = jin.get_object();
+            JsonObject const jsobj = jin.get_object();
             ma_buffs.load( jsobj, "" );
             return mabuff_id( jsobj.get_string( "id" ) );
         }
@@ -298,10 +298,10 @@ void martialart::load( const JsonObject &jo, const std::string & )
     mandatory( jo, was_loaded, "name", name );
     mandatory( jo, was_loaded, "description", description );
     mandatory( jo, was_loaded, "initiate", initiate );
-    for( JsonArray skillArray : jo.get_array( "autolearn" ) ) {
-        std::string skill_name = skillArray.get_string( 0 );
+    for( JsonArray const skillArray : jo.get_array( "autolearn" ) ) {
+        std::string const skill_name = skillArray.get_string( 0 );
         int skill_level = 0;
-        std::string skill_level_string = skillArray.get_string( 1 );
+        std::string const skill_level_string = skillArray.get_string( 1 );
         skill_level = stoi( skill_level_string );
         autolearn_skills.emplace_back( skill_name, skill_level );
     }
@@ -488,22 +488,22 @@ bool ma_requirements::is_valid_character( const Character &u ) const
     //to all weapons (such as Ninjutsu sneak attacks or innate weapon techniques like RAPID)
     //or if the weapon is flagged as being compatible with the style. Some techniques have
     //further restrictions on required weapon properties (is_valid_weapon).
-    bool cqb = u.has_active_bionic( bio_cqb );
+    bool const cqb = u.has_active_bionic( bio_cqb );
     // There are 4 different cases of "armedness":
     // Truly unarmed, unarmed weapon, style-allowed weapon, generic weapon
-    bool melee_style = u.martial_arts_data->selected_strictly_melee();
-    bool is_armed = u.is_armed();
-    bool unarmed_weapon = is_armed && u.primary_weapon().has_flag( flag_UNARMED_WEAPON );
-    bool forced_unarmed = u.martial_arts_data->selected_force_unarmed();
-    bool weapon_ok = is_valid_weapon( u.primary_weapon() );
-    bool style_weapon = u.martial_arts_data->selected_has_weapon( u.primary_weapon().typeId() );
-    bool all_weapons = u.martial_arts_data->selected_allow_melee();
+    bool const melee_style = u.martial_arts_data->selected_strictly_melee();
+    bool const is_armed = u.is_armed();
+    bool const unarmed_weapon = is_armed && u.primary_weapon().has_flag( flag_UNARMED_WEAPON );
+    bool const forced_unarmed = u.martial_arts_data->selected_force_unarmed();
+    bool const weapon_ok = is_valid_weapon( u.primary_weapon() );
+    bool const style_weapon = u.martial_arts_data->selected_has_weapon( u.primary_weapon().typeId() );
+    bool const all_weapons = u.martial_arts_data->selected_allow_melee();
 
-    bool unarmed_ok = !is_armed || ( unarmed_weapon && unarmed_weapons_allowed );
-    bool melee_ok = melee_allowed && weapon_ok && ( style_weapon || all_weapons );
+    bool const unarmed_ok = !is_armed || ( unarmed_weapon && unarmed_weapons_allowed );
+    bool const melee_ok = melee_allowed && weapon_ok && ( style_weapon || all_weapons );
 
-    bool valid_unarmed = !melee_style && unarmed_allowed && unarmed_ok;
-    bool valid_melee = !strictly_unarmed && ( forced_unarmed || melee_ok );
+    bool const valid_unarmed = !melee_style && unarmed_allowed && unarmed_ok;
+    bool const valid_melee = !strictly_unarmed && ( forced_unarmed || melee_ok );
 
     if( !valid_unarmed && !valid_melee ) {
         return false;
@@ -738,7 +738,7 @@ std::string ma_buff::get_description( bool passive ) const
     std::string dump;
     dump += string_format( _( "<bold>Buff technique:</bold> %s" ), _( name ) ) + "\n";
 
-    std::string temp = bonuses.get_description();
+    std::string const temp = bonuses.get_description();
     if( !temp.empty() ) {
         dump += string_format( _( "<bold>%s:</bold> " ),
                                vgettext( "Bonus", "Bonus/stack", max_stacks ) ) + "\n" + temp;
@@ -980,7 +980,7 @@ bool Character::can_use_grab_break_tec( const item &weap ) const
         return false;
     }
 
-    ma_technique tec = martial_arts_data->get_grab_break_tec( weap );
+    ma_technique const tec = martial_arts_data->get_grab_break_tec( weap );
 
     return tec.is_valid_character( *this );
 }
@@ -991,7 +991,7 @@ bool Character::can_miss_recovery( const item &weap ) const
         return false;
     }
 
-    ma_technique tec = martial_arts_data->get_miss_recovery_tec( weap );
+    ma_technique const tec = martial_arts_data->get_miss_recovery_tec( weap );
 
     return tec.is_valid_character( *this );
 }
@@ -1000,7 +1000,7 @@ bool character_martial_arts::can_leg_block( const Character &owner ) const
 {
     const martialart &ma = style_selected.obj();
     ///\EFFECT_UNARMED increases ability to perform leg block
-    int unarmed_skill = owner.has_active_bionic( bio_cqb ) ? 5 : owner.get_skill_level(
+    int const unarmed_skill = owner.has_active_bionic( bio_cqb ) ? 5 : owner.get_skill_level(
                             skill_unarmed );
 
     // Success conditions.
@@ -1019,7 +1019,7 @@ bool character_martial_arts::can_arm_block( const Character &owner ) const
 {
     const martialart &ma = style_selected.obj();
     ///\EFFECT_UNARMED increases ability to perform arm block
-    int unarmed_skill = owner.has_active_bionic( bio_cqb ) ? 5 : owner.get_skill_level(
+    int const unarmed_skill = owner.has_active_bionic( bio_cqb ) ? 5 : owner.get_skill_level(
                             skill_unarmed );
 
     // Success conditions.
@@ -1277,7 +1277,7 @@ bool can_autolearn_martial_art( const Character &who, const matype_id &ma_id )
 
 void character_martial_arts::martialart_use_message( const Character &owner ) const
 {
-    martialart ma = style_selected.obj();
+    martialart const ma = style_selected.obj();
     if( ma.force_unarmed || ma.weapon_valid( owner.primary_weapon() ) ) {
         owner.add_msg_if_player( m_info, _( ma.get_initiate_avatar_message() ) );
     } else if( ma.strictly_melee && !owner.is_armed() ) {
@@ -1336,7 +1336,7 @@ std::string ma_technique::get_description() const
 
     dump += string_format( _( "<bold>Type:</bold> %s" ), type ) + "\n";
 
-    std::string temp = bonuses.get_description();
+    std::string const temp = bonuses.get_description();
     if( !temp.empty() ) {
         dump += _( "<bold>Bonus:</bold> " ) + std::string( "\n" ) + temp;
     }
@@ -1540,8 +1540,8 @@ bool ma_style_callback::key( const input_context &ctxt, const input_event &event
             // Iterate over every item in the game.
             for( const itype *itp : item_controller->all() ) {
                 const itype_id &weap_id = itp->get_id();
-                bool wielded = player.primary_weapon().typeId() == weap_id;
-                bool carried = player.has_item_with( [weap_id]( const item & it ) {
+                bool const wielded = player.primary_weapon().typeId() == weap_id;
+                bool const carried = player.has_item_with( [weap_id]( const item & it ) {
                     return it.typeId() == weap_id;
                 } );
                 // Check if the item has any one of the weapon categories listed in the MA.
@@ -1552,7 +1552,7 @@ bool ma_style_callback::key( const input_context &ctxt, const input_event &event
                     if( std::any_of( itp->weapon_category.begin(),
                                      itp->weapon_category.end(), cat_check ) ) {
                         // If so, add it to the categories it applies to.
-                        std::string weaponname = wielded ? colorize( item::nname( weap_id ) + _( " [wielded]" ),
+                        std::string const weaponname = wielded ? colorize( item::nname( weap_id ) + _( " [wielded]" ),
                                                  c_light_cyan ) :
                                                  carried ? colorize( item::nname( weap_id ), c_yellow ) : item::nname( weap_id );
                         weapons_by_category[cat].push_back( weaponname );
@@ -1568,7 +1568,7 @@ bool ma_style_callback::key( const input_context &ctxt, const input_event &event
                 // then sort weapons within alphabetically.
                 std::sort( list.second.begin(), list.second.end(), localized_compare );
                 // If item factory somehow manages to crap out and it has no translation/name, use the ID.
-                std::string cat_name = list.first.is_valid() ? list.first->name().translated()
+                std::string const cat_name = list.first.is_valid() ? list.first->name().translated()
                                        : colorize( "ID: " + std::string( list.first ), c_red );
                 buffer += std::string( "<header>" ) + cat_name + ": " +
                           std::string( "</header>" );
@@ -1579,11 +1579,11 @@ bool ma_style_callback::key( const input_context &ctxt, const input_event &event
                 std::vector<std::string> weapons;
                 for( const itype_id &wid : ma.weapons ) {
                     const itype_id &weap_id = wid->get_id();
-                    bool wielded = player.primary_weapon().typeId() == weap_id;
-                    bool carried = player.has_item_with( [weap_id]( const item & it ) {
+                    bool const wielded = player.primary_weapon().typeId() == weap_id;
+                    bool const carried = player.has_item_with( [weap_id]( const item & it ) {
                         return it.typeId() == weap_id;
                     } );
-                    std::string weaponname = wielded ? colorize( item::nname( wid ) + _( " [wielded]" ),
+                    std::string const weaponname = wielded ? colorize( item::nname( wid ) + _( " [wielded]" ),
                                              c_light_cyan ) :
                                              carried ? colorize( item::nname( wid ), c_yellow ) : item::nname( wid );
                     weapons.push_back( weaponname );
@@ -1655,7 +1655,7 @@ bool ma_style_callback::key( const input_context &ctxt, const input_event &event
 
             ui_manager::redraw();
             const int scroll_lines = catacurses::getmaxy( w ) - 4;
-            std::string action = ict.handle_input();
+            std::string const action = ict.handle_input();
 
             if( action == "QUIT" ) {
                 break;

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -83,7 +83,7 @@ void material_type::load( const JsonObject &jsobj, const std::string & )
     optional( jsobj, was_loaded, "soft", _soft, false );
     optional( jsobj, was_loaded, "reinforces", _reinforces, false );
 
-    for( JsonArray pair : jsobj.get_array( "vitamins" ) ) {
+    for( JsonArray const pair : jsobj.get_array( "vitamins" ) ) {
         _vitamins.emplace( vitamin_id( pair.get_string( 0 ) ), pair.get_float( 1 ) );
     }
 
@@ -93,7 +93,7 @@ void material_type::load( const JsonObject &jsobj, const std::string & )
     mandatory( jsobj, was_loaded, "dmg_adj", _dmg_adj, string_reader() );
 
     if( jsobj.has_array( "burn_data" ) ) {
-        for( JsonObject brn : jsobj.get_array( "burn_data" ) ) {
+        for( JsonObject const brn : jsobj.get_array( "burn_data" ) ) {
             _burn_data.emplace_back( load_mat_burn_data( brn ) );
         }
     }
@@ -331,7 +331,7 @@ std::set<material_id> materials::get_rotting()
 
     // freshly created version is guaranteed to be invalid
     if( !material_data.is_valid( version ) ) {
-        material_list all = get_all();
+        material_list const all = get_all();
         rotting.clear();
         for( const material_type &m : all ) {
             if( m.rotting() ) {

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -94,14 +94,14 @@ bool leap_actor::call( monster &z ) const
     if( !allow_no_target && z.attack_target() == nullptr ) {
         return false;
     }
-    map  const&here = get_map();
+    map  const &here = get_map();
     std::multimap<int, tripoint> candidates;
     for( const tripoint &candidate : here.points_in_radius( z.pos(), max_range ) ) {
         if( candidate == z.pos() ) {
             continue;
         }
         float const leap_dist = trigdist ? trig_dist( z.pos(), candidate ) :
-                          square_dist( z.pos(), candidate );
+                                square_dist( z.pos(), candidate );
         if( leap_dist > max_range || leap_dist < min_range ) {
             continue;
         }
@@ -317,8 +317,8 @@ bool melee_actor::call( monster &z ) const
     damage.mult_damage( multiplier );
 
     body_part const bp_hit = body_parts.empty() ?
-                       target->select_body_part( &z, hitspread ) :
-                       *body_parts.pick();
+                             target->select_body_part( &z, hitspread ) :
+                             *body_parts.pick();
 
     target->on_hit( &z, convert_bp( bp_hit ).id() );
     dealt_damage_instance dealt_damage = target->deal_damage( &z, convert_bp( bp_hit ).id(), damage );
@@ -491,7 +491,7 @@ static std::optional<tripoint> find_target_vehicle( monster &z, int range )
     map &here = get_map();
     bool found = false;
     tripoint aim_at;
-    for( wrapped_vehicle  const&v : here.get_vehicles() ) {
+    for( wrapped_vehicle  const &v : here.get_vehicles() ) {
         if( ( !fov_3d && v.pos.z != z.pos().z ) || v.v->velocity == 0 ) {
             continue;
         }
@@ -514,7 +514,7 @@ static std::optional<tripoint> find_target_vehicle( monster &z, int range )
         if( !found_controls ) {
             std::vector<tripoint> const line = here.find_clear_path( z.pos(), v.v->global_pos3() );
             tripoint prev_point = z.pos();
-            for( tripoint  const&i : line ) {
+            for( tripoint  const &i : line ) {
                 if( here.floor_between( prev_point, i ) ) {
                     break;
                 }

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -82,8 +82,8 @@ bool leap_actor::call( monster &z ) const
     }
 
     std::vector<tripoint> options;
-    tripoint target = z.move_target();
-    float best_float = trigdist ? trig_dist( z.pos(), target ) : square_dist( z.pos(), target );
+    tripoint const target = z.move_target();
+    float const best_float = trigdist ? trig_dist( z.pos(), target ) : square_dist( z.pos(), target );
     if( best_float < min_consider_range || best_float > max_consider_range ) {
         return false;
     }
@@ -94,18 +94,18 @@ bool leap_actor::call( monster &z ) const
     if( !allow_no_target && z.attack_target() == nullptr ) {
         return false;
     }
-    map &here = get_map();
+    map  const&here = get_map();
     std::multimap<int, tripoint> candidates;
     for( const tripoint &candidate : here.points_in_radius( z.pos(), max_range ) ) {
         if( candidate == z.pos() ) {
             continue;
         }
-        float leap_dist = trigdist ? trig_dist( z.pos(), candidate ) :
+        float const leap_dist = trigdist ? trig_dist( z.pos(), candidate ) :
                           square_dist( z.pos(), candidate );
         if( leap_dist > max_range || leap_dist < min_range ) {
             continue;
         }
-        int candidate_dist = rl_dist( candidate, target );
+        int const candidate_dist = rl_dist( candidate, target );
         if( candidate_dist >= best_float ) {
             continue;
         }
@@ -125,7 +125,7 @@ bool leap_actor::call( monster &z ) const
         }
         bool blocked_path = false;
         // check if monster has a clear path to the proposed point
-        std::vector<tripoint> line = here.find_clear_path( z.pos(), dest );
+        std::vector<tripoint> const line = here.find_clear_path( z.pos(), dest );
         tripoint prev_point = z.pos();
         for( auto &i : line ) {
             if( here.impassable( i ) || here.obstructed_by_vehicle_rotation( prev_point, i ) ) {
@@ -169,7 +169,7 @@ std::unique_ptr<mattack_actor> mon_spellcasting_actor::clone() const
 
 void mon_spellcasting_actor::load_internal( const JsonObject &obj, const std::string & )
 {
-    std::string sp_id;
+    std::string const sp_id;
     fake_spell intermediate;
     mandatory( obj, was_loaded, "spell_data", intermediate );
     self = intermediate.self;
@@ -183,7 +183,7 @@ void mon_spellcasting_actor::load_internal( const JsonObject &obj, const std::st
 
 void mon_spellcasting_actor::finalize()
 {
-    avatar fake_player;
+    avatar const fake_player;
     move_cost = spell_data.casting_time( fake_player );
 }
 
@@ -200,7 +200,7 @@ bool mon_spellcasting_actor::call( monster &mon ) const
 
     const tripoint target = self ? mon.pos() : mon.attack_target()->pos();
 
-    std::string fx = spell_data.effect();
+    std::string const fx = spell_data.effect();
     // is the spell an attack that needs to hit the target?
     // examples of spells that don't: summons, teleport self
     const bool targeted_attack = fx == "target_attack" || fx == "projectile_attack" ||
@@ -260,7 +260,7 @@ void melee_actor::load_internal( const JsonObject &obj, const std::string & )
               to_translation( "The %1$s bites <npcname>'s %2$s!" ) );
 
     if( obj.has_array( "body_parts" ) ) {
-        for( JsonArray sub : obj.get_array( "body_parts" ) ) {
+        for( JsonArray const sub : obj.get_array( "body_parts" ) ) {
             const body_part bp = get_body_part_token( sub.get_string( 0 ) );
             const float prob = sub.get_float( 1 );
             body_parts.add_or_replace( bp, prob );
@@ -268,7 +268,7 @@ void melee_actor::load_internal( const JsonObject &obj, const std::string & )
     }
 
     if( obj.has_array( "effects" ) ) {
-        for( JsonObject eff : obj.get_array( "effects" ) ) {
+        for( JsonObject const eff : obj.get_array( "effects" ) ) {
             effects.push_back( load_mon_effect_data( eff ) );
         }
     }
@@ -301,7 +301,7 @@ bool melee_actor::call( monster &z ) const
              target->disp_name() );
 
     const int acc = accuracy >= 0 ? accuracy : z.type->melee_skill;
-    int hitspread = target->deal_melee_attack( &z, dice( acc, 10 ) );
+    int const hitspread = target->deal_melee_attack( &z, dice( acc, 10 ) );
 
     if( hitspread < 0 ) {
         auto msg_type = target->is_avatar() ? m_warning : m_info;
@@ -313,10 +313,10 @@ bool melee_actor::call( monster &z ) const
 
     damage_instance damage = damage_max_instance;
 
-    double multiplier = rng_float( min_mul, max_mul );
+    double const multiplier = rng_float( min_mul, max_mul );
     damage.mult_damage( multiplier );
 
-    body_part bp_hit = body_parts.empty() ?
+    body_part const bp_hit = body_parts.empty() ?
                        target->select_body_part( &z, hitspread ) :
                        *body_parts.pick();
 
@@ -324,7 +324,7 @@ bool melee_actor::call( monster &z ) const
     dealt_damage_instance dealt_damage = target->deal_damage( &z, convert_bp( bp_hit ).id(), damage );
     dealt_damage.bp_hit = bp_hit;
 
-    int damage_total = dealt_damage.total_damage();
+    int const damage_total = dealt_damage.total_damage();
     add_msg( m_debug, "%s's melee_attack did %d damage", z.name(), damage_total );
     if( damage_total > 0 ) {
         on_damage( z, *target, dealt_damage );
@@ -412,7 +412,7 @@ void gun_actor::load_internal( const JsonObject &obj, const std::string & )
     obj.read( "ammo_type", ammo_type );
 
     if( obj.has_array( "fake_skills" ) ) {
-        for( JsonArray cur : obj.get_array( "fake_skills" ) ) {
+        for( JsonArray const cur : obj.get_array( "fake_skills" ) ) {
             fake_skills[skill_id( cur.get_string( 0 ) )] = cur.get_int( 1 );
         }
     }
@@ -422,7 +422,7 @@ void gun_actor::load_internal( const JsonObject &obj, const std::string & )
     obj.read( "fake_int", fake_int );
     obj.read( "fake_per", fake_per );
 
-    for( JsonArray mode : obj.get_array( "ranges" ) ) {
+    for( JsonArray const mode : obj.get_array( "ranges" ) ) {
         if( mode.size() < 2 || mode.get_int( 0 ) > mode.get_int( 1 ) ) {
             obj.throw_error( "incomplete or invalid range specified", "ranges" );
         }
@@ -491,7 +491,7 @@ static std::optional<tripoint> find_target_vehicle( monster &z, int range )
     map &here = get_map();
     bool found = false;
     tripoint aim_at;
-    for( wrapped_vehicle &v : here.get_vehicles() ) {
+    for( wrapped_vehicle  const&v : here.get_vehicles() ) {
         if( ( !fov_3d && v.pos.z != z.pos().z ) || v.v->velocity == 0 ) {
             continue;
         }
@@ -500,7 +500,7 @@ static std::optional<tripoint> find_target_vehicle( monster &z, int range )
 
         for( const vpart_reference &vp : v.v->get_avail_parts( "CONTROLS" ) ) {
             if( z.sees( vp.pos() ) ) {
-                int new_dist = rl_dist( z.pos(), vp.pos() );
+                int const new_dist = rl_dist( z.pos(), vp.pos() );
                 if( new_dist <= range ) {
 
                     aim_at = vp.pos();
@@ -512,15 +512,15 @@ static std::optional<tripoint> find_target_vehicle( monster &z, int range )
         }
 
         if( !found_controls ) {
-            std::vector<tripoint> line = here.find_clear_path( z.pos(), v.v->global_pos3() );
+            std::vector<tripoint> const line = here.find_clear_path( z.pos(), v.v->global_pos3() );
             tripoint prev_point = z.pos();
-            for( tripoint &i : line ) {
+            for( tripoint  const&i : line ) {
                 if( here.floor_between( prev_point, i ) ) {
                     break;
                 }
                 optional_vpart_position vp = here.veh_at( i );
                 if( vp && &vp->vehicle() == v.v ) {
-                    int new_dist = rl_dist( z.pos(), i );
+                    int const new_dist = rl_dist( z.pos(), i );
                     if( new_dist <= range ) {
                         aim_at = i;
                         range = new_dist;
@@ -549,7 +549,7 @@ bool gun_actor::call( monster &z ) const
     bool untargeted = false;
 
     if( z.friendly ) {
-        int max_range = get_max_range();
+        int const max_range = get_max_range();
 
         int hostiles; // hostiles which cannot be engaged without risking friendly fire
         target = z.auto_find_hostile_target( max_range, hostiles );
@@ -585,7 +585,7 @@ bool gun_actor::call( monster &z ) const
     if( z.attitude_to( *target ) == Creature::A_FRIENDLY ) {
         return false;
     }
-    int dist = rl_dist( z.pos(), aim_at );
+    const int dist = rl_dist( z.pos(), aim_at );
     for( const auto &e : ranges ) {
         if( dist >= e.first.first && dist <= e.first.second ) {
             if( untargeted || try_target( z, *target ) ) {
@@ -652,7 +652,7 @@ void gun_actor::shoot( monster &z, const tripoint &target, const gun_mode_id &mo
     item gun( gun_type );
     gun.gun_set_mode( mode );
 
-    itype_id ammo = ammo_type ? ammo_type : gun.ammo_default();
+    itype_id const ammo = ammo_type ? ammo_type : gun.ammo_default();
     if( ammo ) {
         gun.ammo_set( ammo, z.ammo[ammo] );
     }

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -309,7 +309,7 @@ bool Character::handle_melee_wear( item &shield, float wear_multiplier )
                                str );
 
         for( auto &comp : temp.components ) {
-            int break_chance = comp.typeId() == weak_comp ? 2 : 8;
+            int const break_chance = comp.typeId() == weak_comp ? 2 : 8;
 
             if( one_in( break_chance ) ) {
                 add_msg_if_player( m_bad, _( "The %s is destroyed!" ), comp.tname() );
@@ -423,11 +423,11 @@ static void melee_train( Character &p, int lo, int hi, const item &weap )
 
     // allocate XP proportional to damage stats
     // Pure unarmed needs a special case because it has 0 weapon damage
-    int cut = weap.damage_melee( DT_CUT );
-    int stab = weap.damage_melee( DT_STAB );
-    int bash = weap.damage_melee( DT_BASH ) + ( weap.is_null() ? 1 : 0 );
+    int const cut = weap.damage_melee( DT_CUT );
+    int const stab = weap.damage_melee( DT_STAB );
+    int const bash = weap.damage_melee( DT_BASH ) + ( weap.is_null() ? 1 : 0 );
 
-    float total = std::max( cut + stab + bash, 1 );
+    float const total = std::max( cut + stab + bash, 1 );
 
     // Unarmed may deal cut, stab, and bash damage depending on the weapon
     if( weap.is_unarmed_weapon() ) {
@@ -445,7 +445,7 @@ void Character::melee_attack( Creature &t, bool allow_special, const matec_id *f
                               bool allow_unarmed )
 {
     melee::melee_stats.attack_count += 1;
-    int hit_spread = t.deal_melee_attack( this, hit_roll() );
+    int const hit_spread = t.deal_melee_attack( this, hit_roll() );
     if( !t.is_player() ) {
         // TODO: Per-NPC tracking? Right now monster hit by either npc or player will draw aggro...
         t.add_effect( effect_hit_by_player, 10_minutes ); // Flag as attacked by us for AI
@@ -480,7 +480,7 @@ void Character::melee_attack( Creature &t, bool allow_special, const matec_id *f
     int move_cost = attack_cost( cur_weapon );
 
     if( hit_spread < 0 ) {
-        int stumble_pen = stumble( *this, cur_weapon );
+        int const stumble_pen = stumble( *this, cur_weapon );
         sfx::generate_melee_sound( pos(), t.pos(), false, false );
         if( is_player() ) { // Only display messages if this is the player
 
@@ -492,7 +492,7 @@ void Character::melee_attack( Creature &t, bool allow_special, const matec_id *f
             }
 
             if( can_miss_recovery( cur_weapon ) ) {
-                ma_technique tec = martial_arts_data->get_miss_recovery_tec( cur_weapon );
+                ma_technique const tec = martial_arts_data->get_miss_recovery_tec( cur_weapon );
                 add_msg( _( tec.avatar_message ), t.disp_name() );
             } else if( stumble_pen >= 60 ) {
                 add_msg( m_bad, _( "You miss and stumble with the momentum." ) );
@@ -570,7 +570,7 @@ void Character::melee_attack( Creature &t, bool allow_special, const matec_id *f
         // Proceed with melee attack.
         if( !t.is_dead_state() ) {
             // Handles speed penalties to monster & us, etc
-            std::string specialmsg = melee_special_effects( t, d, cur_weapon );
+            std::string const specialmsg = melee_special_effects( t, d, cur_weapon );
 
             // gets overwritten with the dealt damage values
             dealt_damage_instance dealt_dam;
@@ -606,7 +606,7 @@ void Character::melee_attack( Creature &t, bool allow_special, const matec_id *f
                 }
             }
             sfx::generate_melee_sound( pos(), t.pos(), true, t.is_monster(), material );
-            int dam = dealt_dam.total_damage();
+            int const dam = dealt_dam.total_damage();
             melee::melee_stats.damage_amount += dam;
 
             // Practice melee and relevant weapon skill (if any) except when using CQB bionic
@@ -620,7 +620,7 @@ void Character::melee_attack( Creature &t, bool allow_special, const matec_id *f
 
             // Treat monster as seen if we see it before or after the attack
             if( seen || g->u.sees( t ) ) {
-                std::string message = melee_message( technique, *this, dealt_dam );
+                std::string const message = melee_message( technique, *this, dealt_dam );
                 player_hit_message( this, message, t, dam, critical_hit );
             } else {
                 add_msg_player_or_npc( m_good, _( "You hit something." ),
@@ -668,7 +668,7 @@ void Character::melee_attack( Creature &t, bool allow_special, const matec_id *f
     // some things (shattering weapons) can harm the attacking creature.
     check_dead_state();
     if( t.as_character() ) {
-        dealt_projectile_attack dp = dealt_projectile_attack();
+        dealt_projectile_attack const dp = dealt_projectile_attack();
         t.as_character()->on_hit( this, bodypart_id( "num_bp" ), &dp );
     }
     return;
@@ -685,22 +685,22 @@ void Character::reach_attack( const tripoint &p )
     map &here = get_map();
     Creature *critter = g->critter_at( p );
     // Original target size, used when there are monsters in front of our target
-    int target_size = critter != nullptr ? ( critter->get_size() + 1 ) : 2;
+    int const target_size = critter != nullptr ? ( critter->get_size() + 1 ) : 2;
     // Reset last target pos
     as_player()->last_target_pos = std::nullopt;
     // Max out recoil
     recoil = MAX_RECOIL;
 
     int move_cost = attack_cost( primary_weapon() );
-    int skill = std::min( 10, get_skill_level( skill_stabbing ) );
-    int t = 0;
+    int const skill = std::min( 10, get_skill_level( skill_stabbing ) );
+    int const t = 0;
     std::vector<tripoint> path = line_to( pos(), p, t, 0 );
     tripoint last_point = pos();
     path.pop_back(); // Last point is our critter
     for( const tripoint &path_point : path ) {
         // Possibly hit some unintended target instead
         Creature *inter = g->critter_at( path_point );
-        int inter_block_size = inter != nullptr ? ( inter->get_size() + 1 ) : 2;
+        int const inter_block_size = inter != nullptr ? ( inter->get_size() + 1 ) : 2;
         /** @EFFECT_STABBING decreases chance of hitting intervening target on reach attack */
         if( inter != nullptr &&
             !x_in_y( ( target_size * target_size + 1 ) * skill,
@@ -993,7 +993,7 @@ void Character::roll_bash_damage( bool crit, damage_instance &di, bool average,
     /** @EFFECT_UNARMED caps bash damage with unarmed weapons */
 
     /** @EFFECT_BASHING caps bash damage with bashing weapons */
-    float bash_cap = 2 * stat + 2 * skill;
+    float const bash_cap = 2 * stat + 2 * skill;
     float bash_mul = 1.0f;
 
     // 80%, 88%, 96%, 104%, 112%, 116%, 120%, 124%, 128%, 132%
@@ -1018,7 +1018,7 @@ void Character::roll_bash_damage( bool crit, damage_instance &di, bool average,
     bash_mul *= mabuff_damage_mult( DT_BASH );
 
     float armor_mult = 1.0f;
-    int arpen = mabuff_arpen_bonus( DT_BASH );
+    int const arpen = mabuff_arpen_bonus( DT_BASH );
 
     // Finally, extra critical effects
     if( crit ) {
@@ -1109,7 +1109,7 @@ void Character::roll_stab_damage( bool crit, damage_instance &di, bool /*average
 {
     float stab_dam = mabuff_damage_bonus( DT_STAB ) + weap.damage_melee( DT_STAB );
 
-    int unarmed_skill = get_skill_level( skill_unarmed );
+    int const unarmed_skill = get_skill_level( skill_unarmed );
     int stabbing_skill = get_skill_level( skill_stabbing );
 
     if( has_active_bionic( bio_cqb ) ) {
@@ -1124,7 +1124,7 @@ void Character::roll_stab_damage( bool crit, damage_instance &di, bool /*average
             float per_hand = 0.0f;
 
             for( const trait_id &mut : get_mutations() ) {
-                int stab_bonus = mut->pierce_dmg_bonus;
+                int const stab_bonus = mut->pierce_dmg_bonus;
                 int unarmed_bonus = 0;
                 if( mut->flags.count( "UNARMED_BONUS" ) > 0 && stab_bonus > 0 ) {
                     unarmed_bonus = std::min( unarmed_skill / 2, 4 );
@@ -1157,7 +1157,7 @@ void Character::roll_stab_damage( bool crit, damage_instance &di, bool /*average
     } else {
         stab_mul = 0.86 + 0.06 * stabbing_skill;
     }
-    int arpen = mabuff_arpen_bonus( DT_STAB );
+    int const arpen = mabuff_arpen_bonus( DT_STAB );
     stab_mul *= mabuff_damage_mult( DT_STAB );
     float armor_mult = 1.0f;
 
@@ -1179,9 +1179,9 @@ matec_id Character::pick_technique( Creature &t, const item &weap,
 
     std::vector<matec_id> possible;
 
-    bool downed = t.has_effect( effect_downed );
-    bool stunned = t.has_effect( effect_stunned );
-    bool wall_adjacent = g->m.is_wall_adjacent( pos() );
+    bool const downed = t.has_effect( effect_downed );
+    bool const stunned = t.has_effect( effect_stunned );
+    bool const wall_adjacent = g->m.is_wall_adjacent( pos() );
 
     // first add non-aoe tecs
     for( const matec_id &tec_id : all ) {
@@ -1292,16 +1292,16 @@ bool Character::valid_aoe_technique( Creature &t, const ma_technique &technique,
     std::array<int, 9> offset_b = { {-1, -1, 0, -1, 0, 1, 0, 1, 1 } };
 
     // filter the values to be between -1 and 1 to avoid indexing the array out of bounds
-    int dy = std::max( -1, std::min( 1, t.posy() - posy() ) );
-    int dx = std::max( -1, std::min( 1, t.posx() - posx() ) );
-    int lookup = dy + 1 + 3 * ( dx + 1 );
+    int const dy = std::max( -1, std::min( 1, t.posy() - posy() ) );
+    int const dx = std::max( -1, std::min( 1, t.posx() - posx() ) );
+    int const lookup = dy + 1 + 3 * ( dx + 1 );
 
     //wide hits all targets adjacent to the attacker and the target
     if( technique.aoe == "wide" ) {
         //check if either (or both) of the squares next to our target contain a possible victim
         //offsets are a pre-computed matrix allowing us to quickly lookup adjacent squares
-        tripoint left = pos() + tripoint( offset_a[lookup], offset_b[lookup], 0 );
-        tripoint right = pos() + tripoint( offset_b[lookup], -offset_a[lookup], 0 );
+        tripoint const left = pos() + tripoint( offset_a[lookup], offset_b[lookup], 0 );
+        tripoint const right = pos() + tripoint( offset_b[lookup], -offset_a[lookup], 0 );
 
         monster *const mon_l = g->critter_at<monster>( left );
         if( mon_l && mon_l->friendly == 0 ) {
@@ -1329,9 +1329,9 @@ bool Character::valid_aoe_technique( Creature &t, const ma_technique &technique,
         // Impale hits the target and a single target behind them
         // Check if the square cardinally behind our target, or to the left / right,
         // contains a possible target.
-        tripoint left = t.pos() + tripoint( offset_a[lookup], offset_b[lookup], 0 );
-        tripoint target_pos = t.pos() + ( t.pos() - pos() );
-        tripoint right = t.pos() + tripoint( offset_b[lookup], -offset_b[lookup], 0 );
+        tripoint const left = t.pos() + tripoint( offset_a[lookup], offset_b[lookup], 0 );
+        tripoint const target_pos = t.pos() + ( t.pos() - pos() );
+        tripoint const right = t.pos() + tripoint( offset_b[lookup], -offset_b[lookup], 0 );
 
         monster *const mon_l = g->critter_at<monster>( left );
         monster *const mon_t = g->critter_at<monster>( target_pos );
@@ -1415,7 +1415,7 @@ static void print_damage_info( const damage_instance &di )
     int total = 0;
     std::string ss;
     for( auto &du : di.damage_units ) {
-        int amount = di.type_damage( du.type );
+        int const amount = di.type_damage( du.type );
         total += amount;
         ss += name_by_dt( du.type ) + ":" + std::to_string( amount ) + ",";
     }
@@ -1489,7 +1489,7 @@ void Character::perform_technique( const ma_technique &technique, Creature &t, d
         const tripoint prev_pos = t.pos(); // track target startpoint for knockback_follow
         const int kb_offset_x = rng( -technique.knockback_spread, technique.knockback_spread );
         const int kb_offset_y = rng( -technique.knockback_spread, technique.knockback_spread );
-        tripoint kb_point( posx() + kb_offset_x, posy() + kb_offset_y, posz() );
+        tripoint const kb_point( posx() + kb_offset_x, posy() + kb_offset_y, posz() );
         for( int dist = rng( 1, technique.knockback_dist ); dist > 0; dist-- ) {
             t.knock_back_from( kb_point );
         }
@@ -1497,11 +1497,11 @@ void Character::perform_technique( const ma_technique &technique, Creature &t, d
         if( technique.knockback_follow ) {
             const optional_vpart_position vp0 = g->m.veh_at( pos() );
             vehicle *const veh0 = veh_pointer_or_null( vp0 );
-            bool to_swimmable = g->m.has_flag( "SWIMMABLE", prev_pos );
-            bool to_deepwater = g->m.has_flag( TFLAG_DEEP_WATER, prev_pos );
+            bool const to_swimmable = g->m.has_flag( "SWIMMABLE", prev_pos );
+            bool const to_deepwater = g->m.has_flag( TFLAG_DEEP_WATER, prev_pos );
 
             // Check if it's possible to move to the new tile
-            bool move_issue =
+            bool const move_issue =
                 g->is_dangerous_tile( prev_pos ) || // Tile contains fire, etc
                 ( to_swimmable && to_deepwater ) || // Dive into deep water
                 is_mounted() ||
@@ -1563,7 +1563,7 @@ void Character::perform_technique( const ma_technique &technique, Creature &t, d
         }
 
         //hit the targets in the lists (all candidates if wide or burst, or just the unlucky sod if deep)
-        int count_hit = 0;
+        int const count_hit = 0;
         for( Creature *const c : targets ) {
             melee_attack( *c, false );
         }
@@ -1654,12 +1654,12 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
     // Extract this to make it easier to implement shields/multiwield later
     item &shield = best_shield();
     block_bonus = blocking_ability( shield );
-    bool conductive_shield = shield.conductive();
-    bool unarmed = primary_weapon().has_flag( "UNARMED_WEAPON" ) || primary_weapon().is_null();
-    bool force_unarmed = martial_arts_data->is_force_unarmed();
+    bool const conductive_shield = shield.conductive();
+    bool const unarmed = primary_weapon().has_flag( "UNARMED_WEAPON" ) || primary_weapon().is_null();
+    bool const force_unarmed = martial_arts_data->is_force_unarmed();
 
-    int melee_skill = get_skill_level( skill_melee );
-    int unarmed_skill = get_skill_level( skill_unarmed );
+    int const melee_skill = get_skill_level( skill_melee );
+    int const unarmed_skill = get_skill_level( skill_unarmed );
 
     // Check if we are going to block with an item. This could
     // be worn equipment with the BLOCK_WHILE_WORN flag.
@@ -1755,7 +1755,7 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
         // block physical damage "normally"
         if( elem.type == DT_BASH || elem.type == DT_CUT || elem.type == DT_STAB ) {
             // use up our flat block bonus first
-            float block_amount = std::min( total_phys_block, elem.amount );
+            float const block_amount = std::min( total_phys_block, elem.amount );
             total_phys_block -= block_amount;
             elem.amount -= block_amount;
             damage_blocked += block_amount;
@@ -1764,7 +1764,7 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
                 continue;
             }
 
-            float previous_amount = elem.amount;
+            float const previous_amount = elem.amount;
             elem.amount *= physical_block_multiplier;
             damage_blocked += previous_amount - elem.amount;
         }
@@ -1774,7 +1774,7 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
         else if( elem.type == DT_HEAT || elem.type == DT_ACID || elem.type == DT_COLD ) {
             // Unarmed weapons won't block those
             if( item_blocking ) {
-                float previous_amount = elem.amount;
+                float const previous_amount = elem.amount;
                 elem.amount /= 5;
                 damage_blocked += previous_amount - elem.amount;
             }
@@ -1783,7 +1783,7 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
         } else if( elem.type == DT_ELECTRIC ) {
             // Unarmed weapons and conductive weapons won't block this
             if( item_blocking && !conductive_shield ) {
-                float previous_amount = elem.amount;
+                float const previous_amount = elem.amount;
                 elem.amount /= 5;
                 damage_blocked += previous_amount - elem.amount;
             }
@@ -1830,7 +1830,7 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
     martial_arts_data->ma_onblock_effects( *this );
 
     // Check if we have any block counters
-    matec_id tec = pick_technique( *source, shield, false, false, true );
+    matec_id const tec = pick_technique( *source, shield, false, false, true );
 
     if( tec != tec_none && !is_dead_state() ) {
         if( get_stamina() < get_stamina_max() / 3 ) {
@@ -1847,7 +1847,7 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
 
 void Character::perform_special_attacks( Creature &t, dealt_damage_instance &dealt_dam )
 {
-    std::vector<special_attack> special_attacks = mutation_attacks( t );
+    std::vector<special_attack> const special_attacks = mutation_attacks( t );
 
     bool practiced = false;
     for( const auto &att : special_attacks ) {
@@ -1856,7 +1856,7 @@ void Character::perform_special_attacks( Creature &t, dealt_damage_instance &dea
         }
 
         // TODO: Make this hit roll use unarmed skill, not weapon skill + weapon to_hit
-        int hit_spread = t.deal_melee_attack( this, hit_roll() * 0.8 );
+        int const hit_spread = t.deal_melee_attack( this, hit_roll() * 0.8 );
         if( hit_spread >= 0 ) {
             t.deal_melee_hit( this, hit_spread, false, att.damage, dealt_dam );
             if( !practiced ) {
@@ -1865,7 +1865,7 @@ void Character::perform_special_attacks( Creature &t, dealt_damage_instance &dea
                 as_player()->practice( skill_unarmed, rng( 0, 10 ) );
             }
         }
-        int dam = dealt_dam.total_damage();
+        int const dam = dealt_dam.total_damage();
         if( dam > 0 ) {
             player_hit_message( this, att.text, t, dam );
         }
@@ -1876,7 +1876,7 @@ std::string Character::melee_special_effects( Creature &t, damage_instance &d, i
 {
     std::string dump;
 
-    std::string target = t.disp_name();
+    std::string const target = t.disp_name();
 
     const bionic_id bio_shock( "bio_shock" );
     if( has_active_bionic( bio_shock ) && get_power_level() >= bio_shock->power_trigger &&
@@ -1970,7 +1970,7 @@ static damage_instance hardcoded_mutation_attack( const Character &u, const trai
         /** @EFFECT_DEX increases number of hits with BEAK_PECK */
 
         /** @EFFECT_UNARMED increases number of hits with BEAK_PECK */
-        int num_hits = std::max( 1, std::min<int>( 6,
+        int const num_hits = std::max( 1, std::min<int>( 6,
                                  u.get_dex() + u.get_skill_level( skill_unarmed ) - rng( 4, 10 ) ) );
         return damage_instance::physical( 0, 0, num_hits * 10 );
     }
@@ -2021,7 +2021,7 @@ std::vector<special_attack> Character::mutation_attacks( Creature &t ) const
 {
     std::vector<special_attack> ret;
 
-    std::string target = t.disp_name();
+    std::string const target = t.disp_name();
 
     const body_part_set usable_body_parts = exclusive_flag_coverage( "ALLOWS_NATURAL_ATTACKS" );
     const int unarmed = get_skill_level( skill_unarmed );
@@ -2327,7 +2327,7 @@ double npc_ai::wielded_value( const Character &who )
     if( !ideal_weapon.ammo_default().is_null() ) {
         ideal_weapon.ammo_set( ideal_weapon.ammo_default(), -1 );
     }
-    double weap_val = weapon_value( who, ideal_weapon, ideal_weapon.ammo_capacity() );
+    double const weap_val = weapon_value( who, ideal_weapon, ideal_weapon.ammo_capacity() );
     who.set_npc_ai_info_cache( npc_ai_info::ideal_weapon_value, weap_val );
     return weap_val;
 }
@@ -2350,7 +2350,7 @@ double npc_ai::melee_value( const Character &who, const item &weap )
     // start with average effective dps against a range of enemies
     double my_value = weap.average_dps( *who.as_player() );
 
-    float reach = weap.reach_range( who );
+    float const reach = weap.reach_range( who );
     // value reach weapons more
     if( reach > 1.0f ) {
         my_value *= 1.0f + 0.5f * ( std::sqrt( reach ) - 1.0f );
@@ -2398,10 +2398,10 @@ void avatar_funcs::try_disarm_npc( avatar &you, npc &target )
     their_roll += dice( 3, target.get_per() );
     their_roll += dice( 3, target.get_skill_level( skill_melee ) );
 
-    item &it = target.primary_weapon();
+    item  const&it = target.primary_weapon();
 
     // roll your melee and target's dodge skills to check if grab/smash attack succeeds
-    int hitspread = target.deal_melee_attack( &you, you.hit_roll() );
+    int const hitspread = target.deal_melee_attack( &you, you.hit_roll() );
     if( hitspread < 0 ) {
         add_msg( _( "You lunge for the %s, but miss!" ), it.tname() );
         you.mod_moves( -100 - stumble( you,
@@ -2476,7 +2476,7 @@ void avatar_funcs::try_steal_from_npc( avatar &you, npc &target )
         my_roll += dice( 2, 6 );
     }
 
-    int their_roll = dice( 5, target.get_per() );
+    int const their_roll = dice( 5, target.get_per() );
 
     const item *it = loc.get_item();
     if( my_roll >= their_roll ) {

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1971,7 +1971,7 @@ static damage_instance hardcoded_mutation_attack( const Character &u, const trai
 
         /** @EFFECT_UNARMED increases number of hits with BEAK_PECK */
         int const num_hits = std::max( 1, std::min<int>( 6,
-                                 u.get_dex() + u.get_skill_level( skill_unarmed ) - rng( 4, 10 ) ) );
+                                       u.get_dex() + u.get_skill_level( skill_unarmed ) - rng( 4, 10 ) ) );
         return damage_instance::physical( 0, 0, num_hits * 10 );
     }
 
@@ -2398,7 +2398,7 @@ void avatar_funcs::try_disarm_npc( avatar &you, npc &target )
     their_roll += dice( 3, target.get_per() );
     their_roll += dice( 3, target.get_skill_level( skill_melee ) );
 
-    item  const&it = target.primary_weapon();
+    item  const &it = target.primary_weapon();
 
     // roll your melee and target's dodge skills to check if grab/smash attack succeeds
     int const hitspread = target.deal_melee_attack( &you, you.hit_roll() );

--- a/src/memorial_logger.cpp
+++ b/src/memorial_logger.cpp
@@ -105,7 +105,7 @@ void memorial_logger::add( const std::string &male_msg,
     const oter_id &cur_ter = overmap_buffer.ter( g->u.global_omt_location() );
     const std::string &location = cur_ter->get_name();
 
-    std::string log_message = "| " + to_string( calendar::turn ) + " | " + location + " | " + msg;
+    std::string const log_message = "| " + to_string( calendar::turn ) + " | " + location + " | " + msg;
 
     log.push_back( log_message );
 }
@@ -230,7 +230,7 @@ void memorial_logger::write( std::ostream &file, const std::string &epitaph ) co
 
     //Last 20 messages
     file << _( "Final Messages:" ) << eol;
-    std::vector<std::pair<std::string, std::string> > recent_messages =
+    std::vector<std::pair<std::string, std::string> > const recent_messages =
         Messages::recent_messages( 20 );
     for( const std::pair<std::string, std::string> &recent_message : recent_messages ) {
         file << indent << recent_message.first << " " << recent_message.second;
@@ -248,7 +248,7 @@ void memorial_logger::write( std::ostream &file, const std::string &epitaph ) co
     // map <name, sym> to kill count
     const kill_tracker &kills = g->get_kill_tracker();
     for( const mtype &type : MonsterGenerator::generator().get_all_mtypes() ) {
-        int this_count = kills.kill_count( type.id );
+        int const this_count = kills.kill_count( type.id );
         if( this_count > 0 ) {
             kill_counts[std::make_tuple( type.nname(), type.sym )] += this_count;
             total_kills += this_count;
@@ -334,7 +334,7 @@ void memorial_logger::write( std::ostream &file, const std::string &epitaph ) co
     //Inventory
     file << _( "Inventory:" ) << eol;
     u.inv.restack( u );
-    invslice slice = u.inv.slice();
+    invslice const slice = u.inv.slice();
     for( const std::list<item> *elem : slice ) {
         const item &next_item = elem->front();
         file << indent << next_item.invlet << " - " <<
@@ -368,9 +368,9 @@ void memorial_logger::notify( const cata::event &e )
 {
     switch( e.type() ) {
         case event_type::activates_artifact: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
-                std::string item_name = e.get<cata_variant_type::string>( "item_name" );
+                std::string const item_name = e.get<cata_variant_type::string>( "item_name" );
                 //~ %s is artifact name
                 add( pgettext( "memorial_male", "Activated the %s." ),
                      pgettext( "memorial_female", "Activated the %s." ),
@@ -379,7 +379,7 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::activates_mininuke: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
                 add( pgettext( "memorial_male", "Activated a mininuke." ),
                      pgettext( "memorial_female", "Activated a mininuke." ) );
@@ -387,9 +387,9 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::administers_mutagen: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
-                mutagen_technique technique = e.get<mutagen_technique>( "technique" );
+                mutagen_technique const technique = e.get<mutagen_technique>( "technique" );
                 switch( technique ) {
                     case mutagen_technique::consumed_mutagen:
                         add( pgettext( "memorial_male", "Consumed mutagen." ),
@@ -428,7 +428,7 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::becomes_wanted: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
                 add( pgettext( "memorial_male", "Became wanted by the police!" ),
                      pgettext( "memorial_female", "Became wanted by the police!" ) );
@@ -436,9 +436,9 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::broken_bone_mends: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
-                body_part part = e.get<body_part>( "part" );
+                body_part const part = e.get<body_part>( "part" );
                 //~ %s is bodypart
                 add( pgettext( "memorial_male", "Broken %s began to mend." ),
                      pgettext( "memorial_female", "Broken %s began to mend." ),
@@ -447,10 +447,10 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::buries_corpse: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
                 const mtype &corpse_type = e.get<mtype_id>( "corpse_type" ).obj();
-                std::string corpse_name = e.get<cata_variant_type::string>( "corpse_name" );
+                std::string const corpse_name = e.get<cata_variant_type::string>( "corpse_name" );
                 if( corpse_name.empty() ) {
                     if( corpse_type.has_flag( MF_HUMAN ) ) {
                         add( pgettext( "memorial_male",
@@ -472,7 +472,7 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::character_gains_effect: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
                 const effect_type &type = e.get<efftype_id>( "effect" ).obj();
                 const std::string message = type.get_apply_memorial_log();
@@ -484,11 +484,11 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::character_kills_character: {
-            character_id ch = e.get<character_id>( "killer" );
+            character_id const ch = e.get<character_id>( "killer" );
             if( ch == g->u.getID() ) {
-                std::string name = e.get<cata_variant_type::string>( "victim_name" );
-                bool cannibal = g->u.has_trait( trait_CANNIBAL );
-                bool psycho = g->u.has_trait( trait_PSYCHOPATH );
+                std::string const name = e.get<cata_variant_type::string>( "victim_name" );
+                bool const cannibal = g->u.has_trait( trait_CANNIBAL );
+                bool const psycho = g->u.has_trait( trait_PSYCHOPATH );
                 if( g->u.has_trait( trait_SAPIOVORE ) ) {
                     add( pgettext( "memorial_male",
                                    "Caught and killed an ape.  Prey doesn't have a name." ),
@@ -523,9 +523,9 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::character_kills_monster: {
-            character_id ch = e.get<character_id>( "killer" );
+            character_id const ch = e.get<character_id>( "killer" );
             if( ch == g->u.getID() ) {
-                mtype_id victim_type = e.get<mtype_id>( "victim_type" );
+                mtype_id const victim_type = e.get<mtype_id>( "victim_type" );
                 if( victim_type->difficulty >= 30 ) {
                     add( pgettext( "memorial_male", "Killed a %s." ),
                          pgettext( "memorial_female", "Killed a %s." ),
@@ -535,7 +535,7 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::character_loses_effect: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
                 const effect_type &type = e.get<efftype_id>( "effect" ).obj();
                 const std::string message = type.get_remove_memorial_log();
@@ -547,9 +547,9 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::character_triggers_trap: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
-                trap_str_id trap = e.get<trap_str_id>( "trap" );
+                trap_str_id const trap = e.get<trap_str_id>( "trap" );
                 if( trap == tr_bubblewrap ) {
                     add( pgettext( "memorial_male", "Stepped on bubble wrap." ),
                          pgettext( "memorial_female", "Stepped on bubble wrap." ) );
@@ -636,17 +636,17 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::consumes_marloss_item: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
-                itype_id it = e.get<cata_variant_type::itype_id>( "itype" );
-                std::string itname = it->nname( 1 );
+                itype_id const it = e.get<cata_variant_type::itype_id>( "itype" );
+                std::string const itname = it->nname( 1 );
                 add( pgettext( "memorial_male", "Consumed a %s." ),
                      pgettext( "memorial_female", "Consumed a %s." ), itname );
             }
             break;
         }
         case event_type::crosses_marloss_threshold: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
                 add( pgettext( "memorial_male", "Opened the Marloss Gateway." ),
                      pgettext( "memorial_female", "Opened the Marloss Gateway." ) );
@@ -654,9 +654,9 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::crosses_mutation_threshold: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
-                std::string category_id =
+                std::string const category_id =
                     e.get<cata_variant_type::mutation_category_id>( "category" );
                 const mutation_category_trait &category =
                     mutation_category_trait::get_category( category_id );
@@ -666,7 +666,7 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::crosses_mycus_threshold: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
                 add( pgettext( "memorial_male", "Became one with the Mycus." ),
                      pgettext( "memorial_female", "Became one with the Mycus." ) );
@@ -674,7 +674,7 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::dermatik_eggs_hatch: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
                 add( pgettext( "memorial_male", "Dermatik eggs hatched." ),
                      pgettext( "memorial_female", "Dermatik eggs hatched." ) );
@@ -682,7 +682,7 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::dermatik_eggs_injected: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
                 add( pgettext( "memorial_male", "Injected with dermatik eggs." ),
                      pgettext( "memorial_female", "Injected with dermatik eggs." ) );
@@ -695,7 +695,7 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::dies_from_asthma_attack: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
                 add( pgettext( "memorial_male", "Succumbed to an asthma attack." ),
                      pgettext( "memorial_female", "Succumbed to an asthma attack." ) );
@@ -703,9 +703,9 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::dies_from_drug_overdose: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
-                efftype_id effect = e.get<efftype_id>( "effect" );
+                efftype_id const effect = e.get<efftype_id>( "effect" );
                 if( effect == effect_datura ) {
                     add( pgettext( "memorial_male", "Died of datura overdose." ),
                          pgettext( "memorial_female", "Died of datura overdose." ) );
@@ -726,7 +726,7 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::dies_of_infection: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
                 add( pgettext( "memorial_male", "Succumbed to the infection." ),
                      pgettext( "memorial_female", "Succumbed to the infection." ) );
@@ -734,7 +734,7 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::dies_of_starvation: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
                 add( pgettext( "memorial_male", "Died of starvation." ),
                      pgettext( "memorial_female", "Died of starvation." ) );
@@ -742,7 +742,7 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::dies_of_thirst: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
                 add( pgettext( "memorial_male", "Died of thirst." ),
                      pgettext( "memorial_female", "Died of thirst." ) );
@@ -765,10 +765,10 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::evolves_mutation: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
-                trait_id from = e.get<trait_id>( "from_trait" );
-                trait_id to = e.get<trait_id>( "to_trait" );
+                trait_id const from = e.get<trait_id>( "from_trait" );
+                trait_id const to = e.get<trait_id>( "to_trait" );
                 add( pgettext( "memorial_male", "'%s' mutation turned into '%s'" ),
                      pgettext( "memorial_female", "'%s' mutation turned into '%s'" ),
                      from->name(), to->name() );
@@ -776,7 +776,7 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::exhumes_grave: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
                 add( pgettext( "memorial_male", "Exhumed a grave." ),
                      pgettext( "memorial_female", "Exhumed a grave." ) );
@@ -784,9 +784,9 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::fails_to_install_cbm: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
-                std::string cbm_name = e.get<bionic_id>( "bionic" )->name.translated();
+                std::string const cbm_name = e.get<bionic_id>( "bionic" )->name.translated();
                 add( pgettext( "memorial_male", "Failed install of bionic: %s." ),
                      pgettext( "memorial_female", "Failed install of bionic: %s." ),
                      cbm_name );
@@ -794,9 +794,9 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::fails_to_remove_cbm: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
-                std::string cbm_name = e.get<bionic_id>( "bionic" )->name.translated();
+                std::string const cbm_name = e.get<bionic_id>( "bionic" )->name.translated();
                 add( pgettext( "memorial_male", "Failed to remove bionic: %s." ),
                      pgettext( "memorial_female", "Failed to remove bionic: %s." ),
                      cbm_name );
@@ -804,7 +804,7 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::falls_asleep_from_exhaustion: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
                 add( pgettext( "memorial_male", "Succumbed to lack of sleep." ),
                      pgettext( "memorial_female", "Succumbed to lack of sleep." ) );
@@ -812,16 +812,16 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::fuel_tank_explodes: {
-            std::string name = e.get<cata_variant_type::string>( "vehicle_name" );
+            std::string const name = e.get<cata_variant_type::string>( "vehicle_name" );
             add( pgettext( "memorial_male", "The fuel tank of the %s exploded!" ),
                  pgettext( "memorial_female", "The fuel tank of the %s exploded!" ),
                  name );
             break;
         }
         case event_type::gains_addiction: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
-                add_type type = e.get<add_type>( "add_type" );
+                add_type const type = e.get<add_type>( "add_type" );
                 const std::string &type_name = addiction_type_name( type );
                 //~ %s is addiction name
                 add( pgettext( "memorial_male", "Became addicted to %s." ),
@@ -831,9 +831,9 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::gains_mutation: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
-                trait_id trait = e.get<trait_id>( "trait" );
+                trait_id const trait = e.get<trait_id>( "trait" );
                 add( pgettext( "memorial_male", "Gained the mutation '%s'." ),
                      pgettext( "memorial_female", "Gained the mutation '%s'." ),
                      trait->name() );
@@ -841,10 +841,10 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::gains_skill_level: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
-                skill_id skill = e.get<skill_id>( "skill" );
-                int new_level = e.get<int>( "new_level" );
+                skill_id const skill = e.get<skill_id>( "skill" );
+                int const new_level = e.get<int>( "new_level" );
                 if( new_level % 4 == 0 ) {
                     add( pgettext( "memorial_male",
                                    //~ %d is skill level %s is skill name
@@ -858,8 +858,8 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::game_over: {
-            bool suicide = e.get<bool>( "is_suicide" );
-            std::string last_words = e.get<cata_variant_type::string>( "last_words" );
+            bool const suicide = e.get<bool>( "is_suicide" );
+            std::string const last_words = e.get<cata_variant_type::string>( "last_words" );
             if( suicide ) {
                 add( pgettext( "memorial_male", "%s committed suicide." ),
                      pgettext( "memorial_female", "%s committed suicide." ),
@@ -884,9 +884,9 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::installs_cbm: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
-                std::string cbm_name = e.get<bionic_id>( "bionic" )->name.translated();
+                std::string const cbm_name = e.get<bionic_id>( "bionic" )->name.translated();
                 add( pgettext( "memorial_male", "Installed bionic: %s." ),
                      pgettext( "memorial_female", "Installed bionic: %s." ),
                      cbm_name );
@@ -894,9 +894,9 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::installs_faulty_cbm: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
-                std::string cbm_name = e.get<bionic_id>( "bionic" )->name.translated();
+                std::string const cbm_name = e.get<bionic_id>( "bionic" )->name.translated();
                 add( pgettext( "memorial_male", "Installed bad bionic: %s." ),
                      pgettext( "memorial_female", "Installed bad bionic: %s." ),
                      cbm_name );
@@ -904,9 +904,9 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::learns_martial_art: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
-                matype_id mastyle = e.get<matype_id>( "martial_art" );
+                matype_id const mastyle = e.get<matype_id>( "martial_art" );
                 //~ %s is martial art
                 add( pgettext( "memorial_male", "Learned %s." ),
                      pgettext( "memorial_female", "Learned %s." ),
@@ -915,9 +915,9 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::loses_addiction: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
-                add_type type = e.get<add_type>( "add_type" );
+                add_type const type = e.get<add_type>( "add_type" );
                 const std::string &type_name = addiction_type_name( type );
                 //~ %s is addiction name
                 add( pgettext( "memorial_male", "Overcame addiction to %s." ),
@@ -927,7 +927,7 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::npc_becomes_hostile: {
-            std::string name = e.get<cata_variant_type::string>( "npc_name" );
+            std::string const name = e.get<cata_variant_type::string>( "npc_name" );
             add( pgettext( "memorial_male", "%s became hostile." ),
                  pgettext( "memorial_female", "%s became hostile." ),
                  name );
@@ -944,7 +944,7 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::player_levels_spell: {
-            std::string spell_name = e.get<spell_id>( "spell" )->name.translated();
+            std::string const spell_name = e.get<spell_id>( "spell" )->name.translated();
             add( pgettext( "memorial_male", "Gained a spell level on %s." ),
                  pgettext( "memorial_female", "Gained a spell level on %s." ),
                  spell_name );
@@ -956,9 +956,9 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::removes_cbm: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
-                std::string cbm_name = e.get<bionic_id>( "bionic" )->name.translated();
+                std::string const cbm_name = e.get<bionic_id>( "bionic" )->name.translated();
                 add( pgettext( "memorial_male", "Removed bionic: %s." ),
                      pgettext( "memorial_female", "Removed bionic: %s." ),
                      cbm_name );
@@ -971,9 +971,9 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::telefrags_creature: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
-                std::string victim_name = e.get<cata_variant_type::string>( "victim_name" );
+                std::string const victim_name = e.get<cata_variant_type::string>( "victim_name" );
                 add( pgettext( "memorial_male", "Telefragged a %s." ),
                      pgettext( "memorial_female", "Telefragged a %s." ),
                      victim_name );
@@ -981,7 +981,7 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::teleglow_teleports: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
                 add( pgettext( "memorial_male", "Spontaneous teleport." ),
                      pgettext( "memorial_female", "Spontaneous teleport." ) );
@@ -989,9 +989,9 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::teleports_into_wall: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
-                std::string obstacle_name = e.get<cata_variant_type::string>( "obstacle_name" );
+                std::string const obstacle_name = e.get<cata_variant_type::string>( "obstacle_name" );
                 add( pgettext( "memorial_male", "Teleported into a %s." ),
                      pgettext( "memorial_female", "Teleported into a %s." ),
                      obstacle_name );
@@ -1004,7 +1004,7 @@ void memorial_logger::notify( const cata::event &e )
             break;
         }
         case event_type::throws_up: {
-            character_id ch = e.get<character_id>( "character" );
+            character_id const ch = e.get<character_id>( "character" );
             if( ch == g->u.getID() ) {
                 add( pgettext( "memorial_male", "Threw up." ),
                      pgettext( "memorial_female", "Threw up." ) );

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -92,7 +92,7 @@ struct game_message : public JsonDeserializer, public JsonSerializer {
     }
 
     void deserialize( JsonIn &jsin ) override {
-        JsonObject obj = jsin.get_object();
+        JsonObject const obj = jsin.get_object();
         obj.read( "turn", timestamp_in_turns );
         message = obj.get_string( "message" );
         count = obj.get_int( "count" );
@@ -189,7 +189,7 @@ class messages_impl
                 return;
             }
 
-            unsigned int message_limit = get_option<int>( "MESSAGE_LIMIT" );
+            unsigned int const message_limit = get_option<int>( "MESSAGE_LIMIT" );
             while( messages.size() > message_limit ) {
                 messages.pop_front();
             }
@@ -333,7 +333,7 @@ void Messages::deserialize( const JsonObject &json )
         return;
     }
 
-    JsonObject obj = json.get_object( "player_messages" );
+    JsonObject const obj = json.get_object( "player_messages" );
     obj.read( "messages", player_messages.messages );
     obj.read( "curmes", player_messages.curmes );
 }

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -296,17 +296,17 @@ void mission::wrap_up()
             std::vector<item *> items = std::vector<item *>();
             tmp_inv.dump( items );
             item_group_id grp_type = type->group_id;
-            itype_id container = type->container_id;
+            itype_id const container = type->container_id;
             bool specific_container_required = !container.is_null();
-            bool remove_container = type->remove_container;
-            itype_id empty_container = type->empty_container;
+            bool const remove_container = type->remove_container;
+            itype_id const empty_container = type->empty_container;
 
             std::map<itype_id, int> matches = std::map<itype_id, int>();
             get_all_item_group_matches(
                 items, grp_type, matches,
                 container, itype_id::NULL_ID(), specific_container_required );
 
-            for( std::pair<const itype_id, int> &cnt : matches ) {
+            for( std::pair<const itype_id, int>  const&cnt : matches ) {
                 if( cnt.second >= type->item_count ) {
                     comps.push_back( item_comp( cnt.first, type->item_count ) );
                 }
@@ -365,7 +365,7 @@ bool mission::is_complete( const character_id &_npc_id ) const
             std::vector<item *> items = std::vector<item *>();
             tmp_inv.dump( items );
             item_group_id grp_type = type->group_id;
-            itype_id container = type->container_id;
+            itype_id const container = type->container_id;
             bool specific_container_required = !container.is_null();
 
             std::map<itype_id, int> matches = std::map<itype_id, int>();
@@ -373,7 +373,7 @@ bool mission::is_complete( const character_id &_npc_id ) const
                 items, grp_type, matches,
                 container, itype_id::NULL_ID(), specific_container_required );
 
-            for( std::pair<const itype_id, int> &pair : matches ) {
+            for( std::pair<const itype_id, int>  const&pair : matches ) {
                 if( pair.second >= type->item_count ) {
                     return true;
                 }
@@ -470,10 +470,10 @@ void mission::get_all_item_group_matches( std::vector<item *> &items,
         bool &specific_container_required )
 {
     for( item *itm : items ) {
-        bool correct_container = ( required_container == actual_container ) ||
+        bool const correct_container = ( required_container == actual_container ) ||
                                  !specific_container_required;
 
-        bool item_in_group = item_group::group_contains_item( grp_type, itm->typeId() );
+        bool const item_in_group = item_group::group_contains_item( grp_type, itm->typeId() );
 
         //check whether item itself is target
         if( item_in_group && correct_container ) {

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -306,7 +306,7 @@ void mission::wrap_up()
                 items, grp_type, matches,
                 container, itype_id::NULL_ID(), specific_container_required );
 
-            for( std::pair<const itype_id, int>  const&cnt : matches ) {
+            for( std::pair<const itype_id, int>  const &cnt : matches ) {
                 if( cnt.second >= type->item_count ) {
                     comps.push_back( item_comp( cnt.first, type->item_count ) );
                 }
@@ -373,7 +373,7 @@ bool mission::is_complete( const character_id &_npc_id ) const
                 items, grp_type, matches,
                 container, itype_id::NULL_ID(), specific_container_required );
 
-            for( std::pair<const itype_id, int>  const&pair : matches ) {
+            for( std::pair<const itype_id, int>  const &pair : matches ) {
                 if( pair.second >= type->item_count ) {
                     return true;
                 }
@@ -471,7 +471,7 @@ void mission::get_all_item_group_matches( std::vector<item *> &items,
 {
     for( item *itm : items ) {
         bool const correct_container = ( required_container == actual_container ) ||
-                                 !specific_container_required;
+                                       !specific_container_required;
 
         bool const item_in_group = item_group::group_contains_item( grp_type, itm->typeId() );
 

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -92,7 +92,7 @@ struct comp_rank {
 mission_data::mission_data()
 {
     for( int tab_num = base_camps::TAB_MAIN; tab_num != base_camps::TAB_NW + 3; tab_num++ ) {
-        std::vector<mission_entry> k;
+        std::vector<mission_entry> const k;
         entries.push_back( k );
     }
 }
@@ -113,7 +113,7 @@ void talk_function::companion_mission( npc &p )
 {
     mission_data mission_key;
 
-    std::string role_id = p.companion_mission_role_id;
+    std::string const role_id = p.companion_mission_role_id;
     const tripoint_abs_omt omt_pos = p.global_omt_location();
     std::string title = _( "Outpost Missions" );
     if( role_id == "SCAVENGER" ) {
@@ -152,7 +152,7 @@ void talk_function::scavenger_patrol( mission_data &mission_key, npc &p )
                            "skills while engaging in relatively safe combat against isolated "
                            "creatures." );
     mission_key.add( "Assign Scavenging Patrol", _( "Assign Scavenging Patrol" ), entry );
-    std::vector<npc_ptr> npc_list = companion_list( p, "_scavenging_patrol" );
+    std::vector<npc_ptr> const npc_list = companion_list( p, "_scavenging_patrol" );
     if( !npc_list.empty() ) {
         entry = _( "Profit: $25-$500\nDanger: Low\nTime: 10 hour missions\n\nPatrol Roster:\n" );
         for( auto &elem : npc_list ) {
@@ -173,7 +173,7 @@ void talk_function::scavenger_raid( mission_data &mission_key, npc &p )
                            "can't be guaranteed.  The rewards are greater and there is a chance "
                            "of the companion bringing back items." );
     mission_key.add( "Assign Scavenging Raid", _( "Assign Scavenging Raid" ), entry );
-    std::vector<npc_ptr> npc_list = companion_list( p, "_scavenging_raid" );
+    std::vector<npc_ptr> const npc_list = companion_list( p, "_scavenging_raid" );
     if( !npc_list.empty() ) {
         entry = _( "Profit: $200-$1000\nDanger: Medium\nTime: 10 hour missions\n\n"
                    "Raid Roster:\n" );
@@ -189,7 +189,7 @@ void talk_function::scavenger_raid( mission_data &mission_key, npc &p )
 void talk_function::commune_menial( mission_data &mission_key, npc &p )
 {
     mission_key.add( "Assign Ally to Menial Labor", _( "Assign Ally to Menial Labor" ) );
-    std::vector<npc_ptr> npc_list = companion_list( p, "_labor" );
+    std::vector<npc_ptr> const npc_list = companion_list( p, "_labor" );
     if( !npc_list.empty() ) {
         std::string entry = _( "Profit: $8/hour\nDanger: Minimal\nTime: 1 hour minimum\n\n"
                                "Assigning one of your allies to menial labor is a safe way to teach "
@@ -212,7 +212,7 @@ void talk_function::commune_carpentry( mission_data &mission_key, npc &p )
                            "modestly improved pay.  It is unlikely that your companions will face "
                            "combat but there are hazards working on makeshift buildings." );
     mission_key.add( "Assign Ally to Carpentry Work", _( "Assign Ally to Carpentry Work" ), entry );
-    std::vector<npc_ptr>  npc_list = companion_list( p, "_carpenter" );
+    std::vector<npc_ptr>  const npc_list = companion_list( p, "_carpenter" );
     if( !npc_list.empty() ) {
         entry = _( "Profit: $12/hour\nDanger: Minimal\nTime: 1 hour minimum\n\nLabor Roster:\n" );
         for( auto &elem : npc_list ) {
@@ -228,7 +228,7 @@ void talk_function::commune_carpentry( mission_data &mission_key, npc &p )
 void talk_function::commune_farmfield( mission_data &mission_key, npc &p )
 {
     if( !p.has_trait( trait_NPC_CONSTRUCTION_LEV_1 ) ) {
-        std::string entry = _( "Cost: $1000\n\n\n"
+        std::string const entry = _( "Cost: $1000\n\n\n"
                                "                .........\n" // NOLINT(cata-text-style)
                                "                .........\n" // NOLINT(cata-text-style)
                                "                .........\n" // NOLINT(cata-text-style)
@@ -247,7 +247,7 @@ void talk_function::commune_farmfield( mission_data &mission_key, npc &p )
         mission_key.add( "Purchase East Field", _( "Purchase East Field" ), entry );
     }
     if( p.has_trait( trait_NPC_CONSTRUCTION_LEV_1 ) && !p.has_trait( trait_NPC_CONSTRUCTION_LEV_2 ) ) {
-        std::string entry = _( "Cost: $5500\n\n"
+        std::string const entry = _( "Cost: $5500\n\n"
                                "\n              ........." // NOLINT(cata-text-style)
                                "\n              ........." // NOLINT(cata-text-style)
                                "\n              ........." // NOLINT(cata-text-style)
@@ -304,7 +304,7 @@ void talk_function::commune_forage( mission_data &mission_key, npc &p )
                            "hauls." );
     mission_key.add( "Assign Ally to Forage for Food", _( "Assign Ally to Forage for Food" ),
                      entry );
-    std::vector<npc_ptr> npc_list = companion_list( p, "_forage" );
+    std::vector<npc_ptr> const npc_list = companion_list( p, "_forage" );
     if( !npc_list.empty() ) {
         entry = _( "Profit: $10/hour\nDanger: Low\nTime: 4 hour minimum\n\nLabor Roster:\n" );
         for( auto &elem : npc_list ) {
@@ -328,7 +328,7 @@ void talk_function::commune_refuge_caravan( mission_data &mission_key, npc &p )
                            "Center as part of a tax and in exchange for skilled labor." );
     mission_key.add( "Caravan Commune-Refugee Center", _( "Caravan Commune-Refugee Center" ),
                      entry );
-    std::vector<npc_ptr> npc_list = companion_list( p, "_commune_refugee_caravan" );
+    std::vector<npc_ptr> const npc_list = companion_list( p, "_commune_refugee_caravan" );
     std::vector<npc_ptr> npc_list_aux;
     if( !npc_list.empty() ) {
         entry = _( "Profit: $18/hour\nDanger: High\nTime: UNKNOWN\n\n"
@@ -386,7 +386,7 @@ bool talk_function::display_and_choose_opts(
     // The following are for managing the right pane scrollbar.
     size_t info_offset = 0;
     nc_color col = c_white;
-    std::vector<std::string> name_text;
+    std::vector<std::string> const name_text;
     std::vector<std::string> mission_text;
 
     input_context ctxt( "FACTIONS" );
@@ -476,7 +476,7 @@ bool talk_function::display_and_choose_opts(
         size_t folded_names_lines = 0;
         for( size_t i = 0; i < cur_key_list.size(); i++ ) {
             const mission_entry &e = cur_key_list[i];
-            std::vector<std::string> lines = foldstring( e.name_display, MAX_FAC_NAME_SIZE - 5, ' ' );
+            std::vector<std::string> const lines = foldstring( e.name_display, MAX_FAC_NAME_SIZE - 5, ' ' );
             nc_color col = i == sel ? h_white : c_white;
 
             //highlight important missions
@@ -502,7 +502,7 @@ bool talk_function::display_and_choose_opts(
         for( size_t i = 0; i < sel; i++ ) {
             sel_pos_min += disp_names[i].lines.size();
         }
-        size_t sel_pos_max = sel_pos_min + disp_names[sel].lines.size() - 1;
+        size_t const sel_pos_max = sel_pos_min + disp_names[sel].lines.size() - 1;
 
         // Make sure the selected entry is fully visible,
         // and the cursor is positioned at 1st line of the entry.
@@ -512,13 +512,13 @@ bool talk_function::display_and_choose_opts(
         // Some entries may be shown only partially,
         // but that's fine since it makes scrolling smoother.
         int name_curr = 0;
-        int name_max = name_offset + static_cast<int>( info_height );
+        int const name_max = name_offset + static_cast<int>( info_height );
         for( const disp_entry &e : disp_names ) {
             for( size_t i = 0; i < e.lines.size() && name_curr < name_max; i++, name_curr++ ) {
                 if( name_curr < name_offset ) {
                     continue;
                 }
-                point p( i == 0 ? 1 : 5, name_curr - name_offset + 2 );
+                point const p( i == 0 ? 1 : 5, name_curr - name_offset + 2 );
                 nc_color col = e.col;
                 print_colored_text( w_list, p, col, col, e.lines[i] );
             }
@@ -749,9 +749,9 @@ npc_ptr talk_function::individual_mission( const tripoint_abs_omt &omt_pos,
 
 void talk_function::caravan_depart( npc &p, const std::string &dest, const std::string &id )
 {
-    std::vector<npc_ptr> npc_list = companion_list( p, id );
-    int distance = caravan_dist( dest );
-    time_duration time = 20_minutes + distance * 10_minutes;
+    std::vector<npc_ptr> const npc_list = companion_list( p, id );
+    int const distance = caravan_dist( dest );
+    time_duration const time = 20_minutes + distance * 10_minutes;
     popup( _( "The caravan departs with an estimated total travel time of %d hours…" ),
            to_hours<int>( time ) );
 
@@ -766,16 +766,16 @@ void talk_function::caravan_depart( npc &p, const std::string &dest, const std::
 //Could be expanded to actually path to the site, just returns the distance
 int talk_function::caravan_dist( const std::string &dest )
 {
-    Character &player_character = get_player_character();
+    Character  const&player_character = get_player_character();
     const tripoint_abs_omt site =
         overmap_buffer.find_closest( player_character.global_omt_location(), dest, 0, false );
-    int distance = rl_dist( player_character.global_omt_location(), site );
+    int const distance = rl_dist( player_character.global_omt_location(), site );
     return distance;
 }
 
 void talk_function::caravan_return( npc &p, const std::string &dest, const std::string &id )
 {
-    npc_ptr comp = companion_choose_return( p, id, calendar::turn );
+    npc_ptr const comp = companion_choose_return( p, id, calendar::turn );
     if( comp == nullptr ) {
         return;
     }
@@ -789,7 +789,7 @@ void talk_function::caravan_return( npc &p, const std::string &dest, const std::
     //and will simulate the mission and return together
     std::vector<npc_ptr> caravan_party;
     std::vector<npc_ptr> bandit_party;
-    std::vector<npc_ptr> npc_list = companion_list( p, id );
+    std::vector<npc_ptr> const npc_list = companion_list( p, id );
     const int rand_caravan_size = rng( 1, 3 );
     caravan_party.reserve( npc_list.size() + rand_caravan_size );
     for( int i = 0; i < rand_caravan_size; i++ ) {
@@ -801,9 +801,9 @@ void talk_function::caravan_return( npc &p, const std::string &dest, const std::
         }
     }
 
-    int distance = caravan_dist( dest );
-    int time = 200 + distance * 100;
-    int experience = rng( 10, time / 300 );
+    int const distance = caravan_dist( dest );
+    int const time = 200 + distance * 100;
+    int const experience = rng( 10, time / 300 );
 
     const int rand_bandit_size = rng( 1, 3 );
     bandit_party.reserve( rand_bandit_size * 2 );
@@ -995,7 +995,7 @@ void talk_function::field_plant( npc &p, const std::string &place )
         popup( _( "It is too cold to plant anything now." ) );
         return;
     }
-    std::vector<item *> seed_inv = g->u.items_with( []( const item & itm ) {
+    std::vector<item *> const seed_inv = g->u.items_with( []( const item & itm ) {
         return itm.is_seed() && itm.typeId() != itype_marloss_seed &&
                itm.typeId() != itype_fungal_seeds;
     } );
@@ -1051,7 +1051,7 @@ void talk_function::field_plant( npc &p, const std::string &place )
         limiting_number = empty_plots;
     }
 
-    signed int a = limiting_number * 300;
+    signed int const a = limiting_number * 300;
     if( a > g->u.cash ) {
         popup( _( "I'm sorry, you don't have enough money to plant those seeds…" ) );
         return;
@@ -1084,7 +1084,7 @@ void talk_function::field_plant( npc &p, const std::string &place )
 
 void talk_function::field_harvest( npc &p, const std::string &place )
 {
-    Character &player_character = get_player_character();
+    Character  const&player_character = get_player_character();
     //First we need a list of plants that can be harvested...
     const tripoint_abs_omt site = overmap_buffer.find_closest(
                                       player_character.global_omt_location(), place, 20, false );
@@ -1098,7 +1098,7 @@ void talk_function::field_harvest( npc &p, const std::string &place )
         map_stack items = bay.i_at( plot );
         if( bay.furn( plot ) == furn_str_id( "f_plant_harvest" ) && !items.empty() ) {
             // Can't use item_stack::only_item() since there might be fertilizer
-            map_stack::iterator seed = std::find_if( items.begin(), items.end(), []( const item & it ) {
+            map_stack::iterator const seed = std::find_if( items.begin(), items.end(), []( const item & it ) {
                 return it.is_seed();
             } );
 
@@ -1144,7 +1144,7 @@ void talk_function::field_harvest( npc &p, const std::string &place )
         if( bay.furn( plot ) == furn_str_id( "f_plant_harvest" ) ) {
             // Can't use item_stack::only_item() since there might be fertilizer
             map_stack items = bay.i_at( plot );
-            map_stack::iterator seed = std::find_if( items.begin(), items.end(), []( const item & it ) {
+            map_stack::iterator const seed = std::find_if( items.begin(), items.end(), []( const item & it ) {
                 return it.is_seed();
             } );
 
@@ -1170,10 +1170,10 @@ void talk_function::field_harvest( npc &p, const std::string &place )
     }
     bay.save();
     tmp = item( plant_types[plant_index], calendar::turn );
-    int money = ( number_plants * tmp.price( true ) - number_plots * 2 ) / 100;
+    int const money = ( number_plants * tmp.price( true ) - number_plots * 2 ) / 100;
     bool liquidate = false;
 
-    signed int a = number_plots * 2;
+    signed int const a = number_plots * 2;
     if( a > g->u.cash ) {
         liquidate = true;
         popup( _( "You don't have enough to pay the workers to harvest the crop so you are forced "
@@ -1230,7 +1230,7 @@ static int scavenging_combat_skill( npc &p, int bonus, bool guns )
 
 bool talk_function::scavenging_patrol_return( npc &p )
 {
-    npc_ptr comp = companion_choose_return( p, "_scavenging_patrol",
+    npc_ptr const comp = companion_choose_return( p, "_scavenging_patrol",
                                             calendar::turn - 10_hours );
     if( comp == nullptr ) {
         return false;
@@ -1239,12 +1239,12 @@ bool talk_function::scavenging_patrol_return( npc &p )
     if( one_in( 4 ) ) {
         popup( _( "While scavenging, %s's party suddenly found itself set upon by a large mob of "
                   "undead…" ), comp->name );
-        int skill = scavenging_combat_skill( *comp, 4, true );
+        int const skill = scavenging_combat_skill( *comp, 4, true );
         if( one_in( 6 ) ) {
             popup( _( "Through quick thinking the group was able to evade combat!" ) );
         } else {
             popup( _( "Combat took place in close quarters, focusing on melee skills…" ) );
-            int monsters = rng( 8, 30 );
+            int const monsters = rng( 8, 30 );
             if( skill * rng_float( .60, 1.4 ) > .35 * monsters * rng_float( .6, 1.4 ) ) {
                 popup( _( "Through brute force the party smashed through the group of %d"
                           " undead!" ), monsters );
@@ -1257,7 +1257,7 @@ bool talk_function::scavenging_patrol_return( npc &p )
         }
     }
 
-    int money = rng( 25, 450 );
+    int const money = rng( 25, 450 );
     g->u.cash += money * 100;
 
     companion_skill_trainer( *comp, "combat", experience * 10_minutes, 10 );
@@ -1279,7 +1279,7 @@ bool talk_function::scavenging_patrol_return( npc &p )
 
 bool talk_function::scavenging_raid_return( npc &p )
 {
-    npc_ptr comp = companion_choose_return( p, "_scavenging_raid",
+    npc_ptr const comp = companion_choose_return( p, "_scavenging_raid",
                                             calendar::turn - 10_hours );
     if( comp == nullptr ) {
         return false;
@@ -1288,12 +1288,12 @@ bool talk_function::scavenging_raid_return( npc &p )
     if( one_in( 2 ) ) {
         popup( _( "While scavenging, %s's party suddenly found itself set upon by a large mob of "
                   "undead…" ), comp->name );
-        int skill = scavenging_combat_skill( *comp, 4, true );
+        int const skill = scavenging_combat_skill( *comp, 4, true );
         if( one_in( 6 ) ) {
             popup( _( "Through quick thinking the group was able to evade combat!" ) );
         } else {
             popup( _( "Combat took place in close quarters, focusing on melee skills…" ) );
-            int monsters = rng( 8, 30 );
+            int const monsters = rng( 8, 30 );
             if( skill * rng_float( .60, 1.4 ) > ( .35 * monsters * rng_float( .6, 1.4 ) ) ) {
                 popup( _( "Through brute force the party smashed through the group of %d "
                           "undead!" ), monsters );
@@ -1316,7 +1316,7 @@ bool talk_function::scavenging_raid_return( npc &p )
         loot_building( site );
     }
 
-    int money = rng( 200, 900 );
+    int const money = rng( 200, 900 );
     g->u.cash += money * 100;
 
     companion_skill_trainer( *comp, "combat", experience * 10_minutes, 10 );
@@ -1344,13 +1344,13 @@ bool talk_function::scavenging_raid_return( npc &p )
 
 bool talk_function::labor_return( npc &p )
 {
-    npc_ptr comp = companion_choose_return( p, "_labor", calendar::turn - 1_hours );
+    npc_ptr const comp = companion_choose_return( p, "_labor", calendar::turn - 1_hours );
     if( comp == nullptr ) {
         return false;
     }
 
-    float hours = to_hours<float>( calendar::turn - comp->companion_mission_time );
-    int money = 8 * hours;
+    float const hours = to_hours<float>( calendar::turn - comp->companion_mission_time );
+    int const money = 8 * hours;
     g->u.cash += money * 100;
 
     companion_skill_trainer( *comp, "menial", calendar::turn - comp->companion_mission_time, 1 );
@@ -1369,7 +1369,7 @@ bool talk_function::labor_return( npc &p )
 
 bool talk_function::carpenter_return( npc &p )
 {
-    npc_ptr comp = companion_choose_return( p, "_carpenter",
+    npc_ptr const comp = companion_choose_return( p, "_carpenter",
                                             calendar::turn - 1_hours );
     if( comp == nullptr ) {
         return false;
@@ -1383,9 +1383,9 @@ bool talk_function::carpenter_return( npc &p )
         ///\EFFECT_DODGE_NPC affects carpenter mission results
 
         ///\EFFECT_SURVIVAL_NPC affects carpenter mission results
-        int skill_1 = comp->get_skill_level( skill_fabrication );
-        int skill_2 = comp->get_skill_level( skill_dodge );
-        int skill_3 = comp->get_skill_level( skill_survival );
+        int const skill_1 = comp->get_skill_level( skill_fabrication );
+        int const skill_2 = comp->get_skill_level( skill_dodge );
+        int const skill_3 = comp->get_skill_level( skill_survival );
         popup( _( "While %s was framing a building one of the walls began to collapse…" ),
                comp->name );
         if( skill_1 > rng( 1, 8 ) ) {
@@ -1406,8 +1406,8 @@ bool talk_function::carpenter_return( npc &p )
         }
     }
 
-    float hours = to_hours<float>( calendar::turn - comp->companion_mission_time );
-    int money = 12 * hours;
+    float const hours = to_hours<float>( calendar::turn - comp->companion_mission_time );
+    int const money = 12 * hours;
     g->u.cash += money * 100;
 
     companion_skill_trainer( *comp, "construction", calendar::turn -
@@ -1421,7 +1421,7 @@ bool talk_function::carpenter_return( npc &p )
 
 bool talk_function::forage_return( npc &p )
 {
-    npc_ptr comp = companion_choose_return( p, "_forage", calendar::turn - 4_hours );
+    npc_ptr const comp = companion_choose_return( p, "_forage", calendar::turn - 4_hours );
     if( comp == nullptr ) {
         return false;
     }
@@ -1433,8 +1433,8 @@ bool talk_function::forage_return( npc &p )
         ///\EFFECT_SURVIVAL_NPC affects forage mission results
 
         ///\EFFECT_DODGE_NPC affects forage mission results
-        int skill_1 = comp->get_skill_level( skill_survival );
-        int skill_2 = comp->get_skill_level( skill_dodge );
+        int const skill_1 = comp->get_skill_level( skill_survival );
+        int const skill_2 = comp->get_skill_level( skill_dodge );
         if( skill_1 > rng( -2, 8 ) ) {
             popup( _( "Alerted by a rustle, %s fled to the safety of the outpost!" ), comp->name );
         } else if( skill_2 > rng( -2, 8 ) ) {
@@ -1443,8 +1443,8 @@ bool talk_function::forage_return( npc &p )
         } else {
             popup( _( "%s was caught unaware and was forced to fight the creature at close "
                       "range!" ), comp->name );
-            int skill = scavenging_combat_skill( *comp, 0, false );
-            int monsters = rng( 0, 10 );
+            int const skill = scavenging_combat_skill( *comp, 0, false );
+            int const monsters = rng( 0, 10 );
             if( skill * rng_float( .80, 1.2 ) > monsters * rng_float( .8, 1.2 ) ) {
                 if( one_in( 2 ) ) {
                     popup( _( "%s was able to scare off the bear after delivering a nasty "
@@ -1468,8 +1468,8 @@ bool talk_function::forage_return( npc &p )
         }
     }
 
-    float hours = to_hours<float>( calendar::turn - comp->companion_mission_time );
-    int money = 10 * hours;
+    float const hours = to_hours<float>( calendar::turn - comp->companion_mission_time );
+    int const money = 10 * hours;
     g->u.cash += money * 100;
 
     companion_skill_trainer( *comp, "gathering", calendar::turn -
@@ -1480,7 +1480,7 @@ bool talk_function::forage_return( npc &p )
     // the following doxygen aliases do not yet exist. this is marked for future reference
 
     ///\EFFECT_SURVIVAL_NPC affects forage mission results
-    int skill = comp->get_skill_level( skill_survival );
+    int const skill = comp->get_skill_level( skill_survival );
     if( skill > rng_float( -.5, 8 ) ) {
         std::string itemlist = "farming_seeds";
         if( one_in( 2 ) ) {
@@ -1524,14 +1524,14 @@ bool talk_function::companion_om_combat_check( const std::vector<npc_ptr> &group
         //return true;
     }
 
-    tripoint_abs_sm sm_tgt = project_to<coords::sm>( om_tgt );
+    tripoint_abs_sm const sm_tgt = project_to<coords::sm>( om_tgt );
 
     tinymap target_bay;
     target_bay.load( sm_tgt, false );
     std::vector< monster * > monsters_around;
     for( int x = 0; x < 2; x++ ) {
         for( int y = 0; y < 2; y++ ) {
-            tripoint_abs_sm sm = sm_tgt + point( x, y );
+            tripoint_abs_sm const sm = sm_tgt + point( x, y );
             point_abs_om omp;
             tripoint_om_sm local_sm;
             std::tie( omp, local_sm ) = project_remain<coords::om>( sm );
@@ -1551,15 +1551,15 @@ bool talk_function::companion_om_combat_check( const std::vector<npc_ptr> &group
     }
     avg_survival = avg_survival / group.size();
 
-    monster mon;
+    monster const mon;
 
     std::vector< monster * > monsters_fighting;
     for( auto mons : monsters_around ) {
         if( mons->get_hp() <= 0 ) {
             continue;
         }
-        int d_modifier = avg_survival - mons->type->difficulty;
-        int roll = rng( 1, 20 ) + d_modifier;
+        int const d_modifier = avg_survival - mons->type->difficulty;
+        int const roll = rng( 1, 20 ) + d_modifier;
         if( roll > 10 ) {
             if( try_engage ) {
                 mons->death_drops = false;
@@ -1572,7 +1572,7 @@ bool talk_function::companion_om_combat_check( const std::vector<npc_ptr> &group
     }
 
     if( !monsters_fighting.empty() ) {
-        bool outcome = force_on_force( group, "Patrol", monsters_fighting, "attacking monsters",
+        bool const outcome = force_on_force( group, "Patrol", monsters_fighting, "attacking monsters",
                                        rng( -1, 2 ) );
         for( auto mons : monsters_fighting ) {
             mons->death_drops = true;
@@ -1719,7 +1719,7 @@ void talk_function::companion_skill_trainer( npc &comp, const std::string &skill
         time_duration time_worked, int difficulty )
 {
     difficulty = std::max( 1, difficulty );
-    int checks = 1 + to_minutes<int>( time_worked ) / 10;
+    int const checks = 1 + to_minutes<int>( time_worked ) / 10;
 
     weighted_int_list<skill_id> skill_practice;
     if( skill_tested == "combat" ) {
@@ -1728,7 +1728,7 @@ void talk_function::companion_skill_trainer( npc &comp, const std::string &skill
             skill_practice.add( best_skill, 30 );
         }
     }
-    for( Skill &sk : Skill::skills ) {
+    for( Skill  const&sk : Skill::skills ) {
         skill_practice.add( sk.ident(), sk.get_companion_skill_practice( skill_tested ) );
     }
     if( skill_practice.empty() ) {
@@ -1776,7 +1776,7 @@ std::vector<npc_ptr> talk_function::companion_list( const npc &p, const std::str
     std::vector<npc_ptr> available;
     const tripoint_abs_omt omt_pos = p.global_omt_location();
     for( const auto &elem : overmap_buffer.get_companion_mission_npcs() ) {
-        npc_companion_mission c_mission = elem->get_companion_mission();
+        npc_companion_mission const c_mission = elem->get_companion_mission();
         if( c_mission.position == omt_pos && c_mission.mission_id == mission_id &&
             c_mission.role_id == p.companion_mission_role_id ) {
             available.push_back( elem );
@@ -1896,7 +1896,7 @@ npc_ptr talk_function::companion_choose( const std::map<skill_id, int> &required
     std::optional<basecamp *> bcp = overmap_buffer.find_camp( g->u.global_omt_location().xy() );
 
     for( auto &elem : g->get_follower_list() ) {
-        npc_ptr guy = overmap_buffer.find_npc( elem );
+        npc_ptr const guy = overmap_buffer.find_npc( elem );
         if( !guy ) {
             continue;
         }
@@ -1969,8 +1969,8 @@ npc_ptr talk_function::companion_choose( const std::map<skill_id, int> &required
                 } else {
                     npc_desc += ", ";
                 }
-                skill_id skill_tested_id = skill_tested.first;
-                int skill_level = skill_tested.second;
+                skill_id const skill_tested_id = skill_tested.first;
+                int const skill_level = skill_tested.second;
                 if( skill_level == 0 ) {
                     //~ %1$s: skill name, %2$d: companion skill level
                     npc_desc += string_format( pgettext( "companion skill", "%1$s %2$d" ),
@@ -1986,7 +1986,7 @@ npc_ptr talk_function::companion_choose( const std::map<skill_id, int> &required
                 }
             }
         }
-        uilist_entry npc_entry = uilist_entry( x, can_do, x, npc_desc );
+        uilist_entry const npc_entry = uilist_entry( x, can_do, x, npc_desc );
         npc_menu.push_back( npc_entry );
         x++;
     }
@@ -2013,8 +2013,8 @@ npc_ptr talk_function::companion_choose_return( const tripoint_abs_omt &omt_pos,
         const bool by_mission )
 {
     std::vector<npc_ptr> available;
-    for( npc_ptr &guy : overmap_buffer.get_companion_mission_npcs() ) {
-        npc_companion_mission c_mission = guy->get_companion_mission();
+    for( npc_ptr  const&guy : overmap_buffer.get_companion_mission_npcs() ) {
+        npc_companion_mission const c_mission = guy->get_companion_mission();
         if( c_mission.position != omt_pos ||
             ( by_mission && c_mission.mission_id != mission_id ) || c_mission.role_id != role_id ) {
             continue;

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -229,37 +229,37 @@ void talk_function::commune_farmfield( mission_data &mission_key, npc &p )
 {
     if( !p.has_trait( trait_NPC_CONSTRUCTION_LEV_1 ) ) {
         std::string const entry = _( "Cost: $1000\n\n\n"
-                               "                .........\n" // NOLINT(cata-text-style)
-                               "                .........\n" // NOLINT(cata-text-style)
-                               "                .........\n" // NOLINT(cata-text-style)
-                               "                .........\n" // NOLINT(cata-text-style)
-                               "                .........\n" // NOLINT(cata-text-style)
-                               "                .........\n" // NOLINT(cata-text-style)
-                               "                ..#....**\n" // NOLINT(cata-text-style)
-                               "                ..#Ov..**\n" // NOLINT(cata-text-style)
-                               "                ...O|....\n\n" // NOLINT(cata-text-style)
-                               "We're willing to let you purchase a field at a substantial "
-                               "discount to use for your own agricultural enterprises.  We'll "
-                               "plow it for you so you know exactly what is yours… after you "
-                               "have a field you can hire workers to plant or harvest crops for "
-                               "you.  If the crop is something we have a demand for, we'll be "
-                               "willing to liquidate it." );
+                                     "                .........\n" // NOLINT(cata-text-style)
+                                     "                .........\n" // NOLINT(cata-text-style)
+                                     "                .........\n" // NOLINT(cata-text-style)
+                                     "                .........\n" // NOLINT(cata-text-style)
+                                     "                .........\n" // NOLINT(cata-text-style)
+                                     "                .........\n" // NOLINT(cata-text-style)
+                                     "                ..#....**\n" // NOLINT(cata-text-style)
+                                     "                ..#Ov..**\n" // NOLINT(cata-text-style)
+                                     "                ...O|....\n\n" // NOLINT(cata-text-style)
+                                     "We're willing to let you purchase a field at a substantial "
+                                     "discount to use for your own agricultural enterprises.  We'll "
+                                     "plow it for you so you know exactly what is yours… after you "
+                                     "have a field you can hire workers to plant or harvest crops for "
+                                     "you.  If the crop is something we have a demand for, we'll be "
+                                     "willing to liquidate it." );
         mission_key.add( "Purchase East Field", _( "Purchase East Field" ), entry );
     }
     if( p.has_trait( trait_NPC_CONSTRUCTION_LEV_1 ) && !p.has_trait( trait_NPC_CONSTRUCTION_LEV_2 ) ) {
         std::string const entry = _( "Cost: $5500\n\n"
-                               "\n              ........." // NOLINT(cata-text-style)
-                               "\n              ........." // NOLINT(cata-text-style)
-                               "\n              ........." // NOLINT(cata-text-style)
-                               "\n              ........." // NOLINT(cata-text-style)
-                               "\n              ........." // NOLINT(cata-text-style)
-                               "\n              ........." // NOLINT(cata-text-style)
-                               "\n              ..#....**" // NOLINT(cata-text-style)
-                               "\n              ..#Ov..**" // NOLINT(cata-text-style)
-                               "\n              ...O|....\n\n" // NOLINT(cata-text-style)
-                               "Protecting your field with a sturdy picket fence will keep most "
-                               "wildlife from nibbling your crops apart.  You can expect yields to "
-                               "increase." );
+                                     "\n              ........." // NOLINT(cata-text-style)
+                                     "\n              ........." // NOLINT(cata-text-style)
+                                     "\n              ........." // NOLINT(cata-text-style)
+                                     "\n              ........." // NOLINT(cata-text-style)
+                                     "\n              ........." // NOLINT(cata-text-style)
+                                     "\n              ........." // NOLINT(cata-text-style)
+                                     "\n              ..#....**" // NOLINT(cata-text-style)
+                                     "\n              ..#Ov..**" // NOLINT(cata-text-style)
+                                     "\n              ...O|....\n\n" // NOLINT(cata-text-style)
+                                     "Protecting your field with a sturdy picket fence will keep most "
+                                     "wildlife from nibbling your crops apart.  You can expect yields to "
+                                     "increase." );
         mission_key.add( "Upgrade East Field I", _( "Upgrade East Field I" ), entry );
     }
 
@@ -766,7 +766,7 @@ void talk_function::caravan_depart( npc &p, const std::string &dest, const std::
 //Could be expanded to actually path to the site, just returns the distance
 int talk_function::caravan_dist( const std::string &dest )
 {
-    Character  const&player_character = get_player_character();
+    Character  const &player_character = get_player_character();
     const tripoint_abs_omt site =
         overmap_buffer.find_closest( player_character.global_omt_location(), dest, 0, false );
     int const distance = rl_dist( player_character.global_omt_location(), site );
@@ -1084,7 +1084,7 @@ void talk_function::field_plant( npc &p, const std::string &place )
 
 void talk_function::field_harvest( npc &p, const std::string &place )
 {
-    Character  const&player_character = get_player_character();
+    Character  const &player_character = get_player_character();
     //First we need a list of plants that can be harvested...
     const tripoint_abs_omt site = overmap_buffer.find_closest(
                                       player_character.global_omt_location(), place, 20, false );
@@ -1231,7 +1231,7 @@ static int scavenging_combat_skill( npc &p, int bonus, bool guns )
 bool talk_function::scavenging_patrol_return( npc &p )
 {
     npc_ptr const comp = companion_choose_return( p, "_scavenging_patrol",
-                                            calendar::turn - 10_hours );
+                         calendar::turn - 10_hours );
     if( comp == nullptr ) {
         return false;
     }
@@ -1280,7 +1280,7 @@ bool talk_function::scavenging_patrol_return( npc &p )
 bool talk_function::scavenging_raid_return( npc &p )
 {
     npc_ptr const comp = companion_choose_return( p, "_scavenging_raid",
-                                            calendar::turn - 10_hours );
+                         calendar::turn - 10_hours );
     if( comp == nullptr ) {
         return false;
     }
@@ -1370,7 +1370,7 @@ bool talk_function::labor_return( npc &p )
 bool talk_function::carpenter_return( npc &p )
 {
     npc_ptr const comp = companion_choose_return( p, "_carpenter",
-                                            calendar::turn - 1_hours );
+                         calendar::turn - 1_hours );
     if( comp == nullptr ) {
         return false;
     }
@@ -1573,7 +1573,7 @@ bool talk_function::companion_om_combat_check( const std::vector<npc_ptr> &group
 
     if( !monsters_fighting.empty() ) {
         bool const outcome = force_on_force( group, "Patrol", monsters_fighting, "attacking monsters",
-                                       rng( -1, 2 ) );
+                                             rng( -1, 2 ) );
         for( auto mons : monsters_fighting ) {
             mons->death_drops = true;
         }
@@ -1728,7 +1728,7 @@ void talk_function::companion_skill_trainer( npc &comp, const std::string &skill
             skill_practice.add( best_skill, 30 );
         }
     }
-    for( Skill  const&sk : Skill::skills ) {
+    for( Skill  const &sk : Skill::skills ) {
         skill_practice.add( sk.ident(), sk.get_companion_skill_practice( skill_tested ) );
     }
     if( skill_practice.empty() ) {
@@ -2013,7 +2013,7 @@ npc_ptr talk_function::companion_choose_return( const tripoint_abs_omt &omt_pos,
         const bool by_mission )
 {
     std::vector<npc_ptr> available;
-    for( npc_ptr  const&guy : overmap_buffer.get_companion_mission_npcs() ) {
+    for( npc_ptr  const &guy : overmap_buffer.get_companion_mission_npcs() ) {
         npc_companion_mission const c_mission = guy->get_companion_mission();
         if( c_mission.position != omt_pos ||
             ( by_mission && c_mission.mission_id != mission_id ) || c_mission.role_id != role_id ) {

--- a/src/mission_start.cpp
+++ b/src/mission_start.cpp
@@ -222,7 +222,7 @@ void mission_start::place_npc_software( mission *miss )
     compmap.load( project_to<coords::sm>( place ), false );
     tripoint comppoint;
 
-    oter_id oter = overmap_buffer.ter( place );
+    oter_id const oter = overmap_buffer.ter( place );
     if( is_ot_match( "house", oter, ot_match_type::prefix ) ||
         is_ot_match( "s_pharm", oter, ot_match_type::type ) || oter == "" ) {
         comppoint = find_potential_computer_point( compmap );
@@ -304,7 +304,7 @@ void mission_start::find_safety( mission *miss )
     const tripoint_abs_omt place = get_player_character().global_omt_location();
     for( int radius = 0; radius <= 20; radius++ ) {
         for( int dist = 0 - radius; dist <= radius; dist++ ) {
-            int offset = rng( 0, 3 ); // Randomizes the direction we check first
+            int const offset = rng( 0, 3 ); // Randomizes the direction we check first
             for( int i = 0; i <= 3; i++ ) { // Which direction?
                 tripoint_abs_omt check = place;
                 switch( ( offset + i ) % 4 ) {
@@ -354,7 +354,7 @@ const int RANCH_SIZE = 5;
 void mission_start::ranch_nurse_1( mission *miss )
 {
     //Improvements to clinic...
-    tripoint_abs_omt site = mission_util::target_om_ter_random(
+    tripoint_abs_omt const site = mission_util::target_om_ter_random(
                                 "ranch_camp_59", 1, miss, false, RANCH_SIZE );
     tinymap bay;
     bay.load( project_to<coords::sm>( site ), false );
@@ -367,7 +367,7 @@ void mission_start::ranch_nurse_1( mission *miss )
 void mission_start::ranch_nurse_2( mission *miss )
 {
     //Improvements to clinic...
-    tripoint_abs_omt site = mission_util::target_om_ter_random(
+    tripoint_abs_omt const site = mission_util::target_om_ter_random(
                                 "ranch_camp_59", 1, miss, false, RANCH_SIZE );
     tinymap bay;
     bay.load( project_to<coords::sm>( site ), false );
@@ -518,7 +518,7 @@ void mission_start::ranch_nurse_8( mission *miss )
 void mission_start::ranch_nurse_9( mission *miss )
 {
     //Improvements to clinic...
-    tripoint_abs_omt site = mission_util::target_om_ter_random(
+    tripoint_abs_omt const site = mission_util::target_om_ter_random(
                                 "ranch_camp_50", 1, miss, false, RANCH_SIZE );
     tinymap bay;
     bay.load( project_to<coords::sm>( site ), false );
@@ -651,13 +651,13 @@ void static create_lab_consoles(
 {
     // Drop four computers in nearby lab spaces so the player can stumble upon one of them.
     for( int i = 0; i < 4; ++i ) {
-        tripoint_abs_omt om_place = mission_util::target_om_ter_random(
+        tripoint_abs_omt const om_place = mission_util::target_om_ter_random(
                                         otype, -1, miss, false, 4, place );
 
         tinymap compmap;
         compmap.load( project_to<coords::sm>( om_place ), false );
 
-        tripoint comppoint = find_potential_computer_point( compmap );
+        tripoint const comppoint = find_potential_computer_point( compmap );
 
         computer *tmpcomp = compmap.add_computer( comppoint, _( comp_name ), security );
         tmpcomp->set_mission( miss->get_id() );
@@ -672,7 +672,7 @@ void static create_lab_consoles(
 
 void mission_start::create_lab_console( mission *miss )
 {
-    Character &player_character = get_player_character();
+    Character  const&player_character = get_player_character();
     // Pick a lab that has spaces on z = -1: e.g., in hidden labs.
     tripoint_abs_omt loc = player_character.global_omt_location();
     loc.z() = -1;
@@ -688,7 +688,7 @@ void mission_start::create_lab_console( mission *miss )
 
 void mission_start::create_hidden_lab_console( mission *miss )
 {
-    Character &player_character = get_player_character();
+    Character  const&player_character = get_player_character();
     // Pick a hidden lab entrance.
     tripoint_abs_omt loc = player_character.global_omt_location();
     loc.z() = -1;
@@ -706,7 +706,7 @@ void mission_start::create_hidden_lab_console( mission *miss )
 
 void mission_start::create_ice_lab_console( mission *miss )
 {
-    Character &player_character = get_player_character();
+    Character  const&player_character = get_player_character();
     // Pick an ice lab with spaces on z = -4.
     tripoint_abs_omt loc = player_character.global_omt_location();
     loc.z() = -4;
@@ -722,7 +722,7 @@ void mission_start::create_ice_lab_console( mission *miss )
 
 void mission_start::reveal_lab_train_depot( mission *miss )
 {
-    Character &player_character = get_player_character();
+    Character  const&player_character = get_player_character();
     // Find and prepare lab location.
     tripoint_abs_omt loc = player_character.global_omt_location();
     loc.z() = -4;  // tunnels are at z = -4

--- a/src/mission_start.cpp
+++ b/src/mission_start.cpp
@@ -355,7 +355,7 @@ void mission_start::ranch_nurse_1( mission *miss )
 {
     //Improvements to clinic...
     tripoint_abs_omt const site = mission_util::target_om_ter_random(
-                                "ranch_camp_59", 1, miss, false, RANCH_SIZE );
+                                      "ranch_camp_59", 1, miss, false, RANCH_SIZE );
     tinymap bay;
     bay.load( project_to<coords::sm>( site ), false );
     bay.draw_square_furn( f_rack, point( 16, 9 ), point( 17, 9 ) );
@@ -368,7 +368,7 @@ void mission_start::ranch_nurse_2( mission *miss )
 {
     //Improvements to clinic...
     tripoint_abs_omt const site = mission_util::target_om_ter_random(
-                                "ranch_camp_59", 1, miss, false, RANCH_SIZE );
+                                      "ranch_camp_59", 1, miss, false, RANCH_SIZE );
     tinymap bay;
     bay.load( project_to<coords::sm>( site ), false );
     bay.draw_square_furn( f_counter, point( 3, 7 ), point( 5, 7 ) );
@@ -519,7 +519,7 @@ void mission_start::ranch_nurse_9( mission *miss )
 {
     //Improvements to clinic...
     tripoint_abs_omt const site = mission_util::target_om_ter_random(
-                                "ranch_camp_50", 1, miss, false, RANCH_SIZE );
+                                      "ranch_camp_50", 1, miss, false, RANCH_SIZE );
     tinymap bay;
     bay.load( project_to<coords::sm>( site ), false );
     bay.furn_set( point( 3, 22 ), f_dresser );
@@ -652,7 +652,7 @@ void static create_lab_consoles(
     // Drop four computers in nearby lab spaces so the player can stumble upon one of them.
     for( int i = 0; i < 4; ++i ) {
         tripoint_abs_omt const om_place = mission_util::target_om_ter_random(
-                                        otype, -1, miss, false, 4, place );
+                                              otype, -1, miss, false, 4, place );
 
         tinymap compmap;
         compmap.load( project_to<coords::sm>( om_place ), false );
@@ -672,7 +672,7 @@ void static create_lab_consoles(
 
 void mission_start::create_lab_console( mission *miss )
 {
-    Character  const&player_character = get_player_character();
+    Character  const &player_character = get_player_character();
     // Pick a lab that has spaces on z = -1: e.g., in hidden labs.
     tripoint_abs_omt loc = player_character.global_omt_location();
     loc.z() = -1;
@@ -688,7 +688,7 @@ void mission_start::create_lab_console( mission *miss )
 
 void mission_start::create_hidden_lab_console( mission *miss )
 {
-    Character  const&player_character = get_player_character();
+    Character  const &player_character = get_player_character();
     // Pick a hidden lab entrance.
     tripoint_abs_omt loc = player_character.global_omt_location();
     loc.z() = -1;
@@ -706,7 +706,7 @@ void mission_start::create_hidden_lab_console( mission *miss )
 
 void mission_start::create_ice_lab_console( mission *miss )
 {
-    Character  const&player_character = get_player_character();
+    Character  const &player_character = get_player_character();
     // Pick an ice lab with spaces on z = -4.
     tripoint_abs_omt loc = player_character.global_omt_location();
     loc.z() = -4;
@@ -722,7 +722,7 @@ void mission_start::create_ice_lab_console( mission *miss )
 
 void mission_start::reveal_lab_train_depot( mission *miss )
 {
-    Character  const&player_character = get_player_character();
+    Character  const &player_character = get_player_character();
     // Find and prepare lab location.
     tripoint_abs_omt loc = player_character.global_omt_location();
     loc.z() = -4;  // tunnels are at z = -4

--- a/src/mission_ui.cpp
+++ b/src/mission_ui.cpp
@@ -106,7 +106,7 @@ void game::list_missions()
             const std::vector<std::pair<int, itype_id>> &rewards ) {
                 std::string formatted_description = description;
                 for( const auto &reward : rewards ) {
-                    std::string token = "<reward_count:" + reward.second.str() + ">";
+                    std::string const token = "<reward_count:" + reward.second.str() + ">";
                     formatted_description = replace_all( formatted_description, token,
                                                          string_format( "%d", reward.first ) );
                 }

--- a/src/mission_util.cpp
+++ b/src/mission_util.cpp
@@ -118,7 +118,7 @@ static tripoint_abs_omt random_house_in_city( const city_reference &cref )
 
 tripoint_abs_omt mission_util::random_house_in_closest_city()
 {
-    Character &player_character = get_player_character();
+    Character  const&player_character = get_player_character();
     // TODO: fix point types
     const tripoint_abs_sm center( player_character.global_sm_location() );
     const city_reference cref = overmap_buffer.closest_city( center );
@@ -135,7 +135,7 @@ tripoint_abs_omt mission_util::target_closest_lab_entrance(
     tripoint_abs_omt testpoint = origin;
     // Get the surface locations for labs and for spaces above hidden lab stairs.
     testpoint.z() = 0;
-    tripoint_abs_omt surface = overmap_buffer.find_closest( testpoint, "lab_stairs", 0, false,
+    tripoint_abs_omt const surface = overmap_buffer.find_closest( testpoint, "lab_stairs", 0, false,
                                ot_match_type::contains );
 
     testpoint.z() = -1;
@@ -267,7 +267,7 @@ std::optional<tripoint_abs_omt> mission_util::assign_mission_target(
     const mission_target_params &params )
 {
     // use the player or NPC's current position, adjust for the z value if any
-    tripoint_abs_omt origin_pos = get_mission_om_origin( params );
+    tripoint_abs_omt const origin_pos = get_mission_om_origin( params );
 
     std::optional<tripoint_abs_omt> target_pos = find_or_create_om_terrain( origin_pos, params );
 
@@ -291,7 +291,7 @@ std::optional<tripoint_abs_omt> mission_util::assign_mission_target(
 tripoint_abs_omt mission_util::get_om_terrain_pos( const mission_target_params &params )
 {
     // use the player or NPC's current position, adjust for the z value if any
-    tripoint_abs_omt origin_pos = get_mission_om_origin( params );
+    tripoint_abs_omt const origin_pos = get_mission_om_origin( params );
 
     tripoint_abs_omt target_pos = origin_pos;
     if( !params.overmap_terrain.empty() ) {
@@ -438,7 +438,7 @@ void mission_util::set_reveal_any( const JsonArray &ja,
 void mission_util::set_assign_om_target( const JsonObject &jo,
         std::vector<std::function<void( mission *miss )>> &funcs )
 {
-    mission_target_params p = parse_mission_om_target( jo );
+    mission_target_params const p = parse_mission_om_target( jo );
     const auto mission_func = [p]( mission * miss ) {
         mission_target_params mtp = p;
         mtp.mission_pointer = miss;
@@ -451,7 +451,7 @@ bool mission_util::set_update_mapgen( const JsonObject &jo,
                                       std::vector<std::function<void( mission *miss )>> &funcs )
 {
     bool defer = false;
-    mapgen_update_func update_map = add_mapgen_update_func( jo, defer );
+    mapgen_update_func const update_map = add_mapgen_update_func( jo, defer );
     if( defer ) {
         jo.allow_omitted_members();
         return false;
@@ -460,13 +460,13 @@ bool mission_util::set_update_mapgen( const JsonObject &jo,
     if( jo.has_member( "om_terrain" ) ) {
         const std::string om_terrain = jo.get_string( "om_terrain" );
         const auto mission_func = [update_map, om_terrain]( mission * miss ) {
-            tripoint_abs_omt update_pos3 = mission_util::reveal_om_ter( om_terrain, 1, false );
+            tripoint_abs_omt const update_pos3 = mission_util::reveal_om_ter( om_terrain, 1, false );
             update_map( update_pos3, miss );
         };
         funcs.emplace_back( mission_func );
     } else {
         const auto mission_func = [update_map]( mission * miss ) {
-            tripoint_abs_omt update_pos3 = miss->get_target();
+            tripoint_abs_omt const update_pos3 = miss->get_target();
             update_map( update_pos3, miss );
         };
         funcs.emplace_back( mission_func );
@@ -483,17 +483,17 @@ bool mission_util::load_funcs( const JsonObject &jo,
     } else if( jo.has_member( "reveal_om_ter" ) ) {
         set_reveal_any( jo.get_array( "reveal_om_ter" ), funcs );
     } else if( jo.has_member( "assign_mission_target" ) ) {
-        JsonObject mission_target = jo.get_object( "assign_mission_target" );
+        JsonObject const mission_target = jo.get_object( "assign_mission_target" );
         set_assign_om_target( mission_target, funcs );
     }
 
     if( jo.has_object( "update_mapgen" ) ) {
-        JsonObject update_mapgen = jo.get_object( "update_mapgen" );
+        JsonObject const update_mapgen = jo.get_object( "update_mapgen" );
         if( !set_update_mapgen( update_mapgen, funcs ) ) {
             return false;
         }
     } else {
-        for( JsonObject update_mapgen : jo.get_array( "update_mapgen" ) ) {
+        for( JsonObject const update_mapgen : jo.get_array( "update_mapgen" ) ) {
             if( !set_update_mapgen( update_mapgen, funcs ) ) {
                 return false;
             }
@@ -531,7 +531,7 @@ bool mission_type::parse_funcs( const JsonObject &jo, std::function<void( missio
         }
     };
 
-    for( talk_effect_fun_t &effect : talk_effects.effects ) {
+    for( talk_effect_fun_t  const&effect : talk_effects.effects ) {
         auto rewards = effect.get_likely_rewards();
         if( !rewards.empty() ) {
             likely_rewards.insert( likely_rewards.end(), rewards.begin(), rewards.end() );

--- a/src/mission_util.cpp
+++ b/src/mission_util.cpp
@@ -118,7 +118,7 @@ static tripoint_abs_omt random_house_in_city( const city_reference &cref )
 
 tripoint_abs_omt mission_util::random_house_in_closest_city()
 {
-    Character  const&player_character = get_player_character();
+    Character  const &player_character = get_player_character();
     // TODO: fix point types
     const tripoint_abs_sm center( player_character.global_sm_location() );
     const city_reference cref = overmap_buffer.closest_city( center );
@@ -136,7 +136,7 @@ tripoint_abs_omt mission_util::target_closest_lab_entrance(
     // Get the surface locations for labs and for spaces above hidden lab stairs.
     testpoint.z() = 0;
     tripoint_abs_omt const surface = overmap_buffer.find_closest( testpoint, "lab_stairs", 0, false,
-                               ot_match_type::contains );
+                                     ot_match_type::contains );
 
     testpoint.z() = -1;
     tripoint_abs_omt underground =
@@ -531,7 +531,7 @@ bool mission_type::parse_funcs( const JsonObject &jo, std::function<void( missio
         }
     };
 
-    for( talk_effect_fun_t  const&effect : talk_effects.effects ) {
+    for( talk_effect_fun_t  const &effect : talk_effects.effects ) {
         auto rewards = effect.get_likely_rewards();
         if( !rewards.empty() ) {
             likely_rewards.insert( likely_rewards.end(), rewards.begin(), rewards.end() );

--- a/src/missiondef.cpp
+++ b/src/missiondef.cpp
@@ -285,7 +285,7 @@ void mission_type::load( const JsonObject &jo, const std::string &src )
         if( jo.has_string( phase ) ) {
             assign_function( jo, phase, phase_func, mission_function_map );
         } else if( jo.has_member( phase ) ) {
-            JsonObject j_start = jo.get_object( phase );
+            JsonObject const j_start = jo.get_object( phase );
             if( !parse_funcs( j_start, phase_func ) ) {
                 deferred.emplace_back( jo.get_source_location(), src );
                 jo.allow_omitted_members();

--- a/src/mod_manager_ui.cpp
+++ b/src/mod_manager_ui.cpp
@@ -95,7 +95,7 @@ std::string mod_ui::get_information( const MOD_INFORMATION *mod )
     info += colorize( _( "Mod info path" ), c_light_blue ) + ": " + mod->path_full + "\n";
 
     std::string const note = !mm_tree.is_available( mod->ident ) ? mm_tree.get_node(
-                           mod->ident )->s_errors() : "";
+                                 mod->ident )->s_errors() : "";
     if( !note.empty() ) {
         info += colorize( note, c_red );
     }
@@ -243,7 +243,7 @@ void mod_ui::try_rem( size_t selection, std::vector<mod_id> &active_list )
         }
     }
     std::vector<mod_id>::iterator const rem = std::find( active_list.begin(), active_list.end(),
-                                        sel_string );
+            sel_string );
     if( rem != active_list.end() ) {
         active_list.erase( rem );
     }

--- a/src/mod_manager_ui.cpp
+++ b/src/mod_manager_ui.cpp
@@ -78,9 +78,9 @@ std::string mod_ui::get_information( const MOD_INFORMATION *mod )
     }
 
     if( mod->lua_api_version ) {
-        nc_color col_lua = cata::has_lua() ? c_light_blue : c_red;
-        int this_api = cata::get_lua_api_version();
-        nc_color col_api = this_api == *mod->lua_api_version ? c_white : c_yellow;
+        nc_color const col_lua = cata::has_lua() ? c_light_blue : c_red;
+        int const this_api = cata::get_lua_api_version();
+        nc_color const col_api = this_api == *mod->lua_api_version ? c_white : c_yellow;
         info += string_format(
                     _( "%s: API version %s\n" ),
                     colorize( _( "Needs Lua" ), col_lua ),
@@ -94,7 +94,7 @@ std::string mod_ui::get_information( const MOD_INFORMATION *mod )
 
     info += colorize( _( "Mod info path" ), c_light_blue ) + ": " + mod->path_full + "\n";
 
-    std::string note = !mm_tree.is_available( mod->ident ) ? mm_tree.get_node(
+    std::string const note = !mm_tree.is_available( mod->ident ) ? mm_tree.get_node(
                            mod->ident )->s_errors() : "";
     if( !note.empty() ) {
         info += colorize( note, c_red );
@@ -168,7 +168,7 @@ ret_val<bool> mod_ui::try_add( const mod_id &mod_to_add, std::vector<mod_id> &ac
     }
 
     // get dependencies of selection in the order that they would appear from the top of the active list
-    std::vector<mod_id> dependencies = mm_tree.get_dependencies_of_X_as_strings( mod.ident );
+    std::vector<mod_id> const dependencies = mm_tree.get_dependencies_of_X_as_strings( mod.ident );
 
     std::vector<conflict_pair> conflicts;
     check_conflicts( mod_to_add, active_list, conflicts );
@@ -233,7 +233,7 @@ void mod_ui::try_rem( size_t selection, std::vector<mod_id> &active_list )
 
     const MOD_INFORMATION &mod = *active_list[selection];
 
-    std::vector<mod_id> dependents = mm_tree.get_dependents_of_X_as_strings( mod.ident );
+    std::vector<mod_id> const dependents = mm_tree.get_dependents_of_X_as_strings( mod.ident );
 
     // search through the rest of the active list for mods that depend on this one
     for( auto &i : dependents ) {
@@ -242,7 +242,7 @@ void mod_ui::try_rem( size_t selection, std::vector<mod_id> &active_list )
             active_list.erase( rem );
         }
     }
-    std::vector<mod_id>::iterator rem = std::find( active_list.begin(), active_list.end(),
+    std::vector<mod_id>::iterator const rem = std::find( active_list.begin(), active_list.end(),
                                         sel_string );
     if( rem != active_list.end() ) {
         active_list.erase( rem );
@@ -279,8 +279,8 @@ void mod_ui::try_shift( char direction, size_t &selection, std::vector<mod_id> &
         return;
     }
 
-    mod_id modstring = active_list[newsel];
-    mod_id selstring = active_list[oldsel];
+    mod_id const modstring = active_list[newsel];
+    mod_id const selstring = active_list[oldsel];
 
     // we can shift!
     // switch values!
@@ -306,10 +306,10 @@ bool mod_ui::can_shift_up( size_t selection, const std::vector<mod_id> &active_l
         return false;
     }
     // see if the mod at selection-1 is a) a core, or b) is depended on by this mod
-    int newsel = selection - 1;
+    int const newsel = selection - 1;
 
-    mod_id newsel_id = active_list[newsel];
-    bool newsel_is_dependency =
+    mod_id const newsel_id = active_list[newsel];
+    bool const newsel_is_dependency =
         std::find( dependencies.begin(), dependencies.end(), newsel_id ) != dependencies.end();
 
     return !newsel_id->core && !newsel_is_dependency;
@@ -329,12 +329,12 @@ bool mod_ui::can_shift_down( size_t selection, const std::vector<mod_id> &active
         // can't move down, don't bother trying
         return false;
     }
-    int newsel = selection;
-    int oldsel = selection + 1;
+    int const newsel = selection;
+    int const oldsel = selection + 1;
 
-    mod_id modstring = active_list[newsel];
-    mod_id selstring = active_list[oldsel];
-    bool sel_is_dependency =
+    mod_id const modstring = active_list[newsel];
+    mod_id const selstring = active_list[oldsel];
+    bool const sel_is_dependency =
         std::find( dependents.begin(), dependents.end(), selstring ) != dependents.end();
 
     return !modstring->core && !sel_is_dependency;

--- a/src/mod_tileset.cpp
+++ b/src/mod_tileset.cpp
@@ -25,7 +25,7 @@ void load_mod_tileset( const JsonObject &jsobj, const std::string &, const std::
     }
 
     all_mod_tilesets.emplace_back( base_path, full_path, new_num_in_file );
-    std::vector<std::string> compatibility = jsobj.get_string_array( "compatibility" );
+    std::vector<std::string> const compatibility = jsobj.get_string_array( "compatibility" );
     for( const std::string &compatible_tileset_id : compatibility ) {
         all_mod_tilesets.back().add_compatible_tileset( compatible_tileset_id );
     }

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -252,7 +252,7 @@ static bool sting_shoot( monster *z, Creature *target, damage_instance &dam, flo
     proj.add_effect( ammo_effect_NO_OVERSHOOT );
 
     dealt_projectile_attack const atk = projectile_attack( proj, z->pos(), target->pos(),
-                                  dispersion_sources{ 500 }, z );
+                                        dispersion_sources{ 500 }, z );
     if( atk.dealt_dam.total_damage() > 0 ) {
         target->add_msg_if_player( m_bad, _( "The %s shoots a dart into you!" ), z->name() );
         return true;
@@ -759,8 +759,8 @@ bool mattack::shockstorm( monster *z )
         sfx::play_variant_sound( "fire_gun", "bio_lightning", sfx::get_heard_volume( z->pos() ) );
     }
     tripoint const tarp( target->posx() + rng( -1, 1 ) + rng( -1, 1 ),
-                   target->posy() + rng( -1, 1 ) + rng( -1, 1 ),
-                   target->posz() );
+                         target->posy() + rng( -1, 1 ) + rng( -1, 1 ),
+                         target->posz() );
     std::vector<tripoint> const bolt = line_to( z->pos(), tarp, 0, 0 );
     // Fill the LOS with electricity
     for( auto &i : bolt ) {
@@ -2102,9 +2102,10 @@ bool mattack::impale( monster *z )
         return true;
     }
 
-    int const dam = target->deal_damage( z, bodypart_id( "torso" ), damage_instance( DT_STAB, rng( 10, 20 ),
-                                   rng( 5, 15 ),
-                                   .5 ) ).total_damage();
+    int const dam = target->deal_damage( z, bodypart_id( "torso" ), damage_instance( DT_STAB, rng( 10,
+                                         20 ),
+                                         rng( 5, 15 ),
+                                         .5 ) ).total_damage();
     if( dam > 0 ) {
         auto msg_type = target == &g->u ? m_bad : m_info;
         target->add_msg_player_or_npc( msg_type,
@@ -2172,7 +2173,7 @@ bool mattack::dermatik( monster *z )
 
     ///\EFFECT_UNARMED increases chance to deflect dermatik attack
     int const swat_skill = ( foe->get_skill_level( skill_melee ) + foe->get_skill_level(
-                           skill_unarmed ) * 2 ) / 3;
+                                 skill_unarmed ) * 2 ) / 3;
     int player_swat = dice( swat_skill, 10 );
     if( foe->has_trait( trait_TAIL_CATTLE ) ) {
         target->add_msg_if_player( _( "You swat at the %s with your tail!" ), z->name() );
@@ -2716,7 +2717,7 @@ bool mattack::grab( monster *z )
         return true;
     }
 
-    item  const&cur_weapon = pl->primary_weapon();
+    item  const &cur_weapon = pl->primary_weapon();
     ///\EFFECT_DEX increases chance to avoid being grabbed
     if( pl->can_use_grab_break_tec( cur_weapon ) &&
         rng( 0, pl->get_dex() ) > rng( 0, z->type->melee_sides + z->type->melee_dice ) ) {
@@ -3060,8 +3061,9 @@ bool mattack::nurse_operate( monster *z )
 
         z->friendly = 0;
         z->anger = 100;
-        std::list<tripoint> const couch_pos = g->m.find_furnitures_or_vparts_with_flag_in_radius( z->pos(), 10,
-                                        flag_AUTODOC_COUCH );
+        std::list<tripoint> const couch_pos = g->m.find_furnitures_or_vparts_with_flag_in_radius( z->pos(),
+                                              10,
+                                              flag_AUTODOC_COUCH );
 
         if( couch_pos.empty() ) {
             add_msg( m_info, _( "The %s looks for something but doesn't seem to find it." ), z->name() );
@@ -3294,8 +3296,9 @@ void mattack::taze( monster *z, Creature *target )
         return;
     }
 
-    int const dam = target->deal_damage( z, bodypart_id( "torso" ), damage_instance( DT_ELECTRIC, rng( 1,
-                                   5 ) ) ).total_damage();
+    int const dam = target->deal_damage( z, bodypart_id( "torso" ), damage_instance( DT_ELECTRIC,
+                                         rng( 1,
+                                                 5 ) ) ).total_damage();
     if( dam == 0 ) {
         target->add_msg_player_or_npc( _( "The %s unsuccessfully attempts to shock you." ),
                                        _( "The %s unsuccessfully attempts to shock <npcname>." ),
@@ -4904,8 +4907,8 @@ bool mattack::riotbot( monster *z )
         }
 
         tripoint const dest( target->posx() + rng( 0, delta ) - rng( 0, delta ),
-                       target->posy() + rng( 0, delta ) - rng( 0, delta ),
-                       target->posz() );
+                             target->posy() + rng( 0, delta ) - rng( 0, delta ),
+                             target->posz() );
 
         //~ Sound of a riotbot using its blinding flash
         sounds::sound( z->pos(), 3, sounds::sound_t::combat, _( "fzzzzzt" ), false, "misc", "flash" );
@@ -5431,7 +5434,7 @@ bool mattack::bio_op_disarm( monster *z )
     their_roll += dice( 3, foe->get_per() );
     their_roll += dice( 3, foe->get_skill_level( skill_melee ) );
 
-    item  const&it = foe->primary_weapon();
+    item  const &it = foe->primary_weapon();
 
     target->add_msg_if_player( m_bad, _( "The zombie grabs your %s…" ), it.tname() );
 
@@ -5559,7 +5562,8 @@ bool mattack::kamikaze( monster *z )
     // We double target speed because if the player is walking and then start to run their effective speed doubles
     // .65 factor was determined experimentally to be about the factor required for players to be able to *just barely*
     // outrun the explosion if they drop everything and run.
-    float const factor = static_cast<float>( z->get_speed() ) / static_cast<float>( target->get_speed() * 2 );
+    float const factor = static_cast<float>( z->get_speed() ) / static_cast<float>
+                         ( target->get_speed() * 2 );
     int const range = std::max( 1, static_cast<int>( .65 * ( radius + 1 + factor * charges ) ) );
 
     // Check if we are in range to begin the countdown

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -251,7 +251,7 @@ static bool sting_shoot( monster *z, Creature *target, damage_instance &dam, flo
     proj.impact.add( dam );
     proj.add_effect( ammo_effect_NO_OVERSHOOT );
 
-    dealt_projectile_attack atk = projectile_attack( proj, z->pos(), target->pos(),
+    dealt_projectile_attack const atk = projectile_attack( proj, z->pos(), target->pos(),
                                   dispersion_sources{ 500 }, z );
     if( atk.dealt_dam.total_damage() > 0 ) {
         target->add_msg_if_player( m_bad, _( "The %s shoots a dart into you!" ), z->name() );
@@ -496,7 +496,7 @@ bool mattack::shriek_stun( monster *z )
         return false;
     }
 
-    int dist = rl_dist( z->pos(), target->pos() );
+    int const dist = rl_dist( z->pos(), target->pos() );
     // Currently the cone is 2D, so don't use it for 3D attacks
     if( dist > 7 ||
         z->posz() != target->posz() ||
@@ -504,12 +504,12 @@ bool mattack::shriek_stun( monster *z )
         return false;
     }
 
-    units::angle target_angle = coord_to_angle( z->pos(), target->pos() );
-    units::angle cone_angle = 20_degrees;
+    units::angle const target_angle = coord_to_angle( z->pos(), target->pos() );
+    units::angle const cone_angle = 20_degrees;
     map &here = get_map();
     for( const tripoint &cone : here.points_in_radius( z->pos(), 4 ) ) {
-        units::angle tile_angle = coord_to_angle( z->pos(), cone );
-        units::angle diff = units::fabs( target_angle - tile_angle );
+        units::angle const tile_angle = coord_to_angle( z->pos(), cone );
+        units::angle const diff = units::fabs( target_angle - tile_angle );
         // Skip the target, because it's outside cone or it's the source
         if( diff + cone_angle > 360_degrees || diff > cone_angle || cone == z->pos() ) {
             continue;
@@ -625,7 +625,7 @@ bool mattack::acid( monster *z )
 
     for( int i = -3; i <= 3; i++ ) {
         for( int j = -3; j <= 3; j++ ) {
-            tripoint dest = hitp + tripoint( i, j, 0 );
+            tripoint const dest = hitp + tripoint( i, j, 0 );
             if( g->m.passable( dest ) &&
                 g->m.clear_path( dest, hitp, 6, 1, 100 ) &&
                 ( ( one_in( std::abs( j ) ) && one_in( std::abs( i ) ) ) || ( i == 0 && j == 0 ) ) ) {
@@ -652,7 +652,7 @@ bool mattack::acid_barf( monster *z )
     z->moves -= 80;
     // Make sure it happens before uncanny dodge
     g->m.add_field( target->pos(), fd_acid, 1 );
-    bool uncanny = target->uncanny_dodge();
+    bool const uncanny = target->uncanny_dodge();
     // Can we dodge the attack? Uses player dodge function % chance (melee.cpp)
     if( uncanny || dodge_check( z, target ) ) {
         auto msg_type = target == &g->u ? m_warning : m_info;
@@ -667,7 +667,7 @@ bool mattack::acid_barf( monster *z )
         return true;
     }
 
-    body_part hit = target->get_random_body_part()->token;
+    body_part const hit = target->get_random_body_part()->token;
     int dam = rng( 5, 12 );
     dam = target->deal_damage( z, convert_bp( hit ).id(), damage_instance( DT_ACID,
                                dam ) ).total_damage();
@@ -741,7 +741,7 @@ bool mattack::shockstorm( monster *z )
         return false;
     }
 
-    bool seen = g->u.sees( *z );
+    bool const seen = g->u.sees( *z );
     // Can't see/reach target, no attack
     if( !z->sees( *target ) ||
         !g->m.clear_path( z->pos(), target->pos(), 12, 1, 100 ) ) {
@@ -758,10 +758,10 @@ bool mattack::shockstorm( monster *z )
     if( !g->u.is_deaf() ) {
         sfx::play_variant_sound( "fire_gun", "bio_lightning", sfx::get_heard_volume( z->pos() ) );
     }
-    tripoint tarp( target->posx() + rng( -1, 1 ) + rng( -1, 1 ),
+    tripoint const tarp( target->posx() + rng( -1, 1 ) + rng( -1, 1 ),
                    target->posy() + rng( -1, 1 ) + rng( -1, 1 ),
                    target->posz() );
-    std::vector<tripoint> bolt = line_to( z->pos(), tarp, 0, 0 );
+    std::vector<tripoint> const bolt = line_to( z->pos(), tarp, 0, 0 );
     // Fill the LOS with electricity
     for( auto &i : bolt ) {
         if( !one_in( 4 ) ) {
@@ -817,7 +817,7 @@ bool mattack::pull_metal_weapon( monster *z )
               weapon.made_of( material_id( "hardsteel" ) ) ||
               weapon.made_of( material_id( "steel" ) ) ||
               weapon.made_of( material_id( "budget_steel" ) ) ) ) {
-            int wp_skill = foe->get_skill_level( skill_melee );
+            int const wp_skill = foe->get_skill_level( skill_melee );
             // It takes a while
             z->moves -= att_cost_pull;
             int success = 100;
@@ -861,7 +861,7 @@ bool mattack::boomer( monster *z )
     std::vector<tripoint> line = here.find_clear_path( z->pos(), target->pos() );
     // It takes a while
     z->moves -= 250;
-    bool u_see = g->u.sees( *z );
+    bool const u_see = g->u.sees( *z );
     if( u_see ) {
         add_msg( m_warning, _( "The %s spews bile!" ), z->name() );
     }
@@ -920,7 +920,7 @@ bool mattack::boomer_glow( monster *z )
     std::vector<tripoint> line = here.find_clear_path( z->pos(), target->pos() );
     // It takes a while
     z->moves -= 250;
-    bool u_see = g->u.sees( *z );
+    bool const u_see = g->u.sees( *z );
     if( u_see ) {
         add_msg( m_warning, _( "The %s spews bile!" ), z->name() );
     }
@@ -951,7 +951,7 @@ bool mattack::boomer_glow( monster *z )
             target->add_env_effect( effect_boomered, bp_eyes, 5, 25_turns );
             target->on_dodge( z, 5 );
             for( int i = 0; i < rng( 2, 4 ); i++ ) {
-                body_part bp = random_body_part();
+                body_part const bp = random_body_part();
                 target->add_env_effect( effect_glowing, bp, 4, 4_minutes );
                 if( target->has_effect( effect_glowing ) ) {
                     break;
@@ -985,10 +985,10 @@ bool mattack::resurrect( monster *z )
         raising_level = z->get_effect_int( effect_raising ) * 40;
     }
 
-    bool sees_necromancer = g->u.sees( *z );
+    bool const sees_necromancer = g->u.sees( *z );
     std::vector<std::pair<tripoint, item *>> corpses;
     // Find all corpses that we can see within 10 tiles.
-    int range = 10;
+    int const range = 10;
     bool found_eligible_corpse = false;
     int lowest_raise_score = INT_MAX;
     for( const tripoint &p : g->m.points_in_radius( z->pos(), range ) ) {
@@ -1016,7 +1016,7 @@ bool mattack::resurrect( monster *z )
                 }
                 return false;
             }
-            int raise_score = ( i.damage_level( 4 ) + 1 ) * mt->hp + i.burnt;
+            int const raise_score = ( i.damage_level( 4 ) + 1 ) * mt->hp + i.burnt;
             lowest_raise_score = std::min( lowest_raise_score, raise_score );
             if( raise_score <= raising_level ) {
                 corpses.push_back( std::make_pair( p, &i ) );
@@ -1065,11 +1065,11 @@ bool mattack::resurrect( monster *z )
         return false;
     }
 
-    std::pair<tripoint, item *> raised = random_entry( corpses );
+    std::pair<tripoint, item *> const raised = random_entry( corpses );
     // To appease static analysis
     assert( raised.second );
     // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
-    float corpse_damage = raised.second->damage_level( 4 );
+    float const corpse_damage = raised.second->damage_level( 4 );
     // Did we successfully raise something?
     if( g->revive_corpse( raised.first, *raised.second ) ) {
         g->m.i_rem( raised.first, raised.second );
@@ -1080,7 +1080,7 @@ bool mattack::resurrect( monster *z )
         // Takes one turn
         z->moves -= z->type->speed;
         // Penalize speed by between 10% and 50% based on how damaged the corpse is.
-        float speed_penalty = 0.1 + ( corpse_damage * 0.1 );
+        float const speed_penalty = 0.1 + ( corpse_damage * 0.1 );
         z->set_speed_base( z->get_speed_base() - speed_penalty * z->type->speed );
         monster *const zed = g->critter_at<monster>( raised.first );
         if( !zed ) {
@@ -1346,7 +1346,7 @@ bool mattack::science( monster *const z ) // I said SCIENCE again!
                 target->add_msg_player_or_npc( _( "You dodge the beam!" ),
                                                _( "<npcname> dodges the beam!" ) );
             } else {
-                bool rad_proof = !foe->irradiate( rng( att_rad_dose_min, att_rad_dose_max ) );
+                bool const rad_proof = !foe->irradiate( rng( att_rad_dose_min, att_rad_dose_max ) );
                 if( rad_proof ) {
                     target->add_msg_if_player( m_good, _( "Your armor protects you from the radiation!" ) );
                 } else if( one_in( att_rad_mutate_chance ) ) {
@@ -1556,7 +1556,7 @@ bool mattack::grow_vine( monster *z )
 bool mattack::vine( monster *z )
 {
     int vine_neighbors = 0;
-    bool parent_out_of_range = !g->m.inbounds( z->move_target() );
+    bool const parent_out_of_range = !g->m.inbounds( z->move_target() );
     monster *parent = g->critter_at<monster>( z->move_target() );
     if( !parent_out_of_range && ( parent == nullptr || parent->type->id != mon_creeper_hub ) ) {
         // TODO: Should probably die instead.
@@ -1570,7 +1570,7 @@ bool mattack::vine( monster *z )
                 return true;
             }
 
-            bodypart_id bphit = critter->get_random_body_part();
+            bodypart_id const bphit = critter->get_random_body_part();
             critter->add_msg_player_or_npc( m_bad,
                                             //~ 1$s monster name(vine), 2$s bodypart in accusative
                                             _( "The %1$s lashes your %2$s!" ),
@@ -1593,7 +1593,7 @@ bool mattack::vine( monster *z )
         }
     }
     // Calculate distance from nearest hub
-    int dist_from_hub = rl_dist( z->pos(), z->move_target() );
+    int const dist_from_hub = rl_dist( z->pos(), z->move_target() );
     if( dist_from_hub > 20 || vine_neighbors > 5 || one_in( 7 - vine_neighbors ) ||
         !one_in( dist_from_hub ) ) {
         return true;
@@ -1647,7 +1647,7 @@ bool mattack::triffid_heartbeat( monster *z )
         return true;
     }
 
-    static pathfinding_settings root_pathfind( 10, 20, 50, 0, false, false, false, false, false );
+    static pathfinding_settings const root_pathfind( 10, 20, 50, 0, false, false, false, false, false );
     if( rl_dist( z->pos(), g->u.pos() ) > 5 &&
         !g->m.route( g->u.pos(), z->pos(), root_pathfind ).empty() ) {
         add_msg( m_warning, _( "The root walls creak around you." ) );
@@ -1662,8 +1662,8 @@ bool mattack::triffid_heartbeat( monster *z )
         int tries = 0;
         while( g->m.route( g->u.pos(), z->pos(), root_pathfind ).empty() &&
                tries < 20 ) {
-            point p( rng( g->u.posx(), z->posx() - 3 ), rng( g->u.posy(), z->posy() - 3 ) );
-            tripoint dest( p, z->posz() );
+            point const p( rng( g->u.posx(), z->posx() - 3 ), rng( g->u.posy(), z->posy() - 3 ) );
+            tripoint const dest( p, z->posz() );
             tries++;
             g->m.ter_set( dest, t_dirt );
             if( rl_dist( dest, g->u.pos() ) > 3 && g->num_creatures() < 30 &&
@@ -1705,9 +1705,9 @@ bool mattack::fungus( monster *z )
         add_msg( m_warning, _( "Spores are released from the %s!" ), z->name() );
     }
 
-    bool on_fungus = g->m.has_flag_ter( "FUNGUS", z->pos() );
-    int radius = one_in( 4 ) ? 2 : 1;
-    double spore_chance = ( on_fungus ? 0.5f : 0.2f ) / ( ( radius + 1 ) * ( radius + 1 ) );
+    bool const on_fungus = g->m.has_flag_ter( "FUNGUS", z->pos() );
+    int const radius = one_in( 4 ) ? 2 : 1;
+    double const spore_chance = ( on_fungus ? 0.5f : 0.2f ) / ( ( radius + 1 ) * ( radius + 1 ) );
     fungal_effects fe( *g, g->m );
     for( const tripoint &sporep : g->m.points_in_radius( z->pos(), radius ) ) {
         if( sporep == z->pos() ) {
@@ -2089,7 +2089,7 @@ bool mattack::impale( monster *z )
     }
 
     z->moves -= 80;
-    bool uncanny = target->uncanny_dodge();
+    bool const uncanny = target->uncanny_dodge();
     if( uncanny || dodge_check( z, target ) ) {
         auto msg_type = target == &g->u ? m_warning : m_info;
         target->add_msg_player_or_npc( msg_type, _( "The %s lunges at you, but you dodge!" ),
@@ -2102,7 +2102,7 @@ bool mattack::impale( monster *z )
         return true;
     }
 
-    int dam = target->deal_damage( z, bodypart_id( "torso" ), damage_instance( DT_STAB, rng( 10, 20 ),
+    int const dam = target->deal_damage( z, bodypart_id( "torso" ), damage_instance( DT_STAB, rng( 10, 20 ),
                                    rng( 5, 15 ),
                                    .5 ) ).total_damage();
     if( dam > 0 ) {
@@ -2167,11 +2167,11 @@ bool mattack::dermatik( monster *z )
     }
 
     // Can we swat the bug away?
-    int dodge_roll = z->dodge_roll();
+    int const dodge_roll = z->dodge_roll();
     ///\EFFECT_MELEE increases chance to deflect dermatik attack
 
     ///\EFFECT_UNARMED increases chance to deflect dermatik attack
-    int swat_skill = ( foe->get_skill_level( skill_melee ) + foe->get_skill_level(
+    int const swat_skill = ( foe->get_skill_level( skill_melee ) + foe->get_skill_level(
                            skill_unarmed ) * 2 ) / 3;
     int player_swat = dice( swat_skill, 10 );
     if( foe->has_trait( trait_TAIL_CATTLE ) ) {
@@ -2401,7 +2401,7 @@ bool mattack::callblobs( monster *z )
     // if we want to deal with NPCS and friendly monsters as well.
     // The strategy is to send about 1/3 of the available blobs after the player,
     // and keep the rest near the brain blob for protection.
-    tripoint enemy = g->u.pos();
+    tripoint const enemy = g->u.pos();
     std::list<monster *> allies;
     std::vector<tripoint> nearby_points = closest_points_first( z->pos(), 3 );
     for( monster &candidate : g->all_monsters() ) {
@@ -2419,7 +2419,7 @@ bool mattack::callblobs( monster *z )
         tripoint post = enemy;
         if( guards < num_guards ) {
             // Each guard is assigned a spot in the nearby_points vector based on their order.
-            int assigned_spot = ( nearby_points.size() * guards ) / num_guards;
+            int const assigned_spot = ( nearby_points.size() * guards ) / num_guards;
             post = nearby_points[ assigned_spot ];
         }
         ( *ally )->set_dest( post );
@@ -2451,7 +2451,7 @@ bool mattack::jackson( monster *z )
         tripoint post = z->pos();
         if( dancers < num_dancers ) {
             // Each dancer is assigned a spot in the nearby_points vector based on their order.
-            int assigned_spot = ( nearby_points.size() * dancers ) / num_dancers;
+            int const assigned_spot = ( nearby_points.size() * dancers ) / num_dancers;
             post = nearby_points[ assigned_spot ];
         }
         if( ( *ally )->type->id != mon_zombie_dancer ) {
@@ -2545,7 +2545,7 @@ bool mattack::tentacle( monster *z )
     if( target == nullptr || rl_dist( z->pos(), target->pos() ) > 3 || !z->sees( *target ) ) {
         return false;
     }
-    game_message_type msg_type = target == &g->u ? m_bad : m_info;
+    game_message_type const msg_type = target == &g->u ? m_bad : m_info;
     target->add_msg_player_or_npc( msg_type,
                                    _( "The %s lashes its tentacle at you!" ),
                                    _( "The %s lashes its tentacle at <npcname>!" ),
@@ -2602,8 +2602,8 @@ bool mattack::ranged_pull( monster *z )
     map &here = get_map();
 
     player *foe = dynamic_cast< player * >( target );
-    std::vector<tripoint> line = here.find_clear_path( z->pos(), target->pos() );
-    bool seen = g->u.sees( *z );
+    std::vector<tripoint> const line = here.find_clear_path( z->pos(), target->pos() );
+    bool const seen = g->u.sees( *z );
     tripoint prev_point = z->pos();
     for( auto &i : line ) {
         // Player can't be pulled though bars, furniture, cars or creatures
@@ -2716,7 +2716,7 @@ bool mattack::grab( monster *z )
         return true;
     }
 
-    item &cur_weapon = pl->primary_weapon();
+    item  const&cur_weapon = pl->primary_weapon();
     ///\EFFECT_DEX increases chance to avoid being grabbed
     if( pl->can_use_grab_break_tec( cur_weapon ) &&
         rng( 0, pl->get_dex() ) > rng( 0, z->type->melee_sides + z->type->melee_dice ) ) {
@@ -2728,7 +2728,7 @@ bool mattack::grab( monster *z )
             target->add_msg_if_player( m_info, _( "The %s tries to grab you…" ), z->name() );
             thrown_by_judo( z );
         } else if( pl->has_grab_break_tec() ) {
-            ma_technique tech = pl->martial_arts_data->get_grab_break_tec( cur_weapon );
+            ma_technique const tech = pl->martial_arts_data->get_grab_break_tec( cur_weapon );
             target->add_msg_player_or_npc( m_info, _( tech.avatar_message ), _( tech.npc_message ), z->name() );
         } else {
             target->add_msg_player_or_npc( m_info, _( "The %s tries to grab you, but you break its grab!" ),
@@ -2807,7 +2807,7 @@ bool mattack::grab_drag( monster *z )
         target->add_msg_player_or_npc( m_good, _( "You resist the %s as it tries to drag you!" ),
                                        _( "<npcname> resist the %s as it tries to drag them!" ), z->name() );
     }
-    int prev_effect = target->get_effect_int( effect_grabbed );
+    int const prev_effect = target->get_effect_int( effect_grabbed );
     z->add_effect( effect_grabbing, 2_turns );
     target->add_effect( effect_grabbed, 2_turns, bp_torso, prev_effect + 3 );
 
@@ -2827,7 +2827,7 @@ bool mattack::gene_sting( monster *z )
 
     damage_instance dam = damage_instance();
     dam.add_damage( DT_STAB, 6, 10, 0.6, 1 );
-    bool hit = sting_shoot( z, target, dam, range );
+    bool const hit = sting_shoot( z, target, dam, range );
     if( hit ) {
         //Add checks if previous NPC/player conditions are removed
         dynamic_cast<player *>( target )->mutate();
@@ -2848,7 +2848,7 @@ bool mattack::para_sting( monster *z )
 
     damage_instance dam = damage_instance();
     dam.add_damage( DT_STAB, 6, 8, 0.8, 1 );
-    bool hit = sting_shoot( z, target, dam, range );
+    bool const hit = sting_shoot( z, target, dam, range );
     if( hit ) {
         target->add_msg_if_player( m_bad, _( "You feel poison enter your body!" ) );
         target->add_effect( effect_paralyzepoison, 5_minutes );
@@ -3060,7 +3060,7 @@ bool mattack::nurse_operate( monster *z )
 
         z->friendly = 0;
         z->anger = 100;
-        std::list<tripoint> couch_pos = g->m.find_furnitures_or_vparts_with_flag_in_radius( z->pos(), 10,
+        std::list<tripoint> const couch_pos = g->m.find_furnitures_or_vparts_with_flag_in_radius( z->pos(), 10,
                                         flag_AUTODOC_COUCH );
 
         if( couch_pos.empty() ) {
@@ -3294,7 +3294,7 @@ void mattack::taze( monster *z, Creature *target )
         return;
     }
 
-    int dam = target->deal_damage( z, bodypart_id( "torso" ), damage_instance( DT_ELECTRIC, rng( 1,
+    int const dam = target->deal_damage( z, bodypart_id( "torso" ), damage_instance( DT_ELECTRIC, rng( 1,
                                    5 ) ) ).total_damage();
     if( dam == 0 ) {
         target->add_msg_player_or_npc( _( "The %s unsuccessfully attempts to shock you." ),
@@ -3351,7 +3351,7 @@ void mattack::rifle( monster *z, Creature *target )
     }
 
     tmp.set_primary_weapon( item( "m4a1" ).ammo_set( ammo_type, z->ammo[ ammo_type ] ) );
-    int burst = std::max( tmp.primary_weapon().gun_get_mode( gun_mode_id( "AUTO" ) ).qty, 1 );
+    int const burst = std::max( tmp.primary_weapon().gun_get_mode( gun_mode_id( "AUTO" ) ).qty, 1 );
 
     z->ammo[ ammo_type ] -= ranged::fire_gun( tmp, target->pos(),
                             burst ) * tmp.primary_weapon().ammo_required();
@@ -3412,7 +3412,7 @@ void mattack::frag( monster *z, Creature *target ) // This is for the bots, not 
     }
 
     tmp.set_primary_weapon( item( "mgl" ).ammo_set( ammo_type, z->ammo[ ammo_type ] ) );
-    int burst = std::max( tmp.primary_weapon().gun_get_mode( gun_mode_id( "AUTO" ) ).qty, 1 );
+    int const burst = std::max( tmp.primary_weapon().gun_get_mode( gun_mode_id( "AUTO" ) ).qty, 1 );
 
     z->ammo[ ammo_type ] -= ranged::fire_gun( tmp, target->pos(),
                             burst ) * tmp.primary_weapon().ammo_required();
@@ -3432,7 +3432,7 @@ void mattack::tankgun( monster *z, Creature *target )
         z->ammo[ammo_type] = 40;
     }
 
-    int dist = rl_dist( z->pos(), target->pos() );
+    int const dist = rl_dist( z->pos(), target->pos() );
     if( dist > 50 ) {
         return;
     }
@@ -3472,7 +3472,7 @@ void mattack::tankgun( monster *z, Creature *target )
         add_msg( m_warning, _( "The %s's 120mm cannon fires!" ), z->name() );
     }
     tmp.set_primary_weapon( item( "TANK" ).ammo_set( ammo_type, z->ammo[ ammo_type ] ) );
-    int burst = std::max( tmp.primary_weapon().gun_get_mode( gun_mode_id( "AUTO" ) ).qty, 1 );
+    int const burst = std::max( tmp.primary_weapon().gun_get_mode( gun_mode_id( "AUTO" ) ).qty, 1 );
 
     z->ammo[ ammo_type ] -= ranged::fire_gun( tmp, target->pos(),
                             burst ) * tmp.primary_weapon().ammo_required();
@@ -3536,7 +3536,7 @@ bool mattack::searchlight( monster *z )
 
         for( int x = zposx - 24; x < zposx + 24; x++ ) {
             for( int y = zposy - 24; y < zposy + 24; y++ ) {
-                tripoint dest( x, y, z->posz() );
+                tripoint const dest( x, y, z->posz() );
                 if( g->m.ter( dest ) == ter_str_id( "t_plut_generator" ) ) {
                     generator_ok = true;
                 }
@@ -3702,7 +3702,7 @@ bool mattack::flamethrower( monster *z )
 
 void mattack::flame( monster *z, Creature *target )
 {
-    int dist = rl_dist( z->pos(), target->pos() );
+    int const dist = rl_dist( z->pos(), target->pos() );
 
     map &here = get_map();
     if( target != &g->u ) {
@@ -3747,7 +3747,7 @@ void mattack::flame( monster *z, Creature *target )
         // shouldn't happen
         debugmsg( "mattack::flame invoked on invisible target" );
     }
-    std::vector<tripoint> traj = here.find_clear_path( z->pos(), target->pos() );
+    std::vector<tripoint> const traj = here.find_clear_path( z->pos(), target->pos() );
     tripoint prev_point = z->pos();
     for( auto &i : traj ) {
         if( here.obstructed_by_vehicle_rotation( prev_point, i ) ) {
@@ -3790,8 +3790,8 @@ bool mattack::copbot( monster *z )
 
     // TODO: Make it recognize zeds as human, but ignore animals
     player *foe = dynamic_cast<player *>( target );
-    bool sees_u = foe != nullptr && z->sees( *foe );
-    bool cuffed = foe != nullptr && foe->primary_weapon().typeId() == itype_e_handcuffs;
+    bool const sees_u = foe != nullptr && z->sees( *foe );
+    bool const cuffed = foe != nullptr && foe->primary_weapon().typeId() == itype_e_handcuffs;
     // Taze first, then ask questions (simplifies later checks for non-humans)
     if( !cuffed && is_adjacent( z, target, true ) ) {
         taze( z, target );
@@ -3863,8 +3863,8 @@ bool mattack::chickenbot( monster *z )
         cap += 2;
     }
 
-    int dist = rl_dist( z->pos(), target->pos() );
-    int player_dist = rl_dist( target->pos(), g->u.pos() );
+    int const dist = rl_dist( z->pos(), target->pos() );
+    int const player_dist = rl_dist( target->pos(), g->u.pos() );
     if( dist == 1 && one_in( 2 ) ) {
         // Use tazer at point-blank range, and even then, not continuously.
         mode = 1;
@@ -3945,7 +3945,7 @@ bool mattack::multi_robot( monster *z )
         cap += 2;
     }
 
-    int dist = rl_dist( z->pos(), target->pos() );
+    int const dist = rl_dist( z->pos(), target->pos() );
     if( dist <= 15 ) {
         mode = 1;
     } else if( dist <= 30 ) {
@@ -4061,7 +4061,7 @@ bool mattack::upgrade( monster *z )
 
     monster *target = random_entry( targets );
 
-    std::string old_name = target->name();
+    std::string const old_name = target->name();
     const auto could_see = g->u.sees( *target );
     target->hasten_upgrade();
     target->try_upgrade( false );
@@ -4154,7 +4154,7 @@ bool mattack::stretch_bite( monster *z )
         }
         prev_point = pnt;
     }
-    bool uncanny = target->uncanny_dodge();
+    bool const uncanny = target->uncanny_dodge();
     // Can we dodge the attack? Uses player dodge function % chance (melee.cpp)
     if( uncanny || dodge_check( z, target ) ) {
         z->moves -= 150;
@@ -4234,7 +4234,7 @@ bool mattack::flesh_golem( monster *z )
         return false;
     }
 
-    int dist = rl_dist( z->pos(), target->pos() );
+    int const dist = rl_dist( z->pos(), target->pos() );
     if( dist > 20 ||
         !z->sees( *target ) ) {
         return false;
@@ -4273,7 +4273,7 @@ bool mattack::flesh_golem( monster *z )
     }
     const bodypart_id hit = target->get_random_body_part();
     // TODO: 10 bashing damage doesn't sound like a "massive claw" but a mediocre punch
-    int dam = rng( 5, 10 );
+    int const dam = rng( 5, 10 );
     target->deal_damage( z, hit, damage_instance( DT_BASH, dam ) );
     if( one_in( 6 ) ) {
         target->add_effect( effect_downed, 3_minutes );
@@ -4350,13 +4350,13 @@ bool mattack::lunge( monster *z )
         return false;
     }
 
-    int dist = rl_dist( z->pos(), target->pos() );
+    int const dist = rl_dist( z->pos(), target->pos() );
     if( dist > 20 ||
         !z->sees( *target ) ) {
         return false;
     }
 
-    bool seen = g->u.sees( *z );
+    bool const seen = g->u.sees( *z );
     if( dist > 1 ) {
         if( one_in( 5 ) ) {
             // Out of range
@@ -4903,14 +4903,14 @@ bool mattack::riotbot( monster *z )
             delta = 1;
         }
 
-        tripoint dest( target->posx() + rng( 0, delta ) - rng( 0, delta ),
+        tripoint const dest( target->posx() + rng( 0, delta ) - rng( 0, delta ),
                        target->posy() + rng( 0, delta ) - rng( 0, delta ),
                        target->posz() );
 
         //~ Sound of a riotbot using its blinding flash
         sounds::sound( z->pos(), 3, sounds::sound_t::combat, _( "fzzzzzt" ), false, "misc", "flash" );
 
-        std::vector<tripoint> traj = line_to( z->pos(), dest, 0, 0 );
+        std::vector<tripoint> const traj = line_to( z->pos(), dest, 0, 0 );
         tripoint prev_point = z->pos();
         for( auto &elem : traj ) {
             if( !here.is_transparent( elem ) || here.obscured_by_vehicle_rotation( prev_point, elem ) ) {
@@ -4959,7 +4959,7 @@ bool mattack::evolve_kill_strike( monster *z )
     damage.mult_damage( 1.33f );
     damage.add( damage_instance( DT_STAB, dice( z->type->melee_dice, z->type->melee_sides ), rng( 5,
                                  15 ), 1.0, 0.5 ) );
-    int damage_dealt = target->deal_damage( z, bodypart_id( "torso" ), damage ).total_damage();
+    int const damage_dealt = target->deal_damage( z, bodypart_id( "torso" ), damage ).total_damage();
     if( damage_dealt > 0 ) {
         auto msg_type = target == &g->u ? m_bad : m_warning;
         target->add_msg_player_or_npc( msg_type,
@@ -5140,7 +5140,7 @@ bool mattack::flesh_tendril( monster *z )
 
     if( ( distance_to_target == 2 || distance_to_target == 3 ) && one_in( 4 ) ) {
         //it pulls you towards itself and then knocks you away
-        bool pulled = ranged_pull( z );
+        bool const pulled = ranged_pull( z );
         if( pulled && one_in( 4 ) ) {
             sounds::sound( z->pos(), 60, sounds::sound_t::alarm, _( "a deafening roar!" ), false, "shout",
                            "roar" );
@@ -5218,7 +5218,7 @@ bool mattack::bio_op_takedown( monster *z )
         return false;
     }
 
-    bool seen = g->u.sees( *z );
+    bool const seen = g->u.sees( *z );
     player *foe = dynamic_cast< player * >( target );
     if( seen ) {
         add_msg( _( "The %1$s mechanically grabs at %2$s!" ), z->name(),
@@ -5419,7 +5419,7 @@ bool mattack::bio_op_disarm( monster *z )
         return true;
     }
 
-    int mon_stat = z->type->melee_dice * z->type->melee_sides;
+    int const mon_stat = z->type->melee_dice * z->type->melee_sides;
     int my_roll = dice( 3, 2 * mon_stat );
     my_roll += dice( 3, z->type->melee_skill );
 
@@ -5431,7 +5431,7 @@ bool mattack::bio_op_disarm( monster *z )
     their_roll += dice( 3, foe->get_per() );
     their_roll += dice( 3, foe->get_skill_level( skill_melee ) );
 
-    item &it = foe->primary_weapon();
+    item  const&it = foe->primary_weapon();
 
     target->add_msg_if_player( m_bad, _( "The zombie grabs your %s…" ), it.tname() );
 
@@ -5536,7 +5536,7 @@ bool mattack::kamikaze( monster *z )
     }
     // Extra check here to avoid sqrt if not needed
     if( exp_actor->explosion ) {
-        int tmp = static_cast<int>( exp_actor->explosion.safe_range() / 2 );
+        int const tmp = static_cast<int>( exp_actor->explosion.safe_range() / 2 );
         if( tmp > radius ) {
             radius = tmp;
         }
@@ -5559,8 +5559,8 @@ bool mattack::kamikaze( monster *z )
     // We double target speed because if the player is walking and then start to run their effective speed doubles
     // .65 factor was determined experimentally to be about the factor required for players to be able to *just barely*
     // outrun the explosion if they drop everything and run.
-    float factor = static_cast<float>( z->get_speed() ) / static_cast<float>( target->get_speed() * 2 );
-    int range = std::max( 1, static_cast<int>( .65 * ( radius + 1 + factor * charges ) ) );
+    float const factor = static_cast<float>( z->get_speed() ) / static_cast<float>( target->get_speed() * 2 );
+    int const range = std::max( 1, static_cast<int>( .65 * ( radius + 1 + factor * charges ) ) );
 
     // Check if we are in range to begin the countdown
     if( !within_target_range( z, target, range ) ) {
@@ -5627,7 +5627,7 @@ static int grenade_helper( monster *const z, Creature *const target, const int d
     for( const auto &amm : z->ammo ) {
         curr_ammo += amm.second;
     }
-    float rat = curr_ammo / static_cast<float>( total_ammo );
+    float const rat = curr_ammo / static_cast<float>( total_ammo );
 
     if( curr_ammo == 0 ) {
         // We've run out of ammo, get angry and toggle the special off.
@@ -5643,7 +5643,7 @@ static int grenade_helper( monster *const z, Creature *const target, const int d
             possible_attacks.add( amm.first, 1.0 / data[amm.first].chance );
         }
     }
-    itype_id att = *possible_attacks.pick();
+    itype_id const att = *possible_attacks.pick();
 
     z->moves -= moves;
     z->ammo[att]--;
@@ -5702,7 +5702,7 @@ bool mattack::grenadier( monster *const z )
     if( z->attitude_to( *target ) == Creature::A_FRIENDLY ) {
         return false;
     }
-    int ret = grenade_helper( z, target, 30, 60, grenades );
+    int const ret = grenade_helper( z, target, 30, 60, grenades );
     if( ret == -1 ) {
         // Something broke badly, disable our special
         z->disable_special( "GRENADIER" );
@@ -5737,7 +5737,7 @@ bool mattack::grenadier_elite( monster *const z )
     if( z->attitude_to( *target ) == Creature::A_FRIENDLY ) {
         return false;
     }
-    int ret = grenade_helper( z, target, 30, 60, grenades );
+    int const ret = grenade_helper( z, target, 30, 60, grenades );
     if( ret == -1 ) {
         // Something broke badly, disable our special
         z->disable_special( "GRENADIER_ELITE" );
@@ -5757,7 +5757,7 @@ bool mattack::stretch_attack( monster *z )
         return false;
     }
 
-    int distance = rl_dist( z->pos(), target->pos() );
+    int const distance = rl_dist( z->pos(), target->pos() );
     if( distance < 2 || distance > 3 || !z->sees( *target ) ) {
         return false;
     }
@@ -5886,6 +5886,6 @@ bool mattack::doot( monster *z )
 bool mattack::dodge_check( monster *z, Creature *target )
 {
     ///\EFFECT_DODGE increases chance of dodging, vs their melee skill
-    float dodge = std::max( target->get_dodge() - rng( 0, z->get_hit() ), 0.0f );
+    float const dodge = std::max( target->get_dodge() - rng( 0, z->get_hit() ), 0.0f );
     return rng( 0, 10000 ) < 10000 / ( 1 + 99 * std::exp( -.6 * dodge ) );
 }

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -475,8 +475,10 @@ void mdeath::guilt( monster &z )
 
     int moraleMalus = -50 * ( 1.0 - ( static_cast<float>( kill_count ) / maxKills ) );
     int const maxMalus = -250 * ( 1.0 - ( static_cast<float>( kill_count ) / maxKills ) );
-    time_duration const duration = 30_minutes * ( 1.0 - ( static_cast<float>( kill_count ) / maxKills ) );
-    time_duration const decayDelay = 3_minutes * ( 1.0 - ( static_cast<float>( kill_count ) / maxKills ) );
+    time_duration const duration = 30_minutes * ( 1.0 - ( static_cast<float>
+                                   ( kill_count ) / maxKills ) );
+    time_duration const decayDelay = 3_minutes * ( 1.0 - ( static_cast<float>
+                                     ( kill_count ) / maxKills ) );
     if( z.type->in_species( ZOMBIE ) ) {
         moraleMalus /= 10;
         if( g->u.has_trait( trait_PACIFIST ) ) {
@@ -620,10 +622,11 @@ void mdeath::focused_beam( monster &z )
             add_msg( m_warning, _( "As the final light is destroyed, it erupts in a blinding flare!" ) );
         }
 
-        item  const&settings = z.inv[0];
+        item  const &settings = z.inv[0];
 
-        point const p2( z.posx() + settings.get_var( "SL_SPOT_X", 0 ), z.posy() + settings.get_var( "SL_SPOT_Y",
-                  0 ) );
+        point const p2( z.posx() + settings.get_var( "SL_SPOT_X", 0 ),
+                        z.posy() + settings.get_var( "SL_SPOT_Y",
+                                0 ) );
         tripoint const p( p2, z.posz() );
 
         std::vector <tripoint> const traj = line_to( z.pos(), p, 0, 0 );
@@ -764,8 +767,8 @@ void mdeath::jabberwock( monster &z )
     player *ch = dynamic_cast<player *>( z.get_killer() );
 
     bool const vorpal = ch && ch->is_player() &&
-                  ch->primary_weapon().has_flag( "DIAMOND" ) &&
-                  ch->primary_weapon().volume() > 750_ml;
+                        ch->primary_weapon().has_flag( "DIAMOND" ) &&
+                        ch->primary_weapon().volume() > 750_ml;
 
     if( vorpal && !ch->primary_weapon().has_technique( matec_id( "VORPAL" ) ) ) {
         if( ch->sees( z ) ) {
@@ -957,7 +960,7 @@ void mdeath::fireball( monster &z )
     if( one_in( 10 ) ) {
         g->m.propagate_field( z.pos(), fd_fire, 15, 3 );
         std::string const explode = string_format( _( "an explosion of tank of the %s's flamethrower!" ),
-                                             z.name() );
+                                    z.name() );
         sounds::sound( z.pos(), 24, sounds::sound_t::combat, explode, false, "explosion", "default" );
         add_msg( m_good, _( "I love the smell of burning zed in the morning." ) );
     } else {

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -228,13 +228,13 @@ void mdeath::splatter( monster &z )
     gibbed_weight = std::min( static_cast<uint64_t>( gibbed_weight ), z_weight * 15 / 100 );
 
     if( pulverized && gibbable ) {
-        float overflow_ratio = overflow_damage / max_hp + 1;
-        int gib_distance = std::round( rng( 2, 4 ) );
+        float const overflow_ratio = overflow_damage / max_hp + 1;
+        int const gib_distance = std::round( rng( 2, 4 ) );
         for( const auto &entry : *z.type->harvest ) {
             // only flesh and bones survive.
             if( entry.type == "flesh" || entry.type == "bone" ) {
                 // the larger the overflow damage, the less you get
-                itype_id item_id( entry.drop );
+                itype_id const item_id( entry.drop );
                 const int chunk_amt = entry.mass_ratio / overflow_ratio / 10 * z_weight /
                                       to_gram( item_id->weight );
                 scatter_chunks( item_id, chunk_amt, z, gib_distance,
@@ -269,7 +269,7 @@ void mdeath::acid( monster &z )
 
 void mdeath::boomer( monster &z )
 {
-    std::string explode = string_format( _( "a %s explode!" ), z.name() );
+    std::string const explode = string_format( _( "a %s explode!" ), z.name() );
     sounds::sound( z.pos(), 24, sounds::sound_t::combat, explode, false, "explosion", "small" );
     for( const tripoint &dest : g->m.points_in_radius( z.pos(), 1 ) ) { // *NOPAD*
         g->m.bash( dest, 10 );
@@ -288,7 +288,7 @@ void mdeath::boomer( monster &z )
 
 void mdeath::boomer_glow( monster &z )
 {
-    std::string explode = string_format( _( "a %s explode!" ), z.name() );
+    std::string const explode = string_format( _( "a %s explode!" ), z.name() );
     sounds::sound( z.pos(), 24, sounds::sound_t::combat, explode, false, "explosion", "small" );
 
     for( const tripoint &dest : g->m.points_in_radius( z.pos(), 1 ) ) { // *NOPAD*
@@ -300,7 +300,7 @@ void mdeath::boomer_glow( monster &z )
         if( Creature *const critter = g->critter_at( dest ) ) {
             critter->add_env_effect( effect_boomered, bp_eyes, 5, 25_turns );
             for( int i = 0; i < rng( 2, 4 ); i++ ) {
-                body_part bp = random_body_part();
+                body_part const bp = random_body_part();
                 critter->add_env_effect( effect_glowing, bp, 4, 4_minutes );
                 if( critter->has_effect( effect_glowing ) ) {
                     break;
@@ -324,8 +324,8 @@ void mdeath::kill_vines( monster &z )
     } );
 
     for( Creature *const vine : vines ) {
-        int dist = rl_dist( vine->pos(), z.pos() );
-        bool closer = false;
+        int const dist = rl_dist( vine->pos(), z.pos() );
+        bool const closer = false;
         for( auto &j : hubs ) {
             if( rl_dist( vine->pos(), j->pos() ) < dist ) {
                 break;
@@ -427,8 +427,8 @@ void mdeath::disappear( monster &z )
 void mdeath::guilt( monster &z )
 {
     const int MAX_GUILT_DISTANCE = 5;
-    int kill_count = g->get_kill_tracker().kill_count( z.type->id );
-    int maxKills = 100; // this is when the player stop caring altogether.
+    int const kill_count = g->get_kill_tracker().kill_count( z.type->id );
+    int const maxKills = 100; // this is when the player stop caring altogether.
 
     // different message as we kill more of the same monster
     std::string msg = _( "You feel guilty for killing %s." ); // default guilt message
@@ -474,9 +474,9 @@ void mdeath::guilt( monster &z )
     add_msg( msgtype, msg, z.name() );
 
     int moraleMalus = -50 * ( 1.0 - ( static_cast<float>( kill_count ) / maxKills ) );
-    int maxMalus = -250 * ( 1.0 - ( static_cast<float>( kill_count ) / maxKills ) );
-    time_duration duration = 30_minutes * ( 1.0 - ( static_cast<float>( kill_count ) / maxKills ) );
-    time_duration decayDelay = 3_minutes * ( 1.0 - ( static_cast<float>( kill_count ) / maxKills ) );
+    int const maxMalus = -250 * ( 1.0 - ( static_cast<float>( kill_count ) / maxKills ) );
+    time_duration const duration = 30_minutes * ( 1.0 - ( static_cast<float>( kill_count ) / maxKills ) );
+    time_duration const decayDelay = 3_minutes * ( 1.0 - ( static_cast<float>( kill_count ) / maxKills ) );
     if( z.type->in_species( ZOMBIE ) ) {
         moraleMalus /= 10;
         if( g->u.has_trait( trait_PACIFIST ) ) {
@@ -493,7 +493,7 @@ void mdeath::guilt( monster &z )
 
 void mdeath::blobsplit( monster &z )
 {
-    int speed = z.get_speed() - rng( 30, 50 );
+    int const speed = z.get_speed() - rng( 30, 50 );
     g->m.spawn_item( z.pos(), "slime_scrap", 1, 0, calendar::turn );
     if( z.get_speed() <= 0 ) {
         if( g->u.sees( z ) ) {
@@ -620,13 +620,13 @@ void mdeath::focused_beam( monster &z )
             add_msg( m_warning, _( "As the final light is destroyed, it erupts in a blinding flare!" ) );
         }
 
-        item &settings = z.inv[0];
+        item  const&settings = z.inv[0];
 
-        point p2( z.posx() + settings.get_var( "SL_SPOT_X", 0 ), z.posy() + settings.get_var( "SL_SPOT_Y",
+        point const p2( z.posx() + settings.get_var( "SL_SPOT_X", 0 ), z.posy() + settings.get_var( "SL_SPOT_Y",
                   0 ) );
-        tripoint p( p2, z.posz() );
+        tripoint const p( p2, z.posz() );
 
-        std::vector <tripoint> traj = line_to( z.pos(), p, 0, 0 );
+        std::vector <tripoint> const traj = line_to( z.pos(), p, 0, 0 );
         tripoint last_point = z.pos();
         for( auto &elem : traj ) {
             if( !g->m.is_transparent( elem ) || get_map().obscured_by_vehicle_rotation( last_point, elem ) ) {
@@ -669,7 +669,7 @@ void mdeath::broken( monster &z )
                 bool spawned = false;
                 for( const std::pair<const std::string, mtype_special_attack> &attack : z.type->special_attacks ) {
                     if( attack.second->id == "gun" ) {
-                        item gun = item( dynamic_cast<const gun_actor *>( attack.second.get() )->gun_type );
+                        item const gun = item( dynamic_cast<const gun_actor *>( attack.second.get() )->gun_type );
                         bool same_ammo = false;
                         for( const ammotype &at : gun.ammo_types() ) {
                             if( at == item( ammo_entry.first ).ammo_type() ) {
@@ -732,14 +732,14 @@ void mdeath::darkman( monster &z )
 
 void mdeath::gas( monster &z )
 {
-    std::string explode = string_format( _( "a %s explode!" ), z.name() );
+    std::string const explode = string_format( _( "a %s explode!" ), z.name() );
     sounds::sound( z.pos(), 24, sounds::sound_t::combat, explode, false, "explosion", "small" );
     g->m.emit_field( z.pos(), emit_id( "emit_toxic_blast" ) );
 }
 
 void mdeath::smokeburst( monster &z )
 {
-    std::string explode = string_format( _( "a %s explode!" ), z.name() );
+    std::string const explode = string_format( _( "a %s explode!" ), z.name() );
     sounds::sound( z.pos(), 24, sounds::sound_t::combat, explode, false, "explosion", "small" );
     g->m.emit_field( z.pos(), emit_id( "emit_smoke_blast" ) );
 }
@@ -754,7 +754,7 @@ void mdeath::fungalburst( monster &z )
         return;
     }
 
-    std::string explode = string_format( _( "a %s explodes!" ), z.name() );
+    std::string const explode = string_format( _( "a %s explodes!" ), z.name() );
     sounds::sound( z.pos(), 24, sounds::sound_t::combat, explode, false, "explosion", "small" );
     g->m.emit_field( z.pos(), emit_id( "emit_fungal_blast" ) );
 }
@@ -763,7 +763,7 @@ void mdeath::jabberwock( monster &z )
 {
     player *ch = dynamic_cast<player *>( z.get_killer() );
 
-    bool vorpal = ch && ch->is_player() &&
+    bool const vorpal = ch && ch->is_player() &&
                   ch->primary_weapon().has_flag( "DIAMOND" ) &&
                   ch->primary_weapon().volume() > 750_ml;
 
@@ -809,7 +809,7 @@ void mdeath::detonate( monster &z )
             break;
         }
         // Grab one item
-        itype_id tmp = *amm_list.pick();
+        itype_id const tmp = *amm_list.pick();
         // and reduce its weight by 1
         amm_list.add_or_replace( tmp, amm_list.get_specific_weight( tmp ) - 1 );
         // and stash it for use
@@ -924,7 +924,7 @@ void make_mon_corpse( monster &z, int damageLvl )
         // Pre-gen bionic on death rather than on butcher
         for( const harvest_entry &entry : *z.type->harvest ) {
             if( entry.type == "bionic" || entry.type == "bionic_group" ) {
-                std::vector<item> contained_bionics =
+                std::vector<item> const contained_bionics =
                     entry.type == "bionic"
                     ? butcher_cbm_item( itype_id( entry.drop ), calendar::turn, entry.flags, entry.faults )
                     : butcher_cbm_group( item_group_id( entry.drop ), calendar::turn, entry.flags, entry.faults );
@@ -956,7 +956,7 @@ void mdeath::fireball( monster &z )
 {
     if( one_in( 10 ) ) {
         g->m.propagate_field( z.pos(), fd_fire, 15, 3 );
-        std::string explode = string_format( _( "an explosion of tank of the %s's flamethrower!" ),
+        std::string const explode = string_format( _( "an explosion of tank of the %s's flamethrower!" ),
                                              z.name() );
         sounds::sound( z.pos(), 24, sounds::sound_t::combat, explode, false, "explosion", "default" );
         add_msg( m_good, _( "I love the smell of burning zed in the morning." ) );

--- a/src/mondefense.cpp
+++ b/src/mondefense.cpp
@@ -175,7 +175,7 @@ void mdefense::return_fire( monster &m, Creature *source, const dealt_projectile
     // TODO: implement different rule, dependent on sound and probably some other things
     const tripoint fire_point = source->pos();
     // Add some innacuracy since it is blind fire
-    int dispersion = 150;
+    int const dispersion = 150;
 
     for( const std::pair<const std::string, mtype_special_attack> &attack : m.type->special_attacks ) {
         if( attack.second->id == "gun" ) {

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -101,7 +101,7 @@ bool monexamine::pet_menu( monster &z )
 
     uilist amenu;
     std::string pet_name = z.get_name();
-    bool is_zombie = z.type->in_species( ZOMBIE );
+    bool const is_zombie = z.type->in_species( ZOMBIE );
     const auto mon_item_id = z.type->revert_to_itype;
     avatar &you = get_avatar();
     if( is_zombie ) {
@@ -152,7 +152,7 @@ bool monexamine::pet_menu( monster &z )
     }
     if( !z.has_effect( effect_leashed ) && !z.has_flag( MF_RIDEABLE_MECH ) ) {
         Character &player_character = get_player_character();
-        std::vector<item *> rope_inv = player_character.items_with( []( const item & it ) {
+        std::vector<item *> const rope_inv = player_character.items_with( []( const item & it ) {
             return it.has_flag( "TIE_UP" );
         } );
         if( !rope_inv.empty() ) {
@@ -216,7 +216,7 @@ bool monexamine::pet_menu( monster &z )
         }
     } else {
         const itype &type = *z.type->mech_battery;
-        int max_charge = type.magazine->capacity;
+        int const max_charge = type.magazine->capacity;
         float charge_percent;
         if( z.battery_item ) {
             charge_percent = static_cast<float>( z.battery_item->ammo_remaining() ) / max_charge * 100;
@@ -249,7 +249,7 @@ bool monexamine::pet_menu( monster &z )
         }
     }
     amenu.query();
-    int choice = amenu.ret;
+    int const choice = amenu.ret;
 
     switch( choice ) {
         case swap_pos:
@@ -423,7 +423,7 @@ void monexamine::insert_battery( monster &z )
         return;
     }
     item *bat_item = bat_inv[index - 1];
-    int item_pos = you.get_item_position( bat_item );
+    int const item_pos = you.get_item_position( bat_item );
     if( item_pos != INT_MIN ) {
         z.battery_item = cata::make_value<item>( *bat_item );
         you.i_rem( item_pos );
@@ -432,7 +432,7 @@ void monexamine::insert_battery( monster &z )
 
 bool monexamine::mech_hack( monster &z )
 {
-    itype_id card_type = itype_id_military;
+    itype_id const card_type = itype_id_military;
     avatar &you = get_avatar();
     if( you.has_amount( card_type, 1 ) ) {
         if( query_yn( _( "Swipe your ID card into the mech's security port?" ) ) ) {
@@ -466,7 +466,7 @@ static int prompt_for_amount( const char *const msg, const int max )
 bool monexamine::pay_bot( monster &z )
 {
     avatar &you = get_avatar();
-    time_duration friend_time = z.get_effect_dur( effect_pet );
+    time_duration const friend_time = z.get_effect_dur( effect_pet );
     const int charge_count = you.charges_of( itype_cash_card );
 
     int amount = 0;
@@ -487,7 +487,7 @@ bool monexamine::pay_bot( monster &z )
                          vgettext( "How much friendship do you get?  Max: %d minute.  (0 to cancel)",
                                    "How much friendship do you get?  Max: %d minutes.", charge_count / 10 ), charge_count / 10 );
             if( amount > 0 ) {
-                time_duration time_bought = time_duration::from_minutes( amount );
+                time_duration const time_bought = time_duration::from_minutes( amount );
                 you.use_charges( itype_cash_card, amount * 10 );
                 z.add_effect( effect_pet, time_bought );
                 z.add_effect( effect_paid, time_bought, num_bp );
@@ -589,14 +589,14 @@ void monexamine::mount_pet( monster &z )
 
 void monexamine::swap( monster &z )
 {
-    std::string pet_name = z.get_name();
+    std::string const pet_name = z.get_name();
     avatar &you = get_avatar();
     you.moves -= 150;
 
     ///\EFFECT_STR increases chance to successfully swap positions with your pet
     ///\EFFECT_DEX increases chance to successfully swap positions with your pet
     if( !one_in( ( you.str_cur + you.dex_cur ) / 6 ) ) {
-        bool t = z.has_effect( effect_tied );
+        bool const t = z.has_effect( effect_tied );
         if( t ) {
             z.remove_effect( effect_tied );
         }
@@ -614,7 +614,7 @@ void monexamine::swap( monster &z )
 
 void monexamine::push( monster &z )
 {
-    std::string pet_name = z.get_name();
+    std::string const pet_name = z.get_name();
     avatar &you = get_avatar();
     you.moves -= 30;
 
@@ -626,13 +626,13 @@ void monexamine::push( monster &z )
         return;
     }
 
-    point delta( z.posx() - you.posx(), z.posy() - you.posy() );
+    point const delta( z.posx() - you.posx(), z.posy() - you.posy() );
     z.move_to( tripoint( z.posx() + delta.x, z.posy() + delta.y, z.posz() ) );
 }
 
 void monexamine::rename_pet( monster &z )
 {
-    std::string unique_name = string_input_popup()
+    std::string const unique_name = string_input_popup()
                               .title( _( "Enter new pet name:" ) )
                               .width( 20 )
                               .query_string();
@@ -643,7 +643,7 @@ void monexamine::rename_pet( monster &z )
 
 void monexamine::attach_bag_to( monster &z )
 {
-    std::string pet_name = z.get_name();
+    std::string const pet_name = z.get_name();
 
     auto filter = []( const item & it ) {
         return it.is_armor() && it.get_storage() > 0_ml;
@@ -657,7 +657,7 @@ void monexamine::attach_bag_to( monster &z )
         return;
     }
 
-    item &it = *loc;
+    item  const&it = *loc;
     z.storage_item = cata::make_value<item>( it );
     add_msg( _( "You mount the %1$s on your %2$s." ), it.display_name(), pet_name );
     you.i_rem( &it );
@@ -669,7 +669,7 @@ void monexamine::attach_bag_to( monster &z )
 
 void monexamine::remove_bag_from( monster &z )
 {
-    std::string pet_name = z.get_name();
+    std::string const pet_name = z.get_name();
     if( z.storage_item ) {
         if( !z.inv.empty() ) {
             dump_items( z );
@@ -687,7 +687,7 @@ void monexamine::remove_bag_from( monster &z )
 
 void monexamine::dump_items( monster &z )
 {
-    std::string pet_name = z.get_name();
+    std::string const pet_name = z.get_name();
     avatar &you = get_avatar();
     map &here = get_map();
     for( auto &it : z.inv ) {
@@ -700,25 +700,25 @@ void monexamine::dump_items( monster &z )
 
 bool monexamine::give_items_to( monster &z )
 {
-    std::string pet_name = z.get_name();
+    std::string const pet_name = z.get_name();
     if( !z.storage_item ) {
         add_msg( _( "There is no container on your %s to put things in!" ), pet_name );
         return true;
     }
 
-    item &storage = *z.storage_item;
+    item  const&storage = *z.storage_item;
     units::mass max_weight = z.weight_capacity() - z.get_carried_weight();
     units::volume max_volume = storage.get_storage() - z.get_carried_volume();
     avatar &you = get_avatar();
-    drop_locations items = game_menus::inv::multidrop( you );
+    drop_locations const items = game_menus::inv::multidrop( you );
     drop_locations to_move;
     for( const drop_location &itq : items ) {
         item it_copy = *itq.loc;
         if( it_copy.count_by_charges() ) {
             it_copy.charges = itq.count;
         }
-        units::volume item_volume = it_copy.volume();
-        units::mass item_weight = it_copy.weight();
+        units::volume const item_volume = it_copy.volume();
+        units::mass const item_weight = it_copy.weight();
         if( max_weight < item_weight ) {
             add_msg( _( "The %1$s is too heavy for the %2$s to carry." ), it_copy.tname(), pet_name );
             continue;
@@ -762,7 +762,7 @@ void monexamine::take_items_from( monster &z )
 
     // because the first entry is the cancel option
     const int selection = index - 1;
-    item retrieved_item = monster_inv[selection];
+    item const retrieved_item = monster_inv[selection];
     monster_inv.erase( monster_inv.begin() + selection );
 
     add_msg( _( "You remove the %1$s from the %2$s's bag." ), retrieved_item.tname(), pet_name );
@@ -773,7 +773,7 @@ void monexamine::take_items_from( monster &z )
 
 bool monexamine::add_armor( monster &z )
 {
-    std::string pet_name = z.get_name();
+    std::string const pet_name = z.get_name();
     item_location loc = pet_armor_loc( z );
 
     if( !loc ) {
@@ -782,7 +782,7 @@ bool monexamine::add_armor( monster &z )
     }
 
     item &armor = *loc;
-    units::mass max_weight = z.weight_capacity() - z.get_carried_weight();
+    units::mass const max_weight = z.weight_capacity() - z.get_carried_weight();
     if( max_weight <= armor.weight() ) {
         add_msg( pgettext( "pet armor", "Your %1$s is too heavy for your %2$s." ), armor.tname( 1 ),
                  pet_name );
@@ -808,7 +808,7 @@ void monexamine::remove_harness( monster &z )
 
 void monexamine::remove_armor( monster &z )
 {
-    std::string pet_name = z.get_name();
+    std::string const pet_name = z.get_name();
     if( z.armor_item ) {
         z.armor_item->erase_var( "pet_armor" );
         get_map().add_item_or_charges( z.pos(), *z.armor_item );
@@ -825,7 +825,7 @@ void monexamine::remove_armor( monster &z )
 
 void monexamine::play_with( monster &z )
 {
-    std::string pet_name = z.get_name();
+    std::string const pet_name = z.get_name();
     avatar &you = get_avatar();
     you.assign_activity( ACT_PLAY_WITH_PET, rng( 50, 125 ) * 100 );
     you.activity.str_values.push_back( pet_name );
@@ -868,7 +868,7 @@ void monexamine::add_leash( monster &z )
     }
     selection_menu.selected = 1;
     selection_menu.query();
-    int index = selection_menu.ret;
+    int const index = selection_menu.ret;
     if( index == 0 || index == UILIST_CANCEL || index < 0 ||
         index > static_cast<int>( rope_inv.size() ) ) {
         return;
@@ -977,7 +977,7 @@ void monexamine::deactivate_pet( monster &z )
 
 void monexamine::milk_source( monster &source_mon )
 {
-    itype_id milked_item = source_mon.type->starting_ammo.begin()->first;
+    itype_id const milked_item = source_mon.type->starting_ammo.begin()->first;
     auto milkable_ammo = source_mon.ammo.find( milked_item );
     if( milkable_ammo == source_mon.ammo.end() ) {
         debugmsg( "The %s has no milkable %s.", source_mon.get_name(), milked_item.str() );
@@ -989,7 +989,7 @@ void monexamine::milk_source( monster &source_mon )
         you.assign_activity( ACT_MILK, moves, -1 );
         you.activity.coords.push_back( get_map().getabs( source_mon.pos() ) );
         // pin the cow in place if it isn't already
-        bool temp_tie = !source_mon.has_effect( effect_tied );
+        bool const temp_tie = !source_mon.has_effect( effect_tied );
         if( temp_tie ) {
             source_mon.add_effect( effect_tied, 1_turns, num_bp );
             you.activity.str_values.push_back( "temp_tie" );

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -749,7 +749,7 @@ void monexamine::take_items_from( monster &z )
     uilist selection_menu;
     selection_menu.text = string_format( _( "Select an item to remove from the %s." ), pet_name );
     selection_menu.addentry( i++, true, MENU_AUTOASSIGN, _( "Cancel" ) );
-    for( auto iter : monster_inv ) {
+    for( const auto& iter : monster_inv ) {
         selection_menu.addentry( i++, true, MENU_AUTOASSIGN, _( "Retrieve %s" ), iter.tname() );
     }
     selection_menu.selected = 1;

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -633,9 +633,9 @@ void monexamine::push( monster &z )
 void monexamine::rename_pet( monster &z )
 {
     std::string const unique_name = string_input_popup()
-                              .title( _( "Enter new pet name:" ) )
-                              .width( 20 )
-                              .query_string();
+                                    .title( _( "Enter new pet name:" ) )
+                                    .width( 20 )
+                                    .query_string();
     if( !unique_name.empty() ) {
         z.unique_name = unique_name;
     }
@@ -657,7 +657,7 @@ void monexamine::attach_bag_to( monster &z )
         return;
     }
 
-    item  const&it = *loc;
+    item  const &it = *loc;
     z.storage_item = cata::make_value<item>( it );
     add_msg( _( "You mount the %1$s on your %2$s." ), it.display_name(), pet_name );
     you.i_rem( &it );
@@ -706,7 +706,7 @@ bool monexamine::give_items_to( monster &z )
         return true;
     }
 
-    item  const&storage = *z.storage_item;
+    item  const &storage = *z.storage_item;
     units::mass max_weight = z.weight_capacity() - z.get_carried_weight();
     units::volume max_volume = storage.get_storage() - z.get_carried_volume();
     avatar &you = get_avatar();
@@ -749,7 +749,7 @@ void monexamine::take_items_from( monster &z )
     uilist selection_menu;
     selection_menu.text = string_format( _( "Select an item to remove from the %s." ), pet_name );
     selection_menu.addentry( i++, true, MENU_AUTOASSIGN, _( "Cancel" ) );
-    for( const auto& iter : monster_inv ) {
+    for( const auto &iter : monster_inv ) {
         selection_menu.addentry( i++, true, MENU_AUTOASSIGN, _( "Retrieve %s" ), iter.tname() );
     }
     selection_menu.selected = 1;

--- a/src/monfaction.cpp
+++ b/src/monfaction.cpp
@@ -178,7 +178,7 @@ void monfactions::finalize()
 
     // Traverse the tree (breadth-first), starting from root
     while( !queue.empty() ) {
-        mfaction_id cur = queue.front();
+        mfaction_id const cur = queue.front();
         queue.pop();
         if( unloaded.count( cur ) != 0 ) {
             unloaded.erase( cur );
@@ -232,10 +232,10 @@ void add_to_attitude_map( const std::set< std::string > &keys, mfaction_att_map 
 void monfactions::load_monster_faction( const JsonObject &jo )
 {
     // Factions inherit values from their parent factions - this is set during finalization
-    std::set< std::string > by_mood = jo.get_tags( "by_mood" );
-    std::set< std::string > neutral = jo.get_tags( "neutral" );
-    std::set< std::string > friendly = jo.get_tags( "friendly" );
-    std::set< std::string > hate = jo.get_tags( "hate" );
+    std::set< std::string > const by_mood = jo.get_tags( "by_mood" );
+    std::set< std::string > const neutral = jo.get_tags( "neutral" );
+    std::set< std::string > const friendly = jo.get_tags( "friendly" );
+    std::set< std::string > const hate = jo.get_tags( "hate" );
     // Need to make sure adding new factions won't invalidate our current faction's reference
     // That +1 is for base faction
     faction_list.reserve( faction_list.size() + by_mood.size() + neutral.size() + friendly.size() +
@@ -246,9 +246,9 @@ void monfactions::load_monster_faction( const JsonObject &jo )
     prealloc( hate );
 
     std::string name = jo.get_string( "name" );
-    mfaction_id cur_id = get_or_add_faction( mfaction_str_id( name ) );
+    mfaction_id const cur_id = get_or_add_faction( mfaction_str_id( name ) );
     std::string base_faction = jo.get_string( "base_faction", "" );
-    mfaction_id base_id = get_or_add_faction( mfaction_str_id( base_faction ) );
+    mfaction_id const base_id = get_or_add_faction( mfaction_str_id( base_faction ) );
     // Don't get the reference until here (to avoid vector reallocation messing it up)
     monfaction &faction = faction_list[cur_id.to_i()];
     faction.base_faction = base_id;

--- a/src/mongroup.cpp
+++ b/src/mongroup.cpp
@@ -389,7 +389,7 @@ void MonsterGroupManager::LoadMonsterGroup( const JsonObject &jo )
     g.freq_total = jo.get_int( "freq_total", ( extending ? g.freq_total : 1000 ) );
     if( jo.get_bool( "auto_total", false ) ) { //Fit the max size to the sum of all freqs
         int total = 0;
-        for( MonsterGroupEntry  const&mon : g.monsters ) {
+        for( MonsterGroupEntry  const &mon : g.monsters ) {
             total += mon.frequency;
         }
         g.freq_total = total;

--- a/src/mongroup.cpp
+++ b/src/mongroup.cpp
@@ -331,13 +331,13 @@ void MonsterGroupManager::FinalizeMonsterGroups()
 
 void MonsterGroupManager::LoadMonsterGroup( const JsonObject &jo )
 {
-    float mon_upgrade_factor = get_option<float>( "MONSTER_UPGRADE_FACTOR" );
+    float const mon_upgrade_factor = get_option<float>( "MONSTER_UPGRADE_FACTOR" );
 
     MonsterGroup g;
 
     g.name = mongroup_id( jo.get_string( "name" ) );
     bool extending = false;  //If already a group with that name, add to it instead of overwriting it
-    bool allow_override = jo.get_bool( "override", false );
+    bool const allow_override = jo.get_bool( "override", false );
     if( monsterGroupMap.count( g.name ) != 0 && !allow_override ) {
         g = monsterGroupMap[g.name];
         extending = true;
@@ -348,11 +348,11 @@ void MonsterGroupManager::LoadMonsterGroup( const JsonObject &jo )
     }
     g.is_animal = jo.get_bool( "is_animal", false );
     if( jo.has_array( "monsters" ) ) {
-        for( JsonObject mon : jo.get_array( "monsters" ) ) {
+        for( JsonObject const mon : jo.get_array( "monsters" ) ) {
             const mtype_id name = mtype_id( mon.get_string( "monster" ) );
 
-            int freq = mon.get_int( "freq" );
-            int cost = mon.get_int( "cost_multiplier" );
+            int const freq = mon.get_int( "freq" );
+            int const cost = mon.get_int( "cost_multiplier" );
             int pack_min = 1;
             int pack_max = 1;
             if( mon.has_member( "pack_size" ) ) {
@@ -389,7 +389,7 @@ void MonsterGroupManager::LoadMonsterGroup( const JsonObject &jo )
     g.freq_total = jo.get_int( "freq_total", ( extending ? g.freq_total : 1000 ) );
     if( jo.get_bool( "auto_total", false ) ) { //Fit the max size to the sum of all freqs
         int total = 0;
-        for( MonsterGroupEntry &mon : g.monsters ) {
+        for( MonsterGroupEntry  const&mon : g.monsters ) {
             total += mon.frequency;
         }
         g.freq_total = total;

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -119,7 +119,7 @@ static bool z_is_valid( int z )
 bool monster::will_move_to( const tripoint &p ) const
 {
     if( g->m.impassable( p ) ) {
-        tripoint above_p( p.x, p.y, p.z + 1 );
+        tripoint const above_p( p.x, p.y, p.z + 1 );
         if( digging() ) {
             if( !g->m.has_flag( "BURROWABLE", p ) ) {
                 return false;
@@ -155,7 +155,7 @@ bool monster::will_move_to( const tripoint &p ) const
     bool avoid_fire = has_flag( MF_AVOID_FIRE );
     bool avoid_fall = has_flag( MF_AVOID_FALL );
     bool avoid_simple = has_flag( MF_AVOID_DANGER_1 );
-    bool avoid_complex = has_flag( MF_AVOID_DANGER_2 );
+    bool const avoid_complex = has_flag( MF_AVOID_DANGER_2 );
     /*
      * Because some avoidance behaviors are supersets of others,
      * we can cascade through the implications. Complex implies simple,
@@ -231,7 +231,7 @@ bool monster::will_move_to( const tripoint &p ) const
 
 bool monster::can_reach_to( const tripoint &p ) const
 {
-    map &here = get_map();
+    map  const&here = get_map();
     if( p.z > pos().z && z_is_valid( pos().z ) ) {
         if( here.has_flag( TFLAG_RAMP_UP, tripoint( p.xy(), p.z - 1 ) ) ) {
             return true;
@@ -252,7 +252,7 @@ bool monster::can_reach_to( const tripoint &p ) const
 
 bool monster::can_squeeze_to( const tripoint &p ) const
 {
-    map &m = get_map();
+    map  const&m = get_map();
 
     return !m.obstructed_by_vehicle_rotation( pos(), p );
 }
@@ -320,14 +320,14 @@ void monster::plan()
     const auto &factions = g->critter_tracker->factions();
 
     // Bots are more intelligent than most living stuff
-    bool smart_planning = has_flag( MF_PRIORITIZE_TARGETS );
+    bool const smart_planning = has_flag( MF_PRIORITIZE_TARGETS );
     Creature *target = nullptr;
-    int max_sight_range = std::max( type->vision_day, type->vision_night );
+    int const max_sight_range = std::max( type->vision_day, type->vision_night );
     // 8.6f is rating for tank drone 60 tiles away, moose 16 or boomer 33
     float dist = !smart_planning ? max_sight_range : 8.6f;
     bool fleeing = false;
-    bool docile = friendly != 0 && has_effect( effect_docile );
-    bool waiting = has_effect( effect_ai_waiting );
+    bool const docile = friendly != 0 && has_effect( effect_docile );
+    bool const waiting = has_effect( effect_ai_waiting );
 
     const bool angers_hostile_weak = type->has_anger_trigger( mon_trigger::HOSTILE_WEAK );
     const int angers_hostile_near = type->has_anger_trigger( mon_trigger::HOSTILE_CLOSE ) ? 5 : 0;
@@ -349,7 +349,7 @@ void monster::plan()
             morale -= fears_hostile_near;
             if( angers_mating_season > 0 ) {
                 bool mating_angry = false;
-                season_type season = season_of_year( calendar::turn );
+                season_type const season = season_of_year( calendar::turn );
                 for( auto &elem : type->baby_flags ) {
                     if( ( season == SUMMER && elem == "SUMMER" ) ||
                         ( season == WINTER && elem == "WINTER" ) ||
@@ -365,7 +365,7 @@ void monster::plan()
             }
         }
         if( angers_cub_threatened > 0 ) {
-            for( monster &tmp : g->all_monsters() ) {
+            for( monster  const&tmp : g->all_monsters() ) {
                 if( type->baby_monster == tmp.type->id ) {
                     // baby nearby; is the player too close?
                     dist = tmp.rate_target( g->u, dist, smart_planning );
@@ -380,7 +380,7 @@ void monster::plan()
     } else if( friendly != 0 && !docile && !waiting ) {
         for( monster &tmp : g->all_monsters() ) {
             if( tmp.friendly == 0 ) {
-                float rating = rate_target( tmp, dist, smart_planning );
+                float const rating = rate_target( tmp, dist, smart_planning );
                 if( rating < dist ) {
                     target = &tmp;
                     dist = rating;
@@ -409,8 +409,8 @@ void monster::plan()
             continue;
         }
 
-        float rating = rate_target( who, dist, smart_planning );
-        bool fleeing_from = is_fleeing( who );
+        float const rating = rate_target( who, dist, smart_planning );
+        bool const fleeing_from = is_fleeing( who );
         if( rating == dist && ( fleeing || attitude( &who ) == MATT_ATTACK ) ) {
             ++valid_targets;
             if( one_in( valid_targets ) ) {
@@ -432,7 +432,7 @@ void monster::plan()
             morale -= fears_hostile_near;
             if( angers_mating_season > 0 ) {
                 bool mating_angry = false;
-                season_type season = season_of_year( calendar::turn );
+                season_type const season = season_of_year( calendar::turn );
                 for( auto &elem : type->baby_flags ) {
                     if( ( season == SUMMER && elem == "SUMMER" ) ||
                         ( season == WINTER && elem == "WINTER" ) ||
@@ -463,7 +463,7 @@ void monster::plan()
                     continue;
                 }
                 monster &mon = *shared;
-                float rating = rate_target( mon, dist, smart_planning );
+                float const rating = rate_target( mon, dist, smart_planning );
                 if( rating == dist ) {
                     ++valid_targets;
                     if( one_in( valid_targets ) ) {
@@ -502,7 +502,7 @@ void monster::plan()
                 continue;
             }
             monster &mon = *shared;
-            float rating = rate_target( mon, dist, smart_planning );
+            float const rating = rate_target( mon, dist, smart_planning );
             if( group_morale && rating <= 10 ) {
                 morale += 10 - rating;
             }
@@ -523,7 +523,7 @@ void monster::plan()
 
     // Operating monster keep you safe while they operate, how nice....
     if( type->has_special_attack( "OPERATE" ) ) {
-        int prev_friendlyness = friendly;
+        int const prev_friendlyness = friendly;
         if( has_effect( effect_operating ) ) {
             friendly = 100;
             for( auto critter : g->m.get_creatures_in_radius( pos(), 6 ) ) {
@@ -567,7 +567,7 @@ void monster::plan()
 
     } else if( target != nullptr ) {
 
-        tripoint dest = target->pos();
+        tripoint const dest = target->pos();
         auto att_to_target = attitude_to( *target );
         if( att_to_target == Attitude::A_HOSTILE && !fleeing ) {
             set_dest( dest );
@@ -575,7 +575,7 @@ void monster::plan()
             set_dest( tripoint( posx() * 2 - dest.x, posy() * 2 - dest.y, posz() ) );
         }
         if( angers_hostile_weak && att_to_target != Attitude::A_FRIENDLY ) {
-            int hp_per = target->hp_percentage();
+            int const hp_per = target->hp_percentage();
             if( hp_per <= 70 ) {
                 anger += 10 - static_cast<int>( hp_per / 10 );
             }
@@ -690,12 +690,12 @@ void monster::move()
         die( nullptr );
         return;
     }
-    map &here = get_map();
+    map  const&here = get_map();
 
     behavior::monster_oracle_t oracle( this );
     behavior::tree goals;
     goals.add( type->get_goals() );
-    std::string action = goals.tick( &oracle );
+    std::string const action = goals.tick( &oracle );
     //The monster can consume objects it stands on. Check if there are any.
     //If there are. Consume them.
     // TODO: Stick this in a map and dispatch to it via the action string.
@@ -725,7 +725,7 @@ void monster::move()
         g->m.i_clear( pos() );
     }
     // record position before moving to put the player there if we're dragging
-    tripoint drag_to = g->m.getabs( pos() );
+    tripoint const drag_to = g->m.getabs( pos() );
 
     const bool pacified = has_effect( effect_pacified );
 
@@ -740,7 +740,7 @@ void monster::move()
         if( local_iter == special_attacks.end() ) {
             continue;
         }
-        mon_special_attack &local_attack_data = local_iter->second;
+        mon_special_attack  const&local_attack_data = local_iter->second;
         if( !local_attack_data.enabled ) {
             continue;
         }
@@ -785,7 +785,7 @@ void monster::move()
     }
 
     // TODO: Move this to attack_at/move_to/etc. functions
-    bool attacking = false;
+    bool const attacking = false;
     if( !move_effects( attacking ) ) {
         moves = 0;
         return;
@@ -809,7 +809,7 @@ void monster::move()
 
     // don't move if a passenger in a moving vehicle
     auto vp = g->m.veh_at( pos() );
-    bool harness_part = static_cast<bool>( g->m.veh_at( pos() ).part_with_feature( "ANIMAL_CTRL",
+    bool const harness_part = static_cast<bool>( g->m.veh_at( pos() ).part_with_feature( "ANIMAL_CTRL",
                                            true ) );
     if( vp && vp->vehicle().is_moving() && vp->vehicle().get_pet( vp->part_index() ) ) {
         moves = 0;
@@ -888,7 +888,7 @@ void monster::move()
         // No sight... or our plans are invalid (e.g. moving through a transparent, but
         //  solid, square of terrain).  Fall back to smell if we have it.
         unset_dest();
-        tripoint tmp = scent_move();
+        tripoint const tmp = scent_move();
         if( tmp.x != -1 ) {
             destination = tmp;
             moved = true;
@@ -907,7 +907,7 @@ void monster::move()
         destination.z = posz();
     }
 
-    point new_d( destination.xy() - pos().xy() );
+    point const new_d( destination.xy() - pos().xy() );
 
     // toggle facing direction for sdl flip
     if( !tile_iso ) {
@@ -950,7 +950,7 @@ void monster::move()
                 via_ramp = true;
                 candidate.z -= 1;
             }
-            tripoint candidate_abs = g->m.getabs( candidate );
+            tripoint const candidate_abs = g->m.getabs( candidate );
 
             bool can_z_move = true;
             if( candidate.z != posz() ) {
@@ -1213,7 +1213,7 @@ void monster::footsteps( const tripoint &p )
     if( volume == 0 ) {
         return;
     }
-    int dist = rl_dist( p, g->u.pos() );
+    int const dist = rl_dist( p, g->u.pos() );
     sounds::add_footstep( p, volume, dist, this, type->get_footsteps() );
     return;
 }
@@ -1249,7 +1249,7 @@ tripoint monster::scent_move()
     }
     const bool can_bash = bash_skill() > 0;
     for( const auto &dest : g->m.points_in_radius( pos(), 1, SCENT_MAP_Z_REACH ) ) {
-        int smell = g->scent.get( dest );
+        int const smell = g->scent.get( dest );
         const scenttype_id &type_scent = g->scent.get_type( dest );
 
         bool right_scent = false;
@@ -1382,8 +1382,8 @@ static std::vector<tripoint> get_bashing_zone( const tripoint &bashee, const tri
     zone.reserve( 3 * maxdepth );
     tripoint previous = bashee;
     for( const tripoint &p : path ) {
-        std::vector<point> swath = squares_in_direction( previous.xy(), p.xy() );
-        for( point q : swath ) {
+        std::vector<point> const swath = squares_in_direction( previous.xy(), p.xy() );
+        for( point const q : swath ) {
             zone.push_back( tripoint( q, bashee.z ) );
         }
 
@@ -1410,26 +1410,26 @@ bool monster::bash_at( const tripoint &p )
         return false;
     }
 
-    bool try_bash = !can_move_to( p ) || one_in( 3 );
+    bool const try_bash = !can_move_to( p ) || one_in( 3 );
     if( !try_bash ) {
         return false;
     }
 
-    bool can_bash = g->m.is_bashable( p ) && bash_skill() > 0;
+    bool const can_bash = g->m.is_bashable( p ) && bash_skill() > 0;
     if( !can_bash ) {
         return false;
     }
 
-    bool flat_ground = g->m.has_flag( "ROAD", p ) || g->m.has_flag( "FLAT", p );
+    bool const flat_ground = g->m.has_flag( "ROAD", p ) || g->m.has_flag( "FLAT", p );
     if( flat_ground && !g->m.is_bashable_furn( p ) ) {
-        bool can_bash_ter = g->m.is_bashable_ter( p );
-        bool try_bash_ter = one_in( 50 );
+        bool const can_bash_ter = g->m.is_bashable_ter( p );
+        bool const try_bash_ter = one_in( 50 );
         if( !( can_bash_ter && try_bash_ter ) ) {
             return false;
         }
     }
 
-    int bashskill = group_bash_skill( p );
+    int const bashskill = group_bash_skill( p );
     g->m.bash( p, bashskill );
     moves -= 100;
     return true;
@@ -1464,7 +1464,7 @@ int monster::group_bash_skill( const tripoint &target )
 
     for( const tripoint &candidate : bzone ) {
         // Drawing this line backwards excludes the target and includes the candidate.
-        std::vector<tripoint> path_to_target = line_to( target, candidate, 0, 0 );
+        std::vector<tripoint> const path_to_target = line_to( target, candidate, 0, 0 );
         bool connected = true;
         monster *mon = nullptr;
         for( const tripoint &in_path : path_to_target ) {
@@ -1475,7 +1475,7 @@ int monster::group_bash_skill( const tripoint &target )
                 connected = false;
                 break;
             }
-            monster &helpermon = *mon;
+            monster  const&helpermon = *mon;
             if( !helpermon.has_flag( MF_GROUP_BASH ) || helpermon.is_hallucination() ) {
                 connected = false;
                 break;
@@ -1547,7 +1547,7 @@ bool monster::attack_at( const tripoint &p )
 
 static tripoint find_closest_stair( const tripoint &near_this, const ter_bitflags stair_type )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     for( const tripoint &candidate : closest_points_first( near_this, 10 ) ) {
         if( here.has_flag( stair_type, candidate ) ) {
             return candidate;
@@ -1582,7 +1582,7 @@ bool monster::move_to( const tripoint &p, bool force, bool step_on_critter,
     // Allows climbing monsters to move on terrain with movecost <= 0
     Creature *critter = g->critter_at( destination, is_hallucination() );
     if( g->m.has_flag( "CLIMBABLE", destination ) ) {
-        tripoint above_dest( destination.x, destination.y, destination.z + 1 );
+        tripoint const above_dest( destination.x, destination.y, destination.z + 1 );
         if( g->m.impassable( destination ) && critter == nullptr &&
             !g->m.has_floor_or_support( above_dest ) ) {
             if( flies() ) {
@@ -1635,8 +1635,8 @@ bool monster::move_to( const tripoint &p, bool force, bool step_on_critter,
     }
 
     //Check for moving into/out of water
-    bool was_water = g->m.is_divable( pos() );
-    bool will_be_water = on_ground && can_submerge() && g->m.is_divable( destination );
+    bool const was_water = g->m.is_divable( pos() );
+    bool const will_be_water = on_ground && can_submerge() && g->m.is_divable( destination );
 
     // Attitude check is kinda slow, better gate it
     if( was_water != will_be_water && !flies() ) {
@@ -1823,7 +1823,7 @@ bool monster::push_to( const tripoint &p, const int boost, const size_t depth )
             continue;
         }
 
-        tripoint dest( p + d );
+        tripoint const dest( p + d );
         const int dest_movecost_from = 50 * g->m.move_cost( dest );
 
         // Pushing into cars/windows etc. is harder
@@ -1833,7 +1833,7 @@ bool monster::push_to( const tripoint &p, const int boost, const size_t depth )
             continue;
         }
 
-        int roll = attack - ( defend + direction_penalty + movecost_penalty );
+        int const roll = attack - ( defend + direction_penalty + movecost_penalty );
         if( roll < 0 ) {
             continue;
         }
@@ -1911,7 +1911,7 @@ void monster::stumble()
         return;
     }
 
-    map &here = get_map();
+    map  const&here = get_map();
 
     std::vector<tripoint> valid_stumbles;
     valid_stumbles.reserve( 11 );
@@ -1929,7 +1929,7 @@ void monster::stumble()
     }
 
     if( here.has_zlevels() ) {
-        tripoint below( posx(), posy(), posz() - 1 );
+        tripoint const below( posx(), posy(), posz() - 1 );
         if( here.valid_move( pos(), below, false, true ) ) {
             valid_stumbles.push_back( below );
         }
@@ -1962,7 +1962,7 @@ void monster::knock_back_to( const tripoint &to )
         return;
     }
 
-    bool u_see = g->u.sees( to );
+    bool const u_see = g->u.sees( to );
 
     // First, see if we hit another monster
     if( monster *const z = g->critter_at<monster>( to ) ) {
@@ -2034,7 +2034,7 @@ void monster::knock_back_to( const tripoint &to )
  */
 bool monster::will_reach( point p )
 {
-    monster_attitude att = attitude( &g->u );
+    monster_attitude const att = attitude( &g->u );
     if( att != MATT_FOLLOW && att != MATT_ATTACK && att != MATT_FRIEND && att != MATT_ZLAVE ) {
         return false;
     }

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -231,7 +231,7 @@ bool monster::will_move_to( const tripoint &p ) const
 
 bool monster::can_reach_to( const tripoint &p ) const
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     if( p.z > pos().z && z_is_valid( pos().z ) ) {
         if( here.has_flag( TFLAG_RAMP_UP, tripoint( p.xy(), p.z - 1 ) ) ) {
             return true;
@@ -252,7 +252,7 @@ bool monster::can_reach_to( const tripoint &p ) const
 
 bool monster::can_squeeze_to( const tripoint &p ) const
 {
-    map  const&m = get_map();
+    map  const &m = get_map();
 
     return !m.obstructed_by_vehicle_rotation( pos(), p );
 }
@@ -365,7 +365,7 @@ void monster::plan()
             }
         }
         if( angers_cub_threatened > 0 ) {
-            for( monster  const&tmp : g->all_monsters() ) {
+            for( monster  const &tmp : g->all_monsters() ) {
                 if( type->baby_monster == tmp.type->id ) {
                     // baby nearby; is the player too close?
                     dist = tmp.rate_target( g->u, dist, smart_planning );
@@ -690,7 +690,7 @@ void monster::move()
         die( nullptr );
         return;
     }
-    map  const&here = get_map();
+    map  const &here = get_map();
 
     behavior::monster_oracle_t oracle( this );
     behavior::tree goals;
@@ -740,7 +740,7 @@ void monster::move()
         if( local_iter == special_attacks.end() ) {
             continue;
         }
-        mon_special_attack  const&local_attack_data = local_iter->second;
+        mon_special_attack  const &local_attack_data = local_iter->second;
         if( !local_attack_data.enabled ) {
             continue;
         }
@@ -810,7 +810,7 @@ void monster::move()
     // don't move if a passenger in a moving vehicle
     auto vp = g->m.veh_at( pos() );
     bool const harness_part = static_cast<bool>( g->m.veh_at( pos() ).part_with_feature( "ANIMAL_CTRL",
-                                           true ) );
+                              true ) );
     if( vp && vp->vehicle().is_moving() && vp->vehicle().get_pet( vp->part_index() ) ) {
         moves = 0;
         return;
@@ -1475,7 +1475,7 @@ int monster::group_bash_skill( const tripoint &target )
                 connected = false;
                 break;
             }
-            monster  const&helpermon = *mon;
+            monster  const &helpermon = *mon;
             if( !helpermon.has_flag( MF_GROUP_BASH ) || helpermon.is_hallucination() ) {
                 connected = false;
                 break;
@@ -1547,7 +1547,7 @@ bool monster::attack_at( const tripoint &p )
 
 static tripoint find_closest_stair( const tripoint &near_this, const ter_bitflags stair_type )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     for( const tripoint &candidate : closest_points_first( near_this, 10 ) ) {
         if( here.has_flag( stair_type, candidate ) ) {
             return candidate;
@@ -1911,7 +1911,7 @@ void monster::stumble()
         return;
     }
 
-    map  const&here = get_map();
+    map  const &here = get_map();
 
     std::vector<tripoint> valid_stumbles;
     valid_stumbles.reserve( 11 );

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -237,7 +237,7 @@ void monster::setpos( const tripoint &p )
         return;
     }
 
-    bool wandering = wander();
+    bool const wandering = wander();
     g->update_zombie_pos( *this, p );
     position = p;
     if( has_effect( effect_ridden ) && mounted_player && mounted_player->pos() != pos() ) {
@@ -256,7 +256,7 @@ const tripoint &monster::pos() const
 
 void monster::poly( const mtype_id &id )
 {
-    double hp_percentage = static_cast<double>( hp ) / static_cast<double>( type->hp );
+    double const hp_percentage = static_cast<double>( hp ) / static_cast<double>( type->hp );
     type = &id.obj();
     moves = 0;
     Creature::set_speed_base( type->speed );
@@ -403,7 +403,7 @@ void monster::try_reproduce()
     bool season_match = true;
 
     // only 50% of animals should reproduce
-    bool female = one_in( 2 );
+    bool const female = one_in( 2 );
     for( auto &elem : type->baby_flags ) {
         if( elem == "SUMMER" || elem == "WINTER" || elem == "SPRING" || elem == "AUTUMN" ) {
             season_spawn = true;
@@ -431,7 +431,7 @@ void monster::try_reproduce()
 
         chance += 2;
         if( season_match && female && one_in( chance ) ) {
-            int spawn_cnt = rng( 1, type->baby_count );
+            int const spawn_cnt = rng( 1, type->baby_count );
             if( type->baby_monster ) {
                 g->m.add_spawn( type->baby_monster, spawn_cnt, pos() );
             } else {
@@ -663,7 +663,7 @@ int monster::print_info( const catacurses::window &w, int vStart, int vLines, in
     const auto speed_desc = speed_description( speed_rating(), has_flag( MF_IMMOBILE ) );
     mvwprintz( w, point( column, ++vStart ), speed_desc.second, speed_desc.first );
 
-    std::string effects = get_effect_status();
+    std::string const effects = get_effect_status();
     if( !effects.empty() ) {
         trim_and_print( w, point( column, ++vStart ), getmaxx( w ) - 2, h_white, effects );
     }
@@ -675,7 +675,7 @@ int monster::print_info( const catacurses::window &w, int vStart, int vLines, in
     }
 
     std::vector<std::string> lines = foldstring( type->get_description(), getmaxx( w ) - 1 - column );
-    int numlines = lines.size();
+    int const numlines = lines.size();
     for( int i = 0; i < numlines && vStart <= vEnd; i++ ) {
         mvwprintz( w, point( column, ++vStart ), c_white, lines[i] );
     }
@@ -687,7 +687,7 @@ std::string monster::extended_description() const
 {
     std::string ss;
     const std::pair<std::string, nc_color> att = get_attitude();
-    std::string att_colored = colorize( att.first, att.second );
+    std::string const att_colored = colorize( att.first, att.second );
     std::string difficulty_str;
     if( debug_mode ) {
         difficulty_str = _( "Difficulty " ) + std::to_string( type->difficulty );
@@ -759,7 +759,7 @@ std::string monster::extended_description() const
                                     const std::string & format,
                                     const std::vector<flag_description> &flags_names,
     const std::string &if_empty = "" ) {
-        std::string flag_descriptions = enumerate_as_string( flags_names.begin(),
+        std::string const flag_descriptions = enumerate_as_string( flags_names.begin(),
         flags_names.end(), [this]( const flag_description & fd ) {
             return type->has_flag( fd.first ) ? fd.second : "";
         } );
@@ -775,7 +775,7 @@ std::string monster::extended_description() const
                                          const std::string & format,
                                          const std::vector<property_description> &property_names,
     const std::string &if_empty = "" ) {
-        std::string property_descriptions = enumerate_as_string( property_names.begin(),
+        std::string const property_descriptions = enumerate_as_string( property_names.begin(),
         property_names.end(), []( const property_description & pd ) {
             return pd.first ? pd.second : "";
         } );
@@ -1038,7 +1038,7 @@ bool monster::is_fleeing( player &u ) const
     if( anger >= 100 || morale >= 100 ) {
         return false;
     }
-    monster_attitude att = attitude( &u );
+    monster_attitude const att = attitude( &u );
     return att == MATT_FLEE || ( att == MATT_FOLLOW && rl_dist( pos(), u.pos() ) <= 4 );
 }
 
@@ -1439,7 +1439,7 @@ void monster::melee_attack( Creature &target, float accuracy )
         return;
     }
 
-    int hitspread = target.deal_melee_attack( this, melee::melee_hit_range( accuracy ) );
+    int const hitspread = target.deal_melee_attack( this, melee::melee_hit_range( accuracy ) );
 
     if( target.is_player() ||
         ( target.is_npc() && g->u.attitude_to( target ) == A_FRIENDLY ) ) {
@@ -1463,7 +1463,7 @@ void monster::melee_attack( Creature &target, float accuracy )
     if( hitspread >= 0 ) {
         target.deal_melee_hit( this, hitspread, false, damage, dealt_dam );
     }
-    body_part bp_hit = dealt_dam.bp_hit;
+    body_part const bp_hit = dealt_dam.bp_hit;
 
     const int total_dealt = dealt_dam.total_damage();
     if( hitspread < 0 ) {
@@ -1722,7 +1722,7 @@ bool monster::move_effects( bool )
         return true;
     }
 
-    bool u_see_me = g->u.sees( *this );
+    bool const u_see_me = g->u.sees( *this );
     if( has_effect( effect_tied ) ) {
         // friendly pet, will stay tied down and obey.
         if( friendly == -1 ) {
@@ -1730,7 +1730,7 @@ bool monster::move_effects( bool )
         }
         // non-friendly monster will struggle to get free occasionally.
         // some monsters can't be tangled up with a net/bolas/lasso etc.
-        bool immediate_break = type->in_species( FISH ) || type->in_species( MOLLUSK ) ||
+        bool const immediate_break = type->in_species( FISH ) || type->in_species( MOLLUSK ) ||
                                type->in_species( ROBOT ) || type->bodytype == "snake" || type->bodytype == "blob";
         if( !immediate_break && rng( 0, 900 ) > type->melee_dice * type->melee_sides * 1.5 ) {
             if( u_see_me ) {
@@ -1922,7 +1922,7 @@ int monster::get_armor_bullet( bodypart_id bp ) const
 
 int monster::get_armor_type( damage_type dt, bodypart_id bp ) const
 {
-    int worn_armor = get_worn_armor_val( dt );
+    int const worn_armor = get_worn_armor_val( dt );
 
     switch( dt ) {
         case DT_TRUE:
@@ -2424,7 +2424,7 @@ void monster::die( Creature *nkiller )
     }
 
     if( anger_adjust != 0 || morale_adjust != 0 ) {
-        int light = g->light_level( posz() );
+        int const light = g->light_level( posz() );
         for( monster &critter : g->all_monsters() ) {
             if( !critter.type->same_species( *type ) ) {
                 continue;
@@ -2537,7 +2537,7 @@ void monster::drop_items_on_death()
 void monster::process_one_effect( effect &it, bool is_new )
 {
     // Monsters don't get trait-based reduction, but they do get effect based reduction
-    bool reduced = resists_effect( it );
+    bool const reduced = resists_effect( it );
     const auto get_effect = [&it, is_new]( const std::string & arg, bool reduced ) {
         if( is_new ) {
             return it.get_amount( arg, reduced );
@@ -2548,7 +2548,7 @@ void monster::process_one_effect( effect &it, bool is_new )
     mod_speed_bonus( get_effect( "SPEED", reduced ) );
     mod_dodge_bonus( get_effect( "DODGE", reduced ) );
 
-    int val = get_effect( "HURT", reduced );
+    int const val = get_effect( "HURT", reduced );
     if( val > 0 ) {
         if( is_new || it.activated( calendar::turn, "HURT", val, reduced, 1 ) ) {
             apply_damage( nullptr, bodypart_id( "torso" ), val );
@@ -2597,7 +2597,7 @@ void monster::process_effects_internal()
     //Apply effect-triggered regeneration modifiers
     for( const auto &regeneration_modifier : type->regeneration_modifiers ) {
         if( has_effect( regeneration_modifier.first ) ) {
-            effect &e = get_effect( regeneration_modifier.first );
+            effect  const&e = get_effect( regeneration_modifier.first );
             regen_multiplier = 1.00 + regeneration_modifier.second.base_modifier +
                                ( e.get_intensity() - 1 ) * regeneration_modifier.second.scale_modifier;
             regeneration_amount = round( regeneration_amount * regen_multiplier );
@@ -2909,7 +2909,7 @@ void monster::on_hit( Creature *source, bodypart_id, dealt_projectile_attack con
     }
 
     if( anger_adjust != 0 || morale_adjust != 0 ) {
-        int light = g->light_level( posz() );
+        int const light = g->light_level( posz() );
         for( monster &critter : g->all_monsters() ) {
             if( !critter.type->same_species( *type ) ) {
                 continue;
@@ -2929,7 +2929,7 @@ void monster::on_hit( Creature *source, bodypart_id, dealt_projectile_attack con
 void monster::on_damage_of_type( int amt, damage_type dt, const bodypart_id &bp )
 {
     Creature::on_damage_of_type( amt, dt, bp );
-    int full_hp = get_hp_max();
+    int const full_hp = get_hp_max();
     if( has_effect( effect_grabbing ) && ( dt == DT_BASH || dt == DT_CUT || dt == DT_STAB ) &&
         x_in_y( amt * 10, full_hp ) ) {
         remove_effect( effect_grabbing );
@@ -3000,11 +3000,11 @@ void monster::hear_sound( const tripoint &source, const int vol, const int dist 
         max_error = 1;
     }
 
-    int target_x = source.x + rng( -max_error, max_error );
-    int target_y = source.y + rng( -max_error, max_error );
+    int const target_x = source.x + rng( -max_error, max_error );
+    int const target_y = source.y + rng( -max_error, max_error );
     // target_z will require some special check due to soil muffling sounds
 
-    int wander_turns = volume * ( goodhearing ? 6 : 1 );
+    int const wander_turns = volume * ( goodhearing ? 6 : 1 );
 
     process_trigger( mon_trigger::SOUND, volume );
     if( morale >= 0 && anger >= 10 ) {
@@ -3079,7 +3079,7 @@ void monster::on_load()
     const int healed = heal( heal_amount );
     int healed_speed = 0;
     if( healed < heal_amount && get_speed_base() < type->speed ) {
-        int old_speed = get_speed_base();
+        int const old_speed = get_speed_base();
         set_speed_base( std::min( get_speed_base() + heal_amount - healed, type->speed ) );
         healed_speed = get_speed_base() - old_speed;
     }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1731,7 +1731,7 @@ bool monster::move_effects( bool )
         // non-friendly monster will struggle to get free occasionally.
         // some monsters can't be tangled up with a net/bolas/lasso etc.
         bool const immediate_break = type->in_species( FISH ) || type->in_species( MOLLUSK ) ||
-                               type->in_species( ROBOT ) || type->bodytype == "snake" || type->bodytype == "blob";
+                                     type->in_species( ROBOT ) || type->bodytype == "snake" || type->bodytype == "blob";
         if( !immediate_break && rng( 0, 900 ) > type->melee_dice * type->melee_sides * 1.5 ) {
             if( u_see_me ) {
                 add_msg( _( "The %s struggles to break free of its bonds." ), name() );
@@ -2597,7 +2597,7 @@ void monster::process_effects_internal()
     //Apply effect-triggered regeneration modifiers
     for( const auto &regeneration_modifier : type->regeneration_modifiers ) {
         if( has_effect( regeneration_modifier.first ) ) {
-            effect  const&e = get_effect( regeneration_modifier.first );
+            effect  const &e = get_effect( regeneration_modifier.first );
             regen_multiplier = 1.00 + regeneration_modifier.second.base_modifier +
                                ( e.get_intensity() - 1 ) * regeneration_modifier.second.scale_modifier;
             regeneration_amount = round( regeneration_amount * regen_multiplier );

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -319,12 +319,12 @@ void load_monster_adjustment( const JsonObject &jsobj )
     monster_adjustment adj;
     adj.species = species_id( jsobj.get_string( "species" ) );
     if( jsobj.has_member( "stat" ) ) {
-        JsonObject stat = jsobj.get_object( "stat" );
+        JsonObject const stat = jsobj.get_object( "stat" );
         stat.read( "name", adj.stat );
         stat.read( "modifier", adj.stat_adjust );
     }
     if( jsobj.has_member( "flag" ) ) {
-        JsonObject flag = jsobj.get_object( "flag" );
+        JsonObject const flag = jsobj.get_object( "flag" );
         flag.read( "name", adj.flag );
         flag.read( "value", adj.flag_val );
     }
@@ -654,7 +654,7 @@ void MonsterGenerator::load_monster( const JsonObject &jo, const std::string &sr
 
 mon_effect_data load_mon_effect_data( const JsonObject &e )
 {
-    bool permanent = e.get_bool( "permanent", false );
+    bool const permanent = e.get_bool( "permanent", false );
     if( permanent && json_report_strict ) {
         try {
             e.throw_error( "Effect permanence has been moved to effect_type.  Set permanence there.",
@@ -674,7 +674,7 @@ class mon_attack_effect_reader : public generic_typed_reader<mon_attack_effect_r
 {
     public:
         mon_effect_data get_next( JsonIn &jin ) const {
-            JsonObject e = jin.get_object();
+            JsonObject const e = jin.get_object();
             return load_mon_effect_data( e );
         }
         template<typename C>
@@ -762,12 +762,12 @@ void mtype::load( const JsonObject &jo, const std::string &src )
         // Note: regeneration_modifiers left as is, new modifiers are added to it!
         // Note: member name prefixes are compatible with those used by generic_typed_reader
         if( jo.has_object( "extend" ) ) {
-            JsonObject tmp = jo.get_object( "extend" );
+            JsonObject const tmp = jo.get_object( "extend" );
             tmp.allow_omitted_members();
             add_regeneration_modifiers( tmp, "regeneration_modifiers", src );
         }
         if( jo.has_object( "delete" ) ) {
-            JsonObject tmp = jo.get_object( "delete" );
+            JsonObject const tmp = jo.get_object( "delete" );
             tmp.allow_omitted_members();
             remove_regeneration_modifiers( tmp, "regeneration_modifiers", src );
         }
@@ -828,7 +828,7 @@ void mtype::load( const JsonObject &jo, const std::string &src )
             }
         } else {
             while( jar.has_more() ) {
-                JsonObject obj = jar.next_object();
+                JsonObject const obj = jar.next_object();
                 emit_fields.emplace( emit_id( obj.get_string( "emit_id" ) ),
                                      read_from_json_string<time_duration>( *obj.get_raw( "delay" ), time_duration::units ) );
             }
@@ -856,12 +856,12 @@ void mtype::load( const JsonObject &jo, const std::string &src )
         // Note: special_attacks left as is, new attacks are added to it!
         // Note: member name prefixes are compatible with those used by generic_typed_reader
         if( jo.has_object( "extend" ) ) {
-            JsonObject tmp = jo.get_object( "extend" );
+            JsonObject const tmp = jo.get_object( "extend" );
             tmp.allow_omitted_members();
             add_special_attacks( tmp, "special_attacks", src );
         }
         if( jo.has_object( "delete" ) ) {
-            JsonObject tmp = jo.get_object( "delete" );
+            JsonObject const tmp = jo.get_object( "delete" );
             tmp.allow_omitted_members();
             remove_special_attacks( tmp, "special_attacks", src );
         }
@@ -874,7 +874,7 @@ void mtype::load( const JsonObject &jo, const std::string &src )
         upgrade_into = mtype_id::NULL_ID();
         upgrades = false;
     } else if( jo.has_member( "upgrades" ) ) {
-        JsonObject up = jo.get_object( "upgrades" );
+        JsonObject const up = jo.get_object( "upgrades" );
         optional( up, was_loaded, "half_life", half_life, -1 );
         optional( up, was_loaded, "age_grow", age_grow, -1 );
         optional( up, was_loaded, "into_group", upgrade_group, auto_flags_reader<mongroup_id> {},
@@ -886,7 +886,7 @@ void mtype::load( const JsonObject &jo, const std::string &src )
 
     //Reproduction
     if( jo.has_member( "reproduction" ) ) {
-        JsonObject repro = jo.get_object( "reproduction" );
+        JsonObject const repro = jo.get_object( "reproduction" );
         optional( repro, was_loaded, "baby_count", baby_count, -1 );
         if( repro.has_int( "baby_timer" ) ) {
             baby_timer = time_duration::from_days( repro.get_int( "baby_timer" ) );

--- a/src/morale.cpp
+++ b/src/morale.cpp
@@ -304,7 +304,7 @@ void player_morale::add( morale_type type, const morale_subtype &subtype, int bo
                          bool capped )
 {
     if( ( duration == 0_turns ) && !type->is_permanent() ) {
-        std::string full_desc = subtype.has_description()
+        std::string const full_desc = subtype.has_description()
                                 ? type.obj().describe( subtype.describe() )
                                 : type.obj().describe();
         debugmsg( "Tried to set a non-permanent morale \"%s\" as permanent.", full_desc );
@@ -327,7 +327,7 @@ void player_morale::add( morale_type type, const morale_subtype &subtype, int bo
         }
     }
 
-    morale_point new_morale( type, subtype, bonus, max_bonus, duration, decay_start, capped );
+    morale_point const new_morale( type, subtype, bonus, max_bonus, duration, decay_start, capped );
 
     if( !new_morale.is_expired() ) {
         points.push_back( new_morale );
@@ -339,7 +339,7 @@ void player_morale::add( morale_type type, int bonus, int max_bonus,
                          const time_duration &duration, const time_duration &decay_start,
                          bool capped )
 {
-    morale_subtype subtype;
+    morale_subtype const subtype;
     add( type, subtype, bonus, max_bonus, duration, decay_start, capped );
 }
 
@@ -347,7 +347,7 @@ void player_morale::add( morale_type type, int bonus, int max_bonus,
                          const time_duration &duration, const time_duration &decay_start,
                          bool capped, const itype &item_type )
 {
-    morale_subtype subtype( item_type );
+    morale_subtype const subtype( item_type );
     add( type, subtype, bonus, max_bonus, duration, decay_start, capped );
 }
 
@@ -355,7 +355,7 @@ void player_morale::add( morale_type type, int bonus, int max_bonus,
                          const time_duration &duration, const time_duration &decay_start,
                          bool capped, const efftype_id &effect_type )
 {
-    morale_subtype subtype( effect_type );
+    morale_subtype const subtype( effect_type );
     add( type, subtype, bonus, max_bonus, duration, decay_start, capped );
 }
 
@@ -620,7 +620,7 @@ void player_morale::display( int focus_eq, int pain_penalty, int fatigue_cap )
             }
 
             void draw( catacurses::window &w, const int posy ) const {
-                int width = getmaxx( w );
+                int const width = getmaxx( w );
                 if( sep_line ) {
                     mvwhline( w, point( 0, posy ), LINE_XXXO, 1 );
                     mvwhline( w, point( 1, posy ), 0, width - 2 );
@@ -986,10 +986,10 @@ void player_morale::on_effect_int_change( const efftype_id &eid, int intensity,
 
     const morale_type &mt = eid->get_morale_type();
     if( mt ) {
-        morale_subtype subtype( eid );
+        morale_subtype const subtype( eid );
         if( intensity > 0 ) {
-            effect ugly_hack( &*eid, 1_turns, bp_id, intensity, calendar::turn_zero );
-            int value = ugly_hack.get_amount( "MORALE" );
+            effect const ugly_hack( &*eid, 1_turns, bp_id, intensity, calendar::turn_zero );
+            int const value = ugly_hack.get_amount( "MORALE" );
             set_permanent_typed( mt, value, subtype );
         } else {
             remove( mt, subtype );

--- a/src/morale.cpp
+++ b/src/morale.cpp
@@ -305,8 +305,8 @@ void player_morale::add( morale_type type, const morale_subtype &subtype, int bo
 {
     if( ( duration == 0_turns ) && !type->is_permanent() ) {
         std::string const full_desc = subtype.has_description()
-                                ? type.obj().describe( subtype.describe() )
-                                : type.obj().describe();
+                                      ? type.obj().describe( subtype.describe() )
+                                      : type.obj().describe();
         debugmsg( "Tried to set a non-permanent morale \"%s\" as permanent.", full_desc );
         return;
     }

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -702,7 +702,7 @@ static std::map<std::string, float> calc_category_weights( const std::map<std::s
     float const h_lvl = std::max<float>( max_lvl_iter->second, 20.0f );
     for( const auto &cat_lvl : mcl ) {
         float const weight = addition ? ( 1 + 4 * ( cat_lvl.second / h_lvl ) )
-                       : ( 5 - 4 * ( cat_lvl.second / h_lvl ) );
+                             : ( 5 - 4 * ( cat_lvl.second / h_lvl ) );
         category_weights[cat_lvl.first] = weight;
     }
     category_weights[max_lvl_iter->first] *= 2;

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -131,8 +131,8 @@ void Character::toggle_trait( const trait_id &trait_ )
     const auto titer = my_traits.find( trait );
     const auto miter = my_mutations.find( trait );
     // These shouldn't be inlined, otherwise the sync check uses invalid iterators
-    bool no_trait = titer == my_traits.end();
-    bool no_mutation = miter == my_mutations.end();
+    bool const no_trait = titer == my_traits.end();
+    bool const no_mutation = miter == my_mutations.end();
     if( no_trait ) {
         my_traits.insert( trait );
     } else {
@@ -203,8 +203,8 @@ int Character::get_mod( const trait_id &mut, const std::string &arg ) const
 
 void Character::apply_mods( const trait_id &mut, bool add_remove )
 {
-    int sign = add_remove ? 1 : -1;
-    int str_change = get_mod( mut, "STR" );
+    int const sign = add_remove ? 1 : -1;
+    int const str_change = get_mod( mut, "STR" );
     str_max += sign * str_change;
     per_max += sign * get_mod( mut, "PER" );
     dex_max += sign * get_mod( mut, "DEX" );
@@ -221,7 +221,7 @@ bool mutation_branch::conflicts_with_item( const item &it ) const
         return false;
     }
 
-    for( body_part bp : restricts_gear ) {
+    for( body_part const bp : restricts_gear ) {
         if( it.covers( bp ) ) {
             return true;
         }
@@ -674,7 +674,7 @@ template<class T, class V = typename T::value_type>
 static T normalized_map( const T &ctn )
 {
     T ret;
-    float sum = std::accumulate( std::begin( ctn ), std::end( ctn ), 0.0f,
+    float const sum = std::accumulate( std::begin( ctn ), std::end( ctn ), 0.0f,
     []( float acc, const V & v ) {
         return acc + v.second;
     } );
@@ -699,9 +699,9 @@ static std::map<std::string, float> calc_category_weights( const std::map<std::s
     []( const auto & best, const auto & current ) {
         return current.second > best.second;
     } );
-    float h_lvl = std::max<float>( max_lvl_iter->second, 20.0f );
+    float const h_lvl = std::max<float>( max_lvl_iter->second, 20.0f );
     for( const auto &cat_lvl : mcl ) {
-        float weight = addition ? ( 1 + 4 * ( cat_lvl.second / h_lvl ) )
+        float const weight = addition ? ( 1 + 4 * ( cat_lvl.second / h_lvl ) )
                        : ( 5 - 4 * ( cat_lvl.second / h_lvl ) );
         category_weights[cat_lvl.first] = weight;
     }
@@ -732,10 +732,10 @@ std::map<trait_id, float> Character::mutation_chances() const
         force_bad = true;
     }
 
-    int current_score = genetic_score( *this );
+    int const current_score = genetic_score( *this );
     // 10/10/10/10 in stats, balanced traits, plus tip
-    int expected_score = 4 * 10 + 6;
-    int direction = expected_score - current_score;
+    int const expected_score = 4 * 10 + 6;
+    int const direction = expected_score - current_score;
 
     // Duplicates allowed - they'll increase chances of change
     std::vector<potential_mutation> potential;
@@ -743,10 +743,10 @@ std::map<trait_id, float> Character::mutation_chances() const
     for( const mutation_branch &traits_iter : mutation_branch::get_all() ) {
         const trait_id &base_mutation = traits_iter.id;
         const mutation_branch &base_mdata = traits_iter;
-        bool thresh_save = base_mdata.threshold;
-        bool prof_save = base_mdata.profession;
-        bool purify_save = !base_mdata.purifiable;
-        bool can_remove = !thresh_save && !prof_save && !purify_save;
+        bool const thresh_save = base_mdata.threshold;
+        bool const prof_save = base_mdata.profession;
+        bool const purify_save = !base_mdata.purifiable;
+        bool const can_remove = !thresh_save && !prof_save && !purify_save;
 
         if( has_trait( base_mutation ) ) {
             for( const trait_id &mutation : base_mdata.replacements ) {
@@ -793,23 +793,23 @@ std::map<trait_id, float> Character::mutation_chances() const
 
     // Warning: has duplicates
     for( const potential_mutation &pm : potential ) {
-        int cost_from = pm.from.is_valid() ? pm.from->cost : 0;
-        int cost_to = pm.to.is_valid() ? pm.to->cost : 0;
-        int score_diff = cost_to - cost_from;
+        int const cost_from = pm.from.is_valid() ? pm.from->cost : 0;
+        int const cost_to = pm.to.is_valid() ? pm.to->cost : 0;
+        int const score_diff = cost_to - cost_from;
 
         if( pm.to.is_valid() ) {
-            float cat_mod = std::accumulate( pm.to->category.begin(), pm.to->category.end(), 0.0f,
+            float const cat_mod = std::accumulate( pm.to->category.begin(), pm.to->category.end(), 0.0f,
             [&add_weighs]( float m, const std::string & cat ) {
                 return std::max( m, add_weighs.at( cat ) );
             } );
-            float c = score_difference_to_chance( direction + score_diff );
+            float const c = score_difference_to_chance( direction + score_diff );
             chances[pm.to] += c * cat_mod;
         } else if( pm.from.is_valid() ) {
-            float cat_mod = std::accumulate( pm.from->category.begin(), pm.from->category.end(), 0.0f,
+            float const cat_mod = std::accumulate( pm.from->category.begin(), pm.from->category.end(), 0.0f,
             [&rem_weighs]( float m, const std::string & cat ) {
                 return std::min( m, rem_weighs.at( cat ) );
             } );
-            float c = score_difference_to_chance( direction - score_diff );
+            float const c = score_difference_to_chance( direction - score_diff );
             chances[pm.from] += c * cat_mod;
         }
     }
@@ -828,7 +828,7 @@ void Character::mutate()
                           ( mutagen.get_int_dur_factor() );
         add_msg_if_player( m_debug, "Mutation accumulation: %.1f", mut_power );
         while( mut_power > 1 || roll_remainder( mut_power ) > 0 ) {
-            std::map<trait_id, float> chances = mutation_chances();
+            std::map<trait_id, float> const chances = mutation_chances();
 
             weighted_float_list<trait_id> mutation_picker;
             for( const auto &p : chances ) {
@@ -891,16 +891,16 @@ void Character::old_mutate()
     for( const mutation_branch &traits_iter : mutation_branch::get_all() ) {
         const trait_id &base_mutation = traits_iter.id;
         const mutation_branch &base_mdata = traits_iter;
-        bool thresh_save = base_mdata.threshold;
-        bool prof_save = base_mdata.profession;
+        bool const thresh_save = base_mdata.threshold;
+        bool const prof_save = base_mdata.profession;
         // are we unpurifiable? (saved from mutating away)
-        bool purify_save = !base_mdata.purifiable;
+        bool const purify_save = !base_mdata.purifiable;
 
         // ...that we have...
         if( has_trait( base_mutation ) ) {
             // ...consider the mutations that replace it.
             for( const trait_id &mutation : base_mdata.replacements ) {
-                bool valid_ok = mutation->valid;
+                bool const valid_ok = mutation->valid;
 
                 if( ( mutation_ok( mutation, force_good, force_bad ) ) &&
                     ( valid_ok ) ) {
@@ -910,7 +910,7 @@ void Character::old_mutate()
 
             // ...consider the mutations that add to it.
             for( const trait_id &mutation : base_mdata.additions ) {
-                bool valid_ok = mutation->valid;
+                bool const valid_ok = mutation->valid;
 
                 if( ( mutation_ok( mutation, force_good, force_bad ) ) &&
                     ( valid_ok ) ) {
@@ -921,7 +921,7 @@ void Character::old_mutate()
             // ...consider whether its in our highest category
             if( has_trait( base_mutation ) && !has_base_trait( base_mutation ) ) {
                 // Starting traits don't count toward categories
-                std::vector<trait_id> group = mutations_category[cat];
+                std::vector<trait_id> const group = mutations_category[cat];
                 bool in_cat = false;
                 for( const trait_id &elem : group ) {
                     if( elem == base_mutation ) {
@@ -946,7 +946,7 @@ void Character::old_mutate()
     if( one_in( 2 ) ) {
         if( !upgrades.empty() ) {
             // (upgrade count) chances to pick an upgrade, 4 chances to pick something else.
-            size_t roll = rng( 0, upgrades.size() + 4 );
+            size_t const roll = rng( 0, upgrades.size() + 4 );
             if( roll < upgrades.size() ) {
                 // We got a valid upgrade index, so use it and return.
                 mutate_towards( upgrades[roll] );
@@ -956,7 +956,7 @@ void Character::old_mutate()
     } else {
         // Remove existing mutations that don't fit into our category
         if( !downgrades.empty() && !cat.empty() ) {
-            size_t roll = rng( 0, downgrades.size() + 4 );
+            size_t const roll = rng( 0, downgrades.size() + 4 );
             if( roll < downgrades.size() ) {
                 remove_mutation( downgrades[roll] );
                 return;
@@ -1072,7 +1072,7 @@ static std::vector<trait_id> get_all_mutation_prereqs( const trait_id &id )
 bool Character::mutate_towards( std::vector<trait_id> muts, int num_tries )
 {
     while( !muts.empty() && num_tries > 0 ) {
-        int i = rng( 0, muts.size() - 1 );
+        int const i = rng( 0, muts.size() - 1 );
 
         if( mutate_towards( muts[i] ) ) {
             return true;
@@ -1100,7 +1100,7 @@ bool Character::mutate_towards( const trait_id &mut )
     std::vector<trait_id> prereq = mdata.prereqs;
     std::vector<trait_id> prereqs2 = mdata.prereqs2;
     std::vector<trait_id> cancel = mdata.cancels;
-    std::vector<trait_id> same_type = get_mutations_in_types( mdata.types );
+    std::vector<trait_id> const same_type = get_mutations_in_types( mdata.types );
     std::vector<trait_id> all_prereqs = get_all_mutation_prereqs( mut );
 
     // Check mutations of the same type - except for the ones we might need for pre-reqs
@@ -1124,7 +1124,7 @@ bool Character::mutate_towards( const trait_id &mut )
 
     for( size_t i = 0; i < cancel.size(); i++ ) {
         if( !cancel.empty() ) {
-            trait_id removed = cancel[i];
+            trait_id const removed = cancel[i];
             remove_mutation( removed );
             cancel.erase( cancel.begin() + i );
             i--;
@@ -1159,8 +1159,8 @@ bool Character::mutate_towards( const trait_id &mut )
     }
 
     // Check for threshold mutation, if needed
-    bool threshold = mdata.threshold;
-    bool profession = mdata.profession;
+    bool const threshold = mdata.threshold;
+    bool const profession = mdata.profession;
     bool has_threshreq = false;
     std::vector<trait_id> threshreq = mdata.threshreq;
 
@@ -1317,7 +1317,7 @@ void Character::remove_mutation( const trait_id &mut, bool silent )
     trait_id replacing = trait_id::NULL_ID();
     std::vector<trait_id> originals = mdata.prereqs;
     for( size_t i = 0; !replacing && i < originals.size(); i++ ) {
-        trait_id pre = originals[i];
+        trait_id const pre = originals[i];
         const auto &p = pre.obj();
         for( size_t j = 0; !replacing && j < p.replacements.size(); j++ ) {
             if( p.replacements[j] == mut ) {
@@ -1329,7 +1329,7 @@ void Character::remove_mutation( const trait_id &mut, bool silent )
     trait_id replacing2 = trait_id::NULL_ID();
     std::vector<trait_id> originals2 = mdata.prereqs2;
     for( size_t i = 0; !replacing2 && i < originals2.size(); i++ ) {
-        trait_id pre2 = originals2[i];
+        trait_id const pre2 = originals2[i];
         const auto &p = pre2.obj();
         for( size_t j = 0; !replacing2 && j < p.replacements.size(); j++ ) {
             if( p.replacements[j] == mut ) {
@@ -1566,7 +1566,7 @@ mutagen_attempt mutagen_common_checks( Character &guy, const item &it, bool stro
                                        const mutagen_technique technique )
 {
     g->events().send<event_type::administers_mutagen>( guy.getID(), technique );
-    mutagen_rejection status = try_reject_mutagen( guy, it, strong );
+    mutagen_rejection const status = try_reject_mutagen( guy, it, strong );
     if( status == mutagen_rejection::rejected ) {
         return mutagen_attempt( false, 0 );
     }
@@ -1590,14 +1590,14 @@ void test_crossing_threshold( Character &guy, const mutation_category_trait &m_c
         return;
     }
 
-    std::string mutation_category = m_category.id;
+    std::string const mutation_category = m_category.id;
     int total = 0;
     for( const auto &iter : mutation_category_trait::get_all() ) {
         total += guy.mutation_category_level[ iter.first ];
     }
     // Threshold-breaching
     const std::string &primary = guy.get_highest_category();
-    int breach_power = guy.mutation_category_level[primary];
+    int const breach_power = guy.mutation_category_level[primary];
     // Only if you were pushing for more in your primary category.
     // You wanted to be more like it and less human.
     // That said, you're required to have hit third-stage dreams first.
@@ -1610,7 +1610,7 @@ void test_crossing_threshold( Character &guy, const mutation_category_trait &m_c
         if( mutation_category == "URSINE"  || mutation_category == "ALPHA" ) {
             booster = 50;
         }
-        int breacher = breach_power + booster;
+        int const breacher = breach_power + booster;
         if( x_in_y( breacher, total ) ) {
             guy.add_msg_if_player( m_good,
                                    _( "Something strains mightily for a moment… and then… you're… FREE!" ) );
@@ -1699,7 +1699,7 @@ void Character::mutation_spend_resources( const trait_id &mut )
 {
     const mutation_branch &mdata = mut.obj();
     char_trait_data &tdata = my_mutations[mut];
-    int cost = mdata.cost;
+    int const cost = mdata.cost;
     if( tdata.powered && tdata.charge > 0 ) {
         // Already-on units just lose a bit of charge
         tdata.charge--;

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -86,7 +86,7 @@ static void extract_mod(
     const JsonObject &j, std::unordered_map<std::pair<bool, std::string>, int, cata::tuple_hash> &data,
     const std::string &mod_type, bool active, const std::string &type_key )
 {
-    int val = j.get_int( mod_type, 0 );
+    int const val = j.get_int( mod_type, 0 );
     if( val != 0 ) {
         data[std::make_pair( active, type_key )] = val;
     }
@@ -97,7 +97,7 @@ static void load_mutation_mods(
     std::unordered_map<std::pair<bool, std::string>, int, cata::tuple_hash> &mods )
 {
     if( jsobj.has_object( member ) ) {
-        JsonObject j = jsobj.get_object( member );
+        JsonObject const j = jsobj.get_object( member );
         bool active = false;
         if( member == "active_mods" ) {
             active = true;
@@ -248,14 +248,14 @@ static mut_attack load_mutation_attack( const JsonObject &jo )
     if( jo.has_array( "base_damage" ) ) {
         ret.base_damage = load_damage_instance( jo.get_array( "base_damage" ) );
     } else if( jo.has_object( "base_damage" ) ) {
-        JsonObject jo_dam = jo.get_object( "base_damage" );
+        JsonObject const jo_dam = jo.get_object( "base_damage" );
         ret.base_damage = load_damage_instance( jo_dam );
     }
 
     if( jo.has_array( "strength_damage" ) ) {
         ret.strength_damage = load_damage_instance( jo.get_array( "strength_damage" ) );
     } else if( jo.has_object( "strength_damage" ) ) {
-        JsonObject jo_dam = jo.get_object( "strength_damage" );
+        JsonObject const jo_dam = jo.get_object( "strength_damage" );
         ret.strength_damage = load_damage_instance( jo_dam );
     }
 
@@ -294,7 +294,7 @@ mut_transform::mut_transform() : active( false ), moves( 0 ) {}
 
 bool mut_transform::load( const JsonObject &jsobj, const std::string &member )
 {
-    JsonObject j = jsobj.get_object( member );
+    JsonObject const j = jsobj.get_object( member );
 
     assign( j, "target", target );
     assign( j, "msg_transform", msg_transform );
@@ -359,15 +359,15 @@ void mutation_branch::load( const JsonObject &jo, const std::string & )
     optional( jo, was_loaded, "debug", debug, false );
     optional( jo, was_loaded, "player_display", player_display, true );
 
-    for( JsonArray pair : jo.get_array( "vitamin_rates" ) ) {
+    for( JsonArray const pair : jo.get_array( "vitamin_rates" ) ) {
         vitamin_rates.emplace( vitamin_id( pair.get_string( 0 ) ),
                                time_duration::from_turns( pair.get_int( 1 ) ) );
     }
 
-    for( JsonArray pair : jo.get_array( "vitamins_absorb_multi" ) ) {
+    for( JsonArray const pair : jo.get_array( "vitamins_absorb_multi" ) ) {
         std::map<vitamin_id, double> vit;
         // fill the inner map with vitamins
-        for( JsonArray vitamins : pair.get_array( 1 ) ) {
+        for( JsonArray const vitamins : pair.get_array( 1 ) ) {
             vit.emplace( vitamin_id( vitamins.get_string( 0 ) ), vitamins.get_float( 1 ) );
         }
         // assign the inner vitamin map to the material_id key
@@ -429,19 +429,19 @@ void mutation_branch::load( const JsonObject &jo, const std::string & )
     optional( jo, was_loaded, "mana_regen_multiplier", mana_regen_multiplier, 1.0f );
 
     if( jo.has_object( "rand_cut_bonus" ) ) {
-        JsonObject sm = jo.get_object( "rand_cut_bonus" );
+        JsonObject const sm = jo.get_object( "rand_cut_bonus" );
         rand_cut_bonus.first = sm.get_int( "min" );
         rand_cut_bonus.second = sm.get_int( "max" );
     }
 
     if( jo.has_object( "rand_bash_bonus" ) ) {
-        JsonObject sm = jo.get_object( "rand_bash_bonus" );
+        JsonObject const sm = jo.get_object( "rand_bash_bonus" );
         rand_bash_bonus.first = sm.get_int( "min" );
         rand_bash_bonus.second = sm.get_int( "max" );
     }
 
     if( jo.has_object( "social_modifiers" ) ) {
-        JsonObject sm = jo.get_object( "social_modifiers" );
+        JsonObject const sm = jo.get_object( "social_modifiers" );
         social_mods = load_mutation_social_mods( sm );
     }
 
@@ -492,24 +492,24 @@ void mutation_branch::load( const JsonObject &jo, const std::string & )
 
     }
 
-    for( JsonObject wp : jo.get_array( "wet_protection" ) ) {
-        std::string part_id = wp.get_string( "part" );
-        int ignored = wp.get_int( "ignored", 0 );
-        int neutral = wp.get_int( "neutral", 0 );
-        int good = wp.get_int( "good", 0 );
-        tripoint protect = tripoint( ignored, neutral, good );
+    for( JsonObject const wp : jo.get_array( "wet_protection" ) ) {
+        std::string const part_id = wp.get_string( "part" );
+        int const ignored = wp.get_int( "ignored", 0 );
+        int const neutral = wp.get_int( "neutral", 0 );
+        int const good = wp.get_int( "good", 0 );
+        tripoint const protect = tripoint( ignored, neutral, good );
         protection[get_body_part_token( part_id )] = protect;
     }
 
     for( JsonArray ea : jo.get_array( "encumbrance_always" ) ) {
-        std::string part_id = ea.next_string();
-        int enc = ea.next_int();
+        std::string const part_id = ea.next_string();
+        int const enc = ea.next_int();
         encumbrance_always[get_body_part_token( part_id )] = enc;
     }
 
     for( JsonArray ec : jo.get_array( "encumbrance_covered" ) ) {
-        std::string part_id = ec.next_string();
-        int enc = ec.next_int();
+        std::string const part_id = ec.next_string();
+        int const enc = ec.next_int();
         encumbrance_covered[get_body_part_token( part_id )] = enc;
     }
 
@@ -517,7 +517,7 @@ void mutation_branch::load( const JsonObject &jo, const std::string & )
         restricts_gear.insert( get_body_part_token( line ) );
     }
 
-    for( JsonObject ao : jo.get_array( "armor" ) ) {
+    for( JsonObject const ao : jo.get_array( "armor" ) ) {
         auto parts = ao.get_tags( "parts" );
         std::set<body_part> bps;
         for( const std::string &part_string : parts ) {
@@ -529,19 +529,19 @@ void mutation_branch::load( const JsonObject &jo, const std::string & )
             }
         }
 
-        resistances res = load_resistances_instance( ao );
+        resistances const res = load_resistances_instance( ao );
 
-        for( body_part bp : bps ) {
+        for( body_part const bp : bps ) {
             armor[ bp ] = res;
         }
     }
 
     if( jo.has_array( "attacks" ) ) {
-        for( JsonObject ao : jo.get_array( "attacks" ) ) {
+        for( JsonObject const ao : jo.get_array( "attacks" ) ) {
             attacks_granted.emplace_back( load_mutation_attack( ao ) );
         }
     } else if( jo.has_object( "attacks" ) ) {
-        JsonObject attack = jo.get_object( "attacks" );
+        JsonObject const attack = jo.get_object( "attacks" );
         attacks_granted.emplace_back( load_mutation_attack( attack ) );
     }
 }
@@ -771,13 +771,13 @@ void mutation_branch::load_trait_group( const JsonArray &entries,
     for( const JsonValue entry : entries ) {
         // Backwards-compatibility with old format ["TRAIT", 100]
         if( entry.test_array() ) {
-            JsonArray subarr = entry.get_array();
+            JsonArray const subarr = entry.get_array();
 
-            trait_id id( subarr.get_string( 0 ) );
+            trait_id const id( subarr.get_string( 0 ) );
             tg.add_entry( std::make_unique<Single_trait_creator>( id, subarr.get_int( 1 ) ) );
             // Otherwise load new format {"trait": ... } or {"group": ...}
         } else {
-            JsonObject subobj = entry.get_object();
+            JsonObject const subobj = entry.get_object();
             add_entry( tg, subobj );
         }
     }
@@ -795,7 +795,7 @@ void mutation_branch::load_trait_group( const JsonObject &jsobj,
 
     // TODO: (sm) Looks like this makes the new code backwards-compatible with the old format. Great if so!
     if( subtype == "old" ) {
-        for( JsonArray pair : jsobj.get_array( "traits" ) ) {
+        for( JsonArray const pair : jsobj.get_array( "traits" ) ) {
             tg.add_trait_entry( trait_id( pair.get_string( 0 ) ), pair.get_int( 1 ) );
         }
         return;
@@ -803,7 +803,7 @@ void mutation_branch::load_trait_group( const JsonObject &jsobj,
 
     // TODO: (sm) Taken from item_factory.cpp almost verbatim. Ensure that these work!
     if( jsobj.has_member( "entries" ) ) {
-        for( JsonObject subobj : jsobj.get_array( "entries" ) ) {
+        for( JsonObject const subobj : jsobj.get_array( "entries" ) ) {
             add_entry( tg, subobj );
         }
     }
@@ -812,10 +812,10 @@ void mutation_branch::load_trait_group( const JsonObject &jsobj,
             if( entry.test_string() ) {
                 tg.add_trait_entry( trait_id( entry.get_string() ), 100 );
             } else if( entry.test_array() ) {
-                JsonArray subtrait = entry.get_array();
+                JsonArray const subtrait = entry.get_array();
                 tg.add_trait_entry( trait_id( subtrait.get_string( 0 ) ), subtrait.get_int( 1 ) );
             } else {
-                JsonObject subobj = entry.get_object();
+                JsonObject const subobj = entry.get_object();
                 add_entry( tg, subobj );
             }
         }
@@ -825,11 +825,11 @@ void mutation_branch::load_trait_group( const JsonObject &jsobj,
             if( entry.test_string() ) {
                 tg.add_group_entry( trait_group::Trait_group_tag( entry.get_string() ), 100 );
             } else if( entry.test_array() ) {
-                JsonArray subtrait = entry.get_array();
+                JsonArray const subtrait = entry.get_array();
                 tg.add_group_entry( trait_group::Trait_group_tag( subtrait.get_string( 0 ) ),
                                     subtrait.get_int( 1 ) );
             } else {
-                JsonObject subobj = entry.get_object();
+                JsonObject const subobj = entry.get_object();
                 add_entry( tg, subobj );
             }
         }
@@ -839,7 +839,7 @@ void mutation_branch::load_trait_group( const JsonObject &jsobj,
 void mutation_branch::add_entry( Trait_group &tg, const JsonObject &obj )
 {
     std::unique_ptr<Trait_creation_data> ptr;
-    int probability = obj.get_int( "prob", 100 );
+    int const probability = obj.get_int( "prob", 100 );
     JsonArray jarr;
 
     if( obj.has_member( "collection" ) ) {
@@ -860,7 +860,7 @@ void mutation_branch::add_entry( Trait_group &tg, const JsonObject &obj )
     }
 
     if( obj.has_member( "trait" ) ) {
-        trait_id id( obj.get_string( "trait" ) );
+        trait_id const id( obj.get_string( "trait" ) );
         ptr = std::make_unique<Single_trait_creator>( id, probability );
     } else if( obj.has_member( "group" ) ) {
         ptr = std::make_unique<Trait_group_creator>( trait_group::Trait_group_tag(

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -107,7 +107,7 @@ void show_mutations_ui( Character &who )
     // Mutation selection UI obscures the terrain,
     // but some mutations may ask to select a tile when activated.
     // As such, we must (de-)activate only after destroying the UI.
-    detail::mutations_ui_result res = detail::show_mutations_ui_internal( who );
+    detail::mutations_ui_result const res = detail::show_mutations_ui_internal( who );
 
     switch( res.cmd ) {
         case detail::mutations_ui_cmd::exit:

--- a/src/name.cpp
+++ b/src/name.cpp
@@ -65,7 +65,7 @@ static void load( JsonIn &jsin )
     jsin.start_array();
 
     while( !jsin.end_array() ) {
-        JsonObject jo = jsin.get_object();
+        JsonObject const jo = jsin.get_object();
 
         // get flags of name.
         const nameFlags type =

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -215,7 +215,8 @@ void avatar::randomize( const bool random_scenario, points_left &points, bool pl
     init_age = rng( 16, 55 );
     // if adjusting min and max height from 145 and 200, make sure to see set_description()
     init_height = rng( 145, 200 );
-    bool const cities_enabled = world_generator->active_world->WORLD_OPTIONS["CITY_SIZE"].getValue() != "0";
+    bool const cities_enabled = world_generator->active_world->WORLD_OPTIONS["CITY_SIZE"].getValue() !=
+                                "0";
     if( random_scenario ) {
         std::vector<const scenario *> scenarios;
         for( const auto &scen : scenario::get_all() ) {
@@ -1265,7 +1266,8 @@ tab_direction set_traits( avatar &u, points_left &points )
             const mutation_branch &mdata = cur_trait.obj();
 
             // Look through the profession bionics, and see if any of them conflict with this trait
-            std::vector<bionic_id> const cbms_blocking_trait = bionics_cancelling_trait( u.prof->CBMs(), cur_trait );
+            std::vector<bionic_id> const cbms_blocking_trait = bionics_cancelling_trait( u.prof->CBMs(),
+                    cur_trait );
 
             if( u.has_trait( cur_trait ) ) {
 
@@ -1616,12 +1618,12 @@ tab_direction set_profession( avatar &u, points_left &points,
             draw_sorting_indicator( w_sorting, ctxt, profession_sorter );
 
             std::string const g_switch_msg = u.male ?
-                                       //~ Gender switch message. 1s - change key name, 2s - profession name.
-                                       _( "Press <color_light_green>%1$s</color> to switch "
-                                          "to <color_magenta>%2$s</color> (<color_pink>female</color>)." ) :
-                                       //~ Gender switch message. 1s - change key name, 2s - profession name.
-                                       _( "Press <color_light_green>%1$s</color> to switch "
-                                          "to <color_magenta>%2$s</color> (<color_light_cyan>male</color>)." );
+                                             //~ Gender switch message. 1s - change key name, 2s - profession name.
+                                             _( "Press <color_light_green>%1$s</color> to switch "
+                                                "to <color_magenta>%2$s</color> (<color_pink>female</color>)." ) :
+                                             //~ Gender switch message. 1s - change key name, 2s - profession name.
+                                             _( "Press <color_light_green>%1$s</color> to switch "
+                                                "to <color_magenta>%2$s</color> (<color_light_cyan>male</color>)." );
             fold_and_print( w_genderswap, point_zero, ( TERMX / 2 ), c_light_gray, g_switch_msg.c_str(),
                             ctxt.get_desc( "CHANGE_GENDER" ),
                             sorted_profs[cur_id]->gender_appropriate_name( !u.male ) );
@@ -2448,7 +2450,7 @@ tab_direction set_description( avatar &you, const bool allow_reroll,
     for( const auto &loc : start_locations::get_all() ) {
         if( g->scen->allowed_start( loc.id ) ) {
             uilist_entry const entry( loc.id.id().to_i(), true, -1,
-                                string_format( START_LOC_TEXT_TEMPLATE, loc.name(), loc.targets_count() ) );
+                                      string_format( START_LOC_TEXT_TEMPLATE, loc.name(), loc.targets_count() ) );
 
             select_location.entries.emplace_back( entry );
 

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -215,7 +215,7 @@ void avatar::randomize( const bool random_scenario, points_left &points, bool pl
     init_age = rng( 16, 55 );
     // if adjusting min and max height from 145 and 200, make sure to see set_description()
     init_height = rng( 145, 200 );
-    bool cities_enabled = world_generator->active_world->WORLD_OPTIONS["CITY_SIZE"].getValue() != "0";
+    bool const cities_enabled = world_generator->active_world->WORLD_OPTIONS["CITY_SIZE"].getValue() != "0";
     if( random_scenario ) {
         std::vector<const scenario *> scenarios;
         for( const auto &scen : scenario::get_all() ) {
@@ -315,7 +315,7 @@ void avatar::randomize( const bool random_scenario, points_left &points, bool pl
     while( points.has_spare() && loops <= 100000 ) {
         const bool allow_stats = points.stat_points_left() > 0;
         const bool allow_traits = points.trait_points_left() > 0 && num_gtraits < max_trait_points;
-        int r = rng( 1, 9 );
+        int const r = rng( 1, 9 );
         trait_id rn;
         switch( r ) {
             case 1:
@@ -560,7 +560,7 @@ bool avatar::create( character_type type, const std::string &tempname )
             learn_recipe( &r );
         }
     }
-    for( mtype_id elem : prof->pets() ) {
+    for( mtype_id const elem : prof->pets() ) {
         starting_pets.push_back( elem );
     }
 
@@ -643,7 +643,7 @@ bool avatar::create( character_type type, const std::string &tempname )
 
 static void draw_character_tabs( const catacurses::window &w, const std::string &sTab )
 {
-    std::vector<std::string> tab_captions = {
+    std::vector<std::string> const tab_captions = {
         _( "POINTS" ),
         _( "SCENARIO" ),
         _( "PROFESSION" ),
@@ -666,8 +666,8 @@ static void draw_points( const catacurses::window &w, points_left &points, int n
 {
     // Clear line (except borders)
     mvwprintz( w, point( 2, 3 ), c_black, std::string( getmaxx( w ) - 3, ' ' ) );
-    std::string points_msg = points.to_string();
-    int pMsg_length = utf8_width( remove_color_tags( points_msg ), true );
+    std::string const points_msg = points.to_string();
+    int const pMsg_length = utf8_width( remove_color_tags( points_msg ), true );
     nc_color color = c_light_gray;
     print_colored_text( w, point( 2, 3 ), color, c_light_gray, points_msg );
     if( netPointCost > 0 ) {
@@ -1114,8 +1114,8 @@ tab_direction set_traits( avatar &u, points_left &points )
 
         for( int i = 0; i < 3; i++ ) {
             // Shift start position to avoid iterating beyond end
-            int total = static_cast<int>( traits_size[i] );
-            int heigth = static_cast<int>( iContentHeight );
+            int const total = static_cast<int>( traits_size[i] );
+            int const heigth = static_cast<int>( iContentHeight );
             iStartPos[i] = std::min( iStartPos[i], std::max( 0, total - heigth ) );
         }
     };
@@ -1140,7 +1140,7 @@ tab_direction set_traits( avatar &u, points_left &points )
         int full_string_length = 0;
         const int remaining_points_length = utf8_width( points.to_string(), true );
         if( !points.is_freeform() ) {
-            std::string full_string =
+            std::string const full_string =
                 string_format( "<color_light_green>%2d/%-2d</color> <color_light_red>%3d/-%-2d</color>",
                                num_good, max_trait_points, num_bad, max_trait_points );
             fold_and_print( w, point( remaining_points_length + 3, 3 ), getmaxx( w ) - 2, c_white,
@@ -1177,16 +1177,16 @@ tab_direction set_traits( avatar &u, points_left &points )
             }
 
             int &start = iStartPos[iCurrentPage];
-            int current = iCurrentLine[iCurrentPage];
+            int const current = iCurrentLine[iCurrentPage];
             calcStartPos( start, current, iContentHeight, traits_size[iCurrentPage] );
-            int end = start + static_cast<int>( std::min( traits_size[iCurrentPage], iContentHeight ) );
+            int const end = start + static_cast<int>( std::min( traits_size[iCurrentPage], iContentHeight ) );
 
             for( int i = start; i < end; i++ ) {
                 const trait_entry &entry = vStartingTraits[iCurrentPage][i];
                 const mutation_branch &mdata = entry.id.obj();
                 if( current == i && iCurrentPage == iCurWorkingPage ) {
                     int points = mdata.points;
-                    bool negativeTrait = points < 0;
+                    bool const negativeTrait = points < 0;
                     if( negativeTrait ) {
                         points *= -1;
                     }
@@ -1222,8 +1222,8 @@ tab_direction set_traits( avatar &u, points_left &points )
                     }
                 }
 
-                int cur_y = 5 + i - start;
-                int cur_x = 2 + iCurrentPage * page_width;
+                int const cur_y = 5 + i - start;
+                int const cur_x = 2 + iCurrentPage * page_width;
                 mvwprintz( w, point( cur_x, cur_y ), col, utf8_truncate( mdata.name(), page_width - 2 ) );
             }
 
@@ -1265,7 +1265,7 @@ tab_direction set_traits( avatar &u, points_left &points )
             const mutation_branch &mdata = cur_trait.obj();
 
             // Look through the profession bionics, and see if any of them conflict with this trait
-            std::vector<bionic_id> cbms_blocking_trait = bionics_cancelling_trait( u.prof->CBMs(), cur_trait );
+            std::vector<bionic_id> const cbms_blocking_trait = bionics_cancelling_trait( u.prof->CBMs(), cur_trait );
 
             if( u.has_trait( cur_trait ) ) {
 
@@ -1422,15 +1422,15 @@ tab_direction set_profession( avatar &u, points_left &points,
 
         werase( w_description );
         if( cur_id_is_valid ) {
-            int netPointCost = sorted_profs[cur_id]->point_cost() - u.prof->point_cost();
-            bool can_pick = can_pick_prof( *sorted_profs[cur_id], u, points.skill_points_left() );
+            int const netPointCost = sorted_profs[cur_id]->point_cost() - u.prof->point_cost();
+            bool const can_pick = can_pick_prof( *sorted_profs[cur_id], u, points.skill_points_left() );
             const std::string clear_line( getmaxx( w ) - 2, ' ' );
 
             // Clear the bottom of the screen and header.
             mvwprintz( w, point( 1, 3 ), c_light_gray, clear_line );
 
             int pointsForProf = sorted_profs[cur_id]->point_cost();
-            bool negativeProf = pointsForProf < 0;
+            bool const negativeProf = pointsForProf < 0;
             if( negativeProf ) {
                 pointsForProf *= -1;
             }
@@ -1449,7 +1449,7 @@ tab_direction set_profession( avatar &u, points_left &points,
                                           pointsForProf );
             }
 
-            int pMsg_length = utf8_width( remove_color_tags( points.to_string() ) );
+            int const pMsg_length = utf8_width( remove_color_tags( points.to_string() ) );
             mvwprintz( w, point( pMsg_length + 9, 3 ), can_pick ? c_green : c_light_red, prof_msg_temp.c_str(),
                        sorted_profs[cur_id]->gender_appropriate_name( u.male ),
                        pointsForProf );
@@ -1590,14 +1590,14 @@ tab_direction set_profession( avatar &u, points_left &points,
             if( !sorted_profs[cur_id]->pets().empty() ) {
                 buffer += colorize( _( "Pets:" ), c_light_blue ) + "\n";
                 for( auto elem : sorted_profs[cur_id]->pets() ) {
-                    monster mon( elem );
+                    monster const mon( elem );
                     buffer += mon.get_name() + "\n";
                 }
             }
             // Profession vehicle
             if( sorted_profs[cur_id]->vehicle() ) {
                 buffer += colorize( _( "Vehicle:" ), c_light_blue ) + "\n";
-                vproto_id veh_id = sorted_profs[cur_id]->vehicle();
+                vproto_id const veh_id = sorted_profs[cur_id]->vehicle();
                 buffer += veh_id->name;
             }
             // Profession spells
@@ -1615,7 +1615,7 @@ tab_direction set_profession( avatar &u, points_left &points,
 
             draw_sorting_indicator( w_sorting, ctxt, profession_sorter );
 
-            std::string g_switch_msg = u.male ?
+            std::string const g_switch_msg = u.male ?
                                        //~ Gender switch message. 1s - change key name, 2s - profession name.
                                        _( "Press <color_light_green>%1$s</color> to switch "
                                           "to <color_magenta>%2$s</color> (<color_pink>female</color>)." ) :
@@ -1839,8 +1839,8 @@ tab_direction set_skills( avatar &u, points_left &points )
             }
             //Find out if the current skill and its level is in the requirement list
             auto req_skill = r.required_skills.find( currentSkill->ident() );
-            int skill = req_skill != r.required_skills.end() ? req_skill->second : 0;
-            bool would_autolearn_recipe =
+            int const skill = req_skill != r.required_skills.end() ? req_skill->second : 0;
+            bool const would_autolearn_recipe =
                 recipe_dict.all_autolearn().count( &r ) &&
                 with_prof_skills.meets_skill_requirements( r.autolearn_requirements );
 
@@ -1880,7 +1880,7 @@ tab_direction set_skills( avatar &u, points_left &points )
         rec_disp = currentSkill->description() + rec_disp;
 
         const auto vFolded = foldstring( rec_disp, getmaxx( w_description ) );
-        int iLines = vFolded.size();
+        int const iLines = vFolded.size();
 
         if( selected < 0 ) {
             selected = 0;
@@ -2079,15 +2079,15 @@ tab_direction set_scenario( avatar &u, points_left &points,
 
         werase( w_description );
         if( cur_id_is_valid ) {
-            int netPointCost = sorted_scens[cur_id]->point_cost() - g->scen->point_cost();
-            bool can_pick = sorted_scens[cur_id]->can_pick( *g->scen, points.skill_points_left() );
+            int const netPointCost = sorted_scens[cur_id]->point_cost() - g->scen->point_cost();
+            bool const can_pick = sorted_scens[cur_id]->can_pick( *g->scen, points.skill_points_left() );
             const std::string clear_line( getmaxx( w_description ), ' ' );
 
             // Clear the bottom of the screen and header.
             mvwprintz( w, point( 1, 3 ), c_light_gray, clear_line );
 
             int pointsForScen = sorted_scens[cur_id]->point_cost();
-            bool negativeScen = pointsForScen < 0;
+            bool const negativeScen = pointsForScen < 0;
             if( negativeScen ) {
                 pointsForScen *= -1;
             }
@@ -2108,7 +2108,7 @@ tab_direction set_scenario( avatar &u, points_left &points,
                                           pointsForScen );
             }
 
-            int pMsg_length = utf8_width( remove_color_tags( points.to_string() ) );
+            int const pMsg_length = utf8_width( remove_color_tags( points.to_string() ) );
             mvwprintz( w, point( pMsg_length + 9, 3 ), can_pick ? c_green : c_light_red, scen_msg_temp.c_str(),
                        sorted_scens[cur_id]->gender_appropriate_name( u.male ),
                        pointsForScen );
@@ -2362,7 +2362,7 @@ static void draw_height( const catacurses::window &w_height, const avatar &you,
 {
     werase( w_height );
     mvwprintz( w_height, point_zero, highlight ? h_light_gray : c_light_gray, _( "Height:" ) );
-    unsigned height_pos = 1 + utf8_width( _( "Height:" ) );
+    unsigned const height_pos = 1 + utf8_width( _( "Height:" ) );
     mvwprintz( w_height, point( height_pos, 0 ), c_white, string_format( "%d cm",
                you.base_height() ) );
     wnoutrefresh( w_height );
@@ -2372,7 +2372,7 @@ static void draw_age( const catacurses::window &w_age, const avatar &you, const 
 {
     werase( w_age );
     mvwprintz( w_age, point_zero, highlight ? h_light_gray : c_light_gray, _( "Age:" ) );
-    unsigned age_pos = 1 + utf8_width( _( "Age:" ) );
+    unsigned const age_pos = 1 + utf8_width( _( "Age:" ) );
     mvwprintz( w_age, point( age_pos, 0 ), c_white, string_format( "%d", you.base_age() ) );
     wnoutrefresh( w_age );
 }
@@ -2442,12 +2442,12 @@ tab_direction set_description( avatar &you, const bool allow_reroll,
     int offset = 1;
     const std::string random_start_location_text = string_format( RANDOM_START_LOC_TEXT_TEMPLATE,
             g->scen->start_location_targets_count() );
-    uilist_entry entry_random_start_location( RANDOM_START_LOC_ENTRY, true, -1,
+    uilist_entry const entry_random_start_location( RANDOM_START_LOC_ENTRY, true, -1,
             random_start_location_text );
     select_location.entries.emplace_back( entry_random_start_location );
     for( const auto &loc : start_locations::get_all() ) {
         if( g->scen->allowed_start( loc.id ) ) {
-            uilist_entry entry( loc.id.id().to_i(), true, -1,
+            uilist_entry const entry( loc.id.id().to_i(), true, -1,
                                 string_format( START_LOC_TEXT_TEMPLATE, loc.name(), loc.targets_count() ) );
 
             select_location.entries.emplace_back( entry );
@@ -2536,7 +2536,7 @@ tab_direction set_description( avatar &you, const bool allow_reroll,
 
         int line = 1;
         bool has_skills = false;
-        profession::StartingSkillList list_skills = you.prof->skills();
+        profession::StartingSkillList const list_skills = you.prof->skills();
         skill_displayType_id last_category = skill_displayType_id::NULL_ID();
         for( auto &elem : skillslist ) {
             int level = you.get_skill_level( elem->ident() );
@@ -2677,13 +2677,13 @@ tab_direction set_description( avatar &you, const bool allow_reroll,
     } );
 
     // do not switch IME mode now, but restore previous mode on return
-    ime_sentry sentry( ime_sentry::keep );
+    ime_sentry const sentry( ime_sentry::keep );
 
-    int min_allowed_age = 16;
-    int max_allowed_age = 55;
+    int const min_allowed_age = 16;
+    int const max_allowed_age = 55;
     // in centimeters. 2 std. deviations below average female height
-    int min_allowed_height = 145;
-    int max_allowed_height = 200;
+    int const min_allowed_height = 145;
+    int const max_allowed_height = 200;
 
     do {
         ui_manager::redraw();
@@ -2961,8 +2961,8 @@ std::optional<std::string> query_for_template_name()
         '/'
 #endif
     };
-    std::string title = _( "Name of template:" );
-    std::string desc = _( "Keep in mind you may not use special characters like / in filenames" );
+    std::string const title = _( "Name of template:" );
+    std::string const desc = _( "Keep in mind you may not use special characters like / in filenames" );
 
     string_input_popup spop;
     spop.title( title );
@@ -2994,7 +2994,7 @@ void avatar::character_to_template( const std::string &name )
 
 void avatar::save_template( const std::string &name, const points_left &points )
 {
-    std::string name_san = ensure_valid_file_name( name );
+    std::string const name_san = ensure_valid_file_name( name );
     write_to_file( PATH_INFO::templatedir() + name_san + ".template", [&]( std::ostream & fout ) {
         JsonOut jsout( fout, true );
 
@@ -3031,7 +3031,7 @@ bool avatar::load_template( const std::string &template_name, points_left &point
                 return;
             }
 
-            JsonObject jobj = jsin.get_object();
+            JsonObject const jobj = jsin.get_object();
 
             points.stat_points = jobj.get_int( "stat_points" );
             points.trait_points = jobj.get_int( "trait_points" );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -893,7 +893,8 @@ int npc::time_to_read( const item &book, const player &reader ) const
     // Reading speed is assumed to be how well you learn from books (as opposed to hands-on experience)
     const bool try_understand = character_funcs::is_fun_to_read( reader, book ) ||
                                 reader.get_skill_level( skill ) < type->level;
-    int const reading_speed = try_understand ? std::max( reader.read_speed(), read_speed() ) : read_speed();
+    int const reading_speed = try_understand ? std::max( reader.read_speed(),
+                              read_speed() ) : read_speed();
 
     int retval = type->time * reading_speed;
     retval *= std::min(
@@ -1013,7 +1014,7 @@ void npc::finish_read( item_location loc )
 
 void npc::start_read( item_location loc, player *pl )
 {
-    item  const&chosen = *loc;
+    item  const &chosen = *loc;
     const int time_taken = time_to_read( chosen, *pl );
     const double penalty = static_cast<double>( time_taken ) / time_to_read( chosen, *pl );
     player_activity act( ACT_READ, time_taken, 0, pl->getID().get_value() );
@@ -1260,7 +1261,7 @@ void npc::form_opinion( const player &u )
     }
 
     int u_ugly = 0;
-    for( trait_id  const&mut : u.get_mutations() ) {
+    for( trait_id  const &mut : u.get_mutations() ) {
         u_ugly += mut.obj().ugliness;
     }
     op_of_u.fear += u_ugly / 2;
@@ -1383,7 +1384,7 @@ float npc::vehicle_danger( int radius ) const
 
             point const a( wrapped_veh.v->global_pos3().xy() );
             point const b( static_cast<int>( a.x + units::cos( facing ) * radius ),
-                     static_cast<int>( a.y + units::sin( facing ) * radius ) );
+                           static_cast<int>( a.y + units::sin( facing ) * radius ) );
 
             // fake size
             /* This will almost certainly give the wrong size/location on customized
@@ -1397,9 +1398,10 @@ float npc::vehicle_danger( int radius ) const
             int const size = std::max( last_part.mount.x, last_part.mount.y );
 
             double const normal = std::sqrt( static_cast<float>( ( b.x - a.x ) * ( b.x - a.x ) + ( b.y - a.y ) *
-                                       ( b.y - a.y ) ) );
-            int const closest = static_cast<int>( std::abs( ( posx() - a.x ) * ( b.y - a.y ) - ( posy() - a.y ) *
-                                            ( b.x - a.x ) ) / normal );
+                                             ( b.y - a.y ) ) );
+            int const closest = static_cast<int>( std::abs( ( posx() - a.x ) * ( b.y - a.y ) -
+                                                  ( posy() - a.y ) *
+                                                  ( b.x - a.x ) ) / normal );
 
             if( size > closest ) {
                 danger = i;
@@ -1489,7 +1491,7 @@ void npc::decide_needs()
         int const ups_drain = primary_weapon().get_gun_ups_drain();
         if( ups_drain > 0 ) {
             int const ups_charges = charges_of( itype_UPS_off, ups_drain ) +
-                              charges_of( itype_UPS_off, ups_drain );
+                                    charges_of( itype_UPS_off, ups_drain );
             needrank[need_ammo] = static_cast<double>( ups_charges ) / ups_drain;
         } else {
             needrank[need_ammo] = character_funcs::get_ammo_items(
@@ -1753,7 +1755,7 @@ int npc::value( const item &it, int market_price ) const
 
     int ret = 0;
     double const weapon_val = npc_ai::weapon_value( *this, it, it.ammo_capacity() )
-                        - npc_ai::wielded_value( *this );
+                              - npc_ai::wielded_value( *this );
     if( weapon_val > 0 ) {
         ret += weapon_val;
     }
@@ -2837,11 +2839,11 @@ void npc::process_turn()
         // Penalize for bad impression
         // TODO: Penalize for traits and actions (especially murder, unless NPC is psycho)
         int const op_penalty = std::max( 0, op_of_u.anger ) +
-                         std::max( 0, -op_of_u.value ) +
-                         std::max( 0, op_of_u.fear );
+                               std::max( 0, -op_of_u.value ) +
+                               std::max( 0, op_of_u.fear );
         // Being barely hungry and thirsty, not in pain and not wounded means good care
         int const state_penalty = ( max_stored_kcal() - get_stored_kcal() ) / 10 + get_thirst()
-                            + ( 100 - hp_percentage() ) + get_pain();
+                                  + ( 100 - hp_percentage() ) + get_pain();
         if( x_in_y( trust_chance, 240 + 10 * op_penalty + state_penalty ) ) {
             op_of_u.trust++;
         }
@@ -2952,7 +2954,7 @@ const pathfinding_settings &npc::get_pathfinding_settings( bool no_bashing ) con
 std::set<tripoint> npc::get_path_avoid() const
 {
     std::set<tripoint> ret;
-    for( Creature  const&critter : g->all_creatures() ) {
+    for( Creature  const &critter : g->all_creatures() ) {
         // TODO: Cache this somewhere
         ret.insert( critter.pos() );
     }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3367,7 +3367,7 @@ std::vector<activity_id> job_data::get_prioritised_vector() const
     const std::pair<activity_id, int> &b ) {
         return a.second > b.second;
     } );
-    for( std::pair<activity_id, int> const elem : pairs ) {
+    for( std::pair<activity_id, int> const &elem : pairs ) {
         ret.push_back( elem.first );
     }
     return ret;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -167,7 +167,7 @@ npc::npc()
     attitude = NPCATT_NULL;
 
     *path_settings = pathfinding_settings( 0, 1000, 1000, 10, true, true, true, false, true );
-    for( direction threat_dir : npc_threat_dir ) {
+    for( direction const threat_dir : npc_threat_dir ) {
         ai_cache.threat_map[ threat_dir ] = 0.0f;
     }
 
@@ -359,7 +359,7 @@ void npc::randomize( const npc_class_id &type )
     per_max = the_class.roll_perception();
 
     for( auto &skill : Skill::skills ) {
-        int level = myclass->roll_skill( skill.ident() );
+        int const level = myclass->roll_skill( skill.ident() );
 
         set_skill_level( skill.ident(), level );
     }
@@ -441,7 +441,7 @@ void npc::randomize( const npc_class_id &type )
 
     // Run mutation rounds
     for( const auto &mr : type->mutation_rounds ) {
-        int rounds = mr.second.roll();
+        int const rounds = mr.second.roll();
         for( int i = 0; i < rounds; ++i ) {
             mutate_category( mr.first );
         }
@@ -453,13 +453,13 @@ void npc::randomize( const npc_class_id &type )
 
     // Add bionics
     for( const auto &bl : type->bionic_list ) {
-        int chance = bl.second;
+        int const chance = bl.second;
         if( rng( 0, 100 ) <= chance ) {
             add_bionic( bl.first );
         }
     }
     // Add spells for magiclysm mod
-    for( std::pair<spell_id, int> spell_pair : type->_starting_spells ) {
+    for( std::pair<spell_id, int> const spell_pair : type->_starting_spells ) {
         this->magic->learn_spell( spell_pair.first, *this, true );
         spell &sp = this->magic->get_spell( spell_pair.first );
         while( sp.get_level() < spell_pair.second && !sp.is_max_level() ) {
@@ -893,7 +893,7 @@ int npc::time_to_read( const item &book, const player &reader ) const
     // Reading speed is assumed to be how well you learn from books (as opposed to hands-on experience)
     const bool try_understand = character_funcs::is_fun_to_read( reader, book ) ||
                                 reader.get_skill_level( skill ) < type->level;
-    int reading_speed = try_understand ? std::max( reader.read_speed(), read_speed() ) : read_speed();
+    int const reading_speed = try_understand ? std::max( reader.read_speed(), read_speed() ) : read_speed();
 
     int retval = type->time * reading_speed;
     retval *= std::min(
@@ -926,7 +926,7 @@ void npc::finish_read( item_location loc )
     const bool display_messages = my_fac->id == faction_id( "your_followers" ) && g->u.sees( pos() );
     bool continuous = false; //whether to continue reading or not
 
-    int book_fun_for = character_funcs::get_book_fun_for( *this, book );
+    int const book_fun_for = character_funcs::get_book_fun_for( *this, book );
     if( book_fun_for != 0 ) {
         add_morale( MORALE_BOOK, book_fun_for * 5, book_fun_for * 15, 1_hours, 30_minutes, true,
                     book.type );
@@ -957,7 +957,7 @@ void npc::finish_read( item_location loc )
             max_ex = min_ex;
         }
         const std::string &s = activity.get_str_value( 0, "1" );
-        double penalty = strtod( s.c_str(), nullptr );
+        double const penalty = strtod( s.c_str(), nullptr );
         min_ex *= ( originalSkillLevel + 1 ) * penalty;
         min_ex = std::max( min_ex, 1 );
         max_ex *= ( originalSkillLevel + 1 ) * penalty;
@@ -965,7 +965,7 @@ void npc::finish_read( item_location loc )
 
         skill_level.readBook( min_ex, max_ex, reading->level );
 
-        std::string skill_name = skill.obj().name();
+        std::string const skill_name = skill.obj().name();
 
         if( skill_level != originalSkillLevel ) {
             g->events().send<event_type::gains_skill_level>( getID(), skill, skill_level.level() );
@@ -1013,7 +1013,7 @@ void npc::finish_read( item_location loc )
 
 void npc::start_read( item_location loc, player *pl )
 {
-    item &chosen = *loc;
+    item  const&chosen = *loc;
     const int time_taken = time_to_read( chosen, *pl );
     const double penalty = static_cast<double>( time_taken ) / time_to_read( chosen, *pl );
     player_activity act( ACT_READ, time_taken, 0, pl->getID().get_value() );
@@ -1070,8 +1070,8 @@ bool npc::wear_if_wanted( const item &it, std::string &reason )
     // TODO: Drop splints when healed
     if( it.has_flag( flag_SPLINT ) ) {
         for( int i = 0; i < num_hp_parts; i++ ) {
-            hp_part hpp = static_cast<hp_part>( i );
-            body_part bp = player::hp_to_bp( hpp );
+            hp_part const hpp = static_cast<hp_part>( i );
+            body_part const bp = player::hp_to_bp( hpp );
             if( is_limb_broken( convert_bp( bp ) ) && !has_effect( effect_mending, bp ) &&
                 it.covers( convert_bp( bp ).id() ) ) {
                 reason = _( "Thanks, I'll wear that now." );
@@ -1260,7 +1260,7 @@ void npc::form_opinion( const player &u )
     }
 
     int u_ugly = 0;
-    for( trait_id &mut : u.get_mutations() ) {
+    for( trait_id  const&mut : u.get_mutations() ) {
         u_ugly += mut.obj().ugliness;
     }
     op_of_u.fear += u_ugly / 2;
@@ -1379,10 +1379,10 @@ float npc::vehicle_danger( int radius ) const
         const wrapped_vehicle &wrapped_veh = vehicles[i];
         if( wrapped_veh.v->is_moving() ) {
             // FIXME: this can't be the right way to do this
-            units::angle facing = wrapped_veh.v->face.dir();
+            units::angle const facing = wrapped_veh.v->face.dir();
 
-            point a( wrapped_veh.v->global_pos3().xy() );
-            point b( static_cast<int>( a.x + units::cos( facing ) * radius ),
+            point const a( wrapped_veh.v->global_pos3().xy() );
+            point const b( static_cast<int>( a.x + units::cos( facing ) * radius ),
                      static_cast<int>( a.y + units::sin( facing ) * radius ) );
 
             // fake size
@@ -1394,11 +1394,11 @@ float npc::vehicle_danger( int radius ) const
             for( const vpart_reference &vpr : wrapped_veh.v->get_all_parts() ) {
                 last_part = vpr.part();
             }
-            int size = std::max( last_part.mount.x, last_part.mount.y );
+            int const size = std::max( last_part.mount.x, last_part.mount.y );
 
-            double normal = std::sqrt( static_cast<float>( ( b.x - a.x ) * ( b.x - a.x ) + ( b.y - a.y ) *
+            double const normal = std::sqrt( static_cast<float>( ( b.x - a.x ) * ( b.x - a.x ) + ( b.y - a.y ) *
                                        ( b.y - a.y ) ) );
-            int closest = static_cast<int>( std::abs( ( posx() - a.x ) * ( b.y - a.y ) - ( posy() - a.y ) *
+            int const closest = static_cast<int>( std::abs( ( posx() - a.x ) * ( b.y - a.y ) - ( posy() - a.y ) *
                                             ( b.x - a.x ) ) / normal );
 
             if( size > closest ) {
@@ -1486,9 +1486,9 @@ void npc::decide_needs()
         elem = 20;
     }
     if( primary_weapon().is_gun() ) {
-        int ups_drain = primary_weapon().get_gun_ups_drain();
+        int const ups_drain = primary_weapon().get_gun_ups_drain();
         if( ups_drain > 0 ) {
-            int ups_charges = charges_of( itype_UPS_off, ups_drain ) +
+            int const ups_charges = charges_of( itype_UPS_off, ups_drain ) +
                               charges_of( itype_UPS_off, ups_drain );
             needrank[need_ammo] = static_cast<double>( ups_charges ) / ups_drain;
         } else {
@@ -1548,7 +1548,7 @@ void npc::say( const std::string &line, const sounds::sound_t spriority ) const
         return;
     }
 
-    std::string sound = string_format( _( "%1$s saying \"%2$s\"" ), name, formatted_line );
+    std::string const sound = string_format( _( "%1$s saying \"%2$s\"" ), name, formatted_line );
     if( g->u.sees( *this ) && g->u.is_deaf() ) {
         add_msg( m_warning, _( "%1$s says something but you can't hear it!" ), name );
     }
@@ -1688,7 +1688,7 @@ void npc::shop_restock()
             item my_currency( my_fac->currency );
             if( !my_currency.is_null() ) {
                 my_currency.set_owner( *this );
-                int my_amount = rng( 5, 15 ) * shop_value / 100 / my_currency.price( true );
+                int const my_amount = rng( 5, 15 ) * shop_value / 100 / my_currency.price( true );
                 for( int lcv = 0; lcv < my_amount; lcv++ ) {
                     ret.push_back( my_currency );
                 }
@@ -1727,7 +1727,7 @@ void npc::update_worst_item_value()
 {
     worst_item_value = 99999;
     // TODO: Cache this
-    int inv_val = inv.worst_item_value( this );
+    int const inv_val = inv.worst_item_value( this );
     if( inv_val < worst_item_value ) {
         worst_item_value = inv_val;
     }
@@ -1735,7 +1735,7 @@ void npc::update_worst_item_value()
 
 int npc::value( const item &it ) const
 {
-    int market_price = it.price( true );
+    int const market_price = it.price( true );
     return value( it, market_price );
 }
 
@@ -1752,7 +1752,7 @@ int npc::value( const item &it, int market_price ) const
     }
 
     int ret = 0;
-    double weapon_val = npc_ai::weapon_value( *this, it, it.ammo_capacity() )
+    double const weapon_val = npc_ai::weapon_value( *this, it, it.ammo_capacity() )
                         - npc_ai::wielded_value( *this );
     if( weapon_val > 0 ) {
         ret += weapon_val;
@@ -1782,7 +1782,7 @@ int npc::value( const item &it, int market_price ) const
             ret += 14;
         }
 
-        bool has_gun_for_ammo = has_item_with( [at]( const item & itm ) {
+        bool const has_gun_for_ammo = has_item_with( [at]( const item & itm ) {
             // item::ammo_type considers the active gunmod.
             return itm.is_gun() && itm.ammo_types().count( at );
         } );
@@ -2035,7 +2035,7 @@ bool npc::within_boundaries_of_camp() const
     for( int x2 = -3; x2 < 3; x2++ ) {
         for( int y2 = -3; y2 < 3; y2++ ) {
             const point_abs_omt nearby = p + point( x2, y2 );
-            std::optional<basecamp *> bcp = overmap_buffer.find_camp( nearby );
+            std::optional<basecamp *> const bcp = overmap_buffer.find_camp( nearby );
             if( bcp ) {
                 return true;
             }
@@ -2505,8 +2505,8 @@ void npc::die( Creature *nkiller )
     }
 
     if( killer == &g->u && ( !guaranteed_hostile() || hit_by_player ) ) {
-        bool cannibal = g->u.has_trait( trait_CANNIBAL );
-        bool psycho = g->u.has_trait( trait_PSYCHOPATH ) || g->u.has_trait( trait_KILLER );
+        bool const cannibal = g->u.has_trait( trait_CANNIBAL );
+        bool const psycho = g->u.has_trait( trait_PSYCHOPATH ) || g->u.has_trait( trait_KILLER );
         if( g->u.has_trait( trait_SAPIOVORE ) || psycho ) {
             // No morale penalty
         } else if( cannibal ) {
@@ -2833,14 +2833,14 @@ void npc::process_turn()
         get_kcal_percent() > 0.95 && get_thirst() < thirst_levels::very_thirsty && op_of_u.trust < 5 ) {
         // Friends who are well fed will like you more
         // 24 checks per day, best case chance at trust 0 is 1 in 48 for +1 trust per 2 days
-        float trust_chance = 5 - op_of_u.trust;
+        float const trust_chance = 5 - op_of_u.trust;
         // Penalize for bad impression
         // TODO: Penalize for traits and actions (especially murder, unless NPC is psycho)
-        int op_penalty = std::max( 0, op_of_u.anger ) +
+        int const op_penalty = std::max( 0, op_of_u.anger ) +
                          std::max( 0, -op_of_u.value ) +
                          std::max( 0, op_of_u.fear );
         // Being barely hungry and thirsty, not in pain and not wounded means good care
-        int state_penalty = ( max_stored_kcal() - get_stored_kcal() ) / 10 + get_thirst()
+        int const state_penalty = ( max_stored_kcal() - get_stored_kcal() ) / 10 + get_thirst()
                             + ( 100 - hp_percentage() ) + get_pain();
         if( x_in_y( trust_chance, 240 + 10 * op_penalty + state_penalty ) ) {
             op_of_u.trust++;
@@ -2952,7 +2952,7 @@ const pathfinding_settings &npc::get_pathfinding_settings( bool no_bashing ) con
 std::set<tripoint> npc::get_path_avoid() const
 {
     std::set<tripoint> ret;
-    for( Creature &critter : g->all_creatures() ) {
+    for( Creature  const&critter : g->all_creatures() ) {
         // TODO: Cache this somewhere
         ret.insert( critter.pos() );
     }
@@ -3048,7 +3048,7 @@ void npc::set_companion_mission( npc &p, const std::string &mission_id )
 
 std::pair<std::string, nc_color> npc::hp_description() const
 {
-    int cur_hp = hp_percentage();
+    int const cur_hp = hp_percentage();
     std::string damage_info;
     std::string pronoun;
     if( male ) {
@@ -3180,8 +3180,8 @@ void npc::set_attitude( npc_attitude new_attitude )
 
     add_msg( m_debug, "%s changes attitude from %s to %s",
              name, npc_attitude_id( attitude ), npc_attitude_id( new_attitude ) );
-    attitude_group new_group = get_attitude_group( new_attitude );
-    attitude_group old_group = get_attitude_group( attitude );
+    attitude_group const new_group = get_attitude_group( new_attitude );
+    attitude_group const old_group = get_attitude_group( attitude );
     if( new_group != old_group && !is_fake() && g->u.sees( *this ) ) {
         switch( new_group ) {
             case attitude_group::hostile:
@@ -3365,7 +3365,7 @@ std::vector<activity_id> job_data::get_prioritised_vector() const
     const std::pair<activity_id, int> &b ) {
         return a.second > b.second;
     } );
-    for( std::pair<activity_id, int> elem : pairs ) {
+    for( std::pair<activity_id, int> const elem : pairs ) {
         ret.push_back( elem.first );
     }
     return ret;

--- a/src/npc_class.cpp
+++ b/src/npc_class.cpp
@@ -100,7 +100,7 @@ void apply_all_to_unassigned( T &skills )
     } );
 
     if( iter != skills.end() ) {
-        distribution dis = iter->second;
+        distribution const dis = iter->second;
         skills.erase( iter );
         for( const auto &sk : Skill::skills ) {
             if( skills.count( sk.ident() ) == 0 ) {
@@ -175,12 +175,12 @@ static distribution load_distribution( const JsonObject &jo )
     }
 
     if( jo.has_array( "dice" ) ) {
-        JsonArray jarr = jo.get_array( "dice" );
+        JsonArray const jarr = jo.get_array( "dice" );
         return distribution::dice_roll( jarr.get_int( 0 ), jarr.get_int( 1 ) );
     }
 
     if( jo.has_array( "rng" ) ) {
-        JsonArray jarr = jo.get_array( "rng" );
+        JsonArray const jarr = jo.get_array( "rng" );
         return distribution::rng_roll( jarr.get_int( 0 ), jarr.get_int( 1 ) );
     }
 
@@ -223,7 +223,7 @@ static distribution load_distribution( const JsonObject &jo, const std::string &
     }
 
     if( jo.has_object( name ) ) {
-        JsonObject obj = jo.get_object( name );
+        JsonObject const obj = jo.get_object( name );
         return load_distribution( obj );
     }
 
@@ -253,7 +253,7 @@ void npc_class::load( const JsonObject &jo, const std::string & )
     }
 
     if( jo.has_array( "spells" ) ) {
-        for( JsonObject subobj : jo.get_array( "spells" ) ) {
+        for( JsonObject const subobj : jo.get_array( "spells" ) ) {
             const int level = subobj.get_int( "level" );
             const spell_id sp = spell_id( subobj.get_string( "id" ) );
             _starting_spells.emplace( sp, level );
@@ -285,7 +285,7 @@ void npc_class::load( const JsonObject &jo, const std::string & )
     }
 
     if( jo.has_array( "skills" ) ) {
-        for( JsonObject skill_obj : jo.get_array( "skills" ) ) {
+        for( JsonObject const skill_obj : jo.get_array( "skills" ) ) {
             auto skill_ids = skill_obj.get_tags( "skill" );
             if( skill_obj.has_object( "level" ) ) {
                 const distribution dis = load_distribution( skill_obj, "level" );
@@ -302,9 +302,9 @@ void npc_class::load( const JsonObject &jo, const std::string & )
     }
 
     if( jo.has_array( "bionics" ) ) {
-        for( JsonObject bionic_obj : jo.get_array( "bionics" ) ) {
+        for( JsonObject const bionic_obj : jo.get_array( "bionics" ) ) {
             auto bionic_ids = bionic_obj.get_tags( "id" );
-            int chance = bionic_obj.get_int( "chance" );
+            int const chance = bionic_obj.get_int( "chance" );
             for( const auto &bid : bionic_ids ) {
                 bionic_list[ bionic_id( bid )] = chance;
             }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -200,7 +200,7 @@ bool compare_sound_alert( const dangerous_sound &sound_a, const dangerous_sound 
 static bool clear_shot_reach( const tripoint &from, const tripoint &to, bool check_ally = true )
 {
     std::vector<tripoint> path = line_to( from, to );
-    tripoint target_point = path.back();
+    tripoint const target_point = path.back();
     path.pop_back();
     if( path.empty() ) {
         return true;
@@ -225,7 +225,7 @@ tripoint npc::good_escape_direction( bool include_pos )
 {
     map &here = get_map();
     if( path.empty() ) {
-        zone_type_id retreat_zone = zone_type_id( "NPC_RETREAT" );
+        zone_type_id const retreat_zone = zone_type_id( "NPC_RETREAT" );
         const tripoint &abs_pos = global_square_location();
         const zone_manager &mgr = zone_manager::get_manager();
         std::optional<tripoint> retreat_target = mgr.get_nearest( retreat_zone, abs_pos, 60,
@@ -258,9 +258,9 @@ tripoint npc::good_escape_direction( bool include_pos )
     candidates.emplace_back( pos() );
 
     std::map<direction, float> adj_map;
-    for( direction pt_dir : npc_threat_dir ) {
+    for( direction const pt_dir : npc_threat_dir ) {
         const tripoint &pt = pos() + direction_XY( pt_dir );
-        float cur_rating = rate_pt( pt, ai_cache.threat_map[ pt_dir ] );
+        float const cur_rating = rate_pt( pt, ai_cache.threat_map[ pt_dir ] );
         adj_map[pt_dir] = cur_rating;
         if( cur_rating == best_rating ) {
             candidates.emplace_back( pos() + direction_XY( pt_dir ) );
@@ -341,7 +341,7 @@ float npc::evaluate_enemy( const Creature &target ) const
 {
     if( target.is_monster() ) {
         const monster &mon = dynamic_cast<const monster &>( target );
-        float diff = static_cast<float>( mon.type->difficulty );
+        float const diff = static_cast<float>( mon.type->difficulty );
         return std::min( diff, NPC_DANGER_MAX );
     } else if( target.is_npc() || target.is_player() ) {
         return std::min( character_danger( dynamic_cast<const player &>( target ) ),
@@ -418,7 +418,7 @@ void npc::assess_danger()
     };
     std::map<direction, float> cur_threat_map;
     // start with a decayed version of last turn's map
-    for( direction threat_dir : npc_threat_dir ) {
+    for( direction const threat_dir : npc_threat_dir ) {
         cur_threat_map[ threat_dir ] = 0.25f * ai_cache.threat_map[ threat_dir ];
     }
     map &here = get_map();
@@ -472,9 +472,9 @@ void npc::assess_danger()
         if( !sees( critter ) ) {
             continue;
         }
-        float critter_threat = evaluate_enemy( critter );
+        float const critter_threat = evaluate_enemy( critter );
         // warn and consider the odds for distant enemies
-        int dist = rl_dist( pos(), critter.pos() );
+        int const dist = rl_dist( pos(), critter.pos() );
         if( ( is_enemy() || !critter.friendly ) ) {
             assessment += critter_threat;
             if( critter_threat > ( 8.0f + personality.bravery + rng( 0, 5 ) ) ) {
@@ -489,9 +489,9 @@ void npc::assess_danger()
             continue;
         }
 
-        float scaled_distance = std::max( 1.0f, dist / critter.speed_rating() );
-        float hp_percent = 1.0f - static_cast<float>( critter.get_hp() ) / critter.get_hp_max();
-        float critter_danger = std::max( critter_threat * ( hp_percent * 0.5f + 0.5f ),
+        float const scaled_distance = std::max( 1.0f, dist / critter.speed_rating() );
+        float const hp_percent = 1.0f - static_cast<float>( critter.get_hp() ) / critter.get_hp_max();
+        float const critter_danger = std::max( critter_threat * ( hp_percent * 0.5f + 0.5f ),
                                          NPC_DANGER_VERY_LOW );
         ai_cache.total_danger += critter_danger / scaled_distance;
 
@@ -517,7 +517,7 @@ void npc::assess_danger()
         // prioritize the biggest, nearest threats, or the biggest threats that are threatening
         // us or an ally
         // critter danger is always at least NPC_DANGER_VERY_LOW
-        float priority = std::max( critter_danger - 2.0f * ( scaled_distance - 1.0f ),
+        float const priority = std::max( critter_danger - 2.0f * ( scaled_distance - 1.0f ),
                                    is_too_close ? critter_danger : 0.0f );
         cur_threat_map[direction_from( pos(), critter.pos() )] += priority;
         if( priority > highest_priority ) {
@@ -533,12 +533,12 @@ void npc::assess_danger()
     }
     const auto handle_hostile = [&]( const Character & foe, float foe_threat,
     const std::string & bogey, const std::string & warning ) {
-        int dist = rl_dist( pos(), foe.pos() );
+        int const dist = rl_dist( pos(), foe.pos() );
         if( foe_threat > ( 8.0f + personality.bravery + rng( 0, 5 ) ) ) {
             warn_about( "monster", 10_minutes, bogey, dist, foe.pos() );
         }
 
-        int scaled_distance = std::max( 1, ( 100 * dist ) / foe.get_speed() );
+        int const scaled_distance = std::max( 1, ( 100 * dist ) / foe.get_speed() );
         ai_cache.total_danger += foe_threat / scaled_distance;
         if( must_retreat || no_fighting ) {
             return 0.0f;
@@ -559,7 +559,7 @@ void npc::assess_danger()
         }
 
         if( !is_player_ally() || is_too_close || ok_by_rules( foe, dist, scaled_distance ) ) {
-            float priority = std::max( foe_threat - 2.0f * ( scaled_distance - 1 ),
+            float const priority = std::max( foe_threat - 2.0f * ( scaled_distance - 1 ),
                                        is_too_close ? std::max( foe_threat, NPC_DANGER_VERY_LOW ) :
                                        0.0f );
             cur_threat_map[direction_from( pos(), foe.pos() )] += priority;
@@ -585,28 +585,28 @@ void npc::assess_danger()
         if( !( ally && ally->is_npc() ) ) {
             continue;
         }
-        float guy_threat = evaluate_enemy( *ally );
-        float min_danger = assessment >= NPC_DANGER_VERY_LOW ? NPC_DANGER_VERY_LOW : -10.0f;
+        float const guy_threat = evaluate_enemy( *ally );
+        float const min_danger = assessment >= NPC_DANGER_VERY_LOW ? NPC_DANGER_VERY_LOW : -10.0f;
         assessment = std::max( min_danger, assessment - guy_threat * 0.5f );
     }
 
     if( sees( player_character.pos() ) ) {
         // Mod for the player
         // cap player difficulty at 150
-        float player_diff = evaluate_enemy( player_character );
+        float const player_diff = evaluate_enemy( player_character );
         if( is_enemy() ) {
             assessment += handle_hostile( player_character, player_diff, "maniac", "kill_player" );
         } else if( is_friendly( player_character ) ) {
-            float min_danger = assessment >= NPC_DANGER_VERY_LOW ? NPC_DANGER_VERY_LOW : -10.0f;
+            float const min_danger = assessment >= NPC_DANGER_VERY_LOW ? NPC_DANGER_VERY_LOW : -10.0f;
             assessment = std::max( min_danger, assessment - player_diff * 0.5f );
             ai_cache.friends.emplace_back( g->shared_from( player_character ) );
         }
     }
     assessment *= 0.1f;
     if( !has_effect( effect_npc_run_away ) && !has_effect( effect_npc_fire_bad ) ) {
-        float my_diff = evaluate_enemy( *this );
+        float const my_diff = evaluate_enemy( *this );
         if( ( my_diff * 0.5f + personality.bravery + rng( 0, 10 ) ) < assessment ) {
-            time_duration run_away_for = 5_turns + 1_turns * rng( 0, 5 );
+            time_duration const run_away_for = 5_turns + 1_turns * rng( 0, 5 );
             warn_about( "run_away", run_away_for );
             add_effect( effect_npc_run_away, run_away_for );
             path.clear();
@@ -614,9 +614,9 @@ void npc::assess_danger()
     }
     // update the threat cache
     for( size_t i = 0; i < 8; i++ ) {
-        direction threat_dir = npc_threat_dir[i];
-        direction dir_right = npc_threat_dir[( i + 1 ) % 8];
-        direction dir_left = npc_threat_dir[( i + 7 ) % 8 ];
+        direction const threat_dir = npc_threat_dir[i];
+        direction const dir_right = npc_threat_dir[( i + 1 ) % 8];
+        direction const dir_left = npc_threat_dir[( i + 7 ) % 8 ];
         ai_cache.threat_map[threat_dir] = cur_threat_map[threat_dir] + 0.1f *
                                           ( cur_threat_map[dir_right] + cur_threat_map[dir_left] );
     }
@@ -629,8 +629,8 @@ void npc::assess_danger()
 float npc::character_danger( const Character &u ) const
 {
     float ret = 0.0;
-    bool u_gun = u.primary_weapon().is_gun();
-    bool my_gun = primary_weapon().is_gun();
+    bool const u_gun = u.primary_weapon().is_gun();
+    bool const my_gun = primary_weapon().is_gun();
     double u_weap_val = npc_ai::wielded_value( u );
     const double &my_weap_val = ai_cache.my_weapon_value;
     if( u_gun && !my_gun ) {
@@ -650,7 +650,7 @@ float npc::character_danger( const Character &u ) const
 
 void npc::regen_ai_cache()
 {
-    map &here = get_map();
+    map  const&here = get_map();
     auto i = std::begin( ai_cache.sound_alerts );
     while( i != std::end( ai_cache.sound_alerts ) ) {
         if( sees( here.getlocal( i->abs_pos ) ) ) {
@@ -662,7 +662,7 @@ void npc::regen_ai_cache()
             ++i;
         }
     }
-    float old_assessment = ai_cache.danger_assessment;
+    float const old_assessment = ai_cache.danger_assessment;
     ai_cache.friends.clear();
     ai_cache.target = shared_ptr_fast<Creature>();
     ai_cache.ally = shared_ptr_fast<Creature>();
@@ -680,7 +680,7 @@ void npc::regen_ai_cache()
     }
     // Non-allied NPCs with a completed mission should move to the player
     if( !is_player_ally() && !is_stationary( true ) ) {
-        Character &player_character = get_player_character();
+        Character  const&player_character = get_player_character();
         for( auto &miss : chatbin.missions_assigned ) {
             if( miss->is_complete( getID() ) ) {
                 // unless the player found an item and already told the NPC he wanted to keep it
@@ -770,7 +770,7 @@ void npc::move()
         ai_cache.target = g->shared_from( player_character );
     }
 
-    map &here = get_map();
+    map  const&here = get_map();
     if( !ai_cache.dangerous_explosives.empty() ) {
         action = npc_escape_explosion;
     } else if( target == &player_character && attitude == NPCATT_FLEE_TEMP ) {
@@ -784,7 +784,7 @@ void npc::move()
     } else if( target != nullptr && ai_cache.danger > 0 ) {
         action = method_of_attack();
     } else if( !ai_cache.sound_alerts.empty() && !is_walking_with() ) {
-        tripoint cur_s_abs_pos = ai_cache.s_abs_pos;
+        tripoint const cur_s_abs_pos = ai_cache.s_abs_pos;
         if( !ai_cache.guard_pos ) {
             ai_cache.guard_pos = here.getabs( pos() );
         }
@@ -824,7 +824,7 @@ void npc::move()
             print_action( "address_player %s", action );
         }
         if( ai_cache.sound_alerts.empty() && ai_cache.guard_pos ) {
-            tripoint return_guard_pos = *ai_cache.guard_pos;
+            tripoint const return_guard_pos = *ai_cache.guard_pos;
             add_msg( m_debug, "NPC %s: returning to guard spot at x(%d) y(%d)", name,
                      return_guard_pos.x, return_guard_pos.y );
             action = npc_return_to_guard_pos;
@@ -956,7 +956,7 @@ void npc::move()
 
 void npc::execute_action( npc_action action )
 {
-    int oldmoves = moves;
+    int const oldmoves = moves;
     tripoint tar = pos();
     Creature *cur = current_target();
     if( action == npc_flee ) {
@@ -970,7 +970,7 @@ void npc::execute_action( npc_action action )
     */
 
     Character &player_character = get_player_character();
-    map &here = get_map();
+    map  const&here = get_map();
     switch( action ) {
         case npc_pause:
             move_pause();
@@ -984,7 +984,7 @@ void npc::execute_action( npc_action action )
         break;
 
         case npc_investigate_sound: {
-            tripoint cur_pos = pos();
+            tripoint const cur_pos = pos();
             update_path( here.getlocal( ai_cache.s_abs_pos ) );
             move_to_next();
             if( pos() == cur_pos ) {
@@ -1104,7 +1104,7 @@ void npc::execute_action( npc_action action )
                             cbm_fake_active.gun_current_mode();
 
             if( !mode ) {
-                std::string error_weapon = cbm_active.is_null() ? primary_weapon().tname() :
+                std::string const error_weapon = cbm_active.is_null() ? primary_weapon().tname() :
                                            cbm_fake_active.tname();
                 debugmsg( "NPC tried to shoot %s without valid mode.", error_weapon );
             }
@@ -1255,7 +1255,7 @@ void npc::execute_action( npc_action action )
 
                 const int cur_part = seats[i].second;
 
-                tripoint pp = veh->global_part_pos3( cur_part );
+                tripoint const pp = veh->global_part_pos3( cur_part );
                 update_path( pp, true );
                 if( !path.empty() ) {
                     // All is fine
@@ -1338,7 +1338,7 @@ npc_action npc::method_of_fleeing()
 
 npc_action npc::method_of_attack()
 {
-    Character &player_character = get_player_character();
+    Character  const&player_character = get_player_character();
     Creature *critter = current_target();
     if( critter == nullptr ) {
         // This function shouldn't be called...
@@ -1346,8 +1346,8 @@ npc_action npc::method_of_attack()
         return npc_pause;
     }
 
-    tripoint tar = critter->pos();
-    int dist = rl_dist( pos(), tar );
+    tripoint const tar = critter->pos();
+    int const dist = rl_dist( pos(), tar );
     const bool has_los = clear_shot_reach( pos(), tar, false );
     const bool same_z = tar.z == pos().z;
     const int cur_recoil = ranged::recoil_total( *this );
@@ -1357,9 +1357,9 @@ npc_action npc::method_of_attack()
                            rules.engagement == combat_engagement::FREE_FIRE;
     // NPCs engage in free fire can move to avoid allies, but not if they're in a vehicle
     const bool dont_move_ff = in_vehicle || rules.engagement == combat_engagement::NO_MOVE;
-    bool can_use_gun = ( ( !is_player_ally() || rules.has_flag( ally_rule::use_guns ) ) &&
+    bool const can_use_gun = ( ( !is_player_ally() || rules.has_flag( ally_rule::use_guns ) ) &&
                          ( ai_cache.danger >= 3 || emergency() || dist < 0 ) );
-    bool use_silent = ( is_player_ally() && rules.has_flag( ally_rule::use_silent ) );
+    bool const use_silent = ( is_player_ally() && rules.has_flag( ally_rule::use_silent ) );
 
     // if there's enough of a threat to be here, power up the combat CBMs
     activate_combat_cbms();
@@ -1384,7 +1384,7 @@ npc_action npc::method_of_attack()
     }
 
     // reach attacks are silent and consume no ammo so prefer these if available
-    int reach_range = primary_weapon().reach_range( *this );
+    int const reach_range = primary_weapon().reach_range( *this );
     if( reach_range > 1 && reach_range >= dist && clear_shot_reach( pos(), tar ) ) {
         add_msg( m_debug, "%s is trying a reach attack", disp_name() );
         return npc_reach_attack;
@@ -1416,7 +1416,7 @@ npc_action npc::method_of_attack()
     }
 
     // TODO: Needs a check for transparent but non-passable tiles on the way
-    int effective_range = g_mode ? confident_gun_mode_range( g_mode,
+    int const effective_range = g_mode ? confident_gun_mode_range( g_mode,
                           ranged::get_most_accurate_sight( *this, *g_mode ) ) : 0;
     if( g_mode && sees( *critter ) && ranged::aim_per_move( *this, *g_mode, recoil ) > 0 &&
         effective_range >= dist ) {
@@ -1454,11 +1454,11 @@ static bool wants_to_reload( const npc &who, const item &it )
 static bool wants_to_reload_with( const item &weap, const item &ammo, bool danger )
 {
     // Only reload loose ammo if gun has integral magazine or not in danger.
-    bool combat_reload = !ammo.is_magazine() && ( danger || weap.magazine_integral() );
+    bool const combat_reload = !ammo.is_magazine() && ( danger || weap.magazine_integral() );
     // If in danger, only swap magazines if ammo is both greater and it's sufficient for a shot
     // To prevent them from constantly swapping magazines while entering range.
     // If not in danger, swap magazines if ammo is greater than current.
-    bool want_swap = ammo.ammo_remaining() > weap.ammo_remaining() && ( !danger ||
+    bool const want_swap = ammo.ammo_remaining() > weap.ammo_remaining() && ( !danger ||
                      ammo.ammo_remaining() > weap.ammo_required() );
     return combat_reload || want_swap;
 }
@@ -1470,7 +1470,7 @@ void npc::check_or_reload_cbm()
         return;
     }
 
-    std::vector<std::pair<bionic_id, item>> checklist = find_reloadable_cbms( *this );
+    std::vector<std::pair<bionic_id, item>> const checklist = find_reloadable_cbms( *this );
 
     if( !checklist.empty() ) {
         for( auto& [bid, itm] : checklist ) {
@@ -1663,8 +1663,8 @@ bool npc::consume_cbm_items( const std::function<bool( const item & )> &filter )
     if( index < 0 ) {
         return false;
     }
-    int old_moves = moves;
-    item_location loc = item_location( *this, &i_at( index ) );
+    int const old_moves = moves;
+    item_location const loc = item_location( *this, &i_at( index ) );
     consume( loc );
     // TODO: a more reliable check for whether item has been consumed
     return old_moves != moves;
@@ -1678,7 +1678,7 @@ bool npc::recharge_cbm()
         return true;
     }
 
-    for( bionic_id &bid : get_fueled_bionics() ) {
+    for( bionic_id  const&bid : get_fueled_bionics() ) {
         if( has_active_bionic( bid ) ) {
             continue;
         }
@@ -1834,7 +1834,7 @@ npc_action npc::address_needs( float danger )
 
     check_or_reload_cbm();
 
-    item &reloadable = find_reloadable();
+    item  const&reloadable = find_reloadable();
     if( !reloadable.is_null() ) {
         do_reload( reloadable );
         return npc_noop;
@@ -1920,7 +1920,7 @@ npc_action npc::address_needs( float danger )
 
 npc_action npc::address_player()
 {
-    Character &player_character = get_player_character();
+    Character  const&player_character = get_player_character();
     if( ( attitude == NPCATT_TALK ) && sees( player_character ) ) {
         if( player_character.in_sleep_state() ) {
             // Leave sleeping characters alone.
@@ -1959,7 +1959,7 @@ npc_action npc::address_player()
 
     if( attitude == NPCATT_LEAD ) {
         if( rl_dist( pos(), player_character.pos() ) >= 12 || !sees( player_character ) ) {
-            int intense = get_effect_int( effect_catch_up );
+            int const intense = get_effect_int( effect_catch_up );
             if( intense < 10 ) {
                 say( "<keep_up>" );
                 add_effect( effect_catch_up, 5_turns );
@@ -2051,16 +2051,16 @@ int npc::confident_gun_mode_range( const gun_mode &gun, int at_recoil ) const
 
     // Doesn't use calculate_dispersion because that requires a map
     // TODO: Turn this into a common function.
-    int gun_recoil = gun->gun_recoil();
-    int eff_recoil = at_recoil + ( gun.qty > 1 ? ranged::burst_penalty( *this, *gun, gun_recoil ) : 0 );
+    int const gun_recoil = gun->gun_recoil();
+    int const eff_recoil = at_recoil + ( gun.qty > 1 ? ranged::burst_penalty( *this, *gun, gun_recoil ) : 0 );
     dispersion_sources mode_disp = ranged::get_weapon_dispersion( *this, *gun );
     mode_disp.add_range( eff_recoil );
     double max_dispersion = mode_disp.max();
     if( gun->ammo_current() ) {
         max_dispersion += gun->ammo_current()->ammo->dispersion;
     }
-    double even_chance_range = range_with_even_chance_of_good_hit( max_dispersion );
-    double confident_range = even_chance_range * confidence_mult();
+    double const even_chance_range = range_with_even_chance_of_good_hit( max_dispersion );
+    double const confident_range = even_chance_range * confidence_mult();
     add_msg( m_debug, "%s confident_gun (%s<=%.2f) at %.1f", gun->tname(), gun.name(), confident_range,
              max_dispersion );
     return std::max<int>( confident_range, 1 );
@@ -2068,10 +2068,10 @@ int npc::confident_gun_mode_range( const gun_mode &gun, int at_recoil ) const
 
 int npc::confident_throw_range( const item &thrown, Creature *target ) const
 {
-    double average_dispersion = ranged::throwing_dispersion( *this, thrown, target, false ) / 2.0;
-    double even_chance_range = ( target == nullptr ? 0.5 : target->ranged_target_size() ) /
+    double const average_dispersion = ranged::throwing_dispersion( *this, thrown, target, false ) / 2.0;
+    double const even_chance_range = ( target == nullptr ? 0.5 : target->ranged_target_size() ) /
                                average_dispersion;
-    double confident_range = even_chance_range * confidence_mult();
+    double const confident_range = even_chance_range * confidence_mult();
     add_msg( m_debug, "confident_throw_range == %d", static_cast<int>( confident_range ) );
     return static_cast<int>( confident_range );
 }
@@ -2083,10 +2083,10 @@ double item::ideal_ranged_dps( const Character &who, gun_mode &mode ) const
     }
     damage_instance gun_damage = this->gun_damage();
     if( ammo_current() ) {
-        itype_id ammo = ammo_current();
+        itype_id const ammo = ammo_current();
         gun_damage.add( ammo->ammo->damage );
     } else if( ammo_default() ) {
-        itype_id ammo = ammo_default();
+        itype_id const ammo = ammo_default();
         gun_damage.add( ammo->ammo->damage );
     }
     float damage_factor = gun_damage.total_damage();
@@ -2111,7 +2111,7 @@ double item::ideal_ranged_dps( const Character &who, gun_mode &mode ) const
     }
     move_cost += ranged::gun_engagement_moves( who, *this, ( *regular ).threshold );
 
-    double dps = damage_factor / ( move_cost / 100.0f );
+    double const dps = damage_factor / ( move_cost / 100.0f );
 
     return dps;
 }
@@ -2120,7 +2120,7 @@ double item::ideal_ranged_dps( const Character &who, gun_mode &mode ) const
 bool npc::wont_hit_friend( const tripoint &tar, const item &it, bool throwing ) const
 {
     // TODO: Get actual dispersion instead of extracting it (badly) from confident range
-    int confident = throwing ?
+    int const confident = throwing ?
                     confident_throw_range( it, nullptr ) :
                     confident_shoot_range( it, ranged::recoil_total( *this ) );
     // if there is no confidence at using weapon, it's not used at range
@@ -2133,10 +2133,10 @@ bool npc::wont_hit_friend( const tripoint &tar, const item &it, bool throwing ) 
         return true;    // If we're *really* sure that our aim is dead-on
     }
 
-    units::angle target_angle = coord_to_angle( pos(), tar );
+    units::angle const target_angle = coord_to_angle( pos(), tar );
 
     // TODO: Base on dispersion
-    units::angle safe_angle = 30_degrees;
+    units::angle const safe_angle = 30_degrees;
 
     for( const auto &fr : ai_cache.friends ) {
         const shared_ptr_fast<Creature> ally_p = fr.lock();
@@ -2147,12 +2147,12 @@ bool npc::wont_hit_friend( const tripoint &tar, const item &it, bool throwing ) 
 
         // TODO: Extract common functions with turret target selection
         units::angle safe_angle_ally = safe_angle;
-        int ally_dist = rl_dist( pos(), ally.pos() );
+        int const ally_dist = rl_dist( pos(), ally.pos() );
         if( ally_dist < 3 ) {
             safe_angle_ally += ( 3 - ally_dist ) * 30_degrees;
         }
 
-        units::angle ally_angle = coord_to_angle( pos(), ally.pos() );
+        units::angle const ally_angle = coord_to_angle( pos(), ally.pos() );
         units::angle angle_diff = units::fabs( ally_angle - target_angle );
         angle_diff = std::min( 360_degrees - angle_diff, angle_diff );
         if( angle_diff < safe_angle_ally ) {
@@ -2166,7 +2166,7 @@ bool npc::wont_hit_friend( const tripoint &tar, const item &it, bool throwing ) 
 
 bool npc::enough_time_to_reload( const item &gun ) const
 {
-    int rltime = item_reload_cost( gun, item( gun.ammo_default() ),
+    int const rltime = item_reload_cost( gun, item( gun.ammo_default() ),
                                    gun.ammo_capacity() );
     const float turns_til_reloaded = static_cast<float>( rltime ) / get_speed();
 
@@ -2195,7 +2195,7 @@ bool npc::enough_time_to_reload( const item &gun ) const
 
 void npc::aim()
 {
-    item r_weapon = cbm_active.is_null() ? primary_weapon() : cbm_fake_active;
+    item const r_weapon = cbm_active.is_null() ? primary_weapon() : cbm_fake_active;
     double aim_amount = ranged::aim_per_move( *this, r_weapon, recoil );
     while( aim_amount > 0 && recoil > 0 && moves > 0 ) {
         moves--;
@@ -2255,7 +2255,7 @@ bool npc::can_open_door( const tripoint &p, const bool inside ) const
 
 bool npc::can_move_to( const tripoint &p, bool no_bashing ) const
 {
-    map &here = get_map();
+    map  const&here = get_map();
     // Allow moving into any bashable spots, but penalize them during pathing
     // Doors are not passable for hallucinations
     return( rl_dist( pos(), p ) <= 1 && here.has_floor( p ) && !g->is_dangerous_tile( p ) &&
@@ -2403,7 +2403,7 @@ void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomo
         moves -= 100;
         moved = true;
     } else if( here.passable( p ) && !here.has_flag( "DOOR", p ) ) {
-        bool diag = trigdist && posx() != p.x && posy() != p.y;
+        bool const diag = trigdist && posx() != p.x && posy() != p.y;
         if( is_mounted() ) {
             const double base_moves = run_cost( here.combined_movecost( pos(), p ),
                                                 diag ) * 100.0 / mounted_creature->get_speed();
@@ -2426,7 +2426,7 @@ void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomo
         }
     } else if( get_dex() > 1 && here.has_flag_ter_or_furn( "CLIMBABLE", p ) ) {
         ///\EFFECT_DEX_NPC increases chance to climb CLIMBABLE furniture or terrain
-        int climb = get_dex();
+        int const climb = get_dex();
         if( one_in( climb ) ) {
             add_msg_if_npc( m_neutral, _( "%1$s tries to climb the %2$s but slips." ), name,
                             here.tername( p ) );
@@ -2523,12 +2523,12 @@ void npc::avoid_friendly_fire()
     // Calculate center of weight of friends and move away from that
     tripoint center;
     for( const auto &fr : ai_cache.friends ) {
-        if( shared_ptr_fast<Creature> fr_p = fr.lock() ) {
+        if( shared_ptr_fast<Creature> const fr_p = fr.lock() ) {
             center += fr_p->pos();
         }
     }
 
-    float friend_count = ai_cache.friends.size();
+    float const friend_count = ai_cache.friends.size();
     center.x = std::round( center.x / friend_count );
     center.y = std::round( center.y / friend_count );
     center.z = std::round( center.z / friend_count );
@@ -2553,7 +2553,7 @@ void npc::avoid_friendly_fire()
      * We pass a <danger> value of NPC_DANGER_VERY_LOW + 1 so that we won't start
      * eating food (or, god help us, sleeping).
      */
-    npc_action action = address_needs( NPC_DANGER_VERY_LOW + 1 );
+    npc_action const action = address_needs( NPC_DANGER_VERY_LOW + 1 );
     if( action == npc_undecided ) {
         move_pause();
     }
@@ -2576,7 +2576,7 @@ void npc::move_away_from( const tripoint &pt, bool no_bash_atk, std::set<tripoin
     tripoint best_pos = pos();
     int best = -1;
     int chance = 2;
-    map &here = get_map();
+    map  const&here = get_map();
     for( const tripoint &p : here.points_in_radius( pos(), 1 ) ) {
         if( nomove != nullptr && nomove->find( p ) != nomove->end() ) {
             continue;
@@ -2613,7 +2613,7 @@ void npc::move_away_from( const tripoint &pt, bool no_bash_atk, std::set<tripoin
 
 bool npc::find_job_to_perform()
 {
-    for( activity_id &elem : job.get_prioritised_vector() ) {
+    for( activity_id  const&elem : job.get_prioritised_vector() ) {
         if( job.get_priority_of_job( elem ) == 0 ) {
             continue;
         }
@@ -2630,7 +2630,7 @@ bool npc::find_job_to_perform()
 
 void npc::worker_downtime()
 {
-    map &here = get_map();
+    map  const&here = get_map();
     // are we already in a chair
     if( here.has_flag_furn( "CAN_SIT", pos() ) ) {
         // just chill here
@@ -2841,8 +2841,8 @@ void npc::find_item()
     fetching_item = false;
     int best_value = minimum_item_value();
     // Not perfect, but has to mirror pickup code
-    units::volume volume_allowed = volume_capacity() - volume_carried();
-    units::mass   weight_allowed = weight_capacity() - weight_carried();
+    units::volume const volume_allowed = volume_capacity() - volume_carried();
+    units::mass   const weight_allowed = weight_capacity() - weight_carried();
     // For some reason range limiting by vision doesn't work properly
     const int range = 6;
     //int range = sight_range( g->light_level( posz() ) );
@@ -2867,14 +2867,14 @@ void npc::find_item()
         }
         std::vector<npc *> followers;
         for( auto &elem : g->get_follower_list() ) {
-            shared_ptr_fast<npc> npc_to_get = overmap_buffer.find_npc( elem );
+            shared_ptr_fast<npc> const npc_to_get = overmap_buffer.find_npc( elem );
             if( !npc_to_get ) {
                 continue;
             }
             npc *npc_to_add = npc_to_get.get();
             followers.push_back( npc_to_add );
         }
-        Character &player_character = get_player_character();
+        Character  const&player_character = get_player_character();
         for( auto &elem : followers ) {
             if( !it.is_owned_by( *this, true ) && ( player_character.sees( this->pos() ) ||
                                                     player_character.sees( wanted_item_pos ) ||
@@ -2888,7 +2888,7 @@ void npc::find_item()
 
         // When using a whitelist, skip the value check
         // TODO: Whitelist hierarchy?
-        int itval = whitelisting ? 1000 : value( it );
+        int const itval = whitelisting ? 1000 : value( it );
 
         if( itval > best_value &&
             ( it.volume() <= volume_allowed && it.weight() <= weight_allowed ) ) {
@@ -2934,7 +2934,7 @@ void npc::find_item()
         if( vp ) {
             const std::optional<vpart_reference> cargo = vp.part_with_feature( VPFLAG_CARGO, true );
             if( cargo ) {
-                vehicle_stack v_stack = cargo->vehicle().get_items( cargo->part_index() );
+                vehicle_stack const v_stack = cargo->vehicle().get_items( cargo->part_index() );
                 num_items += v_stack.size();
             }
         }
@@ -3048,7 +3048,7 @@ void npc::pick_up_item()
 
     const int dist_to_pickup = rl_dist( pos(), wanted_item_pos );
 
-    bool cant_reach = dist_to_pickup > 1 ||
+    bool const cant_reach = dist_to_pickup > 1 ||
                       get_map().obstructed_by_vehicle_rotation( pos(), wanted_item_pos );
     if( cant_reach && !path.empty() ) {
         add_msg( m_debug, "Moving; [%d, %d, %d] => [%d, %d, %d]",
@@ -3081,9 +3081,9 @@ void npc::pick_up_item()
             return;
         }
     }
-    Character &player_character = get_player_character();
+    Character  const&player_character = get_player_character();
     // Describe the pickup to the player
-    bool u_see = player_character.sees( *this ) || player_character.sees( wanted_item_pos );
+    bool const u_see = player_character.sees( *this ) || player_character.sees( wanted_item_pos );
     if( u_see ) {
         if( picked_up.size() == 1 ) {
             add_msg( _( "%1$s picks up a %2$s." ), name, picked_up.front().tname() );
@@ -3098,7 +3098,7 @@ void npc::pick_up_item()
     }
 
     for( auto &it : picked_up ) {
-        int itval = value( it );
+        int const itval = value( it );
         if( itval < worst_item_value ) {
             worst_item_value = itval;
         }
@@ -3143,7 +3143,7 @@ std::list<item> npc_pickup_from_stack( npc &who, T &items )
             continue;
         }
 
-        int itval = whitelisting ? 1000 : who.value( it );
+        int const itval = whitelisting ? 1000 : who.value( it );
         if( itval < min_value ) {
             iter++;
             continue;
@@ -3196,7 +3196,7 @@ void npc::drop_items( units::mass drop_weight, units::volume drop_volume, int mi
     // First fill our ratio vectors, so we know which things to drop first
     invslice slice = inv.slice();
     for( size_t i = 0; i < slice.size(); i++ ) {
-        item &it = slice[i]->front();
+        item  const&it = slice[i]->front();
         double wgt_ratio = 0.0;
         double vol_ratio = 0.0;
         if( value( it ) == 0 || value( it ) <= min_val ) {
@@ -3235,9 +3235,9 @@ void npc::drop_items( units::mass drop_weight, units::volume drop_volume, int mi
     while( weight_dropped < drop_weight || volume_dropped < drop_volume ) {
         // weight and volume may be passed as 0 or a negative value, to indicate that
         // decreasing that variable is not important.
-        int dWeight = units::to_gram<int>( drop_weight ) <= 0 ? -1 :
+        int const dWeight = units::to_gram<int>( drop_weight ) <= 0 ? -1 :
                       units::to_gram<int>( drop_weight - weight_dropped ) / 250;
-        int dVolume = units::to_milliliter<int>( drop_volume ) <= 0 ? -1 :
+        int const dVolume = units::to_milliliter<int>( drop_volume ) <= 0 ? -1 :
                       units::to_milliliter<int>( drop_volume - volume_dropped ) / 250;
         int index;
         // Which is more important, weight or volume?
@@ -3266,7 +3266,7 @@ void npc::drop_items( units::mass drop_weight, units::volume drop_volume, int mi
         }
         weight_dropped += slice[index]->front().weight();
         volume_dropped += slice[index]->front().volume();
-        item dropped = i_rem( index );
+        item const dropped = i_rem( index );
         num_items_dropped++;
         if( num_items_dropped == 1 ) {
             item_name += dropped.tname();
@@ -3291,7 +3291,7 @@ void npc::drop_items( units::mass drop_weight, units::volume drop_volume, int mi
 
 bool npc::find_corpse_to_pulp()
 {
-    Character &player_character = get_player_character();
+    Character  const&player_character = get_player_character();
     if( ( is_player_ally() && ( !rules.has_flag( ally_rule::allow_pulp ) ||
                                 player_character.in_vehicle ) ) ||
         is_hallucination() ) {
@@ -3380,7 +3380,7 @@ bool npc::do_pulp()
         return false;
     }
     // TODO: Don't recreate the activity every time
-    int old_moves = moves;
+    int const old_moves = moves;
     assign_activity( ACT_PULP, calendar::INDEFINITELY_LONG, 0 );
     activity.placement = get_map().getabs( *pulp_location );
     activity.do_turn( *this );
@@ -3389,7 +3389,7 @@ bool npc::do_pulp()
 
 bool npc::do_player_activity()
 {
-    int old_moves = moves;
+    int const old_moves = moves;
     if( moves > 200 && activity && ( activity.is_multi_type() ||
                                      activity.id() == activity_id( "ACT_TIDY_UP" ) ) ) {
         // a huge backlog of a multi-activity type can forever loop
@@ -3454,9 +3454,9 @@ bool npc::wield_better_weapon()
     }
 
     // TODO: Allow wielding weaker weapons against weaker targets
-    bool can_use_gun = ( ( !is_player_ally() || rules.has_flag( ally_rule::use_guns ) ) &&
+    bool const can_use_gun = ( ( !is_player_ally() || rules.has_flag( ally_rule::use_guns ) ) &&
                          ( ai_cache.danger >= 3 || emergency() || dist < 0 ) );
-    bool use_silent = ( is_player_ally() && rules.has_flag( ally_rule::use_silent ) );
+    bool const use_silent = ( is_player_ally() && rules.has_flag( ally_rule::use_silent ) );
 
     // Check if there's something better to wield
     item *best = &primary_weapon();
@@ -3466,7 +3466,7 @@ bool npc::wield_better_weapon()
     const auto compare_weapon =
     [this, &best, &best_dps, can_use_gun, use_silent, dist, &mode_pairs ]( const item & it ) {
         // If dist is 1 then we're in melee range, so disallow shooting guns.
-        bool gun_usable = can_use_gun && ( dist > 1 || dist == -1 ) && ( !use_silent || it.is_silent() );
+        bool const gun_usable = can_use_gun && ( dist > 1 || dist == -1 ) && ( !use_silent || it.is_silent() );
         double dps = 0.0f;
         auto [mode_id, mode_] = npc_ai::best_mode_for_range( *this, it, dist );
 
@@ -3678,7 +3678,7 @@ bool npc::alt_attack()
         return false;
     }
 
-    int weapon_index = get_item_position( used );
+    int const weapon_index = get_item_position( used );
     if( weapon_index == INT_MIN ) {
         debugmsg( "npc::alt_attack() couldn't find expected item %s", used->tname() );
         return false;
@@ -3693,7 +3693,7 @@ bool npc::alt_attack()
     }
 
     // We are throwing it!
-    int conf = confident_throw_range( *used, critter );
+    int const conf = confident_throw_range( *used, critter );
     const bool wont_hit = wont_hit_friend( tar, *used, true );
     if( dist <= conf && wont_hit ) {
         npc_throw( *this, *used, weapon_index, tar );
@@ -3714,12 +3714,12 @@ bool npc::alt_attack()
         return true;
     }
 
-    map &here = get_map();
+    map  const&here = get_map();
     // We need to throw this live (grenade, etc) NOW! Pick another target?
     for( int dist = 2; dist <= conf; dist++ ) {
         for( const tripoint &pt : here.points_in_radius( pos(), dist ) ) {
             const monster *const target_ptr = g->critter_at<monster>( pt );
-            int newdist = rl_dist( pos(), pt );
+            int const newdist = rl_dist( pos(), pt );
             // TODO: Change "newdist >= 2" to "newdist >= safe_distance(used)"
             if( newdist <= conf && newdist >= 2 && target_ptr &&
                 wont_hit_friend( pt, *used, true ) ) {
@@ -3742,7 +3742,7 @@ bool npc::alt_attack()
     int best_dist = 0;
     for( int dist = 2; dist <= conf; dist++ ) {
         for( const tripoint &pt : here.points_in_radius( pos(), dist ) ) {
-            int new_dist = rl_dist( pos(), pt );
+            int const new_dist = rl_dist( pos(), pt );
             if( new_dist > best_dist && wont_hit_friend( pt, *used, true ) ) {
                 best_dist = new_dist;
                 tar = pt;
@@ -3774,7 +3774,7 @@ void npc::activate_item( int item_index )
 
 void npc::heal_player( player &patient )
 {
-    int dist = rl_dist( pos(), patient.pos() );
+    int const dist = rl_dist( pos(), patient.pos() );
 
     if( dist > 1 ) {
         // We need to move to the player
@@ -3783,9 +3783,9 @@ void npc::heal_player( player &patient )
         return;
     }
 
-    Character &player_character = get_player_character();
+    Character  const&player_character = get_player_character();
     // Close enough to heal!
-    bool u_see = player_character.sees( *this ) || player_character.sees( patient );
+    bool const u_see = player_character.sees( *this ) || player_character.sees( patient );
     if( u_see ) {
         add_msg( _( "%1$s heals %2$s." ), disp_name(), patient.disp_name() );
     }
@@ -3796,7 +3796,7 @@ void npc::heal_player( player &patient )
         return;
     }
     if( !is_hallucination() ) {
-        int charges_used = used.type->invoke( *this, used, patient.pos(), "heal" );
+        int const charges_used = used.type->invoke( *this, used, patient.pos(), "heal" );
         consume_charges( used, charges_used );
     } else {
         pretend_heal( patient, used );
@@ -3845,7 +3845,7 @@ void npc::heal_self()
     }
     warn_about( "heal_self", 1_turns );
 
-    int charges_used = used.type->invoke( *this, used, pos(), "heal" );
+    int const charges_used = used.type->invoke( *this, used, pos(), "heal" );
     if( used.is_medication() ) {
         consume_charges( used, charges_used );
     }
@@ -3863,7 +3863,7 @@ void npc::use_painkiller()
         if( get_player_character().sees( *this ) ) {
             add_msg( _( "%1$s takes some %2$s." ), disp_name(), it->tname() );
         }
-        item_location loc = item_location( *this, it );
+        item_location const loc = item_location( *this, it );
         consume( loc );
         moves = 0;
     }
@@ -3886,8 +3886,8 @@ static float rate_food( const item &it, int want_nutr, int want_quench )
         return 0.0;
     }
 
-    int nutr = food->get_default_nutr();
-    int quench = food->quench;
+    int const nutr = food->get_default_nutr();
+    int const quench = food->quench;
 
     if( nutr <= 0 && quench <= 0 ) {
         // Not food - may be salt, drugs etc.
@@ -3912,7 +3912,7 @@ static float rate_food( const item &it, int want_nutr, int want_quench )
         return 0.0f;
     }
 
-    double relative_rot = it.get_relative_rot();
+    double const relative_rot = it.get_relative_rot();
     if( relative_rot >= 1.0f ) {
         // TODO: Allow sapro mutants to eat it anyway and make them prefer it
         return 0.0f;
@@ -3961,7 +3961,7 @@ bool npc::consume_food_from_camp()
     if( !is_player_ally() ) {
         return false;
     }
-    Character &player_character = get_player_character();
+    Character  const&player_character = get_player_character();
     std::optional<basecamp *> potential_bc;
     for( const tripoint_abs_omt &camp_pos : player_character.camps ) {
         if( rl_dist( camp_pos, global_omt_location() ) < 3 ) {
@@ -3981,7 +3981,7 @@ bool npc::consume_food_from_camp()
         return true;
     }
     faction *yours = player_character.get_faction();
-    int camp_kcals = std::min( std::max( 0, 19 * max_stored_kcal() / 20 - get_stored_kcal() -
+    int const camp_kcals = std::min( std::max( 0, 19 * max_stored_kcal() / 20 - get_stored_kcal() -
                                          stomach.get_calories() ), yours->food_supply );
     if( camp_kcals > 0 ) {
         complain_about( "camp_food_thanks", 1_hours, "<camp_food_thanks>", false );
@@ -3997,13 +3997,13 @@ bool npc::consume_food()
 {
     float best_weight = 0.0f;
     int index = -1;
-    int want_hunger = std::max<int>( 0, ( max_stored_kcal() - get_stored_kcal() ) / 10 );
-    int want_quench = std::max( 0, get_thirst() );
+    int const want_hunger = std::max<int>( 0, ( max_stored_kcal() - get_stored_kcal() ) / 10 );
+    int const want_quench = std::max( 0, get_thirst() );
     invslice slice = inv.slice();
     for( size_t i = 0; i < slice.size(); i++ ) {
         const item &it = slice[i]->front();
         if( const item *food_item = it.get_food() ) {
-            float cur_weight = rate_food( *food_item, want_hunger, want_quench );
+            float const cur_weight = rate_food( *food_item, want_hunger, want_quench );
             // Note: will_eat is expensive, avoid calling it if possible
             if( cur_weight > best_weight && will_eat( *food_item ).success() ) {
                 best_weight = cur_weight;
@@ -4023,11 +4023,11 @@ bool npc::consume_food()
 
     // consume doesn't return a meaningful answer, we need to compare moves
     // TODO: Make player::consume return false if it fails to consume
-    int old_moves = moves;
-    item_location loc = item_location( *this, &i_at( index ) );
+    int const old_moves = moves;
+    item_location const loc = item_location( *this, &i_at( index ) );
     consume( loc );
     // TODO: a more reliable check for whether item has been consumed
-    bool consumed = old_moves != moves;
+    bool const consumed = old_moves != moves;
     if( !consumed ) {
         debugmsg( "%s failed to consume %s", name, i_at( index ).tname() );
     }
@@ -4047,7 +4047,7 @@ void npc::mug_player( Character &mark )
         return;
     }
 
-    Character &player_character = get_player_character();
+    Character  const&player_character = get_player_character();
     const bool u_see = player_character.sees( *this ) || player_character.sees( mark );
     if( mark.cash > 0 ) {
         if( !is_hallucination() ) { // hallucinations can't take items
@@ -4078,7 +4078,7 @@ void npc::mug_player( Character &mark )
     }
     double best_value = minimum_item_value() * value_mod;
     item *to_steal = nullptr;
-    invslice slice = mark.inv.slice();
+    invslice const slice = mark.inv.slice();
     for( std::list<item> *stack : slice ) {
         item &front_stack = stack->front();
         if( value( front_stack ) >= best_value &&
@@ -4172,12 +4172,12 @@ void npc::reach_omt_destination()
     if( !omt_path.empty() ) {
         omt_path.clear();
     }
-    map &here = get_map();
+    map  const&here = get_map();
     if( is_travelling() ) {
         guard_pos = here.getabs( pos() );
         goal = no_goal_point;
         if( is_player_ally() ) {
-            Character &player_character = get_player_character();
+            Character  const&player_character = get_player_character();
             talk_function::assign_guard( *this );
             if( rl_dist( player_character.pos(), pos() ) > SEEX * 2 || !player_character.sees( pos() ) ) {
                 if( player_character.has_item_with_flag( "TWO_WAY_RADIO", true ) &&
@@ -4264,7 +4264,7 @@ void npc::set_omt_destination()
         needs.push_back( need_none );
     }
 
-    std::string dest_type;
+    std::string const dest_type;
     for( const auto &fulfill : needs ) {
         // look for the closest occurence of any of that locations terrain types
         std::vector<oter_type_id> loc_list = get_location_for( fulfill )->get_all_terrains();
@@ -4315,7 +4315,7 @@ void npc::set_omt_destination()
 
 void npc::go_to_omt_destination()
 {
-    map &here = get_map();
+    map  const&here = get_map();
     if( ai_cache.guard_pos ) {
         if( here.getabs( pos() ) == *ai_cache.guard_pos ) {
             path.clear();
@@ -4360,7 +4360,7 @@ void npc::go_to_omt_destination()
         }
     }
     // TODO: fix point types
-    tripoint sm_tri =
+    tripoint const sm_tri =
         here.getlocal( project_to<coords::ms>( omt_path.back() ).raw() );
     tripoint centre_sub = sm_tri + point( SEEX, SEEY );
     if( !here.passable( centre_sub ) ) {
@@ -4613,9 +4613,9 @@ bool npc::complain()
     // When infected, complain every (4-intensity) hours
     // At intensity 3, ignore player wanting us to shut up
     if( has_effect( effect_infected ) ) {
-        body_part bp = bp_affected( *this, effect_infected );
+        body_part const bp = bp_affected( *this, effect_infected );
         const auto &eff = get_effect( effect_infected, bp );
-        int intensity = eff.get_intensity();
+        int const intensity = eff.get_intensity();
         const std::string speech = string_format( _( "My %s wound is infected…" ),
                                    body_part_name( bp ) );
         if( complain_about( infected_string, time_duration::from_hours( 4 - intensity ), speech,
@@ -4627,7 +4627,7 @@ bool npc::complain()
 
     // When bitten, complain every hour, but respect restrictions
     if( has_effect( effect_bite ) ) {
-        body_part bp = bp_affected( *this, effect_bite );
+        body_part const bp = bp_affected( *this, effect_bite );
         const std::string speech = string_format( _( "The bite wound on my %s looks bad." ),
                                    body_part_name( bp ) );
         if( complain_about( bite_string, 1_hours, speech ) ) {
@@ -4646,7 +4646,7 @@ bool npc::complain()
     // Radiation every 10 minutes
     if( get_rad() > 90 ) {
         activate_bionic_by_id( bio_radscrubber );
-        std::string speech = _( "I'm suffering from radiation sickness…" );
+        std::string const speech = _( "I'm suffering from radiation sickness…" );
         if( complain_about( radiation_string, 10_minutes, speech, get_rad() > 150 ) ) {
             return true;
         }
@@ -4671,8 +4671,8 @@ bool npc::complain()
 
     //Bleeding every 5 minutes
     if( has_effect( effect_bleed ) ) {
-        body_part bp = bp_affected( *this, effect_bleed );
-        std::string speech = string_format( _( "My %s is bleeding!" ), body_part_name( bp ) );
+        body_part const bp = bp_affected( *this, effect_bleed );
+        std::string const speech = string_format( _( "My %s is bleeding!" ), body_part_name( bp ) );
         if( complain_about( bleed_string, 5_minutes, speech ) ) {
             return true;
         }
@@ -4697,10 +4697,10 @@ void npc::do_reload( const item &it )
 
     // If in danger, don't spend multiple turns reloading a weapon to full one by one.
     // Get enough to shoot the enemy once, then unload it on them.
-    int qty = ai_cache.danger > 0 ? std::max( 1, std::min( usable_ammo->charges,
+    int const qty = ai_cache.danger > 0 ? std::max( 1, std::min( usable_ammo->charges,
               it.ammo_required() - it.ammo_remaining() ) ) :
               std::max( 1, std::min( usable_ammo->charges, it.ammo_capacity() - it.ammo_remaining() ) );
-    int reload_time = item_reload_cost( it, *usable_ammo, qty );
+    int const reload_time = item_reload_cost( it, *usable_ammo, qty );
     // TODO: Consider printing this info to player too
     const std::string ammo_name = usable_ammo->tname();
     if( !target.reload( *this, std::move( usable_ammo ), qty ) ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -492,7 +492,7 @@ void npc::assess_danger()
         float const scaled_distance = std::max( 1.0f, dist / critter.speed_rating() );
         float const hp_percent = 1.0f - static_cast<float>( critter.get_hp() ) / critter.get_hp_max();
         float const critter_danger = std::max( critter_threat * ( hp_percent * 0.5f + 0.5f ),
-                                         NPC_DANGER_VERY_LOW );
+                                               NPC_DANGER_VERY_LOW );
         ai_cache.total_danger += critter_danger / scaled_distance;
 
         // don't ignore monsters that are too close or too close to an ally if we can move
@@ -518,7 +518,7 @@ void npc::assess_danger()
         // us or an ally
         // critter danger is always at least NPC_DANGER_VERY_LOW
         float const priority = std::max( critter_danger - 2.0f * ( scaled_distance - 1.0f ),
-                                   is_too_close ? critter_danger : 0.0f );
+                                         is_too_close ? critter_danger : 0.0f );
         cur_threat_map[direction_from( pos(), critter.pos() )] += priority;
         if( priority > highest_priority ) {
             highest_priority = priority;
@@ -560,8 +560,8 @@ void npc::assess_danger()
 
         if( !is_player_ally() || is_too_close || ok_by_rules( foe, dist, scaled_distance ) ) {
             float const priority = std::max( foe_threat - 2.0f * ( scaled_distance - 1 ),
-                                       is_too_close ? std::max( foe_threat, NPC_DANGER_VERY_LOW ) :
-                                       0.0f );
+                                             is_too_close ? std::max( foe_threat, NPC_DANGER_VERY_LOW ) :
+                                             0.0f );
             cur_threat_map[direction_from( pos(), foe.pos() )] += priority;
             if( priority > highest_priority ) {
                 warn_about( warning, 1_minutes );
@@ -650,7 +650,7 @@ float npc::character_danger( const Character &u ) const
 
 void npc::regen_ai_cache()
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     auto i = std::begin( ai_cache.sound_alerts );
     while( i != std::end( ai_cache.sound_alerts ) ) {
         if( sees( here.getlocal( i->abs_pos ) ) ) {
@@ -680,7 +680,7 @@ void npc::regen_ai_cache()
     }
     // Non-allied NPCs with a completed mission should move to the player
     if( !is_player_ally() && !is_stationary( true ) ) {
-        Character  const&player_character = get_player_character();
+        Character  const &player_character = get_player_character();
         for( auto &miss : chatbin.missions_assigned ) {
             if( miss->is_complete( getID() ) ) {
                 // unless the player found an item and already told the NPC he wanted to keep it
@@ -770,7 +770,7 @@ void npc::move()
         ai_cache.target = g->shared_from( player_character );
     }
 
-    map  const&here = get_map();
+    map  const &here = get_map();
     if( !ai_cache.dangerous_explosives.empty() ) {
         action = npc_escape_explosion;
     } else if( target == &player_character && attitude == NPCATT_FLEE_TEMP ) {
@@ -970,7 +970,7 @@ void npc::execute_action( npc_action action )
     */
 
     Character &player_character = get_player_character();
-    map  const&here = get_map();
+    map  const &here = get_map();
     switch( action ) {
         case npc_pause:
             move_pause();
@@ -1105,7 +1105,7 @@ void npc::execute_action( npc_action action )
 
             if( !mode ) {
                 std::string const error_weapon = cbm_active.is_null() ? primary_weapon().tname() :
-                                           cbm_fake_active.tname();
+                                                 cbm_fake_active.tname();
                 debugmsg( "NPC tried to shoot %s without valid mode.", error_weapon );
             }
 
@@ -1338,7 +1338,7 @@ npc_action npc::method_of_fleeing()
 
 npc_action npc::method_of_attack()
 {
-    Character  const&player_character = get_player_character();
+    Character  const &player_character = get_player_character();
     Creature *critter = current_target();
     if( critter == nullptr ) {
         // This function shouldn't be called...
@@ -1358,7 +1358,7 @@ npc_action npc::method_of_attack()
     // NPCs engage in free fire can move to avoid allies, but not if they're in a vehicle
     const bool dont_move_ff = in_vehicle || rules.engagement == combat_engagement::NO_MOVE;
     bool const can_use_gun = ( ( !is_player_ally() || rules.has_flag( ally_rule::use_guns ) ) &&
-                         ( ai_cache.danger >= 3 || emergency() || dist < 0 ) );
+                               ( ai_cache.danger >= 3 || emergency() || dist < 0 ) );
     bool const use_silent = ( is_player_ally() && rules.has_flag( ally_rule::use_silent ) );
 
     // if there's enough of a threat to be here, power up the combat CBMs
@@ -1417,7 +1417,7 @@ npc_action npc::method_of_attack()
 
     // TODO: Needs a check for transparent but non-passable tiles on the way
     int const effective_range = g_mode ? confident_gun_mode_range( g_mode,
-                          ranged::get_most_accurate_sight( *this, *g_mode ) ) : 0;
+                                ranged::get_most_accurate_sight( *this, *g_mode ) ) : 0;
     if( g_mode && sees( *critter ) && ranged::aim_per_move( *this, *g_mode, recoil ) > 0 &&
         effective_range >= dist ) {
         add_msg( m_debug, "%s is aiming", disp_name() );
@@ -1459,7 +1459,7 @@ static bool wants_to_reload_with( const item &weap, const item &ammo, bool dange
     // To prevent them from constantly swapping magazines while entering range.
     // If not in danger, swap magazines if ammo is greater than current.
     bool const want_swap = ammo.ammo_remaining() > weap.ammo_remaining() && ( !danger ||
-                     ammo.ammo_remaining() > weap.ammo_required() );
+                           ammo.ammo_remaining() > weap.ammo_required() );
     return combat_reload || want_swap;
 }
 
@@ -1678,7 +1678,7 @@ bool npc::recharge_cbm()
         return true;
     }
 
-    for( bionic_id  const&bid : get_fueled_bionics() ) {
+    for( bionic_id  const &bid : get_fueled_bionics() ) {
         if( has_active_bionic( bid ) ) {
             continue;
         }
@@ -1834,7 +1834,7 @@ npc_action npc::address_needs( float danger )
 
     check_or_reload_cbm();
 
-    item  const&reloadable = find_reloadable();
+    item  const &reloadable = find_reloadable();
     if( !reloadable.is_null() ) {
         do_reload( reloadable );
         return npc_noop;
@@ -1920,7 +1920,7 @@ npc_action npc::address_needs( float danger )
 
 npc_action npc::address_player()
 {
-    Character  const&player_character = get_player_character();
+    Character  const &player_character = get_player_character();
     if( ( attitude == NPCATT_TALK ) && sees( player_character ) ) {
         if( player_character.in_sleep_state() ) {
             // Leave sleeping characters alone.
@@ -2052,7 +2052,8 @@ int npc::confident_gun_mode_range( const gun_mode &gun, int at_recoil ) const
     // Doesn't use calculate_dispersion because that requires a map
     // TODO: Turn this into a common function.
     int const gun_recoil = gun->gun_recoil();
-    int const eff_recoil = at_recoil + ( gun.qty > 1 ? ranged::burst_penalty( *this, *gun, gun_recoil ) : 0 );
+    int const eff_recoil = at_recoil + ( gun.qty > 1 ? ranged::burst_penalty( *this, *gun,
+                                         gun_recoil ) : 0 );
     dispersion_sources mode_disp = ranged::get_weapon_dispersion( *this, *gun );
     mode_disp.add_range( eff_recoil );
     double max_dispersion = mode_disp.max();
@@ -2070,7 +2071,7 @@ int npc::confident_throw_range( const item &thrown, Creature *target ) const
 {
     double const average_dispersion = ranged::throwing_dispersion( *this, thrown, target, false ) / 2.0;
     double const even_chance_range = ( target == nullptr ? 0.5 : target->ranged_target_size() ) /
-                               average_dispersion;
+                                     average_dispersion;
     double const confident_range = even_chance_range * confidence_mult();
     add_msg( m_debug, "confident_throw_range == %d", static_cast<int>( confident_range ) );
     return static_cast<int>( confident_range );
@@ -2121,8 +2122,8 @@ bool npc::wont_hit_friend( const tripoint &tar, const item &it, bool throwing ) 
 {
     // TODO: Get actual dispersion instead of extracting it (badly) from confident range
     int const confident = throwing ?
-                    confident_throw_range( it, nullptr ) :
-                    confident_shoot_range( it, ranged::recoil_total( *this ) );
+                          confident_throw_range( it, nullptr ) :
+                          confident_shoot_range( it, ranged::recoil_total( *this ) );
     // if there is no confidence at using weapon, it's not used at range
     // zero confidence leads to divide by zero otherwise
     if( confident < 1 ) {
@@ -2167,7 +2168,7 @@ bool npc::wont_hit_friend( const tripoint &tar, const item &it, bool throwing ) 
 bool npc::enough_time_to_reload( const item &gun ) const
 {
     int const rltime = item_reload_cost( gun, item( gun.ammo_default() ),
-                                   gun.ammo_capacity() );
+                                         gun.ammo_capacity() );
     const float turns_til_reloaded = static_cast<float>( rltime ) / get_speed();
 
     const Creature *target = current_target();
@@ -2255,7 +2256,7 @@ bool npc::can_open_door( const tripoint &p, const bool inside ) const
 
 bool npc::can_move_to( const tripoint &p, bool no_bashing ) const
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     // Allow moving into any bashable spots, but penalize them during pathing
     // Doors are not passable for hallucinations
     return( rl_dist( pos(), p ) <= 1 && here.has_floor( p ) && !g->is_dangerous_tile( p ) &&
@@ -2576,7 +2577,7 @@ void npc::move_away_from( const tripoint &pt, bool no_bash_atk, std::set<tripoin
     tripoint best_pos = pos();
     int best = -1;
     int chance = 2;
-    map  const&here = get_map();
+    map  const &here = get_map();
     for( const tripoint &p : here.points_in_radius( pos(), 1 ) ) {
         if( nomove != nullptr && nomove->find( p ) != nomove->end() ) {
             continue;
@@ -2613,7 +2614,7 @@ void npc::move_away_from( const tripoint &pt, bool no_bash_atk, std::set<tripoin
 
 bool npc::find_job_to_perform()
 {
-    for( activity_id  const&elem : job.get_prioritised_vector() ) {
+    for( activity_id  const &elem : job.get_prioritised_vector() ) {
         if( job.get_priority_of_job( elem ) == 0 ) {
             continue;
         }
@@ -2630,7 +2631,7 @@ bool npc::find_job_to_perform()
 
 void npc::worker_downtime()
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     // are we already in a chair
     if( here.has_flag_furn( "CAN_SIT", pos() ) ) {
         // just chill here
@@ -2874,7 +2875,7 @@ void npc::find_item()
             npc *npc_to_add = npc_to_get.get();
             followers.push_back( npc_to_add );
         }
-        Character  const&player_character = get_player_character();
+        Character  const &player_character = get_player_character();
         for( auto &elem : followers ) {
             if( !it.is_owned_by( *this, true ) && ( player_character.sees( this->pos() ) ||
                                                     player_character.sees( wanted_item_pos ) ||
@@ -3049,7 +3050,7 @@ void npc::pick_up_item()
     const int dist_to_pickup = rl_dist( pos(), wanted_item_pos );
 
     bool const cant_reach = dist_to_pickup > 1 ||
-                      get_map().obstructed_by_vehicle_rotation( pos(), wanted_item_pos );
+                            get_map().obstructed_by_vehicle_rotation( pos(), wanted_item_pos );
     if( cant_reach && !path.empty() ) {
         add_msg( m_debug, "Moving; [%d, %d, %d] => [%d, %d, %d]",
                  posx(), posy(), posz(), path[0].x, path[0].y, path[0].z );
@@ -3081,7 +3082,7 @@ void npc::pick_up_item()
             return;
         }
     }
-    Character  const&player_character = get_player_character();
+    Character  const &player_character = get_player_character();
     // Describe the pickup to the player
     bool const u_see = player_character.sees( *this ) || player_character.sees( wanted_item_pos );
     if( u_see ) {
@@ -3196,7 +3197,7 @@ void npc::drop_items( units::mass drop_weight, units::volume drop_volume, int mi
     // First fill our ratio vectors, so we know which things to drop first
     invslice slice = inv.slice();
     for( size_t i = 0; i < slice.size(); i++ ) {
-        item  const&it = slice[i]->front();
+        item  const &it = slice[i]->front();
         double wgt_ratio = 0.0;
         double vol_ratio = 0.0;
         if( value( it ) == 0 || value( it ) <= min_val ) {
@@ -3236,9 +3237,9 @@ void npc::drop_items( units::mass drop_weight, units::volume drop_volume, int mi
         // weight and volume may be passed as 0 or a negative value, to indicate that
         // decreasing that variable is not important.
         int const dWeight = units::to_gram<int>( drop_weight ) <= 0 ? -1 :
-                      units::to_gram<int>( drop_weight - weight_dropped ) / 250;
+                            units::to_gram<int>( drop_weight - weight_dropped ) / 250;
         int const dVolume = units::to_milliliter<int>( drop_volume ) <= 0 ? -1 :
-                      units::to_milliliter<int>( drop_volume - volume_dropped ) / 250;
+                            units::to_milliliter<int>( drop_volume - volume_dropped ) / 250;
         int index;
         // Which is more important, weight or volume?
         if( dWeight > dVolume ) {
@@ -3291,7 +3292,7 @@ void npc::drop_items( units::mass drop_weight, units::volume drop_volume, int mi
 
 bool npc::find_corpse_to_pulp()
 {
-    Character  const&player_character = get_player_character();
+    Character  const &player_character = get_player_character();
     if( ( is_player_ally() && ( !rules.has_flag( ally_rule::allow_pulp ) ||
                                 player_character.in_vehicle ) ) ||
         is_hallucination() ) {
@@ -3455,7 +3456,7 @@ bool npc::wield_better_weapon()
 
     // TODO: Allow wielding weaker weapons against weaker targets
     bool const can_use_gun = ( ( !is_player_ally() || rules.has_flag( ally_rule::use_guns ) ) &&
-                         ( ai_cache.danger >= 3 || emergency() || dist < 0 ) );
+                               ( ai_cache.danger >= 3 || emergency() || dist < 0 ) );
     bool const use_silent = ( is_player_ally() && rules.has_flag( ally_rule::use_silent ) );
 
     // Check if there's something better to wield
@@ -3466,7 +3467,8 @@ bool npc::wield_better_weapon()
     const auto compare_weapon =
     [this, &best, &best_dps, can_use_gun, use_silent, dist, &mode_pairs ]( const item & it ) {
         // If dist is 1 then we're in melee range, so disallow shooting guns.
-        bool const gun_usable = can_use_gun && ( dist > 1 || dist == -1 ) && ( !use_silent || it.is_silent() );
+        bool const gun_usable = can_use_gun && ( dist > 1 || dist == -1 ) && ( !use_silent ||
+                                it.is_silent() );
         double dps = 0.0f;
         auto [mode_id, mode_] = npc_ai::best_mode_for_range( *this, it, dist );
 
@@ -3714,7 +3716,7 @@ bool npc::alt_attack()
         return true;
     }
 
-    map  const&here = get_map();
+    map  const &here = get_map();
     // We need to throw this live (grenade, etc) NOW! Pick another target?
     for( int dist = 2; dist <= conf; dist++ ) {
         for( const tripoint &pt : here.points_in_radius( pos(), dist ) ) {
@@ -3783,7 +3785,7 @@ void npc::heal_player( player &patient )
         return;
     }
 
-    Character  const&player_character = get_player_character();
+    Character  const &player_character = get_player_character();
     // Close enough to heal!
     bool const u_see = player_character.sees( *this ) || player_character.sees( patient );
     if( u_see ) {
@@ -3961,7 +3963,7 @@ bool npc::consume_food_from_camp()
     if( !is_player_ally() ) {
         return false;
     }
-    Character  const&player_character = get_player_character();
+    Character  const &player_character = get_player_character();
     std::optional<basecamp *> potential_bc;
     for( const tripoint_abs_omt &camp_pos : player_character.camps ) {
         if( rl_dist( camp_pos, global_omt_location() ) < 3 ) {
@@ -3982,7 +3984,7 @@ bool npc::consume_food_from_camp()
     }
     faction *yours = player_character.get_faction();
     int const camp_kcals = std::min( std::max( 0, 19 * max_stored_kcal() / 20 - get_stored_kcal() -
-                                         stomach.get_calories() ), yours->food_supply );
+                                     stomach.get_calories() ), yours->food_supply );
     if( camp_kcals > 0 ) {
         complain_about( "camp_food_thanks", 1_hours, "<camp_food_thanks>", false );
         mod_stored_kcal( camp_kcals );
@@ -4047,7 +4049,7 @@ void npc::mug_player( Character &mark )
         return;
     }
 
-    Character  const&player_character = get_player_character();
+    Character  const &player_character = get_player_character();
     const bool u_see = player_character.sees( *this ) || player_character.sees( mark );
     if( mark.cash > 0 ) {
         if( !is_hallucination() ) { // hallucinations can't take items
@@ -4172,12 +4174,12 @@ void npc::reach_omt_destination()
     if( !omt_path.empty() ) {
         omt_path.clear();
     }
-    map  const&here = get_map();
+    map  const &here = get_map();
     if( is_travelling() ) {
         guard_pos = here.getabs( pos() );
         goal = no_goal_point;
         if( is_player_ally() ) {
-            Character  const&player_character = get_player_character();
+            Character  const &player_character = get_player_character();
             talk_function::assign_guard( *this );
             if( rl_dist( player_character.pos(), pos() ) > SEEX * 2 || !player_character.sees( pos() ) ) {
                 if( player_character.has_item_with_flag( "TWO_WAY_RADIO", true ) &&
@@ -4315,7 +4317,7 @@ void npc::set_omt_destination()
 
 void npc::go_to_omt_destination()
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     if( ai_cache.guard_pos ) {
         if( here.getabs( pos() ) == *ai_cache.guard_pos ) {
             path.clear();
@@ -4698,8 +4700,8 @@ void npc::do_reload( const item &it )
     // If in danger, don't spend multiple turns reloading a weapon to full one by one.
     // Get enough to shoot the enemy once, then unload it on them.
     int const qty = ai_cache.danger > 0 ? std::max( 1, std::min( usable_ammo->charges,
-              it.ammo_required() - it.ammo_remaining() ) ) :
-              std::max( 1, std::min( usable_ammo->charges, it.ammo_capacity() - it.ammo_remaining() ) );
+                    it.ammo_required() - it.ammo_remaining() ) ) :
+                    std::max( 1, std::min( usable_ammo->charges, it.ammo_capacity() - it.ammo_remaining() ) );
     int const reload_time = item_reload_cost( it, *usable_ammo, qty );
     // TODO: Consider printing this info to player too
     const std::string ammo_name = usable_ammo->tname();

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -147,7 +147,7 @@ int calc_skill_training_cost( const npc &p, const skill_id &skill )
     if( p.is_player_ally() ) {
         return 0;
     }
-    avatar &you = get_avatar();
+    avatar  const&you = get_avatar();
     return 1000 * ( 1 + you.get_skill_level( skill ) ) * ( 1 + you.get_skill_level( skill ) );
 }
 
@@ -186,7 +186,7 @@ int npc_trading::cash_to_favor( const npc &, int cash )
     // TODO: It should affect different NPCs to a different degree
     // Square root of mission value in dollars
     // ~31 for zed mom, 50 for horde master, ~63 for plutonium cells
-    double scaled_mission_val = std::sqrt( cash / 100.0 );
+    double const scaled_mission_val = std::sqrt( cash / 100.0 );
     return roll_remainder( scaled_mission_val );
 }
 
@@ -341,7 +341,7 @@ static void npc_temp_orders_menu( const std::vector<npc *> &npc_list )
 
 static void tell_veh_stop_following()
 {
-    for( wrapped_vehicle &veh : get_map().get_vehicles() ) {
+    for( wrapped_vehicle  const&veh : get_map().get_vehicles() ) {
         vehicle *v = veh.v;
         if( v->has_engine_type( fuel_type_animal, false ) && v->is_owned_by( get_avatar() ) ) {
             v->is_following = false;
@@ -352,7 +352,7 @@ static void tell_veh_stop_following()
 
 static void assign_veh_to_follow()
 {
-    for( wrapped_vehicle &veh : get_map().get_vehicles() ) {
+    for( wrapped_vehicle  const&veh : get_map().get_vehicles() ) {
         vehicle *v = veh.v;
         if( v->has_engine_type( fuel_type_animal, false ) && v->is_owned_by( get_avatar() ) ) {
             v->activate_animal_follow();
@@ -362,7 +362,7 @@ static void assign_veh_to_follow()
 
 static void tell_magic_veh_to_follow()
 {
-    for( wrapped_vehicle &veh : get_map().get_vehicles() ) {
+    for( wrapped_vehicle  const&veh : get_map().get_vehicles() ) {
         vehicle *v = veh.v;
         if( v->magic ) {
             for( const vpart_reference &vp : v->get_all_parts() ) {
@@ -378,7 +378,7 @@ static void tell_magic_veh_to_follow()
 
 static void tell_magic_veh_stop_following()
 {
-    for( wrapped_vehicle &veh : get_map().get_vehicles() ) {
+    for( wrapped_vehicle  const&veh : get_map().get_vehicles() ) {
         vehicle *v = veh.v;
         if( v->magic ) {
             for( const vpart_reference &vp : v->get_all_parts() ) {
@@ -518,7 +518,7 @@ void game::chat()
             message = _( "loudly." );
             break;
         case NPC_CHAT_SENTENCE: {
-            std::string popupdesc = _( "Enter a sentence to yell" );
+            std::string const popupdesc = _( "Enter a sentence to yell" );
             string_input_popup popup;
             popup.title( _( "Yell a sentence" ) )
             .width( 64 )
@@ -552,7 +552,7 @@ void game::chat()
                 return;
             }
 
-            map &here = get_map();
+            map  const&here = get_map();
             std::optional<tripoint> p = look_around();
 
             if( !p ) {
@@ -662,7 +662,7 @@ void game::chat()
 void npc::handle_sound( const sounds::sound_t spriority, const std::string &description,
                         int heard_volume, const tripoint &spos )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     const tripoint s_abs_pos = here.getabs( spos );
     const tripoint my_abs_pos = here.getabs( pos() );
 
@@ -670,9 +670,9 @@ void npc::handle_sound( const sounds::sound_t spriority, const std::string &desc
              disp_name(), description, static_cast<int>( spriority ), heard_volume,
              s_abs_pos.x, s_abs_pos.y, my_abs_pos.x, my_abs_pos.y );
 
-    bool player_ally = get_player_character().pos() == spos && is_player_ally();
+    bool const player_ally = get_player_character().pos() == spos && is_player_ally();
     player *const sound_source = g->critter_at<player>( spos );
-    bool npc_ally = sound_source && sound_source->is_npc() && is_ally( *sound_source );
+    bool const npc_ally = sound_source && sound_source->is_npc() && is_ally( *sound_source );
 
     if( ( player_ally || npc_ally ) && spriority == sounds::sound_t::order ) {
         say( "<acknowledged>" );
@@ -901,7 +901,7 @@ void npc::talk_to_u( bool radio_contact )
         }
         const talk_topic next = d.opt( d_win, name, d.topic_stack.back() );
         if( next.id == "TALK_NONE" ) {
-            int cat = topic_category( d.topic_stack.back() );
+            int const cat = topic_category( d.topic_stack.back() );
             do {
                 d.topic_stack.pop_back();
             } while( cat != -1 && topic_category( d.topic_stack.back() ) == cat );
@@ -961,8 +961,8 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic ) const
                    beta->name );
     }
     if( topic == "TALK_SEDATED" ) {
-        int firstaid_lvl = get_player_character().get_skill_level( skill_id( "firstaid" ) );
-        time_duration dur = character_funcs::estimate_effect_dur( firstaid_lvl, effect_narcosis, 15_minutes,
+        int const firstaid_lvl = get_player_character().get_skill_level( skill_id( "firstaid" ) );
+        time_duration const dur = character_funcs::estimate_effect_dur( firstaid_lvl, effect_narcosis, 15_minutes,
                             6, *beta );
         return string_format(
                    _( "%1$s is sedated and can't be moved or woken up until the medication or sedation wears off.\nYou estimate it will wear off in %2$s." ),
@@ -1013,8 +1013,8 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic ) const
         if( !you.backlog.empty() && you.backlog.front().id() == ACT_TRAIN ) {
             return _( "Shall we resume?" );
         }
-        std::vector<skill_id> trainable = p->skills_offered_to( you );
-        std::vector<matype_id> styles = p->styles_offered_to( you );
+        std::vector<skill_id> const trainable = p->skills_offered_to( you );
+        std::vector<matype_id> const styles = p->styles_offered_to( you );
         const std::vector<spell_id> spells = p->magic->spells();
         std::vector<spell_id> teachable_spells;
         for( const spell_id &sp : spells ) {
@@ -1088,29 +1088,29 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic ) const
         }
 
         std::string info = "&";
-        int str_range = static_cast<int>( 100 / ability );
-        int str_min = static_cast<int>( p->str_max / str_range ) * str_range;
+        int const str_range = static_cast<int>( 100 / ability );
+        int const str_min = static_cast<int>( p->str_max / str_range ) * str_range;
         info += string_format( _( "Str %d - %d" ), str_min, str_min + str_range );
 
         if( ability >= 40 ) {
-            int dex_range = static_cast<int>( 160 / ability );
-            int dex_min = static_cast<int>( p->dex_max / dex_range ) * dex_range;
+            int const dex_range = static_cast<int>( 160 / ability );
+            int const dex_min = static_cast<int>( p->dex_max / dex_range ) * dex_range;
             info += string_format( _( "  Dex %d - %d" ), dex_min, dex_min + dex_range );
         }
 
         if( ability >= 50 ) {
-            int int_range = static_cast<int>( 200 / ability );
-            int int_min = static_cast<int>( p->int_max / int_range ) * int_range;
+            int const int_range = static_cast<int>( 200 / ability );
+            int const int_min = static_cast<int>( p->int_max / int_range ) * int_range;
             info += string_format( _( "  Int %d - %d" ), int_min, int_min + int_range );
         }
 
         if( ability >= 60 ) {
-            int per_range = static_cast<int>( 240 / ability );
-            int per_min = static_cast<int>( p->per_max / per_range ) * per_range;
+            int const per_range = static_cast<int>( 240 / ability );
+            int const per_min = static_cast<int>( p->per_max / per_range ) * per_range;
             info += string_format( _( "  Per %d - %d" ), per_min, per_min + per_range );
         }
 
-        needs_rates rates = p->calc_needs_rates();
+        needs_rates const rates = p->calc_needs_rates();
         if( ability >= 100 - ( p->get_fatigue() / 10 ) ) {
             std::string how_tired;
             if( p->get_fatigue() > fatigue_levels::exhausted ) {
@@ -1122,7 +1122,7 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic ) const
             } else {
                 how_tired = _( "Not tired" );
                 if( ability >= 100 ) {
-                    time_duration sleep_at = 5_minutes * ( fatigue_levels::tired - p->get_fatigue() ) /
+                    time_duration const sleep_at = 5_minutes * ( fatigue_levels::tired - p->get_fatigue() ) /
                                              rates.fatigue;
                     how_tired += _( ".  Will need sleep in " ) + to_string_approx( sleep_at );
                 }
@@ -1131,7 +1131,7 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic ) const
         }
         if( ability >= 100 ) {
             if( p->get_thirst() < thirst_levels::thirsty ) {
-                time_duration thirst_at = 5_minutes * ( thirst_levels::thirsty - p->get_thirst() ) / rates.thirst;
+                time_duration const thirst_at = 5_minutes * ( thirst_levels::thirsty - p->get_thirst() ) / rates.thirst;
                 if( thirst_at > 1_hours ) {
                     info += _( "\nWill need water in " ) + to_string_approx( thirst_at );
                 }
@@ -1139,7 +1139,7 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic ) const
                 info += _( "\nThirsty" );
             }
             if( p->max_stored_kcal() - p->get_stored_kcal() > 500 ) {
-                time_duration hunger_at = 5_minutes
+                time_duration const hunger_at = 5_minutes
                                           * ( 500 - p->max_stored_kcal() + p->get_stored_kcal() )
                                           / p->bmr();
                 if( hunger_at > 1_hours ) {
@@ -1155,7 +1155,7 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic ) const
     } else if( topic == "TALK_OPINION" ) {
         return "&" + p->opinion_text();
     } else if( topic == "TALK_MIND_CONTROL" ) {
-        bool not_following = g->get_follower_list().count( p->getID() ) == 0;
+        bool const not_following = g->get_follower_list().count( p->getID() ) == 0;
         p->companion_mission_role_id.clear();
         talk_function::follow( *p );
         if( not_following ) {
@@ -1174,7 +1174,7 @@ void dialogue::apply_speaker_effects( const talk_topic &the_topic )
     if( iter == json_talk_topics.end() ) {
         return;
     }
-    for( json_dynamic_line_effect &npc_effect : iter->second.get_speaker_effects() ) {
+    for( json_dynamic_line_effect  const&npc_effect : iter->second.get_speaker_effects() ) {
         if( npc_effect.test_condition( *this ) ) {
             npc_effect.apply( *this );
         }
@@ -1281,7 +1281,7 @@ void dialogue::gen_responses( const talk_topic &the_topic )
     ret.clear();
     const auto iter = json_talk_topics.find( topic );
     if( iter != json_talk_topics.end() ) {
-        json_talk_topic &jtt = iter->second;
+        json_talk_topic  const&jtt = iter->second;
         if( jtt.gen_responses( *this ) ) {
             return;
         }
@@ -1329,8 +1329,8 @@ void dialogue::gen_responses( const talk_topic &the_topic )
                               "TALK_TRAIN_START", skillt );
             }
         }
-        std::vector<matype_id> styles = p->styles_offered_to( you );
-        std::vector<skill_id> trainable = p->skills_offered_to( you );
+        std::vector<matype_id> const styles = p->styles_offered_to( you );
+        std::vector<skill_id> const trainable = p->skills_offered_to( you );
         const std::vector<spell_id> spells = p->magic->spells();
         std::vector<spell_id> teachable_spells;
         for( const spell_id &sp : spells ) {
@@ -1382,7 +1382,7 @@ void dialogue::gen_responses( const talk_topic &the_topic )
             const int next_level_exercise = skill_level_obj.exercise();
 
             //~Skill name: current level (exercise) -> next level (exercise) (cost in dollars)
-            std::string text = string_format( cost > 0 ? _( "%s: %d (%d%%) -> %d (%d%%) (cost $%d)" ) :
+            std::string const text = string_format( cost > 0 ? _( "%s: %d (%d%%) -> %d (%d%%) (cost $%d)" ) :
                                               _( "%s: %d (%d%%) -> %d (%d%%)" ),
                                               trained.obj().name(), cur_level, cur_level_exercise,
                                               next_level, next_level_exercise, cost / 100 );
@@ -1406,7 +1406,7 @@ void dialogue::gen_responses( const talk_topic &the_topic )
 
 static int parse_mod( const dialogue &d, const std::string &attribute, const int factor )
 {
-    player &u = *d.alpha;
+    player  const&u = *d.alpha;
     npc &p = *d.beta;
     int modifier = 0;
     if( attribute == "ANGER" ) {
@@ -1440,13 +1440,13 @@ static int parse_mod( const dialogue &d, const std::string &attribute, const int
 
 int talk_trial::calc_chance( const dialogue &d ) const
 {
-    player &u = *d.alpha;
+    player  const&u = *d.alpha;
     if( u.has_trait( trait_DEBUG_MIND_CONTROL ) ) {
         return 100;
     }
     const social_modifiers &u_mods = u.get_mutation_social_mods();
 
-    npc &p = *d.beta;
+    npc  const&p = *d.beta;
     int chance = difficulty;
     switch( type ) {
         case NUM_TALK_TRIALS:
@@ -1625,7 +1625,7 @@ void parse_tags( std::string &phrase, const Character &u, const Character &me,
     do {
         fa = phrase.find( '<' );
         fb = phrase.find( '>' );
-        int l = fb - fa + 1;
+        int const l = fb - fa + 1;
         if( fa != std::string::npos && fb != std::string::npos ) {
             tag = phrase.substr( fa, fb - fa + 1 );
         } else {
@@ -1669,12 +1669,12 @@ void parse_tags( std::string &phrase, const Character &u, const Character &me,
                     break;
             }
         } else if( tag == "<mypronoun>" ) {
-            std::string npcstr = me.male ? pgettext( "npc", "He" ) : pgettext( "npc", "She" );
+            std::string const npcstr = me.male ? pgettext( "npc", "He" ) : pgettext( "npc", "She" );
             phrase.replace( fa, l, npcstr );
         } else if( tag == "<topic_item>" ) {
             phrase.replace( fa, l, item::nname( item_type, 2 ) );
         } else if( tag == "<topic_item_price>" ) {
-            item tmp( item_type );
+            item const tmp( item_type );
             phrase.replace( fa, l, format_money( tmp.price( true ) ) );
         } else if( tag == "<topic_item_my_total_price>" ) {
             item tmp( item_type );
@@ -1719,7 +1719,7 @@ talk_data talk_response::create_option_line( const dialogue &d, const char lette
     parse_tags( ftext, *d.alpha, *d.beta, success.next_topic.item_type );
 
     nc_color color;
-    std::set<dialogue_consequence> consequences = get_consequences( d );
+    std::set<dialogue_consequence> const consequences = get_consequences( d );
     if( consequences.count( dialogue_consequence::hostile ) > 0 ) {
         color = c_red;
     } else if( text[0] == '*' || consequences.count( dialogue_consequence::helpless ) > 0 ) {
@@ -1734,7 +1734,7 @@ talk_data talk_response::create_option_line( const dialogue &d, const char lette
 
 std::set<dialogue_consequence> talk_response::get_consequences( const dialogue &d ) const
 {
-    int chance = trial.calc_chance( d );
+    int const chance = trial.calc_chance( d );
     if( chance >= 100 ) {
         return { success.get_consequence( d ) };
     } else if( chance <= 0 ) {
@@ -1853,7 +1853,7 @@ talk_topic dialogue::opt( dialogue_window &d_win, const std::string &npc_name,
             }
         } while( ( ch < 0 || ch >= static_cast<int>( responses.size() ) ) );
         okay = true;
-        std::set<dialogue_consequence> consequences = responses[ch].get_consequences( *this );
+        std::set<dialogue_consequence> const consequences = responses[ch].get_consequences( *this );
         if( consequences.count( dialogue_consequence::hostile ) > 0 ) {
             okay = query_yn( _( "You may be attacked!  Proceed?" ) );
         } else if( consequences.count( dialogue_consequence::helpless ) > 0 ) {
@@ -1861,8 +1861,8 @@ talk_topic dialogue::opt( dialogue_window &d_win, const std::string &npc_name,
         }
     } while( !okay );
 
-    talk_response chosen = responses[ch];
-    std::string response_printed = string_format( pgettext( "you say something", "You: %s" ),
+    talk_response const chosen = responses[ch];
+    std::string const response_printed = string_format( pgettext( "you say something", "You: %s" ),
                                    response_lines[ch].text );
     d_win.add_to_history( response_printed );
 
@@ -1967,7 +1967,7 @@ void talk_effect_fun_t::set_companion_mission( const std::string &role_id )
 void talk_effect_fun_t::set_add_effect( const JsonObject &jo, const std::string &member,
                                         bool is_npc )
 {
-    efftype_id new_effect( jo.get_string( member ) );
+    efftype_id const new_effect( jo.get_string( member ) );
     time_duration duration = 1_turns;
     bool permanent = false;
     if( jo.has_string( "duration" ) ) {
@@ -2004,7 +2004,7 @@ void talk_effect_fun_t::set_add_effect( const JsonObject &jo, const std::string 
 void talk_effect_fun_t::set_remove_effect( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    std::string old_effect = jo.get_string( member );
+    std::string const old_effect = jo.get_string( member );
     function = [is_npc, old_effect]( const dialogue & d ) {
         player *actor = d.alpha;
         if( is_npc ) {
@@ -2017,7 +2017,7 @@ void talk_effect_fun_t::set_remove_effect( const JsonObject &jo, const std::stri
 void talk_effect_fun_t::set_add_trait( const JsonObject &jo, const std::string &member,
                                        bool is_npc )
 {
-    std::string new_trait = jo.get_string( member );
+    std::string const new_trait = jo.get_string( member );
     function = [is_npc, new_trait]( const dialogue & d ) {
         player *actor = d.alpha;
         if( is_npc ) {
@@ -2030,7 +2030,7 @@ void talk_effect_fun_t::set_add_trait( const JsonObject &jo, const std::string &
 void talk_effect_fun_t::set_remove_trait( const JsonObject &jo, const std::string &member,
         bool is_npc )
 {
-    std::string old_trait = jo.get_string( member );
+    std::string const old_trait = jo.get_string( member );
     function = [is_npc, old_trait]( const dialogue & d ) {
         player *actor = d.alpha;
         if( is_npc ) {
@@ -2168,7 +2168,7 @@ void talk_effect_fun_t::set_consume_item( const JsonObject &jo, const std::strin
     function = [is_npc, item_name, count]( const dialogue & d ) {
         // this is stupid, but I couldn't get the assignment to work
         const auto consume_item = [&]( player & p, const itype_id & item_name, int count ) {
-            item old_item( item_name );
+            item const old_item( item_name );
             if( p.has_charges( item_name, count ) ) {
                 p.use_charges( item_name, count );
             } else if( p.has_amount( item_name, count ) ) {
@@ -2195,7 +2195,7 @@ void talk_effect_fun_t::set_remove_item_with( const JsonObject &jo, const std::s
         if( is_npc ) {
             actor = dynamic_cast<player *>( d.beta );
         }
-        itype_id item_id = itype_id( item_name );
+        itype_id const item_id = itype_id( item_name );
         actor->remove_items_with( [item_id]( const item & it ) {
             return it.typeId() == item_id;
         } );
@@ -2228,7 +2228,7 @@ void talk_effect_fun_t::set_npc_change_class( const std::string &class_name )
 void talk_effect_fun_t::set_change_faction_rep( int rep_change )
 {
     function = [rep_change]( const dialogue & d ) {
-        npc &p = *d.beta;
+        npc  const&p = *d.beta;
         if( p.get_faction()->id != faction_id( "no_faction" ) ) {
             p.get_faction()->likes_u += rep_change;
             p.get_faction()->respects_u += rep_change;
@@ -2331,7 +2331,7 @@ void talk_effect_fun_t::set_npc_cbm_recharge_rule( const std::string &setting )
 
 void talk_effect_fun_t::set_mapgen_update( const JsonObject &jo, const std::string &member )
 {
-    mission_target_params target_params = mission_util::parse_mission_om_target( jo );
+    mission_target_params const target_params = mission_util::parse_mission_om_target( jo );
     std::vector<std::string> update_ids;
 
     if( jo.has_string( member ) ) {
@@ -2361,16 +2361,16 @@ void talk_effect_fun_t::set_bulk_trade_accept( bool is_trade, bool is_npc )
             seller = dynamic_cast<player *>( d.beta );
             buyer = d.alpha;
         }
-        int seller_has = seller->charges_of( d.cur_item );
+        int const seller_has = seller->charges_of( d.cur_item );
         item tmp( d.cur_item );
         tmp.charges = seller_has;
         if( is_trade ) {
             int price = tmp.price( true ) * ( is_npc ? -1 : 1 ) + d.beta->op_of_u.owed;
             if( d.beta->get_faction() && !d.beta->get_faction()->currency.is_empty() ) {
                 const itype_id &pay_in = d.beta->get_faction()->currency;
-                item pay( pay_in );
+                item const pay( pay_in );
                 if( d.beta->value( pay ) > 0 ) {
-                    int required = price / d.beta->value( pay );
+                    int const required = price / d.beta->value( pay );
                     int buyer_has = required;
                     if( is_npc ) {
                         buyer_has = std::min( buyer_has, buyer->charges_of( pay_in ) );
@@ -2426,7 +2426,7 @@ void talk_effect_fun_t::set_u_buy_monster( const std::string &monster_type_id, i
 {
     function = [monster_type_id, cost, count, pacified, name]( const dialogue & d ) {
         npc &p = *d.beta;
-        player &u = *d.alpha;
+        player  const&u = *d.alpha;
         if( !npc_trading::pay_npc( p, cost ) ) {
             popup( _( "You can't afford it!" ) );
             return;
@@ -2488,7 +2488,7 @@ void talk_effect_t::set_effect_consequence( const talk_effect_fun_t &fun, dialog
 void talk_effect_t::set_effect_consequence( std::function<void( npc &p )> ptr,
         dialogue_consequence con )
 {
-    talk_effect_fun_t npctalk_setter( ptr );
+    talk_effect_fun_t const npctalk_setter( ptr );
     set_effect_consequence( npctalk_setter, con );
 }
 
@@ -2500,7 +2500,7 @@ void talk_effect_t::set_effect( const talk_effect_fun_t &fun )
 
 void talk_effect_t::set_effect( talkfunction_ptr ptr )
 {
-    talk_effect_fun_t npctalk_setter( ptr );
+    talk_effect_fun_t const npctalk_setter( ptr );
     dialogue_consequence response;
     if( ptr == &talk_function::hostile ) {
         response = dialogue_consequence::hostile;
@@ -2525,8 +2525,8 @@ talk_topic talk_effect_t::apply( dialogue &d ) const
     d.beta->op_of_u += opinion;
     if( miss && ( mission_opinion.trust || mission_opinion.fear ||
                   mission_opinion.value || mission_opinion.anger ) ) {
-        int m_value = npc_trading::cash_to_favor( *d.beta, miss->get_value() );
-        npc_opinion mod = npc_opinion( mission_opinion.trust ?
+        int const m_value = npc_trading::cash_to_favor( *d.beta, miss->get_value() );
+        npc_opinion const mod = npc_opinion( mission_opinion.trust ?
                                        m_value / mission_opinion.trust : 0,
                                        mission_opinion.fear ?
                                        m_value / mission_opinion.fear : 0,
@@ -2570,7 +2570,7 @@ void talk_effect_t::parse_sub_effect( const JsonObject &jo )
     talk_effect_fun_t subeffect_fun;
     const bool is_npc = true;
     if( jo.has_string( "companion_mission" ) ) {
-        std::string role_id = jo.get_string( "companion_mission" );
+        std::string const role_id = jo.get_string( "companion_mission" );
         subeffect_fun.set_companion_mission( role_id );
     } else if( jo.has_string( "u_add_effect" ) ) {
         subeffect_fun.set_add_effect( jo, "u_add_effect" );
@@ -2601,7 +2601,7 @@ void talk_effect_t::parse_sub_effect( const JsonObject &jo )
     } else if( jo.has_string( "npc_lose_trait" ) ) {
         subeffect_fun.set_remove_trait( jo, "npc_lose_trait", is_npc );
     } else if( jo.has_int( "u_spend_ecash" ) ) {
-        int cash_change = jo.get_int( "u_spend_ecash" );
+        int const cash_change = jo.get_int( "u_spend_ecash" );
         subeffect_fun.set_u_spend_ecash( cash_change );
     } else if( jo.has_string( "u_sell_item" ) || jo.has_string( "u_buy_item" ) ||
                jo.has_string( "u_consume_item" ) || jo.has_string( "npc_consume_item" ) ||
@@ -2636,16 +2636,16 @@ void talk_effect_t::parse_sub_effect( const JsonObject &jo )
             subeffect_fun.set_remove_item_with( jo, "npc_remove_item_with", is_npc );
         }
     } else if( jo.has_string( "npc_change_class" ) ) {
-        std::string class_name = jo.get_string( "npc_change_class" );
+        std::string const class_name = jo.get_string( "npc_change_class" );
         subeffect_fun.set_npc_change_class( class_name );
     } else if( jo.has_string( "add_mission" ) ) {
-        std::string mission_id = jo.get_string( "add_mission" );
+        std::string const mission_id = jo.get_string( "add_mission" );
         subeffect_fun.set_add_mission( mission_id );
     } else if( jo.has_string( "npc_change_faction" ) ) {
-        std::string faction_name = jo.get_string( "npc_change_faction" );
+        std::string const faction_name = jo.get_string( "npc_change_faction" );
         subeffect_fun.set_npc_change_faction( faction_name );
     } else if( jo.has_int( "u_faction_rep" ) ) {
-        int faction_rep = jo.get_int( "u_faction_rep" );
+        int const faction_rep = jo.get_int( "u_faction_rep" );
         subeffect_fun.set_change_faction_rep( faction_rep );
     } else if( jo.has_array( "add_debt" ) ) {
         std::vector<trial_mod> debt_modifiers;
@@ -2792,15 +2792,15 @@ void talk_effect_t::parse_string_effect( const std::string &effect_id, const Jso
     talk_effect_fun_t subeffect_fun;
     if( effect_id == "u_bulk_trade_accept" || effect_id == "npc_bulk_trade_accept" ||
         effect_id == "u_bulk_donate" || effect_id == "npc_bulk_donate" ) {
-        bool is_npc = effect_id == "npc_bulk_trade_accept" || effect_id == "npc_bulk_donate";
-        bool is_trade = effect_id == "u_bulk_trade_accept" || effect_id == "npc_bulk_trade_accept";
+        bool const is_npc = effect_id == "npc_bulk_trade_accept" || effect_id == "npc_bulk_donate";
+        bool const is_trade = effect_id == "u_bulk_trade_accept" || effect_id == "npc_bulk_trade_accept";
         subeffect_fun.set_bulk_trade_accept( is_trade, is_npc );
         set_effect( subeffect_fun );
         return;
     }
 
     if( effect_id == "npc_gets_item" || effect_id == "npc_gets_item_to_use" ) {
-        bool to_use = effect_id == "npc_gets_item_to_use";
+        bool const to_use = effect_id == "npc_gets_item_to_use";
         subeffect_fun.set_npc_gets_item( to_use );
         set_effect( subeffect_fun );
         return;
@@ -2828,7 +2828,7 @@ void talk_effect_t::load_effect( const JsonObject &jo )
         const std::string type = jo.get_string( member_name );
         parse_string_effect( type, jo );
     } else if( jo.has_object( member_name ) ) {
-        JsonObject sub_effect = jo.get_object( member_name );
+        JsonObject const sub_effect = jo.get_object( member_name );
         parse_sub_effect( sub_effect );
     } else if( jo.has_array( member_name ) ) {
         for( const JsonValue entry : jo.get_array( member_name ) ) {
@@ -2836,7 +2836,7 @@ void talk_effect_t::load_effect( const JsonObject &jo )
                 const std::string type = entry.get_string();
                 parse_string_effect( type, jo );
             } else if( entry.test_object() ) {
-                JsonObject sub_effect = entry.get_object();
+                JsonObject const sub_effect = entry.get_object();
                 parse_sub_effect( sub_effect );
             } else {
                 jo.throw_error( "invalid effect array syntax", member_name );
@@ -2861,7 +2861,7 @@ talk_response::talk_response()
 talk_response::talk_response( const JsonObject &jo )
 {
     if( jo.has_member( "truefalsetext" ) ) {
-        JsonObject truefalse_jo = jo.get_object( "truefalsetext" );
+        JsonObject const truefalse_jo = jo.get_object( "truefalsetext" );
         read_condition<dialogue>( truefalse_jo, "condition", truefalse_condition, true );
         truefalse_jo.read( "true", truetext );
         truefalse_jo.read( "false", falsetext );
@@ -2872,11 +2872,11 @@ talk_response::talk_response( const JsonObject &jo )
         };
     }
     if( jo.has_member( "trial" ) ) {
-        JsonObject trial_obj = jo.get_object( "trial" );
+        JsonObject const trial_obj = jo.get_object( "trial" );
         trial = talk_trial( trial_obj );
     }
     if( jo.has_member( "success" ) ) {
-        JsonObject success_obj = jo.get_object( "success" );
+        JsonObject const success_obj = jo.get_object( "success" );
         success = talk_effect_t( success_obj );
     } else if( jo.has_string( "topic" ) ) {
         // This is for simple topic switching without a possible failure
@@ -2889,7 +2889,7 @@ talk_response::talk_response( const JsonObject &jo )
         jo.throw_error( "the failure effect is mandatory if a talk_trial has been defined" );
     }
     if( jo.has_member( "failure" ) ) {
-        JsonObject failure_obj = jo.get_object( "failure" );
+        JsonObject const failure_obj = jo.get_object( "failure" );
         failure = talk_effect_t( failure_obj );
     }
 
@@ -2925,7 +2925,7 @@ json_talk_repeat_response::json_talk_repeat_response( const JsonObject &jo )
         jo.throw_error( "Repeat response with empty repeat information!" );
     }
     if( jo.has_object( "response" ) ) {
-        JsonObject response_obj = jo.get_object( "response" );
+        JsonObject const response_obj = jo.get_object( "response" );
         response = json_talk_response( response_obj );
     } else {
         jo.throw_error( "Repeat response with no response!" );
@@ -3138,7 +3138,7 @@ json_dynamic_line_effect::json_dynamic_line_effect( const JsonObject &jo, const 
         condition = [varname, tmp_condition]( const dialogue & d ) {
             return d.alpha->get_value( varname ) != "yes" && tmp_condition( d );
         };
-        std::function<void( const dialogue &d )> function = [varname]( const dialogue & d ) {
+        std::function<void( const dialogue &d )> const function = [varname]( const dialogue & d ) {
             d.alpha->set_value( varname, "yes" );
         };
         tmp_effect.effects.emplace_back( function );
@@ -3171,21 +3171,21 @@ void json_talk_topic::load( const JsonObject &jo )
             id = jo.get_array( "id" ).next_string();
         }
         if( jo.has_object( "speaker_effect" ) ) {
-            JsonObject speaker_effect = jo.get_object( "speaker_effect" );
+            JsonObject const speaker_effect = jo.get_object( "speaker_effect" );
             speaker_effects.emplace_back( speaker_effect, id );
         } else if( jo.has_array( "speaker_effect" ) ) {
-            for( JsonObject speaker_effect : jo.get_array( "speaker_effect" ) ) {
+            for( JsonObject const speaker_effect : jo.get_array( "speaker_effect" ) ) {
                 speaker_effects.emplace_back( speaker_effect, id );
             }
         }
     }
-    for( JsonObject response : jo.get_array( "responses" ) ) {
+    for( JsonObject const response : jo.get_array( "responses" ) ) {
         responses.emplace_back( response );
     }
     if( jo.has_object( "repeat_responses" ) ) {
         repeat_responses.emplace_back( jo.get_object( "repeat_responses" ) );
     } else if( jo.has_array( "repeat_responses" ) ) {
-        for( JsonObject elem : jo.get_array( "repeat_responses" ) ) {
+        for( JsonObject const elem : jo.get_array( "repeat_responses" ) ) {
             repeat_responses.emplace_back( elem );
         }
     }
@@ -3209,7 +3209,7 @@ bool json_talk_topic::gen_responses( dialogue &d ) const
         if( repeat.is_npc ) {
             actor = dynamic_cast<player *>( d.beta );
         }
-        std::function<bool( const item & )> filter = return_true<item>;
+        std::function<bool( const item & )> const filter = return_true<item>;
         for( const itype_id &item_id : repeat.for_item ) {
             if( actor->charges_of( item_id ) > 0 || actor->has_amount( item_id, 1 ) ) {
                 switch_done |= repeat.response.gen_repeat_response( d, item_id, switch_done );
@@ -3306,7 +3306,7 @@ enum consumption_result {
 static consumption_result try_consume( npc &p, item &it, std::string &reason )
 {
     // TODO: Unify this with 'player::consume_item()'
-    bool consuming_contents = it.is_container() && !it.contents.empty();
+    bool const consuming_contents = it.is_container() && !it.contents.empty();
     item &to_eat = consuming_contents ? it.contents.front() : it;
     const auto &comest = to_eat.get_comestible();
     if( !comest ) {
@@ -3397,8 +3397,8 @@ std::string give_item_to( npc &p, bool allow_use )
 
     bool taken = false;
     std::string reason = _( "Nope." );
-    int our_ammo = character_funcs::ammo_count_for( p, p.primary_weapon() );
-    int new_ammo = character_funcs::ammo_count_for( p, given );
+    int const our_ammo = character_funcs::ammo_count_for( p, p.primary_weapon() );
+    int const new_ammo = character_funcs::ammo_count_for( p, given );
     const double new_weapon_value = npc_ai::weapon_value( p, given, new_ammo );
     const double cur_weapon_value = npc_ai::weapon_value( p, p.primary_weapon(), our_ammo );
     add_msg( m_debug, "NPC evaluates own %s (%d ammo): %0.1f",

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -147,7 +147,7 @@ int calc_skill_training_cost( const npc &p, const skill_id &skill )
     if( p.is_player_ally() ) {
         return 0;
     }
-    avatar  const&you = get_avatar();
+    avatar  const &you = get_avatar();
     return 1000 * ( 1 + you.get_skill_level( skill ) ) * ( 1 + you.get_skill_level( skill ) );
 }
 
@@ -341,7 +341,7 @@ static void npc_temp_orders_menu( const std::vector<npc *> &npc_list )
 
 static void tell_veh_stop_following()
 {
-    for( wrapped_vehicle  const&veh : get_map().get_vehicles() ) {
+    for( wrapped_vehicle  const &veh : get_map().get_vehicles() ) {
         vehicle *v = veh.v;
         if( v->has_engine_type( fuel_type_animal, false ) && v->is_owned_by( get_avatar() ) ) {
             v->is_following = false;
@@ -352,7 +352,7 @@ static void tell_veh_stop_following()
 
 static void assign_veh_to_follow()
 {
-    for( wrapped_vehicle  const&veh : get_map().get_vehicles() ) {
+    for( wrapped_vehicle  const &veh : get_map().get_vehicles() ) {
         vehicle *v = veh.v;
         if( v->has_engine_type( fuel_type_animal, false ) && v->is_owned_by( get_avatar() ) ) {
             v->activate_animal_follow();
@@ -362,7 +362,7 @@ static void assign_veh_to_follow()
 
 static void tell_magic_veh_to_follow()
 {
-    for( wrapped_vehicle  const&veh : get_map().get_vehicles() ) {
+    for( wrapped_vehicle  const &veh : get_map().get_vehicles() ) {
         vehicle *v = veh.v;
         if( v->magic ) {
             for( const vpart_reference &vp : v->get_all_parts() ) {
@@ -378,7 +378,7 @@ static void tell_magic_veh_to_follow()
 
 static void tell_magic_veh_stop_following()
 {
-    for( wrapped_vehicle  const&veh : get_map().get_vehicles() ) {
+    for( wrapped_vehicle  const &veh : get_map().get_vehicles() ) {
         vehicle *v = veh.v;
         if( v->magic ) {
             for( const vpart_reference &vp : v->get_all_parts() ) {
@@ -552,7 +552,7 @@ void game::chat()
                 return;
             }
 
-            map  const&here = get_map();
+            map  const &here = get_map();
             std::optional<tripoint> p = look_around();
 
             if( !p ) {
@@ -662,7 +662,7 @@ void game::chat()
 void npc::handle_sound( const sounds::sound_t spriority, const std::string &description,
                         int heard_volume, const tripoint &spos )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     const tripoint s_abs_pos = here.getabs( spos );
     const tripoint my_abs_pos = here.getabs( pos() );
 
@@ -962,8 +962,9 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic ) const
     }
     if( topic == "TALK_SEDATED" ) {
         int const firstaid_lvl = get_player_character().get_skill_level( skill_id( "firstaid" ) );
-        time_duration const dur = character_funcs::estimate_effect_dur( firstaid_lvl, effect_narcosis, 15_minutes,
-                            6, *beta );
+        time_duration const dur = character_funcs::estimate_effect_dur( firstaid_lvl, effect_narcosis,
+                                  15_minutes,
+                                  6, *beta );
         return string_format(
                    _( "%1$s is sedated and can't be moved or woken up until the medication or sedation wears off.\nYou estimate it will wear off in %2$s." ),
                    beta->name, to_string_approx( dur ) );
@@ -1123,7 +1124,7 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic ) const
                 how_tired = _( "Not tired" );
                 if( ability >= 100 ) {
                     time_duration const sleep_at = 5_minutes * ( fatigue_levels::tired - p->get_fatigue() ) /
-                                             rates.fatigue;
+                                                   rates.fatigue;
                     how_tired += _( ".  Will need sleep in " ) + to_string_approx( sleep_at );
                 }
             }
@@ -1131,7 +1132,8 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic ) const
         }
         if( ability >= 100 ) {
             if( p->get_thirst() < thirst_levels::thirsty ) {
-                time_duration const thirst_at = 5_minutes * ( thirst_levels::thirsty - p->get_thirst() ) / rates.thirst;
+                time_duration const thirst_at = 5_minutes * ( thirst_levels::thirsty - p->get_thirst() ) /
+                                                rates.thirst;
                 if( thirst_at > 1_hours ) {
                     info += _( "\nWill need water in " ) + to_string_approx( thirst_at );
                 }
@@ -1140,8 +1142,8 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic ) const
             }
             if( p->max_stored_kcal() - p->get_stored_kcal() > 500 ) {
                 time_duration const hunger_at = 5_minutes
-                                          * ( 500 - p->max_stored_kcal() + p->get_stored_kcal() )
-                                          / p->bmr();
+                                                * ( 500 - p->max_stored_kcal() + p->get_stored_kcal() )
+                                                / p->bmr();
                 if( hunger_at > 1_hours ) {
                     info += _( "\nWill need food in " ) + to_string_approx( hunger_at );
                 }
@@ -1174,7 +1176,7 @@ void dialogue::apply_speaker_effects( const talk_topic &the_topic )
     if( iter == json_talk_topics.end() ) {
         return;
     }
-    for( json_dynamic_line_effect  const&npc_effect : iter->second.get_speaker_effects() ) {
+    for( json_dynamic_line_effect  const &npc_effect : iter->second.get_speaker_effects() ) {
         if( npc_effect.test_condition( *this ) ) {
             npc_effect.apply( *this );
         }
@@ -1281,7 +1283,7 @@ void dialogue::gen_responses( const talk_topic &the_topic )
     ret.clear();
     const auto iter = json_talk_topics.find( topic );
     if( iter != json_talk_topics.end() ) {
-        json_talk_topic  const&jtt = iter->second;
+        json_talk_topic  const &jtt = iter->second;
         if( jtt.gen_responses( *this ) ) {
             return;
         }
@@ -1383,9 +1385,9 @@ void dialogue::gen_responses( const talk_topic &the_topic )
 
             //~Skill name: current level (exercise) -> next level (exercise) (cost in dollars)
             std::string const text = string_format( cost > 0 ? _( "%s: %d (%d%%) -> %d (%d%%) (cost $%d)" ) :
-                                              _( "%s: %d (%d%%) -> %d (%d%%)" ),
-                                              trained.obj().name(), cur_level, cur_level_exercise,
-                                              next_level, next_level_exercise, cost / 100 );
+                                                    _( "%s: %d (%d%%) -> %d (%d%%)" ),
+                                                    trained.obj().name(), cur_level, cur_level_exercise,
+                                                    next_level, next_level_exercise, cost / 100 );
             add_response( text, "TALK_TRAIN_START", trained );
         }
         add_response_none( _( "Eh, never mind." ) );
@@ -1406,7 +1408,7 @@ void dialogue::gen_responses( const talk_topic &the_topic )
 
 static int parse_mod( const dialogue &d, const std::string &attribute, const int factor )
 {
-    player  const&u = *d.alpha;
+    player  const &u = *d.alpha;
     npc &p = *d.beta;
     int modifier = 0;
     if( attribute == "ANGER" ) {
@@ -1440,13 +1442,13 @@ static int parse_mod( const dialogue &d, const std::string &attribute, const int
 
 int talk_trial::calc_chance( const dialogue &d ) const
 {
-    player  const&u = *d.alpha;
+    player  const &u = *d.alpha;
     if( u.has_trait( trait_DEBUG_MIND_CONTROL ) ) {
         return 100;
     }
     const social_modifiers &u_mods = u.get_mutation_social_mods();
 
-    npc  const&p = *d.beta;
+    npc  const &p = *d.beta;
     int chance = difficulty;
     switch( type ) {
         case NUM_TALK_TRIALS:
@@ -1863,7 +1865,7 @@ talk_topic dialogue::opt( dialogue_window &d_win, const std::string &npc_name,
 
     talk_response const chosen = responses[ch];
     std::string const response_printed = string_format( pgettext( "you say something", "You: %s" ),
-                                   response_lines[ch].text );
+                                         response_lines[ch].text );
     d_win.add_to_history( response_printed );
 
     if( chosen.mission_selected != nullptr ) {
@@ -2228,7 +2230,7 @@ void talk_effect_fun_t::set_npc_change_class( const std::string &class_name )
 void talk_effect_fun_t::set_change_faction_rep( int rep_change )
 {
     function = [rep_change]( const dialogue & d ) {
-        npc  const&p = *d.beta;
+        npc  const &p = *d.beta;
         if( p.get_faction()->id != faction_id( "no_faction" ) ) {
             p.get_faction()->likes_u += rep_change;
             p.get_faction()->respects_u += rep_change;
@@ -2426,7 +2428,7 @@ void talk_effect_fun_t::set_u_buy_monster( const std::string &monster_type_id, i
 {
     function = [monster_type_id, cost, count, pacified, name]( const dialogue & d ) {
         npc &p = *d.beta;
-        player  const&u = *d.alpha;
+        player  const &u = *d.alpha;
         if( !npc_trading::pay_npc( p, cost ) ) {
             popup( _( "You can't afford it!" ) );
             return;
@@ -2527,13 +2529,13 @@ talk_topic talk_effect_t::apply( dialogue &d ) const
                   mission_opinion.value || mission_opinion.anger ) ) {
         int const m_value = npc_trading::cash_to_favor( *d.beta, miss->get_value() );
         npc_opinion const mod = npc_opinion( mission_opinion.trust ?
-                                       m_value / mission_opinion.trust : 0,
-                                       mission_opinion.fear ?
-                                       m_value / mission_opinion.fear : 0,
-                                       mission_opinion.value ?
-                                       m_value / mission_opinion.value : 0,
-                                       mission_opinion.anger ?
-                                       m_value / mission_opinion.anger : 0, 0 );
+                                             m_value / mission_opinion.trust : 0,
+                                             mission_opinion.fear ?
+                                             m_value / mission_opinion.fear : 0,
+                                             mission_opinion.value ?
+                                             m_value / mission_opinion.value : 0,
+                                             mission_opinion.anger ?
+                                             m_value / mission_opinion.anger : 0, 0 );
         d.beta->op_of_u += mod;
     }
     if( d.beta->turned_hostile() ) {

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -240,7 +240,7 @@ void talk_function::dismount( npc &p )
 void talk_function::find_mount( npc &p )
 {
     // first find one nearby
-    for( monster  const&critter : g->all_monsters() ) {
+    for( monster  const &critter : g->all_monsters() ) {
         if( p.can_mount( critter ) ) {
             // keep the horse still for some time, so that NPC can catch up to it and mount it.
             p.assign_activity( ACT_FIND_MOUNT );
@@ -302,7 +302,7 @@ void talk_function::goto_location( npc &p )
     selection_menu.text = _( "Select a destination" );
     std::vector<basecamp *> camps;
     tripoint_abs_omt destination;
-    Character  const&player_character = get_player_character();
+    Character  const &player_character = get_player_character();
     for( const auto &elem : player_character.camps ) {
         if( elem == p.global_omt_location() ) {
             continue;
@@ -499,7 +499,7 @@ void talk_function::bionic_remove( npc &p )
     }
     // Choose bionic if applicable
     int const bionic_index = uilist( _( "Which bionic do you wish to uninstall?" ),
-                               bionic_names );
+                                     bionic_names );
     // Did we cancel?
     if( bionic_index < 0 ) {
         popup( _( "You decide to hold off…" ) );

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -117,12 +117,12 @@ void talk_function::mission_success( npc &p )
         return;
     }
 
-    int miss_val = npc_trading::cash_to_favor( p, miss->get_value() );
-    npc_opinion tmp( 0, 0, 1 + miss_val / 5, -1, 0 );
+    int const miss_val = npc_trading::cash_to_favor( p, miss->get_value() );
+    npc_opinion const tmp( 0, 0, 1 + miss_val / 5, -1, 0 );
     p.op_of_u += tmp;
     faction *p_fac = p.get_faction();
     if( p_fac != nullptr ) {
-        int fac_val = std::min( 1 + miss_val / 10, 10 );
+        int const fac_val = std::min( 1 + miss_val / 10, 10 );
         p_fac->likes_u += fac_val;
         p_fac->respects_u += fac_val;
         p_fac->power += fac_val;
@@ -137,7 +137,7 @@ void talk_function::mission_failure( npc &p )
         debugmsg( "mission_failure: mission_selected == nullptr" );
         return;
     }
-    npc_opinion tmp( -1, 0, -1, 1, 0 );
+    npc_opinion const tmp( -1, 0, -1, 1, 0 );
     p.op_of_u += tmp;
     miss->fail();
 }
@@ -177,7 +177,7 @@ void talk_function::mission_reward( npc &p )
         return;
     }
 
-    int mission_value = miss->get_value();
+    int const mission_value = miss->get_value();
     p.op_of_u.owed += mission_value;
     npc_trading::trade( p, 0, _( "Reward" ) );
 }
@@ -240,7 +240,7 @@ void talk_function::dismount( npc &p )
 void talk_function::find_mount( npc &p )
 {
     // first find one nearby
-    for( monster &critter : g->all_monsters() ) {
+    for( monster  const&critter : g->all_monsters() ) {
         if( p.can_mount( critter ) ) {
             // keep the horse still for some time, so that NPC can catch up to it and mount it.
             p.assign_activity( ACT_FIND_MOUNT );
@@ -302,7 +302,7 @@ void talk_function::goto_location( npc &p )
     selection_menu.text = _( "Select a destination" );
     std::vector<basecamp *> camps;
     tripoint_abs_omt destination;
-    Character &player_character = get_player_character();
+    Character  const&player_character = get_player_character();
     for( const auto &elem : player_character.camps ) {
         if( elem == p.global_omt_location() ) {
             continue;
@@ -460,7 +460,7 @@ void talk_function::bionic_install( npc &p )
     const item *tmp = bionic.get_item();
     const itype &it = *tmp->type;
 
-    signed int price = tmp->price( true ) * 2;
+    signed int const price = tmp->price( true ) * 2;
     if( !npc_trading::pay_npc( p, price ) ) {
         return;
     }
@@ -489,7 +489,7 @@ void talk_function::bionic_remove( npc &p )
                 bio.id != bio_power_storage_mkII ) {
                 bionic_types.push_back( bio.info().itype() );
                 if( bio.info().itype().is_valid() ) {
-                    item tmp = item( bio.id.str(), calendar::start_of_cataclysm );
+                    item const tmp = item( bio.id.str(), calendar::start_of_cataclysm );
                     bionic_names.push_back( tmp.tname() + " - " + format_money( 50000 + ( tmp.price( true ) / 4 ) ) );
                 } else {
                     bionic_names.push_back( bio.id.str() + " - " + format_money( 50000 ) );
@@ -498,7 +498,7 @@ void talk_function::bionic_remove( npc &p )
         }
     }
     // Choose bionic if applicable
-    int bionic_index = uilist( _( "Which bionic do you wish to uninstall?" ),
+    int const bionic_index = uilist( _( "Which bionic do you wish to uninstall?" ),
                                bionic_names );
     // Did we cancel?
     if( bionic_index < 0 ) {
@@ -508,7 +508,7 @@ void talk_function::bionic_remove( npc &p )
 
     int price;
     if( bionic_types[bionic_index].is_valid() ) {
-        int tmp = item( bionic_types[bionic_index], calendar::start_of_cataclysm ).price( true );
+        int const tmp = item( bionic_types[bionic_index], calendar::start_of_cataclysm ).price( true );
         price = 50000 + ( tmp / 4 );
     } else {
         price = 50000;
@@ -530,7 +530,7 @@ void talk_function::give_equipment( npc &p )
     std::vector<item_pricing> giving = npc_trading::init_selling( p );
     int chosen = -1;
     while( chosen == -1 && !giving.empty() ) {
-        int index = rng( 0, giving.size() - 1 );
+        int const index = rng( 0, giving.size() - 1 );
         if( giving[index].price < p.op_of_u.owed ) {
             chosen = index;
         } else {
@@ -557,7 +557,7 @@ void talk_function::give_equipment( npc &p )
 static void give_aid_to( Character &guy )
 {
     for( const bodypart_id &bp : guy.get_all_body_parts() ) {
-        bodypart_str_id bp_healed = bp->main_part;
+        bodypart_str_id const bp_healed = bp->main_part;
         guy.heal( bp_healed, 5 * rng( 2, 5 ) );
         if( guy.has_effect( effect_bite, bp_healed ) ) {
             guy.remove_effect( effect_bite, bp_healed );
@@ -622,7 +622,7 @@ static void generic_barber( const std::string &mut_type )
         hair_menu.addentry( index, true, MENU_AUTOASSIGN, elem.obj().name() );
     }
     hair_menu.query();
-    int choice = hair_menu.ret;
+    int const choice = hair_menu.ret;
     if( choice != 0 ) {
         if( g->u.has_trait( cur_hair ) ) {
             g->u.remove_mutation( cur_hair, true );
@@ -677,7 +677,7 @@ void talk_function::morale_chat_activity( npc &p )
 
 void talk_function::buy_10_logs( npc &p )
 {
-    std::vector<tripoint_abs_omt> places =
+    std::vector<tripoint_abs_omt> const places =
         overmap_buffer.find_all( get_player_character().global_omt_location(), "ranch_camp_67", 1,
                                  false );
     if( places.empty() ) {
@@ -704,7 +704,7 @@ void talk_function::buy_10_logs( npc &p )
 
 void talk_function::buy_100_logs( npc &p )
 {
-    std::vector<tripoint_abs_omt> places =
+    std::vector<tripoint_abs_omt> const places =
         overmap_buffer.find_all( get_player_character().global_omt_location(), "ranch_camp_67", 1,
                                  false );
     if( places.empty() ) {
@@ -932,7 +932,7 @@ void talk_function::start_training( npc &p )
         if( knows ) {
             time = 1_hours;
         } else {
-            int seconds = g->u.magic->time_to_learn_spell( g->u, sp_id ) / 50;
+            int const seconds = g->u.magic->time_to_learn_spell( g->u, sp_id ) / 50;
             time = time_duration::from_seconds( clamp( seconds, 7200, 21600 ) );
         }
     } else {

--- a/src/npctrade.cpp
+++ b/src/npctrade.cpp
@@ -98,7 +98,7 @@ std::vector<item_pricing> npc_trading::init_selling( npc &np )
     std::vector<item_pricing> result;
     invslice slice = np.inv.slice();
     for( auto &i : slice ) {
-        item  const&it = i->front();
+        item  const &it = i->front();
 
         const int price = it.price( true );
         int const val = np.value( it );
@@ -130,8 +130,8 @@ double npc_trading::net_price_adjustment( const player &buyer, const player &sel
 
     ///\EFFECT_BARTER increases bartering price changes, relative to NPC BARTER
     double const adjust = 0.05 * ( seller.int_cur - buyer.int_cur ) +
-                    price_adjustment( seller.get_skill_level( skill_barter ) -
-                                      buyer.get_skill_level( skill_barter ) );
+                          price_adjustment( seller.get_skill_level( skill_barter ) -
+                                            buyer.get_skill_level( skill_barter ) );
     return( std::max( adjust, 1.0 ) );
 }
 
@@ -163,7 +163,7 @@ std::vector<item_pricing> npc_trading::init_buying( player &buyer, player &selle
         if( it_ptr == nullptr || it_ptr->is_null() ) {
             return;
         }
-        item  const&it = *it_ptr;
+        item  const &it = *it_ptr;
 
         // Don't sell items we don't own.
         if( !it.is_owned_by( seller ) ) {
@@ -344,7 +344,7 @@ void trading_window::update_win( npc &np, const std::string &deal )
         const size_t &offset = they ? them_off : you_off;
         const player &person = they ? static_cast<player &>( np ) :
                                static_cast<player &>( g->u );
-        catacurses::window  const&w_whose = they ? w_them : w_you;
+        catacurses::window  const &w_whose = they ? w_them : w_you;
         int win_w = getmaxx( w_whose );
         // Borders
         win_w -= 2;
@@ -387,8 +387,9 @@ void trading_window::update_win( npc &np, const std::string &deal )
 #endif
 
             std::string const price_str = format_money( ip.price );
-            nc_color const price_color = np.will_exchange_items_freely() ? c_dark_gray : ( ip.selected ? c_white :
-                                   c_light_gray );
+            nc_color const price_color = np.will_exchange_items_freely() ? c_dark_gray :
+                                         ( ip.selected ? c_white :
+                                           c_light_gray );
             mvwprintz( w_whose, point( win_w - utf8_width( price_str ), i - offset + 1 ),
                        price_color, price_str );
         }

--- a/src/npctrade.cpp
+++ b/src/npctrade.cpp
@@ -57,8 +57,8 @@ void npc_trading::transfer_items( std::vector<item_pricing> &stuff, player &give
 
         item gift = *ip.loc.get_item();
         gift.set_owner( receiver );
-        int charges = npc_gives ? ip.u_charges : ip.npc_charges;
-        int count = npc_gives ? ip.u_has : ip.npc_has;
+        int const charges = npc_gives ? ip.u_charges : ip.npc_charges;
+        int const count = npc_gives ? ip.u_has : ip.npc_has;
 
         if( ip.charges ) {
             gift.charges = charges;
@@ -98,10 +98,10 @@ std::vector<item_pricing> npc_trading::init_selling( npc &np )
     std::vector<item_pricing> result;
     invslice slice = np.inv.slice();
     for( auto &i : slice ) {
-        item &it = i->front();
+        item  const&it = i->front();
 
         const int price = it.price( true );
-        int val = np.value( it );
+        int const val = np.value( it );
         if( np.wants_to_sell( it, val, price ) ) {
             result.emplace_back( np, i->front(), val, static_cast<int>( i->size() ) );
         }
@@ -129,7 +129,7 @@ double npc_trading::net_price_adjustment( const player &buyer, const player &sel
     ///\EFFECT_INT slightly increases bartering price changes, relative to NPC INT
 
     ///\EFFECT_BARTER increases bartering price changes, relative to NPC BARTER
-    double adjust = 0.05 * ( seller.int_cur - buyer.int_cur ) +
+    double const adjust = 0.05 * ( seller.int_cur - buyer.int_cur ) +
                     price_adjustment( seller.get_skill_level( skill_barter ) -
                                       buyer.get_skill_level( skill_barter ) );
     return( std::max( adjust, 1.0 ) );
@@ -155,7 +155,7 @@ std::vector<item_pricing> npc_trading::init_buying( player &buyer, player &selle
     npc &np = *np_p;
     faction *fac = np.get_faction();
 
-    double adjust = net_price_adjustment( buyer, seller );
+    double const adjust = net_price_adjustment( buyer, seller );
 
     const auto check_item = [fac, adjust, is_npc, &np, &result, &seller]( item_location &&
     loc, int count = 1 ) {
@@ -163,7 +163,7 @@ std::vector<item_pricing> npc_trading::init_buying( player &buyer, player &selle
         if( it_ptr == nullptr || it_ptr->is_null() ) {
             return;
         }
-        item &it = *it_ptr;
+        item  const&it = *it_ptr;
 
         // Don't sell items we don't own.
         if( !it.is_owned_by( seller ) ) {
@@ -171,7 +171,7 @@ std::vector<item_pricing> npc_trading::init_buying( player &buyer, player &selle
         }
 
         const int market_price = it.price( true );
-        int val = np.value( it, market_price );
+        int const val = np.value( it, market_price );
         if( ( is_npc && np.wants_to_sell( it, val, market_price ) ) ||
             np.wants_to_buy( it, val, market_price ) ) {
             result.emplace_back( std::move( loc ), val, count );
@@ -284,13 +284,13 @@ void trading_window::update_win( npc &np, const std::string &deal )
         }
     }
 
-    bool npc_out_of_space = volume_left < 0_ml || weight_left < 0_gram;
+    bool const npc_out_of_space = volume_left < 0_ml || weight_left < 0_gram;
 
     // Colors for hinting if the trade will be accepted or not.
     const nc_color trade_color       = npc_will_accept_trade( np ) ? c_green : c_red;
     const nc_color trade_color_light = npc_will_accept_trade( np ) ? c_light_green : c_light_red;
 
-    input_context ctxt( "NPC_TRADE" );
+    input_context const ctxt( "NPC_TRADE" );
 
     werase( w_head );
     fold_and_print( w_head, point_zero, getmaxx( w_head ), c_white,
@@ -344,7 +344,7 @@ void trading_window::update_win( npc &np, const std::string &deal )
         const size_t &offset = they ? them_off : you_off;
         const player &person = they ? static_cast<player &>( np ) :
                                static_cast<player &>( g->u );
-        catacurses::window &w_whose = they ? w_them : w_you;
+        catacurses::window  const&w_whose = they ? w_them : w_you;
         int win_w = getmaxx( w_whose );
         // Borders
         win_w -= 2;
@@ -386,8 +386,8 @@ void trading_window::update_win( npc &np, const std::string &deal )
             ctxt.register_manual_key( keychar, itname );
 #endif
 
-            std::string price_str = format_money( ip.price );
-            nc_color price_color = np.will_exchange_items_freely() ? c_dark_gray : ( ip.selected ? c_white :
+            std::string const price_str = format_money( ip.price );
+            nc_color const price_color = np.will_exchange_items_freely() ? c_dark_gray : ( ip.selected ? c_white :
                                    c_light_gray );
             mvwprintz( w_whose, point( win_w - utf8_width( price_str ), i - offset + 1 ),
                        price_color, price_str );
@@ -453,7 +453,7 @@ void trading_window::show_item_data( size_t offset,
             help += offset;
             if( help < target_list.size() ) {
                 const item &itm = *target_list[help].loc.get_item();
-                std::vector<iteminfo> info = itm.info();
+                std::vector<iteminfo> const info = itm.info();
 
                 item_info_data data( itm.tname(),
                                      itm.type_name(),
@@ -612,8 +612,8 @@ bool trading_window::perform_trade( npc &np, const std::string &deal )
                         if( focus_them && your_balance > 0 ) {
                             return your_balance / ip.price;
                         } else if( !focus_them && your_balance < 0 ) {
-                            int amt = your_balance / ip.price;
-                            int rem = ( your_balance % ip.price ) == 0 ? 0 : 1;
+                            int const amt = your_balance / ip.price;
+                            int const rem = ( your_balance % ip.price ) == 0 ? 0 : 1;
                             return amt - rem;
                         }
                     }
@@ -629,7 +629,7 @@ bool trading_window::perform_trade( npc &np, const std::string &deal )
                         owner_sells = 0;
                     }
                 } else if( ip.charges > 0 ) {
-                    int hint = calc_amount_hint();
+                    int const hint = calc_amount_hint();
                     change_amount = get_var_trade( *ip.loc.get_item(), ip.charges, hint );
                     if( change_amount < 1 ) {
                         continue;
@@ -637,7 +637,7 @@ bool trading_window::perform_trade( npc &np, const std::string &deal )
                     owner_sells_charge = change_amount;
                 } else {
                     if( ip.count > 1 ) {
-                        int hint = calc_amount_hint();
+                        int const hint = calc_amount_hint();
                         change_amount = get_var_trade( *ip.loc.get_item(), ip.count, hint );
                         if( change_amount < 1 ) {
                             continue;
@@ -649,7 +649,7 @@ bool trading_window::perform_trade( npc &np, const std::string &deal )
                 if( ip.selected != focus_them ) {
                     change_amount *= -1;
                 }
-                int delta_price = ip.price * change_amount;
+                int const delta_price = ip.price * change_amount;
                 if( !np.will_exchange_items_freely() ) {
                     your_balance -= delta_price;
                 }
@@ -706,9 +706,9 @@ bool npc_trading::trade( npc &np, int cost, const std::string &deal )
     trading_window trade_win;
     trade_win.setup_trade( cost, np );
 
-    bool traded = trade_win.perform_trade( np, deal );
+    bool const traded = trade_win.perform_trade( np, deal );
     if( traded ) {
-        int practice = 0;
+        int const practice = 0;
 
         std::list<item_location *> from_map;
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1106,7 +1106,7 @@ std::vector<options_manager::id_and_option> options_manager::build_tilesets_list
     // Load from user directory
     std::vector<options_manager::id_and_option> const user_tilesets = load_tilesets_from(
                 PATH_INFO::user_gfx() );
-    for( options_manager::id_and_option const id : user_tilesets ) {
+    for( options_manager::id_and_option const& id : user_tilesets ) {
         if( std::find( result.begin(), result.end(), id ) == result.end() ) {
             result.emplace_back( id );
         }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -190,7 +190,7 @@ void options_manager::enable_json( const std::string &lvar )
 
 void options_manager::add_retry( const std::string &lvar, const::std::string &lval )
 {
-    std::map<std::string, std::string>::const_iterator it = post_json_verify.find( lvar );
+    std::map<std::string, std::string>::const_iterator const it = post_json_verify.find( lvar );
     if( it != post_json_verify.end() && it->second == blank_value ) {
         // initialized with impossible value: valid
         post_json_verify[ lvar ] = lval;
@@ -200,7 +200,7 @@ void options_manager::add_retry( const std::string &lvar, const::std::string &lv
 void options_manager::add_value( const std::string &lvar, const std::string &lval,
                                  const translation &lvalname )
 {
-    std::map<std::string, std::string>::const_iterator it = post_json_verify.find( lvar );
+    std::map<std::string, std::string>::const_iterator const it = post_json_verify.find( lvar );
     if( it != post_json_verify.end() ) {
         auto ot = options.find( lvar );
         if( ot != options.end() && ot->second.sType == "string_select" ) {
@@ -522,7 +522,7 @@ void options_manager::add_option_group( const std::string &page_id,
                   group.id_, adding_to_group_ );
         return;
     }
-    for( Group &g : groups_ ) {
+    for( Group  const&g : groups_ ) {
         if( g.id_ == group.id_ ) {
             debugmsg( "Option group with id '%s' already exists", group.id_ );
             return;
@@ -545,7 +545,7 @@ void options_manager::add_option_group( const std::string &page_id,
 
 const options_manager::Group &options_manager::find_group( const std::string &id ) const
 {
-    static Group null_group;
+    static Group const null_group;
     if( id.empty() ) {
         return null_group;
     }
@@ -858,7 +858,7 @@ int options_manager::cOpt::getIntPos( const int iSearch ) const
 std::optional< std::tuple<int, std::string> > options_manager::cOpt::findInt(
     const int iSearch ) const
 {
-    int i = static_cast<int>( getIntPos( iSearch ) );
+    int const i = static_cast<int>( getIntPos( iSearch ) );
     if( i == -1 ) {
         return std::nullopt;
     }
@@ -886,7 +886,7 @@ void options_manager::cOpt::setNext()
         sSet = vItems[iNext].first;
 
     } else if( sType == "string_input" ) {
-        int iMenuTextLength = utf8_width( _( sMenuText ) );
+        int const iMenuTextLength = utf8_width( _( sMenuText ) );
         string_input_popup()
         .width( iMaxLength > 80 ? 80 : iMaxLength < iMenuTextLength ? iMenuTextLength : iMaxLength + 1 )
         .description( _( sMenuText ) )
@@ -1104,9 +1104,9 @@ std::vector<options_manager::id_and_option> options_manager::build_tilesets_list
     result.insert( result.end(), data_tilesets.begin(), data_tilesets.end() );
 
     // Load from user directory
-    std::vector<options_manager::id_and_option> user_tilesets = load_tilesets_from(
+    std::vector<options_manager::id_and_option> const user_tilesets = load_tilesets_from(
                 PATH_INFO::user_gfx() );
-    for( options_manager::id_and_option id : user_tilesets ) {
+    for( options_manager::id_and_option const id : user_tilesets ) {
         if( std::find( result.begin(), result.end(), id ) == result.end() ) {
             result.emplace_back( id );
         }
@@ -2025,7 +2025,7 @@ void options_manager::add_options_graphics()
     "software", COPT_CURSES_HIDE );
 #   else
     std::vector<options_manager::id_and_option> renderer_list = cata_tiles::build_renderer_list();
-    std::string default_renderer = renderer_list.front().first;
+    std::string const default_renderer = renderer_list.front().first;
 #   if defined(_WIN32)
     for( const id_and_option &renderer : renderer_list ) {
         if( renderer.first == "direct3d11" ) {
@@ -2653,11 +2653,11 @@ static void refresh_tiles( bool used_tiles_changed, bool pixel_minimap_height_ch
 {
     if( used_tiles_changed ) {
         // Disable UIs below to avoid accessing the tile context during loading.
-        ui_adaptor dummy( ui_adaptor::disable_uis_below {} );
+        ui_adaptor const dummy( ui_adaptor::disable_uis_below {} );
         //try and keep SDL calls limited to source files that deal specifically with them
         try {
             tilecontext->reinit();
-            std::vector<mod_id> dummy;
+            std::vector<mod_id> const dummy;
 
             tilecontext->load_tileset(
                 get_option<std::string>( "TILES" ),
@@ -2912,11 +2912,11 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
             switch( it.type )
             {
                 case ItemType::BlankLine: {
-                    std::string name = it.group.empty() ? "" : IN_GROUP_PREFIX;
+                    std::string const name = it.group.empty() ? "" : IN_GROUP_PREFIX;
                     return { string_col( name, c_white ), string_col() };
                 }
                 case ItemType::GroupHeader: {
-                    bool expanded = groups_state[it.group];
+                    bool const expanded = groups_state[it.group];
                     std::string name = expanded ? "- " : "+ ";
                     name += find_group( it.group ).name_.translated();
                     return std::make_pair( string_col( name, c_white ), string_col() );
@@ -2926,8 +2926,8 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
                     const bool hasPrerequisite = opt.hasPrerequisite();
                     const bool hasPrerequisiteFulfilled = opt.checkPrerequisite();
 
-                    std::string name_prefix = it.group.empty() ? "" : IN_GROUP_PREFIX;
-                    string_col name( name_prefix + opt.getMenuText(), !hasPrerequisite ||
+                    std::string const name_prefix = it.group.empty() ? "" : IN_GROUP_PREFIX;
+                    string_col const name( name_prefix + opt.getMenuText(), !hasPrerequisite ||
                                      hasPrerequisiteFulfilled ? c_white : c_light_gray );
 
                     nc_color cLineColor;
@@ -2939,7 +2939,7 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
                         cLineColor = c_light_green;
                     }
 
-                    string_col value( opt.getValueName(), is_selected ? hilite( cLineColor ) : cLineColor );
+                    string_col const value( opt.getValueName(), is_selected ? hilite( cLineColor ) : cLineColor );
 
                     return std::make_pair( name, value );
                 }
@@ -2949,7 +2949,7 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
         };
 
         // Draw separation lines
-        for( int x : vert_lines ) {
+        for( int const x : vert_lines ) {
             for( int y = 0; y < iContentHeight; y++ ) {
                 mvwputch( w_options, point( x, y ), BORDER_COLOR, LINE_XOXO );
             }
@@ -2971,11 +2971,11 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
              i < iStartPos + ( iContentHeight > static_cast<int>( visible_items.size() ) ?
                                static_cast<int>( visible_items.size() ) : iContentHeight ); i++ ) {
 
-            int line_pos = i - iStartPos; // Current line position in window.
+            int const line_pos = i - iStartPos; // Current line position in window.
 
             mvwprintz( w_options, point( 1, line_pos ), c_white, "%d", visible_items[i] + 1 );
 
-            bool is_selected = visible_items[i] == iCurrentLine;
+            bool const is_selected = visible_items[i] == iCurrentLine;
             if( is_selected ) {
                 mvwprintz( w_options, point( name_col, line_pos ), c_yellow, ">>" );
             }
@@ -3015,7 +3015,7 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
         wnoutrefresh( w_options_header );
 
         const PageItem &curr_item = page_items[iCurrentLine];
-        std::string tooltip = curr_item.fmt_tooltip( find_group( curr_item.group ), cOPTIONS );
+        std::string const tooltip = curr_item.fmt_tooltip( find_group( curr_item.group ), cOPTIONS );
         fold_and_print( w_options_tooltip, point_zero, iMinScreenWidth - 2, c_white, tooltip );
 
         if( ingame && iCurrentPage == iWorldOptPage ) {
@@ -3049,8 +3049,8 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
         const auto on_select_option = [&]() {
             cOpt &current_opt = cOPTIONS[curr_item.data];
 
-            bool hasPrerequisite = current_opt.hasPrerequisite();
-            bool hasPrerequisiteFulfilled = current_opt.checkPrerequisite();
+            bool const hasPrerequisite = current_opt.hasPrerequisite();
+            bool const hasPrerequisiteFulfilled = current_opt.checkPrerequisite();
 
             if( hasPrerequisite && !hasPrerequisiteFulfilled ) {
                 popup( _( "Prerequisite for this option not met!\n(%s)" ),
@@ -3246,7 +3246,7 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
 
 #if !defined(__ANDROID__) && (defined(TILES) || defined(_WIN32))
     if( terminal_size_changed ) {
-        int scaling_factor = get_scaling_factor();
+        int const scaling_factor = get_scaling_factor();
         int TERMX = ::get_option<int>( "TERMINAL_X" );
         int TERMY = ::get_option<int>( "TERMINAL_Y" );
         TERMX -= TERMX % scaling_factor;
@@ -3298,7 +3298,7 @@ void options_manager::deserialize( JsonIn &jsin )
 {
     jsin.start_array();
     while( !jsin.end_array() ) {
-        JsonObject joOptions = jsin.get_object();
+        JsonObject const joOptions = jsin.get_object();
         joOptions.allow_omitted_members();
 
         const std::string name = migrateOptionName( joOptions.get_string( "name" ) );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -522,7 +522,7 @@ void options_manager::add_option_group( const std::string &page_id,
                   group.id_, adding_to_group_ );
         return;
     }
-    for( Group  const&g : groups_ ) {
+    for( Group  const &g : groups_ ) {
         if( g.id_ == group.id_ ) {
             debugmsg( "Option group with id '%s' already exists", group.id_ );
             return;
@@ -1106,7 +1106,7 @@ std::vector<options_manager::id_and_option> options_manager::build_tilesets_list
     // Load from user directory
     std::vector<options_manager::id_and_option> const user_tilesets = load_tilesets_from(
                 PATH_INFO::user_gfx() );
-    for( options_manager::id_and_option const& id : user_tilesets ) {
+    for( options_manager::id_and_option const &id : user_tilesets ) {
         if( std::find( result.begin(), result.end(), id ) == result.end() ) {
             result.emplace_back( id );
         }
@@ -2928,7 +2928,7 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
 
                     std::string const name_prefix = it.group.empty() ? "" : IN_GROUP_PREFIX;
                     string_col const name( name_prefix + opt.getMenuText(), !hasPrerequisite ||
-                                     hasPrerequisiteFulfilled ? c_white : c_light_gray );
+                                           hasPrerequisiteFulfilled ? c_white : c_light_gray );
 
                     nc_color cLineColor;
                     if( hasPrerequisite && !hasPrerequisiteFulfilled ) {

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -81,7 +81,7 @@ std::vector<std::string> foldstring( const std::string &str, int width, const ch
             // if the line is empty.
             lines.emplace_back();
         } else {
-            std::string wrapped = word_rewrap( strline, width, split );
+            std::string const wrapped = word_rewrap( strline, width, split );
             std::stringstream swrapped( wrapped );
             std::string wline;
             while( std::getline( swrapped, wline, '\n' ) ) {
@@ -131,9 +131,9 @@ std::vector<std::string> foldstring( const std::string &str, int width, const ch
 std::vector<std::string> split_by_color( const std::string &s )
 {
     std::vector<std::string> ret;
-    std::vector<size_t> tag_positions = get_tag_positions( s );
+    std::vector<size_t> const tag_positions = get_tag_positions( s );
     size_t last_pos = 0;
-    for( size_t tag_position : tag_positions ) {
+    for( size_t const tag_position : tag_positions ) {
         ret.push_back( s.substr( last_pos, tag_position - last_pos ) );
         last_pos = tag_position;
     }
@@ -145,11 +145,11 @@ std::vector<std::string> split_by_color( const std::string &s )
 std::string remove_color_tags( const std::string &s )
 {
     std::string ret;
-    std::vector<size_t> tag_positions = get_tag_positions( s );
+    std::vector<size_t> const tag_positions = get_tag_positions( s );
     size_t next_pos = 0;
 
     if( !tag_positions.empty() ) {
-        for( size_t tag_position : tag_positions ) {
+        for( size_t const tag_position : tag_positions ) {
             ret += s.substr( next_pos, tag_position - next_pos );
             next_pos = s.find( ">", tag_position, 1 ) + 1;
         }
@@ -165,7 +165,7 @@ color_tag_parse_result::tag_type update_color_stack(
     std::stack<nc_color> &color_stack, const std::string &seg,
     const report_color_error color_error )
 {
-    color_tag_parse_result tag = get_color_from_tag( seg, color_error );
+    color_tag_parse_result const tag = get_color_from_tag( seg, color_error );
     switch( tag.type ) {
         case color_tag_parse_result::open_color_tag:
             color_stack.push( tag.color );
@@ -216,7 +216,7 @@ void trim_and_print( const catacurses::window &w, point begin,
                      const std::string &text,
                      const report_color_error color_error )
 {
-    std::string sText = trim_by_length( text, width );
+    std::string const sText = trim_by_length( text, width );
     nc_color dummy = base_color;
     print_colored_text( w, begin, dummy, base_color, sText, color_error );
 }
@@ -336,7 +336,7 @@ int fold_and_print_from( const catacurses::window &w, point begin, int width,
                     l = rm_prefix( l );
                 }
                 if( l != "--" ) { // -- is a separation line!
-                    nc_color color = color_stack.empty() ? base_color : color_stack.top();
+                    nc_color const color = color_stack.empty() ? base_color : color_stack.top();
                     wprintz( w, color, l );
                 } else {
                     for( int i = 0; i < width; i++ ) {
@@ -446,8 +446,8 @@ std::string name_and_value( const std::string &name, int value, int field_width 
 void center_print( const catacurses::window &w, const int y, const nc_color &FG,
                    const std::string &text )
 {
-    int window_width = getmaxx( w );
-    int string_width = utf8_width( text, true );
+    int const window_width = getmaxx( w );
+    int const string_width = utf8_width( text, true );
     int x;
     if( string_width >= window_width ) {
         x = 0;
@@ -490,7 +490,7 @@ void mvwputch( const catacurses::window &w, point p, nc_color FG, const std::str
 
 void mvwputch_inv( const catacurses::window &w, point p, nc_color FG, int ch )
 {
-    nc_color HC = invert_color( FG );
+    nc_color const HC = invert_color( FG );
     wattron( w, HC );
     mvwaddch( w, p, ch );
     wattroff( w, HC );
@@ -499,7 +499,7 @@ void mvwputch_inv( const catacurses::window &w, point p, nc_color FG, int ch )
 void mvwputch_inv( const catacurses::window &w, point p, nc_color FG,
                    const std::string &ch )
 {
-    nc_color HC = invert_color( FG );
+    nc_color const HC = invert_color( FG );
     wattron( w, HC );
     mvwprintw( w, p, ch );
     wattroff( w, HC );
@@ -507,7 +507,7 @@ void mvwputch_inv( const catacurses::window &w, point p, nc_color FG,
 
 void mvwputch_hi( const catacurses::window &w, point p, nc_color FG, int ch )
 {
-    nc_color HC = hilite( FG );
+    nc_color const HC = hilite( FG );
     wattron( w, HC );
     mvwaddch( w, p, ch );
     wattroff( w, HC );
@@ -515,7 +515,7 @@ void mvwputch_hi( const catacurses::window &w, point p, nc_color FG, int ch )
 
 void mvwputch_hi( const catacurses::window &w, point p, nc_color FG, const std::string &ch )
 {
-    nc_color HC = hilite( FG );
+    nc_color const HC = hilite( FG );
     wattron( w, HC );
     mvwprintw( w, p, ch );
     wattroff( w, HC );
@@ -586,8 +586,8 @@ void draw_border( const catacurses::window &w, nc_color border_color, const std:
 
 void draw_border_below_tabs( const catacurses::window &w, nc_color border_color )
 {
-    int width = getmaxx( w );
-    int height = getmaxy( w );
+    int const width = getmaxx( w );
+    int const height = getmaxy( w );
     for( int i = 1; i < width - 1; i++ ) {
         mvwputch( w, point( i, height - 1 ), border_color, LINE_OXOX );
     }
@@ -745,8 +745,8 @@ bool query_int( int &result, const std::string &text )
 std::vector<std::string> get_hotkeys( const std::string &s )
 {
     std::vector<std::string> hotkeys;
-    size_t start = s.find_first_of( '<' );
-    size_t end = s.find_first_of( '>' );
+    size_t const start = s.find_first_of( '<' );
+    size_t const end = s.find_first_of( '>' );
     if( start != std::string::npos && end != std::string::npos ) {
         // hotkeys separated by '|' inside '<' and '>', for example "<e|E|?>"
         size_t lastsep = start;
@@ -793,7 +793,7 @@ int popup( const std::string &text, PopupFlags flags )
 input_event draw_item_info( const int iLeft, const int iWidth, const int iTop, const int iHeight,
                             item_info_data &data )
 {
-    catacurses::window win =
+    catacurses::window const win =
         catacurses::newwin( iHeight, iWidth,
                             point( iLeft, iTop ) );
 
@@ -874,11 +874,11 @@ std::string format_item_info( const std::vector<iteminfo> &item_display,
                 buffer += i.sName;
             }
 
-            std::string sFmt = i.sFmt;
+            std::string const sFmt = i.sFmt;
             std::string sPost;
 
             //A bit tricky, find %d and split the string
-            size_t pos = sFmt.find( "<num>" );
+            size_t const pos = sFmt.find( "<num>" );
             if( pos != std::string::npos ) {
                 buffer += sFmt.substr( 0, pos );
                 sPost = sFmt.substr( pos + 5 );
@@ -1149,7 +1149,7 @@ std::string word_rewrap( const std::string &in, int width, const uint32_t split 
     for( int j = 0, x = 0; j < static_cast<int>( in.size() ); ) {
         const char *ins = instr + j;
         int len = ANY_LENGTH;
-        uint32_t uc = UTF8_getch( &ins, &len );
+        uint32_t const uc = UTF8_getch( &ins, &len );
 
         if( uc == '<' ) { // maybe skip non-printing tag
             std::vector<size_t>::iterator it;
@@ -1214,7 +1214,7 @@ std::string word_rewrap( const std::string &in, int width, const uint32_t split 
 
 void draw_tab( const catacurses::window &w, int iOffsetX, const std::string &sText, bool bSelected )
 {
-    int iOffsetXRight = iOffsetX + utf8_width( sText ) + 1;
+    int const iOffsetXRight = iOffsetX + utf8_width( sText ) + 1;
 
     mvwputch( w, point( iOffsetX, 0 ),      c_light_gray, LINE_OXXO ); // |^
     mvwputch( w, point( iOffsetXRight, 0 ), c_light_gray, LINE_OOXX ); // ^|
@@ -1248,7 +1248,7 @@ void draw_subtab( const catacurses::window &w, int iOffsetX, const std::string &
                   bool bSelected,
                   bool bDecorate, bool bDisabled )
 {
-    int iOffsetXRight = iOffsetX + utf8_width( sText ) + 1;
+    int const iOffsetXRight = iOffsetX + utf8_width( sText ) + 1;
 
     if( !bDisabled ) {
         mvwprintz( w, point( iOffsetX + 1, 0 ), ( bSelected ) ? h_light_gray : c_light_gray, sText );
@@ -1274,7 +1274,7 @@ void draw_subtab( const catacurses::window &w, int iOffsetX, const std::string &
 void draw_tabs( const catacurses::window &w, const std::vector<std::string> &tab_texts,
                 size_t current_tab )
 {
-    int width = getmaxx( w );
+    int const width = getmaxx( w );
     for( int i = 0; i < width; i++ ) {
         mvwputch( w, point( i, 2 ), BORDER_COLOR, LINE_OXOX ); // -
     }
@@ -1405,9 +1405,9 @@ void scrollbar::apply( const catacurses::window &window )
         mvwputch( window, point( offset_x_v, offset_y_v ), arrow_color_v, '^' );
         mvwputch( window, point( offset_x_v, offset_y_v + viewport_size_v - 1 ), arrow_color_v, 'v' );
 
-        int slot_size = viewport_size_v - 2;
-        int bar_size = std::max( 2, slot_size * viewport_size_v / content_size_v );
-        int scrollable_size = scroll_to_last_v ? content_size_v : content_size_v - viewport_size_v + 1;
+        int const slot_size = viewport_size_v - 2;
+        int const bar_size = std::max( 2, slot_size * viewport_size_v / content_size_v );
+        int const scrollable_size = scroll_to_last_v ? content_size_v : content_size_v - viewport_size_v + 1;
 
         int bar_start;
         if( viewport_pos_v == 0 ) {
@@ -1417,7 +1417,7 @@ void scrollbar::apply( const catacurses::window &window )
         } else {
             bar_start = slot_size - bar_size;
         }
-        int bar_end = bar_start + bar_size;
+        int const bar_end = bar_start + bar_size;
 
         for( int i = 0; i < slot_size; ++i ) {
             if( i >= bar_start && i < bar_end ) {
@@ -1480,7 +1480,7 @@ void scrolling_text_view::draw( const nc_color &base_color )
     }
 
     nc_color color = base_color;
-    int end = std::min( num_lines() - offset_, height );
+    int const end = std::min( num_lines() - offset_, height );
     for( int line_num = 0; line_num < end; ++line_num ) {
         print_colored_text( w_, point( 1, line_num ), color, base_color,
                             text_[line_num + offset_] );
@@ -1529,7 +1529,7 @@ void calcStartPos( int &iStartPos, const int iCurrentLine, const int iContentHei
 std::string rm_prefix( std::string str, char c1, char c2 )
 {
     if( !str.empty() && str[0] == c1 ) {
-        size_t pos = str.find_first_of( c2 );
+        size_t const pos = str.find_first_of( c2 );
         if( pos != std::string::npos ) {
             str = str.substr( pos + 1 );
         }
@@ -1551,7 +1551,7 @@ size_t shortcut_print( const catacurses::window &w, point p, nc_color text_color
 size_t shortcut_print( const catacurses::window &w, nc_color text_color, nc_color shortcut_color,
                        const std::string &fmt )
 {
-    std::string text = shortcut_text( shortcut_color, fmt );
+    std::string const text = shortcut_text( shortcut_color, fmt );
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     print_colored_text( w, point( -1, -1 ), text_color, text_color, text );
 
@@ -1561,13 +1561,13 @@ size_t shortcut_print( const catacurses::window &w, nc_color text_color, nc_colo
 //generate colorcoded shortcut text
 std::string shortcut_text( nc_color shortcut_color, const std::string &fmt )
 {
-    size_t pos = fmt.find_first_of( '<' );
-    size_t pos_end = fmt.find_first_of( '>' );
+    size_t const pos = fmt.find_first_of( '<' );
+    size_t const pos_end = fmt.find_first_of( '>' );
     if( pos_end != std::string::npos && pos < pos_end ) {
-        size_t sep = std::min( fmt.find_first_of( '|', pos ), pos_end );
-        std::string prestring = fmt.substr( 0, pos );
-        std::string poststring = fmt.substr( pos_end + 1, std::string::npos );
-        std::string shortcut = fmt.substr( pos + 1, sep - pos - 1 );
+        size_t const sep = std::min( fmt.find_first_of( '|', pos ), pos_end );
+        std::string const prestring = fmt.substr( 0, pos );
+        std::string const poststring = fmt.substr( pos_end + 1, std::string::npos );
+        std::string const shortcut = fmt.substr( pos + 1, sep - pos - 1 );
 
         return prestring + colorize( shortcut, shortcut_color ) + poststring;
     }
@@ -1584,7 +1584,7 @@ get_bar( float cur, float max, int width, bool extra_resolution,
     float status = cur / max;
     status = status > 1 ? 1 : status;
     status = status < 0 ? 0 : status;
-    float sw = status * width;
+    float const sw = status * width;
 
     nc_color col = colors[static_cast<int>( ( 1 - status ) * colors.size() )];
     if( status == 0 ) {
@@ -1668,7 +1668,7 @@ void insert_table( const catacurses::window &w, int pad, int line, int columns,
         indent = ( col_width * columns ) + 1;
     }
     int div = columns - 1;
-    int offset = 0;
+    int const offset = 0;
 
 #if defined(__ANDROID__)
     input_context ctxt( "INSERT_TABLE" );
@@ -1678,7 +1678,7 @@ void insert_table( const catacurses::window &w, int pad, int line, int columns,
         if( i + offset * columns >= static_cast<int>( data.size() ) ) {
             break;
         }
-        int y = line + ( i / columns );
+        int const y = line + ( i / columns );
         if( r_align ) {
             indent -= col_width;
         }
@@ -1733,7 +1733,7 @@ scrollingcombattext::cSCT::cSCT( point p_pos, const direction p_oDir,
     oLeft = iso_mode ? direction::NORTHWEST : direction::WEST;
     oUpLeft = iso_mode ? direction::NORTH : direction::NORTHWEST;
 
-    point pairDirXY = direction_XY( oDir );
+    point const pairDirXY = direction_XY( oDir );
 
     dir = pairDirXY;
 
@@ -1987,7 +1987,7 @@ std::string string_from_int( const catacurses::chtype ch )
             charcode = ch;
             break;
     }
-    char buffer[2] = { static_cast<char>( charcode ), '\0' };
+    char const buffer[2] = { static_cast<char>( charcode ), '\0' };
     return buffer;
 }
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1407,7 +1407,8 @@ void scrollbar::apply( const catacurses::window &window )
 
         int const slot_size = viewport_size_v - 2;
         int const bar_size = std::max( 2, slot_size * viewport_size_v / content_size_v );
-        int const scrollable_size = scroll_to_last_v ? content_size_v : content_size_v - viewport_size_v + 1;
+        int const scrollable_size = scroll_to_last_v ? content_size_v : content_size_v - viewport_size_v +
+                                    1;
 
         int bar_start;
         if( viewport_pos_v == 0 ) {

--- a/src/overlay_ordering.cpp
+++ b/src/overlay_ordering.cpp
@@ -16,8 +16,8 @@ void load_overlay_ordering( const JsonObject &jsobj )
 void load_overlay_ordering_into_array( const JsonObject &jsobj,
                                        std::map<std::string, int> &orderarray )
 {
-    for( JsonObject ordering : jsobj.get_array( "overlay_ordering" ) ) {
-        int order = ordering.get_int( "order" );
+    for( JsonObject const ordering : jsobj.get_array( "overlay_ordering" ) ) {
+        int const order = ordering.get_int( "order" );
         for( auto &id : ordering.get_tags( "id" ) ) {
             orderarray[id] = order;
         }

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1475,7 +1475,7 @@ void overmap::delete_note( const tripoint_om_omt &p )
 std::vector<point_abs_omt> overmap::find_notes( const int z, const std::string &text )
 {
     std::vector<point_abs_omt> note_locations;
-    map_layer  const&this_layer = layer[z + OVERMAP_DEPTH];
+    map_layer  const &this_layer = layer[z + OVERMAP_DEPTH];
     for( const auto &note : this_layer.notes ) {
         if( match_include_exclude( note.text, text ) ) {
             note_locations.push_back( project_combine( pos(), note.p ) );
@@ -1545,7 +1545,7 @@ void overmap::delete_extra( const tripoint_om_omt &p )
 std::vector<point_abs_omt> overmap::find_extras( const int z, const std::string &text )
 {
     std::vector<point_abs_omt> extra_locations;
-    map_layer  const&this_layer = layer[z + OVERMAP_DEPTH];
+    map_layer  const &this_layer = layer[z + OVERMAP_DEPTH];
     for( const auto &extra : this_layer.extras ) {
         const std::string extra_text = extra.id.c_str();
         if( match_include_exclude( extra_text, text ) ) {
@@ -1591,7 +1591,7 @@ static void fixup_labs( overmap &om )
     }
 
     bool has_endgame = false;
-    for( lab  const&l : om.labs ) {
+    for( lab  const &l : om.labs ) {
         if( l.type != lab_type::central ) {
             continue;
         }
@@ -1827,7 +1827,8 @@ bool overmap::generate_sub( const int z )
                           pos().to_string() );
                 continue;
             }
-            int const size = l->type == lab_type::central ? rng( std::max( 1, 7 + z ), 9 + z ) : rng( 1, 5 + z );
+            int const size = l->type == lab_type::central ? rng( std::max( 1, 7 + z ), 9 + z ) : rng( 1,
+                             5 + z );
             bool const goes_lower = build_lab( p, *l, size, lab_train_points, prefix, lab_train_odds );
             requires_sub |= goes_lower;
             if( !goes_lower && ter( p ) == oter_id( prefix + "lab_core" ) ) {
@@ -1950,7 +1951,7 @@ bool overmap::generate_sub( const int z )
             continue;
         }
         mongroup_id const ant_group( ter( p_loc + tripoint_above ) == "anthill" ?
-                               "GROUP_ANT" : "GROUP_ANT_ACID" );
+                                     "GROUP_ANT" : "GROUP_ANT_ACID" );
         add_mon_group(
             mongroup( ant_group, tripoint_om_sm( project_to<coords::sm>( i.pos ), z ),
                       ( i.size * 3 ) / 2, rng( 6000, 8000 ) ) );
@@ -2178,7 +2179,7 @@ void mongroup::wander( const overmap &om )
         for( const city &check_city : om.cities ) {
             // Check if this is the nearest city so far.
             int const distance = rl_dist( project_to<coords::sm>( check_city.pos ),
-                                    pos.xy() );
+                                          pos.xy() );
             if( !target_city || distance < target_distance ) {
                 target_distance = distance;
                 target_city = &check_city;
@@ -2494,7 +2495,7 @@ void overmap::place_forest_trails()
             // calculating the actual centroid--it's not that important) to have another
             // good point to form the foundation of the trail system.
             point_om_omt const center( westmost.x() + ( eastmost.x() - westmost.x() ) / 2,
-                                 northmost.y() + ( southmost.y() - northmost.y() ) / 2 );
+                                       northmost.y() + ( southmost.y() - northmost.y() ) / 2 );
 
             point_om_omt center_point = center;
 
@@ -3232,9 +3233,9 @@ overmap_special_id overmap::pick_random_building_to_place( int town_dist ) const
     //Clamp at 1/2 radius to prevent houses from spawning in the city center.
     //Parks are nearly guaranteed to have a non-zero chance of spawning anywhere in the city.
     int const shop_normal = std::max( static_cast<int>( normal_roll( shop_radius, shop_sigma ) ),
-                                shop_radius );
+                                      shop_radius );
     int const park_normal = std::max( static_cast<int>( normal_roll( park_radius, park_sigma ) ),
-                                park_radius );
+                                      park_radius );
 
     if( shop_normal > town_dist ) {
         return city_spec.pick_shop();
@@ -3380,7 +3381,8 @@ bool overmap::build_lab( const tripoint_om_omt &p, lab &l, int s,
         }
         const int dist = manhattan_dist( p.xy(), cand.xy() );
         if( dist <= s * 2 ) { // increase radius to compensate for sparser new algorithm
-            int const dist_increment = s > 3 ? 3 : 2; // Determines at what distance the odds of placement decreases
+            int const dist_increment = s > 3 ? 3 :
+                                       2; // Determines at what distance the odds of placement decreases
             if( one_in( dist / dist_increment + 1 ) ) { // odds diminish farther away from the stairs
                 // make an ants lab if it's a basic lab and ants were there before.
                 if( prefix.empty() && check_ot( "ants", ot_match_type::type, cand ) ) {
@@ -3404,7 +3406,7 @@ bool overmap::build_lab( const tripoint_om_omt &p, lab &l, int s,
     }
 
     bool generate_stairs = true;
-    for( tripoint_om_omt  const&elem : generated_lab ) {
+    for( tripoint_om_omt  const &elem : generated_lab ) {
         // Use a check for "_stairs" to catch the hidden_lab_stairs tiles.
         if( is_ot_match( "_stairs", ter( elem + tripoint_above ), ot_match_type::contains ) ) {
             generate_stairs = false;

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -449,7 +449,7 @@ void overmap_special_connection::deserialize( const JsonObject &jo )
         }
 
         if( !jo.has_member( "connection" ) ) {
-            std::string t = jo.get_string( "terrain" );
+            std::string const t = jo.get_string( "terrain" );
             if( t == "sewer" ) {
                 connection = overmap_connection_id( "sewer_tunnel" );
             } else if( t == "subway" ) {
@@ -629,7 +629,7 @@ static void load_overmap_terrain_mapgens( const JsonObject &jo, const std::strin
     const std::string jsonkey( "mapgen" + suffix );
     register_mapgen_function( fmapkey );
     if( jo.has_array( jsonkey ) ) {
-        for( JsonObject jio : jo.get_array( jsonkey ) ) {
+        for( JsonObject const jio : jo.get_array( jsonkey ) ) {
             // NOLINTNEXTLINE(cata-use-named-point-constants)
             load_and_add_mapgen_function( jio, fmapkey, point_zero, point( 1, 1 ) );
         }
@@ -712,7 +712,7 @@ void oter_type_t::finalize()
     directional_peers.clear();  // In case of a second finalization.
 
     if( is_rotatable() ) {
-        for( om_direction::type dir : om_direction::all ) {
+        for( om_direction::type const dir : om_direction::all ) {
             register_terrain( oter_t( *this, dir ), static_cast<size_t>( dir ), om_direction::size );
         }
     } else if( has_flag( line_drawing ) ) {
@@ -1140,7 +1140,7 @@ void overmap_special::check() const
 overmap::overmap( const point_abs_om &p ) : loc( p )
 {
     const std::string rsettings_id = get_option<std::string>( "DEFAULT_REGION" );
-    t_regional_settings_map_citr rsit = region_settings_map.find( rsettings_id );
+    t_regional_settings_map_citr const rsit = region_settings_map.find( rsettings_id );
 
     if( rsit == region_settings_map.end() ) {
         // gonna die now =[
@@ -1475,7 +1475,7 @@ void overmap::delete_note( const tripoint_om_omt &p )
 std::vector<point_abs_omt> overmap::find_notes( const int z, const std::string &text )
 {
     std::vector<point_abs_omt> note_locations;
-    map_layer &this_layer = layer[z + OVERMAP_DEPTH];
+    map_layer  const&this_layer = layer[z + OVERMAP_DEPTH];
     for( const auto &note : this_layer.notes ) {
         if( match_include_exclude( note.text, text ) ) {
             note_locations.push_back( project_combine( pos(), note.p ) );
@@ -1545,7 +1545,7 @@ void overmap::delete_extra( const tripoint_om_omt &p )
 std::vector<point_abs_omt> overmap::find_extras( const int z, const std::string &text )
 {
     std::vector<point_abs_omt> extra_locations;
-    map_layer &this_layer = layer[z + OVERMAP_DEPTH];
+    map_layer  const&this_layer = layer[z + OVERMAP_DEPTH];
     for( const auto &extra : this_layer.extras ) {
         const std::string extra_text = extra.id.c_str();
         if( match_include_exclude( extra_text, text ) ) {
@@ -1591,7 +1591,7 @@ static void fixup_labs( overmap &om )
     }
 
     bool has_endgame = false;
-    for( lab &l : om.labs ) {
+    for( lab  const&l : om.labs ) {
         if( l.type != lab_type::central ) {
             continue;
         }
@@ -1632,7 +1632,7 @@ void overmap::generate( const overmap *north, const overmap *east,
 
     clear_labs();
 
-    bool needs_endgame = std::any_of( enabled_specials.begin(),
+    bool const needs_endgame = std::any_of( enabled_specials.begin(),
     enabled_specials.end(), []( const overmap_special_placement & pl ) {
         return pl.special_details->flags.count( "ENDGAME" );
     } );
@@ -1693,7 +1693,7 @@ bool overmap::generate_sub( const int z )
     std::vector<point_om_omt> ice_lab_points;
     std::vector<point_om_omt> central_lab_points;
     std::vector<point_om_omt> lab_train_points;
-    std::vector<point_om_omt> central_lab_train_points;
+    std::vector<point_om_omt> const central_lab_train_points;
     std::vector<city> mine_points;
     // These are so common that it's worth checking first as int.
     const oter_id skip_above[5] = {
@@ -1729,12 +1729,12 @@ bool overmap::generate_sub( const int z )
 
     for( int i = 0; i < OMAPX; i++ ) {
         for( int j = 0; j < OMAPY; j++ ) {
-            tripoint_om_omt p( i, j, z );
+            tripoint_om_omt const p( i, j, z );
             const oter_id oter_above = ter( p + tripoint_above );
             const oter_id oter_ground = ter( tripoint_om_omt( p.xy(), 0 ) );
 
             if( is_ot_match( "microlab_sub_connector", ter( p ), ot_match_type::type ) ) {
-                om_direction::type rotation = ter( p )->get_dir();
+                om_direction::type const rotation = ter( p )->get_dir();
                 ter_set( p, oter_id( "subway_end_north" )->get_rotated( rotation ) );
                 subway_points.emplace_back( p.xy() );
             }
@@ -1827,8 +1827,8 @@ bool overmap::generate_sub( const int z )
                           pos().to_string() );
                 continue;
             }
-            int size = l->type == lab_type::central ? rng( std::max( 1, 7 + z ), 9 + z ) : rng( 1, 5 + z );
-            bool goes_lower = build_lab( p, *l, size, lab_train_points, prefix, lab_train_odds );
+            int const size = l->type == lab_type::central ? rng( std::max( 1, 7 + z ), 9 + z ) : rng( 1, 5 + z );
+            bool const goes_lower = build_lab( p, *l, size, lab_train_points, prefix, lab_train_odds );
             requires_sub |= goes_lower;
             if( !goes_lower && ter( p ) == oter_id( prefix + "lab_core" ) ) {
                 ter_set( p, oter_id( prefix + "lab" ) );
@@ -1845,7 +1845,7 @@ bool overmap::generate_sub( const int z )
     std::vector<point_om_omt> &real_train_points ) {
         bool is_first_in_pair = true;
         for( auto &p : train_points ) {
-            tripoint_om_omt i( p, z );
+            tripoint_om_omt const i( p, z );
             const std::vector<tripoint_om_omt> nearby_locations {
                 i + point_north,
                 i + point_south,
@@ -1893,7 +1893,7 @@ bool overmap::generate_sub( const int z )
         bool is_first_in_pair = true;
         std::vector<point_om_omt> extra_route;
         for( auto &p : train_points ) {
-            tripoint_om_omt i( p, z );
+            tripoint_om_omt const i( p, z );
             if( is_first_in_pair ) {
                 const std::vector<tripoint_om_omt> subway_possible_loc {
                     i + point_north,
@@ -1926,8 +1926,8 @@ bool overmap::generate_sub( const int z )
     create_train_depots( oter_id( "central_lab_train_depot" ), central_lab_train_points );
 
     for( auto &i : cities ) {
-        tripoint_om_omt omt_pos( i.pos, z );
-        tripoint_om_sm sm_pos = project_to<coords::sm>( omt_pos );
+        tripoint_om_omt const omt_pos( i.pos, z );
+        tripoint_om_sm const sm_pos = project_to<coords::sm>( omt_pos );
         // Sewers and city subways are present at z == -1 and z == -2. Don't spawn CHUD on other z-levels.
         if( ( z == -1 || z == -2 ) && one_in( 3 ) ) {
             add_mon_group( mongroup( GROUP_CHUD,
@@ -1949,7 +1949,7 @@ bool overmap::generate_sub( const int z )
         if( ter( p_loc ) != "empty_rock" ) {
             continue;
         }
-        mongroup_id ant_group( ter( p_loc + tripoint_above ) == "anthill" ?
+        mongroup_id const ant_group( ter( p_loc + tripoint_above ) == "anthill" ?
                                "GROUP_ANT" : "GROUP_ANT_ACID" );
         add_mon_group(
             mongroup( ant_group, tripoint_om_sm( project_to<coords::sm>( i.pos ), z ),
@@ -1975,7 +1975,7 @@ static void elevate_bridges(
     std::vector<std::pair<point_om_omt, om_direction::type>> bridgehead_points;
     std::set<point_om_omt> flatten_points;
     for( const point_om_omt &bp : bridge_points ) {
-        tripoint_om_omt bp_om( bp, 0 );
+        tripoint_om_omt const bp_om( bp, 0 );
 
         const oter_id &ot_here = om.ter( bp_om );
         const std::string &type_here = ot_here->get_type_id().str();
@@ -1985,12 +1985,12 @@ static void elevate_bridges(
             debugmsg( "Potential bridgehead %s at %s has invalid rotation.", ot_here.id(), bp_om.to_string() );
             continue;
         }
-        point vec = om_direction::displace( dir );
+        point const vec = om_direction::displace( dir );
         const bool is_bridge_fwd = is_ot_match( type_here, om.ter( bp_om + vec ), ot_match_type::type );
         const bool is_bridge_bck = is_ot_match( type_here, om.ter( bp_om - vec ), ot_match_type::type );
 
         if( is_bridge_fwd ^ is_bridge_bck ) {
-            om_direction::type ramp_facing = is_bridge_fwd ? om_direction::opposite( dir ) : dir;
+            om_direction::type const ramp_facing = is_bridge_fwd ? om_direction::opposite( dir ) : dir;
             bridgehead_points.emplace_back( bp, ramp_facing );
         } else if( !is_bridge_fwd && !is_bridge_bck ) {
             flatten_points.emplace( bp );
@@ -1998,8 +1998,8 @@ static void elevate_bridges(
     }
     // Flatten 1-tile-long bridges
     for( const point_om_omt &bp : flatten_points ) {
-        tripoint_om_omt p( bp, 0 );
-        om_direction::type rot = oter_get_rotation_dir( om.ter( p ) );
+        tripoint_om_omt const p( bp, 0 );
+        om_direction::type const rot = oter_get_rotation_dir( om.ter( p ) );
         if( rot == om_direction::type::east || rot == om_direction::type::west ) {
             om.ter_set( p, oter_id( bridge_flat_ew_id ) );
         } else {
@@ -2011,14 +2011,14 @@ static void elevate_bridges(
         if( flatten_points.count( bp ) != 0 ) {
             continue;
         }
-        tripoint_om_omt p( bp, 0 );
+        tripoint_om_omt const p( bp, 0 );
         const std::string &rot_sfx = oter_get_rotation_string( om.ter( p ) );
         om.ter_set( p + tripoint_above, oter_id( bridge_overpass_id + rot_sfx ) );
         om.ter_set( p, oter_id( bridge_under_id + rot_sfx ) );
     }
     // Put bridgeheads
     for( const std::pair<point_om_omt, om_direction::type> &bhp : bridgehead_points ) {
-        tripoint_om_omt p( bhp.first, 0 );
+        tripoint_om_omt const p( bhp.first, 0 );
         const std::string &dir_suffix = om_direction::all_suffixes[static_cast<int>( bhp.second )];
         om.ter_set( p, oter_id( bridgehead_ground_id + dir_suffix ) );
         om.ter_set( p + tripoint_above, oter_id( bridgehead_ramp_id + dir_suffix ) );
@@ -2027,7 +2027,7 @@ static void elevate_bridges(
 
 bool overmap::generate_over( const int z )
 {
-    bool requires_over = false;
+    bool const requires_over = false;
     std::vector<point_om_omt> bridge_points;
 
     if( !get_option<bool>( "ELEVATED_BRIDGES" ) ) {
@@ -2043,8 +2043,8 @@ bool overmap::generate_over( const int z )
     if( z == 1 ) {
         for( int i = 0; i < OMAPX; i++ ) {
             for( int j = 0; j < OMAPY; j++ ) {
-                tripoint_om_omt p( i, j, z );
-                tripoint_om_omt p_below( p + tripoint_below );
+                tripoint_om_omt const p( i, j, z );
+                tripoint_om_omt const p_below( p + tripoint_below );
                 const oter_id oter_below = ter( p_below );
                 const oter_id oter_ground = ter( tripoint_om_omt( p.xy(), 0 ) );
 
@@ -2078,7 +2078,7 @@ std::vector<point_abs_omt> overmap::find_terrain( const std::string &term, int z
     std::vector<point_abs_omt> found;
     for( int x = 0; x < OMAPX; x++ ) {
         for( int y = 0; y < OMAPY; y++ ) {
-            tripoint_om_omt p( x, y, zlevel );
+            tripoint_om_omt const p( x, y, zlevel );
             if( seen( p ) &&
                 lcmatch( ter( p )->get_name(), term ) ) {
                 found.push_back( project_combine( pos(), p.xy() ) );
@@ -2102,7 +2102,7 @@ const city &overmap::get_nearest_city( const tripoint_om_omt &p ) const
     if( res != nullptr ) {
         return *res;
     }
-    static city invalid_city;
+    static city const invalid_city;
     return invalid_city;
 }
 
@@ -2113,7 +2113,7 @@ const
     for( int i = 0; i < OMAPX; i++ ) {
         for( int j = 0; j < OMAPY; j++ ) {
             for( int k = -OVERMAP_DEPTH; k <= OVERMAP_HEIGHT; k++ ) {
-                tripoint_om_omt p( i, j, k );
+                tripoint_om_omt const p( i, j, k );
                 if( is_ot_match( target.first, ter( p ), target.second ) ) {
                     valid.push_back( p );
                 }
@@ -2164,7 +2164,7 @@ void overmap::clear_connections_out()
 void overmap::place_special_forced( const overmap_special_id &special_id, const tripoint_om_omt &p,
                                     om_direction::type dir )
 {
-    static city invalid_city;
+    static city const invalid_city;
     place_special( *special_id, p, dir, invalid_city, false, true );
 }
 
@@ -2177,7 +2177,7 @@ void mongroup::wander( const overmap &om )
         // Find a nearby city to return to..
         for( const city &check_city : om.cities ) {
             // Check if this is the nearest city so far.
-            int distance = rl_dist( project_to<coords::sm>( check_city.pos ),
+            int const distance = rl_dist( project_to<coords::sm>( check_city.pos ),
                                     pos.xy() );
             if( !target_city || distance < target_distance ) {
                 target_distance = distance;
@@ -2343,7 +2343,7 @@ void overmap::move_hordes()
 */
 void overmap::signal_hordes( const tripoint_rel_sm &p_rel, const int sig_power )
 {
-    tripoint_om_sm p( p_rel.raw() );
+    tripoint_om_sm const p( p_rel.raw() );
     for( auto &elem : zg ) {
         mongroup &mg = elem.second;
         if( !mg.horde ) {
@@ -2442,9 +2442,9 @@ void overmap::place_forest_trails()
 
     for( int i = 0; i < OMAPX; i++ ) {
         for( int j = 0; j < OMAPY; j++ ) {
-            tripoint_om_omt seed_point( i, j, 0 );
+            tripoint_om_omt const seed_point( i, j, 0 );
 
-            oter_id oter = ter( seed_point );
+            oter_id const oter = ter( seed_point );
             if( !is_ot_match( "forest", oter, ot_match_type::prefix ) ) {
                 continue;
             }
@@ -2493,7 +2493,7 @@ void overmap::place_forest_trails()
             // Do a simplistic calculation of the center of the forest (rather than
             // calculating the actual centroid--it's not that important) to have another
             // good point to form the foundation of the trail system.
-            point_om_omt center( westmost.x() + ( eastmost.x() - westmost.x() ) / 2,
+            point_om_omt const center( westmost.x() + ( eastmost.x() - westmost.x() ) / 2,
                                  northmost.y() + ( southmost.y() - northmost.y() ) / 2 );
 
             point_om_omt center_point = center;
@@ -2502,7 +2502,7 @@ void overmap::place_forest_trails()
             // guarantee that our center point is actually within the bounds of the
             // forest. Just find the point within our set that is closest to our
             // center point and use that.
-            point_om_omt actual_center_point =
+            point_om_omt const actual_center_point =
                 *std::min_element( forest_points.begin(), forest_points.end(),
             [&center_point]( const point_om_omt & lhs, const point_om_omt & rhs ) {
                 return square_dist( lhs, center_point ) < square_dist( rhs,
@@ -2580,7 +2580,7 @@ void overmap::place_forest_trailheads()
     const auto try_place_trailhead_special = [&]( const tripoint_om_omt & trail_end,
     const om_direction::type & dir ) {
         const tripoint_om_omt potential_trailhead = trail_end + om_direction::displace( dir, 1 );
-        overmap_special_id trailhead = settings->forest_trail.trailheads.pick();
+        overmap_special_id const trailhead = settings->forest_trail.trailheads.pick();
         if( one_in( settings->forest_trail.trailhead_chance ) &&
             trailhead_close_to_road( potential_trailhead ) &&
             can_place_special( *trailhead, potential_trailhead, dir, false ) ) {
@@ -2592,7 +2592,7 @@ void overmap::place_forest_trailheads()
     for( int i = 2; i < OMAPX - 2; i++ ) {
         for( int j = 2; j < OMAPY - 2; j++ ) {
             const tripoint_om_omt p( i, j, 0 );
-            oter_id oter = ter( p );
+            oter_id const oter = ter( p );
             if( is_ot_match( "forest_trail_end", oter, ot_match_type::prefix ) ) {
                 try_place_trailhead_special( p, oter->get_dir() );
             }
@@ -2649,7 +2649,7 @@ void overmap::place_lakes()
 
     for( int i = 0; i < OMAPX; i++ ) {
         for( int j = 0; j < OMAPY; j++ ) {
-            point_om_omt seed_point( i, j );
+            point_om_omt const seed_point( i, j );
             if( visited.find( seed_point ) != visited.end() ) {
                 continue;
             }
@@ -2752,8 +2752,8 @@ void overmap::place_lakes()
                 return lhs.y() < rhs.y();
             } );
 
-            point_om_omt northmost = *north_south_most.first;
-            point_om_omt southmost = *north_south_most.second;
+            point_om_omt const northmost = *north_south_most.first;
+            point_om_omt const southmost = *north_south_most.second;
 
             // It's possible that our northmost/southmost points in the lake are not on this overmap, because our
             // lake may extend across multiple overmaps.
@@ -2774,8 +2774,8 @@ void overmap::place_rivers( const overmap *north, const overmap *east, const ove
     if( settings->river_scale == 0.0 ) {
         return;
     }
-    int river_chance = static_cast<int>( std::max( 1.0, 1.0 / settings->river_scale ) );
-    int river_scale = static_cast<int>( std::max( 1.0, settings->river_scale ) );
+    int const river_chance = static_cast<int>( std::max( 1.0, 1.0 / settings->river_scale ) );
+    int const river_scale = static_cast<int>( std::max( 1.0, settings->river_scale ) );
     // West/North endpoints of rivers
     std::vector<point_om_omt> river_start;
     // East/South endpoints of rivers
@@ -2803,7 +2803,7 @@ void overmap::place_rivers( const overmap *north, const overmap *east, const ove
             }
         }
     }
-    size_t rivers_from_north = river_start.size();
+    size_t const rivers_from_north = river_start.size();
     if( west != nullptr ) {
         for( int i = 2; i < OMAPY - 2; i++ ) {
             const tripoint_om_omt p_neighbour( OMAPX - 1, i, 0 );
@@ -2840,7 +2840,7 @@ void overmap::place_rivers( const overmap *north, const overmap *east, const ove
             }
         }
     }
-    size_t rivers_to_south = river_end.size();
+    size_t const rivers_to_south = river_end.size();
     if( east != nullptr ) {
         for( int i = 2; i < OMAPY - 2; i++ ) {
             const tripoint_om_omt p_neighbour( 0, i, 0 );
@@ -2890,7 +2890,7 @@ void overmap::place_rivers( const overmap *north, const overmap *east, const ove
 
     // Now actually place those rivers.
     if( river_start.size() > river_end.size() && !river_end.empty() ) {
-        std::vector<point_om_omt> river_end_copy = river_end;
+        std::vector<point_om_omt> const river_end_copy = river_end;
         while( !river_start.empty() ) {
             const point_om_omt start = random_entry_removed( river_start );
             if( !river_end.empty() ) {
@@ -2901,7 +2901,7 @@ void overmap::place_rivers( const overmap *north, const overmap *east, const ove
             }
         }
     } else if( river_end.size() > river_start.size() && !river_start.empty() ) {
-        std::vector<point_om_omt> river_start_copy = river_start;
+        std::vector<point_om_omt> const river_start_copy = river_start;
         while( !river_end.empty() ) {
             const point_om_omt end = random_entry_removed( river_end );
             if( !river_start.empty() ) {
@@ -2932,7 +2932,7 @@ void overmap::place_swamps()
         for( int y = 0; y < OMAPY; y++ ) {
             const tripoint_om_omt pos( x, y, 0 );
             if( is_ot_match( "river", ter( pos ), ot_match_type::contains ) ) {
-                std::vector<point_om_omt> buffered_points = closest_points_first( pos.xy(),
+                std::vector<point_om_omt> const buffered_points = closest_points_first( pos.xy(),
                         rng(
                             settings->overmap_forest.river_floodplain_buffer_distance_min,
                             settings->overmap_forest.river_floodplain_buffer_distance_max ) );
@@ -3060,8 +3060,8 @@ void overmap::place_roads( const overmap *north, const overmap *east, const over
 void overmap::place_river( point_om_omt pa, point_om_omt pb )
 {
     const oter_id river_center( "river_center" );
-    int river_chance = static_cast<int>( std::max( 1.0, 1.0 / settings->river_scale ) );
-    int river_scale = static_cast<int>( std::max( 1.0, settings->river_scale ) );
+    int const river_chance = static_cast<int>( std::max( 1.0, 1.0 / settings->river_scale ) );
+    int const river_scale = static_cast<int>( std::max( 1.0, settings->river_scale ) );
     point_om_omt p2( pa );
     do {
         p2.x() += rng( -1, 1 );
@@ -3144,11 +3144,11 @@ void overmap::place_river( point_om_omt pa, point_om_omt pb )
 
 void overmap::place_cities()
 {
-    int op_city_size = get_option<int>( "CITY_SIZE" );
+    int const op_city_size = get_option<int>( "CITY_SIZE" );
     if( op_city_size <= 0 ) {
         return;
     }
-    int op_city_spacing = get_option<int>( "CITY_SPACING" );
+    int const op_city_spacing = get_option<int>( "CITY_SPACING" );
 
     // spacing dictates how much of the map is covered in cities
     //   city  |  cities  |   size N cities per overmap
@@ -3222,18 +3222,18 @@ void overmap::place_cities()
 overmap_special_id overmap::pick_random_building_to_place( int town_dist ) const
 {
     const city_settings &city_spec = settings->city_spec;
-    int shop_radius = city_spec.shop_radius;
-    int park_radius = city_spec.park_radius;
+    int const shop_radius = city_spec.shop_radius;
+    int const park_radius = city_spec.park_radius;
 
-    int shop_sigma = city_spec.shop_sigma;
-    int park_sigma = city_spec.park_sigma;
+    int const shop_sigma = city_spec.shop_sigma;
+    int const park_sigma = city_spec.park_sigma;
 
     //Normally distribute shops and parks
     //Clamp at 1/2 radius to prevent houses from spawning in the city center.
     //Parks are nearly guaranteed to have a non-zero chance of spawning anywhere in the city.
-    int shop_normal = std::max( static_cast<int>( normal_roll( shop_radius, shop_sigma ) ),
+    int const shop_normal = std::max( static_cast<int>( normal_roll( shop_radius, shop_sigma ) ),
                                 shop_radius );
-    int park_normal = std::max( static_cast<int>( normal_roll( park_radius, park_sigma ) ),
+    int const park_normal = std::max( static_cast<int>( normal_roll( park_radius, park_sigma ) ),
                                 park_radius );
 
     if( shop_normal > town_dist ) {
@@ -3286,7 +3286,7 @@ void overmap::build_city_street(
     const auto to = street_path.nodes.end();
 
     //Alternate wide and thin blocks
-    int new_width = block_width == 2 ? rng( 3, 5 ) : 2;
+    int const new_width = block_width == 2 ? rng( 3, 5 ) : 2;
 
     for( auto iter = from; iter != to; ++iter ) {
         --c;
@@ -3353,7 +3353,7 @@ bool overmap::build_lab( const tripoint_om_omt &p, lab &l, int s,
     const oter_id labt_ants( "ants_lab" );
     const oter_id labt_ants_stairs( "ants_lab_stairs" );
 
-    bool is_true_center = pos() == point_abs_om() && l.type == lab_type::central;
+    bool const is_true_center = pos() == point_abs_om() && l.type == lab_type::central;
 
     ter_set( p, labt );
     generated_lab.push_back( p );
@@ -3380,7 +3380,7 @@ bool overmap::build_lab( const tripoint_om_omt &p, lab &l, int s,
         }
         const int dist = manhattan_dist( p.xy(), cand.xy() );
         if( dist <= s * 2 ) { // increase radius to compensate for sparser new algorithm
-            int dist_increment = s > 3 ? 3 : 2; // Determines at what distance the odds of placement decreases
+            int const dist_increment = s > 3 ? 3 : 2; // Determines at what distance the odds of placement decreases
             if( one_in( dist / dist_increment + 1 ) ) { // odds diminish farther away from the stairs
                 // make an ants lab if it's a basic lab and ants were there before.
                 if( prefix.empty() && check_ot( "ants", ot_match_type::type, cand ) ) {
@@ -3392,7 +3392,7 @@ bool overmap::build_lab( const tripoint_om_omt &p, lab &l, int s,
                 }
                 generated_lab.push_back( cand );
                 // add new candidates, don't backtrack
-                for( point offset : four_adjacent_offsets ) {
+                for( point const offset : four_adjacent_offsets ) {
                     const tripoint_om_omt new_cand = cand + offset;
                     const int new_dist = manhattan_dist( p.xy(), new_cand.xy() );
                     if( closed_candidates.count( new_cand ) == 0 && new_dist > dist ) {
@@ -3404,7 +3404,7 @@ bool overmap::build_lab( const tripoint_om_omt &p, lab &l, int s,
     }
 
     bool generate_stairs = true;
-    for( tripoint_om_omt &elem : generated_lab ) {
+    for( tripoint_om_omt  const&elem : generated_lab ) {
         // Use a check for "_stairs" to catch the hidden_lab_stairs tiles.
         if( is_ot_match( "_stairs", ter( elem + tripoint_above ), ot_match_type::contains ) ) {
             generate_stairs = false;
@@ -3415,7 +3415,7 @@ bool overmap::build_lab( const tripoint_om_omt &p, lab &l, int s,
 
         // we want a spot where labs are above, but we'll settle for the last element if necessary.
         tripoint_om_omt lab_pos;
-        for( tripoint_om_omt elem : generated_lab ) {
+        for( tripoint_om_omt const elem : generated_lab ) {
             lab_pos = elem;
             if( ter( lab_pos + tripoint_above ) == labt ) {
                 break;
@@ -3445,7 +3445,7 @@ bool overmap::build_lab( const tripoint_om_omt &p, lab &l, int s,
         }
     }
 
-    bool endgame_finale = is_true_center && numstairs == 0;
+    bool const endgame_finale = is_true_center && numstairs == 0;
     // We need a finale on the bottom of labs.  Central labs have a chance of additional finales.
     if( numstairs == 0 || ( l.type == lab_type::central && one_in( -p.z() - 1 ) ) ) {
         std::set<tripoint_om_omt> finale_candidates;
@@ -3460,7 +3460,7 @@ bool overmap::build_lab( const tripoint_om_omt &p, lab &l, int s,
         if( endgame_finale ) {
             for( const tripoint_om_omt &c : closest_points_first( p, 2 * s + 1 ) ) {
                 if( is_ot_match( labt.id().str(), ter( c ), ot_match_type::contains ) ) {
-                    for( point offset : four_adjacent_offsets ) {
+                    for( point const offset : four_adjacent_offsets ) {
                         if( inbounds( c + offset ) && ter( c + offset ) != labt_stairs ) {
                             secondary_candidates.insert( c + offset );
                         }
@@ -3499,7 +3499,7 @@ bool overmap::build_lab( const tripoint_om_omt &p, lab &l, int s,
             tries++;
 
             adjacent_labs = 0;
-            for( point offset : four_adjacent_offsets ) {
+            for( point const offset : four_adjacent_offsets ) {
                 if( is_ot_match( "lab", ter( train + offset ), ot_match_type::contains ) ) {
                     ++adjacent_labs;
                 }
@@ -3512,7 +3512,7 @@ bool overmap::build_lab( const tripoint_om_omt &p, lab &l, int s,
         if( tries < 50 ) {
             lab_train_points.push_back( train.xy() ); // possible train depot
             // next is rail connection
-            for( point offset : four_adjacent_offsets ) {
+            for( point const offset : four_adjacent_offsets ) {
                 if( is_ot_match( "lab", ter( train + offset ), ot_match_type::contains ) ) {
                     lab_train_points.push_back( train.xy() - offset );
                     break;
@@ -3533,7 +3533,7 @@ bool overmap::build_lab( const tripoint_om_omt &p, lab &l, int s,
             tries++;
 
             adjacent_labs = 0;
-            for( point offset : four_adjacent_offsets ) {
+            for( point const offset : four_adjacent_offsets ) {
                 if( is_ot_match( "lab", ter( cell + offset ), ot_match_type::contains ) ) {
                     ++adjacent_labs;
                 }
@@ -3554,7 +3554,7 @@ bool overmap::build_lab( const tripoint_om_omt &p, lab &l, int s,
 
 void overmap::build_anthill( const tripoint_om_omt &p, int s, bool ordinary_ants )
 {
-    for( om_direction::type dir : om_direction::all ) {
+    for( om_direction::type const dir : om_direction::all ) {
         build_tunnel( p, s - rng( 0, 3 ), dir, ordinary_ants );
     }
 
@@ -3585,7 +3585,7 @@ void overmap::build_anthill( const tripoint_om_omt &p, int s, bool ordinary_ants
             }
             if( root_id == ter( root )->id ) {
                 const oter_id &oter = ter( root );
-                for( om_direction::type dir : om_direction::all ) {
+                for( om_direction::type const dir : om_direction::all ) {
                     const tripoint_om_omt neighbor = root + om_direction::displace( dir );
                     if( check_ot( "ants", ot_match_type::prefix, neighbor ) ) {
                         size_t line = oter->get_line();
@@ -3624,7 +3624,7 @@ void overmap::build_tunnel( const tripoint_om_omt &p, int s, om_direction::type 
 
     std::vector<om_direction::type> valid;
     valid.reserve( om_direction::size );
-    for( om_direction::type r : om_direction::all ) {
+    for( om_direction::type const r : om_direction::all ) {
         const tripoint_om_omt cand = p + om_direction::displace( r );
         if( !check_ot( "ants", ot_match_type::type, cand ) &&
             is_ot_match( "empty_rock", ter( cand ), ot_match_type::type ) ) {
@@ -3668,7 +3668,7 @@ bool overmap::build_slimepit( const tripoint_om_omt &origin, int s )
 
     bool requires_sub = false;
     for( auto p : points_in_radius( origin, s + origin.z() + 1, 0 ) ) {
-        int dist = square_dist( origin.xy(), p.xy() );
+        int const dist = square_dist( origin.xy(), p.xy() );
         if( one_in( 2 * dist ) ) {
             chip_rock( p );
             if( one_in( 8 ) && origin.z() > -OVERMAP_DEPTH ) {
@@ -3685,7 +3685,7 @@ bool overmap::build_slimepit( const tripoint_om_omt &origin, int s )
 
 void overmap::build_mine( const tripoint_om_omt &origin, int s )
 {
-    bool finale = s <= rng( 1, 3 );
+    bool const finale = s <= rng( 1, 3 );
     const oter_id mine( "mine" );
     const oter_id mine_finale_or_down( finale ? "mine_finale" : "mine_down" );
     const oter_id empty_rock( "empty_rock" );
@@ -3706,7 +3706,7 @@ void overmap::build_mine( const tripoint_om_omt &origin, int s )
     while( built < s ) {
         ter_set( p, mine );
         std::vector<tripoint_om_omt> next;
-        for( point offset : four_adjacent_offsets ) {
+        for( point const offset : four_adjacent_offsets ) {
             if( ter( p + offset ) == empty_rock ) {
                 next.push_back( p + offset );
             }
@@ -3987,7 +3987,7 @@ void overmap::chip_rock( const tripoint_om_omt &p )
     const oter_id rock( "rock" );
     const oter_id empty_rock( "empty_rock" );
 
-    for( point offset : four_adjacent_offsets ) {
+    for( point const offset : four_adjacent_offsets ) {
         if( ter( p + offset ) == empty_rock ) {
             ter_set( p + offset, rock );
         }
@@ -4236,7 +4236,7 @@ om_direction::type overmap::random_special_rotation( const overmap_special &spec
 
     int top_score = 0; // Maximal number of existing connections (roads).
     // Try to find the most suitable rotation: satisfy as many connections as possible with the existing terrain.
-    for( om_direction::type r : om_direction::all ) {
+    for( om_direction::type const r : om_direction::all ) {
         int score = 0; // Number of existing connections when rotated by 'r'.
         bool valid = true;
 
@@ -4519,7 +4519,7 @@ void overmap::place_specials( overmap_special_batch &enabled_specials )
     om_special_sectors sectors = get_sectors( OMSPEC_FREQ );
 
     // At true center, central lab is truly mandatory and can't be pushed to neighbors
-    bool is_true_center = pos() == point_abs_om();
+    bool const is_true_center = pos() == point_abs_om();
     if( is_true_center ) {
         std::vector<const overmap_special *> truly_mandatory_specials;
         // Ugly hack. TODO: Un-ugly
@@ -4611,7 +4611,7 @@ void overmap::place_specials( overmap_special_batch &enabled_specials )
         for( const point_abs_om &candidate_addr : closest_points_first(
                  custom_overmap_specials.get_origin(), 2 ) ) {
             if( !overmap_buffer.has( candidate_addr ) ) {
-                int current_distance = square_dist( pos(), candidate_addr );
+                int const current_distance = square_dist( pos(), candidate_addr );
                 if( nearest_candidates.empty() || current_distance == previous_distance ) {
                     nearest_candidates.push_back( candidate_addr );
                     previous_distance = current_distance;
@@ -4622,7 +4622,7 @@ void overmap::place_specials( overmap_special_batch &enabled_specials )
         }
         if( !nearest_candidates.empty() ) {
             std::shuffle( nearest_candidates.begin(), nearest_candidates.end(), rng_get_engine() );
-            point_abs_om new_om_addr = nearest_candidates.front();
+            point_abs_om const new_om_addr = nearest_candidates.front();
             overmap_buffer.create_custom_overmap( new_om_addr, custom_overmap_specials );
         } else {
             add_msg( _( "Unable to place all configured specials, some missions may fail to initialize." ) );
@@ -4650,7 +4650,7 @@ void overmap::place_specials( overmap_special_batch &enabled_specials )
     // Loop through the specials we started with.
     for( auto it = enabled_specials.begin(); it != enabled_specials.end(); ) {
         // Determine if this special is still in our callee's list of specials...
-        std::map<overmap_special_id, int>::iterator iter = processed_specials.find(
+        std::map<overmap_special_id, int>::iterator const iter = processed_specials.find(
                     it->special_details->id );
         if( iter != processed_specials.end() ) {
             // ... and if so, increment the placement count to reflect the callee's.
@@ -4731,7 +4731,7 @@ void overmap::place_mongroups()
         // Figure out where the dimensional lab is, and flood area with nether critters
         for( int x = 0; x < OMAPX; x++ ) {
             for( int y = 0; y < OMAPY; y++ ) {
-                tripoint_om_omt p( x, y, 0 );
+                tripoint_om_omt const p( x, y, 0 );
                 if( ter( p ) == "central_lab_entrance" ) {
                     add_mon_group( mongroup( GROUP_DIMENSIONAL_SURFACE, project_to<coords::sm>( p ), 5, 30 ) );
                 }
@@ -4740,7 +4740,7 @@ void overmap::place_mongroups()
     }
 
     // Place the "put me anywhere" groups
-    int numgroups = rng( 0, 3 );
+    int const numgroups = rng( 0, 3 );
     for( int i = 0; i < numgroups; i++ ) {
         add_mon_group( mongroup( GROUP_WORM, tripoint( rng( 0, OMAPX * 2 - 1 ), rng( 0,
                                  OMAPY * 2 - 1 ), 0 ),
@@ -4761,8 +4761,8 @@ void overmap::place_radios()
     std::string message;
     for( int i = 0; i < OMAPX; i++ ) {
         for( int j = 0; j < OMAPY; j++ ) {
-            tripoint_om_omt pos_omt( i, j, 0 );
-            point_om_sm pos_sm = project_to<coords::sm>( pos_omt.xy() );
+            tripoint_om_omt const pos_omt( i, j, 0 );
+            point_om_sm const pos_sm = project_to<coords::sm>( pos_omt.xy() );
 
             // Since location have id such as "radio_tower_1_north", we must check the beginning of the id
             if( is_ot_match( "radio_tower", ter( pos_omt ), ot_match_type::prefix ) ) {
@@ -4783,7 +4783,7 @@ void overmap::place_radios()
                                             "  This is FEMA camp %d%d.  A designated long-term emergency shelter." ), i, j, i, j );
                 radios.push_back( radio_tower( pos_sm, strength(), message ) );
             } else if( ter( pos_omt ) == "central_lab_entrance" && pos() == point_abs_om() ) {
-                std::string message =
+                std::string const message =
                     _( "If you can hear this message, the probe to 021XC is functioning correctly." );
                 // Repeat the message on different frequencies
                 for( int i = 0; i < 10; i++ ) {
@@ -4960,10 +4960,10 @@ void overmap::set_electric_grid_connections( const tripoint_om_omt &p,
 {
     electric_grid_connections[p] = connections;
     for( size_t i = 0; i < six_cardinal_directions.size(); i++ ) {
-        tripoint_om_omt other_p = p + six_cardinal_directions[i];
-        tripoint_abs_omt other_p_global = project_combine( pos(), other_p );
-        overmap_with_local_coords other = overmap_buffer.get_om_global( other_p_global );
-        size_t opposite_direction = i + ( ( i % 2 ) ? -1 : 1 );
+        tripoint_om_omt const other_p = p + six_cardinal_directions[i];
+        tripoint_abs_omt const other_p_global = project_combine( pos(), other_p );
+        overmap_with_local_coords const other = overmap_buffer.get_om_global( other_p_global );
+        size_t const opposite_direction = i + ( ( i % 2 ) ? -1 : 1 );
         other.om->electric_grid_connections[other.local][opposite_direction] = connections[i];
     }
 }
@@ -5014,7 +5014,7 @@ constexpr tripoint_abs_omt overmap::invalid_tripoint;
 std::string oter_no_dir( const oter_id &oter )
 {
     std::string base_oter_id = oter.id().c_str();
-    size_t oter_len = base_oter_id.size();
+    size_t const oter_len = base_oter_id.size();
     if( oter_len > 7 ) {
         if( base_oter_id.substr( oter_len - 6, 6 ) == "_south" ) {
             return base_oter_id.substr( 0, oter_len - 6 );

--- a/src/overmap_connection.cpp
+++ b/src/overmap_connection.cpp
@@ -60,7 +60,7 @@ void overmap_connection::subtype::load( const JsonObject &jo )
 
 void overmap_connection::subtype::deserialize( JsonIn &jsin )
 {
-    JsonObject jo = jsin.get_object();
+    JsonObject const jo = jsin.get_object();
     load( jo );
 }
 

--- a/src/overmap_location.cpp
+++ b/src/overmap_location.cpp
@@ -56,7 +56,7 @@ void overmap_location::load( const JsonObject &jo, const std::string & )
 std::vector<oter_type_id> overmap_location::get_all_terrains() const
 {
     std::vector<oter_type_id> ret;
-    for( oter_type_str_id elem : terrains ) {
+    for( oter_type_str_id const elem : terrains ) {
         ret.push_back( elem );
     }
     return ret;
@@ -78,7 +78,7 @@ void overmap_location::finalize()
         if( it == oter_flags_map.end() ) {
             continue;
         }
-        oter_flags check_flag = it->second;
+        oter_flags const check_flag = it->second;
         for( const oter_t &ter_elem : overmap_terrains::get_all() ) {
             if( ter_elem.has_flag( check_flag ) ) {
                 terrains.push_back( ter_elem.get_type_id() );

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -335,7 +335,7 @@ static bool get_scent_glyph( const tripoint_abs_omt &pos, nc_color &ter_color,
 {
     auto possible_scent = overmap_buffer.scent_at( pos );
     if( possible_scent.creation_time != calendar::before_time_starts ) {
-        color_manager  const&color_list = get_all_colors();
+        color_manager  const &color_list = get_all_colors();
         int i = 0;
         time_duration scent_age = calendar::turn - possible_scent.creation_time;
         while( i < num_colors && scent_age > 0_turns ) {
@@ -541,11 +541,11 @@ class map_notes_callback : public uilist_callback
                         // NOLINTNEXTLINE(cata-text-style): No need for two whitespaces
                         const std::string popupmsg = _( "Danger radius in overmap squares? ( 0-20 )" );
                         int const amount = string_input_popup()
-                                     .title( popupmsg )
-                                     .width( 20 )
-                                     .text( std::to_string( 0 ) )
-                                     .only_digits( true )
-                                     .query_int();
+                                           .title( popupmsg )
+                                           .width( 20 )
+                                           .text( std::to_string( 0 ) )
+                                           .only_digits( true )
+                                           .query_int();
                         if( amount > -1 && amount <= max_amount ) {
                             overmap_buffer.mark_note_dangerous( note_location(), amount, true );
                             menu->ret = UILIST_MAP_NOTE_EDITED;
@@ -1478,10 +1478,10 @@ static void create_note( const tripoint_abs_omt &curs )
     }
 
     std::string const helper_text = string_format( ".\n\n%s\n%s\n%s\n",
-                              _( "Type GLYPH:TEXT to set a custom glyph." ),
-                              _( "Type COLOR;TEXT to set a custom color." ),
-                              // NOLINTNEXTLINE(cata-text-style): literal exclaimation mark
-                              _( "Examples: B:Base | g;Loot | !:R;Minefield" ) );
+                                    _( "Type GLYPH:TEXT to set a custom glyph." ),
+                                    _( "Type COLOR;TEXT to set a custom color." ),
+                                    // NOLINTNEXTLINE(cata-text-style): literal exclaimation mark
+                                    _( "Examples: B:Base | g;Loot | !:R;Minefield" ) );
     color_notes = color_notes.replace( color_notes.end() - 2, color_notes.end(), helper_text );
     std::string const title = _( "Note:" );
 
@@ -1835,7 +1835,7 @@ static std::vector<tripoint_abs_omt> get_overmap_path_to( const tripoint_abs_omt
         return {};
     }
     const Character &player_character = get_player_character();
-    map  const&here = get_map();
+    map  const &here = get_map();
     const tripoint_abs_omt player_omt_pos = player_character.global_omt_location();
     overmap_path_params params;
     vehicle *player_veh = nullptr;

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -104,7 +104,7 @@ struct grids_draw_data {
     public:
         std::optional<char> get_active( const tripoint_abs_omt &omp ) {
             // TODO: fix point types
-            uintptr_t id = get_distribution_grid_tracker().debug_grid_id( omp );
+            uintptr_t const id = get_distribution_grid_tracker().debug_grid_id( omp );
             if( id == 0 ) {
                 return std::nullopt;
             }
@@ -129,14 +129,14 @@ struct grids_draw_data {
         }
 
         std::optional<char> get_inactive( const tripoint_abs_omt &omp ) {
-            std::set<tripoint_abs_omt> grid = overmap_buffer.electric_grid_at( omp );
+            std::set<tripoint_abs_omt> const grid = overmap_buffer.electric_grid_at( omp );
             if( grid.size() <= 1 ) {
                 return std::nullopt;
             }
             std::vector<tripoint_abs_omt> sorted( grid.begin(), grid.end() );
             std::sort( sorted.begin(), sorted.end() );
 
-            std::size_t id = cata::range_hash{}( sorted );
+            std::size_t const id = cata::range_hash{}( sorted );
 
             auto it = list_inactive.find( id );
             if( it != list_inactive.end() ) {
@@ -170,7 +170,7 @@ struct grids_draw_data {
         // Fn(char) -> bool
         template<typename Fn>
         std::optional<char> pick_char( Fn filter_func ) {
-            static std::string candidates( "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ" );
+            static std::string const candidates( "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ" );
             for( char c : candidates ) {
                 if( filter_func( c ) ) {
                     return c;
@@ -251,7 +251,7 @@ static std::array<std::pair<nc_color, std::string>, npm_width *npm_height> get_o
         const bool see = has_debug_vision || overmap_buffer.seen( dest );
         if( see ) {
             // Only load terrain if we can actually see it
-            oter_id cur_ter = overmap_buffer.ter( dest );
+            oter_id const cur_ter = overmap_buffer.ter( dest );
             ter_color = cur_ter->get_color();
             ter_sym = cur_ter->get_symbol();
         } else {
@@ -286,7 +286,7 @@ static void update_note_preview( const std::string &note,
     nc_color default_color = c_unset;
     print_colored_text( *w_preview_title, point_zero, default_color, note_color, note_text,
                         report_color_error::no );
-    int note_text_width = utf8_width( note_text );
+    int const note_text_width = utf8_width( note_text );
     mvwputch( *w_preview_title, point( note_text_width, 0 ), c_white, LINE_XOXO );
     for( int i = 0; i < note_text_width; i++ ) {
         mvwputch( *w_preview_title, point( i, 1 ), c_white, LINE_OXOX );
@@ -321,7 +321,7 @@ weather_type_id get_weather_at_point( const point_abs_omt &pos )
     auto iter = weather_cache.find( pos );
     if( iter == weather_cache.end() ) {
         // TODO: fix point types
-        tripoint_abs_omt pos_z( pos, OVERMAP_HEIGHT );
+        tripoint_abs_omt const pos_z( pos, OVERMAP_HEIGHT );
         const tripoint abs_ms_pos = project_to<coords::ms>( pos_z ).raw();
         const auto &wgen = overmap_buffer.get_settings( pos_z ).weather;
         auto weather = wgen.get_weather_conditions( abs_ms_pos, calendar::turn, g->get_seed() );
@@ -335,7 +335,7 @@ static bool get_scent_glyph( const tripoint_abs_omt &pos, nc_color &ter_color,
 {
     auto possible_scent = overmap_buffer.scent_at( pos );
     if( possible_scent.creation_time != calendar::before_time_starts ) {
-        color_manager &color_list = get_all_colors();
+        color_manager  const&color_list = get_all_colors();
         int i = 0;
         time_duration scent_age = calendar::turn - possible_scent.creation_time;
         while( i < num_colors && scent_age > 0_turns ) {
@@ -540,7 +540,7 @@ class map_notes_callback : public uilist_callback
                         const int max_amount = 20;
                         // NOLINTNEXTLINE(cata-text-style): No need for two whitespaces
                         const std::string popupmsg = _( "Danger radius in overmap squares? ( 0-20 )" );
-                        int amount = string_input_popup()
+                        int const amount = string_input_popup()
                                      .title( popupmsg )
                                      .width( 20 )
                                      .text( std::to_string( 0 ) )
@@ -640,7 +640,7 @@ static tripoint_abs_omt show_notes_manager( const tripoint_abs_omt &origin )
 
         std::vector<note_cached> notes;
         for( int zlev = -OVERMAP_DEPTH; zlev <= OVERMAP_HEIGHT; zlev++ ) {
-            overmapbuffer::t_notes_vector notes_raw = overmap_buffer.get_all_notes( zlev );
+            overmapbuffer::t_notes_vector const notes_raw = overmap_buffer.get_all_notes( zlev );
             notes.reserve( notes.size() + notes_raw.size() );
             for( const auto &it : notes_raw ) {
                 auto om_symbol = get_note_display_info( it.second );
@@ -909,7 +909,7 @@ static void draw_ascii( const catacurses::window &w,
             const tripoint_abs_omt pos = np->global_omt_location();
             if( has_debug_vision || overmap_buffer.seen( pos ) ) {
                 auto iter = npc_color.find( pos );
-                nc_color np_color = np->basic_symbol_color();
+                nc_color const np_color = np->basic_symbol_color();
                 if( iter == npc_color.end() ) {
                     npc_color[pos] = { np_color, 1 };
                 } else {
@@ -924,7 +924,7 @@ static void draw_ascii( const catacurses::window &w,
         std::vector<npc *> followers;
         // get friendly followers
         for( auto &elem : g->get_follower_list() ) {
-            shared_ptr_fast<npc> npc_to_get = overmap_buffer.find_npc( elem );
+            shared_ptr_fast<npc> const npc_to_get = overmap_buffer.find_npc( elem );
             if( !npc_to_get ) {
                 continue;
             }
@@ -954,7 +954,7 @@ static void draw_ascii( const catacurses::window &w,
             }
             const tripoint_abs_omt pos = np->global_omt_location();
             auto iter = npc_color.find( pos );
-            nc_color np_color = np->basic_symbol_color();
+            nc_color const np_color = np->basic_symbol_color();
             if( iter == npc_color.end() ) {
                 npc_color[pos] = { np_color, 1 };
             } else {
@@ -967,7 +967,7 @@ static void draw_ascii( const catacurses::window &w,
         }
     }
 
-    tripoint_abs_omt pl_pos = get_player_character().global_omt_location();
+    tripoint_abs_omt const pl_pos = get_player_character().global_omt_location();
 
     for( int i = 0; i < om_map_width; ++i ) {
         for( int j = 0; j < om_map_height; ++j ) {
@@ -1149,7 +1149,7 @@ static void draw_ascii( const catacurses::window &w,
         draw_camp_labels( w, center );
     }
 
-    half_open_rectangle<point_abs_omt> screen_bounds(
+    half_open_rectangle<point_abs_omt> const screen_bounds(
         corner.xy(), corner.xy() + point( om_map_width, om_map_height ) );
 
     if( has_target && blink && !screen_bounds.contains( target.xy() ) ) {
@@ -1477,13 +1477,13 @@ static void create_note( const tripoint_abs_omt &curs )
                                       _( color_pair.second ), replace_all( color_pair.second, " ", "_" ) );
     }
 
-    std::string helper_text = string_format( ".\n\n%s\n%s\n%s\n",
+    std::string const helper_text = string_format( ".\n\n%s\n%s\n%s\n",
                               _( "Type GLYPH:TEXT to set a custom glyph." ),
                               _( "Type COLOR;TEXT to set a custom color." ),
                               // NOLINTNEXTLINE(cata-text-style): literal exclaimation mark
                               _( "Examples: B:Base | g;Loot | !:R;Minefield" ) );
     color_notes = color_notes.replace( color_notes.end() - 2, color_notes.end(), helper_text );
-    std::string title = _( "Note:" );
+    std::string const title = _( "Note:" );
 
     const std::string old_note = overmap_buffer.note( curs );
     std::string new_note = old_note;
@@ -1514,7 +1514,7 @@ static void create_note( const tripoint_abs_omt &curs )
     } );
 
     // this implies enable_ime() and ensures that ime mode is always restored on return
-    ime_sentry sentry;
+    ime_sentry const sentry;
 
     bool esc_pressed = false;
     string_input_popup input_popup;
@@ -1569,8 +1569,8 @@ static bool search( const ui_adaptor &om_ui, tripoint_abs_omt &curs, const tripo
         overmap_with_local_coords om_loc = overmap_buffer.get_existing_om_global( p );
 
         if( om_loc ) {
-            tripoint_om_omt om_relative = om_loc.local;
-            point_abs_om om_cache = project_to<coords::om>( p.xy() );
+            tripoint_om_omt const om_relative = om_loc.local;
+            point_abs_om const om_cache = project_to<coords::om>( p.xy() );
 
             if( std::find( overmap_checked.begin(), overmap_checked.end(),
                            om_cache ) == overmap_checked.end() ) {
@@ -1624,13 +1624,13 @@ static bool search( const ui_adaptor &om_ui, tripoint_abs_omt &curs, const tripo
     ui.on_redraw( [&]( const ui_adaptor & ) {
         //Draw search box
 
-        int a = utf8_width( _( "Search:" ) );
-        int b = utf8_width( _( "Result:" ) );
-        int c = utf8_width( _( "Results:" ) );
-        int d = utf8_width( _( "Direction:" ) );
+        int const a = utf8_width( _( "Search:" ) );
+        int const b = utf8_width( _( "Result:" ) );
+        int const c = utf8_width( _( "Results:" ) );
+        int const d = utf8_width( _( "Direction:" ) );
         int align_width = 0;
-        int align_w_value[4] = { a, b, c, d};
-        for( int n : align_w_value ) {
+        int const align_w_value[4] = { a, b, c, d};
+        for( int const n : align_w_value ) {
             if( n > align_width ) {
                 align_width = n + 2;
             }
@@ -1748,7 +1748,7 @@ static void place_ter_or_special( const ui_adaptor &om_ui, tripoint_abs_omt &cur
         uistate.omedit_rotation = om_direction::type::none;
         // If user chose an already rotated submap, figure out its direction
         if( terrain && can_rotate ) {
-            for( om_direction::type r : om_direction::all ) {
+            for( om_direction::type const r : om_direction::all ) {
                 if( uistate.place_terrain->id.id() == uistate.place_terrain->get_rotated( r ) ) {
                     uistate.omedit_rotation = r;
                     break;
@@ -1835,7 +1835,7 @@ static std::vector<tripoint_abs_omt> get_overmap_path_to( const tripoint_abs_omt
         return {};
     }
     const Character &player_character = get_player_character();
-    map &here = get_map();
+    map  const&here = get_map();
     const tripoint_abs_omt player_omt_pos = player_character.global_omt_location();
     overmap_path_params params;
     vehicle *player_veh = nullptr;
@@ -1887,13 +1887,13 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
 {
     const int previous_zoom = g->get_zoom();
     g->set_zoom( overmap_zoom_level );
-    on_out_of_scope reset_zoom( [&]() {
+    on_out_of_scope const reset_zoom( [&]() {
         overmap_zoom_level = g->get_zoom();
         g->set_zoom( previous_zoom );
         g->mark_main_ui_adaptor_resize();
     } );
 
-    background_pane bg_pane;
+    background_pane const bg_pane;
 
     ui_adaptor ui;
     ui.on_screen_resize( []( ui_adaptor & ui ) {
@@ -1964,7 +1964,7 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
     std::string action;
     bool show_explored = true;
     bool fast_scroll = false; /* fast scroll state should reset every time overmap UI is opened */
-    int fast_scroll_offset = get_option<int>( "FAST_SCROLL_OFFSET" );
+    int const fast_scroll_offset = get_option<int>( "FAST_SCROLL_OFFSET" );
     std::optional<tripoint> mouse_pos;
     std::chrono::time_point<std::chrono::steady_clock> last_blink = std::chrono::steady_clock::now();
     grids_draw_data grids_data;
@@ -1988,7 +1988,7 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
         action = ictxt.handle_input( get_option<int>( "BLINK_SPEED" ) );
 #endif
         if( const std::optional<tripoint> vec = ictxt.get_direction( action ) ) {
-            int scroll_d = fast_scroll ? fast_scroll_offset : 1;
+            int const scroll_d = fast_scroll ? fast_scroll_offset : 1;
             curs += vec->xy() * scroll_d;
         } else if( action == "MOUSE_MOVE" || action == "TIMEOUT" ) {
             tripoint edge_scroll = g->mouse_edge_scrolling_overmap( ictxt );
@@ -2102,7 +2102,7 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
             g->list_missions();
         }
 
-        std::chrono::time_point<std::chrono::steady_clock> now = std::chrono::steady_clock::now();
+        std::chrono::time_point<std::chrono::steady_clock> const now = std::chrono::steady_clock::now();
         if( now > last_blink + std::chrono::milliseconds( get_option<int>( "BLINK_SPEED" ) ) ) {
             if( uistate.overmap_blinking ) {
                 uistate.overmap_show_overlays = !uistate.overmap_show_overlays;
@@ -2122,7 +2122,7 @@ void ui::omap::display()
 
 void ui::omap::display_hordes()
 {
-    overmap_ui::draw_data_t data;
+    overmap_ui::draw_data_t const data;
     uistate.overmap_debug_mongroup = true;
     overmap_ui::display( get_player_character().global_omt_location(), data );
     uistate.overmap_debug_mongroup = false;
@@ -2130,7 +2130,7 @@ void ui::omap::display_hordes()
 
 void ui::omap::display_weather()
 {
-    overmap_ui::draw_data_t data;
+    overmap_ui::draw_data_t const data;
     uistate.overmap_debug_weather = true;
     tripoint_abs_omt pos = get_player_character().global_omt_location();
     pos.z() = 10;
@@ -2140,7 +2140,7 @@ void ui::omap::display_weather()
 
 void ui::omap::display_visible_weather()
 {
-    overmap_ui::draw_data_t data;
+    overmap_ui::draw_data_t const data;
     uistate.overmap_visible_weather = true;
     tripoint_abs_omt pos = get_player_character().global_omt_location();
     pos.z() = 10;

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -155,7 +155,7 @@ void overmapbuffer::fix_npcs( overmap &new_overmap )
     // accessed anymore!
     decltype( overmap::npcs ) to_relocate;
     for( auto it = new_overmap.npcs.begin(); it != new_overmap.npcs.end(); ) {
-        npc  const&np = **it;
+        npc  const &np = **it;
         const tripoint_abs_omt npc_omt_pos = np.global_omt_location();
         const point_abs_om npc_om_pos = project_to<coords::om>( npc_omt_pos.xy() );
         const point_abs_om loc = new_overmap.pos();
@@ -1465,7 +1465,7 @@ void overmapbuffer::spawn_monster( const tripoint_abs_sm &p )
     auto monster_bucket = om.monster_map->equal_range( current_submap_loc );
     std::for_each( monster_bucket.first, monster_bucket.second,
     [&]( std::pair<const tripoint_om_sm, monster> &monster_entry ) {
-        monster  const&this_monster = monster_entry.second;
+        monster  const &this_monster = monster_entry.second;
         // The absolute position in map squares, (x,y) is already global, but it's a
         // submap coordinate, so translate it and add the exact monster position on
         // the submap. modulo because the zombies position might be negative, as it

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -131,7 +131,7 @@ void overmapbuffer::fix_mongroups( overmap &new_overmap )
             ++it;
             continue;
         }
-        point_abs_sm smabs = project_combine( new_overmap.pos(), mg.pos.xy() );
+        point_abs_sm const smabs = project_combine( new_overmap.pos(), mg.pos.xy() );
         point_abs_om omp;
         point_om_sm sm_rem;
         std::tie( omp, sm_rem ) = project_remain<coords::om>( smabs );
@@ -155,7 +155,7 @@ void overmapbuffer::fix_npcs( overmap &new_overmap )
     // accessed anymore!
     decltype( overmap::npcs ) to_relocate;
     for( auto it = new_overmap.npcs.begin(); it != new_overmap.npcs.end(); ) {
-        npc &np = **it;
+        npc  const&np = **it;
         const tripoint_abs_omt npc_omt_pos = np.global_omt_location();
         const point_abs_om npc_om_pos = project_to<coords::om>( npc_omt_pos.xy() );
         const point_abs_om loc = new_overmap.pos();
@@ -329,7 +329,7 @@ overmapbuffer::get_existing_om_global( const tripoint_abs_omt &p )
 
 bool overmapbuffer::is_omt_generated( const tripoint_abs_omt &loc )
 {
-    if( overmap_with_local_coords om_loc = get_existing_om_global( loc ) ) {
+    if( overmap_with_local_coords const om_loc = get_existing_om_global( loc ) ) {
         return om_loc.om->is_omt_generated( om_loc.local );
     }
 
@@ -509,9 +509,9 @@ std::vector<mongroup *> overmapbuffer::monsters_at( const tripoint_abs_omt &p )
 {
     // (x,y) are overmap terrain coordinates, they spawn 2x2 submaps,
     // but monster groups are defined with submap coordinates.
-    tripoint_abs_sm p_sm = project_to<coords::sm>( p );
+    tripoint_abs_sm const p_sm = project_to<coords::sm>( p );
     std::vector<mongroup *> result;
-    for( point offset : std::array<point, 4> { { { point_zero }, { point_south }, { point_east }, { point_south_east } } } ) {
+    for( point const offset : std::array<point, 4> { { { point_zero }, { point_south }, { point_east }, { point_south_east } } } ) {
         std::vector<mongroup *> tmp = groups_at( p_sm + offset );
         result.insert( result.end(), tmp.begin(), tmp.end() );
     }
@@ -546,7 +546,7 @@ std::array<std::array<scent_trace, 3>, 3> overmapbuffer::scents_near( const trip
 
     for( int x = -1; x <= 1 ; ++x ) {
         for( int y = -1; y <= 1; ++y ) {
-            tripoint_abs_omt iter = origin + point( x, y );
+            tripoint_abs_omt const iter = origin + point( x, y );
             found_traces[x + 1][y + 1] = scent_at( iter );
         }
     }
@@ -565,7 +565,7 @@ scent_trace overmapbuffer::scent_at( const tripoint_abs_omt &p )
 void overmapbuffer::set_scent( const tripoint_abs_omt &loc, int strength )
 {
     const overmap_with_local_coords om_loc = get_om_global( loc );
-    scent_trace new_scent( calendar::turn, strength );
+    scent_trace const new_scent( calendar::turn, strength );
     om_loc.om->set_scent( loc, new_scent );
 }
 
@@ -685,7 +685,7 @@ bool overmapbuffer::reveal( const tripoint_abs_omt &center, int radius )
 bool overmapbuffer::reveal( const tripoint_abs_omt &center, int radius,
                             const std::function<bool( const oter_id & )> &filter )
 {
-    int radius_squared = radius * radius;
+    int const radius_squared = radius * radius;
     bool result = false;
     for( int i = -radius; i <= radius; i++ ) {
         for( int j = -radius; j <= radius; j++ ) {
@@ -1171,7 +1171,7 @@ shared_ptr_fast<npc> overmapbuffer::remove_npc( const character_id &id )
 
 std::vector<shared_ptr_fast<npc>> overmapbuffer::get_npcs_near_player( int radius )
 {
-    tripoint_abs_omt plpos_omt = get_player_character().global_omt_location();
+    tripoint_abs_omt const plpos_omt = get_player_character().global_omt_location();
     // get_npcs_near needs submap coordinates
     tripoint_abs_sm plpos = project_to<coords::sm>( plpos_omt );
     // INT_MIN is a (a bit ugly) way to inform get_npcs_near not to filter by z-level
@@ -1456,7 +1456,7 @@ std::string overmapbuffer::get_description_at( const tripoint_abs_sm &where )
 void overmapbuffer::spawn_monster( const tripoint_abs_sm &p )
 {
     // Create a copy, so we can reuse x and y later
-    point_abs_sm abs_sm = p.xy();
+    point_abs_sm const abs_sm = p.xy();
     point_om_sm sm;
     point_abs_om omp;
     std::tie( omp, sm ) = project_remain<coords::om>( abs_sm );
@@ -1465,7 +1465,7 @@ void overmapbuffer::spawn_monster( const tripoint_abs_sm &p )
     auto monster_bucket = om.monster_map->equal_range( current_submap_loc );
     std::for_each( monster_bucket.first, monster_bucket.second,
     [&]( std::pair<const tripoint_om_sm, monster> &monster_entry ) {
-        monster &this_monster = monster_entry.second;
+        monster  const&this_monster = monster_entry.second;
         // The absolute position in map squares, (x,y) is already global, but it's a
         // submap coordinate, so translate it and add the exact monster position on
         // the submap. modulo because the zombies position might be negative, as it
@@ -1493,7 +1493,7 @@ void overmapbuffer::despawn_monster( const monster &critter )
 {
     // Get absolute coordinates of the monster in map squares, translate to submap position
     // TODO: fix point types
-    tripoint_abs_sm abs_sm( ms_to_sm_copy( get_map().getabs( critter.pos() ) ) );
+    tripoint_abs_sm const abs_sm( ms_to_sm_copy( get_map().getabs( critter.pos() ) ) );
     // Get the overmap coordinates and get the overmap, sm is now local to that overmap
     point_abs_om omp;
     tripoint_om_sm sm;
@@ -1529,7 +1529,7 @@ overmapbuffer::t_extras_vector overmapbuffer::get_extras( int z, const std::stri
         const overmap &om = *it.second;
         for( int i = 0; i < OMAPX; i++ ) {
             for( int j = 0; j < OMAPY; j++ ) {
-                tripoint_om_omt p( i, j, z );
+                tripoint_om_omt const p( i, j, z );
                 const string_id<map_extra> &extra = om.extra( p );
                 if( extra.is_null() ) {
                     continue;
@@ -1691,11 +1691,11 @@ std::set<tripoint_abs_omt> overmapbuffer::electric_grid_at( const tripoint_abs_o
         // It's weired that the game takes a lot of time to copy a tripoint_abs_omt, so use reference here.
         const tripoint_abs_omt &elem = open.front();
         result.emplace( elem );
-        overmap_with_local_coords omc = get_om_global( elem );
+        overmap_with_local_coords const omc = get_om_global( elem );
         const auto &connections_bitset = omc.om->electric_grid_connections[omc.local];
         for( size_t i = 0; i < six_cardinal_directions.size(); i++ ) {
             if( connections_bitset.test( i ) ) {
-                tripoint_abs_omt other = elem + six_cardinal_directions[i];
+                tripoint_abs_omt const other = elem + six_cardinal_directions[i];
                 if( result.count( other ) == 0 ) {
                     open.emplace( other );
                 }
@@ -1713,7 +1713,7 @@ overmapbuffer::electric_grid_connectivity_at( const tripoint_abs_omt &p )
     std::vector<tripoint_rel_omt> ret;
     ret.reserve( six_cardinal_directions.size() );
 
-    overmap_with_local_coords omc = get_om_global( p );
+    overmap_with_local_coords const omc = get_om_global( p );
     const auto &connections_bitset = omc.om->electric_grid_connections[omc.local];
     for( size_t i = 0; i < six_cardinal_directions.size(); i++ ) {
         if( connections_bitset.test( i ) ) {
@@ -1737,8 +1737,8 @@ bool overmapbuffer::add_grid_connection( const tripoint_abs_omt &lhs, const trip
         return false;
     }
 
-    overmap_with_local_coords lhs_omc = get_om_global( lhs );
-    overmap_with_local_coords rhs_omc = get_om_global( rhs );
+    overmap_with_local_coords const lhs_omc = get_om_global( lhs );
+    overmap_with_local_coords const rhs_omc = get_om_global( rhs );
 
     const auto lhs_iter = std::find( six_cardinal_directions.begin(),
                                      six_cardinal_directions.end(),
@@ -1747,8 +1747,8 @@ bool overmapbuffer::add_grid_connection( const tripoint_abs_omt &lhs, const trip
                                      six_cardinal_directions.end(),
                                      -coord_diff.raw() );
 
-    size_t lhs_i = std::distance( six_cardinal_directions.begin(), lhs_iter );
-    size_t rhs_i = std::distance( six_cardinal_directions.begin(), rhs_iter );
+    size_t const lhs_i = std::distance( six_cardinal_directions.begin(), lhs_iter );
+    size_t const rhs_i = std::distance( six_cardinal_directions.begin(), rhs_iter );
 
     std::bitset<six_cardinal_directions.size()> &lhs_bitset =
         lhs_omc.om->electric_grid_connections[lhs_omc.local];
@@ -1778,8 +1778,8 @@ bool overmapbuffer::remove_grid_connection( const tripoint_abs_omt &lhs,
         return false;
     }
 
-    overmap_with_local_coords lhs_omc = get_om_global( lhs );
-    overmap_with_local_coords rhs_omc = get_om_global( rhs );
+    overmap_with_local_coords const lhs_omc = get_om_global( lhs );
+    overmap_with_local_coords const rhs_omc = get_om_global( rhs );
 
     const auto lhs_iter = std::find( six_cardinal_directions.begin(),
                                      six_cardinal_directions.end(),
@@ -1788,8 +1788,8 @@ bool overmapbuffer::remove_grid_connection( const tripoint_abs_omt &lhs,
                                      six_cardinal_directions.end(),
                                      -coord_diff.raw() );
 
-    size_t lhs_i = std::distance( six_cardinal_directions.begin(), lhs_iter );
-    size_t rhs_i = std::distance( six_cardinal_directions.begin(), rhs_iter );
+    size_t const lhs_i = std::distance( six_cardinal_directions.begin(), lhs_iter );
+    size_t const rhs_i = std::distance( six_cardinal_directions.begin(), rhs_iter );
 
     std::bitset<six_cardinal_directions.size()> &lhs_bitset =
         lhs_omc.om->electric_grid_connections[lhs_omc.local];

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -222,7 +222,7 @@ void overmap_ui::draw_overmap_chunk( const catacurses::window &w_minimap, const 
                         colorStart = symbolIndex + 1;
                     }
 
-                    std::string sym = note_text.substr( colorStart, colorIndex - colorStart );
+                    std::string const sym = note_text.substr( colorStart, colorIndex - colorStart );
 
                     ter_color = get_note_color( sym );
                 }
@@ -260,7 +260,7 @@ void overmap_ui::draw_overmap_chunk( const catacurses::window &w_minimap, const 
 
     // Print arrow to mission if we have one!
     if( !drew_mission ) {
-        double slope = curs.x() != targ.x() ?
+        double const slope = curs.x() != targ.x() ?
                        static_cast<double>( targ.y() - curs.y() ) / ( targ.x() - curs.x() ) : 4;
 
         if( curs.x() == targ.x() || std::fabs( slope ) > 3.5 ) {  // Vertical slope
@@ -298,7 +298,7 @@ void overmap_ui::draw_overmap_chunk( const catacurses::window &w_minimap, const 
                 continue; // only do hordes on the border, skip inner map
             }
             const tripoint_abs_omt omp( curs + point( i, j ), g->get_levz() );
-            int horde_size = overmap_buffer.get_horde_size( omp );
+            int const horde_size = overmap_buffer.get_horde_size( omp );
             if( horde_size >= HORDE_VISIBILITY_SIZE ) {
                 if( overmap_buffer.seen( omp )
                     && player_character.overmap_los( omp, sight_points ) ) {
@@ -479,7 +479,7 @@ static int define_temp_level( const int lvl )
 static std::string temp_delta_string( const avatar &u )
 {
     std::string temp_message;
-    std::pair<int, int> temp_pair = temp_delta( u );
+    std::pair<int, int> const temp_pair = temp_delta( u );
     // Assign zones for comparisons
     const int cur_zone = define_temp_level( u.temp_cur[temp_pair.first] );
     const int conv_zone = define_temp_level( u.temp_conv[temp_pair.second] );
@@ -509,7 +509,7 @@ static std::pair<nc_color, std::string> temp_delta_arrows( const avatar &u )
 {
     std::string temp_message;
     nc_color temp_color = c_white;
-    std::pair<int, int> temp_pair = temp_delta( u );
+    std::pair<int, int> const temp_pair = temp_delta( u );
     // Assign zones for comparisons
     const int cur_zone = define_temp_level( u.temp_cur[temp_pair.first] );
     const int conv_zone = define_temp_level( u.temp_conv[temp_pair.second] );
@@ -546,7 +546,7 @@ static std::pair<nc_color, std::string> temp_stat( const avatar &u )
 {
     /// Find hottest/coldest bodypart
     // Calculate the most extreme body temperatures
-    int current_bp_extreme = temp_delta( u ).first;
+    int const current_bp_extreme = temp_delta( u ).first;
 
     // printCur the hottest/coldest bodypart
     std::string temp_string;
@@ -731,8 +731,8 @@ static nc_color safe_color()
 {
     nc_color s_color = g->safe_mode ? c_green : c_red;
     if( g->safe_mode == SAFE_MODE_OFF && get_option<bool>( "AUTOSAFEMODE" ) ) {
-        int s_return = get_option<int>( "AUTOSAFEMODETURNS" );
-        int iPercent = g->turnssincelastmon * 100 / s_return;
+        int const s_return = get_option<int>( "AUTOSAFEMODETURNS" );
+        int const iPercent = g->turnssincelastmon * 100 / s_return;
         if( iPercent >= 100 ) {
             s_color = c_green;
         } else if( iPercent >= 75 ) {
@@ -748,7 +748,7 @@ static nc_color safe_color()
 
 static int get_int_digits( const int &digits )
 {
-    int temp = std::abs( digits );
+    int const temp = std::abs( digits );
     if( digits > 0 ) {
         return static_cast<int>( std::log10( static_cast<double>( temp ) ) ) + 1;
     } else if( digits < 0 ) {
@@ -799,7 +799,7 @@ static void draw_limb_health( avatar &u, const catacurses::window &w, int limb_i
 
     const int hp_cur = u.get_part_hp_cur( bp );
     const int hp_max = u.get_part_hp_max( bp );
-    std::pair<std::string, nc_color> hp = get_hp_bar( hp_cur, hp_max );
+    std::pair<std::string, nc_color> const hp = get_hp_bar( hp_cur, hp_max );
 
     if( is_self_aware || u.has_effect( effect_got_checked ) ) {
         wprintz( w, hp.second, "%3d  ", hp_cur );
@@ -837,9 +837,9 @@ static void draw_limb2( avatar &u, const catacurses::window &w )
     }
 
     // print mood
-    std::pair<nc_color, int> morale_pair = morale_stat( u );
-    bool m_style = get_option<std::string>( "MORALE_STYLE" ) == "horizontal";
-    std::string smiley = morale_emotion( morale_pair.second, get_face_type( u ), m_style );
+    std::pair<nc_color, int> const morale_pair = morale_stat( u );
+    bool const m_style = get_option<std::string>( "MORALE_STYLE" ) == "horizontal";
+    std::string const smiley = morale_emotion( morale_pair.second, get_face_type( u ), m_style );
 
     // print safe mode
     std::string safe_str;
@@ -914,8 +914,8 @@ static void draw_stealth( avatar &u, const catacurses::window &w )
     werase( w );
     mvwprintz( w, point_zero, c_light_gray, _( "Speed" ) );
     mvwprintz( w, point( 7, 0 ), value_color( u.get_speed() ), "%s", u.get_speed() );
-    nc_color move_color = move_mode_color( u );
-    std::string move_string = std::to_string( u.movecounter ) + move_mode_string( u );
+    nc_color const move_color = move_mode_color( u );
+    std::string const move_string = std::to_string( u.movecounter ) + move_mode_string( u );
     mvwprintz( w, point( 15 - utf8_width( move_string ), 0 ), move_color, move_string );
     if( u.is_deaf() ) {
         mvwprintz( w, point( 22, 0 ), c_red, _( "DEAF" ) );
@@ -977,7 +977,7 @@ static void draw_time( const avatar &u, const catacurses::window &w )
     werase( w );
     // display date
     mvwprintz( w, point_zero, c_light_gray, calendar::name_season( season_of_year( calendar::turn ) ) );
-    std::string day = std::to_string( day_of_season<int>( calendar::turn ) + 1 );
+    std::string const day = std::to_string( day_of_season<int>( calendar::turn ) + 1 );
     mvwprintz( w, point( 10 - utf8_width( day ), 0 ), c_light_gray, day );
     // display time
     if( u.has_watch() ) {
@@ -1024,16 +1024,16 @@ static void draw_needs_compact( const avatar &u, const catacurses::window &w )
 
 static std::string carry_weight_string( const avatar &u )
 {
-    double weight_carried = round_up( convert_weight( u.weight_carried() ), 1 ); // In kg/lbs
-    double weight_capacity = round_up( convert_weight( u.weight_capacity() ), 1 );
+    double const weight_carried = round_up( convert_weight( u.weight_carried() ), 1 ); // In kg/lbs
+    double const weight_capacity = round_up( convert_weight( u.weight_capacity() ), 1 );
     return string_format( "%.1f/%.1f", weight_carried, weight_capacity );
 }
 
 static std::string carry_volume_string( const avatar &u )
 {
-    double volume_carried = round_up( convert_volume( to_milliliter( u.volume_carried() ) ),
+    double const volume_carried = round_up( convert_volume( to_milliliter( u.volume_carried() ) ),
                                       2 );
-    double volume_capacity = round_up( convert_volume( to_milliliter( u.volume_capacity() ) ),
+    double const volume_capacity = round_up( convert_volume( to_milliliter( u.volume_capacity() ) ),
                                        2 ); // In liters/cups/wolf paws or whatever burger units
     return string_format( "%.2f/%.2f", volume_carried, volume_capacity );
 }
@@ -1159,10 +1159,10 @@ static void draw_limb_wide( avatar &u, const catacurses::window &w )
     };
     werase( w );
     for( int i = 0; i < num_hp_parts; i++ ) {
-        int offset = i * 15;
-        int ny = offset / 45;
-        int nx = offset % 45;
-        std::string str = string_format( " %s: ",
+        int const offset = i * 15;
+        int const ny = offset / 45;
+        int const nx = offset % 45;
+        std::string const str = string_format( " %s: ",
                                          left_justify( body_part_hp_bar_ui_text( parts[i].first ), 5 ) );
         nc_color part_color = u.limb_color( parts[i].first, true, true, true );
         print_colored_text( w, point( nx, ny ), part_color, c_white, str );
@@ -1174,7 +1174,7 @@ static void draw_limb_wide( avatar &u, const catacurses::window &w )
 static void draw_char_narrow( avatar &u, const catacurses::window &w )
 {
     werase( w );
-    std::pair<nc_color, int> morale_pair = morale_stat( u );
+    std::pair<nc_color, int> const morale_pair = morale_stat( u );
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     mvwprintz( w, point( 1, 0 ), c_light_gray, _( "Sound:" ) );
     // NOLINTNEXTLINE(cata-use-named-point-constants)
@@ -1184,11 +1184,11 @@ static void draw_char_narrow( avatar &u, const catacurses::window &w )
     mvwprintz( w, point( 19, 1 ), c_light_gray, _( "Speed:" ) );
     mvwprintz( w, point( 19, 2 ), c_light_gray, _( "Move :" ) );
 
-    nc_color move_color =  move_mode_color( u );
-    std::string move_char = move_mode_string( u );
-    std::string movecost = std::to_string( u.movecounter ) + "(" + move_char + ")";
-    bool m_style = get_option<std::string>( "MORALE_STYLE" ) == "horizontal";
-    std::string smiley = morale_emotion( morale_pair.second, get_face_type( u ), m_style );
+    nc_color const move_color =  move_mode_color( u );
+    std::string const move_char = move_mode_string( u );
+    std::string const movecost = std::to_string( u.movecounter ) + "(" + move_char + ")";
+    bool const m_style = get_option<std::string>( "MORALE_STYLE" ) == "horizontal";
+    std::string const smiley = morale_emotion( morale_pair.second, get_face_type( u ), m_style );
     mvwprintz( w, point( 8, 0 ), c_light_gray, "%s", u.volume );
 
     // print stamina
@@ -1215,7 +1215,7 @@ static void draw_char_narrow( avatar &u, const catacurses::window &w )
 static void draw_char_wide( avatar &u, const catacurses::window &w )
 {
     werase( w );
-    std::pair<nc_color, int> morale_pair = morale_stat( u );
+    std::pair<nc_color, int> const morale_pair = morale_stat( u );
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     mvwprintz( w, point( 1, 0 ), c_light_gray, _( "Sound:" ) );
     mvwprintz( w, point( 16, 0 ), c_light_gray, _( "Mood :" ) );
@@ -1225,11 +1225,11 @@ static void draw_char_wide( avatar &u, const catacurses::window &w )
     mvwprintz( w, point( 16, 1 ), c_light_gray, _( "Speed:" ) );
     mvwprintz( w, point( 31, 1 ), c_light_gray, _( "Move :" ) );
 
-    nc_color move_color =  move_mode_color( u );
-    std::string move_char = move_mode_string( u );
-    std::string movecost = std::to_string( u.movecounter ) + "(" + move_char + ")";
-    bool m_style = get_option<std::string>( "MORALE_STYLE" ) == "horizontal";
-    std::string smiley = morale_emotion( morale_pair.second, get_face_type( u ), m_style );
+    nc_color const move_color =  move_mode_color( u );
+    std::string const move_char = move_mode_string( u );
+    std::string const movecost = std::to_string( u.movecounter ) + "(" + move_char + ")";
+    bool const m_style = get_option<std::string>( "MORALE_STYLE" ) == "horizontal";
+    std::string const smiley = morale_emotion( morale_pair.second, get_face_type( u ), m_style );
 
     mvwprintz( w, point( 8, 0 ), c_light_gray, "%s", u.volume );
     mvwprintz( w, point( 23, 0 ), morale_pair.first, "%s", smiley );
@@ -1269,7 +1269,7 @@ static void draw_stat_narrow( avatar &u, const catacurses::window &w )
     stat_clr = per_string( u ).first;
     mvwprintz( w, point( 26, 1 ), stat_clr, "%s", u.get_per() );
 
-    std::pair<nc_color, std::string> pwr_pair = power_stat( u );
+    std::pair<nc_color, std::string> const pwr_pair = power_stat( u );
     mvwprintz( w, point( 1, 2 ), c_light_gray, _( "Power:" ) );
     mvwprintz( w, point( 19, 2 ), c_light_gray, _( "Safe :" ) );
     mvwprintz( w, point( 8, 2 ), pwr_pair.first, "%s", pwr_pair.second );
@@ -1295,7 +1295,7 @@ static void draw_stat_wide( avatar &u, const catacurses::window &w )
     stat_clr = per_string( u ).first;
     mvwprintz( w, point( 23, 1 ), stat_clr, "%s", u.get_per() );
 
-    std::pair<nc_color, std::string> pwr_pair = power_stat( u );
+    std::pair<nc_color, std::string> const pwr_pair = power_stat( u );
     mvwprintz( w, point( 31, 0 ), c_light_gray, _( "Power:" ) );
     mvwprintz( w, point( 31, 1 ), c_light_gray, _( "Safe :" ) );
     mvwprintz( w, point( 38, 0 ), pwr_pair.first, "%s", pwr_pair.second );
@@ -1402,7 +1402,7 @@ static void draw_weightvolume_labels( const avatar &u, const catacurses::window 
 
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     mvwprintz( w, point( 1, 0 ), c_light_gray, _( "Wgt  :" ) );
-    std::string weight_string = carry_weight_string( u );
+    std::string const weight_string = carry_weight_string( u );
     if( u.weight_carried() > u.weight_capacity() ) {
         mvwprintz( w, point( 8, 0 ), c_red, weight_string );
     } else if( u.weight_carried() > u.weight_capacity() * 0.75 ) {
@@ -1412,7 +1412,7 @@ static void draw_weightvolume_labels( const avatar &u, const catacurses::window 
     }
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     mvwprintz( w, point( 23, 0 ), c_light_gray, _( "Volume:" ) );
-    std::string volume_string = carry_volume_string( u );
+    std::string const volume_string = carry_volume_string( u );
     if( u.volume_carried() > u.volume_capacity() * 0.85 ) {
         mvwprintz( w, point( 30, 0 ), c_red, volume_string );
     } else if( u.volume_carried() > u.volume_capacity() * 0.65 ) {
@@ -1427,11 +1427,11 @@ static void draw_weightvolume_labels( const avatar &u, const catacurses::window 
 static void draw_needs_narrow( const avatar &u, const catacurses::window &w )
 {
     werase( w );
-    std::pair<std::string, nc_color> hunger_pair = u.get_hunger_description();
-    std::pair<std::string, nc_color> thirst_pair = u.get_thirst_description();
-    std::pair<std::string, nc_color> rest_pair = u.get_fatigue_description();
-    std::pair<nc_color, std::string> temp_pair = temp_stat( u );
-    std::pair<std::string, nc_color> pain_pair = u.get_pain_description();
+    std::pair<std::string, nc_color> const hunger_pair = u.get_hunger_description();
+    std::pair<std::string, nc_color> const thirst_pair = u.get_thirst_description();
+    std::pair<std::string, nc_color> const rest_pair = u.get_fatigue_description();
+    std::pair<nc_color, std::string> const temp_pair = temp_stat( u );
+    std::pair<std::string, nc_color> const pain_pair = u.get_pain_description();
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     mvwprintz( w, point( 1, 0 ), c_light_gray, _( "Hunger:" ) );
     // NOLINTNEXTLINE(cata-use-named-point-constants)
@@ -1450,11 +1450,11 @@ static void draw_needs_narrow( const avatar &u, const catacurses::window &w )
 static void draw_needs_labels( const avatar &u, const catacurses::window &w )
 {
     werase( w );
-    std::pair<std::string, nc_color> hunger_pair = u.get_hunger_description();
-    std::pair<std::string, nc_color> thirst_pair = u.get_thirst_description();
-    std::pair<std::string, nc_color> rest_pair = u.get_fatigue_description();
-    std::pair<nc_color, std::string> temp_pair = temp_stat( u );
-    std::pair<std::string, nc_color> pain_pair = u.get_pain_description();
+    std::pair<std::string, nc_color> const hunger_pair = u.get_hunger_description();
+    std::pair<std::string, nc_color> const thirst_pair = u.get_thirst_description();
+    std::pair<std::string, nc_color> const rest_pair = u.get_fatigue_description();
+    std::pair<nc_color, std::string> const temp_pair = temp_stat( u );
+    std::pair<std::string, nc_color> const pain_pair = u.get_pain_description();
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     mvwprintz( w, point( 1, 0 ), c_light_gray, _( "Pain :" ) );
     mvwprintz( w, point( 8, 0 ), pain_pair.second, pain_pair.first );
@@ -1524,13 +1524,13 @@ static void draw_env_compact( avatar &u, const catacurses::window &w )
     mvwprintz( w, point( 8, 4 ), ll.second, ll.first );
     // wind
     const oter_id &cur_om_ter = overmap_buffer.ter( u.global_omt_location() );
-    double windpower = get_local_windpower( weather.windspeed, cur_om_ter,
+    double const windpower = get_local_windpower( weather.windspeed, cur_om_ter,
                                             u.pos(), weather.winddirection, g->is_sheltered( u.pos() ) );
     mvwprintz( w, point( 8, 5 ), get_wind_color( windpower ),
                get_wind_desc( windpower ) + " " + get_wind_arrow( weather.winddirection ) );
 
     if( u.has_item_with_flag( "THERMOMETER" ) || u.has_bionic( bionic_id( "bio_meteorologist" ) ) ) {
-        std::string temp = print_temperature( weather.get_temperature( u.pos() ) );
+        std::string const temp = print_temperature( weather.get_temperature( u.pos() ) );
         mvwprintz( w, point( 31 - utf8_width( temp ), 5 ), c_light_gray, temp );
     }
 
@@ -1545,7 +1545,7 @@ static void render_wind( avatar &u, const catacurses::window &w, const std::stri
                string_format( formatstr, left_justify( _( "Wind" ), 5 ) ) );
     const oter_id &cur_om_ter = overmap_buffer.ter( u.global_omt_location() );
     const weather_manager &weather = get_weather();
-    double windpower = get_local_windpower( weather.windspeed, cur_om_ter,
+    double const windpower = get_local_windpower( weather.windspeed, cur_om_ter,
                                             u.pos(), weather.winddirection, g->is_sheltered( u.pos() ) );
     mvwprintz( w, point( 8, 0 ), get_wind_color( windpower ),
                get_wind_desc( windpower ) + " " + get_wind_arrow( weather.winddirection ) );
@@ -1601,9 +1601,9 @@ static void draw_health_classic( avatar &u, const catacurses::window &w )
     mvwprintz( w, point( 21, 0 ), pain_pair.second, pain_pair.first );
 
     // print mood
-    std::pair<nc_color, int> morale_pair = morale_stat( u );
-    bool m_style = get_option<std::string>( "MORALE_STYLE" ) == "horizontal";
-    std::string smiley = morale_emotion( morale_pair.second, get_face_type( u ), m_style );
+    std::pair<nc_color, int> const morale_pair = morale_stat( u );
+    bool const m_style = get_option<std::string>( "MORALE_STYLE" ) == "horizontal";
+    std::string const smiley = morale_emotion( morale_pair.second, get_face_type( u ), m_style );
     mvwprintz( w, point( 34, 1 ), morale_pair.first, smiley );
 
     if( !veh ) {
@@ -1639,8 +1639,8 @@ static void draw_health_classic( avatar &u, const catacurses::window &w )
     if( !veh ) {
         mvwprintz( w, point( 21, 5 ), u.get_speed() < 100 ? c_red : c_white,
                    _( "Spd " ) + std::to_string( u.get_speed() ) );
-        nc_color move_color = u.movement_mode_is( CMM_WALK ) ? c_white : move_mode_color( u );
-        std::string move_string = std::to_string( u.movecounter ) + " " + move_mode_string( u );
+        nc_color const move_color = u.movement_mode_is( CMM_WALK ) ? c_white : move_mode_color( u );
+        std::string const move_string = std::to_string( u.movecounter ) + " " + move_mode_string( u );
         mvwprintz( w, point( 29, 5 ), move_color, move_string );
     }
 
@@ -1659,12 +1659,12 @@ static void draw_health_classic( avatar &u, const catacurses::window &w )
         mvwprintz( w, point( 35, 4 ), c_light_gray, veh->face.to_string_azimuth_from_north() );
         // target speed > current speed
         const float strain = veh->strain();
-        nc_color col_vel = strain <= 0 ? c_light_blue :
+        nc_color const col_vel = strain <= 0 ? c_light_blue :
                            ( strain <= 0.2 ? c_yellow :
                              ( strain <= 0.4 ? c_light_red : c_red ) );
-        int t_speed = static_cast<int>( convert_velocity( veh->cruise_velocity, VU_VEHICLE ) );
-        int c_speed = static_cast<int>( convert_velocity( veh->velocity, VU_VEHICLE ) );
-        int offset = get_int_digits( c_speed );
+        int const t_speed = static_cast<int>( convert_velocity( veh->cruise_velocity, VU_VEHICLE ) );
+        int const c_speed = static_cast<int>( convert_velocity( veh->velocity, VU_VEHICLE ) );
+        int const offset = get_int_digits( c_speed );
         const std::string type = get_option<std::string>( "USE_METRIC_SPEEDS" );
         mvwprintz( w, point( 21, 5 ), c_light_gray, type );
         mvwprintz( w, point( 26, 5 ), col_vel, "%d", c_speed );
@@ -1689,7 +1689,7 @@ static void draw_armor_padding( const avatar &u, const catacurses::window &w )
     mvwprintz( w, point( 1, 3 ), color, _( "Legs :" ) );
     mvwprintz( w, point( 1, 4 ), color, _( "Feet :" ) );
 
-    unsigned int max_length = getmaxx( w ) - 8;
+    unsigned int const max_length = getmaxx( w ) - 8;
     print_colored_text( w, point( 8, 0 ), color, color, get_armor( u, bp_head, max_length ) );
     print_colored_text( w, point( 8, 1 ), color, color, get_armor( u, bp_torso, max_length ) );
     print_colored_text( w, point( 8, 2 ), color, color, get_armor( u, bp_arm_r, max_length ) );
@@ -1709,7 +1709,7 @@ static void draw_armor( const avatar &u, const catacurses::window &w )
     mvwprintz( w, point( 0, 3 ), color, _( "Legs :" ) );
     mvwprintz( w, point( 0, 4 ), color, _( "Feet :" ) );
 
-    unsigned int max_length = getmaxx( w ) - 7;
+    unsigned int const max_length = getmaxx( w ) - 7;
     print_colored_text( w, point( 7, 0 ), color, color, get_armor( u, bp_head, max_length ) );
     print_colored_text( w, point( 7, 1 ), color, color, get_armor( u, bp_torso, max_length ) );
     print_colored_text( w, point( 7, 2 ), color, color, get_armor( u, bp_arm_r, max_length ) );
@@ -1721,8 +1721,8 @@ static void draw_armor( const avatar &u, const catacurses::window &w )
 static void draw_messages( avatar &, const catacurses::window &w )
 {
     werase( w );
-    int line = getmaxy( w ) - 2;
-    int maxlength = getmaxx( w );
+    int const line = getmaxy( w ) - 2;
+    int const maxlength = getmaxx( w );
     Messages::display_messages( w, 1, 0 /*topline*/, maxlength - 1, line );
     wnoutrefresh( w );
 }
@@ -1730,8 +1730,8 @@ static void draw_messages( avatar &, const catacurses::window &w )
 static void draw_messages_classic( avatar &, const catacurses::window &w )
 {
     werase( w );
-    int line = getmaxy( w ) - 2;
-    int maxlength = getmaxx( w );
+    int const line = getmaxy( w ) - 2;
+    int const maxlength = getmaxx( w );
     Messages::display_messages( w, 0, 0 /*topline*/, maxlength, line );
     wnoutrefresh( w );
 }
@@ -1773,12 +1773,12 @@ static void draw_veh_compact( const avatar &u, const catacurses::window &w )
         mvwprintz( w, point( 6, 0 ), c_light_gray, veh->face.to_string_azimuth_from_north() );
         // target speed > current speed
         const float strain = veh->strain();
-        nc_color col_vel = strain <= 0 ? c_light_blue :
+        nc_color const col_vel = strain <= 0 ? c_light_blue :
                            ( strain <= 0.2 ? c_yellow :
                              ( strain <= 0.4 ? c_light_red : c_red ) );
-        int t_speed = static_cast<int>( convert_velocity( veh->cruise_velocity, VU_VEHICLE ) );
-        int c_speed = static_cast<int>( convert_velocity( veh->velocity, VU_VEHICLE ) );
-        int offset = get_int_digits( c_speed );
+        int const t_speed = static_cast<int>( convert_velocity( veh->cruise_velocity, VU_VEHICLE ) );
+        int const c_speed = static_cast<int>( convert_velocity( veh->velocity, VU_VEHICLE ) );
+        int const offset = get_int_digits( c_speed );
         const std::string type = get_option<std::string>( "USE_METRIC_SPEEDS" );
         mvwprintz( w, point( 12, 0 ), c_light_gray, "%s :", type );
         mvwprintz( w, point( 19, 0 ), col_vel, "%d", c_speed );
@@ -1805,12 +1805,12 @@ static void draw_veh_padding( const avatar &u, const catacurses::window &w )
         mvwprintz( w, point( 7, 0 ), c_light_gray, veh->face.to_string_azimuth_from_north() );
         // target speed > current speed
         const float strain = veh->strain();
-        nc_color col_vel = strain <= 0 ? c_light_blue :
+        nc_color const col_vel = strain <= 0 ? c_light_blue :
                            ( strain <= 0.2 ? c_yellow :
                              ( strain <= 0.4 ? c_light_red : c_red ) );
-        int t_speed = static_cast<int>( convert_velocity( veh->cruise_velocity, VU_VEHICLE ) );
-        int c_speed = static_cast<int>( convert_velocity( veh->velocity, VU_VEHICLE ) );
-        int offset = get_int_digits( c_speed );
+        int const t_speed = static_cast<int>( convert_velocity( veh->cruise_velocity, VU_VEHICLE ) );
+        int const c_speed = static_cast<int>( convert_velocity( veh->velocity, VU_VEHICLE ) );
+        int const offset = get_int_digits( c_speed );
         const std::string type = get_option<std::string>( "USE_METRIC_SPEEDS" );
         mvwprintz( w, point( 13, 0 ), c_light_gray, "%s :", type );
         mvwprintz( w, point( 20, 0 ), col_vel, "%d", c_speed );
@@ -1829,7 +1829,7 @@ static void draw_ai_goal( const avatar &u, const catacurses::window &w )
     behavior::tree needs;
     needs.add( &string_id<behavior::node_t>( "npc_needs" ).obj() );
     behavior::character_oracle_t player_oracle( &u );
-    std::string current_need = needs.tick( &player_oracle );
+    std::string const current_need = needs.tick( &player_oracle );
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     mvwprintz( w, point( 1, 0 ), c_light_gray, _( "Goal: %s" ), current_need );
     wnoutrefresh( w );
@@ -1931,7 +1931,7 @@ static void draw_time_classic( const avatar &u, const catacurses::window &w )
     // display date
     mvwprintz( w, point_zero, c_white,
                calendar::name_season( season_of_year( calendar::turn ) ) + "," );
-    std::string day = std::to_string( day_of_season<int>( calendar::turn ) + 1 );
+    std::string const day = std::to_string( day_of_season<int>( calendar::turn ) + 1 );
     mvwprintz( w, point( 8, 0 ), c_white, _( "Day " ) + day );
     // display time
     if( u.has_watch() ) {
@@ -1945,7 +1945,7 @@ static void draw_time_classic( const avatar &u, const catacurses::window &w )
     }
 
     if( u.has_item_with_flag( "THERMOMETER" ) || u.has_bionic( bionic_id( "bio_meteorologist" ) ) ) {
-        std::string temp = print_temperature( get_weather().get_temperature( u.pos() ) );
+        std::string const temp = print_temperature( get_weather().get_temperature( u.pos() ) );
         mvwprintz( w, point( 31, 0 ), c_light_gray, _( "Temp : " ) + temp );
     }
 
@@ -1955,7 +1955,7 @@ static void draw_time_classic( const avatar &u, const catacurses::window &w )
 static void draw_hint( const avatar &, const catacurses::window &w )
 {
     werase( w );
-    std::string press = press_x( ACTION_TOGGLE_PANEL_ADM );
+    std::string const press = press_x( ACTION_TOGGLE_PANEL_ADM );
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     mvwprintz( w, point( 1, 0 ), c_light_green, press );
     mvwprintz( w, point( 2 + utf8_width( press ), 0 ), c_white, _( "to open sidebar options" ) );
@@ -2008,10 +2008,10 @@ static void draw_mana_wide( const player &u, const catacurses::window &w )
 
 static bool spell_panel()
 {
-    std::vector<spell_id> spells = get_avatar().magic->spells();
+    std::vector<spell_id> const spells = get_avatar().magic->spells();
     bool has_manacasting = false;
-    for( spell_id sp : spells ) {
-        spell temp_spell = get_avatar().magic->get_spell( sp );
+    for( spell_id const sp : spells ) {
+        spell const temp_spell = get_avatar().magic->get_spell( sp );
         if( temp_spell.energy_source() == mana_energy ) {
             has_manacasting = true;
         }
@@ -2266,22 +2266,22 @@ void panel_manager::serialize( JsonOut &json )
 void panel_manager::deserialize( JsonIn &jsin )
 {
     jsin.start_array();
-    JsonObject joLayouts( jsin.get_object() );
+    JsonObject const joLayouts( jsin.get_object() );
 
     current_layout_id = joLayouts.get_string( "current_layout_id" );
-    for( JsonObject joLayout : joLayouts.get_array( "layouts" ) ) {
-        std::string layout_id = joLayout.get_string( "layout_id" );
+    for( JsonObject const joLayout : joLayouts.get_array( "layouts" ) ) {
+        std::string const layout_id = joLayout.get_string( "layout_id" );
         auto &layout = layouts.find( layout_id )->second;
         auto it = layout.begin();
 
-        for( JsonObject joPanel : joLayout.get_array( "panels" ) ) {
-            std::string name = joPanel.get_string( "name" );
-            bool toggle = joPanel.get_bool( "toggle" );
+        for( JsonObject const joPanel : joLayout.get_array( "panels" ) ) {
+            std::string const name = joPanel.get_string( "name" );
+            bool const toggle = joPanel.get_bool( "toggle" );
 
             for( auto it2 = layout.begin() + std::distance( layout.begin(), it ); it2 != layout.end(); ++it2 ) {
                 if( it2->get_name() == name ) {
                     if( it->get_name() != name ) {
-                        window_panel panel = *it2;
+                        window_panel const panel = *it2;
                         layout.erase( it2 );
                         it = layout.insert( it, panel );
                     }
@@ -2341,8 +2341,8 @@ void panel_manager::show_adm()
         werase( w );
         decorate_panel( _( "SIDEBAR OPTIONS" ), w );
 
-        for( std::pair<size_t, size_t> row_indx : row_indices ) {
-            std::string name = _( panels[row_indx.second].get_name() );
+        for( std::pair<size_t, size_t> const row_indx : row_indices ) {
+            std::string const name = _( panels[row_indx.second].get_name() );
             if( swapping && source_index == row_indx.second ) {
                 mvwprintz( w, point( 5, current_row + 1 ), c_yellow, name );
             } else {
@@ -2375,7 +2375,7 @@ void panel_manager::show_adm()
         mvwvline( w, point( column_widths[0] + column_widths[1], 1 ), 0, 18 );
 
         col_offset = column_widths[0] + 2;
-        int col_width = column_widths[1] - 4;
+        int const col_width = column_widths[1] - 4;
         mvwprintz( w, point( col_offset, 1 ), c_light_green, trunc_ellipse( ctxt.get_desc( "TOGGLE_PANEL" ),
                    col_width ) + ":" );
         mvwprintz( w, point( col_offset, 2 ), c_white, _( "Toggle panels on/off" ) );
@@ -2434,8 +2434,8 @@ void panel_manager::show_adm()
                 // saving win2 index
                 const size_t target_index = row_indices[current_row];
 
-                int distance = target_index - source_index;
-                size_t step_dir = distance > 0 ? 1 : -1;
+                int const distance = target_index - source_index;
+                size_t const step_dir = distance > 0 ? 1 : -1;
                 for( size_t i = source_index; i != target_index; i += step_dir ) {
                     std::swap( panels[i], panels[i + step_dir] );
                 }

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -261,7 +261,7 @@ void overmap_ui::draw_overmap_chunk( const catacurses::window &w_minimap, const 
     // Print arrow to mission if we have one!
     if( !drew_mission ) {
         double const slope = curs.x() != targ.x() ?
-                       static_cast<double>( targ.y() - curs.y() ) / ( targ.x() - curs.x() ) : 4;
+                             static_cast<double>( targ.y() - curs.y() ) / ( targ.x() - curs.x() ) : 4;
 
         if( curs.x() == targ.x() || std::fabs( slope ) > 3.5 ) {  // Vertical slope
             const int arrowy = targ.y() > curs.y() ? 6 : 0;
@@ -1032,9 +1032,9 @@ static std::string carry_weight_string( const avatar &u )
 static std::string carry_volume_string( const avatar &u )
 {
     double const volume_carried = round_up( convert_volume( to_milliliter( u.volume_carried() ) ),
-                                      2 );
+                                            2 );
     double const volume_capacity = round_up( convert_volume( to_milliliter( u.volume_capacity() ) ),
-                                       2 ); // In liters/cups/wolf paws or whatever burger units
+                                   2 ); // In liters/cups/wolf paws or whatever burger units
     return string_format( "%.2f/%.2f", volume_carried, volume_capacity );
 }
 
@@ -1163,7 +1163,7 @@ static void draw_limb_wide( avatar &u, const catacurses::window &w )
         int const ny = offset / 45;
         int const nx = offset % 45;
         std::string const str = string_format( " %s: ",
-                                         left_justify( body_part_hp_bar_ui_text( parts[i].first ), 5 ) );
+                                               left_justify( body_part_hp_bar_ui_text( parts[i].first ), 5 ) );
         nc_color part_color = u.limb_color( parts[i].first, true, true, true );
         print_colored_text( w, point( nx, ny ), part_color, c_white, str );
         draw_limb_health( u, w, parts[i].second );
@@ -1525,7 +1525,7 @@ static void draw_env_compact( avatar &u, const catacurses::window &w )
     // wind
     const oter_id &cur_om_ter = overmap_buffer.ter( u.global_omt_location() );
     double const windpower = get_local_windpower( weather.windspeed, cur_om_ter,
-                                            u.pos(), weather.winddirection, g->is_sheltered( u.pos() ) );
+                             u.pos(), weather.winddirection, g->is_sheltered( u.pos() ) );
     mvwprintz( w, point( 8, 5 ), get_wind_color( windpower ),
                get_wind_desc( windpower ) + " " + get_wind_arrow( weather.winddirection ) );
 
@@ -1546,7 +1546,7 @@ static void render_wind( avatar &u, const catacurses::window &w, const std::stri
     const oter_id &cur_om_ter = overmap_buffer.ter( u.global_omt_location() );
     const weather_manager &weather = get_weather();
     double const windpower = get_local_windpower( weather.windspeed, cur_om_ter,
-                                            u.pos(), weather.winddirection, g->is_sheltered( u.pos() ) );
+                             u.pos(), weather.winddirection, g->is_sheltered( u.pos() ) );
     mvwprintz( w, point( 8, 0 ), get_wind_color( windpower ),
                get_wind_desc( windpower ) + " " + get_wind_arrow( weather.winddirection ) );
     wnoutrefresh( w );
@@ -1660,8 +1660,8 @@ static void draw_health_classic( avatar &u, const catacurses::window &w )
         // target speed > current speed
         const float strain = veh->strain();
         nc_color const col_vel = strain <= 0 ? c_light_blue :
-                           ( strain <= 0.2 ? c_yellow :
-                             ( strain <= 0.4 ? c_light_red : c_red ) );
+                                 ( strain <= 0.2 ? c_yellow :
+                                   ( strain <= 0.4 ? c_light_red : c_red ) );
         int const t_speed = static_cast<int>( convert_velocity( veh->cruise_velocity, VU_VEHICLE ) );
         int const c_speed = static_cast<int>( convert_velocity( veh->velocity, VU_VEHICLE ) );
         int const offset = get_int_digits( c_speed );
@@ -1774,8 +1774,8 @@ static void draw_veh_compact( const avatar &u, const catacurses::window &w )
         // target speed > current speed
         const float strain = veh->strain();
         nc_color const col_vel = strain <= 0 ? c_light_blue :
-                           ( strain <= 0.2 ? c_yellow :
-                             ( strain <= 0.4 ? c_light_red : c_red ) );
+                                 ( strain <= 0.2 ? c_yellow :
+                                   ( strain <= 0.4 ? c_light_red : c_red ) );
         int const t_speed = static_cast<int>( convert_velocity( veh->cruise_velocity, VU_VEHICLE ) );
         int const c_speed = static_cast<int>( convert_velocity( veh->velocity, VU_VEHICLE ) );
         int const offset = get_int_digits( c_speed );
@@ -1806,8 +1806,8 @@ static void draw_veh_padding( const avatar &u, const catacurses::window &w )
         // target speed > current speed
         const float strain = veh->strain();
         nc_color const col_vel = strain <= 0 ? c_light_blue :
-                           ( strain <= 0.2 ? c_yellow :
-                             ( strain <= 0.4 ? c_light_red : c_red ) );
+                                 ( strain <= 0.2 ? c_yellow :
+                                   ( strain <= 0.4 ? c_light_red : c_red ) );
         int const t_speed = static_cast<int>( convert_velocity( veh->cruise_velocity, VU_VEHICLE ) );
         int const c_speed = static_cast<int>( convert_velocity( veh->velocity, VU_VEHICLE ) );
         int const offset = get_int_digits( c_speed );

--- a/src/path_info.cpp
+++ b/src/path_info.cpp
@@ -119,7 +119,7 @@ void PATH_INFO::set_standard_filenames()
 std::string find_translated_file( const std::string &base_path, const std::string &extension,
                                   const std::string &fallback )
 {
-    std::vector<std::string> opts = get_lang_path_substring( get_language().id );
+    std::vector<std::string> const opts = get_lang_path_substring( get_language().id );
 
     for( const std::string &s : opts ) {
         const std::string local_path = base_path + s + extension;
@@ -329,9 +329,9 @@ std::string PATH_INFO::motd()
 
 std::string PATH_INFO::title( const holiday )
 {
-    std::string theme_basepath = datadir_value + "title/";
-    std::string theme_extension = ".title";
-    std::string theme_fallback = theme_basepath + "en.title";
+    std::string const theme_basepath = datadir_value + "title/";
+    std::string const theme_extension = ".title";
+    std::string const theme_fallback = theme_basepath + "en.title";
     return find_translated_file( theme_basepath, theme_extension, theme_fallback );
 }
 

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -168,10 +168,10 @@ bool is_disjoint( const Set1 &set1, const Set2 &set2 )
     }
 
     typename Set1::const_iterator it1 = set1.begin();
-    typename Set1::const_iterator it1_end = set1.end();
+    typename Set1::const_iterator const it1_end = set1.end();
 
     typename Set2::const_iterator it2 = set2.begin();
-    typename Set2::const_iterator it2_end = set2.end();
+    typename Set2::const_iterator const it2_end = set2.end();
 
     if( *set2.rbegin() < *it1 || *set1.rbegin() < *it2 ) {
         return true;
@@ -233,13 +233,13 @@ std::vector<tripoint> map::route( const tripoint &f, const tripoint &t,
         return ret;
     }
 
-    int max_length = settings.max_length;
-    int bash = settings.bash_strength;
-    int climb_cost = settings.climb_cost;
-    bool doors = settings.allow_open_doors;
-    bool trapavoid = settings.avoid_traps;
-    bool roughavoid = settings.avoid_rough_terrain;
-    bool sharpavoid = settings.avoid_sharp;
+    int const max_length = settings.max_length;
+    int const bash = settings.bash_strength;
+    int const climb_cost = settings.climb_cost;
+    bool const doors = settings.allow_open_doors;
+    bool const trapavoid = settings.avoid_traps;
+    bool const roughavoid = settings.avoid_rough_terrain;
+    bool const sharpavoid = settings.avoid_sharp;
 
     const int pad = 16;  // Should be much bigger - low value makes pathfinders dumb!
     int minx = std::min( f.x, t.x ) - pad;
@@ -427,7 +427,7 @@ std::vector<tripoint> map::route( const tripoint &f, const tripoint &t,
                             // Special case - ledge in z-levels
                             // Warning: really expensive, needs a cache
                             if( valid_move( p, tripoint( p.xy(), p.z - 1 ), false, true ) ) {
-                                tripoint below( p.xy(), p.z - 1 );
+                                tripoint const below( p.xy(), p.z - 1 );
                                 if( !has_flag( TFLAG_NO_FLOOR, below ) ) {
                                     // Otherwise this would have been a huge fall
                                     auto &layer = pf.get_layer( p.z - 1 );

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -192,18 +192,18 @@ bool pickup::query_thief()
     const auto &allow_key = force_uc ? input_context::disallow_lower_case
                             : input_context::allow_all_keys;
     std::string const answer = query_popup()
-                         .allow_cancel( false )
-                         .context( "YES_NO_ALWAYS_NEVER" )
-                         .message( "%s", force_uc
-                                   ? _( "Picking up this item will be considered stealing, continue?  (Case sensitive)" )
-                                   : _( "Picking up this item will be considered stealing, continue?" ) )
-                         .option( "YES", allow_key ) // yes, steal all items in this location that is selected
-                         .option( "NO", allow_key ) // no, pick up only what is free
-                         .option( "ALWAYS", allow_key ) // Yes, steal all items and stop asking me this question
-                         .option( "NEVER", allow_key ) // no, only grab free item and never ask me again
-                         .cursor( 1 ) // default to the second option `NO`
-                         .query()
-                         .action; // retrieve the input action
+                               .allow_cancel( false )
+                               .context( "YES_NO_ALWAYS_NEVER" )
+                               .message( "%s", force_uc
+                                         ? _( "Picking up this item will be considered stealing, continue?  (Case sensitive)" )
+                                         : _( "Picking up this item will be considered stealing, continue?" ) )
+                               .option( "YES", allow_key ) // yes, steal all items in this location that is selected
+                               .option( "NO", allow_key ) // no, pick up only what is free
+                               .option( "ALWAYS", allow_key ) // Yes, steal all items and stop asking me this question
+                               .option( "NEVER", allow_key ) // no, only grab free item and never ask me again
+                               .cursor( 1 ) // default to the second option `NO`
+                               .query()
+                               .action; // retrieve the input action
     if( answer == "YES" ) {
         u.set_value( "THIEF_MODE", "THIEF_STEAL" );
         u.set_value( "THIEF_MODE_KEEP", "NO" );
@@ -373,7 +373,7 @@ static bool pick_one_up( pickup::pick_drop_selection &selection, bool &got_water
         // Children have to be picked up first, since removing parent would re-index the stack
         if( option != EMPTY ) {
             for( item_location &child_loc : children ) {
-                item  const&added = u.i_add( *child_loc );
+                item  const &added = u.i_add( *child_loc );
                 auto &pickup_entry = map_pickup[added.tname()];
                 pickup_entry.first = added;
                 pickup_entry.second += added.count();
@@ -408,7 +408,7 @@ namespace pickup
 bool do_pickup( std::vector<pick_drop_selection> &targets, bool autopickup )
 {
     bool got_water = false;
-    Character  const&u = get_avatar();
+    Character  const &u = get_avatar();
     bool const weight_was_okay = ( u.weight_carried() <= u.weight_capacity() );
     bool const volume_was_okay = ( u.volume_carried() <= u.volume_capacity() );
     bool offered_swap = false;
@@ -488,21 +488,22 @@ std::vector<stacked_items> stack_for_pickup_ui( const
                 calendar::before_time_starts, 0 );
     std::map<std::pair<time_point, int>, parent_child_check_t> parent_child_check;
     // First, we need to check which parent-child groups exist
-    for( item_stack::iterator const& it : unstacked ) {
+    for( item_stack::iterator const &it : unstacked ) {
         const auto &token = *it->drop_token;
         if( token.drop_number > 0 ) {
             std::pair<time_point, int> const turn_and_drop = std::make_pair( token.turn, token.drop_number );
             parent_child_check[turn_and_drop].parent_exists = true;
         }
         if( token.parent_number != token.drop_number && token.parent_number > 0 ) {
-            std::pair<time_point, int> const turn_and_parent = std::make_pair( token.turn, token.parent_number );
+            std::pair<time_point, int> const turn_and_parent = std::make_pair( token.turn,
+                    token.parent_number );
             parent_child_check[turn_and_parent].child_exists = true;
         }
     }
 
     // Second pass: we group children and parents together, but only if both sides are known to exist
     std::map<std::pair<time_point, int>, unstacked_items> children_by_parent;
-    for( item_stack::iterator const& it : unstacked ) {
+    for( item_stack::iterator const &it : unstacked ) {
         const auto &token = *it->drop_token;
         std::pair<time_point, int> const turn_and_drop = std::make_pair( token.turn, token.drop_number );
         if( token.drop_number > 0 && parent_child_check[turn_and_drop].child_exists ) {
@@ -510,7 +511,8 @@ std::vector<stacked_items> stack_for_pickup_ui( const
             continue;
         }
 
-        std::pair<time_point, int> const turn_and_parent = std::make_pair( token.turn, token.parent_number );
+        std::pair<time_point, int> const turn_and_parent = std::make_pair( token.turn,
+                token.parent_number );
         if( token.parent_number > 0 && token.parent_number != token.drop_number &&
             parent_child_check[turn_and_parent].parent_exists ) {
             children_by_parent[turn_and_parent].unstacked_children.push_back( it );
@@ -522,7 +524,7 @@ std::vector<stacked_items> stack_for_pickup_ui( const
     std::vector<stacked_items> restacked_with_parents;
     for( const auto &pr : children_by_parent ) {
         std::vector<std::list<item_stack::iterator>> restacked_children;
-        for( item_stack::iterator const& it : pr.second.unstacked_children ) {
+        for( item_stack::iterator const &it : pr.second.unstacked_children ) {
             bool found_stack = false;
             for( std::list<item_stack::iterator> &stack : restacked_children ) {
                 const item &stack_top = *stack.front();
@@ -796,8 +798,8 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
 
             if( selected >= 0 && selected <= static_cast<int>( stacked_here.size() ) - 1 ) {
                 item_location const loc = from_vehicle
-                                    ? item_location( vehicle_cursor( *veh, cargo_part ), &*stacked_here[matches[selected]].front() )
-                                    : item_location( map_cursor( p ), &*stacked_here[matches[selected]].front() );
+                                          ? item_location( vehicle_cursor( *veh, cargo_part ), &*stacked_here[matches[selected]].front() )
+                                          : item_location( map_cursor( p ), &*stacked_here[matches[selected]].front() );
                 temperature_flag const temperature = rot::temperature_flag_for_location( get_map(), loc );
 
                 std::vector<iteminfo> const this_item = selected_item.info( temperature );
@@ -849,8 +851,8 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
                     if( getitem[true_it].parent ) {
                         const pickup_count &parent = getitem[*getitem[true_it].parent];
                         nc_color const color = parent.pick ?
-                                         ( parent.all_children_picked ? c_light_blue : c_yellow ) :
-                                         c_dark_gray;
+                                               ( parent.all_children_picked ? c_light_blue : c_yellow ) :
+                                               c_dark_gray;
                         // TODO: Cute symbol here
                         wprintz( w_pickup, color, "\\" );
                     } else {
@@ -1147,7 +1149,7 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
                             temp.charges = *getitem[i].count;
                         }
                         int const num_picked = std::min( stacked_here[i].size(),
-                                                   getitem[i].count ? *getitem[i].count : stacked_here[i].size() );
+                                                         getitem[i].count ? *getitem[i].count : stacked_here[i].size() );
                         weight_picked_up += temp.weight() * num_picked;
                         volume_picked_up += temp.volume() * num_picked;
                     }
@@ -1208,7 +1210,7 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
     std::vector<item_location> locations;
     std::vector<int> quantities;
 
-    for( std::pair<item_stack::iterator, int>  const&iter_qty : pick_values ) {
+    for( std::pair<item_stack::iterator, int>  const &iter_qty : pick_values ) {
         item_location loc;
         if( from_vehicle ) {
             loc = item_location( vehicle_cursor( *veh, cargo_part ), &*iter_qty.first );
@@ -1219,7 +1221,8 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
         quantities.push_back( iter_qty.second );
     }
 
-    std::vector<pickup::pick_drop_selection> const targets = pickup::optimize_pickup( locations, quantities );
+    std::vector<pickup::pick_drop_selection> const targets = pickup::optimize_pickup( locations,
+            quantities );
     g->u.assign_activity( player_activity( pickup_activity_actor( targets, g->u.pos() ) ) );
     if( min == -1 ) {
         // Auto pickup will need to auto resume since there can be several of them on the stack.

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -86,7 +86,7 @@ static bool select_autopickup_items( const std::vector<std::list<item_stack::ite
     for( size_t rounded_volume = 0, num_checked = 0; num_checked < here.size(); rounded_volume++ ) {
         for( size_t i = 0; i < here.size(); i++ ) {
             do_pickup = false;
-            item_stack::const_iterator begin_iterator = here[i].front();
+            item_stack::const_iterator const begin_iterator = here[i].front();
             if( begin_iterator->volume() / units::legacy_volume_factor == static_cast<int>( rounded_volume ) ) {
                 num_checked++;
                 const std::string item_name = begin_iterator->tname( 1, false );
@@ -107,8 +107,8 @@ static bool select_autopickup_items( const std::vector<std::list<item_stack::ite
                 //Auto Pickup all items with Volume <= AUTO_PICKUP_VOL_LIMIT * 50 and Weight <= AUTO_PICKUP_ZERO * 50
                 //items will either be in the autopickup list ("true") or unmatched ("")
                 if( !do_pickup ) {
-                    int weight_limit = get_option<int>( "AUTO_PICKUP_WEIGHT_LIMIT" );
-                    int volume_limit = get_option<int>( "AUTO_PICKUP_VOL_LIMIT" );
+                    int const weight_limit = get_option<int>( "AUTO_PICKUP_WEIGHT_LIMIT" );
+                    int const volume_limit = get_option<int>( "AUTO_PICKUP_VOL_LIMIT" );
                     if( weight_limit && volume_limit ) {
                         if( begin_iterator->volume() <= units::from_milliliter( volume_limit * 50 ) &&
                             begin_iterator->weight() <= weight_limit * 50_gram &&
@@ -176,7 +176,7 @@ static pickup_answer handle_problematic_pickup( const item &it, bool &offered_sw
     }
 
     amenu.query();
-    int choice = amenu.ret;
+    int const choice = amenu.ret;
 
     if( choice <= CANCEL || choice >= NUM_ANSWERS ) {
         return CANCEL;
@@ -191,7 +191,7 @@ bool pickup::query_thief()
     const bool force_uc = get_option<bool>( "FORCE_CAPITAL_YN" );
     const auto &allow_key = force_uc ? input_context::disallow_lower_case
                             : input_context::allow_all_keys;
-    std::string answer = query_popup()
+    std::string const answer = query_popup()
                          .allow_cancel( false )
                          .context( "YES_NO_ALWAYS_NEVER" )
                          .message( "%s", force_uc
@@ -233,7 +233,7 @@ static bool pick_one_up( pickup::pick_drop_selection &selection, bool &got_water
                          pickup_map &map_pickup, bool autopickup )
 {
     player &u = get_avatar();
-    int moves_taken = 100;
+    int const moves_taken = 100;
     bool picked_up = false;
     pickup_answer option = CANCEL;
 
@@ -269,17 +269,17 @@ static bool pick_one_up( pickup::pick_drop_selection &selection, bool &got_water
         newit.charges = *quantity;
     }
     // Ammo can sometimes be picked up into containers
-    int charges_picked_to_cont = newit.charges - u.i_add_to_container( newit, false );
+    int const charges_picked_to_cont = newit.charges - u.i_add_to_container( newit, false );
     newit.charges -= charges_picked_to_cont;
 
     const ret_val<bool> wield_check = u.can_wield( newit );
     bool did_prompt = false;
 
-    units::volume children_volume = std::accumulate( children.begin(), children.end(), 0_ml,
+    units::volume const children_volume = std::accumulate( children.begin(), children.end(), 0_ml,
     []( units::volume acc, const item_location & c ) {
         return acc + c->volume();
     } );
-    units::mass children_weight = std::accumulate( children.begin(), children.end(), 0_gram,
+    units::mass const children_weight = std::accumulate( children.begin(), children.end(), 0_gram,
     []( units::mass acc, const item_location & c ) {
         return acc + c->weight();
     } );
@@ -373,7 +373,7 @@ static bool pick_one_up( pickup::pick_drop_selection &selection, bool &got_water
         // Children have to be picked up first, since removing parent would re-index the stack
         if( option != EMPTY ) {
             for( item_location &child_loc : children ) {
-                item &added = u.i_add( *child_loc );
+                item  const&added = u.i_add( *child_loc );
                 auto &pickup_entry = map_pickup[added.tname()];
                 pickup_entry.first = added;
                 pickup_entry.second += added.count();
@@ -408,9 +408,9 @@ namespace pickup
 bool do_pickup( std::vector<pick_drop_selection> &targets, bool autopickup )
 {
     bool got_water = false;
-    Character &u = get_avatar();
-    bool weight_was_okay = ( u.weight_carried() <= u.weight_capacity() );
-    bool volume_was_okay = ( u.volume_carried() <= u.volume_capacity() );
+    Character  const&u = get_avatar();
+    bool const weight_was_okay = ( u.weight_carried() <= u.weight_capacity() );
+    bool const volume_was_okay = ( u.volume_carried() <= u.volume_capacity() );
     bool offered_swap = false;
 
     // Map of items picked up so we can output them all at the end and
@@ -488,29 +488,29 @@ std::vector<stacked_items> stack_for_pickup_ui( const
                 calendar::before_time_starts, 0 );
     std::map<std::pair<time_point, int>, parent_child_check_t> parent_child_check;
     // First, we need to check which parent-child groups exist
-    for( item_stack::iterator it : unstacked ) {
+    for( item_stack::iterator const it : unstacked ) {
         const auto &token = *it->drop_token;
         if( token.drop_number > 0 ) {
-            std::pair<time_point, int> turn_and_drop = std::make_pair( token.turn, token.drop_number );
+            std::pair<time_point, int> const turn_and_drop = std::make_pair( token.turn, token.drop_number );
             parent_child_check[turn_and_drop].parent_exists = true;
         }
         if( token.parent_number != token.drop_number && token.parent_number > 0 ) {
-            std::pair<time_point, int> turn_and_parent = std::make_pair( token.turn, token.parent_number );
+            std::pair<time_point, int> const turn_and_parent = std::make_pair( token.turn, token.parent_number );
             parent_child_check[turn_and_parent].child_exists = true;
         }
     }
 
     // Second pass: we group children and parents together, but only if both sides are known to exist
     std::map<std::pair<time_point, int>, unstacked_items> children_by_parent;
-    for( item_stack::iterator it : unstacked ) {
+    for( item_stack::iterator const it : unstacked ) {
         const auto &token = *it->drop_token;
-        std::pair<time_point, int> turn_and_drop = std::make_pair( token.turn, token.drop_number );
+        std::pair<time_point, int> const turn_and_drop = std::make_pair( token.turn, token.drop_number );
         if( token.drop_number > 0 && parent_child_check[turn_and_drop].child_exists ) {
             children_by_parent[turn_and_drop].parent = it;
             continue;
         }
 
-        std::pair<time_point, int> turn_and_parent = std::make_pair( token.turn, token.parent_number );
+        std::pair<time_point, int> const turn_and_parent = std::make_pair( token.turn, token.parent_number );
         if( token.parent_number > 0 && token.parent_number != token.drop_number &&
             parent_child_check[turn_and_parent].parent_exists ) {
             children_by_parent[turn_and_parent].unstacked_children.push_back( it );
@@ -522,7 +522,7 @@ std::vector<stacked_items> stack_for_pickup_ui( const
     std::vector<stacked_items> restacked_with_parents;
     for( const auto &pr : children_by_parent ) {
         std::vector<std::list<item_stack::iterator>> restacked_children;
-        for( item_stack::iterator it : pr.second.unstacked_children ) {
+        for( item_stack::iterator const it : pr.second.unstacked_children ) {
             bool found_stack = false;
             for( std::list<item_stack::iterator> &stack : restacked_children ) {
                 const item &stack_top = *stack.front();
@@ -586,7 +586,7 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
             const bool veh_has_items = carg && !veh->get_items( carg->part_index() ).empty();
             const bool map_has_items = g->m.has_items( p );
             if( veh_has_items && map_has_items ) {
-                uilist amenu( _( "Get items from where?" ), { _( "Get items from vehicle cargo" ), _( "Get items on the ground" ) } );
+                uilist const amenu( _( "Get items from where?" ), { _( "Get items from vehicle cargo" ), _( "Get items on the ground" ) } );
                 if( amenu.ret == UILIST_CANCEL ) {
                     return;
                 }
@@ -735,7 +735,7 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
             }
 
             pickupX = 0;
-            std::string position = get_option<std::string>( "PICKUP_POSITION" );
+            std::string const position = get_option<std::string>( "PICKUP_POSITION" );
             if( position == "left" ) {
                 pickupX = panel_manager::get_manager().get_width_left();
             } else if( position == "right" ) {
@@ -795,12 +795,12 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
             const item &selected_item = *stacked_here[matches[selected]].front();
 
             if( selected >= 0 && selected <= static_cast<int>( stacked_here.size() ) - 1 ) {
-                item_location loc = from_vehicle
+                item_location const loc = from_vehicle
                                     ? item_location( vehicle_cursor( *veh, cargo_part ), &*stacked_here[matches[selected]].front() )
                                     : item_location( map_cursor( p ), &*stacked_here[matches[selected]].front() );
-                temperature_flag temperature = rot::temperature_flag_for_location( get_map(), loc );
+                temperature_flag const temperature = rot::temperature_flag_for_location( get_map(), loc );
 
-                std::vector<iteminfo> this_item = selected_item.info( temperature );
+                std::vector<iteminfo> const this_item = selected_item.info( temperature );
 
                 item_info_data dummy( {}, {}, this_item, {}, iScrollPos );
                 dummy.without_getch = true;
@@ -825,7 +825,7 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
             werase( w_pickup );
             for( int cur_it = start; cur_it < start + maxitems; cur_it++ ) {
                 if( cur_it < static_cast<int>( matches.size() ) ) {
-                    int true_it = matches[cur_it];
+                    int const true_it = matches[cur_it];
                     const item &this_item = *stacked_here[true_it].front();
                     nc_color icolor = this_item.color_in_inventory();
                     if( cur_it == selected ) {
@@ -838,9 +838,9 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
                     } else if( cur_it < static_cast<int>( pickup_chars.size() ) + static_cast<int>
                                ( pickup_chars.size() ) *
                                static_cast<int>( pickup_chars.size() ) ) {
-                        int p = cur_it - pickup_chars.size();
-                        int p1 = p / pickup_chars.size();
-                        int p2 = p % pickup_chars.size();
+                        int const p = cur_it - pickup_chars.size();
+                        int const p1 = p / pickup_chars.size();
+                        int const p2 = p % pickup_chars.size();
                         mvwprintz( w_pickup, point( 0, 1 + ( cur_it % maxitems ) ), icolor, "`%c%c",
                                    static_cast<char>( pickup_chars[p1] ), static_cast<char>( pickup_chars[p2] ) );
                     } else {
@@ -848,7 +848,7 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
                     }
                     if( getitem[true_it].parent ) {
                         const pickup_count &parent = getitem[*getitem[true_it].parent];
-                        nc_color color = parent.pick ?
+                        nc_color const color = parent.pick ?
                                          ( parent.all_children_picked ? c_light_blue : c_yellow ) :
                                          c_dark_gray;
                         // TODO: Cute symbol here
@@ -879,7 +879,7 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
                                         charges_total );
                         } else {
                             unsigned int charges = 0;
-                            int item_count = getitem[true_it].count ? *getitem[true_it].count : 0;
+                            int const item_count = getitem[true_it].count ? *getitem[true_it].count : 0;
                             int c = item_count;
                             for( std::list<item_stack::iterator>::const_iterator it = stacked_here[true_it].begin();
                                  it != stacked_here[true_it].end() && c > 0; ++it, --c ) {
@@ -953,7 +953,7 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
 
             if( action == "ANY_INPUT" &&
                 raw_input_char >= '0' && raw_input_char <= '9' ) {
-                int raw_input_char_value = static_cast<char>( raw_input_char ) - '0';
+                int const raw_input_char_value = static_cast<char>( raw_input_char ) - '0';
                 if( !itemcount ) {
                     itemcount.emplace( 0 );
                 }
@@ -1026,8 +1026,8 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
                                   .max_length( 2 )
                                   .query_string();
                 if( ext.size() == 2 ) {
-                    int p1 = pickup_chars.find( ext.at( 0 ) );
-                    int p2 = pickup_chars.find( ext.at( 1 ) );
+                    int const p1 = pickup_chars.find( ext.at( 0 ) );
+                    int const p2 = pickup_chars.find( ext.at( 1 ) );
                     if( p1 != -1 && p2 != -1 ) {
                         idx = pickup_chars.size() + ( p1 * pickup_chars.size() ) + p2;
                     }
@@ -1056,11 +1056,11 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
             }
 
             if( idx >= 0 && idx < static_cast<int>( matches.size() ) ) {
-                size_t true_idx = matches[idx];
+                size_t const true_idx = matches[idx];
                 pickup_count &selected_stack = getitem[true_idx];
                 if( itemcount || selected_stack.count ) {
                     const item &temp = *stacked_here[true_idx].front();
-                    int amount_available = temp.count_by_charges() ? temp.charges : stacked_here[true_idx].size();
+                    int const amount_available = temp.count_by_charges() ? temp.charges : stacked_here[true_idx].size();
                     if( itemcount && *itemcount >= amount_available ) {
                         itemcount.reset();
                     }
@@ -1081,7 +1081,7 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
                     selected_stack.count.reset();
                 }
                 selected_stack.all_children_picked = selected_stack.pick;
-                for( size_t child_index : selected_stack.children ) {
+                for( size_t const child_index : selected_stack.children ) {
                     pickup_count &child_stack = getitem[child_index];
                     child_stack.pick = selected_stack.pick;
                     child_stack.count.reset();
@@ -1146,7 +1146,7 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
                         if( temp.count_by_charges() && getitem[i].count && *getitem[i].count < temp.charges ) {
                             temp.charges = *getitem[i].count;
                         }
-                        int num_picked = std::min( stacked_here[i].size(),
+                        int const num_picked = std::min( stacked_here[i].size(),
                                                    getitem[i].count ? *getitem[i].count : stacked_here[i].size() );
                         weight_picked_up += temp.weight() * num_picked;
                         volume_picked_up += temp.volume() * num_picked;
@@ -1195,7 +1195,7 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
             }
 
             if( it->count_by_charges() ) {
-                int num_picked = std::min( it->charges, count );
+                int const num_picked = std::min( it->charges, count );
                 pick_values.emplace_back( it, num_picked );
                 count -= num_picked;
             } else {
@@ -1208,7 +1208,7 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
     std::vector<item_location> locations;
     std::vector<int> quantities;
 
-    for( std::pair<item_stack::iterator, int> &iter_qty : pick_values ) {
+    for( std::pair<item_stack::iterator, int>  const&iter_qty : pick_values ) {
         item_location loc;
         if( from_vehicle ) {
             loc = item_location( vehicle_cursor( *veh, cargo_part ), &*iter_qty.first );
@@ -1219,7 +1219,7 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
         quantities.push_back( iter_qty.second );
     }
 
-    std::vector<pickup::pick_drop_selection> targets = pickup::optimize_pickup( locations, quantities );
+    std::vector<pickup::pick_drop_selection> const targets = pickup::optimize_pickup( locations, quantities );
     g->u.assign_activity( player_activity( pickup_activity_actor( targets, g->u.pos() ) ) );
     if( min == -1 ) {
         // Auto pickup will need to auto resume since there can be several of them on the stack.
@@ -1304,7 +1304,7 @@ void pick_drop_selection::serialize( JsonOut &jsout ) const
 
 void pick_drop_selection::deserialize( JsonIn &jin )
 {
-    JsonObject jo = jin.get_object();
+    JsonObject const jo = jin.get_object();
     jo.read( "target", target );
     jo.read( "quantity", quantity );
     jo.read( "children", children );
@@ -1328,7 +1328,7 @@ std::vector<pick_drop_selection> optimize_pickup( const std::vector<item_locatio
             optimized.back().children.emplace_back( loc );
         } else {
             last_token = *loc->drop_token;
-            std::optional<int> q = quantities[i] != 0 ? quantities[i] : std::optional<int>();
+            std::optional<int> const q = quantities[i] != 0 ? quantities[i] : std::optional<int>();
             optimized.push_back( {loc, q, {}} );
         }
     }

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -488,7 +488,7 @@ std::vector<stacked_items> stack_for_pickup_ui( const
                 calendar::before_time_starts, 0 );
     std::map<std::pair<time_point, int>, parent_child_check_t> parent_child_check;
     // First, we need to check which parent-child groups exist
-    for( item_stack::iterator const it : unstacked ) {
+    for( item_stack::iterator const& it : unstacked ) {
         const auto &token = *it->drop_token;
         if( token.drop_number > 0 ) {
             std::pair<time_point, int> const turn_and_drop = std::make_pair( token.turn, token.drop_number );
@@ -502,7 +502,7 @@ std::vector<stacked_items> stack_for_pickup_ui( const
 
     // Second pass: we group children and parents together, but only if both sides are known to exist
     std::map<std::pair<time_point, int>, unstacked_items> children_by_parent;
-    for( item_stack::iterator const it : unstacked ) {
+    for( item_stack::iterator const& it : unstacked ) {
         const auto &token = *it->drop_token;
         std::pair<time_point, int> const turn_and_drop = std::make_pair( token.turn, token.drop_number );
         if( token.drop_number > 0 && parent_child_check[turn_and_drop].child_exists ) {
@@ -522,7 +522,7 @@ std::vector<stacked_items> stack_for_pickup_ui( const
     std::vector<stacked_items> restacked_with_parents;
     for( const auto &pr : children_by_parent ) {
         std::vector<std::list<item_stack::iterator>> restacked_children;
-        for( item_stack::iterator const it : pr.second.unstacked_children ) {
+        for( item_stack::iterator const& it : pr.second.unstacked_children ) {
             bool found_stack = false;
             for( std::list<item_stack::iterator> &stack : restacked_children ) {
                 const item &stack_top = *stack.front();

--- a/src/pixel_minimap.cpp
+++ b/src/pixel_minimap.cpp
@@ -285,7 +285,7 @@ void pixel_minimap::flush_cache_updates()
             }
         }
 
-        for( point p : mcp.second.update_list ) {
+        for( point const p : mcp.second.update_list ) {
             const point tile_pos = projector->get_tile_pos( p, { SEEX, SEEY } );
             const SDL_Color tile_color = mcp.second.color_at( p );
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -247,7 +247,7 @@ bool character_martial_arts::pick_style( const avatar &you )    // Style selecti
     }
 
     kmenu.query();
-    int selection = kmenu.ret;
+    int const selection = kmenu.ret;
 
     if( selection >= STYLE_OFFSET ) {
         style_selected = selectable_styles[selection - STYLE_OFFSET];
@@ -282,7 +282,7 @@ recipe_subset player::get_recipes_from_books( const inventory &crafting_inv,
     for( const auto &stack : crafting_inv.const_slice() ) {
         const item &candidate = stack->front();
 
-        for( std::pair<const recipe *, int> recipe_entry :
+        for( std::pair<const recipe *, int> const recipe_entry :
              candidate.get_available_recipes( *this ) ) {
             if( filter && !filter( *recipe_entry.first ) ) {
                 continue;

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -146,9 +146,10 @@ static std::string craft_progress_message( const avatar &u, const player_activit
     const float total_mult = light_mult * bench_mult * morale_mult * assist_mult * speed_mult;
 
     const double remaining_percentage = 1.0 - craft->item_counter / 10'000'000.0;
-    int const remaining_turns = remaining_percentage * base_total_moves / 100 / std::max( 0.01f, total_mult );
+    int const remaining_turns = remaining_percentage * base_total_moves / 100 / std::max( 0.01f,
+                                total_mult );
     std::string const time_desc = string_format( _( "Time left: %s" ),
-                                           to_string( time_duration::from_turns( remaining_turns ) ) );
+                                  to_string( time_duration::from_turns( remaining_turns ) ) );
 
     const std::array<std::pair<float, std::string>, 6> mults_with_data = {{
             { total_mult, _( "Total" ) },

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -131,7 +131,7 @@ static std::string craft_progress_message( const avatar &u, const player_activit
     const recipe &rec = craft->get_making();
     const tripoint bench_pos = act.coords.front();
     // Ugly
-    bench_type bench_t = bench_type( act.values[1] );
+    bench_type const bench_t = bench_type( act.values[1] );
 
     const bench_location bench{bench_t, bench_pos};
 
@@ -146,8 +146,8 @@ static std::string craft_progress_message( const avatar &u, const player_activit
     const float total_mult = light_mult * bench_mult * morale_mult * assist_mult * speed_mult;
 
     const double remaining_percentage = 1.0 - craft->item_counter / 10'000'000.0;
-    int remaining_turns = remaining_percentage * base_total_moves / 100 / std::max( 0.01f, total_mult );
-    std::string time_desc = string_format( _( "Time left: %s" ),
+    int const remaining_turns = remaining_percentage * base_total_moves / 100 / std::max( 0.01f, total_mult );
+    std::string const time_desc = string_format( _( "Time left: %s" ),
                                            to_string( time_duration::from_turns( remaining_turns ) ) );
 
     const std::array<std::pair<float, std::string>, 6> mults_with_data = {{
@@ -163,10 +163,10 @@ static std::string craft_progress_message( const avatar &u, const player_activit
     // Hack to make sure total always shows
     bool first = true;
     for( const std::pair<float, std::string> &p : mults_with_data ) {
-        int percent = static_cast<int>( p.first * 100 );
+        int const percent = static_cast<int>( p.first * 100 );
         if( first || percent != 100 ) {
-            nc_color col = percent > 100 ? c_green : c_red;
-            std::string colorized = colorize( std::to_string( percent ) + '%', col );
+            nc_color const col = percent > 100 ? c_green : c_red;
+            std::string const colorized = colorize( std::to_string( percent ) + '%', col );
             mults_desc += string_format( _( "%s: %s\n" ), p.second, colorized );
         }
         first = false;
@@ -247,7 +247,7 @@ std::optional<std::string> player_activity::get_progress_message( const avatar &
         if( type == activity_id( "ACT_BUILD" ) ) {
             partial_con *pc = get_map().partial_con_at( get_map().getlocal( u.activity.placement ) );
             if( pc ) {
-                int counter = std::min( pc->counter, 10000000 );
+                int const counter = std::min( pc->counter, 10000000 );
                 const int percentage = counter / 100000;
 
                 extra_info = string_format( "%d%%", percentage );
@@ -309,7 +309,7 @@ void player_activity::do_turn( player &p )
             moves_left = 0;
         }
     }
-    int previous_stamina = p.get_stamina();
+    int const previous_stamina = p.get_stamina();
     if( p.is_npc() && p.check_outbounds_activity( *this ) ) {
         // npc might be operating at the edge of the reality bubble.
         // or just now reloaded back into it, and their activity target might
@@ -418,7 +418,7 @@ bool player_activity::can_resume_with( const player_activity &other, const Chara
         if( values.size() != other.values.size() ) {
             return false;
         }
-        for( int foo : other.values ) {
+        for( int const foo : other.values ) {
             if( std::find( values.begin(), values.end(), foo ) == values.end() ) {
                 return false;
             }

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -175,7 +175,7 @@ static void eff_fun_fungus( player &u, effect &it )
             break;
         case 3: {
             // Permanent symptoms
-            bool is_fungal_ter = g->m.has_flag_ter( "FUNGUS", u.pos() );
+            bool const is_fungal_ter = g->m.has_flag_ter( "FUNGUS", u.pos() );
             if( !is_fungal_ter && one_in( 600 + 4 * bonus ) ) {
                 u.add_effect( effect_nausea, 5_minutes );
             }
@@ -449,20 +449,20 @@ static void eff_fun_mutating( player &u, effect &it )
         // "Activate" toxins that would otherwise need to accumulate first
         // There is some loss
         const vitamin &tox = *vitamin_mutant_toxin;
-        int vit_amt = u.vitamin_get( vitamin_mutant_toxin );
-        time_duration extra_duration = it.get_max_duration() / 2 * vit_amt / tox.max();
+        int const vit_amt = u.vitamin_get( vitamin_mutant_toxin );
+        time_duration const extra_duration = it.get_max_duration() / 2 * vit_amt / tox.max();
         it.mod_duration( extra_duration );
         u.vitamin_set( vitamin_mutant_toxin, 0 );
     }
 
     // At intensity 1
     constexpr time_duration base_time_per_mut = 2_days;
-    int mutation_mult = it.get_intensity() * it.get_intensity();
-    float muts_per_second = mutation_mult / to_seconds<float>( base_time_per_mut );
-    float mgen_per_mut = to_seconds<float>( effect_accumulated_mutagen->get_int_dur_factor() );
-    float mgen_per_second = mgen_per_mut * muts_per_second;
+    int const mutation_mult = it.get_intensity() * it.get_intensity();
+    float const muts_per_second = mutation_mult / to_seconds<float>( base_time_per_mut );
+    float const mgen_per_mut = to_seconds<float>( effect_accumulated_mutagen->get_int_dur_factor() );
+    float const mgen_per_second = mgen_per_mut * muts_per_second;
     // How much accumulated mutagen effect do we add per second
-    time_duration mgen_time_mult = 1_seconds * roll_remainder( mgen_per_second );
+    time_duration const mgen_time_mult = 1_seconds * roll_remainder( mgen_per_second );
     u.add_effect( effect_accumulated_mutagen, mgen_time_mult );
     if( u.get_effect_int( effect_accumulated_mutagen ) > 1 ) {
         u.mutate();
@@ -503,9 +503,9 @@ void Character::hardcoded_effects( effect &it )
     }
 
     const time_duration dur = it.get_duration();
-    int intense = it.get_intensity();
-    body_part bp = it.get_bp()->token;
-    bool sleeping = has_effect( effect_sleep );
+    int const intense = it.get_intensity();
+    body_part const bp = it.get_bp()->token;
+    bool const sleeping = has_effect( effect_sleep );
     if( id == effect_dermatik ) {
         bool triggered = false;
         int formication_chance = 3600;
@@ -577,7 +577,7 @@ void Character::hardcoded_effects( effect &it )
             if( dur < 1_hours ) {
                 mod_dex_bonus( 1 );
             } else {
-                int dex_mod = -( dur > 360_minutes ? 10.0 : ( dur - 1_hours ) / 30_minutes );
+                int const dex_mod = -( dur > 360_minutes ? 10.0 : ( dur - 1_hours ) / 30_minutes );
                 mod_dex_bonus( dex_mod );
                 add_miss_reason( _( "Why waste your time on that insignificant speck?" ), -dex_mod );
             }
@@ -586,7 +586,7 @@ void Character::hardcoded_effects( effect &it )
         } else {
             // Major effects, all bad.
             mod_str_bonus( -( dur > 500_minutes ? 10.0 : dur / 50_minutes ) );
-            int dex_mod = -( dur > 600_minutes ? 10.0 : dur / 60_minutes );
+            int const dex_mod = -( dur > 600_minutes ? 10.0 : dur / 60_minutes );
             mod_dex_bonus( dex_mod );
             add_miss_reason( _( "Why waste your time on that insignificant speck?" ), -dex_mod );
             mod_int_bonus( -( dur > 450_minutes ? 10.0 : dur / 45_minutes ) );
@@ -733,7 +733,7 @@ void Character::hardcoded_effects( effect &it )
                     if( g->m.impassable( dest ) ) {
                         g->m.make_rubble( dest, f_rubble_rock );
                     }
-                    MonsterGroupResult spawn_details = MonsterGroupManager::GetResultFromGroup(
+                    MonsterGroupResult const spawn_details = MonsterGroupManager::GetResultFromGroup(
                                                            GROUP_NETHER );
                     g->place_critter_at( spawn_details.name, dest );
                     if( g->u.sees( dest ) ) {
@@ -783,7 +783,7 @@ void Character::hardcoded_effects( effect &it )
         if( one_in( 5000 ) ) {
             add_msg_if_player( m_bad, _( "A strange sound reverberates around the edges of reality." ) );
             // Comparable to the humming anomaly trap, with a narrower range
-            int volume = rng( 25, 150 );
+            int const volume = rng( 25, 150 );
             std::string sfx;
             if( volume <= 50 ) {
                 sfx = _( "hrmmm" );
@@ -1111,8 +1111,8 @@ void Character::hardcoded_effects( effect &it )
         }
 
         // Check mutation category strengths to see if we're mutated enough to get a dream
-        std::string highcat = get_highest_category();
-        int highest = mutation_category_level[highcat];
+        std::string const highcat = get_highest_category();
+        int const highest = mutation_category_level[highcat];
 
         // Determine the strength of effects or dreams based upon category strength
         int strength = 0; // Category too weak for any effect or dream
@@ -1131,7 +1131,7 @@ void Character::hardcoded_effects( effect &it )
             //Once every 6 / 3 / 2 hours, with a bit of randomness
             if( calendar::once_every( 6_hours / strength ) && one_in( 3 ) ) {
                 // Select a dream
-                std::string dream = dreams::get_random_for_category( highcat, strength );
+                std::string const dream = dreams::get_random_for_category( highcat, strength );
                 if( !dream.empty() ) {
                     add_msg_if_player( dream );
                 }
@@ -1148,7 +1148,7 @@ void Character::hardcoded_effects( effect &it )
         }
 
         bool woke_up = false;
-        int tirednessVal = rng( 5, 200 ) + rng( 0, std::abs( get_fatigue() * 2 * 5 ) );
+        int const tirednessVal = rng( 5, 200 ) + rng( 0, std::abs( get_fatigue() * 2 * 5 ) );
         if( !is_blind() && !has_effect( effect_narcosis ) ) {
             if( !has_trait(
                     trait_SEESLEEP ) ) { // People who can see while sleeping are acclimated to the light.
@@ -1224,7 +1224,7 @@ void Character::hardcoded_effects( effect &it )
                 if( one_in( 2 ) ) {
                     sound_hallu();
                 } else {
-                    int max_count = rng( 1, 3 );
+                    int const max_count = rng( 1, 3 );
                     int count = 0;
                     for( const tripoint &mp : g->m.points_in_radius( pos(), 1 ) ) {
                         if( mp == pos() ) {
@@ -1259,7 +1259,7 @@ void Character::hardcoded_effects( effect &it )
                         activity.set_to_null();
                     } else {
                         // Secure the flag before wake_up() clears the effect
-                        bool slept_through = has_effect( effect_slept_through_alarm );
+                        bool const slept_through = has_effect( effect_slept_through_alarm );
                         wake_up();
                         if( slept_through ) {
                             add_msg_if_player( _( "Your internal chronometer finally wakes you up." ) );

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -734,7 +734,7 @@ void Character::hardcoded_effects( effect &it )
                         g->m.make_rubble( dest, f_rubble_rock );
                     }
                     MonsterGroupResult const spawn_details = MonsterGroupManager::GetResultFromGroup(
-                                                           GROUP_NETHER );
+                                GROUP_NETHER );
                     g->place_critter_at( spawn_details.name, dest );
                     if( g->u.sees( dest ) ) {
                         g->cancel_activity_or_ignore_query( distraction_type::hostile_spotted_far,

--- a/src/point.cpp
+++ b/src/point.cpp
@@ -60,7 +60,7 @@ std::vector<tripoint> closest_points_first( const tripoint &center, int min_dist
     std::vector<tripoint> result;
     result.reserve( points.size() );
 
-    for( point p : points ) {
+    for( point const p : points ) {
         result.emplace_back( p, center.z );
     }
 

--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -88,7 +88,7 @@ std::vector<std::vector<std::string>> query_popup::fold_query(
                                        const std::vector<query_option> &options,
                                        const int max_width, const int horz_padding )
 {
-    input_context ctxt( category );
+    input_context const ctxt( category );
 
     std::vector<std::vector<std::string>> folded_query;
     folded_query.emplace_back();
@@ -134,7 +134,7 @@ void query_popup::invalidate_ui() const
         folded_msg.clear();
         buttons.clear();
     }
-    std::shared_ptr<ui_adaptor> ui = adaptor.lock();
+    std::shared_ptr<ui_adaptor> const ui = adaptor.lock();
     if( ui ) {
         ui->mark_resize();
     }
@@ -208,7 +208,7 @@ void query_popup::init() const
     const int win_y = ontop ? 0 : ( TERMY - win_height ) / 2;
     win = catacurses::newwin( win_height, win_width, point( win_x, win_y ) );
 
-    std::shared_ptr<ui_adaptor> ui = adaptor.lock();
+    std::shared_ptr<ui_adaptor> const ui = adaptor.lock();
     if( ui ) {
         ui->position_from_window( win );
     }
@@ -270,7 +270,7 @@ query_popup::result query_popup::query_once()
         return { false, "ERROR", {} };
     }
 
-    std::shared_ptr<ui_adaptor> ui = create_or_get_adaptor();
+    std::shared_ptr<ui_adaptor> const ui = create_or_get_adaptor();
 
     ui_manager::redraw();
 
@@ -347,9 +347,9 @@ query_popup::result query_popup::query_once()
 
 query_popup::result query_popup::query()
 {
-    ime_sentry sentry( ime_sentry::disable );
+    ime_sentry const sentry( ime_sentry::disable );
 
-    std::shared_ptr<ui_adaptor> ui = create_or_get_adaptor();
+    std::shared_ptr<ui_adaptor> const ui = create_or_get_adaptor();
 
     result res;
     do {

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -90,7 +90,7 @@ class skilllevel_reader : public generic_typed_reader<skilllevel_reader>
 {
     public:
         std::pair<skill_id, int> get_next( JsonIn &jin ) const {
-            JsonObject jo = jin.get_object();
+            JsonObject const jo = jin.get_object();
             return std::pair<skill_id, int>( skill_id( jo.get_string( "name" ) ), jo.get_int( "level" ) );
         }
         template<typename C>
@@ -106,7 +106,7 @@ class addiction_reader : public generic_typed_reader<addiction_reader>
 {
     public:
         addiction get_next( JsonIn &jin ) const {
-            JsonObject jo = jin.get_object();
+            JsonObject const jo = jin.get_object();
             return addiction( addiction_type( jo.get_string( "type" ) ), jo.get_int( "intensity" ) );
         }
         template<typename C>
@@ -127,7 +127,7 @@ class item_reader : public generic_typed_reader<item_reader>
             if( jin.test_string() ) {
                 return profession::itypedec( jin.get_string() );
             }
-            JsonArray jarr = jin.get_array();
+            JsonArray const jarr = jin.get_array();
             const auto id = jarr.get_string( 0 );
             const snippet_id snippet( jarr.get_string( 1 ) );
             return profession::itypedec( id, snippet );
@@ -146,7 +146,7 @@ void profession::load( const JsonObject &jo, const std::string & )
     // If the "name" is an object then we may have to deal with gender-specific titles
     bool add_name_context = false;
     if( jo.has_object( "name" ) ) {
-        JsonObject name_obj = jo.get_object( "name" );
+        JsonObject const name_obj = jo.get_object( "name" );
         if( name_obj.has_member( "male" ) && name_obj.has_member( "female" ) ) {
             // Gender-specific titles
             _name_male.deserialize( *name_obj.get_raw( "male" ) );
@@ -191,9 +191,9 @@ void profession::load( const JsonObject &jo, const std::string & )
         _starting_vehicle = vproto_id( jo.get_string( "vehicle" ) );
     }
     if( jo.has_array( "pets" ) ) {
-        for( JsonObject subobj : jo.get_array( "pets" ) ) {
-            int count = subobj.get_int( "amount" );
-            mtype_id mon = mtype_id( subobj.get_string( "name" ) );
+        for( JsonObject const subobj : jo.get_array( "pets" ) ) {
+            int const count = subobj.get_int( "amount" );
+            mtype_id const mon = mtype_id( subobj.get_string( "name" ) );
             for( int start = 0; start < count; ++start ) {
                 _starting_pets.push_back( mon );
             }
@@ -201,7 +201,7 @@ void profession::load( const JsonObject &jo, const std::string & )
     }
 
     if( jo.has_array( "spells" ) ) {
-        for( JsonObject subobj : jo.get_array( "spells" ) ) {
+        for( JsonObject const subobj : jo.get_array( "spells" ) ) {
             int level = subobj.get_int( "level" );
             spell_id sp = spell_id( subobj.get_string( "id" ) );
             _starting_spells.emplace( sp, level );
@@ -211,7 +211,7 @@ void profession::load( const JsonObject &jo, const std::string & )
     mandatory( jo, was_loaded, "points", _point_cost );
 
     if( !was_loaded || jo.has_member( "items" ) ) {
-        JsonObject items_obj = jo.get_object( "items" );
+        JsonObject const items_obj = jo.get_object( "items" );
 
         if( items_obj.has_array( "both" ) ) {
             optional( items_obj, was_loaded, "both", legacy_starting_items, item_reader {} );
@@ -409,7 +409,7 @@ std::list<item> profession::items( bool male, const std::vector<trait_id> &trait
     result.insert( result.begin(), std::make_move_iterator( group_gender.begin() ),
                    std::make_move_iterator( group_gender.end() ) );
 
-    std::vector<itype_id> bonus = item_substitutions.get_bonus_items( traits );
+    std::vector<itype_id> const bonus = item_substitutions.get_bonus_items( traits );
     for( const itype_id &elem : bonus ) {
         if( elem != no_bonus ) {
             result.push_back( item( elem, advanced_spawn_time(), item::default_charges_tag {} ) );
@@ -577,7 +577,7 @@ void json_item_substitution::load( const JsonObject &jo )
 
         for( const JsonValue sub : jo.get_array( "sub" ) ) {
             substitution s;
-            JsonObject obj = sub.get_object();
+            JsonObject const obj = sub.get_object();
             s.trait_reqs = trait_requirements( obj );
             for( const JsonValue info : obj.get_array( "new" ) ) {
                 s.infos.emplace_back( info );

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -139,7 +139,7 @@ void apply_ammo_effects( const tripoint &p, const std::set<std::string> &effects
 {
     std::set<ammo_effect_str_id> effect_ids;
     for( const std::string &s : effects ) {
-        ammo_effect_str_id id( s );
+        ammo_effect_str_id const id( s );
         if( id.is_valid() ) {
             effect_ids.emplace( id );
         }
@@ -154,7 +154,7 @@ static int aoe_of( const ammo_effect_str_id &ae_id )
 
 static int aoe_of( const std::string &s )
 {
-    ammo_effect_str_id ae_id( s );
+    ammo_effect_str_id const ae_id( s );
     if( ae_id.is_valid() ) {
         return std::max( ae_id->aoe_size, ae_id->aoe_explosion_data.safe_range() - 1 );
     } else {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -442,7 +442,7 @@ target_handler::trajectory target_handler::mode_throw( avatar &you, item &releva
     ui.relevant = &relevant;
     ui.range = you.throw_range( relevant );
 
-    restore_on_out_of_scope<tripoint> view_offset_prev( you.view_offset );
+    restore_on_out_of_scope<tripoint> const view_offset_prev( you.view_offset );
     return ui.run();
 }
 
@@ -454,7 +454,7 @@ target_handler::trajectory target_handler::mode_reach( avatar &you, item &weapon
     ui.relevant = &weapon;
     ui.range = weapon.reach_range( you );
 
-    restore_on_out_of_scope<tripoint> view_offset_prev( you.view_offset );
+    restore_on_out_of_scope<tripoint> const view_offset_prev( you.view_offset );
     return ui.run();
 }
 
@@ -466,7 +466,7 @@ target_handler::trajectory target_handler::mode_turret_manual( avatar &you, turr
     ui.turret = &turret;
     ui.relevant = &*turret.base();
 
-    restore_on_out_of_scope<tripoint> view_offset_prev( you.view_offset );
+    restore_on_out_of_scope<tripoint> const view_offset_prev( you.view_offset );
     return ui.run();
 }
 
@@ -478,8 +478,8 @@ target_handler::trajectory target_handler::mode_turrets( avatar &you, vehicle &v
     //        when used with real circles
     int range_total = 0;
     for( vehicle_part *t : turrets ) {
-        int range = veh.turret_query( *t ).range();
-        tripoint pos = veh.global_part_pos3( *t );
+        int const range = veh.turret_query( *t ).range();
+        tripoint const pos = veh.global_part_pos3( *t );
 
         int res = 0;
         res = std::max( res, rl_dist( you.pos(), pos + point( range, 0 ) ) );
@@ -496,7 +496,7 @@ target_handler::trajectory target_handler::mode_turrets( avatar &you, vehicle &v
     ui.vturrets = &turrets;
     ui.range = range_total;
 
-    restore_on_out_of_scope<tripoint> view_offset_prev( you.view_offset );
+    restore_on_out_of_scope<tripoint> const view_offset_prev( you.view_offset );
     return ui.run();
 }
 
@@ -511,7 +511,7 @@ target_handler::trajectory target_handler::mode_spell( avatar &you, spell &casti
     ui.no_fail = no_fail;
     ui.no_mana = no_mana;
 
-    restore_on_out_of_scope<tripoint> view_offset_prev( you.view_offset );
+    restore_on_out_of_scope<tripoint> const view_offset_prev( you.view_offset );
     return ui.run();
 }
 
@@ -586,7 +586,7 @@ int ranged::gun_engagement_moves( const Character &who, const item &gun, int tar
     double penalty = start;
 
     while( penalty > target ) {
-        double adj = ranged::aim_per_move( who, gun, penalty );
+        double const adj = ranged::aim_per_move( who, gun, penalty );
         if( adj <= 0 ) {
             break;
         }
@@ -638,7 +638,7 @@ bool ranged::handle_gun_damage( Character &shooter, item &it )
     // As a result this causes no damage to the firearm, note that some guns are waterproof
     // and so are immune to this effect, note also that WATERPROOF_GUN status does not
     // mean the gun will actually be accurate underwater.
-    int effective_durability = firing.durability;
+    int const effective_durability = firing.durability;
     if( shooter.is_underwater() && !it.has_flag( "WATERPROOF_GUN" ) &&
         one_in( effective_durability ) ) {
         shooter.add_msg_player_or_npc( _( "Your %s misfires with a wet click!" ),
@@ -676,8 +676,8 @@ bool ranged::handle_gun_damage( Character &shooter, item &it )
         for( auto mod : it.gunmods() ) {
             if( mod->has_flag( flag_CONSUMABLE ) ) {
                 int dmgamt = uncork / mod->type->gunmod->consume_divisor;
-                int modconsume = mod->type->gunmod->consume_chance;
-                int initstate = it.damage();
+                int const modconsume = mod->type->gunmod->consume_chance;
+                int const initstate = it.damage();
                 // fuzz damage if it's small
                 if( dmgamt < 1000 ) {
                     dmgamt = rng( dmgamt, dmgamt + 200 );
@@ -767,7 +767,7 @@ bool ranged::handle_gun_damage( Character &shooter, item &it )
 void npc::pretend_fire( npc *source, int shots, item &gun )
 {
     int curshot = 0;
-    avatar &you = get_avatar();
+    avatar  const&you = get_avatar();
     if( you.sees( *source ) && one_in( 50 ) ) {
         add_msg( m_info, _( "%s shoots something." ), source->disp_name() );
     }
@@ -805,10 +805,10 @@ bool can_use_bipod( const map &m, const tripoint &pos )
 dispersion_sources calculate_dispersion( const map &m, const Character &who, const item &gun,
         int at_recoil, bool burst )
 {
-    bool bipod = can_use_bipod( m, who.pos() );
+    bool const bipod = can_use_bipod( m, who.pos() );
 
-    int gun_recoil = gun.gun_recoil( bipod );
-    int eff_recoil = at_recoil + ( burst ? ranged::burst_penalty( who, gun, gun_recoil ) : 0 );
+    int const gun_recoil = gun.gun_recoil( bipod );
+    int const eff_recoil = at_recoil + ( burst ? ranged::burst_penalty( who, gun, gun_recoil ) : 0 );
     dispersion_sources dispersion( ranged::get_weapon_dispersion( who, gun ) );
     dispersion.add_range( eff_recoil );
     return dispersion;
@@ -822,7 +822,7 @@ int ranged::fire_gun( Character &who, const tripoint &target, int shots )
 int ranged::fire_gun( Character &who, const tripoint &target, int max_shots, item &gun,
                       item_location ammo )
 {
-    int attack_moves = time_to_attack( who, gun, ammo );
+    int const attack_moves = time_to_attack( who, gun, ammo );
 
     if( !gun.is_gun() ) {
         debugmsg( "%s tried to fire non-gun (%s).", who.name, gun.tname() );
@@ -858,15 +858,15 @@ int ranged::fire_gun( Character &who, const tripoint &target, int max_shots, ite
 
     std::optional<shape_factory> shape = ranged::get_shape_factory( gun );
 
-    map &here = get_map();
+    map  const&here = get_map();
     // Shaped attacks don't allow aiming, so they don't suffer from lack of aim either
-    int character_recoil = shape ? recoil_vehicle( who ) : recoil_total( who );
+    int const character_recoil = shape ? recoil_vehicle( who ) : recoil_total( who );
     // Penalty is (intentionally) based off mode shots, not ammo-limited.
-    dispersion_sources dispersion = calculate_dispersion( here, who, gun, character_recoil,
+    dispersion_sources const dispersion = calculate_dispersion( here, who, gun, character_recoil,
                                     max_shots > 1 );
 
-    bool aoe_attack = gun.gun_skill() == skill_launcher || shape;
-    tripoint aim = target;
+    bool const aoe_attack = gun.gun_skill() == skill_launcher || shape;
+    tripoint const aim = target;
     int curshot = 0;
     int hits = 0; // total shots on target
     while( curshot != shots ) {
@@ -907,15 +907,15 @@ int ranged::fire_gun( Character &who, const tripoint &target, int max_shots, ite
             }
         } else {
             // 30 degree cap, like for projectiles
-            double angle_offset_arcmin = std::min( dispersion.roll(), 1800.0 ) * ( one_in( 2 ) ? 1 : -1 );
-            double angle_offset = units::to_radians( units::from_arcmin( angle_offset_arcmin ) );
-            double dx = aim.x - who.posx();
-            double dy = aim.y - who.posy();
-            double new_angle = atan2( dy, dx ) + angle_offset;
+            double const angle_offset_arcmin = std::min( dispersion.roll(), 1800.0 ) * ( one_in( 2 ) ? 1 : -1 );
+            double const angle_offset = units::to_radians( units::from_arcmin( angle_offset_arcmin ) );
+            double const dx = aim.x - who.posx();
+            double const dy = aim.y - who.posy();
+            double const new_angle = atan2( dy, dx ) + angle_offset;
             // Always using trig here, rotations in maximum metric are weird
-            double length = trig_dist( who.pos(), aim );
-            rl_vec3d vec_pos( who.pos() );
-            rl_vec3d new_aim = vec_pos + rl_vec3d( length, 0, 0 ).rotated( new_angle );
+            double const length = trig_dist( who.pos(), aim );
+            rl_vec3d const vec_pos( who.pos() );
+            rl_vec3d const new_aim = vec_pos + rl_vec3d( length, 0, 0 ).rotated( new_angle );
             ranged::execute_shaped_attack( *shape->create( vec_pos, new_aim ), projectile, who );
         }
         curshot++;
@@ -978,7 +978,7 @@ int ranged::fire_gun( Character &who, const tripoint &target, int max_shots, ite
     // Practice the base gun skill proportionally to number of hits, but always by one.
     who.as_player()->practice( skill_gun, ( hits + 1 ) * 5 );
     // launchers train weapon skill for both hits and misses.
-    int practice_units = aoe_attack ? curshot : hits;
+    int const practice_units = aoe_attack ? curshot : hits;
     who.as_player()->practice( gun.gun_skill(), ( practice_units + 1 ) * 5 );
 
     return curshot;
@@ -1024,7 +1024,7 @@ float get_str_draw_penalty( const item &it, const Character &p )
         return 1.0f;
     }
     // We also don't want to actually reduce values to zero, even if user is debuffed to zero strength.
-    float archer_str = std::max( 1, p.get_str() );
+    float const archer_str = std::max( 1, p.get_str() );
     return ( archer_str / it.get_min_str() );
 }
 
@@ -1076,7 +1076,7 @@ int throw_dispersion_per_dodge( const Character &c, bool add_encumbrance )
     // Maybe TODO: Only use one hand
     const int encumbrance = add_encumbrance ? c.encumb( bp_hand_l ) + c.encumb( bp_hand_r ) : 0;
     ///\EFFECT_DEX increases throwing accuracy against targets with good dodge stat
-    float effective_dex = 2 + c.get_dex() / 4.0f - ( encumbrance ) / 40.0f;
+    float const effective_dex = 2 + c.get_dex() / 4.0f - ( encumbrance ) / 40.0f;
     return static_cast<int>( 100.0f / std::max( 1.0f, effective_dex ) );
 }
 
@@ -1110,7 +1110,7 @@ int throwing_dispersion( const Character &c, const item &to_throw, Creature *cri
     if( critter != nullptr ) {
         // It's easier to dodge at close range (thrower needs to adjust more)
         // Dodge x10 at point blank, x5 at 1 dist, then flat
-        float effective_dodge = critter->get_dodge() * std::max( 1, 10 - 5 * rl_dist( c.pos(),
+        float const effective_dodge = critter->get_dodge() * std::max( 1, 10 - 5 * rl_dist( c.pos(),
                                 critter->pos() ) );
         dispersion += throw_dispersion_per_dodge( c, true ) * effective_dodge;
     }
@@ -1137,8 +1137,8 @@ dealt_projectile_attack throw_item( Character &who, const tripoint &target, cons
     who.mod_moves( -move_cost );
 
     const int throwing_skill = who.get_skill_level( skill_throw );
-    units::volume volume = to_throw.volume();
-    units::mass weight = to_throw.weight();
+    units::volume const volume = to_throw.volume();
+    units::mass const weight = to_throw.weight();
 
     // Previously calculated as 2_gram * std::max( 1, str_cur )
     // using 16_gram normalizes it to 8 str. Same effort expenditure
@@ -1176,7 +1176,7 @@ dealt_projectile_attack throw_item( Character &who, const tripoint &target, cons
 
     static const std::set<material_id> ferric = { material_id( "iron" ), material_id( "steel" ) };
 
-    bool do_railgun = who.has_active_bionic( bio_railgun ) && thrown.made_of_any( ferric ) &&
+    bool const do_railgun = who.has_active_bionic( bio_railgun ) && thrown.made_of_any( ferric ) &&
                       !throw_assist;
 
     // The damage dealt due to item's weight, player's strength, and skill level
@@ -1264,9 +1264,9 @@ dealt_projectile_attack throw_item( Character &who, const tripoint &target, cons
     // throw from the the blind throw position instead.
     const tripoint throw_from = blind_throw_from_pos ? *blind_throw_from_pos : who.pos();
 
-    float range = rl_dist( throw_from, target );
+    float const range = rl_dist( throw_from, target );
     proj.range = range;
-    int skill_lvl = who.get_skill_level( skill_used );
+    int const skill_lvl = who.get_skill_level( skill_used );
     // Avoid awarding tons of xp for lucky throws against hard to hit targets
     const float range_factor = std::min<float>( range, skill_lvl + 3 );
     // We're aiming to get a damaging hit, not just an accurate one - reward proper weapons
@@ -1321,7 +1321,7 @@ static int print_steadiness( const catacurses::window &w, int line_number, doubl
     const int window_width = getmaxx( w ) - 2; // Window width minus borders.
 
     if( get_option<std::string>( "ACCURACY_DISPLAY" ) == "numbers" ) {
-        std::string steadiness_s = string_format( "%s: %d%%", _( "Steadiness" ),
+        std::string const steadiness_s = string_format( "%s: %d%%", _( "Steadiness" ),
                                    static_cast<int>( 100.0 * steadiness ) );
         mvwprintw( w, point( 1, line_number++ ), steadiness_s );
     } else {
@@ -1399,32 +1399,32 @@ static int print_ranged_chance( const catacurses::window &w, int line_number,
                                 double range, double target_size )
 {
     int window_width = getmaxx( w ) - 2; // Window width minus borders.
-    std::string display_type = get_option<std::string>( "ACCURACY_DISPLAY" );
-    std::string panel_type = panel_manager::get_manager().get_current_layout_id();
+    std::string const display_type = get_option<std::string>( "ACCURACY_DISPLAY" );
+    std::string const panel_type = panel_manager::get_manager().get_current_layout_id();
     const int bars_pad = 3; // Padding for "bars" to fit moves_to_fire value.
     if( ( panel_type == "compact" || panel_type == "labels-narrow" ) && display_type != "numbers" ) {
         window_width -= bars_pad;
     }
 
-    std::string label_m = _( "Moves" );
+    std::string const label_m = _( "Moves" );
     std::vector<std::string> t_aims( 4 ), t_confidence( 16 );
     int aim_iter = 0, conf_iter = 0;
 
     nc_color col = c_dark_gray;
 
     if( display_type != "numbers" ) {
-        std::string symbols;
+        std::string const symbols;
         int column_number = 1;
         if( !( panel_type == "compact" || panel_type == "labels-narrow" ) ) {
-            std::string label = _( "Symbols:" );
+            std::string const label = _( "Symbols:" );
             mvwprintw( w, point( column_number, line_number ), label );
             column_number += utf8_width( label ) + 1; // 1 for whitespace after 'Symbols:'
         }
         for( const confidence_rating &cr : confidence_config ) {
-            std::string label = pgettext( "aim_confidence", cr.label.c_str() );
-            std::string symbols = string_format( "<color_%s>%s</color> = %s", cr.color, cr.symbol,
+            std::string const label = pgettext( "aim_confidence", cr.label.c_str() );
+            std::string const symbols = string_format( "<color_%s>%s</color> = %s", cr.color, cr.symbol,
                                                  label );
-            int line_len = utf8_width( label ) + 5; // 5 for '# = ' and whitespace at end
+            int const line_len = utf8_width( label ) + 5; // 5 for '# = ' and whitespace at end
             if( ( window_width + bars_pad - column_number ) < line_len ) {
                 column_number = 1;
                 line_number++;
@@ -1435,11 +1435,11 @@ static int print_ranged_chance( const catacurses::window &w, int line_number,
         line_number++;
     }
     if( ( panel_type == "compact" || panel_type == "labels-narrow" ) && display_type == "numbers" ) {
-        std::string symbols = _( " <color_green>Great</color> - <color_light_gray>Normal</color>"
+        std::string const symbols = _( " <color_green>Great</color> - <color_light_gray>Normal</color>"
                                  " - <color_magenta>Graze</color> - <color_light_blue>Moves</color>" );
         fold_and_print( w, point( 1, line_number++ ), window_width + bars_pad,
                         c_dark_gray, symbols );
-        int len = utf8_width( symbols ) - 96; // 96 to subtract color codes
+        int const len = utf8_width( symbols ) - 96; // 96 to subtract color codes
         if( len > window_width + bars_pad ) {
             line_number++;
         }
@@ -1454,14 +1454,14 @@ static int print_ranged_chance( const catacurses::window &w, int line_number,
     };
 
     for( const ranged::aim_type &type : aim_types ) {
-        dispersion_sources current_dispersion = dispersion_fun( type );
+        dispersion_sources const current_dispersion = dispersion_fun( type );
         std::string label = _( "Current" );
-        std::string aim_l = _( "Aim" );
+        std::string const aim_l = _( "Aim" );
         if( type.has_threshold ) {
             label = type.name;
         }
 
-        int moves_to_fire = cost_fun( type );
+        int const moves_to_fire = cost_fun( type );
 
         auto hotkey = front_or( type.action.empty() ? "FIRE" : type.action, ' ' );
         if( ( panel_type == "compact" || panel_type == "labels-narrow" ) ) {
@@ -1487,7 +1487,7 @@ static int print_ranged_chance( const catacurses::window &w, int line_number,
             if( panel_type == "compact" || panel_type == "labels-narrow" ) {
                 int last_chance = 0;
                 for( const confidence_rating &cr : confidence_config ) {
-                    int chance = std::min<int>( 100, 100.0 * ( cr.aim_level ) * confidence ) - last_chance;
+                    int const chance = std::min<int>( 100, 100.0 * ( cr.aim_level ) * confidence ) - last_chance;
                     last_chance += chance;
                     t_confidence[conf_iter] = string_format( "<color_%s>%3d%%</color>", cr.color, chance );
                     conf_iter++;
@@ -1498,10 +1498,10 @@ static int print_ranged_chance( const catacurses::window &w, int line_number,
                 aim_iter++;
             } else {
                 int last_chance = 0;
-                std::string confidence_s = enumerate_as_string( confidence_config.begin(), confidence_config.end(),
+                std::string const confidence_s = enumerate_as_string( confidence_config.begin(), confidence_config.end(),
                 [&]( const confidence_rating & config ) {
                     // TODO: Consider not printing 0 chances, but only if you can print something (at least miss 100% or so)
-                    int chance = std::min<int>( 100, 100.0 * ( config.aim_level * confidence ) ) - last_chance;
+                    int const chance = std::min<int>( 100, 100.0 * ( config.aim_level * confidence ) ) - last_chance;
                     last_chance += chance;
                     return string_format( "%s: <color_%s>%3d%%</color>", pgettext( "aim_confidence",
                                           config.label.c_str() ), config.color, chance );
@@ -1540,7 +1540,7 @@ static int print_ranged_chance( const catacurses::window &w, int line_number,
 // Whether player character knows creature's position and can roughly track it with the aim cursor
 static bool pl_sees( const Creature &cr )
 {
-    Character &u = get_player_character();
+    Character  const&u = get_player_character();
     return u.sees( cr ) || u.sees_with_infrared( cr ) || u.sees_with_specials( cr );
 }
 
@@ -1595,11 +1595,11 @@ static int print_aim( const Character &p, const catacurses::window &w, int line_
 
     int shots = std::max( 1, weapon.gun_current_mode().qty );
     const auto dispersion_fun = [&]( const ranged::aim_type & at ) {
-        int at_recoil = at.has_threshold ? at.threshold : static_cast<int>( predicted_recoil );
+        int const at_recoil = at.has_threshold ? at.threshold : static_cast<int>( predicted_recoil );
         return calculate_dispersion( get_map(), p, weapon, at_recoil, shots > 1 );
     };
     const auto cost_fun = [&]( const ranged::aim_type & at ) {
-        int at_recoil = at.has_threshold ? at.threshold : static_cast<int>( predicted_recoil );
+        int const at_recoil = at.has_threshold ? at.threshold : static_cast<int>( predicted_recoil );
         return ranged::gun_engagement_moves( p, weapon, at_recoil, p.recoil ) +
                ranged::time_to_attack( p, weapon, load_loc );
     };
@@ -1653,7 +1653,7 @@ std::vector<ranged::aim_type> ranged::get_aim_types( const Character &who, const
     if( !gun.is_gun() ) {
         return aim_types;
     }
-    int sight_dispersion = effective_dispersion( who, gun.sight_dispersion() );
+    int const sight_dispersion = effective_dispersion( who, gun.sight_dispersion() );
     // Aiming thresholds are dependent on weapon sight dispersion, attempting to place thresholds
     // at 10%, 5% and 0% of the difference between MAX_RECOIL and sight dispersion.
     std::vector<int> thresholds = {
@@ -1707,7 +1707,7 @@ static projectile make_gun_projectile( const item &gun )
         assert( gun.ammo_data()->ammo );
         const islot_ammo &ammo = *gun.ammo_data()->ammo;
         // Some projectiles have a chance of being recoverable
-        bool recover = !one_in( ammo.dont_recover_one_in );
+        bool const recover = !one_in( ammo.dont_recover_one_in );
 
         if( recover && !fx.has_effect( ammo_effect_IGNITE ) && !fx.has_effect( ammo_effect_EXPLOSIVE ) ) {
             item drop( gun.ammo_current(), calendar::turn, 1 );
@@ -1743,7 +1743,7 @@ int ranged::time_to_attack( const Character &p, const item &firing, const item_l
         // At low stamina levels, firing starts getting slow.
         const int sta_percent = ( 100 * p.get_stamina() ) / p.get_stamina_max();
         const int reload_stamina_penalty = ( sta_percent < 25 ) ? ( ( 25 - sta_percent ) * 2 ) : 0;
-        item_reload_option opt = item_reload_option( p.as_player(), &firing, &firing, loc );
+        item_reload_option const opt = item_reload_option( p.as_player(), &firing, &firing, loc );
         RAS_time = opt.moves() + reload_stamina_penalty;
     }
     return std::max( info.min_time,
@@ -1759,7 +1759,7 @@ static void cycle_action( item &weap, const tripoint &pos )
     tiles.erase( std::remove_if( tiles.begin(), tiles.end(), [&pos, &here]( const tripoint & e ) {
         return !here.passable( e ) || here.obstructed_by_vehicle_rotation( pos, e );
     } ), tiles.end() );
-    tripoint eject = tiles.empty() ? pos : random_entry( tiles );
+    tripoint const eject = tiles.empty() ? pos : random_entry( tiles );
 
     // for turrets try and drop casings or linkages directly to any CARGO part on the same tile
     const optional_vpart_position vp = here.veh_at( pos );
@@ -1896,17 +1896,17 @@ static double dispersion_from_skill( double skill, double weapon_dispersion )
     if( skill >= MAX_SKILL ) {
         return 0.0;
     }
-    double skill_shortfall = double( MAX_SKILL ) - skill;
+    double const skill_shortfall = double( MAX_SKILL ) - skill;
     double dispersion_penalty = 3 * skill_shortfall;
-    double skill_threshold = 5;
+    double const skill_threshold = 5;
     if( skill >= skill_threshold ) {
-        double post_threshold_skill_shortfall = double( MAX_SKILL ) - skill;
+        double const post_threshold_skill_shortfall = double( MAX_SKILL ) - skill;
         // Lack of mastery multiplies the dispersion of the weapon.
         return dispersion_penalty + ( weapon_dispersion * post_threshold_skill_shortfall * 1.25 ) /
                ( double( MAX_SKILL ) - skill_threshold );
     }
     // Unskilled shooters suffer greater penalties, still scaling with weapon penalties.
-    double pre_threshold_skill_shortfall = skill_threshold - skill;
+    double const pre_threshold_skill_shortfall = skill_threshold - skill;
     dispersion_penalty += weapon_dispersion *
                           ( 1.25 + pre_threshold_skill_shortfall * 3.75 / skill_threshold );
 
@@ -1916,7 +1916,7 @@ static double dispersion_from_skill( double skill, double weapon_dispersion )
 // utility functions for projectile_attack
 dispersion_sources ranged::get_weapon_dispersion( const Character &who, const item &obj )
 {
-    int weapon_dispersion = obj.gun_dispersion();
+    int const weapon_dispersion = obj.gun_dispersion();
     dispersion_sources dispersion( weapon_dispersion );
     dispersion.add_range( who.ranged_dex_mod() );
 
@@ -1976,7 +1976,7 @@ std::pair<gun_mode_id, gun_mode> npc_ai::best_mode_for_range( const Character &w
     }
     int min_recoil = MAX_RECOIL;
     min_recoil = ranged::get_most_accurate_sight( who, firing );
-    int range = static_cast<const npc *>( &who )->confident_shoot_range( firing, min_recoil );
+    int const range = static_cast<const npc *>( &who )->confident_shoot_range( firing, min_recoil );
 
     if( dist > range ) {
         return res;
@@ -2029,14 +2029,14 @@ double npc_ai::gun_value( const Character &who, const item &weap, int ammo )
 
     // Doesn't use calculate_dispersion because that requires a map
     // TODO: Turn this into a common function.
-    dispersion_sources mode_disp = ranged::get_weapon_dispersion( who, ideal_weapon );
+    dispersion_sources const mode_disp = ranged::get_weapon_dispersion( who, ideal_weapon );
     double total_dispersion = mode_disp.max();
     if( ideal_weapon.ammo_current() ) {
         total_dispersion += ideal_weapon.ammo_current()->ammo->dispersion;
     }
     // Necessary so that ideal_ranged_dps will include the reload cost in calc.
     ideal_weapon.ammo_unset();
-    double dps = ideal_weapon.ideal_ranged_dps( who, mode_ );
+    double const dps = ideal_weapon.ideal_ranged_dps( who, mode_ );
 
     // "Medium range" below means 9 tiles, "short range" means 4
     // Those are guarantees (assuming maximum time spent aiming)
@@ -2061,9 +2061,9 @@ double npc_ai::gun_value( const Character &who, const item &weap, int ammo )
         }
     };
 
-    float dispersion_factor = multi_lerp( dispersion_thresholds, total_dispersion );
+    float const dispersion_factor = multi_lerp( dispersion_thresholds, total_dispersion );
 
-    double gun_value = dps * dispersion_factor;
+    double const gun_value = dps * dispersion_factor;
 
     add_msg( m_debug, "%s as gun: %.1f total, %.1f dispersion, %.1f dps",
              weap.type->get_id().str(), gun_value, dispersion_factor, dps );
@@ -2123,10 +2123,10 @@ std::vector<Creature *> targetable_creatures( const Character &c, const int rang
             return false;
         }
 
-        map &here = get_map();
+        map  const&here = get_map();
 
         // TODO: It should use projectile passability checks when finding path, not vision checks.
-        std::vector<tripoint> path = here.find_clear_path( c.pos(), critter.pos() );
+        std::vector<tripoint> const path = here.find_clear_path( c.pos(), critter.pos() );
         tripoint prev_point = c.pos();
         for( const tripoint &point : path )
         {
@@ -2162,15 +2162,15 @@ std::vector<Creature *> targetable_creatures( const Character &c, const int rang
 int burst_penalty( const Character &p, const item &gun, int gun_recoil )
 {
     ///\EFFECT_DEX reduces burst penalty by flat amount
-    int dex_effect = p.get_dex() * 10;
+    int const dex_effect = p.get_dex() * 10;
     ///\EFFECT_STR reduces burst fire penalty
-    float str_effect = p.get_str() * 0.5f;
+    float const str_effect = p.get_str() * 0.5f;
 
     /** @EFFECT_PISTOL reduces burst fire penalty */
     /** @EFFECT_SMG reduces burst fire penalty */
     /** @EFFECT_RIFLE reduces burst fire penalty */
     /** @EFFECT_SHOTGUN reduces burst fire penalty */
-    int skill_lvl = std::min( p.get_skill_level( gun.gun_skill() ), MAX_SKILL );
+    int const skill_lvl = std::min( p.get_skill_level( gun.gun_skill() ), MAX_SKILL );
 
     return std::max<int>( 0, 3 * ( gun_recoil - dex_effect ) / std::max( 1.0f,
                           str_effect + skill_lvl ) );
@@ -2203,11 +2203,11 @@ target_handler::trajectory target_ui::run()
     }
 
     avatar &player_character = *you;
-    on_out_of_scope cleanup( [&here, &player_character]() {
+    on_out_of_scope const cleanup( [&here, &player_character]() {
         here.invalidate_map_cache( player_character.pos().z + player_character.view_offset.z );
     } );
 
-    shared_ptr_fast<game::draw_callback_t> target_ui_cb = make_shared_fast<game::draw_callback_t>(
+    shared_ptr_fast<game::draw_callback_t> const target_ui_cb = make_shared_fast<game::draw_callback_t>(
     [&]() {
         draw_terrain_overlay();
     } );
@@ -2232,7 +2232,7 @@ target_handler::trajectory target_ui::run()
     if( mode == TargetMode::Fire && !activity->action.empty() ) {
         // We were in this UI during previous turn...
         reentered = true;
-        std::string act_data = activity->action;
+        std::string const act_data = activity->action;
         if( act_data == "AIM" ) {
             // ...and ran out of moves while aiming.
         } else {
@@ -2310,7 +2310,7 @@ target_handler::trajectory target_ui::run()
 
         // Wait for user input (or use value retrieved from activity)
         if( action.empty() ) {
-            int timeout = get_option<int>( "EDGE_SCROLL" );
+            int const timeout = get_option<int>( "EDGE_SCROLL" );
             action = ctxt.handle_input( timeout );
         }
 
@@ -2351,7 +2351,7 @@ target_handler::trajectory target_ui::run()
             if( status != Status::Good ) {
                 continue;
             }
-            bool can_skip_confirm = ( mode == TargetMode::Spell && casting->damage() <= 0 );
+            bool const can_skip_confirm = ( mode == TargetMode::Spell && casting->damage() <= 0 );
             if( !can_skip_confirm && !confirm_non_enemy_target() ) {
                 continue;
             }
@@ -2401,7 +2401,7 @@ target_handler::trajectory target_ui::run()
             break;
         }
         case ExitCode::Fire: {
-            bool harmful = !( mode == TargetMode::Spell && casting->damage() <= 0 );
+            bool const harmful = !( mode == TargetMode::Spell && casting->damage() <= 0 );
             on_target_accepted( harmful );
             break;
         }
@@ -2428,11 +2428,11 @@ target_handler::trajectory target_ui::run()
 
 void target_ui::init_window_and_input()
 {
-    std::string display_type = get_option<std::string>( "ACCURACY_DISPLAY" );
-    std::string panel_type = panel_manager::get_manager().get_current_layout_id();
+    std::string const display_type = get_option<std::string>( "ACCURACY_DISPLAY" );
+    std::string const panel_type = panel_manager::get_manager().get_current_layout_id();
     narrow = ( panel_type == "compact" || panel_type == "labels-narrow" );
 
-    int top = 0;
+    int const top = 0;
     int width;
     int height;
     if( narrow ) {
@@ -2445,7 +2445,7 @@ void target_ui::init_window_and_input()
         width = 55;
         compact = TERMY < 41;
         tiny = TERMY < 28;
-        bool use_whole_sidebar = TERMY < 32;
+        bool const use_whole_sidebar = TERMY < 32;
         if( use_whole_sidebar ) {
             // If we're extremely short on space, use the whole sidebar.
             height = TERMY;
@@ -2492,7 +2492,7 @@ void target_ui::init_window_and_input()
         ctxt.register_action( "AIM" );
 
         aim_types = ranged::get_aim_types( *you, *relevant );
-        for( ranged::aim_type &type : aim_types ) {
+        for( ranged::aim_type  const&type : aim_types ) {
             if( type.has_threshold ) {
                 ctxt.register_action( type.action );
             }
@@ -2544,7 +2544,7 @@ bool target_ui::handle_cursor_movement( const std::string &action, bool &skip_re
         set_cursor_pos( *mouse_pos );
     } else if( action == "LEVEL_UP" || action == "LEVEL_DOWN" ) {
         // Shift view/cursor up/down one z level
-        tripoint delta = tripoint(
+        tripoint const delta = tripoint(
                              0,
                              0,
                              action == "LEVEL_UP" ? 1 : -1
@@ -2580,7 +2580,7 @@ bool target_ui::set_cursor_pos( const tripoint &new_pos )
     // Make sure new position is valid or find a closest valid position
     std::vector<tripoint> new_traj;
     tripoint valid_pos = new_pos;
-    map &here = get_map();
+    map  const&here = get_map();
     if( new_pos != src ) {
         // On Z axis, make sure we do not exceed map boundaries
         valid_pos.z = clamp( valid_pos.z, -OVERMAP_DEPTH, OVERMAP_HEIGHT );
@@ -2609,7 +2609,7 @@ bool target_ui::set_cursor_pos( const tripoint &new_pos )
                 }
             }
         } else {
-            tripoint delta = valid_pos - src;
+            tripoint const delta = valid_pos - src;
             valid_pos = src + tripoint(
                             clamp( delta.x, -range, range ),
                             clamp( delta.y, -range, range ),
@@ -2637,7 +2637,7 @@ bool target_ui::set_cursor_pos( const tripoint &new_pos )
     }
 
     // Make player's sprite flip to face the current target
-    point d( dst.xy() - src.xy() );
+    point const d( dst.xy() - src.xy() );
     if( !tile_iso ) {
 
         if( d.x > 0 ) {
@@ -2683,10 +2683,10 @@ bool target_ui::set_cursor_pos( const tripoint &new_pos )
     } else if( mode == TargetMode::Turrets ) {
         update_turrets_in_range();
     } else if( mode == TargetMode::Shape ) {
-        std::shared_ptr<shape> sh = shape_gen->create( src, dst );
+        std::shared_ptr<shape> const sh = shape_gen->create( src, dst );
         projectile proj = make_gun_projectile( *relevant );
         // Same as in map::shoot (should probably be a function!)
-        int expected_bash_force = std::accumulate( proj.impact.begin(), proj.impact.end(), 0.0,
+        int const expected_bash_force = std::accumulate( proj.impact.begin(), proj.impact.end(), 0.0,
         []( double acc, const damage_unit & du ) {
             return acc + du.amount + du.res_pen;
         } );
@@ -2728,7 +2728,7 @@ void target_ui::update_target_list()
 tripoint target_ui::choose_initial_target()
 {
     // Try previously targeted creature
-    shared_ptr_fast<Creature> cr = you->last_target.lock();
+    shared_ptr_fast<Creature> const cr = you->last_target.lock();
     if( cr && pl_sees( *cr ) && dist_fn( cr->pos() ) <= range ) {
         return cr->pos();
     }
@@ -2757,7 +2757,7 @@ bool target_ui::try_reacquire_target( bool critter, tripoint &new_dst )
 {
     if( critter ) {
         // Try to re-acquire the creature
-        shared_ptr_fast<Creature> cr = you->last_target.lock();
+        shared_ptr_fast<Creature> const cr = you->last_target.lock();
         if( cr && pl_sees( *cr ) && dist_fn( cr->pos() ) <= range ) {
             new_dst = cr->pos();
             return true;
@@ -2770,7 +2770,7 @@ bool target_ui::try_reacquire_target( bool critter, tripoint &new_dst )
     }
 
     // Try to re-acquire target tile or tile where the target creature used to be
-    tripoint local_lt = get_map().getlocal( *you->last_target_pos );
+    tripoint const local_lt = get_map().getlocal( *you->last_target_pos );
     if( dist_fn( local_lt ) <= range ) {
         new_dst = local_lt;
         // Abort aiming if a creature moved in
@@ -2841,14 +2841,14 @@ bool target_ui::prompt_friendlies_in_lof()
         return true;
     }
 
-    std::vector<weak_ptr_fast<Creature>> in_lof = list_friendlies_in_lof();
+    std::vector<weak_ptr_fast<Creature>> const in_lof = list_friendlies_in_lof();
     std::vector<Creature *> new_in_lof;
     for( const weak_ptr_fast<Creature> &cr_ptr : in_lof ) {
         bool found = false;
-        shared_ptr_fast<Creature> ptr_lock = cr_ptr.lock();
+        shared_ptr_fast<Creature> const ptr_lock = cr_ptr.lock();
         Creature *cr = ptr_lock.get();
         for( const weak_ptr_fast<Creature> &cr2_ptr : activity->acceptable_losses ) {
-            shared_ptr_fast<Creature> ptr2_lock = cr2_ptr.lock();
+            shared_ptr_fast<Creature> const ptr2_lock = cr2_ptr.lock();
             Creature *cr2 = ptr2_lock.get();
             if( cr == cr2 ) {
                 found = true;
@@ -2883,7 +2883,7 @@ std::vector<weak_ptr_fast<Creature>> target_ui::list_friendlies_in_lof()
         if( p != dst && p != src ) {
             Creature *cr = g->critter_at( p, true );
             if( cr && you->sees( *cr ) ) {
-                Creature::Attitude a = cr->attitude_to( *this->you );
+                Creature::Attitude const a = cr->attitude_to( *this->you );
                 if(
                     ( cr->is_npc() && a != Creature::A_HOSTILE ) ||
                     ( !cr->is_npc() && a == Creature::A_FRIENDLY )
@@ -2918,7 +2918,7 @@ void target_ui::cycle_targets( int direction )
         auto t = std::find( targets.begin(), targets.end(), dst_critter );
         size_t new_target = 0;
         if( t != targets.end() ) {
-            size_t idx = std::distance( targets.begin(), t );
+            size_t const idx = std::distance( targets.begin(), t );
             new_target = ( idx + targets.size() + direction ) % targets.size();
             set_cursor_pos( targets[new_target]->pos() );
             return;
@@ -2939,7 +2939,7 @@ void target_ui::set_view_offset( const tripoint &new_offset )
     tripoint new_( new_offset.xy(), clamp( new_offset.z, -fov_3d_z_range, fov_3d_z_range ) );
     new_.z = clamp( new_.z + src.z, -OVERMAP_DEPTH, OVERMAP_HEIGHT ) - src.z;
 
-    bool changed_z = you->view_offset.z != new_.z;
+    bool const changed_z = you->view_offset.z != new_.z;
     you->view_offset = new_;
     if( changed_z ) {
         // We need to do a bunch of cache updates since we're
@@ -2952,9 +2952,9 @@ void target_ui::update_turrets_in_range()
 {
     turrets_in_range.clear();
     for( vehicle_part *t : *vturrets ) {
-        turret_data td = veh->turret_query( *t );
+        turret_data const td = veh->turret_query( *t );
         if( td.in_range( dst ) ) {
-            tripoint src = veh->global_part_pos3( *t );
+            tripoint const src = veh->global_part_pos3( *t );
             turrets_in_range.push_back( { t, line_to( src, dst ) } );
         }
     }
@@ -2968,9 +2968,9 @@ void target_ui::recalc_aim_turning_penalty()
         return;
     }
 
-    double curr_recoil = you->recoil;
+    double const curr_recoil = you->recoil;
     tripoint curr_recoil_pos;
-    shared_ptr_fast<Creature> ptr_lock = you->last_target.lock();
+    shared_ptr_fast<Creature> const ptr_lock = you->last_target.lock();
     const Creature *lt_ptr = ptr_lock.get();
     if( lt_ptr ) {
         curr_recoil_pos = lt_ptr->pos();
@@ -3066,7 +3066,7 @@ void target_ui::action_switch_mode()
 
     menu.query();
     if( menu.ret >= 0 && menu.ret < static_cast<int>( on_select.size() ) ) {
-        size_t i = static_cast<size_t>( menu.ret );
+        size_t const i = static_cast<size_t>( menu.ret );
         on_select[i]();
     } // else - just refresh
 
@@ -3085,7 +3085,7 @@ void target_ui::ensure_ranged_gun_mode()
 void target_ui::update_ammo_range_from_gun_mode()
 {
     if( mode == TargetMode::TurretManual ) {
-        itype_id ammo_current = turret->ammo_current();
+        itype_id const ammo_current = turret->ammo_current();
         // Test no-ammo and not a UPS weapon
         if( !ammo_current && ( relevant->get_gun_ups_drain() == 0 ) ) {
             ammo = nullptr;
@@ -3154,7 +3154,7 @@ bool target_ui::action_aim_and_shoot( const std::string &action )
         debugmsg( "Could not find a valid aim_type for %s", action.c_str() );
         aim_mode = aim_types.begin();
     }
-    int aim_threshold = it->threshold;
+    int const aim_threshold = it->threshold;
     set_last_target();
     apply_aim_turning_penalty();
     const double min_recoil = calculate_aim_cap( *you, dst );
@@ -3167,7 +3167,7 @@ bool target_ui::action_aim_and_shoot( const std::string &action )
     // Also fire if we're at our best aim level already.
     // If no critter is at dst then sight dispersion does not apply,
     // so it would lock into an infinite loop.
-    bool done_aiming = you->recoil <= aim_threshold || you->recoil - sight_dispersion == min_recoil ||
+    bool const done_aiming = you->recoil <= aim_threshold || you->recoil - sight_dispersion == min_recoil ||
                        ( !g->critter_at( dst ) && you->recoil == min_recoil );
     return done_aiming;
 }
@@ -3195,7 +3195,7 @@ void target_ui::draw_terrain_overlay()
         //       We merge all lines together and draw them as a big malformed one
         std::set<tripoint> points;
         for( const turret_with_lof &it : turrets_in_range ) {
-            std::vector<tripoint> this_z = filter_this_z( it.line );
+            std::vector<tripoint> const this_z = filter_this_z( it.line );
             for( const tripoint &p : this_z ) {
                 points.insert( p );
             }
@@ -3213,7 +3213,7 @@ void target_ui::draw_terrain_overlay()
 
     // Draw trajectory
     if( mode != TargetMode::Turrets && dst != src ) {
-        std::vector<tripoint> this_z = filter_this_z( traj );
+        std::vector<tripoint> const this_z = filter_this_z( traj );
 
         // Draw a highlighted trajectory only if we can see the endpoint.
         // Provides feedback to the player, but avoids leaking information
@@ -3229,7 +3229,7 @@ void target_ui::draw_terrain_overlay()
 
     // Draw spell AOE
     if( mode == TargetMode::Spell ) {
-        drawsq_params params = drawsq_params().highlight( true ).center( center );
+        drawsq_params const params = drawsq_params().highlight( true ).center( center );
         for( const tripoint &tile : spell_aoe ) {
             if( tile.z != center.z ) {
                 continue;
@@ -3245,7 +3245,7 @@ void target_ui::draw_terrain_overlay()
 #endif
         }
     } else if( mode == TargetMode::Shape ) {
-        drawsq_params params = drawsq_params().highlight( true ).center( center );
+        drawsq_params const params = drawsq_params().highlight( true ).center( center );
         for( const std::pair<const tripoint, double> &pr : shape_coverage ) {
             const tripoint &tile = pr.first;
 #ifdef TILES
@@ -3268,8 +3268,8 @@ void target_ui::draw_terrain_overlay()
 void target_ui::draw_ui_window()
 {
     // Clear target window and make it non-transparent.
-    int width = getmaxx( w_target );
-    int height = getmaxy( w_target );
+    int const width = getmaxx( w_target );
+    int const height = getmaxy( w_target );
     for( int y = 0; y < height; y++ ) {
         for( int x = 0; x < width; x++ ) {
             mvwputch( w_target, point( x, y ), c_white, ' ' );
@@ -3294,7 +3294,7 @@ void target_ui::draw_ui_window()
         text_y += compact ? 0 : 1;
     }
 
-    bool fill_with_blank_if_no_target = !tiny;
+    bool const fill_with_blank_if_no_target = !tiny;
     panel_target_info( text_y, fill_with_blank_if_no_target );
     text_y += compact ? 0 : 1;
 
@@ -3305,7 +3305,7 @@ void target_ui::draw_ui_window()
         if( mode == TargetMode::Fire ) {
             panel_fire_mode_aim( text_y );
         } else if( mode == TargetMode::Throw || mode == TargetMode::ThrowBlind ) {
-            bool blind = ( mode == TargetMode::ThrowBlind );
+            bool const blind = ( mode == TargetMode::ThrowBlind );
             draw_throw_aim( *you, w_target, text_y, ctxt, *relevant, dst, blind );
         }
     }
@@ -3354,13 +3354,13 @@ void target_ui::draw_window_title()
 
 void target_ui::draw_help_notice()
 {
-    int text_y = getmaxy( w_target ) - 1;
-    int width = getmaxx( w_target );
+    int const text_y = getmaxy( w_target ) - 1;
+    int const width = getmaxx( w_target );
     const std::string label_help = string_format(
                                        narrow ? _( "[%s] show help" ) : _( "[%s] show all controls" ),
                                        ctxt.get_desc( "HELP_KEYBINDINGS", 1 ) );
-    int label_width = std::min( utf8_width( label_help ), width - 6 ); // 6 for borders and "< " + " >"
-    int text_x = width - label_width - 6;
+    int const label_width = std::min( utf8_width( label_help ), width - 6 ); // 6 for borders and "< " + " >"
+    int const text_x = width - label_width - 6;
     mvwprintz( w_target, point( text_x + 1, text_y ), c_white, "< " );
     trim_and_print( w_target, point( text_x + 3, text_y ), label_width, c_white, label_help );
     wprintz( w_target, c_white, " >" );
@@ -3370,10 +3370,10 @@ void target_ui::draw_controls_list( int text_y )
 {
     // Change UI colors for visual feedback
     // TODO: Colorize keys inside brackets to be consistent with other UI windows
-    nc_color col_enabled = c_white;
-    nc_color col_disabled = c_light_gray;
-    nc_color col_move = ( status != Status::OutOfAmmo ? col_enabled : col_disabled );
-    nc_color col_fire = ( status == Status::Good ? col_enabled : col_disabled );
+    nc_color const col_enabled = c_white;
+    nc_color const col_disabled = c_light_gray;
+    nc_color const col_move = ( status != Status::OutOfAmmo ? col_enabled : col_disabled );
+    nc_color const col_fire = ( status == Status::Good ? col_enabled : col_disabled );
 
     // Get first key bound to given action OR ' ' if there are none.
     const auto bound_key = [this]( const std::string & s ) {
@@ -3402,17 +3402,17 @@ void target_ui::draw_controls_list( int text_y )
         lines.push_back( { 8, colored( col_move, _( "Move cursor with directional keys" ) ) } );
     }
     if( is_mouse_enabled() ) {
-        std::string move = _( "Mouse: LMB: Target, Wheel: Cycle," );
-        std::string fire = _( "RMB: Fire" );
+        std::string const move = _( "Mouse: LMB: Target, Wheel: Cycle," );
+        std::string const fire = _( "RMB: Fire" );
         lines.push_back( { 7, colored( col_move, move ) + " " + colored( col_fire, fire ) } );
     }
     {
-        std::string cycle = string_format( _( "[%s] Cycle targets;" ), ctxt.get_desc( "NEXT_TARGET", 1 ) );
-        std::string fire = string_format( _( "[%c] %s." ), bound_key( "FIRE" ), uitext_fire() );
+        std::string const cycle = string_format( _( "[%s] Cycle targets;" ), ctxt.get_desc( "NEXT_TARGET", 1 ) );
+        std::string const fire = string_format( _( "[%c] %s." ), bound_key( "FIRE" ), uitext_fire() );
         lines.push_back( { 0, colored( col_move, cycle ) + " " + colored( col_fire, fire ) } );
     }
     {
-        std::string text = string_format( _( "[%c] target self; [%c] toggle snap-to-target" ),
+        std::string const text = string_format( _( "[%c] target self; [%c] toggle snap-to-target" ),
                                           bound_key( "CENTER" ), bound_key( "TOGGLE_SNAP_TO_TARGET" ) );
         lines.push_back( { 3, colored( col_enabled, text ) } );
     }
@@ -3425,7 +3425,7 @@ void target_ui::draw_controls_list( int text_y )
         }
         aim_and_fire += _( "to aim and fire." );
 
-        std::string aim = string_format( _( "[%c] to steady your aim.  (10 moves)" ),
+        std::string const aim = string_format( _( "[%c] to steady your aim.  (10 moves)" ),
                                          bound_key( "AIM" ) );
 
         lines.push_back( { 2, colored( col_fire, aim ) } );
@@ -3445,8 +3445,8 @@ void target_ui::draw_controls_list( int text_y )
     }
 
     // Shrink the list until it fits
-    int height = getmaxy( w_target );
-    int available_lines = height - text_y - 1; // 1 for bottom border
+    int const height = getmaxy( w_target );
+    int const available_lines = height - text_y - 1; // 1 for bottom border
     if( available_lines <= 0 ) {
         return;
     }
@@ -3485,11 +3485,11 @@ void target_ui::panel_cursor_info( int &text_y )
     labels.push_back( string_format( _( "Targets: %d" ), targets.size() ) );
 
     nc_color col = c_light_gray;
-    int width = getmaxx( w_target );
+    int const width = getmaxx( w_target );
     int text_x = 1;
     for( const std::string &s : labels ) {
-        int x_left = width - text_x - 1;
-        int len = utf8_width( s, true );
+        int const x_left = width - text_x - 1;
+        int const len = utf8_width( s, true );
         if( len > x_left ) {
             text_x = 1;
             text_y++;
@@ -3503,7 +3503,7 @@ void target_ui::panel_cursor_info( int &text_y )
 void target_ui::panel_gun_info( int &text_y )
 {
     gun_mode m = relevant->gun_current_mode();
-    std::string mode_name = m.tname();
+    std::string const mode_name = m.tname();
     std::string gunmod_name;
     if( m.target != relevant ) {
         // Gun mode comes from a gunmod, not base gun. Add gunmod's name
@@ -3577,7 +3577,7 @@ void target_ui::panel_spell_info( int &text_y )
     print_colored_text( w_target, point( 1, text_y++ ), clr, clr, fail_str );
 
     if( casting->aoe() > 0 ) {
-        nc_color color = c_light_gray;
+        nc_color const color = c_light_gray;
         const std::string fx = casting->effect();
         const std::string aoes = casting->aoe_string();
         if( fx == "projectile_attack" || fx == "target_attack" ||
@@ -3604,14 +3604,14 @@ void target_ui::panel_spell_info( int &text_y )
 
 void target_ui::panel_target_info( int &text_y, bool fill_with_blank_if_no_target )
 {
-    int max_lines = 4;
+    int const max_lines = 4;
     if( dst_critter ) {
         if( you->sees( *dst_critter ) ) {
             // FIXME: print_info doesn't really care about line limit
             //        and can always occupy up to 4 of them (or even more?).
             //        To make things consistent, we ask it for 2 lines
             //        and somewhat reliably get 4.
-            int fix_for_print_info = max_lines - 2;
+            int const fix_for_print_info = max_lines - 2;
             dst_critter->print_info( w_target, text_y, fix_for_print_info, 1 );
             text_y += max_lines;
         } else {
@@ -3639,7 +3639,7 @@ void target_ui::panel_target_info( int &text_y, bool fill_with_blank_if_no_targe
 void target_ui::panel_fire_mode_aim( int &text_y )
 {
     // TODO: saving & restoring pc.recoil may actually be unnecessary
-    double saved_pc_recoil = you->recoil;
+    double const saved_pc_recoil = you->recoil;
     you->recoil = predicted_recoil;
     double predicted_recoil = you->recoil;
     int predicted_delay = 0;
@@ -3659,7 +3659,7 @@ void target_ui::panel_fire_mode_aim( int &text_y )
     const double target_size = dst_critter ? dst_critter->ranged_target_size() :
                                occupied_tile_fraction( m_size::MS_MEDIUM );
 
-    item_location load_loc = activity->reload_loc;
+    item_location const load_loc = activity->reload_loc;
     text_y = print_aim( *you, w_target, text_y, ctxt, *relevant->gun_current_mode(),
                         target_size, dst, predicted_recoil, load_loc );
 
@@ -3677,7 +3677,7 @@ void target_ui::panel_turret_list( int &text_y )
                vturrets->size() );
 
     for( const turret_with_lof &it : turrets_in_range ) {
-        std::string str = string_format( "* %s", it.turret->name() );
+        std::string const str = string_format( "* %s", it.turret->name() );
         nc_color clr = c_white;
         print_colored_text( w_target, point( 1, text_y++ ), clr, clr, str );
     }
@@ -3789,7 +3789,7 @@ bool ranged::gunmode_checks_weapon( avatar &you, const map &m, std::vector<std::
 
         const bool v_mountable = static_cast<bool>( m.veh_at( you.pos() ).part_with_feature( "MOUNTABLE",
                                  true ) );
-        bool t_mountable = m.has_flag_ter_or_furn( flag_MOUNTABLE, you.pos() );
+        bool const t_mountable = m.has_flag_ter_or_furn( flag_MOUNTABLE, you.pos() );
         if( !mech_mount && !t_mountable && !v_mountable && !( you.get_size() > MS_MEDIUM ) ) {
             messages.push_back( string_format(
                                     _( "You must stand near acceptable terrain or furniture to fire the %s.  A table, a mound of dirt, a broken window, etc." ),
@@ -3897,7 +3897,7 @@ double ranged::aim_speed_encumbrance_modifier( const Character &who )
 
 double ranged::aim_cap_from_volume( const item &gun )
 {
-    skill_id gun_skill = gun.gun_skill();
+    skill_id const gun_skill = gun.gun_skill();
     double aim_cap = std::min( 49.0, 49.0 - static_cast<float>( gun.volume() / 75_ml ) );
     // TODO: also scale with skill level.
     if( gun_skill == skill_smg ) {
@@ -3922,9 +3922,9 @@ double ranged::aim_per_move( const Character &who, const item &gun, double recoi
         return 0.0;
     }
 
-    std::pair<int, int> best_sight = get_fastest_sight( who, gun, recoil );
-    int sight_speed_modifier = best_sight.first;
-    int limit = best_sight.second;
+    std::pair<int, int> const best_sight = get_fastest_sight( who, gun, recoil );
+    int const sight_speed_modifier = best_sight.first;
+    int const limit = best_sight.second;
     if( sight_speed_modifier == INT_MIN ) {
         // No suitable sights (already at maximum aim).
         return 0;
@@ -3936,7 +3936,7 @@ double ranged::aim_per_move( const Character &who, const item &gun, double recoi
     // Base speed is non-zero to prevent extreme rate changes as aim speed approaches 0.
     double aim_speed = 10.0;
 
-    skill_id gun_skill = gun.gun_skill();
+    skill_id const gun_skill = gun.gun_skill();
     // Ranges [0 - 10]
     aim_speed += aim_speed_skill_modifier( who, gun_skill );
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -767,7 +767,7 @@ bool ranged::handle_gun_damage( Character &shooter, item &it )
 void npc::pretend_fire( npc *source, int shots, item &gun )
 {
     int curshot = 0;
-    avatar  const&you = get_avatar();
+    avatar  const &you = get_avatar();
     if( you.sees( *source ) && one_in( 50 ) ) {
         add_msg( m_info, _( "%s shoots something." ), source->disp_name() );
     }
@@ -858,12 +858,12 @@ int ranged::fire_gun( Character &who, const tripoint &target, int max_shots, ite
 
     std::optional<shape_factory> shape = ranged::get_shape_factory( gun );
 
-    map  const&here = get_map();
+    map  const &here = get_map();
     // Shaped attacks don't allow aiming, so they don't suffer from lack of aim either
     int const character_recoil = shape ? recoil_vehicle( who ) : recoil_total( who );
     // Penalty is (intentionally) based off mode shots, not ammo-limited.
     dispersion_sources const dispersion = calculate_dispersion( here, who, gun, character_recoil,
-                                    max_shots > 1 );
+                                          max_shots > 1 );
 
     bool const aoe_attack = gun.gun_skill() == skill_launcher || shape;
     tripoint const aim = target;
@@ -1111,7 +1111,7 @@ int throwing_dispersion( const Character &c, const item &to_throw, Creature *cri
         // It's easier to dodge at close range (thrower needs to adjust more)
         // Dodge x10 at point blank, x5 at 1 dist, then flat
         float const effective_dodge = critter->get_dodge() * std::max( 1, 10 - 5 * rl_dist( c.pos(),
-                                critter->pos() ) );
+                                      critter->pos() ) );
         dispersion += throw_dispersion_per_dodge( c, true ) * effective_dodge;
     }
     // 1 perception per 1 eye encumbrance
@@ -1177,7 +1177,7 @@ dealt_projectile_attack throw_item( Character &who, const tripoint &target, cons
     static const std::set<material_id> ferric = { material_id( "iron" ), material_id( "steel" ) };
 
     bool const do_railgun = who.has_active_bionic( bio_railgun ) && thrown.made_of_any( ferric ) &&
-                      !throw_assist;
+                            !throw_assist;
 
     // The damage dealt due to item's weight, player's strength, and skill level
     // Up to str/2 or weight/100g (lower), so 10 str is 5 damage before multipliers
@@ -1322,7 +1322,7 @@ static int print_steadiness( const catacurses::window &w, int line_number, doubl
 
     if( get_option<std::string>( "ACCURACY_DISPLAY" ) == "numbers" ) {
         std::string const steadiness_s = string_format( "%s: %d%%", _( "Steadiness" ),
-                                   static_cast<int>( 100.0 * steadiness ) );
+                                         static_cast<int>( 100.0 * steadiness ) );
         mvwprintw( w, point( 1, line_number++ ), steadiness_s );
     } else {
         const std::string &steadiness_bar = get_labeled_bar( steadiness, window_width,
@@ -1423,7 +1423,7 @@ static int print_ranged_chance( const catacurses::window &w, int line_number,
         for( const confidence_rating &cr : confidence_config ) {
             std::string const label = pgettext( "aim_confidence", cr.label.c_str() );
             std::string const symbols = string_format( "<color_%s>%s</color> = %s", cr.color, cr.symbol,
-                                                 label );
+                                        label );
             int const line_len = utf8_width( label ) + 5; // 5 for '# = ' and whitespace at end
             if( ( window_width + bars_pad - column_number ) < line_len ) {
                 column_number = 1;
@@ -1436,7 +1436,7 @@ static int print_ranged_chance( const catacurses::window &w, int line_number,
     }
     if( ( panel_type == "compact" || panel_type == "labels-narrow" ) && display_type == "numbers" ) {
         std::string const symbols = _( " <color_green>Great</color> - <color_light_gray>Normal</color>"
-                                 " - <color_magenta>Graze</color> - <color_light_blue>Moves</color>" );
+                                       " - <color_magenta>Graze</color> - <color_light_blue>Moves</color>" );
         fold_and_print( w, point( 1, line_number++ ), window_width + bars_pad,
                         c_dark_gray, symbols );
         int const len = utf8_width( symbols ) - 96; // 96 to subtract color codes
@@ -1498,7 +1498,8 @@ static int print_ranged_chance( const catacurses::window &w, int line_number,
                 aim_iter++;
             } else {
                 int last_chance = 0;
-                std::string const confidence_s = enumerate_as_string( confidence_config.begin(), confidence_config.end(),
+                std::string const confidence_s = enumerate_as_string( confidence_config.begin(),
+                                                 confidence_config.end(),
                 [&]( const confidence_rating & config ) {
                     // TODO: Consider not printing 0 chances, but only if you can print something (at least miss 100% or so)
                     int const chance = std::min<int>( 100, 100.0 * ( config.aim_level * confidence ) ) - last_chance;
@@ -1540,7 +1541,7 @@ static int print_ranged_chance( const catacurses::window &w, int line_number,
 // Whether player character knows creature's position and can roughly track it with the aim cursor
 static bool pl_sees( const Creature &cr )
 {
-    Character  const&u = get_player_character();
+    Character  const &u = get_player_character();
     return u.sees( cr ) || u.sees_with_infrared( cr ) || u.sees_with_specials( cr );
 }
 
@@ -2123,7 +2124,7 @@ std::vector<Creature *> targetable_creatures( const Character &c, const int rang
             return false;
         }
 
-        map  const&here = get_map();
+        map  const &here = get_map();
 
         // TODO: It should use projectile passability checks when finding path, not vision checks.
         std::vector<tripoint> const path = here.find_clear_path( c.pos(), critter.pos() );
@@ -2492,7 +2493,7 @@ void target_ui::init_window_and_input()
         ctxt.register_action( "AIM" );
 
         aim_types = ranged::get_aim_types( *you, *relevant );
-        for( ranged::aim_type  const&type : aim_types ) {
+        for( ranged::aim_type  const &type : aim_types ) {
             if( type.has_threshold ) {
                 ctxt.register_action( type.action );
             }
@@ -2545,10 +2546,10 @@ bool target_ui::handle_cursor_movement( const std::string &action, bool &skip_re
     } else if( action == "LEVEL_UP" || action == "LEVEL_DOWN" ) {
         // Shift view/cursor up/down one z level
         tripoint const delta = tripoint(
-                             0,
-                             0,
-                             action == "LEVEL_UP" ? 1 : -1
-                         );
+                                   0,
+                                   0,
+                                   action == "LEVEL_UP" ? 1 : -1
+                               );
         shift_view_or_cursor( delta );
     } else if( action == "NEXT_TARGET" ) {
         cycle_targets( 1 );
@@ -2580,7 +2581,7 @@ bool target_ui::set_cursor_pos( const tripoint &new_pos )
     // Make sure new position is valid or find a closest valid position
     std::vector<tripoint> new_traj;
     tripoint valid_pos = new_pos;
-    map  const&here = get_map();
+    map  const &here = get_map();
     if( new_pos != src ) {
         // On Z axis, make sure we do not exceed map boundaries
         valid_pos.z = clamp( valid_pos.z, -OVERMAP_DEPTH, OVERMAP_HEIGHT );
@@ -3167,8 +3168,9 @@ bool target_ui::action_aim_and_shoot( const std::string &action )
     // Also fire if we're at our best aim level already.
     // If no critter is at dst then sight dispersion does not apply,
     // so it would lock into an infinite loop.
-    bool const done_aiming = you->recoil <= aim_threshold || you->recoil - sight_dispersion == min_recoil ||
-                       ( !g->critter_at( dst ) && you->recoil == min_recoil );
+    bool const done_aiming = you->recoil <= aim_threshold ||
+                             you->recoil - sight_dispersion == min_recoil ||
+                             ( !g->critter_at( dst ) && you->recoil == min_recoil );
     return done_aiming;
 }
 
@@ -3359,7 +3361,8 @@ void target_ui::draw_help_notice()
     const std::string label_help = string_format(
                                        narrow ? _( "[%s] show help" ) : _( "[%s] show all controls" ),
                                        ctxt.get_desc( "HELP_KEYBINDINGS", 1 ) );
-    int const label_width = std::min( utf8_width( label_help ), width - 6 ); // 6 for borders and "< " + " >"
+    int const label_width = std::min( utf8_width( label_help ),
+                                      width - 6 ); // 6 for borders and "< " + " >"
     int const text_x = width - label_width - 6;
     mvwprintz( w_target, point( text_x + 1, text_y ), c_white, "< " );
     trim_and_print( w_target, point( text_x + 3, text_y ), label_width, c_white, label_help );
@@ -3407,13 +3410,14 @@ void target_ui::draw_controls_list( int text_y )
         lines.push_back( { 7, colored( col_move, move ) + " " + colored( col_fire, fire ) } );
     }
     {
-        std::string const cycle = string_format( _( "[%s] Cycle targets;" ), ctxt.get_desc( "NEXT_TARGET", 1 ) );
+        std::string const cycle = string_format( _( "[%s] Cycle targets;" ), ctxt.get_desc( "NEXT_TARGET",
+                                  1 ) );
         std::string const fire = string_format( _( "[%c] %s." ), bound_key( "FIRE" ), uitext_fire() );
         lines.push_back( { 0, colored( col_move, cycle ) + " " + colored( col_fire, fire ) } );
     }
     {
         std::string const text = string_format( _( "[%c] target self; [%c] toggle snap-to-target" ),
-                                          bound_key( "CENTER" ), bound_key( "TOGGLE_SNAP_TO_TARGET" ) );
+                                                bound_key( "CENTER" ), bound_key( "TOGGLE_SNAP_TO_TARGET" ) );
         lines.push_back( { 3, colored( col_enabled, text ) } );
     }
     if( mode == TargetMode::Fire ) {
@@ -3426,7 +3430,7 @@ void target_ui::draw_controls_list( int text_y )
         aim_and_fire += _( "to aim and fire." );
 
         std::string const aim = string_format( _( "[%c] to steady your aim.  (10 moves)" ),
-                                         bound_key( "AIM" ) );
+                                               bound_key( "AIM" ) );
 
         lines.push_back( { 2, colored( col_fire, aim ) } );
         lines.push_back( { 4, colored( col_fire, aim_and_fire ) } );

--- a/src/ranged_aoe.cpp
+++ b/src/ranged_aoe.cpp
@@ -58,7 +58,7 @@ void execute_shaped_attack( const shape &sh, const projectile &proj, Creature &a
     std::set<tripoint> closed;
 
     for( const tripoint &child : here.points_in_radius( origin, 1 ) ) {
-        double coverage = sigdist_to_coverage( sh.distance_at( child ) );
+        double const coverage = sigdist_to_coverage( sh.distance_at( child ) );
         if( coverage > 0.0 && !get_map().obstructed_by_vehicle_rotation( origin, child ) ) {
             open[child] = aoe_flood_node( origin, 1.0 );
             queue.emplace( child, trig_dist_squared( origin, child ) );
@@ -69,13 +69,13 @@ void execute_shaped_attack( const shape &sh, const projectile &proj, Creature &a
 
     std::map<tripoint, double> final_coverage;
     while( !queue.empty() ) {
-        tripoint p = queue.top().p;
+        tripoint const p = queue.top().p;
         queue.pop();
         if( closed.count( p ) != 0 || !here.inbounds( p ) ) {
             continue;
         }
         closed.insert( p );
-        double parent_coverage = open.at( p ).parent_coverage;
+        double const parent_coverage = open.at( p ).parent_coverage;
         if( parent_coverage <= 0.0 ) {
             continue;
         }
@@ -91,8 +91,8 @@ void execute_shaped_attack( const shape &sh, const projectile &proj, Creature &a
                 continue;
             }
 
-            float total_dmg = proj_copy.impact.total_damage();
-            float old_total_dmg = proj.impact.total_damage();
+            float const total_dmg = proj_copy.impact.total_damage();
+            float const old_total_dmg = proj.impact.total_damage();
             if( old_total_dmg != total_dmg ) {
                 current_coverage *= std::min( 1.0f, old_total_dmg / total_dmg );
             }
@@ -100,7 +100,7 @@ void execute_shaped_attack( const shape &sh, const projectile &proj, Creature &a
 
         if( current_coverage > 0.0 ) {
             for( const tripoint &child : here.points_in_radius( p, 1 ) ) {
-                double coverage = sigdist_to_coverage( sh.distance_at( child ) );
+                double const coverage = sigdist_to_coverage( sh.distance_at( child ) );
                 if( coverage > 0.0 && !get_map().obstructed_by_vehicle_rotation( p, child ) &&
                     closed.count( child ) == 0 &&
                     ( open.count( child ) == 0 || open.at( child ).parent_coverage < current_coverage ) ) {
@@ -137,7 +137,7 @@ std::map<tripoint, double> expected_coverage( const shape &sh, const map &here, 
     std::set<tripoint> closed;
 
     for( const tripoint &child : here.points_in_radius( origin, 1 ) ) {
-        double coverage = sigdist_to_coverage( sh.distance_at( child ) );
+        double const coverage = sigdist_to_coverage( sh.distance_at( child ) );
         if( coverage > 0.0 && !get_map().obstructed_by_vehicle_rotation( origin, child ) ) {
             open[child] = aoe_flood_node( origin, 1.0 );
             queue.emplace( child, trig_dist_squared( origin, child ) );
@@ -148,13 +148,13 @@ std::map<tripoint, double> expected_coverage( const shape &sh, const map &here, 
 
     std::map<tripoint, double> final_coverage;
     while( !queue.empty() ) {
-        tripoint p = queue.top().p;
+        tripoint const p = queue.top().p;
         queue.pop();
         if( closed.count( p ) != 0 ) {
             continue;
         }
         closed.insert( p );
-        double parent_coverage = open.at( p ).parent_coverage;
+        double const parent_coverage = open.at( p ).parent_coverage;
         if( parent_coverage <= 0.0 ) {
             continue;
         }
@@ -165,14 +165,14 @@ std::map<tripoint, double> expected_coverage( const shape &sh, const map &here, 
             ( here.is_transparent( p ) && here.has_flag_furn( TFLAG_PERMEABLE, p ) ) ) {
             // noop
         } else {
-            int bash_str = here.bash_strength( p );
-            int bash_res = here.bash_resistance( p );
+            int const bash_str = here.bash_strength( p );
+            int const bash_res = here.bash_resistance( p );
             if( bash_power < bash_res ) {
                 continue;
             }
-            int range_width = bash_str - bash_res + 1;
-            int fail_width = bash_str - bash_power;
-            double fail_chance = static_cast<double>( fail_width ) / ( range_width );
+            int const range_width = bash_str - bash_res + 1;
+            int const fail_width = bash_str - bash_power;
+            double const fail_chance = static_cast<double>( fail_width ) / ( range_width );
             current_coverage *= 1.0 - std::max( 0.0, fail_chance );
         }
 
@@ -183,7 +183,7 @@ std::map<tripoint, double> expected_coverage( const shape &sh, const map &here, 
 
         if( current_coverage > 0.0 ) {
             for( const tripoint &child : here.points_in_radius( p, 1 ) ) {
-                double coverage = sigdist_to_coverage( sh.distance_at( child ) );
+                double const coverage = sigdist_to_coverage( sh.distance_at( child ) );
                 if( coverage > 0.0 && !get_map().obstructed_by_vehicle_rotation( p, child ) &&
                     closed.count( child ) == 0 &&
                     ( open.count( child ) == 0 || open.at( child ).parent_coverage < current_coverage ) ) {

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -767,7 +767,7 @@ void recipe::check_blueprint_requirements()
     get_build_reqs_for_furn_ter_ids( ident(), changed_ids, total_reqs );
 
     requirement_data const req_data_blueprint = std::accumulate(
-            reqs_blueprint.begin(), reqs_blueprint.end(), requirement_data(),
+                reqs_blueprint.begin(), reqs_blueprint.end(), requirement_data(),
     []( const requirement_data & lhs, const std::pair<requirement_id, int> &rhs ) {
         return lhs + ( *rhs.first * rhs.second );
     } );
@@ -781,8 +781,10 @@ void recipe::check_blueprint_requirements()
     req_data_calc.consolidate();
     if( time_blueprint != total_reqs.time || skills_blueprint != total_reqs.skills
         || !req_data_blueprint.has_same_requirements_as( req_data_calc ) ) {
-        std::string const calc_req_str = dump_requirements( req_data_calc, total_reqs.time, total_reqs.skills );
-        std::string const got_req_str = dump_requirements( req_data_blueprint, time_blueprint, skills_blueprint );
+        std::string const calc_req_str = dump_requirements( req_data_calc, total_reqs.time,
+                                         total_reqs.skills );
+        std::string const got_req_str = dump_requirements( req_data_blueprint, time_blueprint,
+                                        skills_blueprint );
 
         std::stringstream ss;
         for( auto &id_count : changed_ids.first ) {

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -151,7 +151,7 @@ void recipe::load( const JsonObject &jo, const std::string &src )
 
         } else if( sk.has_array( 0 ) ) {
             // multiple requirements
-            for( JsonArray arr : sk ) {
+            for( JsonArray const arr : sk ) {
                 required_skills[skill_id( arr.get_string( 0 ) )] = arr.get_int( 1 );
             }
 
@@ -167,7 +167,7 @@ void recipe::load( const JsonObject &jo, const std::string &src )
 
     } else if( jo.has_array( "autolearn" ) ) {
         autolearn = true;
-        for( JsonArray arr : jo.get_array( "autolearn" ) ) {
+        for( JsonArray const arr : jo.get_array( "autolearn" ) ) {
             autolearn_requirements[skill_id( arr.get_string( 0 ) )] = arr.get_int( 1 );
         }
     }
@@ -187,7 +187,7 @@ void recipe::load( const JsonObject &jo, const std::string &src )
             assign( jo, "decomp_learn", learn_by_disassembly[skill_used] );
 
         } else if( jo.has_array( "decomp_learn" ) ) {
-            for( JsonArray arr : jo.get_array( "decomp_learn" ) ) {
+            for( JsonArray const arr : jo.get_array( "decomp_learn" ) ) {
                 learn_by_disassembly[skill_id( arr.get_string( 0 ) )] = arr.get_int( 1 );
             }
         }
@@ -214,7 +214,7 @@ void recipe::load( const JsonObject &jo, const std::string &src )
 
     } else if( jo.has_array( "using" ) ) {
         reqs_external.clear();
-        for( JsonArray cur : jo.get_array( "using" ) ) {
+        for( JsonArray const cur : jo.get_array( "using" ) ) {
             reqs_external.emplace_back( requirement_id( cur.get_string( 0 ) ), cur.get_int( 1 ) );
         }
     }
@@ -249,8 +249,8 @@ void recipe::load( const JsonObject &jo, const std::string &src )
                 jo.throw_error( "Recipe cannot be reversible and have byproducts" );
             }
             byproducts.clear();
-            for( JsonArray arr : jo.get_array( "byproducts" ) ) {
-                itype_id byproduct( arr.get_string( 0 ) );
+            for( JsonArray const arr : jo.get_array( "byproducts" ) ) {
+                itype_id const byproduct( arr.get_string( 0 ) );
                 byproducts[ byproduct ] += arr.size() == 2 ? arr.get_int( 1 ) : 1;
             }
         }
@@ -261,19 +261,19 @@ void recipe::load( const JsonObject &jo, const std::string &src )
             for( const std::string resource : jo.get_array( "blueprint_resources" ) ) {
                 bp_resources.emplace_back( resource );
             }
-            for( JsonObject provide : jo.get_array( "blueprint_provides" ) ) {
+            for( JsonObject const provide : jo.get_array( "blueprint_provides" ) ) {
                 bp_provides.emplace_back( std::make_pair( provide.get_string( "id" ),
                                           provide.get_int( "amount", 1 ) ) );
             }
             // all blueprints provide themselves with needing it written in JSON
             bp_provides.emplace_back( std::make_pair( result_.str(), 1 ) );
-            for( JsonObject require : jo.get_array( "blueprint_requires" ) ) {
+            for( JsonObject const require : jo.get_array( "blueprint_requires" ) ) {
                 bp_requires.emplace_back( std::make_pair( require.get_string( "id" ),
                                           require.get_int( "amount", 1 ) ) );
             }
             // all blueprints exclude themselves with needing it written in JSON
             bp_excludes.emplace_back( std::make_pair( result_.str(), 1 ) );
-            for( JsonObject exclude : jo.get_array( "blueprint_excludes" ) ) {
+            for( JsonObject const exclude : jo.get_array( "blueprint_excludes" ) ) {
                 bp_excludes.emplace_back( std::make_pair( exclude.get_string( "id" ),
                                           exclude.get_int( "amount", 1 ) ) );
             }
@@ -291,7 +291,7 @@ void recipe::load( const JsonObject &jo, const std::string &src )
                     time += time_blueprint;
                 }
                 if( jneeds.has_member( "skills" ) ) {
-                    for( JsonArray cur : jneeds.get_array( "skills" ) ) {
+                    for( JsonArray const cur : jneeds.get_array( "skills" ) ) {
                         skills_blueprint[skill_id( cur.get_string( 0 ) )] = cur.get_int( 1 );
                     }
                     for( const std::pair<const skill_id, int> &p : skills_blueprint ) {
@@ -492,7 +492,7 @@ std::vector<item> recipe::create_results( int batch ) const
         // by_charges items get their charges multiplied in create_result
         const int num_results = by_charges ? batch : batch * result_mult;
         for( int i = 0; i < num_results; i++ ) {
-            item newit = create_result();
+            item const newit = create_result();
             items.push_back( newit );
         }
     } else {
@@ -548,7 +548,7 @@ std::string required_skills_as_string( Iter first, Iter last, const Character *c
     return enumerate_as_string( first, last,
     [&]( const std::pair<skill_id, int> &skill ) {
         const int player_skill = c ? c->get_skill_level( skill.first ) : 0;
-        std::string difficulty_color = skill.second > player_skill ? "yellow" : "green";
+        std::string const difficulty_color = skill.second > player_skill ? "yellow" : "green";
         std::string skill_level_string = print_skill_level ? "" : ( std::to_string( player_skill ) + "/" );
         skill_level_string += std::to_string( skill.second );
         return string_format( "<color_cyan>%s</color> <color_%s>(%s)</color>",
@@ -766,7 +766,7 @@ void recipe::check_blueprint_requirements()
             = get_changed_ids_from_update( blueprint );
     get_build_reqs_for_furn_ter_ids( ident(), changed_ids, total_reqs );
 
-    requirement_data req_data_blueprint = std::accumulate(
+    requirement_data const req_data_blueprint = std::accumulate(
             reqs_blueprint.begin(), reqs_blueprint.end(), requirement_data(),
     []( const requirement_data & lhs, const std::pair<requirement_id, int> &rhs ) {
         return lhs + ( *rhs.first * rhs.second );
@@ -781,8 +781,8 @@ void recipe::check_blueprint_requirements()
     req_data_calc.consolidate();
     if( time_blueprint != total_reqs.time || skills_blueprint != total_reqs.skills
         || !req_data_blueprint.has_same_requirements_as( req_data_calc ) ) {
-        std::string calc_req_str = dump_requirements( req_data_calc, total_reqs.time, total_reqs.skills );
-        std::string got_req_str = dump_requirements( req_data_blueprint, time_blueprint, skills_blueprint );
+        std::string const calc_req_str = dump_requirements( req_data_calc, total_reqs.time, total_reqs.skills );
+        std::string const got_req_str = dump_requirements( req_data_blueprint, time_blueprint, skills_blueprint );
 
         std::stringstream ss;
         for( auto &id_count : changed_ids.first ) {

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -411,7 +411,7 @@ void recipe_dictionary::find_items_on_loops()
     }
 
     // Now check that graph for loops
-    std::vector<std::vector<itype_id>> loops = cata::find_cycles( potential_components_of );
+    std::vector<std::vector<itype_id>> const loops = cata::find_cycles( potential_components_of );
     for( const std::vector<itype_id> &loop : loops ) {
         std::string error_message =
             "loop in comestible recipes detected: " + loop.back().str();
@@ -447,8 +447,8 @@ void recipe_dictionary::finalize()
 
         for( const auto &bk : r.booksets ) {
             const itype *booktype = &*bk.first;
-            int req = bk.second > 0 ? bk.second : std::max( booktype->book->req, r.difficulty );
-            islot_book::recipe_with_description_t desc{ &r, req, r.result_name(), false };
+            int const req = bk.second > 0 ? bk.second : std::max( booktype->book->req, r.difficulty );
+            islot_book::recipe_with_description_t const desc{ &r, req, r.result_name(), false };
             const_cast<islot_book &>( *booktype->book ).recipes.insert( desc );
         }
 
@@ -465,7 +465,7 @@ void recipe_dictionary::finalize()
 
         // books that don't already have an uncrafting recipe
         if( e->book && !recipe_dict.uncraft.count( rid ) && e->volume > 0_ml ) {
-            int pages = e->volume / 12.5_ml;
+            int const pages = e->volume / 12.5_ml;
             auto &bk = recipe_dict.uncraft[rid];
             bk.ident_ = rid;
             bk.result_ = id;

--- a/src/recipe_groups.cpp
+++ b/src/recipe_groups.cpp
@@ -40,7 +40,7 @@ generic_factory<recipe_group_data> recipe_groups_data( "recipe group type" );
 void recipe_group_data::load( const JsonObject &jo, const std::string & )
 {
     building_type = jo.get_string( "building_type" );
-    for( JsonObject ordering : jo.get_array( "recipes" ) ) {
+    for( JsonObject const ordering : jo.get_array( "recipes" ) ) {
         recipe_id name_id;
         ordering.read( "id", name_id );
         translation desc;
@@ -90,7 +90,7 @@ std::map<recipe_id, translation> recipe_group::get_recipes_by_id( const std::str
     }
     const recipe_group_data &group = recipe_groups_data.obj( group_id( id ) );
     if( om_terrain_id != "ANY" ) {
-        std::string base_om_ter_id = oter_no_dir( oter_id( om_terrain_id ) );
+        std::string const base_om_ter_id = oter_no_dir( oter_id( om_terrain_id ) );
 
         for( const auto &recp : group.recipes ) {
             const auto &recp_terrain = group.om_terrains.find( recp.first );

--- a/src/regional_settings.cpp
+++ b/src/regional_settings.cpp
@@ -112,7 +112,7 @@ static void load_forest_biome( const JsonObject &jo, forest_biome &forest_biome,
             if( member.is_comment() ) {
                 continue;
             }
-            JsonObject component_jo = member.get_object();
+            JsonObject const component_jo = member.get_object();
             load_forest_biome_component( component_jo, forest_biome.unfinalized_biome_components[member.name()],
                                          overlay );
         }
@@ -144,7 +144,7 @@ static void load_forest_biome( const JsonObject &jo, forest_biome &forest_biome,
             if( member.is_comment() ) {
                 continue;
             }
-            JsonObject terrain_furniture_jo = member.get_object();
+            JsonObject const terrain_furniture_jo = member.get_object();
             load_forest_biome_terrain_dependent_furniture( terrain_furniture_jo,
                     forest_biome.unfinalized_terrain_dependent_furniture[member.name()], overlay );
         }
@@ -165,7 +165,7 @@ static void load_forest_mapgen_settings( const JsonObject &jo,
             if( member.is_comment() ) {
                 continue;
             }
-            JsonObject forest_biome_jo = member.get_object();
+            JsonObject const forest_biome_jo = member.get_object();
             load_forest_biome( forest_biome_jo, forest_mapgen_settings.unfinalized_biomes[member.name()],
                                overlay );
         }
@@ -181,7 +181,7 @@ static void load_forest_trail_settings( const JsonObject &jo,
             jo.throw_error( "\"forest_trail_settings\": { … } required for default" );
         }
     } else {
-        JsonObject forest_trail_settings_jo = jo.get_object( "forest_trail_settings" );
+        JsonObject const forest_trail_settings_jo = jo.get_object( "forest_trail_settings" );
         read_and_set_or_throw<int>( forest_trail_settings_jo, "chance", forest_trail_settings.chance,
                                     !overlay );
         read_and_set_or_throw<int>( forest_trail_settings_jo, "border_point_chance",
@@ -248,7 +248,7 @@ static void load_overmap_feature_flag_settings( const JsonObject &jo,
             jo.throw_error( "\"overmap_feature_flag_settings\": { … } required for default" );
         }
     } else {
-        JsonObject overmap_feature_flag_settings_jo = jo.get_object( "overmap_feature_flag_settings" );
+        JsonObject const overmap_feature_flag_settings_jo = jo.get_object( "overmap_feature_flag_settings" );
         read_and_set_or_throw<bool>( overmap_feature_flag_settings_jo, "clear_blacklist",
                                      overmap_feature_flag_settings.clear_blacklist, !overlay );
         read_and_set_or_throw<bool>( overmap_feature_flag_settings_jo, "clear_whitelist",
@@ -293,7 +293,7 @@ static void load_overmap_forest_settings(
             jo.throw_error( "\"overmap_forest_settings\": { … } required for default" );
         }
     } else {
-        JsonObject overmap_forest_settings_jo = jo.get_object( "overmap_forest_settings" );
+        JsonObject const overmap_forest_settings_jo = jo.get_object( "overmap_forest_settings" );
         read_and_set_or_throw<double>( overmap_forest_settings_jo, "noise_threshold_forest",
                                        overmap_forest_settings.noise_threshold_forest, !overlay );
         read_and_set_or_throw<double>( overmap_forest_settings_jo, "noise_threshold_forest_thick",
@@ -318,7 +318,7 @@ static void load_overmap_lake_settings( const JsonObject &jo,
             jo.throw_error( "\"overmap_lake_settings\": { … } required for default" );
         }
     } else {
-        JsonObject overmap_lake_settings_jo = jo.get_object( "overmap_lake_settings" );
+        JsonObject const overmap_lake_settings_jo = jo.get_object( "overmap_lake_settings" );
         read_and_set_or_throw<double>( overmap_lake_settings_jo, "noise_threshold_lake",
                                        overmap_lake_settings.noise_threshold_lake, !overlay );
         read_and_set_or_throw<int>( overmap_lake_settings_jo, "lake_size_min",
@@ -343,7 +343,7 @@ static void load_overmap_lake_settings( const JsonObject &jo,
                 overmap_lake_settings_jo.throw_error( "shore_extendable_overmap_terrain_aliases required" );
             }
         } else {
-            for( JsonObject alias_entry :
+            for( JsonObject const alias_entry :
                  overmap_lake_settings_jo.get_array( "shore_extendable_overmap_terrain_aliases" ) ) {
                 shore_extendable_overmap_terrain_alias alias;
                 alias_entry.read( "om_terrain", alias.overmap_terrain );
@@ -365,7 +365,7 @@ static void load_region_terrain_and_furniture_settings( const JsonObject &jo,
             jo.throw_error( "\"region_terrain_and_furniture\": { … } required for default" );
         }
     } else {
-        JsonObject region_terrain_and_furniture_settings_jo =
+        JsonObject const region_terrain_and_furniture_settings_jo =
             jo.get_object( "region_terrain_and_furniture" );
 
         if( !region_terrain_and_furniture_settings_jo.has_object( "terrain" ) ) {
@@ -415,7 +415,7 @@ void load_region_settings( const JsonObject &jo )
     if( !jo.read( "id", new_region.id ) ) {
         jo.throw_error( "No 'id' field." );
     }
-    bool strict = new_region.id == "default";
+    bool const strict = new_region.id == "default";
     if( !jo.read( "default_oter", new_region.default_oter ) && strict ) {
         jo.throw_error( "default_oter required for default ( though it should probably remain 'field' )" );
     }
@@ -424,7 +424,7 @@ void load_region_settings( const JsonObject &jo )
     }
     if( jo.has_array( "default_groundcover" ) ) {
         new_region.default_groundcover_str.reset( new weighted_int_list<ter_str_id> );
-        for( JsonArray inner : jo.get_array( "default_groundcover" ) ) {
+        for( JsonArray const inner : jo.get_array( "default_groundcover" ) ) {
             if( new_region.default_groundcover_str->add( ter_str_id( inner.get_string( 0 ) ),
                     inner.get_int( 1 ) ) == nullptr ) {
                 jo.throw_error( "'default_groundcover' must be a weighted list: an array of pairs [ \"id\", weight ]" );
@@ -439,7 +439,7 @@ void load_region_settings( const JsonObject &jo )
             jo.throw_error( "\"field_coverage\": { … } required for default" );
         }
     } else {
-        JsonObject pjo = jo.get_object( "field_coverage" );
+        JsonObject const pjo = jo.get_object( "field_coverage" );
         double tmpval = 0.0f;
         if( !pjo.read( "percent_coverage", tmpval ) ) {
             pjo.throw_error( "field_coverage: percent_coverage required" );
@@ -493,7 +493,7 @@ void load_region_settings( const JsonObject &jo )
             if( zone.is_comment() ) {
                 continue;
             }
-            JsonObject zjo = zone.get_object();
+            JsonObject const zjo = zone.get_object();
             map_extras extras( 0 );
 
             if( !zjo.read( "chance", extras.chance ) && strict ) {
@@ -558,7 +558,7 @@ void load_region_settings( const JsonObject &jo )
             jo.throw_error( "\"weather\": { … } required for default" );
         }
     } else {
-        JsonObject wjo = jo.get_object( "weather" );
+        JsonObject const wjo = jo.get_object( "weather" );
         new_region.weather = weather_generator::load( wjo );
     }
 
@@ -586,7 +586,7 @@ void reset_region_settings()
 void load_region_overlay( const JsonObject &jo )
 {
     if( jo.has_array( "regions" ) ) {
-        JsonArray regions = jo.get_array( "regions" );
+        JsonArray const regions = jo.get_array( "regions" );
         for( const std::string regionid : regions ) {
             if( regionid == "all" ) {
                 if( regions.size() != 1 ) {
@@ -616,7 +616,7 @@ void apply_region_overlay( const JsonObject &jo, regional_settings &region )
     jo.read( "river_scale", region.river_scale );
     if( jo.has_array( "default_groundcover" ) ) {
         region.default_groundcover_str.reset( new weighted_int_list<ter_str_id> );
-        for( JsonArray inner : jo.get_array( "default_groundcover" ) ) {
+        for( JsonArray const inner : jo.get_array( "default_groundcover" ) ) {
             if( region.default_groundcover_str->add( ter_str_id( inner.get_string( 0 ) ),
                     inner.get_int( 1 ) ) == nullptr ) {
                 jo.throw_error( "'default_groundcover' must be a weighted list: an array of pairs [ \"id\", weight ]" );
@@ -624,7 +624,7 @@ void apply_region_overlay( const JsonObject &jo, regional_settings &region )
         }
     }
 
-    JsonObject fieldjo = jo.get_object( "field_coverage" );
+    JsonObject const fieldjo = jo.get_object( "field_coverage" );
     double tmpval = 0.0f;
     if( fieldjo.read( "percent_coverage", tmpval ) ) {
         region.field_coverage.mpercent_coverage = static_cast<int>( tmpval * 10000.0 );
@@ -678,7 +678,7 @@ void apply_region_overlay( const JsonObject &jo, regional_settings &region )
         if( zone.is_comment() ) {
             continue;
         }
-        JsonObject zonejo = zone.get_object();
+        JsonObject const zonejo = zone.get_object();
 
         int tmpval = 0;
         if( zonejo.read( "chance", tmpval ) ) {
@@ -923,7 +923,7 @@ void overmap_lake_settings::finalize()
         shore_extendable_overmap_terrain.emplace_back( ot.id() );
     }
 
-    for( shore_extendable_overmap_terrain_alias &alias : shore_extendable_overmap_terrain_aliases ) {
+    for( shore_extendable_overmap_terrain_alias  const&alias : shore_extendable_overmap_terrain_aliases ) {
         if( std::find( shore_extendable_overmap_terrain.begin(), shore_extendable_overmap_terrain.end(),
                        alias.alias ) == shore_extendable_overmap_terrain.end() ) {
             debugmsg( " %s was referenced as an alias in overmap_lake_settings shore_extendable_overmap_terrain_alises, but the value is not present in the shore_extendable_overmap_terrain.",
@@ -1078,7 +1078,7 @@ void building_bin::finalize()
         overmap_special_id current_id = pr.first;
         if( !current_id.is_valid() ) {
             // First, try to convert oter to special
-            oter_type_str_id converted_id( pr.first.str() );
+            oter_type_str_id const converted_id( pr.first.str() );
             if( !converted_id.is_valid() ) {
                 debugmsg( "Tried to add city building %s, but it is neither a special nor a terrain type",
                           pr.first.c_str() );

--- a/src/regional_settings.cpp
+++ b/src/regional_settings.cpp
@@ -248,7 +248,8 @@ static void load_overmap_feature_flag_settings( const JsonObject &jo,
             jo.throw_error( "\"overmap_feature_flag_settings\": { … } required for default" );
         }
     } else {
-        JsonObject const overmap_feature_flag_settings_jo = jo.get_object( "overmap_feature_flag_settings" );
+        JsonObject const overmap_feature_flag_settings_jo =
+            jo.get_object( "overmap_feature_flag_settings" );
         read_and_set_or_throw<bool>( overmap_feature_flag_settings_jo, "clear_blacklist",
                                      overmap_feature_flag_settings.clear_blacklist, !overlay );
         read_and_set_or_throw<bool>( overmap_feature_flag_settings_jo, "clear_whitelist",
@@ -923,7 +924,8 @@ void overmap_lake_settings::finalize()
         shore_extendable_overmap_terrain.emplace_back( ot.id() );
     }
 
-    for( shore_extendable_overmap_terrain_alias  const&alias : shore_extendable_overmap_terrain_aliases ) {
+    for( shore_extendable_overmap_terrain_alias  const &alias :
+         shore_extendable_overmap_terrain_aliases ) {
         if( std::find( shore_extendable_overmap_terrain.begin(), shore_extendable_overmap_terrain.end(),
                        alias.alias ) == shore_extendable_overmap_terrain.end() ) {
             debugmsg( " %s was referenced as an alias in overmap_lake_settings shore_extendable_overmap_terrain_alises, but the value is not present in the shore_extendable_overmap_terrain.",

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -116,7 +116,7 @@ void relic_recharge::serialize( JsonOut &json ) const
 
 void relic_recharge::deserialize( JsonIn &jsin )
 {
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
     load( data );
 }
 
@@ -163,14 +163,14 @@ void relic::add_recharge_scheme( const relic_recharge &r )
 void relic::load( const JsonObject &jo )
 {
     if( jo.has_array( "active_effects" ) ) {
-        for( JsonObject jobj : jo.get_array( "active_effects" ) ) {
+        for( JsonObject const jobj : jo.get_array( "active_effects" ) ) {
             fake_spell sp;
             sp.load( jobj );
             add_active_effect( sp );
         }
     }
     if( jo.has_array( "passive_effects" ) ) {
-        for( JsonObject jobj : jo.get_array( "passive_effects" ) ) {
+        for( JsonObject const jobj : jo.get_array( "passive_effects" ) ) {
             enchantment ench;
             ench.load( jobj );
             if( !ench.id.is_empty() ) {
@@ -180,7 +180,7 @@ void relic::load( const JsonObject &jo )
         }
     }
     if( jo.has_array( "recharge_scheme" ) ) {
-        for( JsonObject jobj : jo.get_array( "recharge_scheme" ) ) {
+        for( JsonObject const jobj : jo.get_array( "recharge_scheme" ) ) {
             relic_recharge recharge;
             recharge.load( jobj );
             add_recharge_scheme( recharge );
@@ -193,7 +193,7 @@ void relic::load( const JsonObject &jo )
 
 void relic::deserialize( JsonIn &jsin )
 {
-    JsonObject jobj = jsin.get_object();
+    JsonObject const jobj = jsin.get_object();
     load( jobj );
 }
 
@@ -339,7 +339,7 @@ bool check_recharge_reqs( const item &itm, const relic_recharge &rech, const Cha
             return get_map().get_radiation( carrier.pos() ) > 0 || carrier.get_rad() > 0;
         }
         case relic_recharge_req::wet: {
-            bool has_wet = std::any_of( carrier.body_wetness.begin(), carrier.body_wetness.end(),
+            bool const has_wet = std::any_of( carrier.body_wetness.begin(), carrier.body_wetness.end(),
             []( const int w ) {
                 return w != 0;
             } );
@@ -405,7 +405,7 @@ bool process_recharge_entry( item &itm, const relic_recharge &rech, Character &c
                 if( !field_at ) {
                     continue;
                 }
-                int int_here = field_at->get_field_intensity();
+                int const int_here = field_at->get_field_intensity();
                 if( int_here >= rech.intensity_min && int_here <= rech.intensity_max ) {
                     here.remove_field( dest, rech.field_type );
                     consumed = true;
@@ -435,7 +435,7 @@ bool process_recharge_entry( item &itm, const relic_recharge &rech, Character &c
         }
     }
     // If relic has a valid ammo type, make sure the first charge loaded isn't a "none"
-    bool was_zero = itm.charges == 0;
+    bool const was_zero = itm.charges == 0;
     itm.charges = clamp( itm.charges + rech.rate, 0, itm.ammo_capacity() );
     if( was_zero && !itm.ammo_types().empty() ) {
         itm.ammo_set( itm.ammo_default(), itm.charges );

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -1452,7 +1452,7 @@ deduped_requirement_data::deduped_requirement_data( const requirement_data &in,
             // Factor this requirement out into its own separate case
 
             alter_item_comp_vector const req_prefix( next.components.begin(),
-                                               next.components.begin() + next.index );
+                    next.components.begin() + next.index );
             std::vector<alter_item_comp_vector> result;
             expand_item_in_reqs( *comp_it, req_prefix, next.components, next.index, next.index + 1,
                                  result );

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -88,7 +88,7 @@ void quality::load( const JsonObject &jo, const std::string & )
 {
     mandatory( jo, was_loaded, "name", name );
 
-    for( JsonArray levels : jo.get_array( "usages" ) ) {
+    for( JsonArray const levels : jo.get_array( "usages" ) ) {
         const int level = levels.get_int( 0 );
         for( const std::string line : levels.get_array( 1 ) ) {
             usages.emplace_back( level, line );
@@ -213,7 +213,7 @@ void tool_comp::load( const JsonValue &value )
         value.read( type, true );
         count = -1;
     } else {
-        JsonArray comp = value.get_array();
+        JsonArray const comp = value.get_array();
         comp.read( 0, type, true );
         count = comp.get_int( 1 );
         requirement = comp.size() > 2 && comp.get_string( 2 ) == "LIST";
@@ -237,7 +237,7 @@ void tool_comp::dump( JsonOut &jsout ) const
 
 void item_comp::load( const JsonValue &value )
 {
-    JsonArray comp = value.get_array();
+    JsonArray const comp = value.get_array();
     comp.read( 0, type, true );
     count = comp.get_int( 1 );
     size_t handled = 2;
@@ -571,7 +571,7 @@ void requirement_data::finalize()
                 const std::list<itype_id> replacements = item_controller->subtype_replacement( comp.type );
                 for( const itype_id &replacing_type : replacements ) {
                     // Don't replace if replacement is already in list (e.g. it was explicitly specified)
-                    bool exists = std::any_of( new_list.begin(), new_list.end(), [&]( const tool_comp & elem ) {
+                    bool const exists = std::any_of( new_list.begin(), new_list.end(), [&]( const tool_comp & elem ) {
                         return elem.type == replacing_type;
                     } );
                     if( exists ) {
@@ -793,7 +793,7 @@ bool tool_comp::has(
             charges_required = crafting::charges_for_continuing( charges_required );
         }
 
-        int charges_found = crafting_inv.charges_of( type, charges_required, filter, visitor );
+        int const charges_found = crafting_inv.charges_of( type, charges_required, filter, visitor );
         return charges_found == charges_required;
     }
 }
@@ -1159,7 +1159,7 @@ requirement_data requirement_data::continue_requirements( const std::vector<item
                 return false;
             } );
         } else {
-            int amount = craft_components.amount_of( comp.type, comp.count );
+            int const amount = craft_components.amount_of( comp.type, comp.count );
             comp.count -= amount;
             craft_components.use_amount( comp.type, amount );
         }
@@ -1451,7 +1451,7 @@ deduped_requirement_data::deduped_requirement_data( const requirement_data &in,
         for( auto comp_it = first_duplicated; comp_it != this_requirement.end(); ++comp_it ) {
             // Factor this requirement out into its own separate case
 
-            alter_item_comp_vector req_prefix( next.components.begin(),
+            alter_item_comp_vector const req_prefix( next.components.begin(),
                                                next.components.begin() + next.index );
             std::vector<alter_item_comp_vector> result;
             expand_item_in_reqs( *comp_it, req_prefix, next.components, next.index, next.index + 1,
@@ -1459,7 +1459,7 @@ deduped_requirement_data::deduped_requirement_data( const requirement_data &in,
             for( const alter_item_comp_vector &v : result ) {
                 // When v is smaller, that means the current requirement was
                 // deleted, in which case we don't advance index.
-                size_t index_inc = v.size() == next.components.size() ? 1 : 0;
+                size_t const index_inc = v.size() == next.components.size() ? 1 : 0;
                 pending.push( { v, next.index + index_inc } );
             }
         }

--- a/src/rng.cpp
+++ b/src/rng.cpp
@@ -96,7 +96,7 @@ int dice( int number, int sides )
 int roll_remainder( double value )
 {
     double integ;
-    double frac = modf( value, &integ );
+    double const frac = modf( value, &integ );
     if( value > 0.0 && value > integ && x_in_y( frac, 1.0 ) ) {
         integ++;
     } else if( value < 0.0 && value < integ && x_in_y( -frac, 1.0 ) ) {
@@ -129,7 +129,7 @@ double rng_normal( double lo, double hi )
     if( stddev == 0.0 ) {
         return hi;
     }
-    double val = normal_roll( ( hi + lo ) / 2, stddev );
+    double const val = normal_roll( ( hi + lo ) / 2, stddev );
     return clamp( val, lo, hi );
 }
 

--- a/src/rot.cpp
+++ b/src/rot.cpp
@@ -17,7 +17,7 @@ temperature_flag temperature_flag_for_location( const map &m, const item_locatio
         case item_location::type::character:
             return temperature_flag::TEMP_NORMAL;
         case item_location::type::map: {
-            tripoint pos = loc.position();
+            tripoint const pos = loc.position();
             if( m.has_flag_furn( TFLAG_FREEZER, pos ) ) {
                 return temperature_flag::TEMP_FREEZER;
             }
@@ -31,13 +31,13 @@ temperature_flag temperature_flag_for_location( const map &m, const item_locatio
             return temperature_flag::TEMP_NORMAL;
         }
         case item_location::type::vehicle: {
-            tripoint pos = loc.position();
+            tripoint const pos = loc.position();
             optional_vpart_position veh = m.veh_at( pos );
             if( !veh ) {
                 debugmsg( "Expected vehicle at %d, %d, %d, but couldn't find any", pos.x, pos.y, pos.z );
                 return temperature_flag::TEMP_NORMAL;
             }
-            int cargo_index = veh->vehicle().part_with_feature( veh->part_index(), VPFLAG_CARGO, true );
+            int const cargo_index = veh->vehicle().part_with_feature( veh->part_index(), VPFLAG_CARGO, true );
             if( cargo_index < 0 ) {
                 debugmsg( "Expected cargo part at %d, %d, %d, but couldn't find any", pos.x, pos.y, pos.z );
                 return temperature_flag::TEMP_NORMAL;

--- a/src/rotatable_symbols.cpp
+++ b/src/rotatable_symbols.cpp
@@ -48,7 +48,7 @@ void load( const JsonObject &jo, const std::string &src )
     }
     std::vector<uint32_t> tuple;
     tuple.reserve( tuple_temp.size() );
-    for( std::string  const&elem : tuple_temp ) {
+    for( std::string  const &elem : tuple_temp ) {
         tuple.emplace_back( UTF8_getch( elem ) );
     }
 

--- a/src/rotatable_symbols.cpp
+++ b/src/rotatable_symbols.cpp
@@ -48,7 +48,7 @@ void load( const JsonObject &jo, const std::string &src )
     }
     std::vector<uint32_t> tuple;
     tuple.reserve( tuple_temp.size() );
-    for( std::string &elem : tuple_temp ) {
+    for( std::string  const&elem : tuple_temp ) {
         tuple.emplace_back( UTF8_getch( elem ) );
     }
 

--- a/src/safemode_ui.cpp
+++ b/src/safemode_ui.cpp
@@ -43,7 +43,7 @@ void safemode::show()
 
 std::string safemode::npc_type_name()
 {
-    static std::string name = "human";
+    static std::string const name = "human";
     return name;
 }
 
@@ -496,7 +496,7 @@ void safemode::test_pattern( const int tab_in, const int row_in )
 
     //Loop through all monster mtypes
     for( const auto &mtype : MonsterGenerator::generator().get_all_mtypes() ) {
-        std::string creature_name = mtype.nname();
+        std::string const creature_name = mtype.nname();
         if( wildcard_match( creature_name, temp_rules[row_in].rule ) ) {
             creature_list.push_back( creature_name );
         }
@@ -528,7 +528,7 @@ void safemode::test_pattern( const int tab_in, const int row_in )
     init_windows( ui );
     ui.on_screen_resize( init_windows );
 
-    int nmatch = creature_list.size();
+    int const nmatch = creature_list.size();
     const std::string buf = string_format( vgettext( "%1$d monster matches: %2$s",
                                            "%1$d monsters match: %2$s",
                                            nmatch ), nmatch, temp_rules[row_in].rule.c_str() );
@@ -560,7 +560,7 @@ void safemode::test_pattern( const int tab_in, const int row_in )
         for( int i = start_pos; i < static_cast<int>( creature_list.size() ); i++ ) {
             if( i >= start_pos &&
                 i < start_pos + std::min( content_height, static_cast<int>( creature_list.size() ) ) ) {
-                nc_color line_color = c_white;
+                nc_color const line_color = c_white;
 
                 mvwprintz( w_test_rule_content, point( 0, i - start_pos ), line_color, "%d", i + 1 );
                 mvwprintz( w_test_rule_content, point( 4, i - start_pos ), line_color, "" );
@@ -680,7 +680,7 @@ void safemode::add_rules( const std::vector<rules_class> &rules_in )
 
 void safemode::set_rule( const rules_class &rule_in, const std::string &name_in, rule_state rs_in )
 {
-    static std::vector<Creature::Attitude> attitude_any = { {Creature::A_HOSTILE, Creature::A_NEUTRAL, Creature::A_FRIENDLY} };
+    static std::vector<Creature::Attitude> const attitude_any = { {Creature::A_HOSTILE, Creature::A_NEUTRAL, Creature::A_FRIENDLY} };
     switch( rule_in.category ) {
         case HOSTILE_SPOTTED:
             if( !rule_in.rule.empty() && rule_in.active && wildcard_match( name_in, rule_in.rule ) ) {
@@ -840,7 +840,7 @@ void safemode::deserialize( JsonIn &jsin )
 
     jsin.start_array();
     while( !jsin.end_array() ) {
-        JsonObject jo = jsin.get_object();
+        JsonObject const jo = jsin.get_object();
 
         const std::string rule = jo.get_string( "rule" );
         const bool active = jo.get_bool( "active" );

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -174,7 +174,7 @@ void game::unserialize( std::istream &fin )
     point com;
     JsonIn jsin( fin );
     try {
-        JsonObject data = jsin.get_object();
+        JsonObject const data = jsin.get_object();
 
         data.read( "turn", tmpturn );
         data.read( "calendar_start", tmpcalstart );
@@ -367,8 +367,8 @@ void overmap::convert_terrain(
             std::string new_id;
         };
 
-        std::vector<convert_nearby> nearby;
-        std::vector<std::pair<tripoint, std::string>> convert_unrelated_adjacent_tiles;
+        std::vector<convert_nearby> const nearby;
+        std::vector<std::pair<tripoint, std::string>> const convert_unrelated_adjacent_tiles;
 
         if( old == "fema" || old == "fema_entrance" || old == "fema_1_3" ||
             old == "fema_2_1" || old == "fema_2_2" || old == "fema_2_3" ||
@@ -476,7 +476,7 @@ void overmap::unserialize( std::istream &fin, const std::string &file_path )
             std::string new_region_id;
             jsin.read( new_region_id );
             if( settings->id != new_region_id ) {
-                t_regional_settings_map_citr rit = region_settings_map.find( new_region_id );
+                t_regional_settings_map_citr const rit = region_settings_map.find( new_region_id );
                 if( rit != region_settings_map.end() ) {
                     // TODO: optimize
                     settings = &rit->second;
@@ -492,7 +492,7 @@ void overmap::unserialize( std::istream &fin, const std::string &file_path )
                 jsin.start_object();
                 city new_city;
                 while( !jsin.end_object() ) {
-                    std::string city_member_name = jsin.get_member_name();
+                    std::string const city_member_name = jsin.get_member_name();
                     if( city_member_name == "name" ) {
                         jsin.read( new_city.name );
                     } else if( city_member_name == "x" ) {
@@ -511,7 +511,7 @@ void overmap::unserialize( std::istream &fin, const std::string &file_path )
                 jsin.start_object();
                 lab new_lab;
                 while( !jsin.end_object() ) {
-                    std::string lab_member_name = jsin.get_member_name();
+                    std::string const lab_member_name = jsin.get_member_name();
                     if( lab_member_name == "type" ) {
                         std::string string_type;
                         jsin.read( string_type );
@@ -592,7 +592,7 @@ void overmap::unserialize( std::istream &fin, const std::string &file_path )
                 om_vehicle new_tracker;
                 int id;
                 while( !jsin.end_object() ) {
-                    std::string tracker_member_name = jsin.get_member_name();
+                    std::string const tracker_member_name = jsin.get_member_name();
                     if( tracker_member_name == "id" ) {
                         jsin.read( id );
                     } else if( tracker_member_name == "x" ) {
@@ -613,7 +613,7 @@ void overmap::unserialize( std::istream &fin, const std::string &file_path )
                 time_point time = calendar::before_time_starts;
                 int strength = 0;
                 while( !jsin.end_object() ) {
-                    std::string scent_member_name = jsin.get_member_name();
+                    std::string const scent_member_name = jsin.get_member_name();
                     if( scent_member_name == "pos" ) {
                         jsin.read( pos );
                     } else if( scent_member_name == "time" ) {
@@ -627,7 +627,7 @@ void overmap::unserialize( std::istream &fin, const std::string &file_path )
         } else if( name == "npcs" ) {
             jsin.start_array();
             while( !jsin.end_array() ) {
-                shared_ptr_fast<npc> new_npc = make_shared_fast<npc>();
+                shared_ptr_fast<npc> const new_npc = make_shared_fast<npc>();
                 new_npc->deserialize( jsin );
                 if( !new_npc->get_fac_id().str().empty() ) {
                     new_npc->set_fac( new_npc->get_fac_id() );
@@ -647,7 +647,7 @@ void overmap::unserialize( std::istream &fin, const std::string &file_path )
                 jsin.start_object();
                 overmap_special_id s;
                 while( !jsin.end_object() ) {
-                    std::string name = jsin.get_member_name();
+                    std::string const name = jsin.get_member_name();
                     if( name == "special" ) {
                         jsin.read( s );
                     } else if( name == "placements" ) {
@@ -655,14 +655,14 @@ void overmap::unserialize( std::istream &fin, const std::string &file_path )
                         while( !jsin.end_array() ) {
                             jsin.start_object();
                             while( !jsin.end_object() ) {
-                                std::string name = jsin.get_member_name();
+                                std::string const name = jsin.get_member_name();
                                 if( name == "points" ) {
                                     jsin.start_array();
                                     while( !jsin.end_array() ) {
                                         jsin.start_object();
                                         tripoint_om_omt p;
                                         while( !jsin.end_object() ) {
-                                            std::string name = jsin.get_member_name();
+                                            std::string const name = jsin.get_member_name();
                                             if( name == "p" ) {
                                                 jsin.read( p );
                                                 overmap_special_placements[p] = s;
@@ -929,7 +929,7 @@ void overmap::serialize( std::ostream &fout ) const
         for( int j = 0; j < OMAPY; j++ ) {
             // NOLINTNEXTLINE(modernize-loop-convert)
             for( int i = 0; i < OMAPX; i++ ) {
-                oter_id t = layer_terrain[i][j];
+                oter_id const t = layer_terrain[i][j];
                 if( t != last_tertype ) {
                     if( count ) {
                         json.write( count );
@@ -1126,7 +1126,7 @@ void mongroup::io( Archive &archive )
 
 void mongroup::deserialize( JsonIn &data )
 {
-    JsonObject jo = data.get_object();
+    JsonObject const jo = data.get_object();
     jo.allow_omitted_members();
     io::JsonObjectInputArchive archive( jo );
     io( archive );
@@ -1142,7 +1142,7 @@ void mongroup::deserialize_legacy( JsonIn &json )
 {
     json.start_object();
     while( !json.end_object() ) {
-        std::string name = json.get_member_name();
+        std::string const name = json.get_member_name();
         if( name == "type" ) {
             type = mongroup_id( json.get_string() );
         } else if( name == "pos" ) {
@@ -1207,7 +1207,7 @@ void game::unserialize_master( std::istream &fin )
         JsonIn jsin( fin );
         jsin.start_object();
         while( !jsin.end_object() ) {
-            std::string name = jsin.get_member_name();
+            std::string const name = jsin.get_member_name();
             if( name == "next_mission_id" ) {
                 next_mission_id = jsin.get_int();
             } else if( name == "next_npc_id" ) {
@@ -1219,7 +1219,7 @@ void game::unserialize_master( std::istream &fin )
             } else if( name == "seed" ) {
                 jsin.read( seed );
             } else if( name == "weather" ) {
-                JsonObject w = jsin.get_object();
+                JsonObject const w = jsin.get_object();
                 w.read( "lightning", get_weather().lightning_active );
             } else {
                 // silently ignore anything else
@@ -1319,7 +1319,7 @@ void Creature_tracker::deserialize( JsonIn &jsin )
     jsin.start_array();
     while( !jsin.end_array() ) {
         // TODO: would be nice if monster had a constructor using JsonIn or similar, so this could be one statement.
-        shared_ptr_fast<monster> mptr = make_shared_fast<monster>();
+        shared_ptr_fast<monster> const mptr = make_shared_fast<monster>();
         jsin.read( *mptr );
         add( mptr );
     }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -149,7 +149,7 @@ static void serialize( const weak_ptr_fast<monster> &obj, JsonOut &jsout )
 
 static void deserialize( weak_ptr_fast<monster> &obj, JsonIn &jsin )
 {
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
     data.allow_omitted_members();
     tripoint temp_pos;
 
@@ -185,7 +185,7 @@ void item_contents::serialize( JsonOut &json ) const
 
 void item_contents::deserialize( JsonIn &jsin )
 {
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
     data.allow_omitted_members();
     data.read( "items", items );
 }
@@ -218,7 +218,7 @@ void player_activity::serialize( JsonOut &json ) const
 
 void player_activity::deserialize( JsonIn &jsin )
 {
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
     data.allow_omitted_members();
     data.read( "type", type );
 
@@ -275,7 +275,7 @@ void requirement_data::serialize( JsonOut &json ) const
 
 void requirement_data::deserialize( JsonIn &jsin )
 {
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
     data.allow_omitted_members();
 
     data.read( "blacklisted", blacklisted );
@@ -301,7 +301,7 @@ void SkillLevel::serialize( JsonOut &json ) const
 
 void SkillLevel::deserialize( JsonIn &jsin )
 {
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
     data.allow_omitted_members();
     data.read( "level", _level );
     data.read( "exercise", _exercise );
@@ -343,7 +343,7 @@ void char_trait_data::serialize( JsonOut &json ) const
 
 void char_trait_data::deserialize( JsonIn &jsin )
 {
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
     data.allow_omitted_members();
     data.read( "key", key );
     data.read( "charge", charge );
@@ -374,7 +374,7 @@ void consumption_event::serialize( JsonOut &json ) const
 
 void consumption_event::deserialize( JsonIn &jsin )
 {
-    JsonObject jo = jsin.get_object();
+    JsonObject const jo = jsin.get_object();
     jo.allow_omitted_members();
     jo.read( "time", time );
     jo.read( "type_id", type_id );
@@ -457,11 +457,11 @@ void Character::load( const JsonObject &data )
         data.read( "martial_arts_data", martial_arts_data );
     }
 
-    JsonObject vits = data.get_object( "vitamin_levels" );
+    JsonObject const vits = data.get_object( "vitamin_levels" );
     vits.allow_omitted_members();
     for( const std::pair<const vitamin_id, vitamin> &v : vitamin::all() ) {
         if( vits.has_member( v.first.str() ) ) {
-            int lvl = vits.get_int( v.first.str() );
+            int const lvl = vits.get_int( v.first.str() );
             vitamin_levels[v.first] = clamp( lvl, v.first->min(), v.first->max() );
         }
     }
@@ -506,7 +506,7 @@ void Character::load( const JsonObject &data )
     data.read( "damage_bandaged", damage_bandaged );
     data.read( "damage_disinfected", damage_disinfected );
     data.read( "magic", magic );
-    JsonArray parray;
+    JsonArray const parray;
 
     data.read( "traits", my_traits );
     for( auto it = my_traits.begin(); it != my_traits.end(); ) {
@@ -639,7 +639,7 @@ void Character::load( const JsonObject &data )
     data.read( "automoveroute", auto_move_route );
 
     known_traps.clear();
-    for( JsonObject pmap : data.get_array( "known_traps" ) ) {
+    for( JsonObject const pmap : data.get_array( "known_traps" ) ) {
         pmap.allow_omitted_members();
         const tripoint p( pmap.get_int( "x" ), pmap.get_int( "y" ), pmap.get_int( "z" ) );
         const std::string t = pmap.get_string( "trap" );
@@ -720,7 +720,7 @@ void Character::store( JsonOut &json ) const
     if( !backlog.empty() && !backlog.front().str_values.empty() && ( ( activity &&
             activity.id() == activity_id( "ACT_FETCH_REQUIRED" ) ) || ( destination_activity &&
                     destination_activity.id() == activity_id( "ACT_FETCH_REQUIRED" ) ) ) ) {
-        requirement_data things_to_fetch = requirement_id( backlog.front().str_values.back() ).obj();
+        requirement_data const things_to_fetch = requirement_id( backlog.front().str_values.back() ).obj();
         json.member( "fetch_data", things_to_fetch );
     }
 
@@ -867,7 +867,7 @@ void player::load( const JsonObject &data )
 {
     Character::load( data );
 
-    JsonArray parray;
+    JsonArray const parray;
     character_id tmpid;
 
     data.read( "tank_plut", tank_plut );
@@ -925,7 +925,7 @@ void player::load( const JsonObject &data )
     data.read( "destination_point", destination_point );
     // TODO: move to Character
     camps.clear();
-    for( JsonObject bcdata : data.get_array( "camps" ) ) {
+    for( JsonObject const bcdata : data.get_array( "camps" ) ) {
         bcdata.allow_omitted_members();
         tripoint_abs_omt bcpt;
         bcdata.read( "pos", bcpt );
@@ -1011,7 +1011,7 @@ void avatar::store( JsonOut &json ) const
 
 void avatar::deserialize( JsonIn &jsin )
 {
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
     data.allow_omitted_members();
     load( data );
 }
@@ -1133,7 +1133,7 @@ void avatar::load( const JsonObject &data )
 
     data.read( "show_map_memory", show_map_memory );
 
-    for( JsonArray pair : data.get_array( "assigned_invlet" ) ) {
+    for( JsonArray const pair : data.get_array( "assigned_invlet" ) ) {
         inv.assigned_invlet[static_cast<char>( pair.get_int( 0 ) )] =
             itype_id( pair.get_string( 1 ) );
     }
@@ -1146,10 +1146,10 @@ void avatar::load( const JsonObject &data )
     data.read( "preferred_aiming_mode", preferred_aiming_mode );
 
     if( data.has_array( "faction_warnings" ) ) {
-        for( JsonObject warning_data : data.get_array( "faction_warnings" ) ) {
+        for( JsonObject const warning_data : data.get_array( "faction_warnings" ) ) {
             warning_data.allow_omitted_members();
             std::string fac_id = warning_data.get_string( "fac_warning_id" );
-            int warning_num = warning_data.get_int( "fac_warning_num" );
+            int const warning_num = warning_data.get_int( "fac_warning_num" );
             time_point warning_time = calendar::before_time_starts;
             warning_data.read( "fac_warning_time", warning_time );
             warning_record[faction_id( fac_id )] = std::make_pair( warning_num, warning_time );
@@ -1186,7 +1186,7 @@ void npc_follower_rules::serialize( JsonOut &json ) const
 
 void npc_follower_rules::deserialize( JsonIn &jsin )
 {
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
     data.allow_omitted_members();
     int tmpeng = 0;
     data.read( "engagement", tmpeng );
@@ -1277,7 +1277,7 @@ void npc_chatbin::serialize( JsonOut &json ) const
 
 void npc_chatbin::deserialize( JsonIn &jsin )
 {
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
     data.allow_omitted_members();
 
     if( data.has_int( "first_topic" ) ) {
@@ -1315,7 +1315,7 @@ void npc_chatbin::deserialize( JsonIn &jsin )
 
 void npc_personality::deserialize( JsonIn &jsin )
 {
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
     data.allow_omitted_members();
     int tmpagg = 0;
     int tmpbrav = 0;
@@ -1346,7 +1346,7 @@ void npc_personality::serialize( JsonOut &json ) const
 
 void npc_opinion::deserialize( JsonIn &jsin )
 {
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
     data.allow_omitted_members();
     data.read( "trust", trust );
     data.read( "fear", fear );
@@ -1368,7 +1368,7 @@ void npc_opinion::serialize( JsonOut &json ) const
 
 void npc_favor::deserialize( JsonIn &jsin )
 {
-    JsonObject jo = jsin.get_object();
+    JsonObject const jo = jsin.get_object();
     jo.allow_omitted_members();
     type = static_cast<npc_favor_type>( jo.get_int( "type" ) );
     jo.read( "value", value );
@@ -1401,7 +1401,7 @@ void job_data::serialize( JsonOut &json ) const
 void job_data::deserialize( JsonIn &jsin )
 {
     if( jsin.test_object() ) {
-        JsonObject jo = jsin.get_object();
+        JsonObject const jo = jsin.get_object();
         jo.allow_omitted_members();
         jo.read( "task_priorities", task_priorities );
     }
@@ -1412,7 +1412,7 @@ void job_data::deserialize( JsonIn &jsin )
  */
 void npc::deserialize( JsonIn &jsin )
 {
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
     load( data );
 }
 
@@ -1749,7 +1749,7 @@ void inventory::json_load_invcache( JsonIn &jsin )
 {
     try {
         std::unordered_map<itype_id, std::string> map;
-        for( JsonObject jo : jsin.get_array() ) {
+        for( JsonObject const jo : jsin.get_array() ) {
             jo.allow_omitted_members();
             for( const JsonMember member : jo ) {
                 std::string invlets;
@@ -1794,7 +1794,7 @@ void inventory::json_load_items( JsonIn &jsin )
 
 void monster::deserialize( JsonIn &jsin )
 {
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
     data.allow_omitted_members();
     load( data );
 }
@@ -1876,7 +1876,7 @@ void monster::load( const JsonObject &data )
     // special_attacks indicates a save after the special_attacks refactor
     if( data.has_object( "special_attacks" ) ) {
         for( const JsonMember member : data.get_object( "special_attacks" ) ) {
-            JsonObject saobject = member.get_object();
+            JsonObject const saobject = member.get_object();
             saobject.allow_omitted_members();
             auto &entry = special_attacks[member.name()];
             entry.cooldown = saobject.get_int( "cooldown" );
@@ -2120,7 +2120,7 @@ const std::set<itype_id> &get()
 }
 void load( const JsonObject &jo )
 {
-    std::set<std::string> d = jo.get_tags( "list" );
+    std::set<std::string> const d = jo.get_tags( "list" );
     for( const std::string &s : d ) {
         removal_list.insert( itype_id( s ) );
     }
@@ -2137,7 +2137,7 @@ static std::set<itype_id> the_list;
 
 void load( const JsonObject &jo )
 {
-    std::set<std::string> d = jo.get_tags( "list" );
+    std::set<std::string> const d = jo.get_tags( "list" );
     for( const std::string &s : d ) {
         the_list.insert( itype_id( s ) );
     }
@@ -2405,7 +2405,7 @@ void item::serialize( JsonOut &json ) const
  */
 void vehicle_part::deserialize( JsonIn &jsin )
 {
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
     data.allow_omitted_members();
     vpart_id pid;
     data.read( "id", pid );
@@ -2490,15 +2490,15 @@ void vehicle_part::deserialize( JsonIn &jsin )
     data.read( "flags", flags );
     data.read( "passenger_id", passenger_id );
     if( data.has_int( "z_offset" ) ) {
-        int z_offset = data.get_int( "z_offset" );
+        int const z_offset = data.get_int( "z_offset" );
         if( std::abs( z_offset ) > 10 ) {
             data.throw_error( "z_offset out of range", "z_offset" );
         }
         precalc[0].z = z_offset;
         precalc[1].z = z_offset;
     }
-    JsonArray ja = data.get_array( "carry" );
-    size_t sz = ja.size();
+    JsonArray const ja = data.get_array( "carry" );
+    size_t const sz = ja.size();
     for( size_t index = 0; index < sz; index++ ) {
         carry_names.push( ja.get_string( sz - index - 1 ) );
     }
@@ -2595,7 +2595,7 @@ void vehicle_part::serialize( JsonOut &json ) const
  */
 void label::deserialize( JsonIn &jsin )
 {
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
     data.allow_omitted_members();
     data.read( "x", x );
     data.read( "y", y );
@@ -2649,7 +2649,7 @@ void vehicle::deserialize( JsonIn &jsin )
         last_update = calendar::turn;
     }
 
-    units::angle fdir_angle = units::from_degrees( fdir );
+    units::angle const fdir_angle = units::from_degrees( fdir );
     face.init( fdir_angle );
     move.init( units::from_degrees( mdir ) );
     data.read( "name", name );
@@ -2755,7 +2755,7 @@ void vehicle::deserialize( JsonIn &jsin )
 
     point p;
     zone_data zd;
-    for( JsonObject sdata : data.get_array( "zones" ) ) {
+    for( JsonObject const sdata : data.get_array( "zones" ) ) {
         sdata.allow_omitted_members();
         sdata.read( "point", p );
         sdata.read( "zone", zd );
@@ -2860,7 +2860,7 @@ void vehicle::serialize( JsonOut &json ) const
 ////
 void mission::deserialize( JsonIn &jsin )
 {
-    JsonObject jo = jsin.get_object();
+    JsonObject const jo = jsin.get_object();
     jo.allow_omitted_members();
 
     if( jo.has_int( "type_id" ) ) {
@@ -2891,7 +2891,7 @@ void mission::deserialize( JsonIn &jsin )
     jo.read( "kill_count_to_reach", kill_count_to_reach );
     jo.read( "reward", reward );
     jo.read( "uid", uid );
-    JsonArray ja = jo.get_array( "target" );
+    JsonArray const ja = jo.get_array( "target" );
     if( ja.size() == 3 ) {
         target.x() = ja.get_int( 0 );
         target.y() = ja.get_int( 1 );
@@ -2979,7 +2979,7 @@ void mission::serialize( JsonOut &json ) const
 ////
 void faction::deserialize( JsonIn &jsin )
 {
-    JsonObject jo = jsin.get_object();
+    JsonObject const jo = jsin.get_object();
     jo.allow_omitted_members();
 
     jo.read( "id", id );
@@ -3101,7 +3101,7 @@ void Creature::load( const JsonObject &jsin )
                     key_num = 0;
                 }
                 const bodypart_str_id &bp = convert_bp( static_cast<body_part>( key_num ) );
-                effect &e = i.second;
+                effect  const&e = i.second;
 
                 ( *effects )[id][bp] = e;
                 on_effect_int_change( id, e.get_intensity(), bp );
@@ -3156,7 +3156,7 @@ void player_morale::morale_subtype::serialize( JsonOut &json ) const
 
 void player_morale::morale_subtype::deserialize( JsonIn &jsin )
 {
-    JsonObject jo = jsin.get_object();
+    JsonObject const jo = jsin.get_object();
     jo.allow_omitted_members();
     jo.read( "subtype_type", subtype_type );
     switch( subtype_type ) {
@@ -3177,7 +3177,7 @@ void player_morale::morale_subtype::deserialize( JsonIn &jsin )
 
 void player_morale::morale_point::deserialize( JsonIn &jsin )
 {
-    JsonObject jo = jsin.get_object();
+    JsonObject const jo = jsin.get_object();
     jo.allow_omitted_members();
     jo.read( "type", type );
     if( !jo.read( "subtype", subtype ) && jo.has_string( "item_type" ) ) {
@@ -3244,7 +3244,7 @@ void mm_submap::serialize( JsonOut &jsout ) const
 
     for( size_t y = 0; y < SEEY; y++ ) {
         for( size_t x = 0; x < SEEX; x++ ) {
-            point p( x, y );
+            point const p( x, y );
             const mm_elem elem = { tile( p ), symbol( p ) };
             if( x == 0 && y == 0 ) {
                 last = elem;
@@ -3288,7 +3288,7 @@ void mm_submap::deserialize( JsonIn &jsin )
                 }
                 jsin.end_array();
             }
-            point p( x, y );
+            point const p( x, y );
             // Try to avoid assigning to save up on memory
             if( elem.tile != mm_submap::default_tile ) {
                 set_tile( p, elem.tile );
@@ -3373,7 +3373,7 @@ void map_memory::load_legacy( JsonIn &jsin )
     jsin.end_array();
 
     for( const std::pair<const tripoint, mig_elem> &elem : elems ) {
-        coord_pair cp( elem.first );
+        coord_pair const cp( elem.first );
         shared_ptr_fast<mm_submap> sm = find_submap( cp.sm );
         if( !sm ) {
             sm = allocate_submap( cp.sm );
@@ -3432,7 +3432,7 @@ void addiction::serialize( JsonOut &json ) const
 
 void addiction::deserialize( JsonIn &jsin )
 {
-    JsonObject jo = jsin.get_object();
+    JsonObject const jo = jsin.get_object();
     jo.allow_omitted_members();
     type = static_cast<add_type>( jo.get_int( "type_enum" ) );
     intensity = jo.get_int( "intensity" );
@@ -3481,7 +3481,7 @@ static void serialize( const tool_comp &value, JsonOut &jsout )
 
 static void deserialize( item_comp &value, JsonIn &jsin )
 {
-    JsonObject jo = jsin.get_object();
+    JsonObject const jo = jsin.get_object();
     jo.allow_omitted_members();
     jo.read( "type", value.type );
     jo.read( "count", value.count );
@@ -3490,7 +3490,7 @@ static void deserialize( item_comp &value, JsonIn &jsin )
 
 static void deserialize( tool_comp &value, JsonIn &jsin )
 {
-    JsonObject jo = jsin.get_object();
+    JsonObject const jo = jsin.get_object();
     jo.allow_omitted_members();
     jo.read( "type", value.type );
     jo.read( "count", value.count );
@@ -3510,7 +3510,7 @@ static void serialize( const quality_requirement &value, JsonOut &jsout )
 
 static void deserialize( quality_requirement &value, JsonIn &jsin )
 {
-    JsonObject jo = jsin.get_object();
+    JsonObject const jo = jsin.get_object();
     jo.allow_omitted_members();
     jo.read( "type", value.type );
     jo.read( "count", value.count );
@@ -3603,12 +3603,12 @@ void basecamp::serialize( JsonOut &json ) const
 
 void basecamp::deserialize( JsonIn &jsin )
 {
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
     data.allow_omitted_members();
     data.read( "name", name );
     data.read( "pos", omt_pos );
     data.read( "bb_pos", bb_pos );
-    for( JsonObject edata : data.get_array( "expansions" ) ) {
+    for( JsonObject const edata : data.get_array( "expansions" ) ) {
         edata.allow_omitted_members();
         expansion_data e;
         point dir;
@@ -3625,10 +3625,10 @@ void basecamp::deserialize( JsonIn &jsin )
         }
         if( edata.has_array( "provides" ) ) {
             e.cur_level = -1;
-            for( JsonObject provide_data : edata.get_array( "provides" ) ) {
+            for( JsonObject const provide_data : edata.get_array( "provides" ) ) {
                 provide_data.allow_omitted_members();
-                std::string id = provide_data.get_string( "id" );
-                int amount = provide_data.get_int( "amount" );
+                std::string const id = provide_data.get_string( "id" );
+                int const amount = provide_data.get_int( "amount" );
                 e.provides[ id ] = amount;
             }
         }
@@ -3637,10 +3637,10 @@ void basecamp::deserialize( JsonIn &jsin )
         if( e.provides.find( initial_provide ) == e.provides.end() ) {
             e.provides[ initial_provide ] = 1;
         }
-        for( JsonObject in_progress_data : edata.get_array( "in_progress" ) ) {
+        for( JsonObject const in_progress_data : edata.get_array( "in_progress" ) ) {
             in_progress_data.allow_omitted_members();
-            std::string id = in_progress_data.get_string( "id" );
-            int amount = in_progress_data.get_int( "amount" );
+            std::string const id = in_progress_data.get_string( "id" );
+            int const amount = in_progress_data.get_int( "amount" );
             e.in_progress[ id ] = amount;
         }
         edata.read( "pos", e.pos );
@@ -3649,7 +3649,7 @@ void basecamp::deserialize( JsonIn &jsin )
             directions.push_back( dir );
         }
     }
-    for( JsonObject edata : data.get_array( "fortifications" ) ) {
+    for( JsonObject const edata : data.get_array( "fortifications" ) ) {
         edata.allow_omitted_members();
         tripoint_abs_omt restore_pos;
         edata.read( "pos", restore_pos );
@@ -3678,7 +3678,7 @@ void kill_tracker::serialize( JsonOut &jsout ) const
 
 void kill_tracker::deserialize( JsonIn &jsin )
 {
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
     data.allow_omitted_members();
     for( const JsonMember member : data.get_object( "kills" ) ) {
         kills[mtype_id( member.name() )] = member.get_int();
@@ -3709,14 +3709,14 @@ void cata_variant::deserialize( JsonIn &jsin )
 void event_multiset::serialize( JsonOut &jsout ) const
 {
     jsout.start_object();
-    std::vector<counts_type::value_type> copy( counts_.begin(), counts_.end() );
+    std::vector<counts_type::value_type> const copy( counts_.begin(), counts_.end() );
     jsout.member( "event_counts", copy );
     jsout.end_object();
 }
 
 void event_multiset::deserialize( JsonIn &jsin )
 {
-    JsonObject jo = jsin.get_object();
+    JsonObject const jo = jsin.get_object();
     jo.allow_omitted_members();
     std::vector<std::pair<cata::event::data_type, int>> copy;
     jo.read( "event_counts", copy );
@@ -3733,7 +3733,7 @@ void stats_tracker::serialize( JsonOut &jsout ) const
 
 void stats_tracker::deserialize( JsonIn &jsin )
 {
-    JsonObject jo = jsin.get_object();
+    JsonObject const jo = jsin.get_object();
     jo.allow_omitted_members();
     jo.read( "data", data );
     for( std::pair<const event_type, event_multiset> &d : data ) {
@@ -3799,7 +3799,7 @@ void submap::store( JsonOut &jsout ) const
         for( int i = 0; i < SEEX; i++ ) {
             const point p( i, j );
             // Save radiation, re-examine this because it doesn't look like it works right
-            int r = get_radiation( p );
+            int const r = get_radiation( p );
             if( r == lastrad ) {
                 count++;
             } else {
@@ -4009,8 +4009,8 @@ void submap::load( JsonIn &jsin, const std::string &member_name, int version )
         int rad_cell = 0;
         jsin.start_array();
         while( !jsin.end_array() ) {
-            int rad_strength = jsin.get_int();
-            int rad_num = jsin.get_int();
+            int const rad_strength = jsin.get_int();
+            int const rad_num = jsin.get_int();
             for( int i = 0; i < rad_num; ++i ) {
                 if( rad_cell < SEEX * SEEY ) {
                     set_radiation( { 0 % SEEX, rad_cell / SEEX }, rad_strength );
@@ -4022,16 +4022,16 @@ void submap::load( JsonIn &jsin, const std::string &member_name, int version )
         jsin.start_array();
         while( !jsin.end_array() ) {
             jsin.start_array();
-            int i = jsin.get_int();
-            int j = jsin.get_int();
+            int const i = jsin.get_int();
+            int const j = jsin.get_int();
             frn[i][j] = furn_id( jsin.get_string() );
             jsin.end_array();
         }
     } else if( member_name == "items" ) {
         jsin.start_array();
         while( !jsin.end_array() ) {
-            int i = jsin.get_int();
-            int j = jsin.get_int();
+            int const i = jsin.get_int();
+            int const j = jsin.get_int();
             const point p( i, j );
             jsin.start_array();
             while( !jsin.end_array() ) {
@@ -4061,8 +4061,8 @@ void submap::load( JsonIn &jsin, const std::string &member_name, int version )
         jsin.start_array();
         while( !jsin.end_array() ) {
             jsin.start_array();
-            int i = jsin.get_int();
-            int j = jsin.get_int();
+            int const i = jsin.get_int();
+            int const j = jsin.get_int();
             const point p( i, j );
             // TODO: jsin should support returning an id like jsin.get_id<trap>()
             trp[p.x][p.y] = trap_str_id( jsin.get_string() ).id();
@@ -4072,8 +4072,8 @@ void submap::load( JsonIn &jsin, const std::string &member_name, int version )
         jsin.start_array();
         while( !jsin.end_array() ) {
             // Coordinates loop
-            int i = jsin.get_int();
-            int j = jsin.get_int();
+            int const i = jsin.get_int();
+            int const j = jsin.get_int();
             jsin.start_array();
             while( !jsin.end_array() ) {
                 // TODO: Check enum->string migration below
@@ -4084,8 +4084,8 @@ void submap::load( JsonIn &jsin, const std::string &member_name, int version )
                 } else {
                     type_str = jsin.get_string();
                 }
-                int intensity = jsin.get_int();
-                int age = jsin.get_int();
+                int const intensity = jsin.get_int();
+                int const age = jsin.get_int();
                 field_type_id ft;
                 if( !type_str.empty() ) {
                     ft = field_type_id( type_str );
@@ -4102,8 +4102,8 @@ void submap::load( JsonIn &jsin, const std::string &member_name, int version )
         jsin.start_array();
         while( !jsin.end_array() ) {
             jsin.start_array();
-            int i = jsin.get_int();
-            int j = jsin.get_int();
+            int const i = jsin.get_int();
+            int const j = jsin.get_int();
             const point p( i, j );
             set_graffiti( p, jsin.get_string() );
             jsin.end_array();
@@ -4114,8 +4114,8 @@ void submap::load( JsonIn &jsin, const std::string &member_name, int version )
 
         while( !jsin.end_array() ) {
             jsin.start_array();
-            int i = jsin.get_int();
-            int j = jsin.get_int();
+            int const i = jsin.get_int();
+            int const j = jsin.get_int();
             const point p( i, j );
             std::string type, str;
             // Try to read as current format
@@ -4140,16 +4140,16 @@ void submap::load( JsonIn &jsin, const std::string &member_name, int version )
             jsin.start_array();
             // TODO: json should know how to read an string_id
             const mtype_id type = mtype_id( jsin.get_string() );
-            int count = jsin.get_int();
-            int i = jsin.get_int();
-            int j = jsin.get_int();
+            int const count = jsin.get_int();
+            int const i = jsin.get_int();
+            int const j = jsin.get_int();
             const point p( i, j );
-            int faction_id = jsin.get_int();
-            int mission_id = jsin.get_int();
-            bool friendly = jsin.get_bool();
-            std::string name = jsin.get_string();
+            int const faction_id = jsin.get_int();
+            int const mission_id = jsin.get_int();
+            bool const friendly = jsin.get_bool();
+            std::string const name = jsin.get_string();
             jsin.end_array();
-            spawn_point tmp( type, count, p, faction_id, mission_id, friendly, name );
+            spawn_point const tmp( type, count, p, faction_id, mission_id, friendly, name );
             spawns.push_back( tmp );
         }
     } else if( member_name == "vehicles" ) {
@@ -4163,10 +4163,10 @@ void submap::load( JsonIn &jsin, const std::string &member_name, int version )
         jsin.start_array();
         while( !jsin.end_array() ) {
             partial_con pc;
-            int i = jsin.get_int();
-            int j = jsin.get_int();
-            int k = jsin.get_int();
-            tripoint pt = tripoint( i, j, k );
+            int const i = jsin.get_int();
+            int const j = jsin.get_int();
+            int const k = jsin.get_int();
+            tripoint const pt = tripoint( i, j, k );
             pc.counter = jsin.get_int();
             if( jsin.test_int() ) {
                 // Oops, int id incorrectly saved by legacy code, just load it and hope for the best

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3040,7 +3040,7 @@ void Creature::store( JsonOut &jsout ) const
 
     // Because JSON requires string keys we need to convert our int keys
     std::unordered_map<std::string, std::unordered_map<std::string, effect>> tmp_map;
-    for( const auto& maps : *effects ) {
+    for( const auto &maps : *effects ) {
         for( const auto &i : maps.second ) {
             if( i.second.is_removed() ) {
                 continue;
@@ -3090,18 +3090,18 @@ void Creature::load( const JsonObject &jsin )
         std::unordered_map<std::string, std::unordered_map<std::string, effect>> tmp_map;
         jsin.read( "effects", tmp_map );
         int key_num = 0;
-        for( const auto& maps : tmp_map ) {
+        for( const auto &maps : tmp_map ) {
             const efftype_id id( maps.first );
             if( !id.is_valid() ) {
                 debugmsg( "Invalid effect: %s", id.c_str() );
                 continue;
             }
-            for( const auto& i : maps.second ) {
+            for( const auto &i : maps.second ) {
                 if( !( std::istringstream( i.first ) >> key_num ) ) {
                     key_num = 0;
                 }
                 const bodypart_str_id &bp = convert_bp( static_cast<body_part>( key_num ) );
-                effect  const&e = i.second;
+                effect  const &e = i.second;
 
                 ( *effects )[id][bp] = e;
                 on_effect_int_change( id, e.get_intensity(), bp );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3040,7 +3040,7 @@ void Creature::store( JsonOut &jsout ) const
 
     // Because JSON requires string keys we need to convert our int keys
     std::unordered_map<std::string, std::unordered_map<std::string, effect>> tmp_map;
-    for( auto maps : *effects ) {
+    for( const auto& maps : *effects ) {
         for( const auto &i : maps.second ) {
             if( i.second.is_removed() ) {
                 continue;
@@ -3090,13 +3090,13 @@ void Creature::load( const JsonObject &jsin )
         std::unordered_map<std::string, std::unordered_map<std::string, effect>> tmp_map;
         jsin.read( "effects", tmp_map );
         int key_num = 0;
-        for( auto maps : tmp_map ) {
+        for( const auto& maps : tmp_map ) {
             const efftype_id id( maps.first );
             if( !id.is_valid() ) {
                 debugmsg( "Invalid effect: %s", id.c_str() );
                 continue;
             }
-            for( auto i : maps.second ) {
+            for( const auto& i : maps.second ) {
                 if( !( std::istringstream( i.first ) >> key_num ) ) {
                     key_num = 0;
                 }

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -309,7 +309,7 @@ std::vector<profession_id> scenario::permitted_professions() const
         const bool present = std::find( professions.begin(), professions.end(),
                                         p.ident() ) != professions.end();
 
-        bool conflicting_traits = scenario_traits_conflict_with_profession_traits( p );
+        bool const conflicting_traits = scenario_traits_conflict_with_profession_traits( p );
 
         if( blacklist || professions.empty() ) {
             if( !present && !p.has_flag( "SCEN_ONLY" ) && !conflicting_traits ) {

--- a/src/scent_block.cpp
+++ b/src/scent_block.cpp
@@ -24,14 +24,14 @@ void scent_block::commit_modifications()
                 case NONE:
                     break;
                 case SET: {
-                    tripoint p = origin + tripoint( x, y, 0 );
+                    tripoint const p = origin + tripoint( x, y, 0 );
                     if( scents.inbounds( p ) ) {
                         scents.set_unsafe( p, assignment[x][y].intensity );
                     }
                     break;
                 }
                 case MAX: {
-                    tripoint p = origin + tripoint( x, y, 0 );
+                    tripoint const p = origin + tripoint( x, y, 0 );
                     if( scents.inbounds( p ) ) {
                         scents.set_unsafe( p, std::max( assignment[x][y].intensity, scents.get_unsafe( p ) ) );
                     }

--- a/src/scent_map.cpp
+++ b/src/scent_map.cpp
@@ -166,7 +166,7 @@ void scent_map::update( const tripoint &center, map &m )
     std::array < std::array < int, 3 + SCENT_RADIUS * 2 >, 1 + SCENT_RADIUS * 2 > sum_3_scent_y;
     std::array < std::array < char, 3 + SCENT_RADIUS * 2 >, 1 + SCENT_RADIUS * 2 > squares_used_y;
 
-    diagonal_blocks( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = m.access_cache(
+    diagonal_blocks const( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = m.access_cache(
                 center.z ).vehicle_obstructed_cache;
 
     // for loop constants
@@ -189,7 +189,7 @@ void scent_map::update( const tripoint &center, map &m )
     for( int x = 0; x < SCENT_RADIUS * 2 + 3; ++x ) {
         for( int y = 0; y < SCENT_RADIUS * 2 + 1; ++y ) {
 
-            point abs( x + scentmap_minx - 1, y + scentmap_miny );
+            point const abs( x + scentmap_minx - 1, y + scentmap_miny );
 
             // remember the sum of the scent val for the 3 neighboring squares that can defuse into
             sum_3_scent_y[y][x] = 0;

--- a/src/scores_ui.cpp
+++ b/src/scores_ui.cpp
@@ -36,7 +36,7 @@ static std::string get_achievements_text( const achievements_tracker &achievemen
     std::transform( valid_achievements.begin(), valid_achievements.end(),
                     std::back_inserter( sortable_achievements ),
     [&]( const achievement * ach ) {
-        achievement_completion comp = achievements.is_completed( ach->id );
+        achievement_completion const comp = achievements.is_completed( ach->id );
         return std::make_tuple( comp, ach->name().translated(), ach );
     } );
     std::sort( sortable_achievements.begin(), sortable_achievements.end(), localized_compare );
@@ -54,7 +54,7 @@ static std::string get_achievements_text( const achievements_tracker &achievemen
 static std::string get_scores_text( stats_tracker &stats )
 {
     std::string os;
-    std::vector<const score *> valid_scores = stats.valid_scores();
+    std::vector<const score *> const valid_scores = stats.valid_scores();
     for( const score *scr : valid_scores ) {
         os += scr->description( stats ) + "\n";
     }

--- a/src/sdl_font.cpp
+++ b/src/sdl_font.cpp
@@ -389,7 +389,8 @@ BitmapFont::BitmapFont(
         SDL_LockSurface( ascii_surf[a].get() );
         int const size = ascii_surf[a]->h * ascii_surf[a]->w;
         Uint32 *pixels = static_cast<Uint32 *>( ascii_surf[a]->pixels );
-        Uint32 const color = ( windowsPalette[a].r << 16 ) | ( windowsPalette[a].g << 8 ) | windowsPalette[a].b;
+        Uint32 const color = ( windowsPalette[a].r << 16 ) | ( windowsPalette[a].g << 8 ) |
+                             windowsPalette[a].b;
         for( int i = 0; i < size; i++ ) {
             if( pixels[i] == 0xFFFFFF ) {
                 pixels[i] = color;

--- a/src/sdl_font.cpp
+++ b/src/sdl_font.cpp
@@ -14,7 +14,7 @@ static int test_face_size( const std::string &f, int size, int faceIndex )
     if( font ) {
         const char *font_style = TTF_FontFaceStyleName( font.get() );
         if( font_style != nullptr ) {
-            int num_faces = TTF_FontFaces( font.get() );
+            int const num_faces = TTF_FontFaces( font.get() );
             for( int face_i = num_faces - 1; face_i >= 0; face_i-- ) {
                 const TTF_Font_Ptr face( TTF_OpenFontIndex( f.c_str(), size, face_i ) );
                 if( !face ) {
@@ -80,7 +80,7 @@ std::unique_ptr<Font> Font::load_font( SDL_Renderer_Ptr &renderer, SDL_PixelForm
 void Font::draw_ascii_lines( const SDL_Renderer_Ptr &renderer, const GeometryRenderer_Ptr &geometry,
                              unsigned char line_id, point p, unsigned char color ) const
 {
-    SDL_Color sdl_color = palette[color];
+    SDL_Color const sdl_color = palette[color];
     switch( line_id ) {
         // box bottom/top side (horizontal line)
         case LINE_OXOX_C:
@@ -182,7 +182,7 @@ CachedTTFFont::CachedTTFFont(
 {
     int faceIndex = 0;
     std::vector<std::string> typefaces;
-    std::vector<std::string> known_suffixes = { ".ttf", ".otf", ".ttc", ".fon" };
+    std::vector<std::string> const known_suffixes = { ".ttf", ".otf", ".ttc", ".fon" };
     bool add_suffix = true;
     for( const std::string &ks : known_suffixes ) {
         if( string_ends_with( typeface, ks ) ) {
@@ -349,7 +349,7 @@ void CachedTTFFont::OutputChar( const SDL_Renderer_Ptr &renderer, const Geometry
         // Nothing we can do here )-:
         return;
     }
-    SDL_Rect rect {p.x, p.y, value.width, height};
+    SDL_Rect const rect {p.x, p.y, value.width, height};
     if( opacity != 1.0f ) {
         SDL_SetTextureAlphaMod( value.texture.get(), opacity * 255.0f );
     }
@@ -373,7 +373,7 @@ BitmapFont::BitmapFont(
     if( asciiload->w * asciiload->h < ( width * height * 256 ) ) {
         throw std::runtime_error( "bitmap for font is to small" );
     }
-    Uint32 key = SDL_MapRGB( asciiload->format, 0xFF, 0, 0xFF );
+    Uint32 const key = SDL_MapRGB( asciiload->format, 0xFF, 0, 0xFF );
     SDL_SetColorKey( asciiload.get(), SDL_TRUE, key );
     SDL_Surface_Ptr ascii_surf[std::tuple_size<decltype( ascii )>::value];
     ascii_surf[0].reset( SDL_ConvertSurface( asciiload.get(), format.get(), 0 ) );
@@ -387,9 +387,9 @@ BitmapFont::BitmapFont(
 
     for( size_t a = 0; a < std::tuple_size<decltype( ascii )>::value - 1; ++a ) {
         SDL_LockSurface( ascii_surf[a].get() );
-        int size = ascii_surf[a]->h * ascii_surf[a]->w;
+        int const size = ascii_surf[a]->h * ascii_surf[a]->w;
         Uint32 *pixels = static_cast<Uint32 *>( ascii_surf[a]->pixels );
-        Uint32 color = ( windowsPalette[a].r << 16 ) | ( windowsPalette[a].g << 8 ) | windowsPalette[a].b;
+        Uint32 const color = ( windowsPalette[a].r << 16 ) | ( windowsPalette[a].g << 8 ) | windowsPalette[a].b;
         for( int i = 0; i < size; i++ ) {
             if( pixels[i] == 0xFFFFFF ) {
                 pixels[i] = color;

--- a/src/sdl_geometry.cpp
+++ b/src/sdl_geometry.cpp
@@ -7,21 +7,21 @@
 void GeometryRenderer::horizontal_line( const SDL_Renderer_Ptr &renderer, point pos, int x2,
                                         int thickness, const SDL_Color &color ) const
 {
-    SDL_Rect rect { pos.x, pos.y, x2 - pos.x, thickness };
+    SDL_Rect const rect { pos.x, pos.y, x2 - pos.x, thickness };
     this->rect( renderer, rect, color );
 }
 
 void GeometryRenderer::vertical_line( const SDL_Renderer_Ptr &renderer, point pos, int y2,
                                       int thickness, const SDL_Color &color ) const
 {
-    SDL_Rect rect { pos.x, pos.y, thickness, y2 - pos.y };
+    SDL_Rect const rect { pos.x, pos.y, thickness, y2 - pos.y };
     this->rect( renderer, rect, color );
 }
 
 void GeometryRenderer::rect( const SDL_Renderer_Ptr &renderer, point pos, int width,
                              int height, const SDL_Color &color ) const
 {
-    SDL_Rect rect { pos.x, pos.y, width, height };
+    SDL_Rect const rect { pos.x, pos.y, width, height };
     this->rect( renderer, rect, color );
 }
 
@@ -54,7 +54,7 @@ ColorModulatedGeometryRenderer::ColorModulatedGeometryRenderer( const SDL_Render
         alt_surf.reset();
 
         // Test to make sure color modulation is supported by renderer
-        bool tex_enable = !SetTextureColorMod( tex, 0, 0, 0 );
+        bool const tex_enable = !SetTextureColorMod( tex, 0, 0, 0 );
         if( !tex_enable ) {
             tex.reset();
         }

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -120,7 +120,7 @@ bool init_sound()
         DebugLog( DL::Info, DC::Main ) << "Active audio driver: " << driver;
 
         int const open_code = Mix_OpenAudioDevice( audio_rate, audio_format, audio_channels,
-                                             chunksize, audio_device, flags );
+                              chunksize, audio_device, flags );
         if( open_code == 0 ) {
             int dev_rate = 0;
             Uint16 dev_format = 0;
@@ -531,7 +531,8 @@ void sfx::play_variant_sound( const std::string &id, const std::string &variant,
     Mix_Chunk *effect_to_play = get_sfx_resource( selected_sound_effect.resource_id );
     Mix_VolumeChunk( effect_to_play,
                      selected_sound_effect.volume * get_option<int>( "SOUND_EFFECT_VOLUME" ) * volume / ( 100 * 100 ) );
-    bool const failed = ( Mix_PlayChannel( static_cast<int>( channel::any ), effect_to_play, 0 ) == -1 );
+    bool const failed = ( Mix_PlayChannel( static_cast<int>( channel::any ), effect_to_play,
+                                           0 ) == -1 );
     if( failed ) {
         dbg( DL::Warn ) << "Failed to play sound effect: " << Mix_GetError();
     }

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -104,22 +104,22 @@ static inline bool check_sound( const int volume = 1 )
  */
 bool init_sound()
 {
-    int audio_rate = 44100;
-    Uint16 audio_format = AUDIO_S16;
-    int audio_channels = 2;
-    int chunksize = 2048;
+    int const audio_rate = 44100;
+    Uint16 const audio_format = AUDIO_S16;
+    int const audio_channels = 2;
+    int const chunksize = 2048;
     // Autodetect device
     const char *audio_device = nullptr;
     // We only care about sample format and number of channels.
     // SDL will be allowed to choose a different frequency if it needs to.
-    int flags = SDL_AUDIO_ALLOW_FREQUENCY_CHANGE;
+    int const flags = SDL_AUDIO_ALLOW_FREQUENCY_CHANGE;
 
     // We should only need to init once
     if( !sound_init_success ) {
         const char *driver = SDL_GetCurrentAudioDriver();
         DebugLog( DL::Info, DC::Main ) << "Active audio driver: " << driver;
 
-        int open_code = Mix_OpenAudioDevice( audio_rate, audio_format, audio_channels,
+        int const open_code = Mix_OpenAudioDevice( audio_rate, audio_format, audio_channels,
                                              chunksize, audio_device, flags );
         if( open_code == 0 ) {
             int dev_rate = 0;
@@ -326,7 +326,7 @@ void update_volumes()
 // memory. Mix_FreeChunk will free the SDL_malloc'd Mix_Chunk pointer.
 static Mix_Chunk *make_null_chunk()
 {
-    static Mix_Chunk null_chunk = { 0, nullptr, 0, 0 };
+    static Mix_Chunk const null_chunk = { 0, nullptr, 0, 0 };
     // SDL_malloc to match up with Mix_FreeChunk's SDL_free call
     // to free the Mix_Chunk object memory
     Mix_Chunk *nchunk = static_cast<Mix_Chunk *>( SDL_malloc( sizeof( Mix_Chunk ) ) );
@@ -353,7 +353,7 @@ static inline Mix_Chunk *get_sfx_resource( int resource_id )
 {
     sound_effect_resource &resource = sfx_resources.resource[ resource_id ];
     if( !resource.chunk ) {
-        std::string path = ( current_soundpack_path + "/" + resource.path );
+        std::string const path = ( current_soundpack_path + "/" + resource.path );
         resource.chunk.reset( load_chunk( path ) );
     }
     return resource.chunk.get();
@@ -365,7 +365,7 @@ static inline int add_sfx_path( const std::string &path )
     if( find_result != unique_paths.end() ) {
         return find_result->second;
     } else {
-        int result = sfx_resources.resource.size();
+        int const result = sfx_resources.resource.size();
         sound_effect_resource new_resource;
         new_resource.path = path;
         new_resource.chunk.reset();
@@ -398,7 +398,7 @@ void sfx::load_sound_effect_preload( const JsonObject &jsobj )
         return;
     }
 
-    for( JsonObject aobj : jsobj.get_array( "preload" ) ) {
+    for( JsonObject const aobj : jsobj.get_array( "preload" ) ) {
         const id_and_variant preload_key( aobj.get_string( "id" ), aobj.get_string( "variant",
                                           "default" ) );
         sfx_preload.push_back( preload_key );
@@ -411,12 +411,12 @@ void sfx::load_playlist( const JsonObject &jsobj )
         return;
     }
 
-    for( JsonObject playlist : jsobj.get_array( "playlists" ) ) {
+    for( JsonObject const playlist : jsobj.get_array( "playlists" ) ) {
         const std::string playlist_id = playlist.get_string( "id" );
         music_playlist playlist_to_load;
         playlist_to_load.shuffle = playlist.get_bool( "shuffle", false );
 
-        for( JsonObject entry : playlist.get_array( "files" ) ) {
+        for( JsonObject const entry : playlist.get_array( "files" ) ) {
             const music_playlist::entry e{ entry.get_string( "file" ),  entry.get_int( "volume" ) };
             playlist_to_load.entries.push_back( e );
         }
@@ -467,9 +467,9 @@ static void empty_effect( int /* chan */, void * /* stream */, int /* len */, vo
 
 static Mix_Chunk *do_pitch_shift( Mix_Chunk *s, float pitch )
 {
-    Uint32 s_in = s->alen / 4;
-    Uint32 s_out = static_cast<Uint32>( static_cast<float>( s_in ) * pitch );
-    float pitch_real = static_cast<float>( s_out ) / static_cast<float>( s_in );
+    Uint32 const s_in = s->alen / 4;
+    Uint32 const s_out = static_cast<Uint32>( static_cast<float>( s_in ) * pitch );
+    float const pitch_real = static_cast<float>( s_out ) / static_cast<float>( s_in );
     Mix_Chunk *result = static_cast<Mix_Chunk *>( malloc( sizeof( Mix_Chunk ) ) );
     result->allocated = 1;
     result->alen = s_out * 4;
@@ -482,7 +482,7 @@ static Mix_Chunk *do_pitch_shift( Mix_Chunk *s, float pitch )
         Sint16 rt_out = 0;
         Sint64 lt_avg = 0;
         Sint64 rt_avg = 0;
-        Uint32 begin = static_cast<Uint32>( static_cast<float>( i ) / pitch_real );
+        Uint32 const begin = static_cast<Uint32>( static_cast<float>( i ) / pitch_real );
         Uint32 end = static_cast<Uint32>( static_cast<float>( i + 1 ) / pitch_real );
 
         // check for boundary case
@@ -531,7 +531,7 @@ void sfx::play_variant_sound( const std::string &id, const std::string &variant,
     Mix_Chunk *effect_to_play = get_sfx_resource( selected_sound_effect.resource_id );
     Mix_VolumeChunk( effect_to_play,
                      selected_sound_effect.volume * get_option<int>( "SOUND_EFFECT_VOLUME" ) * volume / ( 100 * 100 ) );
-    bool failed = ( Mix_PlayChannel( static_cast<int>( channel::any ), effect_to_play, 0 ) == -1 );
+    bool const failed = ( Mix_PlayChannel( static_cast<int>( channel::any ), effect_to_play, 0 ) == -1 );
     if( failed ) {
         dbg( DL::Warn ) << "Failed to play sound effect: " << Mix_GetError();
     }
@@ -556,14 +556,14 @@ void sfx::play_variant_sound( const std::string &id, const std::string &variant,
     const sound_effect &selected_sound_effect = *eff;
 
     Mix_Chunk *effect_to_play = get_sfx_resource( selected_sound_effect.resource_id );
-    bool is_pitched = ( pitch_min > 0 ) && ( pitch_max > 0 );
+    bool const is_pitched = ( pitch_min > 0 ) && ( pitch_max > 0 );
     if( is_pitched ) {
-        double pitch_random = rng_float( pitch_min, pitch_max );
+        double const pitch_random = rng_float( pitch_min, pitch_max );
         effect_to_play = do_pitch_shift( effect_to_play, static_cast<float>( pitch_random ) );
     }
     Mix_VolumeChunk( effect_to_play,
                      selected_sound_effect.volume * get_option<int>( "SOUND_EFFECT_VOLUME" ) * volume / ( 100 * 100 ) );
-    int channel = Mix_PlayChannel( static_cast<int>( sfx::channel::any ), effect_to_play, 0 );
+    int const channel = Mix_PlayChannel( static_cast<int>( sfx::channel::any ), effect_to_play, 0 );
     bool failed = ( channel == -1 );
     if( !failed && is_pitched ) {
         if( Mix_RegisterEffect( channel, empty_effect, cleanup_when_channel_finished,
@@ -610,14 +610,14 @@ void sfx::play_ambient_variant_sound( const std::string &id, const std::string &
     const sound_effect &selected_sound_effect = *eff;
 
     Mix_Chunk *effect_to_play = get_sfx_resource( selected_sound_effect.resource_id );
-    bool is_pitched = ( pitch > 0 );
+    bool const is_pitched = ( pitch > 0 );
     if( is_pitched ) {
         effect_to_play = do_pitch_shift( effect_to_play, static_cast<float>( pitch ) );
     }
     Mix_VolumeChunk( effect_to_play,
                      selected_sound_effect.volume * get_option<int>( "AMBIENT_SOUND_VOLUME" ) * volume / ( 100 * 100 ) );
     bool failed = false;
-    int ch = static_cast<int>( channel );
+    int const ch = static_cast<int>( channel );
     if( fade_in_duration ) {
         failed = ( Mix_FadeInChannel( ch, effect_to_play, loops, fade_in_duration ) == -1 );
     } else {

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1151,7 +1151,7 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
         const auto draw_note_text = [&]( point  draw_pos, const std::string & name,
         nc_color & color ) {
             char const note_fg_color = color == c_yellow ? 11 :
-                                 cata_cursesport::colorpairs[color.to_color_pair_index()].FG;
+                                       cata_cursesport::colorpairs[color.to_color_pair_index()].FG;
             return draw_string( *font, renderer, geometry, name, draw_pos, note_fg_color );
         };
 
@@ -1202,7 +1202,7 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
                     }
                 }
 
-                nc_color  const&color = color_stack.empty() ? default_color : color_stack.top();
+                nc_color  const &color = color_stack.empty() ? default_color : color_stack.top();
                 colored_lines.emplace_back( color, seg );
                 line_length += utf8_width( seg );
             }
@@ -1218,7 +1218,7 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
 
             // Draw colored text segments
             for( auto &colored_line : colored_lines ) {
-                std::string  const&text = std::get<1>( colored_line );
+                std::string  const &text = std::get<1>( colored_line );
                 draw_point.x = draw_note_text( draw_point, text, std::get<0>( colored_line ) ).x;
             }
 
@@ -1514,9 +1514,10 @@ void cata_cursesport::curses_drawwindow( const catacurses::window &w )
 
         //calculate width differences between map_font and font
         int const partial_width = std::max( TERRAIN_WINDOW_TERM_WIDTH * fontwidth - TERRAIN_WINDOW_WIDTH *
-                                      map_font->width, 0 );
-        int const partial_height = std::max( TERRAIN_WINDOW_TERM_HEIGHT * fontheight - TERRAIN_WINDOW_HEIGHT *
-                                       map_font->height, 0 );
+                                            map_font->width, 0 );
+        int const partial_height = std::max( TERRAIN_WINDOW_TERM_HEIGHT * fontheight - TERRAIN_WINDOW_HEIGHT
+                                             *
+                                             map_font->height, 0 );
         //Gap between terrain and lower window edge
         if( partial_height > 0 ) {
             geometry->rect( renderer, point( win->pos.x * map_font->width,

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -170,7 +170,7 @@ static void ClearScreen()
 
 static void InitSDL()
 {
-    int init_flags = SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_TIMER;
+    int const init_flags = SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_TIMER;
     int ret;
 
 #if defined(SDL_HINT_WINDOWS_DISABLE_THREAD_NAMING)
@@ -228,7 +228,7 @@ static bool SetupRenderTarget()
 //Registers, creates, and shows the Window!!
 static void WinCreate()
 {
-    std::string version = string_format( "Cataclysm: Bright Nights - %s", getVersionString() );
+    std::string const version = string_format( "Cataclysm: Bright Nights - %s", getVersionString() );
 
     // Common flags used for fulscreen and for windowed
     int window_flags = 0;
@@ -399,7 +399,7 @@ static void WinCreate()
     }
 
     // Initialize joysticks.
-    int numjoy = SDL_NumJoysticks();
+    int const numjoy = SDL_NumJoysticks();
 
     if( get_option<bool>( "ENABLE_JOYSTICK" ) && numjoy >= 1 ) {
         if( numjoy > 1 ) {
@@ -561,7 +561,7 @@ void refresh_display()
 // only update if the set interval has elapsed
 static void try_sdl_update()
 {
-    uint32_t now = SDL_GetTicks();
+    uint32_t const now = SDL_GetTicks();
     if( now - lastupdate >= interval ) {
         refresh_display();
     } else {
@@ -698,9 +698,9 @@ static std::optional<std::pair<tripoint_abs_omt, std::string>> get_mission_arrow
         return std::make_pair( mission_target, mission_arrow_variant );
     }
 
-    inclusive_rectangle<point> area_flat( overmap_area.p_min.xy(), overmap_area.p_max.xy() );
+    inclusive_rectangle<point> const area_flat( overmap_area.p_min.xy(), overmap_area.p_max.xy() );
     if( area_flat.contains( mission_target.raw().xy() ) ) {
-        int area_z = center.z();
+        int const area_z = center.z();
         if( mission_target.z() > area_z ) {
             mission_arrow_variant = "mission_arrow_up";
         } else {
@@ -774,10 +774,10 @@ std::string cata_tiles::get_omt_id_rotation_and_subtile(
         return cur_ter;
     };
 
-    oter_id ot_id = oter_at( omp );
+    oter_id const ot_id = oter_at( omp );
     const oter_t &ot = *ot_id;
-    oter_type_id ot_type_id = ot.get_type_id();
-    oter_type_t ot_type = *ot_type_id;
+    oter_type_id const ot_type_id = ot.get_type_id();
+    oter_type_t const ot_type = *ot_type_id;
 
     if( ot_type.has_connections() ) {
         // This would be for connected terrain
@@ -841,12 +841,12 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
     }
 #endif
 
-    int width = OVERMAP_WINDOW_TERM_WIDTH * font->width;
-    int height = OVERMAP_WINDOW_TERM_HEIGHT * font->height;
+    int const width = OVERMAP_WINDOW_TERM_WIDTH * font->width;
+    int const height = OVERMAP_WINDOW_TERM_HEIGHT * font->height;
 
     {
         //set clipping to prevent drawing over stuff we shouldn't
-        SDL_Rect clipRect = { dest.x, dest.y, width, height };
+        SDL_Rect const clipRect = { dest.x, dest.y, width, height };
         printErrorIf( SDL_RenderSetClipRect( renderer.get(), &clipRect ) != 0,
                       "SDL_RenderSetClipRect failed" );
 
@@ -859,7 +859,7 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
     screentile_width = divide_round_up( width, tile_width );
     screentile_height = divide_round_up( height, tile_height );
 
-    window_dimensions wnd_dim = get_window_dimensions( g->w_overmap );
+    window_dimensions const wnd_dim = get_window_dimensions( g->w_overmap );
 
     const int min_col = 0;
     const int max_col = screentile_width;
@@ -992,7 +992,7 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
                 std::tie( ter_sym, ter_color, std::ignore ) =
                     overmap_ui::get_note_display_info( overmap_buffer.note( omp ) );
 
-                std::string note_name = "note_" + ter_sym + "_" + string_from_color( ter_color );
+                std::string const note_name = "note_" + ter_sym + "_" + string_from_color( ter_color );
                 draw_from_id_string( note_name, TILE_CATEGORY::C_OVERMAP_NOTE, "overmap_note",
                                      omp.raw(), 0, 0, lit_level::LIT, false, 0 );
             }
@@ -1002,7 +1002,7 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
     if( uistate.place_terrain ) {
         const oter_str_id &terrain_id = uistate.place_terrain->id;
         const oter_t &terrain = *terrain_id;
-        std::string id = terrain.get_type_id().str();
+        std::string const id = terrain.get_type_id().str();
         int rotation;
         int subtile;
         terrain.get_rotation_and_subtile( rotation, subtile );
@@ -1014,9 +1014,9 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
             if( s_ter.p.z == 0 ) {
                 // TODO: fix point types
                 const point_rel_omt rp( om_direction::rotate( s_ter.p.xy(), uistate.omedit_rotation ) );
-                oter_id rotated_id = s_ter.terrain->get_rotated( uistate.omedit_rotation );
+                oter_id const rotated_id = s_ter.terrain->get_rotated( uistate.omedit_rotation );
                 const oter_t &terrain = *rotated_id;
-                std::string id = terrain.get_type_id().str();
+                std::string const id = terrain.get_type_id().str();
                 int rotation;
                 int subtile;
                 terrain.get_rotation_and_subtile( rotation, subtile );
@@ -1087,7 +1087,7 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
         const auto label_bg = [&]( const tripoint_abs_sm & pos, const std::string & name ) {
             const int name_length = utf8_width( name );
             const point draw_pos = abs_sm_to_draw_label( pos, name_length );
-            SDL_Rect clipRect = { draw_pos.x, draw_pos.y, name_length * fontwidth, fontheight };
+            SDL_Rect const clipRect = { draw_pos.x, draw_pos.y, name_length * fontwidth, fontheight };
 
             geometry->rect( renderer, clipRect, SDL_Color() );
 
@@ -1150,7 +1150,7 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
 
         const auto draw_note_text = [&]( point  draw_pos, const std::string & name,
         nc_color & color ) {
-            char note_fg_color = color == c_yellow ? 11 :
+            char const note_fg_color = color == c_yellow ? 11 :
                                  cata_cursesport::colorpairs[color.to_color_pair_index()].FG;
             return draw_string( *font, renderer, geometry, name, draw_pos, note_fg_color );
         };
@@ -1167,7 +1167,7 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
         // Draw notes header. Very simple label at the moment
         nc_color header_color = c_white;
         const std::string header_string = _( "-- Notes: --" );
-        SDL_Rect header_background_rect = {
+        SDL_Rect const header_background_rect = {
             draw_point.x - padding,
             draw_point.y - padding,
             fontwidth * utf8_width( header_string ) + padding * 2,
@@ -1182,7 +1182,7 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
         for( auto &line : notes_window_text ) {
             const auto color_segments = split_by_color( line.second );
             std::stack<nc_color> color_stack;
-            nc_color default_color = std::get<0>( line );
+            nc_color const default_color = std::get<0>( line );
             color_stack.push( default_color );
             std::vector<std::tuple<nc_color, std::string>> colored_lines;
 
@@ -1202,13 +1202,13 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
                     }
                 }
 
-                nc_color &color = color_stack.empty() ? default_color : color_stack.top();
+                nc_color  const&color = color_stack.empty() ? default_color : color_stack.top();
                 colored_lines.emplace_back( color, seg );
                 line_length += utf8_width( seg );
             }
 
             // Draw background first for the whole line
-            SDL_Rect background_rect = {
+            SDL_Rect const background_rect = {
                 draw_point.x - padding,
                 draw_point.y - padding,
                 fontwidth *line_length + padding * 2,
@@ -1218,7 +1218,7 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
 
             // Draw colored text segments
             for( auto &colored_line : colored_lines ) {
-                std::string &text = std::get<1>( colored_line );
+                std::string  const&text = std::get<1>( colored_line );
                 draw_point.x = draw_note_text( draw_point, text, std::get<0>( colored_line ) ).x;
             }
 
@@ -1254,7 +1254,7 @@ static bool draw_window( Font_Ptr &font, const catacurses::window &w, point offs
     invalidate_framebuffer_proportion( win );
 
     // use the oversize buffer when dealing with windows that can have a different font than the main text font
-    bool use_oversized_framebuffer = g && ( w == g->w_terrain || w == g->w_overmap );
+    bool const use_oversized_framebuffer = g && ( w == g->w_terrain || w == g->w_overmap );
 
     std::vector<curseline> &framebuffer = use_oversized_framebuffer ? oversized_framebuffer :
                                           terminal_framebuffer;
@@ -1340,7 +1340,7 @@ static bool draw_window( Font_Ptr &font, const catacurses::window &w, point offs
             const int codepoint = UTF8_getch( cell.ch );
             const catacurses::base_color FG = cell.FG;
             const catacurses::base_color BG = cell.BG;
-            int cw = ( codepoint == UNKNOWN_UNICODE ) ? 1 : utf8_width( cell.ch );
+            int const cw = ( codepoint == UNKNOWN_UNICODE ) ? 1 : utf8_width( cell.ch );
             if( cw < 1 ) {
                 // utf8_width() may return a negative width
                 continue;
@@ -1469,7 +1469,7 @@ void cata_cursesport::curses_drawwindow( const catacurses::window &w )
                 int full_text_length = 0;
                 const auto range = overlay_strings.equal_range( coord );
                 for( auto ri = range.first; ri != range.second; ++ri ) {
-                    utf8_wrapper rt( ri->second.text );
+                    utf8_wrapper const rt( ri->second.text );
                     full_text_length += rt.display_width();
                 }
 
@@ -1513,9 +1513,9 @@ void cata_cursesport::curses_drawwindow( const catacurses::window &w )
         // to keep various former interface elements from showing through the gaps
 
         //calculate width differences between map_font and font
-        int partial_width = std::max( TERRAIN_WINDOW_TERM_WIDTH * fontwidth - TERRAIN_WINDOW_WIDTH *
+        int const partial_width = std::max( TERRAIN_WINDOW_TERM_WIDTH * fontwidth - TERRAIN_WINDOW_WIDTH *
                                       map_font->width, 0 );
-        int partial_height = std::max( TERRAIN_WINDOW_TERM_HEIGHT * fontheight - TERRAIN_WINDOW_HEIGHT *
+        int const partial_height = std::max( TERRAIN_WINDOW_TERM_HEIGHT * fontheight - TERRAIN_WINDOW_HEIGHT *
                                        map_font->height, 0 );
         //Gap between terrain and lower window edge
         if( partial_height > 0 ) {
@@ -1600,7 +1600,7 @@ static int HandleDPad()
         // When someone tries to press a diagonal, they likely will
         // press a single direction first. Wait a few milliseconds to
         // give them time to press both of the buttons for the diagonal.
-        int button = SDL_JoystickGetHat( joystick, 0 );
+        int const button = SDL_JoystickGetHat( joystick, 0 );
         int lc = ERR;
         if( button == SDL_HAT_LEFT ) {
             lc = JOY_LEFT;
@@ -3107,7 +3107,7 @@ static void CheckMessages()
 #endif
                 is_repeat = ev.key.repeat;
                 if( ev.key.keysym.sym == SDLK_LALT || ev.key.keysym.sym == SDLK_RALT ) {
-                    int code = end_alt_code();
+                    int const code = end_alt_code();
                     if( code ) {
                         last_input = input_event( code, CATA_INPUT_KEYBOARD );
                         last_input.text = utf32_to_utf8( code );
@@ -3372,7 +3372,7 @@ static void CheckMessages()
     }
     bool resized = false;
     if( resize_dims.has_value() ) {
-        restore_on_out_of_scope<input_event> prev_last_input( last_input );
+        restore_on_out_of_scope<input_event> const prev_last_input( last_input );
         needupdate = resized = handle_resize( resize_dims.value().x, resize_dims.value().y );
     }
     // resizing already reinitializes the render target
@@ -3380,7 +3380,7 @@ static void CheckMessages()
         throwErrorIf( !SetupRenderTarget(), "SetupRenderTarget failed" );
         reinitialize_framebuffer( true );
         needupdate = true;
-        restore_on_out_of_scope<input_event> prev_last_input( last_input );
+        restore_on_out_of_scope<input_event> const prev_last_input( last_input );
         // FIXME: SDL_RENDER_TARGETS_RESET only seems to be fired after the first redraw
         // when restoring the window after system sleep, rather than immediately
         // on focus gain. This seems to mess up the first redraw and
@@ -3430,7 +3430,7 @@ static void init_term_size_and_scaling_factor()
 
         int max_width, max_height;
 
-        int current_display_id = std::stoi( get_option<std::string>( "DISPLAY" ) );
+        int const current_display_id = std::stoi( get_option<std::string>( "DISPLAY" ) );
         SDL_DisplayMode current_display;
 
         if( SDL_GetDesktopDisplayMode( current_display_id, &current_display ) == 0 ) {
@@ -3543,7 +3543,7 @@ void catacurses::init_interface()
     dbg( DL::Info ) << "Initializing SDL Tiles context";
     tilecontext = std::make_unique<cata_tiles>( renderer, geometry );
     try {
-        std::vector<mod_id> dummy;
+        std::vector<mod_id> const dummy;
         tilecontext->load_tileset(
             get_option<std::string>( "TILES" ),
             dummy,
@@ -3666,7 +3666,7 @@ input_event input_manager::get_input_event()
             SDL_Delay( 1 );
         } while( last_input.type == CATA_INPUT_ERROR );
     } else if( inputdelay > 0 ) {
-        uint32_t starttime = SDL_GetTicks();
+        uint32_t const starttime = SDL_GetTicks();
         uint32_t endtime = 0;
         bool timedout = false;
         do {
@@ -3782,8 +3782,8 @@ std::optional<tripoint> input_context::get_coordinates( const catacurses::window
 
     const int &fw = dim.scaled_font_size.x;
     const int &fh = dim.scaled_font_size.y;
-    point win_min = dim.window_pos_pixel;
-    point win_size = dim.window_size_pixel;
+    point const win_min = dim.window_pos_pixel;
+    point const win_size = dim.window_size_pixel;
     const point win_max = win_min + win_size;
 
     // Translate mouse coordinates to map coordinates based on tile size

--- a/src/shape.cpp
+++ b/src/shape.cpp
@@ -65,7 +65,7 @@ void shape_factory::serialize( JsonOut &jsout ) const
 void shape_factory::deserialize( JsonIn &jsin )
 {
     jsin.start_array();
-    std::string type_string = jsin.get_string();
+    std::string const type_string = jsin.get_string();
     if( type_string == "cone" ) {
         impl = std::make_shared<cone_factory>();
         impl->deserialize( jsin );

--- a/src/simple_pathfinding.cpp
+++ b/src/simple_pathfinding.cpp
@@ -90,7 +90,7 @@ directed_path<point> greedy_path( point source, point dest, point max,
             res.nodes.emplace_back( p );
             return res;
         }
-        for( om_direction::type dir : om_direction::all ) {
+        for( om_direction::type const dir : om_direction::all ) {
             const point p = mn.pos + om_direction::displace( dir );
             const int n = map_index( p );
             // don't allow out of bounds or already traversed tiles
@@ -257,7 +257,7 @@ simple_path<tripoint_abs_omt> find_overmap_path( const tripoint_abs_omt &source,
         if( other_known_nodes.find( cur_addr ) != other_known_nodes.end() ) {
             meet = true;
             tripoint_abs_omt addr = cur_addr;
-            tripoint_abs_omt other_start = start == source ? dest : source;
+            tripoint_abs_omt const other_start = start == source ? dest : source;
             while( addr != other_start ) {
                 ret.points.emplace_back( addr );
                 addr = addr + direction_to_tripoint( other_known_nodes.at( addr ).get_prev_dir() );
@@ -271,7 +271,7 @@ simple_path<tripoint_abs_omt> find_overmap_path( const tripoint_abs_omt &source,
             return;
         }
         const navigation_node &cur_node = known_nodes.at( cur_addr );
-        for( direction dir : enumerate_directions( cur_node.allow_z_change ) ) {
+        for( direction const dir : enumerate_directions( cur_node.allow_z_change ) ) {
             if( dir == cur_node.prev_dir ) {
                 continue; // don't go back the way we just came
             }

--- a/src/simplexnoise.cpp
+++ b/src/simplexnoise.cpp
@@ -189,18 +189,18 @@ float raw_noise_2d( const float x, const float y )
     // Skew the input space to determine which simplex cell we're in
     static const float F2 = 0.5f * ( std::sqrt( 3.0f ) - 1.0f );
     // Hairy factor for 2D
-    float s = ( x + y ) * F2;
-    int i = fastfloor( x + s );
-    int j = fastfloor( y + s );
+    float const s = ( x + y ) * F2;
+    int const i = fastfloor( x + s );
+    int const j = fastfloor( y + s );
 
     static const float G2 = ( 3.0f - std::sqrt( 3.0f ) ) / 6.0f;
-    float t = ( i + j ) * G2;
+    float const t = ( i + j ) * G2;
     // Unskew the cell origin back to (x,y) space
-    float X0 = i - t;
-    float Y0 = j - t;
+    float const X0 = i - t;
+    float const Y0 = j - t;
     // The x,y distances from the cell origin
-    float x0 = x - X0;
-    float y0 = y - Y0;
+    float const x0 = x - X0;
+    float const y0 = y - Y0;
 
     // For the 2D case, the simplex shape is an equilateral triangle.
     // Determine which simplex we are in.
@@ -216,17 +216,17 @@ float raw_noise_2d( const float x, const float y )
     // A step of (1,0) in (i,j) means a step of (1-c,-c) in (x,y), and
     // a step of (0,1) in (i,j) means a step of (-c,1-c) in (x,y), where
     // c = (3-sqrt(3))/6
-    float x1 = x0 - i1 + G2; // Offsets for middle corner in (x,y) unskewed coordinates
-    float y1 = y0 - j1 + G2;
-    float x2 = x0 - 1.0f + 2.0f * G2; // Offsets for last corner in (x,y) unskewed coordinates
-    float y2 = y0 - 1.0f + 2.0f * G2;
+    float const x1 = x0 - i1 + G2; // Offsets for middle corner in (x,y) unskewed coordinates
+    float const y1 = y0 - j1 + G2;
+    float const x2 = x0 - 1.0f + 2.0f * G2; // Offsets for last corner in (x,y) unskewed coordinates
+    float const y2 = y0 - 1.0f + 2.0f * G2;
 
     // Work out the hashed gradient indices of the three simplex corners
-    int ii = i & 255;
-    int jj = j & 255;
-    int gi0 = perm[ii + perm[jj]] % 12;
-    int gi1 = perm[ii + i1 + perm[jj + j1]] % 12;
-    int gi2 = perm[ii + 1 + perm[jj + 1]] % 12;
+    int const ii = i & 255;
+    int const jj = j & 255;
+    int const gi0 = perm[ii + perm[jj]] % 12;
+    int const gi1 = perm[ii + i1 + perm[jj + j1]] % 12;
+    int const gi2 = perm[ii + 1 + perm[jj + 1]] % 12;
 
     // Calculate the contribution from the three corners
     float t0 = 0.5f - x0 * x0 - y0 * y0;
@@ -264,20 +264,20 @@ float raw_noise_3d( const float x, const float y, const float z )
     float n0, n1, n2, n3; // Noise contributions from the four corners
 
     // Skew the input space to determine which simplex cell we're in
-    float F3 = 1.0f / 3.0f;
-    float s = ( x + y + z ) * F3; // Very nice and simple skew factor for 3D
-    int i = fastfloor( x + s );
-    int j = fastfloor( y + s );
-    int k = fastfloor( z + s );
+    float const F3 = 1.0f / 3.0f;
+    float const s = ( x + y + z ) * F3; // Very nice and simple skew factor for 3D
+    int const i = fastfloor( x + s );
+    int const j = fastfloor( y + s );
+    int const k = fastfloor( z + s );
 
-    float G3 = 1.0f / 6.0f; // Very nice and simple unskew factor, too
-    float t = ( i + j + k ) * G3;
-    float X0 = i - t; // Unskew the cell origin back to (x,y,z) space
-    float Y0 = j - t;
-    float Z0 = k - t;
-    float x0 = x - X0; // The x,y,z distances from the cell origin
-    float y0 = y - Y0;
-    float z0 = z - Z0;
+    float const G3 = 1.0f / 6.0f; // Very nice and simple unskew factor, too
+    float const t = ( i + j + k ) * G3;
+    float const X0 = i - t; // Unskew the cell origin back to (x,y,z) space
+    float const Y0 = j - t;
+    float const Z0 = k - t;
+    float const x0 = x - X0; // The x,y,z distances from the cell origin
+    float const y0 = y - Y0;
+    float const z0 = z - Z0;
 
     // For the 3D case, the simplex shape is a slightly irregular tetrahedron.
     // Determine which simplex we are in.
@@ -336,24 +336,24 @@ float raw_noise_3d( const float x, const float y, const float z )
     // a step of (0,1,0) in (i,j,k) means a step of (-c,1-c,-c) in (x,y,z), and
     // a step of (0,0,1) in (i,j,k) means a step of (-c,-c,1-c) in (x,y,z), where
     // c = 1/6.
-    float x1 = x0 - i1 + G3; // Offsets for second corner in (x,y,z) coordinates
-    float y1 = y0 - j1 + G3;
-    float z1 = z0 - k1 + G3;
-    float x2 = x0 - i2 + 2.0f * G3; // Offsets for third corner in (x,y,z) coordinates
-    float y2 = y0 - j2 + 2.0f * G3;
-    float z2 = z0 - k2 + 2.0f * G3;
-    float x3 = x0 - 1.0f + 3.0f * G3; // Offsets for last corner in (x,y,z) coordinates
-    float y3 = y0 - 1.0f + 3.0f * G3;
-    float z3 = z0 - 1.0f + 3.0f * G3;
+    float const x1 = x0 - i1 + G3; // Offsets for second corner in (x,y,z) coordinates
+    float const y1 = y0 - j1 + G3;
+    float const z1 = z0 - k1 + G3;
+    float const x2 = x0 - i2 + 2.0f * G3; // Offsets for third corner in (x,y,z) coordinates
+    float const y2 = y0 - j2 + 2.0f * G3;
+    float const z2 = z0 - k2 + 2.0f * G3;
+    float const x3 = x0 - 1.0f + 3.0f * G3; // Offsets for last corner in (x,y,z) coordinates
+    float const y3 = y0 - 1.0f + 3.0f * G3;
+    float const z3 = z0 - 1.0f + 3.0f * G3;
 
     // Work out the hashed gradient indices of the four simplex corners
-    int ii = i & 255;
-    int jj = j & 255;
-    int kk = k & 255;
-    int gi0 = perm[ii + perm[jj + perm[kk]]] % 12;
-    int gi1 = perm[ii + i1 + perm[jj + j1 + perm[kk + k1]]] % 12;
-    int gi2 = perm[ii + i2 + perm[jj + j2 + perm[kk + k2]]] % 12;
-    int gi3 = perm[ii + 1 + perm[jj + 1 + perm[kk + 1]]] % 12;
+    int const ii = i & 255;
+    int const jj = j & 255;
+    int const kk = k & 255;
+    int const gi0 = perm[ii + perm[jj + perm[kk]]] % 12;
+    int const gi1 = perm[ii + i1 + perm[jj + j1 + perm[kk + k1]]] % 12;
+    int const gi2 = perm[ii + i2 + perm[jj + j2 + perm[kk + k2]]] % 12;
+    int const gi3 = perm[ii + 1 + perm[jj + 1 + perm[kk + 1]]] % 12;
 
     // Calculate the contribution from the four corners
     float t0 = 0.6f - x0 * x0 - y0 * y0 - z0 * z0;
@@ -402,21 +402,21 @@ float raw_noise_4d( const float x, const float y, const float z, const float w )
     float n0, n1, n2, n3, n4; // Noise contributions from the five corners
 
     // Skew the (x,y,z,w) space to determine which cell of 24 simplices we're in
-    float s = ( x + y + z + w ) * F4; // Factor for 4D skewing
-    int i = fastfloor( x + s );
-    int j = fastfloor( y + s );
-    int k = fastfloor( z + s );
-    int l = fastfloor( w + s );
-    float t = ( i + j + k + l ) * G4; // Factor for 4D unskewing
-    float X0 = i - t; // Unskew the cell origin back to (x,y,z,w) space
-    float Y0 = j - t;
-    float Z0 = k - t;
-    float W0 = l - t;
+    float const s = ( x + y + z + w ) * F4; // Factor for 4D skewing
+    int const i = fastfloor( x + s );
+    int const j = fastfloor( y + s );
+    int const k = fastfloor( z + s );
+    int const l = fastfloor( w + s );
+    float const t = ( i + j + k + l ) * G4; // Factor for 4D unskewing
+    float const X0 = i - t; // Unskew the cell origin back to (x,y,z,w) space
+    float const Y0 = j - t;
+    float const Z0 = k - t;
+    float const W0 = l - t;
 
-    float x0 = x - X0; // The x,y,z,w distances from the cell origin
-    float y0 = y - Y0;
-    float z0 = z - Z0;
-    float w0 = w - W0;
+    float const x0 = x - X0; // The x,y,z,w distances from the cell origin
+    float const y0 = y - Y0;
+    float const z0 = z - Z0;
+    float const w0 = w - W0;
 
     // For the 4D case, the simplex is a 4D shape I won't even try to describe.
     // To find out which of the 24 possible simplices we're in, we need to
@@ -426,13 +426,13 @@ float raw_noise_4d( const float x, const float y, const float z, const float w )
     // First, six pair-wise comparisons are performed between each possible pair
     // of the four coordinates, and the results are used to add up binary bits
     // for an integer index.
-    int c1 = ( x0 > y0 ) ? 32 : 0;
-    int c2 = ( x0 > z0 ) ? 16 : 0;
-    int c3 = ( y0 > z0 ) ? 8 : 0;
-    int c4 = ( x0 > w0 ) ? 4 : 0;
-    int c5 = ( y0 > w0 ) ? 2 : 0;
-    int c6 = ( z0 > w0 ) ? 1 : 0;
-    int c = c1 + c2 + c3 + c4 + c5 + c6;
+    int const c1 = ( x0 > y0 ) ? 32 : 0;
+    int const c2 = ( x0 > z0 ) ? 16 : 0;
+    int const c3 = ( y0 > z0 ) ? 8 : 0;
+    int const c4 = ( x0 > w0 ) ? 4 : 0;
+    int const c5 = ( y0 > w0 ) ? 2 : 0;
+    int const c6 = ( z0 > w0 ) ? 1 : 0;
+    int const c = c1 + c2 + c3 + c4 + c5 + c6;
 
     int i1, j1, k1, l1; // The integer offsets for the second simplex corner
     int i2, j2, k2, l2; // The integer offsets for the third simplex corner
@@ -459,33 +459,33 @@ float raw_noise_4d( const float x, const float y, const float z, const float w )
     l3 = simplex[c][3] >= 1 ? 1 : 0;
     // The fifth corner has all coordinate offsets = 1, so no need to look that up.
 
-    float x1 = x0 - i1 + G4; // Offsets for second corner in (x,y,z,w) coordinates
-    float y1 = y0 - j1 + G4;
-    float z1 = z0 - k1 + G4;
-    float w1 = w0 - l1 + G4;
-    float x2 = x0 - i2 + 2.0f * G4; // Offsets for third corner in (x,y,z,w) coordinates
-    float y2 = y0 - j2 + 2.0f * G4;
-    float z2 = z0 - k2 + 2.0f * G4;
-    float w2 = w0 - l2 + 2.0f * G4;
-    float x3 = x0 - i3 + 3.0f * G4; // Offsets for fourth corner in (x,y,z,w) coordinates
-    float y3 = y0 - j3 + 3.0f * G4;
-    float z3 = z0 - k3 + 3.0f * G4;
-    float w3 = w0 - l3 + 3.0f * G4;
-    float x4 = x0 - 1.0f + 4.0f * G4; // Offsets for last corner in (x,y,z,w) coordinates
-    float y4 = y0 - 1.0f + 4.0f * G4;
-    float z4 = z0 - 1.0f + 4.0f * G4;
-    float w4 = w0 - 1.0f + 4.0f * G4;
+    float const x1 = x0 - i1 + G4; // Offsets for second corner in (x,y,z,w) coordinates
+    float const y1 = y0 - j1 + G4;
+    float const z1 = z0 - k1 + G4;
+    float const w1 = w0 - l1 + G4;
+    float const x2 = x0 - i2 + 2.0f * G4; // Offsets for third corner in (x,y,z,w) coordinates
+    float const y2 = y0 - j2 + 2.0f * G4;
+    float const z2 = z0 - k2 + 2.0f * G4;
+    float const w2 = w0 - l2 + 2.0f * G4;
+    float const x3 = x0 - i3 + 3.0f * G4; // Offsets for fourth corner in (x,y,z,w) coordinates
+    float const y3 = y0 - j3 + 3.0f * G4;
+    float const z3 = z0 - k3 + 3.0f * G4;
+    float const w3 = w0 - l3 + 3.0f * G4;
+    float const x4 = x0 - 1.0f + 4.0f * G4; // Offsets for last corner in (x,y,z,w) coordinates
+    float const y4 = y0 - 1.0f + 4.0f * G4;
+    float const z4 = z0 - 1.0f + 4.0f * G4;
+    float const w4 = w0 - 1.0f + 4.0f * G4;
 
     // Work out the hashed gradient indices of the five simplex corners
-    int ii = i & 255;
-    int jj = j & 255;
-    int kk = k & 255;
-    int ll = l & 255;
-    int gi0 = perm[ii + perm[jj + perm[kk + perm[ll]]]] % 32;
-    int gi1 = perm[ii + i1 + perm[jj + j1 + perm[kk + k1 + perm[ll + l1]]]] % 32;
-    int gi2 = perm[ii + i2 + perm[jj + j2 + perm[kk + k2 + perm[ll + l2]]]] % 32;
-    int gi3 = perm[ii + i3 + perm[jj + j3 + perm[kk + k3 + perm[ll + l3]]]] % 32;
-    int gi4 = perm[ii + 1 + perm[jj + 1 + perm[kk + 1 + perm[ll + 1]]]] % 32;
+    int const ii = i & 255;
+    int const jj = j & 255;
+    int const kk = k & 255;
+    int const ll = l & 255;
+    int const gi0 = perm[ii + perm[jj + perm[kk + perm[ll]]]] % 32;
+    int const gi1 = perm[ii + i1 + perm[jj + j1 + perm[kk + k1 + perm[ll + l1]]]] % 32;
+    int const gi2 = perm[ii + i2 + perm[jj + j2 + perm[kk + k2 + perm[ll + l2]]]] % 32;
+    int const gi3 = perm[ii + i3 + perm[jj + j3 + perm[kk + k3 + perm[ll + l3]]]] % 32;
+    int const gi4 = perm[ii + 1 + perm[jj + 1 + perm[kk + 1 + perm[ll + 1]]]] % 32;
 
     // Calculate the contribution from the five corners
     float t0 = 0.6f - x0 * x0 - y0 * y0 - z0 * z0 - w0 * w0;

--- a/src/skill.cpp
+++ b/src/skill.cpp
@@ -101,17 +101,17 @@ void Skill::load_skill( const JsonObject &jsobj )
     translation desc;
     jsobj.read( "description", desc );
     std::unordered_map<std::string, int> companion_skill_practice;
-    for( JsonObject jo_csp : jsobj.get_array( "companion_skill_practice" ) ) {
+    for( JsonObject const jo_csp : jsobj.get_array( "companion_skill_practice" ) ) {
         companion_skill_practice.emplace( jo_csp.get_string( "skill" ), jo_csp.get_int( "weight" ) );
     }
     time_info_t time_to_attack;
     if( jsobj.has_object( "time_to_attack" ) ) {
-        JsonObject jso_tta = jsobj.get_object( "time_to_attack" );
+        JsonObject const jso_tta = jsobj.get_object( "time_to_attack" );
         jso_tta.read( "min_time", time_to_attack.min_time );
         jso_tta.read( "base_time", time_to_attack.base_time );
         jso_tta.read( "time_reduction_per_level", time_to_attack.time_reduction_per_level );
     }
-    skill_displayType_id display_type = skill_displayType_id( jsobj.get_string( "display_category" ) );
+    skill_displayType_id const display_type = skill_displayType_id( jsobj.get_string( "display_category" ) );
     Skill sk( ident, name, desc, jsobj.get_tags( "tags" ), display_type );
 
     sk._time_to_attack = time_to_attack;

--- a/src/skill.cpp
+++ b/src/skill.cpp
@@ -111,7 +111,8 @@ void Skill::load_skill( const JsonObject &jsobj )
         jso_tta.read( "base_time", time_to_attack.base_time );
         jso_tta.read( "time_reduction_per_level", time_to_attack.time_reduction_per_level );
     }
-    skill_displayType_id const display_type = skill_displayType_id( jsobj.get_string( "display_category" ) );
+    skill_displayType_id const display_type = skill_displayType_id(
+                jsobj.get_string( "display_category" ) );
     Skill sk( ident, name, desc, jsobj.get_tags( "tags" ), display_type );
 
     sk._time_to_attack = time_to_attack;

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -895,7 +895,7 @@ void sfx::do_ambient()
         return;
     }
 
-    Character  const&player_character = get_player_character();
+    Character  const &player_character = get_player_character();
     if( player_character.in_sleep_state() && !audio_muted ) {
         fade_audio_channel( channel::any, 300 );
         audio_muted = true;
@@ -1235,7 +1235,7 @@ void sfx::do_danger_music()
         return;
     }
 
-    avatar  const&player_character = get_avatar();
+    avatar  const &player_character = get_avatar();
     if( player_character.in_sleep_state() && !audio_muted ) {
         fade_audio_channel( channel::any, 100 );
         audio_muted = true;
@@ -1290,7 +1290,7 @@ void sfx::do_fatigue()
         return;
     }
 
-    avatar  const&player_character = get_avatar();
+    avatar  const &player_character = get_avatar();
     /*15: Stamina 75%
     16: Stamina 50%
     17: Stamina 25%*/
@@ -1571,7 +1571,7 @@ void sfx::play_activity_sound( const std::string &id, const std::string &variant
         return;
     }
 
-    avatar  const&player_character = get_avatar();
+    avatar  const &player_character = get_avatar();
     if( act != player_character.activity.id() ) {
         act = player_character.activity.id();
         play_ambient_variant_sound( id, variant, volume, channel::player_activities, 0 );

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -234,7 +234,7 @@ static std::vector<centroid> cluster_sounds( std::vector<std::pair<tripoint, int
                                     tripoint( MAPSIZE_X, MAPSIZE_Y, OVERMAP_HEIGHT ) );
     // Randomly choose cluster seeds.
     for( size_t i = input_sounds.size(); i > stopping_point; i-- ) {
-        size_t index = rng( 0, i - 1 );
+        size_t const index = rng( 0, i - 1 );
         // The volume and cluster weight are the same for the first element.
         sound_clusters.push_back(
             // Assure the compiler that these int->float conversions are safe.
@@ -252,7 +252,7 @@ static std::vector<centroid> cluster_sounds( std::vector<std::pair<tripoint, int
         for( auto centroid_iter = sound_clusters.begin(); centroid_iter != cluster_end;
              ++centroid_iter ) {
             // Scale the distance between the two by the max possible distance.
-            tripoint centroid_pos { static_cast<int>( centroid_iter->x ), static_cast<int>( centroid_iter->y ), static_cast<int>( centroid_iter->z ) };
+            tripoint const centroid_pos { static_cast<int>( centroid_iter->x ), static_cast<int>( centroid_iter->y ), static_cast<int>( centroid_iter->z ) };
             const int dist = sound_distance( sound_event_pair.first, centroid_pos );
             if( dist * dist < dist_factor ) {
                 found_centroid = centroid_iter;
@@ -287,7 +287,7 @@ static int get_signal_for_hordes( const centroid &centr )
     const int min_sig_cap = 8; //Signal for hordes can't be lower that this if it pass min_vol_cap
     const int max_sig_cap = 26; //Signal for hordes can't be higher that this
     //Lower the level - lower the sound
-    int vol_hordes = ( ( centr.z < 0 ) ? vol / ( underground_div * std::abs( centr.z ) ) : vol );
+    int const vol_hordes = ( ( centr.z < 0 ) ? vol / ( underground_div * std::abs( centr.z ) ) : vol );
     if( vol_hordes > min_vol_cap ) {
         //Calculating horde hearing signal
         int sig_power = std::ceil( static_cast<float>( vol_hordes ) / hordes_sig_div );
@@ -303,7 +303,7 @@ static int get_signal_for_hordes( const centroid &centr )
 
 void sounds::process_sounds()
 {
-    std::vector<centroid> sound_clusters = cluster_sounds( recent_sounds );
+    std::vector<centroid> const sound_clusters = cluster_sounds( recent_sounds );
     const int weather_vol = get_weather().weather_id->sound_attn;
     for( const auto &this_centroid : sound_clusters ) {
         // Since monsters don't go deaf ATM we can just use the weather modified volume
@@ -313,7 +313,7 @@ void sounds::process_sounds()
         const tripoint source = tripoint( this_centroid.x, this_centroid.y, this_centroid.z );
         // --- Monster sound handling here ---
         // Alert all hordes
-        int sig_power = get_signal_for_hordes( this_centroid );
+        int const sig_power = get_signal_for_hordes( this_centroid );
         if( sig_power > 0 ) {
 
             const point abs_ms = get_map().getabs( source.xy() );
@@ -449,7 +449,7 @@ void sounds::process_sound_markers( player *p )
         }
 
         // Secure the flag before wake_up() clears the effect
-        bool slept_through = p->has_effect( effect_slept_through_alarm );
+        bool const slept_through = p->has_effect( effect_slept_through_alarm );
         // See if we need to wake someone up
         if( p->has_effect( effect_sleep ) ) {
             if( ( ( !( p->has_trait( trait_HEAVYSLEEPER ) ||
@@ -494,7 +494,7 @@ void sounds::process_sound_markers( player *p )
             } else if( p->sees( pos ) ) {
                 add_msg( severity, _( "You hear %1$s" ), description );
             } else {
-                std::string direction = direction_name( direction_from( p->pos(), pos ) );
+                std::string const direction = direction_name( direction_from( p->pos(), pos ) );
                 add_msg( severity, _( "From the %1$s you hear %2$s" ), direction, description );
             }
         }
@@ -662,7 +662,7 @@ int sfx::set_channel_volume( channel channel, int volume )
     if( test_mode ) {
         return 0;
     }
-    int ch = static_cast<int>( channel );
+    int const ch = static_cast<int>( channel );
     if( !Mix_Playing( ch ) ) {
         return -1;
     }
@@ -739,7 +739,7 @@ void sfx::do_vehicle_engine_sfx()
         in_reverse = true;
     }
     double pitch = 1.0;
-    int safe_speed = veh->safe_velocity();
+    int const safe_speed = veh->safe_velocity();
     int current_gear;
     if( in_reverse ) {
         current_gear = -1;
@@ -819,12 +819,12 @@ void sfx::do_vehicle_exterior_engine_sfx()
         return;
     }
 
-    VehicleList vehs = get_map().get_vehicles();
+    VehicleList const vehs = get_map().get_vehicles();
     unsigned char noise_factor = 0;
     unsigned char vol = 0;
     vehicle *veh = nullptr;
 
-    for( wrapped_vehicle vehicle : vehs ) {
+    for( wrapped_vehicle const vehicle : vehs ) {
         if( vehicle.v->vehicle_noise > 0 &&
             vehicle.v->vehicle_noise -
             sound_distance( player_character.pos(), vehicle.v->global_pos3() ) > noise_factor ) {
@@ -895,7 +895,7 @@ void sfx::do_ambient()
         return;
     }
 
-    Character &player_character = get_player_character();
+    Character  const&player_character = get_player_character();
     if( player_character.in_sleep_state() && !audio_muted ) {
         fade_audio_channel( channel::any, 300 );
         audio_muted = true;
@@ -1216,7 +1216,7 @@ void sfx::do_player_death_hurt( const player &target, bool death )
         return;
     }
 
-    int heard_volume = get_heard_volume( target.pos() );
+    int const heard_volume = get_heard_volume( target.pos() );
     const bool male = target.male;
     if( !male && !death ) {
         play_variant_sound( "deal_damage", "hurt_f", heard_volume );
@@ -1235,7 +1235,7 @@ void sfx::do_danger_music()
         return;
     }
 
-    avatar &player_character = get_avatar();
+    avatar  const&player_character = get_avatar();
     if( player_character.in_sleep_state() && !audio_muted ) {
         fade_audio_channel( channel::any, 100 );
         audio_muted = true;
@@ -1290,7 +1290,7 @@ void sfx::do_fatigue()
         return;
     }
 
-    avatar &player_character = get_avatar();
+    avatar  const&player_character = get_avatar();
     /*15: Stamina 75%
     16: Stamina 50%
     17: Stamina 25%*/
@@ -1542,7 +1542,7 @@ void sfx::do_obstacle( const std::string &obst )
         return;
     }
 
-    int heard_volume = sfx::get_heard_volume( get_avatar().pos() );
+    int const heard_volume = sfx::get_heard_volume( get_avatar().pos() );
 
     static const std::set<std::string> water = {
         "t_water_sh",
@@ -1571,7 +1571,7 @@ void sfx::play_activity_sound( const std::string &id, const std::string &variant
         return;
     }
 
-    avatar &player_character = get_avatar();
+    avatar  const&player_character = get_avatar();
     if( act != player_character.activity.id() ) {
         act = player_character.activity.id();
         play_ambient_variant_sound( id, variant, volume, channel::player_activities, 0 );
@@ -1640,7 +1640,7 @@ void sfx::do_obstacle( const std::string & ) { }
 /*@{*/
 int sfx::get_heard_volume( const tripoint &source )
 {
-    int distance = sound_distance( get_avatar().pos(), source );
+    int const distance = sound_distance( get_avatar().pos(), source );
     // fract = -100 / 24
     const float fract = -4.166666;
     int heard_volume = fract * distance - 1 + 100;

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -216,7 +216,7 @@ tripoint_abs_omt start_location::find_player_initial_location() const
     // Shuffle 8 first ones so that we don't always start at (1,0)
     std::shuffle( overmaps.begin(), overmaps.begin() + 7, rng_get_engine() );
     for( const point_abs_om &omp : overmaps ) {
-        overmap  const&omap = overmap_buffer.get( omp );
+        overmap  const &omap = overmap_buffer.get( omp );
         const tripoint_om_omt omtstart = omap.find_random_omt( random_target() );
         if( omtstart.raw() != tripoint_min ) {
             return project_combine( omp, omtstart );
@@ -341,8 +341,8 @@ void start_location::place_player( player &u ) const
 
     while( !found_good_spot && tries < 100 ) {
         tripoint const rand_point( HALF_MAPSIZE_X + rng( 0, SEEX * 2 - 1 ),
-                             HALF_MAPSIZE_Y + rng( 0, SEEY * 2 - 1 ),
-                             u.posz() );
+                                   HALF_MAPSIZE_Y + rng( 0, SEEY * 2 - 1 ),
+                                   u.posz() );
         check_spot( rand_point );
     }
     // If we haven't got a good location by now, screw it and brute force it

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -89,7 +89,7 @@ void start_location::load( const JsonObject &jo, const std::string & )
         if( entry.test_string() ) {
             ter = entry.get_string();
         } else {
-            JsonObject jot = entry.get_object();
+            JsonObject const jot = entry.get_object();
             ter = jot.get_string( "om_terrain" );
             ter_match_type = jot.get_enum_value<ot_match_type>( "om_terrain_match_type", ter_match_type );
         }
@@ -216,7 +216,7 @@ tripoint_abs_omt start_location::find_player_initial_location() const
     // Shuffle 8 first ones so that we don't always start at (1,0)
     std::shuffle( overmaps.begin(), overmaps.begin() + 7, rng_get_engine() );
     for( const point_abs_om &omp : overmaps ) {
-        overmap &omap = overmap_buffer.get( omp );
+        overmap  const&omap = overmap_buffer.get( omp );
         const tripoint_om_omt omtstart = omap.find_random_omt( random_target() );
         if( omtstart.raw() != tripoint_min ) {
             return project_combine( omp, omtstart );
@@ -340,7 +340,7 @@ void start_location::place_player( player &u ) const
     };
 
     while( !found_good_spot && tries < 100 ) {
-        tripoint rand_point( HALF_MAPSIZE_X + rng( 0, SEEX * 2 - 1 ),
+        tripoint const rand_point( HALF_MAPSIZE_X + rng( 0, SEEX * 2 - 1 ),
                              HALF_MAPSIZE_Y + rng( 0, SEEY * 2 - 1 ),
                              u.posz() );
         check_spot( rand_point );

--- a/src/stomach.cpp
+++ b/src/stomach.cpp
@@ -14,7 +14,7 @@ void nutrients::min_in_place( const nutrients &r )
     kcal = std::min( kcal, r.kcal );
     for( const std::pair<const vitamin_id, vitamin> &vit_pair : vitamin::all() ) {
         const vitamin_id &vit = vit_pair.first;
-        int other = r.get_vitamin( vit );
+        int const other = r.get_vitamin( vit );
         if( other == 0 ) {
             vitamins.erase( vit );
         } else {
@@ -31,7 +31,7 @@ void nutrients::max_in_place( const nutrients &r )
     kcal = std::max( kcal, r.kcal );
     for( const std::pair<const vitamin_id, vitamin> &vit_pair : vitamin::all() ) {
         const vitamin_id &vit = vit_pair.first;
-        int other = r.get_vitamin( vit );
+        int const other = r.get_vitamin( vit );
         if( other != 0 ) {
             int &val = vitamins[vit];
             val = std::max( val, other );
@@ -117,7 +117,7 @@ void stomach_contents::serialize( JsonOut &json ) const
 
 void stomach_contents::deserialize( JsonIn &json )
 {
-    JsonObject jo = json.get_object();
+    JsonObject const jo = json.get_object();
     jo.read( "vitamins", nutr.vitamins );
     jo.read( "calories", nutr.kcal );
     jo.read( "last_ate", last_ate );
@@ -132,16 +132,16 @@ void stomach_contents::ingest( const food_summary &ingested )
 food_summary stomach_contents::digest( const needs_rates &metabolic_rates, int five_mins )
 {
     food_summary digested{};
-    stomach_digest_rates rates = get_digest_rates( metabolic_rates );
+    stomach_digest_rates const rates = get_digest_rates( metabolic_rates );
 
     // Digest kCal -- use min_kcal by default, but no more than what's in stomach,
     // and no less than percentage_kcal of what's in stomach.
-    int kcal_fraction = std::lround( nutr.kcal * rates.percent_kcal );
+    int const kcal_fraction = std::lround( nutr.kcal * rates.percent_kcal );
     digested.nutr.kcal = clamp( five_mins * rates.min_kcal, five_mins * kcal_fraction, nutr.kcal );
 
     // Digest vitamins just like we did kCal, but we need to do one at a time.
     for( const std::pair<const vitamin_id, int> &vit : nutr.vitamins ) {
-        int vit_fraction = std::lround( vit.second * rates.percent_vitamin );
+        int const vit_fraction = std::lround( vit.second * rates.percent_vitamin );
         digested.nutr.vitamins[vit.first] =
             five_mins * clamp( rates.min_vitamin, vit_fraction, vit.second );
     }

--- a/src/string_id.cpp
+++ b/src/string_id.cpp
@@ -23,7 +23,7 @@ inline static ReverseLookupVecType &get_reverse_lookup_vec()
 template<typename S>
 inline static int universal_string_id_intern( S &&s )
 {
-    int next_id = get_reverse_lookup_vec().size();
+    int const next_id = get_reverse_lookup_vec().size();
     const auto &pair = get_intern_map().emplace( std::forward<S>( s ), next_id );
     if( pair.second ) { // inserted
         get_reverse_lookup_vec().push_back( &pair.first->first );
@@ -53,6 +53,6 @@ const std::string &string_identity_static::get_interned_string( int id )
 
 int string_identity_static::empty_interned_string()
 {
-    static int empty_string_id = string_id_intern( "" );
+    static int const empty_string_id = string_id_intern( "" );
     return empty_string_id;
 }

--- a/src/string_input_popup.cpp
+++ b/src/string_input_popup.cpp
@@ -451,8 +451,8 @@ const std::string &string_input_popup::query_string( const bool loop, const bool
                 ret.erase( _position, 1 );
             }
         } else if( ch == KEY_F( 2 ) ) {
-            std::string tmp = get_input_string_from_file();
-            int tmplen = utf8_width( tmp );
+            std::string const tmp = get_input_string_from_file();
+            int const tmplen = utf8_width( tmp );
             if( tmplen > 0 && ( tmplen + utf8_width( ret ) <= _max_length || _max_length == 0 ) ) {
                 ret.append( tmp );
             }

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -126,7 +126,7 @@ int ci_find_substr( const std::string &str1, const std::string &str2 )
 {
     std::locale loc = std::locale();
 
-    std::string::const_iterator it = std::search( str1.begin(), str1.end(), str2.begin(), str2.end(),
+    std::string::const_iterator const it = std::search( str1.begin(), str1.end(), str2.begin(), str2.end(),
     [&]( const char str1_in, const char str2_in ) {
         return std::toupper( str1_in, loc ) == std::toupper( str2_in, loc );
     } );
@@ -169,7 +169,7 @@ bool wildcard_match( const std::string &text_in, const std::string &pattern_in )
             }
         } else {
             if( !( *it ).empty() ) {
-                int pos = ci_find_substr( text, *it );
+                int const pos = ci_find_substr( text, *it );
                 if( pos == -1 ) {
                     return false;
                 }
@@ -283,8 +283,8 @@ void replace_first( std::string &input, const std::string &what, const std::stri
     if( what.empty() || what == with ) {
         return;
     }
-    size_t len = what.length();
-    size_t offset = input.find( what );
+    size_t const len = what.length();
+    size_t const offset = input.find( what );
     if( offset != std::string::npos ) {
         input.replace( offset, len, with );
     }

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -126,7 +126,8 @@ int ci_find_substr( const std::string &str1, const std::string &str2 )
 {
     std::locale loc = std::locale();
 
-    std::string::const_iterator const it = std::search( str1.begin(), str1.end(), str2.begin(), str2.end(),
+    std::string::const_iterator const it = std::search( str1.begin(), str1.end(), str2.begin(),
+                                           str2.end(),
     [&]( const char str1_in, const char str2_in ) {
         return std::toupper( str1_in, loc ) == std::toupper( str2_in, loc );
     } );

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -375,7 +375,7 @@ void Character::suffer_from_chemimbalance()
         mod_pain( 3 * rng( 1, 3 ) );
     }
     if( one_turn_in( 6_hours ) ) {
-        int pkilladd = 5 * rng( -1, 2 );
+        int const pkilladd = 5 * rng( -1, 2 );
         if( pkilladd > 0 ) {
             add_msg_if_player( m_bad, _( "You suddenly feel numb." ) );
         } else if( ( pkilladd < 0 ) && ( !( has_trait( trait_NOPAIN ) ) ) ) {
@@ -388,7 +388,7 @@ void Character::suffer_from_chemimbalance()
         moves -= rng( 10, 30 );
     }
     if( one_turn_in( 6_hours ) ) {
-        int hungadd = 5 * rng( -1, 3 );
+        int const hungadd = 5 * rng( -1, 3 );
         if( hungadd > 0 ) {
             add_msg_if_player( m_bad, _( "You suddenly feel hungry." ) );
         } else {
@@ -462,7 +462,7 @@ void Character::suffer_from_schizophrenia()
     if( one_turn_in( 6_hours ) ) {
         const translation snip = SNIPPET.random_from_category( "schizo_formication" ).value_or(
                                      translation() );
-        body_part bp = random_body_part( true );
+        body_part const bp = random_body_part( true );
         add_effect( effect_formication, 45_minutes, bp );
         add_msg_if_player( m_bad, "%s", snip );
         return;
@@ -503,7 +503,7 @@ void Character::suffer_from_schizophrenia()
         str[0] = toupper( str[0] );
 
         add_msg_if_player( m_bad, "%s", str );
-        item_location loc( *this, &weapon );
+        item_location const loc( *this, &weapon );
         drop( loc, pos() );
         return;
     }
@@ -525,7 +525,7 @@ void Character::suffer_from_schizophrenia()
     }
     // Follower turns hostile
     if( one_turn_in( 4_hours ) ) {
-        std::vector<shared_ptr_fast<npc>> followers = overmap_buffer.get_npcs_near_player( 12 );
+        std::vector<shared_ptr_fast<npc>> const followers = overmap_buffer.get_npcs_near_player( 12 );
 
         std::string who_gets_angry = name;
         if( !followers.empty() ) {
@@ -555,7 +555,7 @@ void Character::suffer_from_schizophrenia()
 
     // NPC chat
     if( one_turn_in( 4_hours ) ) {
-        std::string i_name = Name::generate( one_in( 2 ) );
+        std::string const i_name = Name::generate( one_in( 2 ) );
 
         std::string i_talk = SNIPPET.expand( SNIPPET.random_from_category( "<lets_talk>" ).value_or(
                 translation() ).translated() );
@@ -567,7 +567,7 @@ void Character::suffer_from_schizophrenia()
 
     // Skill raise
     if( one_turn_in( 12_hours ) ) {
-        skill_id raised_skill = Skill::random_skill();
+        skill_id const raised_skill = Skill::random_skill();
         add_msg_if_player( m_good, _( "You increase %1$s to level %2$d." ), raised_skill.obj().name(),
                            get_skill_level( raised_skill ) + 1 );
         return;
@@ -580,13 +580,13 @@ void Character::suffer_from_schizophrenia()
         // Weapon is concerned for player if bleeding
         // Weapon is concerned for itself if damaged
         // Otherwise random chit-chat
-        std::vector<weak_ptr_fast<monster>> mons = g->all_monsters().items;
+        std::vector<weak_ptr_fast<monster>> const mons = g->all_monsters().items;
 
         std::string i_talk_w;
         bool does_talk = false;
         if( !mons.empty() && one_turn_in( 12_minutes ) ) {
             std::vector<std::string> seen_mons;
-            for( weak_ptr_fast<monster> &n : mons ) {
+            for( weak_ptr_fast<monster>  const&n : mons ) {
                 if( sees( *n.lock() ) ) {
                     seen_mons.emplace_back( n.lock()->get_name() );
                 }
@@ -634,7 +634,7 @@ void Character::suffer_from_asthma( const int current_stim )
     }
     bool auto_use = has_charges( itype_inhaler, 1 ) || has_charges( itype_oxygen_tank, 1 ) ||
                     has_charges( itype_smoxygen_tank, 1 );
-    bool oxygenator = has_bionic( bio_gills ) && get_power_level() >= ( bio_gills->power_trigger / 8 );
+    bool const oxygenator = has_bionic( bio_gills ) && get_power_level() >= ( bio_gills->power_trigger / 8 );
     if( is_underwater() ) {
         oxygen = oxygen / 2;
         auto_use = false;
@@ -647,7 +647,7 @@ void Character::suffer_from_asthma( const int current_stim )
         inventory map_inv;
         map_inv.form_from_map( g->u.pos(), 2, &g->u );
         // check if an inhaler is somewhere near
-        bool nearby_use = auto_use || oxygenator || map_inv.has_charges( itype_inhaler, 1 ) ||
+        bool const nearby_use = auto_use || oxygenator || map_inv.has_charges( itype_inhaler, 1 ) ||
                           map_inv.has_charges( itype_oxygen_tank, 1 ) ||
                           map_inv.has_charges( itype_smoxygen_tank, 1 );
         // check if character has an oxygenator first
@@ -808,7 +808,7 @@ void Character::suffer_feral_kill_withdrawl()
 
 void Character::suffer_in_sunlight()
 {
-    double sleeve_factor = armwear_factor();
+    double const sleeve_factor = armwear_factor();
     const bool has_hat = wearing_something_on( bodypart_id( "head" ) );
     const bool leafy = has_trait( trait_LEAVES ) || has_trait( trait_LEAVES2 ) ||
                        has_trait( trait_LEAVES3 );
@@ -819,12 +819,12 @@ void Character::suffer_in_sunlight()
         const float weather_factor = ( get_weather().weather_id->sun_intensity >=
                                        sun_intensity_type::normal ) ? 1.0 : 0.5;
         const int player_local_temp = get_weather().get_temperature( pos() );
-        int flux = ( player_local_temp - 65 ) / 2;
+        int const flux = ( player_local_temp - 65 ) / 2;
         if( !has_hat ) {
             sunlight_nutrition += ( 100 + flux ) * weather_factor;
         }
         if( leafier ) {
-            int rate = ( ( 100 * sleeve_factor ) + flux ) * 2;
+            int const rate = ( ( 100 * sleeve_factor ) + flux ) * 2;
             sunlight_nutrition += ( rate * ( leafiest ? 2 : 1 ) ) * weather_factor;
         }
     }
@@ -884,13 +884,13 @@ std::map<bodypart_id, float> Character::bodypart_exposure()
     // For every item worn, for every body part, adjust coverage
     for( const item &it : worn ) {
         // What body parts does this item cover?
-        body_part_set covered = it.get_covered_body_parts();
+        body_part_set const covered = it.get_covered_body_parts();
         for( const bodypart_id &bp : all_body_parts )  {
             if( bp->token != num_bp && !covered.test( bp->token ) ) {
                 continue;
             }
             // How much exposure does this item leave on this part? (1.0 == naked)
-            float part_exposure = 1.0 - it.get_coverage() / 100.0f;
+            float const part_exposure = 1.0 - it.get_coverage() / 100.0f;
             // Coverage multiplies, so two layers with 50% coverage will together give 75%
             bp_exposure[bp] = bp_exposure[bp] * part_exposure;
         }
@@ -980,7 +980,7 @@ void Character::suffer_from_sunburn()
         }
     }
     // Get singular or plural body part name; append "and other body parts" if appropriate
-    std::string bp_name = body_part_name( most_exposed_bp, count_limbs );
+    std::string const bp_name = body_part_name( most_exposed_bp, count_limbs );
     if( count_affected_bp == count_limbs ) {
         add_msg_if_player( m_bad, _( "%s your %s." ), sunlight_effect, bp_name );
     } else {
@@ -1047,7 +1047,7 @@ void Character::suffer_from_other_mutations()
                        "insect_wings" );
     }
 
-    bool wearing_shoes = is_wearing_shoes( side::LEFT ) || is_wearing_shoes( side::RIGHT );
+    bool const wearing_shoes = is_wearing_shoes( side::LEFT ) || is_wearing_shoes( side::RIGHT );
     int root_vitamins = 0;
     int root_water = 0;
     if( has_trait( trait_ROOTS3 ) && here.has_flag( flag_PLOWABLE, pos() ) && !wearing_shoes ) {
@@ -1075,7 +1075,7 @@ void Character::suffer_from_other_mutations()
             if( bp == bp_head ) {
                 continue;
             }
-            int sores_pain = 5 + 0.4 * std::abs( encumb( bp ) );
+            int const sores_pain = 5 + 0.4 * std::abs( encumb( bp ) );
             if( get_pain() < sores_pain ) {
                 set_pain( sores_pain );
             }
@@ -1178,7 +1178,7 @@ void Character::suffer_from_radiation()
         if( rad_mut_proc && !kept_in ) {
             // Irradiate a random nearby point
             // If you can't, irradiate the player instead
-            tripoint rad_point = pos() + point( rng( -3, 3 ), rng( -3, 3 ) );
+            tripoint const rad_point = pos() + point( rng( -3, 3 ), rng( -3, 3 ) );
             // TODO: Radioactive vehicles?
             if( here.get_radiation( rad_point ) < rad_mut ) {
                 here.adjust_radiation( rad_point, 1 );
@@ -1189,7 +1189,7 @@ void Character::suffer_from_radiation()
     }
 
     // Used to control vomiting from radiation to make it not-annoying
-    bool radiation_increasing = irradiate( rads );
+    bool const radiation_increasing = irradiate( rads );
 
     if( radiation_increasing && calendar::once_every( 3_minutes ) && has_bionic( bio_geiger ) ) {
         add_msg_if_player( m_warning,
@@ -1369,7 +1369,7 @@ void Character::suffer_from_bad_bionics()
     if( has_bionic( bio_itchy ) && one_turn_in( 50_minutes ) && !has_effect( effect_formication ) &&
         !has_effect( effect_narcosis ) ) {
         add_msg_if_player( m_bad, _( "Your malfunctioning bionic itches!" ) );
-        body_part bp = random_body_part( true );
+        body_part const bp = random_body_part( true );
         add_effect( effect_formication, 10_minutes, bp );
     }
     if( has_bionic( bio_glowy ) && !has_effect( effect_glowy_led ) && one_turn_in( 50_minutes ) &&
@@ -1626,7 +1626,7 @@ bool Character::irradiate( float rads, bool bypass )
             rads *= 0.3f + 0.1f * rad_mut;
         }
 
-        int rads_max = roll_remainder( rads );
+        int const rads_max = roll_remainder( rads );
         mod_rad( rng( 0, rads_max ) );
 
         // Apply rads to any radiation badges.
@@ -1808,11 +1808,11 @@ void Character::sound_hallu()
     std::string i_desc;
     std::pair<std::string, std::string> i_sound;
     if( one_in( 5 ) ) {
-        int r_int = rng( 0, desc_big.size() - 1 );
+        int const r_int = rng( 0, desc_big.size() - 1 );
         i_desc = std::get<0>( desc_big[r_int] );
         i_sound = std::make_pair( std::get<1>( desc_big[r_int] ), std::get<2>( desc_big[r_int] ) );
     } else {
-        int r_int = rng( 0, desc.size() - 1 );
+        int const r_int = rng( 0, desc.size() - 1 );
         i_desc = std::get<0>( desc[r_int] );
         i_sound = std::make_pair( std::get<1>( desc[r_int] ), std::get<2>( desc[r_int] ) );
     }
@@ -1845,8 +1845,8 @@ void Character::drench( int saturation, const body_part_set &flags, bool ignore_
             continue;
         }
         // Different sources will only make the bodypart wet to a limit
-        int source_wet_max = saturation * bp_wetness_max * 2 / 100;
-        int wetness_increment = ignore_waterproof ? 100 : 2;
+        int const source_wet_max = saturation * bp_wetness_max * 2 / 100;
+        int const wetness_increment = ignore_waterproof ? 100 : 2;
         // Respect maximums
         const int wetness_max = std::min( source_wet_max, bp_wetness_max );
         if( body_wetness[bp] < wetness_max ) {

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -586,7 +586,7 @@ void Character::suffer_from_schizophrenia()
         bool does_talk = false;
         if( !mons.empty() && one_turn_in( 12_minutes ) ) {
             std::vector<std::string> seen_mons;
-            for( weak_ptr_fast<monster>  const&n : mons ) {
+            for( weak_ptr_fast<monster>  const &n : mons ) {
                 if( sees( *n.lock() ) ) {
                     seen_mons.emplace_back( n.lock()->get_name() );
                 }
@@ -634,7 +634,8 @@ void Character::suffer_from_asthma( const int current_stim )
     }
     bool auto_use = has_charges( itype_inhaler, 1 ) || has_charges( itype_oxygen_tank, 1 ) ||
                     has_charges( itype_smoxygen_tank, 1 );
-    bool const oxygenator = has_bionic( bio_gills ) && get_power_level() >= ( bio_gills->power_trigger / 8 );
+    bool const oxygenator = has_bionic( bio_gills ) &&
+                            get_power_level() >= ( bio_gills->power_trigger / 8 );
     if( is_underwater() ) {
         oxygen = oxygen / 2;
         auto_use = false;
@@ -648,8 +649,8 @@ void Character::suffer_from_asthma( const int current_stim )
         map_inv.form_from_map( g->u.pos(), 2, &g->u );
         // check if an inhaler is somewhere near
         bool const nearby_use = auto_use || oxygenator || map_inv.has_charges( itype_inhaler, 1 ) ||
-                          map_inv.has_charges( itype_oxygen_tank, 1 ) ||
-                          map_inv.has_charges( itype_smoxygen_tank, 1 );
+                                map_inv.has_charges( itype_oxygen_tank, 1 ) ||
+                                map_inv.has_charges( itype_smoxygen_tank, 1 );
         // check if character has an oxygenator first
         if( oxygenator ) {
             mod_power_level( -bio_gills->power_trigger / 8 );

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -31,7 +31,7 @@ bool teleport::teleport( Creature &critter, int min_distance, int max_distance, 
     player *const p = critter.as_player();
     const bool c_is_u = p != nullptr && p->is_avatar();
     int tries = 0;
-    tripoint origin = critter.pos();
+    tripoint const origin = critter.pos();
     tripoint new_pos = origin;
     map &here = get_map();
     //The teleportee is dimensionally anchored so nothing happens
@@ -41,8 +41,8 @@ bool teleport::teleport( Creature &critter, int min_distance, int max_distance, 
         return false;
     }
     do {
-        int rangle = rng( 0, 360 );
-        int rdistance = rng( min_distance, max_distance );
+        int const rangle = rng( 0, 360 );
+        int const rdistance = rng( min_distance, max_distance );
         new_pos.x = origin.x + rdistance * std::cos( rangle );
         new_pos.y = origin.y + rdistance * std::sin( rangle );
         tries++;

--- a/src/text_snippets.cpp
+++ b/src/text_snippets.cpp
@@ -41,7 +41,7 @@ void snippet_library::add_snippets_from_json( const std::string &category, const
             }
             snippets_by_category[category].no_id.emplace_back( text );
         } else {
-            JsonObject jo = entry.get_object();
+            JsonObject const jo = entry.get_object();
             add_snippet_from_json( category, jo );
         }
     }
@@ -109,16 +109,16 @@ bool snippet_library::has_snippet_with_id( const snippet_id &id ) const
 
 std::string snippet_library::expand( const std::string &str ) const
 {
-    size_t tag_begin = str.find( '<' );
+    size_t const tag_begin = str.find( '<' );
     if( tag_begin == std::string::npos ) {
         return str;
     }
-    size_t tag_end = str.find( '>', tag_begin + 1 );
+    size_t const tag_end = str.find( '>', tag_begin + 1 );
     if( tag_end == std::string::npos ) {
         return str;
     }
 
-    std::string symbol = str.substr( tag_begin, tag_end - tag_begin + 1 );
+    std::string const symbol = str.substr( tag_begin, tag_end - tag_begin + 1 );
     std::optional<translation> replacement = random_from_category( symbol );
     if( !replacement.has_value() ) {
         return str.substr( 0, tag_end + 1 )
@@ -210,22 +210,22 @@ std::string get_random_tip_of_the_day()
 
     if( !did_load ) {
         did_load = true;
-        bool success = read_from_file_json( PATH_INFO::main_menu_tips(), [&]( JsonIn & jsin ) {
+        bool const success = read_from_file_json( PATH_INFO::main_menu_tips(), [&]( JsonIn & jsin ) {
             JsonArray jarr = jsin.get_array();
             if( jarr.size() != 1 ) {
                 jarr.throw_error( "expected 1 element in main array" );
             }
             all_tips.reserve( jarr.size() );
-            for( JsonValue jval : jarr ) {
-                JsonObject jobj = jval.get_object();
+            for( JsonValue const jval : jarr ) {
+                JsonObject const jobj = jval.get_object();
                 if( jobj.get_string( "type" ) != "snippet" ) {
                     jobj.throw_error( "expected 'snippet' type", "type" );
                 }
                 if( jobj.get_string( "category" ) != "tip" ) {
                     jobj.throw_error( "expected 'tip' category", "category" );
                 }
-                JsonArray text = jobj.get_array( "text" );
-                for( JsonValue entry : text ) {
+                JsonArray const text = jobj.get_array( "text" );
+                for( JsonValue const entry : text ) {
                     all_tips.push_back( entry.get_string() );
                 }
             }

--- a/src/tileray.cpp
+++ b/src/tileray.cpp
@@ -47,7 +47,7 @@ void tileray::init( units::angle adir )
     // Clamp adir to the range [0, 360)
     direction = normalize( adir );
     last_d = point_zero;
-    rl_vec2d delta_f( units::cos( direction ), units::sin( direction ) );
+    rl_vec2d const delta_f( units::cos( direction ), units::sin( direction ) );
     delta = ( delta_f * 100 ).as_point();
     abs_d = delta.abs();
     steps = 0;
@@ -197,7 +197,7 @@ void tileray::advance( int num )
     if( num == 0 ) {
         return;
     }
-    int anum = std::abs( num );
+    int const anum = std::abs( num );
     steps += anum;
     const bool vertical = mostly_vertical();
     if( abs_d.x && abs_d.y ) {
@@ -226,7 +226,7 @@ void tileray::advance( int num )
     }
 
     // offset calculated for 0-90 deg quadrant, we need to adjust if direction is other
-    int quadr = quadrant();
+    int const quadr = quadrant();
     last_d.x *= sx[quadr];
     last_d.y *= sy[quadr];
     if( num < 0 ) {

--- a/src/timed_event.cpp
+++ b/src/timed_event.cpp
@@ -62,7 +62,7 @@ void timed_event::actualize()
 
                 g->events().send<event_type::becomes_wanted>( g->u.getID() );
                 point const rob( u_pos.x > map_point.x ? 0 - SEEX * 2 : SEEX * 4,
-                           u_pos.y > map_point.y ? 0 - SEEY * 2 : SEEY * 4 );
+                                 u_pos.y > map_point.y ? 0 - SEEY * 2 : SEEY * 4 );
                 g->place_critter_at( robot_type, tripoint( rob, g->u.posz() ) );
             }
         }

--- a/src/timed_event.cpp
+++ b/src/timed_event.cpp
@@ -61,7 +61,7 @@ void timed_event::actualize()
                 const mtype_id &robot_type = one_in( 2 ) ? mon_copbot : mon_riotbot;
 
                 g->events().send<event_type::becomes_wanted>( g->u.getID() );
-                point rob( u_pos.x > map_point.x ? 0 - SEEX * 2 : SEEX * 4,
+                point const rob( u_pos.x > map_point.x ? 0 - SEEX * 2 : SEEX * 4,
                            u_pos.y > map_point.y ? 0 - SEEY * 2 : SEEY * 4 );
                 g->place_critter_at( robot_type, tripoint( rob, g->u.posz() ) );
             }
@@ -95,7 +95,7 @@ void timed_event::actualize()
 
         case TIMED_EVENT_AMIGARA: {
             g->events().send<event_type::angers_amigara_horrors>();
-            int num_horrors = rng( 3, 5 );
+            int const num_horrors = rng( 3, 5 );
             std::optional<tripoint> fault_point;
             bool horizontal = false;
             for( const tripoint &p : g->m.points_on_zlevel() ) {
@@ -243,7 +243,7 @@ void timed_event::per_turn()
         case TIMED_EVENT_WANTED: {
             // About once every 5 minutes. Suppress in classic zombie mode.
             if( g->get_levz() >= 0 && one_in( 50 ) && !get_option<bool>( "DISABLE_ROBOT_RESPONSE" ) ) {
-                point place = g->m.random_outdoor_tile();
+                point const place = g->m.random_outdoor_tile();
                 if( place.x == -1 && place.y == -1 ) {
                     // We're safely indoors!
                     return;

--- a/src/trait_group.cpp
+++ b/src/trait_group.cpp
@@ -58,7 +58,7 @@ Trait_group_tag trait_group::load_trait_group( const JsonValue &value,
     } else if( value.test_object() ) {
         const Trait_group_tag group = get_unique_trait_group_id();
 
-        JsonObject jo = value.get_object();
+        JsonObject const jo = value.get_object();
         const std::string subtype = jo.get_string( "subtype", default_subtype );
 
         mutation_branch::load_trait_group( jo, group, subtype );

--- a/src/translations.cpp
+++ b/src/translations.cpp
@@ -66,7 +66,7 @@ std::string gettext_gendered( const GenderMap &genders, const std::string &msg )
         }
         chosen_genders.push_back( subject_genders.first + ":" + chosen_gender );
     }
-    std::string context = join( chosen_genders, " " );
+    std::string const context = join( chosen_genders, " " );
     return pgettext( context.c_str(), msg.c_str() );
 }
 
@@ -195,7 +195,7 @@ void translation::deserialize( JsonIn &jsin )
         }
         needs_translation = true;
     } else {
-        JsonObject jsobj = jsin.get_object();
+        JsonObject const jsobj = jsin.get_object();
         if( jsobj.has_string( "ctxt" ) ) {
             ctxt = cata::make_value<std::string>( jsobj.get_string( "ctxt" ) );
         } else {

--- a/src/trap.cpp
+++ b/src/trap.cpp
@@ -130,7 +130,7 @@ void trap::load( const JsonObject &jo, const std::string & )
         int quantity = 0;
         int charges = 0;
         if( entry.test_object() ) {
-            JsonObject jc = entry.get_object();
+            JsonObject const jc = entry.get_object();
             jc.read( "item", item_type, true );
             quantity = jc.get_int( "quantity", 1 );
             charges = jc.get_int( "charges", 1 );
@@ -144,7 +144,7 @@ void trap::load( const JsonObject &jo, const std::string & )
         }
     }
     if( jo.has_object( "vehicle_data" ) ) {
-        JsonObject jv = jo.get_object( "vehicle_data" );
+        JsonObject const jv = jo.get_object( "vehicle_data" );
         vehicle_data.remove_trap = jv.get_bool( "remove_trap", false );
         vehicle_data.do_explosion = jv.get_bool( "do_explosion", false );
         vehicle_data.is_falling = jv.get_bool( "is_falling", false );
@@ -159,7 +159,7 @@ void trap::load( const JsonObject &jo, const std::string & )
         if( jv.has_array( "spawn_items" ) ) {
             for( const JsonValue entry : jv.get_array( "spawn_items" ) ) {
                 if( entry.test_object() ) {
-                    JsonObject joitm = entry.get_object();
+                    JsonObject const joitm = entry.get_object();
                     vehicle_data.spawn_items.emplace_back(
                         itype_id( joitm.get_string( "id" ) ), joitm.get_float( "chance" ) );
                 } else {
@@ -233,7 +233,7 @@ void trap::trigger( const tripoint &pos, Creature *creature, item *item ) const
 {
     const bool is_real_creature = creature != nullptr && !creature->is_hallucination();
     if( is_real_creature || item != nullptr ) {
-        bool triggered = act( pos, creature, item );
+        bool const triggered = act( pos, creature, item );
         if( triggered && is_real_creature ) {
             if( Character *ch = creature->as_character() ) {
                 get_event_bus().send<event_type::character_triggers_trap>( ch->getID(), id );

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -368,7 +368,7 @@ bool trapfunc::crossbow( const tripoint &p, Creature *c, item * )
                                           _( "<npcname> dodges the shot!" ) );
             }
         } else if( z != nullptr ) {
-            bool seen = g->u.sees( *z );
+            bool const seen = g->u.sees( *z );
             int chance = 0;
             // adapted from shotgun code - chance of getting hit depends on size
             switch( z->type->size ) {
@@ -469,7 +469,7 @@ bool trapfunc::shotgun( const tripoint &p, Creature *c, item * )
                                           _( "<npcname> dodges the shot!" ) );
             }
         } else if( z != nullptr ) {
-            bool seen = g->u.sees( *z );
+            bool const seen = g->u.sees( *z );
             int chance = 0;
             switch( z->type->size ) {
                 case MS_TINY:
@@ -777,9 +777,9 @@ bool trapfunc::pit( const tripoint &p, Creature *c, item * )
             n->add_msg_if_player( m_info,
                                   _( "You hit the ground hard, but your shock absorbers handle the impact admirably!" ) );
         } else {
-            int dodge = n->get_dodge();
+            int const dodge = n->get_dodge();
             ///\EFFECT_DODGE reduces damage taken falling into a pit
-            int damage = eff * rng( 10, 20 ) - rng( dodge, dodge * 5 );
+            int const damage = eff * rng( 10, 20 ) - rng( dodge, dodge * 5 );
             if( damage > 0 ) {
                 n->add_msg_if_player( m_bad, _( "You hurt yourself!" ) );
                 // like the message says \-:
@@ -817,8 +817,8 @@ bool trapfunc::pit_spikes( const tripoint &p, Creature *c, item * )
     monster *z = dynamic_cast<monster *>( c );
     player *n = dynamic_cast<player *>( c );
     if( n != nullptr ) {
-        int dodge = n->get_dodge();
-        int damage = pit_effectiveness( p ) * rng( 20, 50 );
+        int const dodge = n->get_dodge();
+        int const damage = pit_effectiveness( p ) * rng( 20, 50 );
         if( ( n->has_trait( trait_WINGS_BIRD ) ) || ( ( one_in( 2 ) ) &&
                 ( n->has_trait( trait_WINGS_BUTTERFLY ) ) ) ) {
             n->add_msg_if_player( _( "You flap your wings and flutter down gracefully." ) );
@@ -896,8 +896,8 @@ bool trapfunc::pit_glass( const tripoint &p, Creature *c, item * )
     monster *z = dynamic_cast<monster *>( c );
     player *n = dynamic_cast<player *>( c );
     if( n != nullptr ) {
-        int dodge = n->get_dodge();
-        int damage = pit_effectiveness( p ) * rng( 15, 35 );
+        int const dodge = n->get_dodge();
+        int const damage = pit_effectiveness( p ) * rng( 15, 35 );
         if( ( n->has_trait( trait_WINGS_BIRD ) ) || ( ( one_in( 2 ) ) &&
                 ( n->has_trait( trait_WINGS_BUTTERFLY ) ) ) ) {
             n->add_msg_if_player( _( "You flap your wings and flutter down gracefully." ) );
@@ -1326,7 +1326,7 @@ bool trapfunc::glow( const tripoint &p, Creature *c, item * )
 
 bool trapfunc::hum( const tripoint &p, Creature *, item * )
 {
-    int volume = rng( 1, 200 );
+    int const volume = rng( 1, 200 );
     std::string sfx;
     if( volume <= 10 ) {
         //~ a quiet humming sound
@@ -1380,7 +1380,7 @@ bool trapfunc::map_regen( const tripoint &p, Creature *c, item * )
         if( n ) {
             map &here = get_map();
             n->add_msg_if_player( m_warning, _( "Your surroundings shift!" ) );
-            tripoint_abs_omt omt_pos = n->global_omt_location();
+            tripoint_abs_omt const omt_pos = n->global_omt_location();
             const std::string &regen_mapgen = here.tr_at( p ).map_regen_target();
             here.remove_trap( p );
             if( !run_mapgen_update_func( regen_mapgen, omt_pos, nullptr, false ) ) {

--- a/src/turret.cpp
+++ b/src/turret.cpp
@@ -204,8 +204,8 @@ bool turret_data::in_range( const tripoint &target ) const
     if( !veh || !part ) {
         return false;
     }
-    int range = veh->turret_query( *part ).range();
-    int dist = rl_dist( veh->global_part_pos3( *part ), target );
+    int const range = veh->turret_query( *part ).range();
+    int const dist = rl_dist( veh->global_part_pos3( *part ), target );
     return range >= dist;
 }
 
@@ -266,8 +266,8 @@ void turret_data::prepare_fire( player &p )
     // set fuel tank fluid as ammo, if appropriate
     if( part->info().has_flag( "USE_TANKS" ) ) {
         auto mode = base()->gun_current_mode();
-        int qty  = mode->ammo_required();
-        int fuel_left = veh->fuel_left( ammo_current() );
+        int const qty  = mode->ammo_required();
+        int const fuel_left = veh->fuel_left( ammo_current() );
         mode->ammo_set( ammo_current(), std::min( qty * mode.qty, fuel_left ) );
     }
 }
@@ -310,7 +310,7 @@ void vehicle::turrets_aim_and_fire_single()
 
     // Find all turrets that are ready to fire
     for( auto &t : turrets() ) {
-        turret_data data = turret_query( *t );
+        turret_data const data = turret_query( *t );
         if( data.query() == turret_data::status::ready ) {
             option_names.push_back( t->name() );
             options.push_back( t );
@@ -367,7 +367,7 @@ int vehicle::turrets_aim_and_fire( std::vector<vehicle_part *> &turrets )
     int shots = 0;
     if( turrets_aim( turrets ) ) {
         for( vehicle_part *t : turrets ) {
-            bool has_target = t->target.first != t->target.second;
+            bool const has_target = t->target.first != t->target.second;
             if( has_target ) {
                 turret_data turret = turret_query( *t );
                 npc cpu = get_targeting_npc( *t );
@@ -393,9 +393,9 @@ bool vehicle::turrets_aim( std::vector<vehicle_part *> &turrets )
     // Get target
     target_handler::trajectory trajectory = target_handler::mode_turrets( g->u, *this, turrets );
 
-    bool got_target = !trajectory.empty();
+    bool const got_target = !trajectory.empty();
     if( got_target ) {
-        tripoint target = trajectory.back();
+        tripoint const target = trajectory.back();
         // Set target for any turret in range
         for( vehicle_part *t : turrets ) {
             if( turret_query( *t ).in_range( target ) ) {
@@ -473,7 +473,7 @@ void vehicle::turrets_set_targeting()
         }
 
         // clear the turret's current targets to prevent unwanted auto-firing
-        tripoint pos = locations[ sel ];
+        tripoint const pos = locations[ sel ];
         turrets[ sel ]->reset_target( pos );
     }
 }
@@ -550,7 +550,7 @@ int vehicle::automatic_fire_turret( vehicle_part &pt )
     }
 
     // The position of the vehicle part.
-    tripoint pos = global_part_pos3( pt );
+    tripoint const pos = global_part_pos3( pt );
 
     // Create the targeting computer's npc
     npc cpu = get_targeting_npc( pt );
@@ -573,8 +573,8 @@ int vehicle::automatic_fire_turret( vehicle_part &pt )
         int boo_hoo;
 
         // TODO: calculate chance to hit and cap range based upon this
-        int max_range = 20;
-        int range = std::min( gun.range(), max_range );
+        int const max_range = 20;
+        int const range = std::min( gun.range(), max_range );
         Creature *auto_target = cpu.auto_find_hostile_target( range, boo_hoo, area );
         if( auto_target == nullptr ) {
             if( boo_hoo ) {
@@ -608,7 +608,7 @@ int vehicle::automatic_fire_turret( vehicle_part &pt )
     }
 
     // Get the turret's target and reset it
-    tripoint targ = target.second;
+    tripoint const targ = target.second;
     pt.reset_target( pos );
 
     shots = gun.fire( cpu, targ );

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -29,9 +29,9 @@
 
 catacurses::window new_centered_win( int nlines, int ncols )
 {
-    int height = std::min( nlines, TERMY );
-    int width = std::min( ncols, TERMX );
-    point pos( ( TERMX - width ) / 2, ( TERMY - height ) / 2 );
+    int const height = std::min( nlines, TERMY );
+    int const width = std::min( ncols, TERMX );
+    point const pos( ( TERMX - width ) / 2, ( TERMY - height ) / 2 );
     return catacurses::newwin( height, width, pos );
 }
 
@@ -123,7 +123,7 @@ uilist::uilist( const std::string &msg, std::initializer_list<const char *const>
 
 uilist::~uilist()
 {
-    shared_ptr_fast<ui_adaptor> current_ui = ui.lock();
+    shared_ptr_fast<ui_adaptor> const current_ui = ui.lock();
     if( current_ui ) {
         current_ui->reset();
     }
@@ -213,17 +213,17 @@ void uilist::init()
 
 void uilist::filterlist()
 {
-    bool filtering = ( this->filtering && !filter.empty() );
+    bool const filtering = ( this->filtering && !filter.empty() );
 
     // TODO: && is_all_lc( filter )
-    bool ignore_case = filtering_igncase;
+    bool const ignore_case = filtering_igncase;
     fentries.clear();
     fselected = -1;
 
     int f = 0;
-    int num_entries = entries.size();
+    int const num_entries = entries.size();
     // check if string begin by " and finish by ". If that's the case, we only return a result if it matches it exactly
-    bool exact_match_only = !filter.empty() && filter.front() == '\"' && filter.back() == '\"';
+    bool const exact_match_only = !filter.empty() && filter.front() == '\"' && filter.back() == '\"';
     if( exact_match_only ) {
         filter.erase( std::remove( filter.begin(), filter.end(), '\"' ), filter.end() );
     }
@@ -300,7 +300,7 @@ void uilist::inputfilter()
     .ignore_custom_actions( false )
     .max_length( 256 )
     .window( window, point( 4, w_height - 1 ), w_width - 4 );
-    ime_sentry sentry;
+    ime_sentry const sentry;
     do {
         ui_manager::redraw();
         filter = filter_popup->query_string( false );
@@ -358,9 +358,9 @@ static int find_minimum_fold_width( const std::string &str, int max_lines,
         // minimum width that folds the string to such number of lines instead.
         max_lines = std::max<int>( max_lines, foldstring( str, max_width ).size() );
         while( min_width < max_width ) {
-            int width = ( min_width + max_width ) / 2;
+            int const width = ( min_width + max_width ) / 2;
             // width may equal min_width, but will always be less than max_width.
-            int lines = foldstring( str, width ).size();
+            int const lines = foldstring( str, width ).size();
             // If the current width folds the string to no more than max_lines
             if( lines <= max_lines ) {
                 // The minimum width is between min_width and width.
@@ -381,7 +381,7 @@ static int find_minimum_fold_width( const std::string &str, int max_lines,
  */
 void uilist::setup()
 {
-    bool w_auto = !w_width_setup.fun;
+    bool const w_auto = !w_width_setup.fun;
 
     // Space for a line between text and entries. Only needed if there is actually text.
     const int text_separator_line = text.empty() ? 0 : 1;
@@ -395,7 +395,7 @@ void uilist::setup()
     }
     const int max_desc_width = w_auto ? TERMX - 4 : w_width - 4;
 
-    bool h_auto = !w_height_setup.fun;
+    bool const h_auto = !w_height_setup.fun;
     if( h_auto ) {
         w_height = 4;
     } else {
@@ -408,18 +408,18 @@ void uilist::setup()
     std::vector<int> autoassign;
     pad_left = pad_left_setup.fun ? pad_left_setup.fun() : 0;
     pad_right = pad_right_setup.fun ? pad_right_setup.fun() : 0;
-    int pad = pad_left + pad_right + 2;
+    int const pad = pad_left + pad_right + 2;
     int descwidth_final = 0; // for description width guard
     for( size_t i = 0; i < entries.size(); i++ ) {
-        int txtwidth = utf8_width( remove_color_tags( entries[i].txt ) );
-        int ctxtwidth = utf8_width( remove_color_tags( entries[i].ctxt ) );
+        int const txtwidth = utf8_width( remove_color_tags( entries[i].txt ) );
+        int const ctxtwidth = utf8_width( remove_color_tags( entries[i].ctxt ) );
         if( txtwidth > max_entry_len ) {
             max_entry_len = txtwidth;
         }
         if( ctxtwidth > max_column_len ) {
             max_column_len = ctxtwidth;
         }
-        int clen = ( ctxtwidth > 0 ) ? ctxtwidth + 2 : 0;
+        int const clen = ( ctxtwidth > 0 ) ? ctxtwidth + 2 : 0;
         if( entries[ i ].enabled ) {
             if( entries[ i ].hotkey > 0 ) {
                 keymap[ entries[ i ].hotkey ] = i;
@@ -475,7 +475,7 @@ void uilist::setup()
     }
 
     if( !text.empty() ) {
-        int twidth = utf8_width( remove_color_tags( text ) );
+        int const twidth = utf8_width( remove_color_tags( text ) );
         bool formattxt = true;
         int realtextwidth = 0;
         if( textwidth == -1 ) {
@@ -582,7 +582,7 @@ void uilist::reposition( ui_adaptor &ui )
 
 void uilist::apply_scrollbar()
 {
-    int sbside = ( pad_left <= 0 ? 0 : w_width - 1 );
+    int const sbside = ( pad_left <= 0 ? 0 : w_width - 1 );
     int estart = textformatted.size();
     if( estart > 0 ) {
         estart += 2;
@@ -645,7 +645,7 @@ void uilist::show()
 
     for( int fei = vshift, si = 0; si < vmax; fei++, si++ ) {
         if( fei < static_cast<int>( fentries.size() ) ) {
-            int ei = fentries [ fei ];
+            int const ei = fentries [ fei ];
             nc_color co;
             nc_color hk_co;
             if( ei == selected ) {
@@ -686,7 +686,7 @@ void uilist::show()
                                     max_column_len, co, _color_error, "%s", centry.str() );
                 }
             }
-            mvwzstr menu_entry_extra_text = entries[ei].extratxt;
+            mvwzstr const menu_entry_extra_text = entries[ei].extratxt;
             if( !menu_entry_extra_text.txt.empty() ) {
                 mvwprintz( window, point( pad_left + 1 + menu_entry_extra_text.left, estart + si ),
                            menu_entry_extra_text.color, menu_entry_extra_text.txt );
@@ -767,8 +767,8 @@ bool uilist::scrollby( const int scrollby )
         return false;
     }
 
-    bool looparound = ( scrollby == -1 || scrollby == 1 );
-    bool backwards = ( scrollby < 0 );
+    bool const looparound = ( scrollby == -1 || scrollby == 1 );
+    bool const backwards = ( scrollby < 0 );
 
     fselected += scrollby;
     if( !looparound ) {
@@ -867,7 +867,7 @@ void uilist::query( bool loop, int timeout )
     }
     hotkeys = ctxt.get_available_single_char_hotkeys( hotkeys );
 
-    shared_ptr_fast<ui_adaptor> ui = create_or_get_ui_adaptor();
+    shared_ptr_fast<ui_adaptor> const ui = create_or_get_ui_adaptor();
 
     ui_manager::redraw();
 
@@ -912,7 +912,7 @@ void uilist::query( bool loop, int timeout )
             ret = UILIST_TIMEOUT;
         } else {
             // including HELP_KEYBINDINGS, in case the caller wants to refresh their contents
-            bool unhandled = callback == nullptr || !callback->key( ctxt, event, selected, this );
+            bool const unhandled = callback == nullptr || !callback->key( ctxt, event, selected, this );
             if( unhandled && allow_anykey ) {
                 ret = UILIST_UNBOUND;
             } else if( unhandled && allow_additional ) {

--- a/src/ui_manager.cpp
+++ b/src/ui_manager.cpp
@@ -296,7 +296,7 @@ void ui_adaptor::redraw_invalidated()
         // Apply deferred resizing.
         bool needs_resize = false;
         for( auto it = first_enabled; !needs_resize && it != ui_stack_orig->end(); ++it ) {
-            ui_adaptor  const&ui = *it;
+            ui_adaptor  const &ui = *it;
             if( ui.deferred_resize && ui.screen_resized_cb ) {
                 needs_resize = true;
             }

--- a/src/ui_manager.cpp
+++ b/src/ui_manager.cpp
@@ -265,8 +265,8 @@ void ui_adaptor::redraw_invalidated()
         return;
     }
 
-    restore_on_out_of_scope<bool> prev_redraw_in_progress( redraw_in_progress );
-    restore_on_out_of_scope<bool> prev_restart_redrawing( restart_redrawing );
+    restore_on_out_of_scope<bool> const prev_redraw_in_progress( redraw_in_progress );
+    restore_on_out_of_scope<bool> const prev_restart_redrawing( restart_redrawing );
     redraw_in_progress = true;
 
     do {
@@ -296,7 +296,7 @@ void ui_adaptor::redraw_invalidated()
         // Apply deferred resizing.
         bool needs_resize = false;
         for( auto it = first_enabled; !needs_resize && it != ui_stack_orig->end(); ++it ) {
-            ui_adaptor &ui = *it;
+            ui_adaptor  const&ui = *it;
             if( ui.deferred_resize && ui.screen_resized_cb ) {
                 needs_resize = true;
             }

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -187,12 +187,12 @@ vehicle_part &veh_interact::select_part( const vehicle &veh, const part_selector
     auto act = [&]( const vehicle_part & pt ) {
         res = const_cast<vehicle_part *>( &pt );
     };
-    std::function<bool( const vpart_reference & )> sel_wrapper = [sel]( const vpart_reference & vpr ) {
+    std::function<bool( const vpart_reference & )> const sel_wrapper = [sel]( const vpart_reference & vpr ) {
         return sel( vpr.part() );
     };
 
     const vehicle_part_range vpr = veh.get_all_parts();
-    int opts = std::count_if( vpr.begin(), vpr.end(), sel_wrapper );
+    int const opts = std::count_if( vpr.begin(), vpr.end(), sel_wrapper );
 
     if( opts == 1 ) {
         act( std::find_if( vpr.begin(), vpr.end(), sel_wrapper )->part() );
@@ -314,7 +314,7 @@ bool veh_interact::format_reqs( std::string &msg, const requirement_data &reqs,
 
     msg += _( "<color_white>Skills required:</color>\n" );
     for( const auto &e : skills ) {
-        bool hasSkill = you.get_skill_level( e.first ) >= e.second;
+        bool const hasSkill = you.get_skill_level( e.first ) >= e.second;
         if( !hasSkill ) {
             ok = false;
         }
@@ -417,7 +417,7 @@ void veh_interact::do_main_loop()
         owner_fac = g->faction_manager_ptr->get( faction_id( "no_faction" ) );
     }
 
-    shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
+    shared_ptr_fast<ui_adaptor> const current_ui = create_or_get_ui_adaptor();
 
     while( !finish ) {
         calc_overview();
@@ -691,7 +691,7 @@ task_reason veh_interact::cant_do( char mode )
 bool veh_interact::is_drive_conflict()
 {
     std::string conflict_type;
-    bool has_conflict = veh->has_engine_conflict( sel_vpart_info, conflict_type );
+    bool const has_conflict = veh->has_engine_conflict( sel_vpart_info, conflict_type );
 
     if( has_conflict ) {
         //~ %1$s is fuel_type
@@ -703,7 +703,7 @@ bool veh_interact::is_drive_conflict()
 
 bool veh_interact::can_self_jack()
 {
-    int lvl = jack_quality( *veh );
+    int const lvl = jack_quality( *veh );
 
     for( const vpart_reference &vp : veh->get_avail_parts( "SELF_JACK" ) ) {
         if( vp.part().base.has_quality( qual_SELF_JACK, lvl ) ) {
@@ -753,7 +753,7 @@ bool veh_interact::update_part_requirements()
     // installed engine and # of installed engines,
     // but can never be less than 6 or more than 10.
     // Engines without E_HIGHER_SKILL flag are excluded from the check.
-    bool is_engine = sel_vpart_info->has_flag( "ENGINE" );
+    bool const is_engine = sel_vpart_info->has_flag( "ENGINE" );
     int dif_eng = 0;
     if( is_engine && sel_vpart_info->has_flag( "E_HIGHER_SKILL" ) ) {
         int engines = 0;
@@ -765,7 +765,7 @@ bool veh_interact::update_part_requirements()
             }
         }
         if( engines > 0 ) {
-            int lvl = std::max( 6, dif_max + 3 );
+            int const lvl = std::max( 6, dif_max + 3 );
             dif_eng = std::min( 10, lvl + ( engines - 1 ) * 2 );
         }
     }
@@ -824,7 +824,7 @@ bool veh_interact::update_part_requirements()
     quality_id qual;
     bool use_aid = false;
     bool use_str = false;
-    item base( sel_vpart_info->item );
+    item const base( sel_vpart_info->item );
     if( sel_vpart_info->has_flag( "NEEDS_JACKING" ) ) {
         lifting_or_jacking_required = true;
         qual = qual_JACK;
@@ -849,8 +849,8 @@ bool veh_interact::update_part_requirements()
         ok = false;
     }
 
-    nc_color aid_color = use_aid ? c_green : ( use_str ? c_dark_gray : c_red );
-    nc_color str_color = use_str ? c_green : ( use_aid ? c_dark_gray : c_red );
+    nc_color const aid_color = use_aid ? c_green : ( use_str ? c_dark_gray : c_red );
+    nc_color const str_color = use_str ? c_green : ( use_aid ? c_dark_gray : c_red );
 
     const auto helpers = character_funcs::get_crafting_helpers( you );
     std::string str_string;
@@ -862,7 +862,7 @@ bool veh_interact::update_part_requirements()
         }
 
         //~ %1$s is quality name, %2$d is quality level
-        std::string aid_string = string_format( _( "1 tool with %1$s %2$d" ),
+        std::string const aid_string = string_format( _( "1 tool with %1$s %2$d" ),
                                                 qual.obj().name, lvl );
         additional_requirements += string_format( _( "> %1$s <color_white>OR</color> %2$s" ),
                                    colorize( aid_string, aid_color ),
@@ -886,8 +886,8 @@ bool veh_interact::update_part_requirements()
  */
 void veh_interact::move_fuel_cursor( int delta )
 {
-    int max_fuel_indicators = static_cast<int>( veh->get_printable_fuel_types().size() );
-    int height = 5;
+    int const max_fuel_indicators = static_cast<int>( veh->get_printable_fuel_types().size() );
+    int const height = 5;
     fuel_index += delta;
 
     if( fuel_index < 0 ) {
@@ -928,21 +928,21 @@ static void sort_uilist_entries_by_line_drawing( std::vector<uilist_entry> &shap
 
 void veh_interact::do_install()
 {
-    task_reason reason = cant_do( 'i' );
+    task_reason const reason = cant_do( 'i' );
 
     if( reason == INVALID_TARGET ) {
         msg = _( "Cannot install any part here." );
         return;
     }
 
-    restore_on_out_of_scope<std::optional<std::string>> prev_title( title );
+    restore_on_out_of_scope<std::optional<std::string>> const prev_title( title );
     title = _( "Choose new part to install here:" );
 
-    restore_on_out_of_scope<std::unique_ptr<install_info_t>> prev_install_info( std::move(
+    restore_on_out_of_scope<std::unique_ptr<install_info_t>> const prev_install_info( std::move(
                 install_info ) );
     install_info = std::make_unique<install_info_t>();
 
-    std::array<std::string, 8> &tab_list = install_info->tab_list = { {
+    std::array<std::string, 8>  const&tab_list = install_info->tab_list = { {
             pgettext( "Vehicle Parts|", "All" ),
             pgettext( "Vehicle Parts|", "Cargo" ),
             pgettext( "Vehicle Parts|", "Light" ),
@@ -1056,7 +1056,7 @@ void veh_interact::do_install()
     // full list of mountable parts, to be filtered according to tab
     std::vector<const vpart_info *> &tab_vparts = install_info->tab_vparts = can_mount;
 
-    shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
+    shared_ptr_fast<ui_adaptor> const current_ui = create_or_get_ui_adaptor();
 
     int &pos = install_info->pos = 0;
     size_t &tab = install_info->tab = 0;
@@ -1064,7 +1064,7 @@ void veh_interact::do_install()
     while( true ) {
         sel_vpart_info = tab_vparts.empty() ? nullptr : tab_vparts[pos]; // filtered list can be empty
 
-        bool can_install = update_part_requirements();
+        bool const can_install = update_part_requirements();
 
         ui_manager::redraw();
 
@@ -1162,7 +1162,7 @@ void veh_interact::do_install()
 bool veh_interact::move_in_list( int &pos, const std::string &action, const int size,
                                  const int header ) const
 {
-    int lines_per_page = page_size - header;
+    int const lines_per_page = page_size - header;
     if( action == "PREV_TAB" || action == "LEFT" ) {
         pos -= lines_per_page;
     } else if( action == "NEXT_TAB" || action == "RIGHT" ) {
@@ -1219,18 +1219,18 @@ void veh_interact::do_repair()
         return;
     }
 
-    restore_on_out_of_scope<std::optional<std::string>> prev_title( title );
+    restore_on_out_of_scope<std::optional<std::string>> const prev_title( title );
     title = _( "Choose a part here to repair:" );
 
-    shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
+    shared_ptr_fast<ui_adaptor> const current_ui = create_or_get_ui_adaptor();
 
     int pos = 0;
 
-    restore_on_out_of_scope<int> prev_hilight_part( highlight_part );
+    restore_on_out_of_scope<int> const prev_hilight_part( highlight_part );
 
-    player &you = *get_player_character().as_player();
+    player  const&you = *get_player_character().as_player();
     while( true ) {
-        vehicle_part &pt = veh->part( parts_here[need_repair[pos]] );
+        vehicle_part  const&pt = veh->part( parts_here[need_repair[pos]] );
         const vpart_info &vp = pt.info();
 
         std::string nmsg;
@@ -1301,7 +1301,7 @@ void veh_interact::do_mend()
             break;
     }
 
-    restore_on_out_of_scope<std::optional<std::string>> prev_title( title );
+    restore_on_out_of_scope<std::optional<std::string>> const prev_title( title );
     title = _( "Choose a part here to mend:" );
 
     avatar &you = get_avatar();
@@ -1337,7 +1337,7 @@ void veh_interact::do_refill()
             break;
     }
 
-    restore_on_out_of_scope<std::optional<std::string>> prev_title( title );
+    restore_on_out_of_scope<std::optional<std::string>> const prev_title( title );
     title = _( "Select part to refill:" );
 
     auto act = [&]( const vehicle_part & pt ) {
@@ -1347,7 +1347,7 @@ void veh_interact::do_refill()
                     return pt.can_reload( obj.contents.front() );
                 }
             } else if( pt.is_fuel_store() ) {
-                bool can_reload = pt.can_reload( obj );
+                bool const can_reload = pt.can_reload( obj );
                 if( obj.typeId() == fuel_type_battery && can_reload ) {
                     msg = _( "You cannot recharge a vehicle battery with handheld batteries" );
                     return false;
@@ -1408,7 +1408,7 @@ void veh_interact::calc_overview()
     overview_opts.clear();
     overview_headers.clear();
 
-    int epower_w = veh->net_battery_charge_rate_w();
+    int const epower_w = veh->net_battery_charge_rate_w();
     overview_headers["ENGINE"] = [this]( const catacurses::window & w, int y ) {
         trim_and_print( w, point( 1, y ), getmaxx( w ) - 2, c_light_gray,
                         string_format( _( "Engines: %sSafe %4d kW</color> %sMax %4d kW</color>" ),
@@ -1500,7 +1500,7 @@ void veh_interact::calc_overview()
                     if( it.rotten() ) {
                         specials += _( " (rotten)" );
                     }
-                    units::volume vol = pt.base.contents.front().volume();
+                    units::volume const vol = pt.base.contents.front().volume();
                     const itype *pt_ammo_cur = &*pt.ammo_current();
                     int offset = 1;
                     std::string fmtstring = "%s %s  %5.1fL";
@@ -1513,7 +1513,7 @@ void veh_interact::calc_overview()
                                                 round_up( to_liter( vol ), 1 ) ) );
                 } else {
                     if( pt.is_leaking() ) {
-                        std::string outputstr = leak_marker + "      " + leak_marker;
+                        std::string const outputstr = leak_marker + "      " + leak_marker;
                         right_print( w, y, 0, c_light_gray, outputstr );
                     }
                 }
@@ -1544,7 +1544,7 @@ void veh_interact::calc_overview()
         if( vpr.part().is_battery() && vpr.part().is_available() ) {
             // always display total battery capacity and percentage charge
             auto details = []( const vehicle_part & pt, const catacurses::window & w, int y ) {
-                int pct = ( static_cast<double>( pt.ammo_remaining() ) / pt.ammo_capacity() ) * 100;
+                int const pct = ( static_cast<double>( pt.ammo_remaining() ) / pt.ammo_capacity() ) * 100;
                 int offset = 1;
                 std::string fmtstring = "%i    %3i%%";
                 if( pt.is_leaking() ) {
@@ -1628,7 +1628,7 @@ void veh_interact::display_overview()
         }
 
         // print part name
-        nc_color col = overview_opts[idx].hotkey ? c_white : c_dark_gray;
+        nc_color const col = overview_opts[idx].hotkey ? c_white : c_dark_gray;
         trim_and_print( w_list, point( 1, y ), getmaxx( w_list ) - 1,
                         highlighted ? hilite( col ) : col,
                         "<color_dark_gray>%c </color>%s",
@@ -1653,14 +1653,14 @@ void veh_interact::display_overview()
 void veh_interact::overview( const overview_enable_t &enable,
                              const overview_action_t &action )
 {
-    restore_on_out_of_scope<overview_enable_t> prev_overview_enable( overview_enable );
-    restore_on_out_of_scope<overview_action_t> prev_overview_action( overview_action );
+    restore_on_out_of_scope<overview_enable_t> const prev_overview_enable( overview_enable );
+    restore_on_out_of_scope<overview_action_t> const prev_overview_action( overview_action );
     overview_enable = enable;
     overview_action = action;
 
-    restore_on_out_of_scope<int> prev_overview_pos( overview_pos );
+    restore_on_out_of_scope<int> const prev_overview_pos( overview_pos );
 
-    shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
+    shared_ptr_fast<ui_adaptor> const current_ui = create_or_get_ui_adaptor();
 
     while( true ) {
         calc_overview();
@@ -1777,7 +1777,7 @@ bool veh_interact::can_remove_part( int idx, const player &p )
                     _( "<color_white>Removing the broken %1$s may yield some fragments.</color>\n" ),
                     sel_vehicle_part->name() );
     } else {
-        item result_of_removal = sel_vehicle_part->properties_to_item();
+        item const result_of_removal = sel_vehicle_part->properties_to_item();
         nmsg += string_format(
                     _( "<color_white>Removing the %1$s will yield:</color>\n> %2$s\n" ),
                     sel_vehicle_part->name(), result_of_removal.display_name() );
@@ -1794,7 +1794,7 @@ bool veh_interact::can_remove_part( int idx, const player &p )
     quality_id qual;
     bool use_aid = false;
     bool use_str = false;
-    item base( sel_vpart_info->item );
+    item const base( sel_vpart_info->item );
     if( sel_vpart_info->has_flag( "NEEDS_JACKING" ) ) {
         lifting_or_jacking_required = true;
         qual = qual_JACK;
@@ -1819,11 +1819,11 @@ bool veh_interact::can_remove_part( int idx, const player &p )
         ok = false;
     }
     if( lifting_or_jacking_required ) {
-        nc_color aid_color = use_aid ? c_green : ( use_str ? c_dark_gray : c_red );
-        nc_color str_color = use_str ? c_green : ( use_aid ? c_dark_gray : c_red );
+        nc_color const aid_color = use_aid ? c_green : ( use_str ? c_dark_gray : c_red );
+        nc_color const str_color = use_str ? c_green : ( use_aid ? c_dark_gray : c_red );
         const auto helpers = character_funcs::get_crafting_helpers( p );
         //~ %1$s is quality name, %2$d is quality level
-        std::string aid_string = string_format( _( "1 tool with %1$s %2$d" ),
+        std::string const aid_string = string_format( _( "1 tool with %1$s %2$d" ),
                                                 qual.obj().name, lvl );
 
         std::string str_string;
@@ -1857,17 +1857,17 @@ bool veh_interact::can_remove_part( int idx, const player &p )
 
 void veh_interact::do_remove()
 {
-    task_reason reason = cant_do( 'o' );
+    task_reason const reason = cant_do( 'o' );
 
     if( reason == INVALID_TARGET ) {
         msg = _( "No parts here." );
         return;
     }
 
-    restore_on_out_of_scope<std::optional<std::string>> prev_title( title );
+    restore_on_out_of_scope<std::optional<std::string>> const prev_title( title );
     title = _( "Choose a part here to remove:" );
 
-    player &you = *get_player_character().as_player();
+    player  const&you = *get_player_character().as_player();
     int pos = 0;
     for( size_t i = 0; i < parts_here.size(); i++ ) {
         if( can_remove_part( parts_here[ i ], you ) ) {
@@ -1877,16 +1877,16 @@ void veh_interact::do_remove()
     }
     msg.reset();
 
-    shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
+    shared_ptr_fast<ui_adaptor> const current_ui = create_or_get_ui_adaptor();
 
-    restore_on_out_of_scope<overview_enable_t> prev_overview_enable( overview_enable );
+    restore_on_out_of_scope<overview_enable_t> const prev_overview_enable( overview_enable );
 
-    restore_on_out_of_scope<int> prev_hilight_part( highlight_part );
+    restore_on_out_of_scope<int> const prev_hilight_part( highlight_part );
 
     while( true ) {
-        int part = parts_here[ pos ];
+        int const part = parts_here[ pos ];
 
-        bool can_remove = can_remove_part( part, you );
+        bool const can_remove = can_remove_part( part, you );
 
         overview_enable = [this, part]( const vehicle_part & pt ) {
             return &pt == &veh->part( part );
@@ -1950,7 +1950,7 @@ void veh_interact::do_siphon()
             break;
     }
 
-    restore_on_out_of_scope<std::optional<std::string>> prev_title( title );
+    restore_on_out_of_scope<std::optional<std::string>> const prev_title( title );
     title = _( "Select part to siphon:" );
 
     auto sel = [&]( const vehicle_part & pt ) {
@@ -1958,7 +1958,7 @@ void veh_interact::do_siphon()
     };
 
     auto act = [&]( const vehicle_part & pt ) {
-        on_out_of_scope restore_ui( [&]() {
+        on_out_of_scope const restore_ui( [&]() {
             hide_ui( false );
         } );
         hide_ui( true );
@@ -2045,7 +2045,7 @@ void veh_interact::do_assign_crew()
         return;
     }
 
-    restore_on_out_of_scope<std::optional<std::string>> prev_title( title );
+    restore_on_out_of_scope<std::optional<std::string>> const prev_title( title );
     title = _( "Assign crew positions:" );
 
     auto sel = []( const vehicle_part & pt ) {
@@ -2078,7 +2078,7 @@ void veh_interact::do_assign_crew()
 
 void veh_interact::do_rename()
 {
-    std::string name = string_input_popup()
+    std::string const name = string_input_popup()
                        .title( _( "Enter new vehicle name:" ) )
                        .width( 20 )
                        .query_string();
@@ -2100,7 +2100,7 @@ void veh_interact::do_relabel()
     }
 
     const vpart_position vp( *veh, cpart );
-    std::string text = string_input_popup()
+    std::string const text = string_input_popup()
                        .title( _( "New label:" ) )
                        .width( 20 )
                        .text( vp.get_label().value_or( "" ) )
@@ -2271,8 +2271,8 @@ void veh_interact::display_veh()
     if( debug_mode ) {
         // show CoM, pivot in debug mode
 
-        point pivot = veh->pivot_point();
-        point com = veh->local_center_of_mass();
+        point const pivot = veh->pivot_point();
+        point const com = veh->local_center_of_mass();
         const point cur = -dd;
 
         mvwprintz( w_disp, point_zero, c_green, "CoM   %d,%d", com.x, com.y );
@@ -2314,10 +2314,10 @@ void veh_interact::display_veh()
     }
 
     //Iterate over structural parts so we only hit each square once
-    std::vector<int> structural_parts = veh->all_parts_at_location( "structure" );
+    std::vector<int> const structural_parts = veh->all_parts_at_location( "structure" );
     for( auto &structural_part : structural_parts ) {
         const int p = structural_part;
-        int sym = veh->part_sym( p );
+        int const sym = veh->part_sym( p );
         nc_color col = veh->part_color( p );
 
         const point q = ( veh->part( p ).mount + dd ).rotate( 3 );
@@ -2349,8 +2349,8 @@ void veh_interact::display_veh()
             obstruct = false;
         }
     }
-    nc_color col = cpart >= 0 ? veh->part_color( cpart ) : c_black;
-    int sym = cpart >= 0 ? veh->part_sym( cpart ) : ' ';
+    nc_color const col = cpart >= 0 ? veh->part_color( cpart ) : c_black;
+    int const sym = cpart >= 0 ? veh->part_sym( cpart ) : ' ';
     mvwputch( w_disp, point( hw, hh ), obstruct ? red_background( col ) : hilite( col ),
               special_symbol( sym ) );
     wnoutrefresh( w_disp );
@@ -2358,15 +2358,15 @@ void veh_interact::display_veh()
 
 static std::string wheel_state_description( const vehicle &veh )
 {
-    bool is_boat = !veh.floating.empty();
-    bool is_land = !veh.wheelcache.empty() || !is_boat;
+    bool const is_boat = !veh.floating.empty();
+    bool const is_land = !veh.wheelcache.empty() || !is_boat;
 
-    bool suf_land = veh.sufficient_wheel_config();
-    bool bal_land = veh.balanced_wheel_config();
+    bool const suf_land = veh.sufficient_wheel_config();
+    bool const bal_land = veh.balanced_wheel_config();
 
-    bool suf_boat = veh.can_float();
+    bool const suf_boat = veh.can_float();
 
-    float steer = veh.steering_effectiveness();
+    float const steer = veh.steering_effectiveness();
 
     std::string wheel_status;
     if( !suf_land && is_boat ) {
@@ -2445,9 +2445,9 @@ void veh_interact::display_stats() const
         }
     }
 
-    bool is_boat = !veh->floating.empty();
-    bool is_ground = !veh->wheelcache.empty() || !is_boat;
-    bool is_aircraft = veh->is_rotorcraft() && veh->is_flying_in_air();
+    bool const is_boat = !veh->floating.empty();
+    bool const is_ground = !veh->wheelcache.empty() || !is_boat;
+    bool const is_aircraft = veh->is_rotorcraft() && veh->is_flying_in_air();
 
     const auto vel_to_int = []( const double vel ) {
         return static_cast<int>( convert_velocity( vel, VU_VEHICLE ) );
@@ -2519,7 +2519,7 @@ void veh_interact::display_stats() const
         convert_weight( veh->total_mass() ), weight_units() );
     if( veh->has_part( "ROTOR" ) ) {
         // convert newton to kg.
-        units::mass lift_as_mass = units::from_newton(
+        units::mass const lift_as_mass = units::from_newton(
                                        veh->lift_thrust_of_rotorcraft( true ) );
         print_stat(
             _( "Maximum Lift: <color_light_blue>%5.0f</color> %s" ),
@@ -2528,7 +2528,7 @@ void veh_interact::display_stats() const
     }
     if( is_boat ) {
         // convert newton to kg.
-        units::mass buoyancy_as_mass = units::from_newton(
+        units::mass const buoyancy_as_mass = units::from_newton(
                                            veh->max_buoyancy() );
         print_stat(
             _( "Maximum Buoyancy: <color_light_blue>%5.0f</color> %s" ),
@@ -2550,7 +2550,7 @@ void veh_interact::display_stats() const
     //for the veh_interact ui
     const auto print_part = [&]( const std::string & str, int slot, vehicle_part * pt ) {
         mvwprintz( w_stats, point( x[slot], y[slot] ), c_light_gray, str );
-        int iw = utf8_width( str ) + 1;
+        int const iw = utf8_width( str ) + 1;
         return fold_and_print( w_stats, point( x[slot] + iw, y[slot] ), w[slot], c_light_gray, pt->name() );
     };
 
@@ -2599,7 +2599,7 @@ void veh_interact::display_stats() const
     if( is_boat ) {
 
         const double water_clearance = veh->water_hull_height() - veh->water_draft();
-        std::string draft_string = water_clearance > 0 ?
+        std::string const draft_string = water_clearance > 0 ?
                                    _( "Draft/Clearance:<color_light_blue>%4.2f</color>m/<color_light_blue>%4.2f</color>m" ) :
                                    _( "Draft/Clearance:<color_light_blue>%4.2f</color>m/<color_light_red>%4.2f</color>m" );
 
@@ -2627,9 +2627,9 @@ void veh_interact::display_stats() const
     if( install_info ) {
         const int details_w = getmaxx( w_details );
         // clear rightmost blocks of w_stats to avoid overlap
-        int stats_col_2 = 33;
-        int stats_col_3 = 65 + ( ( TERMX - FULL_SCREEN_WIDTH ) / 4 );
-        int clear_x = getmaxx( w_stats ) - details_w + 1 >= stats_col_3 ? stats_col_3 : stats_col_2;
+        int const stats_col_2 = 33;
+        int const stats_col_3 = 65 + ( ( TERMX - FULL_SCREEN_WIDTH ) / 4 );
+        int const clear_x = getmaxx( w_stats ) - details_w + 1 >= stats_col_3 ? stats_col_3 : stats_col_2;
         for( int i = 0; i < getmaxy( w_stats ); i++ ) {
             mvwhline( w_stats, point( clear_x, i ), ' ', getmaxx( w_stats ) - clear_x );
         }
@@ -2662,7 +2662,7 @@ void veh_interact::display_mode()
         // NOLINTNEXTLINE(cata-use-named-point-constants)
         print_colored_text( w_mode, point( 1, 0 ), title_col, title_col, title.value() );
     } else {
-        size_t esc_pos = display_esc( w_mode );
+        size_t const esc_pos = display_esc( w_mode );
 
         // broken indentation preserved to avoid breaking git history for large number of lines
         const std::array<std::string, 11> actions = { {
@@ -2700,8 +2700,8 @@ void veh_interact::display_mode()
         for( size_t i = 0; i < actions.size(); i++ ) {
             pos[i + 1] = pos[i] + utf8_width( actions[i] ) - 2;
         }
-        int spacing = static_cast<int>( ( esc_pos - 1 - pos[actions.size()] ) / actions.size() );
-        int shift = static_cast<int>( ( esc_pos - pos[actions.size()] - spacing *
+        int const spacing = static_cast<int>( ( esc_pos - 1 - pos[actions.size()] ) / actions.size() );
+        int const shift = static_cast<int>( ( esc_pos - pos[actions.size()] - spacing *
                                         ( actions.size() - 1 ) ) / 2 ) - 1;
         for( size_t i = 0; i < actions.size(); i++ ) {
             shortcut_print( w_mode, point( pos[i] + spacing * i + shift, 0 ),
@@ -2714,9 +2714,9 @@ void veh_interact::display_mode()
 
 size_t veh_interact::display_esc( const catacurses::window &win )
 {
-    std::string backstr = _( "<ESC>-back" );
+    std::string const backstr = _( "<ESC>-back" );
     // right text align
-    size_t pos = getmaxx( win ) - utf8_width( backstr ) + 2;
+    size_t const pos = getmaxx( win ) - utf8_width( backstr ) + 2;
     shortcut_print( win, point( pos, 0 ), c_light_gray, c_light_green, backstr );
     return pos;
 }
@@ -2732,13 +2732,13 @@ void veh_interact::display_list( size_t pos, const std::vector<const vpart_info 
                                  const int header )
 {
     werase( w_list );
-    int lines_per_page = page_size - header;
-    size_t page = pos / lines_per_page;
+    int const lines_per_page = page_size - header;
+    size_t const page = pos / lines_per_page;
     for( size_t i = page * lines_per_page; i < ( page + 1 ) * lines_per_page && i < list.size(); i++ ) {
         const vpart_info &info = *list[i];
-        int y = i - page * lines_per_page + header;
+        int const y = i - page * lines_per_page + header;
         mvwputch( w_list, point( 1, y ), info.color, special_symbol( info.sym ) );
-        nc_color col = can_potentially_install( info ) ? c_white : c_dark_gray;
+        nc_color const col = can_potentially_install( info ) ? c_white : c_dark_gray;
         trim_and_print( w_list, point( 3, y ), getmaxx( w_list ) - 3, pos == i ? hilite( col ) : col,
                         info.name() );
     }
@@ -2750,7 +2750,7 @@ void veh_interact::display_list( size_t pos, const std::vector<const vpart_info 
         // draw tab menu
         int tab_x = 0;
         for( size_t i = 0; i < tab_list.size(); i++ ) {
-            std::string tab_name = ( tab == i ) ? tab_list[i] : tab_list_short[i]; // full name for selected tab
+            std::string const tab_name = ( tab == i ) ? tab_list[i] : tab_list_short[i]; // full name for selected tab
             tab_x += ( tab == i ); // add a space before selected tab
             draw_subtab( w_list, tab_x, tab_name, tab == i, false );
             tab_x += ( 1 + utf8_width( tab_name ) + ( tab ==
@@ -2778,11 +2778,11 @@ void veh_interact::display_details( const vpart_info *part )
         return;
     }
     // displays data in two columns
-    int column_width = details_w / 2;
-    int col_1 = 2;
-    int col_2 = col_1 + column_width;
-    int line = 0;
-    bool small_mode = column_width < 20;
+    int const column_width = details_w / 2;
+    int const col_1 = 2;
+    int const col_2 = col_1 + column_width;
+    int const line = 0;
+    bool const small_mode = column_width < 20;
 
     // line 0: part name
     fold_and_print( w_details, point( col_1, line ), details_w, c_light_green, part->name() );
@@ -2872,7 +2872,7 @@ void veh_interact::display_details( const vpart_info *part )
                         c_white, _( "Charge: <color_light_gray>%s</color>" ),
                         item::nname( part->fuel_type ) );
     }
-    int part_consumption = part->energy_consumption;
+    int const part_consumption = part->energy_consumption;
     if( part_consumption != 0 ) {
         fold_and_print( w_details, point( col_2, line + 4 ), column_width, c_white,
                         _( "Drain: <color_light_gray>%+8d</color>" ), -part_consumption );
@@ -2914,17 +2914,17 @@ void veh_interact::display_details( const vpart_info *part )
 void veh_interact::count_durability()
 {
     const vehicle_part_range vpr = veh->get_all_parts();
-    int qty = std::accumulate( vpr.begin(), vpr.end(), 0,
+    int const qty = std::accumulate( vpr.begin(), vpr.end(), 0,
     []( int lhs, const vpart_reference & rhs ) {
         return lhs + std::max( rhs.part().base.damage(), 0 );
     } );
 
-    int total = std::accumulate( vpr.begin(), vpr.end(), 0,
+    int const total = std::accumulate( vpr.begin(), vpr.end(), 0,
     []( int lhs, const vpart_reference & rhs ) {
         return lhs + rhs.part().base.max_damage();
     } );
 
-    int pct = total ? 100 * qty / total : 0;
+    int const pct = total ? 100 * qty / total : 0;
 
     if( pct < 5 ) {
         total_durability_text = _( "like new" );
@@ -2950,7 +2950,7 @@ void veh_interact::count_durability()
 
 void act_vehicle_siphon( vehicle *veh )
 {
-    std::vector<itype_id> fuels;
+    std::vector<itype_id> const fuels;
     bool has_liquid = false;
     for( const vpart_reference &vp : veh->get_any_parts( VPFLAG_FLUIDTANK ) ) {
         if( vp.part().get_base().contents_made_of( LIQUID ) ) {
@@ -2963,11 +2963,11 @@ void act_vehicle_siphon( vehicle *veh )
         return;
     }
 
-    std::string title = _( "Select tank to siphon:" );
+    std::string const title = _( "Select tank to siphon:" );
     auto sel = []( const vehicle_part & pt ) {
         return pt.is_tank() && pt.get_base().contents_made_of( LIQUID );
     };
-    vehicle_part &tank = veh_interact::select_part( *veh, sel, title );
+    vehicle_part  const&tank = veh_interact::select_part( *veh, sel, title );
     if( tank ) {
         const item &base = tank.get_base();
         const int idx = veh->find_part( base );
@@ -3017,7 +3017,7 @@ void act_vehicle_unload_fuel( vehicle *veh )
         fuel = fuels.front();
     }
 
-    int qty = veh->fuel_left( fuel );
+    int const qty = veh->fuel_left( fuel );
     if( fuel == itype_plut_cell ) {
         if( qty / PLUTONIUM_CHARGES == 0 ) {
             add_msg( m_info, _( "The vehicle has no fully charged plutonium cells." ) );
@@ -3068,7 +3068,7 @@ void veh_interact::complete_vehicle( player &p )
     }
     vehicle *const veh = &vp->vehicle();
 
-    point d( p.activity.values[4], p.activity.values[5] );
+    point const d( p.activity.values[4], p.activity.values[5] );
     int vehicle_part = p.activity.values[6];
     const vpart_id part_id( p.activity.str_values[0] );
 
@@ -3109,7 +3109,7 @@ void veh_interact::complete_vehicle( player &p )
 
             p.invalidate_crafting_inventory();
 
-            int partnum = !base.is_null() ? veh->install_part( d, part_id,
+            int const partnum = !base.is_null() ? veh->install_part( d, part_id,
                           std::move( base ) ) : -1;
             if( partnum < 0 ) {
                 debugmsg( "complete_vehicle install part fails dx=%d dy=%d id=%s", d.x, d.y, part_id.c_str() );
@@ -3143,7 +3143,7 @@ void veh_interact::complete_vehicle( player &p )
                 // Restore previous view offsets.
                 p.view_offset = old_view_offset;
 
-                units::angle dir = normalize( atan2( delta ) - veh->face.dir() );
+                units::angle const dir = normalize( atan2( delta ) - veh->face.dir() );
 
                 veh->part( partnum ).direction = dir;
             }
@@ -3260,7 +3260,7 @@ void veh_interact::complete_vehicle( player &p )
                 }
                 veh->tow_data.clear_towing();
             }
-            bool broken = veh->part( vehicle_part ).is_broken();
+            bool const broken = veh->part( vehicle_part ).is_broken();
 
             if( broken ) {
                 p.add_msg_if_player( _( "You remove the broken %1$s from the %2$s." ),
@@ -3288,7 +3288,7 @@ void veh_interact::complete_vehicle( player &p )
                 here.destroy_vehicle( veh );
                 here.reset_vehicle_cache( );
             } else {
-                point mount = veh->part( vehicle_part ).mount;
+                point const mount = veh->part( vehicle_part ).mount;
                 const tripoint &part_pos = veh->global_part_pos3( vehicle_part );
                 veh->remove_part( vehicle_part );
                 // part_removal_cleanup calls refresh, so parts_at_relative is valid

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -187,7 +187,8 @@ vehicle_part &veh_interact::select_part( const vehicle &veh, const part_selector
     auto act = [&]( const vehicle_part & pt ) {
         res = const_cast<vehicle_part *>( &pt );
     };
-    std::function<bool( const vpart_reference & )> const sel_wrapper = [sel]( const vpart_reference & vpr ) {
+    std::function<bool( const vpart_reference & )> const sel_wrapper = [sel](
+    const vpart_reference & vpr ) {
         return sel( vpr.part() );
     };
 
@@ -863,7 +864,7 @@ bool veh_interact::update_part_requirements()
 
         //~ %1$s is quality name, %2$d is quality level
         std::string const aid_string = string_format( _( "1 tool with %1$s %2$d" ),
-                                                qual.obj().name, lvl );
+                                       qual.obj().name, lvl );
         additional_requirements += string_format( _( "> %1$s <color_white>OR</color> %2$s" ),
                                    colorize( aid_string, aid_color ),
                                    colorize( str_string, str_color ) ) + "\n";
@@ -942,7 +943,7 @@ void veh_interact::do_install()
                 install_info ) );
     install_info = std::make_unique<install_info_t>();
 
-    std::array<std::string, 8>  const&tab_list = install_info->tab_list = { {
+    std::array<std::string, 8>  const &tab_list = install_info->tab_list = { {
             pgettext( "Vehicle Parts|", "All" ),
             pgettext( "Vehicle Parts|", "Cargo" ),
             pgettext( "Vehicle Parts|", "Light" ),
@@ -1228,9 +1229,9 @@ void veh_interact::do_repair()
 
     restore_on_out_of_scope<int> const prev_hilight_part( highlight_part );
 
-    player  const&you = *get_player_character().as_player();
+    player  const &you = *get_player_character().as_player();
     while( true ) {
-        vehicle_part  const&pt = veh->part( parts_here[need_repair[pos]] );
+        vehicle_part  const &pt = veh->part( parts_here[need_repair[pos]] );
         const vpart_info &vp = pt.info();
 
         std::string nmsg;
@@ -1824,7 +1825,7 @@ bool veh_interact::can_remove_part( int idx, const player &p )
         const auto helpers = character_funcs::get_crafting_helpers( p );
         //~ %1$s is quality name, %2$d is quality level
         std::string const aid_string = string_format( _( "1 tool with %1$s %2$d" ),
-                                                qual.obj().name, lvl );
+                                       qual.obj().name, lvl );
 
         std::string str_string;
         if( !helpers.empty() ) {
@@ -1867,7 +1868,7 @@ void veh_interact::do_remove()
     restore_on_out_of_scope<std::optional<std::string>> const prev_title( title );
     title = _( "Choose a part here to remove:" );
 
-    player  const&you = *get_player_character().as_player();
+    player  const &you = *get_player_character().as_player();
     int pos = 0;
     for( size_t i = 0; i < parts_here.size(); i++ ) {
         if( can_remove_part( parts_here[ i ], you ) ) {
@@ -2079,9 +2080,9 @@ void veh_interact::do_assign_crew()
 void veh_interact::do_rename()
 {
     std::string const name = string_input_popup()
-                       .title( _( "Enter new vehicle name:" ) )
-                       .width( 20 )
-                       .query_string();
+                             .title( _( "Enter new vehicle name:" ) )
+                             .width( 20 )
+                             .query_string();
     if( !name.empty() ) {
         veh->name = name;
         if( veh->tracking_on ) {
@@ -2101,10 +2102,10 @@ void veh_interact::do_relabel()
 
     const vpart_position vp( *veh, cpart );
     std::string const text = string_input_popup()
-                       .title( _( "New label:" ) )
-                       .width( 20 )
-                       .text( vp.get_label().value_or( "" ) )
-                       .query_string();
+                             .title( _( "New label:" ) )
+                             .width( 20 )
+                             .text( vp.get_label().value_or( "" ) )
+                             .query_string();
     // empty input removes the label
     vp.set_label( text );
 }
@@ -2520,7 +2521,7 @@ void veh_interact::display_stats() const
     if( veh->has_part( "ROTOR" ) ) {
         // convert newton to kg.
         units::mass const lift_as_mass = units::from_newton(
-                                       veh->lift_thrust_of_rotorcraft( true ) );
+                                             veh->lift_thrust_of_rotorcraft( true ) );
         print_stat(
             _( "Maximum Lift: <color_light_blue>%5.0f</color> %s" ),
             convert_weight( lift_as_mass ),
@@ -2529,7 +2530,7 @@ void veh_interact::display_stats() const
     if( is_boat ) {
         // convert newton to kg.
         units::mass const buoyancy_as_mass = units::from_newton(
-                                           veh->max_buoyancy() );
+                veh->max_buoyancy() );
         print_stat(
             _( "Maximum Buoyancy: <color_light_blue>%5.0f</color> %s" ),
             convert_weight( buoyancy_as_mass ),
@@ -2600,8 +2601,8 @@ void veh_interact::display_stats() const
 
         const double water_clearance = veh->water_hull_height() - veh->water_draft();
         std::string const draft_string = water_clearance > 0 ?
-                                   _( "Draft/Clearance:<color_light_blue>%4.2f</color>m/<color_light_blue>%4.2f</color>m" ) :
-                                   _( "Draft/Clearance:<color_light_blue>%4.2f</color>m/<color_light_red>%4.2f</color>m" );
+                                         _( "Draft/Clearance:<color_light_blue>%4.2f</color>m/<color_light_blue>%4.2f</color>m" ) :
+                                         _( "Draft/Clearance:<color_light_blue>%4.2f</color>m/<color_light_red>%4.2f</color>m" );
 
         print_stat(
             draft_string.c_str(),
@@ -2702,7 +2703,7 @@ void veh_interact::display_mode()
         }
         int const spacing = static_cast<int>( ( esc_pos - 1 - pos[actions.size()] ) / actions.size() );
         int const shift = static_cast<int>( ( esc_pos - pos[actions.size()] - spacing *
-                                        ( actions.size() - 1 ) ) / 2 ) - 1;
+                                              ( actions.size() - 1 ) ) / 2 ) - 1;
         for( size_t i = 0; i < actions.size(); i++ ) {
             shortcut_print( w_mode, point( pos[i] + spacing * i + shift, 0 ),
                             enabled[i] ? c_light_gray : c_dark_gray, enabled[i] ? c_light_green : c_green,
@@ -2750,7 +2751,8 @@ void veh_interact::display_list( size_t pos, const std::vector<const vpart_info 
         // draw tab menu
         int tab_x = 0;
         for( size_t i = 0; i < tab_list.size(); i++ ) {
-            std::string const tab_name = ( tab == i ) ? tab_list[i] : tab_list_short[i]; // full name for selected tab
+            std::string const tab_name = ( tab == i ) ? tab_list[i] :
+                                         tab_list_short[i]; // full name for selected tab
             tab_x += ( tab == i ); // add a space before selected tab
             draw_subtab( w_list, tab_x, tab_name, tab == i, false );
             tab_x += ( 1 + utf8_width( tab_name ) + ( tab ==
@@ -2967,7 +2969,7 @@ void act_vehicle_siphon( vehicle *veh )
     auto sel = []( const vehicle_part & pt ) {
         return pt.is_tank() && pt.get_base().contents_made_of( LIQUID );
     };
-    vehicle_part  const&tank = veh_interact::select_part( *veh, sel, title );
+    vehicle_part  const &tank = veh_interact::select_part( *veh, sel, title );
     if( tank ) {
         const item &base = tank.get_base();
         const int idx = veh->find_part( base );
@@ -3110,7 +3112,7 @@ void veh_interact::complete_vehicle( player &p )
             p.invalidate_crafting_inventory();
 
             int const partnum = !base.is_null() ? veh->install_part( d, part_id,
-                          std::move( base ) ) : -1;
+                                std::move( base ) ) : -1;
             if( partnum < 0 ) {
                 debugmsg( "complete_vehicle install part fails dx=%d dy=%d id=%s", d.x, d.y, part_id.c_str() );
                 break;

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -740,7 +740,8 @@ int vpart_info::format_description( std::string &msg, const nc_color &format_col
     if( has_flag( "TURRET" ) ) {
         class::item base( item );
         if( base.ammo_required() && !base.ammo_remaining() ) {
-            itype_id const default_ammo = base.magazine_current() ? base.common_ammo_default() : base.ammo_default();
+            itype_id const default_ammo = base.magazine_current() ? base.common_ammo_default() :
+                                          base.ammo_default();
             base.ammo_set( default_ammo );
         }
         long_descrip += string_format( _( "\nRange: %1$5d     Damage: %2$5.0f" ),

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -166,13 +166,13 @@ static void parse_vp_reqs( const JsonObject &obj, const std::string &id, const s
     if( !obj.has_object( key ) ) {
         return;
     }
-    JsonObject src = obj.get_object( key );
+    JsonObject const src = obj.get_object( key );
 
     auto sk = src.get_array( "skills" );
     if( !sk.empty() ) {
         skills.clear();
     }
-    for( JsonArray cur : sk ) {
+    for( JsonArray const cur : sk ) {
         skills.emplace( skill_id( cur.get_string( 0 ) ), cur.size() >= 2 ? cur.get_int( 1 ) : 1 );
     }
 
@@ -187,7 +187,7 @@ static void parse_vp_reqs( const JsonObject &obj, const std::string &id, const s
         reqs = { { requirement_id( src.get_string( "using" ) ), 1 } };
     } else if( src.has_array( "using" ) ) {
         reqs.clear();
-        for( JsonArray cur : src.get_array( "using" ) ) {
+        for( JsonArray const cur : src.get_array( "using" ) ) {
             reqs.emplace_back( requirement_id( cur.get_string( 0 ) ), cur.get_int( 1 ) );
         }
     } else {
@@ -296,7 +296,7 @@ void vpart_info::load_workbench( std::optional<vpslot_workbench> &wbptr, const J
         wb_info = *wbptr;
     }
 
-    JsonObject wb_jo = jo.get_object( "workbench" );
+    JsonObject const wb_jo = jo.get_object( "workbench" );
 
     assign( wb_jo, "multiplier", wb_info.multiplier );
     assign( wb_jo, "mass", wb_info.allowed_mass );
@@ -361,7 +361,7 @@ void vpart_info::load( const JsonObject &jo, const std::string &src )
     assign( jo, "bonus_fire_warmth_feet", def.bonus_fire_warmth_feet );
 
     if( jo.has_member( "transform_terrain" ) ) {
-        JsonObject jttd = jo.get_object( "transform_terrain" );
+        JsonObject const jttd = jo.get_object( "transform_terrain" );
         for( const std::string pre_flag : jttd.get_array( "pre_flags" ) ) {
             def.transform_terrain.pre_flags.emplace( pre_flag );
         }
@@ -413,13 +413,13 @@ void vpart_info::load( const JsonObject &jo, const std::string &src )
     auto qual = jo.get_array( "qualities" );
     if( !qual.empty() ) {
         def.qualities.clear();
-        for( JsonArray pair : qual ) {
+        for( JsonArray const pair : qual ) {
             def.qualities[ quality_id( pair.get_string( 0 ) ) ] = pair.get_int( 1 );
         }
     }
 
     if( jo.has_member( "damage_reduction" ) ) {
-        JsonObject dred = jo.get_object( "damage_reduction" );
+        JsonObject const dred = jo.get_object( "damage_reduction" );
         def.damage_reduction = load_damage_array( dred );
     }
 
@@ -678,7 +678,7 @@ void vpart_info::check()
         std::none_of( handled.begin(), handled.end(), [&part]( const std::string & flag ) {
         return part.has_flag( flag );
         } ) ) {
-            std::string warnings_are_good_docs = enumerate_as_string( handled );
+            std::string const warnings_are_good_docs = enumerate_as_string( handled );
             debugmsg( "%s has non-zero epower, but lacks a flag that would make it affect epower (one of %s)",
                       part.id.c_str(), warnings_are_good_docs.c_str() );
         }
@@ -721,7 +721,7 @@ int vpart_info::format_description( std::string &msg, const nc_color &format_col
         if( flagid == "ALARMCLOCK" || flagid == "WATCH" ) {
             continue;
         }
-        json_flag flag = json_flag::get( flagid );
+        json_flag const flag = json_flag::get( flagid );
         if( !flag.info().empty() ) {
             if( !long_descrip.empty() ) {
                 long_descrip += "  ";
@@ -730,17 +730,17 @@ int vpart_info::format_description( std::string &msg, const nc_color &format_col
         }
     }
     if( ( has_flag( "SEAT" ) || has_flag( "BED" ) ) && !has_flag( "BELTABLE" ) ) {
-        json_flag nobelt = json_flag::get( "NONBELTABLE" );
+        json_flag const nobelt = json_flag::get( "NONBELTABLE" );
         long_descrip += "  " + _( nobelt.info() );
     }
     if( has_flag( "BOARDABLE" ) && has_flag( "OPENABLE" ) ) {
-        json_flag nobelt = json_flag::get( "DOOR" );
+        json_flag const nobelt = json_flag::get( "DOOR" );
         long_descrip += "  " + _( nobelt.info() );
     }
     if( has_flag( "TURRET" ) ) {
         class::item base( item );
         if( base.ammo_required() && !base.ammo_remaining() ) {
-            itype_id default_ammo = base.magazine_current() ? base.common_ammo_default() : base.ammo_default();
+            itype_id const default_ammo = base.magazine_current() ? base.common_ammo_default() : base.ammo_default();
             base.ammo_set( default_ammo );
         }
         long_descrip += string_format( _( "\nRange: %1$5d     Damage: %2$5.0f" ),
@@ -1002,25 +1002,25 @@ void vehicle_prototype::load( const JsonObject &jo )
         jo.get_array( "blueprint" );
     }
 
-    for( JsonObject part : jo.get_array( "parts" ) ) {
-        point pos = point( part.get_int( "x" ), part.get_int( "y" ) );
+    for( JsonObject const part : jo.get_array( "parts" ) ) {
+        point const pos = point( part.get_int( "x" ), part.get_int( "y" ) );
 
         if( part.has_string( "part" ) ) {
             add_part_obj( part, pos );
         } else if( part.has_array( "parts" ) ) {
             for( const JsonValue entry : part.get_array( "parts" ) ) {
                 if( entry.test_string() ) {
-                    std::string part_name = entry.get_string();
+                    std::string const part_name = entry.get_string();
                     add_part_string( part_name, pos );
                 } else {
-                    JsonObject subpart = entry.get_object();
+                    JsonObject const subpart = entry.get_object();
                     add_part_obj( subpart, pos );
                 }
             }
         }
     }
 
-    for( JsonObject spawn_info : jo.get_array( "items" ) ) {
+    for( JsonObject const spawn_info : jo.get_array( "items" ) ) {
         vehicle_item_spawn next_spawn;
         next_spawn.pos.x = spawn_info.get_int( "x" );
         next_spawn.pos.y = spawn_info.get_int( "y" );

--- a/src/veh_utils.cpp
+++ b/src/veh_utils.cpp
@@ -110,7 +110,7 @@ bool repair_part( vehicle &veh, vehicle_part &pt, Character &who_c )
 {
     // TODO: Get rid of this cast after moving relevant functions down to Character
     player &who = static_cast<player &>( who_c );
-    int part_index = veh.index_of_part( &pt );
+    int const part_index = veh.index_of_part( &pt );
     auto &vp = pt.info();
 
     // TODO: Expose base part damage somewhere, don't recalculate it here
@@ -152,13 +152,13 @@ bool repair_part( vehicle &veh, vehicle_part &pt, Character &who_c )
     }
 
     // If part is broken, it will be destroyed and references invalidated
-    std::string partname = pt.name( false );
+    std::string const partname = pt.name( false );
     const std::string startdurability = colorize( pt.get_base().damage_symbol(),
                                         pt.get_base().damage_color() );
-    bool wasbroken = pt.is_broken();
+    bool const wasbroken = pt.is_broken();
     if( wasbroken ) {
         const units::angle dir = pt.direction;
-        point loc = pt.mount;
+        point const loc = pt.mount;
         auto replacement_id = pt.info().get_id();
         get_map().spawn_items( who.pos(), pt.pieces_for_broken_part() );
         veh.remove_part( part_index );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -363,7 +363,7 @@ void vehicle::add_steerable_wheels()
         }
 
         if( vp.has_feature( VPFLAG_WHEEL ) ) {
-            vpart_id steerable_id( vp.info().get_id().str() + "_steerable" );
+            vpart_id const steerable_id( vp.info().get_id().str() + "_steerable" );
             if( steerable_id.is_valid() ) {
                 // We can convert this.
                 if( vp.mount().x != axle ) {
@@ -423,7 +423,7 @@ void vehicle::init_state( int init_veh_fuel, int init_veh_status )
         veh_status = 0;
     }
     if( init_veh_status == 1 ) {
-        int rand = rng( 1, 100 );
+        int const rand = rng( 1, 100 );
         veh_status = 1;
 
         if( rand <= 5 ) {          //  seats are destroyed 5%
@@ -461,7 +461,7 @@ void vehicle::init_state( int init_veh_fuel, int init_veh_status )
     if( veh_status != 0 ) {
         //Leave engine running in some vehicles, if the engine has not been destroyed
         //chance decays from 1 in 4 vehicles on day 0 to 1 in (day + 4) in the future.
-        int current_day = std::max( to_days<int>( calendar::turn - calendar::turn_zero ), 0 );
+        int const current_day = std::max( to_days<int>( calendar::turn - calendar::turn_zero ), 0 );
         if( veh_fuel_mult > 0 && !empty( get_avail_parts( "ENGINE" ) ) &&
             one_in( current_day + 4 ) && !destroyEngine && !has_no_key &&
             has_engine_type_not( fuel_type_muscle, true ) ) {
@@ -554,7 +554,7 @@ void vehicle::init_state( int init_veh_fuel, int init_veh_status )
             qty /= to_milliliter( units::legacy_volume_factor );
             pt.ammo_set( type->parts[ p ].fuel, qty );
         } else if( pt.is_fuel_store() && !type->parts[p].fuel.is_null() ) {
-            int qty = pt.ammo_capacity() * veh_fuel_mult / 100;
+            int const qty = pt.ammo_capacity() * veh_fuel_mult / 100;
             pt.ammo_set( type->parts[ p ].fuel, qty );
         }
 
@@ -574,9 +574,9 @@ void vehicle::init_state( int init_veh_fuel, int init_veh_status )
         } else {
             //a bit of initial damage :)
             //clamp 4d8 to the range of [8,20]. 8=broken, 20=undamaged.
-            int broken = 8;
-            int unhurt = 20;
-            int roll = dice( 4, 8 );
+            int const broken = 8;
+            int const unhurt = 20;
+            int const roll = dice( 4, 8 );
             if( roll < unhurt ) {
                 if( roll <= broken ) {
                     set_hp( pt, 0 );
@@ -727,7 +727,7 @@ void vehicle::autopilot_patrol()
         drive_to_local_target( autodrive_local_target, false );
         return;
     }
-    zone_manager &mgr = zone_manager::get_manager();
+    zone_manager  const&mgr = zone_manager::get_manager();
     const auto &zone_src_set = mgr.get_near( zone_type_id( "VEHICLE_PATROL" ),
                                global_square_location().raw(), 60 );
     if( zone_src_set.empty() ) {
@@ -776,14 +776,14 @@ std::set<point> vehicle::immediate_path( units::angle rotate )
     adjusted_angle = round_to_multiple_of( adjusted_angle, 15_degrees );
     tileray collision_vector;
     collision_vector.init( adjusted_angle );
-    point top_left_actual = global_pos3().xy() + coord_translate( front_left );
-    point top_right_actual = global_pos3().xy() + coord_translate( front_right );
-    std::vector<point> front_row = line_to( g->m.getabs( top_left_actual ),
+    point const top_left_actual = global_pos3().xy() + coord_translate( front_left );
+    point const top_right_actual = global_pos3().xy() + coord_translate( front_right );
+    std::vector<point> const front_row = line_to( g->m.getabs( top_left_actual ),
                                             g->m.getabs( top_right_actual ) );
-    for( point elem : front_row ) {
+    for( point const elem : front_row ) {
         for( int i = 0; i < distance_to_check; ++i ) {
             collision_vector.advance( i );
-            point point_to_add = elem + point( collision_vector.dx(), collision_vector.dy() );
+            point const point_to_add = elem + point( collision_vector.dx(), collision_vector.dy() );
             points_to_check.emplace( point_to_add );
         }
     }
@@ -821,14 +821,14 @@ void vehicle::drive_to_local_target( const tripoint &target, bool follow_protoco
         return;
     }
     refresh();
-    tripoint vehpos = global_square_location().raw();
-    units::angle angle = get_angle_from_targ( target );
+    tripoint const vehpos = global_square_location().raw();
+    units::angle const angle = get_angle_from_targ( target );
     // now we got the angle to the target, we can work out when we are heading towards disaster.
     // Check the tileray in the direction we need to head towards.
-    std::set<point> points_to_check = immediate_path( angle );
+    std::set<point> const points_to_check = immediate_path( angle );
     bool stop = false;
-    for( point pt_elem : points_to_check ) {
-        point elem = g->m.getlocal( pt_elem );
+    for( point const pt_elem : points_to_check ) {
+        point const elem = g->m.getlocal( pt_elem );
         if( stop ) {
             break;
         }
@@ -875,7 +875,7 @@ void vehicle::drive_to_local_target( const tripoint &target, bool follow_protoco
         stop_autodriving();
         return;
     }
-    int turn_x = get_turn_from_angle( angle, vehpos, target );
+    int const turn_x = get_turn_from_angle( angle, vehpos, target );
     int accel_y = 0;
     // best to cruise around at a safe velocity or 40mph, whichever is lowest
     // accelerate when it dosnt need to turn.
@@ -916,14 +916,14 @@ void vehicle::drive_to_local_target( const tripoint &target, bool follow_protoco
 
 units::angle vehicle::get_angle_from_targ( const tripoint &targ )
 {
-    tripoint vehpos = global_square_location().raw();
-    rl_vec2d facevec = face_vec();
-    point rel_pos_target = targ.xy() - vehpos.xy();
-    rl_vec2d targetvec = rl_vec2d( rel_pos_target.x, rel_pos_target.y );
+    tripoint const vehpos = global_square_location().raw();
+    rl_vec2d const facevec = face_vec();
+    point const rel_pos_target = targ.xy() - vehpos.xy();
+    rl_vec2d const targetvec = rl_vec2d( rel_pos_target.x, rel_pos_target.y );
     // cross product
-    double crossy = ( facevec.x * targetvec.y ) - ( targetvec.x * facevec.y );
+    double const crossy = ( facevec.x * targetvec.y ) - ( targetvec.x * facevec.y );
     // dot product.
-    double dotx = ( facevec.x * targetvec.x ) + ( facevec.y * targetvec.y );
+    double const dotx = ( facevec.x * targetvec.x ) + ( facevec.y * targetvec.y );
 
     return units::atan2( crossy, dotx );
 }
@@ -943,7 +943,7 @@ void vehicle::smash( map &m, float hp_percent_loss_min, float hp_percent_loss_ma
             continue;
         }
 
-        std::vector<int> parts_in_square = parts_at_relative( part.mount, true );
+        std::vector<int> const parts_in_square = parts_at_relative( part.mount, true );
         int structures_found = 0;
         for( auto &square_part_index : parts_in_square ) {
             if( part_info( square_part_index ).location == part_location_structure ) {
@@ -953,17 +953,17 @@ void vehicle::smash( map &m, float hp_percent_loss_min, float hp_percent_loss_ma
 
         if( structures_found > 1 ) {
             //Destroy everything in the square
-            for( int idx : parts_in_square ) {
+            for( int const idx : parts_in_square ) {
                 mod_hp( parts[ idx ], 0 - parts[ idx ].hp(), DT_BASH );
                 parts[ idx ].ammo_unset();
             }
             continue;
         }
 
-        int roll = dice( 1, 1000 );
-        int pct_af = ( percent_of_parts_to_affect * 1000.0f );
+        int const roll = dice( 1, 1000 );
+        int const pct_af = ( percent_of_parts_to_affect * 1000.0f );
         if( roll < pct_af ) {
-            double dist =  damage_size == 0.0f ? 1.0f :
+            double const dist =  damage_size == 0.0f ? 1.0f :
                            clamp( 1.0f - trig_dist( damage_origin, part.precalc[0].xy() ) /
                                   damage_size, 0.0f, 1.0f );
             //Everywhere else, drop by 10-120% of max HP (anything over 100 = broken)
@@ -978,13 +978,13 @@ void vehicle::smash( map &m, float hp_percent_loss_min, float hp_percent_loss_ma
     std::unique_ptr<RemovePartHandler> handler_ptr;
     // clear out any duplicated locations
     for( int p = static_cast<int>( parts.size() ) - 1; p >= 0; p-- ) {
-        vehicle_part &part = parts[ p ];
+        vehicle_part  const&part = parts[ p ];
         if( part.removed ) {
             continue;
         }
         std::vector<int> parts_here = parts_at_relative( part.mount, true );
         for( int other_i = static_cast<int>( parts_here.size() ) - 1; other_i >= 0; other_i -- ) {
-            int other_p = parts_here[ other_i ];
+            int const other_p = parts_here[ other_i ];
             if( p == other_p ) {
                 continue;
             }
@@ -1012,7 +1012,7 @@ void vehicle::smash( map &m, float hp_percent_loss_min, float hp_percent_loss_ma
 
 int vehicle::lift_strength() const
 {
-    units::mass mass = total_mass();
+    units::mass const mass = total_mass();
     return std::max<std::int64_t>( mass / 10000_gram, 1 );
 }
 
@@ -1059,7 +1059,7 @@ bool vehicle::has_engine_conflict( const vpart_info *possible_conflict,
 
     bool has_conflict = false;
 
-    for( int engine : engines ) {
+    for( int const engine : engines ) {
         std::vector<std::string> install_excludes = part_info( engine ).engine_excludes();
         std::vector<std::string> conflicts;
         std::set_intersection( new_excludes.begin(), new_excludes.end(), install_excludes.begin(),
@@ -1114,7 +1114,7 @@ bool vehicle::has_security_working() const
 {
     bool found_security = false;
     if( fuel_left( fuel_type_battery ) > 0 ) {
-        for( int s : speciality ) {
+        for( int const s : speciality ) {
             if( part_flag( s, "SECURITY" ) && parts[ s ].is_available() ) {
                 found_security = true;
                 break;
@@ -1170,20 +1170,20 @@ int vehicle::part_vpower_w( const int index, const bool at_full_hp ) const
         /// wind-powered vehicles have differing power depending on wind direction
         if( vp.info().fuel_type == fuel_type_wind ) {
             const weather_manager &weather = get_weather();
-            int windpower = weather.windspeed;
+            int const windpower = weather.windspeed;
             rl_vec2d windvec;
-            double raddir = ( ( weather.winddirection + 180 ) % 360 ) * ( M_PI / 180 );
+            double const raddir = ( ( weather.winddirection + 180 ) % 360 ) * ( M_PI / 180 );
             windvec = windvec.normalized();
             windvec.y = -std::cos( raddir );
             windvec.x = std::sin( raddir );
-            rl_vec2d fv = face_vec();
+            rl_vec2d const fv = face_vec();
             double dot = windvec.dot_product( fv );
             if( dot <= 0 ) {
                 dot = std::min( -0.1, dot );
             } else {
                 dot = std::max( 0.1, dot );
             }
-            int windeffectint = static_cast<int>( ( windpower * dot ) * 200 );
+            int const windeffectint = static_cast<int>( ( windpower * dot ) * 200 );
             pwr = std::max( 1, pwr + windeffectint );
         }
     }
@@ -1195,11 +1195,11 @@ int vehicle::part_vpower_w( const int index, const bool at_full_hp ) const
         return pwr; // Assume full hp
     }
     // Damaged engines give less power, but some engines handle it better
-    double health = parts[index].health_percent();
+    double const health = parts[index].health_percent();
     // dpf is 0 for engines that scale power linearly with damage and
     // provides a floor otherwise
-    float dpf = part_info( index ).engine_damaged_power_factor();
-    double effective_percent = dpf + ( ( 1 - dpf ) * health );
+    float const dpf = part_info( index ).engine_damaged_power_factor();
+    double const effective_percent = dpf + ( ( 1 - dpf ) * health );
     return static_cast<int>( pwr * effective_percent );
 }
 
@@ -1208,7 +1208,7 @@ int vehicle::part_vpower_w( const int index, const bool at_full_hp ) const
 // for motor consumption see @ref vpart_info::energy_consumption instead
 int vehicle::part_epower_w( const int index ) const
 {
-    int e = part_info( index ).epower;
+    int const e = part_info( index ).epower;
     if( e < 0 ) {
         return e; // Consumers always draw full power, even if broken
     }
@@ -1220,9 +1220,9 @@ int vehicle::power_to_energy_bat( const int power_w, const time_duration &d ) co
     // Integrate constant epower (watts) over time to get units of battery energy
     // Thousands of watts over millions of seconds can happen, so 32-bit int
     // insufficient.
-    int64_t energy_j = power_w * to_seconds<int64_t>( d );
+    int64_t const energy_j = power_w * to_seconds<int64_t>( d );
     int energy_bat = energy_j / bat_energy_j;
-    int sign = power_w >= 0 ? 1 : -1;
+    int const sign = power_w >= 0 ? 1 : -1;
     // energy_bat remainder results in chance at additional charge/discharge
     energy_bat += x_in_y( std::abs( energy_j % bat_energy_j ), bat_energy_j ) ? sign : 0;
     return energy_bat;
@@ -1394,7 +1394,7 @@ bool vehicle::can_unmount( const int p, std::string &reason ) const
 
     // Find all the flags on parts in this tile that require other flags
     const point pt = parts[p].mount;
-    std::vector<int> parts_here = parts_at_relative( pt, false );
+    std::vector<int> const parts_here = parts_at_relative( pt, false );
 
     for( auto &elem : parts_here ) {
         for( const std::string &flag : part_info( elem ).get_flags() ) {
@@ -1414,7 +1414,7 @@ bool vehicle::can_unmount( const int p, std::string &reason ) const
     //Structural parts have extra requirements
     if( part_info( p ).location == part_location_structure ) {
 
-        std::vector<int> parts_in_square = parts_at_relative( parts[p].mount, false );
+        std::vector<int> const parts_in_square = parts_at_relative( parts[p].mount, false );
         /* To remove a structural part, there can be only structural parts left
          * in that square (might be more than one in the case of wreckage) */
         for( auto &elem : parts_in_square ) {
@@ -1496,12 +1496,12 @@ bool vehicle::is_connected( const vehicle_part &to, const vehicle_part &from,
     discovered.push_back( from );
 
     while( !discovered.empty() ) {
-        vehicle_part current_part = discovered.front();
+        vehicle_part const current_part = discovered.front();
         discovered.pop_front();
         auto current = current_part.mount;
 
-        for( point offset : four_adjacent_offsets ) {
-            point next = current + offset;
+        for( point const offset : four_adjacent_offsets ) {
+            point const next = current + offset;
 
             if( next == target ) {
                 //Success!
@@ -1533,7 +1533,7 @@ bool vehicle::is_connected( const vehicle_part &to, const vehicle_part &from,
                     }
                 }
                 if( !found ) {
-                    vehicle_part next_part = parts[parts_there[0]];
+                    vehicle_part const next_part = parts[parts_there[0]];
                     discovered.push_back( next_part );
                 }
             }
@@ -1626,14 +1626,14 @@ bool vehicle::try_to_rack_nearby_vehicle( const std::vector<std::vector<int>> &l
         std::vector<vehicle *> carry_vehs;
         carry_vehs.assign( 4, nullptr );
         vehicle *test_veh = nullptr;
-        std::set<tripoint> veh_partial_match;
+        std::set<tripoint> const veh_partial_match;
         std::vector<std::set<tripoint>> partial_matches;
         partial_matches.assign( 4, veh_partial_match );
         for( auto rack_part : this_bike_rack ) {
-            tripoint rack_pos = global_part_pos3( rack_part );
+            tripoint const rack_pos = global_part_pos3( rack_part );
             int i = 0;
-            for( point offset : four_cardinal_directions ) {
-                tripoint search_pos( rack_pos + offset );
+            for( point const offset : four_cardinal_directions ) {
+                tripoint const search_pos( rack_pos + offset );
                 test_veh = veh_pointer_or_null( g->m.veh_at( search_pos ) );
                 if( test_veh == nullptr || test_veh == this ) {
                     continue;
@@ -1671,7 +1671,7 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
     invalidate_towing( true );
     // By structs, we mean all the parts of the carry vehicle that are at the structure location
     // of the vehicle (i.e. frames)
-    std::vector<int> carry_veh_structs = carry_veh->all_parts_at_location( part_location_structure );
+    std::vector<int> const carry_veh_structs = carry_veh->all_parts_at_location( part_location_structure );
     std::vector<mapping> carry_data;
     carry_data.reserve( carry_veh_structs.size() );
 
@@ -1688,8 +1688,8 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
     }
 
     units::angle relative_dir = normalize( carry_veh->face.dir() - face.dir() );
-    units::angle relative_180 = units::fmod( relative_dir, 180_degrees );
-    units::angle face_dir_180 = normalize( face.dir(), 180_degrees );
+    units::angle const relative_180 = units::fmod( relative_dir, 180_degrees );
+    units::angle const face_dir_180 = normalize( face.dir(), 180_degrees );
 
     // if the carrier is skewed N/S and the carried vehicle isn't aligned with
     // the carrier, force the carried vehicle to be at a right angle
@@ -1710,17 +1710,17 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
     for( auto carry_part : carry_veh_structs ) {
 
         // The current position on the original vehicle for this part
-        tripoint carry_pos = carry_veh->global_part_pos3( carry_part );
+        tripoint const carry_pos = carry_veh->global_part_pos3( carry_part );
 
         bool merged_part = false;
-        for( int rack_part : rack_parts ) {
+        for( int const rack_part : rack_parts ) {
             size_t j = 0;
             // There's no mathematical transform from global pos3 to vehicle mount, so search for the
             // carry part in global pos3 after translating
             point carry_mount;
-            for( point offset : four_cardinal_directions ) {
+            for( point const offset : four_cardinal_directions ) {
                 carry_mount = parts[ rack_part ].mount + offset;
-                tripoint possible_pos = mount_to_tripoint( carry_mount );
+                tripoint const possible_pos = mount_to_tripoint( carry_mount );
                 if( possible_pos == carry_pos ) {
                     break;
                 }
@@ -1733,7 +1733,7 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
             const bool carry_part_next_to_this_rack = j < four_adjacent_offsets.size();
             if( carry_part_next_to_this_rack ) {
                 mapping carry_map;
-                point old_mount = carry_veh->parts[ carry_part ].mount;
+                point const old_mount = carry_veh->parts[ carry_part ].mount;
                 carry_map.carry_parts_here = carry_veh->parts_at_relative( old_mount, true );
                 carry_map.rack_part = rack_part;
                 carry_map.carry_mount = carry_mount;
@@ -1757,12 +1757,12 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
     if( found_all_parts ) {
         decltype( loot_zones ) new_zones;
         for( auto carry_map : carry_data ) {
-            std::string offset = string_format( "%s%3d", carry_map.old_mount == mount_zero ? axis : " ",
+            std::string const offset = string_format( "%s%3d", carry_map.old_mount == mount_zero ? axis : " ",
                                                 axis == "X" ? carry_map.old_mount.x : carry_map.old_mount.y );
-            std::string unique_id = string_format( "%s%3d%s", offset,
+            std::string const unique_id = string_format( "%s%3d%s", offset,
                                                    static_cast<int>( to_degrees( relative_dir ) ),
                                                    carry_veh->name );
-            for( int carry_part : carry_map.carry_parts_here ) {
+            for( int const carry_part : carry_map.carry_parts_here ) {
                 parts.push_back( carry_veh->parts[ carry_part ] );
                 vehicle_part &carried_part = parts.back();
                 carried_part.mount = carry_map.carry_mount;
@@ -1849,7 +1849,7 @@ bool vehicle::remove_part( const int p, RemovePartHandler &handler )
     const auto remove_dependent_part = [&]( const std::string & parent_flag,
     const std::string & child_flag ) {
         if( part_flag( p, parent_flag ) ) {
-            int dep = part_with_feature( p, child_flag, false );
+            int const dep = part_with_feature( p, child_flag, false );
             if( dep >= 0 && !magic ) {
                 handler.add_item_or_charges( part_loc, parts[dep].properties_to_item(), false );
                 remove_part( dep, handler );
@@ -1914,7 +1914,7 @@ bool vehicle::remove_part( const int p, RemovePartHandler &handler )
 
     handler.removed( *this, p );
 
-    point vp_mount = parts[p].mount;
+    point const vp_mount = parts[p].mount;
     const auto iter = labels.find( label( vp_mount ) );
     if( iter != labels.end() && parts_at_relative( vp_mount, false ).empty() ) {
         labels.erase( iter );
@@ -1923,7 +1923,7 @@ bool vehicle::remove_part( const int p, RemovePartHandler &handler )
     for( auto &i : get_items( p ) ) {
         // Note: this can spawn items on the other side of the wall!
         // TODO: fix this ^^
-        tripoint dest( part_loc + point( rng( -3, 3 ), rng( -3, 3 ) ) );
+        tripoint const dest( part_loc + point( rng( -3, 3 ), rng( -3, 3 ) ) );
         if( !magic ) {
             // This new point might be out of the map bounds.  It's not
             // reasonable to try to spawn it outside the currently valid map,
@@ -2012,7 +2012,7 @@ bool vehicle::remove_carried_vehicle( const std::vector<int> &carried_parts )
     bool x_aligned = false;
     bool tracked_parts =
         false; // we will set this to true if any of the vehicle parts carry a tracked_flag
-    for( int carried_part : carried_parts ) {
+    for( int const carried_part : carried_parts ) {
         //check if selected part carries tracking flag
         if( parts[carried_part].has_flag(
                 vehicle_part::tracked_flag ) ) { //this should only need to run once
@@ -2020,7 +2020,7 @@ bool vehicle::remove_carried_vehicle( const std::vector<int> &carried_parts )
         }
         const auto &carry_names = parts[carried_part].carry_names;
         if( !carry_names.empty() ) {
-            std::string id_string = carry_names.top().substr( 0, 1 );
+            std::string const id_string = carry_names.top().substr( 0, 1 );
             if( id_string == "X" || id_string == "Y" ) {
                 veh_record = carry_names.top();
                 new_pos3 = global_part_pos3( carried_part );
@@ -2034,7 +2034,7 @@ bool vehicle::remove_carried_vehicle( const std::vector<int> &carried_parts )
     }
     units::angle new_dir =
         normalize( units::from_degrees( std::stoi( veh_record.substr( 4, 3 ) ) ) + face.dir() );
-    units::angle host_dir = normalize( face.dir(), 180_degrees );
+    units::angle const host_dir = normalize( face.dir(), 180_degrees );
     // if the host is skewed N/S, and the carried vehicle is going to come at an angle,
     // force it to east/west instead
     if( host_dir >= 45_degrees && host_dir <= 135_degrees ) {
@@ -2117,7 +2117,7 @@ bool vehicle::remove_carried_vehicle( const std::vector<int> &carried_parts )
 // split the current vehicle into up to 3 new vehicles that do not connect to each other
 bool vehicle::find_and_split_vehicles( int exclude )
 {
-    std::vector<int> valid_parts = all_parts_at_location( part_location_structure );
+    std::vector<int> const valid_parts = all_parts_at_location( part_location_structure );
     std::set<int> checked_parts;
     checked_parts.insert( exclude );
 
@@ -2141,7 +2141,7 @@ bool vehicle::find_and_split_vehicles( int exclude )
         std::queue<std::pair<int, std::vector<int>>> search_queue;
 
         const auto push_neighbor = [&]( int p, const std::vector<int> &with_p ) {
-            std::pair<int, std::vector<int>> data( p, with_p );
+            std::pair<int, std::vector<int>> const data( p, with_p );
             search_queue.push( data );
         };
         auto pop_neighbor = [&]() {
@@ -2153,7 +2153,7 @@ bool vehicle::find_and_split_vehicles( int exclude )
         std::vector<int> veh_parts;
         push_neighbor( test_part, parts_at_relative( parts[ test_part ].mount, true ) );
         while( !search_queue.empty() ) {
-            std::pair<int, std::vector<int>> test_set = pop_neighbor();
+            std::pair<int, std::vector<int>> const test_set = pop_neighbor();
             test_part = test_set.first;
             if( checked_parts.find( test_part ) != checked_parts.end() ) {
                 continue;
@@ -2162,11 +2162,11 @@ bool vehicle::find_and_split_vehicles( int exclude )
                 veh_parts.push_back( p );
             }
             checked_parts.insert( test_part );
-            for( point offset : four_adjacent_offsets ) {
+            for( point const offset : four_adjacent_offsets ) {
                 const point dp = parts[test_part].mount + offset;
-                std::vector<int> all_neighbor_parts = parts_at_relative( dp, true );
+                std::vector<int> const all_neighbor_parts = parts_at_relative( dp, true );
                 int neighbor_struct_part = -1;
-                for( int p : all_neighbor_parts ) {
+                for( int const p : all_neighbor_parts ) {
                     if( parts[ p ].removed ) {
                         continue;
                     }
@@ -2187,7 +2187,7 @@ bool vehicle::find_and_split_vehicles( int exclude )
     }
 
     if( !all_vehicles.empty() ) {
-        bool success = split_vehicles( all_vehicles );
+        bool const success = split_vehicles( all_vehicles );
         if( success ) {
             // update the active cache
             shift_parts( point_zero );
@@ -2248,7 +2248,7 @@ bool vehicle::split_vehicles( const std::vector<std::vector <int>> &new_vehs,
             // make sure the split_part0 is a legal 0,0 part
             if( split_parts.size() > 1 ) {
                 for( size_t sp = 0; sp < split_parts.size(); sp++ ) {
-                    int p = split_parts[ sp ];
+                    int const p = split_parts[ sp ];
                     if( part_info( p ).location == part_location_structure &&
                         !part_info( p ).has_flag( "PROTRUSION" ) ) {
                         split_part0 = sp;
@@ -2278,8 +2278,8 @@ bool vehicle::split_vehicles( const std::vector<std::vector <int>> &new_vehs,
 
         std::vector<player *> passengers;
         for( size_t new_part = 0; new_part < split_parts.size(); new_part++ ) {
-            int mov_part = split_parts[ new_part ];
-            point cur_mount = parts[ mov_part ].mount;
+            int const mov_part = split_parts[ new_part ];
+            point const cur_mount = parts[ mov_part ].mount;
             point new_mount = cur_mount;
             if( !split_mounts.empty() ) {
                 new_mount = split_mounts[ new_part ];
@@ -2312,7 +2312,7 @@ bool vehicle::split_vehicles( const std::vector<std::vector <int>> &new_vehs,
             // remove labels associated with the mov_part
             const auto iter = labels.find( label( cur_mount ) );
             if( iter != labels.end() ) {
-                std::string label_str = iter->text;
+                std::string const label_str = iter->text;
                 labels.erase( iter );
                 new_labels.insert( label( new_mount, label_str ) );
             }
@@ -2384,7 +2384,7 @@ bool vehicle::split_vehicles( const std::vector<std::vector <int>> &new_vehs )
 {
     std::vector<vehicle *> null_vehicles;
     std::vector<std::vector <point>> null_mounts;
-    std::vector<point> nothing;
+    std::vector<point> const nothing;
     null_vehicles.assign( new_vehs.size(), nullptr );
     null_mounts.assign( new_vehs.size(), nothing );
     return split_vehicles( new_vehs, null_vehicles, null_mounts );
@@ -2452,7 +2452,7 @@ std::optional<vpart_reference> vpart_position::obstacle_at_part() const
 
 std::optional<vpart_reference> vpart_position::part_displayed() const
 {
-    int part_id = vehicle().part_displayed_at( mount() );
+    int const part_id = vehicle().part_displayed_at( mount() );
     if( part_id == -1 ) {
         return std::nullopt;
     }
@@ -2525,7 +2525,7 @@ int vehicle::part_with_feature( int part, const std::string &flag, bool unbroken
 
 int vehicle::part_with_feature( point pt, const std::string &flag, bool unbroken ) const
 {
-    std::vector<int> parts_here = parts_at_relative( pt, false );
+    std::vector<int> const parts_here = parts_at_relative( pt, false );
     for( auto &elem : parts_here ) {
         if( part_flag( elem, flag ) && ( !unbroken || !parts[ elem ].is_broken() ) ) {
             return elem;
@@ -2536,7 +2536,7 @@ int vehicle::part_with_feature( point pt, const std::string &flag, bool unbroken
 
 int vehicle::avail_part_with_feature( int part, vpart_bitflags const flag, bool unbroken ) const
 {
-    int part_a = part_with_feature( part, flag, unbroken );
+    int const part_a = part_with_feature( part, flag, unbroken );
     if( ( part_a >= 0 ) && parts[ part_a ].is_available() ) {
         return part_a;
     }
@@ -2551,7 +2551,7 @@ int vehicle::avail_part_with_feature( int part, const std::string &flag, bool un
 int vehicle::avail_part_with_feature( point pt, const std::string &flag,
                                       bool unbroken ) const
 {
-    int part_a = part_with_feature( pt, flag, unbroken );
+    int const part_a = part_with_feature( pt, flag, unbroken );
     if( ( part_a >= 0 ) && parts[ part_a ].is_available() ) {
         return part_a;
     }
@@ -2582,7 +2582,7 @@ bool vehicle::has_part( const tripoint &pos, const std::string &flag, bool enabl
 
 int vehicle::obstacle_at_position( point pos ) const
 {
-    int i = part_with_feature( pos, "OBSTACLE", true );
+    int const i = part_with_feature( pos, "OBSTACLE", true );
 
     if( i == -1 ) {
         return -1;
@@ -2599,7 +2599,7 @@ int vehicle::obstacle_at_position( point pos ) const
 
 int vehicle::opaque_at_position( point pos ) const
 {
-    int i = part_with_feature( pos, "OPAQUE", true );
+    int const i = part_with_feature( pos, "OPAQUE", true );
 
     if( i == -1 ) {
         return -1;
@@ -2700,7 +2700,7 @@ int vehicle::next_part_to_close( int p, bool outside ) const
 
 int vehicle::next_part_to_open( int p, bool outside ) const
 {
-    std::vector<int> parts_here = parts_at_relative( parts[p].mount, true );
+    std::vector<int> const parts_here = parts_at_relative( parts[p].mount, true );
 
     // We want forwards, since we open the innermost thing first (curtains), and then the innermost thing (door)
     for( auto &elem : parts_here ) {
@@ -2833,9 +2833,9 @@ std::vector<std::vector<int>> vehicle::find_lines_of_parts( int part, const std:
 
     std::vector<int> x_parts;
     std::vector<int> y_parts;
-    vpart_id part_id = part_info( part ).get_id();
+    vpart_id const part_id = part_info( part ).get_id();
     // create vectors of parts on the same X or Y axis
-    point target = parts[ part ].mount;
+    point const target = parts[ part ].mount;
     for( const vpart_reference &vp : possible_parts ) {
         if( vp.part().is_unavailable() ||
             !vp.has_feature( "MULTISQUARE" ) ||
@@ -2985,7 +2985,7 @@ int vehicle::part_displayed_at( point dp ) const
     bool in_vehicle = g->u.in_vehicle;
     if( in_vehicle ) {
         // They're in a vehicle, but are they in /this/ vehicle?
-        std::vector<int> psg_parts = boarded_parts();
+        std::vector<int> const psg_parts = boarded_parts();
         in_vehicle = false;
         for( auto &psg_part : psg_parts ) {
             if( get_passenger( psg_part ) == &g->u ) {
@@ -2995,7 +2995,7 @@ int vehicle::part_displayed_at( point dp ) const
         }
     }
 
-    int hide_z_at_or_above = ( in_vehicle ) ? ( ON_ROOF_Z ) : INT_MAX;
+    int const hide_z_at_or_above = ( in_vehicle ) ? ( ON_ROOF_Z ) : INT_MAX;
 
     int top_part = 0;
     for( size_t index = 1; index < parts_in_square.size(); index++ ) {
@@ -3012,7 +3012,7 @@ int vehicle::part_displayed_at( point dp ) const
 
 int vehicle::roof_at_part( const int part ) const
 {
-    std::vector<int> parts_in_square = parts_at_relative( parts[part].mount, true );
+    std::vector<int> const parts_in_square = parts_at_relative( parts[part].mount, true );
     for( const int p : parts_in_square ) {
         if( part_info( p ).location == "on_roof" || part_flag( p, "ROOF" ) ) {
             return p;
@@ -3065,9 +3065,9 @@ void vehicle::coord_translate( units::angle dir, point pivot, point p,
                                tripoint &q ) const
 {
 
-    int increment = angle_to_increment( dir );
-    point relative = p - pivot;
-    float skew = std::trunc( relative.x * rotation_info[increment].gradient );
+    int const increment = angle_to_increment( dir );
+    point const relative = p - pivot;
+    float const skew = std::trunc( relative.x * rotation_info[increment].gradient );
 
     q.x = relative.x;
     q.y = relative.y + skew;
@@ -3088,7 +3088,7 @@ void vehicle::coord_translate( units::angle dir, point pivot, point p,
 void vehicle::coord_translate_reverse( units::angle dir, point pivot, const tripoint &p,
                                        point &q ) const
 {
-    int increment = angle_to_increment( dir );
+    int const increment = angle_to_increment( dir );
 
     q.x = p.x;
     q.y = p.y;
@@ -3108,7 +3108,7 @@ void vehicle::coord_translate_reverse( units::angle dir, point pivot, const trip
         q.y = swap;
     }
 
-    float skew = std::trunc( q.x * rotation_info[increment].gradient );
+    float const skew = std::trunc( q.x * rotation_info[increment].gradient );
 
     q.y -= skew;
 
@@ -3130,7 +3130,7 @@ tripoint vehicle::mount_to_tripoint( point mount, point offset ) const
 
 point vehicle::tripoint_to_mount( const tripoint &p ) const
 {
-    tripoint translated = p - global_pos3();
+    tripoint const translated = p - global_pos3();
 
     point result;
     coord_translate_reverse( pivot_rotation[0], pivot_anchor[0], translated, result );
@@ -3174,7 +3174,7 @@ void vehicle::precalc_mounts( int idir, units::angle dir, point pivot )
 bool vehicle::check_rotated_intervening( point from, point to,
         bool( *check )( const vehicle *, point ) ) const
 {
-    point delta = to - from;
+    point const delta = to - from;
     if( abs( delta.x ) <= 1 && abs( delta.y ) <= 1 ) { //Just a normal move
         return true;
     }
@@ -3186,23 +3186,23 @@ bool vehicle::check_rotated_intervening( point from, point to,
     }
 
     if( abs( delta.x ) == 2 ) { //Mostly horizontal move
-        point t1 = from + point( delta.x / 2, delta.y );
+        point const t1 = from + point( delta.x / 2, delta.y );
         if( check( this, t1 ) ) {
             return true;
         }
 
-        point t2 = from + point( delta.x / 2, 0 );
+        point const t2 = from + point( delta.x / 2, 0 );
         if( check( this, t2 ) ) {
             return true;
         }
 
     } else { //Mostly vertical move
-        point t1 = from + point( delta.x, delta.y / 2 );
+        point const t1 = from + point( delta.x, delta.y / 2 );
         if( check( this, t1 ) ) {
             return true;
         }
 
-        point t2 = from + point( 0, delta.y / 2 );
+        point const t2 = from + point( 0, delta.y / 2 );
         if( check( this, t2 ) ) {
             return true;
         }
@@ -3382,7 +3382,7 @@ int vehicle::fuel_left( const itype_id &ftype, bool recurse ) const
     if( ftype == fuel_type_muscle ) {
         // TODO: Allow NPCs to power those
         const optional_vpart_position vp = g->m.veh_at( g->u.pos() );
-        bool player_controlling = player_in_control( g->u );
+        bool const player_controlling = player_in_control( g->u );
 
         //if the engine in the player tile is a muscle engine, and player is controlling vehicle
         if( vp && &vp->vehicle() == this && player_controlling ) {
@@ -3430,7 +3430,7 @@ int vehicle::drain( const itype_id &ftype, int amount )
         // Batteries get special handling to take advantage of jumper
         // cables -- discharge_battery knows how to recurse properly
         // (including taking cable power loss into account).
-        int remnant = discharge_battery( amount, true );
+        int const remnant = discharge_battery( amount, true );
 
         // discharge_battery returns amount of charges that were not
         // found anywhere in the power network, whereas this function
@@ -3444,7 +3444,7 @@ int vehicle::drain( const itype_id &ftype, int amount )
             break;
         }
         if( p.ammo_current() == ftype ) {
-            int qty = p.ammo_consume( amount, global_part_pos3( p ) );
+            int const qty = p.ammo_consume( amount, global_part_pos3( p ) );
             drained += qty;
             amount -= qty;
         }
@@ -3498,15 +3498,15 @@ int vehicle::basic_consumption( const itype_id &ftype ) const
 
 int vehicle::consumption_per_hour( const itype_id &ftype, int fuel_rate_w ) const
 {
-    item fuel = item( ftype );
+    item const fuel = item( ftype );
     if( fuel_rate_w == 0 || fuel.has_flag( "PERPETUAL" ) || !engine_on ) {
         return 0;
     }
 
-    float j_per_turn = fuel_rate_w;
-    float j_per_second = j_per_turn / to_seconds<float>( time_duration::from_turns( 1 ) );
-    float kj_per_hour = j_per_second * 3.6f;
-    float kj_per_mL = fuel.fuel_energy();
+    float const j_per_turn = fuel_rate_w;
+    float const j_per_second = j_per_turn / to_seconds<float>( time_duration::from_turns( 1 ) );
+    float const kj_per_hour = j_per_second * 3.6f;
+    float const kj_per_mL = fuel.fuel_energy();
 
     return kj_per_hour / kj_per_mL;
 }
@@ -3517,7 +3517,7 @@ int vehicle::total_power_w( const bool fueled, const bool safe ) const
     int cnt = 0;
 
     for( size_t e = 0; e < engines.size(); e++ ) {
-        int p = engines[e];
+        int const p = engines[e];
         if( is_engine_on( e ) && ( !fueled || engine_fuel_left( e ) ) ) {
             int m2c = safe ? part_info( engines[e] ).engine_m2c() : 100;
             if( parts[ engines[e] ].faults().count( fault_filter_fuel ) ) {
@@ -3529,7 +3529,7 @@ int vehicle::total_power_w( const bool fueled, const bool safe ) const
     }
 
     for( size_t a = 0; a < alternators.size(); a++ ) {
-        int p = alternators[a];
+        int const p = alternators[a];
         if( is_alternator_on( a ) ) {
             pwr += part_vpower_w( p ); // alternators have negative power
         }
@@ -3558,8 +3558,8 @@ int vehicle::ground_acceleration( const bool fueled, int at_vel_in_vmi ) const
     if( !( engine_on || skidding ) ) {
         return 0;
     }
-    int target_vmiph = std::max( at_vel_in_vmi, std::max( 1000, max_velocity( fueled ) / 4 ) );
-    int cmps = vmiph_to_cmps( target_vmiph );
+    int const target_vmiph = std::max( at_vel_in_vmi, std::max( 1000, max_velocity( fueled ) / 4 ) );
+    int const cmps = vmiph_to_cmps( target_vmiph );
     double weight = to_kilogram( total_mass() );
     if( is_towing() ) {
         vehicle *other_veh = tow_data.get_towed();
@@ -3567,8 +3567,8 @@ int vehicle::ground_acceleration( const bool fueled, int at_vel_in_vmi ) const
             weight = weight + to_kilogram( other_veh->total_mass() );
         }
     }
-    int engine_power_ratio = total_power_w( fueled ) / weight;
-    int accel_at_vel = 100 * 100 * engine_power_ratio / cmps;
+    int const engine_power_ratio = total_power_w( fueled ) / weight;
+    int const accel_at_vel = 100 * 100 * engine_power_ratio / cmps;
     add_msg( m_debug, "%s: accel at %d vimph is %d", name, target_vmiph,
              cmps_to_vmiph( accel_at_vel ) );
     return cmps_to_vmiph( accel_at_vel );
@@ -3589,9 +3589,9 @@ int vehicle::water_acceleration( const bool fueled, int at_vel_in_vmi ) const
     if( !( engine_on || skidding ) ) {
         return 0;
     }
-    int target_vmiph = std::max( at_vel_in_vmi, std::max( 1000,
+    int const target_vmiph = std::max( at_vel_in_vmi, std::max( 1000,
                                  max_water_velocity( fueled ) / 4 ) );
-    int cmps = vmiph_to_cmps( target_vmiph );
+    int const cmps = vmiph_to_cmps( target_vmiph );
     double weight = to_kilogram( total_mass() );
     if( is_towing() ) {
         vehicle *other_veh = tow_data.get_towed();
@@ -3599,8 +3599,8 @@ int vehicle::water_acceleration( const bool fueled, int at_vel_in_vmi ) const
             weight = weight + to_kilogram( other_veh->total_mass() );
         }
     }
-    int engine_power_ratio = total_power_w( fueled ) / weight;
-    int accel_at_vel = 100 * 100 * engine_power_ratio / cmps;
+    int const engine_power_ratio = total_power_w( fueled ) / weight;
+    int const accel_at_vel = 100 * 100 * engine_power_ratio / cmps;
     add_msg( m_debug, "%s: water accel at %d vimph is %d", name, target_vmiph,
              cmps_to_vmiph( accel_at_vel ) );
     return cmps_to_vmiph( accel_at_vel );
@@ -3611,18 +3611,18 @@ int vehicle::water_acceleration( const bool fueled, int at_vel_in_vmi ) const
 // see https://math.vanderbilt.edu/schectex/courses/cubic/ for the gory details
 static double simple_cubic_solution( double a, double b, double c, double d )
 {
-    double p = -b / ( 3 * a );
-    double q = p * p * p + ( b * c - 3 * a * d ) / ( 6 * a * a );
-    double r = c / ( 3 * a );
-    double t = r - p * p;
-    double tricky_bit = q * q + t * t * t;
+    double const p = -b / ( 3 * a );
+    double const q = p * p * p + ( b * c - 3 * a * d ) / ( 6 * a * a );
+    double const r = c / ( 3 * a );
+    double const t = r - p * p;
+    double const tricky_bit = q * q + t * t * t;
     if( tricky_bit < 0 ) {
-        double cr = 1.0 / 3.0; // approximate the cube root of a complex number
-        std::complex<double> q_complex( q );
-        std::complex<double> tricky_complex( std::sqrt( std::complex<double>( tricky_bit ) ) );
-        std::complex<double> term1( std::pow( q_complex + tricky_complex, cr ) );
-        std::complex<double> term2( std::pow( q_complex - tricky_complex, cr ) );
-        std::complex<double> term_sum( term1 + term2 );
+        double const cr = 1.0 / 3.0; // approximate the cube root of a complex number
+        std::complex<double> const q_complex( q );
+        std::complex<double> const tricky_complex( std::sqrt( std::complex<double>( tricky_bit ) ) );
+        std::complex<double> const term1( std::pow( q_complex + tricky_complex, cr ) );
+        std::complex<double> const term2( std::pow( q_complex - tricky_complex, cr ) );
+        std::complex<double> const term_sum( term1 + term2 );
 
         if( imag( term_sum ) < 2 ) {
             return p + real( term_sum );
@@ -3631,11 +3631,11 @@ static double simple_cubic_solution( double a, double b, double c, double d )
             return 0;
         }
     } else {
-        double tricky_final = std::sqrt( tricky_bit );
-        double term1_part = q + tricky_final;
-        double term2_part = q - tricky_final;
-        double term1 = std::cbrt( term1_part );
-        double term2 = std::cbrt( term2_part );
+        double const tricky_final = std::sqrt( tricky_bit );
+        double const term1_part = q + tricky_final;
+        double const term2_part = q - tricky_final;
+        double const term1 = std::cbrt( term1_part );
+        double const term2 = std::cbrt( term2_part );
         return p + term1 + term2;
     }
 }
@@ -3682,9 +3682,9 @@ int vehicle::current_acceleration( const bool fueled ) const
 // got it? quiz on Wednesday.
 int vehicle::max_ground_velocity( const bool fueled ) const
 {
-    int total_engine_w = total_power_w( fueled );
-    double c_rolling_drag = coeff_rolling_drag();
-    double max_in_mps = simple_cubic_solution( coeff_air_drag(), c_rolling_drag,
+    int const total_engine_w = total_power_w( fueled );
+    double const c_rolling_drag = coeff_rolling_drag();
+    double const max_in_mps = simple_cubic_solution( coeff_air_drag(), c_rolling_drag,
                         c_rolling_drag * vehicles::rolling_constant_to_variable,
                         -total_engine_w );
     add_msg( m_debug, "%s: power %d, c_air %3.2f, c_rolling %3.2f, max_in_mps %3.2f",
@@ -3704,9 +3704,9 @@ int vehicle::max_ground_velocity( const bool fueled ) const
 // velocity = cube root( engine_power / ( c_water_drag + c_air_drag ) )
 int vehicle::max_water_velocity( const bool fueled ) const
 {
-    int total_engine_w = total_power_w( fueled );
-    double total_drag = coeff_water_drag() + coeff_air_drag();
-    double max_in_mps = std::cbrt( total_engine_w / total_drag );
+    int const total_engine_w = total_power_w( fueled );
+    double const total_drag = coeff_water_drag() + coeff_air_drag();
+    double const max_in_mps = std::cbrt( total_engine_w / total_drag );
     add_msg( m_debug, "%s: power %d, c_air %3.2f, c_water %3.2f, water max_in_mps %3.2f",
              name, total_engine_w, coeff_air_drag(), coeff_water_drag(), max_in_mps );
     return mps_to_vmiph( max_in_mps );
@@ -3734,7 +3734,7 @@ int vehicle::max_velocity( const bool fueled ) const
 
 int vehicle::max_reverse_velocity( const bool fueled ) const
 {
-    int max_vel = max_velocity( fueled );
+    int const max_vel = max_velocity( fueled );
     if( has_engine_type( fuel_type_battery, true ) ) {
         // Electric motors can go in reverse as well as forward
         return -max_vel;
@@ -3753,7 +3753,7 @@ int vehicle::safe_ground_velocity( const bool fueled ) const
         if( vp.info().fuel_type == fuel_type_animal && engines.size() != 1 ) {
             monster *mon = get_pet( e );
             if( mon != nullptr && mon->has_effect( effect_harnessed ) ) {
-                int animal_vel_cur = mon->get_speed() * 12;
+                int const animal_vel_cur = mon->get_speed() * 12;
                 if( animal_vel > 0 ) {
                     animal_vel = std::min( animal_vel, animal_vel_cur );
                 } else {
@@ -3767,9 +3767,9 @@ int vehicle::safe_ground_velocity( const bool fueled ) const
             return std::min( animal_vel, max_ground_velocity( fueled ) );
         }
     }
-    int effective_engine_w = total_power_w( fueled, true );
-    double c_rolling_drag = coeff_rolling_drag();
-    double safe_in_mps = simple_cubic_solution( coeff_air_drag(), c_rolling_drag,
+    int const effective_engine_w = total_power_w( fueled, true );
+    double const c_rolling_drag = coeff_rolling_drag();
+    double const safe_in_mps = simple_cubic_solution( coeff_air_drag(), c_rolling_drag,
                          c_rolling_drag * vehicles::rolling_constant_to_variable,
                          -effective_engine_w );
     return mps_to_vmiph( safe_in_mps );
@@ -3785,9 +3785,9 @@ int vehicle::safe_rotor_velocity( const bool fueled ) const
 // the same physics as max_water_velocity, but with a smaller engine power
 int vehicle::safe_water_velocity( const bool fueled ) const
 {
-    int total_engine_w = total_power_w( fueled, true );
-    double total_drag = coeff_water_drag() + coeff_air_drag();
-    double safe_in_mps = std::cbrt( total_engine_w / total_drag );
+    int const total_engine_w = total_power_w( fueled, true );
+    double const total_drag = coeff_water_drag() + coeff_air_drag();
+    double const safe_in_mps = std::cbrt( total_engine_w / total_drag );
     return mps_to_vmiph( safe_in_mps );
 }
 
@@ -3832,7 +3832,7 @@ void vehicle::spew_field( double joules, int part, field_type_id type, int inten
     while( relative_parts.find( p ) != relative_parts.end() ) {
         p.x += ( velocity < 0 ? 1 : -1 );
     }
-    point q = coord_translate( p );
+    point const q = coord_translate( p );
     const tripoint dest = global_pos3() + tripoint( q, 0 );
     g->m.mod_field_intensity( dest, type, intensity );
 }
@@ -3869,12 +3869,12 @@ void vehicle::noise_and_smoke( int load, time_duration time )
     bool combustion = false;
 
     for( size_t e = 0; e < engines.size(); e++ ) {
-        int p = engines[e];
+        int const p = engines[e];
         if( is_engine_on( e ) &&  engine_fuel_left( e ) ) {
             // convert current engine load to units of watts/40K
             // then spew more smoke and make more noise as the engine load increases
-            int part_watts = part_vpower_w( p, true );
-            double max_stress = static_cast<double>( part_watts / 40000.0 );
+            int const part_watts = part_vpower_w( p, true );
+            double const max_stress = static_cast<double>( part_watts / 40000.0 );
             double cur_stress = load / 1000.0 * max_stress;
             // idle stress = 1.0 resulting in nominal working engine noise = engine_noise_factor()
             // and preventing noise = 0
@@ -4002,8 +4002,8 @@ double vehicle::coeff_air_drag() const
     constexpr double sail_height = 0.8;
     constexpr double rotor_height = 0.6;
 
-    std::vector<int> structure_indices = all_parts_at_location( part_location_structure );
-    int width = mount_max.y - mount_min.y + 1;
+    std::vector<int> const structure_indices = all_parts_at_location( part_location_structure );
+    int const width = mount_max.y - mount_min.y + 1;
 
     // a mess of lambdas to make the next bit slightly easier to read
     const auto d_exposed = [&]( const vehicle_part & p ) {
@@ -4034,14 +4034,14 @@ double vehicle::coeff_air_drag() const
     // windshield, halfboard and is twice as long as it is wide.
     // find the first instance of each item and compare against the ideal configuration.
     std::vector<drag_column> drag( width );
-    for( int p : structure_indices ) {
+    for( int const p : structure_indices ) {
         if( parts[ p ].removed ) {
             continue;
         }
-        int col = parts[ p ].mount.y - mount_min.y;
-        std::vector<int> parts_at = parts_at_relative( parts[ p ].mount, true );
+        int const col = parts[ p ].mount.y - mount_min.y;
+        std::vector<int> const parts_at = parts_at_relative( parts[ p ].mount, true );
         d_check_min( drag[ col ].pro, parts[ p ], d_protrusion( parts_at ) );
-        for( int pa_index : parts_at ) {
+        for( int const pa_index : parts_at ) {
             const vehicle_part &pa = parts[ pa_index ];
             d_check_max( drag[ col ].hboard, pa, pa.info().has_flag( "HALF_BOARD" ) );
             d_check_max( drag[ col ].fboard, pa, pa.info().has_flag( "FULL_BOARD" ) );
@@ -4065,7 +4065,7 @@ double vehicle::coeff_air_drag() const
     double height = 0;
     double c_air_drag = 0;
     // tally the results of each row and prorate them relative to vehicle width
-    for( drag_column &dc : drag ) {
+    for( drag_column  const&dc : drag ) {
         // even as m_debug you rarely want to see this
         // add_msg( m_debug, "veh %: pro %d, hboard %d, fboard %d, shield %d, seat %d, roof %d, aisle %d, turret %d, panel %d, exposed %d, last %d\n", name, dc.pro, dc.hboard, dc.fboard, dc.shield, dc.seat, dc.roof, dc.aisle, dc.turret, dc.panel, dc.exposed, dc.last );
 
@@ -4116,7 +4116,7 @@ double vehicle::coeff_air_drag() const
     // prorate per row height and c_air_drag
     height /= width;
     c_air_drag /= width;
-    double cross_area = height * tile_to_width( width );
+    double const cross_area = height * tile_to_width( width );
     add_msg( m_debug, "%s: height %3.2fm, width %3.2fm (%d tiles), c_air %3.2f\n", name, height,
              tile_to_width( width ), width, c_air_drag );
     // F_air_drag = c_air_drag * cross_area * 1/2 * air_density * v^2
@@ -4252,7 +4252,7 @@ double vehicle::coeff_water_drag() const
     if( !coeff_water_dirty ) {
         return coefficient_water_resistance;
     }
-    std::vector<int> structure_indices = all_parts_at_location( part_location_structure );
+    std::vector<int> const structure_indices = all_parts_at_location( part_location_structure );
     if( structure_indices.empty() ) {
         // huh?
         coeff_water_dirty = false;
@@ -4260,10 +4260,10 @@ double vehicle::coeff_water_drag() const
         draft_m = 1.0;
         return 1250.0;
     }
-    double hull_coverage = static_cast<double>( floating.size() ) / structure_indices.size();
+    double const hull_coverage = static_cast<double>( floating.size() ) / structure_indices.size();
 
-    int tile_width = mount_max.y - mount_min.y + 1;
-    double width_m = tile_to_width( tile_width );
+    int const tile_width = mount_max.y - mount_min.y + 1;
+    double const width_m = tile_to_width( tile_width );
 
     // actual area of the hull in m^2 (handles non-rectangular shapes)
     // footprint area in tiles = tile width * tile length
@@ -4273,7 +4273,7 @@ double vehicle::coeff_water_drag() const
     // actual area in m = # of structure tiles * length in tiles * width in meters /
     //                    ( length in tiles * width in tiles )
     // actual area in m = # of structure tiles * width in meters / width in tiles
-    double actual_area_m = width_m * structure_indices.size() / tile_width;
+    double const actual_area_m = width_m * structure_indices.size() / tile_width;
 
     // effective hull area is actual hull area * hull coverage
     hull_area = actual_area_m * std::max( 0.1, hull_coverage );
@@ -4286,7 +4286,7 @@ double vehicle::coeff_water_drag() const
     // depth = vehicle_mass / water_density / area
     draft_m = to_kilogram( total_mass() ) / water_density / hull_area;
     // increase the streamlining as more of the boat is covered in boat boards
-    double c_water_drag = 1.25 - hull_coverage;
+    double const c_water_drag = 1.25 - hull_coverage;
     // hull height starts at 0.3m and goes up as you add more boat boards
     hull_height = 0.3 + 0.5 * hull_coverage;
     // F_water_drag = c_water_drag * cross_area * 1/2 * water_density * v^2
@@ -4322,7 +4322,7 @@ float vehicle::k_traction( float wheel_traction_area ) const
         return 1.0f;
     }
     const float mass_penalty = fraction_without_traction * to_kilogram( total_mass() );
-    float traction = std::min( 1.0f, wheel_traction_area / mass_penalty );
+    float const traction = std::min( 1.0f, wheel_traction_area / mass_penalty );
     add_msg( m_debug, "%s has traction %.2f", name, traction );
 
     // For now make it easy until it gets properly balanced: add a low cap of 0.1
@@ -4337,7 +4337,7 @@ int vehicle::static_drag( bool actual ) const
 float vehicle::strain() const
 {
     int mv = max_velocity();
-    int sv = safe_velocity();
+    int const sv = safe_velocity();
     if( mv <= sv ) {
         mv = sv + 1;
     }
@@ -4473,7 +4473,7 @@ bool vehicle::balanced_wheel_config() const
     }
 
     // Check center of mass inside support of wheels (roughly)
-    point com = local_center_of_mass();
+    point const com = local_center_of_mass();
     const inclusive_rectangle<point> support( min, max );
     return support.contains( com );
 }
@@ -4514,7 +4514,7 @@ float vehicle::steering_effectiveness() const
     // TODO: return something less than 1.0 if the steering isn't so good
     // (unbalanced, long wheelbase, back-heavy vehicle with front wheel steering,
     // etc)
-    for( int p : steering ) {
+    for( int const p : steering ) {
         if( parts[ p ].is_available() ) {
             return 1.0f;
         }
@@ -4601,7 +4601,7 @@ double vehicle::drain_energy( const itype_id &ftype, double energy_j )
 
 void vehicle::consume_fuel( int load, const int t_seconds, bool skip_electric )
 {
-    double st = strain();
+    double const st = strain();
     for( auto &fuel_pr : fuel_usage() ) {
         auto &ft = fuel_pr.first;
         if( skip_electric && ft == fuel_type_battery ) {
@@ -4612,7 +4612,7 @@ void vehicle::consume_fuel( int load, const int t_seconds, bool skip_electric )
         amnt_precise_j *= load / 1000.0 * ( 1.0 + st * st * 100.0 );
         auto inserted = fuel_used_last_turn.insert( { ft, 0.0f } );
         inserted.first->second += amnt_precise_j;
-        double remainder = fuel_remainder[ ft ];
+        double const remainder = fuel_remainder[ ft ];
         amnt_precise_j -= remainder;
 
         if( amnt_precise_j > 0.0f ) {
@@ -4625,7 +4625,7 @@ void vehicle::consume_fuel( int load, const int t_seconds, bool skip_electric )
     if( load > 0 && fuel_left( fuel_type_muscle ) > 0 ) {
         //do this as a function of current load
         // But only if the player is actually there!
-        int eff_load = load / 10;
+        int const eff_load = load / 10;
         int mod = 4 * st; // strain
         int base_burn = static_cast<int>( get_option<float>( "PLAYER_BASE_STAMINA_REGEN_RATE" ) ) -
                         3;
@@ -4716,7 +4716,7 @@ int vehicle::total_engine_epower_w() const
 int vehicle::total_solar_epower_w() const
 {
     int epower_w = 0;
-    for( int part : solar_panels ) {
+    for( int const part : solar_panels ) {
         if( parts[ part ].is_unavailable() ) {
             continue;
         }
@@ -4731,17 +4731,17 @@ int vehicle::total_solar_epower_w() const
     // sample it once.
     const weather_type_id &wtype = current_weather( global_pos3() );
     const float tick_sunlight = incident_sunlight( wtype, calendar::turn );
-    double intensity = tick_sunlight / default_daylight_level();
+    double const intensity = tick_sunlight / default_daylight_level();
     return epower_w * intensity;
 }
 
 int vehicle::total_wind_epower_w() const
 {
-    map &here = get_map();
+    map  const&here = get_map();
     const oter_id &cur_om_ter = overmap_buffer.ter( global_omt_location() );
     const weather_manager &weather = get_weather();
     int epower_w = 0;
-    for( int part : wind_turbines ) {
+    for( int const part : wind_turbines ) {
         if( parts[ part ].is_unavailable() ) {
             continue;
         }
@@ -4750,7 +4750,7 @@ int vehicle::total_wind_epower_w() const
             continue;
         }
 
-        double windpower = get_local_windpower( weather.windspeed, cur_om_ter, global_part_pos3( part ),
+        double const windpower = get_local_windpower( weather.windspeed, cur_om_ter, global_part_pos3( part ),
                                                 weather.winddirection, false );
         if( windpower <= ( weather.windspeed / 10.0 ) ) {
             continue;
@@ -4763,7 +4763,7 @@ int vehicle::total_wind_epower_w() const
 int vehicle::total_water_wheel_epower_w() const
 {
     int epower_w = 0;
-    for( int part : water_wheels ) {
+    for( int const part : water_wheels ) {
         if( parts[ part ].is_unavailable() ) {
             continue;
         }
@@ -4787,7 +4787,7 @@ int vehicle::net_battery_charge_rate_w() const
 int vehicle::max_reactor_epower_w() const
 {
     int epower_w = 0;
-    for( int elem : reactors ) {
+    for( int const elem : reactors ) {
         epower_w += is_part_on( elem ) ? part_epower_w( elem ) : 0;
     }
     return epower_w;
@@ -4822,11 +4822,11 @@ void vehicle::power_parts()
 {
     update_alternator_load();
     // Things that drain energy: engines and accessories.
-    int engine_epower = total_engine_epower_w();
-    int epower = engine_epower + total_accessory_epower_w() + total_alternator_epower_w();
+    int const engine_epower = total_engine_epower_w();
+    int const epower = engine_epower + total_accessory_epower_w() + total_alternator_epower_w();
 
     int delta_energy_bat = power_to_energy_bat( epower, 1_turns );
-    int storage_deficit_bat = std::max( 0, fuel_capacity( fuel_type_battery ) -
+    int const storage_deficit_bat = std::max( 0, fuel_capacity( fuel_type_battery ) -
                                         fuel_left( fuel_type_battery ) - delta_energy_bat );
     // Reactors trigger only on demand. If we'd otherwise run out of power, see
     // if we can spin up the reactors.
@@ -4922,14 +4922,14 @@ void vehicle::power_parts()
 vehicle *vehicle::find_vehicle( const tripoint &where )
 {
     // Is it in the reality bubble?
-    tripoint veh_local = g->m.getlocal( where );
+    tripoint const veh_local = g->m.getlocal( where );
     if( const optional_vpart_position vp = g->m.veh_at( veh_local ) ) {
         return &vp->vehicle();
     }
 
     // Nope. Load up its submap...
     tripoint veh_in_sm = where;
-    tripoint veh_sm = ms_to_sm_remain( veh_in_sm );
+    tripoint const veh_sm = ms_to_sm_remain( veh_in_sm );
 
     auto sm = MAPBUFFER.lookup_submap( veh_sm );
     if( sm == nullptr ) {
@@ -5137,14 +5137,14 @@ int vehicle::charge_battery( int amount, bool include_other_vehicles )
     while( amount > 0 && !chargeable_parts.empty() ) {
         // Grab first part, charge until it reaches the next %, then re-insert with new % key.
         auto iter = chargeable_parts.begin();
-        int charge_level = iter->first;
+        int const charge_level = iter->first;
         vehicle_part *p = iter->second;
         chargeable_parts.erase( iter );
         // Calculate number of charges to reach the next %, but insure it's at least
         // one more than current charge.
         int next_charge_level = ( ( charge_level + 1 ) * p->ammo_capacity() ) / 100;
         next_charge_level = std::max( next_charge_level, p->ammo_remaining() + 1 );
-        int qty = std::min( amount, next_charge_level - p->ammo_remaining() );
+        int const qty = std::min( amount, next_charge_level - p->ammo_remaining() );
         p->ammo_set( fuel_type_battery, p->ammo_remaining() + qty );
         amount -= qty;
         if( p->ammo_capacity() > p->ammo_remaining() ) {
@@ -5184,13 +5184,13 @@ int vehicle::discharge_battery( int amount, bool recurse )
     while( amount > 0 && !dischargeable_parts.empty() ) {
         // Grab first part, discharge until it reaches the next %, then re-insert with new % key.
         auto iter = std::prev( dischargeable_parts.end() );
-        int charge_level = iter->first;
+        int const charge_level = iter->first;
         vehicle_part *p = iter->second;
         dischargeable_parts.erase( iter );
         // Calculate number of charges to reach the previous %.
         int prev_charge_level = ( ( charge_level - 1 ) * p->ammo_capacity() ) / 100;
         prev_charge_level = std::max( 0, prev_charge_level );
-        int amount_to_discharge = std::min( p->ammo_remaining() - prev_charge_level, amount );
+        int const amount_to_discharge = std::min( p->ammo_remaining() - prev_charge_level, amount );
         p->ammo_consume( amount_to_discharge, global_part_pos3( *p ) );
         amount -= amount_to_discharge;
         if( p->ammo_remaining() > 0 ) {
@@ -5222,7 +5222,7 @@ void vehicle::do_engine_damage( size_t e, int strain )
     strain = std::min( 25, strain );
     if( is_engine_on( e ) && !is_perpetual_type( e ) &&
         engine_fuel_left( e ) && rng( 1, 100 ) < strain ) {
-        int dmg = rng( 0, strain * 4 );
+        int const dmg = rng( 0, strain * 4 );
         damage_direct( engines[e], dmg );
         if( one_in( 2 ) ) {
             add_msg( _( "Your engine emits a high pitched whine." ) );
@@ -5323,8 +5323,8 @@ void vehicle::slow_leak()
         }
 
         auto fuel = p.ammo_current();
-        int qty = std::max( ( 0.5 - health ) * ( 0.5 - health ) * p.ammo_remaining() / 10, 1.0 );
-        point q = coord_translate( p.mount );
+        int const qty = std::max( ( 0.5 - health ) * ( 0.5 - health ) * p.ammo_remaining() / 10, 1.0 );
+        point const q = coord_translate( p.mount );
         const tripoint dest = global_pos3() + tripoint( q, 0 );
 
         if( fuel != fuel_type_battery && !g->m.inbounds( dest ) ) {
@@ -5334,12 +5334,12 @@ void vehicle::slow_leak()
 
         // damaged batteries self-discharge without leaking, plutonium leaks slurry
         if( fuel != fuel_type_battery && fuel != fuel_type_plutonium_cell ) {
-            item leak( fuel, calendar::turn, qty );
+            item const leak( fuel, calendar::turn, qty );
             g->m.add_item_or_charges( dest, leak );
             p.ammo_consume( qty, global_part_pos3( p ) );
         } else if( fuel == fuel_type_plutonium_cell ) {
             if( p.ammo_remaining() >= PLUTONIUM_CHARGES / 10 ) {
-                item leak( "plut_slurry_dense", calendar::turn, qty );
+                item const leak( "plut_slurry_dense", calendar::turn, qty );
                 g->m.add_item_or_charges( dest, leak );
                 p.ammo_consume( qty * PLUTONIUM_CHARGES / 10, global_part_pos3( p ) );
             } else {
@@ -5400,7 +5400,7 @@ int vehicle::add_charges( int part, const item &itm )
 
 std::optional<vehicle_stack::iterator> vehicle::add_item( vehicle_part &pt, const item &obj )
 {
-    int idx = index_of_part( &pt );
+    int const idx = index_of_part( &pt );
     if( idx < 0 ) {
         debugmsg( "Tried to add item to invalid part" );
         return std::nullopt;
@@ -5426,7 +5426,7 @@ std::optional<vehicle_stack::iterator> vehicle::add_item( int part, const item &
             return std::nullopt;
         }
     }
-    bool charge = itm.count_by_charges();
+    bool const charge = itm.count_by_charges();
     vehicle_stack istack = get_items( part );
     const int to_move = istack.amount_can_fit( itm );
     if( to_move == 0 || ( charge && to_move < itm.charges ) ) {
@@ -5502,7 +5502,7 @@ void vehicle::place_spawn_items()
 
     for( const auto &pt : type->parts ) {
         if( pt.with_ammo ) {
-            int turret = part_with_feature( pt.pos, "TURRET", true );
+            int const turret = part_with_feature( pt.pos, "TURRET", true );
             if( turret >= 0 && x_in_y( pt.with_ammo, 100 ) ) {
                 parts[ turret ].ammo_set( random_entry( pt.ammo_types ), rng( pt.ammo_qty.first,
                                           pt.ammo_qty.second ) );
@@ -5512,13 +5512,13 @@ void vehicle::place_spawn_items()
 
     for( const auto &spawn : type.obj().item_spawns ) {
         if( rng( 1, 100 ) <= spawn.chance ) {
-            int part = part_with_feature( spawn.pos, "CARGO", false );
+            int const part = part_with_feature( spawn.pos, "CARGO", false );
             if( part < 0 ) {
                 debugmsg( "No CARGO parts at (%d, %d) of %s!", spawn.pos.x, spawn.pos.y, name );
 
             } else {
                 // if vehicle part is broken only 50% of items spawn and they will be variably damaged
-                bool broken = parts[ part ].is_broken();
+                bool const broken = parts[ part ].is_broken();
                 if( broken && one_in( 2 ) ) {
                     continue;
                 }
@@ -5528,7 +5528,7 @@ void vehicle::place_spawn_items()
                     created.emplace_back( item( e ).in_its_container() );
                 }
                 for( const item_group_id &e : spawn.item_groups ) {
-                    item_group::ItemList group_items = item_group::items_from( e, calendar::start_of_cataclysm );
+                    item_group::ItemList const group_items = item_group::items_from( e, calendar::start_of_cataclysm );
                     for( auto spawn_item : group_items ) {
                         created.emplace_back( spawn_item );
                     }
@@ -5542,8 +5542,8 @@ void vehicle::place_spawn_items()
                         continue; // we destroyed the item
                     }
                     if( e.is_tool() || e.is_gun() || e.is_magazine() ) {
-                        bool spawn_ammo = rng( 0, 99 ) < spawn.with_ammo && e.ammo_remaining() == 0;
-                        bool spawn_mag  = rng( 0, 99 ) < spawn.with_magazine && !e.magazine_integral() &&
+                        bool const spawn_ammo = rng( 0, 99 ) < spawn.with_ammo && e.ammo_remaining() == 0;
+                        bool const spawn_mag  = rng( 0, 99 ) < spawn.with_magazine && !e.magazine_integral() &&
                                           !e.magazine_current();
 
                         if( spawn_mag ) {
@@ -5617,7 +5617,7 @@ void vehicle::gain_moves()
 void vehicle::dump_items_from_part( const size_t index )
 {
     vehicle_part &vp = parts[ index ];
-    for( item &e : vp.items ) {
+    for( item  const&e : vp.items ) {
         g->m.add_item_or_charges( global_part_pos3( vp ), e );
     }
     vp.items.clear();
@@ -5734,7 +5734,7 @@ void vehicle::refresh()
         mount_max.y = std::max( mount_max.y, pt.y );
 
         // This will keep the parts at point pt sorted
-        std::vector<int>::iterator vii = std::lower_bound( relative_parts[pt].begin(),
+        std::vector<int>::iterator const vii = std::lower_bound( relative_parts[pt].begin(),
                                          relative_parts[pt].end(),
                                          static_cast<int>( p ), svpv );
         relative_parts[pt].insert( vii, p );
@@ -5916,11 +5916,11 @@ void vehicle::refresh_pivot() const
     float yc_numerator = 0;
     float yc_denominator = 0;
 
-    for( int p : wheelcache ) {
+    for( int const p : wheelcache ) {
         const auto &wheel = parts[p];
 
         // TODO: load on tire?
-        int contact_area = wheel.wheel_area();
+        int const contact_area = wheel.wheel_area();
         float weight_i;  // weighting for the in-line part
         float weight_p;  // weighting for the perpendicular part
         if( wheel.is_broken() ) {
@@ -5993,11 +5993,11 @@ void vehicle::do_towing_move()
     const tripoint tower_tow_point = g->m.getabs( global_part_pos3( tow_index ) );
     const tripoint towed_tow_point = g->m.getabs( towed_veh->global_part_pos3( other_tow_index ) );
     // same as above, but where the pulling vehicle is pulling from
-    units::angle towing_veh_angle = towed_veh->get_angle_from_targ( tower_tow_point );
+    units::angle const towing_veh_angle = towed_veh->get_angle_from_targ( tower_tow_point );
     const bool reverse = towed_veh->tow_data.tow_direction == TOW_BACK;
     int accel_y = 0;
-    tripoint vehpos = global_square_location().raw();
-    int turn_x = get_turn_from_angle( towing_veh_angle, vehpos, tower_tow_point, reverse );
+    tripoint const vehpos = global_square_location().raw();
+    int const turn_x = get_turn_from_angle( towing_veh_angle, vehpos, tower_tow_point, reverse );
     if( rl_dist( towed_tow_point, tower_tow_point ) < 6 ) {
         accel_y = reverse ? -1 : 1;
     }
@@ -6171,7 +6171,7 @@ void vehicle::invalidate_towing( bool first_vehicle )
         if( part_with_feature( p, "TOW_CABLE", true ) >= 0 ) {
             if( first_vehicle ) {
                 vehicle_part *part = &parts[part_with_feature( p, "TOW_CABLE", true )];
-                item drop = part->properties_to_item();
+                item const drop = part->properties_to_item();
                 g->m.add_item_or_charges( global_part_pos3( *part ), drop );
             }
             remove_part( part_with_feature( p, "TOW_CABLE", true ) );
@@ -6188,23 +6188,23 @@ bool vehicle::tow_cable_too_far() const
         debugmsg( "checking tow cable length on a vehicle that has no towing vehicle" );
         return false;
     }
-    int index = get_tow_part();
+    int const index = get_tow_part();
     if( index == -1 ) {
         debugmsg( "towing data exists but no towing part" );
         return false;
     }
-    tripoint towing_point = g->m.getabs( global_part_pos3( index ) );
+    tripoint const towing_point = g->m.getabs( global_part_pos3( index ) );
     if( !tow_data.get_towed_by()->tow_data.get_towed() ) {
         debugmsg( "vehicle %s has data for a towing vehicle, but that towing vehicle does not have %s listed as towed",
                   disp_name(), disp_name() );
         return false;
     }
-    int other_index = tow_data.get_towed_by()->get_tow_part();
+    int const other_index = tow_data.get_towed_by()->get_tow_part();
     if( other_index == -1 ) {
         debugmsg( "towing data exists but no towing part" );
         return false;
     }
-    tripoint towed_point = g->m.getabs( tow_data.get_towed_by()->global_part_pos3( other_index ) );
+    tripoint const towed_point = g->m.getabs( tow_data.get_towed_by()->global_part_pos3( other_index ) );
     if( towing_point == tripoint_zero || towed_point == tripoint_zero ) {
         debugmsg( "towing data exists but no towing part" );
         return false;
@@ -6219,23 +6219,23 @@ bool vehicle::no_towing_slack() const
     if( !tow_data.get_towed() ) {
         return false;
     }
-    int index = get_tow_part();
+    int const index = get_tow_part();
     if( index == -1 ) {
         debugmsg( "towing data exists but no towing part" );
         return false;
     }
-    tripoint towing_point = g->m.getabs( global_part_pos3( index ) );
+    tripoint const towing_point = g->m.getabs( global_part_pos3( index ) );
     if( !tow_data.get_towed()->tow_data.get_towed_by() ) {
         debugmsg( "vehicle %s has data for a towed vehicle, but that towed vehicle does not have %s listed as tower",
                   disp_name(), disp_name() );
         return false;
     }
-    int other_index = tow_data.get_towed()->get_tow_part();
+    int const other_index = tow_data.get_towed()->get_tow_part();
     if( other_index == -1 ) {
         debugmsg( "towing data exists but no towing part" );
         return false;
     }
-    tripoint towed_point = g->m.getabs( tow_data.get_towed()->global_part_pos3( other_index ) );
+    tripoint const towed_point = g->m.getabs( tow_data.get_towed()->global_part_pos3( other_index ) );
     if( towing_point == tripoint_zero || towed_point == tripoint_zero ) {
         debugmsg( "towing data exists but no towing part" );
         return false;
@@ -6265,7 +6265,7 @@ void vehicle::remove_remote_part( int part_num )
         const tripoint local_abs = g->m.getabs( global_part_pos3( part_num ) );
 
         for( size_t j = 0; j < veh->loose_parts.size(); j++ ) {
-            int remote_partnum = veh->loose_parts[j];
+            int const remote_partnum = veh->loose_parts[j];
             auto remote_part = &veh->parts[remote_partnum];
 
             if( veh->part_flag( remote_partnum, "POWER_TRANSFER" ) && remote_part->target.first == local_abs ) {
@@ -6295,7 +6295,7 @@ void vehicle::shed_loose_parts()
             tow_data.clear_towing();
         }
         auto part = &parts[elem];
-        item drop = part->properties_to_item();
+        item const drop = part->properties_to_item();
         if( !magic ) {
             g->m.add_item_or_charges( global_part_pos3( *part ), drop );
         }
@@ -6336,9 +6336,9 @@ void vehicle::refresh_insides()
         // inside if not otherwise
         parts[p].inside = true;
         // let's check four neighbor parts
-        for( point offset : four_adjacent_offsets ) {
-            point near_mount = parts[ p ].mount + offset;
-            std::vector<int> parts_n3ar = parts_at_relative( near_mount, true );
+        for( point const offset : four_adjacent_offsets ) {
+            point const near_mount = parts[ p ].mount + offset;
+            std::vector<int> const parts_n3ar = parts_at_relative( near_mount, true );
             // if we aren't covered from sides, the roof at p won't save us
             bool cover = false;
             for( auto &j : parts_n3ar ) {
@@ -6376,7 +6376,7 @@ bool vpart_position::is_inside() const
 
 void vehicle::unboard_all()
 {
-    std::vector<int> bp = boarded_parts();
+    std::vector<int> const bp = boarded_parts();
     for( auto &i : bp ) {
         g->m.unboard_vehicle( global_part_pos3( i ) );
     }
@@ -6388,7 +6388,7 @@ int vehicle::damage( int p, int dmg, damage_type type, bool aimed )
         return dmg;
     }
 
-    std::vector<int> pl = parts_at_relative( parts[p].mount, true );
+    std::vector<int> const pl = parts_at_relative( parts[p].mount, true );
     if( pl.empty() ) {
         // We ran out of non removed parts at this location already.
         return dmg;
@@ -6416,9 +6416,9 @@ int vehicle::damage( int p, int dmg, damage_type type, bool aimed )
         // find the most strong openable that is not open
         int strongest_door_part = -1;
         int strongest_door_durability = INT_MIN;
-        for( int part : pl ) {
+        for( int const part : pl ) {
             if( part_flag( part, "OPENABLE" ) && !parts[part].open ) {
-                int door_durability = part_info( part ).durability;
+                int const door_durability = part_info( part ).durability;
                 if( door_durability > strongest_door_durability ) {
                     strongest_door_part = part;
                     strongest_door_durability = door_durability;
@@ -6434,15 +6434,15 @@ int vehicle::damage( int p, int dmg, damage_type type, bool aimed )
 
     int damage_dealt;
 
-    int armor_part = part_with_feature( p, "ARMOR", true );
+    int const armor_part = part_with_feature( p, "ARMOR", true );
     if( armor_part < 0 ) {
         // Not covered by armor -- damage part
         damage_dealt = damage_direct( target_part, dmg, type );
     } else {
         // Covered by armor -- hit both armor and part, but reduce damage by armor's reduction
-        int protection = part_info( armor_part ).damage_reduction[ type ];
+        int const protection = part_info( armor_part ).damage_reduction[ type ];
         // Parts on roof aren't protected
-        bool overhead = part_flag( target_part, "ROOF" ) || part_info( target_part ).location == "on_roof";
+        bool const overhead = part_flag( target_part, "ROOF" ) || part_info( target_part ).location == "on_roof";
         // Calling damage_direct may remove the damaged part
         // completely, therefore the other index (target_part) becomes
         // wrong if target_part > armor_part.
@@ -6473,7 +6473,7 @@ void vehicle::damage_all( int dmg1, int dmg2, damage_type type, point impact )
 
     for( const vpart_reference &vp : get_all_parts() ) {
         const size_t p = vp.part_index();
-        int distance = 1 + square_dist( vp.mount(), impact );
+        int const distance = 1 + square_dist( vp.mount(), impact );
         if( distance > 1 && part_info( p ).location == part_location_structure &&
             !part_info( p ).has_flag( "PROTRUSION" ) ) {
             damage_direct( p, rng( dmg1, dmg2 ) / ( distance * distance ), type );
@@ -6591,7 +6591,7 @@ int vehicle::break_off( int p, int dmg )
                     add_msg( m_bad, _( "The %1$s's %2$s is torn off!" ), name,
                              parts[ parts_in_square[ index ] ].name() );
                 }
-                item part_as_item = parts[parts_in_square[index]].properties_to_item();
+                item const part_as_item = parts[parts_in_square[index]].properties_to_item();
                 if( !magic ) {
                     g->m.add_item_or_charges( pos, part_as_item );
                 }
@@ -6625,13 +6625,13 @@ bool vehicle::explode_fuel( int p, damage_type type )
     if( !fuel.has_explosion_data() ) {
         return false;
     }
-    fuel_explosion data = fuel.get_explosion_data();
+    fuel_explosion const data = fuel.get_explosion_data();
 
     if( parts[ p ].is_broken() ) {
         leak_fuel( parts[ p ] );
     }
 
-    int explosion_chance = type == DT_HEAT ? data.explosion_chance_hot : data.explosion_chance_cold;
+    int const explosion_chance = type == DT_HEAT ? data.explosion_chance_hot : data.explosion_chance_cold;
     if( one_in( explosion_chance ) ) {
         g->events().send<event_type::fuel_tank_explodes>( name );
         const int pow = 120 * ( 1 - std::exp( data.explosion_factor / -5000 *
@@ -6663,7 +6663,7 @@ int vehicle::damage_direct( int p, int dmg, damage_type type )
         return break_off( p, dmg );
     }
 
-    int tsh = std::min( 20, part_info( p ).durability / 10 );
+    int const tsh = std::min( 20, part_info( p ).durability / 10 );
     if( dmg < tsh && type != DT_TRUE ) {
         if( type == DT_HEAT && parts[p].is_fuel_store() ) {
             explode_fuel( p, type );
@@ -6673,7 +6673,7 @@ int vehicle::damage_direct( int p, int dmg, damage_type type )
     }
 
     dmg -= std::min<int>( dmg, part_info( p ).damage_reduction[ type ] );
-    int dres = dmg - parts[p].hp();
+    int const dres = dmg - parts[p].hp();
     if( mod_hp( parts[ p ], 0 - dmg, type ) ) {
         insides_dirty = true;
         pivot_dirty = true;
@@ -6727,7 +6727,7 @@ void vehicle::leak_fuel( vehicle_part &pt )
     // leak up to 1/3 of remaining fuel per iteration and continue until the part is empty
     const itype *fuel = &*pt.ammo_current();
     while( !tiles.empty() && pt.ammo_remaining() ) {
-        int qty = pt.ammo_consume( rng( 0, std::max( pt.ammo_remaining() / 3, 1 ) ),
+        int const qty = pt.ammo_consume( rng( 0, std::max( pt.ammo_remaining() / 3, 1 ) ),
                                    global_part_pos3( pt ) );
         if( qty > 0 ) {
             g->m.add_item_or_charges( random_entry( tiles ), item( fuel, calendar::turn, qty ) );
@@ -6881,7 +6881,7 @@ void vehicle::update_time( const time_point &update_to )
         // We don't need to check every turn
         return;
     }
-    time_duration elapsed = update_to - last_update;
+    time_duration const elapsed = update_to - last_update;
     last_update = update_to;
 
     if( sm_pos.z < 0 ) {
@@ -6900,7 +6900,7 @@ void vehicle::update_time( const time_point &update_to )
     const item water( "water" );
     const item water_clean( "water_clean" );
 
-    for( int idx : funnels ) {
+    for( int const idx : funnels ) {
         const auto &pt = parts[idx];
 
         // we need an unbroken funnel mounted on the exterior of the vehicle
@@ -6918,10 +6918,10 @@ void vehicle::update_time( const time_point &update_to )
             continue;
         }
 
-        double area = std::pow( pt.info().size / units::legacy_volume_factor, 2 ) * M_PI;
-        int qty = roll_remainder( funnel_charges_per_turn( area, accum_weather.rain_amount ) );
-        int c_qty = qty + ( tank->can_reload( water_clean ) ?  tank->ammo_remaining() : 0 );
-        int cost_to_purify = c_qty * itype_water_purifier->charges_to_use();
+        double const area = std::pow( pt.info().size / units::legacy_volume_factor, 2 ) * M_PI;
+        int const qty = roll_remainder( funnel_charges_per_turn( area, accum_weather.rain_amount ) );
+        int const c_qty = qty + ( tank->can_reload( water_clean ) ?  tank->ammo_remaining() : 0 );
+        int const cost_to_purify = c_qty * itype_water_purifier->charges_to_use();
 
         if( qty > 0 ) {
             if( has_part( global_part_pos3( pt ), "WATER_PURIFIER", true ) &&
@@ -6937,7 +6937,7 @@ void vehicle::update_time( const time_point &update_to )
 
     if( !solar_panels.empty() ) {
         int epower_w = 0;
-        for( int part : solar_panels ) {
+        for( int const part : solar_panels ) {
             if( parts[ part ].is_unavailable() ) {
                 continue;
             }
@@ -6948,8 +6948,8 @@ void vehicle::update_time( const time_point &update_to )
 
             epower_w += part_epower_w( part );
         }
-        double intensity = accum_weather.sunlight / default_daylight_level() / to_turns<double>( elapsed );
-        int energy_bat = power_to_energy_bat( epower_w * intensity, elapsed );
+        double const intensity = accum_weather.sunlight / default_daylight_level() / to_turns<double>( elapsed );
+        int const energy_bat = power_to_energy_bat( epower_w * intensity, elapsed );
         if( energy_bat > 0 ) {
             add_msg( m_debug, "%s got %d kJ energy from solar panels", name, energy_bat );
             charge_battery( energy_bat );
@@ -6958,16 +6958,16 @@ void vehicle::update_time( const time_point &update_to )
     if( !wind_turbines.empty() ) {
         // TODO: use accum_weather wind data to backfill wind turbine
         // generation capacity.
-        int epower_w = total_wind_epower_w();
-        int energy_bat = power_to_energy_bat( epower_w, elapsed );
+        int const epower_w = total_wind_epower_w();
+        int const energy_bat = power_to_energy_bat( epower_w, elapsed );
         if( energy_bat > 0 ) {
             add_msg( m_debug, "%s got %d kJ energy from wind turbines", name, energy_bat );
             charge_battery( energy_bat );
         }
     }
     if( !water_wheels.empty() ) {
-        int epower_w = total_water_wheel_epower_w();
-        int energy_bat = power_to_energy_bat( epower_w, elapsed );
+        int const epower_w = total_water_wheel_epower_w();
+        int const energy_bat = power_to_energy_bat( epower_w, elapsed );
         if( energy_bat > 0 ) {
             add_msg( m_debug, "%s got %d kJ energy from water wheels", name, energy_bat );
             charge_battery( energy_bat );
@@ -6978,7 +6978,7 @@ void vehicle::update_time( const time_point &update_to )
 void vehicle::process_emitters()
 {
     // Parts emitting fields
-    for( int idx : emitters ) {
+    for( int const idx : emitters ) {
         const vehicle_part &pt = parts[idx];
         if( pt.is_unavailable() || !pt.enabled ) {
             continue;
@@ -7069,7 +7069,7 @@ bounding_box vehicle::get_bounding_box( )
 
     set_facing( turn_dir );
 
-    int i_use = 0;
+    int const i_use = 0;
     for( const tripoint &p : get_points( true ) ) {
         const point pt = parts[part_at( p.xy() )].precalc[i_use].xy();
         if( pt.x < min_x ) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -727,7 +727,7 @@ void vehicle::autopilot_patrol()
         drive_to_local_target( autodrive_local_target, false );
         return;
     }
-    zone_manager  const&mgr = zone_manager::get_manager();
+    zone_manager  const &mgr = zone_manager::get_manager();
     const auto &zone_src_set = mgr.get_near( zone_type_id( "VEHICLE_PATROL" ),
                                global_square_location().raw(), 60 );
     if( zone_src_set.empty() ) {
@@ -779,7 +779,7 @@ std::set<point> vehicle::immediate_path( units::angle rotate )
     point const top_left_actual = global_pos3().xy() + coord_translate( front_left );
     point const top_right_actual = global_pos3().xy() + coord_translate( front_right );
     std::vector<point> const front_row = line_to( g->m.getabs( top_left_actual ),
-                                            g->m.getabs( top_right_actual ) );
+                                         g->m.getabs( top_right_actual ) );
     for( point const elem : front_row ) {
         for( int i = 0; i < distance_to_check; ++i ) {
             collision_vector.advance( i );
@@ -964,8 +964,8 @@ void vehicle::smash( map &m, float hp_percent_loss_min, float hp_percent_loss_ma
         int const pct_af = ( percent_of_parts_to_affect * 1000.0f );
         if( roll < pct_af ) {
             double const dist =  damage_size == 0.0f ? 1.0f :
-                           clamp( 1.0f - trig_dist( damage_origin, part.precalc[0].xy() ) /
-                                  damage_size, 0.0f, 1.0f );
+                                 clamp( 1.0f - trig_dist( damage_origin, part.precalc[0].xy() ) /
+                                        damage_size, 0.0f, 1.0f );
             //Everywhere else, drop by 10-120% of max HP (anything over 100 = broken)
             if( mod_hp( part, 0 - ( rng_float( hp_percent_loss_min * dist,
                                                hp_percent_loss_max * dist ) *
@@ -978,7 +978,7 @@ void vehicle::smash( map &m, float hp_percent_loss_min, float hp_percent_loss_ma
     std::unique_ptr<RemovePartHandler> handler_ptr;
     // clear out any duplicated locations
     for( int p = static_cast<int>( parts.size() ) - 1; p >= 0; p-- ) {
-        vehicle_part  const&part = parts[ p ];
+        vehicle_part  const &part = parts[ p ];
         if( part.removed ) {
             continue;
         }
@@ -1671,7 +1671,8 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
     invalidate_towing( true );
     // By structs, we mean all the parts of the carry vehicle that are at the structure location
     // of the vehicle (i.e. frames)
-    std::vector<int> const carry_veh_structs = carry_veh->all_parts_at_location( part_location_structure );
+    std::vector<int> const carry_veh_structs = carry_veh->all_parts_at_location(
+                part_location_structure );
     std::vector<mapping> carry_data;
     carry_data.reserve( carry_veh_structs.size() );
 
@@ -1756,12 +1757,12 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
     const point mount_zero{};
     if( found_all_parts ) {
         decltype( loot_zones ) new_zones;
-        for( const auto& carry_map : carry_data ) {
+        for( const auto &carry_map : carry_data ) {
             std::string const offset = string_format( "%s%3d", carry_map.old_mount == mount_zero ? axis : " ",
-                                                axis == "X" ? carry_map.old_mount.x : carry_map.old_mount.y );
+                                       axis == "X" ? carry_map.old_mount.x : carry_map.old_mount.y );
             std::string const unique_id = string_format( "%s%3d%s", offset,
-                                                   static_cast<int>( to_degrees( relative_dir ) ),
-                                                   carry_veh->name );
+                                          static_cast<int>( to_degrees( relative_dir ) ),
+                                          carry_veh->name );
             for( int const carry_part : carry_map.carry_parts_here ) {
                 parts.push_back( carry_veh->parts[ carry_part ] );
                 vehicle_part &carried_part = parts.back();
@@ -3590,7 +3591,7 @@ int vehicle::water_acceleration( const bool fueled, int at_vel_in_vmi ) const
         return 0;
     }
     int const target_vmiph = std::max( at_vel_in_vmi, std::max( 1000,
-                                 max_water_velocity( fueled ) / 4 ) );
+                                       max_water_velocity( fueled ) / 4 ) );
     int const cmps = vmiph_to_cmps( target_vmiph );
     double weight = to_kilogram( total_mass() );
     if( is_towing() ) {
@@ -3685,8 +3686,8 @@ int vehicle::max_ground_velocity( const bool fueled ) const
     int const total_engine_w = total_power_w( fueled );
     double const c_rolling_drag = coeff_rolling_drag();
     double const max_in_mps = simple_cubic_solution( coeff_air_drag(), c_rolling_drag,
-                        c_rolling_drag * vehicles::rolling_constant_to_variable,
-                        -total_engine_w );
+                              c_rolling_drag * vehicles::rolling_constant_to_variable,
+                              -total_engine_w );
     add_msg( m_debug, "%s: power %d, c_air %3.2f, c_rolling %3.2f, max_in_mps %3.2f",
              name, total_engine_w, coeff_air_drag(), c_rolling_drag, max_in_mps );
     return mps_to_vmiph( max_in_mps );
@@ -3770,8 +3771,8 @@ int vehicle::safe_ground_velocity( const bool fueled ) const
     int const effective_engine_w = total_power_w( fueled, true );
     double const c_rolling_drag = coeff_rolling_drag();
     double const safe_in_mps = simple_cubic_solution( coeff_air_drag(), c_rolling_drag,
-                         c_rolling_drag * vehicles::rolling_constant_to_variable,
-                         -effective_engine_w );
+                               c_rolling_drag * vehicles::rolling_constant_to_variable,
+                               -effective_engine_w );
     return mps_to_vmiph( safe_in_mps );
 }
 
@@ -4065,7 +4066,7 @@ double vehicle::coeff_air_drag() const
     double height = 0;
     double c_air_drag = 0;
     // tally the results of each row and prorate them relative to vehicle width
-    for( drag_column  const&dc : drag ) {
+    for( drag_column  const &dc : drag ) {
         // even as m_debug you rarely want to see this
         // add_msg( m_debug, "veh %: pro %d, hboard %d, fboard %d, shield %d, seat %d, roof %d, aisle %d, turret %d, panel %d, exposed %d, last %d\n", name, dc.pro, dc.hboard, dc.fboard, dc.shield, dc.seat, dc.roof, dc.aisle, dc.turret, dc.panel, dc.exposed, dc.last );
 
@@ -4737,7 +4738,7 @@ int vehicle::total_solar_epower_w() const
 
 int vehicle::total_wind_epower_w() const
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     const oter_id &cur_om_ter = overmap_buffer.ter( global_omt_location() );
     const weather_manager &weather = get_weather();
     int epower_w = 0;
@@ -4750,8 +4751,9 @@ int vehicle::total_wind_epower_w() const
             continue;
         }
 
-        double const windpower = get_local_windpower( weather.windspeed, cur_om_ter, global_part_pos3( part ),
-                                                weather.winddirection, false );
+        double const windpower = get_local_windpower( weather.windspeed, cur_om_ter,
+                                 global_part_pos3( part ),
+                                 weather.winddirection, false );
         if( windpower <= ( weather.windspeed / 10.0 ) ) {
             continue;
         }
@@ -4827,7 +4829,7 @@ void vehicle::power_parts()
 
     int delta_energy_bat = power_to_energy_bat( epower, 1_turns );
     int const storage_deficit_bat = std::max( 0, fuel_capacity( fuel_type_battery ) -
-                                        fuel_left( fuel_type_battery ) - delta_energy_bat );
+                                    fuel_left( fuel_type_battery ) - delta_energy_bat );
     // Reactors trigger only on demand. If we'd otherwise run out of power, see
     // if we can spin up the reactors.
     if( !reactors.empty() && storage_deficit_bat > 0 ) {
@@ -5529,7 +5531,7 @@ void vehicle::place_spawn_items()
                 }
                 for( const item_group_id &e : spawn.item_groups ) {
                     item_group::ItemList const group_items = item_group::items_from( e, calendar::start_of_cataclysm );
-                    for( const auto& spawn_item : group_items ) {
+                    for( const auto &spawn_item : group_items ) {
                         created.emplace_back( spawn_item );
                     }
                 }
@@ -5544,7 +5546,7 @@ void vehicle::place_spawn_items()
                     if( e.is_tool() || e.is_gun() || e.is_magazine() ) {
                         bool const spawn_ammo = rng( 0, 99 ) < spawn.with_ammo && e.ammo_remaining() == 0;
                         bool const spawn_mag  = rng( 0, 99 ) < spawn.with_magazine && !e.magazine_integral() &&
-                                          !e.magazine_current();
+                                                !e.magazine_current();
 
                         if( spawn_mag ) {
                             e.put_in( item( e.magazine_default(), e.birthday() ) );
@@ -5617,7 +5619,7 @@ void vehicle::gain_moves()
 void vehicle::dump_items_from_part( const size_t index )
 {
     vehicle_part &vp = parts[ index ];
-    for( item  const&e : vp.items ) {
+    for( item  const &e : vp.items ) {
         g->m.add_item_or_charges( global_part_pos3( vp ), e );
     }
     vp.items.clear();
@@ -5735,8 +5737,8 @@ void vehicle::refresh()
 
         // This will keep the parts at point pt sorted
         std::vector<int>::iterator const vii = std::lower_bound( relative_parts[pt].begin(),
-                                         relative_parts[pt].end(),
-                                         static_cast<int>( p ), svpv );
+                                               relative_parts[pt].end(),
+                                               static_cast<int>( p ), svpv );
         relative_parts[pt].insert( vii, p );
 
         if( vpi.has_flag( VPFLAG_FLOATS ) ) {
@@ -6204,7 +6206,8 @@ bool vehicle::tow_cable_too_far() const
         debugmsg( "towing data exists but no towing part" );
         return false;
     }
-    tripoint const towed_point = g->m.getabs( tow_data.get_towed_by()->global_part_pos3( other_index ) );
+    tripoint const towed_point = g->m.getabs( tow_data.get_towed_by()->global_part_pos3(
+                                     other_index ) );
     if( towing_point == tripoint_zero || towed_point == tripoint_zero ) {
         debugmsg( "towing data exists but no towing part" );
         return false;
@@ -6442,7 +6445,8 @@ int vehicle::damage( int p, int dmg, damage_type type, bool aimed )
         // Covered by armor -- hit both armor and part, but reduce damage by armor's reduction
         int const protection = part_info( armor_part ).damage_reduction[ type ];
         // Parts on roof aren't protected
-        bool const overhead = part_flag( target_part, "ROOF" ) || part_info( target_part ).location == "on_roof";
+        bool const overhead = part_flag( target_part, "ROOF" ) ||
+                              part_info( target_part ).location == "on_roof";
         // Calling damage_direct may remove the damaged part
         // completely, therefore the other index (target_part) becomes
         // wrong if target_part > armor_part.
@@ -6631,7 +6635,8 @@ bool vehicle::explode_fuel( int p, damage_type type )
         leak_fuel( parts[ p ] );
     }
 
-    int const explosion_chance = type == DT_HEAT ? data.explosion_chance_hot : data.explosion_chance_cold;
+    int const explosion_chance = type == DT_HEAT ? data.explosion_chance_hot :
+                                 data.explosion_chance_cold;
     if( one_in( explosion_chance ) ) {
         g->events().send<event_type::fuel_tank_explodes>( name );
         const int pow = 120 * ( 1 - std::exp( data.explosion_factor / -5000 *
@@ -6728,7 +6733,7 @@ void vehicle::leak_fuel( vehicle_part &pt )
     const itype *fuel = &*pt.ammo_current();
     while( !tiles.empty() && pt.ammo_remaining() ) {
         int const qty = pt.ammo_consume( rng( 0, std::max( pt.ammo_remaining() / 3, 1 ) ),
-                                   global_part_pos3( pt ) );
+                                         global_part_pos3( pt ) );
         if( qty > 0 ) {
             g->m.add_item_or_charges( random_entry( tiles ), item( fuel, calendar::turn, qty ) );
         }
@@ -6948,7 +6953,8 @@ void vehicle::update_time( const time_point &update_to )
 
             epower_w += part_epower_w( part );
         }
-        double const intensity = accum_weather.sunlight / default_daylight_level() / to_turns<double>( elapsed );
+        double const intensity = accum_weather.sunlight / default_daylight_level() / to_turns<double>
+                                 ( elapsed );
         int const energy_bat = power_to_energy_bat( epower_w * intensity, elapsed );
         if( energy_bat > 0 ) {
             add_msg( m_debug, "%s got %d kJ energy from solar panels", name, energy_bat );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1756,7 +1756,7 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
     const point mount_zero{};
     if( found_all_parts ) {
         decltype( loot_zones ) new_zones;
-        for( auto carry_map : carry_data ) {
+        for( const auto& carry_map : carry_data ) {
             std::string const offset = string_format( "%s%3d", carry_map.old_mount == mount_zero ? axis : " ",
                                                 axis == "X" ? carry_map.old_mount.x : carry_map.old_mount.y );
             std::string const unique_id = string_format( "%s%3d%s", offset,
@@ -5529,7 +5529,7 @@ void vehicle::place_spawn_items()
                 }
                 for( const item_group_id &e : spawn.item_groups ) {
                     item_group::ItemList const group_items = item_group::items_from( e, calendar::start_of_cataclysm );
-                    for( auto spawn_item : group_items ) {
+                    for( const auto& spawn_item : group_items ) {
                         created.emplace_back( spawn_item );
                     }
                 }

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -563,8 +563,8 @@ void vehicle::autodrive_controller::compute_coordinates()
     data.next_omt_bounds = { {OMT_SIZE, 0}, {OMT_SIZE * 2, OMT_SIZE} };
 
     const tripoint_rel_omt omt_diff = data.next_omt - data.current_omt;
-    quad_rotation next_dir = to_quad_rotation( omt_diff.raw().xy() );
-    point mid_omt( OMT_SIZE / 2, OMT_SIZE / 2 );
+    quad_rotation const next_dir = to_quad_rotation( omt_diff.raw().xy() );
+    point const mid_omt( OMT_SIZE / 2, OMT_SIZE / 2 );
     const tripoint_abs_ms abs_mid_omt = project_to<coords::ms>( data.current_omt ) + mid_omt;
 
     data.nav_to_view = { point_zero, quad_rotation::d0, {NAV_VIEW_PADDING, NAV_VIEW_PADDING} } ;
@@ -604,14 +604,14 @@ vehicle_profile vehicle::autodrive_controller::compute_profile( orientation faci
             ret.occupied_zone.emplace_back( x, y );
         }
     }
-    for( int part_num : driven_veh.rotors ) {
+    for( int const part_num : driven_veh.rotors ) {
         const vehicle_part &part = driven_veh.cpart( part_num );
         const int diameter = part.info().rotor_diameter();
         const int radius = ( diameter + 1 ) / 2;
         if( radius > 0 ) {
             tripoint pos;
             driven_veh.coord_translate( angle, pivot, part.mount, pos );
-            for( tripoint pt : points_in_radius( pos, radius ) ) {
+            for( tripoint const pt : points_in_radius( pos, radius ) ) {
                 ret.occupied_zone.emplace_back( pt.xy() );
             }
         }
@@ -626,7 +626,7 @@ vehicle_profile vehicle::autodrive_controller::compute_profile( orientation faci
     // (a.k.a. "moving first") when the vehicle moves one step; these are the only points
     // we need to check for collision when the vehicle is moving in this direction
     const std::unordered_set<point> occupied_set( ret.occupied_zone.begin(), ret.occupied_zone.end() );
-    for( point pt : ret.occupied_zone ) {
+    for( point const pt : ret.occupied_zone ) {
         if( occupied_set.find( pt + increment ) == occupied_set.end() ) {
             ret.collision_points.emplace_back( pt );
         }
@@ -743,13 +743,13 @@ void vehicle::autodrive_controller::compute_obstacles()
 void vehicle::autodrive_controller::compute_valid_positions()
 {
     const coord_transformation veh_rot = {point_zero, -data.nav_to_map.rotation, point_zero};
-    for( orientation facing : all_orientations() ) {
+    for( orientation const facing : all_orientations() ) {
         const vehicle_profile &profile = data.profile( data.nav_to_map.transform( facing ) );
         for( int mx = 0; mx < NAV_MAP_SIZE_X; mx++ ) {
             for( int my = 0; my < NAV_MAP_SIZE_Y; my++ ) {
                 const point nav_pt( mx, my );
                 bool valid = true;
-                for( point veh_pt : profile.occupied_zone ) {
+                for( point const veh_pt : profile.occupied_zone ) {
                     const point view_pt = data.nav_to_view.transform( nav_pt ) + veh_rot.transform(
                                               veh_pt ) - veh_rot.transform( point_zero );
                     if( !data.view_bounds.contains( view_pt ) || data.is_obstacle[view_pt.x][view_pt.y] ) {
@@ -821,7 +821,7 @@ void vehicle::autodrive_controller::precompute_data()
         // TODO: change it during simulation based on vehicle speed and terrain
         // or maybe just keep track of player moves?
         data.max_steer = 1;
-        for( orientation dir : all_orientations() ) {
+        for( orientation const dir : all_orientations() ) {
             data.profile( dir ) = compute_profile( dir );
         }
 
@@ -861,7 +861,7 @@ scored_address vehicle::autodrive_controller::compute_node_score( const node_add
         return ret;
     }
     static const point neighbor_deltas[4] = { point_east, point_south, point_west, point_north };
-    for( point neighbor_delta : neighbor_deltas ) {
+    for( point const neighbor_delta : neighbor_deltas ) {
         const point p = addr.get_point() + neighbor_delta;
         if( !data.nav_bounds.contains( p ) || !data.valid_position( addr.facing_dir, p ) ) {
             ret.score += nearness_penalty;
@@ -1018,7 +1018,7 @@ void vehicle::autodrive_controller::check_safe_speed()
     // taking damage). We normally determine this at the beginning of path planning and cache it.
     // However, sometimes the vehicle's safe speed may drop (e.g. amphibious vehicle entering
     // water), so this extra check is needed to adjust our max speed.
-    int safe_speed_tps = driven_veh.safe_velocity() / VMIPH_PER_TPS;
+    int const safe_speed_tps = driven_veh.safe_velocity() / VMIPH_PER_TPS;
     if( data.max_speed_tps > safe_speed_tps ) {
         data.max_speed_tps = safe_speed_tps;
     }
@@ -1033,7 +1033,7 @@ collision_check_result vehicle::autodrive_controller::check_collision_zone( orie
     face_dir.advance();
     const point forward_offset( face_dir.dx(), face_dir.dy() );
     bool blind = true;
-    for( point p : data.profile( to_orientation( face_dir.dir() ) ).collision_points ) {
+    for( point const p : data.profile( to_orientation( face_dir.dir() ) ).collision_points ) {
         if( driver.sees( veh_pos + forward_offset + p ) ) {
             blind = false;
         }
@@ -1055,10 +1055,10 @@ collision_check_result vehicle::autodrive_controller::check_collision_zone( orie
     std::unordered_set<point> collision_zone;
     tdir.advance();
     point offset( tdir.dx(), tdir.dy() );
-    for( point p : profile.occupied_zone ) {
+    for( point const p : profile.occupied_zone ) {
         collision_zone.insert( p + offset );
     }
-    for( point p : collision_zone ) {
+    for( point const p : collision_zone ) {
         if( !check_drivable( veh_pos + p ) ) {
             return collision_check_result::close_obstacle;
         }
@@ -1069,11 +1069,11 @@ collision_check_result vehicle::autodrive_controller::check_collision_zone( orie
     for( int i = 1; i < speed_tps; i++ ) {
         tdir.advance();
         offset += point( tdir.dx(), tdir.dy() );
-        for( point p : profile.collision_points ) {
+        for( point const p : profile.collision_points ) {
             collision_zone.insert( p + offset );
         }
     }
-    for( point p : collision_zone ) {
+    for( point const p : collision_zone ) {
         if( !driver.sees( veh_pos + p ) ) {
             return collision_check_result::slow_down;
         }
@@ -1129,7 +1129,7 @@ std::vector<std::tuple<point, int, std::string>> vehicle::get_debug_overlay_data
     if( autodrive_local_target != tripoint_zero ) {
         ret.emplace_back( ( autodrive_local_target - veh_pos.raw() ).xy(), catacurses::red, "T" );
     }
-    for( point pt_elem : collision_check_points ) {
+    for( point const pt_elem : collision_check_points ) {
         ret.emplace_back( pt_elem - veh_pos.raw().xy(), catacurses::yellow, "C" );
     }
 
@@ -1142,14 +1142,14 @@ std::vector<std::tuple<point, int, std::string>> vehicle::get_debug_overlay_data
     for( const std::string &debug_str : debug_what ) {
         if( debug_str == "profiles" ) {
             const vehicle_profile &profile = data.profile( dir );
-            for( point p : profile.occupied_zone ) {
+            for( point const p : profile.occupied_zone ) {
                 if( p.x == 0 && p.y == 0 ) {
                     ret.emplace_back( p, catacurses::cyan, to_string( dir ) );
                 } else {
                     ret.emplace_back( p, catacurses::green, "x" );
                 }
             }
-            for( point p : profile.collision_points ) {
+            for( point const p : profile.collision_points ) {
                 ret.emplace_back( p, catacurses::red, "o" );
             }
         } else if( debug_str == "is_obstacle" ) {
@@ -1183,7 +1183,7 @@ std::vector<std::tuple<point, int, std::string>> vehicle::get_debug_overlay_data
                 ret.emplace_back( pt, color, "g" );
             }
         } else if( debug_str == "goal_points" ) {
-            for( point p : data.goal_points ) {
+            for( point const p : data.goal_points ) {
                 const point pt = data.nav_to_map.transform( p ) - veh_pos.raw().xy();
                 ret.emplace_back( pt, catacurses::white, "G" );
             }
@@ -1195,7 +1195,7 @@ std::vector<std::tuple<point, int, std::string>> vehicle::get_debug_overlay_data
         } else if( debug_str == "omt" ) {
             const point offset = ( project_to<coords::ms>( data.current_omt ) - veh_pos ).raw().xy();
             static const std::vector<point> corners = {point_zero, {0, OMT_SIZE - 1}, {OMT_SIZE - 1, 0}, {OMT_SIZE - 1, OMT_SIZE - 1}};
-            for( point corner : corners ) {
+            for( point const corner : corners ) {
                 ret.emplace_back( corner + offset, catacurses::cyan, "+" );
             }
         }
@@ -1272,7 +1272,7 @@ autodrive_result vehicle::do_autodrive( Character &driver )
             break;
     }
 
-    int turn_delta = orientation_diff( next_step->steering_dir, to_orientation( turn_dir ) );
+    int const turn_delta = orientation_diff( next_step->steering_dir, to_orientation( turn_dir ) );
     // pldrive() does not handle steering multiple times in one call correctly
     // call it multiple times, matching how a player controls the vehicle
     for( int i = 0; i < std::abs( turn_delta ); i++ ) {

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -127,7 +127,7 @@ nc_color vehicle::part_color( const int p, const bool exact ) const
     }
 
     // curtains turn windshields gray
-    int curtains = part_with_feature( p, VPFLAG_CURTAIN, false );
+    int const curtains = part_with_feature( p, VPFLAG_CURTAIN, false );
     if( curtains >= 0 ) {
         if( part_with_feature( p, VPFLAG_WINDOW, true ) >= 0 && !parts[curtains].open ) {
             col = part_info( curtains ).color;
@@ -135,7 +135,7 @@ nc_color vehicle::part_color( const int p, const bool exact ) const
     }
 
     //Invert colors for cargo parts with stuff in them
-    int cargo_part = part_with_feature( p, VPFLAG_CARGO, true );
+    int const cargo_part = part_with_feature( p, VPFLAG_CARGO, true );
     if( cargo_part > 0 && !get_items( cargo_part ).empty() ) {
         return invert_color( col );
     } else {
@@ -197,7 +197,7 @@ int vehicle::print_part_list( const catacurses::window &win, int y1, const int m
                                        volume_units_abbr() );
         }
 
-        bool armor = part_flag( pl[i], "ARMOR" );
+        bool const armor = part_flag( pl[i], "ARMOR" );
         std::string left_sym;
         std::string right_sym;
         if( armor ) {
@@ -210,7 +210,7 @@ int vehicle::print_part_list( const catacurses::window &win, int y1, const int m
             left_sym = "-";
             right_sym = "-";
         }
-        nc_color sym_color = static_cast<int>( i ) == hl ? hilite( c_light_gray ) : c_light_gray;
+        nc_color const sym_color = static_cast<int>( i ) == hl ? hilite( c_light_gray ) : c_light_gray;
         mvwprintz( win, point( 1, y ), sym_color, left_sym );
         trim_and_print( win, point( 2, y ), getmaxx( win ) - 4,
                         static_cast<int>( i ) == hl ? hilite( c_light_gray ) : c_light_gray, partname );
@@ -371,8 +371,8 @@ void vehicle::print_fuel_indicators( const catacurses::window &win, point p, int
     }
 
     int yofs = 0;
-    int max_gauge = ( isHorizontal ? 12 : 5 ) + start_index;
-    int max_size = std::min( static_cast<int>( fuels.size() ), max_gauge );
+    int const max_gauge = ( isHorizontal ? 12 : 5 ) + start_index;
+    int const max_size = std::min( static_cast<int>( fuels.size() ), max_gauge );
 
     for( int i = start_index; i < max_size; i++ ) {
         const itype_id &f = fuels[i];
@@ -399,7 +399,7 @@ void vehicle::print_fuel_indicators( const catacurses::window &win, point p, int
 void vehicle::print_fuel_indicator( const catacurses::window &win, point p,
                                     const itype_id &fuel_type, bool verbose, bool desc )
 {
-    std::map<itype_id, float> fuel_usages;
+    std::map<itype_id, float> const fuel_usages;
     print_fuel_indicator( win, p, fuel_type, fuel_usages, verbose, desc );
 }
 
@@ -409,14 +409,14 @@ void vehicle::print_fuel_indicator( const catacurses::window &win, point p,
                                     bool verbose, bool desc )
 {
     const char fsyms[5] = { 'E', '\\', '|', '/', 'F' };
-    nc_color col_indf1 = c_light_gray;
-    int cap = fuel_capacity( fuel_type );
-    int f_left = fuel_left( fuel_type );
-    nc_color f_color = fuel_type->color;
+    nc_color const col_indf1 = c_light_gray;
+    int const cap = fuel_capacity( fuel_type );
+    int const f_left = fuel_left( fuel_type );
+    nc_color const f_color = fuel_type->color;
     // NOLINTNEXTLINE(cata-text-style): not an ellipsis
     mvwprintz( win, p, col_indf1, "E...F" );
-    int amnt = cap > 0 ? f_left * 99 / cap : 0;
-    int indf = ( amnt / 20 ) % 5;
+    int const amnt = cap > 0 ? f_left * 99 / cap : 0;
+    int const indf = ( amnt / 20 ) % 5;
     mvwprintz( win, p + point( indf, 0 ), f_color, "%c", fsyms[indf] );
     if( verbose ) {
         if( debug_mode ) {
@@ -459,18 +459,18 @@ void vehicle::print_fuel_indicator( const catacurses::window &win, point p,
                 tank_goal = _( "empty" );
             }
 
-            item fitem( fuel_type );
-            int charges_per_L = fitem.charges_per_volume( 1_liter );
+            item const fitem( fuel_type );
+            int const charges_per_L = fitem.charges_per_volume( 1_liter );
             if( charges_per_L == 0 || charges_per_L == item::INFINITE_CHARGES ) {
                 return;
             }
-            float charges_per_mL = charges_per_L / 1000.0f;
+            float const charges_per_mL = charges_per_L / 1000.0f;
             tank_use = tank_use / charges_per_mL;
 
             // promote to double so esimate doesn't overflow for high fuel values
             // 3600 * tank_use overflows signed 32 bit when tank_use is over ~596523
-            double turns = to_turns<double>( 60_minutes );
-            time_duration estimate = time_duration::from_turns( turns * tank_use / std::abs( rate ) );
+            double const turns = to_turns<double>( 60_minutes );
+            time_duration const estimate = time_duration::from_turns( turns * tank_use / std::abs( rate ) );
 
             if( debug_mode ) {
                 wprintz( win, tank_color, _( ", %d %s(%4.2f%%)/hour, %s until %s" ),

--- a/src/vehicle_group.cpp
+++ b/src/vehicle_group.cpp
@@ -74,7 +74,7 @@ void VehicleGroup::load( const JsonObject &jo )
 {
     VehicleGroup &group = vgroups[vgroup_id( jo.get_string( "id" ) )];
 
-    for( JsonArray pair : jo.get_array( "vehicles" ) ) {
+    for( JsonArray const pair : jo.get_array( "vehicles" ) ) {
         group.add_vehicle( vproto_id( pair.get_string( 0 ) ), pair.get_int( 1 ) );
     }
 }
@@ -99,7 +99,7 @@ void VehiclePlacement::load( const JsonObject &jo )
 {
     VehiclePlacement &placement = vplacements[vplacement_id( jo.get_string( "id" ) )];
 
-    for( JsonObject jloc : jo.get_array( "locations" ) ) {
+    for( JsonObject const jloc : jo.get_array( "locations" ) ) {
         placement.add( jmapgen_int( jloc, "x" ), jmapgen_int( jloc, "y" ),
                        VehicleFacings( jloc, "facing" ) );
     }
@@ -128,7 +128,7 @@ VehicleFunction_json::VehicleFunction_json( const JsonObject &jo )
     if( jo.has_string( "placement" ) ) {
         placement = jo.get_string( "placement" );
     } else {
-        VehicleFacings facings( jo, "facing" );
+        VehicleFacings const facings( jo, "facing" );
         location.emplace( jmapgen_int( jo, "x" ), jmapgen_int( jo, "y" ), facings );
     }
 }
@@ -175,9 +175,9 @@ bool string_id<VehicleSpawn>::is_valid() const
 void VehicleSpawn::load( const JsonObject &jo )
 {
     VehicleSpawn &spawn = vspawns[vspawn_id( jo.get_string( "id" ) )];
-    for( JsonObject type : jo.get_array( "spawn_types" ) ) {
+    for( JsonObject const type : jo.get_array( "spawn_types" ) ) {
         if( type.has_object( "vehicle_json" ) ) {
-            JsonObject vjo = type.get_object( "vehicle_json" );
+            JsonObject const vjo = type.get_object( "vehicle_json" );
             spawn.add( type.get_float( "weight" ), make_shared_fast<VehicleFunction_json>( vjo ) );
         } else if( type.has_string( "vehicle_function" ) ) {
             if( builtin_functions.count( type.get_string( "vehicle_function" ) ) == 0 ) {
@@ -228,7 +228,7 @@ static void builtin_jackknifed_semi( map &m, const std::string &terrainid )
     }
 
     const units::angle facing = loc->pick_facing();
-    int facing_degrees = std::lround( to_degrees( facing ) );
+    int const facing_degrees = std::lround( to_degrees( facing ) );
     const point semi_p = loc->pick_point();
     point trailer_p;
 

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -87,7 +87,7 @@ int vmiph_to_cmps( int vmiph )
 
 int vehicle::slowdown( int at_velocity ) const
 {
-    double mps = vmiph_to_mps( std::abs( at_velocity ) );
+    double const mps = vmiph_to_mps( std::abs( at_velocity ) );
 
     // slowdown due to air resistance is proportional to square of speed
     double f_total_drag = coeff_air_drag() * mps * mps;
@@ -95,7 +95,7 @@ int vehicle::slowdown( int at_velocity ) const
         // same with water resistance
         f_total_drag += coeff_water_drag() * mps * mps;
     } else if( !is_falling && !is_flying ) {
-        double f_rolling_drag = coeff_rolling_drag() * ( vehicles::rolling_constant_to_variable + mps );
+        double const f_rolling_drag = coeff_rolling_drag() * ( vehicles::rolling_constant_to_variable + mps );
         if( vehicle_movement::is_on_rails( get_map(), *this ) ) {
             // vehicles on rails don't skid
             f_total_drag += f_rolling_drag;
@@ -105,7 +105,7 @@ int vehicle::slowdown( int at_velocity ) const
             f_total_drag += f_rolling_drag * skid_factor;
         }
     }
-    double accel_slowdown = f_total_drag / to_kilogram( total_mass() );
+    double const accel_slowdown = f_total_drag / to_kilogram( total_mass() );
     // converting m/s^2 to vmiph/s
     int slowdown = mps_to_vmiph( accel_slowdown );
     if( is_towing() ) {
@@ -135,7 +135,7 @@ void vehicle::thrust( int thd, int z )
         turn_dir = face.dir();
         stop();
     }
-    bool pl_ctrl = player_in_control( get_player_character() );
+    bool const pl_ctrl = player_in_control( get_player_character() );
 
     // No need to change velocity if there are no wheels
     if( ( in_water && can_float() ) || ( is_rotorcraft() && ( z != 0 || is_flying ) ) ) {
@@ -156,13 +156,13 @@ void vehicle::thrust( int thd, int z )
     // Accelerate (true) or brake (false)
     bool thrusting = true;
     if( velocity ) {
-        int sgn = ( velocity < 0 ) ? -1 : 1;
+        int const sgn = ( velocity < 0 ) ? -1 : 1;
         thrusting = ( sgn == thd );
     }
 
     // TODO: Pass this as an argument to avoid recalculating
-    float traction = k_traction( get_map().vehicle_wheel_traction( *this ) );
-    int accel = current_acceleration() * traction;
+    float const traction = k_traction( get_map().vehicle_wheel_traction( *this ) );
+    int const accel = current_acceleration() * traction;
     if( accel < 200 && velocity > 0 && is_towing() ) {
         if( pl_ctrl ) {
             add_msg( _( "The %s struggles to pull the %s on this surface!" ), name,
@@ -191,7 +191,7 @@ void vehicle::thrust( int thd, int z )
     int load;
     // Keep exact cruise control speed
     if( cruise_on && accel != 0 ) {
-        int effective_cruise = std::min( cruise_velocity, max_vel );
+        int const effective_cruise = std::min( cruise_velocity, max_vel );
         if( thd > 0 ) {
             vel_inc = std::min( vel_inc, effective_cruise - velocity );
         } else {
@@ -240,7 +240,7 @@ void vehicle::thrust( int thd, int z )
             requested_z_change = z;
         }
         //break the engines a bit, if going too fast.
-        int strn = static_cast<int>( strain() * strain() * 100 );
+        int const strn = static_cast<int>( strain() * strain() * 100 );
         for( size_t e = 0; e < engines.size(); e++ ) {
             do_engine_damage( e, strn );
         }
@@ -275,7 +275,7 @@ void vehicle::thrust( int thd, int z )
             if( mon != nullptr && mon->has_effect( effect_harnessed ) ) {
                 if( velocity > mon->get_speed() * 12 ) {
                     add_msg( m_bad, _( "Your %s is not fast enough to keep up with the %s" ), mon->get_name(), name );
-                    int dmg = rng( 0, 10 );
+                    int const dmg = rng( 0, 10 );
                     damage_direct( e, dmg );
                 }
             }
@@ -288,9 +288,9 @@ void vehicle::cruise_thrust( int amount )
     if( amount == 0 ) {
         return;
     }
-    int safe_vel = safe_velocity();
-    int max_vel = autopilot_on ? safe_velocity() : max_velocity();
-    int max_rev_vel = max_reverse_velocity();
+    int const safe_vel = safe_velocity();
+    int const max_vel = autopilot_on ? safe_velocity() : max_velocity();
+    int const max_rev_vel = max_reverse_velocity();
 
     //if the safe velocity is between the cruise velocity and its next value, set to safe velocity
     if( ( cruise_velocity < safe_vel && safe_vel < ( cruise_velocity + amount ) ) ||
@@ -406,7 +406,7 @@ bool vehicle::collision( std::vector<veh_collision> &colls,
         // Coordinates of where part will go due to movement (dx/dy/dz)
         //  and turning (precalc[1])
         const tripoint dsp = global_pos3() + dp + parts[p].precalc[1];
-        veh_collision coll = part_collision( p, dsp, just_detect, bash_floor );
+        veh_collision const coll = part_collision( p, dsp, just_detect, bash_floor );
         if( coll.type == veh_coll_nothing ) {
             continue;
         }
@@ -460,7 +460,7 @@ static void terrain_collision_data( const tripoint &p, bool bash_floor,
                                     float &mass, float &density, float &elastic )
 {
     elastic = 0.30;
-    map &here = get_map();
+    map  const&here = get_map();
     // Just a rough rescale for now to obtain approximately equal numbers
     const int bash_min = here.bash_resistance( p, bash_floor );
     const int bash_max = here.bash_strength( p, bash_floor );
@@ -550,7 +550,7 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
         ret.part = armor_part;
     }
 
-    int dmg_mod = part_info( ret.part ).dmg_mod;
+    int const dmg_mod = part_info( ret.part ).dmg_mod;
     // Let's calculate type of collision & mass of object we hit
     float mass2 = 0;
     // e = 0 -> plastic collision
@@ -828,7 +828,7 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
         if( turn_amount > 120 ) {
             turn_amount = 120;
         }
-        int turn_roll = rng( 0, 100 );
+        int const turn_roll = rng( 0, 100 );
         // Probability of skidding increases with higher delta_v
         if( turn_roll < std::abs( ( prev_velocity - coll_velocity ) / 100.0f * 2.0f ) ) {
             //delta_v = vel1 - vel1_a
@@ -845,7 +845,7 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
 
 void vehicle::handle_trap( const tripoint &p, int part )
 {
-    int pwh = part_with_feature( part, VPFLAG_WHEEL, true );
+    int const pwh = part_with_feature( part, VPFLAG_WHEEL, true );
     if( pwh < 0 ) {
         return;
     }
@@ -859,7 +859,7 @@ void vehicle::handle_trap( const tripoint &p, int part )
         // If the trap doesn't exist, we can't interact with it, so just return
         return;
     }
-    vehicle_handle_trap_data veh_data = tr.vehicle_data;
+    vehicle_handle_trap_data const veh_data = tr.vehicle_data;
 
     if( veh_data.is_falling ) {
         return;
@@ -893,7 +893,7 @@ void vehicle::handle_trap( const tripoint &p, int part )
             still_has_trap = false;
         }
         for( const auto &it : veh_data.spawn_items ) {
-            int cnt = roll_remainder( it.second );
+            int const cnt = roll_remainder( it.second );
             if( cnt > 0 ) {
                 here.spawn_item( p, it.first, cnt );
             }
@@ -945,10 +945,10 @@ void vehicle::selfdrive( point p )
             }
         }
     }
-    units::angle turn_delta = 15_degrees * p.x;
+    units::angle const turn_delta = 15_degrees * p.x;
     const float handling_diff = handling_difficulty();
     if( turn_delta != 0_degrees ) {
-        float eff = steering_effectiveness();
+        float const eff = steering_effectiveness();
         if( eff == -2 ) {
             return;
         }
@@ -963,7 +963,7 @@ void vehicle::selfdrive( point p )
         turn( turn_delta );
     }
     if( p.y != 0 ) {
-        int thr_amount = 100 * ( std::abs( velocity ) < 2000 ? 4 : 5 );
+        int const thr_amount = 100 * ( std::abs( velocity ) < 2000 ? 4 : 5 );
         if( cruise_on ) {
             cruise_thrust( -p.y * thr_amount );
         } else {
@@ -1002,9 +1002,9 @@ bool vehicle::check_heli_descend( player &p )
     }
     int count = 0;
     int air_count = 0;
-    map &here = get_map();
+    map  const&here = get_map();
     for( const tripoint &pt : get_points( true ) ) {
-        tripoint below( pt.xy(), pt.z - 1 );
+        tripoint const below( pt.xy(), pt.z - 1 );
         if( here.has_zlevels() && ( pt.z < -OVERMAP_DEPTH ||
                                     !here.has_flag_ter_or_furn( TFLAG_NO_FLOOR, pt ) ) ) {
             p.add_msg_if_player( _( "You are already landed!" ) );
@@ -1046,17 +1046,17 @@ bool vehicle::check_heli_ascend( player &p )
     }
     map &here = get_map();
     for( const tripoint &pt : get_points( true ) ) {
-        tripoint above( pt.xy(), pt.z + 1 );
+        tripoint const above( pt.xy(), pt.z + 1 );
         if( !here.inbounds_z( above.z ) ) {
             p.add_msg_if_player( m_bad, _( "It would be unsafe to try and ascend further." ) );
             return false;
         }
-        bool has_ceiling = !here.has_flag_ter( TFLAG_NO_FLOOR, above );
-        bool has_blocking_ter_furn = here.impassable_ter_furn( above );
-        bool has_veh = here.veh_at( above ).has_value();
-        bool has_critter = g->critter_at( above );
+        bool const has_ceiling = !here.has_flag_ter( TFLAG_NO_FLOOR, above );
+        bool const has_blocking_ter_furn = here.impassable_ter_furn( above );
+        bool const has_veh = here.veh_at( above ).has_value();
+        bool const has_critter = g->critter_at( above );
         if( has_ceiling || has_blocking_ter_furn || has_veh || has_critter ) {
-            direction obstacle_direction = direction_from( ( pt - p.pos() ).xy() );
+            direction const obstacle_direction = direction_from( ( pt - p.pos() ).xy() );
             const std::string direction_string = direction_name( obstacle_direction );
             std::string blocker_string;
             if( has_ceiling ) {
@@ -1092,7 +1092,7 @@ void vehicle::pldrive( Character &driver, point p, int z )
     units::angle turn_delta = 15_degrees * p.x;
     const float handling_diff = handling_difficulty();
     if( turn_delta != 0_degrees ) {
-        float eff = steering_effectiveness();
+        float const eff = steering_effectiveness();
         if( eff == -2 ) {
             driver.add_msg_if_player( m_info,
                                       _( "You cannot steer an animal-drawn vehicle with no animal harnessed." ) );
@@ -1119,9 +1119,9 @@ void vehicle::pldrive( Character &driver, point p, int z )
         ///\EFFECT_PER reduces chance of losing control of vehicle when turning
 
         ///\EFFECT_DRIVING reduces chance of losing control of vehicle when turning
-        float skill = std::min( 10.0f, driver.get_skill_level( skill_driving ) +
+        float const skill = std::min( 10.0f, driver.get_skill_level( skill_driving ) +
                                 ( driver.get_dex() + driver.get_per() ) / 10.0f );
-        float penalty = rng_float( 0.0f, handling_diff ) - skill;
+        float const penalty = rng_float( 0.0f, handling_diff ) - skill;
         int cost;
         if( penalty > 0.0f ) {
             // At 10 penalty (rather hard to get), we're taking 4 turns per turn
@@ -1153,7 +1153,7 @@ void vehicle::pldrive( Character &driver, point p, int z )
     }
 
     if( p.y != 0 ) {
-        int thr_amount = 100 * ( std::abs( velocity ) < 2000 ? 4 : 5 );
+        int const thr_amount = 100 * ( std::abs( velocity ) < 2000 ? 4 : 5 );
         if( cruise_on ) {
             cruise_thrust( -p.y * thr_amount );
         } else {
@@ -1187,9 +1187,9 @@ void vehicle::possibly_recover_from_skid()
         return;
     }
 
-    rl_vec2d mv = move_vec();
-    rl_vec2d fv = face_vec();
-    float dot = mv.dot_product( fv );
+    rl_vec2d const mv = move_vec();
+    rl_vec2d const fv = face_vec();
+    float const dot = mv.dot_product( fv );
     // Threshold of recovery is Gaussianesque.
 
     if( std::fabs( dot ) * 100 > dice( 9, 20 ) ) {
@@ -1211,9 +1211,9 @@ void vehicle::possibly_recover_from_skid()
 // if not skidding, move_vec == face_vec, mv <dot> fv == 1, velocity*1 is returned.
 float vehicle::forward_velocity() const
 {
-    rl_vec2d mv = move_vec();
-    rl_vec2d fv = face_vec();
-    float dot = mv.dot_product( fv );
+    rl_vec2d const mv = move_vec();
+    rl_vec2d const fv = face_vec();
+    float const dot = mv.dot_product( fv );
     return velocity * dot;
 }
 
@@ -1275,7 +1275,7 @@ vehicle *vehicle::act_on_map()
     if( decrement_summon_timer() ) {
         return nullptr;
     }
-    Character &player_character = get_player_character();
+    Character  const&player_character = get_player_character();
     const bool pl_ctrl = player_in_control( player_character );
     // TODO: Remove this hack, have vehicle sink a z-level
     if( is_floating && !can_float() ) {
@@ -1359,7 +1359,7 @@ vehicle *vehicle::act_on_map()
     if( one_in( 10 ) ) {
         bool controlled = false;
         // It can even be a NPC, but must be at the controls
-        for( int boarded : boarded_parts() ) {
+        for( int const boarded : boarded_parts() ) {
             if( part_with_feature( boarded, VPFLAG_CONTROLS, true ) >= 0 ) {
                 controlled = true;
                 player *passenger = get_passenger( boarded );
@@ -1438,7 +1438,7 @@ vehicle *vehicle::act_on_map()
 void vehicle::shift_zlevel()
 {
     map &here = get_map();
-    int center = part_at( point_zero );
+    int const center = part_at( point_zero );
 
     int z_shift = 0;
     if( center == -1 ) {
@@ -1461,7 +1461,7 @@ void vehicle::shift_zlevel()
 bool vehicle::check_on_ramp( int idir, const tripoint &offset ) const
 {
     for( auto &prt : get_all_parts() ) {
-        tripoint partPoint = global_pos3() + offset + prt.part().precalc[idir];
+        tripoint const partPoint = global_pos3() + offset + prt.part().precalc[idir];
 
         if( g->m.has_flag( TFLAG_RAMP_UP, partPoint ) || g->m.has_flag( TFLAG_RAMP_DOWN, partPoint ) ) {
             return true;
@@ -1497,7 +1497,7 @@ void vehicle::adjust_zlevel( int idir, const tripoint &offset )
     // it.
 
     auto &m = get_map();
-    tripoint global_pos = global_pos3();
+    tripoint const global_pos = global_pos3();
 
     tripoint new_center = global_pos + offset;
 
@@ -1511,7 +1511,7 @@ void vehicle::adjust_zlevel( int idir, const tripoint &offset )
 
     //Draw a line from the center to each part, going up and down ramps as we do
     for( auto &prt : get_all_parts() ) {
-        tripoint part_point = global_pos + offset + prt.part().precalc[idir];
+        tripoint const part_point = global_pos + offset + prt.part().precalc[idir];
 
         auto cache_entry = z_cache.find( part_point.xy() );
         if( cache_entry != z_cache.end() ) {
@@ -1557,7 +1557,7 @@ void vehicle::check_falling_or_floating()
         return;
     }
 
-    map &here = get_map();
+    map  const&here = get_map();
     is_falling = here.has_zlevels();
 
     if( is_flying && is_rotorcraft() ) {
@@ -1570,7 +1570,7 @@ void vehicle::check_falling_or_floating()
     size_t water_tiles = 0;
     for( const tripoint &p : pts ) {
         if( is_falling ) {
-            tripoint below( p.xy(), p.z - 1 );
+            tripoint const below( p.xy(), p.z - 1 );
             is_falling &= here.has_flag_ter_or_furn( TFLAG_NO_FLOOR, p ) &&
                           ( p.z > -OVERMAP_DEPTH ) && !here.supports_above( below );
         }
@@ -1594,7 +1594,7 @@ float map::vehicle_wheel_traction( const vehicle &veh,
     }
 
     const auto &wheel_indices = veh.wheelcache;
-    int num_wheels = wheel_indices.size();
+    int const num_wheels = wheel_indices.size();
     if( num_wheels == 0 ) {
         // TODO: Assume it is digging in dirt
         // TODO: Return something that could be reused for dragging
@@ -1605,13 +1605,13 @@ float map::vehicle_wheel_traction( const vehicle &veh,
 
     if( vehicle_movement::is_on_rails( *this, veh ) ) {
         // Vehicles on rails are considered to have all of their wheels on rails
-        for( int p : veh.rail_wheelcache ) {
+        for( int const p : veh.rail_wheelcache ) {
             traction_wheel_area += veh.cpart( p ).wheel_area();
         }
         return traction_wheel_area;
     }
 
-    for( int p : wheel_indices ) {
+    for( int const p : wheel_indices ) {
         const tripoint &pp = veh.global_part_pos3( p );
         const int wheel_area = veh.cpart( p ).wheel_area();
 
@@ -1652,7 +1652,7 @@ units::angle map::shake_vehicle( vehicle &veh, const int velocity_before,
 {
     const int d_vel = std::abs( veh.velocity - velocity_before ) / 100;
 
-    std::vector<rider_data> riders = veh.get_riders();
+    std::vector<rider_data> const riders = veh.get_riders();
 
     units::angle coll_turn = 0_degrees;
     for( const rider_data &r : riders ) {
@@ -1719,7 +1719,7 @@ units::angle map::shake_vehicle( vehicle &veh, const int velocity_before,
                 if( turn_amount < 1 ) {
                     turn_amount = 1;
                 }
-                units::angle turn_angle = std::min( turn_amount * 15_degrees, 120_degrees );
+                units::angle const turn_angle = std::min( turn_amount * 15_degrees, 120_degrees );
                 coll_turn = one_in( 2 ) ? turn_angle : -turn_angle;
             }
         }
@@ -1755,11 +1755,11 @@ static bool scan_rails_from_veh_internal(
     point scan_vec )
 {
     for( size_t rail_id = 0; rail_id < veh.rail_profile.size(); rail_id++ ) {
-        int rail_y_rel_to_pivot = veh.rail_profile[rail_id] - veh.pivot_point().y;
-        tripoint scan_pos = scan_initial_pos + rail_y_rel_to_pivot * veh_plus_y_vec;
+        int const rail_y_rel_to_pivot = veh.rail_profile[rail_id] - veh.pivot_point().y;
+        tripoint const scan_pos = scan_initial_pos + rail_y_rel_to_pivot * veh_plus_y_vec;
         for( int step = 0; step < 3; step++ ) {
-            tripoint p = scan_pos + scan_vec * step;
-            bool rail_here = m.has_flag_ter_or_furn( TFLAG_RAIL, p );
+            tripoint const p = scan_pos + scan_vec * step;
+            bool const rail_here = m.has_flag_ter_or_furn( TFLAG_RAIL, p );
             if( !rail_here ) {
                 // Terrain is not a rail
                 return false;
@@ -1801,12 +1801,12 @@ static bool scan_rails_at_shift(
     if( ray_delta.x != 0 && ray_delta.y != 0 ) {
         // We can't cleanly map diagonally oriented vehicles to rail turns.
         // As such, treat the vehicle as if it can have either skew at the same time.
-        int num_cw_rots = get_num_cw_rots_of_ray_delta( ray_delta );
-        point rd_l = point_north.rotate( num_cw_rots );
-        point rd_r = point_east.rotate( num_cw_rots );
+        int const num_cw_rots = get_num_cw_rots_of_ray_delta( ray_delta );
+        point const rd_l = point_north.rotate( num_cw_rots );
+        point const rd_r = point_east.rotate( num_cw_rots );
 
-        point vyp_l = point_east.rotate( num_cw_rots );
-        point vyp_r = point_south.rotate( num_cw_rots );
+        point const vyp_l = point_east.rotate( num_cw_rots );
+        point const vyp_r = point_south.rotate( num_cw_rots );
 
         tripoint scan_start = veh.global_pos3();
         if( shift_sign > 0 ) {
@@ -1815,10 +1815,10 @@ static bool scan_rails_at_shift(
             scan_start += rd_l * velocity_sign;
         }
 
-        point scan_vec = ray_delta * velocity_sign;
+        point const scan_vec = ray_delta * velocity_sign;
 
-        bool scan_res_l = scan_rails_from_veh_internal( m, veh, scan_start, vyp_l, scan_vec );
-        bool scan_res_r = scan_rails_from_veh_internal( m, veh, scan_start, vyp_r, scan_vec );
+        bool const scan_res_l = scan_rails_from_veh_internal( m, veh, scan_start, vyp_l, scan_vec );
+        bool const scan_res_r = scan_rails_from_veh_internal( m, veh, scan_start, vyp_r, scan_vec );
 
         if( scan_res_l || scan_res_r ) {
             if( shift_amt ) {
@@ -1827,8 +1827,8 @@ static bool scan_rails_at_shift(
             return true;
         }
     } else {
-        point veh_plus_y_vec = ray_delta.rotate( 1 );
-        point scan_vec = ray_delta * velocity_sign;
+        point const veh_plus_y_vec = ray_delta.rotate( 1 );
+        point const scan_vec = ray_delta * velocity_sign;
         tripoint scan_start = veh.global_pos3();
         if( shift_sign != 0 ) {
             scan_start += scan_vec + veh_plus_y_vec * shift_sign;
@@ -1866,30 +1866,30 @@ static inline rail_processing_result make_shift( tripoint dp )
 
 rail_processing_result process_movement_on_rails( const map &m, const vehicle &veh )
 {
-    int face_dir_degrees = std::round( units::to_degrees( veh.face.dir() ) );
-    int face_dir_snapped = ( face_dir_degrees / 45 ) * 45;
+    int const face_dir_degrees = std::round( units::to_degrees( veh.face.dir() ) );
+    int const face_dir_snapped = ( face_dir_degrees / 45 ) * 45;
 
-    units::angle dir_straight = normalize( units::from_degrees( face_dir_snapped ) );
-    units::angle dir_left = normalize( dir_straight - 45_degrees );
-    units::angle dir_right = normalize( dir_straight + 45_degrees );
+    units::angle const dir_straight = normalize( units::from_degrees( face_dir_snapped ) );
+    units::angle const dir_left = normalize( dir_straight - 45_degrees );
+    units::angle const dir_right = normalize( dir_straight + 45_degrees );
 
-    int vel_sign = veh.velocity > 0 ? 1 : -1;
+    int const vel_sign = veh.velocity > 0 ? 1 : -1;
 
-    bool can_go_straight = scan_rails_at_shift( m, veh, vel_sign, dir_straight, 0 );
-    bool can_turn_left = scan_rails_at_shift( m, veh, vel_sign, dir_left, 0 );
-    bool can_turn_right = scan_rails_at_shift( m, veh, vel_sign, dir_right, 0 );
+    bool const can_go_straight = scan_rails_at_shift( m, veh, vel_sign, dir_straight, 0 );
+    bool const can_turn_left = scan_rails_at_shift( m, veh, vel_sign, dir_left, 0 );
+    bool const can_turn_right = scan_rails_at_shift( m, veh, vel_sign, dir_right, 0 );
 
-    bool can_go_backwards = scan_rails_at_shift( m, veh, -vel_sign, dir_straight, 0 );
+    bool const can_go_backwards = scan_rails_at_shift( m, veh, -vel_sign, dir_straight, 0 );
 
     tripoint shift_amount_right;
     tripoint shift_amount_left;
 
-    bool can_shift_right = scan_rails_at_shift( m, veh, vel_sign, dir_straight, vel_sign,
+    bool const can_shift_right = scan_rails_at_shift( m, veh, vel_sign, dir_straight, vel_sign,
                            &shift_amount_right );
-    bool can_shift_left = scan_rails_at_shift( m, veh, vel_sign, dir_straight, -vel_sign,
+    bool const can_shift_left = scan_rails_at_shift( m, veh, vel_sign, dir_straight, -vel_sign,
                           &shift_amount_left );
 
-    bool is_on_rails = face_dir_degrees == face_dir_snapped && ( can_go_straight || can_go_backwards );
+    bool const is_on_rails = face_dir_degrees == face_dir_snapped && ( can_go_straight || can_go_backwards );
 
     // Appraise possible vehicle orientations
     if( !is_on_rails ) {
@@ -1913,7 +1913,7 @@ rail_processing_result process_movement_on_rails( const map &m, const vehicle &v
             }
         } else {
             // Manual movement - prefer going in turn direction.
-            units::angle dir_delta = normalize( veh.turn_dir - veh.face.dir() );
+            units::angle const dir_delta = normalize( veh.turn_dir - veh.face.dir() );
             if( dir_delta < 180_degrees ) {
                 // Trying to turn right
                 if( can_turn_right ) {
@@ -1953,8 +1953,8 @@ bool is_on_rails( const map &m, const vehicle &veh )
         return false;
     }
 
-    int face_dir_degrees = std::round( units::to_degrees( veh.face.dir() ) );
-    int face_dir_snapped = ( face_dir_degrees / 45 ) * 45;
+    int const face_dir_degrees = std::round( units::to_degrees( veh.face.dir() ) );
+    int const face_dir_snapped = ( face_dir_degrees / 45 ) * 45;
 
     if( face_dir_degrees != face_dir_snapped ) {
         // When moving on rails, can only rotate in 45-degree increment
@@ -1962,7 +1962,7 @@ bool is_on_rails( const map &m, const vehicle &veh )
     }
 
     // Must have valid rail segment in front of or behind us
-    units::angle dir_straight = normalize( units::from_degrees( face_dir_snapped ) );
+    units::angle const dir_straight = normalize( units::from_degrees( face_dir_snapped ) );
     return scan_rails_at_shift( m, veh, 1, dir_straight, 0 ) ||
            scan_rails_at_shift( m, veh, -1, dir_straight, 0 );
 }

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -95,7 +95,8 @@ int vehicle::slowdown( int at_velocity ) const
         // same with water resistance
         f_total_drag += coeff_water_drag() * mps * mps;
     } else if( !is_falling && !is_flying ) {
-        double const f_rolling_drag = coeff_rolling_drag() * ( vehicles::rolling_constant_to_variable + mps );
+        double const f_rolling_drag = coeff_rolling_drag() * ( vehicles::rolling_constant_to_variable +
+                                      mps );
         if( vehicle_movement::is_on_rails( get_map(), *this ) ) {
             // vehicles on rails don't skid
             f_total_drag += f_rolling_drag;
@@ -460,7 +461,7 @@ static void terrain_collision_data( const tripoint &p, bool bash_floor,
                                     float &mass, float &density, float &elastic )
 {
     elastic = 0.30;
-    map  const&here = get_map();
+    map  const &here = get_map();
     // Just a rough rescale for now to obtain approximately equal numbers
     const int bash_min = here.bash_resistance( p, bash_floor );
     const int bash_max = here.bash_strength( p, bash_floor );
@@ -1002,7 +1003,7 @@ bool vehicle::check_heli_descend( player &p )
     }
     int count = 0;
     int air_count = 0;
-    map  const&here = get_map();
+    map  const &here = get_map();
     for( const tripoint &pt : get_points( true ) ) {
         tripoint const below( pt.xy(), pt.z - 1 );
         if( here.has_zlevels() && ( pt.z < -OVERMAP_DEPTH ||
@@ -1120,7 +1121,7 @@ void vehicle::pldrive( Character &driver, point p, int z )
 
         ///\EFFECT_DRIVING reduces chance of losing control of vehicle when turning
         float const skill = std::min( 10.0f, driver.get_skill_level( skill_driving ) +
-                                ( driver.get_dex() + driver.get_per() ) / 10.0f );
+                                      ( driver.get_dex() + driver.get_per() ) / 10.0f );
         float const penalty = rng_float( 0.0f, handling_diff ) - skill;
         int cost;
         if( penalty > 0.0f ) {
@@ -1275,7 +1276,7 @@ vehicle *vehicle::act_on_map()
     if( decrement_summon_timer() ) {
         return nullptr;
     }
-    Character  const&player_character = get_player_character();
+    Character  const &player_character = get_player_character();
     const bool pl_ctrl = player_in_control( player_character );
     // TODO: Remove this hack, have vehicle sink a z-level
     if( is_floating && !can_float() ) {
@@ -1557,7 +1558,7 @@ void vehicle::check_falling_or_floating()
         return;
     }
 
-    map  const&here = get_map();
+    map  const &here = get_map();
     is_falling = here.has_zlevels();
 
     if( is_flying && is_rotorcraft() ) {
@@ -1885,11 +1886,12 @@ rail_processing_result process_movement_on_rails( const map &m, const vehicle &v
     tripoint shift_amount_left;
 
     bool const can_shift_right = scan_rails_at_shift( m, veh, vel_sign, dir_straight, vel_sign,
-                           &shift_amount_right );
+                                 &shift_amount_right );
     bool const can_shift_left = scan_rails_at_shift( m, veh, vel_sign, dir_straight, -vel_sign,
-                          &shift_amount_left );
+                                &shift_amount_left );
 
-    bool const is_on_rails = face_dir_degrees == face_dir_snapped && ( can_go_straight || can_go_backwards );
+    bool const is_on_rails = face_dir_degrees == face_dir_snapped && ( can_go_straight ||
+                             can_go_backwards );
 
     // Appraise possible vehicle orientations
     if( !is_on_rails ) {

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -66,7 +66,7 @@ void vehicle_part::set_base( const item &new_base )
 
 item vehicle_part::properties_to_item() const
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     item tmp = base;
     tmp.unset_flag( "VEHICLE" );
 

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -66,7 +66,7 @@ void vehicle_part::set_base( const item &new_base )
 
 item vehicle_part::properties_to_item() const
 {
-    map &here = get_map();
+    map  const&here = get_map();
     item tmp = base;
     tmp.unset_flag( "VEHICLE" );
 
@@ -323,7 +323,7 @@ double vehicle_part::consume_energy( const itype_id &ftype, double energy_j )
         } else {
             fuel.charges -= charges_to_use;
         }
-        item fuel_consumed( ftype, calendar::turn, charges_to_use );
+        item const fuel_consumed( ftype, calendar::turn, charges_to_use );
         return energy_p_mL * units::to_milliliter<int>( fuel_consumed.volume( true ) );
     }
     return 0.0;

--- a/src/vehicle_selector.cpp
+++ b/src/vehicle_selector.cpp
@@ -11,7 +11,7 @@
 vehicle_selector::vehicle_selector( const tripoint &pos, int radius, bool accessible,
                                     bool visibility_only )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     for( const tripoint &e : closest_points_first( pos, radius ) ) {
         if( !accessible ||
             ( visibility_only ? here.sees( pos, e, radius ) : here.clear_path( pos, e, radius, 1, 100 ) ) ) {
@@ -25,7 +25,7 @@ vehicle_selector::vehicle_selector( const tripoint &pos, int radius, bool access
 vehicle_selector::vehicle_selector( const tripoint &pos, int radius, bool accessible,
                                     const vehicle &ignore )
 {
-    map  const&here = get_map();
+    map  const &here = get_map();
     for( const tripoint &e : closest_points_first( pos, radius ) ) {
         if( !accessible || here.clear_path( pos, e, radius, 1, 100 ) ) {
             if( const optional_vpart_position vp = here.veh_at( e ) ) {

--- a/src/vehicle_selector.cpp
+++ b/src/vehicle_selector.cpp
@@ -11,7 +11,7 @@
 vehicle_selector::vehicle_selector( const tripoint &pos, int radius, bool accessible,
                                     bool visibility_only )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     for( const tripoint &e : closest_points_first( pos, radius ) ) {
         if( !accessible ||
             ( visibility_only ? here.sees( pos, e, radius ) : here.clear_path( pos, e, radius, 1, 100 ) ) ) {
@@ -25,7 +25,7 @@ vehicle_selector::vehicle_selector( const tripoint &pos, int radius, bool access
 vehicle_selector::vehicle_selector( const tripoint &pos, int radius, bool accessible,
                                     const vehicle &ignore )
 {
-    map &here = get_map();
+    map  const&here = get_map();
     for( const tripoint &e : closest_points_first( pos, radius ) ) {
         if( !accessible || here.clear_path( pos, e, radius, 1, 100 ) ) {
             if( const optional_vpart_position vp = here.veh_at( e ) ) {

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -115,7 +115,7 @@ void vehicle::add_toggle_to_opts( std::vector<uilist_entry> &options,
     bool allow = true;
 
     // determine target state - currently parts of similar type are all switched concurrently
-    bool state = std::none_of( found.begin(), found.end(), []( const vpart_reference & vp ) {
+    bool const state = std::none_of( found.begin(), found.end(), []( const vpart_reference & vp ) {
         return vp.part().enabled;
     } );
 
@@ -156,18 +156,18 @@ void handbrake()
     vehicle *const veh = &vp->vehicle();
     add_msg( _( "You pull a handbrake." ) );
     veh->cruise_velocity = 0;
-    bool is_on_rails = vehicle_movement::is_on_rails( here, *veh );
+    bool const is_on_rails = vehicle_movement::is_on_rails( here, *veh );
     if( !is_on_rails && veh->last_turn != 0_degrees &&
         rng( 15, 60 ) * 100 < std::abs( veh->velocity ) ) {
         veh->skidding = true;
         add_msg( m_warning, _( "You lose control of %s." ), veh->name );
         veh->turn( veh->last_turn > 0_degrees ? 60_degrees : -60_degrees );
     } else {
-        int braking_power = std::abs( veh->velocity ) / 2 + 10 * 100;
+        int const braking_power = std::abs( veh->velocity ) / 2 + 10 * 100;
         if( std::abs( veh->velocity ) < braking_power ) {
             veh->stop();
         } else {
-            int sgn = veh->velocity > 0 ? 1 : -1;
+            int const sgn = veh->velocity > 0 ? 1 : -1;
             veh->velocity = sgn * ( std::abs( veh->velocity ) - braking_power );
         }
     }
@@ -195,12 +195,12 @@ void vehicle::control_doors()
             continue;
         }
         const std::array<int, 2> doors = { { next_part_to_open( p ), next_part_to_close( p ) } };
-        for( int door : doors ) {
+        for( int const door : doors ) {
             if( door == -1 ) {
                 continue;
             }
 
-            int val = doors_with_motors.size();
+            int const val = doors_with_motors.size();
             doors_with_motors.push_back( door );
             locations.push_back( global_part_pos3( p ) );
             const char *actname = parts[door].open ? _( "Close" ) : _( "Open" );
@@ -225,16 +225,16 @@ void vehicle::control_doors()
 
     if( pmenu.ret >= 0 ) {
         if( pmenu.ret < static_cast<int>( doors_with_motors.size() ) ) {
-            int part = doors_with_motors[pmenu.ret];
+            int const part = doors_with_motors[pmenu.ret];
             open_or_close( part, !( parts[part].open ) );
         } else if( pmenu.ret < ( static_cast<int>( doors_with_motors.size() ) + CANCEL ) ) {
-            int option = pmenu.ret - static_cast<int>( doors_with_motors.size() );
-            bool open = option == OPENBOTH || option == OPENCURTAINS;
+            int const option = pmenu.ret - static_cast<int>( doors_with_motors.size() );
+            bool const open = option == OPENBOTH || option == OPENCURTAINS;
             for( const vpart_reference &vp : door_motors ) {
                 const size_t motor = vp.part_index();
                 int next_part = -1;
                 if( open ) {
-                    int part = next_part_to_open( motor );
+                    int const part = next_part_to_open( motor );
                     if( part != -1 ) {
                         if( !part_flag( part, "CURTAIN" ) &&  option == OPENCURTAINS ) {
                             continue;
@@ -248,7 +248,7 @@ void vehicle::control_doors()
                         }
                     }
                 } else {
-                    int part = next_part_to_close( motor );
+                    int const part = next_part_to_close( motor );
                     if( part != -1 ) {
                         if( part_flag( part, "CURTAIN" ) &&  option == CLOSEDOORS ) {
                             continue;
@@ -397,7 +397,7 @@ void vehicle::control_engines()
 
     const auto adjust_engine = [this]( int e_toggle ) {
         int i = 0;
-        for( int e : engines ) {
+        for( int const e : engines ) {
             for( const itype_id &fuel : part_info( e ).engine_fuel_opts() ) {
                 if( i == e_toggle ) {
                     if( parts[ e ].fuel_current() == fuel ) {
@@ -428,13 +428,13 @@ void vehicle::control_engines()
     }
 
     const bool engines_were_on = engine_on;
-    for( int e : engines ) {
+    for( int const e : engines ) {
         engine_on |= is_part_on( e );
     }
 
     // if current velocity greater than new configuration safe speed
     // drop down cruise velocity.
-    int safe_vel = safe_velocity();
+    int const safe_vel = safe_velocity();
     if( velocity > safe_vel ) {
         cruise_velocity = safe_vel;
     }
@@ -484,7 +484,7 @@ int vehicle::select_engine()
 
     int i = 0;
     const auto entry_alt_fuels = [ &, this]( size_t x ) {
-        int engine_id = engines[ x ];
+        int const engine_id = engines[ x ];
         const std::string &part_name = parts[ engine_id ].name();
 
         tmenu.entries.emplace_back( get_title( part_name ) );
@@ -512,13 +512,13 @@ bool vehicle::interact_vehicle_locked()
             if( query_yn( _( "You don't find any keys in the %s. Attempt to hotwire vehicle?" ),
                           name ) ) {
                 ///\EFFECT_MECHANICS speeds up vehicle hotwiring
-                int mechanics_skill = g->u.get_skill_level( skill_mechanics );
+                int const mechanics_skill = g->u.get_skill_level( skill_mechanics );
                 const int hotwire_time = 6000 / ( ( mechanics_skill > 0 ) ? mechanics_skill : 1 );
                 const int moves = to_moves<int>( time_duration::from_turns( hotwire_time ) );
                 //assign long activity
                 g->u.assign_activity( ACT_HOTWIRE_CAR, moves, -1, INT_MIN, _( "Hotwire" ) );
                 // use part 0 as the reference point
-                point q = coord_translate( parts[0].mount );
+                point const q = coord_translate( parts[0].mount );
                 const tripoint abs_veh_pos = global_square_location().raw();
                 //[0]
                 g->u.activity.values.push_back( abs_veh_pos.x + q.x );
@@ -547,7 +547,7 @@ void vehicle::smash_security_system()
     //get security and controls location
     int s = -1;
     int c = -1;
-    for( int p : speciality ) {
+    for( int const p : speciality ) {
         if( part_flag( p, "SECURITY" ) && !parts[ p ].is_broken() ) {
             s = p;
             c = part_with_feature( s, "CONTROLS", true );
@@ -557,10 +557,10 @@ void vehicle::smash_security_system()
     //controls and security must both be valid
     if( c >= 0 && s >= 0 ) {
         ///\EFFECT_MECHANICS reduces chance of damaging controls when smashing security system
-        int skill = g->u.get_skill_level( skill_mechanics );
-        int percent_controls = 70 / ( 1 + skill );
-        int percent_alarm = ( skill + 3 ) * 10;
-        int rand = rng( 1, 100 );
+        int const skill = g->u.get_skill_level( skill_mechanics );
+        int const percent_controls = 70 / ( 1 + skill );
+        int const percent_alarm = ( skill + 3 ) * 10;
+        int const rand = rng( 1, 100 );
 
         if( percent_controls > rand ) {
             damage_direct( c, part_info( c ).durability / 4 );
@@ -593,7 +593,7 @@ std::string vehicle::tracking_toggle_string()
 
 void vehicle::autopilot_patrol_check()
 {
-    zone_manager &mgr = zone_manager::get_manager();
+    zone_manager  const&mgr = zone_manager::get_manager();
     if( mgr.has_near( zone_type_id( "VEHICLE_PATROL" ), global_square_location().raw(), 60 ) ) {
         enable_patrol();
     } else {
@@ -660,7 +660,7 @@ void vehicle::use_controls( const tripoint &pos )
     std::vector<uilist_entry> options;
     std::vector<std::function<void()>> actions;
 
-    bool remote = g->remoteveh() == this;
+    bool const remote = g->remoteveh() == this;
     bool has_electronic_controls = false;
     avatar &you = get_avatar();
     const auto confirm_stop_driving = [this] {
@@ -1223,14 +1223,14 @@ void vehicle::reload_seeds( const tripoint &pos )
 {
     player &p = g->u;
 
-    std::vector<item *> seed_inv = p.items_with( []( const item & itm ) {
+    std::vector<item *> const seed_inv = p.items_with( []( const item & itm ) {
         return itm.is_seed();
     } );
 
     auto seed_entries = iexamine::get_seed_entries( seed_inv );
     seed_entries.emplace( seed_entries.begin(), seed_tuple( itype_id( "null" ), _( "No seed" ), 0 ) );
 
-    int seed_index = iexamine::query_seed( seed_entries );
+    int const seed_index = iexamine::query_seed( seed_entries );
 
     if( seed_index > 0 && seed_index < static_cast<int>( seed_entries.size() ) ) {
         const int count = std::get<2>( seed_entries[seed_index] );
@@ -1244,8 +1244,8 @@ void vehicle::reload_seeds( const tripoint &pos )
                  .query_int();
 
         if( amount > 0 ) {
-            int actual_amount = std::min( amount, count );
-            itype_id seed_id = std::get<0>( seed_entries[seed_index] );
+            int const actual_amount = std::min( amount, count );
+            itype_id const seed_id = std::get<0>( seed_entries[seed_index] );
             std::list<item> used_seed;
             if( item::count_by_charges( seed_id ) ) {
                 used_seed = p.use_charges( seed_id, actual_amount );
@@ -1309,7 +1309,7 @@ void vehicle::crash_terrain_around()
         const transform_terrain_data &ttd = vp.info().transform_terrain;
         for( size_t i = 0; i < eight_horizontal_neighbors.size() &&
              !g->m.inbounds_z( crush_target.z ); i++ ) {
-            tripoint cur_pos = start_pos + eight_horizontal_neighbors.at( i );
+            tripoint const cur_pos = start_pos + eight_horizontal_neighbors.at( i );
             bool busy_pos = false;
             for( const vpart_reference &vp_tmp : get_all_parts() ) {
                 busy_pos |= vp_tmp.pos() == cur_pos;
@@ -1359,7 +1359,7 @@ void vehicle::transform_terrain()
             }
         } else {
             const int speed = std::abs( velocity );
-            int v_damage = rng( 3, speed );
+            int const v_damage = rng( 3, speed );
             damage( vp.part_index(), v_damage, DT_BASH, false );
             sounds::sound( start_pos, v_damage, sounds::sound_t::combat, _( "Clanggggg!" ), false,
                            "smash_success", "hit_vehicle" );
@@ -1380,7 +1380,7 @@ void vehicle::operate_reaper()
         }
         // Can't use item_stack::only_item() since there might be fertilizer
         map_stack items = g->m.i_at( reaper_pos );
-        map_stack::iterator seed = std::find_if( items.begin(), items.end(), []( const item & it ) {
+        map_stack::iterator const seed = std::find_if( items.begin(), items.end(), []( const item & it ) {
             return it.is_seed();
         } );
         if( seed == items.end() || seed->typeId() == itype_fungal_seeds ||
@@ -1507,7 +1507,7 @@ void vehicle::alarm()
 {
     if( one_in( 4 ) ) {
         //first check if the alarm is still installed
-        bool found_alarm = has_security_working();
+        bool const found_alarm = has_security_working();
 
         //if alarm found, make noise, else set alarm disabled
         if( found_alarm ) {
@@ -1584,7 +1584,7 @@ bool vehicle::can_close( int part_index, Character &who )
 
 void vehicle::open_all_at( int p )
 {
-    std::vector<int> parts_here = parts_at_relative( parts[p].mount, true );
+    std::vector<int> const parts_here = parts_at_relative( parts[p].mount, true );
     for( auto &elem : parts_here ) {
         if( part_flag( elem, VPFLAG_OPENABLE ) ) {
             // Note that this will open multi-square and non-multipart parts in the tile. This
@@ -1628,17 +1628,17 @@ void vehicle::use_washing_machine( int p )
 {
     // Get all the items that can be used as detergent
     const inventory &inv = g->u.crafting_inventory();
-    std::vector<const item *> detergents = inv.items_with( [inv]( const item & it ) {
+    std::vector<const item *> const detergents = inv.items_with( [inv]( const item & it ) {
         return it.has_flag( "DETERGENT" ) && inv.has_charges( it.typeId(), 5 );
     } );
 
     auto items = get_items( p );
     static const std::string filthy( "FILTHY" );
-    bool filthy_items = std::all_of( items.begin(), items.end(), []( const item & i ) {
+    bool const filthy_items = std::all_of( items.begin(), items.end(), []( const item & i ) {
         return i.has_flag( filthy );
     } );
 
-    bool cbms = std::any_of( items.begin(), items.end(), []( const item & i ) {
+    bool const cbms = std::any_of( items.begin(), items.end(), []( const item & i ) {
         return i.is_bionic();
     } );
 
@@ -1666,7 +1666,7 @@ void vehicle::use_washing_machine( int p )
 
         std::vector<itype_id> det_types;
         for( const item *it : detergents ) {
-            itype_id det_type = it->typeId();
+            itype_id const det_type = it->typeId();
             // If the vector does not contain the detergent type, add it
             if( std::find( det_types.begin(), det_types.end(), det_type ) == det_types.end() ) {
                 det_types.emplace_back( det_type );
@@ -1711,10 +1711,10 @@ void vehicle::use_washing_machine( int p )
 
 void vehicle::use_dishwasher( int p )
 {
-    bool detergent_is_enough = g->u.crafting_inventory().has_charges( itype_detergent, 5 );
+    bool const detergent_is_enough = g->u.crafting_inventory().has_charges( itype_detergent, 5 );
     auto items = get_items( p );
     static const std::string filthy( "FILTHY" );
-    bool filthy_items = std::all_of( items.begin(), items.end(), []( const item & i ) {
+    bool const filthy_items = std::all_of( items.begin(), items.end(), []( const item & i ) {
         return i.has_flag( filthy );
     } );
 
@@ -1796,7 +1796,7 @@ void vehicle::use_harness( int part, const tripoint &pos )
         if( mon_ptr == nullptr ) {
             return false;
         }
-        monster &f = *mon_ptr;
+        monster  const&f = *mon_ptr;
         return ( f.friendly != 0 && ( f.has_flag( MF_PET_MOUNTABLE ) ||
                                       f.has_flag( MF_PET_HARNESSABLE ) ) );
     };
@@ -1815,7 +1815,7 @@ void vehicle::use_harness( int part, const tripoint &pos )
         return;
     }
     monster &m = *mon_ptr;
-    std::string Harness_Bodytype = "HARNESS_" + m.type->bodytype;
+    std::string const Harness_Bodytype = "HARNESS_" + m.type->bodytype;
     if( m.friendly == 0 ) {
         add_msg( m_info, _( "This creature is not friendly!" ) );
         return;
@@ -1846,7 +1846,7 @@ void vehicle::use_bike_rack( int part )
     if( parts[part].is_unavailable() || parts[part].removed ) {
         return;
     }
-    std::vector<std::vector <int>> racks_parts = find_lines_of_parts( part, "BIKE_RACK_VEH" );
+    std::vector<std::vector <int>> const racks_parts = find_lines_of_parts( part, "BIKE_RACK_VEH" );
     if( racks_parts.empty() ) {
         return;
     }
@@ -1881,8 +1881,8 @@ void vehicle::use_bike_rack( int part )
                 cur_vehicle.clear();
                 continue;
             }
-            for( point mount_dir : five_cardinal_directions ) {
-                point near_loc = parts[ rack_part ].mount + mount_dir;
+            for( point const mount_dir : five_cardinal_directions ) {
+                point const near_loc = parts[ rack_part ].mount + mount_dir;
                 std::vector<int> near_parts = parts_at_relative( near_loc, true );
                 if( near_parts.empty() ) {
                     continue;
@@ -1942,9 +1942,9 @@ void vehicle::use_bike_rack( int part )
 void vehicle::interact_with( const tripoint &pos, int interact_part )
 {
     avatar &you = get_avatar();
-    map &here = get_map();
-    std::vector<std::string> menu_items;
-    std::vector<uilist_entry> options_message;
+    map  const&here = get_map();
+    std::vector<std::string> const menu_items;
+    std::vector<uilist_entry> const options_message;
     const bool has_items_on_ground = here.sees_some_items( pos, g->u );
     const bool items_are_sealed = here.has_flag( "SEALED", pos );
 
@@ -1971,11 +1971,11 @@ void vehicle::interact_with( const tripoint &pos, int interact_part )
     const bool remotely_controlled = g->remoteveh() == this;
     const int washing_machine_part = avail_part_with_feature( interact_part, "WASHING_MACHINE", true );
     const bool has_washmachine = washing_machine_part >= 0;
-    bool washing_machine_on = ( washing_machine_part == -1 ) ? false :
+    bool const washing_machine_on = ( washing_machine_part == -1 ) ? false :
                               parts[washing_machine_part].enabled;
     const int dishwasher_part = avail_part_with_feature( interact_part, "DISHWASHER", true );
     const bool has_dishwasher = dishwasher_part >= 0;
-    bool dishwasher_on = ( dishwasher_part == -1 ) ? false :
+    bool const dishwasher_on = ( dishwasher_part == -1 ) ? false :
                          parts[dishwasher_part].enabled;
     const int monster_capture_part = avail_part_with_feature( interact_part, "CAPTURE_MONSTER_VEH",
                                      true );
@@ -2051,7 +2051,7 @@ void vehicle::interact_with( const tripoint &pos, int interact_part )
         selectmenu.addentry( USE_WELDER, true, 'w', _( "Use the welding rig" ) );
     }
     if( has_purify ) {
-        bool can_purify = fuel_left( itype_battery, true ) >=
+        bool const can_purify = fuel_left( itype_battery, true ) >=
                           itype_water_purifier->charges_to_use();
         selectmenu.addentry( USE_PURIFIER, can_purify,
                              'p', _( "Purify water in carried container" ) );
@@ -2174,7 +2174,7 @@ void vehicle::interact_with( const tripoint &pos, int interact_part )
                              get_all_colors().get_name( itype_water->color ) );
             auto &tank = veh_interact::select_part( *this, sel, title );
             if( tank ) {
-                double cost = itype_water_purifier->charges_to_use();
+                double const cost = itype_water_purifier->charges_to_use();
                 if( fuel_left( itype_battery, true ) < tank.ammo_remaining() * cost ) {
                     //~ $1 - vehicle name, $2 - part name
                     add_msg( m_bad, _( "Insufficient power to purify the contents of the %1$s's %2$s" ),

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -593,7 +593,7 @@ std::string vehicle::tracking_toggle_string()
 
 void vehicle::autopilot_patrol_check()
 {
-    zone_manager  const&mgr = zone_manager::get_manager();
+    zone_manager  const &mgr = zone_manager::get_manager();
     if( mgr.has_near( zone_type_id( "VEHICLE_PATROL" ), global_square_location().raw(), 60 ) ) {
         enable_patrol();
     } else {
@@ -1796,7 +1796,7 @@ void vehicle::use_harness( int part, const tripoint &pos )
         if( mon_ptr == nullptr ) {
             return false;
         }
-        monster  const&f = *mon_ptr;
+        monster  const &f = *mon_ptr;
         return ( f.friendly != 0 && ( f.has_flag( MF_PET_MOUNTABLE ) ||
                                       f.has_flag( MF_PET_HARNESSABLE ) ) );
     };
@@ -1942,7 +1942,7 @@ void vehicle::use_bike_rack( int part )
 void vehicle::interact_with( const tripoint &pos, int interact_part )
 {
     avatar &you = get_avatar();
-    map  const&here = get_map();
+    map  const &here = get_map();
     std::vector<std::string> const menu_items;
     std::vector<uilist_entry> const options_message;
     const bool has_items_on_ground = here.sees_some_items( pos, g->u );
@@ -1972,11 +1972,11 @@ void vehicle::interact_with( const tripoint &pos, int interact_part )
     const int washing_machine_part = avail_part_with_feature( interact_part, "WASHING_MACHINE", true );
     const bool has_washmachine = washing_machine_part >= 0;
     bool const washing_machine_on = ( washing_machine_part == -1 ) ? false :
-                              parts[washing_machine_part].enabled;
+                                    parts[washing_machine_part].enabled;
     const int dishwasher_part = avail_part_with_feature( interact_part, "DISHWASHER", true );
     const bool has_dishwasher = dishwasher_part >= 0;
     bool const dishwasher_on = ( dishwasher_part == -1 ) ? false :
-                         parts[dishwasher_part].enabled;
+                               parts[dishwasher_part].enabled;
     const int monster_capture_part = avail_part_with_feature( interact_part, "CAPTURE_MONSTER_VEH",
                                      true );
     const bool has_monster_capture = monster_capture_part >= 0;
@@ -2052,7 +2052,7 @@ void vehicle::interact_with( const tripoint &pos, int interact_part )
     }
     if( has_purify ) {
         bool const can_purify = fuel_left( itype_battery, true ) >=
-                          itype_water_purifier->charges_to_use();
+                                itype_water_purifier->charges_to_use();
         selectmenu.addentry( USE_PURIFIER, can_purify,
                              'p', _( "Purify water in carried container" ) );
         selectmenu.addentry( PURIFY_TANK, can_purify && fuel_left( itype_water ),

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -504,7 +504,7 @@ VisitResponse visitable<vehicle_cursor>::visit_items(
 {
     auto self = static_cast<vehicle_cursor *>( this );
 
-    int idx = self->veh.part_with_feature( self->part, "CARGO", true );
+    int const idx = self->veh.part_with_feature( self->part, "CARGO", true );
     if( idx >= 0 ) {
         for( auto &e : self->veh.get_items( idx ) ) {
             if( visit_internal( func, &e ) == VisitResponse::ABORT ) {
@@ -788,7 +788,7 @@ std::list<item> visitable<vehicle_cursor>::remove_items_with( const
         return res;
     }
 
-    int idx = cur->veh.part_with_feature( cur->part, "CARGO", false );
+    int const idx = cur->veh.part_with_feature( cur->part, "CARGO", false );
     if( idx < 0 ) {
         return res;
     }

--- a/src/vitamin.cpp
+++ b/src/vitamin.cpp
@@ -76,15 +76,15 @@ void vitamin::load_vitamin( const JsonObject &jo )
         jo.throw_error( "vitamin consumption rate cannot be negative", "rate" );
     }
 
-    for( JsonArray e : jo.get_array( "disease" ) ) {
+    for( JsonArray const e : jo.get_array( "disease" ) ) {
         vit.disease_.emplace_back( e.get_int( 0 ), e.get_int( 1 ) );
     }
 
-    for( JsonArray e : jo.get_array( "disease_excess" ) ) {
+    for( JsonArray const e : jo.get_array( "disease_excess" ) ) {
         vit.disease_excess_.emplace_back( e.get_int( 0 ), e.get_int( 1 ) );
     }
 
-    for( std::string e : jo.get_array( "flags" ) ) {
+    for( std::string const e : jo.get_array( "flags" ) ) {
         vit.flags_.insert( e );
     }
 

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -787,9 +787,9 @@ static double local_windchill_hightemp( double temperature_f, double humidity, d
     // model being designed for reasonable ambient temperature values,
     // rather than extremely high ones.
     double const windchill_c = 0.33 * std::min<float>( 150.00, humidity / 100.00 * 6.105 *
-                         std::exp( 17.27 * temperature_c / ( 237.70 + temperature_c ) ) )
-                         - 0.70 * wind_meters_per_sec
-                         - 4.00;
+                               std::exp( 17.27 * temperature_c / ( 237.70 + temperature_c ) ) )
+                               - 0.70 * wind_meters_per_sec
+                               - 4.00;
     // Convert to Fahrenheit, but omit the '+ 32' because we are only dealing with a piece of the felt air temperature equation.
     return windchill_c * 9 / 5;
 }
@@ -805,8 +805,9 @@ int get_local_windchill( double temperature_f, double humidity, double wind_mph 
 
     // lerp-ing both functions results in a non-monotonous function
     double const windchill_f_hightemp = local_windchill_hightemp( high_temp, humidity, wind_mph );
-    double const windchill_f_lowtemp = std::min( windchill_f_hightemp, local_windchill_lowtemp( low_temp,
-                                           humidity, wind_mph ) );
+    double const windchill_f_lowtemp = std::min( windchill_f_hightemp,
+                                       local_windchill_lowtemp( low_temp,
+                                               humidity, wind_mph ) );
 
     double const t = ( temperature_f - low_temp ) / ( high_temp - low_temp );
     return std::ceil( lerp( std::min( windchill_f_lowtemp, windchill_f_hightemp ),

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -84,7 +84,7 @@ void glare( const weather_type_id &w )
 
     time_duration dur = 0_turns;
     const efftype_id *effect = nullptr;
-    season_type season = season_of_year( calendar::turn );
+    season_type const season = season_of_year( calendar::turn );
     if( season == WINTER ) {
         //Winter snow glare: for both clear & sunny weather
         effect = &effect_snow_glare;
@@ -166,7 +166,7 @@ weather_sum sum_conditions( const time_point &start, const time_point &end,
             tick_size = 1_minutes;
         }
 
-        weather_type_id wtype = current_weather( location, t );
+        weather_type_id const wtype = current_weather( location, t );
         proc_weather_sum( wtype, data, t, tick_size );
         const weather_manager &weather = get_weather();
         data.wind_amount += get_local_windpower( weather.windspeed,
@@ -190,7 +190,7 @@ void retroactively_fill_from_funnel( item &it, const trap &tr, const time_point 
 
     // bday == last fill check
     it.set_birthday( end );
-    weather_sum data = sum_conditions( start, end, pos );
+    weather_sum const data = sum_conditions( start, end, pos );
 
     // Technically 0.0 division is OK, but it will be cleaner without it
     if( data.rain_amount > 0 ) {
@@ -226,8 +226,8 @@ void item::add_rain_to_container( bool acid, int charges )
     } else {
         // The container already has a liquid.
         item &liq = contents.front();
-        int orig = liq.charges;
-        int added = std::min( charges, capa );
+        int const orig = liq.charges;
+        int const added = std::min( charges, capa );
         if( capa > 0 ) {
             liq.charges += added;
         }
@@ -253,9 +253,9 @@ void item::add_rain_to_container( bool acid, int charges )
                 // The container has water, and the acid rain didn't turn it
                 // into weak acid. Poison the water instead, assuming 1
                 // charge of acid would act like a charge of water with poison 5.
-                int total_poison = liq.poison * orig + 5 * added;
+                int const total_poison = liq.poison * orig + 5 * added;
                 liq.poison = total_poison / liq.charges;
-                int leftover_poison = total_poison - liq.poison * liq.charges;
+                int const leftover_poison = total_poison - liq.poison * liq.charges;
                 if( leftover_poison > rng( 0, liq.charges ) ) {
                     liq.poison++;
                 }
@@ -390,7 +390,7 @@ void weather_effect::wet_player( int amount )
         // TODO: Port body part set id changes
         const body_part_set &covered = it.get_covered_body_parts();
         for( size_t i = 0; i < num_bp; i++ ) {
-            body_part token = static_cast<body_part>( i );
+            body_part const token = static_cast<body_part>( i );
             if( covered.test( token ) ) {
                 clothing_map[convert_bp( token )].emplace_back( &it );
             }
@@ -638,7 +638,7 @@ std::string weather_forecast( const point_abs_sm &abs_sm_pos )
 
     const time_point now_hour = calendar::turn - time_duration::from_minutes( minute_of_hour<int>
                                 ( calendar::turn ) );
-    bool now_is_day = is_day( now_hour );
+    bool const now_is_day = is_day( now_hour );
 
     int last_idx = -1;
     bool last_is_day = now_is_day;
@@ -654,7 +654,7 @@ std::string weather_forecast( const point_abs_sm &abs_sm_pos )
         if( is_dusk( last_hour ) || is_dawn( last_hour ) ) {
             continue;
         }
-        bool new_is_day = is_day( last_hour );
+        bool const new_is_day = is_day( last_hour );
         if( new_is_day != last_is_day ) {
             last_is_day = new_is_day;
             last_idx += 1;
@@ -670,9 +670,9 @@ std::string weather_forecast( const point_abs_sm &abs_sm_pos )
 
         forecast_period &period = periods[last_idx];
 
-        w_point w = wgen.get_weather( abs_ms_pos, last_hour, g->get_seed() );
+        w_point const w = wgen.get_weather( abs_ms_pos, last_hour, g->get_seed() );
         const weather_type_id &new_type = wgen.get_weather_conditions( w );
-        int new_priority = wgen.forecast_priority( new_type );
+        int const new_priority = wgen.forecast_priority( new_type );
         if( !period.type || new_priority > period.type_priority ) {
             period.type_priority = new_priority;
             period.type = &new_type.obj();
@@ -761,7 +761,7 @@ static double local_windchill_lowtemp( double temperature_f, double, double wind
     /// Is also used as a standard in North America.
 
     // This model fails when wind is less than 3 mph
-    double wind_mph_lowcapped = std::max( 3.0, wind_mph );
+    double const wind_mph_lowcapped = std::max( 3.0, wind_mph );
 
     // Temperature is removed at the end, because get_local_windchill is meant to calculate the difference.
     // Source : http://en.wikipedia.org/wiki/Wind_chill#North_American_and_United_Kingdom_wind_chill_index
@@ -778,15 +778,15 @@ static double local_windchill_hightemp( double temperature_f, double humidity, d
 
     // Source : http://en.wikipedia.org/wiki/Wind_chill#Australian_Apparent_Temperature
     // Convert to meters per second.
-    double wind_meters_per_sec = wind_mph * 0.44704;
-    double temperature_c = units::fahrenheit_to_celsius( temperature_f );
+    double const wind_meters_per_sec = wind_mph * 0.44704;
+    double const temperature_c = units::fahrenheit_to_celsius( temperature_f );
 
     // Cap the vapor pressure term to 50C of extra heat, as this term
     // otherwise grows logistically to an asymptotic value of about 2e7
     // for large values of temperature. This is presumably due to the
     // model being designed for reasonable ambient temperature values,
     // rather than extremely high ones.
-    double windchill_c = 0.33 * std::min<float>( 150.00, humidity / 100.00 * 6.105 *
+    double const windchill_c = 0.33 * std::min<float>( 150.00, humidity / 100.00 * 6.105 *
                          std::exp( 17.27 * temperature_c / ( 237.70 + temperature_c ) ) )
                          - 0.70 * wind_meters_per_sec
                          - 4.00;
@@ -804,11 +804,11 @@ int get_local_windchill( double temperature_f, double humidity, double wind_mph 
     }
 
     // lerp-ing both functions results in a non-monotonous function
-    double windchill_f_hightemp = local_windchill_hightemp( high_temp, humidity, wind_mph );
-    double windchill_f_lowtemp = std::min( windchill_f_hightemp, local_windchill_lowtemp( low_temp,
+    double const windchill_f_hightemp = local_windchill_hightemp( high_temp, humidity, wind_mph );
+    double const windchill_f_lowtemp = std::min( windchill_f_hightemp, local_windchill_lowtemp( low_temp,
                                            humidity, wind_mph ) );
 
-    double t = ( temperature_f - low_temp ) / ( high_temp - low_temp );
+    double const t = ( temperature_f - low_temp ) / ( high_temp - low_temp );
     return std::ceil( lerp( std::min( windchill_f_lowtemp, windchill_f_hightemp ),
                             windchill_f_hightemp,
                             t ) );
@@ -850,7 +850,7 @@ nc_color get_wind_color( double windpower )
 std::string get_shortdirstring( int angle )
 {
     std::string dirstring;
-    int dirangle = angle;
+    int const dirangle = angle;
     if( dirangle <= 23 || dirangle > 338 ) {
         dirstring = _( "N" );
     } else if( dirangle <= 68 ) {
@@ -875,7 +875,7 @@ std::string get_dirstring( int angle )
 {
     // Convert angle to cardinal directions
     std::string dirstring;
-    int dirangle = angle;
+    int const dirangle = angle;
     if( dirangle <= 23 || dirangle > 338 ) {
         dirstring = _( "North" );
     } else if( dirangle <= 68 ) {
@@ -944,9 +944,9 @@ double get_local_windpower( double windpower, const oter_id &omter, const tripoi
     if( sheltered ) {
         return 0;
     }
-    rl_vec2d windvec = convert_wind_to_coord( winddirection );
+    rl_vec2d const windvec = convert_wind_to_coord( winddirection );
     int tmpwind = static_cast<int>( windpower );
-    tripoint triblocker( location + point( windvec.x, windvec.y ) );
+    tripoint const triblocker( location + point( windvec.x, windvec.y ) );
     // Over map terrain may modify the effect of wind.
     if( is_ot_match( "forest", omter, ot_match_type::type ) ||
         is_ot_match( "forest_water", omter, ot_match_type::type ) ) {
@@ -1061,7 +1061,7 @@ void weather_manager::update_weather()
     if( !weather_id || calendar::turn >= nextweather ) {
         const weather_generator &weather_gen = get_cur_weather_gen();
         w = weather_gen.get_weather( g->u.global_square_location(), calendar::turn, g->get_seed() );
-        weather_type_id old_weather = weather_id;
+        weather_type_id const old_weather = weather_id;
         weather_id = weather_override ? weather_override : weather_gen.get_weather_conditions( w );
         if( !g->u.has_artifact_with( AEP_BAD_WEATHER ) ) {
             weather_override = weather_type_id::NULL_ID();
@@ -1132,8 +1132,8 @@ int weather_manager::get_temperature( const tripoint_abs_omt &location )
         return AVERAGE_ANNUAL_TEMPERATURE;
     }
 
-    tripoint abs_ms = project_to<coords::ms>( location ).raw();
-    w_point w = get_cur_weather_gen().get_weather( abs_ms, calendar::turn, g->get_seed() );
+    tripoint const abs_ms = project_to<coords::ms>( location ).raw();
+    w_point const w = get_cur_weather_gen().get_weather( abs_ms, calendar::turn, g->get_seed() );
     return units::to_fahrenheit( w.temperature );
 }
 

--- a/src/weather_gen.cpp
+++ b/src/weather_gen.cpp
@@ -143,10 +143,10 @@ w_point weather_generator::get_weather( const tripoint_abs_ms &location, const t
     double const mod_h = season_stats[static_cast<size_t>( season )].humidity_mod;
     // Relative humidity, a percentage.
     double const H = std::min( 100., std::max( 0.,
-                                         base_humidity + mod_h + 100 * (
-                                                 .15 * -cgyf +
-                                                 raw_noise_4d( x, y, z, modSEED + 101 ) *
-                                                 .2 * ( cgyf + 2 ) ) ) );
+                               base_humidity + mod_h + 100 * (
+                                   .15 * -cgyf +
+                                   raw_noise_4d( x, y, z, modSEED + 101 ) *
+                                   .2 * ( cgyf + 2 ) ) ) );
 
     // Pressure
     double const P =
@@ -343,7 +343,7 @@ void weather_generator::test_weather( unsigned seed = 1000 ) const
             const weather_type_id &conditions = get_weather_conditions( w );
 
             int const year = to_turns<int>( i - calendar::turn_zero ) / to_turns<int>
-                       ( calendar::year_length() ) + 1;
+                             ( calendar::year_length() ) + 1;
             const int hour = hour_of_day<int>( i );
             const int minute = minute_of_hour<int>( i );
             int day;

--- a/src/weather_gen.cpp
+++ b/src/weather_gen.cpp
@@ -98,7 +98,7 @@ static units::temperature weather_temperature_from_common_data( const weather_ge
     // -1 at coldest_hour, +1 twelve hours later
     const double dayv = std::cos( tau * ( dayFraction + .5 - coldest_hour / 24 ) );
 
-    units::temperature season_factor = season_temp( wg, common.year_fraction );
+    units::temperature const season_factor = season_temp( wg, common.year_fraction );
     const double temperature_celsius =
         units::to_celsius<double>( season_factor ) +
         dayv * units::to_celsius<double>( wg.temperature_daily_amplitude ) +
@@ -136,20 +136,20 @@ w_point weather_generator::get_weather( const tripoint_abs_ms &location, const t
 
     // Noise factors
     const units::temperature T( weather_temperature_from_common_data( *this, common, t ) );
-    double A( raw_noise_4d( x, y, z, modSEED ) * 8.0 );
+    double const A( raw_noise_4d( x, y, z, modSEED ) * 8.0 );
     double W( raw_noise_4d( x / 2.5, y / 2.5, z / 200, modSEED ) * 10.0 );
 
     // Humidity variation
-    double mod_h = season_stats[static_cast<size_t>( season )].humidity_mod;
+    double const mod_h = season_stats[static_cast<size_t>( season )].humidity_mod;
     // Relative humidity, a percentage.
-    double H = std::min( 100., std::max( 0.,
+    double const H = std::min( 100., std::max( 0.,
                                          base_humidity + mod_h + 100 * (
                                                  .15 * -cgyf +
                                                  raw_noise_4d( x, y, z, modSEED + 101 ) *
                                                  .2 * ( cgyf + 2 ) ) ) );
 
     // Pressure
-    double P =
+    double const P =
         base_pressure +
         raw_noise_4d( x, y, z, modSEED + 211 ) *
         10 * ( cgyf + 2 );
@@ -164,16 +164,16 @@ w_point weather_generator::get_weather( const tripoint_abs_ms &location, const t
         current_winddir = convert_winddir( current_winddir );
     } else {
         // When wind strength is low, wind direction is more variable
-        bool changedir = one_in( W * 2160 );
+        bool const changedir = one_in( W * 2160 );
         if( changedir ) {
             current_winddir = get_wind_direction( season );
             current_winddir = convert_winddir( current_winddir );
         }
     }
-    std::string wind_desc = get_wind_desc( W );
+    std::string const wind_desc = get_wind_desc( W );
     // Acid rains
     const double acid_content = base_acid * A;
-    bool acid = acid_content >= 1.0;
+    bool const acid = acid_content >= 1.0;
     return w_point{ T, H, P, W, wind_desc, current_winddir, acid };
 }
 
@@ -205,34 +205,34 @@ int weather_generator::forecast_priority( const weather_type_id &w ) const
 const weather_type_id &weather_generator::get_weather_conditions( const tripoint &location,
         const time_point &t, unsigned seed ) const
 {
-    w_point w( get_weather( location, t, seed ) );
+    w_point const w( get_weather( location, t, seed ) );
     return get_weather_conditions( w );
 }
 
 const weather_type_id &weather_generator::get_weather_conditions( const w_point &w ) const
 {
-    w_point wp2 = w;
+    w_point const wp2 = w;
     const weather_type_id *current_conditions = &weather_type_id::NULL_ID();
     for( const weather_type_id &type : weather_types ) {
         const weather_requirements &wrequires = type->requirements;
-        weather_requirements rq2 = wrequires;
-        bool test_pressure =
+        weather_requirements const rq2 = wrequires;
+        bool const test_pressure =
             wrequires.pressure_max > w.pressure &&
             wrequires.pressure_min < w.pressure;
-        bool test_humidity =
+        bool const test_humidity =
             wrequires.humidity_max > w.humidity &&
             wrequires.humidity_min < w.humidity;
         if( ( wrequires.humidity_and_pressure && !( test_pressure && test_humidity ) ) ||
             ( !wrequires.humidity_and_pressure && !( test_pressure || test_humidity ) ) ) {
             continue;
         }
-        bool test_temperature =
+        bool const test_temperature =
             wrequires.temperature_max > units::to_fahrenheit( w.temperature ) &&
             wrequires.temperature_min < units::to_fahrenheit( w.temperature );
-        bool test_windspeed =
+        bool const test_windspeed =
             wrequires.windpower_max > w.windpower &&
             wrequires.windpower_min < w.windpower;
-        bool test_acidic = !wrequires.acidic || w.acidic;
+        bool const test_acidic = !wrequires.acidic || w.acidic;
         if( !( test_temperature && test_windspeed && test_acidic ) ) {
             continue;
         }
@@ -245,7 +245,7 @@ const weather_type_id &weather_generator::get_weather_conditions( const w_point 
         }
 
         if( wrequires.time != weather_time_requirement_type::both ) {
-            bool day = is_day( calendar::turn );
+            bool const day = is_day( calendar::turn );
             if( ( wrequires.time == weather_time_requirement_type::day && !day ) ||
                 ( wrequires.time == weather_time_requirement_type::night && day ) ) {
                 continue;
@@ -280,7 +280,7 @@ int weather_generator::get_wind_direction( const season_type season ) const
 int weather_generator::convert_winddir( const int inputdir ) const
 {
     // Convert from discrete distribution output to angle
-    float finputdir = inputdir * 22.5;
+    float const finputdir = inputdir * 22.5;
     return static_cast<int>( finputdir );
 }
 
@@ -308,7 +308,7 @@ units::temperature weather_generator::get_water_temperature(
                                             0_c,
                                             [this, location, time, seed, calendar_config]( units::temperature acc,
     const std::pair<time_duration, double> &pr ) {
-        units::temperature weather_temperature =
+        units::temperature const weather_temperature =
             get_weather_temperature( location, time - pr.first, calendar_config, seed );
         return acc + multiply_any_unit( weather_temperature, pr.second );
     } );
@@ -339,10 +339,10 @@ void weather_generator::test_weather( unsigned seed = 1000 ) const
         const time_point begin = calendar::turn;
         const time_point end = begin + 2 * calendar::year_length();
         for( time_point i = begin; i < end; i += 20_minutes ) {
-            w_point w = get_weather( tripoint_zero, i, seed );
+            w_point const w = get_weather( tripoint_zero, i, seed );
             const weather_type_id &conditions = get_weather_conditions( w );
 
-            int year = to_turns<int>( i - calendar::turn_zero ) / to_turns<int>
+            int const year = to_turns<int>( i - calendar::turn_zero ) / to_turns<int>
                        ( calendar::year_length() ) + 1;
             const int hour = hour_of_day<int>( i );
             const int minute = minute_of_hour<int>( i );
@@ -396,7 +396,7 @@ weather_generator weather_generator::load( const JsonObject &jo )
 
     weather_generator ret;
 
-    float base_temp = jo.get_float( "base_temperature", 0.0 );
+    float const base_temp = jo.get_float( "base_temperature", 0.0 );
     // Handling legacy temperature settings
     // Don't handle legacy settings in strict mode, let it error
     if( !json_report_strict ) {

--- a/src/weather_type.cpp
+++ b/src/weather_type.cpp
@@ -141,7 +141,7 @@ void weather_type::load( const JsonObject &jo, const std::string & )
 
     for( const JsonObject weather_effect : jo.get_array( "effects" ) ) {
 
-        std::pair<std::string, int> pair = std::make_pair( weather_effect.get_string( "name" ),
+        std::pair<std::string, int> const pair = std::make_pair( weather_effect.get_string( "name" ),
                                            weather_effect.get_int( "intensity" ) );
 
         static const std::map<std::string, weather_effect_fn> all_weather_effects = {
@@ -160,7 +160,7 @@ void weather_type::load( const JsonObject &jo, const std::string & )
 
     if( jo.has_member( "animation" ) ) {
         animation = {};
-        JsonObject j = jo.get_object( "animation" );
+        JsonObject const j = jo.get_object( "animation" );
 
         mandatory( j, was_loaded, "factor", animation.factor );
         mandatory( j, was_loaded, "tile", animation.tile );
@@ -170,7 +170,7 @@ void weather_type::load( const JsonObject &jo, const std::string & )
 
     if( jo.has_member( "requirements" ) ) {
         requirements = {};
-        JsonObject j = jo.get_object( "requirements" );
+        JsonObject const j = jo.get_object( "requirements" );
 
         optional( j, was_loaded, "pressure_min", requirements.pressure_min, INT_MIN );
         optional( j, was_loaded, "pressure_max", requirements.pressure_max, INT_MAX );

--- a/src/weather_type.cpp
+++ b/src/weather_type.cpp
@@ -142,7 +142,7 @@ void weather_type::load( const JsonObject &jo, const std::string & )
     for( const JsonObject weather_effect : jo.get_array( "effects" ) ) {
 
         std::pair<std::string, int> const pair = std::make_pair( weather_effect.get_string( "name" ),
-                                           weather_effect.get_int( "intensity" ) );
+                weather_effect.get_int( "intensity" ) );
 
         static const std::map<std::string, weather_effect_fn> all_weather_effects = {
             { "wet", &weather_effect::wet_player },

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -210,7 +210,7 @@ class wish_mutate_callback: public uilist_callback
                 line2 += 2;
 
                 std::vector<std::string> const desc = foldstring( mdata.desc(),
-                                                menu->pad_right - 1 );
+                                                      menu->pad_right - 1 );
                 for( auto &elem : desc ) {
                     mvwprintz( menu->window, point( startx, line2 ), c_light_gray, elem );
                     line2++;
@@ -476,7 +476,7 @@ class wish_monster_callback: public uilist_callback
 
         void refresh( uilist *menu ) override {
             catacurses::window const w_info = catacurses::newwin( menu->w_height - 2, menu->pad_right,
-                                        point( menu->w_x + menu->w_width - 1 - menu->pad_right, 1 ) );
+                                              point( menu->w_x + menu->w_width - 1 - menu->pad_right, 1 ) );
             const std::string padding = std::string( getmaxx( w_info ), ' ' );
 
             const int entnum = menu->selected;
@@ -498,7 +498,7 @@ class wish_monster_callback: public uilist_callback
                 tmp.print_info( w_info, 2, 5, 1 );
 
                 std::string const header = string_format( "#%d: %s (%d)%s", entnum, tmp.type->nname(),
-                                                    group, hallucination ? _( " (hallucination)" ) : "" );
+                                           group, hallucination ? _( " (hallucination)" ) : "" );
                 mvwprintz( w_info, point( ( getmaxx( w_info ) - utf8_width( header ) ) / 2, 0 ), c_cyan, header );
             }
 
@@ -862,7 +862,7 @@ void debug_menu::wishskill( player *p )
                 for( size_t skill_id = 0; skill_id < sorted_skills.size(); skill_id++ ) {
                     const Skill &skill = *sorted_skills[skill_id];
                     int const changeto = skmod != 0 ? p->get_skill_level( skill.ident() ) + skmod :
-                                   skset != -1 ? skset : origskills[skill_id];
+                                         skset != -1 ? skset : origskills[skill_id];
                     p->set_skill_level( skill.ident(), std::max( 0, changeto ) );
                     skmenu.entries[skill_id + skoffset].txt = string_format( _( "@ %d: %s  " ),
                             p->get_skill_level( skill.ident() ),

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -209,7 +209,7 @@ class wish_mutate_callback: public uilist_callback
                          );
                 line2 += 2;
 
-                std::vector<std::string> desc = foldstring( mdata.desc(),
+                std::vector<std::string> const desc = foldstring( mdata.desc(),
                                                 menu->pad_right - 1 );
                 for( auto &elem : desc ) {
                     mvwprintz( menu->window, point( startx, line2 ), c_light_gray, elem );
@@ -221,7 +221,7 @@ class wish_mutate_callback: public uilist_callback
 
             mvwprintz( menu->window, point( startx, menu->w_height - 3 ), c_green, msg );
             msg.clear();
-            input_context ctxt( menu->input_category );
+            input_context const ctxt( menu->input_category );
             mvwprintw( menu->window, point( startx, menu->w_height - 2 ),
                        _( "[%s] find, [%s] quit, [t] toggle base trait" ),
                        ctxt.get_desc( "FILTER" ), ctxt.get_desc( "QUIT" ) );
@@ -329,12 +329,12 @@ void debug_menu::wishbionics( Character &c )
     } );
 
     while( true ) {
-        units::energy power_level = c.get_power_level();
-        units::energy power_max = c.get_max_power_level();
-        size_t num_installed = c.get_bionics().size();
+        units::energy const power_level = c.get_power_level();
+        units::energy const power_max = c.get_max_power_level();
+        size_t const num_installed = c.get_bionics().size();
 
-        bool can_uninstall = num_installed > 0;
-        bool can_uninstall_all = can_uninstall || power_max > 0_J;
+        bool const can_uninstall = num_installed > 0;
+        bool const can_uninstall_all = can_uninstall || power_max > 0_J;
 
         uilist smenu;
         smenu.text += string_format(
@@ -355,7 +355,7 @@ void debug_menu::wishbionics( Character &c )
             case 0: {
                 uilist scbms;
                 for( size_t i = 0; i < cbm_items.size(); i++ ) {
-                    bool enabled = !c.has_bionic( cbm_items[i]->bionic->id );
+                    bool const enabled = !c.has_bionic( cbm_items[i]->bionic->id );
                     scbms.addentry( i, enabled, MENU_AUTOASSIGN, "%s", cbm_items[i]->nname( 1 ) );
                 }
                 scbms.query();
@@ -475,7 +475,7 @@ class wish_monster_callback: public uilist_callback
         }
 
         void refresh( uilist *menu ) override {
-            catacurses::window w_info = catacurses::newwin( menu->w_height - 2, menu->pad_right,
+            catacurses::window const w_info = catacurses::newwin( menu->w_height - 2, menu->pad_right,
                                         point( menu->w_x + menu->w_width - 1 - menu->pad_right, 1 ) );
             const std::string padding = std::string( getmaxx( w_info ), ' ' );
 
@@ -497,14 +497,14 @@ class wish_monster_callback: public uilist_callback
             if( valid_entnum ) {
                 tmp.print_info( w_info, 2, 5, 1 );
 
-                std::string header = string_format( "#%d: %s (%d)%s", entnum, tmp.type->nname(),
+                std::string const header = string_format( "#%d: %s (%d)%s", entnum, tmp.type->nname(),
                                                     group, hallucination ? _( " (hallucination)" ) : "" );
                 mvwprintz( w_info, point( ( getmaxx( w_info ) - utf8_width( header ) ) / 2, 0 ), c_cyan, header );
             }
 
             mvwprintz( w_info, point( 0, getmaxy( w_info ) - 3 ), c_green, msg );
             msg.clear();
-            input_context ctxt( menu->input_category );
+            input_context const ctxt( menu->input_category );
             mvwprintw( w_info, point( 0, getmaxy( w_info ) - 2 ),
                        _( "[%s] find, [f]riendly, [h]allucination, [i]ncrease group, [d]ecrease group, [%s] quit" ),
                        ctxt.get_desc( "FILTER" ), ctxt.get_desc( "QUIT" ) );
@@ -560,7 +560,7 @@ void debug_menu::wishmonster( const std::optional<tripoint> &p )
                     }
                     ++num_spawned;
                 }
-                input_context ctxt( wmenu.input_category );
+                input_context const ctxt( wmenu.input_category );
                 cb.msg = string_format( _( "Spawned %d monsters, choose another or [%s] to quit." ),
                                         num_spawned, ctxt.get_desc( "QUIT" ) );
                 if( num_spawned == 0 ) {
@@ -624,7 +624,7 @@ class wish_item_callback: public uilist_callback
             mvwhline( menu->window, point( startx, 1 ), ' ', menu->pad_right - 1 );
             const int entnum = menu->selected;
             if( entnum >= 0 && static_cast<size_t>( entnum ) < standard_itype_ids.size() ) {
-                item tmp( standard_itype_ids[entnum], calendar::turn );
+                item const tmp( standard_itype_ids[entnum], calendar::turn );
                 const std::string header = string_format( "#%d: %s%s%s", entnum,
                                            standard_itype_ids[entnum]->get_id().c_str(),
                                            incontainer ? _( " (contained)" ) : "",
@@ -632,8 +632,8 @@ class wish_item_callback: public uilist_callback
                 mvwprintz( menu->window, point( startx + ( menu->pad_right - 1 - utf8_width( header ) ) / 2, 1 ),
                            c_cyan, header );
 
-                std::vector<iteminfo> info = tmp.info();
-                std::string info_string = format_item_info( info, {} );
+                std::vector<iteminfo> const info = tmp.info();
+                std::string const info_string = format_item_info( info, {} );
                 fold_and_print( menu->window, point( startx, starty ), menu->pad_right - 1, c_light_gray,
                                 info_string );
             }
@@ -644,7 +644,7 @@ class wish_item_callback: public uilist_callback
             }
             mvwprintz( menu->window, point( startx, menu->w_height - 3 ), c_green, msg );
             msg.erase();
-            input_context ctxt( menu->input_category );
+            input_context const ctxt( menu->input_category );
             mvwprintw( menu->window, point( startx, menu->w_height - 2 ),
                        _( "[%s] find, [f] container, [F] flag, [E] everything, [%s] quit" ),
                        ctxt.get_desc( "FILTER" ), ctxt.get_desc( "QUIT" ) );
@@ -689,7 +689,7 @@ void debug_menu::wishitem( player *p, const tripoint &pos )
     wmenu.callback = &cb;
 
     for( size_t i = 0; i < opts.size(); i++ ) {
-        item ity( opts[i].second, calendar::start_of_cataclysm );
+        item const ity( opts[i].second, calendar::start_of_cataclysm );
         wmenu.addentry( i, true, 0, opts[i].first );
         mvwzstr &entry_extra_text = wmenu.entries[i].extratxt;
         entry_extra_text.txt = ity.symbol();
@@ -753,7 +753,7 @@ void debug_menu::wishitem( player *p, const tripoint &pos )
                     wmenu.ret = -1;
                 }
                 if( amount > 0 ) {
-                    input_context ctxt( wmenu.input_category );
+                    input_context const ctxt( wmenu.input_category );
                     cb.msg = string_format( _( "Wish granted.  Wish for more or hit [%s] to quit." ),
                                             ctxt.get_desc( "QUIT" ) );
                 }
@@ -796,7 +796,7 @@ void debug_menu::wishskill( player *p )
         origskills.push_back( level );
     }
 
-    shared_ptr_fast<ui_adaptor> skmenu_ui = skmenu.create_or_get_ui_adaptor();
+    shared_ptr_fast<ui_adaptor> const skmenu_ui = skmenu.create_or_get_ui_adaptor();
 
     do {
         skmenu.query();
@@ -861,7 +861,7 @@ void debug_menu::wishskill( player *p )
                 }
                 for( size_t skill_id = 0; skill_id < sorted_skills.size(); skill_id++ ) {
                     const Skill &skill = *sorted_skills[skill_id];
-                    int changeto = skmod != 0 ? p->get_skill_level( skill.ident() ) + skmod :
+                    int const changeto = skmod != 0 ? p->get_skill_level( skill.ident() ) + skmod :
                                    skset != -1 ? skset : origskills[skill_id];
                     p->set_skill_level( skill.ident(), std::max( 0, changeto ) );
                     skmenu.entries[skill_id + skoffset].txt = string_format( _( "@ %d: %s  " ),

--- a/src/wisheffect.cpp
+++ b/src/wisheffect.cpp
@@ -122,7 +122,7 @@ std::optional<time_duration> query_duration()
     wisheffect_state &last_val = uistate.debug_menu.effect;
     string_input_popup popup;
     popup.title( _( "Input new duration followed by unit (s, m, h, d)" ) );
-    std::string dur_string = popup.query_string();
+    std::string const dur_string = popup.query_string();
     if( !popup.confirmed() ) {
         return std::nullopt;
     }
@@ -180,9 +180,9 @@ class effect_select_callback : public uilist_callback
         }
 
         void refresh( uilist *menu ) override {
-            wisheffect_state &last_val = uistate.debug_menu.effect;
-            size_t selected = clamp<size_t>( menu->selected, 0, all_effects.size() - 1 );
-            input_context ctxt( menu->input_category );
+            wisheffect_state  const&last_val = uistate.debug_menu.effect;
+            size_t const selected = clamp<size_t>( menu->selected, 0, all_effects.size() - 1 );
+            input_context const ctxt( menu->input_category );
 
             const point start( menu->w_width - menu->pad_right, 3 );
             const int width = menu->w_width - start.x;
@@ -195,7 +195,7 @@ class effect_select_callback : public uilist_callback
                                  ? last_val.bodypart->name.translated().c_str()
                                  : "Global" );
 
-            time_duration dur = last_val.duration <= 0_seconds
+            time_duration const dur = last_val.duration <= 0_seconds
                                 ? eff_type->get_max_duration()
                                 : last_val.duration;
             ss << string_format( "[%s] <bold>Duration</bold>: %10d (max: %d)\n",
@@ -324,7 +324,7 @@ class effect_edit_callback : public uilist_callback
             if( submenu.ret >= 0 && submenu.ret < static_cast<int>( all_effects.size() ) ) {
                 const efftype_id eff_type = all_effects[static_cast<size_t>( submenu.ret )];
                 last_val.last_type_selected_index = submenu.ret;
-                time_duration duration = last_val.duration <= 0_seconds ? eff_type->get_max_duration() :
+                time_duration const duration = last_val.duration <= 0_seconds ? eff_type->get_max_duration() :
                                          last_val.duration;
                 c.add_effect( eff_type, duration, last_val.bodypart, last_val.intensity, last_val.force );
                 on_creature_changed();
@@ -343,7 +343,7 @@ class effect_edit_callback : public uilist_callback
                      uilist & ) {
             on_creature_changed();
             foreach_effect( c, meta[entnum], [&]( const effect & eff ) {
-                bool removed = c.remove_effect( eff.get_id(), eff.get_bp()->token );
+                bool const removed = c.remove_effect( eff.get_id(), eff.get_bp()->token );
                 if( !removed ) {
                     debugmsg( "Couldn't remove %s from %s",
                               eff.get_id().str(),
@@ -369,7 +369,7 @@ class effect_edit_callback : public uilist_callback
                 auto iter_to = std::find_if( meta.begin(), meta.end(), [bp]( const entry_data & ed ) {
                     return ed.body_part == *bp;
                 } );
-                size_t bp_index = std::distance( iter_to, meta.begin() ) % meta.size();
+                size_t const bp_index = std::distance( iter_to, meta.begin() ) % meta.size();
                 parent_menu.set_selected( bp_index );
             }
         }
@@ -443,7 +443,7 @@ void effect_edit_menu( Creature &c )
         size_t i = 0;
         const auto add_effect_entry = [&menu, &i]( const effect & eff ) {
             // TODO: Columns
-            std::string effect_description = string_format(
+            std::string const effect_description = string_format(
                                                  "- %s %d, %d s",
                                                  eff.get_id().str(),
                                                  eff.get_intensity(),

--- a/src/wisheffect.cpp
+++ b/src/wisheffect.cpp
@@ -180,7 +180,7 @@ class effect_select_callback : public uilist_callback
         }
 
         void refresh( uilist *menu ) override {
-            wisheffect_state  const&last_val = uistate.debug_menu.effect;
+            wisheffect_state  const &last_val = uistate.debug_menu.effect;
             size_t const selected = clamp<size_t>( menu->selected, 0, all_effects.size() - 1 );
             input_context const ctxt( menu->input_category );
 
@@ -196,8 +196,8 @@ class effect_select_callback : public uilist_callback
                                  : "Global" );
 
             time_duration const dur = last_val.duration <= 0_seconds
-                                ? eff_type->get_max_duration()
-                                : last_val.duration;
+                                      ? eff_type->get_max_duration()
+                                      : last_val.duration;
             ss << string_format( "[%s] <bold>Duration</bold>: %10d (max: %d)\n",
                                  ctxt.get_desc( "CHANGE_DURATION" ),
                                  to_turns<int>( dur ),
@@ -325,7 +325,7 @@ class effect_edit_callback : public uilist_callback
                 const efftype_id eff_type = all_effects[static_cast<size_t>( submenu.ret )];
                 last_val.last_type_selected_index = submenu.ret;
                 time_duration const duration = last_val.duration <= 0_seconds ? eff_type->get_max_duration() :
-                                         last_val.duration;
+                                               last_val.duration;
                 c.add_effect( eff_type, duration, last_val.bodypart, last_val.intensity, last_val.force );
                 on_creature_changed();
             }
@@ -444,10 +444,10 @@ void effect_edit_menu( Creature &c )
         const auto add_effect_entry = [&menu, &i]( const effect & eff ) {
             // TODO: Columns
             std::string const effect_description = string_format(
-                                                 "- %s %d, %d s",
-                                                 eff.get_id().str(),
-                                                 eff.get_intensity(),
-                                                 to_seconds<int>( eff.get_duration() ) );
+                    "- %s %d, %d s",
+                    eff.get_id().str(),
+                    eff.get_intensity(),
+                    to_seconds<int>( eff.get_duration() ) );
             menu.addentry( i++, true, 0, effect_description );
         };
         menu.addentry( i++, true, -1, _( "Global" ) );

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -696,7 +696,8 @@ void worldfactory::draw_mod_list( const catacurses::window &w, int &start, size_
             }
         }
 
-        int const larger = ( iMaxRows > static_cast<int>( iModNum ) ) ? static_cast<int>( iModNum ) : iMaxRows;
+        int const larger = ( iMaxRows > static_cast<int>( iModNum ) ) ? static_cast<int>
+                           ( iModNum ) : iMaxRows;
         for( auto iter = mods.begin(); iter != mods.end(); ) {
             if( iNum >= static_cast<size_t>( start ) && iNum < static_cast<size_t>( start + larger ) ) {
                 if( !mSortCategory[iNum].empty() ) {
@@ -1130,15 +1131,15 @@ int worldfactory::show_modselection_window( const catacurses::window &win,
         if( const MOD_INFORMATION *selmod = get_selected_mod() ) {
             // NOLINTNEXTLINE(cata-use-named-point-constants)
             int const num_lines = fold_and_print( w_description, point( 1, 0 ),
-                                            getmaxx( w_description ) - 1,
-                                            c_white, mman_ui->get_information( selmod ) );
+                                                  getmaxx( w_description ) - 1,
+                                                  c_white, mman_ui->get_information( selmod ) );
             auto window_height = catacurses::getmaxy( w_description );
             auto window_width = catacurses::getmaxx( w_description );
             if( num_lines > window_height ) {
                 // The description didn't fit in the window, so provide a
                 // hint for how to see the whole thing
                 std::string const message = string_format( _( "…%s = View full description " ),
-                                                     ctxt.get_desc( "VIEW_MOD_DESCRIPTION" ) );
+                                            ctxt.get_desc( "VIEW_MOD_DESCRIPTION" ) );
                 nc_color color = c_green;
                 print_colored_text( w_description, point( window_width - utf8_width( message ), window_height - 1 ),
                                     color, color, message );
@@ -1253,7 +1254,7 @@ int worldfactory::show_modselection_window( const catacurses::window &win,
                 ret_val<bool> const ret = mman_ui->try_add( to_add, active_mod_order );
                 if( !ret.success() ) {
                     std::string const msg = string_format( _( "Cannot add mod %s [%s].\n\n%s" ),
-                                                     to_add->name(), to_add, ret.str() );
+                                                           to_add->name(), to_add, ret.str() );
                     popup( msg );
                 }
             } else if( active_header == 1 && !active_mod_order.empty() ) {

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -286,13 +286,13 @@ void worldfactory::init()
         auto world_sav_files = get_files_from_path( SAVE_EXTENSION, world_dir, false );
         // split the save file names between the directory and the extension
         for( auto &world_sav_file : world_sav_files ) {
-            size_t save_index = world_sav_file.find( SAVE_EXTENSION );
+            size_t const save_index = world_sav_file.find( SAVE_EXTENSION );
             world_sav_file = world_sav_file.substr( world_dir.size() + 1,
                                                     save_index - ( world_dir.size() + 1 ) );
         }
         // the directory name is the name of the world
         std::string worldname;
-        size_t name_index = world_dir.find_last_of( "/\\" );
+        size_t const name_index = world_dir.find_last_of( "/\\" );
         worldname = world_dir.substr( name_index + 1 );
 
         // create and store the world
@@ -326,7 +326,7 @@ void worldfactory::init()
             const std::string origin_path = old_world.folder_path();
             // move files from origin_path into new world path
             for( auto &origin_file : get_files_from_path( ".", origin_path, false ) ) {
-                std::string filename = origin_file.substr( origin_file.find_last_of( "/\\" ) );
+                std::string const filename = origin_file.substr( origin_file.find_last_of( "/\\" ) );
 
                 rename( origin_file.c_str(), ( newworld->folder_path() + filename ).c_str() );
             }
@@ -478,9 +478,9 @@ WORLDPTR worldfactory::pick_world( bool show_prompt, bool empty_only )
             mvwprintz( w_worlds, point( 0, static_cast<int>( i ) ), c_white, "%d", i + 1 );
             wmove( w_worlds, point( 4, static_cast<int>( i ) ) );
 
-            std::string world_name = ( world_pages[selpage] )[i];
+            std::string const world_name = ( world_pages[selpage] )[i];
             WORLDPTR world = get_world( world_name );
-            size_t saves_num = world->world_saves.size();
+            size_t const saves_num = world->world_saves.size();
 
             std::string text = string_format( "%s (%d)", world_name, saves_num );
             nc_color col = c_white;
@@ -506,7 +506,7 @@ WORLDPTR worldfactory::pick_world( bool show_prompt, bool empty_only )
         for( size_t i = 0; i < num_pages; ++i ) {
             //skip empty pages
             if( !world_pages[i].empty() ) {
-                nc_color tabcolor = ( selpage == i ) ? hilite( c_white ) : c_white;
+                nc_color const tabcolor = ( selpage == i ) ? hilite( c_white ) : c_white;
                 wprintz( w_worlds_header, c_white, "[" );
                 wprintz( w_worlds_header, tabcolor, _( "Page %lu" ), i + 1 );
                 wprintz( w_worlds_header, c_white, "]" );
@@ -601,7 +601,7 @@ void worldfactory::load_last_world_info()
     }
 
     JsonIn jsin( *file );
-    JsonObject data = jsin.get_object();
+    JsonObject const data = jsin.get_object();
     last_world_name = data.get_string( "world_name" );
     last_character_name = data.get_string( "character_name" );
 }
@@ -696,7 +696,7 @@ void worldfactory::draw_mod_list( const catacurses::window &w, int &start, size_
             }
         }
 
-        int larger = ( iMaxRows > static_cast<int>( iModNum ) ) ? static_cast<int>( iModNum ) : iMaxRows;
+        int const larger = ( iMaxRows > static_cast<int>( iModNum ) ) ? static_cast<int>( iModNum ) : iMaxRows;
         for( auto iter = mods.begin(); iter != mods.end(); ) {
             if( iNum >= static_cast<size_t>( start ) && iNum < static_cast<size_t>( start + larger ) ) {
                 if( !mSortCategory[iNum].empty() ) {
@@ -957,7 +957,7 @@ int worldfactory::show_modselection_window( const catacurses::window &win,
         filter_pos = point( 2, TERMY - 8 );
         filter_view_len = iMinScreenWidth / 2 - 11;
         if( fpopup ) {
-            point inner_pos = filter_pos + point( 2, 0 );
+            point const inner_pos = filter_pos + point( 2, 0 );
             fpopup->window( win, inner_pos, inner_pos.x + filter_view_len );
         }
 
@@ -992,7 +992,7 @@ int worldfactory::show_modselection_window( const catacurses::window &win,
 
     const std::map<std::string, std::string> &cat_tab_map = get_mod_list_cat_tab();
     for( const mod_id &mod : mman->get_all_sorted() ) {
-        int cat_idx = mod->category.first;
+        int const cat_idx = mod->category.first;
         const std::string &cat_id = get_mod_list_categories()[cat_idx].first;
 
         std::string dest_tab = "tab_default";
@@ -1047,7 +1047,7 @@ int worldfactory::show_modselection_window( const catacurses::window &win,
                     continue;
                 }
                 if( !filter_str.empty() ) {
-                    std::string name = ( *mod ).name();
+                    std::string const name = ( *mod ).name();
                     if( !lcmatch( name, filter_str ) ) {
                         continue;
                     }
@@ -1090,7 +1090,7 @@ int worldfactory::show_modselection_window( const catacurses::window &win,
     // Also tries to keep cursor position, though it's rather imprecise
     // when multiple mods are added simultaneously.
     const auto recalc_after_add_remove = [&]() {
-        size_t sel = cursel[0];
+        size_t const sel = cursel[0];
         recalc_visible( current_filter, show_obsolete );
         if( active_header == 0 ) {
             const std::vector<mod_id> &current_tab_mods = all_tabs[iCurrentTab].mods;
@@ -1129,7 +1129,7 @@ int worldfactory::show_modselection_window( const catacurses::window &win,
 
         if( const MOD_INFORMATION *selmod = get_selected_mod() ) {
             // NOLINTNEXTLINE(cata-use-named-point-constants)
-            int num_lines = fold_and_print( w_description, point( 1, 0 ),
+            int const num_lines = fold_and_print( w_description, point( 1, 0 ),
                                             getmaxx( w_description ) - 1,
                                             c_white, mman_ui->get_information( selmod ) );
             auto window_height = catacurses::getmaxy( w_description );
@@ -1137,7 +1137,7 @@ int worldfactory::show_modselection_window( const catacurses::window &win,
             if( num_lines > window_height ) {
                 // The description didn't fit in the window, so provide a
                 // hint for how to see the whole thing
-                std::string message = string_format( _( "…%s = View full description " ),
+                std::string const message = string_format( _( "…%s = View full description " ),
                                                      ctxt.get_desc( "VIEW_MOD_DESCRIPTION" ) );
                 nc_color color = c_green;
                 print_colored_text( w_description, point( window_width - utf8_width( message ), window_height - 1 ),
@@ -1192,7 +1192,7 @@ int worldfactory::show_modselection_window( const catacurses::window &win,
         const std::string old_filter = current_filter;
         fpopup->text( current_filter );
 
-        ime_sentry sentry;
+        ime_sentry const sentry;
 
         // On next redraw, call resize callback which will configure how popup is rendered
         ui.mark_resize();
@@ -1222,11 +1222,11 @@ int worldfactory::show_modselection_window( const catacurses::window &win,
         const int prev_header = ( active_header == 0 ) ? 1 : 0;
 
         size_t selection = ( active_header == 0 ) ? cursel[0] : cursel[1];
-        size_t last_selection = selection;
+        size_t const last_selection = selection;
         size_t next_selection = selection + 1;
         size_t prev_selection = selection - 1;
         if( active_header == 0 ) {
-            size_t num_mods = all_tabs[iCurrentTab].mods.size();
+            size_t const num_mods = all_tabs[iCurrentTab].mods.size();
             next_selection = ( next_selection >= num_mods ) ? 0 : next_selection;
             prev_selection = ( prev_selection > num_mods ) ? num_mods - 1 : prev_selection;
         } else {
@@ -1250,9 +1250,9 @@ int worldfactory::show_modselection_window( const catacurses::window &win,
             if( active_header == 0 && !current_tab_mods.empty() ) {
                 // try-add
                 const mod_id &to_add = current_tab_mods[cursel[0]];
-                ret_val<bool> ret = mman_ui->try_add( to_add, active_mod_order );
+                ret_val<bool> const ret = mman_ui->try_add( to_add, active_mod_order );
                 if( !ret.success() ) {
-                    std::string msg = string_format( _( "Cannot add mod %s [%s].\n\n%s" ),
+                    std::string const msg = string_format( _( "Cannot add mod %s [%s].\n\n%s" ),
                                                      to_add->name(), to_add, ret.str() );
                     popup( msg );
                 }
@@ -1383,7 +1383,7 @@ int worldfactory::show_worldgen_tab_confirm( const catacurses::window &win, WORL
     std::string worldname = world->world_name;
 
     // do not switch IME mode now, but restore previous mode on return
-    ime_sentry sentry( ime_sentry::keep );
+    ime_sentry const sentry( ime_sentry::keep );
 
     ui.on_redraw( [&]( const ui_adaptor & ) {
         draw_worldgen_tabs( win, 2 );
@@ -1454,15 +1454,15 @@ int worldfactory::show_worldgen_tab_confirm( const catacurses::window &win, WORL
             const input_event ev = ctxt.get_raw_input();
             const int ch = ev.get_first_input();
             utf8_wrapper wrap( worldname );
-            utf8_wrapper newtext( ev.text );
+            utf8_wrapper const newtext( ev.text );
             if( ch == KEY_BACKSPACE ) {
                 if( !wrap.empty() ) {
                     wrap.erase( wrap.length() - 1, 1 );
                     worldname = wrap.str();
                 }
             } else if( ch == KEY_F( 2 ) ) {
-                std::string tmp = get_input_string_from_file();
-                int tmplen = utf8_width( tmp );
+                std::string const tmp = get_input_string_from_file();
+                int const tmplen = utf8_width( tmp );
                 if( tmplen > 0 && tmplen + utf8_width( worldname ) < 30 ) {
                     worldname.append( tmp );
                 }
@@ -1490,8 +1490,8 @@ void worldfactory::draw_modselection_borders( const catacurses::window &win,
     std::array<bool, 5> hv = {{true, true, true, false, false}}; // horizontal line = true, vertical line = false
 
     for( int i = 0; i < 5; ++i ) {
-        point p( xs[i], ys[i] );
-        int l = ls[i];
+        point const p( xs[i], ys[i] );
+        int const l = ls[i];
         if( hv[i] ) {
             for( int j = 0; j < l; ++j ) {
                 mvwputch( win, p + point( j, 0 ), BORDER_COLOR, LINE_OXOX ); // -
@@ -1543,7 +1543,7 @@ void worldfactory::draw_modselection_borders( const catacurses::window &win,
     strings.push_back( string_format(
                            _( "[<color_yellow>%s</color>] = keybindings" ),
                            ctxtp.get_desc( "HELP_KEYBINDINGS" ) ) );
-    std::string msg = join( strings, "  " );
+    std::string const msg = join( strings, "  " );
 
     fold_and_print( win, point( 2, TERMY - 7 ), getmaxx( win ) - 4, c_light_gray, msg );
     wnoutrefresh( win );
@@ -1597,7 +1597,7 @@ void WORLD::load_options( JsonIn &jsin )
 
     jsin.start_array();
     while( !jsin.end_array() ) {
-        JsonObject jo = jsin.get_object();
+        JsonObject const jo = jsin.get_object();
         jo.allow_omitted_members();
         const std::string name = opts.migrateOptionName( jo.get_string( "name" ) );
         const std::string value = opts.migrateOptionValue( jo.get_string( "name" ),
@@ -1618,7 +1618,7 @@ void WORLD::load_legacy_options( std::istream &fin )
     while( !fin.eof() ) {
         getline( fin, sLine );
         if( !sLine.empty() && sLine[0] != '#' && std::count( sLine.begin(), sLine.end(), ' ' ) == 1 ) {
-            size_t ipos = sLine.find( ' ' );
+            size_t const ipos = sLine.find( ' ' );
             // make sure that the option being loaded is part of the world_default page in OPTIONS
             // In 0.C some lines consisted of a space and nothing else
             const std::string name = opts.migrateOptionName( sLine.substr( 0, ipos ) );
@@ -1721,7 +1721,7 @@ static bool isForbidden( const std::string &candidate )
 
 void worldfactory::delete_world( const std::string &worldname, const bool delete_folder )
 {
-    std::string worldpath = get_world( worldname )->folder_path();
+    std::string const worldpath = get_world( worldname )->folder_path();
     std::set<std::string> directory_paths;
 
     auto file_paths = get_files_from_path( "", worldpath, true, true );


### PR DESCRIPTION
#### Summary

SUMMARY: Performance "Applied clang-tidy performance fixes"

#### Purpose of change

- make code robust by making [everything const if it can be](https://clang.llvm.org/extra/clang-tidy/checks/misc/const-correctness.html#misc-const-correctness)
- clang-tidy fixes for easy performance gain, notably [not copying array elements in loop](https://clang.llvm.org/extra/clang-tidy/checks/performance/for-range-copy.html)

#### Describe the solution

ran these in sufficient amount:

```sh
/bin/ls -1 src/*.cpp | rargs --threads 10 clang-tidy --fix --checks='-*,performance-<name>' {}
cd build && ninja -j 10 cataclysm-tiles cata_test-tiles
cd .. && ./cata_test
# systemctl suspend
```

#### Testing

local tests passes except:

```sh
[sol2] An exception occurred: Exception thrown on Cpp side!
[sol2] An error occurred and panic has been invoked: attempt to index a sol.custom_udata value

/home/scarf/repo/cata/Cataclysm/tests/vehicle_test.cpp:132: FAILED:
  CHECK( veh_ptr2->name == "Wreckage" )
with expansion:
  "обломки аварии" == "Wreckage"
with message:
  обломки аварии

/home/scarf/repo/cata/Cataclysm/tests/vehicle_test.cpp:132: FAILED:
  CHECK( veh_ptr2->name == "Wreckage" )
with expansion:
  "обломки аварии" == "Wreckage"
with message:
  обломки аварии

/home/scarf/repo/cata/Cataclysm/tests/vehicle_test.cpp:132: FAILED:
  CHECK( veh_ptr2->name == "Wreckage" )
with expansion:
  "обломки аварии" == "Wreckage"
with message:
  обломки аварии
```

#### Additional context

there's still lots of other auto-fixable performance checks, stay tuned?