### PR TITLE
Deconstructable Sewer pipes & pumps

### DIFF
--- a/data/json/furniture_and_terrain/terrain-manufactured.json
+++ b/data/json/furniture_and_terrain/terrain-manufactured.json
@@ -413,10 +413,7 @@
     "flags": [ "TRANSPARENT", "MOUNTABLE", "PERMEABLE", "THIN_OBSTACLE", "MINEABLE" ],
     "deconstruct": {
       "ter_set": "t_bridge",
-      "items": [
-        { "item": "scrap", "count": [ 4, 8 ] },
-        { "item": "steel_plate", "count": [ 0, 2 ] }
-      ]
+      "items": [ { "item": "scrap", "count": [ 4, 8 ] }, { "item": "steel_plate", "count": [ 0, 2 ] } ]
     },
     "bash": {
       "str_min": 30,

--- a/data/json/furniture_and_terrain/terrain-manufactured.json
+++ b/data/json/furniture_and_terrain/terrain-manufactured.json
@@ -411,6 +411,13 @@
     "move_cost": 0,
     "coverage": 50,
     "flags": [ "TRANSPARENT", "MOUNTABLE", "PERMEABLE", "THIN_OBSTACLE", "MINEABLE" ],
+    "deconstruct": {
+      "ter_set": "t_bridge",
+      "items": [
+        { "item": "scrap", "count": [ 4, 8 ] },
+        { "item": "steel_plate", "count": [ 0, 2 ] }
+      ]
+    },
     "bash": {
       "str_min": 30,
       "str_max": 210,
@@ -431,6 +438,14 @@
     "move_cost": 0,
     "coverage": 50,
     "flags": [ "NOITEM", "REDUCE_SCENT", "MOUNTABLE" ],
+    "deconstruct": {
+      "ter_set": "t_bridge",
+      "items": [
+        { "item": "steel_lump", "count": [ 0, 1 ] },
+        { "item": "steel_chunk", "count": [ 1, 4 ] },
+        { "item": "scrap", "count": [ 3, 7 ] }
+      ]
+    },
     "bash": {
       "str_min": 20,
       "str_max": 150,


### PR DESCRIPTION
#### Summary

SUMMARY: [Balance] "Sewage pipes and pumps are deconstructable into their bash products"

#### Purpose of change

Sewer pipes and sewer pumps have no deconstruct, but they're just steel with some pipe fittings, so this lets you deconstruct them.

#### Describe the solution

I used the exact bash products to be safe. If we should up the steel amount I leave that to a maintainer to balance as this is going to add a lot of steel platings in the sewers now. I also set the deconstruct terrain to the bridges in the sewers as you're not bashing the pipe to scrap so it should maintain structural integrity underneath. 

This gives you more reason to go into sewers and allows us to put these sewer connections in the way of building basements for urban development but still let you access the sewers with just tools and not bashing or mining. This source of steel shouldn't be too powerful as so much other stuff gives tons of steel including car wrecks.

#### Describe alternatives you've considered

More Steel. Less Steel. Hacksaw instead. Keeping them mineable even though that is horrible.

#### Testing

Loaded in game and both deconstructs worked as expected.

#### Additional context

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/112293514/e9246722-b46f-48b9-9e9e-3566bec85051)

