### PR TITLE
Improve behavior if on first game start SDL window creation fails

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -660,6 +660,7 @@ int main( int argc, char *argv[] )
 #if !defined(TILES)
     get_options().init();
     get_options().load();
+    get_options().save();
     set_language(); // Have to set locale before initializing ncurses
 #endif
 

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3520,6 +3520,7 @@ void catacurses::init_interface()
 
     get_options().init();
     get_options().load();
+    get_options().save();
 
     font_loader fl;
     fl.load();


### PR DESCRIPTION
#### Summary
SUMMARY: Infrastructure "Improve behavior if on first game start SDL window creation fails"

#### Purpose of change
If on first game launch SDL failed to initialize window for some reason, `options.json` is not created, so it is impossible to tweak the values to make the game run.

#### Describe the solution
Create new `options.json` file as soon as possible, so the players can at least manually tweak values there in case the game experiences issues with window initialization.

#### Describe alternatives you've considered
Figuring out why we can't have backtraces when the game crashes inside SDL code.

#### Testing
Added a mock `std::abort()` in `WinCreate`.
Before: when running the game, it crashes, produces no `options.json`.
After: when running the game, it crashes, but produces `options.json`.