### PR TITLE
Balance: Make SPAM less terrible

### DIFF
--- a/data/json/items/comestibles/meat_dishes.json
+++ b/data/json/items/comestibles/meat_dishes.json
@@ -467,7 +467,7 @@
     "volume": "500 ml",
     "charges": 6,
     "flags": [ "EATEN_HOT" ],
-    "fun": -8,
+    "fun": -2,
     "vitamins": [ [ "iron", 3 ] ]
   },
   {

--- a/tests/basecamp_test.cpp
+++ b/tests/basecamp_test.cpp
@@ -148,17 +148,17 @@ TEST_CASE( "distribute_food" )
                  canned_status::canned_sealed, canned_status::canned_unsealed
              } ) {
             const int previous_kcal = yours->food_supply;
-            const item can_of_spam = make_food( itype_id( "can_spam" ), 1, status, false );
-            g->m.add_item_or_charges( origin, can_of_spam, false );
+            const item can_of_dogfood = make_food( itype_id( "dogfood" ), 1, status, false );
+            g->m.add_item_or_charges( origin, can_of_dogfood, false );
             bcp->distribute_food();
             CHECK( yours->food_supply == previous_kcal );
             const map_stack stack = g->m.i_at( origin );
             CHECK( stack.size() == 1 );
             CHECK( std::all_of( stack.begin(), stack.end(),
-            [&can_of_spam]( const item & it ) {
-                return it.typeId() == can_of_spam.typeId() && it.count() == 1
-                       && it.contents.front().typeId() == can_of_spam.contents.front().typeId()
-                       && it.contents.front().count() == can_of_spam.contents.front().count();
+            [&can_of_dogfood]( const item & it ) {
+                return it.typeId() == can_of_dogfood.typeId() && it.count() == 1
+                       && it.contents.front().typeId() == can_of_dogfood.contents.front().typeId()
+                       && it.contents.front().count() == can_of_dogfood.contents.front().count();
             } ) );
             g->m.i_clear( origin );
         }


### PR DESCRIPTION
#### Summary

SUMMARY: [Balance] "Lowered SPAM morale penalty"

#### Purpose of change

As it stands, SPAM has a fun value of -8, which is even worse than the canonically awful-tasting protein rations. Notably, potted meat, a very similar item, has +1, while fried SPAM has +8. 
-8 is the same amount as... cooked brains. A benign item like this really doesn't warrant such a harsh penalty for consumption, in my opinion.

#### Describe the solution

Lowered the penalty to -2. While still unpleasant, it won't immediately ruin a character's day.

#### Describe alternatives you've considered

Maybe lower the penalty slightly less. Maybe even remove it entirely! Or just... leave it as is, I suppose.

#### Testing

Changed the value, loaded game, ate, gave -2.

#### Additional context

It's really not that bad.
Also, the description still lists it as being "unnaturally pink, oddly rubbery, and not very tasty" and "completely unappetizing," but eh.