### PR TITLE
Rebalanced shotgun shells

### DIFF
--- a/data/json/items/ammo/shot.json
+++ b/data/json/items/ammo/shot.json
@@ -60,8 +60,8 @@
     "stack_size": 20,
     "ammo_type": "shot",
     "casing": "shot_hull",
-    "range": 12,
-    "damage": { "damage_type": "bullet", "amount": 50 },
+    "range": 20,
+    "damage": { "damage_type": "bullet", "amount": 100, "armor_multiplier": 2.0 },
     "recoil": 2500,
     "loudness": 160,
     "effects": [ "COOKOFF", "SHOT" ]
@@ -96,10 +96,10 @@
     "price": 100,
     "price_postapoc": 400,
     "range": 0,
-    "damage": { "damage_type": "bullet", "amount": 20, "armor_multiplier": 2.0 },
+    "damage": { "damage_type": "bullet", "amount": 100, "armor_multiplier": 3.0 },
     "dispersion": 1000,
     "loudness": 80,
-    "shape": [ "cone", { "half_angle": 15, "length": 8 } ],
+    "shape": [ "cone", { "half_angle": 15, "length": 15 } ],
     "extend": { "effects": [ "NOGIB" ] }
   },
   {
@@ -111,10 +111,10 @@
     "price": 1000,
     "price_postapoc": 1600,
     "flags": [ "IRREPLACEABLE_CONSUMABLE" ],
-    "damage": { "damage_type": "heat", "amount": 10 },
+    "damage": { "damage_type": "heat", "amount": 30 },
     "proportional": { "recoil": 0.6, "loudness": 0.8, "dispersion": 1.2 },
     "range": 0,
-    "shape": [ "cone", { "half_angle": 15, "length": 8 } ],
+    "shape": [ "cone", { "half_angle": 15, "length": 15 } ],
     "extend": { "effects": [ "INCENDIARY", "STREAM", "NOGIB" ] }
   },
   {
@@ -128,7 +128,7 @@
     "flags": [ "IRREPLACEABLE_CONSUMABLE" ],
     "count": 10,
     "//": "Balanced as standard AP.",
-    "relative": { "damage": { "damage_type": "bullet", "amount": -15, "armor_penetration": 30 } }
+    "relative": { "damage": { "damage_type": "bullet", "amount": -30, "armor_penetration": 30, "armor_multiplier": -1.0 } }
   },
   {
     "id": "shot_he",
@@ -141,7 +141,7 @@
     "price_postapoc": 1600,
     "flags": [ "IRREPLACEABLE_CONSUMABLE" ],
     "count": 5,
-    "damage": { "damage_type": "bullet", "amount": 10, "armor_penetration": 0 },
+    "damage": { "damage_type": "bullet", "amount": 30, "armor_penetration": 0 },
     "extend": { "effects": [ "EXPLOSIVE" ] }
   },
   {
@@ -172,9 +172,9 @@
     "price": 400,
     "price_postapoc": 400,
     "flags": [ "IRREPLACEABLE_CONSUMABLE" ],
-    "dispersion": 100,
+    "dispersion": 80,
     "//": "Balanced as FMJ",
-    "relative": { "range": 12, "damage": { "damage_type": "bullet", "amount": -10, "armor_penetration": 18 } },
+    "relative": { "range": 12, "damage": { "damage_type": "bullet", "amount": -15, "armor_penetration": 18, "armor_multiplier": -1.0 } },
     "proportional": { "recoil": 1.4 },
     "delete": { "effects": [ "SHOT" ] }
   }

--- a/data/json/items/gun/monster_gun.json
+++ b/data/json/items/gun/monster_gun.json
@@ -78,8 +78,8 @@
     "weight": "3402 g",
     "volume": "2450 ml",
     "bashing": 3,
-    "dispersion": 3250,
-    "range": 65,
+    "dispersion": 6500,
+    "range": 30,
     "durability": 9
   },
   {


### PR DESCRIPTION
#### Summary

SUMMARY: [Balance] "Buffed shotgun shells, nerfed feral biker shotgun."

#### Purpose of change

Shotgun shells were fairly underpowered, doing barely any more damage than a 9mm round and with even less range.

#### Describe the solution

Shotguns are now able to hit much harder and much further, but have an armor multiplier now to compensate; the feral biker's shotgun has had its dispersion and range decreased to compensate.

#### Describe alternatives you've considered

I'm not really sure what alternatives to take, to be honest. Shotguns as-is are weak, inaccurate, and ridiculously short-ranged, making them a genuinely inferior option compared to even a 9mm pistol, let alone a submachine gun.

#### Testing

The json checks out, and I did some basic testing of the shells themselves; the range feels good, albeit perhaps a bit _too_ good, and the power is strong enough to oneshot basic zombies but is much weaker against armored foes unless you use flechette shells or slugs, which are designed to be weaker in raw damage but be far more effective against armor.

#### Additional context

I'd definitely appreciate any input on the full balance, but I think I did a fairly good job.
