### PR TITLE
fix: allow speedloader capacity to be smaller than gun's

### DIFF
--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1440,9 +1440,9 @@ void Item_factory::check_definitions() const
                 } else if( !mag_ptr->magazine->type.count( ammo_variety.first ) ) {
                     msg += string_format( "magazine \"%s\" does not take compatible ammo\n", magazine );
                 } else if( mag_ptr->has_flag( "SPEEDLOADER" ) &&
-                           mag_ptr->magazine->capacity != type->gun->clip ) {
+                           mag_ptr->magazine->capacity > type->gun->clip ) {
                     msg += string_format(
-                               "speedloader %s capacity (%d) does not match gun capacity (%d).\n",
+                               "speedloader %s capacity (%d) is bigger than gun capacity (%d).\n",
                                magazine.str(), mag_ptr->magazine->capacity, type->gun->clip );
                 }
             }


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Allowed speedloader capacity to be smaller than gun's capacity"

#### Purpose of change

original discussion: https://discord.com/channels/830879262763909202/830916415182733322/1150400794189889606

e.g it should be ok to use a 4-rounds speedloader for shotgun of 8-rounds capacity.

#### Describe the solution

changed the condition from `speedloader capacity != gun capacity` to `speedloader capacity > gun capacity`

#### Describe alternatives you've considered

remove the check altogether? tho using 20-rounds speedloader for shotgun of 8-rounds capacity might be weird.

#### Testing

local tests passed.
