### PR TITLE
feat: apply `NUTRIENT_OVERRIDE` for recipes

### DIFF
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1027,6 +1027,7 @@ void complete_craft( player &p, item &craft, const bench_location & )
     const int batch_size = craft.charges;
     std::list<item> &used = craft.components;
     const double relative_rot = craft.get_relative_rot();
+    const bool ignore_component = making.has_flag( flag_NUTRIENT_OVERRIDE );
 
     // Set up the new item, and assign an inventory letter if available
     std::vector<item> newits = making.create_results( batch_size );
@@ -1079,10 +1080,15 @@ void complete_craft( player &p, item &craft, const bench_location & )
             food_contained.unset_flag( flag );
         }
 
-        // Don't store components for things made by charges,
-        // Don't store components for things that can't be uncrafted.
-        if( recipe_dictionary::get_uncraft( making.result() ) && !food_contained.count_by_charges() &&
-            making.is_reversible() ) {
+        // Don't store components for things that ignores components (e.g wow 'conjured bread')
+        if( ignore_component ) {
+            food_contained.set_flag( flag_NUTRIENT_OVERRIDE );
+        } else if( recipe_dictionary::get_uncraft( making.result() ) &&
+                   !food_contained.count_by_charges() &&
+                   making.is_reversible() ) {
+            // Don't store components for things made by charges,
+            // Don't store components for things that can't be uncrafted.
+
             // Setting this for items counted by charges gives only problems:
             // those items are automatically merged everywhere (map/vehicle/inventory),
             // which would either lose this information or merge it somehow.


### PR DESCRIPTION
#### Summary


SUMMARY: Mods "Allow recipes to declare `NUTRIENT_OVERRIDE` flag to ignore components used"

#### Purpose of change

- fix #3025

#### Describe the solution

added `NUTRIENT_OVERRIDE` flag check for recipes. it will propagate the flag to items, also ignoring any components.

#### Describe alternatives you've considered

- make it a separate flag, e.g `NUTRIENT_IGNORE_COMPONENTS` to distinguish it with items?
- do not discard components?

#### Testing

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/f6744b1d-d488-461e-a684-14b68eee2f81

```json
{
  "type": "recipe",
  "result": "carrot",
  "id_suffix": "WithRocks",
  "category": "CC_FOOD",
  "subcategory": "CSC_FOOD_VEGGI",
  "skill_used": "cooking",
  "time": "1 s",
  "result_mult": 1,
  "batch_time_factors": [ 80, 2 ],
  "autolearn": true,
  "components": [ [ [ "rock", 2 ] ] ],
  "flags": ["NUTRIENT_OVERRIDE"]
}
```
conjured carrot from rock. eating it increased body kcal.