### PR TITLE
Move makeshift glaive from tools to weapons

### DIFF
--- a/data/json/items/melee/spears_and_polearms.json
+++ b/data/json/items/melee/spears_and_polearms.json
@@ -316,6 +316,27 @@
     "flags": [ "DURABLE_MELEE", "NONCONDUCTIVE", "POLEARM", "SHEATH_SPEAR", "REACH_ATTACK", "ALWAYS_TWOHAND" ]
   },
   {
+    "id": "makeshift_halberd",
+    "type": "GENERIC",
+    "category": "weapons",
+    "name": { "str": "makeshift glaive" },
+    "//": "Name changed to glaive, but changing the id would break e.g.  tilesets.",
+    "description": "This is a large blade attached to a long stick.  It could do a considerable amount of damage.",
+    "weight": "1800 g",
+    "volume": "3 L",
+    "price": 5000,
+    "price_postapoc": 250,
+    "to_hit": 2,
+    "bashing": 13,
+    "cutting": 36,
+    "material": [ "steel", "wood" ],
+    "symbol": "/",
+    "color": "light_gray",
+    "techniques": "WBLOCK_1",
+    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", -42 ] ],
+    "flags": [ "REACH_ATTACK", "POLEARM", "NONCONDUCTIVE", "SHEATH_SPEAR", "FRAGILE_MELEE" ]
+  },
+  {
     "id": "glaive",
     "type": "GENERIC",
     "category": "weapons",

--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -512,27 +512,6 @@
     "use_action": "WATER_PURIFIER"
   },
   {
-    "id": "makeshift_halberd",
-    "type": "GENERIC",
-    "category": "tools",
-    "name": { "str": "makeshift glaive" },
-    "//": "Name changed to glaive, but changing the id would break e.g.  tilesets.",
-    "description": "This is a large blade attached to a long stick.  It could do a considerable amount of damage.",
-    "weight": "1800 g",
-    "volume": "3 L",
-    "price": 5000,
-    "price_postapoc": 250,
-    "to_hit": 2,
-    "bashing": 13,
-    "cutting": 36,
-    "material": [ "steel", "wood" ],
-    "symbol": "/",
-    "color": "light_gray",
-    "techniques": "WBLOCK_1",
-    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", -42 ] ],
-    "flags": [ "REACH_ATTACK", "POLEARM", "NONCONDUCTIVE", "SHEATH_SPEAR", "FRAGILE_MELEE" ]
-  },
-  {
     "type": "GENERIC",
     "category": "tools",
     "id": "mind_splicer",


### PR DESCRIPTION
#### Summary

SUMMARY: [Infrastructure] "json Move makeshift glaive from tools category to weapons category"

#### Purpose of change

Makeshift glaives don't have any tool-like uses, only weapon-like uses.

#### Describe the solution

This just changes the category of the makeshift glaive and moves the json to the appropriate file.

#### Describe alternatives you've considered

Ignoring it.

#### Testing

Loaded the game after making the change, confirmed the item shows up in the correct category on the advanced inventory management menu.

#### Additional context
