### PR TITLE
Warn when running x32 game on x64 system

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -1837,7 +1837,7 @@ std::optional<int> get_os_bitness()
             // FIXME: other architectures?
             break;
     }
-#elif defined(__linux__)
+#elif defined(__linux__) && !defined(__ANDROID__)
     std::string output;
     output = shell_exec( "getconf LONG_BIT" );
 

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -114,7 +114,7 @@ static bool capturing = false;
 static std::string captured;
 
 
-#if defined(_WIN32) and defined(LIBBACKTRACE)
+#if defined(_WIN32) && defined(LIBBACKTRACE)
 // Get the image base of a module from its PE header
 static uintptr_t get_image_base( const char *const path )
 {

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -685,7 +685,8 @@ void DebugFile::init( DebugOutput output_mode, const std::string &filename )
                        filename.c_str(), std::ios::out | std::ios::app );
             *file << "\n\n-----------------------------------------\n";
             *file << get_time() << " : Starting log.\n";
-            DebugLog( DL::Info, DC::Main ) << "Cataclysm BN version " << getVersionString();
+            DebugLog( DL::Info, DC::Main ) << "Cataclysm BN version " << getVersionString() << " " <<
+                                           game_info::bitness_string();
             if( rename_failed ) {
                 DebugLog( DL::Info, DC::Main ) << "Moving the previous log file to "
                                                << oldfile << " failed.\n"

--- a/src/debug.h
+++ b/src/debug.h
@@ -48,6 +48,7 @@
 // Includes                                                         {{{1
 // ---------------------------------------------------------------------
 #include <iostream>
+#include <optional>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -110,9 +111,12 @@ std::string operating_system();
 /** Return a detailed version of the operating system; e.g. "Ubuntu 18.04" or "(Windows) 10 1809".
  */
 std::string operating_system_version();
-/** Return the "bitness" of the game (not necessarily of the operating system); either: 64-bit, 32-bit or Unknown.
+/** Return the "bitness" of the game (not necessarily of the operating system); either: 64, 32 or nullopt.
  */
-std::string bitness();
+std::optional<int> bitness();
+/** Return the "bitness" string of the game (not necessarily of the operating system); either: 64-bit, 32-bit or Unknown.
+ */
+std::string bitness_string();
 /** Return the game version, as in the entry screen.
  */
 std::string game_version();
@@ -239,6 +243,11 @@ std::string capture_debugmsg_during( const std::function<void()> &func );
  * If catacurses::stdscr is available, shows all buffered debugmsg prompts.
  */
 void replay_buffered_debugmsg_prompts();
+
+/**
+ * Retrieves OS bitness (32, 64 or nullopt if detection failed)
+ */
+std::optional<int> get_os_bitness();
 
 // Debug Only                                                       {{{1
 // ---------------------------------------------------------------------

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -604,6 +604,21 @@ bool main_menu::opening_screen()
         return false;
     }
 
+    std::optional<int> os_bitness = get_os_bitness();
+    std::optional<int> game_bitness = game_info::bitness();
+    if( os_bitness && *os_bitness == 64 && game_bitness && *game_bitness == 32 ) {
+        popup( _(
+                   "You are running x32 build of the game on a x64 operating system.  "
+                   "This means the game will NOT be able to access all memory, "
+                   "and you may experience random out-of-memory crashes.  "
+                   "Consider obtaining a x64 build of the game to avoid that, "
+                   "but if you *really* want to be running x32 build of the game "
+                   "for some reason (or don't have a choice), you may want to lower "
+                   "your memory usage by disabling tileset, soundpack and mods "
+                   "and increasing autosave frequency."
+               ) );
+    }
+
     load_char_templates();
 
     ctxt.register_cardinal();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++ and Markdown: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md

!!!!!!!!!! WARNING !!!!!!!!!!

If you forget to format the PR, autofix.ci app will run automated format commit for you.
When this happens, YOU MUST DO EITHER OF THE FOLLOWING:

- Run `git pull` to merge the automated commit into your PR branch.
- Format your code locally, and force push to your PR branch. 

If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
-->

#### Summary
SUMMARY: Infrastructure "Warn when running x32 game on x64 system"

#### Purpose of change
Many people _still_ don't know the difference between x64 and x32, and it's getting old explaining what these mean when they come complaining about OOM crashes.

#### Describe the solution
Add a warning on game start that explains what's wrong and how it can be fixed.
The warning will show only when the game is completely sure it is a x32 build running on a x64 os; if detection fails, or cannot be done, the warning isn't shown to avoid false positives.
Additionally, the game will now report bitness in the debug log on launch.

#### Describe alternatives you've considered
Dropping x32 builds.

#### Testing
Warning shows properly on Windows with Visual Studio build (x32 and x64 builds on x64 os).
I didn't bother figuring out how to cross-compile for x32 on linux, but it should work as well.
