### PR TITLE
Fixed segfault caused by attitude check when monster shooting vehicle

### DIFF
--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -582,7 +582,7 @@ bool gun_actor::call( monster &z ) const
     }
 
     // One last check to make sure we're not firing on a friendly
-    if( z.attitude_to( *target ) == Creature::A_FRIENDLY ) {
+    if( target && z.attitude_to( *target ) == Creature::A_FRIENDLY ) {
         return false;
     }
     int dist = rl_dist( z.pos(), aim_at );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++ and Markdown: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md

!!!!!!!!!! WARNING !!!!!!!!!!

If you forget to format the PR, autofix.ci app will run automated format commit for you.
When this happens, YOU MUST DO EITHER OF THE FOLLOWING:

- Run `git pull` to merge the automated commit into your PR branch.
- Format your code locally, and force push to your PR branch. 

If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
-->

#### Summary
SUMMARY: Bugfixes "Fixed segfault caused by attitude check when monster shooting vehicle"

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

#### Purpose of change
When monster `target_moving_vehicles` it legitimely have nullptr `target`, and those `untargeted` shoots cause segfault due to friendliness check.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Added null check.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
Pointing author at issue so i don't need to fill exhausting surveys.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded bugged save, no more crashes.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
```
Thread 1 received signal SIGSEGV, Segmentation fault.
0x00007ff611faf9fc in monster::attitude_to (this=0x31d32840, other=...) at src/monster.cpp:1047
1047        const monster *m = other.is_monster() ? static_cast< const monster *>( &other ) : nullptr;
(gdb) p other
$1 = (const Creature &) <error reading variable: Cannot access memory at address 0x0>
(gdb) bt
#0  0x00007ff611faf9fc in monster::attitude_to (this=0x31d32840, other=...) at src/monster.cpp:1047
#1  0x00007ff611e9a0e0 in gun_actor::call (this=0x18d912e0, z=...) at src/mattack_actors.cpp:585
#2  0x00007ff611f976c7 in monster::move (this=0x31d32840) at src/monmove.cpp:751
#3  0x00007ff611a01f8b in game::monmove (this=0x914bd10) at src/game.cpp:4125
#4  0x00007ff6119eb6d9 in game::do_turn (this=0x914bd10) at src/game.cpp:1505
#5  0x00007ff611d87951 in main (argc=0, argv=0xb1fb8) at src/main.cpp:764
(gdb) f 1
#1  0x00007ff611e9a0e0 in gun_actor::call (this=0x18d912e0, z=...) at src/mattack_actors.cpp:585
585         if( z.attitude_to( *target ) == Creature::A_FRIENDLY ) {
(gdb) p untargeted
$2 = true
(gdb) p target_moving_vehicles
$3 = true
```
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
