### PR TITLE
Lua table serde: allow non-string types as table keys

### DIFF
--- a/src/catalua_impl.cpp
+++ b/src/catalua_impl.cpp
@@ -7,6 +7,8 @@
 #include "debug.h"
 #include "string_formatter.h"
 
+#include <cmath>
+#include <limits>
 #include <optional>
 #include <stdexcept>
 
@@ -182,9 +184,20 @@ bool compare_values( sol::object a, sol::object b )
     if( type == sol::type::thread ) {
         throw std::runtime_error( "Can't compare threads" );
     }
-    if( type == sol::type::number &&
-        is_number_integer( lua, a ) != is_number_integer( lua, b )
-      ) {
+    if( type == sol::type::number ) {
+        if( is_number_integer( lua, a ) != is_number_integer( lua, b ) ) {
+            return false;
+        }
+        if( is_number_integer( lua, a ) ) {
+            int num_a = a.as<int>();
+            int num_b = b.as<int>();
+            return num_a == num_b;
+        } else {
+            double num_a = a.as<double>();
+            double num_b = b.as<double>();
+            // FIXME: not suitable for all cases
+            return std::fabs( num_a - num_b ) < 0.0001;
+        }
         return false;
     }
     if( type == sol::type::userdata ) {

--- a/src/catalua_impl.h
+++ b/src/catalua_impl.h
@@ -31,4 +31,12 @@ void run_lua_script( sol::state &lua, const std::string &script_name );
 void run_console_input( sol::state &lua, const std::string &chunk );
 void check_func_result( sol::protected_function_result &res );
 
+// Numbers in Lua can be either integers or floating-point,
+// but you can't determine that with simple get_type()
+bool is_number_integer( sol::state_view lua, sol::object val );
+
+// Returns type name as registered with luna.
+// If type was not registered with luna, or the value is not a userdata, returns nullopt.
+std::optional<std::string> get_luna_type( sol::object val );
+
 #endif // CATA_SRC_CATALUA_IMPL_H

--- a/src/catalua_impl.h
+++ b/src/catalua_impl.h
@@ -39,4 +39,31 @@ bool is_number_integer( sol::state_view lua, sol::object val );
 // If type was not registered with luna, or the value is not a userdata, returns nullopt.
 std::optional<std::string> get_luna_type( sol::object val );
 
+/**
+ * Compare 2 Lua values for equality (by value).
+ *
+ * May contain unhandled cases, use with care.
+ */
+bool compare_values( sol::object a, sol::object b );
+
+/**
+ * Compare 2 Lua tables for equality (by value).
+ *
+ * May contain unhandled cases, use with care.
+ */
+bool compare_tables( sol::table a, sol::table b );
+
+/**
+ * @brief Find key of equivalent value in provided table.
+ *
+ * Since userdata and tables are compared by their reference when used as keys,
+ * if we want to find value with a different userdata instance
+ * we first need to find a key that is equal *by value* to the one we want to use.
+ *
+ * @param t table to search in for the key
+ * @param desired_key found key will be equal to this value
+ * @returns sol::nil on failure, key object from table \p t on success
+ */
+sol::object find_equivalent_key( sol::table t, sol::object desired_key );
+
 #endif // CATA_SRC_CATALUA_IMPL_H

--- a/src/catalua_serde.cpp
+++ b/src/catalua_serde.cpp
@@ -1,6 +1,7 @@
 #if defined(LUA)
 #include "catalua_serde.h"
 
+#include "catalua_impl.h"
 #include "catalua_sol.h"
 #include "debug.h"
 #include "json.h"
@@ -8,11 +9,81 @@
 
 #include <algorithm>
 #include <vector>
+#include <stdexcept>
+#include <utility>
 
 namespace cata
 {
-// Forward declaration to make g++ happy
 void serialize_lua_table_internal( sol::table t, JsonOut &jsout, std::vector<sol::table> &stack );
+
+static void serialize_lua_object( sol::object val, JsonOut &jsout, std::vector<sol::table> &stack )
+{
+    sol::state_view lua( val.lua_state() );
+
+    jsout.start_object();
+    switch( val.get_type() ) {
+        case sol::type::boolean: {
+            jsout.member_as_string( "type", "bool" );
+            jsout.member( "data" );
+            jsout.write( val.as<bool>() );
+            break;
+        }
+        case sol::type::number: {
+            // There's no clear difference in JSON between int and float,
+            // so we have to be explicit to avoid subtle errors down the line
+            if( is_number_integer( lua, val ) ) {
+                jsout.member_as_string( "type", "int" );
+                jsout.member( "data" );
+                jsout.write( val.as<int64_t>() );
+            } else {
+                jsout.member_as_string( "type", "float" );
+                jsout.member( "data" );
+                jsout.write( val.as<double>() );
+            }
+            break;
+        }
+        case sol::type::string: {
+            jsout.member_as_string( "type", "string" );
+            jsout.member( "data" );
+            jsout.write( val.as<std::string>() );
+            break;
+        }
+        case sol::type::table: {
+            jsout.member_as_string( "type", "lua_table" );
+            jsout.member( "data" );
+            serialize_lua_table_internal( val.as<sol::table>(), jsout, stack );
+            break;
+        }
+        case sol::type::userdata: {
+            std::optional<std::string> luna_type = get_luna_type( val );
+            if( !luna_type ) {
+                debugmsg( "Tried to serialize usertype that was not registered with luna." );
+                break;
+            }
+            sol::table table_val = val.as<sol::table>();
+            sol::protected_function serialize_func = table_val["serialize"];
+            if( !serialize_func ) {
+                debugmsg( "Tried to serialize usertype that does not allow serialization." );
+                break;
+            }
+            jsout.member_as_string( "type", "userdata" );
+            jsout.member_as_string( "kind", *luna_type );
+            jsout.member( "data" );
+            sol::protected_function_result res = serialize_func( val, jsout );
+            if( res.status() != sol::call_status::ok ) {
+                sol::error err = res;
+                debugmsg( "Failed to serialize type '%s': %s", *luna_type, err.what() );
+            }
+            break;
+        }
+        default: {
+            // TODO: throw error
+            debugmsg( "Unsupported type encountered when serializing Lua table." );
+            break;
+        }
+    }
+    jsout.end_object();
+}
 
 void serialize_lua_table_internal( sol::table t, JsonOut &jsout, std::vector<sol::table> &stack )
 {
@@ -27,134 +98,20 @@ void serialize_lua_table_internal( sol::table t, JsonOut &jsout, std::vector<sol
     stack.push_back( t );
 
     sol::state_view lua( t.lua_state() );
-
     jsout.start_object();
 
-    std::vector<std::string> keys;
+    if( !t.empty() ) {
+        jsout.member( "entries" );
+        jsout.start_array();
 
-    t.for_each( [&]( sol::object key_obj, sol::object /*val_obj*/ ) {
-        std::string key = key_obj.as<std::string>();
-        keys.push_back( key );
-    } );
+        // TODO: persistent key order?
+        t.for_each( [&]( sol::object key, sol::object val ) {
+            serialize_lua_object( key, jsout, stack );
+            serialize_lua_object( val, jsout, stack );
+        } );
 
-    std::sort( keys.begin(), keys.end() );
-
-    for( const std::string &key : keys ) {
-        jsout.member( key );
-        sol::object val = t[key];
-
-        switch( val.get_type() ) {
-            case sol::type::boolean: {
-                jsout.write( val.as<bool>() );
-                break;
-            }
-            case sol::type::number: {
-                // Horrible hack
-                sol::protected_function math_type = lua.script( "return math.type" );
-                if( !math_type ) {
-                    debugmsg( "Int/float serialization hack failed to acquare math.type" );
-                    jsout.write_null();
-                } else {
-                    sol::protected_function_result res = math_type( val );
-                    if( res.status() != sol::call_status::ok ) {
-                        sol::error err = res;
-                        debugmsg( "Int/float serialization hack failed to run math.type: %s", err.what() );
-                        jsout.write_null();
-                    } else {
-                        sol::object retval = res;
-                        if( !retval.valid() ) {
-                            debugmsg( "Int/float serialization hack returned invalid value" );
-                            jsout.write_null();
-                        } else {
-                            std::string mtype = res;
-                            // There's no clear difference in JSON between int and float,
-                            // so we have to be explicit to avoid subtle errors down the line
-                            if( mtype == "integer" ) {
-                                jsout.start_object();
-                                jsout.member_as_string( "type", "int" );
-                                jsout.member( "data" );
-                                jsout.write( val.as<int64_t>() );
-                                jsout.end_object();
-                            } else if( mtype == "float" ) {
-                                jsout.start_object();
-                                jsout.member_as_string( "type", "float" );
-                                jsout.member( "data" );
-                                jsout.write( val.as<double>() );
-                                jsout.end_object();
-                            } else {
-                                debugmsg( "Int/float serialization hack returned invalid value: %s", mtype );
-                                jsout.write_null();
-                            }
-                        }
-                    }
-                }
-                break;
-            }
-            case sol::type::string: {
-                jsout.write( val.as<std::string>() );
-                break;
-            }
-            case sol::type::table: {
-                jsout.start_object();
-                jsout.member_as_string( "type", "lua_table" );
-                jsout.member( "data" );
-                serialize_lua_table_internal( val.as<sol::table>(), jsout, stack );
-                jsout.end_object();
-                break;
-            }
-            case sol::type::userdata: {
-                sol::table table_val = val.as<sol::table>();
-                if( !table_val.valid() ) {
-                    debugmsg( "Sanity check failed - serializable type can be converted to table." );
-                    jsout.write_null();
-                    break;
-                }
-                try {
-                    if( !table_val["get_luna_type"].valid() ) {
-                        debugmsg( "Tried to serialize usertype that was not registered with luna." );
-                        jsout.write_null();
-                        break;
-                    }
-                } catch( sol::error &e ) {
-                    debugmsg( "Tried to serialize userdata that was not registered as usertype." );
-                    jsout.write_null();
-                    break;
-                }
-                sol::protected_function get_luna_type_func = table_val["get_luna_type"];
-                sol::protected_function serialize_func = table_val["serialize"];
-
-                if( !get_luna_type_func ) {
-                    debugmsg( "Tried to serialize usertype that has not been registered through luna." );
-                    jsout.write_null();
-                    break;
-                }
-                if( !serialize_func ) {
-                    debugmsg( "Tried to serialize usertype that does not allow serialization." );
-                    jsout.write_null();
-                    break;
-                }
-                std::string kind = get_luna_type_func( val );
-                jsout.start_object();
-                jsout.member_as_string( "type", "userdata" );
-                jsout.member_as_string( "kind", kind );
-                jsout.member( "data" );
-                sol::protected_function_result res = serialize_func( val, jsout );
-                if( res.status() != sol::call_status::ok ) {
-                    sol::error err = res;
-                    debugmsg( "Failed to serialize type '%s': %s", kind, err.what() );
-                }
-                jsout.end_object();
-                break;
-            }
-            default: {
-                // TODO: throw error
-                debugmsg( "Unsupported type encountered when serializing Lua table." );
-                jsout.write_null();
-                break;
-            }
-        }
+        jsout.end_array();
     }
-
     jsout.end_object();
 
     stack.pop_back();
@@ -166,64 +123,80 @@ void serialize_lua_table( sol::table t, JsonOut &jsout )
     serialize_lua_table_internal( t, jsout, stack );
 }
 
+static sol::object
+deserialize_lua_object( sol::state_view lua, const JsonObject &jo )
+{
+    std::string entry_type = jo.get_member( "type" );
+    if( entry_type == "string" ) {
+        std::string data = jo.get_string( "data" );
+        return sol::object( lua, sol::in_place, data );
+    } else if( entry_type == "bool" ) {
+        bool data = jo.get_bool( "data" );
+        return sol::object( lua, sol::in_place, data );
+    } else if( entry_type == "int" ) {
+        int data = jo.get_int( "data" );
+        return sol::object( lua, sol::in_place, data );
+    } else if( entry_type == "float" ) {
+        double data = jo.get_float( "data" );
+        return sol::object( lua, sol::in_place, data );
+    } else if( entry_type == "lua_table" ) {
+        JsonObject data = jo.get_object( "data" );
+        sol::table new_table = lua.create_table();
+        deserialize_lua_table( new_table, data );
+        return new_table;
+    } else if( entry_type == "userdata" ) {
+        std::string kind = jo.get_member( "kind" );
+        JsonIn &data_raw = *jo.get_raw( "data" );
+        // Horrible hack ahead
+        std::string script = string_format( "return %s.new()", kind );
+        sol::protected_function_result res = lua.script( script, "deserialize_init", sol::load_mode::any );
+        if( res.status() != sol::call_status::ok ) {
+            debugmsg( "Failed to init container for deserializable type '%s'", kind );
+        } else {
+            sol::object obj = res;
+            sol::table obj_table = obj.as<sol::table>();
+            if( !obj_table ) {
+                debugmsg( "Failed to init container for deserializable type '%s'", kind );
+            } else {
+                sol::protected_function deserialize_func = obj_table["deserialize"];
+                if( !deserialize_func ) {
+                    debugmsg( "Failed to deserialize type '%s': not deserializable.", kind );
+                } else {
+                    sol::protected_function_result res = deserialize_func( obj, data_raw );
+                    if( res.status() != sol::call_status::ok ) {
+                        sol::error err = res;
+                        debugmsg( "Failed to deserialize type '%s': %s", kind, err.what() );
+                    } else {
+                        return obj;
+                    }
+                }
+            }
+        }
+    } else {
+        debugmsg( "Deserialization of record type '%s' is not implemented.", entry_type );
+    }
+    return sol::nil;
+}
+
 void deserialize_lua_table( sol::table t, JsonObject &obj )
 {
     sol::state_view lua( t.lua_state() );
 
-    for( JsonMember it : obj ) {
-        std::string key = it.name();
-        if( it.test_bool() ) {
-            t[key] = it.get_bool();
-        } else if( it.test_string() ) {
-            t[key] = it.get_string();
-        } else if( it.test_object() ) {
-            JsonObject jo = it.get_object();
-            std::string entry_type = jo.get_member( "type" );
-            if( entry_type == "int" ) {
-                int data = jo.get_int( "data" );
-                t[key] = data;
-            } else if( entry_type == "float" ) {
-                double data = jo.get_float( "data" );
-                t[key] = data;
-            } else if( entry_type == "lua_table" ) {
-                JsonObject data = jo.get_object( "data" );
-                sol::table new_table = lua.create_table();
-                deserialize_lua_table( new_table, data );
-                t[key] = new_table;
-            } else if( entry_type == "userdata" ) {
-                std::string kind = jo.get_member( "kind" );
-                JsonIn &data_raw = *jo.get_raw( "data" );
-                // Horrible hack ahead
-                std::string script = string_format( "return %s.new()", kind );
-                sol::protected_function_result res = lua.script( script, "deserialize_init", sol::load_mode::any );
-                if( res.status() != sol::call_status::ok ) {
-                    debugmsg( "Failed to init container for deserializable type '%s'", kind );
-                } else {
-                    sol::object obj = res;
-                    sol::table obj_table = obj.as<sol::table>();
-                    if( !obj_table ) {
-                        debugmsg( "Failed to init container for deserializable type '%s'", kind );
-                    } else {
-                        sol::protected_function deserialize_func = obj_table["deserialize"];
-                        if( !deserialize_func ) {
-                            debugmsg( "Failed to deserialize type '%s': not deserializable.", kind );
-                        } else {
-                            sol::protected_function_result res = deserialize_func( obj, data_raw );
-                            if( res.status() != sol::call_status::ok ) {
-                                sol::error err = res;
-                                debugmsg( "Failed to deserialize type '%s': %s", kind, err.what() );
-                            } else {
-                                t[key] = obj;
-                            }
-                        }
-                    }
-                }
-            } else {
-                debugmsg( "Deserialization of record type '%s' is not implemented.", entry_type );
-            }
-        } else if( it.test_array() ) {
-            debugmsg( "Arrays are not supported when deserializing Lua table." );
-        }
+    if( !obj.has_array( "entries" ) ) {
+        return;
+    }
+
+    JsonArray arr = obj.get_array( "entries" );
+    if( arr.size() % 2 != 0 ) {
+        debugmsg( "invalid array size %d", arr.size() );
+        return;
+    }
+    for( size_t idx = 0; idx < arr.size(); idx += 2 ) {
+        JsonObject jo_key = arr.get_object( idx );
+        JsonObject jo_val = arr.get_object( idx + 1 );
+        sol::object key = deserialize_lua_object( lua, jo_key );
+        sol::object val = deserialize_lua_object( lua, jo_val );
+        t.set( key, val );
     }
 }
 

--- a/tests/stringmaker.h
+++ b/tests/stringmaker.h
@@ -2,6 +2,7 @@
 #ifndef CATA_TESTS_STRINGMAKER_H
 #define CATA_TESTS_STRINGMAKER_H
 
+#include <optional>
 #include <utility>
 
 #include "cuboid_rectangle.h"
@@ -32,6 +33,25 @@ struct StringMaker<string_id<T>> {
     }
 };
 
+template<typename T>
+struct StringMaker<std::optional<T>> {
+    static std::string convert( const std::optional<T> &i ) {
+        if( i.has_value() ) {
+            const T &val = *i;
+            return string_format( "optional( %s )", StringMaker<T>::convert( val ) );
+        } else {
+            return "optional()";
+        }
+    }
+};
+
+template<>
+struct StringMaker<std::nullopt_t> {
+    static std::string convert( const std::nullopt_t & ) {
+        return "optional()";
+    }
+};
+
 template<>
 struct StringMaker<item> {
     static std::string convert( const item &i ) {
@@ -43,6 +63,13 @@ template<>
 struct StringMaker<point> {
     static std::string convert( const point &p ) {
         return string_format( "point( %d, %d )", p.x, p.y );
+    }
+};
+
+template<>
+struct StringMaker<tripoint> {
+    static std::string convert( const tripoint &p ) {
+        return string_format( "tripoint( %d, %d, %d )", p.x, p.y, p.z );
     }
 };
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++ and Markdown: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md

!!!!!!!!!! WARNING !!!!!!!!!!

If you forget to format the PR, autofix.ci app will run automated format commit for you.
When this happens, YOU MUST DO EITHER OF THE FOLLOWING:

- Run `git pull` to merge the automated commit into your PR branch.
- Format your code locally, and force push to your PR branch. 

If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
-->

#### Summary
SUMMARY: Infrastructure "Lua mods can now use non-strings as keys in storage table"

#### Purpose of change
Fixes issue reported on Discord: if Lua table in mod_storage has a non-string key, the game would crash on save.

#### Describe the solution
Overhaul table de-serialization to support same values as keys do.

#### Describe alternatives you've considered
Forbidding non-strings as keys in storage

#### Testing
Added tests