### PR TITLE
feat: auto ladder climbing and ledge prompts

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -108,9 +108,7 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
         dest_loc.y = rng( you.posy() - 1, you.posy() + 1 );
         dest_loc.z = you.posz();
     } else {
-        dest_loc.x = you.posx() + d.x;
-        dest_loc.y = you.posy() + d.y;
-        dest_loc.z = you.posz() + d.z;
+        dest_loc = you.pos() + d;
     }
 
     if( dest_loc == you.pos() ) {

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -88,6 +88,7 @@ static const std::string flag_DIG_TOOL( "DIG_TOOL" );
 static const std::string flag_NO_UNWIELD( "NO_UNWIELD" );
 static const std::string flag_RAMP_END( "RAMP_END" );
 static const std::string flag_SWIMMABLE( "SWIMMABLE" );
+static const std::string flag_LADDER( "LADDER" );
 
 #define dbg(x) DebugLog((x), DC::SDL)
 
@@ -123,7 +124,8 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
     if( m.has_flag( TFLAG_RAMP_UP, dest_loc ) ) {
         dest_loc.z += 1;
         via_ramp = true;
-    } else if( m.has_flag( TFLAG_RAMP_DOWN, dest_loc ) ) {
+    } else if( m.has_flag( TFLAG_RAMP_DOWN, dest_loc ) ||
+               ( !is_riding && m.has_flag( flag_LADDER, dest_loc + tripoint_below ) ) ) {
         dest_loc.z -= 1;
         via_ramp = true;
     }
@@ -433,6 +435,11 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
         if( you.is_auto_moving() ) {
             you.defer_move( dest_loc );
         }
+        return true;
+    }
+
+    if( !is_riding && m.has_flag( flag_LADDER, you.pos() ) &&
+        g->walk_move( dest_loc + tripoint_above ) ) {
         return true;
     }
 

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -115,6 +115,10 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
         // Well that sure was easy
         return true;
     }
+
+    const bool auto_features = get_option<bool>( "AUTO_FEATURES" );
+    const bool auto_mine = auto_features && get_option<bool>( "AUTO_MINING" );
+
     bool via_ramp = false;
     if( m.has_flag( TFLAG_RAMP_UP, dest_loc ) ) {
         dest_loc.z += 1;
@@ -125,8 +129,7 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
     }
 
     if( m.has_flag( TFLAG_MINEABLE, dest_loc ) && g->mostseen == 0 &&
-        get_option<bool>( "AUTO_FEATURES" ) && get_option<bool>( "AUTO_MINING" ) &&
-        !m.veh_at( dest_loc ) && !you.is_underwater() && !you.has_effect( effect_stunned ) &&
+        auto_mine && !m.veh_at( dest_loc ) && !you.is_underwater() && !you.has_effect( effect_stunned ) &&
         !is_riding ) {
         item &digging_tool = you.primary_weapon();
         if( digging_tool.has_flag( flag_DIG_TOOL ) ) {
@@ -394,6 +397,7 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
     if( g->walk_move( dest_loc, via_ramp ) ) {
         return true;
     }
+
     if( veh_closed_door ) {
         if( !veh1->handle_potential_theft( you ) ) {
             return true;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8723,19 +8723,25 @@ bool game::is_dangerous_tile( const tripoint &dest_loc ) const
 
 bool game::prompt_dangerous_tile( const tripoint &dest_loc ) const
 {
+    static const iexamine_function ledge_examine = iexamine_function_from_string( "ledge" );
     std::vector<std::string> harmful_stuff = get_dangerous_tile( dest_loc );
 
-    if( !harmful_stuff.empty() &&
-        !query_yn( _( "Really step into %s?" ), enumerate_as_string( harmful_stuff ) ) ) {
+    if( harmful_stuff.empty() ) {
+        return true;
+    }
+
+    if( !( harmful_stuff.size() == 1 && m.tr_at( dest_loc ).loadid == tr_ledge ) ) {
+        return query_yn( _( "Really step into %s?" ), enumerate_as_string( harmful_stuff ) ) ;
+    }
+
+    if( !u.is_mounted() ) {
+        ledge_examine( u, dest_loc );
         return false;
     }
-    if( !harmful_stuff.empty() && u.is_mounted() &&
-        m.tr_at( dest_loc ).loadid == tr_ledge ) {
-        add_msg( m_warning, _( "Your %s refuses to move over that ledge!" ),
-                 u.mounted_creature->get_name() );
-        return false;
-    }
-    return true;
+
+    add_msg( m_warning, _( "Your %s refuses to move over that ledge!" ),
+             u.mounted_creature->get_name() );
+    return false;
 }
 
 std::vector<std::string> game::get_dangerous_tile( const tripoint &dest_loc ) const

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8896,24 +8896,26 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp )
         std::vector<std::string> harmful_stuff = get_dangerous_tile( dest_loc );
         const auto dangerous_terrain_opt = get_option<std::string>( "DANGEROUS_TERRAIN_WARNING_PROMPT" );
         const auto harmful_text = enumerate_as_string( harmful_stuff );
-        const auto warn_msg = [&]( const char *const msg ) {
-            add_msg( m_warning, msg, harmful_text );
+        const auto looks_risky = _( "Stepping into that %1$s looks risky.  %2$s" );
+
+        const auto warn_msg = [&]( std::string_view action ) {
+            add_msg( m_warning, looks_risky, harmful_text, action.data() );
         };
 
         if( dangerous_terrain_opt == "IGNORE" ) {
-            warn_msg( _( "Stepping into that %1$s looks risky, but you enter anyway." ) );
+            warn_msg( _( "But you enter anyway." ) );
         } else if( dangerous_terrain_opt == "ALWAYS" && !prompt_dangerous_tile( dest_loc ) ) {
             return true;
         } else if( dangerous_terrain_opt == "RUNNING" &&
                    ( !u.movement_mode_is( CMM_RUN ) || !prompt_dangerous_tile( dest_loc ) ) ) {
-            warn_msg( _( "Stepping into that %1$s looks risky.  Run into it if you wish to enter anyway." ) );
+            warn_msg( _( "Run into it if you wish to enter anyway." ) );
             return true;
         } else if( dangerous_terrain_opt == "CROUCHING" &&
                    ( !u.movement_mode_is( CMM_CROUCH ) || !prompt_dangerous_tile( dest_loc ) ) ) {
-            warn_msg( _( "Stepping into that %1$s looks risky.  Crouch and move into it if you wish to enter anyway." ) );
+            warn_msg( _( "Crouch and move into it if you wish to enter anyway." ) );
             return true;
         } else if( dangerous_terrain_opt == "NEVER" && !u.movement_mode_is( CMM_RUN ) ) {
-            warn_msg( _( "Stepping into that %1$s looks risky.  Run into it if you wish to enter anyway." ) );
+            warn_msg( _( "Run into it if you wish to enter anyway." ) );
             return true;
         }
     }


### PR DESCRIPTION
#### Summary

SUMMARY: Features "Made ladders work like ramps and ledges auto-examinable"

#### Purpose of change

There's two way of going down a ledge:

1. jump down (may hurt)
2. climb down

option 2 can only be accessed via `(e)xamine`, and 90% of time climbing down is a better choice.	

moving z-levels up and down with stepladders were also tiresome be

#### Describe the solution

1. made `game::prompt_dangerous_tile` to call `iexamine::ledge` instead if and only if dangerous terrain is ledge.
2. made furniture with `LADDER` flag act as ramps. when climbing up, the check is done just before handling invalid moves to not interfere with walking, opening door, etc.

#### Describe alternatives you've considered

- make it an option?
- make auto ledge examine more granular depending on `Dangerous terrain warning prompt`?

#### Testing

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/73e3ee7c-c828-45d6-a879-efc73544fec3

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/a1ea8f70-10db-45b0-8597-8a3068192db1

auto ladder and grappling hooks climbing (anything with `LADDER` flag will work)

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/d5d58388-efb9-4004-9ff3-d919908ab729

auto ledge prompts


