### PR TITLE
feat(port): move vehicles in elevator

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -898,17 +898,23 @@ void iexamine::elevator( player &p, const tripoint &examp )
     for( Creature &critter : g->all_creatures() ) {
         if( critter.is_player() ) {
             continue;
-        } else if( here.has_flag( flag_ELEVATOR, critter.pos() ) ) {
-            tripoint critter_omt = ms_to_omt_copy( here.getabs( critter.pos() ) );
-            if( critter_omt == new_floor_omt ) {
-                for( const tripoint &candidate : closest_points_first( critter.pos(), 10 ) ) {
-                    if( !here.has_flag( flag_ELEVATOR, candidate ) &&
-                        here.passable( candidate ) &&
-                        !g->critter_at( candidate ) ) {
-                        critter.setpos( candidate );
-                        break;
-                    }
-                }
+        }
+
+        if( !here.has_flag( flag_ELEVATOR, critter.pos() ) ) {
+            continue;
+        }
+
+        tripoint critter_omt = ms_to_omt_copy( here.getabs( critter.pos() ) );
+        if( critter_omt != new_floor_omt ) {
+            continue;
+        }
+
+        for( const tripoint &candidate : closest_points_first( critter.pos(), 10 ) ) {
+            if( !here.has_flag( flag_ELEVATOR, candidate ) &&
+                here.passable( candidate ) &&
+                !g->critter_at( candidate ) ) {
+                critter.setpos( candidate );
+                break;
             }
         }
     }
@@ -947,18 +953,22 @@ void iexamine::elevator( player &p, const tripoint &examp )
     for( Creature &critter : g->all_creatures() ) {
         if( critter.is_player() ) {
             continue;
-        } else if( here.has_flag( flag_ELEVATOR, critter.pos() ) ) {
-            tripoint critter_omt = ms_to_omt_copy( here.getabs( critter.pos() ) );
+        }
 
-            if( critter_omt == original_floor_omt ) {
-                for( const tripoint &candidate : closest_points_first( p.pos(), 10 ) ) {
-                    if( here.has_flag( flag_ELEVATOR, candidate ) &&
-                        candidate != p.pos() &&
-                        !g->critter_at( candidate ) ) {
-                        critter.setpos( candidate );
-                        break;
-                    }
-                }
+        if( !here.has_flag( flag_ELEVATOR, critter.pos() ) ) {
+            continue;
+        }
+
+        tripoint critter_omt = ms_to_omt_copy( here.getabs( critter.pos() ) );
+        if( critter_omt != original_floor_omt ) {
+            continue;
+        }
+
+        for( const tripoint &candidate : closest_points_first( p.pos(), 10 ) ) {
+            if( here.has_flag( flag_ELEVATOR, candidate ) && candidate != p.pos() &&
+                !g->critter_at( candidate ) ) {
+                critter.setpos( candidate );
+                break;
             }
         }
     }

--- a/src/iexamine_elevator.cpp
+++ b/src/iexamine_elevator.cpp
@@ -129,6 +129,12 @@ auto vehicles_on( const elevator::tiles &tiles ) -> elevator_vehicles
     return { false, ret };
 }
 
+auto warn_blocking( const elevator_vehicles &vehs, std::string_view location ) -> void
+{
+    const auto &first_veh_name = vehs.v.front()->name;
+    popup( string_format( _( "%1$s %2$s is blocking the elevator." ), first_veh_name, location ) );
+}
+
 auto move_creatures_away( const elevator::tiles &dest ) -> void
 {
     map &here = get_map();
@@ -208,9 +214,7 @@ void iexamine::elevator( player &p, const tripoint &examp )
     const auto elevator_here = elevator::here( p );
     const auto vehs = elevator::vehicles_on( elevator_here );
     if( vehs.blocking ) {
-        const auto &first_veh_name = vehs.v.front()->name;
-        popup( string_format( _( "The %s is blocking the elevator." ), first_veh_name ) );
-        return;
+        return warn_blocking( vehs, _( "here" ) );
     }
 
     const int movez = elevator::choose_floor( examp, this_omt, sm_orig );
@@ -222,6 +226,10 @@ void iexamine::elevator( player &p, const tripoint &examp )
     const int turns = get_rot_delta( this_omt, that_omt );
 
     const auto elevator_dest = elevator::dest( elevator_here, sm_orig, turns, movez );
+    const auto vehicles_dest = elevator::vehicles_on( elevator_dest );
+    if( !vehicles_dest.v.empty() ) {
+        return warn_blocking( vehicles_dest, _( "at the destination floor" ) );
+    }
 
     elevator::move_creatures_away( elevator_dest );
     elevator::move_items( elevator_here, elevator_dest );

--- a/src/iexamine_elevator.cpp
+++ b/src/iexamine_elevator.cpp
@@ -61,6 +61,7 @@ auto dest( const elevator::tiles &elevator_here,
 auto choose_floor( const tripoint &examp, const tripoint_abs_omt &this_omt,
                    const tripoint &sm_orig ) -> int
 {
+    constexpr int retval_offset = 10000; // workaround for uilist retval autoassign when retval == -1
     const auto this_floor = _( " (this floor)" );
 
     map &here = get_map();
@@ -79,10 +80,10 @@ auto choose_floor( const tripoint &examp, const tripoint_abs_omt &this_omt,
         const auto floor_name = z == examp.z ? this_floor : "";
         const std::string name = string_format( "%3iF %s%s", z, omt_name, floor_name );
 
-        choice.addentry( z, z != examp.z, MENU_AUTOASSIGN, name );
+        choice.addentry( z + retval_offset, z != examp.z, MENU_AUTOASSIGN, name );
     }
     choice.query();
-    return choice.ret;
+    return choice.ret - retval_offset;
 }
 
 enum class overlap_status { outside, inside, overlap };

--- a/src/iexamine_elevator.cpp
+++ b/src/iexamine_elevator.cpp
@@ -1,0 +1,222 @@
+#include "game.h"
+#include "iexamine.h"
+#include "mapdata.h"
+#include "output.h"
+#include "omdata.h"
+#include "overmapbuffer.h"
+#include "player.h"
+#include "coordinates.h"
+#include "map.h"
+#include "point.h"
+#include "ui.h"
+#include "vpart_range.h"
+#include "point_rotate.h"
+
+namespace
+{
+
+using elevator_tiles = std::vector<tripoint>;
+auto get_elevator_here( const Character &you ) -> elevator_tiles
+{
+    const auto &here = get_map();
+    const auto &points = closest_points_first( you.pos(), SEEX - 1 );
+
+    elevator_tiles tiles;
+    std::copy_if( points.begin(), points.end(), std::back_inserter( tiles ),
+    [&here]( const tripoint & pos ) {
+        return here.has_flag( TFLAG_ELEVATOR, pos );
+    } );
+
+    return tiles;
+}
+
+auto get_elevator_dest( const elevator_tiles &elevator_here,
+                        const tripoint &sm_orig,
+                        int turns,
+                        int movez ) -> elevator_tiles
+{
+    elevator_tiles tiles;
+    std::transform( elevator_here.begin(), elevator_here.end(), std::back_inserter( tiles ),
+    [turns, &sm_orig, movez]( tripoint const & p ) {
+        return rotate_point_sm( { p.xy(), movez }, sm_orig, turns );
+    } );
+
+    return tiles;
+}
+
+auto choose_elevator_destz( const tripoint &examp, const tripoint_abs_omt &this_omt,
+                            const tripoint &sm_orig ) -> int
+{
+    const auto this_floor = _( " (this floor)" );
+
+    map &here = get_map();
+    uilist choice;
+    choice.title = _( "Select destination floor" );
+    for( int z = OVERMAP_HEIGHT; z >= -OVERMAP_DEPTH; z-- ) {
+        const tripoint_abs_omt that_omt{ this_omt.xy(), z };
+        const int delta = get_rot_delta( this_omt, that_omt );
+        const tripoint zp =
+            rotate_point_sm( { examp.xy(), z }, sm_orig, delta );
+
+        if( here.ter( zp )->examine == &iexamine::elevator ) {
+            const std::string omt_name = overmap_buffer.ter_existing( that_omt )->get_name();
+            const auto floor_name = z == examp.z ? this_floor : "";
+            const std::string name = string_format( "%3iF %s%s", z, omt_name, floor_name );
+
+            choice.addentry( z, z != examp.z, MENU_AUTOASSIGN, name );
+        }
+    }
+    choice.query();
+    return choice.ret;
+}
+
+} // namespace
+
+namespace
+{
+
+enum class overlap_status { outside, inside, overlap };
+
+auto vehicle_status( const wrapped_vehicle &veh, const elevator_tiles &tiles ) -> overlap_status
+{
+    const auto &ps = veh.v->get_all_parts();
+    const int all_vparts_count = ps.part_count();
+    const int vparts_inside = std::count_if( ps.begin(), ps.end(), [&]( const vpart_reference & vp ) {
+        const tripoint p = veh.pos + vp.part().precalc[0];
+        const auto eit = std::find( tiles.cbegin(), tiles.cend(), p );
+        return eit != tiles.cend();
+    } );
+
+    if( vparts_inside == all_vparts_count ) {
+        return overlap_status::inside;
+    } else if( vparts_inside == 0 ) {
+        return overlap_status::outside;
+    } else {
+        return overlap_status::overlap;
+    }
+}
+
+struct elevator_vehicles {
+    bool blocking = false;
+    std::vector<vehicle *> v;
+};
+
+auto get_vehicles_on_elevator( const elevator_tiles &tiles ) -> elevator_vehicles
+{
+    const VehicleList vehs = get_map().get_vehicles();
+    std::vector<vehicle *> ret;
+
+    for( const wrapped_vehicle &veh : vehs ) {
+        const auto status = vehicle_status( veh, tiles );
+        if( status == overlap_status::overlap ) {
+            return { true, { veh.v } };
+        }
+        if( status == overlap_status::inside ) {
+            ret.push_back( veh.v );
+        }
+    }
+    return { false, ret };
+}
+
+} // namespace
+
+namespace
+{
+
+// still not sure whether there's a utility function for this
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+auto move_item( map &here, const tripoint &src, const tripoint &dest ) -> void
+{
+    map_stack items = here.i_at( src );
+    for( auto it = items.begin(); it != items.end(); ) {
+        here.add_item_or_charges( dest, *it );
+        it = here.i_rem( src, it );
+    }
+};
+
+auto move_creatures_away_from( const elevator_tiles &dest ) -> void
+{
+    map &here = get_map();
+
+    const auto is_movable = [&]( const tripoint & candidate ) {
+        return !here.has_flag( TFLAG_ELEVATOR, candidate )
+               && here.passable( candidate )
+               && !g->critter_at( candidate );
+    };
+
+    for( Creature &critter : g->all_creatures() ) {
+        const tripoint local_pos = here.getlocal( here.getglobal( critter.pos() ) );
+
+        const auto eit = std::find( dest.cbegin(), dest.cend(), local_pos );
+        if( eit == dest.cend() ) {
+            continue;
+        }
+
+        const auto xs = closest_points_first( *eit, 10 );
+        const auto candidate = std::find_if( xs.begin(), xs.end(), is_movable );
+        if( candidate == xs.end() ) {
+            continue;
+        }
+        critter.setpos( *candidate );
+    }
+}
+
+} //namespace
+
+/**
+ * If underground, move 2 levels up else move 2 levels down. Stable movement between levels 0 and -2.
+ */
+void iexamine::elevator( player &p, const tripoint &examp )
+{
+    map &here = get_map();
+    const tripoint_abs_ms old_abs_pos = here.getglobal( p.pos() );
+    const tripoint_abs_omt this_omt = project_to<coords::omt>( here.getglobal( examp ) );
+    const tripoint sm_orig = here.getlocal( project_to<coords::ms>( this_omt ) );
+
+    const auto elevator_here = get_elevator_here( p );
+    const auto vehs = get_vehicles_on_elevator( elevator_here );
+    if( vehs.blocking ) {
+        const auto &first_veh_name = vehs.v.front()->name;
+        popup( string_format( _( "The %s is blocking the elevator." ), first_veh_name ) );
+        return;
+    }
+
+    const int movez = choose_elevator_destz( examp, this_omt, sm_orig );
+    if( movez < -OVERMAP_DEPTH ) {
+        return;
+    }
+
+    const tripoint_abs_omt that_omt{ this_omt.xy(), movez };
+    const int turns = get_rot_delta( this_omt, that_omt );
+
+    const auto elevator_dest = get_elevator_dest( elevator_here, sm_orig, turns, movez );
+
+    move_creatures_away_from( elevator_dest );
+
+    // move along every item in the elevator
+    for( decltype( elevator_here )::size_type i = 0; i < elevator_here.size(); i++ ) {
+        const tripoint &src = elevator_here[i];
+        move_item( here, src, elevator_dest[i] );
+    }
+
+    // move along all creatures on the elevator
+    for( Creature &critter : g->all_creatures() ) {
+        const auto eit = std::find( elevator_here.cbegin(), elevator_here.cend(), critter.pos() );
+        if( eit != elevator_here.cend() ) {
+            critter.setpos( elevator_dest[ std::distance( elevator_here.cbegin(), eit ) ] );
+        }
+    }
+
+    // move vehicles
+    for( vehicle *v : vehs.v ) {
+        const tripoint p = rotate_point_sm( { v->global_pos3().xy(), movez }, sm_orig, turns );
+        here.displace_vehicle( *v, p - v->global_pos3() );
+        v->turn( turns * 90_degrees );
+        v->face = tileray( v->turn_dir );
+        v->precalc_mounts( 0, v->turn_dir, v->pivot_anchor[0] );
+    }
+    here.reset_vehicle_cache();
+
+    g->vertical_shift( movez );
+    cata_event_dispatch::avatar_moves( *p.as_avatar(), here, old_abs_pos.raw() );
+}

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -194,6 +194,7 @@ static const std::unordered_map<std::string, ter_bitflags> ter_bitflags_map = { 
         { "SUSPENDED",                TFLAG_SUSPENDED },      // This furniture is suspended between other terrain, and will cause a cascading failure on break.
         { "FRIDGE",                   TFLAG_FRIDGE },         // This is an active fridge.
         { "FREEZER",                  TFLAG_FREEZER },        // This is an active freezer.
+        { "ELEVATOR",                 TFLAG_ELEVATOR },       // This is an elevator.
     }
 };
 

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -324,6 +324,7 @@ enum ter_bitflags : int {
     TFLAG_SUSPENDED,
     TFLAG_FRIDGE,
     TFLAG_FREEZER,
+    TFLAG_ELEVATOR,
 
     NUM_TERFLAGS
 };

--- a/src/point_rotate.cpp
+++ b/src/point_rotate.cpp
@@ -1,3 +1,4 @@
+#include "point_rotate.h"
 #include "overmapbuffer.h"
 #include "omdata.h"
 #include "point.h"

--- a/src/point_rotate.cpp
+++ b/src/point_rotate.cpp
@@ -1,0 +1,39 @@
+#include "overmapbuffer.h"
+#include "omdata.h"
+#include "point.h"
+
+auto rotate( point p, point dim, int turns ) -> point
+{
+    switch( turns ) {
+        case 1:
+            return { dim.y - p.y - 1, p.x };
+        case 2:
+            return { dim.x - p.x - 1, dim.y - p.y - 1 };
+        case 3:
+            return { p.y, dim.x - p.x - 1 };
+        default:
+            return p;
+    }
+}
+
+auto rotate( const tripoint &p, point dim, int turns ) -> tripoint
+{
+    return { rotate( p.xy(), dim, turns ), p.z };
+}
+
+auto rotate_point_sm( const tripoint &p, const tripoint &orig, int turns ) -> tripoint
+{
+    const tripoint p_sm{ p - orig.xy() };
+    const tripoint rd{ rotate( p_sm, { SEEX * 2, SEEY * 2 }, turns ) };
+
+    return tripoint{ rd + orig.xy() };
+}
+
+auto get_rot_delta( const tripoint_abs_omt &here, const tripoint_abs_omt &there ) -> int
+{
+    const auto this_dir = overmap_buffer.ter( there )->get_dir();
+    const auto that_dir = overmap_buffer.ter( here )->get_dir();
+
+    int const diff = static_cast<int>( this_dir ) - static_cast<int>( that_dir );
+    return diff >= 0 ? diff : 4 + diff;
+}

--- a/src/point_rotate.h
+++ b/src/point_rotate.h
@@ -1,0 +1,26 @@
+#pragma once
+#ifndef CATA_SRC_POINT_ROTATE_H
+#define CATA_SRC_POINT_ROTATE_H
+
+#include "point.h"
+#include "coordinates.h"
+
+/**
+ * Rotate point clockwise @param turns times, 90 degrees per turn,
+ * around the center of a rectangle with the dimensions specified
+ * by @param dim
+ * set dim to (0, 0) to rotate around the origin.
+ */
+auto rotate( point p, point dim, int turns ) -> point;
+
+/**
+ * Rotates just the x,y component of the tripoint. See point::rotate()
+ */
+auto rotate( const tripoint &p, point dim, int turns ) -> tripoint;
+
+/** works like rotate but for submaps. */
+auto rotate_point_sm( const tripoint &p, const tripoint &orig, int turns ) -> tripoint;
+
+auto get_rot_delta( const tripoint_abs_omt &here, const tripoint_abs_omt &there ) -> int;
+
+#endif // CATA_SRC_POINT_ROTATE_H


### PR DESCRIPTION
#### Summary

SUMMARY: Features "Allows elevators transport vehicles as well"

#### Purpose of change

the (not) long awaited sequel of #1531.
looting labs with shopping carts would be very convenient.

#### Describe the solution

port https://github.com/CleverRaven/Cataclysm-DDA/pull/58840 by @andrei8l

#### Describe alternatives you've considered

port more overmap/submap PRs first?

#### Testing

vehicles are moved together (with their directions kept)

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/10f85b63-eab8-41a1-b82d-cf42077ea41e

creatures/npc are shoved away

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/5a4e91de-9952-431b-b8b6-f7b94bff1d26

vehicles can block the elevator from working
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/6c451273-922f-4d7a-aea4-4cd5d5a97f1c)

vehicles at destination floor is also checked to prevent amalgamation

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/4df13f70-8082-49a6-8093-ce43aa836116

#### Additional notes
might have to port these as well
- https://github.com/CleverRaven/Cataclysm-DDA/pull/61774
- https://github.com/CleverRaven/Cataclysm-DDA/pull/62879
- https://github.com/CleverRaven/Cataclysm-DDA/pull/61777