### PR TITLE
Expand range of volume limits for certain holsters

### DIFF
--- a/data/json/items/armor/holster.json
+++ b/data/json/items/armor/holster.json
@@ -45,7 +45,7 @@
     "flags": [ "BELTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ],
     "use_action": {
       "type": "holster",
-      "max_volume": "400 ml",
+      "max_volume": "500 ml",
       "min_volume": "100 ml",
       "max_weight": 1000,
       "draw_cost": 150,
@@ -89,7 +89,7 @@
     "coverage": 2,
     "encumbrance": 2,
     "material_thickness": 1,
-    "use_action": { "type": "holster", "max_volume": "800 ml", "min_volume": "300 ml", "skills": [ "pistol", "smg", "shotgun" ] },
+    "use_action": { "type": "holster", "max_volume": "1 L", "min_volume": "250 ml", "skills": [ "pistol", "smg", "shotgun" ] },
     "flags": [ "WAIST", "OVERSIZE" ]
   },
   {
@@ -163,7 +163,7 @@
     "coverage": 10,
     "encumbrance": 4,
     "material_thickness": 1,
-    "use_action": { "type": "holster", "min_volume": "750 ml", "max_volume": "1250 ml", "skills": [ "pistol", "smg", "shotgun" ] },
+    "use_action": { "type": "holster", "min_volume": "750 ml", "max_volume": "1500 ml", "skills": [ "pistol", "smg", "shotgun" ] },
     "flags": [ "WAIST", "OVERSIZE" ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++ and Markdown: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md

!!!!!!!!!! WARNING !!!!!!!!!!

If you forget to format the PR, autofix.ci app will run automated format commit for you.
When this happens, YOU MUST DO EITHER OF THE FOLLOWING:

- Run `git pull` to merge the automated commit into your PR branch.
- Format your code locally, and force push to your PR branch. 

If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Ankle holsters, holsters, and XL holsters can now hold a wider range of guns"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

As mentioned in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3158, messing with the range of volumes holsters can fit was on my list as one idea to help alleviate various issues with fitting guns in storage being fairly fiddly, especially when magazines and gunmods get added to the fray.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Changed the regular holster's minimum volume from 300 ml to 250 ml, and its maximum volume from 800 ml to 1 liter. Change to the minimum notably affects the Walther P22 and SIG Mosquito (250 and 263 ml, both looking decent and not pocket-pistol size IRL from what I can tell). The change to maximum volume notably affects the Colt Navy (851 ml, standard barrel length IRL is a whole half an inch shorter than the Colt Army that fit in a holster comfortably), homemade hand cannon (1 liter), Magnum Research BFR (1 liter, could maybe bump its volume up if we still want it exclusive to XL holster?), and V-29 laser pistol (historically been a pain in my ass as what holster it belongs in kept changing, back when Arcana had a profession start with one).
2. Changed the XL holster's max volume from 1.25 liters to 1.5 liters. This increases the gap in utility between the normal holster and XL holster from 450 ml to 500 ml. Notably affects the Steyr AUG (1.5 L), handmade carbine (1.5 L), Serbu BFG-50 (1387 ml, seems like that could afford a tad more volume if desired?) and Remington 870 MCS (1284 ml) among others.
3. Changed the ankle holster's max volume from 400 ml to 500 ml. This makes it consistent with the fast draw and deep concealment holsters, being designed for small guns. Notably affects the various models of Glock (typically 443-500 ml), SIG P320 Compact (462 ml), S&W Model 10 (402 ml, evidently made deliberately so a moderately slim revolver couldn't fit in this :V), Colt M1860 Army (486 ml), M1911 (500 ml), various interchangeable 9mm pistols, 12 gauge pistol (500 ml), flaregun (500 ml), among others.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Messing with the max volume of the survivor's harness in either direction because a max volume of 3750 ml feels mildly fucking cursed. Buffing it to 4 L would notably affect: Weatherby Mark V (3761 ml), Mark 19 grenade launcher (4 L, that is hilariously cursed given it weighs over 75 pounds!)
2. As mentioned, increasing the volume of certain guns like the BFR (to 1.1-1.25 L), BFG-50 (to 1.6-1.75 L) to nudge them out of being usable in holsters they may feel weight in.
3. A few weapons notably still have volumes that seem out of logical range, notably the AR pistol and Mini Draco would be reasonable to fit on an XL holster but have volumes of 1758 ml and 2167 ml (more than the Beretta ARX-160 and only a bit less than the SKS) respectively.
4. Nerfing the ankle holster down to a max of 250 ml instead. I feel like this would only be a sane option if we did some hardcore sanity-checking of pocket pistol volumes so ech.
5. Screaming at all these volume amounts that are all like a dozen ml over a threshold visibly for no other reason than because DDA wanted to play merry hell with holster usage, and rounding a fuckton of gun volumes up and down until it becomes slightly less of a headache to work with.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected file for syntax and lint errors.
2. Sifted through search in folder to get a rough idea of what guns will benefit from this, as noted above.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

At some point I intend to also mess with draw costs, though sheathes are where the real wacky draw costs can be found. A fair while ago I'd mused upon adding a wrist sheath for more delicious tacticool but the logically-fast draw speed currently doesn't matter as sheathes all lean towards a draw cost of a fraction of a second, and the way skill reduces skill cost also evidently is a tad overtuned. One of these days probably, weh.