### PR TITLE
Adjust soil from digging to match construction needs

### DIFF
--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -846,7 +846,7 @@
       "sound": "heavy rumbling!",
       "sound_fail": "thump",
       "ter_set": "t_fence_post",
-      "items": [ { "item": "material_soil", "count": [ 100, 150 ] } ]
+      "items": [ { "item": "material_soil", "count": [ 50, 75 ] } ]
     }
   },
   {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2621,7 +2621,7 @@ static digging_moves_and_byproducts dig_pit_moves_and_byproducts( player *p, ite
     // We also must tone down the yield of dirt to avoid potential problems,
     // the old math was generating more than the tile volume limit.
     //
-    // So to keep it simple, 50 liters for shallow pits, 100 for deep pit. We're basically
+    // So to keep it simple, 200 liters for shallow pits, 400 for deep pit. We're basically
     // assuming that the first step is about one-third of the total work.
 
     constexpr int deep_pit_time = 120;
@@ -2647,7 +2647,7 @@ static digging_moves_and_byproducts dig_pit_moves_and_byproducts( player *p, ite
         result_terrain = deep ? ter_id( "t_pit" ) : ter_id( "t_pit_shallow" );
     }
 
-    return { moves, static_cast<int>( dig_minutes / 60 ), "digging_soil_loam_50L", result_terrain };
+    return { moves, static_cast<int>( dig_minutes / 15 ), "digging_soil_loam_50L", result_terrain };
 }
 
 int iuse::dig( player *p, item *it, bool t, const tripoint & )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++ and Markdown: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md

!!!!!!!!!! WARNING !!!!!!!!!!

If you forget to format the PR, autofix.ci app will run automated format commit for you.
When this happens, YOU MUST DO EITHER OF THE FOLLOWING:

- Run `git pull` to merge the automated commit into your PR branch.
- Format your code locally, and force push to your PR branch. 

If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Increase soil yield from digging back up to an amount more in line with construction demand, belated sanity-checking for bashing rammed earth walls"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

When I sanity-checked digging I also reduced how much soil is produced by digging, but I'd overtuned it quite a bit compared to how much soil is used in the construction recipes I'd touched shortly before that.

Along the way, Royalfox on the BN discord pointed out that I forgot to adjust how much soil rammed earth walls give when smashed too, making them give more than they take to make.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. In iuse.cpp, changed `digging_moves_and_byproducts` so that it produces a total of 600 liters of material when excavated, for a maximum of 120 soil per deep pit. This works with rammed earth walls taking 100 soil and earthbag walls taking 108 soil.
2. Set rammed earth walls to give 50-75 soil when bashed.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Reducing soil demand in construction even more instead.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested.
3. Dug a deep pit, confirmed that it spawned over 100 soil altogether.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Side note, boulders got a buff to how much stone they produce but solid rock didn't, I'll likely open another PR aimed towards giving a similar parity to obtaining rocks for stone walls.