### PR TITLE
fix: missing "vehicle_part.h" includes

### DIFF
--- a/src/iexamine_elevator.cpp
+++ b/src/iexamine_elevator.cpp
@@ -10,7 +10,9 @@
 #include "point.h"
 #include "ui.h"
 #include "vpart_range.h"
+#include "vehicle_part.h"
 #include "point_rotate.h"
+
 namespace
 {
 


### PR DESCRIPTION
#### Summary


SUMMARY: Bugfixes "Hotfix build failure do to missing vehicle_part.h inclusion"

#### Purpose of change

1. #3104 changed header inclusions, and fixed all header inclusions
2. #3151 was made without header inclusion in #3104 since it wasn't merged yet
3. #3151 got merged first, with all tests passing
4. #3104 got merged later, with all tests passing, however _it was a lie!_ the source code changed after merging #3151, but no additional tests were ran on #3104

#### Describe the solution

include "vehicle_part.h" header to "iexamine_elevator.cpp"

#### Describe alternatives you've considered

screm

#### Testing

local build passed, should be merged ASAP, sorry

#### Additional context

we should really use merge queue
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue


