### PR TITLE
Fixed AK Semi in nested_guns.json

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
@@ -1223,7 +1223,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "1895sbl", "charges-min": 0, "charges-max": 30 },
+      { "item": "aksemi", "charges-min": 0, "charges-max": 30 },
       { "item": "akmag10" },
       { "item": "akmag10", "prob": 50 },
       { "group": "on_hand_762" }


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fixed nested_aksemi in nested_guns.json by actually using aksemi"

#### Purpose of change

The nested_aksemi itemgroup should not be using a Marlin 1895 SBL instead of the real Semi-auto AK-47.

#### Describe the solution

Replaced "1895sbl" with "aksemi" in the nested_aksemi itemgroup

#### Describe alternatives you've considered

N / A

#### Testing

In a sense, tested by obtaining the wrong gun for the mags and ammo I got from a minehead bridge spawn.

#### Additional context

Bug originated in DDA, and they've been notified of it too.
