### PR TITLE
Smoother rivers connections on overmaps edges

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -4090,10 +4090,8 @@ void overmap::polish_rivers( const overmap *north, const overmap *east, const ov
                         } else {
                             ter_set( p, oter_id( "river_ne" ) );
                         }
-                    } else {
-                        if( water_east ) { // Means it's swampy
-                            ter_set( p, oter_id( "forest_water" ) );
-                        }
+                    } else { // Means it's swampy
+                        ter_set( p, oter_id( "forest_water" ) );
                     }
                 }
             } else {

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1649,7 +1649,7 @@ void overmap::generate( const overmap *north, const overmap *east,
     place_specials( enabled_specials );
     place_forest_trailheads();
 
-    polish_river( north, east, south, west );
+    polish_rivers( north, east, south, west );
 
     // TODO: there is no reason we can't generate the sublevels in one pass
     //       for that matter there is no reason we can't as we add the entrance ways either
@@ -4011,8 +4011,8 @@ bool overmap::check_overmap_special_type( const overmap_special_id &id,
     return found_id->second == id;
 }
 
-void overmap::polish_river( const overmap *north, const overmap *east, const overmap *south,
-                            const overmap *west )
+void overmap::polish_rivers( const overmap *north, const overmap *east, const overmap *south,
+                             const overmap *west )
 {
     for( int x = 0; x < OMAPX; x++ ) {
         for( int y = 0; y < OMAPY; y++ ) {

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -450,8 +450,8 @@ class overmap
                                          const tripoint_om_omt &location ) const;
         void chip_rock( const tripoint_om_omt &p );
 
-        void polish_river( const overmap *north, const overmap *east, const overmap *south,
-                           const overmap *west );
+        void polish_rivers( const overmap *north, const overmap *east, const overmap *south,
+                            const overmap *west );
 
         om_direction::type random_special_rotation( const overmap_special &special,
                 const tripoint_om_omt &p, bool must_be_unexplored ) const;

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -450,8 +450,8 @@ class overmap
                                          const tripoint_om_omt &location ) const;
         void chip_rock( const tripoint_om_omt &p );
 
-        void polish_river();
-        void good_river( const tripoint_om_omt &p );
+        void polish_river( const overmap *north, const overmap *east, const overmap *south,
+                           const overmap *west );
 
         om_direction::type random_special_rotation( const overmap_special &special,
                 const tripoint_om_omt &p, bool must_be_unexplored ) const;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++ and Markdown: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md

!!!!!!!!!! WARNING !!!!!!!!!!

If you forget to format the PR, autofix.ci app will run automated format commit for you.
When this happens, YOU MUST DO EITHER OF THE FOLLOWING:

- Run `git pull` to merge the automated commit into your PR branch.
- Format your code locally, and force push to your PR branch. 

If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
-->

#### Summary
SUMMARY: Bugfixes "Smoother rivers connections on overmaps edges"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

#### Purpose of change
River connections and side touches are often generated with cut edge next to overmap border, without any shore. This change polish all those edges.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
River polishing function will now be aware of adjacent tiles even if they're on different overmap, so it knows where shores should be placed. For not yet generated overmaps it assumes that water continues as it goes, leaving polishing to their mapgens, which can handle that nicely.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
Rewriting `overmap::place_river` to make starting points of rivers always match each others, and never touch borders in any other places.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Jumped between overmaps in debug mode, following river. Looks much better now.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
It's a bit difficult to show the difference due to map randomness, but that should give an idea what it does on pretty similar layouts. 
Overmap edge, before fix, and after fix:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/544763/3f3cfc34-070a-4dc8-8a80-f70cefa3e6c5)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
