### PR TITLE
fix(mission): turn in stalk first then the bag

### DIFF
--- a/data/json/npcs/missiondef.json
+++ b/data/json/npcs/missiondef.json
@@ -809,8 +809,8 @@
     },
     "end": {
       "effect": [
-        { "u_sell_item": "duffelbag" },
         { "u_sell_item": "cattail_stalk", "count": 80 },
+        { "u_sell_item": "duffelbag" },
         { "npc_consume_item": "cattail_stalk", "count": 80 },
         { "u_learn_recipe": "cattail_jelly" },
         { "u_buy_item": "cattail_jelly", "container": "bag_zipper", "count": 7 }


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Turn in cattail stalk first then the bag"

#### Purpose of change

same as https://github.com/CleverRaven/Cataclysm-DDA/pull/68077

