### PR TITLE
fix: turrets aiming moving vehicle it cannot see

### DIFF
--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -524,7 +524,7 @@ auto find_target_vehicle( monster &z, int range ) -> std::optional<tripoint>
             std::vector<tripoint> line = here.find_clear_path( z.pos(), v.v->global_pos3() );
             tripoint prev_point = z.pos();
             for( tripoint &i : line ) {
-                if( here.floor_between( prev_point, i ) ) {
+                if( !z.sees( i ) ||  here.floor_between( prev_point, i ) ) {
                     break;
                 }
                 optional_vpart_position vp = here.veh_at( i );

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -486,31 +486,39 @@ int gun_actor::get_max_range()  const
     }
     return max_range;
 }
-
-static std::optional<tripoint> find_target_vehicle( monster &z, int range )
+namespace
 {
+
+auto find_target_vehicle( monster &z, int range ) -> std::optional<tripoint>
+{
+    const auto is_different_plane = []( const wrapped_vehicle & v, const monster & m ) -> bool {
+        return !fov_3d && v.pos.z != m.pos().z;
+    };
+
     map &here = get_map();
     bool found = false;
     tripoint aim_at;
     for( wrapped_vehicle &v : here.get_vehicles() ) {
-        if( ( !fov_3d && v.pos.z != z.pos().z ) || v.v->velocity == 0 ) {
+        if( is_different_plane( v, z ) || v.v->velocity == 0 ) {
             continue;
         }
 
         bool found_controls = false;
 
         for( const vpart_reference &vp : v.v->get_avail_parts( "CONTROLS" ) ) {
-            if( z.sees( vp.pos() ) ) {
-                int new_dist = rl_dist( z.pos(), vp.pos() );
-                if( new_dist <= range ) {
+            if( !z.sees( vp.pos() ) ) {
+                continue;
+            }
 
-                    aim_at = vp.pos();
-                    range = new_dist;
-                    found = true;
-                    found_controls = true;
-                }
+            int new_dist = rl_dist( z.pos(), vp.pos() );
+            if( new_dist <= range ) {
+                aim_at = vp.pos();
+                range = new_dist;
+                found = true;
+                found_controls = true;
             }
         }
+
 
         if( !found_controls ) {
             std::vector<tripoint> line = here.find_clear_path( z.pos(), v.v->global_pos3() );
@@ -542,6 +550,9 @@ static std::optional<tripoint> find_target_vehicle( monster &z, int range )
         return std::optional<tripoint>();
     }
 }
+
+} // namespace
+
 
 bool gun_actor::call( monster &z ) const
 {


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fixed turrets aiming moving vehicle it cannot see"

#### Purpose of change

while #2589 fixed turrets firing through walls and floors, turrets still ignored their visibility for moving vehicles.

fix https://gall.dcinside.com/board/view/?id=rlike&no=447553

#### Describe the solution

also check for visibility in turrets

#### Describe alternatives you've considered

haha turrets go brrrrrrrrt

#### Testing

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/4cdf6c36-2b0b-401f-8637-fc2d6408bde4


https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/7bca86e3-c15f-4932-b429-763e017a9b52


