### PR TITLE
Prevent poisonous foods from softlocking the game

### DIFF
--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -276,7 +276,7 @@
     "name": { "str_sp": "commercial fertilizer" },
     "weight": "350 g",
     "color": "yellow",
-    "flags": [ "FERTILIZER" ],
+    "flags": [ "FERTILIZER", "UNSAFE_CONSUME" ],
     "use_action": "PLANTBLECH",
     "container": "bag_canvas",
     "comestible_type": "FOOD",

--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -625,7 +625,7 @@
     "material": "flesh",
     "volume": "250 ml",
     "fun": -10,
-    "flags": [ "TRADER_AVOID", "SMOKABLE", "NUTRIENT_OVERRIDE", "RAW" ],
+    "flags": [ "TRADER_AVOID", "SMOKABLE", "NUTRIENT_OVERRIDE", "RAW", "UNSAFE_CONSUME" ],
     "smoking_result": "dry_meat_tainted"
   },
   {
@@ -648,7 +648,7 @@
     "volume": "250 ml",
     "milling": { "into": "meal_bone_tainted", "conversion_rate": 4 },
     "fun": -10,
-    "flags": [ "NO_SALVAGE" ]
+    "flags": [ "NO_SALVAGE", "UNSAFE_CONSUME" ]
   },
   {
     "type": "GENERIC",
@@ -678,7 +678,7 @@
     "material": "flesh",
     "volume": "250 ml",
     "fun": -10,
-    "flags": [ "RAW" ]
+    "flags": [ "RAW", "UNSAFE_CONSUME" ]
   },
   {
     "type": "COMESTIBLE",
@@ -701,7 +701,8 @@
     "volume": "250 ml",
     "charges": 2,
     "stack_size": 4,
-    "fun": -18
+    "fun": -18,
+    "flags": [ "UNSAFE_CONSUME" ]
   },
   {
     "type": "COMESTIBLE",
@@ -764,7 +765,7 @@
     "price": 330,
     "price_postapoc": 20,
     "material": "flesh",
-    "flags": [ "RAW", "TRADER_AVOID" ],
+    "flags": [ "RAW", "TRADER_AVOID", "UNSAFE_CONSUME" ],
     "stack_size": 1,
     "fun": -12
   },
@@ -819,7 +820,7 @@
     "description": "A carefully folded raw skin harvested from a fur-bearing unnatural creature.  It still has the fur attached and is poisonous.  You can cure it for storage and tanning.",
     "price": 0,
     "price_postapoc": 50,
-    "flags": [ "NO_SALVAGE" ]
+    "flags": [ "NO_SALVAGE", "UNSAFE_CONSUME" ]
   },
   {
     "type": "COMESTIBLE",
@@ -920,7 +921,8 @@
         { "id": "badpoison", "duration": 3600 },
         { "id": "shakes", "duration": 810 }
       ]
-    }
+    },
+    "flags": [ "UNSAFE_CONSUME" ]
   },
   {
     "id": "meat_bark",

--- a/data/json/items/comestibles/mushroom.json
+++ b/data/json/items/comestibles/mushroom.json
@@ -30,7 +30,7 @@
     "material": "mushroom",
     "volume": "250 ml",
     "fun": 1,
-    "flags": [ "SMOKABLE" ],
+    "flags": [ "SMOKABLE", "UNSAFE_CONSUME" ],
     "smoking_result": "dry_mushroom",
     "vitamins": [ [ "calcium", 2 ], [ "iron", 52 ] ]
   },
@@ -45,7 +45,8 @@
     "price": 1500,
     "price_postapoc": 50,
     "fun": 4,
-    "vitamins": [ [ "calcium", 2 ], [ "iron", 52 ] ]
+    "vitamins": [ [ "calcium", 2 ], [ "iron", 52 ] ],
+    "delete": { "flags": [ "UNSAFE_CONSUME" ] }
   },
   {
     "type": "COMESTIBLE",

--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -29,7 +29,8 @@
     "price": 0,
     "price_postapoc": 0,
     "volume": "250 ml",
-    "fun": -10
+    "fun": -10,
+    "flags": [ "UNSAFE_CONSUME" ]
   },
   {
     "type": "COMESTIBLE",
@@ -207,7 +208,8 @@
     "material": "powder",
     "volume": "250 ml",
     "charges": 4,
-    "fun": -10
+    "fun": -10,
+    "flags": [ "UNSAFE_CONSUME" ]
   },
   {
     "type": "COMESTIBLE",
@@ -568,7 +570,7 @@
     "price": 80,
     "price_postapoc": 0,
     "material": "hflesh",
-    "flags": [ "TRADER_AVOID" ],
+    "flags": [ "TRADER_AVOID", "UNSAFE_CONSUME" ],
     "volume": "250 ml",
     "fun": -30
   },

--- a/data/json/items/comestibles/raw_veggy.json
+++ b/data/json/items/comestibles/raw_veggy.json
@@ -400,7 +400,8 @@
     "material": [ "veggy" ],
     "volume": "250 ml",
     "price": 0,
-    "price_postapoc": 0
+    "price_postapoc": 0,
+    "flags": [ "UNSAFE_CONSUME" ]
   },
   {
     "type": "COMESTIBLE",
@@ -792,7 +793,8 @@
     "description": "This is a chunk of fungal matter from some sort of alien mushroom creature.  Eating unfamiliar mushrooms is a bad idea.",
     "price": 0,
     "price_postapoc": 0,
-    "smoking_result": "dry_veggy_tainted"
+    "smoking_result": "dry_veggy_tainted",
+    "extend": { "flags": [ "UNSAFE_CONSUME" ] }
   },
   {
     "type": "COMESTIBLE",

--- a/data/json/items/comestibles/seed.json
+++ b/data/json/items/comestibles/seed.json
@@ -15,7 +15,7 @@
     "primary_material": "dried_vegetable",
     "symbol": ".",
     "color": "brown",
-    "flags": [ "NUTRIENT_OVERRIDE", "PLANTABLE_SEED" ]
+    "flags": [ "NUTRIENT_OVERRIDE", "PLANTABLE_SEED", "UNSAFE_CONSUME" ]
   },
   {
     "abstract": "seed_fruit",
@@ -318,6 +318,7 @@
     "material": "garlic",
     "volume": "150 ml",
     "fun": -3,
+    "flags": [ "UNSAFE_CONSUME" ],
     "seed_data": { "plant_name": "garlic", "fruit": "garlic", "byproducts": [ "withered" ], "grow": "10 days" }
   },
   {
@@ -382,7 +383,7 @@
     "price": 100,
     "weight": "2 g",
     "charges": 2,
-    "flags": [ "RAW" ],
+    "flags": [ "RAW", "UNSAFE_CONSUME" ],
     "seed_data": { "plant_name": "cannabis", "fruit": "cannabis", "grow": "14 days" }
   },
   {
@@ -419,6 +420,7 @@
     "volume": "100 ml",
     "stack_size": 10,
     "fun": 30,
+    "flags": [ "UNSAFE_CONSUME" ],
     "seed_data": { "fruit": "null", "//": "dummy entry, results are hardcoded", "plant_name": "marloss berry", "grow": "14 days" }
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++ and Markdown: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md

!!!!!!!!!! WARNING !!!!!!!!!!

If you forget to format the PR, autofix.ci app will run automated format commit for you.
When this happens, YOU MUST DO EITHER OF THE FOLLOWING:

- Run `git pull` to merge the automated commit into your PR branch.
- Format your code locally, and force push to your PR branch. 

If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Add UNSAFE_CONSUME to several foods that triggered query on eat, to prevent them from softlocking when placed in an auto-eat zone"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Viss pointed out to me that if an item in an auto-eat zone has a poison use action or other thing that prompts you about if you want to eat them, but lacks the `UNSAFE_CONSUME` flag, you'll be trapped in an infinite loop should it decide to eat that item, where your only options are to either succumb to peer pressure and eat eat morel mushrooms, or to force-quit the game.

I figured fix all potential cases of this in the JSON for a quick fix to potential softlocks now, and look at the code to make it stop doing that in a separate PR.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Added `UNSAFE_CONSUME` flag to morel mushrooms.
2. Set it so cooked morel mushrooms remove the flag. Fried already does so innately due to overriding the flags.
3. Added `UNSAFE_CONSUME` to the seed abstract, so that all seeds inheriting from it will be skipped over too. This is because the prompt for comestibles with `seed_data` triggers this same issue.
4. Added the flag to garlic cloves, which don't inherit from seeds. It seems to work fine in testing but better safe than sorry, plus plantable seeds in general probably should be skipped over.
5. Added the flag to cannabis seeds, which inherit from the seed abstract but override the flags.
6. Added the flag to marloss seeds, since they don't inherit from seeds. Also they're fungal stuff so.
7. Added the flag to Kentucky coffee pods, as they're poisonous.
8. Added the flag to dogbane, as it has the `BLECH` use action.
9. Added the flag to tainted meat, as it has the `POISON` use action. Testing confirmed these should be skipped over due to not bein fun to eat, but better safe than sorry due to the softlock potential. Plus, dehydrated tainted meat DOES trigger the softlock due to being above -5 fun, and it inherits from this so.
10. Did the same for tainted bones, tainted fat, and tainted tallow, as above.
11. Also added to raw hide just in case, which in turn covers tainted hides.
12. Added to leech flowers, as it gives a fairly potent drug effect while being fun enough it might be eaten anyway.
13. Also added to blob globs, tainted bone meal, and embalmed human brains to continue to be certain.
14. Set alien fungus chunks to `extend` the flag onto its flag list, since it inherits from plant marrow. Confirmed by testing that it can trigger the softlock without this.
15. Added the flag to commercial fertilizer, one of the only chemical items not in the comestible folder that didn't already have this flag.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Focusing on hunting down all the obscure code interactions behind the root problem and fixing them first but weh.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected files for syntax and lint errors.

I also tested a few of the odd cases as mentioned above, in particular garlic cloves are technically safe for reasons I'm not sure of without source-diving to find exactly why the seed prompt triggers. Better off doing so since plantable seeds are generally better off saved anyway, and cloves still count as seeds.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

So I was gonna test if this was still a problem in DDA but on the build I tried (2023-08-10-1558) auto-eat zones just don't even work at all, I tested waiting around with some jerky in it too and the character wouldn't eat that either, even after confirming that they weren't freezing.