### PR TITLE
Prevent auto-eating items with use actions

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3195,6 +3195,11 @@ bool find_auto_consume( player &p, const consume_type type )
         {
             return false;
         }
+        /* Avoid items that may softlock with a Y/N query */
+        if( comest.has_use() )
+        {
+            return false;
+        }
         return true;
     };
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++ and Markdown: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md

!!!!!!!!!! WARNING !!!!!!!!!!

If you forget to format the PR, autofix.ci app will run automated format commit for you.
When this happens, YOU MUST DO EITHER OF THE FOLLOWING:

- Run `git pull` to merge the automated commit into your PR branch.
- Format your code locally, and force push to your PR branch. 

If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Prevent auto-eat code from selection items with use actions to avoid Y/N queries softlocking an auto-eat attempt"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

As mentioned in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3183, I intended to also add a code PR to nip this issue in the bud full-stop via a code solution.

From what I can tell, the root issue is specifically items that have an iuse that brings up a yes/no query. Mundane inedible stuff like meat for an herbivore character is already handled by `will_eat`, but stuff like asking if you want to eat tainted meat is handled through the item having an iuse.

As far as I can tell, the only real ways to check that are `has_use` and `has_iuse`. The latter can check for specific use actions, but it's a member of item factory and not usable in the relevant function, which handles an item. The other drawback is we'd need to manually screen for every iuse that can be canceled in some way if we want to be 100% sure we get all potential abuses that might softlock the player (and for some the answer will vary item by item, e.g. spellcasting items).

`can_use` is a simpler case of just asking if the offending item has any use action, period. Right now every case in the comestibles folder (barring some transforming and disassembly items that aren't actually comestibles) uses a blech/poison action, Mycus-related stuff, an alcohol use action, mutagen, or drug-related use actions, all of which we don't really want to be auto-eaten at the moment, so the simple solution seems like the best option anyway.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

In activity_item_handling.cpp, added a condition to `find_auto_consume` that excludes all items remaining that have a use action defined.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Figuring out or writing a function that lets me check for specific items at the item level so I can manually filter out only those use actions that might trigger the softlock.
2. Rigging some kinda way to check whether a use action will lead to a query or other way to fuck it up and cause a softlock, allowing for stuff like Eater of The Dead players being able to auto-eat poisoned stuff.
3. Rigging it so that selecting no on a query flags the item as blacklisted from auto-eat in some way.
4. Converting the use actions that are causing all these problems to item flags instead so that handling of this can be dumped into `will_eat` instead.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested.
2. Tested placing clean water in an auto-drink zone, confirmed that it overriding use action with a blank entry means it correclty counts as not having a use action.
3. Temporarily removed `UNSAFE_CONSUME` from tainted meat, confirmed that dehydrated meat (which has enough fun to not be skipped over already) still doesn't trigger the softlock like it used to.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

One casualty of this is honeycombs, which use a use action to hack in leaving behind wax when eaten. The only other "normal" food to suffer for this would be special brownies, but whether those should be avoided by auto-eat is more debatable since they are technically triggering drug effects, with the main counterargument being unlike alcohol weed items don't have addiction effects.