### PR TITLE
feat: default to no zombie revival and limited fungal growth

### DIFF
--- a/data/mods/default.json
+++ b/data/mods/default.json
@@ -3,5 +3,7 @@
   "no_npc_food",
   "novitamins",
   "No_Rail_Stations",
-  "elevated_bridges"
+  "elevated_bridges",
+  "no_reviving_zombies",
+  "limit_fungal_growth"
 ]


### PR DESCRIPTION
#### Summary

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/4a2c1697-1073-4a5e-9c5b-c793abfdfb7c)

SUMMARY: Mods "Made 'Prevent Zombie Revivification' and 'Limit Fungal Growth' as default-enabled mod"

#### Purpose of change

[original discussion in discord](https://discord.com/channels/830879262763909202/830916329053487124/1154179815109300275)

- zombie revivification is often not fun as it's more work.
- in current status, fungals expand too rapidly, effectively soft-locking the whole area without proper reward.

#### Describe the solution

following mods were added to default-enabled modlist on worldgen:

- Prevent Zombie Revivification
- Limit Fungal Growth

#### Describe alternatives you've considered

- implement #3188 to make fulgaloids more engaging
