### PR TITLE
ci(fix): temporary disable github environments

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-22.04
-    environment: github-pages
+    # environment: github-pages
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v3
@@ -29,9 +29,9 @@ jobs:
           node-version: 20
           package-manager: pnpm
           pnpm-version: 8.7.x
-        env:
-          CUSTOM_SITE_URL: ${{ vars.CUSTOM_SITE_URL }}
-          CUSTOM_REPO_URL: ${{ vars.CUSTOM_REPO_URL }}
+        # env:
+          # CUSTOM_SITE_URL: ${{ vars.CUSTOM_SITE_URL }}
+          # CUSTOM_REPO_URL: ${{ vars.CUSTOM_REPO_URL }}
 
   deploy:
     needs: build


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Hotfix made to fix deploying github pages"

#### Purpose of change

missing github environments preventing workflow

#### Describe the solution

disabled environments temporary, as they were originally a mean to run in another branch, the site should work without it as-is.

#### Describe alternatives you've considered

this will be reverted once environments are properly set up.

#### Testing

#### Additional context

