### PR TITLE
Rework and sanity-check harvesting of tin

### DIFF
--- a/data/json/obsoletion/recipes.json
+++ b/data/json/obsoletion/recipes.json
@@ -780,11 +780,6 @@
   },
   {
     "type": "recipe",
-    "result": "bowl_pewteruncraft",
-    "obsolete": true
-  },
-  {
-    "type": "recipe",
     "result": "brew_bum_wine",
     "obsolete": true
   },
@@ -2021,11 +2016,6 @@
   {
     "type": "recipe",
     "result": "tieclipuncraft",
-    "obsolete": true
-  },
-  {
-    "type": "recipe",
-    "result": "tin_plateuncraft",
     "obsolete": true
   },
   {

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -1221,13 +1221,14 @@
     "difficulty": 4,
     "autolearn": [ [ "cooking", 6 ] ],
     "book_learn": [ [ "textbook_chemistry", 3 ], [ "textbook_fabrication", 4 ], [ "welding_book", 4 ] ],
-    "time": "30 m",
+    "time": "10 m",
+    "charges": 10,
     "batch_time_factors": [ 50, 2 ],
     "tools": [ [ [ "electrolysis_kit", 100 ] ], [ [ "jar_glass", -1 ], [ "jar_3l_glass", -1 ] ] ],
     "components": [
-      [ [ "acid", 1 ] ],
+      [ [ "acid", 1 ], [ "chem_sulphuric_acid", 1 ] ],
       [ [ "water", 3 ], [ "water_clean", 3 ] ],
-      [ [ "tin_plate", 1 ], [ "tin_cup", 1 ], [ "bowl_pewter", 1 ] ]
+      [ [ "can_food_big_unsealed", 1 ], [ "can_medium_unsealed", 5 ], [ "can_food_unsealed", 10 ] ]
     ]
   },
   {

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -1597,6 +1597,27 @@
     "components": [ [ [ "ceramic_shard", 1 ] ] ]
   },
   {
+    "result": "bowl_pewter",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "HAMMER", "level": 1 } ],
+    "components": [ [ [ "tin", 125 ] ] ]
+  },
+  {
+    "result": "tin_plate",
+    "type": "uncraft",
+    "time": "1 m",
+    "qualities": [ { "id": "HAMMER", "level": 1 } ],
+    "components": [ [ [ "tin", 125 ] ] ]
+  },
+  {
+    "result": "tin_cup",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "HAMMER", "level": 1 } ],
+    "components": [ [ [ "tin", 100 ] ] ]
+  },
+  {
     "result": "char_purifier",
     "type": "uncraft",
     "time": "10 m",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/mod/json/explanation/json_style.md
C++ and Markdown: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/dev/explanation/code_style.md

!!!!!!!!!! WARNING !!!!!!!!!!

If you forget to format the PR, autofix.ci app will run automated format commit for you.
When this happens, YOU MUST DO EITHER OF THE FOLLOWING:

- Run `git pull` to merge the automated commit into your PR branch.
- Format your code locally, and force push to your PR branch. 

If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/src/content/docs/en/contribute/changelog_guidelines.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Bring back deconstruction of pewter items, reimplement salvaging tin from cans via electroplating using new larger can sizes"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Back in the old days, you could simply scrap tin and pewter items to get tin directly, which back when I added bronze made it a bit more convenient.

Eventually, someone had the clever idea to allow extracting tin from tin cans using electrolysis. This is reasonable, while they aren't made wholly of tin it's still common to plate them, and the intended use case was just to get enough tin to make copper pots. Cans are super common so having to stockpile to make up for a low yield seems reasonable enough to me.

Then it went off the rails when someone else changed the recipe to only use pewter and tin items. This of course defeated literally the entire point of the electroplating PR, that being restricted to looting pewter items was a problem.

The followup to this made tin and pewter items more common, but in exchange it obsoleted the ability to easily deconstruct those items on the basis that it "defeats the purpose of the electrolysis tin crafting recipe," when the purpose had already been defeated by the preceding PR by the same contributor.

This aims to fix the problems caused by all this, along with taking advantage of the fact that nowadays we have larger sizes of cans.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Un-obsoleted the original deconstructs for tin and pewter items, set their yield to be closer to the weights of the items being deconstructed.
2. Added a new deconstruct for tin cups, evidently that didn't exist back in the day.
3. Reworked the electrolysis recipes to use all three sizes of tin cans at roughly consistent ratios of weight, with `charges` updated accordingly. The numbers are fudged a lil bit (rough lookup says tin cans have 1-2% tin in them, this is more like 5% to ~5.7% yield) to get the original yield of 10 charges of tin. On the plus side, the 1:5:10 ratio looks less messy than the ratio listed below in alternatives, and unlike the original version of the recipe precludes getting a 250 gram steel chunk out of a 40-gram small can. Still lower yield than the 25% or so the original recipe would get since it was obtaining 10 tin from a single small can.
4. Added sulfuric acid as an option for the acid in the tin extraction recipe. Quick lookup indicates sulfuric acid is commonly used, and in-game it's a lot easier to obtain than the generic acid that will probably get axed one of these days now that there's like a half-dozen specific acids already represented.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Changing the electroplating recipe and/or the weight of tin cans so that we can require 1 kg's worth of tin cans to get a completely realismic max of 2% yield. This would require ~3 large cans, ~15 medium cans, or 25 small cans at their current item weights. That'd be annoying but doable.
2. Obsoleting the electrolysis recipe and just focusing on scraping pewter items because not being able to extract tin from tin cans has long since undermined the original purpose of the recipe anyway.
3. Making it so you uncraft the tin/pewter dining items into a new pewter scrap item, using that in any recipe where we can justify it not needing to be completely pure tin (namely bronze crafting), and then have the electroplating recipe consume that instead of the tin/pewter items directly.
4. Adding cutting, metal sawing, or hammering quality to the tin extraction recipe on the basis that you'd need some way to reduce the cans down to scraps that will fit in a glass jar.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected files for syntax and lint errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Related PR links:
1. Extracting tin from the tinplate of cans, by @Davi-DeGanne: https://github.com/CleverRaven/Cataclysm-DDA/pull/23767
2. Removal of tin cans from electroplating recipe, by @ampersand55: https://github.com/CleverRaven/Cataclysm-DDA/pull/33111
3. Removal of ability to deconstruct tin and pewter items, by @ampersand55: https://github.com/CleverRaven/Cataclysm-DDA/pull/33301

I also plan to do a bit of tweaking to aluminum soon-ish, but when I do, should I go for replacing aluminum ingots with the standard small metal item, or should I just making the ingots a more manageable size (100 ml for example is about right for the archetypal hobbyist muffin tin ingot)?

Worth noting in the above that reducing ingots to 100 ml would make them 270 ml based off their density, and in doing so put things just about right such that we could justify making one with ~20 aluminum cans (13 grams a pop, would be slightly less wonky if adjusted to 14 or 15 grams). That would be a quantity closer to actually worth adding a recipe for aluminum ingots.

On the other hand, converting aluminum to a small metal would mean we could just have it weigh 27 mg per single unit of aluminum, and allow directly scraping aluminum cans into 4-5 units of aluminum without any faffing about with melting it down. Main counterpoints to that are that making muffin pan ingots is a classic metalworking project, and more importantly aluminum powder and aluminum foil make the whole "super low weight stacking aluminum item" category fairly crowded as it is.