### PR TITLE
docs: rollback github environments, fix broken wiki links

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-22.04
-    # environment: github-pages
+    environment: github-pages
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v3
@@ -29,9 +29,9 @@ jobs:
           node-version: 20
           package-manager: pnpm
           pnpm-version: 8.7.x
-        # env:
-          # CUSTOM_SITE_URL: ${{ vars.CUSTOM_SITE_URL }}
-          # CUSTOM_REPO_URL: ${{ vars.CUSTOM_REPO_URL }}
+        env:
+          CUSTOM_SITE_URL: ${{ vars.CUSTOM_SITE_URL }}
+          CUSTOM_REPO_URL: ${{ vars.CUSTOM_REPO_URL }}
 
   deploy:
     needs: build

--- a/README.ko.md
+++ b/README.ko.md
@@ -24,9 +24,8 @@
 카타클리즘을 멈출 방법을 찾거나.... 가장 강력한 괴물 중 하나가 되세요.
 
 > 카타클리즘: 밝은 밤(Cataclysm: Bright Nights)은 카타클리즘: 어두운 나날(Cataclysm: Dark Days
-> Ahead)의 포크입니다.
-> [위키](https://github.com/cataclysmbnteam/cataclysm-BN/wiki/Changes-so-far)에서 어떤 차이가 있는지
-> 확인하세요.
+> Ahead)의 포크입니다. [위키](https://docs.cataclysmbn.org/ko/game/changelog/)에서 어떤 차이가
+> 있는지 확인하세요.
 
 ## 다운로드
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ who want what you have.
 Find a way to stop the Cataclysm ... or become one of its strongest monsters.
 
 > Cataclysm: Bright Nights is a fork of Cataclysm: Dark Days Ahead.
-> [see the differences from its ancestor on the wiki](https://github.com/cataclysmbnteam/Cataclysm-BN/wiki/Changes-so-far).
+> [see the differences from its ancestor.](https://docs.cataclysmbn.org/en/game/changelog/).
 
 ## Downloads
 

--- a/doc/src/content/docs/en/game/changelog.md
+++ b/doc/src/content/docs/en/game/changelog.md
@@ -134,9 +134,8 @@ of [CleverRaven/Cataclysm-DDA.](https://github.com/CleverRaven/Cataclysm-DDA)
   "access shaft" on z = -1) that has a red-colored "L" tile at its bottom z-level. Find the lab,
   reach the bottom, then either sacrifice your own life or put in a mininuke.</details>
 - (Currently WIP, but already functional) Electric grid system, without use of vehicles, but able to
-  connect to them. See
-  [Electric Grids page](https://github.com/cataclysmbnteam/Cataclysm-BN/wiki/Electric-grids) for
-  more info.
+  connect to them. See [Electric Grids page](../mod/json/explanation/electric_grids.md) for more
+  info.
 - Lower height levels (z-levels) drawn.
 - Angled vehicles don't develop "holes" in their normally-impenetrable walls. This affects all
   relevant game mechanics such as monster and player movement, line of sight calculation, light and


### PR DESCRIPTION
#### Summary

SUMMARY: Infrastructure "Fixed broken wiki links in documentation site"

#### Purpose of change

- fix deprecated wiki links in documentation
- revert blunders made in #3191 

#### Describe the solution

- reverted #3191 as
    - it did not work
    - `github-pages` environment is needed for deploying astro-based site on github pages


#### Describe alternatives you've considered

[host on other services](https://docs.astro.build/en/guides/deploy/#overview), such as 
- deno deploy
- netlify
- cloudflare pages
- vercel

#### Testing

checked that the links are valid in both http/relative redirects on local server.
