### PR TITLE
More craftables 1: Clothing

### DIFF
--- a/data/json/recipes/armor/feet.json
+++ b/data/json/recipes/armor/feet.json
@@ -568,5 +568,18 @@
     "book_learn": [ [ "textbook_armwest", 6 ], [ "textbook_fabrication", 6 ], [ "recipe_melee", 6 ] ],
     "using": [ [ "chainmail_standard", 2 ] ],
     "components": [ [ [ "link_sheet", 2 ] ], [ [ "chain_link", 50 ] ], [ [ "wire", 1 ] ], [ [ "rag", 4 ] ] ]
+  },
+  {
+    "result": "heels",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_FEET",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "time": "35 m",
+    "autolearn": true,
+    "book_learn": [ [ "manual_tailor", 2 ] ],
+    "using": [ [ "sewing_standard", 4 ] ],
+    "components": [ [ [ "leather", 4 ] ] ]
   }
 ]

--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -1548,5 +1548,17 @@
     "time": "10 s",
     "autolearn": true,
     "components": [ [ [ "ear_plugs", 1 ] ], [ [ "filament", 100, "LIST" ], [ "cordage_short", 2, "LIST" ] ] ]
+  },
+  {
+    "result": "maid_hat",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_HEAD",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "time": "30 m",
+    "book_learn": [ [ "textbook_tailor", 3 ] ],
+    "using": [ [ "sewing_standard", 3 ] ],
+    "components": [ [ [ "rag", 4 ] ] ]
   }
 ]

--- a/data/json/recipes/armor/legs.json
+++ b/data/json/recipes/armor/legs.json
@@ -617,5 +617,43 @@
     "book_learn": [ [ "textbook_armwest", 4 ], [ "recipe_melee", 4 ] ],
     "using": [ [ "forging_standard", 6 ], [ "bronzesmithing_tools", 1 ] ],
     "components": [ [ [ "fabric_hides_proper", 6, "LIST" ] ], [ [ "scrap_bronze", 12 ] ] ]
+  },
+  {
+    "result": "skirt",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_LEGS",
+    "skill_used": "tailor",
+    "difficulty": 2,
+    "time": "30 m",
+    "autolearn": true,
+    "book_learn": [ [ "manual_tailor", 1 ], [ "mag_beauty", 1 ] ],
+    "using": [ [ "sewing_standard", 12 ] ],
+    "components": [ [ [ "rag", 6 ] ] ]
+  },
+  {
+    "result": "skirt_leather",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_LEGS",
+    "skill_used": "tailor",
+    "difficulty": 4,
+    "time": "40 m",
+    "autolearn": true,
+    "using": [ [ "sewing_standard", 6 ] ],
+    "components": [ [ [ "leather", 6 ] ] ]
+  },
+  {
+    "result": "nanoskirt",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_LEGS",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "time": "30 m",
+    "autolearn": true,
+    "book_learn": [ [ "manual_tailor", 1 ] ],
+    "using": [ [ "sewing_standard", 8 ] ],
+    "components": [ [ [ "rag", 4 ] ] ]
   }
 ]

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -1261,5 +1261,57 @@
     "book_learn": [ [ "textbook_armwest", 8 ] ],
     "using": [ [ "forging_standard", 14 ], [ "bronzesmithing_tools", 1 ] ],
     "components": [ [ [ "scrap_bronze", 28 ] ] ]
+  },
+  {
+    "result": "dress",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_TORSO",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "time": "1 h 45 m",
+    "autolearn": true,
+    "book_learn": [ [ "mag_tailor", 1 ], [ "manual_tailor", 1 ], [ "mag_beauty", 1 ] ],
+    "using": [ [ "sewing_standard", 20 ] ],
+    "components": [ [ [ "rag", 10 ] ] ]
+  },
+  {
+    "result": "gown",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_TORSO",
+    "skill_used": "tailor",
+    "difficulty": 5,
+    "time": "2 h 30 m",
+    "autolearn": true,
+    "book_learn": [ [ "textbook_tailor", 5 ] ],
+    "using": [ [ "sewing_standard", 32 ] ],
+    "components": [ [ [ "rag", 16 ] ] ]
+  },
+  {
+    "result": "dress_wedding",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_TORSO",
+    "skill_used": "tailor",
+    "difficulty": 6,
+    "time": "4 h",
+    "autolearn": true,
+    "book_learn": [ [ "textbook_tailor", 6 ] ],
+    "using": [ [ "sewing_standard", 48 ] ],
+    "components": [ [ [ "rag", 24 ] ] ]
+  },
+  {
+    "result": "maid_dress",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_TORSO",
+    "skill_used": "tailor",
+    "difficulty": 6,
+    "time": "4 h 30 m",
+    "autolearn": true,
+    "book_learn": [ [ "textbook_tailor", 6 ] ],
+    "using": [ [ "sewing_standard", 60 ] ],
+    "components": [ [ [ "rag", 30 ] ] ]
   }
 ]


### PR DESCRIPTION
#### Summary

SUMMARY: [Balance] "Adds recipes for existing clothing items"

#### Purpose of change

A lot of clothes are missing crafting recipes, this adds some and attaches them to the existing books. I may have missed a few but balance is hard and this needs a lookover.

#### Describe the solution

The skirts, dresses, maid outfit, and heels all have recipes of costs and difficulty I found reasonable based on coverage, warmth value, and how fancy it is. I also followed the same tailoring patterns I found of cloth using 2 sewing standard per rag, and clothing not having a reversible true field.

#### Describe alternatives you've considered

Heels are fully leather, but IRL they are mainly plastic. I figured I'd keep them fully leather for now and worry about it in post as it's easy to fix. http://www.madehow.com/Volume-5/High-Heel.html

#### Testing

Loaded it into the game and it worked.
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/112293514/b11ddb95-b65e-4ca1-b9a0-309517aed147)
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/112293514/1464a846-e42e-43e8-9703-1cca3c7991a2)


#### Additional context
Balance is hard. Help me with the numbers. @chaosvolt 