### PR TITLE
ci: format but skip build/release docs/scripts

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -15,3 +15,6 @@ translation:
 
 docs:
   - docs/**/*
+
+scripts:
+  - scripts/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,3 +12,6 @@ mods:
 
 translation:
   - lang/**/*
+
+docs:
+  - docs/**/*

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,6 +16,7 @@ on:
       - "tools/**"
       - "!tools/format/**"
       - "utilities/**"
+      - 'scripts/**'
 
 # We only care about the latest revision of a PR, so cancel previous instances.
 concurrency:

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -2,7 +2,7 @@ name: autofix.ci  # needed to securely identify the workflow
 
 on:
   pull_request:
-    paths: ["**.json", "**.cpp", "**.hpp", "**.h", "**.c"]
+    paths: ["**.json", "**.cpp", "**.hpp", "**.h", "**.c", "**.md", "**.ts"]
 
 permissions:
   contents: read
@@ -25,7 +25,7 @@ jobs:
       - name: format C++ files
         run: make astyle
 
-      - name: format markdown files
+      - name: format markdown and typescript files
         run: deno fmt
 
       - name: json formatting

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -6,11 +6,13 @@ on:
       - upload
     paths-ignore:
       - doc/**
+      - 'scripts/**'
   pull_request:
     branches:
       - upload
     paths-ignore:
       - doc/**
+      - 'scripts/**'
 
 jobs:
   skip-duplicates:

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - upload
+    paths-ignore:
+      - doc/**
   pull_request:
     branches:
       - upload
+    paths-ignore:
+      - doc/**
 
 jobs:
   skip-duplicates:

--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -17,6 +17,7 @@ on:
     - 'tools/**'
     - '!tools/format/**'
     - 'utilities/**'
+    - 'scripts/**'
   pull_request:
     branches:
     - upload
@@ -33,6 +34,7 @@ on:
     - 'tools/**'
     - '!tools/format/**'
     - 'utilities/**'
+    - 'scripts/**'
 
 # We only care about the latest revision of a PR, so cancel previous instances.
 concurrency:

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -14,6 +14,7 @@ on:
     - 'tools/**'
     - '!tools/format/**'
     - 'utilities/**'
+    - 'scripts/**'
   pull_request:
     branches:
     - upload
@@ -27,6 +28,7 @@ on:
     - 'tools/**'
     - '!tools/format/**'
     - 'utilities/**'
+    - 'scripts/**'
 
 # We only care about the latest revision of a PR, so cancel previous instances.
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - upload
     paths-ignore:
       - 'doc/**'
-
+      - 'scripts/**'
 
 env:
   VCPKG_BINARY_SOURCES: "default"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - upload
+    paths-ignore:
+      - 'doc/**'
+
 
 env:
   VCPKG_BINARY_SOURCES: "default"


### PR DESCRIPTION
#### Summary

SUMMARY: Build "Skip docs/script only changes in PRs and commits, but format them"

#### Purpose of change

- skip unnecessary builds/releases
- we don't distribute docs in releases, that could be skipped as well
- make markdown/typescript only changes trigger autofix
- label docs and scripts