### PR TITLE
docs: fix docs page redirection failing

### DIFF
--- a/doc/astro.config.ts
+++ b/doc/astro.config.ts
@@ -29,7 +29,7 @@ console.log({ ...env, site, github })
 
 export default defineConfig({
   site,
-  redirects: { "/": `/en/` },
+  redirects: { "/": `./en/` },
   markdown: {
     remarkPlugins: [fixRelativeLinks],
   },

--- a/doc/astro.config.ts
+++ b/doc/astro.config.ts
@@ -11,8 +11,6 @@ import { fixRelativeLinks } from "./remark.js"
 const envPath = join(fileURLToPath(import.meta.url), "..")
 const env = loadEnv("", envPath, "CUSTOM")
 
-console.log(env)
-
 const { CUSTOM_SITE_URL, CUSTOM_REPO_URL } = env
 
 const site = CUSTOM_SITE_URL || "https://docs.cataclysmbn.org"
@@ -26,6 +24,8 @@ const docModes = (dir: string) => [
   { label: "reference", autogenerate: { directory: `${dir}/reference` } },
   { label: "explanation", autogenerate: { directory: `${dir}/explanation` } },
 ]
+
+console.log({ ...env, site, github })
 
 export default defineConfig({
   site,


### PR DESCRIPTION

## Summary

SUMMARY: Bugfixes "Made documentation page redirects relative to fix edge cases"

## Purpose of change

if the docs page is hosted on subpath (e.g: `/bar` in `https://foo/bar`), absolute redirects such as `/` -> `/en` will redirect to `https://foo/en` not `https://foo/bar/en`.

## Describe the solution

- used relative redirect instead.
- made ENV debug output more helpful by the way

## Describe alternatives you've considered

this can also be solved by using `base` parameter to astro config but this is easier and more robust.

## Testing

worked in local environment.
