### PR TITLE
feat: monster immunity flag for biological damage

### DIFF
--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -661,7 +661,8 @@
       "PATH_AVOID_DANGER_2",
       "PRIORITIZE_TARGETS",
       "FILTHY",
-      "NO_FUNG_DMG"
+      "NO_FUNG_DMG",
+      "BIOPROOF"
     ]
   },
   {
@@ -709,7 +710,8 @@
       "PATH_AVOID_DANGER_1",
       "PRIORITIZE_TARGETS",
       "FILTHY",
-      "NO_FUNG_DMG"
+      "NO_FUNG_DMG",
+      "BIOPROOF"
     ]
   },
   {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1367,8 +1367,7 @@ bool monster::is_immune_damage( const damage_type dt ) const
         case DT_TRUE:
             return false;
         case DT_BIOLOGICAL:
-            // NOTE: Unused
-            return false;
+            return has_flag( MF_BIOPROOF );
         case DT_BASH:
             return false;
         case DT_CUT:

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -25,6 +25,7 @@
 #include "mondeath.h"
 #include "mondefense.h"
 #include "monfaction.h"
+#include "mtype.h"
 #include "options.h"
 #include "pathfinding.h"
 #include "rng.h"
@@ -104,6 +105,7 @@ std::string enum_to_string<m_flag>( m_flag data )
         case MF_SLUDGEPROOF: return "SLUDGEPROOF";
         case MF_SLUDGETRAIL: return "SLUDGETRAIL";
         case MF_COLDPROOF: return "COLDPROOF";
+        case MF_BIOPROOF: return "BIOPROOF";
         case MF_FIREY: return "FIREY";
         case MF_QUEEN: return "QUEEN";
         case MF_ELECTRONIC: return "ELECTRONIC";

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -100,6 +100,7 @@ enum m_flag : int {
     MF_SLUDGEPROOF,         // Ignores the effect of sludge trails
     MF_SLUDGETRAIL,         // Causes monster to leave a sludge trap trail when moving
     MF_COLDPROOF,           // Immune to cold damage
+    MF_BIOPROOF,     // Immune to biological damage
     MF_FIREY,               // Burns stuff and is immune to fire
     MF_QUEEN,               // When it dies, local populations start to die off too
     MF_ELECTRONIC,          // e.g. a robot; affected by EMP blasts, and other stuff

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -95,7 +95,7 @@ enum m_flag : int {
     MF_ELECTRIC,            // Shocks unarmed attackers
     MF_ACIDPROOF,           // Immune to acid
     MF_ACIDTRAIL,           // Leaves a trail of acid
-    MF_SHORTACIDTRAIL,       // Leaves an intermittent trail of acid
+    MF_SHORTACIDTRAIL,      // Leaves an intermittent trail of acid
     MF_FIREPROOF,           // Immune to fire
     MF_SLUDGEPROOF,         // Ignores the effect of sludge trails
     MF_SLUDGETRAIL,         // Causes monster to leave a sludge trap trail when moving
@@ -111,9 +111,9 @@ enum m_flag : int {
     MF_FAT,                 // May produce fat when butchered; if combined with POISON flag, tainted fat
     MF_CONSOLE_DESPAWN,     // Despawns when a nearby console is properly hacked
     MF_IMMOBILE,            // Doesn't move (e.g. turrets)
-    MF_ID_CARD_DESPAWN,      // Despawns when a science ID card is used on a nearby console
+    MF_ID_CARD_DESPAWN,     // Despawns when a science ID card is used on a nearby console
     MF_RIDEABLE_MECH,       // A rideable mech that is immobile until ridden.
-    MF_MILITARY_MECH,        // A rideable mech that was designed for military work.
+    MF_MILITARY_MECH,       // A rideable mech that was designed for military work.
     MF_MECH_RECON_VISION,   // This mech gives you IR night-vision.
     MF_MECH_DEFENSIVE,      // This mech gives you thorough protection.
     MF_HIT_AND_RUN,         // Flee for several turns after a melee attack


### PR DESCRIPTION
## Summary

SUMMARY: Features "Adds BIOPROOF, a new monster immunity flag for biological damage"

## Purpose of change

- fix #3193

## Describe the solution

added `BIOPROOF`

## Describe alternatives you've considered

slep

## Testing
![Cataclysm: Bright Nights - 5afebd651359_02](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/a028ccbd-6324-48b0-9825-8bbf1c59bccc)

1. spawn a zombie master
2. cast necrotic gaze to it
3. master is not affected

## Additional context

@RoyalFox2140 @RobbieNeko pls review
