### PR TITLE
Fix NPCs set to attack what you attack charging blindly

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1361,6 +1361,8 @@ npc_action npc::method_of_attack()
     bool can_use_gun = ( ( !is_player_ally() || rules.has_flag( ally_rule::use_guns ) ) &&
                          ( ai_cache.danger >= 3 || emergency() || dist < 0 ) );
     bool use_silent = ( is_player_ally() && rules.has_flag( ally_rule::use_silent ) );
+    const bool not_engaged_yet = !critter->has_effect( effect_hit_by_player ) &&
+                                 rules.engagement == combat_engagement::HIT;
 
     // if there's enough of a threat to be here, power up the combat CBMs
     activate_combat_cbms();
@@ -1428,7 +1430,7 @@ npc_action npc::method_of_attack()
         return npc_aim;
     }
     add_msg( m_debug, "%s can't figure out what to do", disp_name() );
-    return ( dont_move || !same_z ) ? npc_undecided : npc_melee;
+    return ( dont_move || !same_z || not_engaged_yet ) ? npc_undecided : npc_melee;
 }
 
 npc_action npc::address_needs()


### PR DESCRIPTION
<!-- HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/mod/json/explanation/json_style.md
C++ and Markdown: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/dev/explanation/code_style.md

!!!!!!!!!! WARNING !!!!!!!!!!

If you forget to format the PR, autofix.ci app will run automated format commit for you.
When this happens, YOU MUST DO EITHER OF THE FOLLOWING:

- Run `git pull` to merge the automated commit into your PR branch.
- Format your code locally, and force push to your PR branch. 

If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
-->

## Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/src/content/docs/en/contribute/changelog_guidelines.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Companion NPCs told to only attack what the player attacks no longer charge approaching enemies unless you've actually attacked the target first"

## Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This fixes NPCs set to "attack only what I attack" being stupid and bum-rushing targets you haven't marked for death yet, AKA what used to be my preferred NPC RoE setting back in the old days.

## Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

In npcmove.cpp, changed `npc::method_of_attack` to add an extra boolean that checks if both the target has yet to be hit by the player and the NPC is set to engage targets you attack. If so, the bottom function for fallback behavior will tell them to hold fast as if they were not to not move, instead of going for a charge.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

If anyone can remember any other NPC AI settings that visibly don't work right, lemme know.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested.
2. Recruited the starter NPC and set them to attack what I attack.
3. Gave them a melee weapon and spawned in a zombie.
4. Waited for the zed to approach, they do nothing until the zombie actually gets in melee range.
5. Repeated this test but this time shot the zombie before it approached.
6. NPC responds by charging the zed before it gets close.
7. Checked affected file for astyle.

Also tested giving them a gun, if so they'll shoot attackers as they get near even if you haven't attacked. Not sure if that'd be desirable behavior or not, as opposed to the more obvious case of not making them charge enemies in melee you haven't engaged yet.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

At one point while testing I got an access violation that pointed to `Messages::display_messages` in npcmopve.cpp, pointing to this bit and saying "`m` was nullpointer" but have not been able to reproduce this after several more tests:
```
            const nc_color col = m.get_color( player_messages.curmes );
            std::string message_text = m.get_with_count();
            if( !m.is_recent( player_messages.curmes ) ) {
                message_text = remove_color_tags( message_text );
            }
```