### PR TITLE
BIOPROOF distribution: Robots

### DIFF
--- a/data/json/monsters/defense_bot.json
+++ b/data/json/monsters/defense_bot.json
@@ -31,7 +31,7 @@
     "special_attacks": [ [ "COPBOT", 3 ] ],
     "death_drops": { "groups": [ [ "robots", 4 ], [ "copbot", 1 ] ] },
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "HEARS", "BASHES", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PRIORITIZE_TARGETS", "PATH_AVOID_DANGER_1" ]
+    "flags": [ "SEES", "HEARS", "BASHES", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PRIORITIZE_TARGETS", "PATH_AVOID_DANGER_1", "BIOPROOF" ]
   },
   {
     "id": "mon_riotbot",
@@ -63,7 +63,7 @@
     "special_when_hit": [ "ZAPBACK", 100 ],
     "death_drops": { "groups": [ [ "robots", 4 ], [ "copbot", 1 ] ] },
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "HEARS", "GOODHEARING", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PRIORITIZE_TARGETS", "PATH_AVOID_DANGER_1" ]
+    "flags": [ "SEES", "HEARS", "GOODHEARING", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PRIORITIZE_TARGETS", "PATH_AVOID_DANGER_1", "BIOPROOF" ]
   },
   {
     "id": "mon_secubot",
@@ -113,7 +113,7 @@
     ],
     "death_drops": {  },
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "HEARS", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PATH_AVOID_DANGER_1", "LOUDMOVES", "DROPS_AMMO" ]
+    "flags": [ "SEES", "HEARS", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PATH_AVOID_DANGER_1", "LOUDMOVES", "DROPS_AMMO", "BIOPROOF" ]
   },
   {
     "id": "mon_talon_m202a1",
@@ -163,7 +163,7 @@
     ],
     "death_drops": {  },
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "HEARS", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PATH_AVOID_DANGER_1", "LOUDMOVES", "DROPS_AMMO" ]
+    "flags": [ "SEES", "HEARS", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PATH_AVOID_DANGER_1", "LOUDMOVES", "DROPS_AMMO", "BIOPROOF" ]
   },
   {
     "id": "mon_skitterbot",
@@ -193,7 +193,7 @@
     "special_attacks": [ [ "TAZER", 5 ] ],
     "death_drops": { "groups": [ [ "robots", 4 ], [ "skitterbot", 1 ] ] },
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "HEARS", "GOODHEARING", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PATH_AVOID_DANGER_1" ]
+    "flags": [ "SEES", "HEARS", "GOODHEARING", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PATH_AVOID_DANGER_1", "BIOPROOF" ]
   },
   {
     "id": "mon_science_bot",
@@ -239,7 +239,8 @@
       "NO_BREATHE",
       "PRIORITIZE_TARGETS",
       "PATH_AVOID_DANGER_2",
-      "DROPS_AMMO"
+      "DROPS_AMMO",
+	  "BIOPROOF"
     ]
   },
   {
@@ -282,7 +283,8 @@
       "NO_BREATHE",
       "PRIORITIZE_TARGETS",
       "PATH_AVOID_DANGER_2",
-      "LOUDMOVES"
+      "LOUDMOVES",
+	  "BIOPROOF"
     ]
   },
   {
@@ -327,7 +329,8 @@
       "PRIORITIZE_TARGETS",
       "PATH_AVOID_DANGER_2",
       "LOUDMOVES",
-      "DROPS_AMMO"
+      "DROPS_AMMO",
+	  "BIOPROOF"
     ]
   },
   {
@@ -372,7 +375,8 @@
       "PRIORITIZE_TARGETS",
       "PATH_AVOID_DANGER_2",
       "LOUDMOVES",
-      "DROPS_AMMO"
+      "DROPS_AMMO",
+	  "BIOPROOF"
     ]
   }
 ]

--- a/data/json/monsters/defense_bot.json
+++ b/data/json/monsters/defense_bot.json
@@ -31,7 +31,17 @@
     "special_attacks": [ [ "COPBOT", 3 ] ],
     "death_drops": { "groups": [ [ "robots", 4 ], [ "copbot", 1 ] ] },
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "HEARS", "BASHES", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PRIORITIZE_TARGETS", "PATH_AVOID_DANGER_1", "BIOPROOF" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "BASHES",
+      "ELECTRONIC",
+      "COLDPROOF",
+      "NO_BREATHE",
+      "PRIORITIZE_TARGETS",
+      "PATH_AVOID_DANGER_1",
+      "BIOPROOF"
+    ]
   },
   {
     "id": "mon_riotbot",
@@ -63,7 +73,17 @@
     "special_when_hit": [ "ZAPBACK", 100 ],
     "death_drops": { "groups": [ [ "robots", 4 ], [ "copbot", 1 ] ] },
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "HEARS", "GOODHEARING", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PRIORITIZE_TARGETS", "PATH_AVOID_DANGER_1", "BIOPROOF" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "GOODHEARING",
+      "ELECTRONIC",
+      "COLDPROOF",
+      "NO_BREATHE",
+      "PRIORITIZE_TARGETS",
+      "PATH_AVOID_DANGER_1",
+      "BIOPROOF"
+    ]
   },
   {
     "id": "mon_secubot",
@@ -113,7 +133,17 @@
     ],
     "death_drops": {  },
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "HEARS", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PATH_AVOID_DANGER_1", "LOUDMOVES", "DROPS_AMMO", "BIOPROOF" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "ELECTRONIC",
+      "COLDPROOF",
+      "NO_BREATHE",
+      "PATH_AVOID_DANGER_1",
+      "LOUDMOVES",
+      "DROPS_AMMO",
+      "BIOPROOF"
+    ]
   },
   {
     "id": "mon_talon_m202a1",
@@ -163,7 +193,17 @@
     ],
     "death_drops": {  },
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "HEARS", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PATH_AVOID_DANGER_1", "LOUDMOVES", "DROPS_AMMO", "BIOPROOF" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "ELECTRONIC",
+      "COLDPROOF",
+      "NO_BREATHE",
+      "PATH_AVOID_DANGER_1",
+      "LOUDMOVES",
+      "DROPS_AMMO",
+      "BIOPROOF"
+    ]
   },
   {
     "id": "mon_skitterbot",
@@ -240,7 +280,7 @@
       "PRIORITIZE_TARGETS",
       "PATH_AVOID_DANGER_2",
       "DROPS_AMMO",
-	  "BIOPROOF"
+      "BIOPROOF"
     ]
   },
   {
@@ -284,7 +324,7 @@
       "PRIORITIZE_TARGETS",
       "PATH_AVOID_DANGER_2",
       "LOUDMOVES",
-	  "BIOPROOF"
+      "BIOPROOF"
     ]
   },
   {
@@ -330,7 +370,7 @@
       "PATH_AVOID_DANGER_2",
       "LOUDMOVES",
       "DROPS_AMMO",
-	  "BIOPROOF"
+      "BIOPROOF"
     ]
   },
   {
@@ -376,7 +416,7 @@
       "PATH_AVOID_DANGER_2",
       "LOUDMOVES",
       "DROPS_AMMO",
-	  "BIOPROOF"
+      "BIOPROOF"
     ]
   }
 ]

--- a/data/json/monsters/drones.json
+++ b/data/json/monsters/drones.json
@@ -15,7 +15,7 @@
     "luminance": 5,
     "death_drops": { "subtype": "collection", "groups": [ [ "robots", 80 ] ], "//": "80% chance of an item from group robots" },
     "death_function": [ "BROKEN_AMMO" ],
-    "flags": [ "SEES", "FLIES", "NOHEAD", "ELECTRONIC", "NO_BREATHE", "INTERIOR_AMMO" ]
+    "flags": [ "SEES", "FLIES", "NOHEAD", "ELECTRONIC", "NO_BREATHE", "INTERIOR_AMMO", "BIOPROOF" ]
   },
   {
     "id": "mon_EMP_hack",

--- a/data/json/monsters/turrets.json
+++ b/data/json/monsters/turrets.json
@@ -26,7 +26,7 @@
     "special_attacks": [ [ "SEARCHLIGHT", 1 ] ],
     "death_drops": { "groups": [ [ "robots", 1 ], [ "turret_searchlight", 1 ] ] },
     "death_function": [ "FOCUSEDBEAM" ],
-    "flags": [ "SEES", "NOHEAD", "ELECTRONIC", "COLDPROOF", "IMMOBILE", "NO_BREATHE", "PRIORITIZE_TARGETS" ]
+    "flags": [ "SEES", "NOHEAD", "ELECTRONIC", "COLDPROOF", "IMMOBILE", "NO_BREATHE", "PRIORITIZE_TARGETS", "BIOPROOF" ]
   },
   {
     "id": "mon_laserturret",
@@ -66,7 +66,7 @@
     "special_when_hit": [ "RETURN_FIRE", 100 ],
     "death_drops": {  },
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "NOHEAD", "ELECTRONIC", "COLDPROOF", "IMMOBILE", "NO_BREATHE", "ID_CARD_DESPAWN", "CONSOLE_DESPAWN" ]
+    "flags": [ "SEES", "NOHEAD", "ELECTRONIC", "COLDPROOF", "IMMOBILE", "NO_BREATHE", "ID_CARD_DESPAWN", "CONSOLE_DESPAWN", "BIOPROOF" ]
   },
   {
     "id": "mon_turret_riot",
@@ -120,7 +120,7 @@
     ],
     "death_drops": {  },
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "NOHEAD", "ELECTRONIC", "COLDPROOF", "IMMOBILE", "NO_BREATHE", "DROPS_AMMO" ]
+    "flags": [ "SEES", "NOHEAD", "ELECTRONIC", "COLDPROOF", "IMMOBILE", "NO_BREATHE", "DROPS_AMMO", "BIOPROOF" ]
   },
   {
     "id": "mon_turret_light",
@@ -183,7 +183,8 @@
       "NO_BREATHE",
       "DROPS_AMMO",
       "ID_CARD_DESPAWN",
-      "CONSOLE_DESPAWN"
+      "CONSOLE_DESPAWN",
+	  "BIOPROOF"
     ]
   },
   {
@@ -247,7 +248,8 @@
       "NO_BREATHE",
       "DROPS_AMMO",
       "ID_CARD_DESPAWN",
-      "CONSOLE_DESPAWN"
+      "CONSOLE_DESPAWN",
+	  "BIOPROOF"
     ]
   },
   {
@@ -311,7 +313,8 @@
       "NO_BREATHE",
       "DROPS_AMMO",
       "CONSOLE_DESPAWN",
-      "ID_CARD_DESPAWN"
+      "ID_CARD_DESPAWN",
+	  "BIOPROOF"
     ]
   }
 ]

--- a/data/json/monsters/turrets.json
+++ b/data/json/monsters/turrets.json
@@ -66,7 +66,17 @@
     "special_when_hit": [ "RETURN_FIRE", 100 ],
     "death_drops": {  },
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "NOHEAD", "ELECTRONIC", "COLDPROOF", "IMMOBILE", "NO_BREATHE", "ID_CARD_DESPAWN", "CONSOLE_DESPAWN", "BIOPROOF" ]
+    "flags": [
+      "SEES",
+      "NOHEAD",
+      "ELECTRONIC",
+      "COLDPROOF",
+      "IMMOBILE",
+      "NO_BREATHE",
+      "ID_CARD_DESPAWN",
+      "CONSOLE_DESPAWN",
+      "BIOPROOF"
+    ]
   },
   {
     "id": "mon_turret_riot",
@@ -184,7 +194,7 @@
       "DROPS_AMMO",
       "ID_CARD_DESPAWN",
       "CONSOLE_DESPAWN",
-	  "BIOPROOF"
+      "BIOPROOF"
     ]
   },
   {
@@ -249,7 +259,7 @@
       "DROPS_AMMO",
       "ID_CARD_DESPAWN",
       "CONSOLE_DESPAWN",
-	  "BIOPROOF"
+      "BIOPROOF"
     ]
   },
   {
@@ -314,7 +324,7 @@
       "DROPS_AMMO",
       "CONSOLE_DESPAWN",
       "ID_CARD_DESPAWN",
-	  "BIOPROOF"
+      "BIOPROOF"
     ]
   }
 ]

--- a/data/json/monsters/utility_bot.json
+++ b/data/json/monsters/utility_bot.json
@@ -62,7 +62,7 @@
       "PAY_BOT",
       "PET_HARNESSABLE",
       "PATH_AVOID_DANGER_2",
-	  "BIOPROOF"
+      "BIOPROOF"
     ]
   },
   {
@@ -114,7 +114,17 @@
     "vision_day": 50,
     "revert_to_itype": "bot_hazmatbot",
     "death_function": [ "EXPLODE" ],
-    "flags": [ "SEES", "HEARS", "BASHES", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PRIORITIZE_TARGETS", "PATH_AVOID_DANGER_1", "BIOPROOF" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "BASHES",
+      "ELECTRONIC",
+      "COLDPROOF",
+      "NO_BREATHE",
+      "PRIORITIZE_TARGETS",
+      "PATH_AVOID_DANGER_1",
+      "BIOPROOF"
+    ]
   },
   {
     "id": "mon_haulerbot",
@@ -140,7 +150,17 @@
     "vision_day": 50,
     "revert_to_itype": "bot_haulerbot",
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "HEARS", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PATH_AVOID_DANGER_2", "PACIFIST", "PET_HARNESSABLE", "BIOPROOF" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "ELECTRONIC",
+      "COLDPROOF",
+      "NO_BREATHE",
+      "PATH_AVOID_DANGER_2",
+      "PACIFIST",
+      "PET_HARNESSABLE",
+      "BIOPROOF"
+    ]
   },
   {
     "id": "mon_molebot",
@@ -232,6 +252,17 @@
     "special_attacks": [ [ "OPERATE", 30 ], [ "PARROT", 20 ] ],
     "death_drops": { "groups": [ [ "robots", 4 ] ] },
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PUSH_MON", "HEARS", "PACIFIST", "GRABS", "INTERIOR_AMMO", "BIOPROOF" ]
+    "flags": [
+      "SEES",
+      "ELECTRONIC",
+      "COLDPROOF",
+      "NO_BREATHE",
+      "PUSH_MON",
+      "HEARS",
+      "PACIFIST",
+      "GRABS",
+      "INTERIOR_AMMO",
+      "BIOPROOF"
+    ]
   }
 ]

--- a/data/json/monsters/utility_bot.json
+++ b/data/json/monsters/utility_bot.json
@@ -25,7 +25,7 @@
     "special_attacks": [ [ "PHOTOGRAPH", 30 ] ],
     "death_drops": { "groups": [ [ "robots", 4 ], [ "eyebot", 1 ] ] },
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "FLIES", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "NOHEAD", "PRIORITIZE_TARGETS" ]
+    "flags": [ "SEES", "FLIES", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "NOHEAD", "PRIORITIZE_TARGETS", "BIOPROOF" ]
   },
   {
     "id": "mon_grocerybot",
@@ -61,7 +61,8 @@
       "PACIFIST",
       "PAY_BOT",
       "PET_HARNESSABLE",
-      "PATH_AVOID_DANGER_2"
+      "PATH_AVOID_DANGER_2",
+	  "BIOPROOF"
     ]
   },
   {
@@ -88,7 +89,7 @@
     "special_attacks": [ [ "PAID_BOT", 1 ] ],
     "death_drops": { "groups": [ [ "robots", 4 ] ] },
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PUSH_MON", "HEARS", "PACIFIST", "PAY_BOT" ]
+    "flags": [ "SEES", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PUSH_MON", "HEARS", "PACIFIST", "PAY_BOT", "BIOPROOF" ]
   },
   {
     "id": "mon_hazmatbot",
@@ -113,7 +114,7 @@
     "vision_day": 50,
     "revert_to_itype": "bot_hazmatbot",
     "death_function": [ "EXPLODE" ],
-    "flags": [ "SEES", "HEARS", "BASHES", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PRIORITIZE_TARGETS", "PATH_AVOID_DANGER_1" ]
+    "flags": [ "SEES", "HEARS", "BASHES", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PRIORITIZE_TARGETS", "PATH_AVOID_DANGER_1", "BIOPROOF" ]
   },
   {
     "id": "mon_haulerbot",
@@ -139,7 +140,7 @@
     "vision_day": 50,
     "revert_to_itype": "bot_haulerbot",
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "HEARS", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PATH_AVOID_DANGER_2", "PACIFIST", "PET_HARNESSABLE" ]
+    "flags": [ "SEES", "HEARS", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PATH_AVOID_DANGER_2", "PACIFIST", "PET_HARNESSABLE", "BIOPROOF" ]
   },
   {
     "id": "mon_molebot",
@@ -168,7 +169,7 @@
     "revert_to_itype": "bot_molebot",
     "death_drops": { "groups": [ [ "robots", 4 ], [ "molebot", 1 ] ] },
     "death_function": [ "BROKEN" ],
-    "flags": [ "HEARS", "GOODHEARING", "DIGS", "NO_BREATHE", "ELECTRONIC", "COLDPROOF", "PATH_AVOID_DANGER_1" ]
+    "flags": [ "HEARS", "GOODHEARING", "DIGS", "NO_BREATHE", "ELECTRONIC", "COLDPROOF", "PATH_AVOID_DANGER_1", "BIOPROOF" ]
   },
   {
     "//": "nurse_bot and nurse_bot_defective look very similar, part of the trick is figuring out which one is the good one.  So the sprites should probably look pretty similar to not give it away immediately",
@@ -198,7 +199,7 @@
     "special_attacks": [ [ "ASSIST", 30 ], [ "CHECK_UP", 120 ] ],
     "death_drops": { "groups": [ [ "robots", 4 ] ] },
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PUSH_MON", "HEARS", "PACIFIST" ]
+    "flags": [ "SEES", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PUSH_MON", "HEARS", "PACIFIST", "BIOPROOF" ]
   },
   {
     "//": "nurse_bot and nurse_bot_defective look very similar, part of the trick is figuring out which one is the good one.  So the sprites should probably look pretty similar to not give it away immediately",
@@ -231,6 +232,6 @@
     "special_attacks": [ [ "OPERATE", 30 ], [ "PARROT", 20 ] ],
     "death_drops": { "groups": [ [ "robots", 4 ] ] },
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PUSH_MON", "HEARS", "PACIFIST", "GRABS", "INTERIOR_AMMO" ]
+    "flags": [ "SEES", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PUSH_MON", "HEARS", "PACIFIST", "GRABS", "INTERIOR_AMMO", "BIOPROOF" ]
   }
 ]


### PR DESCRIPTION
## Summary

SUMMARY: Balance "Gave the new BIOPROOF flag to the robots"

## Describe the solution

Adds the BIOPROOF flag to the robots (not cyborgs of any kind yet because that gets more of a disagreement going)

## Describe alternatives you've considered

None

## Testing

Made sure the game didn't error because of this change (it didn't), gazed at a Light Turret Necrotically and it was unfazed.

## Additional context

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/30732426/8724c6e0-4c3e-42d4-aa07-5e69b95d92a0)
RoyalFox is handling giving BIOPROOF to poison monsters, and further ideas are up in the air at the moment.
Changes to Magiclysm in light of the flag (and including it in any relevant monsters) will come later.
