### PR TITLE
Allow steel and superalloy lining for more items

### DIFF
--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -244,6 +244,7 @@
     "covers": [ "arms" ],
     "coverage": 30,
     "material_thickness": 5,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "WATER_FRIENDLY", "BELTED" ]
   },
   {
@@ -266,6 +267,7 @@
     "warmth": 10,
     "material_thickness": 3,
     "environmental_protection": 1,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "STURDY", "BELTED", "WATER_FRIENDLY" ]
   }
 ]

--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -81,6 +81,7 @@
     "warmth": 35,
     "material_thickness": 3,
     "environmental_protection": 8,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
   },
   {

--- a/data/json/items/armor/cloaks.json
+++ b/data/json/items/armor/cloaks.json
@@ -224,6 +224,7 @@
     "warmth": 35,
     "material_thickness": 2,
     "environmental_protection": 1,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE", "OUTER" ]
   },
   {

--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -220,6 +220,7 @@
     "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 1,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE", "POCKETS", "OUTER" ]
   },
   {
@@ -437,6 +438,7 @@
     "storage": "1250 ml",
     "warmth": 25,
     "material_thickness": 3,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "OUTER", "VARSIZE" ]
   },
   {
@@ -481,6 +483,7 @@
     "storage": "1 L",
     "warmth": 35,
     "material_thickness": 4,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE", "POCKETS", "OUTER" ]
   },
   {
@@ -509,6 +512,7 @@
         "text": "A jacket made from denim.  Provides decent protection from cuts.  This one is haphazardly covered with patches featuring metal band logos."
       }
     ],
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE", "POCKETS", "OUTER" ]
   },
   {
@@ -623,6 +627,7 @@
     "encumbrance": 10,
     "warmth": 10,
     "material_thickness": 3,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE", "STURDY" ]
   },
   {
@@ -643,6 +648,7 @@
     "coverage": 80,
     "warmth": 5,
     "material_thickness": 2,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE", "STURDY" ]
   },
   {
@@ -686,6 +692,7 @@
     "coverage": 80,
     "warmth": 5,
     "material_thickness": 2,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE", "STURDY" ]
   },
   {
@@ -868,6 +875,7 @@
     "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 1,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE", "POCKETS", "OUTER" ]
   },
   {
@@ -978,6 +986,7 @@
     "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 1,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE", "POCKETS", "OUTER" ]
   },
   {
@@ -1131,6 +1140,7 @@
     "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 1,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE", "POCKETS", "OUTER" ]
   },
   {
@@ -1278,6 +1288,7 @@
     "storage": "2 L",
     "warmth": 30,
     "material_thickness": 2,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE", "POCKETS", "SUPER_FANCY" ]
   },
   {

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -85,6 +85,7 @@
     "warmth": 25,
     "material_thickness": 4,
     "environmental_protection": 6,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE", "STURDY", "WATERPROOF" ]
   },
   {
@@ -142,6 +143,7 @@
     "warmth": 15,
     "material_thickness": 3,
     "environmental_protection": 1,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "STURDY" ]
   },
   {
@@ -164,6 +166,7 @@
     "warmth": 15,
     "material_thickness": 3,
     "environmental_protection": 1,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "STURDY" ]
   },
   {
@@ -709,6 +712,7 @@
     "warmth": 25,
     "material_thickness": 3,
     "environmental_protection": 5,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "WATERPROOF", "STURDY" ]
   },
   {

--- a/data/json/items/armor/helmets.json
+++ b/data/json/items/armor/helmets.json
@@ -495,6 +495,7 @@
     "warmth": 35,
     "material_thickness": 3,
     "environmental_protection": 4,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE", "WATERPROOF", "SUN_GLASSES" ]
   },
   {
@@ -540,6 +541,7 @@
     "warmth": 40,
     "material_thickness": 3,
     "environmental_protection": 7,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE", "STURDY", "WATERPROOF", "SUN_GLASSES" ]
   },
   {
@@ -701,6 +703,7 @@
     "encumbrance": 20,
     "warmth": 15,
     "material_thickness": 3,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "FANCY", "STAB" ]
   },
   {

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -86,6 +86,7 @@
     "encumbrance": 3,
     "warmth": 10,
     "material_thickness": 3,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "OUTER" ]
   },
   {
@@ -108,6 +109,7 @@
     "storage": "500 ml",
     "warmth": 20,
     "material_thickness": 2,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE" ]
   },
   {
@@ -127,6 +129,7 @@
     "covers": [ "legs" ],
     "coverage": 30,
     "material_thickness": 5,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "WATER_FRIENDLY", "BELTED" ]
   },
   {
@@ -278,6 +281,7 @@
     "warmth": 12,
     "material_thickness": 3,
     "environmental_protection": 1,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE", "WATERPROOF", "POCKETS", "RAINPROOF", "STURDY" ]
   },
   {
@@ -300,6 +304,7 @@
     "warmth": 35,
     "material_thickness": 3,
     "environmental_protection": 2,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE", "WATERPROOF" ]
   },
   {

--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -141,6 +141,7 @@
     "storage": "500 ml",
     "warmth": 10,
     "material_thickness": 3,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE", "POCKETS" ]
   },
   {
@@ -164,6 +165,7 @@
     "storage": "500 ml",
     "warmth": 10,
     "material_thickness": 3,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE", "POCKETS", "FANCY" ]
   },
   {
@@ -361,6 +363,7 @@
     "storage": "2500 ml",
     "warmth": 20,
     "material_thickness": 2,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE", "POCKETS" ]
   },
   {

--- a/data/json/items/armor/masks.json
+++ b/data/json/items/armor/masks.json
@@ -169,6 +169,7 @@
     "warmth": 5,
     "material_thickness": 1,
     "environmental_protection": 1,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "WATER_FRIENDLY" ]
   },
   {
@@ -193,6 +194,7 @@
     "warmth": 5,
     "material_thickness": 3,
     "environmental_protection": 1,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "WATER_FRIENDLY", "STURDY" ]
   },
   {

--- a/data/json/items/armor/suits_clothes.json
+++ b/data/json/items/armor/suits_clothes.json
@@ -20,6 +20,7 @@
     "warmth": 30,
     "material_thickness": 2,
     "environmental_protection": 1,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE", "SKINTIGHT" ]
   },
   {
@@ -67,6 +68,7 @@
     "warmth": 50,
     "material_thickness": 5,
     "environmental_protection": 2,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "OUTER" ]
   },
   {
@@ -187,6 +189,7 @@
     "warmth": 50,
     "material_thickness": 7,
     "environmental_protection": 2,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "OUTER" ]
   },
   {
@@ -208,6 +211,7 @@
     "encumbrance": 20,
     "warmth": 50,
     "material_thickness": 3,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE" ]
   },
   {

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -618,6 +618,7 @@
     "storage": "7500 ml",
     "warmth": 15,
     "material_thickness": 4,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "environmental_protection": 3,
     "flags": [ "VARSIZE", "WATERPROOF", "POCKETS", "HOOD", "RAINPROOF", "STURDY" ]
   },
@@ -707,6 +708,7 @@
     "storage": "2500 ml",
     "warmth": 25,
     "material_thickness": 2,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE", "FANCY", "POCKETS" ]
   },
   {

--- a/data/json/items/armor/torso_armor.json
+++ b/data/json/items/armor/torso_armor.json
@@ -40,6 +40,7 @@
     "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 8,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE", "STURDY" ]
   },
   {
@@ -329,6 +330,7 @@
     "warmth": 15,
     "material_thickness": 4,
     "environmental_protection": 1,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY" ]
   },
   {
@@ -353,6 +355,7 @@
     "warmth": 35,
     "material_thickness": 4,
     "environmental_protection": 2,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE", "WATERPROOF" ]
   },
   {

--- a/data/json/items/armor/torso_clothes.json
+++ b/data/json/items/armor/torso_clothes.json
@@ -20,6 +20,7 @@
     "warmth": 15,
     "material_thickness": 3,
     "environmental_protection": 1,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "POCKETS", "BELTED", "WATER_FRIENDLY" ]
   },
   {
@@ -234,6 +235,7 @@
     "storage": "2250 ml",
     "warmth": 30,
     "material_thickness": 3,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE", "OUTER", "POCKETS", "HOOD" ]
   },
   {

--- a/data/json/items/armor/undergarment.json
+++ b/data/json/items/armor/undergarment.json
@@ -328,6 +328,7 @@
     "warmth": 25,
     "material_thickness": 3,
     "environmental_protection": 1,
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE", "FANCY", "SKINTIGHT" ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/mod/json/explanation/json_style.md
C++ and Markdown: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/dev/explanation/code_style.md

!!!!!!!!!! WARNING !!!!!!!!!!

If you forget to format the PR, autofix.ci app will run automated format commit for you.
When this happens, YOU MUST DO EITHER OF THE FOLLOWING:

- Run `git pull` to merge the automated commit into your PR branch.
- Format your code locally, and force push to your PR branch. 

If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
-->

## Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/src/content/docs/en/contribute/changelog_guidelines.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Add the steel and superalloy armor mod option to more gear related to items already moddable"

## Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This adds the option to add steel and superalloy lining to a few more clothing items, based on other similar items to have the option.

## Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Added steel and alloy lining options to leather corset, only undergarment that seemed like it might be reasonable for. Consistent with various leather clothing items having the option.
2. Added steel and alloy lining options to leather apron, again since leather garment noted to be usable for ersatz armor purposes.
3. Added the lining options to hoodie, it being a bulky jacket-type item, coinsistent with the wool hoodie having the option.
4. Added the lining options to lamellar cuirass. In addition to other (not already plated) leather armor items having this option, this also fits the idea of metal lamellar armor being a thing.
5. Added to light survivor body armor, it being closer to "basically clothing" along with expending the utility of it a bit, and consistent with some survivor gear having the option.
6. Added to motorcycle armor, fitting the leather jacket and touring suit having this option.
7. Added to the light survivor suit, on the basis that the survivor firesuit and regular survivor suit have the option.
8. Added to the regular plain suit, it being a garment most likely including a suit jacket technically.
9. Added to bondage suit, as "up-armored BDSM gear" is honstly 90% of the original Mad Max raider aesthetic.
10. Added to dinosaur suit, being a bulky outer garment. Also gives a bit more use to a meme item.
11. Added to wolf suit, same general reason as above.
12. Added to wool suit. Works with it being a bulky garment and fits the idea of it being really warm gear that looks like armor but isn't, until it is.
13. Added to Guy Fawkes mask, idea being a plastic mask that could potentially be used as backing for up-armoring.
14. Added to hockey mask, same idea as above. This would if anything be the most deserving of it but fawkes mask listed first since it came first in the file.
15. Added to jeans, being reasonably tough fabric backing for that. Also consistent with winter army pants, leather pants, and fur pants allowing this.
16. Added to red jeans, same reasoning as above.
17. Added to army pants, as winter army pants notably allowed it.
18. Added to leather chaps, other leather biker gear already allowing this.
19. Added to fencing pants, as fencing jacket allows it.
20. Added to knee pads, for a modest upgrade to a soft sporting equipment item.
21. Added to light survivor cargo pants, as with light survivor body armor and consistent with its use by regular survivor pants.
22. Added to motorcycle pants, it being available on leather pants and other biker gear.
23. Added to nomad cowl, nomad gear already allowing this.
24. Added to scavenger cowl, again same concept as above.
25. Added to pickelhaube, in case you wanted to slap scrap metal to what may or may not be a museum piece.
26. Added to fire gauntlets, being firefighting gear that could be repurposed as armor.
27. Added to fencing gauntlet, as with fencing jacket.
28. Added to the lefty-only fencing gauntlet.
29. Added to work gloves, leather gloves being moddable and these seemed like the beefiest gloves that might support modding.
30. Added to duster, other coats and duster variants already allowing this.
31. Added to chef's jacket, noted to be thicker than normal.
32. Added to flannel jacket, noted to be related to denim jackets.
32. Speaking of, added to denim jacket, in the vein of leather jackets allowing it.
33. Added to judo gi, it being a decently sturdy fabric backing.
34. Added to karate gi, same reasoning as above.
35. Added to keikogi, again being martial arts outfit.
36. Added to sleeveless duster, as other duster variant allow it.
37. Added to sleeveless trenchcoat.
38. Added to regular trenchcoat.
39. Added to tuxedo, for up-armoring fancy suit jackets.
40. Added to poncho, seemed like the only item not too loose and flowing to make the idea seem implausible.
41. Added to turnout boots, idea being firefighting gear in general being moddable.
42. Added to elbow pads, as with knee pads.
43. Added to leather vambraces, leather arm guards being moddable as well.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Adding plated leather lamellar or armor made of metal lames, in addition to or instead of having the option to up-armor leather lamellar. The o-yoroi is already basically a Japanese-specific implementation of that idea though, so.
2. Allowing you to make ersatz plated mail by adding this option to the mail items.
3. I could've sworn I'd floated the idea of being able to make armored leather chaps in the vein of armored leather jackets before...
4. Adding the option to big beefy hats like the cowboy hat or sombrero. Would be funny but hmm.
5. Adding the option to non-heavy survivor boots, gloves, and hoods?
6. Adding the option to skirts and/or kilts, presumably only leather versions?
7. Adding it to leather helmet, boots, and gauntlets. For those I'd need to test that it's possible to subsequently remove the padding options from items that inherit from another item, so that you can't up-armor the already up-armored plated leather items I added (which inherit from their mundane counterparts).

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Wolf suit:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/6a10154b-0784-4380-8c48-42b78f0d9c07)

Some of these I suspect will be a bit wacky like the above, but given more bonus protection means more bonus encumbrance, becoming The Iron Furry is still not really optimal or OP compared to just making armor that's intended to be good armor from the beginning.