### PR TITLE
Give No Hope the e

### DIFF
--- a/data/mods/No_Hope/Mapgen/parking_garage.json
+++ b/data/mods/No_Hope/Mapgen/parking_garage.json
@@ -39,7 +39,9 @@
       "#": "t_rock",
       "*": "t_open_air",
       "E": "t_elevator",
+      "e": "t_elevator_control",
       "x": "t_console_broken",
+      "X": "t_gates_control_concrete",
       "@": "t_generator_broken",
       "&": "t_machinery_heavy"
     },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/mod/json/explanation/json_style.md
C++ and Markdown: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/dev/explanation/code_style.md

!!!!!!!!!! WARNING !!!!!!!!!!

If you forget to format the PR, autofix.ci app will run automated format commit for you.
When this happens, YOU MUST DO EITHER OF THE FOLLOWING:

- Run `git pull` to merge the automated commit into your PR branch.
- Format your code locally, and force push to your PR branch. 

If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
-->

## Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/src/content/docs/en/contribute/changelog_guidelines.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fix No Hope palette override lacking terrain that caused the game to error on load"

## Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

In another fine example of "why do we even have that lever?" No Hope includes a full oiverride for some map palettes, including one recently touched by https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3224 and this was why the buildbot was cryptically exploding.

Fixes this thing:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/109c1ba5-a91e-48a4-b4c8-fd949e151bdb)

## Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Added missing terrain defs to No Hope's version of `parking_palette`.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Removing palette overrides because it's really weird that No Hope overrides SO MUCH STUFF
2. Also implementing and testing working elevators in the No Hope version but I assume that is against the spirit of the mod. Also effort and it's past midnight and I need to do stuff tomorrow weh

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected file for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/f06f43a2-a852-4ec6-bf88-e0d3f1faca1f)