### PR TITLE
build(cmake): deduplicate library setup

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Cataclysm BN client
 cmake_minimum_required(VERSION 3.16)
 
+include(SetupLibrary.cmake)
+
 set(MAIN_CPP ${CMAKE_SOURCE_DIR}/src/main.cpp)
 set(MESSAGES_CPP ${CMAKE_SOURCE_DIR}/src/messages.cpp)
 set(RESOURCE_RC ${CMAKE_SOURCE_DIR}/src/resource.rc)
@@ -31,16 +33,10 @@ add_custom_command(
         ${CMAKE_SOURCE_DIR}/src/version.cmake
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
+
 # Build tiles version if requested
 if (TILES)
-    add_library(cataclysm-tiles-common OBJECT ${CATACLYSM_BN_SOURCES} ${CATACLYSM_BN_HEADERS}
-                                              ${LUA_C_SOURCES})
-    target_include_directories(cataclysm-tiles-common INTERFACE ${CMAKE_SOURCE_DIR}/src)
-
-    if (USE_PCH_HEADER)
-        target_precompile_headers(cataclysm-tiles-common PRIVATE
-                                  ${CMAKE_SOURCE_DIR}/pch/main-pch.hpp)
-    endif ()
+    setup_library(cataclysm-tiles-common)
 
     if (WIN32)
         add_definitions(-DUSE_WINMAIN)
@@ -49,24 +45,8 @@ if (TILES)
         add_executable(cataclysm-tiles ${MAIN_CPP} ${MESSAGES_CPP})
     endif ()
 
-    if (LUA)
-        target_compile_definitions(cataclysm-tiles-common PUBLIC LUA)
-        target_include_directories(cataclysm-tiles-common PUBLIC ${CMAKE_SOURCE_DIR}/src)
-        target_include_directories(cataclysm-tiles-common PUBLIC ${CMAKE_SOURCE_DIR}/src/lua)
-    endif ()
-
-    add_dependencies(cataclysm-tiles-common get_version)
-
     target_link_libraries(cataclysm-tiles cataclysm-tiles-common)
     target_compile_definitions(cataclysm-tiles-common PUBLIC TILES)
-
-    if (CMAKE_USE_PTHREADS_INIT)
-        target_compile_options(cataclysm-tiles-common PUBLIC "-pthread")
-    endif ()
-
-    if (CMAKE_THREAD_LIBS_INIT)
-        target_link_libraries(cataclysm-tiles-common ${CMAKE_THREAD_LIBS_INIT})
-    endif ()
 
     if (NOT DYNAMIC_LINKING)
         # SDL, SDL_Image, SDL_ttf deps are required for static build
@@ -94,38 +74,15 @@ if (TILES)
         target_link_libraries(cataclysm-tiles-common ${SDL2_MIXER_LIBRARIES})
     endif ()
 
-    if (WIN32)
-        # Global settings for Windows targets (at end)
-        target_link_libraries(cataclysm-tiles-common gdi32.lib)
-        target_link_libraries(cataclysm-tiles-common winmm.lib)
-        target_link_libraries(cataclysm-tiles-common imm32.lib)
-        target_link_libraries(cataclysm-tiles-common ole32.lib)
-        target_link_libraries(cataclysm-tiles-common oleaut32.lib)
-        target_link_libraries(cataclysm-tiles-common version.lib)
-
-        if (BACKTRACE)
-            target_link_libraries(cataclysm-tiles-common dbghelp.lib)
-        endif ()
-    endif ()
-
-    if (LIBBACKTRACE)
-        target_link_libraries(cataclysm-tiles-common backtrace)
-    endif ()
-
     if (RELEASE)
         install(TARGETS cataclysm-tiles DESTINATION ${BIN_PREFIX})
     endif ()
+
 endif ()
 
 # Build curses version if requested
 if (CURSES)
-    add_library(cataclysm-common OBJECT ${CATACLYSM_BN_SOURCES} ${CATACLYSM_BN_HEADERS}
-                                        ${LUA_C_SOURCES})
-    target_include_directories(cataclysm-common INTERFACE ${CMAKE_SOURCE_DIR}/src)
-
-    if (USE_PCH_HEADER)
-        target_precompile_headers(cataclysm-common PRIVATE ${CMAKE_SOURCE_DIR}/pch/main-pch.hpp)
-    endif ()
+    setup_library(cataclysm-common)
 
     if (WIN32)
         add_executable(cataclysm ${MAIN_CPP} ${MESSAGES_CPP} ${RESOURCE_RC})
@@ -133,47 +90,15 @@ if (CURSES)
         add_executable(cataclysm ${MAIN_CPP} ${MESSAGES_CPP})
     endif ()
 
-    if (LUA)
-        target_compile_definitions(cataclysm-common PUBLIC LUA)
-        target_include_directories(cataclysm-common PUBLIC ${CMAKE_SOURCE_DIR}/src)
-        target_include_directories(cataclysm-common PUBLIC ${CMAKE_SOURCE_DIR}/src/lua)
-    endif ()
-
-    add_dependencies(cataclysm-common get_version)
     target_link_libraries(cataclysm cataclysm-common)
 
     target_include_directories(cataclysm-common PUBLIC ${CURSES_INCLUDE_DIR})
     target_link_libraries(cataclysm-common ${CURSES_LIBRARIES})
 
-    if (CMAKE_USE_PTHREADS_INIT)
-        target_compile_options(cataclysm-common PUBLIC "-pthread")
-    endif ()
-
-    if (CMAKE_THREAD_LIBS_INIT)
-        target_link_libraries(cataclysm-common ${CMAKE_THREAD_LIBS_INIT})
-    endif ()
-
-    if (WIN32)
-        # Global settings for Windows targets (at end)
-        target_link_libraries(cataclysm-common gdi32.lib)
-        target_link_libraries(cataclysm-common winmm.lib)
-        target_link_libraries(cataclysm-common imm32.lib)
-        target_link_libraries(cataclysm-common ole32.lib)
-        target_link_libraries(cataclysm-common oleaut32.lib)
-        target_link_libraries(cataclysm-common version.lib)
-
-        if (BACKTRACE)
-            target_link_libraries(cataclysm-common dbghelp.lib)
-        endif ()
-    endif ()
-
-    if (LIBBACKTRACE)
-        target_link_libraries(cataclysm-common backtrace)
-    endif ()
-
     if (RELEASE)
         install(TARGETS cataclysm DESTINATION ${BIN_PREFIX})
     endif ()
+
 endif ()
 
 if (MINGW AND NOT RELEASE)

--- a/src/SetupLibrary.cmake
+++ b/src/SetupLibrary.cmake
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: GPL-3.0-only
+# Author: 2023 scarf <greenscarf005@gmail.com>
+
+function (setup_library TARGET)
+
+    add_library(${TARGET} OBJECT ${CATACLYSM_BN_SOURCES} ${CATACLYSM_BN_HEADERS} ${LUA_C_SOURCES})
+    target_include_directories(${TARGET} INTERFACE ${CMAKE_SOURCE_DIR}/src)
+
+    add_dependencies(${TARGET} get_version)
+
+    if (USE_PCH_HEADER)
+        target_precompile_headers(${TARGET} PRIVATE ${CMAKE_SOURCE_DIR}/pch/main-pch.hpp)
+    endif ()
+
+    if (CMAKE_USE_PTHREADS_INIT)
+        target_compile_options(${TARGET} PUBLIC "-pthread")
+    endif ()
+
+    if (CMAKE_THREAD_LIBS_INIT)
+        target_link_libraries(${TARGET} ${CMAKE_THREAD_LIBS_INIT})
+    endif ()
+
+    if (LUA)
+        target_compile_definitions(${TARGET} PUBLIC LUA)
+        target_include_directories(${TARGET} PUBLIC ${CMAKE_SOURCE_DIR}/src)
+        target_include_directories(${TARGET} PUBLIC ${CMAKE_SOURCE_DIR}/src/lua)
+    endif ()
+
+    if (WIN32)
+        # Global settings for Windows targets (at end)
+        target_link_libraries(${TARGET} gdi32.lib)
+        target_link_libraries(${TARGET} winmm.lib)
+        target_link_libraries(${TARGET} imm32.lib)
+        target_link_libraries(${TARGET} ole32.lib)
+        target_link_libraries(${TARGET} oleaut32.lib)
+        target_link_libraries(${TARGET} version.lib)
+
+        if (BACKTRACE)
+            target_link_libraries(${TARGET} dbghelp.lib)
+        endif ()
+    endif ()
+
+    if (LIBBACKTRACE)
+        target_link_libraries(${TARGET} backtrace)
+    endif ()
+
+endfunction ()

--- a/tools/clang-tidy-plugin/CMakeLists.txt
+++ b/tools/clang-tidy-plugin/CMakeLists.txt
@@ -30,6 +30,11 @@ target_include_directories(CataAnalyzerPlugin SYSTEM PRIVATE ${LLVM_INCLUDE_DIRS
                                                              ${CLANG_INCLUDE_DIRS})
 
 if ("${CATA_CLANG_TIDY_INCLUDE_DIR}" STREQUAL "")
+    # suppress DOWNLOAD_EXTRACT_TIMESTAMP warning
+    if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
+        cmake_policy(SET CMP0135 NEW)
+    endif ()
+
     set(CTPS_RELEASES https://github.com/jbytheway/clang-tidy-plugin-support/releases/download)
     set(CTPS_VERSION llvm-12.0.0-r3)
     set(CTPS_SRC ${CMAKE_CURRENT_BINARY_DIR}/clang-tidy-plugin-support)


### PR DESCRIPTION
## Summary

SUMMARY: Build "deduplicate setting up library for w/wo tiles in CMake"

## Purpose of change

DRY is good

## Describe the solution

- added `setup_library` function to setup common configuration
- also silenced [DOWNLOAD_EXTRACT_TIMESTAMP](https://cmake.org/cmake/help/latest/policy/CMP0135.html) warning

## Describe alternatives you've considered

screm

## Testing

was able to build tiles from source
