### PR TITLE
ci: use merge queue

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -7,6 +7,9 @@ on:
     paths-ignore:
       - doc/**
       - 'scripts/**'
+  merge_group:
+    branches:
+      - upload
   pull_request:
     branches:
       - upload


### PR DESCRIPTION
## Summary

SUMMARY: Build "Used merge queue to prevent build breakages"

## Purpose of change

use merge queues to prevent breakages when merging multiple approved PRs.

## Describe the solution

added merge queue for general build matrix.

- https://github.blog/2023-07-12-github-merge-queue-is-generally-available/
- https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue

## Additional context

- `Require merge queue` needs to be enabled in branch protection settings.