### PR TITLE
feat: show monster immunity in description

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,7 +33,6 @@ add_custom_command(
         ${CMAKE_SOURCE_DIR}/src/version.cmake
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
-
 # Build tiles version if requested
 if (TILES)
     setup_library(cataclysm-tiles-common)

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -757,7 +757,7 @@ std::string monster::extended_description() const
     using flag_description = std::pair<m_flag, std::string>;
     const auto describe_flags = [this, &ss](
                                     const std::string & format,
-                                    const std::vector<flag_description> &flags_names,
+                                    const std::vector<flag_description> &&flags_names,
     const std::string &if_empty = "" ) {
         std::string flag_descriptions = enumerate_as_string( flags_names.begin(),
         flags_names.end(), [this]( const flag_description & fd ) {
@@ -791,6 +791,16 @@ std::string monster::extended_description() const
         {m_flag::MF_SEES, pgettext( "Sight as sense", "sight" )},
         {m_flag::MF_SMELLS, pgettext( "Smell as sense", "smell" )},
     }, _( "It doesn't have senses." ) );
+
+    describe_properties( _( "It is immune to %s." ), {
+        {m_flag::MF_FIREPROOF, pgettext( "Fire as immunity", "fire" )},
+        {m_flag::MF_COLDPROOF, pgettext( "Cold as immunity", "cold" )},
+        {m_flag::MF_ACIDPROOF, pgettext( "Acid as immunity", "acid" )},
+        {m_flag::MF_STUN_IMMUNE, pgettext( "Stun as immunity", "stun" )},
+        {m_flag::MF_SLUDGEPROOF, pgettext( "Sludge as immunity", "sludge" )},
+        {m_flag::MF_BIOPROOF, pgettext( "Smoke as immunity", "smoke" )},
+        {m_flag::MF_BIOPROOF, pgettext( "Poision as immunity", "poison" )},
+    } );
 
     describe_properties( _( "It can %s." ), {
         {swims(), pgettext( "Swim as an action", "swim" )},

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -798,8 +798,7 @@ std::string monster::extended_description() const
         {m_flag::MF_ACIDPROOF, pgettext( "Acid as immunity", "acid" )},
         {m_flag::MF_STUN_IMMUNE, pgettext( "Stun as immunity", "stun" )},
         {m_flag::MF_SLUDGEPROOF, pgettext( "Sludge as immunity", "sludge" )},
-        {m_flag::MF_BIOPROOF, pgettext( "Smoke as immunity", "smoke" )},
-        {m_flag::MF_BIOPROOF, pgettext( "Poision as immunity", "poison" )},
+        {m_flag::MF_BIOPROOF, pgettext( "Biological hazards as immunity", "biohazards" )},
     } );
 
     describe_properties( _( "It can %s." ), {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -792,7 +792,7 @@ std::string monster::extended_description() const
         {m_flag::MF_SMELLS, pgettext( "Smell as sense", "smell" )},
     }, _( "It doesn't have senses." ) );
 
-    describe_properties( _( "It is immune to %s." ), {
+    describe_flags( _( "It is immune to %s." ), {
         {m_flag::MF_FIREPROOF, pgettext( "Fire as immunity", "fire" )},
         {m_flag::MF_COLDPROOF, pgettext( "Cold as immunity", "cold" )},
         {m_flag::MF_ACIDPROOF, pgettext( "Acid as immunity", "acid" )},

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -756,9 +756,9 @@ std::string monster::extended_description() const
 
     using flag_description = std::pair<m_flag, std::string>;
     const auto describe_flags = [this, &ss](
-                                    const std::string & format,
+                                    std::string_view format,
                                     const std::vector<flag_description> &&flags_names,
-    const std::string &if_empty = "" ) {
+    std::string_view if_empty = "" ) {
         std::string flag_descriptions = enumerate_as_string( flags_names.begin(),
         flags_names.end(), [this]( const flag_description & fd ) {
             return type->has_flag( fd.first ) ? fd.second : "";
@@ -766,15 +766,16 @@ std::string monster::extended_description() const
         if( !flag_descriptions.empty() ) {
             ss += string_format( format, flag_descriptions ) + "\n";
         } else if( !if_empty.empty() ) {
-            ss += if_empty + "\n";
+            ss += if_empty;
+            ss += "\n";
         }
     };
 
     using property_description = std::pair<bool, std::string>;
     const auto describe_properties = [&ss](
-                                         const std::string & format,
+                                         std::string_view format,
                                          const std::vector<property_description> &property_names,
-    const std::string &if_empty = "" ) {
+    std::string_view if_empty = "" ) {
         std::string property_descriptions = enumerate_as_string( property_names.begin(),
         property_names.end(), []( const property_description & pd ) {
             return pd.first ? pd.second : "";
@@ -782,7 +783,8 @@ std::string monster::extended_description() const
         if( !property_descriptions.empty() ) {
             ss += string_format( format, property_descriptions ) + "\n";
         } else if( !if_empty.empty() ) {
-            ss += if_empty + "\n";
+            ss += if_empty;
+            ss += "\n";
         }
     };
 


### PR DESCRIPTION
## Summary

SUMMARY: Interface "Show monster immunity in extended description"

## Purpose of change

expose more info to players, in this PR, immunity

## Describe the solution

- reused `describe_flags` lambda

https://github.com/cataclysmbnteam/Cataclysm-BN/blob/b545f49e93df7f4a42191c9512958f84b1ca32dc/src/damage.h#L23

- made it render as 'posion' and 'smoke' despite being a single m_flag (MF_BIOPROOF), because i couldn't figure out a better way

## Describe alternatives you've considered

name its immunity `biohazard`

## Testing

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/998bf0c4-3bcf-4151-bf66-5d9e55626fcd)
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/6ae08f1f-58d2-4283-8606-8e5ef9eb0816)
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/3040003a-cbac-4b5a-ae05-c857d99061ca)
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/9f4a41f7-2001-4a50-af5e-a34847b48923)

1. spawn a zombie, zombie firefighter, zombie master, and prototype robot.
2. e(x)amine then read (e)xtended description
3. its immunity is shown.

## Additional context

- which would be better? `biohazard` or `smoke` + `poison`?
- should we split this damage type into two?
- are there `smoke` or `poison` damage type?