### PR TITLE
Refresh test user dir on each test run

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,7 +33,6 @@ add_custom_command(
         ${CMAKE_SOURCE_DIR}/src/version.cmake
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
-
 # Build tiles version if requested
 if (TILES)
     setup_library(cataclysm-tiles-common)

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -99,6 +99,7 @@ static void init_global_game_state( const std::vector<mod_id> &mods,
                                     option_overrides_t &option_overrides,
                                     const std::string &user_dir )
 {
+    remove_directory( user_dir );
     if( !assure_dir_exist( user_dir ) ) {
         assert( !"Unable to make user_dir directory.  Check permissions." );
     }


### PR DESCRIPTION
## Summary
SUMMARY: Infrastructure "Fix stale config remaining between test invocations."

## Purpose of change
Fix stale config poisoning consecutive test runs https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3208#pullrequestreview-1640783348

## Describe the solution
Re-create test user dir before running tests

## Testing
Before:
Run tests, change language in options to ru, run tests again, see error.
After:
No error occurs.
