### PR TITLE
Fix compile error on MacOS curses

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,7 +33,6 @@ add_custom_command(
         ${CMAKE_SOURCE_DIR}/src/version.cmake
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
-
 # Build tiles version if requested
 if (TILES)
     setup_library(cataclysm-tiles-common)

--- a/src/ncurses_def.cpp
+++ b/src/ncurses_def.cpp
@@ -7,7 +7,9 @@
 // ncurses can define some functions as macros, but we need those identifiers
 // to be unchanged by the preprocessor, as we use them as function names.
 #define NCURSES_NOMACROS
+#if !defined(__APPLE__)
 #define NCURSES_WIDECHAR 1
+#endif
 #if defined(__CYGWIN__)
 #include <ncurses/curses.h>
 #else


### PR DESCRIPTION
## Summary
SUMMARY: None

## Purpose of change
Fix failing osx curses build

## Describe the solution
https://github.com/CleverRaven/Cataclysm-DDA/pull/56918

## Testing
None, will have to be done by CI