### PR TITLE
Allow filling containers directly from blood draw kit

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4592,7 +4592,6 @@ int iuse::blood_draw( player *p, item *it, bool, const tripoint & )
 
     if( acid_blood ) {
         item acid( "acid", calendar::turn );
-        it->put_in( acid );
         if( one_in( 3 ) ) {
             if( it->inc_damage( DT_ACID ) ) {
                 p->add_msg_if_player( m_info, _( "…but acidic blood melts the %s, destroying it!" ),
@@ -4602,6 +4601,9 @@ int iuse::blood_draw( player *p, item *it, bool, const tripoint & )
             }
             p->add_msg_if_player( m_info, _( "…but acidic blood damages the %s!" ), it->tname() );
         }
+        if( !liquid_handler::handle_liquid( acid, nullptr, 1, nullptr ) ) {
+            it->put_in( acid );
+        }
         return it->type->charges_to_use();
     }
 
@@ -4609,7 +4611,9 @@ int iuse::blood_draw( player *p, item *it, bool, const tripoint & )
         return it->type->charges_to_use();
     }
 
-    it->put_in( blood );
+    if( !liquid_handler::handle_liquid( blood, nullptr, 1, nullptr ) ) {
+        it->put_in( blood );
+    }
     return it->type->charges_to_use();
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/mod/json/explanation/json_style.md
C++ and Markdown: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/dev/explanation/code_style.md

!!!!!!!!!! WARNING !!!!!!!!!!

If you forget to format the PR, autofix.ci app will run automated format commit for you.
When this happens, YOU MUST DO EITHER OF THE FOLLOWING:

- Run `git pull` to merge the automated commit into your PR branch.
- Format your code locally, and force push to your PR branch. 

If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
-->

## Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/src/content/docs/en/contribute/changelog_guidelines.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Interface "Using blood draw kit now asks what container to fill, only defaults to filling the item if you cancel"

## Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Whenever I find myself needing to draw blood (usually for alchemical stuff in Arcana), I always have to unload the blood draw kit again and again, every single time I want to reuse it. This fixes it by having the iuse skip right to that step.

## Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

In iuse.cpp, changed `iuse::blood_draw` so that the blood being drawn up gets ran through `liquid_handler::handle_liquid` instead of immediately defaultin to filling the blood draw kit, so you can opt to fill another container with it immediately and go back to sucking blood.

Also means that if drawing acid blood destroys the item, it'll just not produce any acid for you instead of giving you a container of acid that's immediately destroyed.

Lastly, it uses some if function stuff so that if you just hit escape, instead of the liquid ceasing to exist it will go in the blood draw kit by default like normal.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Also figuring out the least annoying way to limit how much blood you can draw out of one corpse. I figure probably adding an item flag to the corpse I guess that stops you with a "this corpse has been drained dry" message, but if so do we want it to do so immediately after a single drain, random chance with each drain that varies depending on critter size, or...
2. Porting over blood being a thing in butcher yield from DDA instead.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested.
2. Spawned in and used a blood draw kit on myself.
3. Liquid handling comes up as expected, in this case only option is the blood draw kit, which correctly prevents any further blood work being done until I empty it.
4. Empty my water bottle and repeat, can opt to just keep going as normal by filling up the bottle instead, until my third unit has to go in the blood draw kit instead.
5. Spawn in and kill a zombie, works the same as with drawing my own blood.
6. Opted to draw some blood then canceled, it correctly defaults to going in the blood draw kit instead.
7. Confirmed it works as normal when drawing from a spitter zombie until a failure destroys the blood draw kit, at which point you get no acid spawned and no prompt to handle liquids.
8. Checked affected file for astyle.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
