### PR TITLE
fix: lab README symlink

### DIFF
--- a/data/json/mapgen/lab/README.md
+++ b/data/json/mapgen/lab/README.md
@@ -1,1 +1,1 @@
-doc/src/content/docs/en/mod/json/guides/map/lab.md
+../../../../doc/src/content/docs/en/mod/json/guides/map/lab.md


### PR DESCRIPTION
## Summary

SUMMARY: Bugfixes "Broken symlink breaking MSVC builds"

## Purpose of change

> Apparently MSVC release does not like symbolic links [cataclysmbnteam/Cataclysm-BN/actions/runs/6298000819/job/17096063672#step:14:1338](https://github.com/cataclysmbnteam/Cataclysm-BN/actions/runs/6298000819/job/17096063672#step:14:1338)

fix [MSVC not liking broken symbolic links](https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3207#discussion_r1336110991)


## Describe the solution

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/cba24a9d-592f-4f44-8cc1-e305e755f5a9)


fix symlink to be correct

## Describe alternatives you've considered

delet the file

## Testing

### before

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/e50ed97c-57d3-4293-bfde-2714d1f83841)

### after

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/9fda51e9-51d8-4314-937b-ec7f5b7d0da2)
