### PR TITLE
Fix eternal drowning when NPC is thrown into deep water.

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2456,6 +2456,7 @@ void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomo
     if( moved ) {
         const tripoint old_pos = pos();
         setpos( p );
+        set_underwater( g->m.is_divable( p ) );
         if( old_pos.x - p.x < 0 ) {
             facing = FD_RIGHT;
         } else {

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -253,7 +253,12 @@ void Character::suffer_while_underwater()
             mod_power_level( -bio_gills->power_trigger );
         } else {
             add_msg_if_player( m_bad, _( "You're drowning!" ) );
-            apply_damage( nullptr, bodypart_id( "torso" ), rng( 1, 4 ) );
+            // NPCs are not currently programmed to avoid or get out of deep water,
+            // so disable drowning damage for them.
+            // https://github.com/cataclysmbnteam/Cataclysm-BN/issues/3266
+            if( !is_npc() ) {
+                apply_damage( nullptr, bodypart_id( "torso" ), rng( 1, 4 ) );
+            }
         }
     }
     if( has_trait( trait_FRESHWATEROSMOSIS ) && !get_map().has_flag_ter( "SALT_WATER", pos() ) &&


### PR DESCRIPTION
## Summary

SUMMARY: Bugfixes "Fix NPCs eternally drowning after being thrown into deep water despite afterwards getting out of it"

## Purpose of change

Prevent NPCs from drowning eternally if they are thrown into deep water, even after walking onto land again.

## Describe the solution


The first commit fixes a bug where an NPC, after being thrown into water (for instance by a kevlar hulk), would eternally drown, even after getting onto land (unless debugging was used to constantly give them health, they would constantly take torso damage and quickly die). This fix also has the second effect that NPCs now will be treated as being submerged when walking into deep water, causing drowning after enough time. This second effect has drawbacks due to the behaviour of NPCs not currently having drowning avoidance programmed into it. The fix is inspired by similar code in `monmove.cpp`, at https://github.com/cataclysmbnteam/Cataclysm-BN/blob/dc43e2353558aa36352b76e0b4b3d577915d6272/src/monmove.cpp#L1638-L1664 which has a method named the same as the method that the first commit changes.

The second commit disables NPCs taking damage from drowning, which fixes the possible issue above where NPCs might unintentionally die from standing around in deep water without trying to get out of it.

The two commits together should have mostly the same effects as before, except:

1. NPCs will no longer have the internal state of not being submerged in deep water if they walked into it (they will now be treated as being submerged in water), even though they will not take damage from drowning (this includes the Respirator CBM draining bionic energy to delay the onset of drowning, even though drowning damage will not happen to NPCs either way now). Before, an NPC walking into deep water would be treated as if it was not submerged in water.
2. NPCs being thrown into deep water will now not drown eternally, specifically, they will not be treated as if they are submerged in deep water once they are on land again.

## Testing

I tested it using debug mode, with an NPC walking into deep water and observing that it did not drown after 30 minutes of waiting in deep water using the quick-wait function, and also tested that an NPC no longer drowns eternally by positioning deep water and a kevlar hulk such that the kevlar hulk would throw the NPC into deep water, and then observing that the NPC is still alive after 30 minutes of waiting once it got onto land using the quick-wait function.

## Additional context

I talked about this bug and how to fix it best with some of the developers on Discord, and from what I understood, what I have implemented here might fit decently what we discussed. This way of fixing it should also mean that implementing NPCs drowning in the future should be easier, since only a few lines should be removed, and those lines have a Github issue attached to it in the code. The issue #3266 has been created as a suggestion on implementing drowning and to help explain in the code why drowning is currently disabled for NPCs .
