### PR TITLE
Update iexamine_elevator.cpp

### DIFF
--- a/src/iexamine_elevator.cpp
+++ b/src/iexamine_elevator.cpp
@@ -28,7 +28,7 @@ auto move_item( map &here, const tripoint &src, const tripoint &dest ) -> void
         here.add_item_or_charges( dest, *it );
         it = here.i_rem( src, it );
     }
-};
+}
 
 namespace elevator
 {


### PR DESCRIPTION
## Summary

SUMMARY: Build "remove extra ';' to make compiler stop complaining"

## Purpose of change

gets rid of `-Werror=pedantic` compile error by removing unnecessary `;`
same deal as #3084 

## Describe the solution

Remove extra `;` that was causing the error
## Testing

Compiles successfully