### PR TITLE
perf: speed up item::has_flag calls

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5329,26 +5329,27 @@ bool item::has_own_flag( const std::string &f ) const
 
 bool item::has_flag( const std::string &f ) const
 {
-    bool ret = false;
-
-    if( json_flag::get( f ).inherit() ) {
-        for( const item *e : is_gun() ? gunmods() : toolmods() ) {
-            // gunmods fired separately do not contribute to base gun flags
-            if( !e->is_gun() && e->has_flag( f ) ) {
-                return true;
+    // Check if we have any gun/toolmods with the flag, and if we do
+    // check if that flag should be inherited.
+    // `json_flag::get` is pretty expensive so it's faster to do it
+    // last as frequently there are no gun/toolmods with the flag f
+    auto mods = is_gun() ? gunmods() : toolmods();
+    if(
+        std::any_of( mods.begin(), mods.end(),
+            [&f]( const item *e ){
+                return ( !e->is_gun() && e->has_flag( f ) );
             }
-        }
+        ) && json_flag::get( f ).inherit() ) {
+        return true;
     }
-
+    
     // other item type flags
-    ret = type->has_flag( f );
-    if( ret ) {
-        return ret;
+    if( type->has_flag( f ) ) {
+        return true;
     }
 
     // now check for item specific flags
-    ret = has_own_flag( f );
-    return ret;
+    return has_own_flag( f );
 }
 
 bool item::has_flag( const flag_str_id &flag ) const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5336,13 +5336,13 @@ bool item::has_flag( const std::string &f ) const
     auto mods = is_gun() ? gunmods() : toolmods();
     if(
         std::any_of( mods.begin(), mods.end(),
-            [&f]( const item *e ){
-                return ( !e->is_gun() && e->has_flag( f ) );
-            }
-        ) && json_flag::get( f ).inherit() ) {
+    [&f]( const item * e ) {
+    return ( !e->is_gun() && e->has_flag( f ) );
+    }
+                   ) && json_flag::get( f ).inherit() ) {
         return true;
     }
-    
+
     // other item type flags
     if( type->has_flag( f ) ) {
         return true;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/mod/json/explanation/json_style.md
C++ and Markdown: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/dev/explanation/code_style.md

!!!!!!!!!! WARNING !!!!!!!!!!

If you forget to format the PR, autofix.ci app will run automated format commit for you.
When this happens, YOU MUST DO EITHER OF THE FOLLOWING:

- Run `git pull` to merge the automated commit into your PR branch.
- Format your code locally, and force push to your PR branch. 

If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
-->

## Summary

SUMMARY: Performance "Speed up item::has_flag calls"

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/src/content/docs/en/contribute/changelog_guidelines.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

## Purpose of change

During my investigation of just why NPCs take so much time to process I discovered `item::has_flag` getting called a lot and taking up a large amount of the total processing time for NPCs. Looked into how the function is implemented and saw that a really expensive call to `json_flag::get( const std::string &)` is done first every time and that most of the time it continues on to checking itype flags and finally item instance flags.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution

Invert the execution a little. We don't care exactly what gunmod or toolmod has the flag. What we care about is if ANY has the flag. This is pretty cheap to check in the common case of `no gunmods, no toolmods` and we'll never need to check the more expensive `json_flag::get( flag )`.

Other minor change is to just get rid of the `bool ret;` entirely. We don't do anything with `ret` other than assigning a value then immediately checking it to see if we should return. It serves no purpose.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

## Testing

Waited for an hour in a refugee center with a fresh character both with the original code and with the modification. Timings are done with my phone's stopwatch, in seconds.

| Mode | Run 1 | Run 2 | Run 3 | Run 4 | Run 5 | Average |
| --- | --- | --- | --- | --- | --- | --- |
| Original | 38.87 | 38.92 | 38.63 | 39.36 | 38.86 | 38.928 |
| Modified | 31.94 | 32.40 | 32.50 | 32.05 | 31.75 | 32.128 |

Modified version saves an average of 6.8 real seconds per 1 hour in game of wait time. `6.8 / 38.928 ~= 17.468%`