### PR TITLE
perf(map): inline `sm_to_ms_copy`

### DIFF
--- a/src/coordinate_conversions.cpp
+++ b/src/coordinate_conversions.cpp
@@ -2,7 +2,8 @@
 
 #include "game_constants.h"
 
-static int divide( int v, int m )
+
+static auto divide( int v, int m ) -> int
 {
     if( v >= 0 ) {
         return v / m;
@@ -10,19 +11,19 @@ static int divide( int v, int m )
     return ( v - m + 1 ) / m;
 }
 
-static int divide( int v, int m, int &r )
+static auto divide( int v, int m, int &r ) -> int
 {
     const int result = divide( v, m );
     r = v - result * m;
     return result;
 }
 
-point omt_to_om_copy( point p )
+auto omt_to_om_copy( point p ) -> point
 {
     return point( divide( p.x, OMAPX ), divide( p.y, OMAPY ) );
 }
 
-tripoint omt_to_om_copy( const tripoint &p )
+auto omt_to_om_copy( const tripoint &p ) -> tripoint
 {
     return tripoint( divide( p.x, OMAPX ), divide( p.y, OMAPY ), p.z );
 }
@@ -33,22 +34,22 @@ void omt_to_om( int &x, int &y )
     y = divide( y, OMAPY );
 }
 
-point omt_to_om_remain( int &x, int &y )
+auto omt_to_om_remain( int &x, int &y ) -> point
 {
     return point( divide( x, OMAPX, x ), divide( y, OMAPY, y ) );
 }
 
-point om_to_omt_copy( point p )
+auto om_to_omt_copy( point p ) -> point
 {
     return point( p.x * OMAPX, p.y * OMAPY );
 }
 
-point sm_to_omt_copy( point p )
+auto sm_to_omt_copy( point p ) -> point
 {
     return point( divide( p.x, 2 ), divide( p.y, 2 ) );
 }
 
-tripoint sm_to_omt_copy( const tripoint &p )
+auto sm_to_omt_copy( const tripoint &p ) -> tripoint
 {
     return tripoint( divide( p.x, 2 ), divide( p.y, 2 ), p.z );
 }
@@ -59,17 +60,17 @@ void sm_to_omt( int &x, int &y )
     y = divide( y, 2 );
 }
 
-point sm_to_omt_remain( int &x, int &y )
+auto sm_to_omt_remain( int &x, int &y ) -> point
 {
     return point( divide( x, 2, x ), divide( y, 2, y ) );
 }
 
-point sm_to_om_copy( point p )
+auto sm_to_om_copy( point p ) -> point
 {
     return point( divide( p.x, 2 * OMAPX ), divide( p.y, 2 * OMAPY ) );
 }
 
-tripoint sm_to_om_copy( const tripoint &p )
+auto sm_to_om_copy( const tripoint &p ) -> tripoint
 {
     return tripoint( divide( p.x, 2 * OMAPX ), divide( p.y, 2 * OMAPY ), p.z );
 }
@@ -80,22 +81,22 @@ void sm_to_om( int &x, int &y )
     y = divide( y, 2 * OMAPY );
 }
 
-point sm_to_om_remain( int &x, int &y )
+auto sm_to_om_remain( int &x, int &y ) -> point
 {
     return point( divide( x, 2 * OMAPX, x ), divide( y, 2 * OMAPY, y ) );
 }
 
-point omt_to_ms_copy( point p )
+auto omt_to_ms_copy( point p ) -> point
 {
     return point( p.x * 2 * SEEX, p.y * 2 * SEEY );
 }
 
-point omt_to_sm_copy( point p )
+auto omt_to_sm_copy( point p ) -> point
 {
     return point( p.x * 2, p.y * 2 );
 }
 
-tripoint omt_to_sm_copy( const tripoint &p )
+auto omt_to_sm_copy( const tripoint &p ) -> tripoint
 {
     return tripoint( p.x * 2, p.y * 2, p.z );
 }
@@ -106,12 +107,12 @@ void omt_to_sm( int &x, int &y )
     y *= 2;
 }
 
-point om_to_sm_copy( point p )
+auto om_to_sm_copy( point p ) -> point
 {
     return point( p.x * 2 * OMAPX, p.y * 2 * OMAPX );
 }
 
-tripoint om_to_sm_copy( const tripoint &p )
+auto om_to_sm_copy( const tripoint &p ) -> tripoint
 {
     return tripoint( p.x * 2 * OMAPX, p.y * 2 * OMAPX, p.z );
 }
@@ -122,12 +123,12 @@ void om_to_sm( int &x, int &y )
     y *= 2 * OMAPY;
 }
 
-point ms_to_sm_copy( point p )
+auto ms_to_sm_copy( point p ) -> point
 {
     return point( divide( p.x, SEEX ), divide( p.y, SEEY ) );
 }
 
-tripoint ms_to_sm_copy( const tripoint &p )
+auto ms_to_sm_copy( const tripoint &p ) -> tripoint
 {
     return tripoint( divide( p.x, SEEX ), divide( p.y, SEEY ), p.z );
 }
@@ -138,17 +139,17 @@ void ms_to_sm( int &x, int &y )
     y = divide( y, SEEY );
 }
 
-point ms_to_sm_remain( int &x, int &y )
+auto ms_to_sm_remain( int &x, int &y ) -> point
 {
     return point( divide( x, SEEX, x ), divide( y, SEEY, y ) );
 }
 
-point sm_to_ms_copy( point p )
+auto sm_to_ms_copy( point p ) -> point
 {
     return point( p.x * SEEX, p.y * SEEY );
 }
 
-tripoint sm_to_ms_copy( const tripoint &p )
+auto sm_to_ms_copy( const tripoint &p ) -> tripoint
 {
     return tripoint( p.x * SEEX, p.y * SEEY, p.z );
 }
@@ -159,12 +160,12 @@ void sm_to_ms( int &x, int &y )
     y *= SEEY;
 }
 
-point ms_to_omt_copy( point p )
+auto ms_to_omt_copy( point p ) -> point
 {
     return point( divide( p.x, SEEX * 2 ), divide( p.y, SEEY * 2 ) );
 }
 
-tripoint ms_to_omt_copy( const tripoint &p )
+auto ms_to_omt_copy( const tripoint &p ) -> tripoint
 {
     return tripoint( divide( p.x, SEEX * 2 ), divide( p.y, SEEY * 2 ), p.z );
 }
@@ -175,22 +176,22 @@ void ms_to_omt( int &x, int &y )
     y = divide( y, SEEY * 2 );
 }
 
-point ms_to_omt_remain( int &x, int &y )
+auto ms_to_omt_remain( int &x, int &y ) -> point
 {
     return point( divide( x, SEEX * 2, x ), divide( y, SEEY * 2, y ) );
 }
 
-tripoint omt_to_seg_copy( const tripoint &p )
+auto omt_to_seg_copy( const tripoint &p ) -> tripoint
 {
     return tripoint( divide( p.x, SEG_SIZE ), divide( p.y, SEG_SIZE ), p.z );
 }
 
-point sm_to_mmr_remain( int &x, int &y )
+auto sm_to_mmr_remain( int &x, int &y ) -> point
 {
     return point( divide( x, MM_REG_SIZE, x ), divide( y, MM_REG_SIZE, y ) );
 }
 
-tripoint mmr_to_sm_copy( const tripoint &p )
+auto mmr_to_sm_copy( const tripoint &p ) -> tripoint
 {
     return tripoint( p.x * MM_REG_SIZE, p.y * MM_REG_SIZE, p.z );
 }

--- a/src/coordinate_conversions.cpp
+++ b/src/coordinate_conversions.cpp
@@ -2,8 +2,10 @@
 
 #include "game_constants.h"
 
+namespace
+{
 
-static auto divide( int v, int m ) -> int
+auto divide( int v, int m ) -> int
 {
     if( v >= 0 ) {
         return v / m;
@@ -11,12 +13,15 @@ static auto divide( int v, int m ) -> int
     return ( v - m + 1 ) / m;
 }
 
-static auto divide( int v, int m, int &r ) -> int
+auto divide( int v, int m, int &r ) -> int
 {
     const int result = divide( v, m );
     r = v - result * m;
     return result;
 }
+
+} // namespace
+
 
 auto omt_to_om_copy( point p ) -> point
 {

--- a/src/coordinate_conversions.cpp
+++ b/src/coordinate_conversions.cpp
@@ -1,7 +1,5 @@
 #include "coordinate_conversions.h"
 
-#include "game_constants.h"
-
 namespace
 {
 
@@ -149,15 +147,6 @@ auto ms_to_sm_remain( int &x, int &y ) -> point
     return point( divide( x, SEEX, x ), divide( y, SEEY, y ) );
 }
 
-auto sm_to_ms_copy( point p ) -> point
-{
-    return point( p.x * SEEX, p.y * SEEY );
-}
-
-auto sm_to_ms_copy( const tripoint &p ) -> tripoint
-{
-    return tripoint( p.x * SEEX, p.y * SEEY, p.z );
-}
 
 void sm_to_ms( int &x, int &y )
 {

--- a/src/coordinate_conversions.h
+++ b/src/coordinate_conversions.h
@@ -39,143 +39,200 @@
 
 // overmap terrain to overmap
 auto omt_to_om_copy( point p ) -> point;
+
 auto omt_to_om_copy( const tripoint &p ) -> tripoint;
+
 void omt_to_om( int &x, int &y );
+
 inline void omt_to_om( point &p )
 {
     omt_to_om( p.x, p.y );
 }
+
 inline void omt_to_om( tripoint &p )
 {
     omt_to_om( p.x, p.y );
 }
+
 auto omt_to_om_remain( int &x, int &y ) -> point;
+
 inline auto omt_to_om_remain( point &p ) -> point
 {
     return omt_to_om_remain( p.x, p.y );
 }
+
 // overmap to overmap terrain
 auto om_to_omt_copy( point p ) -> point;
+
 // submap to overmap terrain
 auto sm_to_omt_copy( point p ) -> point;
+
 auto sm_to_omt_copy( const tripoint &p ) -> tripoint;
+
 void sm_to_omt( int &x, int &y );
+
 inline void sm_to_omt( point &p )
 {
     sm_to_omt( p.x, p.y );
 }
+
 inline void sm_to_omt( tripoint &p )
 {
     sm_to_omt( p.x, p.y );
 }
+
 auto sm_to_omt_remain( int &x, int &y ) -> point;
+
 inline auto sm_to_omt_remain( point &p ) -> point
 {
     return sm_to_omt_remain( p.x, p.y );
 }
+
 // submap to overmap, basically: x / (OMAPX * 2)
 auto sm_to_om_copy( point p ) -> point;
+
 auto sm_to_om_copy( const tripoint &p ) -> tripoint;
+
 void sm_to_om( int &x, int &y );
+
 inline void sm_to_om( point &p )
 {
     sm_to_om( p.x, p.y );
 }
+
 inline void sm_to_om( tripoint &p )
 {
     sm_to_om( p.x, p.y );
 }
+
 auto sm_to_om_remain( int &x, int &y ) -> point;
+
 inline auto sm_to_om_remain( point &p ) -> point
 {
     return sm_to_om_remain( p.x, p.y );
 }
+
 // overmap terrain to submap, basically: x *= 2
 inline auto omt_to_sm_copy( int a ) -> int
 {
     return 2 * a;
 }
+
 auto omt_to_sm_copy( point p ) -> point;
+
 auto omt_to_sm_copy( const tripoint &p ) -> tripoint;
+
 void omt_to_sm( int &x, int &y );
+
 inline void omt_to_sm( point &p )
 {
     omt_to_sm( p.x, p.y );
 }
+
 inline void omt_to_sm( tripoint &p )
 {
     omt_to_sm( p.x, p.y );
 }
+
 // overmap terrain to map square
 auto omt_to_ms_copy( point p ) -> point;
+
 // overmap to submap, basically: x *= 2 * OMAPX
 auto om_to_sm_copy( point p ) -> point;
+
 auto om_to_sm_copy( const tripoint &p ) -> tripoint;
+
 void om_to_sm( int &x, int &y );
+
 inline void om_to_sm( point &p )
 {
     om_to_sm( p.x, p.y );
 }
+
 inline void om_to_sm( tripoint &p )
 {
     om_to_sm( p.x, p.y );
 }
+
 // map squares to submap, basically: x /= SEEX
 auto ms_to_sm_copy( point p ) -> point;
+
 auto ms_to_sm_copy( const tripoint &p ) -> tripoint;
+
 void ms_to_sm( int &x, int &y );
+
 inline void ms_to_sm( point &p )
 {
     ms_to_sm( p.x, p.y );
 }
+
 inline void ms_to_sm( tripoint &p )
 {
     ms_to_sm( p.x, p.y );
 }
+
 auto ms_to_sm_remain( int &x, int &y ) -> point;
+
 inline auto ms_to_sm_remain( point &p ) -> point
 {
     return ms_to_sm_remain( p.x, p.y );
 }
+
 inline auto ms_to_sm_remain( tripoint &p ) -> tripoint
 {
     return tripoint( ms_to_sm_remain( p.x, p.y ), p.z );
 }
+
 // submap back to map squares, basically: x *= SEEX
 // Note: this gives you the map square coordinates of the top-left corner
 // of the given submap.
 auto sm_to_ms_copy( point p ) -> point;
+
 auto sm_to_ms_copy( const tripoint &p ) -> tripoint;
+
 void sm_to_ms( int &x, int &y );
+
 inline void sm_to_ms( point &p )
 {
     sm_to_ms( p.x, p.y );
 }
+
 inline void sm_to_ms( tripoint &p )
 {
     sm_to_ms( p.x, p.y );
 }
+
 // map squares to overmap terrain, basically: x /= SEEX * 2
+
 auto ms_to_omt_copy( point p ) -> point;
+
 auto ms_to_omt_copy( const tripoint &p ) -> tripoint;
+
 void ms_to_omt( int &x, int &y );
+
 inline void ms_to_omt( point &p )
 {
     ms_to_omt( p.x, p.y );
 }
+
 inline void ms_to_omt( tripoint &p )
 {
     ms_to_omt( p.x, p.y );
 }
+
 auto ms_to_omt_remain( int &x, int &y ) -> point;
+
 inline auto ms_to_omt_remain( point &p ) -> point
 {
     return ms_to_omt_remain( p.x, p.y );
 }
+
 // overmap terrain to map segment.
 auto omt_to_seg_copy( const tripoint &p ) -> tripoint;
+
 // Submap to memory map region.
 auto sm_to_mmr_remain( int &x, int &y ) -> point;
+
 // Memory map region to submap.
 // Note: this produces sm coords of top-left corner of the region.
 auto mmr_to_sm_copy( const tripoint &p ) -> tripoint;

--- a/src/coordinate_conversions.h
+++ b/src/coordinate_conversions.h
@@ -38,8 +38,8 @@
  */
 
 // overmap terrain to overmap
-point omt_to_om_copy( point p );
-tripoint omt_to_om_copy( const tripoint &p );
+auto omt_to_om_copy( point p ) -> point;
+auto omt_to_om_copy( const tripoint &p ) -> tripoint;
 void omt_to_om( int &x, int &y );
 inline void omt_to_om( point &p )
 {
@@ -49,16 +49,16 @@ inline void omt_to_om( tripoint &p )
 {
     omt_to_om( p.x, p.y );
 }
-point omt_to_om_remain( int &x, int &y );
-inline point omt_to_om_remain( point &p )
+auto omt_to_om_remain( int &x, int &y ) -> point;
+inline auto omt_to_om_remain( point &p ) -> point
 {
     return omt_to_om_remain( p.x, p.y );
 }
 // overmap to overmap terrain
-point om_to_omt_copy( point p );
+auto om_to_omt_copy( point p ) -> point;
 // submap to overmap terrain
-point sm_to_omt_copy( point p );
-tripoint sm_to_omt_copy( const tripoint &p );
+auto sm_to_omt_copy( point p ) -> point;
+auto sm_to_omt_copy( const tripoint &p ) -> tripoint;
 void sm_to_omt( int &x, int &y );
 inline void sm_to_omt( point &p )
 {
@@ -68,14 +68,14 @@ inline void sm_to_omt( tripoint &p )
 {
     sm_to_omt( p.x, p.y );
 }
-point sm_to_omt_remain( int &x, int &y );
-inline point sm_to_omt_remain( point &p )
+auto sm_to_omt_remain( int &x, int &y ) -> point;
+inline auto sm_to_omt_remain( point &p ) -> point
 {
     return sm_to_omt_remain( p.x, p.y );
 }
 // submap to overmap, basically: x / (OMAPX * 2)
-point sm_to_om_copy( point p );
-tripoint sm_to_om_copy( const tripoint &p );
+auto sm_to_om_copy( point p ) -> point;
+auto sm_to_om_copy( const tripoint &p ) -> tripoint;
 void sm_to_om( int &x, int &y );
 inline void sm_to_om( point &p )
 {
@@ -85,18 +85,18 @@ inline void sm_to_om( tripoint &p )
 {
     sm_to_om( p.x, p.y );
 }
-point sm_to_om_remain( int &x, int &y );
-inline point sm_to_om_remain( point &p )
+auto sm_to_om_remain( int &x, int &y ) -> point;
+inline auto sm_to_om_remain( point &p ) -> point
 {
     return sm_to_om_remain( p.x, p.y );
 }
 // overmap terrain to submap, basically: x *= 2
-inline int omt_to_sm_copy( int a )
+inline auto omt_to_sm_copy( int a ) -> int
 {
     return 2 * a;
 }
-point omt_to_sm_copy( point p );
-tripoint omt_to_sm_copy( const tripoint &p );
+auto omt_to_sm_copy( point p ) -> point;
+auto omt_to_sm_copy( const tripoint &p ) -> tripoint;
 void omt_to_sm( int &x, int &y );
 inline void omt_to_sm( point &p )
 {
@@ -107,10 +107,10 @@ inline void omt_to_sm( tripoint &p )
     omt_to_sm( p.x, p.y );
 }
 // overmap terrain to map square
-point omt_to_ms_copy( point p );
+auto omt_to_ms_copy( point p ) -> point;
 // overmap to submap, basically: x *= 2 * OMAPX
-point om_to_sm_copy( point p );
-tripoint om_to_sm_copy( const tripoint &p );
+auto om_to_sm_copy( point p ) -> point;
+auto om_to_sm_copy( const tripoint &p ) -> tripoint;
 void om_to_sm( int &x, int &y );
 inline void om_to_sm( point &p )
 {
@@ -121,8 +121,8 @@ inline void om_to_sm( tripoint &p )
     om_to_sm( p.x, p.y );
 }
 // map squares to submap, basically: x /= SEEX
-point ms_to_sm_copy( point p );
-tripoint ms_to_sm_copy( const tripoint &p );
+auto ms_to_sm_copy( point p ) -> point;
+auto ms_to_sm_copy( const tripoint &p ) -> tripoint;
 void ms_to_sm( int &x, int &y );
 inline void ms_to_sm( point &p )
 {
@@ -132,20 +132,20 @@ inline void ms_to_sm( tripoint &p )
 {
     ms_to_sm( p.x, p.y );
 }
-point ms_to_sm_remain( int &x, int &y );
-inline point ms_to_sm_remain( point &p )
+auto ms_to_sm_remain( int &x, int &y ) -> point;
+inline auto ms_to_sm_remain( point &p ) -> point
 {
     return ms_to_sm_remain( p.x, p.y );
 }
-inline tripoint ms_to_sm_remain( tripoint &p )
+inline auto ms_to_sm_remain( tripoint &p ) -> tripoint
 {
     return tripoint( ms_to_sm_remain( p.x, p.y ), p.z );
 }
 // submap back to map squares, basically: x *= SEEX
 // Note: this gives you the map square coordinates of the top-left corner
 // of the given submap.
-point sm_to_ms_copy( point p );
-tripoint sm_to_ms_copy( const tripoint &p );
+auto sm_to_ms_copy( point p ) -> point;
+auto sm_to_ms_copy( const tripoint &p ) -> tripoint;
 void sm_to_ms( int &x, int &y );
 inline void sm_to_ms( point &p )
 {
@@ -156,8 +156,8 @@ inline void sm_to_ms( tripoint &p )
     sm_to_ms( p.x, p.y );
 }
 // map squares to overmap terrain, basically: x /= SEEX * 2
-point ms_to_omt_copy( point p );
-tripoint ms_to_omt_copy( const tripoint &p );
+auto ms_to_omt_copy( point p ) -> point;
+auto ms_to_omt_copy( const tripoint &p ) -> tripoint;
 void ms_to_omt( int &x, int &y );
 inline void ms_to_omt( point &p )
 {
@@ -167,17 +167,17 @@ inline void ms_to_omt( tripoint &p )
 {
     ms_to_omt( p.x, p.y );
 }
-point ms_to_omt_remain( int &x, int &y );
-inline point ms_to_omt_remain( point &p )
+auto ms_to_omt_remain( int &x, int &y ) -> point;
+inline auto ms_to_omt_remain( point &p ) -> point
 {
     return ms_to_omt_remain( p.x, p.y );
 }
 // overmap terrain to map segment.
-tripoint omt_to_seg_copy( const tripoint &p );
+auto omt_to_seg_copy( const tripoint &p ) -> tripoint;
 // Submap to memory map region.
-point sm_to_mmr_remain( int &x, int &y );
+auto sm_to_mmr_remain( int &x, int &y ) -> point;
 // Memory map region to submap.
 // Note: this produces sm coords of top-left corner of the region.
-tripoint mmr_to_sm_copy( const tripoint &p );
+auto mmr_to_sm_copy( const tripoint &p ) -> tripoint;
 
 #endif // CATA_SRC_COORDINATE_CONVERSIONS_H

--- a/src/coordinate_conversions.h
+++ b/src/coordinate_conversions.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_COORDINATE_CONVERSIONS_H
 #define CATA_SRC_COORDINATE_CONVERSIONS_H
 
+#include "game_constants.h"
 #include "point.h"
 
 /**
@@ -186,9 +187,15 @@ inline auto ms_to_sm_remain( tripoint &p ) -> tripoint
 // submap back to map squares, basically: x *= SEEX
 // Note: this gives you the map square coordinates of the top-left corner
 // of the given submap.
-auto sm_to_ms_copy( point p ) -> point;
+inline auto sm_to_ms_copy( point p ) -> point
+{
+    return point( p.x * SEEX, p.y * SEEY );
+}
 
-auto sm_to_ms_copy( const tripoint &p ) -> tripoint;
+inline auto sm_to_ms_copy( const tripoint &p ) -> tripoint
+{
+    return tripoint( p.x * SEEX, p.y * SEEY, p.z );
+}
 
 void sm_to_ms( int &x, int &y );
 


### PR DESCRIPTION
## Summary

SUMMARY: Performance "port inlining of sm_to_ms_copy function for performance gain"

## Purpose of change

- port https://github.com/CleverRaven/Cataclysm-DDA/pull/66889 by @akrieger 

## Describe the solution

forgive me for changing to trailing auto return syntax, the header was very hard to read for me as the signatures weren't aligned


## Testing

<details><summary>No noticable changes in wilderness</summary>

![before-empty](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/cc366a51-3613-4859-9115-2ec1944a5fae)

![after-empty](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/c9ee8038-625e-4ed9-bce9-2d1f8ca5351c)

</details> 

### Before Evac Center
![after-evac](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/848e1226-f038-4b40-bbf5-66f9ad8fb2e5)

### After Evac Center
![before-evac](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/c2a458c5-4f01-42b7-a87e-2654bfbacadd)

around 16.67% improvement.

## Additional context

stay tuned for next PR port: https://github.com/CleverRaven/Cataclysm-DDA/pull/67535