### PR TITLE
Mainline Stone Chisel

### DIFF
--- a/data/json/items/tool/woodworking.json
+++ b/data/json/items/tool/woodworking.json
@@ -250,5 +250,23 @@
     "color": "brown",
     "qualities": [ [ "AXE", 1 ], [ "SAW_W", 2 ], [ "BUTCHER", -90 ] ],
     "flags": [ "NONCONDUCTIVE", "BELT_CLIP" ]
+  },
+  {
+    "id": "stone_chisel",
+    "type": "TOOL",
+    "name": { "str": "stone chisel" },
+    "looks_like": "chisel",
+    "description": "This is a short stone chisel.  It can be used to engrave on stone, wood, or soft metals.",
+    "weight": "660 g",
+    "volume": "250 ml",
+    "price": 1600,
+    "to_hit": 2,
+    "bashing": 2,
+    "cutting": 1,
+    "material": "stone",
+    "symbol": ";",
+    "color": "light_gray",
+    "qualities": [ [ "CHISEL", 1 ] ],
+    "flags": [ "BELT_CLIP" ]
   }
 ]

--- a/data/json/recipes/other/tools.json
+++ b/data/json/recipes/other/tools.json
@@ -2721,5 +2721,17 @@
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "HAMMER_FINE", "level": 1 } ],
     "components": [ [ [ "pipe", 1 ] ], [ [ "nail", 1 ], [ "screwdriver", 1 ] ], [ [ "2x4", 1 ], [ "stick", 1 ], [ "splinter", 3 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "stone_chisel",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "fabrication",
+    "difficulty": 0,
+    "time": "20 m",
+    "autolearn": true,
+    "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rock", 1 ], [ "sharp_rock", 1 ] ], [ [ "stick", 1 ], [ "2x4", 1 ] ] ]
   }
 ]

--- a/data/json/recipes/other/tools.json
+++ b/data/json/recipes/other/tools.json
@@ -2728,7 +2728,6 @@
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_TOOLS",
     "skill_used": "fabrication",
-    "difficulty": 0,
     "time": "20 m",
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CUT", "level": 1 } ],


### PR DESCRIPTION
## Summary

SUMMARY: Content "Mainlined Stone Chisel from Magiclysm"

## Purpose of change

The stone chisel wasn't actually in vanilla BN, with Magiclysm having me totally fooled and thinking it was already in vanilla. I see no good reason for vanilla to only have tools with chiseling 3. This will allow for more variety in chiseling requirements in recipes and constructions. I see no good reason for this to not be a vanilla BN item.

## Describe the solution

Adds the stone chisel found in Magiclysm to the list of tools, alongside its recipe. (placed in woodworking due to that being the major use-case I can see)

## Describe alternatives you've considered

None

## Testing

Made sure the game didn't explode in awe of the stone chisel, and confirmed that it is in fact craftable (after fixing the fact that it explicitly said difficulty 0, which the game didn't like)

## Additional context

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/30732426/2c6cdb89-4b3b-40ae-99e9-3f0bb70925cf)

