### PR TITLE
perf: change frequency of cached weapon value update

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -670,7 +670,12 @@ void npc::regen_ai_cache()
     ai_cache.can_heal.clear_all();
     ai_cache.danger = 0.0f;
     ai_cache.total_danger = 0.0f;
-    ai_cache.my_weapon_value = npc_ai::wielded_value( *this );
+    // This value is actually used in only one place, npc::character_danger, and only if
+    // the single caller evaluate_enemy is passed an NPC or Player
+    // Should be fine to update this every minute since it's an expensive call.
+    if( calendar::once_every( 1_minutes ) ) {
+        ai_cache.my_weapon_value = npc_ai::wielded_value( *this );
+    }
     ai_cache.dangerous_explosives = find_dangerous_explosives();
 
     assess_danger();


### PR DESCRIPTION
## Summary

SUMMARY: Performance "Change frequency of NPC cached weapon value update"

## Purpose of change

One of the hotspots of NPC update is regeneration of the AI cache. One part in particular, `ai_cache.my_weapon_value = npc_ai::wielded_value( *this );`, is very slow to process taking around 1/3 of the total singular NPC update time. Looking deeper at where `ai_cache.my_weapon_value` is used we see a single access location in `npc::character_danger` which is itself only called from `npc::evaluate_enemy` when the passed parameter is an NPC or Player.

Because `ai_cache.my_weapon_value` is not the only consideration when evaluating perceived danger I don't think it will be harmful to the NPC to be a little inaccurate in that consideration by having mildly outdated information.

## Describe the solution

Pretty simple. Wrapped the line so that it only is evaluated once per minute instead of every turn. 1/60th the executions => 1/60th the execution time at the expense of a little information inaccuracy.

## Testing

Started a new world, new character in the refugee center as in #3277 and repeatedly wait for 1 hour, timing with phone timer. Times are in seconds to wait 1 hour in the refugee center with 37 NPCs and 19 Monsters in the reality bubble.

| Mode | Run 1 | Run 2 | Run 3 | Run 4 | Run 5 | Average |
| --- | --- | --- | --- | --- | --- | --- |
| Pre #3277 | 38.87 | 38.92 | 38.63 | 39.36 | 38.86 | 38.928 |
| #3277 | 31.94 | 32.40 | 32.50 | 32.05 | 31.75 | 32.128 |
| **This PR** | **23.51** | **23.20** | **23.04** | **23.12** | **23.74** | **23.322** |

Average time saved per waited hour relative to PR-3277 : 8.806s (27.41% better)
Average time saved per waited hour relative to pre-3277 : 15.606s (40.09% better)