### PR TITLE
ci: don't skip checks in merge group

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -8,8 +8,7 @@ on:
       - doc/**
       - 'scripts/**'
   merge_group:
-    branches:
-      - upload
+    types: [checks_requested]
   pull_request:
     branches:
       - upload


### PR DESCRIPTION
## Summary

SUMMARY: Build "Fix merge queue ignoring status checks"

## Purpose of change

- fixes #3284  (hopefully)
