### PR TITLE
fix: only set `cached_dead_state` if npc is actually dead

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -514,15 +514,18 @@ auto Character::is_dead_state() const -> bool
     }
 
     const auto all_bps = get_all_body_parts( true );
-    cached_dead_state = std::any_of( all_bps.begin(), all_bps.end(), [this]( const bodypart_id & bp ) {
+    const bool is_dead = std::any_of( all_bps.begin(), all_bps.end(), [this]( const bodypart_id & bp ) {
         return bp->essential && get_part_hp_cur( bp ) <= 0;
     } );
-    return *cached_dead_state;
+    if( is_dead ) {
+        cached_dead_state = true;
+    }
+    return is_dead;
 }
 
 void Character::set_part_hp_cur( const bodypart_id &id, int set )
 {
-    if( set < 0 ) {
+    if( set <= 0 ) {
         cached_dead_state.reset();
     }
     Creature::set_part_hp_cur( id, set );


### PR DESCRIPTION
## Summary

SUMMARY: Bugfixes "NPCs being immortal and crashing the game"

## Purpose of change

- fixes #3286 

## Describe the solution

1. changed `<` to `<=` when setting bodypart to trigger death check for parts with hp 0
2. `cached_dead_state: std::optional<bool>` means
	- `std::nullopt`: uninitialized 
	- `true` : dead (cached)
	- `false`: not dead (cached, should not be set from `is_dead_state`)

however previous code was setting `cached_dead_state` to false, which shouldn't happen.

## Testing

spawned and killed npcs using guns and debug command.

## Alternatives

maybe just use enum?

## Additional context

aaaaaaaaaahhhhh