### PR TITLE
Fix monsters attacking across z levels when wandering

### DIFF
--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -955,7 +955,7 @@ void monster::move()
 
             bool can_z_move = true;
             if( candidate.z != posz() ) {
-                bool can_z_attack = true;
+                bool can_z_attack = fov_3d;
                 if( !here.valid_move( pos(), candidate, false, true, via_ramp ) ) {
                     // Can't phase through floor
                     can_z_move = false;


### PR DESCRIPTION
## Summary

SUMMARY: Bugfixes "Prevent monsters from wandering into an attack across zlevels when fov_3d is off."

## Purpose of change

A monster that wanders or scent moves into the player will ignore fov_3d restrictions when attacking them.

## Describe the solution

If fov_3d is off it prevents it from attacking across zlevels.

## Testing

Spawned a giant wasp above me. It doesn't attack now.
