### PR TITLE
fix: remove wield value frequency, fix cache invalidation

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -468,9 +468,9 @@ void deactivate_weapon_cbm( npc &who )
     for( bionic &i : *who.my_bionics ) {
         if( i.powered && i.info().has_flag( flag_BIONIC_WEAPON ) ) {
             who.deactivate_bionic( i );
+            who.clear_npc_ai_info_cache( npc_ai_info::ideal_weapon_value );
         }
     }
-    who.clear_npc_ai_info_cache( npc_ai_info::ideal_weapon_value );
 }
 
 std::vector<std::pair<bionic_id, item>> find_reloadable_cbms( npc &who )

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -670,12 +670,7 @@ void npc::regen_ai_cache()
     ai_cache.can_heal.clear_all();
     ai_cache.danger = 0.0f;
     ai_cache.total_danger = 0.0f;
-    // This value is actually used in only one place, npc::character_danger, and only if
-    // the single caller evaluate_enemy is passed an NPC or Player
-    // Should be fine to update this every minute since it's an expensive call.
-    if( calendar::once_every( 1_minutes ) ) {
-        ai_cache.my_weapon_value = npc_ai::wielded_value( *this );
-    }
+    ai_cache.my_weapon_value = npc_ai::wielded_value( *this );
     ai_cache.dangerous_explosives = find_dangerous_explosives();
 
     assess_danger();


### PR DESCRIPTION
## Summary

SUMMARY: Bugfixes "Revert one per minute frequency addition to npc::regen_ai_cache and fix cache invalidation"

## Purpose of change

Having wielded value to be calculated and cached only once per minute is a clunky solution caused by the bug in `deactivate_weapon_cbm`. The bug was forcing the cache to become invalid every turn so the following turn it was recalculated instead of actually being used.

## Describe the solution

Removed the `once_every` wrapping condition introduced in #3283 and move the cache invalidator from outside the loop to inside so the cached value is invalidated only when the NPC is actually turning off weapon cbms. Now, instead of possibly calculating other values using up-to 1 minute old data the NPC will use the most accurate data it can. More accuracy, fewer calls to the expensive function.

## Testing

Waited several hours in both pre-change and post-change configurations. Performance is approximately the same between the two. In profiling the NPCs calculate the cached value once then properly refer to that cached value every turn after.
