### PR TITLE
Water purification tablets now work consistently

### DIFF
--- a/data/json/recipes/food/drinks.json
+++ b/data/json/recipes/food/drinks.json
@@ -15,6 +15,7 @@
   {
     "type": "recipe",
     "result": "water_clean",
+    "charges": 8,
     "category": "CC_FOOD",
     "id_suffix": "using_water_purifier",
     "subcategory": "CSC_FOOD_DRINKS",
@@ -22,7 +23,7 @@
     "time": "9 s",
     "autolearn": true,
     "tools": [ [ [ "water_purifier", 1 ], [ "pur_tablets", 1 ], [ "char_purifier", 1 ] ] ],
-    "components": [ [ [ "water", 1 ] ] ],
+    "components": [ [ [ "water", 8 ] ] ],
     "flags": [ "BLIND_EASY" ]
   },
   {

--- a/data/json/recipes/recipe_deconstruction_package.json
+++ b/data/json/recipes/recipe_deconstruction_package.json
@@ -4,7 +4,7 @@
     "type": "uncraft",
     "time": "4 s",
     "components": [
-      [ [ "pur_tablets", 6 ] ],
+      [ [ "pur_tablets", 1 ] ],
       [ [ "gummy_vitamins", 1 ] ],
       [ [ "coffee_raw", 1 ] ],
       [ [ "lemonade_powder", 1 ] ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/mod/json/explanation/json_style.md
C++ and Markdown: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/dev/explanation/code_style.md

!!!!!!!!!! WARNING !!!!!!!!!!

If you forget to format the PR, autofix.ci app will run automated format commit for you.
When this happens, YOU MUST DO EITHER OF THE FOLLOWING:

- Run `git pull` to merge the automated commit into your PR branch.
- Format your code locally, and force push to your PR branch. 

If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
-->

## Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/src/content/docs/en/contribute/changelog_guidelines.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Make clean water recipe using purification match efficiency of activating water purifiers"

## Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Belated followup updates for https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2832, making the use of water purification tablets consistent between its iuse and recipe, and other updates.

## Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Changed it so that the clean water recipe using tablets takes 8 water and outputs 8 clean water, as per the ratio its iuse now uses. This also fits even with the water filter items, because those use the exact same use action as the tablets and thus were made 8x as effective too. It even affects vehicle water purifiers.
2. Reduced number of tablets gained from taking apart an MRE from 6 to just 1. Still a net increase from 1.5 liters of water purified to 2 relative to the original amounts, and still solidly a whole day's worth of water according to current game logic when you're expected to tear through not much more than 2 of those a day for most characters.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Rigging it to be a less clunky number, not that it matters much since you can just activate the tablets too.
2. Scaling the time up to match what used to be 8 doses worth of the recipe. Not really that worthwhile since the iuse has it only take 2 entire seconds per tablet usage.
3. Converely, making it take more time and nerfing the time cost of the iuse. Since it uses most cost instead of a long action, and allowing it to be interruptible would mean you could magically un-wet your tablets and cancel all progress made in purifying your water (unlike with crafting), this is probably a bad idea for now.
4. Nerfing it down to 1 liter instead of 2 liters for gameplay reasons.
5. Also nerfing how many tablets are in a survival kit. You won't be tearing your way through these like you would MREs so it's probably okay to leave them at the same amount that the bottles typically spawn in.
6. Nerfing the volume of pur tablets so no one will get any wacky ideas about trying to make small bottles hold 100 of them, which would basically cover the water needs of almost any character as permanantly as an infinite water source plus a candle of warding in Arcana does. XD

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled build to confirm I can indeed do basic math.
3. Checked to confirm that activating a water purifier or charcoal filter actually did get buffed by Scarf's changes, confirms it only eats 1 charge when doing that.
4. Build a water purifier vehicle to confirm that examining a vehicle purifier also uses only 1 charge to clean up to 2 liters of water.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

![tumblr_p5cgm9TQkZ1wvuif9o1_1280](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/ef364637-32bc-4bfe-a13c-928d9178643e)