### PR TITLE
Prying nails correctly deconstructs reinforced boarded window

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -4131,6 +4131,11 @@ void activity_handlers::pry_nails_finish( player_activity *act, player *p )
         boards = 3;
         newter = t_fence_post;
         p->add_msg_if_player( _( "You pry out the fence post." ) );
+    } else if( type == t_window_reinforced_noglass ) {
+        nails = 16;
+        boards = 8;
+        newter = t_window_boarded_noglass;
+        p->add_msg_if_player( _( "You pry the boards from the window." ) );
     } else if( type == t_window_reinforced ) {
         nails = 16;
         boards = 8;

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -4131,6 +4131,11 @@ void activity_handlers::pry_nails_finish( player_activity *act, player *p )
         boards = 3;
         newter = t_fence_post;
         p->add_msg_if_player( _( "You pry out the fence post." ) );
+    } else if( type == t_window_reinforced ) {
+        nails = 16;
+        boards = 8;
+        newter = t_window_boarded;
+        p->add_msg_if_player( _( "You pry the boards from the window." ) );
     } else if( type == t_window_boarded ) {
         nails = 8;
         boards = 4;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2387,6 +2387,8 @@ int iuse::hammer( player *p, item *it, bool, const tripoint & )
     }
     const std::set<ter_id> allowed_ter_id {
         t_fence,
+        t_window_reinforced,
+        t_window_reinforced_noglass,
         t_window_boarded,
         t_window_boarded_noglass,
         t_door_boarded,
@@ -2425,6 +2427,7 @@ int iuse::hammer( player *p, item *it, bool, const tripoint & )
     }
 
     if( type == t_fence || type == t_window_boarded || type == t_window_boarded_noglass ||
+        type == t_window_reinforced || type == t_window_reinforced_noglass ||
         type == t_door_boarded || type == t_door_boarded_damaged ||
         type == t_rdoor_boarded || type == t_rdoor_boarded_damaged ||
         type == t_door_boarded_peep || type == t_door_boarded_damaged_peep ) {


### PR DESCRIPTION
## Summary

SUMMARY: [Balance] "Prying nails correctly deconstructs reinforced boarded window"

## Purpose of change

There was no way to deconstructed a reinforced boarded window. I used the hammers pry nails function to do so.

## Describe the solution

I added a new else if for the function in activity_handlers.cpp with the correct planks, nails, target terrain, and resulting terrain based on the construction recipe and the else if for boarded windows. I added it above the one for boarded window as its sequential.

Edit: I also added the two terrains to the iuse.cpp so they can be correctly targeted, and ensured you can't pry nails out while mounted.

## Describe alternatives you've considered

JSONization via targeting a flag, which I can't do.

## Testing

SDL is broken on compiling for me thanks to issues with the main branch. I could not test so it will need testing. This should be relatively simple and work however as its only a few lines and I rigorously copied the other else if for boarded window.

## Additional context

Compiling truly be russian roulette. The day I try to learn is the day the one I choose is broken.
