### PR TITLE
Check mx ids defined for region

### DIFF
--- a/data/mods/DinoMod/regional_overlay.json
+++ b/data/mods/DinoMod/regional_overlay.json
@@ -7,12 +7,10 @@
       "forest_water": {
         "chance": 20,
         "extras": {
-          "mx_mass_grave_dino": 30,
           "mx_nest_acrocanthosaurus": 30,
           "mx_nest_albertosaurus": 30,
           "mx_nest_allosaurus": 30,
           "mx_nest_ceratosaurus": 30,
-          "mx_nest_daspletosaurus": 30,
           "mx_nest_deinonychus": 30,
           "mx_nest_dilophosaurus": 30,
           "mx_nest_dromaeosaurus": 30,

--- a/data/mods/No_Hope/regional_map_settings.json
+++ b/data/mods/No_Hope/regional_map_settings.json
@@ -514,7 +514,6 @@
         }
       },
       "bridgehead_ground": { "chance": 5, "extras": { "mx_minefield": 100 } },
-      "road_nesw_manhole": { "chance": 20, "extras": { "mx_city_trap": 100 } },
       "build": {
         "chance": 90,
         "extras": {
@@ -572,8 +571,6 @@
           "mx_casings": 30
         }
       },
-      "river": { "chance": 3, "extras": { "mx_reed": 100 } },
-      "lake_shore": { "chance": 2, "extras": { "mx_reed": 100 } },
       "sewer": {
         "chance": 1,
         "extras": {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -779,6 +779,7 @@ void DynamicDataLoader::check_consistency( loading_ui &ui )
             { _( "Overmap specials" ), &overmap_specials::check_consistency },
             { _( "Map extras" ), &MapExtras::check_consistency },
             { _( "Start locations" ), &start_locations::check_consistency },
+            { _( "Regional settings" ), &check_regional_settings },
             { _( "Ammunition types" ), &ammunition_type::check_consistency },
             { _( "Traps" ), &trap::check_consistency },
             { _( "Bionics" ), &bionic_data::check_consistency },

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -51,6 +51,7 @@
 #include "translations.h"
 #include "trap.h"
 #include "type_id.h"
+#include "type_id_implement.h"
 #include "ui.h"
 #include "units.h"
 #include "veh_type.h"
@@ -186,12 +187,7 @@ generic_factory<map_extra> extras( "map extra" );
 
 } // namespace
 
-/** @relates string_id */
-template<>
-const map_extra &string_id<map_extra>::obj() const
-{
-    return extras.obj( *this );
-}
+IMPLEMENT_STRING_ID( map_extra, extras )
 
 namespace MapExtras
 {

--- a/src/regional_settings.cpp
+++ b/src/regional_settings.cpp
@@ -7,14 +7,17 @@
 #include <string>
 #include <utility>
 
+#include "consistency_report.h"
 #include "debug.h"
 #include "enum_conversions.h"
 #include "int_id.h"
 #include "json.h"
+#include "map_extras.h"
 #include "options.h"
 #include "overmap_special.h"
 #include "rng.h"
 #include "string_formatter.h"
+#include "string_id.h"
 #include "translations.h"
 
 ter_furn_id::ter_furn_id() : ter( t_null ), furn( f_null ) { }
@@ -1092,4 +1095,24 @@ void building_bin::finalize()
     }
 
     finalized = true;
+}
+
+void check_regional_settings()
+{
+    for( auto const& [region_id, region] : region_settings_map ) {
+        consistency_report rep;
+
+        for( auto const& [extras_group, extras] : region.region_extras ) {
+            for( auto const& [extra_id, extra_weight] : extras.values ) {
+                string_id<map_extra> id( extra_id );
+                if( !id.is_valid() ) {
+                    rep.warn( "defines unknown map extra '%s'", id );
+                }
+            }
+        }
+
+        if( !rep.is_empty() ) {
+            debugmsg( rep.format( "region_settings", region_id ) );
+        }
+    }
 }

--- a/src/regional_settings.h
+++ b/src/regional_settings.h
@@ -246,6 +246,8 @@ using t_regional_settings_map = std::unordered_map<std::string, regional_setting
 using t_regional_settings_map_citr = t_regional_settings_map::const_iterator;
 extern t_regional_settings_map region_settings_map;
 
+void check_regional_settings();
+
 void load_region_settings( const JsonObject &jo );
 void reset_region_settings();
 void load_region_overlay( const JsonObject &jo );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/mod/json/explanation/json_style.md
C++ and Markdown: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/dev/explanation/code_style.md

!!!!!!!!!! WARNING !!!!!!!!!!

If you forget to format the PR, autofix.ci app will run automated format commit for you.
When this happens, YOU MUST DO EITHER OF THE FOLLOWING:

- Run `git pull` to merge the automated commit into your PR branch.
- Format your code locally, and force push to your PR branch. 

If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
-->

## Summary
SUMMARY: Bugfixes "Check mapextra ids for regions"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/src/content/docs/en/contribute/changelog_guidelines.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

## Purpose of change
Trying to track down and fix random test failure from https://github.com/cataclysmbnteam/Cataclysm-BN/actions/runs/6318661870/job/17158134285#step:11:2378

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution
Check mapextra ids for regions
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

## Testing
Waiting for test suite... Done, works as expected:
```
(continued from above) ERROR: Warnings for region_settings "desert_test":
defines unknown map extra 'mx_mass_grave_dino'
defines unknown map extra 'mx_nest_daspletosaurus'
01:35:26.208 ERROR DEBUGMSG : src/regional_settings.cpp:1115 [void check_regional_settings()] Warnings for region_settings "river":
defines unknown map extra 'mx_mass_grave_dino'
defines unknown map extra 'mx_nest_daspletosaurus'
01:35:26.208 ERROR DEBUGMSG : src/regional_settings.cpp:1115 [void check_regional_settings()] Warnings for region_settings "default":
defines unknown map extra 'mx_reed'
defines unknown map extra 'mx_reed'
defines unknown map extra 'mx_city_trap'
```
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->