### PR TITLE
perf: correctly cache and invalidate dead state

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -529,28 +529,32 @@ void Character::set_part_hp_cur( const bodypart_id &id, int set )
     Creature::set_part_hp_cur( id, set );
 }
 
-void Character::set_part_hp_max( const bodypart_id &id, int set ) {
+void Character::set_part_hp_max( const bodypart_id &id, int set )
+{
     if( set <= 0 ) {
         cached_dead_state.reset();
     }
     Creature::set_part_hp_max( id, set );
 }
 
-void Character::mod_part_hp_cur( const bodypart_id &id, int mod ) {
+void Character::mod_part_hp_cur( const bodypart_id &id, int mod )
+{
     if( mod < 0 ) {
         cached_dead_state.reset();
     }
     Creature::mod_part_hp_cur( id, mod );
 }
 
-void Character::mod_part_hp_max( const bodypart_id &id, int mod ) {
+void Character::mod_part_hp_max( const bodypart_id &id, int mod )
+{
     if( mod < 0 ) {
         cached_dead_state.reset();
     }
     Creature::mod_part_hp_max( id, mod );
 }
 
-void Character::set_all_parts_hp_cur( int set ) {
+void Character::set_all_parts_hp_cur( int set )
+{
     if( set <= 0 ) {
         cached_dead_state.reset();
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -31,6 +31,7 @@
 #include "consumption.h"
 #include "coordinate_conversions.h"
 #include "coordinates.h"
+#include "creature.h"
 #include "damage.h"
 #include "debug.h"
 #include "disease.h"
@@ -514,13 +515,10 @@ auto Character::is_dead_state() const -> bool
     }
 
     const auto all_bps = get_all_body_parts( true );
-    const bool is_dead = std::any_of( all_bps.begin(), all_bps.end(), [this]( const bodypart_id & bp ) {
+    cached_dead_state = std::any_of( all_bps.begin(), all_bps.end(), [this]( const bodypart_id & bp ) {
         return bp->essential && get_part_hp_cur( bp ) <= 0;
     } );
-    if( is_dead ) {
-        cached_dead_state = true;
-    }
-    return is_dead;
+    return cached_dead_state.value();
 }
 
 void Character::set_part_hp_cur( const bodypart_id &id, int set )
@@ -529,6 +527,34 @@ void Character::set_part_hp_cur( const bodypart_id &id, int set )
         cached_dead_state.reset();
     }
     Creature::set_part_hp_cur( id, set );
+}
+
+void Character::set_part_hp_max( const bodypart_id &id, int set ) {
+    if( set <= 0 ) {
+        cached_dead_state.reset();
+    }
+    Creature::set_part_hp_max( id, set );
+}
+
+void Character::mod_part_hp_cur( const bodypart_id &id, int mod ) {
+    if( mod < 0 ) {
+        cached_dead_state.reset();
+    }
+    Creature::mod_part_hp_cur( id, mod );
+}
+
+void Character::mod_part_hp_max( const bodypart_id &id, int mod ) {
+    if( mod < 0 ) {
+        cached_dead_state.reset();
+    }
+    Creature::mod_part_hp_max( id, mod );
+}
+
+void Character::set_all_parts_hp_cur( int set ) {
+    if( set <= 0 ) {
+        cached_dead_state.reset();
+    }
+    Creature::set_all_parts_hp_cur( set );
 }
 
 field_type_id Character::bloodType() const

--- a/src/character.h
+++ b/src/character.h
@@ -249,6 +249,12 @@ class Character : public Creature, public visitable<Character>
 
     public:
         void set_part_hp_cur( const bodypart_id &id, int set ) override;
+        void set_part_hp_max( const bodypart_id &id, int set ) override;
+
+        void mod_part_hp_cur( const bodypart_id &id, int mod ) override;
+        void mod_part_hp_max( const bodypart_id &id, int mod ) override;
+
+        void set_all_parts_hp_cur( int set ) override;
 
         field_type_id bloodType() const override;
         field_type_id gibType() const override;

--- a/src/creature.h
+++ b/src/creature.h
@@ -523,14 +523,14 @@ class Creature
         int get_part_healed_total( const bodypart_id &id ) const;
 
         virtual void set_part_hp_cur( const bodypart_id &id, int set );
-        void set_part_hp_max( const bodypart_id &id, int set );
+        virtual void set_part_hp_max( const bodypart_id &id, int set );
         void set_part_healed_total( const bodypart_id &id, int set );
-        void mod_part_hp_cur( const bodypart_id &id, int mod );
-        void mod_part_hp_max( const bodypart_id &id, int mod );
+        virtual void mod_part_hp_cur( const bodypart_id &id, int mod );
+        virtual void mod_part_hp_max( const bodypart_id &id, int mod );
         void mod_part_healed_total( const bodypart_id &id, int mod );
 
 
-        void set_all_parts_hp_cur( int set );
+        virtual void set_all_parts_hp_cur( int set );
         void set_all_parts_hp_to_max();
 
         virtual int get_speed_base() const;


### PR DESCRIPTION
## Summary

SUMMARY: Performance "Fix dead state caching again"

## Purpose of change

revert #3287, rollback #3282

## Describe the solution

use dynamic dispatch for all part hp modification methods, and invalidate dead state cache from there

## Describe alternatives you've considered

duplicate codes are awful, but rewriting API involves editing lots of other files and conflicts with existing PR such as #2250 or #2776

## Testing

could kill NPC using guns and melee. debug NPC killing works as well.