### PR TITLE
feat: vehicle hovering

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4218,7 +4218,7 @@ bool vehicle::has_sufficient_rotorlift() const
 // requires vehicle to have sufficient rotor lift, not suitable for checking if it has rotor.
 bool vehicle::is_rotorcraft() const
 {
-    return has_part( "ROTOR" ) && has_sufficient_rotorlift() && player_in_control( g->u );
+    return has_part( "ROTOR" ) && has_sufficient_rotorlift();
 }
 
 int vehicle::get_z_change() const


### PR DESCRIPTION
## Summary

SUMMARY: Features "Allow vehicles to hover without player control"

## Purpose of change

Doing other stuff while hovering is fun.

## Describe the solution

Remove player control requirement in `vehicle::is_rotorcraft`

## Describe alternatives you've considered

hecc

## Testing
it is _buggy_.

- `jumping over` from hovering helicopter causes this error:
	```
	 DEBUG    : map::unboard_vehicle: vehicle not found
	
	 FUNCTION : void map::unboard_vehicle(const tripoint &, bool)
	 FILE     : /home/scarf/repo/cata/Cataclysm/src/map.cpp
	 LINE     : 1171
	 VERSION  : BN d008f4a7b5b
	```
- it's not possible to jump into hovering vehicle.
- teleporting into hovering helicopter also causes following error:
	```
	 DEBUG    : map::board_vehicle: passenger (Maribel Hearn) is already there
	
	 FUNCTION : void map::board_vehicle(const tripoint &, player *)
	 FILE     : /home/scarf/repo/cata/Cataclysm/src/map.cpp
	 LINE     : 1132
	 VERSION  : BN d008f4a7b5b
	```
- turning off engine does not result in vehicle falling. maybe this could be solved by checking engines are on? thought `vehicle::total_power_w` checked whether vehicle engine was powered but maybe it's not.
- it's very laggy while a vehicle is hovering.
- i haven't removed warning when letting go of vehicle control.
- hovering vehicles will fall without any warning when its fuel gets depleted.

## Additional context

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/d2a371cf-5080-4503-a589-5ffae53c4ef6)

reading books while hovering