### PR TITLE
Fix Repair Nanobots

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1673,6 +1673,12 @@ void Character::process_bionic( bionic &bio )
             }
             if( calendar::once_every( 2_minutes ) ) {
                 std::vector<bodypart_id> damaged_hp_parts;
+                for (const bodypart_id& bp : get_all_body_parts(true)) {
+                    const int hp_cur = get_part_hp_cur(bp);
+                    if (!is_limb_broken(bp) && hp_cur < get_part_hp_max(bp)) {
+                        damaged_hp_parts.push_back(bp);
+                    }
+                }
                 if( !damaged_hp_parts.empty() ) {
                     // Essential parts are considered 10 HP lower than non-essential parts for the purpose of determining priority.
                     // I'd use the essential_value, but it's tied up in the heal_actor class of iuse_actor.

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1673,10 +1673,10 @@ void Character::process_bionic( bionic &bio )
             }
             if( calendar::once_every( 2_minutes ) ) {
                 std::vector<bodypart_id> damaged_hp_parts;
-                for (const bodypart_id& bp : get_all_body_parts(true)) {
-                    const int hp_cur = get_part_hp_cur(bp);
-                    if (!is_limb_broken(bp) && hp_cur < get_part_hp_max(bp)) {
-                        damaged_hp_parts.push_back(bp);
+                for( const bodypart_id &bp : get_all_body_parts( true ) ) {
+                    const int hp_cur = get_part_hp_cur( bp );
+                    if( !is_limb_broken( bp ) && hp_cur < get_part_hp_max( bp ) ) {
+                        damaged_hp_parts.push_back( bp );
                     }
                 }
                 if( !damaged_hp_parts.empty() ) {


### PR DESCRIPTION
## Summary

SUMMARY: Bugfixes "Fix Repair Nanobots"

## Purpose of change

- #3054 caused an issue where repair nanobots weren't healing. Closer examination revealed it was due to damaged parts not being updated.

## Describe the solution

Add back code that marks limbs for repair, keep mending parts out of it.

## Describe alternatives you've considered

Reworking Nanobots for the nth time to do new and weird things.

## Testing

Spawned character, damaged torso and one limb to 60 HP. Added self-aware mutation to track HP.
Installed Repair Nanobots, added 100 kJ power.

- [x] Wait one hour, check that no healing and power draw is observed.
- [x] Turn on Repair Nanobots, check that body parts heal and power draw is as expected.

## Additional context