### PR TITLE
fix: crash in ranged accuracy test related to dead NPC cleanup

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8525,7 +8525,7 @@ void Character::apply_damage( Creature *source, bodypart_id hurt, int dam,
 
     if( is_dead_state() ) {
         // if the player killed himself, add it to the kill count list
-        if( !is_npc() && !killer && source == g->u.as_character() ) {
+        if( !is_npc() && !get_killer() && source == g->u.as_character() ) {
             g->events().send<event_type::character_kills_character>( get_player_character().getID(), getID(),
                     get_name() );
         }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -102,7 +102,7 @@ Creature::Creature()
 {
     moves = 0;
     pain = 0;
-    killer = nullptr;
+    killer.reset();
     speed_base = 100;
     underwater = false;
 
@@ -1466,15 +1466,15 @@ bool Creature::in_sleep_state() const
  */
 Creature *Creature::get_killer() const
 {
-    return killer;
+    return killer.lock().get();
 }
 
-void Creature::set_killer( Creature *const killer )
+void Creature::set_killer( Creature *nkiller )
 {
     // Only the first killer will be stored, calling set_killer again with a different
     // killer would mean it's called on a dead creature and therefore ignored.
-    if( killer != nullptr && !killer->is_fake() && this->killer == nullptr ) {
-        this->killer = killer;
+    if( !get_killer() && nkiller && !nkiller->is_fake() ) {
+        killer = g->shared_from( *nkiller );
     }
 }
 

--- a/src/creature.h
+++ b/src/creature.h
@@ -19,6 +19,7 @@
 #include "units.h"
 #include "cached_options.h"
 #include "enums.h"
+#include "memory_fast.h"
 
 enum game_message_type : int;
 class nc_color;
@@ -809,8 +810,8 @@ class Creature
         effects_map get_all_effects() const;
 
     protected:
-        Creature *killer = nullptr; // whoever killed us. this should be NULL unless we are dead
-        void set_killer( Creature *killer );
+        weak_ptr_fast<Creature> killer; // whoever killed us. this should be NULL unless we are dead
+        void set_killer( Creature *nkiller );
 
         /**
          * Processes one effect on the Creature.

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2517,11 +2517,11 @@ void npc::die( Creature *nkiller )
         add_msg( _( "%s dies!" ), name );
     }
 
-    if( Character *ch = dynamic_cast<Character *>( killer ) ) {
+    if( Character *ch = dynamic_cast<Character *>( get_killer() ) ) {
         g->events().send<event_type::character_kills_character>( ch->getID(), getID(), get_name() );
     }
 
-    if( killer == &g->u && ( !guaranteed_hostile() || hit_by_player ) ) {
+    if( get_killer() == &g->u && ( !guaranteed_hostile() || hit_by_player ) ) {
         bool cannibal = g->u.has_trait( trait_CANNIBAL );
         bool psycho = g->u.has_trait( trait_PSYCHOPATH ) || g->u.has_trait( trait_KILLER );
         if( g->u.has_trait( trait_SAPIOVORE ) || psycho ) {
@@ -2533,14 +2533,14 @@ void npc::die( Creature *nkiller )
         }
     }
 
-    if( killer == &g->u && g->u.has_trait( trait_KILLER ) ) {
+    if( get_killer() == &g->u && g->u.has_trait( trait_KILLER ) ) {
         const translation snip = SNIPPET.random_from_category( "killer_on_kill" ).value_or( translation() );
         g->u.add_msg_if_player( m_good, "%s", snip );
         g->u.add_morale( MORALE_KILLER_HAS_KILLED, 5, 10, 6_hours, 4_hours );
         g->u.rem_morale( MORALE_KILLER_NEED_TO_KILL );
     }
 
-    if( killer == &g->u && g->u.has_trait( trait_PROF_FERAL ) ) {
+    if( get_killer() == &g->u && g->u.has_trait( trait_PROF_FERAL ) ) {
         if( !g->u.has_effect( effect_feral_killed_recently ) ) {
             g->u.add_msg_if_player( m_good, _( "The voices in your head quiet down a bit." ) );
         }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3081,7 +3081,7 @@ void Creature::load( const JsonObject &jsin )
     jsin.read( "moves", moves );
     jsin.read( "pain", pain );
 
-    killer = nullptr; // see Creature::load
+    killer.reset();
 
     if( jsin.has_object( "effects" ) ) {
         // Because JSON requires string keys we need to convert back to our bp keys


### PR DESCRIPTION
## Summary
SUMMARY: Bugfixes "Fix crash in ranged accuracy test related to dead NPC cleanup"

## Purpose of change
Fix test that's randomly failing on macOS, and MSYS2.

## Describe the solution
According to the debugger, the crash happens when the code tries to cast a non-null raw pointer `Creature* killer` that's stored inside the `Creature` class to the pointer of type `Character*` in `npc::die` function. What I suspect happens here is that the killer gets deallocated before their victim, so the cast results in an attempt to use stale pointer.

There's also a random crash in tests on MSYS2 build, and @Vollch examined it and it turned out to have very similar source (`clear_all_state() -> clear_map() -> clear_npcs() -> g->cleanup_dead()` in ranged tests), so I believe this should fix that issue as well.

Solution is to switch `killer` from raw C pointer to smart weak pointer that gets invalidated as soon as the killer gets deallocated.

## Testing
No longer crashes on test Mac 12 with same seed, also no longer crashes with same seed in CI.
Didn't test MSYS2.

