### PR TITLE
fix: `item::ideal_ranged_dps` crash on NPC interaction

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2092,15 +2092,15 @@ double item::ideal_ranged_dps( const Character &who, gun_mode &mode ) const
         itype_id ammo = ammo_default();
         gun_damage.add( ammo->ammo->damage );
     }
-    float damage_factor = gun_damage.total_damage();
-    damage_factor *= mode.qty;
+    const int burst_size = std::max( 1, mode.qty );
+    const float damage_factor = gun_damage.total_damage() * burst_size;
 
     int move_cost = ranged::time_to_attack( who, *this, item_location() );
     if( ammo_remaining() == 0 ) {
         int reload_cost = get_reload_time() + who.encumb( bp_hand_l ) + who.encumb( bp_hand_r );
         // HACK: Doesn't check how much ammo they'll actually get from the reload. Because we don't know.
         // DPS is less impacted the larger the magazine being swapped.
-        reload_cost /= magazine_integral() ? 1 : ammo_capacity() / mode.qty;
+        reload_cost /= magazine_integral() ? 1 : ammo_capacity() / burst_size;
         move_cost += reload_cost;
     }
     std::vector<ranged::aim_type> aim_types = ranged::get_aim_types( who, *this );


### PR DESCRIPTION
## Summary

SUMMARY: Bugfixes "Prevent divide by 0 error on NPC interaction"

## Purpose of change

- fix #3288 
- fix #3293

`gun_mode.qty` can be 0, which cause divide by 0 error when invoking `item::ideal_ranged_dps`.

## Describe the solution

fallback to `1` if qty is `0`

## Describe alternatives you've considered

rewrite `npcmove.cpp` from scratch

## Testing

### #3293

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/2ff0ac02-1f42-4d38-9a63-ad960b02f9b0

### #3288

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/067dc755-d36b-40a7-b573-6b5563716998


## Additional context

cc @KheirFerrum 
