### PR TITLE
ci: always run build matrix test for merge queue

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -8,7 +8,6 @@ on:
       - doc/**
       - 'scripts/**'
   merge_group:
-    types: [checks_requested]
   pull_request:
     branches:
       - upload


### PR DESCRIPTION
## Summary

SUMMARY: Build "Always run build matrix test for merge queue"

## Purpose of change

yet another continuation of #3285

## Describe the solution

remove all preconditions, will always run

## Describe alternatives you've considered

hecc

## Testing

can only be tested from CI

## Additional context

reference: https://scribe.rip/@kojoru/how-to-set-up-merge-queues-in-github-actions-59381e5f435a