### PR TITLE
Port over two improvements to simple deconstruct

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -17,7 +17,7 @@
     "group": "deconstruct_simple_furniture",
     "category": "FURN",
     "required_skills": [ [ "fabrication", 0 ] ],
-    "time": "10 m",
+    "time": "10 s",
     "pre_note": "Certain terrain and furniture can be deconstructed without any tools.",
     "pre_flags": "EASY_DECONSTRUCT",
     "pre_special": "check_deconstruct",

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -978,7 +978,10 @@ bool can_construct( const construction &con, const tripoint &p )
     // see if the flags check out
     place_okay &= std::all_of( con.pre_flags.begin(), con.pre_flags.end(),
     [&p]( const std::string & flag ) {
-        return get_map().has_flag( flag, p );
+        map &m = get_map();
+        furn_id f = m.furn( p );
+        ter_id t = m.ter( p );
+        return f == f_null ? t->has_flag( flag ) : f->has_flag( flag );
     } );
     // make sure the construction would actually do something
     if( !con.post_terrain.is_empty() ) {

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -977,11 +977,10 @@ bool can_construct( const construction &con, const tripoint &p )
     place_okay &= has_pre_terrain( con, p );
     // see if the flags check out
     place_okay &= std::all_of( con.pre_flags.begin(), con.pre_flags.end(),
-    [&p]( const std::string & flag ) {
-        map &m = get_map();
-        furn_id f = m.furn( p );
-        ter_id t = m.ter( p );
-        return f == f_null ? t->has_flag( flag ) : f->has_flag( flag );
+    [&p, &here]( const std::string & flag ) -> bool {
+        const furn_id &furn = here.furn( p );
+        const ter_id &ter = here.ter( p );
+        return furn == f_null ? ter->has_flag( flag ) : furn->has_flag( flag );
     } );
     // make sure the construction would actually do something
     if( !con.post_terrain.is_empty() ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/mod/json/explanation/json_style.md
C++ and Markdown: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/dev/explanation/code_style.md

!!!!!!!!!! WARNING !!!!!!!!!!

If you forget to format the PR, autofix.ci app will run automated format commit for you.
When this happens, YOU MUST DO EITHER OF THE FOLLOWING:

- Run `git pull` to merge the automated commit into your PR branch.
- Format your code locally, and force push to your PR branch. 

If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
-->

## Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/src/content/docs/en/contribute/changelog_guidelines.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Port over fix for deconstructing furniture over carpet, time change"

## Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This ports over a fix related to deconstruction of simple items, along with also porting over a JSON improvement to simple deconstruction.

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/3330

Given rationale for the time change:
> Simple deconstruction is used basically exclusively for furniture that you "pick up". Examples: mattress, carpet, pallet of cement bags, band saw, oven, charcoal kiln, mannequin, hammock, indoor plant, stack of planks, resin pod. None of these deserve to take 10 entire minutes to disassemble.

## Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

C++ changes:
1. In construction.cpp, changed the bigger spicier version of `can_construct` so that its check for requested flags distinguishes between terrain and furniture.

JSON changes:
1. Changed simple deconstruct to take 10 seconds instead of 10 minutes.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Not porting over the time change, doing it in a separate PR when it's such a tiny change, making it like 1-5 minutes instead...
2. Rigging some way to make tools and time for deconstruct vary depending on what's being deconstructed so we can just not have to question whether the step makes sense for all cases or not.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected JSON file for syntax and lint errors.
2. Compiled and load tested.
3. Spawned in carpet with a fridge over it.
4. Confirmed it still goes for the fridge first, then the carpet.
5. Spawned more carpet with a chair over it this time.
6. It no longer allows trying to simple deconstruct so long as the chair is blocking the carpet.
7. Spawned in a toolbox and confirmed you deconstruct the chair first, then go back to being able to take apart the carpet via either method.
8. Checked affected C++ file for astyle.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

PRs ported over:
1. Fix simple deconstruction, by @dseguin: https://github.com/CleverRaven/Cataclysm-DDA/pull/54234
2. Time edit for simple deconstruct, by @anoobindisguise: https://github.com/CleverRaven/Cataclysm-DDA/pull/63656