### PR TITLE
Further consistency updates for shotshells

### DIFF
--- a/data/json/items/ammo/shot.json
+++ b/data/json/items/ammo/shot.json
@@ -22,6 +22,7 @@
     "copy-from": "shot_00",
     "type": "AMMO",
     "name": { "str": "00 shot, black powder" },
+    "proportional": { "price": 0.6, "damage": { "damage_type": "bullet", "amount": 0.8 }, "dispersion": 1.2 },
     "extend": { "effects": [ "RECYCLED", "MUZZLE_SMOKE", "BLACKPOWDER" ] },
     "delete": { "effects": [ "NEVER_MISFIRES" ], "flags": [ "IRREPLACEABLE_CONSUMABLE" ] }
   },
@@ -56,6 +57,7 @@
     "material": [ "plastic", "powder" ],
     "symbol": "=",
     "color": "red",
+    "dispersion": 10,
     "count": 20,
     "stack_size": 20,
     "ammo_type": "shot",
@@ -97,7 +99,6 @@
     "price_postapoc": 400,
     "range": 0,
     "damage": { "damage_type": "bullet", "amount": 50, "armor_multiplier": 3.0 },
-    "dispersion": 1000,
     "loudness": 80,
     "shape": [ "cone", { "half_angle": 15, "length": 8 } ],
     "extend": { "effects": [ "NOGIB" ] }
@@ -150,7 +151,8 @@
     "type": "AMMO",
     "name": { "str": "00 shot, scrap loaded" },
     "description": "A shotgun shell filled with whatever was lying around.  They are more damaging than birdshot, but fairly inaccurate.",
-    "proportional": { "price": 0.4, "damage": { "damage_type": "bullet", "amount": 0.6 }, "dispersion": 1.2 },
+    "dispersion": 60,
+    "proportional": { "price": 0.4, "damage": { "damage_type": "bullet", "amount": 0.75, "armor_multiplier": 1.25 } },
     "extend": { "effects": [ "RECYCLED" ] },
     "delete": { "effects": [ "NEVER_MISFIRES" ], "flags": [ "IRREPLACEABLE_CONSUMABLE" ] }
   },

--- a/data/json/items/ammo/shotpaper.json
+++ b/data/json/items/ammo/shotpaper.json
@@ -11,6 +11,7 @@
     "material": [ "paper", "powder", "lead" ],
     "symbol": "=",
     "color": "white",
+    "dispersion": 20,
     "count": 20,
     "stack_size": 20,
     "ammo_type": "shotpaper",
@@ -33,7 +34,7 @@
     "type": "AMMO",
     "name": { "str": "20ga paper birdshot" },
     "description": "A paper cartridge containing a premeasured amount of black powder and an equal volume of birdshot.  Used mostly for hunting small game or fowl.",
-    "damage": { "damage_type": "bullet", "amount": 40 },
+    "damage": { "damage_type": "bullet", "amount": 40, "armor_multiplier": 3.0 },
     "proportional": { "recoil": 0.6, "loudness": 0.8 },
     "extend": { "effects": [ "NOGIB" ] }
   },
@@ -43,7 +44,8 @@
     "type": "AMMO",
     "name": { "str": "20ga paper pyrotechnic cartridge" },
     "description": "A paper cartridge containing a premeasured amount of black powder and an equal volume of flammable metals.  When fired, burning chunks of metal and sparks will shoot out of the barrel, igniting everything in their path.",
-    "proportional": { "damage": { "damage_type": "bullet", "amount": 0.2 }, "recoil": 0.6, "loudness": 0.8, "dispersion": 1.2 },
+    "damage": { "damage_type": "heat", "amount": 24 },
+    "proportional": { "recoil": 0.6, "loudness": 0.8, "dispersion": 1.2 },
     "range": 0,
     "shape": [ "cone", { "half_angle": 15, "length": 8 } ],
     "extend": { "effects": [ "INCENDIARY", "STREAM", "NOGIB" ] }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/mod/json/explanation/json_style.md
C++ and Markdown: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/dev/explanation/code_style.md

!!!!!!!!!! WARNING !!!!!!!!!!

If you forget to format the PR, autofix.ci app will run automated format commit for you.
When this happens, YOU MUST DO EITHER OF THE FOLLOWING:

- Run `git pull` to merge the automated commit into your PR branch.
- Format your code locally, and force push to your PR branch. 

If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
-->

## Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/src/content/docs/en/contribute/changelog_guidelines.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Give shotshells baseline dispersion, consistency updates for scrap shells, paper shot, birdshot"

## Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Consistency updates for some 12 gauge and 20 gauge shot loads.

## Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Changed scrap shot's damage to be 0.75x that of 00 shot instead of 0.6x. This makes it correctly be more damaging (60) than birdshot is currently.
2. Changed birdshot to not override default dispersion to 1000. It doesn't matter statistically since it still uses AoE effects, but it does make it more visually consistent and makes it less hassle to tweak other dispersion values.
3. Gave 00 shot a baseline dispersion of 20. This makes the increased dispersion of black powder loads actually visible.
4. Set scrap shot to have 60 dispersion, to make its stated poor accuracy evident. Also set it to have an armor multiple in between 00 shot and birdshot.
5. Added baseline 20 dispersion to paper shot abstract to distinguish from 00 shot changes.
6. Set paper birdshot to have an armor modifier of 3.0 like regular birdshot does.
7. Set pyrotechnic 20ga cartridge to have heat-type damage instead of ballistic, matching how dragon's breath is balanced. 24 damage, matching how 12 gauge dragon's breath is 3/8ths that of 00 shot.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Nerfing 00 shot a bit more. Eh, it's beefy but works okay in this role I figure, especially since the armor multipliers do compensate for that somewhat. Only really makes it just hard to feel consistent with respect to earlier ammo balance efforts.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected file for syntax and lint errors.
2. Load-tested and checked that stats on affected items show expected values.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
