### PR TITLE
Fixed some issues with displaying item's mods counter

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4651,19 +4651,6 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
     std::string maintext;
     if( is_corpse() || typeId() == itype_blood || item_vars.find( "name" ) != item_vars.end() ) {
         maintext = type_name( quantity );
-    } else if( is_gun() || is_tool() || is_magazine() ) {
-        int amt = 0;
-        maintext = label( quantity );
-        for( const item *mod : is_gun() ? gunmods() : toolmods() ) {
-            if( !type->gun || !type->gun->built_in_mods.count( mod->typeId() ) ) {
-                amt++;
-            }
-        }
-        if( amt ) {
-            maintext += string_format( "+%d", amt );
-        }
-    } else if( is_armor() && has_clothing_mod() ) {
-        maintext = label( quantity ) + "+1";
     } else if( is_craft() ) {
         maintext = string_format( _( "in progress %s" ), craft_data_->making->result_name() );
         if( charges > 1 ) {
@@ -4671,23 +4658,47 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
         }
         const int percent_progress = item_counter / 100000;
         maintext += string_format( " (%d%%)", percent_progress );
-    } else if( contents.num_item_stacks() == 1 ) {
-        const item &contents_item = contents.front();
-        const unsigned contents_count =
-            ( ( contents_item.made_of( LIQUID ) || contents_item.is_food() ) &&
-              contents_item.charges > 1 )
-            ? contents_item.charges
-            : quantity;
-        maintext = string_format( pgettext( "item name", "%2$s (%1$s)" ), label( quantity ),
-                                  contents_item.tname( contents_count, with_prefix ) );
-    } else if( !contents.empty() ) {
-        maintext = string_format( vpgettext( "item name",
-                                             //~ %1$s: item name, %2$zd: content size
-                                             "%1$s with %2$zd item",
-                                             "%1$s with %2$zd items", contents.num_item_stacks() ),
-                                  label( quantity ), contents.num_item_stacks() );
     } else {
-        maintext = label( quantity );
+        std::string labeltext = label( quantity );
+
+        int modamt = 0;
+        if( is_tool() ) {
+            modamt += toolmods().size();
+        }
+        if( is_gun() ) {
+            for( const item *mod : gunmods() ) {
+                if( !type->gun->built_in_mods.count( mod->typeId() ) ) {
+                    modamt++;
+                }
+            }
+        }
+        if( is_armor() && has_clothing_mod() ) {
+            modamt++;
+        }
+        if( modamt ) {
+            labeltext += string_format( "+%d", modamt );
+        }
+
+        if( is_gun() || is_tool() || is_magazine() ) {
+            maintext = labeltext;
+        } else if( contents.num_item_stacks() == 1 ) {
+            const item &contents_item = contents.front();
+            const unsigned contents_count =
+                ( ( contents_item.made_of( LIQUID ) || contents_item.is_food() ) &&
+                  contents_item.charges > 1 )
+                ? contents_item.charges
+                : quantity;
+            maintext = string_format( pgettext( "item name", "%2$s (%1$s)" ), labeltext,
+                                      contents_item.tname( contents_count, with_prefix ) );
+        } else if( !contents.empty() ) {
+            maintext = string_format( vpgettext( "item name",
+                                                 //~ %1$s: item name, %2$zd: content size
+                                                 "%1$s with %2$zd item",
+                                                 "%1$s with %2$zd items", contents.num_item_stacks() ),
+                                      labeltext, contents.num_item_stacks() );
+        } else {
+            maintext = labeltext;
+        }
     }
 
     avatar &you = get_avatar();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/mod/json/explanation/json_style.md
C++ and Markdown: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/dev/explanation/code_style.md

!!!!!!!!!! WARNING !!!!!!!!!!

If you forget to format the PR, autofix.ci app will run automated format commit for you.
When this happens, YOU MUST DO EITHER OF THE FOLLOWING:

- Run `git pull` to merge the automated commit into your PR branch.
- Format your code locally, and force push to your PR branch. 

If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
-->
## Summary
SUMMARY: Bugfixes "Fixed some issues with displaying item's mods counter"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/src/content/docs/en/contribute/changelog_guidelines.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

## Purpose of change
Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/212. Displayed name is formed by checking long `else if` chain, and because of that mods counter could be processed partially, or skipped, or override later parts.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution
Rearranged processing order to make sure game won't skip any of mods check, nor following formatting.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

## Describe alternatives you've considered
Not fixing this bug.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing
Spawned some items, looks good.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

## Additional context
TOOL_ARMOR with both clothing and tool mods, and scabbard with both clothing mod and content:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/544763/86277dca-e785-496c-87bb-78a5fdf54494)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
