### PR TITLE
feat: acid trail for acid cannons

### DIFF
--- a/data/json/ammo_effects.json
+++ b/data/json/ammo_effects.json
@@ -52,6 +52,16 @@
     "explosion": { "damage": 20, "radius": 7, "fire": true }
   },
   {
+    "id": "ACID_TRAIL",
+    "type": "ammo_effect",
+    "trail": { "field_type": "fd_acid", "intensity_min": 1, "intensity_max": 3, "chance": 66 }
+  },
+  {
+    "id": "ACID_TRAIL_WEAK",
+    "type": "ammo_effect",
+    "trail": { "field_type": "fd_acid", "intensity_min": 1, "intensity_max": 2, "chance": 33 }
+  },
+  {
     "id": "ACIDBOMB",
     "type": "ammo_effect",
     "aoe": { "field_type": "fd_acid", "intensity_min": 3, "intensity_max": 3 }

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -390,7 +390,7 @@
     "phase": "liquid",
     "category": "chems",
     "fun": -30,
-    "ammo_data": { "ammo_type": "acid", "damage": { "damage_type": "acid", "amount": 2 }, "effects": [ "RECOVER_10" ] }
+    "ammo_data": { "ammo_type": "acid", "damage": { "damage_type": "acid", "amount": 2 } }
   },
   {
     "type": "COMESTIBLE",
@@ -412,7 +412,7 @@
     "phase": "liquid",
     "category": "chems",
     "fun": -15,
-    "ammo_data": { "ammo_type": "acid", "damage": { "damage_type": "acid", "amount": 1 }, "effects": [ "RECOVER_10" ] }
+    "ammo_data": { "ammo_type": "acid", "damage": { "damage_type": "acid", "amount": 1 } }
   },
   {
     "type": "COMESTIBLE",
@@ -436,7 +436,7 @@
     "fun": -45,
     "freezing_point": 25,
     "drop_action": { "type": "emit_actor", "emits": [ "emit_acid_splash" ], "scale_qty": true },
-    "ammo_data": { "ammo_type": "acid", "damage": { "damage_type": "acid", "amount": 3 }, "effects": [ "RECOVER_10" ] }
+    "ammo_data": { "ammo_type": "acid", "damage": { "damage_type": "acid", "amount": 3 }, "effects": [ "ACID_TRAIL" ] }
   },
   {
     "type": "COMESTIBLE",
@@ -570,7 +570,7 @@
     "bashing": 1,
     "ammo_type": "acid",
     "damage": { "damage_type": "acid", "amount": 6 },
-    "effects": [ "RECOVER_10" ],
+    "effects": [ "ACID_TRAIL_WEAK" ],
     "phase": "liquid",
     "container": "bottle_glass",
     "//freezing_point": 25,
@@ -592,7 +592,7 @@
     "bashing": 1,
     "ammo_type": "acid",
     "damage": { "damage_type": "acid", "amount": 5 },
-    "effects": [ "RECOVER_10" ],
+    "effects": [ "ACID_TRAIL_WEAK" ],
     "phase": "liquid",
     "container": "bottle_glass",
     "//freezing_point": 25,
@@ -614,7 +614,7 @@
     "bashing": 1,
     "ammo_type": "acid",
     "damage": { "damage_type": "acid", "amount": 4 },
-    "effects": [ "RECOVER_10" ],
+    "effects": [ "ACID_TRAIL_WEAK" ],
     "phase": "liquid",
     "container": "bottle_glass",
     "//freezing_point": -44,
@@ -797,7 +797,6 @@
     "bashing": 1,
     "ammo_type": "acid",
     "damage": { "damage_type": "acid", "amount": 3 },
-    "effects": [ "RECOVER_10" ],
     "phase": "liquid",
     "container": "bottle_glass"
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/mod/json/explanation/json_style.md
C++ and Markdown: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/dev/explanation/code_style.md

!!!!!!!!!! WARNING !!!!!!!!!!

If you forget to format the PR, autofix.ci app will run automated format commit for you.
When this happens, YOU MUST DO EITHER OF THE FOLLOWING:

- Run `git pull` to merge the automated commit into your PR branch.
- Format your code locally, and force push to your PR branch. 

If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
-->

## Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/src/content/docs/en/contribute/changelog_guidelines.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Give acid fired out of a water cannon acid trail effects instead of using emit_actor hackery"

## Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Some belated fixes for weird behavior with acid used in water cannons. In particular, for whatever reason it likes to only spawn acid at the very edge of its range or in front of any walls it hits, even if it has to shoot acid clean through an enemy it is clearly hitting to do so. I tested this with both the fiddly `emit_actor` method and with an aoe-type ammo effect and yeah, it doesn't work good either way.

## Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Removed `RECOVER_10` from all acid items.
2. Instead, added ammo effects `ACID_TRAIL` and `ACID_TRAIL_WEAK` for all acid items that have an acid emit as their `drop_action`. Idea here is, instead of always just dumping a glob of maximum intensity at the end point of firing, they'll have trails of less intense acid spawn instead.
3. Defined `ACID_TRAIL` ammo effect, creating a trail of acid between 1 and 3 intensity 66% of the time. Compare with `emit_acid_drop` always being max intensity at a 100% rate. Used by concentrated acid.
4. Defined `ACID_TRAIL_WEAK` ammo effect for the other acids that spawn fields to use. Trail spawns intensity of 1 or 2, 33% of the time. Contrast with `emit_acid_drop` being max intensity but only 50% of the time.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Removing acid cannons because I'm basic instead.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Load-tested in compiled build.
2. Spawned in a fire truck and replaced its water with a jug of concentrated acid.
3. Fired it off, confirmed it left acid only on one tile.
5. Tested firing on a debug critter, observed that acid spawns occur all throughout the line of fire.

A thing I noticed: acid emission from dumping a jug of acid on the ground spreads the field out with overflow to make a big mess, while with the water cannon it always stayed in one tile. `emit_actor` was being weird when abused via a gun dumping ammo on the ground evidently.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

8 shots with best available acid:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/45891697-60da-4e2c-ad19-b717a2a2b456)