### PR TITLE
fix: misplaced field name error on mutation tileset

### DIFF
--- a/data/json/external_tileset/alternative_mutation.json
+++ b/data/json/external_tileset/alternative_mutation.json
@@ -1,32 +1,31 @@
-{
-  "type": "mod_tileset",
-  "compatibility": [
-    "UNDEAD_PEOPLE_BASE",
-    "UNDEAD_PEOPLE"
-  ],
-  "tiles-new": [
-    {
-      "file": "external_tileset/alternative_mutation.png",
-      "sprite_width": 32,
-      "sprite_height": 32,
-      "sprite_offset_y": -16,
-      "tiles": [
-        { "id": "overlay_mutation_FELINE_EARS", "fg": 0, "rotates": false },
-        { "id": "overlay_mutation_LUPINE_EARS", "fg": 1, "rotates": false },
-        { "id": "overlay_mutation_MOUSE_EARS", "fg": 2, "rotates": false },
-        { "id": "overlay_mutation_CANINE_EARS", "fg": 3, "rotates": false },
-        { "id": "overlay_mutation_URSINE_EARS", "fg": 4, "rotates": false }
-      ]
-    },
-    {
-      "file": "external_tileset/alternative_mutation.png",
-      "sprite_width": 32,
-      "sprite_height": 32,
-      "sprite_offset_y": 16,
-      "tiles": [
-        { "id": "overlay_mutation_TAIL_FLUFFY", "fg": 9, "rotates": false },
-        { "id": "overlay_mutation_TAIL_STUB", "fg": 12, "rotates": false }
-      ]
-    }
-  ]
-}
+[
+  {
+    "type": "mod_tileset",
+    "compatibility": [ "UNDEAD_PEOPLE_BASE", "UNDEAD_PEOPLE" ],
+    "tiles-new": [
+      {
+        "file": "external_tileset/alternative_mutation.png",
+        "sprite_width": 32,
+        "sprite_height": 32,
+        "sprite_offset_y": -16,
+        "tiles": [
+          { "id": "overlay_mutation_FELINE_EARS", "fg": 0, "rotates": false },
+          { "id": "overlay_mutation_LUPINE_EARS", "fg": 1, "rotates": false },
+          { "id": "overlay_mutation_MOUSE_EARS", "fg": 2, "rotates": false },
+          { "id": "overlay_mutation_CANINE_EARS", "fg": 3, "rotates": false },
+          { "id": "overlay_mutation_URSINE_EARS", "fg": 4, "rotates": false }
+        ]
+      },
+      {
+        "file": "external_tileset/alternative_mutation.png",
+        "sprite_width": 32,
+        "sprite_height": 32,
+        "sprite_offset_y": 16,
+        "tiles": [
+          { "id": "overlay_mutation_TAIL_FLUFFY", "fg": 9, "rotates": false },
+          { "id": "overlay_mutation_TAIL_STUB", "fg": 12, "rotates": false }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

SUMMARY: Bugfixes "Strict JSON warnings when loading new mutation tileset"

## Purpose of change

```
 DEBUG    : (json-error)
Json error: <unknown source file>:2:10: Invalid or misplaced field name "type" in JSON data

{
  "type":
         ^
          "mod_tileset",
  "compatibility": [
    "UNDEAD_PEOPLE_BASE",


 FUNCTION : void JsonObject::report_unvisited() const
 FILE     : /home/scarf/repo/cata/Cataclysm/src/json.cpp
 LINE     : 125
 VERSION  : BN 8b4336bb134b
```

hotfix for #3340.
for some reason object format errors wheras array format doesn't

## Describe the solution

wrap it in array

## Describe alternatives you've considered

make the behavior same for objects...

## Testing

loaded without errors.