### PR TITLE
ci: trigger workflow check on merge queue

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - upload
+      - gh-readonly-queue/upload/**
     paths-ignore:
       - doc/**
       - 'scripts/**'


### PR DESCRIPTION
## Summary

SUMMARY: Build "Trigger workflow check on merge queue (for this time, real)"

## Purpose of change

make merge queue actually useful

## Describe the solution

![_03](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/f464af15-583c-4581-ab9d-4e3bebe0ef60)

github merge queue creates temporary branches under `gh-readonly/{target branch}/`. trigger workflow there instead.

## Describe alternatives you've considered

1. add 'require status check' to PRs
2. PRs fail due to flaky tests
3. give everyone admin rights so it could be bypassed
4. ???
5. _chaos insurgency_

## Testing

needs to be merged in order to test.

## Additional context

- https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-third-party-ci-providers
- https://github.com/orgs/community/discussions/46757#discussioncomment-6990903

