### PR TITLE
Updates for homemade explosive/flame ammo

### DIFF
--- a/data/json/items/ranged/archery.json
+++ b/data/json/items/ranged/archery.json
@@ -304,23 +304,25 @@
     "dispersion": 285,
     "loudness": 0,
     "count": 5,
-    "effects": [ "EXPLOSIVE_SMALL" ]
+    "effects": [ "COOKOFF", "EXPLOSIVE_SMALL" ]
   },
   {
-    "type": "GENERIC",
+    "type": "TOOL",
     "id": "exploding_arrow_warhead",
     "category": "spare_parts",
     "symbol": "=",
     "color": "green",
     "name": { "str": "explosive arrowhead" },
-    "description": "This simple IED is designed to be attached to an arrow and detonate on impact.",
+    "description": "This simple IED is designed to be attached to an arrow or crossbow bolt, and detonate on impact.",
     "price": 2000,
     "price_postapoc": 250,
     "material": "steel",
     "weight": "562 g",
     "volume": "250 ml",
     "bashing": 10,
-    "to_hit": -1
+    "to_hit": -1,
+    "explosion": { "damage": 40, "radius": 2 },
+    "explode_in_fire": true
   },
   {
     "type": "AMMO",

--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -287,8 +287,8 @@
     "material": "wood",
     "symbol": "=",
     "color": "brown",
-    "initial_charges": 5,
-    "max_charges": 5,
+    "initial_charges": 1,
+    "max_charges": 1,
     "charges_per_use": 1,
     "use_action": "ARROW_FLAMABLE"
   },

--- a/data/json/recipes/ammo/arrows.json
+++ b/data/json/recipes/ammo/arrows.json
@@ -424,13 +424,17 @@
     "components": [
       [ [ "exploding_arrow_warhead", 1 ] ],
       [
-        [ "arrow_field_point_fletched", 1 ],
-        [ "arrow_fire_hardened_fletched", 1 ],
-        [ "arrow_wood", 1 ],
-        [ "arrow_heavy_fire_hardened_fletched", 1 ],
-        [ "arrow_heavy_field_point_fletched", 1 ],
-        [ "arrow_wood_heavy", 1 ],
-        [ "arrow_metal", 1 ]
+        [ "bolt_simple_wood", 1 ],
+        [ "bolt_simple_small_game", 1 ],
+        [ "bolt_makeshift", 1 ],
+        [ "bolt_wood", 1 ],
+        [ "bolt_wood_bodkin", 1 ],
+        [ "bolt_wood_small_game", 1 ],
+        [ "bolt_metal", 1 ],
+        [ "bolt_steel", 1 ],
+        [ "bolt_steel_bodkin", 1 ],
+        [ "bolt_steel_target", 1 ],
+        [ "bolt_cf", 1 ]
       ]
     ]
   },

--- a/data/json/recipes/ammo/arrows.json
+++ b/data/json/recipes/ammo/arrows.json
@@ -355,29 +355,29 @@
     "skill_used": "fabrication",
     "skills_required": [ "archery", 3 ],
     "difficulty": 3,
-    "time": "5 m",
+    "time": "1 m",
     "reversible": true,
     "book_learn": [ [ "recipe_arrows", 5 ] ],
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [
       [
-        [ "arrow_field_point_fletched", 5 ],
-        [ "arrow_fire_hardened_fletched", 5 ],
-        [ "arrow_wood", 5 ],
-        [ "arrow_heavy_fire_hardened_fletched", 5 ],
-        [ "arrow_heavy_field_point_fletched", 5 ],
-        [ "arrow_wood_heavy", 5 ],
-        [ "arrow_metal", 5 ]
+        [ "arrow_field_point_fletched", 1 ],
+        [ "arrow_fire_hardened_fletched", 1 ],
+        [ "arrow_wood", 1 ],
+        [ "arrow_heavy_fire_hardened_fletched", 1 ],
+        [ "arrow_heavy_field_point_fletched", 1 ],
+        [ "arrow_wood_heavy", 1 ],
+        [ "arrow_metal", 1 ]
       ],
       [ [ "rag", 1, "NO_RECOVER" ] ],
       [
-        [ "lamp_oil", 50, "NO_RECOVER" ],
-        [ "motor_oil", 50, "NO_RECOVER" ],
-        [ "chem_ethanol", 100, "NO_RECOVER" ],
-        [ "denat_alcohol", 100, "NO_RECOVER" ],
-        [ "gasoline", 250, "NO_RECOVER" ],
-        [ "diesel", 250, "NO_RECOVER" ],
-        [ "biodiesel", 250, "NO_RECOVER" ]
+        [ "lamp_oil", 10, "NO_RECOVER" ],
+        [ "motor_oil", 10, "NO_RECOVER" ],
+        [ "chem_ethanol", 20, "NO_RECOVER" ],
+        [ "denat_alcohol", 20, "NO_RECOVER" ],
+        [ "gasoline", 50, "NO_RECOVER" ],
+        [ "diesel", 50, "NO_RECOVER" ],
+        [ "biodiesel", 50, "NO_RECOVER" ]
       ]
     ],
     "delete_flags": [ "FILTHY" ],
@@ -391,19 +391,21 @@
     "skill_used": "fabrication",
     "skills_required": [ [ "archery", 4 ] ],
     "difficulty": 4,
-    "time": "7 m",
+    "time": "90 s",
+    "charges": 1,
+    "reversible": true,
     "book_learn": [ [ "recipe_arrows", 6 ], [ "textbook_anarch", 4 ], [ "recipe_bullets", 7 ] ],
     "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "SCREW", "level": 1 } ],
     "components": [
-      [ [ "exploding_arrow_warhead", 5 ] ],
+      [ [ "exploding_arrow_warhead", 1 ] ],
       [
-        [ "arrow_field_point_fletched", 5 ],
-        [ "arrow_fire_hardened_fletched", 5 ],
-        [ "arrow_wood", 5 ],
-        [ "arrow_heavy_fire_hardened_fletched", 5 ],
-        [ "arrow_heavy_field_point_fletched", 5 ],
-        [ "arrow_wood_heavy", 5 ],
-        [ "arrow_metal", 5 ]
+        [ "arrow_field_point_fletched", 1 ],
+        [ "arrow_fire_hardened_fletched", 1 ],
+        [ "arrow_wood", 1 ],
+        [ "arrow_heavy_fire_hardened_fletched", 1 ],
+        [ "arrow_heavy_field_point_fletched", 1 ],
+        [ "arrow_wood_heavy", 1 ],
+        [ "arrow_metal", 1 ]
       ]
     ]
   },
@@ -413,27 +415,24 @@
     "category": "CC_AMMO",
     "subcategory": "CSC_AMMO_ARROWS",
     "skill_used": "fabrication",
-    "skills_required": [ [ "mechanics", 3 ] ],
-    "difficulty": 5,
-    "time": "10 m",
-    "book_learn": [ [ "recipe_arrows", 7 ], [ "textbook_anarch", 4 ], [ "recipe_bullets", 7 ] ],
-    "using": [ [ "soldering_standard", 10 ] ],
-    "qualities": [ { "id": "SAW_M", "level": 1 } ],
+    "skills_required": [ [ "archery", 4 ] ],
+    "difficulty": 4,
+    "time": "90 s",
+    "reversible": true,
+    "book_learn": [ [ "recipe_arrows", 6 ], [ "textbook_anarch", 4 ], [ "recipe_bullets", 7 ] ],
+    "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "SCREW", "level": 1 } ],
     "components": [
-      [ [ "bolt_metal", 1 ], [ "bolt_steel", 1 ] ],
-      [ [ "can_food_unsealed", 1 ], [ "can_drink_unsealed", 1 ], [ "canister_empty", 1 ] ],
-      [ [ "superglue", 1 ], [ "cordage", 1, "LIST" ] ],
+      [ [ "exploding_arrow_warhead", 1 ] ],
       [
-        [ "smpistol_primer", 1 ],
-        [ "lgpistol_primer", 1 ],
-        [ "smrifle_primer", 1 ],
-        [ "lgrifle_primer", 1 ],
-        [ "shotgun_primer", 1 ]
-      ],
-      [ [ "gunpowder", 20 ], [ "chem_black_powder", 20 ] ]
-    ],
-    "delete_flags": [ "FILTHY" ],
-    "flags": [ "ALLOW_FILTHY" ]
+        [ "arrow_field_point_fletched", 1 ],
+        [ "arrow_fire_hardened_fletched", 1 ],
+        [ "arrow_wood", 1 ],
+        [ "arrow_heavy_fire_hardened_fletched", 1 ],
+        [ "arrow_heavy_field_point_fletched", 1 ],
+        [ "arrow_wood_heavy", 1 ],
+        [ "arrow_metal", 1 ]
+      ]
+    ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/ammo/components.json
+++ b/data/json/recipes/ammo/components.json
@@ -60,13 +60,14 @@
       [ [ "can_food_unsealed", 1 ], [ "can_drink_unsealed", 1 ], [ "canister_empty", 1 ] ],
       [ [ "superglue", 1 ], [ "cordage", 1, "LIST" ] ],
       [
+        [ "impact_fuze", 1 ],
         [ "smpistol_primer", 1 ],
         [ "lgpistol_primer", 1 ],
         [ "smrifle_primer", 1 ],
         [ "lgrifle_primer", 1 ],
         [ "shotgun_primer", 1 ]
       ],
-      [ [ "gunpowder", 20 ], [ "chem_black_powder", 20 ] ]
+      [ [ "volatile_explosive", 2, "LIST" ], [ "stable_explosive", 2, "LIST" ], [ "military_explosive", 2, "LIST" ] ]
     ],
     "delete_flags": [ "FILTHY" ],
     "flags": [ "ALLOW_FILTHY" ]

--- a/data/json/recipes/ammo/other.json
+++ b/data/json/recipes/ammo/other.json
@@ -201,7 +201,15 @@
     "book_learn": [ [ "manual_launcher", 5 ] ],
     "qualities": [ { "id": "HAMMER", "level": 3 }, { "id": "SAW_M", "level": 1 } ],
     "tools": [ [ [ "hotplate", 50 ], [ "toolset", 50 ] ] ],
-    "components": [ [ [ "pipe", 2 ] ], [ [ "chem_black_powder", 150 ] ], [ [ "tool_rocket_candy", 2 ], [ "chem_rocket_fuel", 10 ] ] ]
+    "components": [
+      [ [ "pipe", 2 ] ],
+      [
+        [ "volatile_explosive", 25, "LIST" ],
+        [ "stable_explosive", 25, "LIST" ],
+        [ "military_explosive", 25, "LIST" ]
+      ],
+      [ [ "tool_rocket_candy", 2 ], [ "chem_rocket_fuel", 10 ] ]
+    ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/mod/json/explanation/json_style.md
C++ and Markdown: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/dev/explanation/code_style.md

!!!!!!!!!! WARNING !!!!!!!!!!

If you forget to format the PR, autofix.ci app will run automated format commit for you.
When this happens, YOU MUST DO EITHER OF THE FOLLOWING:

- Run `git pull` to merge the automated commit into your PR branch.
- Format your code locally, and force push to your PR branch. 

If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
-->

## Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/src/content/docs/en/contribute/changelog_guidelines.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Consistency updates for explosive/flammable arrows/bolts, allow using impact fuses in recipes"

## Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This updates some explosive recipes to make use of impact fuzes as an alternative to primers where relevant, and to use an associated crafting requirement that expands on the options for what to feed explosive ammo with. A few other consistency updates too.

## Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Set it so that explosive homemade rockets use any available explosive material instead of only blackpowder, increased explosive requirement a fair bit since its raw damage is MUCH higher than spiked rockets, and added the need for an impact fuze or primer.
2. Reworked explosive bolts to be made by applying explosive arrowheads to regular bolts, updated recipe to be consistent with explosive arrow recipe and allow using a wider variety of bolts (basically any fletched bolt). Also made reversible and take less time.
3. Set explosive arrows to be made 1 at a time and be faster to make, set to be reversible as with explosive bolts.
4. Set it so that flame arrows are likewise made 1 at a time and reduced time taken to make. Does mean it uses more rags but that's the least costly ingredient of the bunch anyway.
5. Set it so flame arrows have only 1 charge since the way they work is...weird.
6. Set explosive arrowheads to allow any adequate explosive filler, set to be close to the amount of smokeless powder it previously required. Also set it so it can use impact fuzes as an alternative to primers.
7. Updated description of explosive arrowhead, and converted it to a tool so that it'll be able to access explosive data and cook off if exposed to fire.
8. Fixed explosive arrows not having `COOKOFF` flag.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Obsoleting impact fuzes instead. Feel like this is more interesting since this allows taking apart unwanted ammo for a type you don't use (or lack the weapon for) to craft for other weapons.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build and confirmed explosive arrows, explosive bolts, and flame arrows were all being made 1 at a time.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
