### PR TITLE
Revert "ci: trigger workflow check on merge queue"

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - upload
-      - gh-readonly-queue/upload/**
     paths-ignore:
       - doc/**
       - 'scripts/**'


### PR DESCRIPTION
## Summary

SUMMARY: Build "Reverts cataclysmbnteam/Cataclysm-BN#3349"

## Purpose of change

1. now the workflow does run on merge queue but it still does not affect status checks. (unless [required status check is enabled on branch protection](https://github.com/orgs/community/discussions/46757#discussioncomment-7192504))
2. [adding only required status check to merge queue](https://github.com/orgs/community/discussions/46757#discussion-4836009) is not possible atm
3. runners are bottlenecked due to workflows running needlessly.



