### PR TITLE
ci: only deploy docs when needed

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,6 +3,7 @@ name: Deploy starlight documentation to GitHub Pages
 on:
   push:
     branches: [upload]
+    paths: [doc/**]
   workflow_dispatch:
 
 


### PR DESCRIPTION
## Summary

SUMMARY: Build "Only deploy docs when needed"

## Purpose of change

There's no need to run workflow when no docs are changed.

## Describe the solution

Only run the workflow when files under `doc/` changes

## Describe alternatives you've considered

create a separate repository, `cataclysmbnteam/doc`. i think it should be eventually done in long-term.
