### PR TITLE
Use std::optional for `best_mode_for_range()`

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -540,6 +540,14 @@ void npc::check_or_use_weapon_cbm()
         int best_dps = -1;
         bool wield_gun = primary_weapon().is_gun();
         item best_cbm_active = null_item_reference();
+
+        // If wielding a gun, best_dps to beat is at minimum the gun wielded.
+        if( wield_gun ) {
+            std::optional<gun_mode> weap_mode = npc_ai::best_mode_for_range(
+                                                    *this, this->primary_weapon(), dist ).second;
+            best_dps = this->primary_weapon().ideal_ranged_dps( *this, weap_mode );
+        }
+
         for( int i : avail_active_cbms ) {
             bionic &bio = ( *my_bionics )[ i ];
             const item cbm_weapon = item( bio.info().fake_item );
@@ -552,12 +560,8 @@ void npc::check_or_use_weapon_cbm()
 
             auto [mode_id, mode_] = npc_ai::best_mode_for_range( *this, cbm_weapon, dist );
             double dps = cbm_weapon.ideal_ranged_dps( *this, mode_ );
-            if( wield_gun && active_index < 0 ) {
-                gun_mode weap_mode = npc_ai::best_mode_for_range( *this, this->primary_weapon(), dist ).second;
-                dps = this->primary_weapon().ideal_ranged_dps( *this, weap_mode );
-            }
 
-            if( ( !wield_gun && active_index < 0 ) || dps > best_dps ) {
+            if( dps > best_dps ) {
                 active_index = i;
                 best_cbm_active = cbm_weapon;
                 best_dps = dps;

--- a/src/item.h
+++ b/src/item.h
@@ -583,7 +583,7 @@ class item : public visitable<item>
         /** return the average dps of the weapon against evaluation monsters */
         double average_dps( const player &guy ) const;
 
-        double ideal_ranged_dps( const Character &who, gun_mode &mode ) const;
+        double ideal_ranged_dps( const Character &who, std::optional<gun_mode> &mode ) const;
 
         /**
          * Whether the character needs both hands to wield this item.

--- a/src/npc.h
+++ b/src/npc.h
@@ -1403,8 +1403,8 @@ double weapon_value( const Character &who, const item &weap, int ammo );
 /** Evaluates item as a gun */
 double gun_value( const Character &who, const item &weap, int ammo );
 /** Chooses best gun_mode for range */
-std::pair<gun_mode_id, gun_mode> best_mode_for_range( const Character &who, const item &firing,
-        int dist );
+std::pair<gun_mode_id, std::optional<gun_mode>> best_mode_for_range(
+            const Character &who, const item &firing, int dist );
 /** Evaluate item as a melee weapon */
 double melee_value( const Character &who, const item &weap );
 /** Evaluate unarmed melee value */

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2088,15 +2088,19 @@ double item::ideal_ranged_dps( const Character &who, std::optional<gun_mode> &mo
         itype_id ammo = ammo_default();
         gun_damage.add( ammo->ammo->damage );
     }
-    float damage_factor = gun_damage.total_damage();
-    damage_factor *= mode->qty;
+    int burst_size = mode->qty;
+    if( burst_size <= 0 ) {
+        debugmsg( "gun_mode for %s has burst size of 0", this->tname() );
+        burst_size = 1;
+    }
+    float damage_factor = gun_damage.total_damage() * burst_size;
 
     int move_cost = ranged::time_to_attack( who, *this, item_location() );
     if( ammo_remaining() == 0 ) {
         int reload_cost = get_reload_time() + who.encumb( bp_hand_l ) + who.encumb( bp_hand_r );
         // HACK: Doesn't check how much ammo they'll actually get from the reload. Because we don't know.
         // DPS is less impacted the larger the magazine being swapped.
-        reload_cost /= magazine_integral() ? 1 : ammo_capacity() / mode->qty;
+        reload_cost /= magazine_integral() ? 1 : ammo_capacity() / burst_size;
         move_cost += reload_cost;
     }
     std::vector<ranged::aim_type> aim_types = ranged::get_aim_types( who, *this );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2075,9 +2075,9 @@ int npc::confident_throw_range( const item &thrown, Creature *target ) const
     return static_cast<int>( confident_range );
 }
 
-double item::ideal_ranged_dps( const Character &who, gun_mode &mode ) const
+double item::ideal_ranged_dps( const Character &who, std::optional<gun_mode> &mode ) const
 {
-    if( !is_gun() ) {
+    if( !is_gun() || !mode ) {
         return 0;
     }
     damage_instance gun_damage = this->gun_damage();
@@ -2089,14 +2089,14 @@ double item::ideal_ranged_dps( const Character &who, gun_mode &mode ) const
         gun_damage.add( ammo->ammo->damage );
     }
     float damage_factor = gun_damage.total_damage();
-    damage_factor *= mode.qty;
+    damage_factor *= mode->qty;
 
     int move_cost = ranged::time_to_attack( who, *this, item_location() );
     if( ammo_remaining() == 0 ) {
         int reload_cost = get_reload_time() + who.encumb( bp_hand_l ) + who.encumb( bp_hand_r );
         // HACK: Doesn't check how much ammo they'll actually get from the reload. Because we don't know.
         // DPS is less impacted the larger the magazine being swapped.
-        reload_cost /= magazine_integral() ? 1 : ammo_capacity() / mode.qty;
+        reload_cost /= magazine_integral() ? 1 : ammo_capacity() / mode->qty;
         move_cost += reload_cost;
     }
     std::vector<ranged::aim_type> aim_types = ranged::get_aim_types( who, *this );

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1953,22 +1953,21 @@ dispersion_sources ranged::get_weapon_dispersion( const Character &who, const it
     return dispersion;
 }
 
-std::pair<gun_mode_id, gun_mode> npc_ai::best_mode_for_range( const Character &who,
+std::pair<gun_mode_id, std::optional<gun_mode>> npc_ai::best_mode_for_range( const Character &who,
         const item &firing,
         int dist )
 {
-    std::pair<gun_mode_id, gun_mode> res = std::make_pair( gun_mode_id(), gun_mode() );
     int shots = who.is_wielding( firing ) ? character_funcs::ammo_count_for( who,
                 firing ) : item_funcs::shots_remaining( who, firing );
     if( !firing.is_gun() || shots == 0 ) {
-        return res;
+        return std::make_pair( gun_mode_id(), std::nullopt );
     }
     int min_recoil = MAX_RECOIL;
     min_recoil = ranged::get_most_accurate_sight( who, firing );
     int range = static_cast<const npc *>( &who )->confident_shoot_range( firing, min_recoil );
 
     if( dist > range ) {
-        return res;
+        return  std::make_pair( gun_mode_id(), std::nullopt );
     }
 
     const auto gun_mode_cmp = []( const std::pair<gun_mode_id, gun_mode> lhs,
@@ -1987,12 +1986,11 @@ std::pair<gun_mode_id, gun_mode> npc_ai::best_mode_for_range( const Character &w
     } );
 
     if( modes.empty() ) {
-        return res;
+        return  std::make_pair( gun_mode_id(), std::nullopt );
     }
 
     const auto g_mode = std::max_element( modes.begin(), modes.end(), gun_mode_cmp );
-    res = *g_mode;
-    return res;
+    return *g_mode;
 }
 
 double npc_ai::gun_value( const Character &who, const item &weap, int ammo )


### PR DESCRIPTION
## Summary

SUMMARY: Bugfixes "Use std::optional for `best_mode_for_range()`"

## Purpose of change

- Fix #3293, fix #3288
- Update #2773 
- closes #3325

## Describe the solution

`best_mode_for_range()` can now return a null value for `gun_mode` if no valid mode is found. This will then be caught in `wield_better_weapon()` where the `mode_id` would be used to set `gun_mode` and in `ideal_ranged_dps(0` which now returns a dps value of 0 if `gun_mode` supplied is null.

## Describe alternatives you've considered

- Turning the whole thing optional.
  - Rejected on the basis of it preventing easy structured binding, as well as mode_id never needing to be null.

## Testing

Load saves from [here](https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3329#issuecomment-1741922208) and #3293. Test and see that it does not crash. 

## Additional context

God I love working with NPCs.
