### PR TITLE
Fix mission names misused as mission description

### DIFF
--- a/data/json/npcs/NPC_Brigitte_LaCroix.json
+++ b/data/json/npcs/NPC_Brigitte_LaCroix.json
@@ -210,7 +210,8 @@
   {
     "id": "MISSION_SEER_GATHER_BONE",
     "type": "mission_definition",
-    "name": { "str": "Gather bones for Brigitte LaCroix.  About 8 should do it." },
+    "name": { "str": "Gather Bones" },
+    "description": { "str": "Gather bones for Brigitte LaCroix.  About 8 should do it." },
     "difficulty": 1,
     "value": 10000,
     "goal": "MGOAL_FIND_ITEM",

--- a/data/json/npcs/missiondef.json
+++ b/data/json/npcs/missiondef.json
@@ -626,7 +626,8 @@
   {
     "id": "MISSION_LAST_DELIVERY",
     "type": "mission_definition",
-    "name": { "str": "Reach The Mansion And Finish This Delivery" },
+    "name": { "str": "Finish The Delivery" },
+    "description": { "str": "Reach the mansion and finish this delivery." },
     "goal": "MGOAL_GO_TO_TYPE",
     "destination": "mansion_c3",
     "difficulty": 1,
@@ -707,7 +708,8 @@
   {
     "id": "MISSION_GET_CITY_COP_MOMENTO",
     "type": "mission_definition",
-    "name": { "str": "Break into armory to retrieve family photo" },
+    "name": { "str": "Retrieve Family Photo" },
+    "description": { "str": "Break into armory to retrieve family photo." },
     "goal": "MGOAL_FIND_ITEM",
     "difficulty": 2,
     "value": 800,
@@ -789,7 +791,7 @@
   {
     "id": "MISSION_LEARN_ABOUT_CATTAIL_JELLY",
     "type": "mission_definition",
-    "name": { "str": "Gather cattail stalks to create cattail jelly" },
+    "name": { "str": "Gather Cattail Stalks" },
     "description": "Gather <color_light_blue>80 cattail stalks</color> from the swamp and bring them back to <color_light_red>learn how to craft cattail jelly</color>.  Raise your <color_light_blue>survival skill to at least 1</color> by harvesting cattail stalks.  <color_light_blue>Bring back the provided bag</color> as well.",
     "goal": "MGOAL_CONDITION",
     "goal_condition": {

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Uyen_Tran.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Uyen_Tran.json
@@ -156,7 +156,8 @@
   {
     "id": "MISSION_REFUGEE_Uyen_1",
     "type": "mission_definition",
-    "name": {
+    "name": { "str": "Find Antiseptic" },
+    "description": {
       "str": "Find 50 doses of antiseptic for Uyen Tran in the refugee center, in exchange for <reward_count:FMCNote> Merch."
     },
     "goal": "MGOAL_FIND_ITEM",
@@ -188,7 +189,8 @@
   {
     "id": "MISSION_REFUGEE_Uyen_2",
     "type": "mission_definition",
-    "name": { "str": "Find 30 bandages for Uyen Tran in the refugee center, in exchange for <reward_count:FMCNote> Merch." },
+    "name": { "str": "Find Bandages" },
+    "description": { "str": "Find 30 bandages for Uyen Tran in the refugee center, in exchange for <reward_count:FMCNote> Merch." },
     "goal": "MGOAL_FIND_ITEM",
     "difficulty": 2,
     "value": 0,
@@ -218,7 +220,8 @@
   {
     "id": "MISSION_REFUGEE_Uyen_3",
     "type": "mission_definition",
-    "name": { "str": "Find 6 bottles of Prozac for Uyen Tran in the refugee center, in exchange for <reward_count:FMCNote> Merch." },
+    "name": { "str": "Find Prozac" },
+    "description": { "str": "Find 6 bottles of Prozac for Uyen Tran in the refugee center, in exchange for <reward_count:FMCNote> Merch." },
     "goal": "MGOAL_FIND_ITEM",
     "difficulty": 2,
     "value": 0,

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Vanessa_Toby.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Vanessa_Toby.json
@@ -240,7 +240,8 @@
   {
     "id": "MISSION_REFUGEE_Vanessa_1",
     "type": "mission_definition",
-    "name": { "str": "Make a makeshift haircut kit for Vanessa Toby in the refugee center" },
+    "name": { "str": "Make A Haircut Kit" },
+    "description": { "str": "Make a makeshift haircut kit for Vanessa Toby in the refugee center." },
     "goal": "MGOAL_FIND_ITEM",
     "difficulty": 2,
     "value": 0,

--- a/data/mods/DinoMod/NPC/NC_BO_BARONYX.json
+++ b/data/mods/DinoMod/NPC/NC_BO_BARONYX.json
@@ -147,7 +147,8 @@
   {
     "id": "MISSION_SWAMPER_GATHER_MEAT",
     "type": "mission_definition",
-    "name": { "str": "Gather meat for Bo Baronyx.  About 8 should do it." },
+    "name": { "str": "Gather Meat" },
+    "description": { "str": "Gather meat for Bo Baronyx.  About 8 should do it." },
     "difficulty": 1,
     "value": 10000,
     "goal": "MGOAL_FIND_ITEM",

--- a/src/missiondef.cpp
+++ b/src/missiondef.cpp
@@ -341,6 +341,13 @@ void mission_type::check_consistency()
         if( !m.item_id.is_empty() && !m.item_id.is_valid() ) {
             debugmsg( "Mission %s has undefined item id %s", m.id.c_str(), m.item_id.c_str() );
         }
+        // 40 is an arbitrary limit, but it's enough to convey the meaning.
+        // Any extra details and such belong in the 'description' field.
+        if( json_report_strict && m.name.debug_get_raw().length() > 40 ) {
+            debugmsg( "Mission %s has name that exceeds recommended width of 40 characters (\"%s\").  "
+                      "Consider moving the details into 'description' field.",
+                      m.id, m.name.debug_get_raw() );
+        }
     }
 }
 

--- a/src/translations.h
+++ b/src/translations.h
@@ -250,6 +250,13 @@ class translation
          */
         std::pair<bool, int> legacy_hash() const;
 
+        /**
+         * Get raw untranslated string for debug purposes.
+         */
+        inline std::string_view debug_get_raw() const {
+            return raw;
+        }
+
     private:
         translation( const std::string &ctxt, const std::string &raw );
         translation( const std::string &raw );


### PR DESCRIPTION
## Summary
SUMMARY: Bugfixes "Fixed mission names misused as mission description"

## Purpose of change
Fix #3229.
Prevent missions from having long and verbose names that look ugly in the UI.

## Describe the solution
The bug was caused by use of tags in mission name, but tags are supported only in mission description.
1st commit changes name into description for affected missions.
2nd commit adds automated check that discourages long names in favor of using the `description` field.
3rd commit tweaks names of the missions that trigger the new check.

## Describe alternatives you've considered
40 is an arbitrary limit, can be changed.

## Testing
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/60584843/70a79bb4-b3d7-4675-89fd-0ba656849fbd)
(The name does not match because Leo is the NPC I've debug-added the mission to)
