### PR TITLE
Fix infinite loop in mine gen

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -3696,12 +3696,17 @@ void overmap::build_mine( const tripoint_om_omt &origin, int s )
     }
     tripoint_om_omt p = origin;
     // Don't overwrite existing mapgen
-    while( ter( p ) != empty_rock ) {
+    int attempts_left = 100;
+    while( ter( p ) != empty_rock && attempts_left > 0 ) {
         if( one_in( 2 ) ) {
             p.x() += rng( 0, 1 ) * 2 - 1;
         } else {
             p.y() += rng( 0, 1 ) * 2 - 1;
         }
+        attempts_left -= 1;
+    }
+    if( !inbounds( p ) ) {
+        return;
     }
     while( built < s ) {
         ter_set( p, mine );


### PR DESCRIPTION
## Summary
SUMMARY: Bugfixes "Fixed infinite loop in mine gen"

## Purpose of change
There's a rare infinite loop condition in mine gen caused by generation point straying beyond overmap boundaries.

## Describe the solution
Limit amount of attempts, and add boundaries check.

## Describe alternatives you've considered
Porting mutable overmapspecials.

## Testing
I had it reproduce when running tests with seed 1696620459 on game version e82ebec7734021ad2ba56208a0bae5030ee15bfc compiled with Clang 15.0.7 (Kubuntu 22.04), after fix it no longer enters infinite loop.