### PR TITLE
fix: H&K G80 rail gun no longer crashes when trading.

### DIFF
--- a/src/item.h
+++ b/src/item.h
@@ -583,6 +583,9 @@ class item : public visitable<item>
         /** return the average dps of the weapon against evaluation monsters */
         double average_dps( const player &guy ) const;
 
+        /**
+         * @param mode Must be "valid".
+         */
         double ideal_ranged_dps( const Character &who, gun_mode &mode ) const;
 
         /**

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2330,6 +2330,9 @@ double npc_ai::wielded_value( const Character &who )
     if( !ideal_weapon.ammo_default().is_null() ) {
         ideal_weapon.ammo_set( ideal_weapon.ammo_default(), -1 );
     }
+    // TODO: Instead of passing in the raw `ammo_capacity()`, which does not consider
+    //   guns with UPS power consumption, use a function like `shots_remaining()` or
+    //   `ammo_count_for()`.
     double weap_val = weapon_value( who, ideal_weapon, ideal_weapon.ammo_capacity() );
     who.set_npc_ai_info_cache( npc_ai_info::ideal_weapon_value, weap_val );
     return weap_val;

--- a/src/npc.h
+++ b/src/npc.h
@@ -1402,7 +1402,11 @@ double wielded_value( const Character &who );
 double weapon_value( const Character &who, const item &weap, int ammo );
 /** Evaluates item as a gun */
 double gun_value( const Character &who, const item &weap, int ammo );
-/** Chooses best gun_mode for range */
+/**
+ * Chooses best gun_mode for range
+ *
+ * @returns [ gun_mode_id(), gun_mode() ] if best mode not found or not applicable (like no ammunition).
+ */
 std::pair<gun_mode_id, gun_mode> best_mode_for_range( const Character &who, const item &firing,
         int dist );
 /** Evaluate item as a melee weapon */

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2016,6 +2016,11 @@ double npc_ai::gun_value( const Character &who, const item &weap, int ammo )
 
     auto [mode_id, mode_] = npc_ai::best_mode_for_range( who, ideal_weapon, -1 );
 
+    if( !mode_ ) {
+        add_msg( m_debug, "No valid gun mode found for %s, gun_value set to 0", weap.type->get_id().str() );
+        return 0.0;
+    }
+
     // Doesn't use calculate_dispersion because that requires a map
     // TODO: Turn this into a common function.
     dispersion_sources mode_disp = ranged::get_weapon_dispersion( who, ideal_weapon );


### PR DESCRIPTION
## Summary

SUMMARY: Bugfixes "H&K G80 rail gun no longer crashes when trading"

## Purpose of change

The purpose of the change is to prevent the game from crashing when trading with the H&K G80 rail gun (and possibly other guns).

Reproduction: Spawn an NPC or have a game that includes beginning with an NPC, then spawn in a H&K G80 rail gun, and then talk with the NPC and try to trade. The game will crash with an arithmetic error.

## Describe the solution

Before, when trading with an NPC, and you had the H&K G80 rail gun in your inventory, the game crashed with an arithmetic error, apparently due to a division-by-zero in https://github.com/cataclysmbnteam/Cataclysm-BN/blob/4b6cb5b2c45da1b768f36b8918ff4171e1a828d0/src/npcmove.cpp#L2099 , due to `mode.qty` being zero. After some investigation, the causes of the bug may be two parts:

- At https://github.com/cataclysmbnteam/Cataclysm-BN/blob/4b6cb5b2c45da1b768f36b8918ff4171e1a828d0/src/melee.cpp#L2333 , the `ideal_weapon.ammo_capacity()` is passed in as the ammunition count, which does not consider UPS power consumption for some weapons, however, in other places where related functions are called, like https://github.com/cataclysmbnteam/Cataclysm-BN/blob/4b6cb5b2c45da1b768f36b8918ff4171e1a828d0/src/npctalk.cpp#L3403-L3404 , one of the two functions `shots_remaining()` or `ammo_count_for()` are used, both of which account for UPS power consumption in weapons when calculating ammunition count. These functions would possibly result in some cases in 0 ammunition (due to no UPS on the NPC, presumably, when holding a rail gun), but in the above line in melee.cpp at 2333, the ammunition count might be greater than 0 while those functions would yield 0.
- In the function `gun_value()`, at https://github.com/cataclysmbnteam/Cataclysm-BN/blob/4b6cb5b2c45da1b768f36b8918ff4171e1a828d0/src/ranged.cpp#L2007-L2010 , the ammunition count is checked, and if it is 0, then the function bails out with no gun value. However, in the above bullet point, the ammunition count (arguably wrongly) is determined to be non-zero, due to not considering UPS. And thus, that check is passed. The function `best_mode_for_range` at https://github.com/cataclysmbnteam/Cataclysm-BN/blob/4b6cb5b2c45da1b768f36b8918ff4171e1a828d0/src/ranged.cpp#L1960-L1965 is then called, and that does calculate considering UPS, and since it does include UPS consumption in its calculation, it gets to the conclusion that there is no ammunition and returns that there are no valid gun (firing) modes.
- In one part of the code, where `best_mode_for_ranged()` is called, the return value is checked for validity: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/4b6cb5b2c45da1b768f36b8918ff4171e1a828d0/src/npcmove.cpp#L3471-L3474 , where the variable `mode_` is of type `gun_mode`. The class `gun_mode` has an implicit conversion to `bool`, at https://github.com/cataclysmbnteam/Cataclysm-BN/blob/4b6cb5b2c45da1b768f36b8918ff4171e1a828d0/src/gun_mode.h#L37-L39 . This is (from what I can figure out) an error check. But that check is missing at https://github.com/cataclysmbnteam/Cataclysm-BN/blob/4b6cb5b2c45da1b768f36b8918ff4171e1a828d0/src/ranged.cpp#L2017-L2028 .

This snippet of code may give a better overview: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/4b6cb5b2c45da1b768f36b8918ff4171e1a828d0/src/ranged.cpp#L1956-L2028

Since the wrong ammunition count is passed in, in one specific code path, and one part of the code basically does not check the error condition for whether the returned gun mode is valid after looking for the best gun mode, an invalid gun mode is passed in to `ideal_ranged_dps()`, which then happens to crash due to the invalid input.

The chosen solution basically adds a check for invalid gun mode. And also adds some comments and a TODO, for passing in the right ammunition count that also considers UPS power consumption.

## Describe alternatives you've considered

There are multiple aspects of the code that makes the code more fragile and which helped enable this bug.

- Having the type of `gun_mode` possibly be invalid (and also having an implicit conversion to `bool`), is not the nicest way of modeling errors, since (as in this case) it is easy to accidentally ignore errors and skip error handling. A cleaner way would arguably be to ensure that `gun_mode` is always valid, and then use some type (maybe `std::optional?`) to clearly signify that the function `best_mode_for_range()` can fail and give an error value. I do not know how much work this would be (I was tempted to attempt to implement it, but the system that I am using for building this project is really low-specification and building is therefore really slow).
- Instead of adding a TODO, the correct way of calculating ammunition could be implemented. The error handling above with `gun_mode` should be kept in either case.
- The ammunition count is currently modeled in these code paths as an `int`, and then `std::min()` is used for determining ammunition count when a gun has both ammunition consumption and UPS power consumption. A larger refactoring might include modeling it not as an `int`, but as some data type that includes ammunition count and UPS (or is generic in regards to ammunition types, but that might be an even larger refactoring and also system change). But such a large refactoring would be a lot of work, might not be worth it, and should be discussed a lot beforehand.

## Testing

I traded with an NPC, and unlike before, it did not cause a crash when trading while having a G80 railgun in the player's inventory.

## Additional context

