### PR TITLE
perf: do not error on SDL sound failure

### DIFF
--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -583,7 +583,7 @@ void sfx::play_variant_sound( const std::string &id, const std::string &variant,
         }
     }
     if( failed ) {
-        dbg( DL::Error ) << "Failed to play sound effect { id: " << id << ", variant: " << variant << " }: "
+        dbg( DL::Debug ) << "Failed to play sound effect { id: " << id << ", variant: " << variant << " }: "
                          << Mix_GetError();
         if( is_pitched ) {
             cleanup_when_channel_finished( channel, effect_to_play );
@@ -633,7 +633,7 @@ void sfx::play_ambient_variant_sound( const std::string &id, const std::string &
         }
     }
     if( failed ) {
-        dbg( DL::Error ) << "Failed to play sound effect { id: " << id << ", variant: " << variant << " }: "
+        dbg( DL::Debug ) << "Failed to play sound effect { id: " << id << ", variant: " << variant << " }: "
                          << Mix_GetError();
         if( is_pitched ) {
             cleanup_when_channel_finished( ch, effect_to_play );


### PR DESCRIPTION
## Summary

SUMMARY: Performance "Prevent lag caused by frequent sfx"

## Purpose of change

- fix #3371 

## Describe the solution

don't generate stack backtrace when sfx fails to play

## Describe alternatives you've considered

- make it WARN instead of DEBUG. iirc failing to find sound also generates this error?
- write proper de-spamming algorithm for repeated sfx to prevent channels chocking up, but it's harder than changing two lines of code.
