### PR TITLE
perf: slightly speed up `weight_carried_reduced_by` and `recalc_speed_bonus`

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2621,15 +2621,18 @@ units::mass Character::weight_carried_reduced_by( const excluded_stacks &without
             debugmsg( "Trying to remove more than one wielded item" );
         }
     }
-    // Exclude wielded item if using lifting tool
-    if( weaponweight + ret > weight_capacity() ) {
-        const float liftrequirement = std::ceil( units::to_gram<float>( weaponweight ) /
-                                      units::to_gram<float>( TOOL_LIFT_FACTOR ) );
-        if( g->new_game || best_nearby_lifting_assist() < liftrequirement ) {
+    // Don't try to add weaponweight if it doesn't exist or is weightless
+    if( weaponweight > 0_gram ) {
+        // Exclude wielded item if using lifting tool
+        if( weaponweight + ret > weight_capacity() ) {
+            const float liftrequirement = std::ceil( units::to_gram<float>( weaponweight ) /
+                                          units::to_gram<float>( TOOL_LIFT_FACTOR ) );
+            if( g->new_game || best_nearby_lifting_assist() < liftrequirement ) {
+                ret += weaponweight;
+            }
+        } else {
             ret += weaponweight;
         }
-    } else {
-        ret += weaponweight;
     }
 
     return ret;

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -96,12 +96,15 @@ static const itype_id itype_UPS( "UPS" );
 void Character::recalc_speed_bonus()
 {
     // Minus some for weight...
-    int carry_penalty = 0;
-    if( weight_carried() > weight_capacity() && !has_trait( trait_id( "DEBUG_STORAGE" ) ) ) {
-        carry_penalty = 25 * ( weight_carried() - weight_capacity() ) / ( weight_capacity() );
+    // Easy test, if Character DOES have this trait then we don't need to check weight carried/capacity
+    if( !has_trait( trait_id( "DEBUG_STORAGE" ) ) ) {
+        // these are nontrivial calculations, store in variables so they aren't calculated multiple times.
+        auto carried = weight_carried();
+        auto capacity = weight_capacity();
+        if( carried > capacity ) {
+            mod_speed_bonus( -25 * ( carried - capacity ) / capacity );
+        }
     }
-    mod_speed_bonus( -carry_penalty );
-
     mod_speed_bonus( -character_effects::get_pain_penalty( *this ).speed );
 
     if( get_thirst() > thirst_levels::very_thirsty ) {

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -60,6 +60,7 @@ static const trait_id trait_URSINE_FUR( "URSINE_FUR" );
 static const trait_id trait_WEBBED( "WEBBED" );
 static const trait_id trait_WHISKERS_RAT( "WHISKERS_RAT" );
 static const trait_id trait_WHISKERS( "WHISKERS" );
+static const trait_id trait_DEBUG_STORAGE( "DEBUG_STORAGE" );
 
 static const efftype_id effect_bloodworms( "bloodworms" );
 static const efftype_id effect_brainworms( "brainworms" );
@@ -97,7 +98,7 @@ void Character::recalc_speed_bonus()
 {
     // Minus some for weight...
     // Easy test, if Character DOES have this trait then we don't need to check weight carried/capacity
-    if( !has_trait( trait_id( "DEBUG_STORAGE" ) ) ) {
+    if( !has_trait( trait_DEBUG_STORAGE ) ) {
         // these are nontrivial calculations, store in variables so they aren't calculated multiple times.
         auto carried = weight_carried();
         auto capacity = weight_capacity();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/mod/json/explanation/json_style.md
C++ and Markdown: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/dev/explanation/code_style.md

!!!!!!!!!! WARNING !!!!!!!!!!

If you forget to format the PR, autofix.ci app will run automated format commit for you.
When this happens, YOU MUST DO EITHER OF THE FOLLOWING:

- Run `git pull` to merge the automated commit into your PR branch.
- Format your code locally, and force push to your PR branch. 

If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
-->

## Summary

SUMMARY: Performance "Remove unnecessary check for lifting equipment if unnecessary and store nontrivial calculations in variables"

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/src/content/docs/en/contribute/changelog_guidelines.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

## Purpose of change

In `recalc_speed_bonus` we were recalculating `weight_carried` and `weight_capacity` multiple times in the worst case. These are not trivial calculations, so store in local variables and reuse if necessary. Additionally, the most trivial call of the three to check for the `DEBUG_STORAGE` trait is done last rather than first. In the very rare case that it is available we will want to short circuit the logic and skip calling `weight_carried` / `weight_capacity` altogether.

In `weight_carried_reduced_by`, which is called as part of `weight_carried` calculation, there is an expensive check of the local area for something with the `"LIFT"` quality. This is done even if the weapon weight is `0_gram` and would have no effect.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution

Store recalculable values in variables, move quick trait check as early as possible, and add a quick check for a weighted weapon before looking for something to help lift it.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

## Describe alternatives you've considered

The costly calculations are mostly cacheable so I could have worked harder on getting caching and invalidation working for speed penalty calculation.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing

Compiles, doesn't crash, doesn't call the costly functions multiple times so not slower than without the change.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->