### PR TITLE
fix: NPCs drop excess items if overburdened, merchants pick up and renew inventory if restocking

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3211,18 +3211,19 @@ ret_val<bool> Character::can_swap( const item &it ) const
 // pretty much the same as inventory::remove_randomly_by_volume but I didn't see a point in
 // adding it to the inventory class when it's only called here in Character::drop_invalid_inventory
 std::list<item> remove_randomly_by_weight( inventory &, const units::mass & );
-std::list<item> remove_randomly_by_weight( inventory &inv, const units::mass &weight ) {
+std::list<item> remove_randomly_by_weight( inventory &inv, const units::mass &weight )
+{
     std::list<item> result;
     struct entry {
         decltype( inv.slice().begin() ) stack;
-        decltype( (*stack)->begin() ) stack_it;
+        decltype( ( *stack )->begin() ) stack_it;
     };
     std::vector<entry> vals;
 
     auto slice = inv.slice();
     size_t ndx = 0;
     for( auto stack = slice.begin(); stack != slice.end(); ++stack ) {
-        for( auto stack_it = (*stack)->begin(); stack_it != (*stack)->end(); ++stack_it ) {
+        for( auto stack_it = ( *stack )->begin(); stack_it != ( *stack )->end(); ++stack_it ) {
             vals.push_back( { stack, stack_it } );
         }
         ++ndx;
@@ -3237,15 +3238,15 @@ std::list<item> remove_randomly_by_weight( inventory &inv, const units::mass &we
         }
         dropped_weight += e.stack_it->weight();
         result.push_back( std::move( *e.stack_it ) );
-        e.stack_it = (*e.stack)->erase( e.stack_it );
-        if( e.stack_it == (*e.stack)->begin() && !(*e.stack)->empty() ) {
+        e.stack_it = ( *e.stack )->erase( e.stack_it );
+        if( e.stack_it == ( *e.stack )->begin() && !( *e.stack )->empty() ) {
             e.stack_it->invlet = result.back().invlet;
         }
     }
     // iterate through items again so that we can remove any empty groups
     ndx = slice.size() - 1;
     for( auto stack = slice.rbegin(); stack != slice.rend(); ++stack ) {
-        if( (*stack)->empty() ) {
+        if( ( *stack )->empty() ) {
             inv.reduce_stack( ndx, -1 );
         }
         --ndx;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -42,6 +42,7 @@
 #include "magic.h"
 #include "map.h"
 #include "map_iterator.h"
+#include "map_selector.h"
 #include "mapdata.h"
 #include "math_defines.h"
 #include "messages.h"
@@ -1708,9 +1709,26 @@ void npc::shop_restock()
         }
     }
 
-    has_new_items = true;
-    inv.clear();
-    inv.push_back( ret );
+    // we have items to restock with, so go ahead and pick up everything so we can clear out properly
+    // If we don't restock for some reason don't clear out inventory since we'd end up not having anything
+    // to trade
+    if( !ret.empty() ) {
+        // Pick up nearby items as a free action since we'll be immediately deleting these items
+        const auto pickup_item_filter = [this]( const item &it ) -> bool {
+            return it.is_owned_by( *this );
+        };
+        auto old_moves = moves;
+        for( map_cursor &cursor : map_selector( pos(), PICKUP_RANGE ) ) {
+            auto pickups = cursor.remove_items_with( pickup_item_filter );
+            inv.push_back( pickups );
+        }
+        set_moves( old_moves );
+
+        // clear out inventory and add in restocked items
+        has_new_items = true;
+        inv.clear();
+        inv.push_back( ret );
+    }
 }
 
 int npc::minimum_item_value() const

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1714,7 +1714,7 @@ void npc::shop_restock()
     // to trade
     if( !ret.empty() ) {
         // Pick up nearby items as a free action since we'll be immediately deleting these items
-        const auto pickup_item_filter = [this]( const item &it ) -> bool {
+        const auto pickup_item_filter = [this]( const item & it ) -> bool {
             return it.is_owned_by( *this );
         };
         auto old_moves = moves;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/mod/json/explanation/json_style.md
C++ and Markdown: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/dev/explanation/code_style.md

!!!!!!!!!! WARNING !!!!!!!!!!

If you forget to format the PR, autofix.ci app will run automated format commit for you.
When this happens, YOU MUST DO EITHER OF THE FOLLOWING:

- Run `git pull` to merge the automated commit into your PR branch.
- Format your code locally, and force push to your PR branch. 

If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
-->

## Summary

SUMMARY: Bugfixes "NPCs drop items if overburdened instead of just overvolume, merchant restocking fix"

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/src/content/docs/en/contribute/changelog_guidelines.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

## Purpose of change

Merchant NPCs in the Refugee Center, `Christopher Flood, Merchant` and `Makayla Sanchez, Arsonist`, stay way overburdened even after calling `drop_invalid_inventory` because it was only able to drop items above volume limits. Combined with the checking for the `"LIFT"` quality when overburdened in `weight_carried_reduced_by`, a very slow check because it looks over all items in tiles (map and vehicle) within `PICKUP_RANGE` distance of the NPC, these two NPCs were using a lot of CPU time to do literally nothing but stand in place.
This problem is mitigated in #3385 since these NPCs do not carry weapons a lot of the time. They're also relatively shielded from the monsters hidden within the Refugee Center so are unlikely to carry weapons unless things go very poorly for the building.

To go with dropping inventory when overburdened the NPC merchants also need to properly restock their wares. If they've dropped their inventory then on restocking their remaining undropped inventory will be deleted and replaced by whatever is generated as new stock. This can lead to an accumulation of items at and around the NPC as new items are stocked then spilled onto the floor. To fix this I have the NPC pick up nearby owned items before clearing the inventory and restocking.
To prevent an issue with the Arsonist, and any other NPC Merchants with the `"no_faction"` faction defined, where restocking items will not actually generate any due to the faction wealth being too low and thus delete the NPC's inventory without replacing with anything I have limited picking up, clearing, and finally replacing the inventory by requiring there be something to restock.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution

Dropping items by weight works very similarly to dropping items by volume. The primary difference is that it is not done within the `inventory` class but outside of it. There is no reason to make it a class method when all necessary functionality is available from outside of the class. By keeping NPCs from being overburdened as much as possible we prevent the costly `"LIFT"` quality check in most cases.

Picking up owned items prevents accumulation of items on the floor, and restricting it to if there are items replacing the old prevents the Arsonist from completely losing their stock. The Arsonist still will not ever restock but that makes some sense as they're a random fire starter, presumably without any backer and unknown means to produce more incendiary devices.

Picking up owned items is made a free action because they're about to get deleted and replaced, and then probably dropped onto the floor again which does take moves away from the merchant.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

## Describe alternatives you've considered

Instead of requiring new wares to allow deletion of old inventory the minimum `shop_value` could have been modified to allow some items, or allow generation of a few "free" items before they start deducting from `shop_value`.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing

NPCs drop items when overburdened, and Merchants pick up nearby items properly when refreshing their stocks. Arsonist no longer deletes their inventory without replacing any of it.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

## Additional context

If the NPC drops items onto a vehicle tile they will not be picked up again when restocking inventory. I'm not sure if that would be desirable and erred on the side of minimizing the NPC's reach. These items picked up ARE about to get deleted so being a bit conservative seemed best.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
