### PR TITLE
Rebalance steam turbine relative to small gas turbine

### DIFF
--- a/data/json/items/vehicle/engine.json
+++ b/data/json/items/vehicle/engine.json
@@ -219,9 +219,9 @@
     "copy-from": "engine_steam",
     "looks_like": "large_turbine_engine",
     "type": "ENGINE",
-    "name": { "str": "750 hp steam turbine engine" },
+    "name": { "str": "1350 hp steam turbine engine" },
     "description": "A powerful steam engine for power plants, burning coal to heat water into steam and driving a turbine.  A condenser recaptures the water, making this a closed cycle system.  Known for its high rate of fuel consumption, but installing multiple turbines will not affect vehicle power.",
-    "weight": "1400 kg",
+    "weight": "700 kg",
     "volume": "230 L",
     "price": "32000 USD",
     "price_postapoc": "110 USD"

--- a/data/json/vehicleparts/combustion.json
+++ b/data/json/vehicleparts/combustion.json
@@ -377,8 +377,8 @@
     "durability": 300,
     "epower": -20,
     "//": "45% energy efficiency",
-    "power": 551700,
-    "energy_consumption": 1226000,
+    "power": 1006695,
+    "energy_consumption": 2237100,
     "extend": { "flags": [ "E_NO_POWER_DECAY" ] },
     "description": "A closed cycle steam engine powering a hefty turbine.  Burns coal or charcoal from a bunker in the vehicle to produce steam, its power will not diminish even when multiple of them are installed.",
     "breaks_into": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/mod/json/explanation/json_style.md
C++ and Markdown: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/dev/explanation/code_style.md

!!!!!!!!!! WARNING !!!!!!!!!!

If you forget to format the PR, autofix.ci app will run automated format commit for you.
When this happens, YOU MUST DO EITHER OF THE FOLLOWING:

- Run `git pull` to merge the automated commit into your PR branch.
- Format your code locally, and force push to your PR branch. 

If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
-->

## Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/src/content/docs/en/contribute/changelog_guidelines.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Rebalance power of steam turbine to a 1 MW turbine like the small gas turbine, lower weight"

## Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Some rebalancing brought about by https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3387 prompting me to look more into what's typical for small power generation steam turbines. 1-5 MW seems more common for power generation turbines, and the low end of that gives me a value that matches the small gas turbine.

## Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Updated steam turbine power to match that of the small gas turbine, and updated energy consumption to be consistent with the listed 45% energy efficiency. I avoided that value previously because I assumed it was better to not have power output identical to another engine of different fuel type, but this is already done with a good number of gas and diesel engines, and even the medium steam engine is set to match the V6s.
2. Reflavored the steam turbine item to 1350 hp instead of 750 hp, consistent with small gas turbine and making it fit for a 1 MW output. Also updated its weight to 700 kg. I still couldn't find some exact numbers for this size steam turbines, but one value I found claimed a ratio of 0.7 kg per kW was common for steam turbine power.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Keeping its output in the 500 kW range and just fixing its weight. This would give it a value closer to 350 kg, which isn't too far off from the 330 kg I found for one example of a portable 500 kW turbine.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected files for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
