### PR TITLE
ci: add comment when autofix is invoked

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -36,7 +36,18 @@ jobs:
       - name: json formatting
         run: make style-all-json-parallel RELEASE=1
 
-      - uses: autofix-ci/action@8caa572fd27b0019a65e4c695447089c8d3138b9
+      - uses: autofix-ci/action@d3e591514b99d0fca6779455ff8338516663f7cc
         if: ${{ always() }}
         with:
           commit-message: "style(autofix.ci): automated formatting"
+          commment: |
+            The app has automatically formatted this PR.
+
+            If you edit your PR on web UI, you can ignore this message.
+            If you edit your PR locally, YOU MUST DO EITHER OF THE FOLLOWING:
+
+            - Run `git pull` to merge the automated commit into your PR branch.
+            - [Format your code locally](https://docs.cataclysmbn.org/en/mod/json/explanation/json_style/), and force push to your PR branch.
+
+            If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
+

--- a/doc/src/content/docs/en/mod/json/explanation/json_style.md
+++ b/doc/src/content/docs/en/mod/json/explanation/json_style.md
@@ -6,13 +6,6 @@ sidebar:
     variant: caution
 ---
 
-:::caution
-
-[A PR may change current JSON style](https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3118) in
-favor of better tooling.
-
-:::
-
 Like in [C++ Code Style](../../../dev/explanation/code_style.md), the JSON styling policy is to
 update JSON as it is added or edited, and in relatively small chunks otherwise in order to prevent
 undue disruption to development.


### PR DESCRIPTION
## Summary

SUMMARY: Build "Add helpful comment instruction on automated format"

## Purpose of change

make lintbot more helpful

## Describe the solution

https://github.com/autofix-ci/action/issues/7
