### PR TITLE
Set required intelligence for Playboy magazine to 0

### DIFF
--- a/data/json/items/book/misc.json
+++ b/data/json/items/book/misc.json
@@ -202,7 +202,7 @@
     "copy-from": "mag_comic",
     "price": 400,
     "price_postapoc": 250,
-	"intelligence": 0,
+    "intelligence": 0,
     "color": "pink"
   },
   {

--- a/data/json/items/book/misc.json
+++ b/data/json/items/book/misc.json
@@ -202,6 +202,7 @@
     "copy-from": "mag_comic",
     "price": 400,
     "price_postapoc": 250,
+	"intelligence": 0,
     "color": "pink"
   },
   {


### PR DESCRIPTION
## Summary

SUMMARY: Bugfixes "Set required intelligence for Playboy magazine to 0"

## Purpose of change

Fixes #3374  - Allows use of playboy magazine while illiterate by lowering intelligence required to 0

## Describe the solution

Lowered the intelligence required for Playboy magazine to 0 so it is able to be "read" while illiterate, just like the First Aid Instruction Booklet

## Describe alternatives you've considered

Possibly creating a category for illustrated books i.e. being able to mark a book as illustrated so it can be read - however 0 intel requirement covers this quite well I think

## Testing

Made an illiterate character, spawned the magazine and "read" it successfully

## Additional context

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/91185016/f6dea57c-8f81-40d1-a329-468fed94dbf8)

