### PR TITLE
fix: missing roof for `s_electronics_2` in multitile city buildings

### DIFF
--- a/data/json/overmap/multitile_city_buildings.json
+++ b/data/json/overmap/multitile_city_buildings.json
@@ -864,6 +864,15 @@
   },
   {
     "type": "city_building",
+    "id": "s_electronics_2",
+    "locations": [ "land" ],
+    "overmaps": [
+      { "point": [ 0, 0, 0 ], "overmap": "s_electronics_2_north" },
+      { "point": [ 0, 0, 1 ], "overmap": "s_electronics_roof_2_north" }
+    ]
+  },
+  {
+    "type": "city_building",
     "id": "stripclub",
     "locations": [ "land" ],
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "stripclub_north" }, { "point": [ 0, 0, 1 ], "overmap": "stripclub_roof_north" } ]


### PR DESCRIPTION
## Summary

SUMMARY: Bugfixes "Add s_electronics_2 to multitile city buildings"

## Purpose of change

Fixes #1896 - links s_electronics_2 and s_electronics_roof_2 in multitile city buildings

## Describe the solution

link s_electronics_2 and s_electronics_roof_2 in multitile city buildings

## Describe alternatives you've considered

None

## Testing

Built game and tested, confirmed by going to electronics store with correct variation 

## Additional context

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/91185016/8f0f657d-9de7-4d65-b18a-6fed31f89158)
