### PR TITLE
Prevents possible use after free in sounds

### DIFF
--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -389,7 +389,8 @@ void sounds::process_sound_markers( player *p )
     bool is_deaf = p->is_deaf();
     const float volume_multiplier = p->hearing_ability();
     const int weather_vol = get_weather().weather_id->sound_attn;
-    for( const auto &sound_event_pair : sounds_since_last_turn ) {
+    auto sounds_copy = sounds_since_last_turn;
+    for( const auto &sound_event_pair : sounds_copy ) {
         const tripoint &pos = sound_event_pair.first;
         const sound_event &sound = sound_event_pair.second;
         const int distance_to_sound = sound_distance( p->pos(), pos );


### PR DESCRIPTION
## Summary

SUMMARY: Bugfixes "Prevent a rare UB in sounds"

## Purpose of change

Prevent a possible use after free. An npc hearing a sound could then make a sound themselves. In that event that this resizes the sound list this will invalidate the iterators and cause a UAF.

## Describe the solution

Make a copy of the list and iterate over that. Not perfect but it prevents the problem. 

## Describe alternatives you've considered

Be more careful about how the list is modified in the first place.

## Testing

It's very difficult to trigger it and it probably won't be noticeable without sanitizers on so...

## Additional context

I triggered it while testing the item identity branch but none of what's going on here has changed there.
