### PR TITLE
Add casings onto dissasembly recipie for M433, M576 and M651 grenades

### DIFF
--- a/data/json/uncraft/ammo/40x46mm.json
+++ b/data/json/uncraft/ammo/40x46mm.json
@@ -16,7 +16,13 @@
     "difficulty": 4,
     "time": "3 m",
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 }, { "id": "PULL", "level": 1 } ],
-    "components": [ [ [ "smpistol_primer", 1 ] ], [ [ "combatnail", 70 ] ], [ [ "gunpowder", 35 ] ], [ [ "impact_fuze", 1 ] ], [ [ "40x46mm_m118_casing", 1 ] ] ],
+    "components": [
+      [ [ "smpistol_primer", 1 ] ],
+      [ [ "combatnail", 70 ] ],
+      [ [ "gunpowder", 35 ] ],
+      [ [ "impact_fuze", 1 ] ],
+      [ [ "40x46mm_m118_casing", 1 ] ]
+    ],
     "charges": 1
   },
   {
@@ -26,7 +32,13 @@
     "difficulty": 4,
     "time": "3 m",
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 }, { "id": "PULL", "level": 1 } ],
-    "components": [ [ [ "lgpistol_primer", 1 ] ], [ [ "chem_compositionb", 32 ] ], [ [ "gunpowder", 35 ] ], [ [ "impact_fuze", 1 ] ], [ [ "40x46mm_m199_casing", 1 ] ] ],
+    "components": [
+      [ [ "lgpistol_primer", 1 ] ],
+      [ [ "chem_compositionb", 32 ] ],
+      [ [ "gunpowder", 35 ] ],
+      [ [ "impact_fuze", 1 ] ],
+      [ [ "40x46mm_m199_casing", 1 ] ]
+    ],
     "charges": 1
   },
   {
@@ -36,7 +48,7 @@
     "difficulty": 4,
     "time": "3 m",
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 }, { "id": "PULL", "level": 1 } ],
-    "components": [ [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 35 ] ], [ [ "40x46mm_m195_casing", 1 ] ]],
+    "components": [ [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 35 ] ], [ [ "40x46mm_m195_casing", 1 ] ] ],
     "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/40x46mm.json
+++ b/data/json/uncraft/ammo/40x46mm.json
@@ -16,7 +16,7 @@
     "difficulty": 4,
     "time": "3 m",
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 }, { "id": "PULL", "level": 1 } ],
-    "components": [ [ [ "smpistol_primer", 1 ] ], [ [ "combatnail", 70 ] ], [ [ "gunpowder", 35 ] ], [ [ "impact_fuze", 1 ] ] ],
+    "components": [ [ [ "smpistol_primer", 1 ] ], [ [ "combatnail", 70 ] ], [ [ "gunpowder", 35 ] ], [ [ "impact_fuze", 1 ] ], [ [ "40x46mm_m118_casing", 1 ] ] ],
     "charges": 1
   },
   {
@@ -26,7 +26,7 @@
     "difficulty": 4,
     "time": "3 m",
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 }, { "id": "PULL", "level": 1 } ],
-    "components": [ [ [ "lgpistol_primer", 1 ] ], [ [ "chem_compositionb", 32 ] ], [ [ "gunpowder", 35 ] ], [ [ "impact_fuze", 1 ] ] ],
+    "components": [ [ [ "lgpistol_primer", 1 ] ], [ [ "chem_compositionb", 32 ] ], [ [ "gunpowder", 35 ] ], [ [ "impact_fuze", 1 ] ], [ [ "40x46mm_m199_casing", 1 ] ] ],
     "charges": 1
   },
   {
@@ -36,7 +36,7 @@
     "difficulty": 4,
     "time": "3 m",
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 }, { "id": "PULL", "level": 1 } ],
-    "components": [ [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 35 ] ] ],
+    "components": [ [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 35 ] ], [ [ "40x46mm_m195_casing", 1 ] ]],
     "charges": 1
   }
 ]


### PR DESCRIPTION
## Summary

SUMMARY: Bugfixes "Add casings onto dissasembly recipie for M433, M576 and M651 grenades"

## Purpose of change

Fixes #1471 - Adds casings onto dissasembly recipie for M433, M576 and M651 grenades, M1106 already has casing in recipie and 40x46 flashbang is now marked as obsolete

## Describe the solution

Add appropriate casings onto dissasembly recipie for M433, M576 and M651 grenades

## Describe alternatives you've considered

Don't add casings in

## Testing

Loaded into built base game and tested 

## Additional context

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/91185016/28745b4f-72b2-47bb-99ee-9bd0f728f6ce)

