### PR TITLE
fix: emit debugmsg on capacity <= 0

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5887,7 +5887,7 @@ int item::get_encumber_when_containing(
                     if( entry.max_encumber == 0 ) {
                         encumber += contents_volume / 500_ml;
                     } else {
-                        if( capacity < 0 ) {
+                        if( capacity <= 0 ) {
                             debugmsg( "Non-rigid item (%s) without storage capacity.", tname() );
                         } else {
                             // Cast up to 64 to prevent overflow. Dividing before would prevent this but lose data.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/mod/json/explanation/json_style.md
C++ and Markdown: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/dev/explanation/code_style.md

!!!!!!!!!! WARNING !!!!!!!!!!

If you forget to format the PR, autofix.ci app will run automated format commit for you.
When this happens, YOU MUST DO EITHER OF THE FOLLOWING:

- Run `git pull` to merge the automated commit into your PR branch.
- Format your code locally, and force push to your PR branch. 

If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
-->

## Summary
SUMMARY: Bugfixes "Emit debugmessage on non-rigid armor capacity <= 0"

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/src/content/docs/en/contribute/changelog_guidelines.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

## Purpose of change
Fixes #3399 
Removes possibility of div-0 error (SIGFPE) when calculating volume-based encumbrance additions. Doesn't happen in the majority of cases, and only really showed up with Cata++'s ammo belts until recently. Clang-tidy gets really upset about it so it should get looked at.
![Screenshot from 2023-10-13 22-40-10](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/8597997/2e7f3043-7423-4ec1-a92a-c39fe83e1ca5)

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution
Change condition from `capacity < 0` to `capacity <= 0` so that it can never be `== 0` during calculation and cause the SIGFPE.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

## Describe alternatives you've considered
Tell Clang-tidy to suck it up until we get more FPE reports.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing
On old Cata++ version emitted errors for its ammo belts
```text
06:11:04.185 ERROR DEBUGMSG : src/item.cpp:5891 [int item::get_encumber_when_containing(const Character&, const volume&, const bodypart_id&) const] Non-rigid item (<color_c_light_green>|| </color>survivor's .223 ammo belt) without storage capacity.
06:11:13.676 ERROR DEBUGMSG : src/item.cpp:5891 [int item::get_encumber_when_containing(const Character&, const volume&, const bodypart_id&) const] Non-rigid item (<color_c_light_green>|| </color>survivor's .223 ammo belt) without storage capacity.
06:11:16.975 ERROR DEBUGMSG : src/item.cpp:5891 [int item::get_encumber_when_containing(const Character&, const volume&, const bodypart_id&) const] Non-rigid item (<color_c_light_green>|| </color>survivor's .308 ammo belt) without storage capacity.
06:11:25.125 ERROR DEBUGMSG : src/item.cpp:5891 [int item::get_encumber_when_containing(const Character&, const volume&, const bodypart_id&) const] Non-rigid item (<color_c_light_green>|| </color>survivor's 7.62x39 ammo belt) without storage capacity.
06:11:25.136 ERROR DEBUGMSG : src/item.cpp:5891 [int item::get_encumber_when_containing(const Character&, const volume&, const bodypart_id&) const] Non-rigid item (<color_c_light_green>|| </color>survivor's 7.62x39 ammo belt) without storage capacity.
06:11:25.145 ERROR DEBUGMSG : src/item.cpp:5891 [int item::get_encumber_when_containing(const Character&, const volume&, const bodypart_id&) const] Non-rigid item (<color_c_light_green>|| </color>survivor's 7.62x54 ammo belt) without storage capacity.
06:11:25.902 ERROR DEBUGMSG : src/item.cpp:5891 [int item::get_encumber_when_containing(const Character&, const volume&, const bodypart_id&) const] Non-rigid item (<color_c_light_green>|| </color>survivor's 7.62x54 ammo belt) without storage capacity.
```

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->