### PR TITLE
fix: armor layer not showing all first

### DIFF
--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -556,7 +556,7 @@ void show_armor_layers_ui( Character &who )
 
         // top bar
         wprintz( w_sort_cat, c_white, _( "Sort Armor" ) );
-        std::string temp = bp != bodypart_id( "num_bp" ) ? body_part_name_as_heading( bp, 1 ) : _( "All" );
+        const auto temp = tabindex != body_part::num_bp ? body_part_name_as_heading( bp, 1 ) : _( "All" );
         wprintz( w_sort_cat, c_yellow, "  << %s >>", temp );
         right_print( w_sort_cat, 0, 0, c_white, string_format(
                          _( "Press [<color_yellow>%s</color>] for help.  "


### PR DESCRIPTION
## Summary

SUMMARY: Bugfixes "armor layer not showing all first"

## Purpose of change

- fix #3423

## Describe the solution

comparison via "num_bp" was not working properly, let's just use tabindex, which is still hacky but at least it uses num_bp to indicate end which works and i want 0.4 merged fast afsdklasdjfsljk

## Describe alternatives you've considered

rewriting this cursed thing

## Testing

![Cataclysm: Bright Nights - 88a435f2120d_01](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/78b26087-6cdb-4a69-a420-8b287214233a)

1. open a save.
2. open align armor display using `+`
3. now it shows `All` correctly

## Additional context

_i want conventional commits soooo bad, Summary isn't very helpful, let's either remove it completely or require it to be as polished as an blogpost section so we can actually use it in devlog or something_