### PR TITLE
feat(content): specials placement rework

### DIFF
--- a/data/json/obsoletion/terrains.json
+++ b/data/json/obsoletion/terrains.json
@@ -18,7 +18,9 @@
       "mine_entrance",
       "mine_shaft",
       "spiral",
-      "spiral_hub"
+      "spiral_hub",
+      "underground_sub_station",
+      "sewer_sub_station"
     ]
   }
 ]

--- a/data/json/overmap/multitile_city_buildings.json
+++ b/data/json/overmap/multitile_city_buildings.json
@@ -955,7 +955,13 @@
     "locations": [ "land" ],
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "sub_station_north" },
-      { "point": [ 0, 0, 1 ], "overmap": "sub_station_roof_north" }
+      { "point": [ 0, 0, 1 ], "overmap": "sub_station_roof_north" },
+      { "point": [ 0, 0, -1 ], "overmap": "sewer_sub_station_north" },
+      { "point": [ 0, 0, -2 ], "overmap": "underground_sub_station_north" }
+    ],
+    "connections": [
+      { "point": [ 0, -1, -2 ], "connection": "subway_tunnel", "from": [ 0, 0, -2 ] },
+      { "point": [ 0, 1, -2 ], "connection": "subway_tunnel", "from": [ 0, 0, -2 ] }
     ]
   },
   {

--- a/data/json/overmap/overmap_connections.json
+++ b/data/json/overmap/overmap_connections.json
@@ -22,7 +22,10 @@
     "type": "overmap_connection",
     "id": "subway_tunnel",
     "default_terrain": "subway",
-    "subtypes": [ { "terrain": "subway", "locations": [ "subterranean_subway" ], "flags": [ "ORTHOGONAL" ] } ]
+    "subtypes": [
+      { "terrain": "underground_sub_station", "locations": [ "underground_sub_station" ], "flags": [ "ORTHOGONAL" ] },
+      { "terrain": "subway", "locations": [ "subterranean_subway" ], "flags": [ "ORTHOGONAL" ] }
+    ]
   },
   {
     "type": "overmap_connection",

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -317,8 +317,7 @@
     ],
     "locations": [ "forest" ],
     "city_distance": [ 25, -1 ],
-    "occurrences": [ 50, 100 ],
-    "//": "Inflated chance, effective rate ~40%",
+    "occurrences": [ 40, 100 ],
     "flags": [ "CLASSIC", "WILDERNESS", "UNIQUE", "ELECTRIC_GRID" ]
   },
   {
@@ -4758,8 +4757,7 @@
     ],
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 6, -1 ],
-    "occurrences": [ 70, 100 ],
-    "//": "Inflated chance, effective rate ~40%",
+    "occurrences": [ 40, 100 ],
     "flags": [ "CLASSIC", "UNIQUE", "ELECTRIC_GRID" ]
   },
   {
@@ -4857,8 +4855,7 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 5, 20 ],
     "city_sizes": [ 6, -1 ],
-    "occurrences": [ 40, 100 ],
-    "//": "Inflated chance, in effect 15%",
+    "occurrences": [ 15, 100 ],
     "flags": [ "CLASSIC", "UNIQUE" ]
   },
   {
@@ -6464,8 +6461,7 @@
     ],
     "locations": [ "land" ],
     "city_distance": [ 5, -1 ],
-    "occurrences": [ 95, 100 ],
-    "//": "Inflated chance, effective rate ~ 30%",
+    "occurrences": [ 30, 100 ],
     "flags": [ "CLASSIC", "FARM", "UNIQUE" ]
   },
   {
@@ -6654,8 +6650,7 @@
     "connections": [ { "point": [ 2, -1, 0 ], "connection": "local_road", "from": [ 2, 0, 0 ] } ],
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 4, -1 ],
-    "occurrences": [ 75, 100 ],
-    "//": "Inflated chance, effective rate ~55%",
+    "occurrences": [ 55, 100 ],
     "flags": [ "CLASSIC", "UNIQUE", "ELECTRIC_GRID" ]
   },
   {
@@ -6743,8 +6738,7 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 8, 40 ],
     "city_sizes": [ 6, -1 ],
-    "occurrences": [ 50, 100 ],
-    "//": "Inflated chance, effective rate ~30%",
+    "occurrences": [ 30, 100 ],
     "flags": [ "CLASSIC", "URBAN", "UNIQUE", "ELECTRIC_GRID" ]
   },
   {
@@ -7006,8 +7000,7 @@
     "connections": [ { "point": [ 3, -2, 0 ], "from": [ 3, -1, 0 ], "connection": "local_road" } ],
     "city_distance": [ 5, -1 ],
     "city_sizes": [ 4, -1 ],
-    "occurrences": [ 45, 100 ],
-    "//": "Inflated chance, in effect ~10%",
+    "occurrences": [ 10, 100 ],
     "flags": [ "MILITARY", "UNIQUE", "ELECTRIC_GRID" ]
   },
   {

--- a/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
@@ -279,7 +279,7 @@
     "color": "yellow",
     "see_cost": 5,
     "extras": "subway",
-    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "NO_ROTATE" ]
+    "flags": [ "KNOWN_UP", "KNOWN_DOWN" ]
   },
   {
     "type": "overmap_terrain",
@@ -289,7 +289,7 @@
     "color": "yellow",
     "see_cost": 5,
     "extras": "subway",
-    "flags": [ "KNOWN_UP", "NO_ROTATE" ]
+    "flags": [ "KNOWN_UP" ]
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/special_locations.json
+++ b/data/json/overmap/special_locations.json
@@ -99,5 +99,10 @@
     "type": "overmap_location",
     "id": "lake_shore",
     "terrains": [ "lake_shore" ]
+  },
+  {
+    "type": "overmap_location",
+    "id": "underground_sub_station",
+    "terrains": [ "underground_sub_station" ]
   }
 ]

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2243,6 +2243,11 @@ void options_manager::add_options_world_default()
          0, 8, 4
        );
 
+    add( "SPECIALS_DENSITY", world_default, translate_marker( "Overmap specials density" ),
+         translate_marker( "A scaling factor that determines density of overmap specials." ),
+         0.0, 10.0, 1, 0.1
+       );
+
     add( "SPAWN_DENSITY", world_default, translate_marker( "Spawn rate scaling factor" ),
          translate_marker( "A scaling factor that determines density of monster spawns." ),
          0.0, 50.0, 1.0, 0.1

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -505,19 +505,6 @@ void overmap_specials::finalize()
 
 void overmap_specials::check_consistency()
 {
-    const size_t max_count = ( OMAPX / OMSPEC_FREQ ) * ( OMAPY / OMSPEC_FREQ );
-    const size_t actual_count = std::accumulate( specials.get_all().begin(), specials.get_all().end(),
-                                static_cast< size_t >( 0 ),
-    []( size_t sum, const overmap_special & elem ) {
-        return sum + ( elem.flags.count( "UNIQUE" ) ? static_cast<size_t>( 0 )  : static_cast<size_t>( (
-                           std::max( elem.occurrences.min, 0 ) ) ) ) ;
-    } );
-
-    if( actual_count > max_count ) {
-        debugmsg( "There are too many mandatory overmap specials (%d > %d). Some of them may not be placed.",
-                  actual_count, max_count );
-    }
-
     specials.check();
 }
 
@@ -4455,257 +4442,101 @@ void overmap::place_special(
     }
 }
 
-om_special_sectors get_sectors( const int sector_width )
+int overmap::place_special_attempt( const overmap_special &special, const int max,
+                                    std::vector<tripoint_om_omt> &points, const bool must_be_unexplored )
 {
-    std::vector<point_om_omt> res;
-
-    res.reserve( ( OMAPX / sector_width ) * ( OMAPY / sector_width ) );
-    for( int x = 0; x < OMAPX; x += sector_width ) {
-        for( int y = 0; y < OMAPY; y += sector_width ) {
-            res.emplace_back( x, y );
-        }
+    if( max < 1 ) {
+        return 0;
     }
-    std::shuffle( res.begin(), res.end(), rng_get_engine() );
-    return om_special_sectors{ res, sector_width };
-}
+    int placed = 0;
+    for( auto p = points.begin(); p != points.end(); ) {
+        const city &nearest_city = get_nearest_city( *p );
 
-bool overmap::place_special_attempt(
-    overmap_special_batch &enabled_specials, const point_om_omt &sector,
-    const int sector_width, const bool place_optional, const bool must_be_unexplored )
-{
-    const tripoint_om_omt p{
-        rng( sector.x(), sector.x() + sector_width - 1 ),
-        rng( sector.y(), sector.y() + sector_width - 1 ),
-        0};
-    const city &nearest_city = get_nearest_city( p );
-
-    std::shuffle( enabled_specials.begin(), enabled_specials.end(), rng_get_engine() );
-    for( auto iter = enabled_specials.begin(); iter != enabled_specials.end(); ++iter ) {
-        const auto &special = *iter->special_details;
-        // If we haven't finished placing minimum instances of all specials,
-        // skip specials that are at their minimum count already.
-        if( !place_optional && iter->instances_placed >= special.occurrences.min ) {
-            continue;
-        }
         // City check is the fastest => it goes first.
-        if( !special.can_belong_to_city( p, nearest_city ) ) {
+        if( !special.can_belong_to_city( *p, nearest_city ) ) {
+            p++;
             continue;
         }
         // See if we can actually place the special there.
-        const auto rotation = random_special_rotation( special, p, must_be_unexplored );
+        const auto rotation = random_special_rotation( special, *p, must_be_unexplored );
         if( rotation == om_direction::type::invalid ) {
+            p++;
             continue;
         }
+        place_special( special, *p, rotation, nearest_city, false, must_be_unexplored );
 
-        place_special( special, p, rotation, nearest_city, false, must_be_unexplored );
-
-        if( ++iter->instances_placed >= special.occurrences.max ) {
-            enabled_specials.erase( iter );
-        }
-
-        return true;
-    }
-
-    return false;
-}
-
-void overmap::place_specials_pass( overmap_special_batch &enabled_specials,
-                                   om_special_sectors &sectors, const bool place_optional, const bool must_be_unexplored )
-{
-    // Walk over sectors in random order, to minimize "clumping".
-    std::shuffle( sectors.sectors.begin(), sectors.sectors.end(), rng_get_engine() );
-    for( auto it = sectors.sectors.begin(); it != sectors.sectors.end(); ) {
-        const size_t attempts = 10;
-        bool placed = false;
-        for( size_t i = 0; i < attempts; ++i ) {
-            if( place_special_attempt( enabled_specials, *it, sectors.sector_width, place_optional,
-                                       must_be_unexplored ) ) {
-                placed = true;
-                it = sectors.sectors.erase( it );
-                if( enabled_specials.empty() ) {
-                    return; // Job done. Bail out.
-                }
-                break;
-            }
-        }
-
-        if( !placed ) {
-            it++;
+        // Sometimes points can be reused with different rotation
+        // wa want to avoid that for better dispertion
+        p = points.erase( p );
+        if( ++placed >= max ) {
+            break;
         }
     }
+    return placed;
 }
 
-// Split map into sections, iterate through sections iterate through specials,
-// check if special is valid  pick & place special.
-// When a sector is populated it's removed from the list,
-// and when a special reaches max instances it is also removed.
+// Iterate over overmap searching for valid locations, and placing specials
 void overmap::place_specials( overmap_special_batch &enabled_specials )
 {
-    // Calculate if this overmap has any lake terrain--if it doesn't, we should just
-    // completely skip placing any lake specials here since they'll never place and if
-    // they're mandatory they just end up causing us to spiral out into adjacent overmaps
-    // which probably don't have lakes either.
-    bool overmap_has_lake = false;
-    for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT && !overmap_has_lake; z++ ) {
-        for( int x = 0; x < OMAPX && !overmap_has_lake; x++ ) {
-            for( int y = 0; y < OMAPY && !overmap_has_lake; y++ ) {
-                overmap_has_lake = ter( { x, y, z } )->is_lake();
-            }
-        }
-    }
-
-    om_special_sectors sectors = get_sectors( OMSPEC_FREQ );
-
-    // At true center, central lab is truly mandatory and can't be pushed to neighbors
+    // Sort specials be they sizes - placing big things is faster
+    // and easier while we have most of map still empty, and also
+    // that central lab will have top priority
     bool is_true_center = pos() == point_abs_om();
-    if( is_true_center ) {
-        std::vector<const overmap_special *> truly_mandatory_specials;
-        // Ugly hack. TODO: Un-ugly
-        for( const auto &s :  overmap_specials::get_all() ) {
-            if( s.flags.count( "ENDGAME" ) > 0 ) {
-                truly_mandatory_specials.push_back( &s );
-            }
-        }
-        overmap_special_batch truly_mandatory_batch( point_abs_om(), truly_mandatory_specials );
-        place_specials_pass( truly_mandatory_batch, sectors, false, false );
-        // Add instances_placed from truly mandatory batch to regular batch, to avoid double placement
-        // But only if they exist in both - we don't want endgame specials to be pushed to neighbor OMs
-        for( const overmap_special_placement &truly_mandatory_placement : truly_mandatory_batch ) {
-            const overmap_special_id &special_id = truly_mandatory_placement.special_details->id;
-            auto iter_normal = std::find_if( enabled_specials.begin(),
-            enabled_specials.end(), [special_id]( const overmap_special_placement & pl ) {
-                return pl.special_details->id == special_id;
-            } );
-            if( iter_normal != enabled_specials.end() ) {
-                iter_normal->instances_placed += truly_mandatory_placement.instances_placed;
-            }
-        }
+    const auto special_weight = [&is_true_center]( const overmap_special * s ) {
+        return s->terrains.size() * ( is_true_center && s->flags.count( "ENDGAME" ) ? 1000 : 1 );
+    };
+    std::sort( enabled_specials.begin(), enabled_specials.end(),
+    [&special_weight]( const overmap_special_placement & a, const overmap_special_placement & b ) {
+        return special_weight( a.special_details ) > special_weight( b.special_details );
+    } );
 
-        for( auto iter = enabled_specials.begin(); iter != enabled_specials.end(); ) {
-            if( iter->special_details->flags.count( "ENDGAME" ) > 0 ) {
-                iter = enabled_specials.erase( iter );
-                continue;
-            }
-            ++iter;
-        }
-    }
-
-    for( auto iter = enabled_specials.begin(); iter != enabled_specials.end(); ) {
-        // If this special has the LAKE flag and the overmap doesn't have any
-        // lake terrain, then remove this special from the candidates for this
-        // overmap.
-        if( iter->special_details->flags.count( "LAKE" ) > 0 && !overmap_has_lake ) {
-            iter = enabled_specials.erase( iter );
-            continue;
-        }
-
-        // Endgame specials were placed above, don't let UNIQUE overwrite that
-        if( iter->special_details->flags.count( "UNIQUE" ) > 0 ) {
-            const int min = iter->special_details->occurrences.min;
-            const int max = iter->special_details->occurrences.max;
-
-            if( x_in_y( min, max ) ) {
-                // Min and max are overloaded to be the chance of occurrence,
-                // so reset instances placed to one short of max so we don't place several.
-                iter->instances_placed = max - 1;
+    // Prepare overmap points
+    std::vector<tripoint_om_omt> lake_points;
+    std::vector<tripoint_om_omt> land_points;
+    for( int x = 0; x < OMAPX; x++ ) {
+        for( int y = 0; y < OMAPY; y++ ) {
+            const tripoint_om_omt p = {x, y, 0};
+            if( ter( p )->is_lake() ) {
+                lake_points.push_back( p );
             } else {
-                iter = enabled_specials.erase( iter );
-                continue;
+                land_points.push_back( p );
             }
         }
-        ++iter;
-    }
-    // Bail out early if we have nothing to place.
-    if( enabled_specials.empty() ) {
-        return;
     }
 
-    std::shuffle( enabled_specials.begin(), enabled_specials.end(), rng_get_engine() );
+    // Calculate water to land ratio to normalize specials occurencies
+    // we don't want to dump all specials on overmap covered by water
+    float lake_rate = lake_points.size() / static_cast<float>( OMAPX * OMAPY ) *
+                      get_option<float>( "SPECIALS_DENSITY" );
+    float land_rate = land_points.size() / static_cast<float>( OMAPX * OMAPY ) *
+                      get_option<float>( "SPECIALS_DENSITY" );
 
-    // First, place the mandatory specials to ensure that all minimum instance
-    // counts are met.
-    place_specials_pass( enabled_specials, sectors, false, false );
+    // Shuffle all points to distribute specials across the overmap
+    std::shuffle( lake_points.begin(), lake_points.end(), rng_get_engine() );
+    std::shuffle( land_points.begin(), land_points.end(), rng_get_engine() );
+    // And here we go
+    for( auto &iter : enabled_specials ) {
+        const overmap_special &special = *iter.special_details;
 
-    // Snapshot remaining specials, which will be the optional specials and
-    // any unplaced mandatory specials. By passing a copy into the creation of
-    // the adjacent overmaps, we ensure that when we unwind the overmap creation
-    // back to filling in our non-mandatory specials for this overmap, we won't
-    // count the placement of the specials in those maps when looking for optional
-    // specials to place here.
-    overmap_special_batch custom_overmap_specials = overmap_special_batch( enabled_specials );
+        const int min = special.occurrences.min;
+        const int max = special.occurrences.max;
 
-    // Check for any unplaced mandatory specials, and if there are any, attempt to
-    // place them on adajacent uncreated overmaps.
-    if( std::any_of( custom_overmap_specials.begin(), custom_overmap_specials.end(),
-    []( overmap_special_placement placement ) {
-    return placement.instances_placed <
-           placement.special_details->occurrences.min;
-} ) ) {
-        // Randomly select from among the nearest uninitialized overmap positions.
-        int previous_distance = 0;
-        std::vector<point_abs_om> nearest_candidates;
-        // Since this starts at enabled_specials::origin, it will only place new overmaps
-        // in the 5x5 area surrounding the initial overmap, bounding the amount of work we will do.
-        for( const point_abs_om &candidate_addr : closest_points_first(
-                 custom_overmap_specials.get_origin(), 2 ) ) {
-            if( !overmap_buffer.has( candidate_addr ) ) {
-                int current_distance = square_dist( pos(), candidate_addr );
-                if( nearest_candidates.empty() || current_distance == previous_distance ) {
-                    nearest_candidates.push_back( candidate_addr );
-                    previous_distance = current_distance;
-                } else {
-                    break;
-                }
-            }
-        }
-        if( !nearest_candidates.empty() ) {
-            std::shuffle( nearest_candidates.begin(), nearest_candidates.end(), rng_get_engine() );
-            point_abs_om new_om_addr = nearest_candidates.front();
-            overmap_buffer.create_custom_overmap( new_om_addr, custom_overmap_specials );
+        const bool is_lake = special.flags.count( "LAKE" );
+        const float rate = is_true_center && special.flags.count( "ENDGAME" ) ? 1 :
+                           ( is_lake ? lake_rate : land_rate );
+
+        int amount_to_place;
+        if( special.flags.count( "UNIQUE" ) ) {
+            int chance = roll_remainder( min * rate );
+            amount_to_place = x_in_y( chance, max ) ? 1 : 0;
         } else {
-            add_msg( _( "Unable to place all configured specials, some missions may fail to initialize." ) );
+            // Number of instances normalized to terrain ratio
+            float real_max = std::max( static_cast<float>( min ), max * rate );
+            amount_to_place = roll_remainder( rng_float( min, real_max ) );
         }
-    }
-    // Then fill in non-mandatory specials.
-    place_specials_pass( enabled_specials, sectors, true, false );
 
-    // Clean up...
-    // Because we passed a copy of the specials for placement in adjacent overmaps rather than
-    // the original, but our caller is concerned with whether or not they were placed at all,
-    // regardless of whether we placed them or our callee did, we need to reconcile the placement
-    // that we did of the optional specials with the placement our callee did of optional
-    // and mandatory.
-
-    // Make a lookup of our callee's specials after processing.
-    // Because specials are removed from the list once they meet their maximum
-    // occurrences, this will only contain those which have not yet met their
-    // maximum.
-    std::map<overmap_special_id, int> processed_specials;
-    for( auto &elem : custom_overmap_specials ) {
-        processed_specials[elem.special_details->id] = elem.instances_placed;
-    }
-
-    // Loop through the specials we started with.
-    for( auto it = enabled_specials.begin(); it != enabled_specials.end(); ) {
-        // Determine if this special is still in our callee's list of specials...
-        std::map<overmap_special_id, int>::iterator iter = processed_specials.find(
-                    it->special_details->id );
-        if( iter != processed_specials.end() ) {
-            // ... and if so, increment the placement count to reflect the callee's.
-            it->instances_placed += ( iter->second - it->instances_placed );
-
-            // If, after incrementing the placement count, we're at our max, remove
-            // this special from our list.
-            if( it->instances_placed >= it->special_details->occurrences.max ) {
-                it = enabled_specials.erase( it );
-            } else {
-                it++;
-            }
-        } else {
-            // This special is no longer in our callee's list, which means it was completely
-            // placed, and we can remove it from our list.
-            it = enabled_specials.erase( it );
-        }
+        iter.instances_placed += place_special_attempt( special,
+                                 amount_to_place, ( is_lake ? lake_points : land_points ), false );
     }
 }
 

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -42,7 +42,6 @@ class npc;
 class overmap_connection;
 class overmap_special;
 class overmap_special_batch;
-struct om_special_sectors;
 struct regional_settings;
 template <typename E> struct enum_traits;
 
@@ -469,24 +468,18 @@ class overmap
          * @param enabled_specials specifies what specials to place, and tracks how many have been placed.
          **/
         void place_specials( overmap_special_batch &enabled_specials );
-        /**
-         * Walk over the overmap and attempt to place specials.
-         * @param enabled_specials vector of objects that track specials being placed.
-         * @param sectors sectors in which to attempt placement.
-         * @param place_optional restricts attempting to place specials that have met their minimum count in the first pass.
-         */
-        void place_specials_pass( overmap_special_batch &enabled_specials,
-                                  om_special_sectors &sectors, bool place_optional, bool must_be_unexplored );
 
         /**
-         * Attempts to place specials within a sector.
-         * @param enabled_specials vector of objects that track specials being placed.
-         * @param sector sector identifies the location where specials are being placed.
-         * @param place_optional restricts attempting to place specials that have met their minimum count in the first pass.
-         */
-        bool place_special_attempt(
-            overmap_special_batch &enabled_specials, const point_om_omt &sector, int sector_width,
-            bool place_optional, bool must_be_unexplored );
+         * Iterate over given points, placing specials if possible.
+         * @param special The overmap special to place.
+         * @param max Maximum amount of specials to place.
+         * @param points Vector of allowed origins for new specials, used points will be erased.
+         * @param must_be_unexplored If true, will require that all of the
+         * terrains where the special would be placed are unexplored.
+         * @returns Actual amount of placed specials.
+         **/
+        int place_special_attempt( const overmap_special &special, const int max,
+                                   std::vector<tripoint_om_omt> &points, const bool must_be_unexplored );
 
         void place_mongroups();
         void place_radios();

--- a/src/overmap_special.h
+++ b/src/overmap_special.h
@@ -30,11 +30,6 @@ class overmap_special;
 // Overmap specials--these are "special encounters," dungeons, nests, etc.
 // This specifies how often and where they may be placed.
 
-// OMSPEC_FREQ determines the length of the side of the square in which each
-// overmap special will be placed.  At OMSPEC_FREQ 6, the overmap is divided
-// into 900 squares; lots of space for interesting stuff!
-static constexpr int OMSPEC_FREQ = 15;
-
 struct overmap_special_spawns : public overmap_spawns {
     numeric_interval<int> radius;
 
@@ -126,17 +121,6 @@ namespace city_buildings
 void load( const JsonObject &jo, const std::string &src );
 
 } // namespace city_buildings
-
-struct om_special_sectors {
-    std::vector<point_om_omt> sectors;
-    int sector_width;
-};
-
-/**
-* Gets a collection of sectors and their width for usage in placing overmap specials.
-* @param sector_width used to divide the OMAPX by OMAPY map into sectors.
-*/
-om_special_sectors get_sectors( int sector_width );
 
 // Wrapper around an overmap special to track progress of placing specials.
 struct overmap_special_placement {

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -373,7 +373,8 @@ void overmap::convert_terrain(
         if( old == "fema" || old == "fema_entrance" || old == "fema_1_3" ||
             old == "fema_2_1" || old == "fema_2_2" || old == "fema_2_3" ||
             old == "fema_3_1" || old == "fema_3_2" || old == "fema_3_3" ||
-            old == "mine_entrance" ) {
+            old == "mine_entrance" || old == "underground_sub_station" ||
+            old == "sewer_sub_station" ) {
             ter_set( pos, oter_id( old + "_north" ) );
         } else if( old.compare( 0, 10, "mass_grave" ) == 0 ) {
             ter_set( pos, oter_id( "field" ) );

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -125,7 +125,8 @@ TEST_CASE( "is_ot_match", "[overmap][terrain]" )
 
         // Does not match if base type does not match
         CHECK_FALSE( is_ot_match( "lab", oter_id( "central_lab" ), ot_match_type::type ) );
-        CHECK_FALSE( is_ot_match( "sub_station", oter_id( "sewer_sub_station" ), ot_match_type::type ) );
+        CHECK_FALSE( is_ot_match( "sub_station", oter_id( "sewer_sub_station_north" ),
+                                  ot_match_type::type ) );
     }
 
     SECTION( "prefix match" ) {

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -51,6 +51,9 @@ TEST_CASE( "default_overmap_generation_always_succeeds", "[slow]" )
         overmap_buffer.create_custom_overmap( candidate_addr, test_specials );
         for( const auto &special_placement : test_specials ) {
             auto special = special_placement.special_details;
+            if( special->flags.count( "UNIQUE" ) > 0 ) {
+                continue;
+            }
             INFO( "In attempt #" << overmaps_to_construct
                   << " failed to place " << special->id.str() );
             CHECK( special->occurrences.min <= special_placement.instances_placed );
@@ -59,58 +62,6 @@ TEST_CASE( "default_overmap_generation_always_succeeds", "[slow]" )
             break;
         }
     }
-}
-
-TEST_CASE( "default_overmap_generation_has_non_mandatory_specials_at_origin", "[slow]" )
-{
-    clear_all_state();
-    const point_abs_om origin{};
-
-    overmap_special mandatory;
-    overmap_special optional;
-
-    // Get some specific overmap specials so we can assert their presence later.
-    // This should probably be replaced with some custom specials created in
-    // memory rather than tying this test to these, but it works for now...
-    for( const auto &elem : overmap_specials::get_all() ) {
-        if( elem.id == overmap_special_id( "Cabin" ) ) {
-            optional = elem;
-        } else if( elem.id == overmap_special_id( "Lab" ) ) {
-            mandatory = elem;
-        }
-    }
-
-    // Make this mandatory special impossible to place.
-    mandatory.city_size.min = 999;
-
-    // Construct our own overmap_special_batch containing only our single mandatory
-    // and single optional special, so we can make some assertions.
-    std::vector<const overmap_special *> specials;
-    specials.push_back( &mandatory );
-    specials.push_back( &optional );
-    overmap_special_batch test_specials = overmap_special_batch( origin, specials );
-
-    // Run the overmap creation, which will try to place our specials.
-    overmap_buffer.create_custom_overmap( origin, test_specials );
-
-    // Get the origin overmap...
-    overmap *test_overmap = overmap_buffer.get_existing( origin );
-
-    // ...and assert that the optional special exists on this map.
-    bool found_optional = false;
-    for( int x = 0; x < OMAPX; ++x ) {
-        for( int y = 0; y < OMAPY; ++y ) {
-            const oter_id t = test_overmap->ter( { x, y, 0 } );
-            if( t->id == "cabin" ||
-                t->id == "cabin_north" || t->id == "cabin_east" ||
-                t->id == "cabin_south" || t->id == "cabin_west" ) {
-                found_optional = true;
-            }
-        }
-    }
-
-    INFO( "Failed to place optional special on origin " );
-    CHECK( found_optional == true );
 }
 namespace
 {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/mod/json/explanation/json_style.md
C++ and Markdown: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/dev/explanation/code_style.md

!!!!!!!!!! WARNING !!!!!!!!!!

If you forget to format the PR, autofix.ci app will run automated format commit for you.
When this happens, YOU MUST DO EITHER OF THE FOLLOWING:

- Run `git pull` to merge the automated commit into your PR branch.
- Format your code locally, and force push to your PR branch. 

If you don't do this, your following work will be based on the old commit, and cause MERGE CONFLICT.
-->

## Summary
SUMMARY: Content "Specials placement rework"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/src/content/docs/en/contribute/changelog_guidelines.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

## Purpose of change
Specials placement is sucks. It's almost impossible to see things with restrictive placement conditions, like marina. That's a draft attempt to make it suck less.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution
Instead of throwing things at random and hoping for the best mapgen will actually search for place where to put things, and as long as overmap *can* fit requested special - it will be placed, no random failures anymore.

Amount of specials is also changed. Old implementation balance that naturally - if 90% of map is covered by water, then 90% of attempts to place farm will fail hitting wrong terrains.
Here, if we're asking game to place 10 farm - it will do that, even if it'll need to put them side by side on tiny island, which is looks ugly. To avoid that overmap calculates its lake\land ratio, and explicitly adjust occurrences to match them - on 90% flooded overmap land specials will have their occurrences reduced down 10%, while lake specials will have 90% occurrences.
Plus there's new "Overmap specials density" option to tune overall amount of specials in world.

Number of occurrences in JSON was reduced to their "inflated" values - they're not inflated anymore, and we don't need Isherwood Farms on every single overmap.
Om_special_sectors are gone, they aren't needed for generation. Pushing specials to neighbor overmaps also gone - there's nothing to push, we'll get exactly what we need.

Also added ability to generate missing special for starting game, intended to make it actually possible to start at very low density, but it also have other side benefits: like allowing to make start-only specials with zero natural occurrences. (2nd commit)

Subways generation got some changes to prevent connecting to stations sides, and incorporate subways defined in json in global transport network. (3rd commit)

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

## Describe alternatives you've considered
Sometimes specials distribution is clustered, especially on water. It might be natural outcome of random, or some weirdness with shuffle, not sure. Maybe partial reintroducing of sectors could make it better, by shuffling points within sectors, shuffling sectors, and then merging them all to final vectors of points.

I'm not perfectly happy with amount of specials. I tried different approaches of calculating `amount_to_place` - sometimes it have too few specials, sometimes too much, sometimes layout are too similar between different overmaps, etc. Density can be configured ofc. but game should look good on default x1.

Regarding performance, since most of specials are 1x1 OMT operational cost of pattern search within overmap would outweighs its benefits. *Currently* bruteforce is fast enough as long as huge things are processed first - it was magnitudes slower when Isherwood was processed at the end. But if some mod will try to spawn a lot of huge and picky(e.g. marina) things game won't be happy. It might be prevented by re-adding max attempts, but that'll break intended reliability.
Currently in average `place_specials()` is 1.5x times slower than old implementation, that's a fair price for correct generation. Under worsts conditions(maxed density, pics below) `place_specials()` can take a couple of seconds per overmap. But it wasn't *properly* profiled(too painful), so i could miss some obvious bottleneck.

For now i'm out of ideas how it can be improved further, so reviews and suggestions are welcome.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing
Spawned bunch of overmaps with different density, started game at different locations, generated new OMT for quest. Everything works.
"default_overmap_generation_has_non_mandatory_specials_at_origin" test could randomly fail. That's normal - it just obsolete by new logic. Non mandatory specials  are not guarantied to spawn. On overmap 30% covered by water chances to spawn 0-1 special will be 0.5*0.7 = 35%.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

## Additional context
Density x0.1:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/544763/727f2fc0-3b5e-45c0-b7b0-7b3e6ae452a1)

Density x1: ()
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/544763/73f88315-503b-45e8-8e7c-7d0ec0eaef3c)

Density x5: 
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/544763/499fbb25-6aee-4e56-b851-00925a370902)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
