### PR TITLE
Fix body_part_set operations

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -595,7 +595,7 @@ void avatar_action::swim( map &m, avatar &you, const tripoint &p )
     };
 
     if( you.is_underwater() ) {
-        drenchFlags.unify_set( { { bodypart_str_id( "head" ), bodypart_str_id( "eyes" ), bodypart_str_id( "mouth" ), bodypart_str_id( "hand_l" ), bodypart_str_id( "hand_r" ) } } );
+        drenchFlags.unify_set( { { bodypart_str_id( "head" ), bodypart_str_id( "eyes" ), bodypart_str_id( "mouth" ) } } );
     }
     you.drench( 100, drenchFlags, true );
 }

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -491,7 +491,7 @@ void bodypart::mod_damage_disinfected( int mod )
     damage_disinfected += mod;
 }
 
-body_part_set body_part_set::unify_set( const body_part_set &rhs )
+body_part_set &body_part_set::unify_set( const body_part_set &rhs )
 {
     for( auto i = rhs.parts.begin(); i != rhs.parts.end(); i++ ) {
         if( parts.count( *i ) == 0 ) {
@@ -501,17 +501,19 @@ body_part_set body_part_set::unify_set( const body_part_set &rhs )
     return *this;
 }
 
-body_part_set body_part_set::intersect_set( const body_part_set &rhs )
+body_part_set &body_part_set::intersect_set( const body_part_set &rhs )
 {
-    for( auto j = parts.begin(); j != parts.end(); j++ ) {
-        if( rhs.parts.count( *j ) == 0 ) {
-            parts.erase( *j );
+    for( auto it = parts.begin(); it < parts.end(); ) {
+        if( rhs.parts.count( *it ) == 0 ) {
+            it = parts.erase( it );
+        } else {
+            it++;
         }
     }
     return *this;
 }
 
-body_part_set body_part_set::substract_set( const body_part_set &rhs )
+body_part_set &body_part_set::substract_set( const body_part_set &rhs )
 {
     for( auto j = rhs.parts.begin(); j != rhs.parts.end(); j++ ) {
         if( parts.count( *j ) > 0 ) {
@@ -521,11 +523,12 @@ body_part_set body_part_set::substract_set( const body_part_set &rhs )
     return *this;
 }
 
-body_part_set body_part_set::make_intersection( const body_part_set &rhs )
+body_part_set body_part_set::make_intersection( const body_part_set &rhs ) const
 {
     body_part_set new_intersection;
     new_intersection.parts = parts;
-    return new_intersection.intersect_set( rhs );
+    new_intersection.intersect_set( rhs );
+    return new_intersection;
 }
 
 void body_part_set::fill( const std::vector<bodypart_id> &bps )

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -226,11 +226,14 @@ class body_part_set
                 set( bp );
             }
         }
-        body_part_set unify_set( const body_part_set &rhs );
-        body_part_set intersect_set( const body_part_set &rhs );
-
-        body_part_set make_intersection( const body_part_set &rhs );
-        body_part_set substract_set( const body_part_set &rhs );
+        /** Adds all elements from provided set to this set. */
+        body_part_set &unify_set( const body_part_set &rhs );
+        /** Removes all elements that are absent from the provided set. */
+        body_part_set &intersect_set( const body_part_set &rhs );
+        /** Removes all elements that are present in the provided set. */
+        body_part_set &substract_set( const body_part_set &rhs );
+        /** Creates new set that is the intersection of this set and provided set. */
+        body_part_set make_intersection( const body_part_set &rhs ) const;
 
         void fill( const std::vector<bodypart_id> &bps );
 


### PR DESCRIPTION
## Summary
SUMMARY: Bugfixes "Fix CTD after wearing power armor"

## Purpose of change
Fix CTD when trying to wear pa helmet anything after wearing power armor

## Describe the solution
Fix segfault caused by removing-while-iterating in `body_part_set`.
Make it so body_part_set operations don't unnecessarily copy the set.
Remove a duplicate code snippet.
Add `const` and comments where appropriate.

## Testing
Does not crash anymore, lets you wear both PA and helmet

## Additional context
Fallout from #2776