### PR TITLE
Fix tidy warnings

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1132,7 +1132,7 @@ static activity_reason_info find_base_construction(
             return !con->requirements->get_components().empty();
         };
         auto check_disassembly = []( const auto & con ) -> bool {
-            return con->byproduct_item_group ? true : false;
+            return !!con->byproduct_item_group;
         };
         bool dis = check_disassembly( con );
         bool ass = check_assembly( con );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2271,9 +2271,8 @@ void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomo
 {
     tripoint p = pt;
     map &here = get_map();
-    tripoint above_p( p.x, p.y, p.z + 1 );
     bool ceiling_blocking_climb = !here.has_floor_or_support( pos() ) ||
-                                  here.has_floor_or_support( above_p );
+                                  here.has_floor_or_support( p + tripoint_above );
     if( sees_dangerous_field( p )
         || ( nomove != nullptr && nomove->find( p ) != nomove->end() ) ) {
         // Move to a neighbor field instead, if possible.


### PR DESCRIPTION
## Summary
SUMMARY: None

## Purpose of change
Housekeeping

## Describe the solution
Fix warnings

## Describe alternatives you've considered
Getting rid of tidy

## Testing
Should work (tm). Iteminfo-related warnings are left in to avoid conflicts with #3434