### PR TITLE
Electric Lighter Description Fix

### DIFF
--- a/data/json/items/tool/fire.json
+++ b/data/json/items/tool/fire.json
@@ -266,7 +266,7 @@
     "id": "electric_lighter",
     "type": "TOOL",
     "name": { "str": "electric lighter" },
-    "description": "A battery-powered lighter.  More efficient than anything you can make yourself, its batteries last for quite a while.",
+    "description": "A battery-powered lighter.  More efficient than a crude electric firestarter, its batteries last for quite a while.",
     "copy-from": "lighter",
     "volume": "25 ml",
     "magazine_well": "25 ml",


### PR DESCRIPTION
## Summary

SUMMARY: [Bugfix] "Fixed the electric lighter's description saying you cannot craft it."

## Purpose of change

You can craft the electric lighter, but the old description says you couldn't.

## Describe the solution

I changed its description.

## Describe alternatives you've considered

I could just leave it as-is.

## Testing

The json checks out.