### PR TITLE
Add faction owner to Isherwood cabin and horse farm items

### DIFF
--- a/data/json/mapgen/isherwood_farms/cabin_isherwood.json
+++ b/data/json/mapgen/isherwood_farms/cabin_isherwood.json
@@ -4,9 +4,7 @@
     "method": "json",
     "om_terrain": "cabin_isherwood",
     "object": {
-      "faction_owner": [
-        { "id": "isherwood_family", "x": [ 0, 23 ], "y": [ 0, 23 ] }
-      ],
+      "faction_owner": [ { "id": "isherwood_family", "x": [ 0, 23 ], "y": [ 0, 23 ] } ],
       "fill_ter": "t_floor",
       "rows": [
         "............//..........",

--- a/data/json/mapgen/isherwood_farms/cabin_isherwood.json
+++ b/data/json/mapgen/isherwood_farms/cabin_isherwood.json
@@ -4,6 +4,9 @@
     "method": "json",
     "om_terrain": "cabin_isherwood",
     "object": {
+      "faction_owner": [
+        { "id": "isherwood_family", "x": [ 0, 23 ], "y": [ 0, 23 ] }
+      ],
       "fill_ter": "t_floor",
       "rows": [
         "............//..........",

--- a/data/json/mapgen/isherwood_farms/farm_horse_isherwood.json
+++ b/data/json/mapgen/isherwood_farms/farm_horse_isherwood.json
@@ -381,6 +381,9 @@
     "method": "json",
     "om_terrain": "horse_farm_isherwood_13_2ndfloor",
     "object": {
+      "faction_owner": [
+        { "id": "isherwood_family", "x": [ 0, 23 ], "y": [ 0, 23 ] }
+      ],
       "fill_ter": "t_floor",
       "rows": [
         "                        ",

--- a/data/json/mapgen/isherwood_farms/farm_horse_isherwood.json
+++ b/data/json/mapgen/isherwood_farms/farm_horse_isherwood.json
@@ -381,9 +381,7 @@
     "method": "json",
     "om_terrain": "horse_farm_isherwood_13_2ndfloor",
     "object": {
-      "faction_owner": [
-        { "id": "isherwood_family", "x": [ 0, 23 ], "y": [ 0, 23 ] }
-      ],
+      "faction_owner": [ { "id": "isherwood_family", "x": [ 0, 23 ], "y": [ 0, 23 ] } ],
       "fill_ter": "t_floor",
       "rows": [
         "                        ",

--- a/data/json/mapgen/isherwood_farms/farm_horse_isherwood.json
+++ b/data/json/mapgen/isherwood_farms/farm_horse_isherwood.json
@@ -14,12 +14,19 @@
         { "id": "isherwood_family", "x": [ 0, 23 ], "y": [ 0, 23 ] },
         { "id": "isherwood_family", "x": [ 24, 47 ], "y": [ 0, 23 ] },
         { "id": "isherwood_family", "x": [ 48, 71 ], "y": [ 0, 23 ] },
+        { "id": "isherwood_family", "x": [ 72, 95 ], "y": [ 0, 23 ] },
         { "id": "isherwood_family", "x": [ 0, 23 ], "y": [ 24, 47 ] },
         { "id": "isherwood_family", "x": [ 24, 47 ], "y": [ 24, 47 ] },
         { "id": "isherwood_family", "x": [ 48, 71 ], "y": [ 24, 47 ] },
+        { "id": "isherwood_family", "x": [ 72, 95 ], "y": [ 24, 47 ] },
         { "id": "isherwood_family", "x": [ 0, 23 ], "y": [ 48, 71 ] },
         { "id": "isherwood_family", "x": [ 24, 47 ], "y": [ 48, 71 ] },
-        { "id": "isherwood_family", "x": [ 48, 71 ], "y": [ 48, 71 ] }
+        { "id": "isherwood_family", "x": [ 48, 71 ], "y": [ 48, 71 ] },
+        { "id": "isherwood_family", "x": [ 72, 95 ], "y": [ 48, 71 ] },
+        { "id": "isherwood_family", "x": [ 0, 23 ], "y": [ 72, 95 ] },
+        { "id": "isherwood_family", "x": [ 24, 47 ], "y": [ 72, 95 ] },
+        { "id": "isherwood_family", "x": [ 48, 71 ], "y": [ 72, 95 ] },
+        { "id": "isherwood_family", "x": [ 72, 95 ], "y": [ 72, 95 ] }
       ],
       "fill_ter": "t_floor",
       "rows": [


### PR DESCRIPTION
## Summary

SUMMARY: Bugfixes "Add faction owner to Isherwood cabin and horse farm items"

## Purpose of change

Fixes #1201 - Adds faction owners to Isherwood cabin and horse farm items

## Describe the solution

- Add faction owner array for Isherwood cabin
- Expand faction owner array for Isherwood Horse Farm
- Add faction owner array for Isherwood Horse Farm second flooe

## Describe alternatives you've considered

None

## Testing

Loaded into base game and tested

## Additional context

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/91185016/bf7926d1-fe7b-47d0-8817-a88c02500f51)
