### PR TITLE
Fix search in crafting menu by description

### DIFF
--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -195,7 +195,7 @@ std::vector<const recipe *> recipe_subset::search( const std::string &txt,
 
             case search_type::description_result: {
                 const item result = r->create_result();
-                return lcmatch( remove_color_tags( result.info_string( iteminfo_query::no_text ) ), txt );
+                return lcmatch( remove_color_tags( result.info_string( iteminfo_query::no_conditions ) ), txt );
             }
 
             default:


### PR DESCRIPTION
## Summary
SUMMARY: Bugfixes "Fixed search in crafting menu by description"

## Purpose of change
Fixes #2903

## Describe the solution
Use correct iteminfo query.

## Testing
I was able to search by martial style with this fix, as well as snippets from item description.