### PR TITLE
fix: bodypart layer not displaying `All` first (again)

### DIFF
--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -32,6 +32,7 @@
 namespace
 {
 const activity_id ACT_ARMOR_LAYERS( "ACT_ARMOR_LAYERS" );
+const bodypart_str_id body_part_appendix( "num_bp" );
 
 std::string clothing_layer( const item &worn_item );
 std::vector<std::string> clothing_properties(
@@ -74,7 +75,7 @@ item_penalties get_item_penalties( std::list<item>::const_iterator worn_item_it,
     std::vector<std::set<std::string>> lists_of_bad_items_within;
 
     for( const bodypart_id &bp : c.get_all_body_parts() ) {
-        if( _bp->token && _bp != bodypart_id( "num_bp" ) ) {
+        if( _bp->token && _bp != body_part_appendix ) {
             continue;
         }
         if( !worn_item_it->covers( bp ) ) {
@@ -283,9 +284,9 @@ std::vector<std::string> clothing_properties(
     props.reserve( 5 );
 
     const std::string space = "  ";
-    const int coverage = bp == bodypart_id( "num_bp" ) ? worn_item.get_avg_coverage() :
+    const int coverage = bp == body_part_appendix ? worn_item.get_avg_coverage() :
                          worn_item.get_coverage( bp );
-    const int encumbrance = bp == bodypart_id( "num_bp" ) ? worn_item.get_avg_encumber(
+    const int encumbrance = bp == body_part_appendix ? worn_item.get_avg_encumber(
                                 c ) : worn_item.get_encumber( c, bp );
     props.push_back( string_format( "<color_c_green>[%s]</color>", _( "Properties" ) ) );
     props.push_back( name_and_value( space + _( "Coverage:" ),
@@ -436,15 +437,17 @@ void show_armor_layers_ui( Character &who )
     * because some items can have multiple entries (i.e. cover a few parts of body).
     */
 
+    const auto all_parts = who.get_all_body_parts();
+    const int num_of_parts = all_parts.size();
+
     // FIXME: get_all_body_parts() doesn't return a sorted list
     //        and bodypart_id is not compatible with std::sort()
     //        so let's use a dirty hack
     cata::flat_set<bodypart_id> armor_cat;
-    for( const bodypart_id &it : who.get_all_body_parts() ) {
+    for( const bodypart_id &it : all_parts ) {
         armor_cat.insert( it );
     }
-    armor_cat.insert( bodypart_id( "num_bp" ) );
-    const int num_of_parts = who.get_all_body_parts().size();
+    armor_cat.insert( body_part_appendix );
 
     int req_right_h = 3 + 1 + 2 + num_of_parts + 1;
     for( const bodypart_id &cover : armor_cat ) {
@@ -558,7 +561,7 @@ void show_armor_layers_ui( Character &who )
 
         // top bar
         wprintz( w_sort_cat, c_white, _( "Sort Armor" ) );
-        const auto name = bp != bodypart_id( "num_bp" ) ? body_part_name_as_heading( bp, 1 ) : _( "All" );
+        const auto name = bp != body_part_appendix ? body_part_name_as_heading( bp, 1 ) : _( "All" );
         wprintz( w_sort_cat, c_yellow, "  << %s >>", name );
         right_print( w_sort_cat, 0, 0, c_white, string_format(
                          _( "Press [<color_yellow>%s</color>] for help.  "
@@ -654,7 +657,7 @@ void show_armor_layers_ui( Character &who )
         }
         int pos = 1, curr = 0;
         for( const bodypart_id cover : rl ) {
-            if( cover == bodypart_id( "num_bp" ) ) {
+            if( cover == body_part_appendix ) {
                 continue;
             }
             if( curr >= rightListOffset && pos <= rightListLines ) {
@@ -716,7 +719,7 @@ void show_armor_layers_ui( Character &who )
         // Create ptr list of items to display
         tmp_worn.clear();
         const bodypart_id &bp = armor_cat[ tabindex ];
-        if( bp == bodypart_id( "num_bp" ) ) {
+        if( bp == body_part_appendix ) {
             // All
             for( auto it = who.worn.begin(); it != who.worn.end(); ++it ) {
                 tmp_worn.push_back( it );

--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -28,10 +28,11 @@
 #include "ui_manager.h"
 #include "units_utility.h"
 
-static const activity_id ACT_ARMOR_LAYERS( "ACT_ARMOR_LAYERS" );
 
 namespace
 {
+const activity_id ACT_ARMOR_LAYERS( "ACT_ARMOR_LAYERS" );
+
 std::string clothing_layer( const item &worn_item );
 std::vector<std::string> clothing_properties(
     const item &worn_item, int width, const Character &, const bodypart_id &bp );
@@ -443,8 +444,9 @@ void show_armor_layers_ui( Character &who )
         armor_cat.insert( it );
     }
     armor_cat.insert( bodypart_id( "num_bp" ) );
+    const int num_of_parts = who.get_all_body_parts().size();
 
-    int req_right_h = 3 + 1 + 2 + body_part::num_bp + 1;
+    int req_right_h = 3 + 1 + 2 + num_of_parts + 1;
     for( const bodypart_id &cover : armor_cat ) {
         for( const item &elem : who.worn ) {
             if( elem.covers( cover ) ) {
@@ -471,8 +473,8 @@ void show_armor_layers_ui( Character &who )
     int right_w  = 0;
     int middle_w = 0;
 
-    int tabindex = body_part::num_bp;
-    const int tabcount = body_part::num_bp + 1;
+    int tabindex = 0;
+    const int tabcount = num_of_parts + 1;
 
     int leftListIndex  = 0;
     int leftListOffset = 0;
@@ -508,12 +510,12 @@ void show_armor_layers_ui( Character &who )
         w_sort_armor = catacurses::newwin( win_h, win_w, win );
         w_sort_cat = catacurses::newwin( 1, win_w - 4, win + point( 2, 1 ) );
         w_sort_left = catacurses::newwin( cont_h, left_w, win + point( 1, 3 ) );
-        w_sort_middle = catacurses::newwin( cont_h - body_part::num_bp - 1, middle_w,
+        w_sort_middle = catacurses::newwin( cont_h - num_of_parts - 1, middle_w,
                                             win + point( 2 + left_w, 3 ) );
         w_sort_right = catacurses::newwin( cont_h, right_w,
                                            win + point( 3 + left_w + middle_w, 3 ) );
-        w_encumb = catacurses::newwin( body_part::num_bp + 1, middle_w,
-                                       win + point( 2 + left_w, -1 + 3 + cont_h - body_part::num_bp ) );
+        w_encumb = catacurses::newwin( num_of_parts + 1, middle_w,
+                                       win + point( 2 + left_w, -1 + 3 + cont_h - num_of_parts ) );
         ui.position_from_window( w_sort_armor );
     } );
     ui.mark_resize();
@@ -556,8 +558,8 @@ void show_armor_layers_ui( Character &who )
 
         // top bar
         wprintz( w_sort_cat, c_white, _( "Sort Armor" ) );
-        const auto temp = tabindex != body_part::num_bp ? body_part_name_as_heading( bp, 1 ) : _( "All" );
-        wprintz( w_sort_cat, c_yellow, "  << %s >>", temp );
+        const auto name = bp != bodypart_id( "num_bp" ) ? body_part_name_as_heading( bp, 1 ) : _( "All" );
+        wprintz( w_sort_cat, c_yellow, "  << %s >>", name );
         right_print( w_sort_cat, 0, 0, c_white, string_format(
                          _( "Press [<color_yellow>%s</color>] for help.  "
                             "Press [<color_yellow>%s</color>] to change keybindings." ),


### PR DESCRIPTION
## Summary

SUMMARY: Bugfixes "bodypart layer ordering UI not displaying `All` first (again)"

## Purpose of change

- fix #3423

## Describe the solution

made tabindex default 0

## Describe alternatives you've considered

hecc

## Testing

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/3aafbad3-91df-4f76-981b-47739e99ecf6

_it works on my machine_

## Additional context

referenced DDA loc: https://github.com/CleverRaven/Cataclysm-DDA/blob/078a7b43be36c11f2431bf52f5f00d2d41c9a53a/src/armor_layers.cpp#L614-L615

~~i have no idea how string_id behave on flat_set~~