### PR TITLE
Decouple crop growth time from season length, add separate scaling option

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2398,10 +2398,6 @@ void iexamine::fertilize_plant( player &p, const tripoint &tile, const itype_id 
 
     std::list<item> planted = p.use_charges( fertilizer, 1 );
 
-    // Reduce the amount of time it takes until the next stage of the plant by
-    // 20% of a seasons length. (default 2.8 days).
-    const time_duration fertilizerEpoch = calendar::season_length() * 0.2;
-
     map &here = get_map();
     // Can't use item_stack::only_item() since there might be fertilizer
     map_stack items = here.i_at( tile );
@@ -2415,8 +2411,11 @@ void iexamine::fertilize_plant( player &p, const tripoint &tile, const itype_id 
         return;
     }
 
-    // TODO: item should probably clamp the value on its own
-    seed->set_birthday( seed->birthday() - fertilizerEpoch );
+    // Reduce the amount of time it takes until the next stage of growth
+    // by 60% of the seed's stage duration, or 20% of its overall growth time
+    const time_duration fertilized_boost = seed->get_plant_epoch() * 0.6;
+
+    seed->set_birthday( seed->birthday() - fertilized_boost );
     // The plant furniture has the NOITEM token which prevents adding items on that square,
     // spawned items are moved to an adjacent field instead, but the fertilizer token
     // must be on the square of the plant, therefore this hack:
@@ -2448,7 +2447,7 @@ itype_id iexamine::choose_fertilizer( player &p, const std::string &pname, bool 
         }
     }
 
-    if( ask_player && !query_yn( _( "Fertilize the %s" ), pname ) ) {
+    if( ask_player && !query_yn( _( "Fertilize the %s?" ), pname ) ) {
         return itype_id();
     }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9613,9 +9613,9 @@ time_duration item::get_plant_epoch() const
     if( !type->seed ) {
         return 0_turns;
     }
-    const int scaling = get_option<int>("GROWTH_SCALING");
+    const int scaling = get_option<int>( "GROWTH_SCALING" );
     // incorporate growth time scaling option
-    if ( scaling == 0 ) {
+    if( scaling == 0 ) {
         // If scaling factor is not set, scale growth time based on
         // current season length relative to the default of 14 days
         return type->seed->grow * calendar::season_ratio() / 3;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9613,13 +9613,18 @@ time_duration item::get_plant_epoch() const
     if( !type->seed ) {
         return 0_turns;
     }
-    // Growing times have been based around real world season length rather than
-    // the default in-game season length to give
-    // more accuracy for longer season lengths
+    const int scaling = get_option<int>("GROWTH_SCALING");
+    // incorporate growth time scaling option
+    if ( scaling == 0 ) {
+        // If scaling factor is not set, scale growth time based on
+        // current season length relative to the default of 14 days
+        return type->seed->grow * calendar::season_ratio() / 3;
+    }
+    // Otherwise apply the explicitly set scaling value
     // Also note that seed->grow is the time it takes from seeding to harvest, this is
     // divided by 3 to get the time it takes from one plant state to the next.
     // TODO: move this into the islot_seed
-    return type->seed->grow * calendar::season_ratio() / 3;
+    return type->seed->grow * scaling / 300.0;
 }
 
 std::string item::get_plant_name() const

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2319,6 +2319,11 @@ void options_manager::add_options_world_default()
          0, 1000, 100
        );
 
+    add("GROWTH_SCALING", world_default, translate_marker("Growth scaling"),
+        translate_marker("Sets the time of crop growth in percents.  '50' is two times faster than default, '200' is two times longer.  '0' automatically scales growth time to match the world's season length."),
+        0, 1000, 0
+       );
+
     add( "ETERNAL_SEASON", world_default, translate_marker( "Eternal season" ),
          translate_marker( "Keep the initial season for ever." ),
          false

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2319,9 +2319,9 @@ void options_manager::add_options_world_default()
          0, 1000, 100
        );
 
-    add("GROWTH_SCALING", world_default, translate_marker("Growth scaling"),
-        translate_marker("Sets the time of crop growth in percents.  '50' is two times faster than default, '200' is two times longer.  '0' automatically scales growth time to match the world's season length."),
-        0, 1000, 0
+    add( "GROWTH_SCALING", world_default, translate_marker( "Growth scaling" ),
+         translate_marker( "Sets the time of crop growth in percents.  '50' is two times faster than default, '200' is two times longer.  '0' automatically scales growth time to match the world's season length." ),
+         0, 1000, 0
        );
 
     add( "ETERNAL_SEASON", world_default, translate_marker( "Eternal season" ),


### PR DESCRIPTION
## Summary

SUMMARY: Balance "Add growth scaling world option to control speed of crop growth instead of directly binding it to season length"

## Purpose of change

Season length in and of itself doesn't affect the game's balance all that much, or at least it shouldn't. A player, especially one switching over from DDA, may choose to set it higher simply due to the obvious appeal of realistic year length, but may not necessarily like that with it comes a heavy impact on the viability of early-game farming.

## Describe the solution

Mirror the existing world option 'Construction scaling' and introduce 'Growth scaling', a player-editable percentage value to apply to seed growth times, while keeping the existing season length scaling in place if set to 0 (this is the default).

Additionally, applying fertilizer to a plot used to advance a seed's growth by 20% of season length. This doesn't make much sense without the scaling, so I changed this to 60% of the seed's stage duration, or 20% of its overall growth time. A lot of seeds have base growth time of 14 days, so the result will be exactly the same for them, but may be slightly different for seeds with longer or shorter maturation periods. This may count as a minor buff to fertilizer when used on certain plants, which is hardly an issue as use of fertilizer seems to not be currenty considered worthwhile by the players.

## Describe alternatives you've considered

Since almost nothing changes by default and the feature is optional, the only alternative is changing nothing at all I guess?
Well, one alternative would be to reuse the existing Construction scaling and rename it to something generic, but I can't see any benefit to that. Better keep balancing options granular.

## Testing

Tested by loading a game with existing recently-planted crops at different scaling values. Changes to maturation stage of plants are immediately obvious.
Tested the fertilizer change by applying fertilizer to select plots and advancing time, while keeping other plots of the same crop as control.
