### PR TITLE
fix: alternative ear mutation not being overriden

### DIFF
--- a/data/json/external_tileset/alternative_mutation.json
+++ b/data/json/external_tileset/alternative_mutation.json
@@ -9,11 +9,16 @@
         "sprite_height": 32,
         "sprite_offset_y": -16,
         "tiles": [
-          { "id": "overlay_mutation_FELINE_EARS", "fg": 0, "rotates": false },
-          { "id": "overlay_mutation_LUPINE_EARS", "fg": 1, "rotates": false },
-          { "id": "overlay_mutation_MOUSE_EARS", "fg": 2, "rotates": false },
-          { "id": "overlay_mutation_CANINE_EARS", "fg": 3, "rotates": false },
-          { "id": "overlay_mutation_URSINE_EARS", "fg": 4, "rotates": false }
+          { "id": "overlay_female_mutation_FELINE_EARS", "fg": 0, "rotates": false },
+          { "id": "overlay_male_mutation_FELINE_EARS", "fg": 0, "rotates": false },
+          { "id": "overlay_female_mutation_LUPINE_EARS", "fg": 1, "rotates": false },
+          { "id": "overlay_male_mutation_LUPINE_EARS", "fg": 1, "rotates": false },
+          { "id": "overlay_female_mutation_MOUSE_EARS", "fg": 2, "rotates": false },
+          { "id": "overlay_male_mutation_MOUSE_EARS", "fg": 2, "rotates": false },
+          { "id": "overlay_female_mutation_CANINE_EARS", "fg": 3, "rotates": false },
+          { "id": "overlay_male_mutation_CANINE_EARS", "fg": 3, "rotates": false },
+          { "id": "overlay_female_mutation_URSINE_EARS", "fg": 4, "rotates": false },
+          { "id": "overlay_male_mutation_URSINE_EARS", "fg": 4, "rotates": false }
         ]
       },
       {
@@ -22,8 +27,10 @@
         "sprite_height": 32,
         "sprite_offset_y": 16,
         "tiles": [
-          { "id": "overlay_mutation_TAIL_FLUFFY", "fg": 9, "rotates": false },
-          { "id": "overlay_mutation_TAIL_STUB", "fg": 12, "rotates": false }
+          { "id": "overlay_female_mutation_TAIL_FLUFFY", "fg": 9, "rotates": false },
+          { "id": "overlay_male_mutation__TAIL_FLUFFY", "fg": 9, "rotates": false },
+          { "id": "overlay_female_mutation_TAIL_STUB", "fg": 12, "rotates": false },
+          { "id": "overlay_male_mutation__TAIL_STUB", "fg": 12, "rotates": false }
         ]
       }
     ]


### PR DESCRIPTION
## Summary

SUMMARY: Bugfixes "alternative ear mutation not being overriden"

## Purpose of change

it was reported that feline ears weren't being overriden after #3340.

## Describe the solution

UDP tileset, for some reason, generates both-gendered overlay. it has higher precedence than genderless varaint, so the overriding wasn't working properly. did the same to alternative overlays.

## Describe alternatives you've considered

RIIR compose.py into something sensible

## Testing

_it works on my machine_
