### PR TITLE
Make grid appliances refund solder on deconstruction

### DIFF
--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -899,10 +899,10 @@
     "deconstruct": {
       "items": [
         { "item": "solder_wire", "charges": 20 },
-        { "item": "sheet_metal_small", "count": [ 4, 6 ] },
+        { "item": "sheet_metal_small", "count": 6 },
         { "item": "plastic_chunk", "count": 2 },
         { "item": "pipe", "count": 4 },
-        { "item": "cable", "charges": [ 5, 10 ] },
+        { "item": "cable", "charges": 10 },
         { "item": "medium_storage_battery", "count": 1 }
       ]
     },
@@ -938,10 +938,10 @@
     "deconstruct": {
       "items": [
         { "item": "solder_wire", "charges": 20 },
-        { "item": "sheet_metal_small", "count": [ 4, 6 ] },
+        { "item": "sheet_metal_small", "count": 6 },
         { "item": "plastic_chunk", "count": 2 },
         { "item": "pipe", "count": 4 },
-        { "item": "cable", "charges": [ 5, 10 ] },
+        { "item": "cable", "charges": 10 },
         { "item": "storage_battery", "count": 1 }
       ]
     },
@@ -977,10 +977,10 @@
     "deconstruct": {
       "items": [
         { "item": "solder_wire", "charges": 20 },
-        { "item": "sheet_metal_small", "count": [ 4, 6 ] },
+        { "item": "sheet_metal_small", "count": 6 },
         { "item": "plastic_chunk", "count": 2 },
         { "item": "pipe", "count": 4 },
-        { "item": "cable", "charges": [ 5, 10 ] },
+        { "item": "cable", "charges": 10 },
         { "item": "large_storage_battery", "count": 1 }
       ]
     },
@@ -1015,8 +1015,8 @@
     "deconstruct": {
       "items": [
         { "item": "solder_wire", "charges": 10 },
-        { "item": "sheet_metal_small", "count": [ 2, 4 ] },
-        { "item": "cable", "charges": [ 2, 5 ] },
+        { "item": "sheet_metal_small", "count": 4 },
+        { "item": "cable", "charges": 5 },
         { "item": "small_storage_battery", "count": 1 }
       ]
     },
@@ -1045,8 +1045,8 @@
     "deconstruct": {
       "items": [
         { "item": "solder_wire", "charges": 10 },
-        { "item": "sheet_metal_small", "count": [ 2, 4 ] },
-        { "item": "cable", "charges": [ 2, 5 ] },
+        { "item": "sheet_metal_small", "count": 4 },
+        { "item": "cable", "charges": 5 },
         { "item": "battery_car", "count": 1 }
       ]
     }
@@ -1063,8 +1063,8 @@
     "deconstruct": {
       "items": [
         { "item": "solder_wire", "charges": 10 },
-        { "item": "sheet_metal_small", "count": [ 2, 4 ] },
-        { "item": "cable", "charges": [ 2, 5 ] },
+        { "item": "sheet_metal_small", "count": 4 },
+        { "item": "cable", "charges": 5 },
         { "item": "battery_motorbike", "count": 1 }
       ]
     }
@@ -1081,8 +1081,8 @@
     "deconstruct": {
       "items": [
         { "item": "solder_wire", "charges": 10 },
-        { "item": "sheet_metal_small", "count": [ 2, 4 ] },
-        { "item": "cable", "charges": [ 2, 5 ] },
+        { "item": "sheet_metal_small", "count": 4 },
+        { "item": "cable", "charges": 5 },
         { "item": "battery_motorbike_small", "count": 1 }
       ]
     }

--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -819,9 +819,9 @@
     "flags": [ "TRANSPARENT" ],
     "deconstruct": {
       "items": [
-        { "item": "scrap", "count": 6 },
+        { "item": "solder_wire", "charges": 20 },
         { "item": "plastic_chunk", "count": 2 },
-        { "item": "steel_chunk", "count": 3 },
+        { "item": "steel_chunk", "count": 5 },
         { "item": "pipe", "count": 4 },
         { "item": "solar_panel", "count": 1 }
       ]
@@ -832,6 +832,7 @@
       "sound": "whack!",
       "sound_fail": "clang!",
       "items": [
+        { "item": "solder_wire", "charges": [ 10, 20 ] },
         { "item": "solar_cell", "count": [ 1, 5 ] },
         { "item": "scrap", "count": [ 3, 6 ] },
         { "item": "amplifier", "prob": 50 },
@@ -857,9 +858,9 @@
     "flags": [ "TRANSPARENT" ],
     "deconstruct": {
       "items": [
-        { "item": "scrap", "count": 6 },
+        { "item": "solder_wire", "charges": 20 },
         { "item": "plastic_chunk", "count": 2 },
-        { "item": "steel_chunk", "count": 3 },
+        { "item": "steel_chunk", "count": 5 },
         { "item": "pipe", "count": 4 },
         { "item": "solar_panel_v2", "count": 1 }
       ]
@@ -870,6 +871,7 @@
       "sound": "whack!",
       "sound_fail": "clang!",
       "items": [
+        { "item": "solder_wire", "charges": [ 10, 20 ] },
         { "item": "solar_cell", "count": [ 1, 8 ] },
         { "item": "scrap", "count": [ 3, 6 ] },
         { "item": "amplifier", "prob": 50 },
@@ -896,6 +898,7 @@
     "examine_action": "check_power",
     "deconstruct": {
       "items": [
+        { "item": "solder_wire", "charges": 20 },
         { "item": "sheet_metal_small", "count": [ 4, 6 ] },
         { "item": "plastic_chunk", "count": 2 },
         { "item": "pipe", "count": 4 },
@@ -909,6 +912,7 @@
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "items": [
+        { "item": "solder_wire", "charges": [ 10, 20 ] },
         { "item": "scrap", "count": [ 4, 8 ] },
         { "item": "plastic_chunk", "count": [ 1, 2 ] },
         { "item": "sheet_metal_small", "count": [ 1, 4 ] },
@@ -933,6 +937,7 @@
     "examine_action": "check_power",
     "deconstruct": {
       "items": [
+        { "item": "solder_wire", "charges": 20 },
         { "item": "sheet_metal_small", "count": [ 4, 6 ] },
         { "item": "plastic_chunk", "count": 2 },
         { "item": "pipe", "count": 4 },
@@ -946,6 +951,7 @@
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "items": [
+        { "item": "solder_wire", "charges": [ 10, 20 ] },
         { "item": "scrap", "count": [ 4, 8 ] },
         { "item": "plastic_chunk", "count": [ 1, 2 ] },
         { "item": "sheet_metal_small", "count": [ 1, 4 ] },
@@ -970,6 +976,7 @@
     "examine_action": "check_power",
     "deconstruct": {
       "items": [
+        { "item": "solder_wire", "charges": 20 },
         { "item": "sheet_metal_small", "count": [ 4, 6 ] },
         { "item": "plastic_chunk", "count": 2 },
         { "item": "pipe", "count": 4 },
@@ -983,6 +990,7 @@
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "items": [
+        { "item": "solder_wire", "charges": [ 10, 20 ] },
         { "item": "scrap", "count": [ 4, 8 ] },
         { "item": "plastic_chunk", "count": [ 1, 2 ] },
         { "item": "sheet_metal_small", "count": [ 1, 4 ] },
@@ -1006,6 +1014,7 @@
     "active": [ "battery", { "max_stored": 500 } ],
     "deconstruct": {
       "items": [
+        { "item": "solder_wire", "charges": 10 },
         { "item": "sheet_metal_small", "count": [ 2, 4 ] },
         { "item": "cable", "charges": [ 2, 5 ] },
         { "item": "small_storage_battery", "count": 1 }
@@ -1017,6 +1026,7 @@
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "items": [
+        { "item": "solder_wire", "charges": [ 5, 10 ] },
         { "item": "scrap", "count": [ 2, 4 ] },
         { "item": "sheet_metal_small", "count": [ 0, 2 ] },
         { "item": "cable", "charges": [ 1, 3 ] }
@@ -1034,6 +1044,7 @@
     "active": [ "battery", { "max_stored": 2500 } ],
     "deconstruct": {
       "items": [
+        { "item": "solder_wire", "charges": 10 },
         { "item": "sheet_metal_small", "count": [ 2, 4 ] },
         { "item": "cable", "charges": [ 2, 5 ] },
         { "item": "battery_car", "count": 1 }
@@ -1051,6 +1062,7 @@
     "active": [ "battery", { "max_stored": 500 } ],
     "deconstruct": {
       "items": [
+        { "item": "solder_wire", "charges": 10 },
         { "item": "sheet_metal_small", "count": [ 2, 4 ] },
         { "item": "cable", "charges": [ 2, 5 ] },
         { "item": "battery_motorbike", "count": 1 }
@@ -1068,6 +1080,7 @@
     "active": [ "battery", { "max_stored": 150 } ],
     "deconstruct": {
       "items": [
+        { "item": "solder_wire", "charges": 10 },
         { "item": "sheet_metal_small", "count": [ 2, 4 ] },
         { "item": "cable", "charges": [ 2, 5 ] },
         { "item": "battery_motorbike_small", "count": 1 }
@@ -1088,7 +1101,8 @@
     "active": [ "charger", { "power": 15 } ],
     "deconstruct": {
       "items": [
-        { "item": "cable", "charges": [ 2, 5 ] },
+        { "item": "solder_wire", "charges": 20 },
+        { "item": "cable", "charges": 5 },
         { "item": "battery_charger", "count": 1 },
         { "item": "power_supply", "count": 1 }
       ]
@@ -1099,6 +1113,7 @@
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "items": [
+        { "item": "solder_wire", "charges": [ 10, 20 ] },
         { "item": "scrap", "count": [ 4, 8 ] },
         { "item": "plastic_chunk", "count": [ 1, 2 ] },
         { "item": "sheet_metal_small", "count": [ 1, 4 ] },
@@ -1120,7 +1135,8 @@
     "active": [ "charger", { "power": 600 } ],
     "deconstruct": {
       "items": [
-        { "item": "cable", "charges": [ 2, 5 ] },
+        { "item": "solder_wire", "charges": 20 },
+        { "item": "cable", "charges": 5 },
         { "item": "recharge_station", "count": 1 },
         { "item": "power_supply", "count": 1 }
       ]
@@ -1140,13 +1156,19 @@
     "max_volume": "5000 ml",
     "active": [ "vehicle_connector", {  } ],
     "flags": [ "TRANSPARENT" ],
-    "deconstruct": { "items": [ { "item": "power_supply" } ] },
+    "deconstruct": { "items": [
+      { "item": "solder_wire", "charges": 20 },
+      { "item": "power_supply" } ]
+    },
     "bash": {
       "str_min": 4,
       "str_max": 30,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [ { "item": "power_supply", "prob": 50 } ]
+      "items": [
+        { "item": "solder_wire", "charges": [ 10, 20 ] },
+        { "item": "power_supply", "prob": 50 }
+      ]
     }
   },
   {
@@ -1164,7 +1186,12 @@
     "examine_action": "use_furn_fake_item",
     "flags": [ "TRANSPARENT", "MOUNTABLE", "EASY_DECONSTRUCT" ],
     "deconstruct": {
-      "items": [ { "item": "welder", "count": 1 }, { "item": "cable", "charges": 5 }, { "item": "power_supply", "count": 1 } ]
+      "items": [
+        { "item": "solder_wire", "charges": 20 },
+        { "item": "welder", "count": 1 },
+        { "item": "cable", "charges": 5 },
+        { "item": "power_supply", "count": 1 }
+      ]
     },
     "bash": {
       "str_min": 4,
@@ -1172,6 +1199,7 @@
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "items": [
+        { "item": "solder_wire", "charges": [ 10, 20 ] },
         { "item": "power_supply", "count": [ 1, 4 ] },
         { "item": "scrap", "count": [ 0, 2 ] },
         { "item": "cable", "charges": [ 1, 4 ] },
@@ -1190,7 +1218,12 @@
     "description": "A vehicle welding rig connected to a electrical grid.  Has a soldering iron attached.",
     "extend": { "crafting_pseudo_item": [ "fake_gridsolderingiron" ] },
     "deconstruct": {
-      "items": [ { "item": "weldrig", "count": 1 }, { "item": "cable", "charges": 5 }, { "item": "power_supply", "count": 1 } ]
+      "items": [
+        { "item": "solder_wire", "charges": 20 },
+        { "item": "weldrig", "count": 1 },
+        { "item": "cable", "charges": 5 },
+        { "item": "power_supply", "count": 1 }
+      ]
     },
     "bash": {
       "str_min": 4,
@@ -1198,6 +1231,7 @@
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "items": [
+        { "item": "solder_wire", "charges": [ 10, 20 ] },
         { "item": "power_supply", "count": [ 1, 4 ] },
         { "item": "scrap", "count": [ 0, 2 ] },
         { "item": "cable", "charges": [ 1, 4 ] },
@@ -1221,7 +1255,12 @@
     "examine_action": "use_furn_fake_item",
     "flags": [ "TRANSPARENT", "MOUNTABLE", "EASY_DECONSTRUCT" ],
     "deconstruct": {
-      "items": [ { "item": "forge", "count": 1 }, { "item": "cable", "charges": 5 }, { "item": "power_supply", "count": 1 } ]
+      "items": [
+        { "item": "solder_wire", "charges": 20 },
+        { "item": "forge", "count": 1 },
+        { "item": "cable", "charges": 5 },
+        { "item": "power_supply", "count": 1 }
+      ]
     },
     "bash": {
       "str_min": 8,
@@ -1229,6 +1268,7 @@
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "items": [
+        { "item": "solder_wire", "charges": [ 10, 20 ] },
         { "item": "power_supply", "count": [ 1, 4 ] },
         { "item": "scrap", "count": [ 0, 2 ] },
         { "item": "cable", "charges": [ 1, 4 ] },
@@ -1246,7 +1286,12 @@
     "description": "A vehicle forge rig connected to a electrical grid.",
     "color": "red",
     "deconstruct": {
-      "items": [ { "item": "forgerig", "count": 1 }, { "item": "cable", "charges": 5 }, { "item": "power_supply", "count": 1 } ]
+      "items": [
+        { "item": "solder_wire", "charges": 20 },
+        { "item": "forgerig", "count": 1 },
+        { "item": "cable", "charges": 5 },
+        { "item": "power_supply", "count": 1 }
+      ]
     },
     "bash": {
       "str_min": 8,
@@ -1254,6 +1299,7 @@
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "items": [
+        { "item": "solder_wire", "charges": [ 10, 20 ] },
         { "item": "power_supply", "count": [ 1, 4 ] },
         { "item": "scrap", "count": [ 0, 2 ] },
         { "item": "cable", "charges": [ 1, 4 ] },
@@ -1275,7 +1321,12 @@
     "crafting_pseudo_item": "fake_gridkiln",
     "flags": [ "TRANSPARENT", "MOUNTABLE", "EASY_DECONSTRUCT" ],
     "deconstruct": {
-      "items": [ { "item": "kiln", "count": 1 }, { "item": "cable", "charges": 5 }, { "item": "power_supply", "count": 1 } ]
+      "items": [
+        { "item": "solder_wire", "charges": 20 },
+        { "item": "kiln", "count": 1 },
+        { "item": "cable", "charges": 5 },
+        { "item": "power_supply", "count": 1 }
+      ]
     },
     "bash": {
       "str_min": 8,
@@ -1283,6 +1334,7 @@
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "items": [
+        { "item": "solder_wire", "charges": [ 10, 20 ] },
         { "item": "power_supply", "count": [ 1, 4 ] },
         { "item": "scrap", "count": [ 0, 2 ] },
         { "item": "cable", "charges": [ 1, 4 ] },
@@ -1304,7 +1356,12 @@
     "crafting_pseudo_item": "fake_griddehydrator",
     "flags": [ "TRANSPARENT", "MOUNTABLE", "EASY_DECONSTRUCT" ],
     "deconstruct": {
-      "items": [ { "item": "dehydrator", "count": 1 }, { "item": "cable", "charges": 5 }, { "item": "power_supply", "count": 1 } ]
+      "items": [
+        { "item": "solder_wire", "charges": 20 },
+        { "item": "dehydrator", "count": 1 },
+        { "item": "cable", "charges": 5 },
+        { "item": "power_supply", "count": 1 }
+      ]
     },
     "bash": {
       "str_min": 8,
@@ -1312,6 +1369,7 @@
       "sound": "crunch!",
       "sound_fail": "whump.",
       "items": [
+        { "item": "solder_wire", "charges": [ 10, 20 ] },
         { "item": "power_supply", "count": [ 1, 4 ] },
         { "item": "scrap", "count": [ 0, 4 ] },
         { "item": "plastic_chunk", "count": [ 0, 9 ] },
@@ -1334,7 +1392,12 @@
     "crafting_pseudo_item": "fake_gridfood_processor",
     "flags": [ "TRANSPARENT", "MOUNTABLE", "EASY_DECONSTRUCT" ],
     "deconstruct": {
-      "items": [ { "item": "food_processor", "count": 1 }, { "item": "cable", "charges": 5 }, { "item": "power_supply", "count": 1 } ]
+      "items": [
+        { "item": "solder_wire", "charges": 20 },
+        { "item": "food_processor", "count": 1 },
+        { "item": "cable", "charges": 5 },
+        { "item": "power_supply", "count": 1 }
+      ]
     },
     "bash": {
       "str_min": 8,
@@ -1342,6 +1405,7 @@
       "sound": "crunch!",
       "sound_fail": "whump.",
       "items": [
+        { "item": "solder_wire", "charges": [ 10, 20 ] },
         { "item": "power_supply", "count": [ 1, 4 ] },
         { "item": "scrap", "count": [ 0, 4 ] },
         { "item": "plastic_chunk", "count": [ 0, 9 ] },
@@ -1364,7 +1428,12 @@
     "crafting_pseudo_item": "fake_gridvac_sealer",
     "flags": [ "TRANSPARENT", "MOUNTABLE", "EASY_DECONSTRUCT" ],
     "deconstruct": {
-      "items": [ { "item": "vac_sealer", "count": 1 }, { "item": "cable", "charges": 5 }, { "item": "power_supply", "count": 1 } ]
+      "items": [
+        { "item": "solder_wire", "charges": 20 },
+        { "item": "vac_sealer", "count": 1 },
+        { "item": "cable", "charges": 5 },
+        { "item": "power_supply", "count": 1 }
+      ]
     },
     "bash": {
       "str_min": 8,
@@ -1372,6 +1441,7 @@
       "sound": "crunch!",
       "sound_fail": "whump.",
       "items": [
+        { "item": "solder_wire", "charges": [ 10, 20 ] },
         { "item": "power_supply", "count": [ 1, 4 ] },
         { "item": "scrap", "count": [ 0, 4 ] },
         { "item": "plastic_chunk", "count": [ 0, 9 ] },
@@ -1393,13 +1463,18 @@
     "required_str": -1,
     "crafting_pseudo_item": [ "fake_gridfood_processor", "fake_griddehydrator", "fake_gridvac_sealer", "fake_gridwater_purifier", "press" ],
     "flags": [ "BLOCKSDOOR", "MINEABLE", "EASY_DECONSTRUCT" ],
-    "deconstruct": { "items": [ { "item": "craftrig", "count": 1 }, { "item": "cable", "charges": 5 } ] },
+    "deconstruct": { "items": [
+      { "item": "solder_wire", "charges": 20 },
+      { "item": "craftrig", "count": 1 },
+      { "item": "cable", "charges": 5 }
+    ] },
     "bash": {
       "str_min": 18,
       "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "items": [
+        { "item": "solder_wire", "charges": [ 10, 20 ] },
         { "count": [ 4, 7 ], "item": "steel_lump" },
         { "count": [ 4, 7 ], "item": "steel_chunk" },
         { "count": [ 4, 7 ], "item": "scrap" },
@@ -1426,6 +1501,7 @@
     "flags": [ "TRANSPARENT", "MOUNTABLE", "EASY_DECONSTRUCT" ],
     "deconstruct": {
       "items": [
+        { "item": "solder_wire", "charges": 20 },
         { "item": "electrolysis_kit", "count": 1 },
         { "item": "cable", "charges": 5 },
         { "item": "power_supply", "count": 1 }
@@ -1436,7 +1512,11 @@
       "str_max": 30,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [ { "item": "scrap", "count": [ 0, 2 ] }, { "item": "cable", "charges": [ 1, 4 ] } ]
+      "items": [
+        { "item": "solder_wire", "charges": [ 10, 20 ] },
+        { "item": "scrap", "count": [ 0, 2 ] },
+        { "item": "cable", "charges": [ 1, 4 ] }
+      ]
     }
   },
   {
@@ -1453,7 +1533,12 @@
     "crafting_pseudo_item": [ "fake_oven", "fake_chemistry_set" ],
     "flags": [ "TRANSPARENT", "MOUNTABLE", "EASY_DECONSTRUCT" ],
     "deconstruct": {
-      "items": [ { "item": "chemistry_set", "count": 1 }, { "item": "cable", "charges": 5 }, { "item": "power_supply", "count": 1 } ]
+      "items": [
+        { "item": "solder_wire", "charges": 20 },
+        { "item": "chemistry_set", "count": 1 },
+        { "item": "cable", "charges": 5 },
+        { "item": "power_supply", "count": 1 }
+      ]
     },
     "bash": {
       "str_min": 8,
@@ -1461,6 +1546,7 @@
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "items": [
+        { "item": "solder_wire", "charges": [ 10, 20 ] },
         { "item": "scrap", "count": [ 0, 2 ] },
         { "item": "glass_shard", "count": [ 0, 2 ] },
         { "item": "cable", "charges": [ 1, 4 ] }
@@ -1478,7 +1564,12 @@
     "color": "blue",
     "crafting_pseudo_item": [ "fake_oven", "fake_chemistry_set", "fake_gridelectrolysis_kit" ],
     "deconstruct": {
-      "items": [ { "item": "chemlab", "count": 1 }, { "item": "cable", "charges": 5 }, { "item": "power_supply", "count": 1 } ]
+      "items": [
+        { "item": "solder_wire", "charges": 20 },
+        { "item": "chemlab", "count": 1 },
+        { "item": "cable", "charges": 5 },
+        { "item": "power_supply", "count": 1 }
+      ]
     },
     "bash": {
       "str_min": 8,
@@ -1486,6 +1577,7 @@
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "items": [
+        { "item": "solder_wire", "charges": [ 10, 20 ] },
         { "item": "scrap", "count": [ 0, 4 ] },
         { "item": "glass_shard", "count": [ 0, 2 ] },
         { "item": "cable", "charges": [ 2, 8 ] },
@@ -1508,14 +1600,23 @@
     "examine_action": "use_furn_fake_item",
     "flags": [ "TRANSPARENT", "MOUNTABLE", "EASY_DECONSTRUCT" ],
     "deconstruct": {
-      "items": [ { "item": "soldering_iron", "count": 1 }, { "item": "cable", "charges": 5 }, { "item": "power_supply", "count": 1 } ]
+      "items": [
+        { "item": "solder_wire", "charges": 20 },
+        { "item": "soldering_iron", "count": 1 },
+        { "item": "cable", "charges": 5 },
+        { "item": "power_supply", "count": 1 }
+      ]
     },
     "bash": {
       "str_min": 2,
       "str_max": 10,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [ { "item": "scrap", "count": [ 0, 2 ] }, { "item": "cable", "charges": [ 1, 4 ] } ]
+      "items": [
+        { "item": "solder_wire", "charges": [ 10, 20 ] },
+        { "item": "scrap", "count": [ 0, 2 ] },
+        { "item": "cable", "charges": [ 1, 4 ] }
+      ]
     }
   },
   {
@@ -1738,7 +1839,12 @@
     "flags": [ "CONTAINER", "PLACE_ITEM", "BLOCKSDOOR", "FLAT_SURF", "EASY_DECONSTRUCT" ],
     "examine_action": "autoclave_empty",
     "deconstruct": {
-      "items": [ { "item": "autoclave", "count": 1 }, { "item": "cable", "charges": 5 }, { "item": "power_supply", "count": 1 } ]
+      "items": [
+        { "item": "solder_wire", "charges": 20 },
+        { "item": "autoclave", "count": 1 },
+        { "item": "cable", "charges": 5 },
+        { "item": "power_supply", "count": 1 }
+      ]
     },
     "bash": {
       "str_min": 40,
@@ -1746,6 +1852,7 @@
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "items": [
+        { "item": "solder_wire", "charges": [ 10, 20 ] },
         { "item": "scrap", "count": [ 2, 7 ] },
         { "item": "steel_chunk", "count": [ 0, 3 ] },
         { "item": "sheet_metal_small", "count": [ 8, 12 ] },
@@ -1767,6 +1874,7 @@
     "flags": [ "TRANSPARENT", "EASY_DECONSTRUCT" ],
     "deconstruct": {
       "items": [
+        { "item": "solder_wire", "charges": 20 },
         { "item": "small_space_heater", "count": 1 },
         { "item": "cable", "charges": 5 },
         { "item": "power_supply", "count": 1 }
@@ -1778,6 +1886,7 @@
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "items": [
+        { "item": "solder_wire", "charges": [ 10, 20 ] },
         { "item": "power_supply", "count": [ 1, 4 ] },
         { "item": "scrap", "count": [ 0, 2 ] },
         { "item": "cable", "charges": [ 1, 4 ] },
@@ -1854,6 +1963,7 @@
     ],
     "deconstruct": {
       "items": [
+        { "item": "solder_wire", "charges": 20 },
         { "item": "large_space_heater", "count": 1 },
         { "item": "cable", "charges": 5 },
         { "item": "power_supply", "count": 1 }
@@ -1873,6 +1983,7 @@
     "message": "You turn the heater on.",
     "deconstruct": {
       "items": [
+        { "item": "solder_wire", "charges": 20 },
         { "item": "large_space_heater", "count": 1 },
         { "item": "cable", "charges": 5 },
         { "item": "power_supply", "count": 1 }
@@ -1904,6 +2015,7 @@
     "emissions": [ "emit_hot_air2_blast" ],
     "deconstruct": {
       "items": [
+        { "item": "solder_wire", "charges": 20 },
         { "item": "large_space_heater", "count": 1 },
         { "item": "cable", "charges": 5 },
         { "item": "power_supply", "count": 1 }


### PR DESCRIPTION
## Summary

SUMMARY: Balance "Make grid appliances refund solder on deconstruction"

## Purpose of change

Deconstructing grid furniture does not return the 20 solder spent on connecting it. Solder can be somewhat hard to procure early on, so simply rearranging items in player's base comes at an unreasonable cost that's both unrealistic and adds nothing gameplay-wise, especially considering that installing those same appliances into a vehicle is free, not counting tool charges.

In short, moving around things player already has should not have noticeable resource costs.

## Describe the solution

Adjust JSON entries for all grid furniture, adding 20 solder to deconstruct items, as well as range of 10-20 solder to bash items (10 and 5-10 respectively for the few articles that cost 10 to install). Additionally, adjust both battery chargers to always return 5 copper wire, and both types of solar panels to return 5 steel chunks, to follow the pattern of grid appliances always refunding full amount of resources required for their installation. 

UPD: also make fixed the material costs for storage battery grid housing (metal sheets and copper wires).

## Describe alternatives you've considered

Removing the solder cost altogether comes to mind, but that's a bit too easy, and likely more work than this.

## Testing

Deconstruct various existing and newly installed grid furniture items, making sure the resources refunded include solder, and amounts are no longer random where applicable.

## Additional context

Disassembling other electronic items in the game already yields solder, and craftable items refund 100% solder, so the change is consistent with that.
Recovering used solder is fairly realistic and something repairmen do when short. The only thing permanently expended is negligible amounts of rosin, which isn't at all a scarce resource in the game and thus can be ignored.
