### PR TITLE
fix: privacy fence refunding incorrect materials on deconstruct

### DIFF
--- a/data/json/furniture_and_terrain/terrain-fences-gates.json
+++ b/data/json/furniture_and_terrain/terrain-fences-gates.json
@@ -805,7 +805,7 @@
         { "item": "2x4", "count": 8 },
         { "item": "pointy_stick", "count": 2 },
         { "item": "nail", "charges": 20 },
-        { "item": "hinge", "count": [ 1, 2 ] }
+        { "item": "hinge", "count": 2 }
       ]
     },
     "bash": {
@@ -842,7 +842,7 @@
         { "item": "2x4", "count": 8 },
         { "item": "pointy_stick", "count": 2 },
         { "item": "nail", "charges": 20 },
-        { "item": "hinge", "count": [ 1, 2 ] }
+        { "item": "hinge", "count": 2 }
       ]
     }
   },

--- a/data/json/furniture_and_terrain/terrain-fences-gates.json
+++ b/data/json/furniture_and_terrain/terrain-fences-gates.json
@@ -778,7 +778,7 @@
     "connects_to": "WOODFENCE",
     "deconstruct": {
       "ter_set": "t_fence_post",
-      "items": [ { "item": "2x4", "count": 10 }, { "item": "nail", "charges": 20 }, { "item": "hinge", "count": [ 1, 2 ] } ]
+      "items": [ { "item": "2x4", "count": 10 }, { "item": "nail", "charges": 20 } ]
     },
     "bash": {
       "str_min": 5,
@@ -786,7 +786,7 @@
       "sound": "whump!",
       "sound_fail": "whack!",
       "ter_set": "t_fence_post",
-      "items": [ { "item": "2x4", "count": [ 4, 10 ] }, { "item": "hinge", "count": [ 1, 2 ] } ]
+      "items": [ { "item": "2x4", "count": [ 4, 10 ] } ]
     }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-fences-gates.json
+++ b/data/json/furniture_and_terrain/terrain-fences-gates.json
@@ -776,10 +776,7 @@
     "examine_action": "chainfence",
     "flags": [ "NOITEM", "CLIMBABLE", "PERMEABLE", "AUTO_WALL_SYMBOL", "FLAMMABLE_ASH", "THIN_OBSTACLE", "BURROWABLE" ],
     "connects_to": "WOODFENCE",
-    "deconstruct": {
-      "ter_set": "t_fence_post",
-      "items": [ { "item": "2x4", "count": 10 }, { "item": "nail", "charges": 20 } ]
-    },
+    "deconstruct": { "ter_set": "t_fence_post", "items": [ { "item": "2x4", "count": 10 }, { "item": "nail", "charges": 20 } ] },
     "bash": {
       "str_min": 5,
       "str_max": 12,

--- a/data/json/furniture_and_terrain/terrain-fences-gates.json
+++ b/data/json/furniture_and_terrain/terrain-fences-gates.json
@@ -776,7 +776,7 @@
     "examine_action": "chainfence",
     "flags": [ "NOITEM", "CLIMBABLE", "PERMEABLE", "AUTO_WALL_SYMBOL", "FLAMMABLE_ASH", "THIN_OBSTACLE", "BURROWABLE" ],
     "connects_to": "WOODFENCE",
-    "deconstruct": { "ter_set": "t_fence_post", "items": [ { "item": "2x4", "count": 10 }, { "item": "nail", "charges": 20 } ] },
+    "deconstruct": { "ter_set": "t_fence_post", "items": [ { "item": "2x4", "count": 8 }, { "item": "nail", "charges": 20 } ] },
     "bash": {
       "str_min": 5,
       "str_max": 12,


### PR DESCRIPTION
## Summary

SUMMARY: Bugfixes "Fix privacy fences refunding incorrect materials on deconstruct"

## Purpose of change

Regular segments of wooden privacy fence return 1-2 door hinges, which is not used for its construction and should be reserved for gate tiles only. They also return 2 more planks than it takes to build them.
Finally, the gate section refunds 1-2 out of 2 hinges. The random element here makes little sense, there's no reason not to return the full amount.

## Describe the solution

Fix the JSON values to not magically create or vanish any materials.

## Testing

Deconstruct private wooden gate and fence tiles. Make sure the materials returned match the building components.