### PR TITLE
Fix vehicles placement in small warehouse

### DIFF
--- a/data/json/mapgen/warehouse.json
+++ b/data/json/mapgen/warehouse.json
@@ -83,7 +83,7 @@
       ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 2 } ],
       "place_vehicles": [
-        { "vehicle": "flatbed_truck", "x": 11, "y": 8, "chance": 50, "rotation": 270 },
+        { "vehicle": "warehouse_truck", "x": 10, "y": 7, "chance": 50, "rotation": 270 },
         { "vehicle": "warehouse_vehicles", "x": 17, "y": 13, "chance": 50, "rotation": 270 }
       ]
     }

--- a/data/json/mapgen/warehouse.json
+++ b/data/json/mapgen/warehouse.json
@@ -83,9 +83,8 @@
       ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 2 } ],
       "place_vehicles": [
-        { "vehicle": "flatbed_truck", "x": 12, "y": 13, "chance": 50, "rotation": 270 },
-        { "vehicle": "warehouse_vehicles", "x": 17, "y": 13, "chance": 50, "rotation": 270 },
-        { "vehicle": "tatra_truck", "x": 8, "y": 7, "chance": 50, "rotation": 270 }
+        { "vehicle": "flatbed_truck", "x": 11, "y": 8, "chance": 50, "rotation": 270 },
+        { "vehicle": "warehouse_vehicles", "x": 17, "y": 13, "chance": 50, "rotation": 270 }
       ]
     }
   },

--- a/data/json/vehicle_groups.json
+++ b/data/json/vehicle_groups.json
@@ -346,6 +346,11 @@
     "vehicles": [ [ "engine_crane", 50 ], [ "handjack", 150 ], [ "wheelbarrow", 100 ], [ "forklift", 100 ] ]
   },
   {
+    "id": "warehouse_truck",
+    "type": "vehicle_group",
+    "vehicles": [ [ "flatbed_truck", 50 ], [ "tatra_truck", 50 ] ]
+  },
+  {
     "id": "school_vehicles",
     "type": "vehicle_group",
     "//": "School bus or fire truck found near school locations",


### PR DESCRIPTION
## Summary

SUMMARY: "Fix vehicles placement in "warehouse" aka small warehouse"

## Purpose of change
Correct misplaced vehicles and remove some.

## Describe the solution
Change the placement point of "flatbed_truck" because is wrecked on walls.
"flatbed_truck"/Flatbed Truck and "tatra_truck"/Heavy Duty Cargo Truck are wrecked if they appear at the same time, so delete "tatra_truck".

## Describe alternatives you've considered
Make a bigger small warehouse...
## Additional context
Before:
<img width="960" alt="Capture d’écran 2023-10-22 144616" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/05ef1fbc-3916-4f4b-8f5d-d31ae6a0d845">
After:
<img width="960" alt="Capture d’écran 2023-10-22 150537" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/3344d4fe-fa41-4b86-93ce-3b3ed3dec6f5">