### PR TITLE
Change the Ubuntu version used from 22.04 to 20.04 for Linux Builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
             ext: zip
             content: application/zip
           - name: Linux Tiles x64
-            os: ubuntu-22.04
+            os: ubuntu-20.04
             mxe: none
             android: none
             tiles: 1
@@ -113,7 +113,7 @@ jobs:
             ext: tar.gz
             content: application/gzip
           - name: linux-curses-x64
-            os: ubuntu-22.04
+            os: ubuntu-20.04
             mxe: none
             android: none
             tiles: 0


### PR DESCRIPTION
## Summary

SUMMARY: Build "Change the Ubuntu version used for Linux builds from 22.04 to 20.04"

## Purpose of change

- fix #2778

Port of https://github.com/CleverRaven/Cataclysm-DDA/pull/64264 because a Debian user brought up their inability to play recent releases due to this

## Describe the solution

Changes the workflow to use Ubuntu 20.04 for Linux builds rather than 22.04

## Describe alternatives you've considered

Let the users of these distros suffer!

## Testing

It worked for DDA, and I can't exactly test how github builds it without creating the PR in the first place. (So far as I know)

## Additional context

Hopefully the co-authorship and link to original PR is worthy enough credit to original PR author over on DDA's side.
