### PR TITLE
Revert previous PR to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
             ext: zip
             content: application/zip
           - name: Linux Tiles x64
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             mxe: none
             android: none
             tiles: 1
@@ -113,7 +113,7 @@ jobs:
             ext: tar.gz
             content: application/gzip
           - name: linux-curses-x64
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             mxe: none
             android: none
             tiles: 0


### PR DESCRIPTION
## Summary

SUMMARY: Build "Revert previous PR to release"

## Purpose of change

Turns out there's a good reason why it was on 22.04, and the compiler downgrade made build very unhappy. Thus, this PR to revert.

## Describe the solution

Changes the version of Ubuntu used for Linux builds back to 22.04

## Describe alternatives you've considered

N/A

## Testing

Reverting back to how it was before I borked it ought to un-bork it

## Additional context

Sorry Debian 11 users, at least I tried. Guess you'll have to use Debian 12.
