### PR TITLE
Set application name to Cataclysm BN on OSX

### DIFF
--- a/build-data/osx/Info.plist
+++ b/build-data/osx/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>Cataclysm</string>
+	<string>Cataclysm BN</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
## Summary
SUMMARY: Build "Set application name to Cataclysm BN on OSX"

## Purpose of change

As described in #3501, having the same application name as CDDA causes problems for some interactions on OSX when you have both installed.

Fixes #3501

## Describe the solution
It's just a static metadata change

## Describe alternatives you've considered
It's possible the bundle name should change, but I'm not sure, so I left it

## ⚠️ Release note
This will cause save data to become located at `~/Library/Application Support/Cataclysm BN` instead of `..../Cataclysm`. This means that after this is released, OSX users will need to `mv` their old save files or rename them in Finder.

As a side benefit, this means that CDDA save data and BN save data are now in separate locations