### PR TITLE
feat(content, port): bog iron

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -2988,6 +2988,18 @@
   },
   {
     "type": "construction",
+    "id": "constr_extract_bog_iron",
+    "group": "extract_bog_iron",
+    "category": "OTHER",
+    "required_skills": [ [ "fabrication", 0 ], [ "survival", 2 ] ],
+    "time": "45 m",
+    "qualities": [ [ { "id": "DIG", "level": 1 } ] ],
+    "byproducts": [ { "item": "iron_ore", "count": [ 1, 4 ] } ],
+    "pre_terrain": "t_bog_iron",
+    "post_special": "done_extract_maybe_revert_to_dirt"
+  },
+  {
+    "type": "construction",
     "id": "constr_remove_gravel",
     "group": "remove_gravel_and_replace_with_dirt",
     "category": "OTHER",

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -846,6 +846,11 @@
   },
   {
     "type": "construction_group",
+    "id": "extract_bog_iron",
+    "name": "Extract Bog Iron"
+  },
+  {
+    "type": "construction_group",
     "id": "extrude_resin_floor_and_roof",
     "name": "Extrude Resin Floor and Roof"
   },

--- a/data/json/furniture_and_terrain/terrain-floors-outdoors.json
+++ b/data/json/furniture_and_terrain/terrain-floors-outdoors.json
@@ -98,6 +98,25 @@
   },
   {
     "type": "terrain",
+    "id": "t_bog_iron",
+    "name": "bog iron",
+    "description": "A wet pit with exposed hints of iron-rich earth.",
+    "symbol": "*",
+    "looks_like": "t_claymound",
+    "color": "brown",
+    "move_cost": 5,
+    "flags": [ "TRANSPARENT", "BURROWABLE" ],
+    "bash": {
+      "str_min": 20,
+      "str_max": 40,
+      "sound": "splosh!",
+      "sound_fail": "splosh!",
+      "ter_set": "t_swater_sh",
+      "items": [ { "item": "iron_ore", "count": [ 6, 12 ] } ]
+    }
+  },
+  {
+    "type": "terrain",
     "id": "t_dirtmound",
     "name": "mound of dirt",
     "description": "An area of heaped dirt, not easily traversable.  If examined more closely, it's quite favorable for planting seeds and the like.",

--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -269,7 +269,11 @@
     "type": "item_group",
     "id": "cave_minerals",
     "subtype": "distribution",
-    "entries": [ { "item": "material_niter", "prob": 20 }, { "item": "material_limestone", "prob": 5 } ]
+    "entries": [
+      { "item": "material_niter", "prob": 20 },
+      { "item": "iron_ore", "prob": 10 },
+      { "item": "material_limestone", "prob": 5 }
+    ]
   },
   {
     "id": "prison_textile",
@@ -1183,6 +1187,7 @@
       [ "toolbox", 5 ],
       [ "coal_lump", 20 ],
       [ "material_shrd_limestone", 40 ],
+      [ "iron_ore", 10 ],
       [ "material_niter", 5 ],
       [ "chem_rdx", 5 ],
       [ "chem_hmtd", 10 ],
@@ -1198,6 +1203,7 @@
       { "item": "rock", "prob": 40, "count": [ 1, 10 ] },
       { "item": "material_shrd_limestone", "prob": 40, "count": [ 1, 10 ] },
       { "item": "material_limestone", "prob": 40, "count": [ 1, 10 ] },
+      { "item": "iron_ore", "prob": 20, "count": [ 1, 10 ] },
       { "item": "material_niter", "prob": 5, "count": [ 1, 10 ] },
       { "item": "material_sand", "prob": 50, "charges": 500, "container-item": "bag_canvas" },
       { "item": "material_soil", "prob": 50, "charges": 500, "container-item": "bag_canvas" },

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -765,6 +765,21 @@
     "ammo_type": "components"
   },
   {
+    "type": "GENERIC",
+    "id": "iron_ore",
+    "category": "spare_parts",
+    "price": 250,
+    "name": { "str": "chunk of iron ore", "str_pl": "chunks of iron ore" },
+    "symbol": ",",
+    "color": "brown",
+    "description": "A large chunk of iron ore, from one source or another.  With the right knowhow, it could be smelted into usable metal.",
+    "material": "stone",
+    "volume": "750 ml",
+    "//": "rounded down from 5.04 to 5.17 grams/cc depending on which ore it is",
+    "weight": "3750 g",
+    "bashing": 2
+  },
+  {
     "type": "AMMO",
     "id": "chem_aluminium_sulphate",
     "category": "chems",

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -1222,6 +1222,28 @@
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
   },
   {
+    "result": "steel_lump",
+    "id_suffix": "smelt",
+    "type": "recipe",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_MATERIALS",
+    "skill_used": "fabrication",
+    "difficulty": 4,
+    "skills_required": [ "survival", 4 ],
+    "time": "75 m",
+    "batch_time_factors": [ 90, 4 ],
+    "autolearn": [ [ "fabrication", 5 ], [ "survival", 5 ] ],
+    "book_learn": [ [ "textbook_armschina", 3 ], [ "survival_book", 3 ], [ "welding_book", 4 ] ],
+    "using": [ [ "forging_standard", 6 ] ],
+    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
+    "//": "Additional coal required for carburization, proportionate by weight.  Yield is roughly 25%.",
+    "components": [
+      [ [ "iron_ore", 1 ] ],
+      [ [ "coal_lump", 4 ], [ "charcoal", 16 ] ],
+      [ [ "material_limestone", 2 ], [ "material_quicklime", 2 ], [ "chem_carbide", 40 ] ]
+    ]
+  },
+  {
     "result": "tin",
     "type": "recipe",
     "byproducts": [ [ "steel_chunk" ] ],

--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -9,7 +9,7 @@
         "t_region_groundcover": { "t_grass": 12, "t_grass_dead": 2, "t_dirt": 1 },
         "t_region_groundcover_urban": { "t_grass": 20, "t_grass_dead": 3 },
         "t_region_groundcover_forest": { "t_grass_long": 5, "t_grass_tall": 1, "t_moss": 1, "t_grass_dead": 3 },
-        "t_region_groundcover_swamp": { "t_grass_long": 3, "t_grass_tall": 1, "t_moss": 2, "t_dirt": 2 },
+        "t_region_groundcover_swamp": { "t_grass_long": 30, "t_grass_tall": 10, "t_moss": 20, "t_dirt": 20, "t_bog_iron": 1 },
         "t_region_groundcover_barren": { "t_dirt": 30, "t_grass_dead": 2, "t_railroad_rubble": 1 },
         "t_region_grass": { "t_grass": 1 },
         "t_region_soil": { "t_dirt": 1 },


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

Please use a descriptive name for the PR title, so it's clear at a glance what the PR is about.
-->

## Summary

<!--
This section should consist of exactly one line, formatted like the example above.

'Category' must be one of the following:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/

If the PR is a port or adaptation of DDA content, please indicate it to be so.
-->

SUMMARY: Content "Port over iron ore and bog iron from Innawoods and Mining Mods"

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

The continued saga of doing literally anything but work on https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3419 due to how convoluted it's looking to be, this time I figured I'd tackle a misc feature on my todo list pertaining to innawoods metalworking.

Takes aspects from both DDA's Innawoods mod and DN's old Mining Mod.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Added generic iron ore items. Could be hematite, could be magnetite, could be a mess of iron-eating bacteria infested mud (currently the latter's the main source so), gods forbid it better not be limonite. Volume and weight leans more on the side of Mining Mod's interpretation of hematite, scaled down to an amount that fits for being processed into a single lump of steel.
2. Added terrain entry for bog iron, based off of the Innawoods mod version, plus relevant craterization change to its bash entry and a tweaked description. Also a looks-like entry that points to a fellow terrain, not furniture.
3. Added construction entry for digging up chunks of iron ore from bog iron. Scaled massively down from the Innawoods version because we aren't going to be hilariously wasteful about it, as seen below. Requires slightly more skill than the basic constructions, 2 survival in this case, on the basis that sifting through and picking out bits of exposed magnetite or finding that delicious iron-bacteria-infested mud the Primitive Technology channel makes use of so much takes a bit of knowledge.
4. Added recipe for smelting iron ore into lumps of steel. Two big things here are it's based more on Mining Mod's crucible steel recipe (because building a bloomery is unneeded fluff if you're just gonna have it be a generic tool and not process large amounts of iron in bulk like a charcoal kiln), and more importantly it has an actually sensible yield. 62 kilograms and 9 hours of work to make 3 kg of metal? Under 5% yield when real-life bloomeries have a 10-20% yield rate? Jesus. I went with what is just a hair over 25% yield, so way more than Innawood's yield, a bit more than a bloomery method (fair since we're using a more modern technique), but less than Mining Mod's yield rate (based off industrial yields far as I can tell). Includes added charcoal (for carburization, player may be using an electric forge) and limestone for flux as in the Mining Mod version, lil more generous rates since these are making single lumps at a time.
5. Added bog iron to regional map settings for swamp terrain, increasing the weights of other terrain accordingly to make it not be super-common, as Innawoods mod does.
6. Added iron ore to relevant itemgroups.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Just saying "fuck it" and porting over DN's Mining Mod wholesale. I do have plans to mainline some bits of it someday, but probably will entail more C++ stuff.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Checked affected files for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Relevant PRs/repos:
1. Innawoods mod PR, by @Light-Wave: https://github.com/CleverRaven/Cataclysm-DDA/pull/53960
2. Mining Mod repo, by @DangerNoodle: https://github.com/DangerNoodle/mining-mod

See also, a shirtless guy in Australia who makes (among other things) iron out of mud: https://www.youtube.com/watch?v=DyGLE0usN_I

Misc related plans:
1. I want to implement Mining Mod's mineral veins in some form or another someday. First obvious application would be to make it so mines can generate them. Likely by way of migrating the forbidden doggo finale that now gets placed in all the generic bonus dead-ends into a dedicated mine type like the other types, and using all those false start finales to place multiple exposed mineral veins instead.
2. Individual clusters of mineral in other areas could be implemented in one of several other methods. Either via Mining Mod's method of specials that have surface indicators above it, making it so that random empty rock can just spawn with veins in them via some method (map extra, completely buried overmap specials, regional groundcover fuckery, who knows), via inventing hills and mountains someday, dunno.
3. Adding a map extra in swamps that places an elevated amount of bog iron, like with clay deposits in forests?