### PR TITLE
feat(balance): fleshing out survivor zombie drops

### DIFF
--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -558,5 +558,10 @@
     "type": "item_group",
     "//": "GParts for military helicopter",
     "items": [ [ "medium_turbine_engine", 30 ], [ "large_turbine_engine", 20 ], [ "heavy_duty_military_rotor", 50 ] ]
+  },
+  {
+    "id": "survivor_currency",
+    "type": "item_group",
+    "entries": [ { "item": "FMCNote", "prob": 80, "count": [ 1, 8 ] }, { "item": "RobofacCoin", "prob": 20, "count": [ 1, 2 ] } ]
   }
 ]

--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -562,6 +562,7 @@
   {
     "id": "survivor_currency",
     "type": "item_group",
+    "subtype": "distribution",
     "entries": [ { "item": "FMCNote", "prob": 80, "count": [ 1, 8 ] }, { "item": "RobofacCoin", "prob": 20, "count": [ 1, 2 ] } ]
   }
 ]

--- a/data/json/monsterdrops/zombie_survivor.json
+++ b/data/json/monsterdrops/zombie_survivor.json
@@ -5,8 +5,64 @@
     "id": "mon_zombie_survivor_death_drops",
     "magazine": 100,
     "entries": [
-      { "group": "clothing_outdoor_set", "damage": [ 1, 4 ] },
-      { "group": "bags", "damage": [ 1, 4 ], "prob": 10 },
+      {
+        "distribution": [
+          { "group": "survivorzed_suits", "prob": 5, "damage": [ 1, 4 ] },
+          {
+            "collection": [
+              {
+                "distribution": [
+                  { "group": "clothing_outdoor_torso", "prob": 95, "damage": [ 1, 4 ] },
+                  { "group": "survivorzed_tops", "prob": 5, "damage": [ 1, 4 ] }
+                ]
+              },
+              {
+                "distribution": [
+                  { "group": "clothing_outdoor_pants", "prob": 95, "damage": [ 1, 4 ] },
+                  { "group": "survivorzed_bottoms", "prob": 5, "damage": [ 1, 4 ] }
+                ]
+              }
+            ],
+            "prob": 95
+          }
+        ]
+      },
+      {
+        "distribution": [
+          { "group": "clothing_outdoor_shoes", "prob": 9, "damage": [ 1, 4 ] },
+          { "group": "survivorzed_boots", "prob": 1, "damage": [ 1, 4 ] }
+        ]
+      },
+      {
+        "distribution": [ { "group": "underwear", "prob": 9, "damage": [ 1, 4 ] }, { "group": "loincloth", "prob": 1, "damage": [ 1, 4 ] } ]
+      },
+      {
+        "distribution": [
+          { "group": "gloves_unisex", "prob": 9, "damage": [ 1, 4 ] },
+          { "group": "survivorzed_gloves", "prob": 1, "damage": [ 1, 4 ] }
+        ],
+        "prob": 10
+      },
+      {
+        "distribution": [
+          { "group": "hats_unisex", "prob": 9, "damage": [ 1, 4 ] },
+          { "group": "survivorzed_head", "prob": 1, "damage": [ 1, 4 ] }
+        ],
+        "prob": 10
+      },
+      {
+        "distribution": [
+          {
+            "collection": [
+              { "group": "clothing_glasses", "prob": 5 },
+              { "group": "clothing_watch", "prob": 5 },
+              { "group": "bags", "damage": [ 1, 4 ], "prob": 10 }
+            ],
+            "prob": 90
+          },
+          { "group": "survivorzed_extra", "count": [ 1, 3 ], "prob": 10, "damage": [ 1, 4 ] }
+        ]
+      },
       {
         "distribution": [
           { "group": "book_survival", "prob": 15 },
@@ -23,7 +79,9 @@
           { "group": "stash_food", "prob": 40 }
         ]
       },
-      { "item": "cash_card", "charges-min": 25000, "charges-max": 100000 },
+      {
+        "distribution": [ { "item": "cash_card", "prob": 75, "charges": [ 25000, 100000 ] }, { "group": "survivor_currency", "prob": 25 } ]
+      },
       { "item": "survival_kit", "prob": 5, "damage": [ 1, 4 ] }
     ]
   },
@@ -107,16 +165,13 @@
         "distribution": [
           { "group": "survivorzed_suits", "prob": 25, "damage": [ 1, 4 ] },
           {
-            "collection": [
-              { "group": "survivorzed_tops", "prob": 25, "damage": [ 1, 4 ] },
-              { "group": "survivorzed_bottoms", "prob": 25, "damage": [ 1, 4 ] }
-            ],
+            "collection": [ { "group": "survivorzed_tops", "damage": [ 1, 4 ] }, { "group": "survivorzed_bottoms", "damage": [ 1, 4 ] } ],
             "prob": 75
           }
         ]
       },
       {
-        "distribution": [ { "group": "underwear", "prob": 10, "damage": [ 1, 4 ] }, { "group": "loincloth", "prob": 1, "damage": [ 1, 4 ] } ]
+        "distribution": [ { "group": "underwear", "prob": 9, "damage": [ 1, 4 ] }, { "group": "loincloth", "prob": 1, "damage": [ 1, 4 ] } ]
       },
       {
         "distribution": [
@@ -134,7 +189,12 @@
           { "group": "mil_surplus", "prob": 6 }
         ]
       },
-      { "item": "cash_card", "prob": 25, "charges-min": 50000, "charges-max": 150000 }
+      {
+        "distribution": [
+          { "item": "cash_card", "prob": 25, "charges": [ 50000, 150000 ] },
+          { "group": "survivor_currency", "prob": 75, "count": 2 }
+        ]
+      }
     ]
   }
 ]


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

Please use a descriptive name for the PR title, so it's clear at a glance what the PR is about.
-->

## Summary
SUMMARY: Balance "Basic survivor zombies have a random smattering of their associated itemgroups, sometimes yield post-apoc currency instead of cash cards"

<!--
This section should consist of exactly one line, formatted like the example above.

'Category' must be one of the following:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/

If the PR is a port or adaptation of DDA content, please indicate it to be so.
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

A minor item on my idea list that came up a while ago, also being something Tefnut mentioned wanting to look at. Their idea if I recall was more along the lines of making the itemgroup contents use a lot more stuff that the average player is likely to end up favoring, which we can always do on top of this later on. Right now my focus is actually using the related item groups more, the contents of which can be tweaked later on if desired.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

Updated the monster drops for basic survivor zombies. In summary:
1. Instead of calling for `clothing_outdoor_set`, it's split up into the relevant component itemgroups, with roughly a 10% chance of spawning its survivorzed counterpart itemgroup instead. In the case of the top and bottom it's instead a 5% chance to spawn `survivorzed_suits`, otherwise two 5% rolls for the relevant top and bottom survivorzed itemgroups.
2. Added an additional 10% chance each of spawning gloves and helmets. Each one has a 90% chance to be a fairly mundane itemgroup, and 10% chance to be the equivalent survivorzed itemgroup instead.
3. Grouped the chances of spawning a bag, glasses, and watch into a collection that gets picked 90% of the time, with the other 10% being 1-3 random calls of `survivorzed_extra`.
4. Removed the odd instance of elite survivor zeds only having a 25% chance to spawn their outfit when it picks top+bottom instead of combined suit.
5. Minor: Set chance of spawning a loincloth to 1 in 10 instead of 1 in 11.
6. Defined a new itemgroup, `survivor_currency` that randomly selects between currency items currently used by the factions with a major trading presence in the game. Elites will use two doses of this itemgroup over their cash card 75% of the time, while regular survivor zeds will use it instead of their basic cash card 25% of the time.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Adding chits and icons to the itemgroup at low weights, since those are used by factions that exist, unlike with whatever flatcoin is supposed to do. That said, in testing it seems that the Isherwoods don't seem to actually have any of their faction currency in their inventory, nor do they give any out in missions, mention them as being a thing, etc.
2. Parallel to the above, removing flatcoin from the evac merchant and giving them a small chance of spawning chits and icons.
3. Splitting up the big misc loot groups in both standards and elites to grant each a given chance of spawning a dedicated weapon separate from their unrelated misc loot.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Checked affected files for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Followup things for me to remember:
1. Add a dedicated monstergroup for gun stores and hunting supply stores to use, which should favor a higher than normal number of survivor zombies, and additionally be a source of feral survivors spawning in later on.
2. Give survivor feral monsterdrops a once-over to make their loot take more inspiration from survivor zeds as well.