### PR TITLE
feat(balance): craftable voltmeter

### DIFF
--- a/data/json/recipes/electronic/tools.json
+++ b/data/json/recipes/electronic/tools.json
@@ -823,12 +823,6 @@
     "autolearn": [ [ "electronics", 3 ] ],
     "book_learn": [ [ "manual_electronics", 1 ] ],
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SCREW", "level": 1 } ],
-    "components": [
-      [ [ "scrap", 2 ] ],
-      [ [ "amplifier", 1 ] ],
-      [ [ "cable", 6 ] ],
-      [ [ "plastic_chunk", 4 ] ],
-      [ [ "e_scrap", 3 ] ]
-    ]
+    "components": [ [ [ "scrap", 2 ] ], [ [ "amplifier", 1 ] ], [ [ "cable", 6 ] ], [ [ "plastic_chunk", 4 ] ], [ [ "e_scrap", 3 ] ] ]
   }
 ]

--- a/data/json/recipes/electronic/tools.json
+++ b/data/json/recipes/electronic/tools.json
@@ -809,5 +809,26 @@
     "book_learn": [ [ "mag_electronics", 3 ], [ "manual_electronics", 2 ] ],
     "using": [ [ "soldering_standard", 5 ] ],
     "components": [ [ [ "wire", 3 ] ], [ [ "plastic_chunk", 1 ] ], [ [ "e_scrap", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "voltmeter",
+    "category": "CC_ELECTRONIC",
+    "subcategory": "CSC_ELECTRONIC_TOOLS",
+    "skill_used": "electronics",
+    "difficulty": 2,
+    "time": "1 h",
+    "reversible": true,
+    "decomp_learn": 0,
+    "autolearn": [ [ "electronics", 3 ] ],
+    "book_learn": [ [ "manual_electronics", 1 ] ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SCREW", "level": 1 } ],
+    "components": [
+      [ [ "scrap", 2 ] ],
+      [ [ "amplifier", 1 ] ],
+      [ [ "cable", 6 ] ],
+      [ [ "plastic_chunk", 4 ] ],
+      [ [ "e_scrap", 3 ] ]
+    ]
   }
 ]

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -3510,14 +3510,6 @@
     "components": [ [ [ "voltmeter", 1 ] ], [ [ "glass_tube_small", 2 ] ] ]
   },
   {
-    "result": "voltmeter",
-    "type": "uncraft",
-    "skill_used": "electronics",
-    "time": "1 h",
-    "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "components": [ [ [ "scrap", 2 ] ], [ [ "amplifier", 1 ] ], [ [ "cable", 6 ] ], [ [ "plastic_chunk", 4 ] ], [ [ "e_scrap", 3 ] ] ]
-  },
-  {
     "result": "microscope",
     "type": "uncraft",
     "skill_used": "fabrication",


### PR DESCRIPTION
## Summary
SUMMARY: Balance "Added a voltmeter recipe"

## Purpose of change

Voltmeters are an important item for messing about with grids but weren't craftable. Now they're a little less random to obtain.

## Describe the solution

I used the uncraft to make a craft recipe, gave it the same time and components plus added cutting, I made it take electronics 2 as it's probably a bit harder than other recipes. I pruned the uncraft instead of obsoletion because this is reversible so it won't change.

## Describe alternatives you've considered

Wait, people use the electric grid?

## Testing

The pure json ran on my copy. Maybe the tests will break so I can be mad about it.

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/112293514/3d484646-3a9d-429a-aa5a-02595517f898)


## Additional context

a
