### PR TITLE
feat(balance): tweaks for crafting and disassembly consistency

### DIFF
--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -1344,7 +1344,7 @@
     "type": "ARMOR",
     "name": { "str": "pair of wool socks", "str_pl": "pairs of wool socks" },
     "description": "Warm socks made of wool.",
-    "weight": "44 g",
+    "weight": "74 g",
     "volume": "250 ml",
     "price": 1200,
     "price_postapoc": 150,

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -891,7 +891,7 @@
     "type": "ARMOR",
     "name": { "str": "pair of mittens", "str_pl": "pairs of mittens" },
     "description": "A pair of warm mittens.  They are extremely cumbersome.",
-    "weight": "364 g",
+    "weight": "135 g",
     "volume": "750 ml",
     "price": 2500,
     "price_postapoc": 50,

--- a/data/json/recipes/armor/feet.json
+++ b/data/json/recipes/armor/feet.json
@@ -465,7 +465,6 @@
     "skill_used": "tailor",
     "difficulty": 1,
     "time": "1 h",
-    "reversible": true,
     "autolearn": true,
     "using": [ [ "tailoring_wool_knitting", 80 ] ]
   },
@@ -500,7 +499,6 @@
     "skill_used": "tailor",
     "difficulty": 2,
     "time": "90 m",
-    "reversible": true,
     "autolearn": true,
     "using": [ [ "tailoring_wool_knitting", 120 ] ]
   },

--- a/data/json/recipes/armor/feet.json
+++ b/data/json/recipes/armor/feet.json
@@ -502,7 +502,7 @@
     "time": "90 m",
     "reversible": true,
     "autolearn": true,
-    "using": [ [ "tailoring_wool_knitting", 320 ] ]
+    "using": [ [ "tailoring_wool_knitting", 120 ] ]
   },
   {
     "result": "straw_sandals",

--- a/data/json/recipes/armor/hands.json
+++ b/data/json/recipes/armor/hands.json
@@ -135,7 +135,7 @@
     "time": "1 h 15 m",
     "reversible": true,
     "autolearn": true,
-    "using": [ [ "tailoring_wool_knitting", 240 ] ]
+    "using": [ [ "tailoring_wool_knitting", 140 ] ]
   },
   {
     "result": "gloves_fur_fingerless",
@@ -330,6 +330,7 @@
     "skill_used": "tailor",
     "difficulty": 1,
     "time": "1 h",
+    "reversible": true,
     "autolearn": [ [ "tailor", 5 ] ],
     "book_learn": [ [ "manual_tailor", 1 ], [ "mag_tailor", 0 ], [ "textbook_survival", 2 ], [ "pocket_survival", 2 ] ],
     "using": [ [ "tailoring_wool_knitting", 160 ] ]
@@ -535,9 +536,10 @@
     "skill_used": "tailor",
     "difficulty": 1,
     "time": "50 m",
+    "reversible": true,
     "autolearn": true,
     "qualities": [ { "id": "KNIT", "level": 1 } ],
-    "components": [ [ [ "yarn", 250 ] ] ]
+    "components": [ [ [ "yarn", 125 ] ] ]
   },
   {
     "result": "nomex_gloves",

--- a/data/json/recipes/armor/hands.json
+++ b/data/json/recipes/armor/hands.json
@@ -133,7 +133,6 @@
     "skill_used": "tailor",
     "difficulty": 2,
     "time": "1 h 15 m",
-    "reversible": true,
     "autolearn": true,
     "using": [ [ "tailoring_wool_knitting", 140 ] ]
   },

--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -374,10 +374,9 @@
     "skill_used": "tailor",
     "difficulty": 1,
     "time": "40 m",
-    "reversible": true,
     "autolearn": true,
     "qualities": [ { "id": "KNIT", "level": 1 } ],
-    "components": [ [ [ "yarn", 75 ] ] ]
+    "components": [ [ [ "yarn", 110 ] ] ]
   },
   {
     "result": "hat_noise_cancelling",
@@ -838,7 +837,7 @@
     "time": "40 m",
     "reversible": true,
     "autolearn": true,
-    "using": [ [ "tailoring_cotton_knitting", 600 ] ]
+    "using": [ [ "tailoring_cotton_knitting", 100 ] ]
   },
   {
     "result": "leather_cat_ears",
@@ -863,7 +862,7 @@
     "time": "1 h",
     "reversible": true,
     "autolearn": true,
-    "using": [ [ "tailoring_cotton_knitting", 900 ] ]
+    "using": [ [ "tailoring_cotton_knitting", 200 ] ]
   },
   {
     "result": "long_patchwork_scarf",
@@ -1324,9 +1323,10 @@
     "skill_used": "tailor",
     "difficulty": 1,
     "time": "1 h",
+    "reversible": true,
     "autolearn": true,
     "qualities": [ { "id": "KNIT", "level": 1 } ],
-    "components": [ [ [ "yarn", 150 ] ] ]
+    "components": [ [ [ "yarn", 75 ] ] ]
   },
   {
     "result": "scarf_fur",
@@ -1382,7 +1382,7 @@
     "time": "1 h 20 m",
     "autolearn": true,
     "qualities": [ { "id": "KNIT", "level": 1 } ],
-    "components": [ [ [ "yarn", 300 ] ] ]
+    "components": [ [ [ "yarn", 150 ] ] ]
   },
   {
     "result": "straw_fedora",

--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -835,7 +835,6 @@
     "skill_used": "tailor",
     "difficulty": 1,
     "time": "40 m",
-    "reversible": true,
     "autolearn": true,
     "using": [ [ "tailoring_cotton_knitting", 100 ] ]
   },
@@ -860,7 +859,6 @@
     "skill_used": "tailor",
     "difficulty": 1,
     "time": "1 h",
-    "reversible": true,
     "autolearn": true,
     "using": [ [ "tailoring_cotton_knitting", 200 ] ]
   },
@@ -1323,7 +1321,6 @@
     "skill_used": "tailor",
     "difficulty": 1,
     "time": "1 h",
-    "reversible": true,
     "autolearn": true,
     "qualities": [ { "id": "KNIT", "level": 1 } ],
     "components": [ [ [ "yarn", 75 ] ] ]

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -605,8 +605,7 @@
     "subcategory": "CSC_ARMOR_TORSO",
     "skill_used": "tailor",
     "difficulty": 4,
-    "time": "3 h",
-    "reversible": true,
+    "time": "6 h",
     "autolearn": true,
     "qualities": [ { "id": "KNIT", "level": 1 } ],
     "components": [ [ [ "yarn", 900 ] ] ]
@@ -990,7 +989,6 @@
     "skill_used": "tailor",
     "difficulty": 3,
     "time": "3 h",
-    "reversible": true,
     "autolearn": true,
     "qualities": [ { "id": "KNIT", "level": 1 } ],
     "components": [ [ [ "yarn", 350 ] ] ]

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -595,7 +595,7 @@
     "time": "3 h",
     "autolearn": true,
     "using": [ [ "sewing_standard", 80 ] ],
-    "components": [ [ [ "felt_patch", 30 ] ] ]
+    "components": [ [ [ "felt_patch", 18 ] ] ]
   },
   {
     "result": "poncho",
@@ -606,9 +606,10 @@
     "skill_used": "tailor",
     "difficulty": 4,
     "time": "3 h",
+    "reversible": true,
     "autolearn": true,
     "qualities": [ { "id": "KNIT", "level": 1 } ],
-    "components": [ [ [ "yarn", 300 ] ] ]
+    "components": [ [ [ "yarn", 900 ] ] ]
   },
   {
     "result": "sleeveless_duster",
@@ -988,10 +989,11 @@
     "subcategory": "CSC_ARMOR_TORSO",
     "skill_used": "tailor",
     "difficulty": 3,
-    "time": "6 h",
+    "time": "3 h",
+    "reversible": true,
     "autolearn": true,
     "qualities": [ { "id": "KNIT", "level": 1 } ],
-    "components": [ [ [ "yarn", 600 ] ] ]
+    "components": [ [ [ "yarn", 350 ] ] ]
   },
   {
     "result": "tank_top",

--- a/data/json/recipes/other/tools.json
+++ b/data/json/recipes/other/tools.json
@@ -983,7 +983,7 @@
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 3 } ],
     "tools": [ [ [ "press", -1 ] ], [ [ "surface_heat", 10, "LIST" ] ] ],
-    "components": [ [ [ "copper_scrap_equivalent", 20, "LIST" ] ], [ [ "tin", 30 ] ] ]
+    "components": [ [ [ "copper_scrap_equivalent", 14, "LIST" ] ], [ [ "tin", 30 ] ] ]
   },
   {
     "type": "recipe",
@@ -998,7 +998,7 @@
     "qualities": [ { "id": "HAMMER", "level": 3 } ],
     "tools": [ [ [ "electrolysis_kit", 10 ] ], [ [ "surface_heat", 10, "LIST" ] ] ],
     "components": [
-      [ [ "copper_scrap_equivalent", 20, "LIST" ] ],
+      [ [ "copper_scrap_equivalent", 14, "LIST" ] ],
       [ [ "tin", 30 ] ],
       [ [ "water", 3 ], [ "water_clean", 3 ] ],
       [ [ "acid", 1 ] ]

--- a/data/json/uncraft/armor.json
+++ b/data/json/uncraft/armor.json
@@ -439,5 +439,59 @@
     "time": "1 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "leather", 8 ] ], [ [ "scrap", 6 ] ] ]
+  },
+  {
+    "result": "socks_wool",
+    "type": "uncraft",
+    "time": "6 m",
+    "components": [ [ [ "yarn", 80 ] ] ]
+  },
+  {
+    "result": "stockings_wool",
+    "type": "uncraft",
+    "time": "9 m",
+    "components": [ [ [ "yarn", 120 ] ] ]
+  },
+  {
+    "result": "gloves_wool_fingerless",
+    "type": "uncraft",
+    "time": "7 m 30 s",
+    "components": [ [ [ "yarn", 140 ] ] ]
+  },
+  {
+    "result": "mittens",
+    "type": "uncraft",
+    "time": "5 m",
+    "components": [ [ [ "yarn", 125 ] ] ]
+  },
+  {
+    "result": "knit_scarf",
+    "type": "uncraft",
+    "time": "4 m",
+    "components": [ [ [ "thread", 100 ] ] ]
+  },
+  {
+    "result": "long_knit_scarf",
+    "type": "uncraft",
+    "time": "6 m",
+    "components": [ [ [ "thread", 200 ] ] ]
+  },
+  {
+    "result": "scarf",
+    "type": "uncraft",
+    "time": "6 m",
+    "components": [ [ [ "yarn", 75 ] ] ]
+  },
+  {
+    "result": "poncho",
+    "type": "uncraft",
+    "time": "36 m",
+    "components": [ [ [ "yarn", 900 ] ] ]
+  },
+  {
+    "result": "sweater",
+    "type": "uncraft",
+    "time": "18 m",
+    "components": [ [ [ "yarn", 350 ] ] ]
   }
 ]

--- a/data/json/uncraft/armor.json
+++ b/data/json/uncraft/armor.json
@@ -2,435 +2,78 @@
   {
     "result": "socks_ankle",
     "type": "uncraft",
-    "time": "10 m",
+    "time": "30 m",
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "thread", 35 ] ] ]
   },
   {
     "result": "socks",
     "type": "uncraft",
-    "time": "10 m",
+    "time": "30 m",
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "thread", 35 ] ] ]
   },
   {
     "result": "boxer_shorts",
     "type": "uncraft",
-    "time": "10 m",
+    "time": "30 m",
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "thread", 40 ] ] ]
   },
   {
     "result": "boxer_briefs",
     "type": "uncraft",
-    "time": "10 m",
+    "time": "30 m",
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "thread", 40 ] ] ]
   },
   {
     "result": "briefs",
     "type": "uncraft",
-    "time": "10 m",
+    "time": "30 m",
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "thread", 35 ] ] ]
-  },
-  {
-    "result": "bikini_top",
-    "type": "uncraft",
-    "time": "5 m",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "thread", 20 ] ] ]
-  },
-  {
-    "result": "bikini_bottom",
-    "type": "uncraft",
-    "time": "5 m",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "thread", 20 ] ] ]
   },
   {
     "result": "panties",
     "type": "uncraft",
-    "time": "10 m",
+    "time": "30 m",
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "thread", 35 ] ] ]
   },
   {
-    "result": "bra",
-    "type": "uncraft",
-    "time": "5 m",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "thread", 15 ] ], [ [ "wire", 1 ] ] ]
-  },
-  {
     "result": "boy_shorts",
     "type": "uncraft",
-    "time": "10 m",
+    "time": "30 m",
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "thread", 40 ] ] ]
-  },
-  {
-    "result": "arm_warmers",
-    "type": "uncraft",
-    "time": "10 m",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "thread", 40 ] ] ]
-  },
-  {
-    "result": "bastsandals",
-    "type": "uncraft",
-    "time": "15 m",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "thread", 70 ] ] ]
-  },
-  {
-    "result": "scarf",
-    "type": "uncraft",
-    "time": "5 m",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "yarn", 35 ] ] ]
-  },
-  {
-    "result": "gloves_medical",
-    "type": "uncraft",
-    "skill_used": "fabrication",
-    "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 2 ] ] ],
-    "flags": [ "BLIND_EASY" ]
-  },
-  {
-    "result": "gloves_liner",
-    "type": "uncraft",
-    "time": "5 m",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "thread", 20 ] ] ]
-  },
-  {
-    "result": "gloves_light",
-    "type": "uncraft",
-    "time": "5 m",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "thread", 25 ] ] ]
-  },
-  {
-    "result": "gloves_light_fingerless",
-    "type": "uncraft",
-    "time": "5 m",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "thread", 25 ] ] ]
-  },
-  {
-    "result": "slippers",
-    "type": "uncraft",
-    "time": "5 m",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "thread", 25 ] ] ]
-  },
-  {
-    "result": "tie_bow",
-    "type": "uncraft",
-    "time": "2 m",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "thread", 10 ] ] ]
-  },
-  {
-    "result": "tie_clipon",
-    "type": "uncraft",
-    "time": "2 m",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "thread", 10 ] ] ]
-  },
-  {
-    "result": "tie_necktie",
-    "type": "uncraft",
-    "time": "2 m",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "thread", 10 ] ] ]
-  },
-  {
-    "result": "tie_skinny",
-    "type": "uncraft",
-    "time": "2 m",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "thread", 10 ] ] ]
-  },
-  {
-    "result": "veil_wedding",
-    "type": "uncraft",
-    "time": "15 m",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "thread", 60 ] ] ]
   },
   {
     "result": "down_blanket",
     "type": "uncraft",
     "time": "20 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "rag", 35 ] ], [ [ "down_feather", 160 ] ] ],
-    "flags": [ "BLIND_HARD" ]
+    "components": [ [ [ "rag", 35 ] ], [ [ "down_feather", 160 ] ] ]
   },
   {
     "result": "blanket",
     "type": "uncraft",
     "time": "20 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "rag", 35 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "hat_cotton",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "rag", 3 ] ] ],
-    "flags": [ "BLIND_HARD" ]
+    "components": [ [ [ "rag", 35 ] ] ]
   },
   {
     "result": "under_armor",
     "type": "uncraft",
-    "time": "30 s",
+    "time": "2 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "nylon", 1 ] ] ],
-    "flags": [ "BLIND_HARD" ]
+    "components": [ [ [ "nylon", 1 ] ] ]
   },
   {
     "result": "under_armor_shorts",
     "type": "uncraft",
-    "time": "30 s",
+    "time": "2 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "nylon", 1 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "undershirt",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "rag", 4 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "balclava",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "rag", 4 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "bandana",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "rag", 2 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "headscarf",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "rag", 2 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "mask_ski",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "felt_patch", 8 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "camisole",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "rag", 2 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "tank_top",
-    "type": "uncraft",
-    "skill_used": "tailor",
-    "time": "30 s",
-    "components": [ [ [ "rag", 4 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "army_top",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "rag", 4 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "tshirt",
-    "type": "uncraft",
-    "skill_used": "tailor",
-    "time": "30 s",
-    "components": [ [ [ "rag", 5 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "tshirt_tour",
-    "type": "uncraft",
-    "skill_used": "tailor",
-    "time": "30 s",
-    "components": [ [ [ "rag", 5 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "halter_top",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "rag", 2 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "skirt",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "rag", 6 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "nanoskirt",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "rag", 4 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "sundress",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "rag", 6 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "bikini_top_leather",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "leather", 3 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "leather_collar",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "leather", 1 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "leather_belt",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "leather", 1 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "leathersandals",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "leather", 1 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "leather_cat_ears",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "leather", 1 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "leather_cat_tail",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "leather", 1 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "bikini_top_fur",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "fur", 3 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "fur_cat_ears",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "fur", 1 ] ], [ [ "plastic_chunk", 1 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "faux_fur_cat_ears",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "faux_fur", 1 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "fur_cat_tail",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "fur", 1 ] ], [ [ "plastic_chunk", 1 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "faux_fur_cat_tail",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "faux_fur", 1 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "fur_collar",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "fur", 1 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "faux_fur_collar",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "faux_fur", 1 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "boots_steel",
-    "type": "uncraft",
-    "skill_used": "tailor",
-    "time": "1 m",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "leather", 8 ] ], [ [ "scrap", 2 ] ] ]
-  },
-  {
-    "result": "rollerskates",
-    "type": "uncraft",
-    "skill_used": "tailor",
-    "time": "1 m",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "leather", 8 ] ], [ [ "scrap", 10 ] ] ]
+    "components": [ [ [ "nylon", 1 ] ] ]
   }
 ]

--- a/data/json/uncraft/armor.json
+++ b/data/json/uncraft/armor.json
@@ -2,51 +2,169 @@
   {
     "result": "socks_ankle",
     "type": "uncraft",
-    "time": "30 m",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "thread", 35 ] ] ]
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
   },
   {
     "result": "socks",
     "type": "uncraft",
-    "time": "30 m",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "thread", 35 ] ] ]
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
   },
   {
     "result": "boxer_shorts",
     "type": "uncraft",
-    "time": "30 m",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "thread", 40 ] ] ]
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
   },
   {
     "result": "boxer_briefs",
     "type": "uncraft",
-    "time": "30 m",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "thread", 40 ] ] ]
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
   },
   {
     "result": "briefs",
     "type": "uncraft",
-    "time": "30 m",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "thread", 35 ] ] ]
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "bikini_top",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "bikini_bottom",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
   },
   {
     "result": "panties",
     "type": "uncraft",
-    "time": "30 m",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "thread", 35 ] ] ]
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "bra",
+    "type": "uncraft",
+    "time": "1 m",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ], [ [ "wire", 1 ] ] ]
   },
   {
     "result": "boy_shorts",
     "type": "uncraft",
-    "time": "30 m",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "thread", 40 ] ] ]
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "arm_warmers",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "gloves_medical",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "time": "6 s",
+    "components": [ [ [ "plastic_scrap", 2 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "result": "gloves_liner",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "gloves_light",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "gloves_light_fingerless",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "slippers",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "tie_bow",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "tie_clipon",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "tie_necktie",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "tie_skinny",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "veil_wedding",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
   },
   {
     "result": "down_blanket",
@@ -63,6 +181,14 @@
     "components": [ [ [ "rag", 35 ] ] ]
   },
   {
+    "result": "hat_cotton",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
     "result": "under_armor",
     "type": "uncraft",
     "time": "2 m",
@@ -74,6 +200,244 @@
     "type": "uncraft",
     "time": "2 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "nylon", 1 ] ] ]
+    "components": [ [ [ "nylon", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "undershirt",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "balclava",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "headscarf",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "mask_ski",
+    "type": "uncraft",
+    "time": "2 m",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "felt_patch", 1 ] ] ]
+  },
+  {
+    "result": "mask_ski_loose",
+    "type": "uncraft",
+    "time": "2 m",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "felt_patch", 1 ] ] ]
+  },
+  {
+    "result": "camisole",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "tank_top",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "army_top",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "tshirt",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "tshirt_tour",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "linuxtshirt",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "halter_top",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "skirt",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "nanoskirt",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "sundress",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "bikini_top_leather",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "leather", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "leather_collar",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "leather", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "leather_belt",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "leather", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "leathersandals",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "leather", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "leather_cat_ears",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "leather", 1 ] ], [ [ "plastic_chunk", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "leather_cat_tail",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "leather", 1 ] ], [ [ "plastic_chunk", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "bikini_top_fur",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "fur", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "fur_cat_ears",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "fur", 1 ] ], [ [ "plastic_chunk", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "faux_fur_cat_ears",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "faux_fur", 1 ] ], [ [ "plastic_chunk", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "fur_cat_tail",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "fur", 1 ] ], [ [ "plastic_chunk", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "faux_fur_cat_tail",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "faux_fur", 1 ] ], [ [ "plastic_chunk", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "fur_collar",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "fur", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "faux_fur_collar",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "faux_fur", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "boots_steel",
+    "type": "uncraft",
+    "skill_used": "tailor",
+    "time": "1 m",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "leather", 8 ] ], [ [ "scrap", 2 ] ] ]
+  },
+  {
+    "result": "rollerskates",
+    "type": "uncraft",
+    "time": "1 m",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "leather", 8 ] ], [ [ "scrap", 6 ] ] ]
   }
 ]

--- a/data/json/uncraft/armor.json
+++ b/data/json/uncraft/armor.json
@@ -2,78 +2,435 @@
   {
     "result": "socks_ankle",
     "type": "uncraft",
-    "time": "30 m",
+    "time": "10 m",
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "thread", 35 ] ] ]
   },
   {
     "result": "socks",
     "type": "uncraft",
-    "time": "30 m",
+    "time": "10 m",
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "thread", 35 ] ] ]
   },
   {
     "result": "boxer_shorts",
     "type": "uncraft",
-    "time": "30 m",
+    "time": "10 m",
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "thread", 40 ] ] ]
   },
   {
     "result": "boxer_briefs",
     "type": "uncraft",
-    "time": "30 m",
+    "time": "10 m",
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "thread", 40 ] ] ]
   },
   {
     "result": "briefs",
     "type": "uncraft",
-    "time": "30 m",
+    "time": "10 m",
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "thread", 35 ] ] ]
+  },
+  {
+    "result": "bikini_top",
+    "type": "uncraft",
+    "time": "5 m",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "thread", 20 ] ] ]
+  },
+  {
+    "result": "bikini_bottom",
+    "type": "uncraft",
+    "time": "5 m",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "thread", 20 ] ] ]
   },
   {
     "result": "panties",
     "type": "uncraft",
-    "time": "30 m",
+    "time": "10 m",
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "thread", 35 ] ] ]
   },
   {
+    "result": "bra",
+    "type": "uncraft",
+    "time": "5 m",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "thread", 15 ] ], [ [ "wire", 1 ] ] ]
+  },
+  {
     "result": "boy_shorts",
     "type": "uncraft",
-    "time": "30 m",
+    "time": "10 m",
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "thread", 40 ] ] ]
+  },
+  {
+    "result": "arm_warmers",
+    "type": "uncraft",
+    "time": "10 m",
+    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
+    "components": [ [ [ "thread", 40 ] ] ]
+  },
+  {
+    "result": "bastsandals",
+    "type": "uncraft",
+    "time": "15 m",
+    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
+    "components": [ [ [ "thread", 70 ] ] ]
+  },
+  {
+    "result": "scarf",
+    "type": "uncraft",
+    "time": "5 m",
+    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
+    "components": [ [ [ "yarn", 35 ] ] ]
+  },
+  {
+    "result": "gloves_medical",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "time": "6 s",
+    "components": [ [ [ "plastic_scrap", 2 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "result": "gloves_liner",
+    "type": "uncraft",
+    "time": "5 m",
+    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
+    "components": [ [ [ "thread", 20 ] ] ]
+  },
+  {
+    "result": "gloves_light",
+    "type": "uncraft",
+    "time": "5 m",
+    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
+    "components": [ [ [ "thread", 25 ] ] ]
+  },
+  {
+    "result": "gloves_light_fingerless",
+    "type": "uncraft",
+    "time": "5 m",
+    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
+    "components": [ [ [ "thread", 25 ] ] ]
+  },
+  {
+    "result": "slippers",
+    "type": "uncraft",
+    "time": "5 m",
+    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
+    "components": [ [ [ "thread", 25 ] ] ]
+  },
+  {
+    "result": "tie_bow",
+    "type": "uncraft",
+    "time": "2 m",
+    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
+    "components": [ [ [ "thread", 10 ] ] ]
+  },
+  {
+    "result": "tie_clipon",
+    "type": "uncraft",
+    "time": "2 m",
+    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
+    "components": [ [ [ "thread", 10 ] ] ]
+  },
+  {
+    "result": "tie_necktie",
+    "type": "uncraft",
+    "time": "2 m",
+    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
+    "components": [ [ [ "thread", 10 ] ] ]
+  },
+  {
+    "result": "tie_skinny",
+    "type": "uncraft",
+    "time": "2 m",
+    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
+    "components": [ [ [ "thread", 10 ] ] ]
+  },
+  {
+    "result": "veil_wedding",
+    "type": "uncraft",
+    "time": "15 m",
+    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
+    "components": [ [ [ "thread", 60 ] ] ]
   },
   {
     "result": "down_blanket",
     "type": "uncraft",
     "time": "20 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "rag", 35 ] ], [ [ "down_feather", 160 ] ] ]
+    "components": [ [ [ "rag", 35 ] ], [ [ "down_feather", 160 ] ] ],
+    "flags": [ "BLIND_HARD" ]
   },
   {
     "result": "blanket",
     "type": "uncraft",
     "time": "20 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "rag", 35 ] ] ]
+    "components": [ [ [ "rag", 35 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "hat_cotton",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 3 ] ] ],
+    "flags": [ "BLIND_HARD" ]
   },
   {
     "result": "under_armor",
     "type": "uncraft",
-    "time": "2 m",
+    "time": "30 s",
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "nylon", 1 ] ] ]
+    "components": [ [ [ "nylon", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
   },
   {
     "result": "under_armor_shorts",
     "type": "uncraft",
-    "time": "2 m",
+    "time": "30 s",
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "nylon", 1 ] ] ]
+    "components": [ [ [ "nylon", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "undershirt",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 4 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "balclava",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 4 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "bandana",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 2 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "headscarf",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 2 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "mask_ski",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "felt_patch", 8 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "camisole",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 2 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "tank_top",
+    "type": "uncraft",
+    "skill_used": "tailor",
+    "time": "30 s",
+    "components": [ [ [ "rag", 4 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "army_top",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 4 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "tshirt",
+    "type": "uncraft",
+    "skill_used": "tailor",
+    "time": "30 s",
+    "components": [ [ [ "rag", 5 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "tshirt_tour",
+    "type": "uncraft",
+    "skill_used": "tailor",
+    "time": "30 s",
+    "components": [ [ [ "rag", 5 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "halter_top",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 2 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "skirt",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 6 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "nanoskirt",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 4 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "sundress",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 6 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "bikini_top_leather",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "leather", 3 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "leather_collar",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "leather", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "leather_belt",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "leather", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "leathersandals",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "leather", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "leather_cat_ears",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "leather", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "leather_cat_tail",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "leather", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "bikini_top_fur",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "fur", 3 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "fur_cat_ears",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "fur", 1 ] ], [ [ "plastic_chunk", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "faux_fur_cat_ears",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "faux_fur", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "fur_cat_tail",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "fur", 1 ] ], [ [ "plastic_chunk", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "faux_fur_cat_tail",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "faux_fur", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "fur_collar",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "fur", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "faux_fur_collar",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "faux_fur", 1 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "boots_steel",
+    "type": "uncraft",
+    "skill_used": "tailor",
+    "time": "1 m",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "leather", 8 ] ], [ [ "scrap", 2 ] ] ]
+  },
+  {
+    "result": "rollerskates",
+    "type": "uncraft",
+    "skill_used": "tailor",
+    "time": "1 m",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "leather", 8 ] ], [ [ "scrap", 10 ] ] ]
   }
 ]

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -392,13 +392,6 @@
     "components": [ [ [ "silver_small", 2 ] ], [ [ "diamond", 1 ] ] ]
   },
   {
-    "result": "leather_collar",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "leather", 1 ] ] ]
-  },
-  {
     "result": "rad_badge",
     "type": "uncraft",
     "time": "30 s",
@@ -418,69 +411,6 @@
     "time": "30 s",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "plastic_chunk", 1 ] ] ]
-  },
-  {
-    "result": "fur_cat_ears",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "fur", 1 ] ], [ [ "plastic_chunk", 1 ] ] ]
-  },
-  {
-    "result": "faux_fur_cat_ears",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "faux_fur", 1 ] ] ]
-  },
-  {
-    "result": "fur_cat_tail",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "fur", 1 ] ], [ [ "plastic_chunk", 1 ] ] ]
-  },
-  {
-    "result": "faux_fur_cat_tail",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "faux_fur", 1 ] ] ]
-  },
-  {
-    "result": "fur_collar",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "fur", 1 ] ] ]
-  },
-  {
-    "result": "faux_fur_collar",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "faux_fur", 1 ] ] ]
-  },
-  {
-    "result": "leather_belt",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "leather", 1 ] ] ]
-  },
-  {
-    "result": "leather_cat_ears",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "leather", 1 ] ] ]
-  },
-  {
-    "result": "leather_cat_tail",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "leather", 1 ] ] ]
   },
   {
     "result": "alarmclock",
@@ -628,14 +558,6 @@
     "time": "1 m 30 s",
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
     "components": [ [ [ "scrap", 3 ] ] ]
-  },
-  {
-    "result": "boots_steel",
-    "type": "uncraft",
-    "skill_used": "tailor",
-    "time": "1 m",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "leather", 8 ] ], [ [ "scrap", 2 ] ] ]
   },
   {
     "result": "box_cigarette",
@@ -1675,8 +1597,7 @@
     "type": "uncraft",
     "time": "1 m 12 s",
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "tools": [ [ [ "surface_heat", 10, "LIST" ] ] ],
-    "components": [ [ [ "copper", 200 ] ] ]
+    "components": [ [ [ "scrap_copper", 7 ] ] ]
   },
   {
     "result": "diamond_dental_grill",
@@ -2522,15 +2443,6 @@
     "components": [ [ [ "plastic_chunk", 8 ] ], [ [ "motor_small", 1 ] ], [ [ "scrap", 4 ] ] ]
   },
   {
-    "result": "pot_copper",
-    "type": "uncraft",
-    "skill_used": "fabrication",
-    "difficulty": 1,
-    "time": "7 m 30 s",
-    "qualities": [ { "id": "SAW_M", "level": 1 } ],
-    "components": [ [ [ "scrap_copper", 5 ] ], [ [ "scrap", 1 ] ] ]
-  },
-  {
     "result": "power_armor_basic",
     "type": "uncraft",
     "skill_used": "fabrication",
@@ -3099,14 +3011,6 @@
     "components": [ [ [ "scrap", 1 ] ], [ [ "plastic_chunk", 2 ] ], [ [ "rag", 2 ] ], [ [ "RAM", 1 ] ], [ [ "e_scrap", 2 ] ] ]
   },
   {
-    "result": "tank_top",
-    "type": "uncraft",
-    "skill_used": "tailor",
-    "time": "30 s",
-    "components": [ [ [ "rag", 4 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
     "result": "television",
     "type": "uncraft",
     "skill_used": "electronics",
@@ -3150,22 +3054,6 @@
     "time": "30 s",
     "components": [ [ [ "paper", 10 ] ] ],
     "flags": [ "BLIND_EASY" ]
-  },
-  {
-    "result": "tshirt",
-    "type": "uncraft",
-    "skill_used": "tailor",
-    "time": "30 s",
-    "components": [ [ [ "rag", 5 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "tshirt_tour",
-    "type": "uncraft",
-    "skill_used": "tailor",
-    "time": "30 s",
-    "components": [ [ [ "rag", 5 ] ] ],
-    "flags": [ "BLIND_HARD" ]
   },
   {
     "result": "usb_drive",
@@ -4008,6 +3896,14 @@
     "components": [ [ [ "plastic_chunk", 1 ] ], [ [ "razor_blade", 1 ] ] ]
   },
   {
+    "result": "razor_blade",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "time": "6 s",
+    "components": [ [ [ "scrap", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
     "result": "hair_dryer",
     "type": "uncraft",
     "skill_used": "mechanics",
@@ -4038,133 +3934,176 @@
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "button_plastic",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 3 ] ] ]
+    "components": [ [ [ "plastic_scrap", 3 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "bottle_folding",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 2 ] ] ]
+    "components": [ [ [ "plastic_scrap", 2 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "plastic_straw",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 3 ] ] ]
+    "components": [ [ [ "plastic_scrap", 3 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "plastic_knife",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 5 ] ] ]
+    "components": [ [ [ "plastic_scrap", 5 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "plastic_spoon",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 5 ] ] ]
+    "components": [ [ [ "plastic_scrap", 5 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "plastic_spoon_kids",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 5 ] ] ]
+    "components": [ [ [ "plastic_scrap", 5 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "plastic_fork",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 5 ] ] ]
+    "components": [ [ [ "plastic_scrap", 5 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "plastic_six_dice",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "bag_plastic",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "bag_zipper",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "cup_plastic",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "cup_plastic",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "sippy_cup",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "result": "condom",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "time": "6 s",
+    "components": [ [ [ "plastic_scrap", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "comb_pocket",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "hairbrush",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ]
+    "components": [ [ [ "plastic_chunk", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "result": "brush",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "time": "6 s",
+    "components": [ [ [ "plastic_chunk", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "barrette",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "result": "hairpin",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "time": "6 s",
+    "components": [ [ [ "scrap", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "fc_hairpin",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "heatpack_used",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 5 ] ] ]
+    "components": [ [ [ "plastic_scrap", 5 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "thermostat",

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -392,6 +392,13 @@
     "components": [ [ [ "silver_small", 2 ] ], [ [ "diamond", 1 ] ] ]
   },
   {
+    "result": "leather_collar",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "leather", 1 ] ] ]
+  },
+  {
     "result": "rad_badge",
     "type": "uncraft",
     "time": "30 s",
@@ -411,6 +418,69 @@
     "time": "30 s",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "plastic_chunk", 1 ] ] ]
+  },
+  {
+    "result": "fur_cat_ears",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "fur", 1 ] ], [ [ "plastic_chunk", 1 ] ] ]
+  },
+  {
+    "result": "faux_fur_cat_ears",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "faux_fur", 1 ] ] ]
+  },
+  {
+    "result": "fur_cat_tail",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "fur", 1 ] ], [ [ "plastic_chunk", 1 ] ] ]
+  },
+  {
+    "result": "faux_fur_cat_tail",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "faux_fur", 1 ] ] ]
+  },
+  {
+    "result": "fur_collar",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "fur", 1 ] ] ]
+  },
+  {
+    "result": "faux_fur_collar",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "faux_fur", 1 ] ] ]
+  },
+  {
+    "result": "leather_belt",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "leather", 1 ] ] ]
+  },
+  {
+    "result": "leather_cat_ears",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "leather", 1 ] ] ]
+  },
+  {
+    "result": "leather_cat_tail",
+    "type": "uncraft",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "leather", 1 ] ] ]
   },
   {
     "result": "alarmclock",
@@ -558,6 +628,14 @@
     "time": "1 m 30 s",
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
     "components": [ [ [ "scrap", 3 ] ] ]
+  },
+  {
+    "result": "boots_steel",
+    "type": "uncraft",
+    "skill_used": "tailor",
+    "time": "1 m",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "leather", 8 ] ], [ [ "scrap", 2 ] ] ]
   },
   {
     "result": "box_cigarette",
@@ -2453,15 +2531,6 @@
     "components": [ [ [ "scrap_copper", 5 ] ], [ [ "scrap", 1 ] ] ]
   },
   {
-    "result": "copper_pan",
-    "type": "uncraft",
-    "skill_used": "fabrication",
-    "difficulty": 1,
-    "time": "7 m",
-    "qualities": [ { "id": "SAW_M", "level": 1 } ],
-    "components": [ [ [ "scrap_copper", 4 ] ], [ [ "scrap", 1 ] ] ]
-  },
-  {
     "result": "power_armor_basic",
     "type": "uncraft",
     "skill_used": "fabrication",
@@ -2545,14 +2614,14 @@
   {
     "result": "rag",
     "type": "uncraft",
-    "time": "20 m",
+    "time": "1 h",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "thread", 80 ] ] ]
   },
   {
     "result": "stick_fiber",
     "type": "uncraft",
-    "time": "20 m",
+    "time": "1 h",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "plant_fibre", 80 ] ] ]
   },
@@ -2561,7 +2630,7 @@
     "type": "uncraft",
     "skill_used": "survival",
     "difficulty": 1,
-    "time": "2 m",
+    "time": "6 m",
     "components": [ [ [ "plant_fibre", 10 ] ] ]
   },
   {
@@ -2569,7 +2638,7 @@
     "type": "uncraft",
     "skill_used": "survival",
     "difficulty": 1,
-    "time": "2 m",
+    "time": "6 m",
     "components": [ [ [ "plant_fibre", 25 ] ] ]
   },
   {
@@ -3030,6 +3099,14 @@
     "components": [ [ [ "scrap", 1 ] ], [ [ "plastic_chunk", 2 ] ], [ [ "rag", 2 ] ], [ [ "RAM", 1 ] ], [ [ "e_scrap", 2 ] ] ]
   },
   {
+    "result": "tank_top",
+    "type": "uncraft",
+    "skill_used": "tailor",
+    "time": "30 s",
+    "components": [ [ [ "rag", 4 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
     "result": "television",
     "type": "uncraft",
     "skill_used": "electronics",
@@ -3073,6 +3150,22 @@
     "time": "30 s",
     "components": [ [ [ "paper", 10 ] ] ],
     "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "result": "tshirt",
+    "type": "uncraft",
+    "skill_used": "tailor",
+    "time": "30 s",
+    "components": [ [ [ "rag", 5 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "tshirt_tour",
+    "type": "uncraft",
+    "skill_used": "tailor",
+    "time": "30 s",
+    "components": [ [ [ "rag", 5 ] ] ],
+    "flags": [ "BLIND_HARD" ]
   },
   {
     "result": "usb_drive",
@@ -3915,13 +4008,6 @@
     "components": [ [ [ "plastic_chunk", 1 ] ], [ [ "razor_blade", 1 ] ] ]
   },
   {
-    "result": "razor_blade",
-    "type": "uncraft",
-    "skill_used": "fabrication",
-    "time": "2 s",
-    "components": [ [ [ "scrap", 1 ] ] ]
-  },
-  {
     "result": "hair_dryer",
     "type": "uncraft",
     "skill_used": "mechanics",
@@ -3952,160 +4038,133 @@
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ],
-    "flags": [ "BLIND_EASY" ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ]
   },
   {
     "result": "button_plastic",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 3 ] ] ],
-    "flags": [ "BLIND_EASY" ]
+    "components": [ [ [ "plastic_scrap", 3 ] ] ]
   },
   {
     "result": "bottle_folding",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 2 ] ] ],
-    "flags": [ "BLIND_EASY" ]
+    "components": [ [ [ "plastic_scrap", 2 ] ] ]
   },
   {
     "result": "plastic_straw",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 3 ] ] ],
-    "flags": [ "BLIND_EASY" ]
+    "components": [ [ [ "plastic_scrap", 3 ] ] ]
   },
   {
     "result": "plastic_knife",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 5 ] ] ],
-    "flags": [ "BLIND_EASY" ]
+    "components": [ [ [ "plastic_scrap", 5 ] ] ]
   },
   {
     "result": "plastic_spoon",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 5 ] ] ],
-    "flags": [ "BLIND_EASY" ]
+    "components": [ [ [ "plastic_scrap", 5 ] ] ]
   },
   {
     "result": "plastic_spoon_kids",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 5 ] ] ],
-    "flags": [ "BLIND_EASY" ]
+    "components": [ [ [ "plastic_scrap", 5 ] ] ]
   },
   {
     "result": "plastic_fork",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 5 ] ] ],
-    "flags": [ "BLIND_EASY" ]
+    "components": [ [ [ "plastic_scrap", 5 ] ] ]
   },
   {
     "result": "plastic_six_dice",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ],
-    "flags": [ "BLIND_EASY" ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ]
   },
   {
     "result": "bag_plastic",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ],
-    "flags": [ "BLIND_EASY" ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ]
   },
   {
     "result": "bag_zipper",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ],
-    "flags": [ "BLIND_EASY" ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ]
   },
   {
     "result": "cup_plastic",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ],
-    "flags": [ "BLIND_EASY" ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ]
   },
   {
-    "result": "cup_plastic_unsealed",
+    "result": "cup_plastic",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ],
-    "flags": [ "BLIND_EASY" ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ]
   },
   {
     "result": "sippy_cup",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ],
-    "flags": [ "BLIND_EASY" ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ]
   },
   {
     "result": "comb_pocket",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ],
-    "flags": [ "BLIND_EASY" ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ]
   },
   {
     "result": "hairbrush",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ],
-    "flags": [ "BLIND_EASY" ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ]
   },
   {
     "result": "barrette",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ],
-    "flags": [ "BLIND_EASY" ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ]
   },
   {
     "result": "fc_hairpin",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ],
-    "flags": [ "BLIND_EASY" ]
-  },
-  {
-    "result": "hairpin",
-    "type": "uncraft",
-    "skill_used": "fabrication",
-    "time": "6 s",
-    "components": [ [ [ "scrap", 1 ] ] ],
-    "flags": [ "BLIND_EASY" ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ]
   },
   {
     "result": "heatpack_used",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 5 ] ] ],
-    "flags": [ "BLIND_EASY" ]
+    "components": [ [ [ "plastic_scrap", 5 ] ] ]
   },
   {
     "result": "thermostat",
@@ -4113,8 +4172,7 @@
     "skill_used": "fabrication",
     "time": "6 s",
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "components": [ [ [ "scrap", 1 ] ] ],
-    "flags": [ "BLIND_EASY" ]
+    "components": [ [ [ "scrap", 1 ] ] ]
   },
   {
     "result": "bathroom_scale",

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -392,13 +392,6 @@
     "components": [ [ [ "silver_small", 2 ] ], [ [ "diamond", 1 ] ] ]
   },
   {
-    "result": "leather_collar",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "leather", 1 ] ] ]
-  },
-  {
     "result": "rad_badge",
     "type": "uncraft",
     "time": "30 s",
@@ -418,69 +411,6 @@
     "time": "30 s",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "plastic_chunk", 1 ] ] ]
-  },
-  {
-    "result": "fur_cat_ears",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "fur", 1 ] ], [ [ "plastic_chunk", 1 ] ] ]
-  },
-  {
-    "result": "faux_fur_cat_ears",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "faux_fur", 1 ] ] ]
-  },
-  {
-    "result": "fur_cat_tail",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "fur", 1 ] ], [ [ "plastic_chunk", 1 ] ] ]
-  },
-  {
-    "result": "faux_fur_cat_tail",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "faux_fur", 1 ] ] ]
-  },
-  {
-    "result": "fur_collar",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "fur", 1 ] ] ]
-  },
-  {
-    "result": "faux_fur_collar",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "faux_fur", 1 ] ] ]
-  },
-  {
-    "result": "leather_belt",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "leather", 1 ] ] ]
-  },
-  {
-    "result": "leather_cat_ears",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "leather", 1 ] ] ]
-  },
-  {
-    "result": "leather_cat_tail",
-    "type": "uncraft",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "leather", 1 ] ] ]
   },
   {
     "result": "alarmclock",
@@ -628,14 +558,6 @@
     "time": "1 m 30 s",
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
     "components": [ [ [ "scrap", 3 ] ] ]
-  },
-  {
-    "result": "boots_steel",
-    "type": "uncraft",
-    "skill_used": "tailor",
-    "time": "1 m",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "leather", 8 ] ], [ [ "scrap", 2 ] ] ]
   },
   {
     "result": "box_cigarette",
@@ -2531,6 +2453,15 @@
     "components": [ [ [ "scrap_copper", 5 ] ], [ [ "scrap", 1 ] ] ]
   },
   {
+    "result": "copper_pan",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "time": "7 m",
+    "qualities": [ { "id": "SAW_M", "level": 1 } ],
+    "components": [ [ [ "scrap_copper", 4 ] ], [ [ "scrap", 1 ] ] ]
+  },
+  {
     "result": "power_armor_basic",
     "type": "uncraft",
     "skill_used": "fabrication",
@@ -2614,14 +2545,14 @@
   {
     "result": "rag",
     "type": "uncraft",
-    "time": "1 h",
+    "time": "20 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "thread", 80 ] ] ]
   },
   {
     "result": "stick_fiber",
     "type": "uncraft",
-    "time": "1 h",
+    "time": "20 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "plant_fibre", 80 ] ] ]
   },
@@ -2630,7 +2561,7 @@
     "type": "uncraft",
     "skill_used": "survival",
     "difficulty": 1,
-    "time": "6 m",
+    "time": "2 m",
     "components": [ [ [ "plant_fibre", 10 ] ] ]
   },
   {
@@ -2638,7 +2569,7 @@
     "type": "uncraft",
     "skill_used": "survival",
     "difficulty": 1,
-    "time": "6 m",
+    "time": "2 m",
     "components": [ [ [ "plant_fibre", 25 ] ] ]
   },
   {
@@ -3099,14 +3030,6 @@
     "components": [ [ [ "scrap", 1 ] ], [ [ "plastic_chunk", 2 ] ], [ [ "rag", 2 ] ], [ [ "RAM", 1 ] ], [ [ "e_scrap", 2 ] ] ]
   },
   {
-    "result": "tank_top",
-    "type": "uncraft",
-    "skill_used": "tailor",
-    "time": "30 s",
-    "components": [ [ [ "rag", 4 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
     "result": "television",
     "type": "uncraft",
     "skill_used": "electronics",
@@ -3150,22 +3073,6 @@
     "time": "30 s",
     "components": [ [ [ "paper", 10 ] ] ],
     "flags": [ "BLIND_EASY" ]
-  },
-  {
-    "result": "tshirt",
-    "type": "uncraft",
-    "skill_used": "tailor",
-    "time": "30 s",
-    "components": [ [ [ "rag", 5 ] ] ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "result": "tshirt_tour",
-    "type": "uncraft",
-    "skill_used": "tailor",
-    "time": "30 s",
-    "components": [ [ [ "rag", 5 ] ] ],
-    "flags": [ "BLIND_HARD" ]
   },
   {
     "result": "usb_drive",
@@ -4008,6 +3915,13 @@
     "components": [ [ [ "plastic_chunk", 1 ] ], [ [ "razor_blade", 1 ] ] ]
   },
   {
+    "result": "razor_blade",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "time": "2 s",
+    "components": [ [ [ "scrap", 1 ] ] ]
+  },
+  {
     "result": "hair_dryer",
     "type": "uncraft",
     "skill_used": "mechanics",
@@ -4038,133 +3952,160 @@
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "button_plastic",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 3 ] ] ]
+    "components": [ [ [ "plastic_scrap", 3 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "bottle_folding",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 2 ] ] ]
+    "components": [ [ [ "plastic_scrap", 2 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "plastic_straw",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 3 ] ] ]
+    "components": [ [ [ "plastic_scrap", 3 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "plastic_knife",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 5 ] ] ]
+    "components": [ [ [ "plastic_scrap", 5 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "plastic_spoon",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 5 ] ] ]
+    "components": [ [ [ "plastic_scrap", 5 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "plastic_spoon_kids",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 5 ] ] ]
+    "components": [ [ [ "plastic_scrap", 5 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "plastic_fork",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 5 ] ] ]
+    "components": [ [ [ "plastic_scrap", 5 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "plastic_six_dice",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "bag_plastic",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "bag_zipper",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "cup_plastic",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
-    "result": "cup_plastic",
+    "result": "cup_plastic_unsealed",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "sippy_cup",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "comb_pocket",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "hairbrush",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "barrette",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "fc_hairpin",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 1 ] ] ]
+    "components": [ [ [ "plastic_scrap", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "result": "hairpin",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "time": "6 s",
+    "components": [ [ [ "scrap", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "heatpack_used",
     "type": "uncraft",
     "skill_used": "fabrication",
     "time": "6 s",
-    "components": [ [ [ "plastic_scrap", 5 ] ] ]
+    "components": [ [ [ "plastic_scrap", 5 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "thermostat",
@@ -4172,7 +4113,8 @@
     "skill_used": "fabrication",
     "time": "6 s",
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "components": [ [ [ "scrap", 1 ] ] ]
+    "components": [ [ [ "scrap", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "bathroom_scale",

--- a/data/json/uncraft/tools.json
+++ b/data/json/uncraft/tools.json
@@ -16,5 +16,25 @@
     "time": "50 s",
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
     "components": [ [ [ "wire", 4 ] ], [ [ "splinter", 8 ] ] ]
+  },
+  {
+    "result": "pot_copper",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "time": "30 m",
+    "qualities": [ { "id": "SAW_M", "level": 1 } ],
+    "tools": [ [ [ "surface_heat", 10, "LIST" ] ] ],
+    "components": [ [ [ "scrap_copper", 14 ] ], [ [ "tin", 30 ] ] ]
+  },
+  {
+    "result": "copper_pan",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "time": "25 m",
+    "qualities": [ { "id": "SAW_M", "level": 1 } ],
+    "tools": [ [ [ "surface_heat", 10, "LIST" ] ] ],
+    "components": [ [ [ "scrap_copper", 12 ] ], [ [ "tin", 20 ] ] ]
   }
 ]


### PR DESCRIPTION
## Summary
SUMMARY: Balance "Improve crafting and disassembling consistency for common clothing and other items"

## Purpose of change

Item disassembly is annoying for two reasons. Firstly, some clothing articles commonly encountered in loot take way too long to take apart for no good reason despite not producing anything particularly valuable.

Secondly, way too many items slip through the cracks of the generic salvage system while having no specific disassembly recipes of their own. After handling another haul of loot you're often left with a bunch of garbage items that are so utterly useless you end up just having to throw them into fire. Or, alternatively, you have to pick and choose your loot more carefully, but that's just one annoyance to escape another.

## Describe the solution

UPDATE: Wow this went outside of initial scope fast. I first planned to focus on disassembly only and keep the existing pattern of using threads as substitute for partial rags in recipe outputs, while reducing the time it takes to unravel rags into thread across the board to compensate, but both ideas quickly went out the window. Let's see what we ended up with instead.

I changed existing uncraft recipes that return threads to instead output a piece of rag. Returning a single rag makes uncraft recipes for cotton items consistent with those for leather and fur that already return a single patch of respective material.

One exception from this is knitted items. Some of the existing kititing recipes are marked as reversible, others are not. I went ahead and ~~made them all reversible~~ gave them special uncraft recipes with 10% the time requirement and full return of material, since any knitted clothing can be easily unraveled IRL. I had to make changes to amounts of crafting inputs, times and / or item weights in a few cases to keep things roughly consistent.

Additionally:
- moved a number of entries for clothing items uncraft recipes from **generic.json** into **armor.json**
- added `BLIND_HARD` tag to recipes that represent cutting an item into pieces (it was already present on some recipes so it was either remove completely or apply to all similar)
- adjusted craft and uncraft recipe for copper pot to be consistent with both each other and the item's weight, added a similar uncraft recipe for copper frying pan
- fixed copper tubing disassembling into more copper than it costs to craft
- fixed wool poncho salvaging into more material than it costs to craft
- added uncraft recipes for a few random household clutter items
- added `BLIND_EASY` tag to generic recipes that result in just plastic or metal scrap, as those clearly require no precision

## Describe alternatives you've considered

~~Maybe knitted items could be given separate uncraft recipes that take less time instead of making them reversible, but that can be changed later.~~ Done

## Testing

Checked that individual items report correct expected components in the deconstruct menu. Then set the character to 'deconstruct everything once' in my garbage pile, until there was nothing left but basic materials.
