### PR TITLE
feat(content): crossbow loading lever gunmod

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
@@ -156,6 +156,6 @@
     "type": "item_group",
     "id": "gunmod_archery",
     "//": "Gunmods for bows and crossbows.",
-    "items": [ [ "arrowrest", 100 ], [ "bow_sight", 100 ], [ "bow_stabilizer", 100 ] ]
+    "items": [ [ "arrowrest", 100 ], [ "bow_sight", 100 ], [ "bow_stabilizer", 100 ], [ "crossbow_lever", 100 ] ]
   }
 ]

--- a/data/json/itemgroups/art_antiques_crafts.json
+++ b/data/json/itemgroups/art_antiques_crafts.json
@@ -133,6 +133,7 @@
       { "item": "cheese_hard", "prob": 1 },
       { "item": "tinderbox", "prob": 4 },
       { "item": "flint_steel", "prob": 7 },
+      { "item": "crossbow_lever", "prob": 2 },
       { "item": "canteen_wood", "prob": 5 },
       { "item": "shield_wooden", "prob": 3 },
       { "item": "shield_wooden_large", "prob": 3 },

--- a/data/json/itemgroups/main.json
+++ b/data/json/itemgroups/main.json
@@ -264,6 +264,7 @@
       { "item": "bow_silencer", "prob": 50 },
       { "item": "bow_stabilizer", "prob": 50 },
       { "item": "bow_stabilizer_set", "prob": 40 },
+      { "item": "crossbow_lever", "prob": 20 },
       { "item": "gun_crossbow", "prob": 40 }
     ]
   },

--- a/data/json/items/gunmod/accessories.json
+++ b/data/json/items/gunmod/accessories.json
@@ -70,6 +70,24 @@
     "loudness_modifier": -8
   },
   {
+    "id": "crossbow_lever",
+    "type": "GUNMOD",
+    "name": { "str": "crossbow spanning lever" },
+    "description": "A medieval-style \"goat's foot\" lever, that hooks onto medium-sized crossbows to assist with drawing them.  Makes reloading easier, but takes a bit longer to set up when wielding.",
+    "weight": "700 g",
+    "volume": "750 ml",
+    "integral_volume": "250 ml",
+    "price": "40 USD",
+    "price_postapoc": "10 USD",
+    "material": [ "steel" ],
+    "symbol": "/",
+    "color": "light_gray",
+    "location": "accessories",
+    "mod_target_category": [ [ "M_XBOWS" ] ],
+    "reload_modifier": -25,
+    "flags": [ "NEEDS_UNFOLD" ]
+  },
+  {
     "id": "belt_clip",
     "type": "GUNMOD",
     "name": { "str": "belt clip" },

--- a/data/json/items/ranged/crossbows.json
+++ b/data/json/items/ranged/crossbows.json
@@ -339,7 +339,14 @@
     "dispersion": 375,
     "durability": 6,
     "reload": 800,
-    "valid_mod_locations": [ [ "dampening", 1 ], [ "rail mount", 1 ], [ "sights mount", 1 ], [ "underbarrel mount", 1 ], [ "mechanism", 1 ] ]
+    "valid_mod_locations": [
+      [ "accessories", 4 ],
+      [ "dampening", 1 ],
+      [ "rail mount", 1 ],
+      [ "sights mount", 1 ],
+      [ "underbarrel mount", 1 ],
+      [ "mechanism", 1 ]
+    ]
   },
   {
     "id": "compositecrossbow",
@@ -426,6 +433,6 @@
     "durability": 6,
     "clip_size": 10,
     "reload": 800,
-    "valid_mod_locations": [ [ "dampening", 1 ], [ "accessories", 2 ], [ "grip", 1 ], [ "mechanism", 1 ] ]
+    "valid_mod_locations": [ [ "dampening", 1 ], [ "grip", 1 ], [ "mechanism", 1 ] ]
   }
 ]

--- a/data/json/recipes/weapon/mods.json
+++ b/data/json/recipes/weapon/mods.json
@@ -1085,5 +1085,17 @@
     "autolearn": true,
     "book_learn": [ [ "mag_archery", 3 ], [ "manual_archery", 2 ] ],
     "using": [ [ "blacksmithing_advanced", 10 ], [ "steel_standard", 2 ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "crossbow_lever",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_MODS",
+    "skill_used": "fabrication",
+    "difficulty": 5,
+    "skills_required": [ [ "mechanics", 3 ] ],
+    "time": "45 m",
+    "book_learn": [ [ "recipe_bows", 4 ], [ "textbook_weapwest", 5 ], [ "textbook_armschina", 5 ] ],
+    "using": [ [ "blacksmithing_advanced", 5 ], [ "steel_standard", 1 ] ]
   }
 ]


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

Please use a descriptive name for the PR title, so it's clear at a glance what the PR is about.
-->

## Summary
SUMMARY: Content "Add a spanning lever gunmod for crossbows"

<!--
This section should consist of exactly one line, formatted like the example above.

'Category' must be one of the following:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/

If the PR is a port or adaptation of DDA content, please indicate it to be so.
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This adds an idea that came up while discussing https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3441 on the discord, that it was decided oughta be set aside as a separate PR to avoid bogging that one down.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Added item for a crossbow spanning lever, based off medieval examples. Toned down the reloading bonus from 50% off to only 25% off compared to my first mockup of it. Realistically it'd be more in the vein of reducing strength requirements to reload, but the way `STR_RELOAD` works means there's nothing to reallly mess with. It's all just a big reload time and a reduction in reload time that scales with strength, and trying to tweak that from either end means faster reloads in the end.
2. Added `accessories` slots to basic crossbows and removed them from repeating crossbows, this being the slot that the lever currently uses. Since there are no other crossbow gunmods in vanilla that use that slot, this means it'll be usable on every crossbow except the hand crossbow (too smol), repeating crossbow (implied to be cocked by a lever already built into it), and the heavy crossbow (implied to already have a winch built into it).
3. Added the lever to the `archery_mods`, `gunmod_archery`, and `medieval` itemgroups.
4. Added recipe for crossbow spanning lever.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Adding a custom `spanning` slot for the lever so I can ensure only specific crossbows can only ever have this specific gunmod.
2. Putting the bowstring on `dampener` since it's a bowstring mod and putting the spanning lever on mechanisms. Problem there is heavy crossbow uses the `dampening` slot and I assume it's meant to not have steel bowstrings due to using beefy ropes already.
3. Adding the weapwest book to the basic crossbow's booklearn list since those are also a medieval European weapon.
4. Conversely, taking the weapwest book out of spanning lever's booklearns.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Checked affected files for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

At some point we oughta unfuck the way `STR_RELOAD` works, it seems to and cap out beyond a given amount of strength and have almost no real impact on reload rates, likely because the math it uses is subtractive instead of multiplicative and it'd have to cap the strength off to avoid ZA WARUDO type problems.