### PR TITLE
feat(balance): shorten uncraft time for rags and fibrous stalks

### DIFF
--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -2614,14 +2614,14 @@
   {
     "result": "rag",
     "type": "uncraft",
-    "time": "1 h",
+    "time": "5 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "thread", 80 ] ] ]
   },
   {
     "result": "stick_fiber",
     "type": "uncraft",
-    "time": "1 h",
+    "time": "8 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "plant_fibre", 80 ] ] ]
   },


### PR DESCRIPTION
## Summary
SUMMARY: Balance "Faster uncraft for rags and fibrous stalks"

## Purpose of change

As I have discussed with @scarf005 rags and fibrous stalks have a very punishing uncraft time of 1 hour.

1. I believe an uncraft time of 1 hour for a single rag or fibrous stalk is unnecessary and tedium. The counterargument is that it encourages you to gain thread from looting locations or from strings, but I feel it is an unnecessary game mechanic to discourage uncrafting rags on bulk and encourages players to hoard a massive supply of rags that they are unwilling to use for thread and won't need for tailoring after a certain point. Example is that uncrafting 4 mattresses gives you more rags than you'll ever need.
2. You can receive 6 short strings from a long string in 5 minutes, and 50 thread per short string in 5 minutes, thus 300 thread in 35 minutes
3. You can get 50 thread from a sheet in 10 minutes. A rag meanwhile is 80 thread in 1 hour.
4. So from one window You can get 300 thread with minimal effort via the long string and sheets. From one mattress you can get 4 sheets to gain thread via minimal effort.
5. Meanwhile it takes 50 minutes to disassemble an oven, or 40 minutes to disassemble a refrigerator, making the rag uncrafts not a useful usage of time relative to other crafts in the game. Many other items have long uncrafts but give components you want, such as speakers, LCD screens, televisions, etc.
6. Fibrous stalks take 1 hour for 80 plant fiber. Same as rags. This is a common complaint on the discord.
7. Other than starts in the woods, tailoring is extremely easy and fast to level up regardless of the 1 hour uncraft time on rags. This is not affecting current game balance, if we wanted thread to be more difficult we would need to change their spawn rates and the time taken to uncraft other items such as strings and sheets.

## Describe the solution

The uncraft for rags is set to 5 minutes, and fibrous stalks to 8 minutes. I set fibrous stalks as slightly worse intentionally, to not affect other sources of plant fiber such as cattails.

## Describe alternatives you've considered

Making it harder to uncraft sheets, strings, and mattresses.

## Testing

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/112293514/e6126ac9-8a67-4269-a78d-43254dadfa78)
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/112293514/d9683053-da17-4f79-96c6-29e7e6e13ec2)

## Additional context

N/A
