### PR TITLE
feat(balance, port): arpen reduction via layered armor, make shields block ranged hits

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10871,8 +10871,7 @@ bool Character::block_ranged_hit( Creature *source, bodypart_id &bp_hit, damage_
         elem.amount -= block_amount;
         blocked_damage += block_amount;
         const resistances res = resistances( shield );
-        elem.res_pen -= res.type_resist( elem.type );
-        elem.res_pen = std::max( 0.0f, elem.res_pen );
+        elem.res_pen = std::max( 0.0f, elem.res_pen - res.type_resist( elem.type ) );
     }
     blocked_damage = std::min( total_damage, blocked_damage );
     add_msg( m_debug, _( "expected base damage: %i" ), total_damage );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10848,7 +10848,7 @@ bool Character::block_ranged_hit( Creature *source, bodypart_id &bp_hit, damage_
     }
     // Modify chance based on coverage and blocking ability, with lowered chance if hitting the legs. Exclude armguards here.
     const float technic_modifier = coverage_modifier_by_technic( level, is_leg_hit( bp_hit ) );
-    const float shield_coverage_modifier = shield.get_coverage( bp_hit ) * technic_modifier;
+    const float shield_coverage_modifier = shield.get_avg_coverage() * technic_modifier;
 
     add_msg( m_debug, _( "block_ranged_hit success rate: %i%%" ),
              static_cast<int>( shield_coverage_modifier ) );
@@ -10870,6 +10870,9 @@ bool Character::block_ranged_hit( Creature *source, bodypart_id &bp_hit, damage_
         const float block_amount = get_block_amount( shield, elem );
         elem.amount -= block_amount;
         blocked_damage += block_amount;
+        const resistances res = resistances( shield );
+        elem.res_pen -= res.type_resist( elem.type );
+        elem.res_pen = std::max( 0.0f, elem.res_pen );
     }
     blocked_damage = std::min( total_damage, blocked_damage );
     add_msg( m_debug, _( "expected base damage: %i" ), total_damage );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6194,6 +6194,10 @@ void item::mitigate_damage( damage_unit &du ) const
 {
     const resistances res = resistances( *this );
     const float mitigation = res.get_effective_resist( du );
+    // get_effective_resist subtracts the flat penetration value before multiplying the remaining armor.
+    // therefore, res_pen is reduced by the full value of the item's armor value even though mitigation might be smaller (such as an attack with a 0.5 armor multiplier)
+    du.res_pen -= res.type_resist( du.type );
+    du.res_pen = std::max( 0.0f, du.res_pen );
     du.amount -= mitigation;
     du.amount = std::max( 0.0f, du.amount );
 }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6196,10 +6196,8 @@ void item::mitigate_damage( damage_unit &du ) const
     const float mitigation = res.get_effective_resist( du );
     // get_effective_resist subtracts the flat penetration value before multiplying the remaining armor.
     // therefore, res_pen is reduced by the full value of the item's armor value even though mitigation might be smaller (such as an attack with a 0.5 armor multiplier)
-    du.res_pen -= res.type_resist( du.type );
-    du.res_pen = std::max( 0.0f, du.res_pen );
-    du.amount -= mitigation;
-    du.amount = std::max( 0.0f, du.amount );
+    du.res_pen = std::max( 0.0f, du.res_pen - res.type_resist( du.type ) );
+    du.amount = std::max( 0.0f, du.amount - mitigation );
 }
 
 int item::damage_resist( damage_type dt, bool to_self ) const


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

Please use a descriptive name for the PR title, so it's clear at a glance what the PR is about.
-->

## Summary
SUMMARY: Balance "Fix shields not blocking ranged hits anymore, port over arpen being reduced by multi-layered armor from DDA"

<!--
This section should consist of exactly one line, formatted like the example above.

'Category' must be one of the following:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/

If the PR is a port or adaptation of DDA content, please indicate it to be so.
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This addresses an issue that was pointed out a while back with the ammo rebalance affects, namely that a high armor penetration is good and working as intended against a single high-armor item, but undermines the effectiveness of layering low-mid value items. Or as the PR OP put it:

> Armor penetration is broken, both because it has absurdly high values and also because it renders single armor layers useless (you could wear 20 individual hypothetical 1mm kevlar shirts and still take full damage from a 5.56 nato round, which has 6 armor penetration, but if you had a single 8mm thick kevlar shirt, it would stop the bullet almost entirely)

This is actually more relevant in BN than in DDA because 6 arpen is like nothing in BN compared to what rifle rounds (especially AP rounds, like 5.56 which gets 32) tend to have. This also makes shields, which have a chance to intercept ranged attacks, more consistently useful against bullets since instead of doing literally nothing to a shot that punches though, it'll at least make it a bit easier on the underlying armor.

Along the way, while testing I discovered a bug caused by https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2776 where basically block chance for ranged attacks is now ONLY being rolled for the OPPOSITE arm from what it's worn on.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. In item.cpp, ported over a change to `item::mitigate_damage` that reduces arpen by how much damage it broke through.
2. In the same function, per Kheir's advice tweaked the way the damage mitigation part is handled to tack on its `std:max` a bit more elegantly.
3. In character.cpp, also implemented the same general change to `Character::block_ranged_hit` so that blocking a ranged attack with a shield will affect arpen the same as it would if it hit the body parts it covers.
4. In the same function, fixed ranged blocking by setting it to use `get_avg_coverage` instead of `get_coverage` to determine block chance.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

If anyone would rather I split off the fixing of blocking ranged hits with shields into a separate PR, lemme know.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

First, tested pre-PR behavior in build 2023-10-24-1439 by layering on two light survivor suits (14 ballistic protection) and spawning in a light turret (uses 9x19mm FMJ, base damage 27, base arpen 15). Damage taken tended to be 28-32.

Second test in said build, spawned in a riot shield (8 ballistic protection) and wore that over a single heavy survivor suit (26 ballistic resistance). Damage taken on a sucessful range block tended to be 18-20. Damage rolls only triggered when the opposite arm was hit.

1. Compiled and load-tested.
2. Redid first test with a pair of light survivor suits vs a light turret.
3. Damage tended to be in the 16-18 range now.
5. Repeated second test with a riot shield and heavy survivor suit.
6. Damaged tended to be 11-12 for hits that punched through the shield and hit the survivor suit.
7. Also observed that hits to the arm it's worn on tended to be in the same 11-12 damage range as blocked shots, so the riot shield is doing the same thing as both armor and when blocking ranged hits to other parts.
8. Confirmed as well via debug that block roll is back to correctly being 90% chance to block when hitting normal parts, and 75% for leg hits.
9. Checked affected files for astyle.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

DDA PR, albative arpen effects by @anoobindisguise: https://github.com/CleverRaven/Cataclysm-DDA/pull/66653