### PR TITLE
fix: stadium overmap terrain

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain_recreational.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_recreational.json
@@ -369,6 +369,7 @@
       "stadium_2_1",
       "stadium_3_1",
       "stadium_0_2",
+      "stadium_3_2",
       "stadium_0_3",
       "stadium_3_3",
       "stadium_1_4",
@@ -389,7 +390,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": [ "stadium_1_2", "stadium_2_2", "stadium_3_2", "stadium_1_3", "stadium_2_3" ],
+    "id": [ "stadium_1_2", "stadium_2_2", "stadium_1_3", "stadium_2_3" ],
     "copy-from": "generic_city_building",
     "name": "stadium field",
     "sym": "X",


### PR DESCRIPTION
## Summary
SUMMARY: "Move "stadium_3_2" to the right place."

## Purpose of change
"stadium_3_2" should not be displayed as a stadium field.

## Describe the solution

## Describe alternatives you've considered

## Testing

## Additional context
From the Hitchhiker's Guide to the Cataclysm (Bright Nights Editon).
"stadium_3_2" appears as a field on the map:
<img width="62" alt="Capture d’écran 2023-10-30 214309" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/0c87392f-bb34-4a3b-bd6f-0d4e0ac988c1">

After, without tile on the map:
<img width="233" alt="Capture d’écran 2023-10-30 215147" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/3a9c553d-47b6-43b0-8734-81abe9dfafd5">

## Checklist

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder.
