### PR TITLE
fix(map): bus station, pizza parlor mapgen

### DIFF
--- a/data/json/mapgen/bus_station.json
+++ b/data/json/mapgen/bus_station.json
@@ -7,7 +7,7 @@
     "object": {
       "fill_ter": "t_floor",
       "rows": [
-        "...........!s________sssssssssssssssPyyyyy___s!s",
+        "...........!s________sssssssssssssssOyyyyy___s!s",
         "....,,,....ss________s,;,,,;,,;,,,;,syyyyy___s,s",
         "||||www||||ss________ssssssssssssssss________s;s",
         "|p       p|ss________________________________s,s",
@@ -83,7 +83,6 @@
         "h": "f_chair",
         "Y": "f_rack_coat",
         "F": "f_filing_cabinet",
-        "P": "f_traffic_light",
         "G": "f_bulletin"
       },
       "items": {
@@ -95,9 +94,13 @@
         "F": { "item": "file_room", "chance": 70, "repeat": [ 1, 3 ] }
       },
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 3, 17 ], "y": [ 13, 15 ] } ],
+      "mapping" : { 
+          "P": { "terrain": "t_thconc_floor", "furniture": "f_traffic_light" },
+          "O": { "terrain": "t_concrete", "furniture": "f_traffic_light" }
+      },
       "place_vehicles": [
-        { "vehicle": "buses", "x": 35, "y": [ 6, 7 ], "chance": 35, "rotation": 360 },
-        { "vehicle": "buses", "x": 35, "y": [ 16, 17 ], "chance": 35, "rotation": 360 }
+        { "vehicle": "buses", "x": 35, "y": [ 5, 6 ], "chance": 35, "rotation": 360 },
+        { "vehicle": "buses", "x": 35, "y": [ 15, 16 ], "chance": 35, "rotation": 360 }
       ],
       "vendingmachines": { "8": { "item_group": "vending_drink" }, "9": { "item_group": "vending_food" } },
       "toilets": { "T": {  } }

--- a/data/json/mapgen/bus_station.json
+++ b/data/json/mapgen/bus_station.json
@@ -94,9 +94,9 @@
         "F": { "item": "file_room", "chance": 70, "repeat": [ 1, 3 ] }
       },
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 3, 17 ], "y": [ 13, 15 ] } ],
-      "mapping" : { 
-          "P": { "terrain": "t_thconc_floor", "furniture": "f_traffic_light" },
-          "O": { "terrain": "t_concrete", "furniture": "f_traffic_light" }
+      "mapping": {
+        "P": { "terrain": "t_thconc_floor", "furniture": "f_traffic_light" },
+        "O": { "terrain": "t_concrete", "furniture": "f_traffic_light" }
       },
       "place_vehicles": [
         { "vehicle": "buses", "x": 35, "y": [ 5, 6 ], "chance": 35, "rotation": 360 },

--- a/data/json/mapgen/pizza_parlor.json
+++ b/data/json/mapgen/pizza_parlor.json
@@ -80,9 +80,11 @@
         "P": "f_indoor_plant",
         "T": "f_table",
         "U": "f_chair",
-        "Y": "f_street_light",
         "s": "f_sink",
         "{": "f_rack"
+      },
+      "mapping" : {
+          "Y": { "terrain": "t_sidewalk", "furniture": "f_street_light" }
       },
       "toilets": { "t": {  } },
       "place_items": [
@@ -268,8 +270,10 @@
         "U": "f_chair",
         "s": "f_sink",
         "W": "f_water_heater",
-        "Y": "f_street_light",
         "{": "f_rack"
+      },
+      "mapping" : {
+          "Y": { "terrain": [ "t_dirt", "t_grass" ], "furniture": "f_street_light" }
       },
       "items": {
         "C": { "item": "pizza_trash", "chance": 50, "repeat": [ 7, 9 ] },

--- a/data/json/mapgen/pizza_parlor.json
+++ b/data/json/mapgen/pizza_parlor.json
@@ -83,9 +83,7 @@
         "s": "f_sink",
         "{": "f_rack"
       },
-      "mapping" : {
-          "Y": { "terrain": "t_sidewalk", "furniture": "f_street_light" }
-      },
+      "mapping": { "Y": { "terrain": "t_sidewalk", "furniture": "f_street_light" } },
       "toilets": { "t": {  } },
       "place_items": [
         { "item": "pizza_display", "x": 6, "y": [ 5, 8 ], "chance": 65, "repeat": [ 3, 4 ] },
@@ -272,9 +270,7 @@
         "W": "f_water_heater",
         "{": "f_rack"
       },
-      "mapping" : {
-          "Y": { "terrain": [ "t_dirt", "t_grass" ], "furniture": "f_street_light" }
-      },
+      "mapping": { "Y": { "terrain": [ "t_dirt", "t_grass" ], "furniture": "f_street_light" } },
       "items": {
         "C": { "item": "pizza_trash", "chance": 50, "repeat": [ 7, 9 ] },
         "F": { "item": "pizza_fridge", "chance": 80, "repeat": [ 9, 10 ] },


### PR DESCRIPTION
## Summary
SUMMARY: "Fix: bus station, pizza parlor mapgen"

## Purpose of change
Fix misplaced vehicles and replace wooden floors under street lights and traffic lights with correct floors.
## Describe the solution
Use "mapping" to get the right floor under street lights and traffic lights.
Change the y point of the buses.
## Describe alternatives you've considered

## Testing

## Additional context
It works.

![Matt Williams __09-22-44_Paris, Madrid](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/1dc07270-5e55-43cb-8dff-69c99ef3c01e)
![Matt Williams __09-23-25_Paris, Madrid](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/82d60f83-2f9c-4c3e-b4c5-f08c1beb283c)
![Matt Williams __09-23-54_Paris, Madrid](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/7388386a-a06f-429d-ac71-aabd29507e74)

## Checklist

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder.
