### PR TITLE
[DinoMod] more dino helmet stats

### DIFF
--- a/data/mods/DinoMod/items/helmets.json
+++ b/data/mods/DinoMod/items/helmets.json
@@ -11,6 +11,11 @@
     "material": [ "leather", "bone" ],
     "symbol": "[",
     "color": "dark_gray",
+    "looks_like": "helmet_skull",
+    "covers": [ "head" ],
+    "coverage": 85,
+    "encumbrance": 26,
+    "warmth": 10,
     "material_thickness": 3,
     "flags": [ "WATER_FRIENDLY" ]
   },
@@ -26,6 +31,11 @@
     "material": [ "leather", "bone" ],
     "symbol": "[",
     "color": "dark_gray",
+    "looks_like": "helmet_skull",
+    "covers": [ "head" ],
+    "coverage": 85,
+    "encumbrance": 26,
+    "warmth": 10,
     "material_thickness": 3,
     "flags": [ "WATER_FRIENDLY" ],
     "qualities": [ [ "COOK", 1 ] ]
@@ -42,6 +52,11 @@
     "material": [ "leather", "bone" ],
     "symbol": "[",
     "color": "dark_gray",
+    "looks_like": "helmet_skull",
+    "covers": [ "head" ],
+    "coverage": 85,
+    "encumbrance": 26,
+    "warmth": 10,
     "material_thickness": 3,
     "flags": [ "WATER_FRIENDLY" ]
   }


### PR DESCRIPTION
## Summary
SUMMARY: Mods "[DinoMod] dino helmets do something"

## Purpose of change

Updates dino helmets to have same stats as wolf skull helmets

## Describe the solution

Adds coverage, encumbrance, warmth, and a looks_like to match wolf skull helmets (actually wolf skulls don't offer warmth, but I think it should)

## Describe alternatives you've considered

Add armor stats to this and wolf skulls, beyond scope. These are intended to match wolf skulls

## Testing

Simple JSON copy and paste

## Additional context

Thanks to MisterWytt on Discord for reporting this

## Checklist

N/A
