### PR TITLE
ci: semantic PR title via conventional commits

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,8 +24,6 @@ https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
 
 If the PR is a port or adaptation of DDA content, please indicate it by adding port in PR title, like:
 feat(port): <feature name> from DDA
-
-COMMENTS: Please remove all comments and unrelevent sections from this template before submitting your PR.
 -->
 
 ## Purpose of change

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,32 +12,20 @@ WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE
 If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
 If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.
 
-Please use a descriptive name for the PR title, so it's clear at a glance what the PR is about.
--->
 
-## Summary
-SUMMARY: Category "Brief description of the change"
+PR TITLE: Please follow conventional commits: https://www.conventionalcommits.org
+This makes it clear at a glance what the PR is about.
 
-<!--
-This section should consist of exactly one line, formatted like the example above.
+for example:
+feat(content, mods): new item for <mod name>
 
-'Category' must be one of the following:
-
-- Features
-- Content
-- Interface
-- Mods
-- Balance
-- Bugfixes
-- Performance
-- Infrastructure
-- Build
-- I18N
-
-For more on the meaning of each category, see:
+for more on which category is available, see:
 https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
 
-If the PR is a port or adaptation of DDA content, please indicate it to be so.
+If the PR is a port or adaptation of DDA content, please indicate it by adding port in PR title, like:
+feat(port): <feature name> from DDA
+
+COMMENTS: Please remove all comments and unrelevent sections from this template before submitting your PR.
 -->
 
 ## Purpose of change

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,3 @@
+# https://github.com/Ezard/semantic-prs?tab=readme-ov-file#configuration-options
+# Validate the PR title, and ignore all commit messages
+titleOnly: true

--- a/.github/workflows/pull-translations.yml
+++ b/.github/workflows/pull-translations.yml
@@ -27,13 +27,13 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3.10.0
         with:
-          commit-message: Routine i18n updates on ${{ steps.get-timestamp.outputs.time }}
+          commit-message: "feat(i18n): routine i18n updates on ${{ steps.get-timestamp.outputs.time }}"
           committer: Coolthulhu (BOT) <Coolthulhu@gmail.com>
           author: Coolthulhu (BOT) <Coolthulhu@gmail.com>
           token: ${{ secrets.TX_PR_CREATOR }}
           branch: i18n
           delete-branch: true
           base: upload
-          title: Routine i18n updates on ${{ steps.get-timestamp.outputs.time }}
-          body: "#### Summary\nNone"
+          title: "feat(i18n): routine i18n updates on ${{ steps.get-timestamp.outputs.time }}"
+          body: ""
           labels: Translation

--- a/doc/src/content/docs/en/contribute/changelog_guidelines.md
+++ b/doc/src/content/docs/en/contribute/changelog_guidelines.md
@@ -2,20 +2,86 @@
 title: Changelog Guidelines
 ---
 
-- categories used by `Pull Request Summary` in the
-  [PR Template](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/.github/pull_request_template.md).
-- these are only guidelines, not rules. choose the best category for your PR freely.
+PR title follows [Convensional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for easier
+changelog generation. The format is one of:
 
-## Features
+```
+<Category>: <PR subject>
+<Category>(<Scope>, <Scope>, ...): <PR subject>
+```
+
+For Example, a PR title can be:
+
+```
+feat: add new mutation
+feat(content, port): port mutation description from DDA
+```
+
+## Category
+
+The category is the first word in the PR title. They specify the type of change being made. When in
+doubt, use `feat` for new features, and `fix` for bugfixes. Here are some frequently used
+categories:
+
+### `feat`: Features
+
+New features, additions, or balance changes.
+
+### `fix`: Bugfixes
+
+Anything that fixes a bug or makes the game more stable.
+
+### `refactor`: Infrastructure
+
+Make development easier without changing its behavior. For example:
+
+- `C++` refactorings and overhaul
+- `Json` reorganizations
+- `docs/`, `.github/` and repository changes
+- other development tools
+
+### `build`: Build
+
+Improve build process:
+
+- more robust
+- easier to use
+- faster compile time
+
+### Others
+
+- `docs`: Documentation changes
+- `style`: Code style changes (whitespace, formatting, etc), usu. fixing JSON formatting.
+- `perf`: Performance Improvements
+- `test`: Adding missing tests or correcting existing tests
+- `ci`: Changes to CI process
+- `chore`: Other changes that don't fit into any of the above categories
+- `revert`: Reverts a previous commit
+
+## Scopes
+
+1. Use them inside parentheses after the category to further narrow the scope of your PR.
+2. There are no limits to number of scopes.
+3. They are optional, but recommended.
+4. these are only guidelines, not rules. choose the best one for your PR freely!
+
+### `<None>`: Player/Worldwide Features
 
 Changes related to player:
 
 - player can do something new (e.g: mutations, skills)
 - something new can happen to the player (e.g: new disease)
 
-## Content
+Example PR title:
 
-Added new contents like:
+```
+feat: strength training activity
+feat: mutation system overhaul
+```
+
+### `content`: Contents
+
+New contents like:
 
 - new monsters
 - new map areas
@@ -23,7 +89,14 @@ Added new contents like:
 - new vehicles
 - new doohickeys
 
-## Interface
+Example PR title:
+
+```
+feat(content): semi-plausible smokeless gunpowder recipe
+feat(content, port): game store
+```
+
+### `UI`: Interfaces
 
 UI/UX changes like:
 
@@ -32,40 +105,47 @@ UI/UX changes like:
 - streamlining workflows
 - quality of life improvements
 
-## Mods
+Example PR title:
+
+```
+feat(UI): More info about items dropped with bags
+feat(UI): overhaul encumbrance UI
+```
+
+### `i18n`: Internationalization
+
+Improve translation and other languages support.
+
+```
+fix(UI, i18n): recipe names not translated unless learned
+```
+
+### `mods/<MOD_ID>`: Mods
 
 - changes contained within a mod
 - extends what is capable within a mod
 
-## Balance
+Example PR title:
+
+```
+feat(mods/magiclysm, content): add missing owlbear pelts recipe
+fix(mods/no_hope): No Hope doesn't make the world freezing
+```
+
+### `balance`: Balance Changes
 
 Changes to game balance.
 
-## Bugfixes
+Example PR title:
 
-Fixes for anything broken.
+```
+feat(balance): Give moose pelts instead of hides
+```
 
-## Performance
+### `port`: Ports from DDA or other forks
 
-Improvements to game performance.
+Example PR title:
 
-## Infrastructure
-
-Make development easier:
-
-- `C++` refactorings and overhaul
-- `Json` reorganizations
-- `docs/`, `.github/` and repository changes
-- other development tools
-
-## Build
-
-Improve build process:
-
-- more robust
-- easier to use
-- faster compile time
-
-## I18N
-
-Improve translation and other languages support.
+```
+feat(content, port): game shop
+```


### PR DESCRIPTION
## Purpose of change

- enforce [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for PR titles
- remove redundant `## Summary`


## Describe the solution

install https://github.com/apps/semantic-prs to enforce PR title

## Describe alternatives you've considered

pain

## Testing

used them on other projects, they work as intended

## Additional context

Q: Nooo, do i have to edit all those PR titles, i don't know how to do that
A: No worries, i've been doing that manually for months and this app just prevents me from overlooking one

Q: Then can i just write whatever on PR title and you'll fix it for me?
A: It'd be very nice if you could follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), tho.

## Checklist

- [x] reword automated i18n PR title
- [x] remove `## Summary` section
- [x] think up of better category
- [x] update docs

## Additional Context

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/eb6ec220-9f96-407c-a9bd-c44a4b269618)

Semantic PR bot also needs to be approved to enforce the PR title consistency.