### PR TITLE
Fix items not spilling from vehicles correctly

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -190,8 +190,7 @@ static void put_into_vehicle( Character &c, item_drop_reason reason,
         if( !it ) {
             continue;
         }
-        veh.add_item( part, std::move( it ) );
-        // NOLINTNEXTLINE(bugprone-use-after-move)
+        it=veh.add_item( part, std::move( it ) );
         if( !it ) {
             into_vehicle = true;
         } else {


### PR DESCRIPTION
## Summary

SUMMARY: Bugfix "Fix items not spilling from vehicles correctly"

## Purpose of change

They were getting deleted rather than dropped on the floor.

## Describe the solution

Don't miss the overflow. 
