### PR TITLE
Fix vehicles going glitchy when parts are added

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -345,8 +345,8 @@ void vehicle::add_missing_frames()
         }
         if( !found ) {
             // Install missing frame
-            //TODO!: check
             parts.emplace_back( frame_id, i.mount, item::spawn( frame_id->item ), this );
+            refresh_locations_hack();
         }
     }
 }
@@ -1625,6 +1625,7 @@ int vehicle::install_part( point dp, vehicle_part &&new_part )
     }
 
     parts.push_back( std::move( new_part ) );
+    refresh_locations_hack();
     auto &pt = parts.back();
     pt.set_vehicle_hack( this );
 
@@ -1782,6 +1783,7 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
             for( int carry_part : carry_map.carry_parts_here ) {
                 //TODO!: check that the carry veh is really destroyed after this
                 parts.push_back( std::move( carry_veh->parts[ carry_part ] ) );
+                refresh_locations_hack();
                 vehicle_part &carried_part = parts.back();
 
                 carried_part.mount = carry_map.carry_mount;
@@ -2326,6 +2328,7 @@ bool vehicle::split_vehicles( const std::vector<std::vector <int>> &new_vehs,
             }
             // transfer the vehicle_part to the new vehicle
             new_vehicle->parts.emplace_back( std::move( parts[ mov_part ] ) );
+            new_vehicle->refresh_locations_hack();
             vehicle_part &np = new_vehicle->parts.back();
             np.mount = new_mount;
             np.set_vehicle_hack( new_vehicle );
@@ -7213,6 +7216,12 @@ bool vehicle_part_with_feature_range<vpart_bitflags>::matches( const size_t part
 bool vehicle::is_loaded() const
 {
     return attached && get_map().inbounds( global_pos3() );
+}
+
+void vehicle::refresh_locations_hack(){
+	for(vehicle_part& part : parts){
+		part.refresh_locations_hack(this);
+	}
 }
 
 vehicle_part &vehicle::get_part_hack( int id )

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -7218,10 +7218,11 @@ bool vehicle::is_loaded() const
     return attached && get_map().inbounds( global_pos3() );
 }
 
-void vehicle::refresh_locations_hack(){
-	for(vehicle_part& part : parts){
-		part.refresh_locations_hack(this);
-	}
+void vehicle::refresh_locations_hack()
+{
+    for( vehicle_part &part : parts ) {
+        part.refresh_locations_hack( this );
+    }
 }
 
 vehicle_part &vehicle::get_part_hack( int id )

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -449,6 +449,7 @@ class vehicle
 
         vehicle_part &get_part_hack( int );
         int get_part_id_hack( int );
+        void refresh_locations_hack();
 
         int get_next_hack_id() {
             return next_hack_id++;

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -65,10 +65,11 @@ vehicle_part::vehicle_part( const vpart_id &vp, point dp, detached_ptr<item> &&o
 void vehicle_part::set_vehicle_hack( vehicle *veh )
 {
     hack_id = veh->get_next_hack_id();
-	refresh_locations_hack(veh);
+    refresh_locations_hack( veh );
 }
 
-void vehicle_part::refresh_locations_hack(vehicle *veh){
+void vehicle_part::refresh_locations_hack( vehicle *veh )
+{
     base.set_loc_hack( new vehicle_base_item_location( veh, hack_id ) );
     items.set_loc_hack( new vehicle_item_location( veh, hack_id ) );
 }
@@ -92,7 +93,7 @@ void vehicle_part::copy_static_from( const vehicle_part &source )
     info_cache = source.info_cache;
     ammo_pref = source.ammo_pref;
     crew_id = source.crew_id;
-    hack_id=source.hack_id;
+    hack_id = source.hack_id;
 }
 
 //TODO!: This is a bit scuffed and will be until vehicles are game objects.

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -65,6 +65,10 @@ vehicle_part::vehicle_part( const vpart_id &vp, point dp, detached_ptr<item> &&o
 void vehicle_part::set_vehicle_hack( vehicle *veh )
 {
     hack_id = veh->get_next_hack_id();
+	refresh_locations_hack(veh);
+}
+
+void vehicle_part::refresh_locations_hack(vehicle *veh){
     base.set_loc_hack( new vehicle_base_item_location( veh, hack_id ) );
     items.set_loc_hack( new vehicle_item_location( veh, hack_id ) );
 }
@@ -88,6 +92,7 @@ void vehicle_part::copy_static_from( const vehicle_part &source )
     info_cache = source.info_cache;
     ammo_pref = source.ammo_pref;
     crew_id = source.crew_id;
+    hack_id=source.hack_id;
 }
 
 //TODO!: This is a bit scuffed and will be until vehicles are game objects.

--- a/src/vehicle_part.h
+++ b/src/vehicle_part.h
@@ -62,6 +62,7 @@ struct vehicle_part {
 
         /** this can be removed when vehicles are made into GOs */
         void set_vehicle_hack( vehicle * );
+        void refresh_locations_hack( vehicle * );
 
         /**
          * Translated name of a part inclusive of any current status effects


### PR DESCRIPTION
## Summary
SUMMARY: Bugfix "Fix problem resizing vehicle parts"

## Purpose of change

Fixes #3545.

## Describe the solution

I forgot that resizing the parts list causes a copy which breaks the locations. It now repairs them afterwards. 

## Describe alternatives you've considered

This is in with the rest of the vehicle hack stuff that's getting removed when they're made into game objects.