### PR TITLE
fix: prevent UB on test suite exit.

### DIFF
--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -95,6 +95,8 @@ void player_activity::migrate_item_position( Character &guy )
 void player_activity::set_to_null()
 {
     type = activity_id::NULL_ID();
+    //Get rid of any safe references now
+    targets.clear();
     sfx::end_activity_sounds(); // kill activity sounds when activity is nullified
 }
 


### PR DESCRIPTION
## Summary
SUMMARY: Bugfixes "Remove UB on test suite exit"

## Purpose of change

I'm hoping this fixes #3551.

## Describe the solution

When the player's activity is set to null it doesn't clean up the activities targets as well. When global deconstruction happens stuff gets cleaned up in a random order. If the target safe_references get cleaned up after the global structures they use it causes UB.

## Testing

Can't reproduce this one locally so we'll have to see if the suite here works.
