### PR TITLE
fix: broken activities

### DIFF
--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -95,8 +95,6 @@ void player_activity::migrate_item_position( Character &guy )
 void player_activity::set_to_null()
 {
     type = activity_id::NULL_ID();
-    //Get rid of any safe references now
-    targets.clear();
     sfx::end_activity_sounds(); // kill activity sounds when activity is nullified
 }
 

--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -89,6 +89,8 @@ void clear_character( player &dummy, bool debug_storage )
     dummy.clear_skills();
     dummy.clear_morale();
     dummy.activity->set_to_null();
+    //Make sure any lingering safe references from the activity are removed
+    dummy.activity->targets.clear();
     dummy.reset_chargen_attributes();
     dummy.set_pain( 0 );
     dummy.reset_bonuses();


### PR DESCRIPTION

## Summary
SUMMARY: Bugfixes "Fix broken activities"

## Purpose of change

Fixes #3564. Turns out a lot of activities are broken right now.

## Describe the solution

The pr to get rid of UB in the test suite was misguided and caused way more problems than it solved. I didn't realise activities are calling set_to_null at the top of their handlers so removing the targets there broke a lot of stuff.

I've reverted that and added something to the test suite state clean to scrub that explicitly. I might come back to look at null activity setting at some point but this should fix the problems for now. 