### PR TITLE
fix: item sorting

### DIFF
--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -228,7 +228,7 @@ void inventory::unsort()
 
 static bool stack_compare( const std::vector<item *> &lhs, const std::vector<item *> &rhs )
 {
-    return lhs.front() < rhs.front();
+    return *lhs.front() < *rhs.front();
 }
 
 void inventory::clear()

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -531,7 +531,7 @@ std::vector<stacked_items> stack_for_pickup_ui( const
         // Each sub-stack has to be sorted separately
         std::sort( restacked_children.begin(), restacked_children.end(),
         []( const std::list<item_stack::iterator> &lhs, const std::list<item_stack::iterator> &rhs ) {
-            return *lhs.front() < *rhs.front();
+            return **lhs.front() < **rhs.front();
         } );
         restacked_with_parents.emplace_back( stacked_items{ pr.second.parent, restacked_children } );
     }
@@ -539,7 +539,7 @@ std::vector<stacked_items> stack_for_pickup_ui( const
     // Sorting by parent is a bit arbitrary (parent-less go last) - sort by count?
     std::sort( restacked_with_parents.begin(), restacked_with_parents.end(),
     []( const stacked_items & lhs, stacked_items & rhs ) {
-        return lhs.parent.has_value() && ( !rhs.parent.has_value() || *lhs.parent < *rhs.parent );
+        return lhs.parent.has_value() && ( !rhs.parent.has_value() || **lhs.parent < **rhs.parent );
     } );
 
 


### PR DESCRIPTION
## Summary
SUMMARY: Bugfixes "make items sorted again"

## Purpose of change

Fixes #3542. 

## Describe the solution

Places where it was previously using item's < operator had a layer of indirection added and so it was happily using the pointer's < instead. * dereferences and fixes this.
