### PR TITLE
fix: invalidate mass when moving items to/from vehicles

### DIFF
--- a/src/locations.cpp
+++ b/src/locations.cpp
@@ -413,7 +413,7 @@ item_location_type vehicle_item_location::where() const
 
 detached_ptr<item> vehicle_item_location::detach( item *it )
 {
-    detached_ptr<item> ret=veh->get_part_hack( hack_id ).remove_item( *it );
+    detached_ptr<item> ret = veh->get_part_hack( hack_id ).remove_item( *it );
     veh->invalidate_mass();
     return ret;
 }

--- a/src/locations.cpp
+++ b/src/locations.cpp
@@ -413,12 +413,15 @@ item_location_type vehicle_item_location::where() const
 
 detached_ptr<item> vehicle_item_location::detach( item *it )
 {
-    return veh->get_part_hack( hack_id ).remove_item( *it );
+    detached_ptr<item> ret=veh->get_part_hack( hack_id ).remove_item( *it );
+    veh->invalidate_mass();
+    return ret;
 }
 
 void vehicle_item_location::attach( detached_ptr<item> &&obj )
 {
     veh->get_part_hack( hack_id ).add_item( std::move( obj ) );
+    veh->invalidate_mass();
 }
 
 int vehicle_item_location::obtain_cost( const Character &ch, int qty, const item *it ) const


### PR DESCRIPTION
## Summary
SUMMARY: Bugfixes "Update vehicle weight when items are moved to/from it with aim"

## Purpose of change

Fixes #3553. 

## Describe the solution

Invalidate the vehicle's mass when moving items around using the new location stuff.