### PR TITLE
fix: mending vehicles

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5018,7 +5018,7 @@ void game::exam_vehicle( vehicle &veh, point c )
         return;
     }
     std::unique_ptr<player_activity> act = veh_interact::run( veh, c );
-    if( act ) {
+    if( *act ) {
         u.moves = 0;
         u.assign_activity( std::move( act ) );
     }


### PR DESCRIPTION
## Summary
SUMMARY: Bugfixes "Fix mending vehicles from the menu"

## Purpose of change
Fixes #3570. 

## Describe the solution

Was checking the act incorrectly meaning even when veh_interact::run returns a null action it would still be used overwriting the action created by mend_item.