### PR TITLE
feat: fix and add `STR_RELOAD` to crossbows

### DIFF
--- a/data/json/items/classes/range.json
+++ b/data/json/items/classes/range.json
@@ -31,7 +31,7 @@
     "skill": "rifle",
     "symbol": "(",
     "color": "green",
-    "flags": [ "PRIMITIVE_RANGED_WEAPON", "CROSSBOW", "RELOAD_ONE" ],
+    "flags": [ "PRIMITIVE_RANGED_WEAPON", "CROSSBOW", "RELOAD_ONE", "STR_RELOAD" ],
     "clip_size": 1,
     "ammo": "bolt",
     "valid_mod_locations": [
@@ -56,7 +56,7 @@
     "range": 12,
     "dispersion": 400,
     "durability": 6,
-    "reload": 1200,
+    "reload": 600,
     "valid_mod_locations": [
       [ "accessories", 2 ],
       [ "grip", 1 ],

--- a/data/json/items/ranged/crossbows.json
+++ b/data/json/items/ranged/crossbows.json
@@ -282,7 +282,6 @@
     "price": 20000,
     "price_postapoc": 2000,
     "material": [ "wood", "iron" ],
-    "extend": { "flags": [ "STR_RELOAD" ] },
     "ammo": "pebble",
     "weight": "1906 g",
     "volume": "1250 ml",
@@ -421,6 +420,7 @@
     "price": 324000,
     "material": [ "steel", "wood" ],
     "extend": { "flags": [ "FIRE_TWOHAND", "TRADER_AVOID" ] },
+    "delete": { "flags": [ "STR_RELOAD" ] },
     "weight": "3628 g",
     "volume": "2500 ml",
     "price_postapoc": 6000,
@@ -432,7 +432,7 @@
     "recoil": 30,
     "durability": 6,
     "clip_size": 10,
-    "reload": 800,
+    "reload": 200,
     "valid_mod_locations": [ [ "dampening", 1 ], [ "grip", 1 ], [ "mechanism", 1 ] ]
   }
 ]

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11710,8 +11710,9 @@ int Character::item_reload_cost( const item &it, item &ammo, int qty ) const
     mv += cost / ( 1.0f + std::min( get_skill_level( sk ) * 0.1f, 1.0f ) );
 
     if( it.has_flag( flag_STR_RELOAD ) ) {
-        /** @EFFECT_STR reduces reload time of some weapons */
-        mv -= get_str() * 20;
+        /** @EFFECT_STR over 10 reduces reload time of some weapons */
+        /** maximum reduction down to 25% of reload rate */
+        mv *= std::max<float>( 10.0f / std::max<float>( 10.0f, get_str() ), 0.25f );
     }
 
     return std::max( mv, 25 );


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

Please use a descriptive name for the PR title, so it's clear at a glance what the PR is about.
-->

## Summary
SUMMARY: Balance "Sanity-check behavior of STR_RELOAD flag, re-add it to crossbows"

<!--
This section should consist of exactly one line, formatted like the example above.

'Category' must be one of the following:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/

If the PR is a port or adaptation of DDA content, please indicate it to be so.
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

So it was a while back brought to my attention that crossbows don't seem to be benefiting from strength anyway. I went into this assuming that the `STR_RELOAD` flag doesn't work, and on looking at its code it is indeed a bit janky and weird-looking.

Then I eventually found the real problem: most crossbows had the flag removed from them ages ago, but their description still implies they should be using them. Instead only a few items use them. There was a "fix" on DDA's end that just amounted to removing it from most weapons and fixing the description, but this fix was still pretty half-baked. Yes, in theory, drawing the crossbow to full draw is only part of the reloading process and being super-strong will only help with that part of the process.

But the rest of those steps should not take any longer than the usual 100-300 moves it takes to insert ammo into an item. Reload times for crossbows do not reflect this, instead they take several hundreds of moves and are clearly designed with the assumption that a weak character will be struggling their way through reloading, while a strong character won't take much longer than it'd take to physically pull something back and slip a bolt in. Needless to say, their "fix" for this did not account for this concept, and you still see fixed reload rates in excess of a thousand moves on DDA's crossbows to this very day.

So while I do want to make the `STR_RELOAD` code a bit less weird behavior-wise, the bulk of the fix is just making more weapons actually have it.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

C++ changes:
1. In character.cpp, changed `Character::item_reload_cost` to go from subtracting 20 moves for every point of strength you have to a multiplicative function. If you have 10 strength or less it does nothing, but beyond that it reduces reload rates up until it maxes at cutting it into a quarter, hit at 40 strength.

Idea is, the fixed subtractive method is simple and all but it also rapidly pushes a light enough crossbow into "ZA WARUDO" territory, meaning the end of the function caps it off at a quarter of a second after relatively low amounts of strength. Meanwhile, for massive heavy crossbows you need increasingly wacky amounts of super strength to see a reasonable benefit from them, as you'd need that 40 strength (normally the peak for a lot of mutant builds, plus or minus some Hydraulic Muscles or mod abuse). This way however, having 20+ strength is immediately and visibly useful even for heavy crossbows, while still ensuring weak baby child crossbows will still take take a second or two to load.

JSON changes:
1. Gave the `STR_RELOAD` flag directly to most crossbows via slapping it on `xbow_base`.
2. In turn, removed the injection of this flag from bullet crossbows, as it will inherit the flag from its copy-from anyway.
3. Reduced the base reload of `s_xbow_base`, and as a result pistol crossbows, from 1200 to 600. Having them take even more effort to reload than normal crossbows while dealing less damage is a bit weird, but its damage isn't THAT much lower than the basic medieval crossbow so doesn't need to be reduced to a downright tiny amount.
4. Set the repeating crossbow to delete the `STR_RELOAD` flag from itself, and reduced reload rate from 800 down to 200. It's noted to be drawn and fired using the lever, reloading instead loads bolts into a magazine, so it needing to take 8 seconds per bolt to reload is a tad odd.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Given the above musings on repeating crossbows, we could tweak it to have a slower aim spread to simulate the need to cock the lever and span the crossbow during the firing process.
2. We could also audit base reload times either further. If we made it so that strength below 10 is actually penalized and slower to reload, we'd need to do this so that the base reload time is made to be representative of how fast we want it to be at exactly the "baseline" level of strength.
3. Making the baseline point 8 instead of 10 strength.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON files for syntax and lint errors.
2. Compiled and load-tested.
3. Spawned in a basic crossbow, and two bolts, one on the floor and another loose in inventory.
4. Checked affected C++ file for astyle.

With both 1 and 10 strength (confirming strength below 10 doesn't currently penalize player):
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/5a722d47-2ba9-4697-a9b4-5acd5c914e56)

Was done to match the test setup I used in my desktop playthrough release.

20 strength:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/6689900b-a535-40f4-b07c-728689040e1e)

It's not quite half but other functions do stuff with `Character::item_reload_cost` so chicanery is to be expected.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Relevant PRs and issues:
1. DDA issue reporting `STR_RELOAD` no longer works, by @Dacendeth: https://github.com/CleverRaven/Cataclysm-DDA/issues/40704
2. DDA's "fix" for this, removing it from most weapons, by @kevingranade: https://github.com/CleverRaven/Cataclysm-DDA/pull/40730

Also gonna at some point tweak bows to in some way benefit from something like this, evidently it works differently from `STR_RELOAD` weapons so might as well save that ofr a later PR.

Bonus, along the way for some reason the reload time for quivers differs now and is slower than reloading from inventory and off the floor.

In build 2023-10-24-1439:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/e8ca6a9c-174d-47ec-ba46-884265b54dbf)

Contrast with build 2023-11-05-1454, and also this PR's branch:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/272bedf6-30eb-4cd4-b061-222660be64e2)
