### PR TITLE
fix: bad clears on inventories

### DIFF
--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -706,7 +706,6 @@ std::vector<detached_ptr<item>> location_inventory::reduce_stack( const int posi
                 }
             } else {
                 for( int i = 0 ; i < quantity ; i++ ) {
-                    //TODO!: check
                     item *it = &inv.remove_item( iter->front() );
                     it->remove_location();
                     ret.push_back( detached_ptr<item>( it ) );
@@ -827,6 +826,7 @@ std::vector<detached_ptr<item>> location_inventory::dump_remove( )
             dest.push_back( detached_ptr<item>( elem_stack_iter ) );
         }
     }
+    inv.clear();
     return dest;
 }
 


### PR DESCRIPTION
## Summary
SUMMARY: Bugfixes "Fix bad clear on inventories"

## Purpose of change

Fixes dump_remove not actually removing the items and potentially causing all sorts of location problems. 

## Describe the solution

Actually clears the inventory. 