### PR TITLE
fix: Add missing favorite on item copy

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -438,7 +438,7 @@ item::item( const item &source ) : game_object<item>( source ), contents( this )
     invlet = source.invlet;
     active = source.active;
     activated_by = source.activated_by;
-    is_favorite=source.is_favorite;
+    is_favorite = source.is_favorite;
 
     for( item * const &it : source.contents.all_items_top() ) {
         contents.insert_item( item::spawn( *it ) );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -438,6 +438,7 @@ item::item( const item &source ) : game_object<item>( source ), contents( this )
     invlet = source.invlet;
     active = source.active;
     activated_by = source.activated_by;
+    is_favorite=source.is_favorite;
 
     for( item * const &it : source.contents.all_items_top() ) {
         contents.insert_item( item::spawn( *it ) );


### PR DESCRIPTION
## Summary
SUMMARY: Bugfixes "Fix being unable to consume favorited items"

## Purpose of change

Fix a missing property in item cloning.

## Describe the solution

Add it. Writing the autogen stuff so we don't have to do this stuff manually is my next goal once the refactor has settled.