### PR TITLE
fix: npc splints and clean up iterator errors

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -483,6 +483,7 @@ item &item::operator=( const item &source )
     invlet = source.invlet;
     active = source.active;
     activated_by = source.activated_by;
+    is_favorite = source.is_favorite;
 
     contents.clear_items();
 

--- a/src/location_vector.cpp
+++ b/src/location_vector.cpp
@@ -215,7 +215,6 @@ void location_vector<T>::push_back( detached_ptr<T> &&obj )
 {
     if( locked > 0 ) {
         debugmsg( "Attempting to push_back to a vector with active iterators" );
-        return;
     }
     if( !obj ) {
         return;
@@ -263,7 +262,6 @@ detached_ptr<T> location_vector<T>::remove( T *obj )
 {
     if( locked > 0 ) {
         debugmsg( "Attempting to remove something from a vector with active iterators" );
-        return detached_ptr<T>();
     }
     if( destroyed ) {
         debugmsg( "Attempted to remove something from a destroyed location." );
@@ -294,7 +292,6 @@ typename location_vector<T>::iterator location_vector<T>::erase( typename
 {
     if( locked > 2 ) {
         debugmsg( "Attempting to erase something from a vector with more than 1 active iterator" );
-        return location_vector<T>::iterator( contents.end(), *this );
     }
     if( destroyed && out ) {
         debugmsg( "Attempted to erase something from a destroyed location." );
@@ -318,7 +315,6 @@ typename location_vector<T>::iterator location_vector<T>::insert( typename
 {
     if( locked > 2 ) {
         debugmsg( "Attempting to insert something into a vector with more than 1 active iterator" );
-        return it;
     }
     if( !obj ) {
         return it;
@@ -347,7 +343,6 @@ typename location_vector<T>::iterator location_vector<T>::insert( typename
 {
     if( locked > 2 ) {
         debugmsg( "Attempting to insert something into a vector with more than 1 active iterator" );
-        return it;
     }
     for( auto iter = start; iter != end; iter++ ) {
         if( !*iter ) {
@@ -469,7 +464,6 @@ typename std::vector<detached_ptr<T>> location_vector<T>::clear()
 {
     if( locked > 0 ) {
         debugmsg( "Attempting to clear a vector with active iterators" );
-        return std::vector<detached_ptr<T>>();
     }
     if( destroyed ) {
         debugmsg( "Attempted to clear a destroyed location." );
@@ -489,7 +483,6 @@ void location_vector<T>::remove_with( std::function < detached_ptr<T>( detached_
 {
     if( locked > 0 ) {
         debugmsg( "Attempting to clear a vector with active iterators" );
-        return;
     }
     if( destroyed ) {
         debugmsg( "Attempted to remove_with from a destroyed location." );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4736,7 +4736,7 @@ bool npc::adjust_worn()
         return false;
     };
 
-	item* splint=nullptr;
+    item *splint = nullptr;
     for( auto &elem : worn ) {
         if( !elem->has_flag( flag_SPLINT ) ) {
             continue;
@@ -4745,21 +4745,21 @@ bool npc::adjust_worn()
         if( !covers_broken( *elem, elem->get_side() ) ) {
             const bool needs_change = covers_broken( *elem, opposite_side( elem->get_side() ) );
             // Try to change side (if it makes sense), or take off.
-            if( needs_change && change_side(*elem) ){
-				return true;
-			}
-			
-			if(can_takeoff(*elem).success()){
-				splint=elem;
-				break;
-			}
-            
+            if( needs_change && change_side( *elem ) ) {
+                return true;
+            }
+
+            if( can_takeoff( *elem ).success() ) {
+                splint = elem;
+                break;
+            }
+
         }
     }
-    if(splint){
-		takeoff(*splint);
-		return true;
-	}
+    if( splint ) {
+        takeoff( *splint );
+        return true;
+    }
 
     return false;
 }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4736,6 +4736,7 @@ bool npc::adjust_worn()
         return false;
     };
 
+	item* splint=nullptr;
     for( auto &elem : worn ) {
         if( !elem->has_flag( flag_SPLINT ) ) {
             continue;
@@ -4744,11 +4745,21 @@ bool npc::adjust_worn()
         if( !covers_broken( *elem, elem->get_side() ) ) {
             const bool needs_change = covers_broken( *elem, opposite_side( elem->get_side() ) );
             // Try to change side (if it makes sense), or take off.
-            if( ( needs_change && change_side( *elem ) ) || takeoff( *elem ) ) {
-                return true;
-            }
+            if( needs_change && change_side(*elem) ){
+				return true;
+			}
+			
+			if(can_takeoff(*elem).success()){
+				splint=elem;
+				break;
+			}
+            
         }
     }
+    if(splint){
+		takeoff(*splint);
+		return true;
+	}
 
     return false;
 }


### PR DESCRIPTION
## Summary
SUMMARY: Bugfixes "Npcs removing splints no longer gives a debugmsg"

## Purpose of change

Fixes #3590. Adds a missing copy property. Also makes the iterator errors not cancel the action. This was how I originally imagined them, I must have autopiloted to make them abort early.

## Describe the solution

Move the removal outside the loop. Turning it into a call to something like remove_with would be the ideal way but this won't conflict with the other pr fixing their AI.