### PR TITLE
fix: crafting leaving 0 item stacks

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8638,7 +8638,7 @@ detached_ptr<item> item::use_charges( detached_ptr<item> &&self, const itype_id 
             }
         } else if( e->count_by_charges() ) {
             if( e->typeId() == what ) {
-                if( e->charges >= qty ) {
+                if( e->charges > qty ) {
                     e->charges -= qty;
                     detached_ptr<item> split = item::spawn( *e );
                     split->charges = qty;


### PR DESCRIPTION
## Summary
SUMMARY: Bugfixes "Fix crafting leaving 0 item stacks"

## Purpose of change

Fixes #3596.

## Describe the solution

Bad comparison. 