### PR TITLE
fix: Repair Item activity occasionally encountering a bad pointer when initiated from vehicle/grid

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2688,16 +2688,17 @@ void activity_handlers::repair_item_finish( player_activity *act, player *p )
 
     const std::string iuse_name_string = act->get_str_value( 0, "repair_item" );
     repeat_type repeat = static_cast<repeat_type>( act->get_value( 0, REPEAT_INIT ) );
-    item *ploc = nullptr;
-    if( !act->targets.empty() && act->targets[0] ) {
-        ploc = &*act->targets[0];
-    }
 
     // nullopt if used real tool
     std::optional<hack::hack_type_t> hack_type = hack::get_hack_type( *act );
     item *fake_tool = nullptr;
+    // real tool if used.
+    item *ploc = nullptr;
+
     if( hack_type ) {
         fake_tool = hack::get_fake_tool( hack_type.value(), *act );
+    } else {
+        ploc = &*act->targets[0];
     }
     const tripoint hack_position = hack_type ? hack::get_position( *act ) : tripoint{};
     const int hack_original_charges = fake_tool ? fake_tool->charges : 0;


### PR DESCRIPTION
## Summary

SUMMARY: Bugfixes "Fix Repair Item activity occasionally encountering a bad pointer when initiated from vehicle/grid"

## Purpose of change

- Should fix #3591.

Repair Item activity was crashing because it tries to construct an item from an invalid pointer when the activity is initiated from vehicle/grid, as the fake_item used to initiate the activity stops existing after initiating the activity. Prior to item identity this wasn't an issue as item location can lead to invalid locations so long as you don't actually use it.

## Describe the solution

Cleaned up `repair_item_finish` a bit, restructuring it so it doesn't even try to call the pointer unless it's confirmed it should have a valid one.

## Describe alternatives you've considered

- Remove the hack for grid/vehicles.
  - Ideal, won't be me though since I don't really know how to do this properly, it was a struggle hooking in grid furniture properly after #2172.

## Testing

This is... difficult, as the bug was random to begin with.
- Spawn a grid with 2 large storage batteries and a welding rig. Use solar panels (2/3 advanced solar panels will probably be fine) to top off the storage batteries. Wait a few hours to fill the batteries.
- Spawn 10 rifle scopes and 2000 aluminum ingots.
- Set skill to 10, activate the grid welder and repeat until reinforced on a single rifle scope.
- If it doesn't crash before the storage batteries deplete (or you run out of aluminum), then it's probably fine?
- Repeat with a welding cart with extra storage batteries (or a minireactor.

## Additional context

Spaghetti and shiny new features colliding is such great fun.

## Checklist