### PR TITLE
fix: calculate modes in gunmods too

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2022,18 +2022,20 @@ double npc::confidence_mult() const
 
 int npc::confident_shoot_range( const item &it, int recoil ) const
 {
-    int res = 0;
     if( !it.is_gun() ) {
-        return res;
+        return 0;
     }
     const auto gun_mode_cmp = []( const std::pair<gun_mode_id, gun_mode> &lhs,
     const std::pair<gun_mode_id, gun_mode> &rhs ) {
         return lhs.second.qty < rhs.second.qty;
     };
     std::map<gun_mode_id, gun_mode> modes = it.gun_all_modes();
+    if( modes.empty() ) {
+        debugmsg( "%s has no gun modes", it.tname() );
+        return 0;
+    }
     auto best = std::min_element( modes.begin(), modes.end(), gun_mode_cmp );
-    res = confident_gun_mode_range( ( *best ).second, recoil );
-    return res;
+    return confident_gun_mode_range( ( *best ).second, recoil );
 }
 
 int npc::confident_gun_mode_range( const gun_mode &gun, int at_recoil ) const

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2076,9 +2076,9 @@ int npc::confident_throw_range( const item &thrown, Creature *target ) const
     return static_cast<int>( confident_range );
 }
 
-double item::ideal_ranged_dps( const Character &who, std::optional<gun_mode> &mode ) const
+auto item::ideal_ranged_dps( const Character &who, std::optional<gun_mode> &mode ) const -> double
 {
-    if( !is_gun() || !mode ) {
+    if( !is_gun() || is_gunmod() || !mode ) {
         return 0;
     }
     damage_instance gun_damage = this->gun_damage();

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1955,13 +1955,15 @@ dispersion_sources ranged::get_weapon_dispersion( const Character &who, const it
     return dispersion;
 }
 
-std::pair<gun_mode_id, std::optional<gun_mode>> npc_ai::best_mode_for_range( const Character &who,
-        const item &firing,
-        int dist )
+auto npc_ai::best_mode_for_range(
+    const Character &who, const item &firing, int dist
+) -> std::pair<gun_mode_id, std::optional<gun_mode>>
 {
-    int shots = who.is_wielding( firing ) ? character_funcs::ammo_count_for( who,
-                firing ) : item_funcs::shots_remaining( who, firing );
-    if( !firing.is_gun() || shots == 0 ) {
+    const int shots = who.is_wielding( firing )
+                      ? character_funcs::ammo_count_for( who, firing )
+                      : item_funcs::shots_remaining( who, firing );
+
+    if( !firing.is_gun() || firing.is_gunmod() || shots == 0 ) {
         return std::make_pair( gun_mode_id(), std::nullopt );
     }
     int min_recoil = MAX_RECOIL;


### PR DESCRIPTION
## Summary

SUMMARY: Bugfixes "Prevent segfault caused by not calculating modes in gunmods"

## Purpose of change

- fix #3315
- possibly fix #3014

## Describe the solution


~~- `item::gun_all_modes`
	- before: require item to **BE** `gun` and **NOT** `gunmod`
	- after: require item to be **EITHER** `gun` **OR** `gunmod`, as the following loop seemed to handle both.~~
- added debugmsg in `[confident_shoot_range](https://github.com/cataclysmbnteam/Cataclysm-BN/commit/0666c90d4bab4b54fbc9679157537d0dac56307e)` to warn empty modes (and prevent segfault)

EDIT:
followed suggestion from
- [kheir](https://discord.com/channels/830879262763909202/830916451517857894/1172521526378123264)
- [olanti](https://discord.com/channels/830879262763909202/830916451517857894/1172528443250970684)
and prevented gunmods from being calculated.

## Describe alternatives you've considered

cri

## Testing

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/889f38e8-932b-4aba-9ed2-e8832530517b

couldn't test #3014 as there were no saves given. however the symptoms look similar.

## Additional context

cc @KheirFerrum 
