### PR TITLE
ci: bump dmgbuild to 1.6.1

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -218,7 +218,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           HOMEBREW_NO_AUTO_UPDATE=yes HOMEBREW_NO_INSTALL_CLEANUP=yes brew install sdl2 sdl2_image sdl2_ttf sdl2_mixer gettext ccache parallel
-          pip3 install mac_alias==2.2.0 dmgbuild==1.4.2 biplist
+          pip3 install mac_alias==2.2.0 dmgbuild==1.6.1 biplist
       - name: Compile translations (windows)
         if: runner.os == 'Windows'
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           HOMEBREW_NO_AUTO_UPDATE=yes HOMEBREW_NO_INSTALL_CLEANUP=yes brew install sdl2 sdl2_image sdl2_ttf sdl2_mixer gettext ccache parallel
-          pip3 install mac_alias==2.2.0 dmgbuild==1.4.2 biplist
+          pip3 install mac_alias==2.2.0 dmgbuild==1.6.1 biplist
       - name: Compile translations (windows)
         if: runner.os == 'Windows'
         shell: bash


### PR DESCRIPTION
## Summary

SUMMARY: Build "bump dmgbuild to 1.6.1 to prevent build failure in macos" 

## Purpose of change

- fix #3578

