### PR TITLE
fix: crash in vehicle activities

### DIFF
--- a/src/veh_interact.h
+++ b/src/veh_interact.h
@@ -58,7 +58,7 @@ class veh_interact
         veh_interact( vehicle &veh, point p = point_zero );
         ~veh_interact();
 
-        item *target;
+        item *target=nullptr;
 
         point dd = point_zero;
         /* starting offset for vehicle parts description display and max offset for scrolling */

--- a/src/veh_interact.h
+++ b/src/veh_interact.h
@@ -58,7 +58,7 @@ class veh_interact
         veh_interact( vehicle &veh, point p = point_zero );
         ~veh_interact();
 
-        item *target=nullptr;
+        item *target = nullptr;
 
         point dd = point_zero;
         /* starting offset for vehicle parts description display and max offset for scrolling */


### PR DESCRIPTION
## Summary
SUMMARY: Bugfixes "Fix crash during save when working on a vehicle"

## Purpose of change

Fixes a crash that could happen when the game autosaves while you work on a vehicle. Don't think there's an issue for this one.

## Describe the solution

Initialize a variable. 