### PR TITLE
feat(content): monstergroup for gunstores, milsurp, etc

### DIFF
--- a/data/json/mapgen/gunsmith.json
+++ b/data/json/mapgen/gunsmith.json
@@ -104,7 +104,8 @@
         { "item": "large_repairkit", "x": [ 9, 10 ], "y": 8, "chance": 30 },
         { "item": "television", "x": 14, "y": 16, "chance": 60 },
         { "item": "laptop", "x": 17, "y": 15, "chance": 30 }
-      ]
+      ],
+      "place_monsters": [ { "monster": "GROUP_ZOMBIE_GUNSTORE", "x": [ 2, 21 ], "y": 2, "chance": 2, "repeat": [ 2, 3 ] } ]
     }
   },
   {

--- a/data/json/mapgen/mil_surplus.json
+++ b/data/json/mapgen/mil_surplus.json
@@ -32,7 +32,8 @@
         "..|&  |4YYYUUYUU<|LL|@|.",
         "..|----YYYYYYYYYY-----|."
       ],
-      "palettes": [ "mil_surplus" ]
+      "palettes": [ "mil_surplus" ],
+      "place_monsters": [ { "monster": "GROUP_ZOMBIE_GUNSTORE", "x": [ 2, 21 ], "y": 1, "chance": 2, "repeat": [ 1, 2 ] } ]
     }
   },
   {
@@ -129,7 +130,8 @@
         ".----------------------.",
         "........................"
       ],
-      "palettes": [ "mil_surplus" ]
+      "palettes": [ "mil_surplus" ],
+      "place_monsters": [ { "monster": "GROUP_ZOMBIE_GUNSTORE", "x": [ 2, 21 ], "y": 1, "chance": 2, "repeat": [ 1, 2 ] } ]
     }
   },
   {
@@ -269,7 +271,8 @@
         { "chance": 75, "repeat": [ 1, 4 ], "item": "mil_surplus", "x": [ 14, 15 ], "y": [ 11, 18 ] },
         { "chance": 75, "repeat": [ 1, 4 ], "item": "mil_surplus", "x": [ 9, 10 ], "y": [ 9, 10 ] },
         { "chance": 3, "repeat": [ 1, 4 ], "item": "pwr_armor_acc", "x": [ 9, 10 ], "y": [ 9, 10 ] }
-      ]
+      ],
+      "place_monsters": [ { "monster": "GROUP_ZOMBIE_GUNSTORE", "x": [ 13, 21 ], "y": [ 2, 3 ], "chance": 2, "repeat": [ 1, 2 ] } ]
     }
   },
   {

--- a/data/json/mapgen/s_gun.json
+++ b/data/json/mapgen/s_gun.json
@@ -128,7 +128,7 @@
         { "item": "ear_plugs", "x": 3, "y": 15, "chance": 50, "repeat": 2 },
         { "item": "powered_earmuffs", "x": 3, "y": 15, "chance": 30 }
       ],
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 0, 0 ], "y": [ 23, 23 ], "chance": 2, "repeat": [ 2, 3 ] } ]
+      "place_monsters": [ { "monster": "GROUP_ZOMBIE_GUNSTORE", "x": [ 2, 21 ], "y": 2, "chance": 2, "repeat": [ 2, 3 ] } ]
     }
   },
   {
@@ -276,7 +276,8 @@
         { "group": "guns_rifle_common_display", "x": 16, "y": [ 9, 10 ], "chance": 85, "repeat": [ 1, 3 ] },
         { "group": "mags_common", "x": [ 14, 16 ], "y": 12, "chance": 100, "repeat": [ 1, 8 ] },
         { "group": "mags_rare", "x": [ 14, 16 ], "y": 13, "chance": 75, "repeat": [ 1, 3 ] }
-      ]
+      ],
+      "place_monsters": [ { "monster": "GROUP_ZOMBIE_GUNSTORE", "x": [ 2, 21 ], "y": 0, "chance": 2, "repeat": [ 2, 3 ] } ]
     }
   },
   {
@@ -411,8 +412,8 @@
       "items": { "B": { "item": "bed", "chance": 65, "repeat": [ 1, 3 ] } },
       "monster": { "7": { "monster": "mon_zombie_cop" } },
       "place_monsters": [
-        { "monster": "GROUP_ZOMBIE", "x": [ 11, 13 ], "y": [ 17, 19 ], "density": 0.08 },
-        { "monster": "GROUP_ZOMBIE", "x": 18, "y": [ 14, 15 ], "density": 0.08 }
+        { "monster": "GROUP_ZOMBIE_GUNSTORE", "x": [ 11, 13 ], "y": [ 17, 19 ], "density": 0.08 },
+        { "monster": "GROUP_ZOMBIE_GUNSTORE", "x": 18, "y": [ 14, 15 ], "density": 0.08 }
       ],
       "place_fields": [
         { "field": "fd_blood", "x": [ 10, 11 ], "y": [ 14, 15 ], "repeat": [ 2, 4 ] },
@@ -539,7 +540,8 @@
         { "chance": 95, "item": "guns_common_display", "x": 19, "y": [ 5, 7 ] },
         { "chance": 45, "item": "trash", "x": 13, "y": 12 },
         { "chance": 45, "item": "trash", "x": 10, "y": 12 }
-      ]
+      ],
+      "place_monsters": [ { "monster": "GROUP_ZOMBIE_GUNSTORE", "x": [ 2, 21 ], "y": 2, "chance": 2, "repeat": [ 2, 3 ] } ]
     }
   },
   {

--- a/data/json/mapgen/store/s_hunting.json
+++ b/data/json/mapgen/store/s_hunting.json
@@ -98,7 +98,7 @@
         { "group": "tools_hunting", "x": [ 14, 20 ], "y": [ 8, 9 ], "chance": 70, "repeat": [ 12, 14 ] },
         { "group": "tools_hunting", "x": [ 14, 20 ], "y": [ 11, 12 ], "chance": 70, "repeat": [ 12, 14 ] }
       ],
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": 2, "chance": 2, "repeat": [ 2, 3 ] } ]
+      "place_monsters": [ { "monster": "GROUP_ZOMBIE_GUNSTORE", "x": [ 2, 21 ], "y": 2, "chance": 2, "repeat": [ 2, 3 ] } ]
     }
   },
   {

--- a/data/json/monstergroups/zombies.json
+++ b/data/json/monstergroups/zombies.json
@@ -621,6 +621,30 @@
     ]
   },
   {
+    "type": "monstergroup",
+    "name": "GROUP_ZOMBIE_GUNSTORE",
+    "//": "Elevated chance of survivor zombies/ferals",
+    "default": "mon_zombie",
+    "monsters": [
+      { "monster": "mon_zombie_fat", "freq": 100, "cost_multiplier": 1 },
+      { "monster": "mon_zombie_tough", "freq": 50, "cost_multiplier": 1 },
+      { "monster": "mon_zombie_rot", "freq": 25, "cost_multiplier": 1 },
+      { "monster": "mon_zombie_crawler", "freq": 50, "cost_multiplier": 1 },
+      { "monster": "mon_zombie_static", "freq": 25, "cost_multiplier": 1 },
+      { "monster": "mon_zombie_cop", "freq": 50, "cost_multiplier": 1 },
+      { "monster": "mon_zombie_swat", "freq": 25, "cost_multiplier": 1 },
+      { "monster": "mon_zombie_soldier", "freq": 25, "cost_multiplier": 2 },
+      { "monster": "mon_dog_zombie_cop", "freq": 25, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_dog", "freq": 10, "cost_multiplier": 2 },
+      { "monster": "mon_dog_zombie_rot", "freq": 15, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_survivor", "freq": 100, "cost_multiplier": 1 },
+      { "monster": "mon_zombie_survivor_elite", "freq": 50, "cost_multiplier": 5, "starts": 1440 },
+      { "monster": "mon_feral_survivalist", "starts": 250, "freq": 40, "cost_multiplier": 1 },
+      { "monster": "mon_feral_prepper", "starts": 500, "freq": 30, "cost_multiplier": 5 },
+      { "monster": "mon_feral_militia", "starts": 500, "freq": 30, "cost_multiplier": 10 }
+    ]
+  },
+  {
     "name": "FERAL_HUMANS",
     "type": "monstergroup",
     "default": "mon_feral_human_pipe",


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

Please use a descriptive name for the PR title, so it's clear at a glance what the PR is about.
-->

## Summary
SUMMARY: Balance "Define a monstergroup for zeds spawning at gunstores, hunting supply stores, and military surplus stores"

<!--
This section should consist of exactly one line, formatted like the example above.

'Category' must be one of the following:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/

If the PR is a port or adaptation of DDA content, please indicate it to be so.
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

One of those misc ideas brought up back when I was adding ferals to monstergroups if I recall, and came up again while adjusting balance of survivor zombie monsterdrops.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Defined monstergroup `GROUP_ZOMBIE_GUNSTORE`, meant to have a higher than normal number of survivor zombies and ferals, though not as high as prepper house spawns. Has survivor zombies/ferals (elites and ferals being offset to spawn later as is normal) about 25% of the time in total, cop/soldier zombies 10% of the time, assorted zombie dogs 5% of the time, and assorted civilian non-profession zeds 25% of the time.
2. Set gunstores and hunting supply stores to use `GROUP_ZOMBIE_GUNSTORE` instead of the normal `GROUP_ZOMBIE`. In the case of the basic variant this entails fixing the janky spawn placement to place them in the parking lot instead of in the bottom-left corner of the map.
3. Added a call to `GROUP_ZOMBIE_GUNSTORE` to the other variants of gun stores and to military surplus stores, which previously lacked any monster spawns at all. In the case of milsurp stores, they spawn one less zed than in other locations since the reward is less worthwhile.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Not adding the new itemgroup to locations previously lacking spawns.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Checked affected files for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
