### PR TITLE
feat(balance): carnivores can eat protein drinks

### DIFF
--- a/data/json/items/comestibles/protein.json
+++ b/data/json/items/comestibles/protein.json
@@ -18,7 +18,7 @@
     "spoils_in": "2 days",
     "phase": "liquid",
     "container": "bottle_plastic",
-    "material": "water",
+    "material": "flesh",
     "calories": 100,
     "quench": 40,
     "healthy": 2,
@@ -80,7 +80,7 @@
       { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "perturbing %s" } }
     ],
     "description": "A thick and tasty beverage made from pure refined protein and nutritious fruit.",
-    "material": "fruit",
+    "material": [ "fruit", "flesh" ],
     "calories": 150,
     "healthy": 4,
     "fun": 4,


### PR DESCRIPTION
## Summary
SUMMARY: Balance "Carnivores can eat protein drinks"

## Purpose of change

Carnivores are tagged to only eat certain materials, such as flesh or milk. Protein drinks are set to water and shakes are set to fruit. Since protein powder is made directly from dried meat, it seems fitting to let them drink it.

## Describe the solution

I set protein shakes to flesh and fruit, and protein drinks to flesh. The reason flesh is the crafting recipe, we don't have a way to extract the whey from cheese to make protein powder so instead its made from meat.

## Describe alternatives you've considered

Set them to milk and add the ability to extract whey, plus differentiate between meat powder and whey powder.

## Testing

I can eat them now.

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/112293514/31d5be1b-d35f-4031-b637-a88d80a0468b)


## Additional context

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/112293514/5d603e11-5235-4697-a503-b6a1bcec4b7b)
