### PR TITLE
fix: crafting destroying tools sometimes

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10294,7 +10294,7 @@ std::vector<detached_ptr<item>> Character::use_charges( const itype_id &what, in
                     e->ammo_consume( n, p );
                 } else {
                     detached_ptr<item> split = item::spawn( *e );
-                    split->ammo_set(e->ammo_current(), n);
+                    split->ammo_set( e->ammo_current(), n );
                     e->ammo_consume( n, p );
                     res.push_back( std::move( split ) );
                 }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10290,11 +10290,12 @@ std::vector<detached_ptr<item>> Character::use_charges( const itype_id &what, in
                 qty -= n;
 
                 if( n == e->ammo_remaining() ) {
-                    res.push_back( std::move( e ) );
-                } else {
+                    res.push_back( item::spawn( *e ) );
                     e->ammo_consume( n, p );
+                } else {
                     detached_ptr<item> split = item::spawn( *e );
-                    split->charges = n;
+                    split->ammo_set(e->ammo_current(), n);
+                    e->ammo_consume( n, p );
                     res.push_back( std::move( split ) );
                 }
             }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8627,12 +8627,12 @@ detached_ptr<item> item::use_charges( detached_ptr<item> &&self, const itype_id 
                 qty -= n;
 
                 if( n == e->ammo_remaining() ) {
-                    used.push_back( std::move( e ) );
-                    return detached_ptr<item>();
-                } else {
+                    used.push_back( item::spawn( *e ) );
                     e->ammo_consume( n, pos );
+                } else {
                     detached_ptr<item> split = item::spawn( *e );
-                    split->charges = n;
+                    split->ammo_set(e->ammo_current(), n);
+                    e->ammo_consume( n, pos );
                     used.push_back( std::move( split ) );
                 }
             }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8631,7 +8631,7 @@ detached_ptr<item> item::use_charges( detached_ptr<item> &&self, const itype_id 
                     e->ammo_consume( n, pos );
                 } else {
                     detached_ptr<item> split = item::spawn( *e );
-                    split->ammo_set(e->ammo_current(), n);
+                    split->ammo_set( e->ammo_current(), n );
                     e->ammo_consume( n, pos );
                     used.push_back( std::move( split ) );
                 }


### PR DESCRIPTION
## Summary
SUMMARY: Bugfixes "Fix crafting destroying tools sometimes"

## Purpose of change

Crafting was sometimes destroying tools that it shouldn't be.

## Describe the solution

Rejig the code so it just consumes ammo rather than destroying. 