### PR TITLE
fix: Dropping wielded `count-by-charges` items causing errors

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2969,7 +2969,7 @@ void activity_handlers::gunmod_add_finish( player_activity *act, player *p )
     if( rng( 0, 100 ) <= roll ) {
         add_msg( m_good, _( "You successfully attached the %1$s to your %2$s." ), mod.tname(),
                  gun.tname() );
-        gun.put_in(  mod.detach() );
+        gun.put_in( mod.detach() );
 
     } else if( rng( 0, 100 ) <= risk ) {
         if( gun.inc_damage() ) {

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2969,7 +2969,7 @@ void activity_handlers::gunmod_add_finish( player_activity *act, player *p )
     if( rng( 0, 100 ) <= roll ) {
         add_msg( m_good, _( "You successfully attached the %1$s to your %2$s." ), mod.tname(),
                  gun.tname() );
-        gun.put_in( p->i_rem( &mod ) );
+        gun.put_in(  mod.detach() );
 
     } else if( rng( 0, 100 ) <= risk ) {
         if( gun.inc_damage() ) {
@@ -2981,7 +2981,7 @@ void activity_handlers::gunmod_add_finish( player_activity *act, player *p )
             }
             add_msg( m_bad, _( "You failed at installing the %s and destroyed your %s!" ), mod.tname(),
                      gun.tname() );
-            p->i_rem( &gun );
+            gun.detach( );
         } else {
             add_msg( m_bad, _( "You failed at installing the %s and damaged your %s!" ), mod.tname(),
                      gun.tname() );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -647,7 +647,7 @@ std::vector<detached_ptr<item>> obtain_and_tokenize_items( player &p, std::list<
         } else if( ait.loc->count_by_charges() ) {
             res.push_back( p.reduce_charges( const_cast<item *>( &*ait.loc ), ait.count ) );
         } else {
-            res.push_back( p.i_rem( &*ait.loc ) );
+            res.push_back( ait.loc->detach() );
         }
 
         // TODO: Get the item consistently instead of using back()
@@ -2049,7 +2049,7 @@ static bool tidy_activity( player &p, const tripoint &src_loc,
         for( item *inv_elem : p.inv_dump() ) {
             if( inv_elem->has_var( "activity_var" ) ) {
                 inv_elem->erase_var( "activity_var" );
-                put_into_vehicle_or_drop( p, item_drop_reason::deliberate, p.i_rem( inv_elem ),
+                put_into_vehicle_or_drop( p, item_drop_reason::deliberate, inv_elem->detach(),
                                           src_loc );
             }
         }

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1244,11 +1244,7 @@ bool avatar::wield( item &target )
     add_msg( m_debug, "wielding took %d moves", mv );
     moves -= mv;
 
-    if( has_item( target ) ) {
-        set_primary_weapon( i_rem( &target ) );
-    } else {
-        set_primary_weapon( target.detach() );
-    }
+    set_primary_weapon( target.detach() );
 
     last_item = target.typeId();
     recoil = MAX_RECOIL;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2846,9 +2846,9 @@ void Character::inv_unsort()
     inv.unsort();
 }
 
-detached_ptr<item> Character::inv_remove_item(item* it)
+detached_ptr<item> Character::inv_remove_item( item *it )
 {
-    return inv.remove_item(it);
+    return inv.remove_item( it );
 }
 
 detached_ptr<item> Character::i_rem( int pos )

--- a/src/character.h
+++ b/src/character.h
@@ -1228,7 +1228,7 @@ class Character : public Creature, public location_visitable<Character>
 
         void inv_restack();
 
-        detached_ptr<item> inv_remove_item(item *);
+        detached_ptr<item> inv_remove_item( item * );
 
         units::volume inv_volume() const;
 

--- a/src/character.h
+++ b/src/character.h
@@ -1228,6 +1228,8 @@ class Character : public Creature, public location_visitable<Character>
 
         void inv_restack();
 
+        detached_ptr<item> inv_remove_item(item *);
+
         units::volume inv_volume() const;
 
         void inv_unsort();
@@ -1322,7 +1324,6 @@ class Character : public Creature, public location_visitable<Character>
          * in the players possession (one can use @ref has_item to check for this).
          * @return A copy of the removed item.
          */
-        detached_ptr<item> i_rem( const item *it );
         detached_ptr<item> i_rem_keep_contents( int idx );
         /** Sets invlet and adds to inventory if possible, drops otherwise.*/
         detached_ptr<item> i_add_or_drop( detached_ptr<item> &&it );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8007,7 +8007,7 @@ int iuse::radiocar( player *p, item *it, bool, const tripoint & )
                 p->moves -= to_moves<int>( 3_seconds );
                 p->add_msg_if_player( _( "You armed your RC car with %s." ),
                                       put.tname() );
-                it->put_in( put.detach( ));
+                it->put_in( put.detach( ) );
             } else if( !put.has_flag( flag_RADIOCARITEM ) ) {
                 p->add_msg_if_player( _( "RC car with %s?  How?" ),
                                       put.tname() );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1849,7 +1849,7 @@ int iuse::fish_trap( player *p, item *it, bool t, const tripoint &pos )
         }
         it->active = true;
         it->set_age( 0_turns );
-        g->m.add_item_or_charges( pnt, p->i_rem( it ) );
+        g->m.add_item_or_charges( pnt, it->detach() );
         p->add_msg_if_player( m_info,
                               _( "You place the fish trap, in three hours or so you may catch some fish." ) );
 
@@ -4675,7 +4675,7 @@ int iuse::blood_draw( player *p, item *it, bool, const tripoint & )
             if( it->inc_damage( DT_ACID ) ) {
                 p->add_msg_if_player( m_info, _( "…but acidic blood melts the %s, destroying it!" ),
                                       it->tname() );
-                p->i_rem( it );
+                it->detach();
                 return 0;
             }
             p->add_msg_if_player( m_info, _( "…but acidic blood damages the %s!" ), it->tname() );
@@ -4785,7 +4785,7 @@ int iuse::lumber( player *p, item *it, bool t, const tripoint & )
         p->add_msg_if_player( m_info, _( "You do not have that item!" ) );
         return 0;
     }
-    p->i_rem( &*loc );
+    loc->detach();
     cut_log_into_planks( *p );
     return it->type->charges_to_use();
 }
@@ -8007,7 +8007,7 @@ int iuse::radiocar( player *p, item *it, bool, const tripoint & )
                 p->moves -= to_moves<int>( 3_seconds );
                 p->add_msg_if_player( _( "You armed your RC car with %s." ),
                                       put.tname() );
-                it->put_in( p->i_rem( &put ) );
+                it->put_in( put.detach( ));
             } else if( !put.has_flag( flag_RADIOCARITEM ) ) {
                 p->add_msg_if_player( _( "RC car with %s?  How?" ),
                                       put.tname() );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -414,7 +414,7 @@ int unpack_actor::use( player &p, item &it, bool, const tripoint & ) const
         here.add_item_or_charges( p.pos(), std::move( content ) );
     }
 
-    p.i_rem( &it );
+    it.detach( );
 
     return 0;
 }

--- a/src/locations.cpp
+++ b/src/locations.cpp
@@ -75,7 +75,7 @@ std::string fake_item_location::describe( const Character *, const item * ) cons
 
 detached_ptr<item> character_item_location::detach( item *it )
 {
-    return holder->i_rem( it );
+    return holder->inv_remove_item( it );
 }
 
 void character_item_location::attach( detached_ptr<item> &&obj )

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2409,12 +2409,12 @@ void avatar_funcs::try_disarm_npc( avatar &you, npc &target )
             //~ %1$s: weapon name, %2$s: NPC name
             add_msg( _( "You forcefully take %1$s from %2$s!" ), it.tname(), target.name );
             // wield() will deduce our moves, consider to deduce more/less moves for balance
-            you.wield( target.i_rem( &it ) );
+            you.wield( it.detach( ) );
         } else if( my_roll >= their_roll / 2 ) {
             add_msg( _( "You grab at %s and pull with all your force, but it drops nearby!" ),
                      it.tname() );
             const tripoint tp = target.pos() + tripoint( rng( -1, 1 ), rng( -1, 1 ), 0 );
-            g->m.add_item_or_charges( tp, target.i_rem( &it ) );
+            g->m.add_item_or_charges( tp, it.detach( ) );
             you.mod_moves( -100 );
         } else {
             add_msg( _( "You grab at %s and pull with all your force, but in vain!" ), it.tname() );
@@ -2431,7 +2431,7 @@ void avatar_funcs::try_disarm_npc( avatar &you, npc &target )
         add_msg( _( "You smash %s with all your might forcing their %s to drop down nearby!" ),
                  target.name, it.tname() );
         const tripoint tp = target.pos() + tripoint( rng( -1, 1 ), rng( -1, 1 ), 0 );
-        g->m.add_item_or_charges( tp, target.i_rem( &it ) );
+        g->m.add_item_or_charges( tp, it.detach( ) );
     } else {
         add_msg( _( "You smash %s with all your might but %s remains in their hands!" ),
                  target.name, it.tname() );
@@ -2465,11 +2465,11 @@ void avatar_funcs::try_steal_from_npc( avatar &you, npc &target )
 
     int their_roll = dice( 5, target.get_per() );
 
-    const item *it = loc;
+    item *it = loc;
     if( my_roll >= their_roll ) {
         add_msg( _( "You sneakily steal %1$s from %2$s!" ),
                  it->tname(), target.name );
-        you.i_add( target.i_rem( it ) );
+        you.i_add( it->detach( ) );
     } else if( my_roll >= their_roll / 2 ) {
         add_msg( _( "You failed to steal %1$s from %2$s, but did not attract attention." ),
                  it->tname(), target.name );

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -5455,7 +5455,7 @@ bool mattack::bio_op_disarm( monster *z )
     if( my_roll >= their_roll && !it.has_flag( flag_NO_UNWIELD ) ) {
         target->add_msg_if_player( m_bad, _( "and throws it to the ground!" ) );
         const tripoint tp = foe->pos() + tripoint( rng( -1, 1 ), rng( -1, 1 ), 0 );
-        g->m.add_item_or_charges( tp, foe->i_rem( &it ) );
+        g->m.add_item_or_charges( tp, it.detach( ) );
     } else {
         target->add_msg_if_player( m_good, _( "but you break its grip!" ) );
     }

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -618,7 +618,7 @@ void monexamine::attach_bag_to( monster &z )
     }
 
     item &it = *loc;
-    z.set_storage_item( you.i_rem( &it ) );
+    z.set_storage_item( it.detach( ) );
     add_msg( _( "You mount the %1$s on your %2$s." ), it.display_name(), pet_name );
     z.add_effect( effect_has_bag, 1_turns, num_bp );
     // Update encumbrance in case we were wearing it
@@ -829,7 +829,7 @@ void monexamine::add_leash( monster &z )
         return;
     }
     item *rope_item = rope_inv[index - 1];
-    z.set_tied_item( player.i_rem( rope_item ) );
+    z.set_tied_item( rope_item->detach( ) );
     z.add_effect( effect_leashed, 1_turns );
     z.get_effect( effect_leashed ).set_permanent();
     add_msg( _( "You add a leash to your %s." ), z.get_name() );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4088,7 +4088,7 @@ void npc::mug_player( Character &mark )
         return;
     }
     if( !is_hallucination() ) {
-        i_add( mark.i_rem( to_steal ) );
+        i_add( to_steal->detach( ) );
         if( mark.is_npc() ) {
             if( u_see ) {
                 add_msg( _( "%1$s takes %2$s's %3$s." ), name, mark.name, to_steal->tname() );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3417,7 +3417,7 @@ std::string give_item_to( npc &p, bool allow_use )
         const auto consume_res = try_consume( p, given, reason );
         if( consume_res != REFUSED ) {
             if( consume_res == CONSUMED_ALL ) {
-                you.i_rem( &given );
+                given.detach( );
             }
             you.moves -= 100;
             if( given.is_container() ) {

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -831,7 +831,7 @@ void talk_function::drop_stolen_item( npc &p )
     map &here = get_map();
     for( auto &elem : g->u.inv_dump() ) {
         if( elem->is_old_owner( p ) ) {
-            detached_ptr<item> to_drop = g->u.i_rem( elem );
+            detached_ptr<item> to_drop = elem->detach( );
             to_drop->remove_old_owner();
             to_drop->set_owner( p );
             here.add_item_or_charges( g->u.pos(), std::move( to_drop ) );

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -168,7 +168,7 @@ detached_ptr<item> player::reduce_charges( item *it, int quantity )
         return detached_ptr<item>();
     }
     if( it->charges <= quantity ) {
-        return i_rem( it );
+        return it->detach();
     }
     it->mod_charges( -quantity );
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -679,7 +679,7 @@ bool ranged::handle_gun_damage( Character &shooter, item &it )
                         shooter.add_msg_player_or_npc( m_bad, _( "Your attached %s is destroyed by your shot!" ),
                                                        _( "<npcname>'s attached %s is destroyed by their shot!" ),
                                                        mod->tname() );
-                        shooter.i_rem( mod );
+                        mod->detach();
                     } else if( it.damage() > initstate ) {
                         shooter.add_msg_player_or_npc( m_bad, _( "Your attached %s is damaged by your shot!" ),
                                                        _( "<npcname>'s %s is damaged by their shot!" ),

--- a/tests/behavior_test.cpp
+++ b/tests/behavior_test.cpp
@@ -161,7 +161,7 @@ TEST_CASE( "check_npc_behavior_tree", "[npc][behavior]" )
         item &sweater = *det;
         test_npc.i_add( std::move( det ) );
         CHECK( npc_needs.tick( &oracle ) == "wear_warmer_clothes" );
-        det = test_npc.i_rem( &sweater );
+        det = sweater.detach( );
         test_npc.wear_item( std::move( det ) );
         CHECK( npc_needs.tick( &oracle ) == "idle" );
         test_npc.i_add( item::spawn( itype_id( "lighter" ) ) );

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -201,7 +201,7 @@ TEST_CASE( "available_recipes", "[recipes]" )
                 }
             }
             AND_WHEN( "he gets rid of the book" ) {
-                dummy.i_rem( &craftbook );
+                craftbook.detach( );
 
                 THEN( "he can't brew the recipe anymore" ) {
                     CHECK_FALSE( dummy.get_recipes_from_books( dummy.crafting_inventory() ).contains( *r ) );
@@ -230,7 +230,7 @@ TEST_CASE( "available_recipes", "[recipes]" )
                 }
             }
             AND_WHEN( "he gets rid of the tablet" ) {
-                dummy.i_rem( &eink );
+                eink.detach( );
 
                 THEN( "he can't make the recipe anymore" ) {
                     CHECK_FALSE( dummy.get_recipes_from_books( dummy.crafting_inventory() ).contains( *r2 ) );

--- a/tests/invlet_test.cpp
+++ b/tests/invlet_test.cpp
@@ -358,7 +358,7 @@ static void move_item( player &p, item &it, const inventory_location from,
                     break;
                 case INVENTORY:
                     if( p.is_wielding( it ) ) {
-                        p.i_add( p.i_rem( &it ) );
+                        p.i_add( it.detach( ) );
                     } else {
                         p.takeoff( it );
                     }


### PR DESCRIPTION
## Summary
SUMMARY: Bugfixes "Fixed error dropping wielded count-by-charges items"

## Purpose of change

Fixes #3606. 

## Describe the solution

Removed character::i_rem(item*). This function is a bit awkward and slow, doesn't work right with cbc items and can be easily replaced with item->detach(). 