### PR TITLE
fix: Better attempt detach logic

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1529,6 +1529,7 @@ detached_ptr<item> Character::consume_item( detached_ptr<item> &&target )
             if( comest.charges <= 0 ) {
                 comest.detach();
             }
+            target->on_contents_changed();
             return std::move( target );
         }
     }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -774,31 +774,31 @@ bool item::attempt_split( int qty,
         return false;
     }
     item &after_split = *det;
-    int starting_charges=after_split.charges;
+    int starting_charges = after_split.charges;
     det = cb( std::move( det ) );
     bool ret = true;
-    bool changed=false;
+    bool changed = false;
     if( det ) {
         if( det->type->get_id() != type->get_id() ) {
             debugmsg( "attempt_split returned the wrong item type" );
         } else {
-			changed|=det->charges!=starting_charges;
-			//Copy any changed properties from the new item, except the charges
-			int old_charges=charges;
-			*this=*det;
-			charges=old_charges;
+            changed |= det->charges != starting_charges;
+            //Copy any changed properties from the new item, except the charges
+            int old_charges = charges;
+            *this = *det;
+            charges = old_charges;
             merge_charges( std::move( det ), true );
         }
         ret = false;
-    }else{
-		changed=true;
-	}
-    if(changed){
-		contents_item_location * contents_loc=dynamic_cast<contents_item_location*>(&*loc);
-		if(contents_loc){
-			contents_loc->on_changed(this);
-		}
-	}
+    } else {
+        changed = true;
+    }
+    if( changed ) {
+        contents_item_location *contents_loc = dynamic_cast<contents_item_location *>( &*loc );
+        if( contents_loc ) {
+            contents_loc->on_changed( this );
+        }
+    }
     after_split.unsafe_rejoin( *this );
     return ret;
 }
@@ -1052,7 +1052,7 @@ bool item::merge_charges( detached_ptr<item> &&rhs, bool force )
         debugmsg( "Attempted to merge %s with itself.", debug_name() );
         return false;
     }
-    if( !count_by_charges() || (!stacks_with( *rhs ) && !force) ) {
+    if( !count_by_charges() || ( !stacks_with( *rhs ) && !force ) ) {
         return false;
     }
     item &obj = *rhs;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -752,7 +752,7 @@ void item::unsafe_rejoin( item &old )
         return;
     }
 
-    merge_charges( old.detach() );
+    merge_charges( old.detach(), true );
 }
 
 bool item::attempt_detach( std::function < detached_ptr<item>( detached_ptr<item> && ) > cb )
@@ -774,16 +774,31 @@ bool item::attempt_split( int qty,
         return false;
     }
     item &after_split = *det;
+    int starting_charges=after_split.charges;
     det = cb( std::move( det ) );
     bool ret = true;
+    bool changed=false;
     if( det ) {
         if( det->type->get_id() != type->get_id() ) {
             debugmsg( "attempt_split returned the wrong item type" );
         } else {
-            merge_charges( std::move( det ) );
+			changed|=det->charges!=starting_charges;
+			//Copy any changed properties from the new item, except the charges
+			int old_charges=charges;
+			*this=*det;
+			charges=old_charges;
+            merge_charges( std::move( det ), true );
         }
         ret = false;
-    }
+    }else{
+		changed=true;
+	}
+    if(changed){
+		contents_item_location * contents_loc=dynamic_cast<contents_item_location*>(&*loc);
+		if(contents_loc){
+			contents_loc->on_changed(this);
+		}
+	}
     after_split.unsafe_rejoin( *this );
     return ret;
 }
@@ -1031,13 +1046,13 @@ bool item::stacks_with( const item &rhs, bool check_components, bool skip_type_c
     return contents.stacks_with( rhs.contents );
 }
 
-bool item::merge_charges( detached_ptr<item> &&rhs )
+bool item::merge_charges( detached_ptr<item> &&rhs, bool force )
 {
     if( this == &*rhs ) {
         debugmsg( "Attempted to merge %s with itself.", debug_name() );
         return false;
     }
-    if( !count_by_charges() || !stacks_with( *rhs ) ) {
+    if( !count_by_charges() || (!stacks_with( *rhs ) && !force) ) {
         return false;
     }
     item &obj = *rhs;

--- a/src/item.h
+++ b/src/item.h
@@ -593,7 +593,7 @@ class item : public location_visitable<item>, public game_object<item>
          * Merging is only done for items counted by charges (@ref count_by_charges) and
          * items that stack together (@ref stacks_with).
          */
-        bool merge_charges( detached_ptr<item> &&rhs );
+        bool merge_charges( detached_ptr<item> &&rhs, bool force=false );
 
         units::mass weight( bool include_contents = true, bool integral = false ) const;
 

--- a/src/item.h
+++ b/src/item.h
@@ -593,7 +593,7 @@ class item : public location_visitable<item>, public game_object<item>
          * Merging is only done for items counted by charges (@ref count_by_charges) and
          * items that stack together (@ref stacks_with).
          */
-        bool merge_charges( detached_ptr<item> &&rhs, bool force=false );
+        bool merge_charges( detached_ptr<item> &&rhs, bool force = false );
 
         units::mass weight( bool include_contents = true, bool integral = false ) const;
 

--- a/src/locations.cpp
+++ b/src/locations.cpp
@@ -490,6 +490,12 @@ bool contents_item_location::is_loaded( const item * ) const
     return container->is_loaded();
 }
 
+void contents_item_location::on_changed( const item * ) const
+{
+    return container->on_contents_changed();
+}
+
+
 item_location_type contents_item_location::where() const
 {
     return item_location_type::container;

--- a/src/locations.h
+++ b/src/locations.h
@@ -208,6 +208,7 @@ class contents_item_location :  public item_location
         item_location_type where() const override;
         int obtain_cost( const Character &ch, int qty, const item *it ) const override;
         std::string describe( const Character *ch, const item *it ) const override;
+        void on_changed(const item * it) const;
 
         item *parent() const;
 };

--- a/src/locations.h
+++ b/src/locations.h
@@ -208,7 +208,7 @@ class contents_item_location :  public item_location
         item_location_type where() const override;
         int obtain_cost( const Character &ch, int qty, const item *it ) const override;
         std::string describe( const Character *ch, const item *it ) const override;
-        void on_changed(const item * it) const;
+        void on_changed( const item *it ) const;
 
         item *parent() const;
 };


### PR DESCRIPTION
## Summary
SUMMARY: Bugfixes "Fix a few item related bugs"

## Purpose of change

Fixes #3631, more completely this time.

## Describe the solution

Missed the case where attempt_detach is used to remove the item. I've improved the logic on attempt_detach in general so property changes during the handler are better respected and the remerging is forced.