### PR TITLE
fix: food rotting incorrectly

### DIFF
--- a/src/active_item_cache.cpp
+++ b/src/active_item_cache.cpp
@@ -100,6 +100,7 @@ std::vector<item *> active_item_cache::get_for_processing()
                           kv.second.second.size(); //Make sure the key isn't larger than the array
         std::advance( it, kv.second.first );
 
+        kv.second.first += num_to_process + 1;
         while( num_to_process >= 0 ) {
             if( *it ) {
                 items_to_process.push_back( & **it );
@@ -116,7 +117,6 @@ std::vector<item *> active_item_cache::get_for_processing()
                 it = kv.second.second.begin();
             }
         }
-        kv.second.first += num_to_process + 1;
     }
     return items_to_process;
 }


### PR DESCRIPTION
## Summary
SUMMARY: Bugfixes "Fix food rotting incorrectly"

## Purpose of change

Fixes half of #3610. Technically that issue is two separate bugs. This fixes the food not rotting away. The food rotting too quickly is fixed by PR #3639. 

## Describe the solution

The num_to_process was being used after it had been iterated down to -1, meaning it would just repeatedly process the first item. This moves the use above the loop.