### PR TITLE
fix: save/load breaking effect of relic stat boosts

### DIFF
--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -760,6 +760,20 @@ void Character::reset_stats()
     mod_str_bonus( std::floor( mutation_value( "str_modifier" ) ) );
     mod_dodge_bonus( std::floor( mutation_value( "dodge_modifier" ) ) );
 
+    mod_str_bonus( enchantment_cache->calc_bonus( enchant_vals::mod::STRENGTH, get_str_base(), true ) );
+    mod_dex_bonus( enchantment_cache->calc_bonus( enchant_vals::mod::DEXTERITY, get_dex_base(),
+                   true ) );
+    mod_per_bonus( enchantment_cache->calc_bonus( enchant_vals::mod::PERCEPTION, get_per_base(),
+                   true ) );
+    mod_int_bonus( enchantment_cache->calc_bonus( enchant_vals::mod::INTELLIGENCE, get_int_base(),
+                   true ) );
+
+    mod_num_dodges_bonus( enchantment_cache->calc_bonus(
+                              enchant_vals::mod::BONUS_DODGE,
+                              get_num_dodges_base(),
+                              true
+                          ) );
+
     apply_skill_boost();
 
     nv_cached = false;
@@ -787,20 +801,6 @@ void Character::reset_stats()
     if( int_cur < 0 ) {
         int_cur = 0;
     }
-
-    mod_str_bonus( enchantment_cache->calc_bonus( enchant_vals::mod::STRENGTH, get_str_base(), true ) );
-    mod_dex_bonus( enchantment_cache->calc_bonus( enchant_vals::mod::DEXTERITY, get_dex_base(),
-                   true ) );
-    mod_per_bonus( enchantment_cache->calc_bonus( enchant_vals::mod::PERCEPTION, get_per_base(),
-                   true ) );
-    mod_int_bonus( enchantment_cache->calc_bonus( enchant_vals::mod::INTELLIGENCE, get_int_base(),
-                   true ) );
-
-    mod_num_dodges_bonus( enchantment_cache->calc_bonus(
-                              enchant_vals::mod::BONUS_DODGE,
-                              get_num_dodges_base(),
-                              true
-                          ) );
 
     recalc_sight_limits();
     recalc_speed_bonus();

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -788,6 +788,20 @@ void Character::reset_stats()
         int_cur = 0;
     }
 
+    mod_str_bonus( enchantment_cache->calc_bonus( enchant_vals::mod::STRENGTH, get_str_base(), true ) );
+    mod_dex_bonus( enchantment_cache->calc_bonus( enchant_vals::mod::DEXTERITY, get_dex_base(),
+                   true ) );
+    mod_per_bonus( enchantment_cache->calc_bonus( enchant_vals::mod::PERCEPTION, get_per_base(),
+                   true ) );
+    mod_int_bonus( enchantment_cache->calc_bonus( enchant_vals::mod::INTELLIGENCE, get_int_base(),
+                   true ) );
+
+    mod_num_dodges_bonus( enchantment_cache->calc_bonus(
+                              enchant_vals::mod::BONUS_DODGE,
+                              get_num_dodges_base(),
+                              true
+                          ) );
+
     recalc_sight_limits();
     recalc_speed_bonus();
 }

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -450,17 +450,6 @@ int enchantment::mult_bonus( enchant_vals::mod value_type, int base_value ) cons
 
 void enchantment::activate_passive( Character &guy ) const
 {
-    guy.mod_str_bonus( calc_bonus( enchant_vals::mod::STRENGTH, guy.get_str_base(), true ) );
-    guy.mod_dex_bonus( calc_bonus( enchant_vals::mod::DEXTERITY, guy.get_dex_base(), true ) );
-    guy.mod_per_bonus( calc_bonus( enchant_vals::mod::PERCEPTION, guy.get_per_base(), true ) );
-    guy.mod_int_bonus( calc_bonus( enchant_vals::mod::INTELLIGENCE, guy.get_int_base(), true ) );
-
-    guy.mod_num_dodges_bonus( calc_bonus(
-                                  enchant_vals::mod::BONUS_DODGE,
-                                  guy.get_num_dodges_base(),
-                                  true
-                              ) );
-
     if( emitter ) {
         get_map().emit_field( guy.pos(), *emitter );
     }


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

Please use a descriptive name for the PR title, so it's clear at a glance what the PR is about.
-->

## Summary
SUMMARY: Bugfixes "Stat changes from relics persist across save/load"

<!--
This section should consist of exactly one line, formatted like the example above.

'Category' must be one of the following:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/

If the PR is a port or adaptation of DDA content, please indicate it to be so.
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

So after returning to the problem of enchantment effects not kicking in properly until a turn later, I figured out what should be a less clunky solution than what I sought to do in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2965.

This at least will fix the issue of save/load negating stat effects, but I'd like to figure out away to also fix the "have to wait a turn for transforming relic effects to kick in" thing. Though, making transforming items have `moves` set high enough might be a good enough work around for that I guess so maybe this'll be good enough.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. In magic_enchantment.cpp, took the stat increases out of `enchantment::activate_passive`...
2. And in character_turn.cpp, put them directly into `Character::reset_stats`, just like how speed modifiers from enchantments are dumped into `Character::recalc_speed_bonus`.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Moving the handling of `ench_effects` there too. During testing I found that effect duration lingers on a character long enough that it doesn't seem to have time to wear back off so it isn't affected by this like stats are.

Likewise, mutations from enchantments seem to stick to the character after a save/load just fine.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Started up a world with Magiclysm in it.
3. Put on a stat-boosting ring, confirmed that I still get my stat boost.
4. Save and load, confirm that the stat boost now shows up on load, where before it'd be absent and need a turn to kick back in.
5. Save and load a couple more times, confirming it doesn't stack or otherwise fuck up the bonus beyond its intended amount.
6. Retest with Arcana temporaly added to the mods folder, turning on a set of abyssal armor and a revenant crown.
7. Confirmed that both still take a turn for their effects to kick in as usual.
8. Did a save/load, confirmed the stat penalties from abyssal armor stayed as intended, also confirmed that mutations from the active revenant crown and the effect from active abyssal armor persist after a save/load without needing any change.
9. Checked affected files for astyle.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

First attempted to fix in: https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2965

So, I would like to fix transforming relics taking a turn to update too if possible, but the root problem far as I can tell is that spamming `activate_passive` will break shit due to doing stuff that's only meant to proc on certain turns, not just during random updates. My rough guess is what would be needed to fix this is:
1. Shift `ench_effect` updates to a new function in magic_enchantment.cpp that we can afford to spam like crazy whenever since 
2. Figure out how to make some kinda lighter version of `reset_stats` that we can afford to use in transform iuse and other cases where it needs to be spammed more often than the normal reset function, and have it used solely to recalc stat effects from enchantments so it will always update itself whenever appropriate.

We could possibly add additional calls to things like `recalc_sight_limits` and possibly `recalculate_enchantment_cache` to places like iuse transform functions to fix misc shit like clairvoyance from transforming relics needing a turn to update, too.