### PR TITLE
fix: red text when refilling cars

### DIFF
--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -3192,9 +3192,7 @@ void veh_interact::complete_vehicle( player &p )
                     p.add_msg_if_player( m_good, _( "You completely refill the %1$s's %2$s." ), veh->name, pt.name() );
                 }
 
-                if( src->contents.front().charges == 0 ) {
-                    src->remove_item( src->contents.front() );
-                } else {
+                if( !src->contents.empty() ) {
                     p.add_msg_if_player( m_good, _( "There's some left over!" ) );
                 }
 


### PR DESCRIPTION
## Summary
SUMMARY: Bugfixes "Fix red text when refilling cars"

## Purpose of change

Fixes red text when filling a car.

## Describe the solution

Get rid of the bit that's trying to remove 0 charge remnants. That's not needed anymore.