### PR TITLE
feat(balance): Constructable furniture consistency updates

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -1839,7 +1839,7 @@
     "required_skills": [ [ "fabrication", 2 ] ],
     "time": "25 m",
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ] ],
-    "components": [ [ [ "2x4", 4 ] ], [ [ "nail", 8 ] ] ],
+    "components": [ [ [ "2x4", 3 ] ], [ [ "nail", 6 ] ] ],
     "pre_special": "check_empty",
     "post_furniture": "f_stool"
   },

--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -595,7 +595,7 @@
     "crafting_pseudo_item": "fake_oven",
     "flags": [ "PLACE_ITEM", "TRANSPARENT", "FIRE_CONTAINER", "CONTAINER", "BLOCKSDOOR", "MOUNTABLE" ],
     "examine_action": "fireplace",
-    "deconstruct": { "items": [ { "item": "kitchen_unit", "count": 1 }, { "item": "cable", "charges": [ 1, 3 ] } ] },
+    "deconstruct": { "items": [ { "item": "kitchen_unit", "count": 1 }, { "item": "cable", "charges": 5 } ] },
     "max_volume": "25 L",
     "bash": {
       "str_min": 8,

--- a/data/json/furniture_and_terrain/furniture-decorative.json
+++ b/data/json/furniture_and_terrain/furniture-decorative.json
@@ -175,6 +175,9 @@
     "move_cost_mod": -1,
     "required_str": 10,
     "flags": [ "BLOCKSDOOR", "PLACE_ITEM", "EASY_DECONSTRUCT" ],
+    "deconstruct": {
+      "items": [ { "item": "stick", "count": 4 }, { "item": "nail", "charges": 20 }, { "item": "pine_bough", "count": 8 } ]
+    },
     "bash": {
       "str_min": 20,
       "str_max": 40,
@@ -182,7 +185,7 @@
       "sound_fail": "thump.",
       "items": [
         { "item": "pine_bough", "count": [ 4, 6 ] },
-        { "item": "nail", "count": [ 5, 14 ] },
+        { "item": "nail", "charges": [ 5, 14 ] },
         { "item": "stick", "count": [ 1, 3 ] }
       ]
     }

--- a/data/json/furniture_and_terrain/furniture-domestic_plants.json
+++ b/data/json/furniture_and_terrain/furniture-domestic_plants.json
@@ -140,10 +140,10 @@
     "flags": [ "TRANSPARENT", "PLANTABLE", "FLAT", "MOUNTABLE" ],
     "deconstruct": {
       "items": [
-        { "item": "2x4", "count": [ 11, 12 ] },
-        { "item": "nail", "charges": [ 30, 36 ] },
-        { "item": "pebble", "charges": [ 180, 200 ] },
-        { "item": "material_soil", "count": [ 70, 75 ] }
+        { "item": "2x4", "count": 12 },
+        { "item": "nail", "charges": 36 },
+        { "item": "pebble", "charges": 200 },
+        { "item": "material_soil", "count": 75 }
       ]
     },
     "bash": {

--- a/data/json/furniture_and_terrain/furniture-seats.json
+++ b/data/json/furniture_and_terrain/furniture-seats.json
@@ -13,7 +13,7 @@
     "bonus_fire_warmth_feet": 1000,
     "required_str": 8,
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC", "MOUNTABLE", "SHORT", "CAN_SIT" ],
-    "deconstruct": { "items": [ { "item": "2x4", "count": 4 }, { "item": "nail", "charges": [ 6, 10 ] } ] },
+    "deconstruct": { "items": [ { "item": "2x4", "count": 4 }, { "item": "nail", "charges": 10 } ] },
     "bash": {
       "str_min": 12,
       "str_max": 40,
@@ -35,9 +35,7 @@
     "floor_bedding_warmth": 500,
     "bonus_fire_warmth_feet": 1000,
     "required_str": 7,
-    "deconstruct": {
-      "items": [ { "item": "2x4", "count": 10 }, { "item": "rag", "count": [ 30, 33 ] }, { "item": "nail", "charges": [ 6, 8 ] } ]
-    },
+    "deconstruct": { "items": [ { "item": "2x4", "count": 10 }, { "item": "rag", "count": 35 }, { "item": "nail", "charges": 8 } ] },
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC", "MOUNTABLE", "CAN_SIT" ],
     "bash": {
       "str_min": 12,
@@ -96,7 +94,7 @@
     "bonus_fire_warmth_feet": 1000,
     "required_str": 4,
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC", "MOUNTABLE", "CAN_SIT" ],
-    "deconstruct": { "items": [ { "item": "2x4", "count": 4 }, { "item": "nail", "charges": [ 6, 8 ] } ] },
+    "deconstruct": { "items": [ { "item": "2x4", "count": 4 }, { "item": "nail", "charges": 8 } ] },
     "bash": {
       "str_min": 6,
       "str_max": 20,
@@ -117,9 +115,7 @@
     "comfort": 4,
     "floor_bedding_warmth": 500,
     "required_str": 10,
-    "deconstruct": {
-      "items": [ { "item": "2x4", "count": 12 }, { "item": "rag", "count": [ 30, 33 ] }, { "item": "nail", "charges": [ 8, 10 ] } ]
-    },
+    "deconstruct": { "items": [ { "item": "2x4", "count": 12 }, { "item": "rag", "count": 12 }, { "item": "nail", "charges": 10 } ] },
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC", "BLOCKSDOOR", "MOUNTABLE", "CAN_SIT" ],
     "bash": {
       "str_min": 12,
@@ -147,7 +143,7 @@
     "bonus_fire_warmth_feet": 1000,
     "required_str": 3,
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC", "MOUNTABLE", "CAN_SIT" ],
-    "deconstruct": { "items": [ { "item": "2x4", "count": 3 }, { "item": "nail", "charges": [ 2, 6 ] } ] },
+    "deconstruct": { "items": [ { "item": "2x4", "count": 3 }, { "item": "nail", "charges": 6 } ] },
     "max_volume": "875 L",
     "bash": {
       "str_min": 6,

--- a/data/json/furniture_and_terrain/furniture-signs.json
+++ b/data/json/furniture_and_terrain/furniture-signs.json
@@ -36,7 +36,7 @@
     "coverage": 35,
     "required_str": -1,
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC", "MOUNTABLE", "SIGN" ],
-    "deconstruct": { "items": [ { "item": "2x4", "count": 3 }, { "item": "nail", "charges": [ 2, 5 ] } ] },
+    "deconstruct": { "items": [ { "item": "2x4", "count": 3 }, { "item": "nail", "charges": 6 } ] },
     "bash": {
       "str_min": 6,
       "str_max": 40,

--- a/data/json/furniture_and_terrain/furniture-sleep.json
+++ b/data/json/furniture_and_terrain/furniture-sleep.json
@@ -40,9 +40,7 @@
     "comfort": 5,
     "floor_bedding_warmth": 1000,
     "required_str": -1,
-    "deconstruct": {
-      "items": [ { "item": "mattress", "count": 2 }, { "item": "2x4", "count": 28 }, { "item": "nail", "charges": [ 20, 30 ] } ]
-    },
+    "deconstruct": { "items": [ { "item": "mattress", "count": 2 }, { "item": "2x4", "count": 30 }, { "item": "nail", "charges": 30 } ] },
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC", "CAN_SIT" ],
     "bash": {
       "str_min": 12,
@@ -68,7 +66,7 @@
     "move_cost_mod": 4,
     "coverage": 40,
     "required_str": 5,
-    "deconstruct": { "items": [ { "item": "2x4", "count": 12 }, { "item": "nail", "charges": [ 8, 10 ] } ] },
+    "deconstruct": { "items": [ { "item": "2x4", "count": 12 }, { "item": "nail", "charges": 10 } ] },
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "PLACE_ITEM", "ORGANIC", "MOUNTABLE", "CAN_SIT" ],
     "bash": {
       "str_min": 10,
@@ -146,9 +144,7 @@
     "comfort": 4,
     "floor_bedding_warmth": 500,
     "required_str": 10,
-    "deconstruct": {
-      "items": [ { "item": "2x4", "count": 4 }, { "item": "rag", "count": [ 30, 35 ] }, { "item": "nail", "charges": [ 4, 6 ] } ]
-    },
+    "deconstruct": { "items": [ { "item": "2x4", "count": 4 }, { "item": "rag", "count": 35 }, { "item": "nail", "charges": 6 } ] },
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC", "MOUNTABLE", "SHORT" ],
     "bash": {
       "str_min": 8,
@@ -175,7 +171,7 @@
     "comfort": 2,
     "floor_bedding_warmth": 200,
     "required_str": -1,
-    "deconstruct": { "items": [ { "item": "stick", "count": 4 }, { "item": "straw_pile", "count": [ 7, 8 ] } ] },
+    "deconstruct": { "items": [ { "item": "stick", "count": 4 }, { "item": "straw_pile", "count": 8 } ] },
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC", "MOUNTABLE", "SHORT", "EASY_DECONSTRUCT" ],
     "bash": {
       "str_min": 6,

--- a/data/json/furniture_and_terrain/furniture-storage.json
+++ b/data/json/furniture_and_terrain/furniture-storage.json
@@ -10,20 +10,18 @@
     "coverage": 80,
     "required_str": 9,
     "flags": [ "FLAMMABLE", "PLACE_ITEM", "ORGANIC", "BLOCKSDOOR" ],
-    "deconstruct": {
-      "items": [
-        { "item": "2x4", "count": 12 },
-        { "item": "wood_panel", "count": [ 0, 1 ] },
-        { "item": "nail", "charges": [ 12, 16 ] }
-      ]
-    },
+    "deconstruct": { "items": [ { "item": "2x4", "count": 6 }, { "item": "wood_panel", "count": 2 }, { "item": "nail", "charges": 16 } ] },
     "max_volume": "2000 L",
     "bash": {
       "str_min": 6,
       "str_max": 40,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [ { "item": "2x4", "count": [ 2, 6 ] }, { "item": "nail", "charges": [ 4, 12 ] }, { "item": "splinter", "count": 1 } ]
+      "items": [
+        { "item": "2x4", "count": [ 2, 6 ] },
+        { "item": "nail", "charges": [ 4, 12 ] },
+        { "item": "splinter", "count": [ 5, 10 ] }
+      ]
     }
   },
   {
@@ -38,9 +36,7 @@
     "coverage": 80,
     "required_str": 10,
     "flags": [ "FLAMMABLE", "PLACE_ITEM", "ORGANIC", "BLOCKSDOOR" ],
-    "deconstruct": {
-      "items": [ { "item": "2x4", "count": 14 }, { "item": "wood_panel", "count": 2 }, { "item": "nail", "charges": [ 12, 20 ] } ]
-    },
+    "deconstruct": { "items": [ { "item": "2x4", "count": 14 }, { "item": "wood_panel", "count": 2 }, { "item": "nail", "charges": 20 } ] },
     "max_volume": "2000 L",
     "bash": {
       "str_min": 6,
@@ -251,16 +247,18 @@
     "coverage": 70,
     "required_str": 8,
     "flags": [ "TRANSPARENT", "CONTAINER", "FLAMMABLE", "PLACE_ITEM", "ORGANIC", "BLOCKSDOOR", "MOUNTABLE" ],
-    "deconstruct": {
-      "items": [ { "item": "2x4", "count": 6 }, { "item": "wood_panel", "count": [ 0, 1 ] }, { "item": "nail", "charges": [ 6, 8 ] } ]
-    },
+    "deconstruct": { "items": [ { "item": "2x4", "count": 4 }, { "item": "wood_panel", "count": 1 }, { "item": "nail", "charges": 8 } ] },
     "max_volume": "2000 L",
     "bash": {
       "str_min": 12,
       "str_max": 40,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [ { "item": "2x4", "count": [ 2, 6 ] }, { "item": "nail", "charges": [ 4, 8 ] }, { "item": "splinter", "count": 1 } ]
+      "items": [
+        { "item": "2x4", "count": [ 2, 4 ] },
+        { "item": "nail", "charges": [ 4, 8 ] },
+        { "item": "splinter", "count": [ 5, 10 ] }
+      ]
     }
   },
   {
@@ -465,9 +463,7 @@
     "move_cost_mod": 1,
     "required_str": -1,
     "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "CONTAINER", "PLACE_ITEM", "MOUNTABLE" ],
-    "deconstruct": {
-      "items": [ { "item": "2x4", "count": 2 }, { "item": "nail", "charges": [ 2, 5 ] }, { "item": "sheet_metal", "count": 1 } ]
-    },
+    "deconstruct": { "items": [ { "item": "2x4", "count": 2 }, { "item": "nail", "charges": 5 }, { "item": "sheet_metal", "count": 1 } ] },
     "max_volume": "10 L",
     "bash": {
       "str_min": 12,
@@ -556,13 +552,7 @@
     "required_str": 7,
     "looks_like": "f_bookcase",
     "flags": [ "FLAMMABLE", "PLACE_ITEM", "ORGANIC", "BLOCKSDOOR", "TRANSPARENT" ],
-    "deconstruct": {
-      "items": [
-        { "item": "2x4", "count": 12 },
-        { "item": "wood_panel", "count": [ 1, 2 ] },
-        { "item": "nail", "charges": [ 32, 40 ] }
-      ]
-    },
+    "deconstruct": { "items": [ { "item": "2x4", "count": 6 }, { "item": "wood_panel", "count": 4 }, { "item": "nail", "charges": 40 } ] },
     "max_volume": "1500 L",
     "bash": {
       "str_min": 6,
@@ -583,7 +573,7 @@
     "coverage": 30,
     "required_str": 4,
     "flags": [ "TRANSPARENT", "FLAMMABLE", "PLACE_ITEM", "BLOCKSDOOR", "MOUNTABLE" ],
-    "deconstruct": { "items": [ { "item": "nail", "charges": [ 2, 6 ] }, { "item": "2x4", "count": 2 } ] },
+    "deconstruct": { "items": [ { "item": "nail", "charges": 8 }, { "item": "2x4", "count": 3 } ] },
     "max_volume": "30 L",
     "bash": {
       "str_min": 6,
@@ -724,7 +714,12 @@
     "required_str": 9,
     "flags": [ "CONTAINER", "FLAMMABLE", "PLACE_ITEM", "ORGANIC", "BLOCKSDOOR", "MOUNTABLE" ],
     "deconstruct": {
-      "items": [ { "item": "2x4", "count": 20 }, { "item": "nail", "charges": [ 16, 24 ] }, { "item": "pipe", "count": 2 } ]
+      "items": [
+        { "item": "2x4", "count": 10 },
+        { "item": "wood_panel", "count": 2 },
+        { "item": "nail", "charges": 24 },
+        { "item": "pipe", "count": 2 }
+      ]
     },
     "max_volume": "500 L",
     "bash": {
@@ -814,13 +809,7 @@
     "coverage": 95,
     "required_str": 10,
     "flags": [ "FLAMMABLE_HARD", "PLACE_ITEM", "BLOCKSDOOR" ],
-    "deconstruct": {
-      "items": [
-        { "item": "pipe", "count": [ 6, 12 ] },
-        { "item": "sheet_metal", "count": [ 4, 8 ] },
-        { "item": "sheet_metal_small", "count": [ 0, 4 ] }
-      ]
-    },
+    "deconstruct": { "items": [ { "item": "pipe", "count": 12 }, { "item": "sheet_metal", "count": 8 } ] },
     "max_volume": "3500 L",
     "bash": {
       "str_min": 8,
@@ -853,10 +842,9 @@
     "deconstruct": {
       "items": [
         { "item": "2x4", "count": 18 },
-        { "item": "nail", "charges": [ 7, 14 ] },
+        { "item": "nail", "charges": 14 },
         { "item": "water_faucet", "count": 1 },
-        { "item": "sheet_metal_small", "count": [ 12, 20 ] },
-        { "item": "scrap", "count": [ 5, 10 ] }
+        { "item": "sheet_metal", "count": 1 }
       ]
     },
     "bash": {

--- a/data/json/furniture_and_terrain/furniture-surfaces.json
+++ b/data/json/furniture_and_terrain/furniture-surfaces.json
@@ -10,15 +10,17 @@
     "coverage": 60,
     "required_str": 10,
     "flags": [ "TRANSPARENT", "FLAMMABLE", "ORGANIC", "MOUNTABLE", "SHORT", "FLAT_SURF" ],
-    "deconstruct": {
-      "items": [ { "item": "2x4", "count": 4 }, { "item": "wood_panel", "count": 1 }, { "item": "nail", "charges": [ 6, 10 ] } ]
-    },
+    "deconstruct": { "items": [ { "item": "2x4", "count": 2 }, { "item": "wood_panel", "count": 2 }, { "item": "nail", "charges": 8 } ] },
     "bash": {
       "str_min": 12,
       "str_max": 40,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [ { "item": "2x4", "count": [ 2, 6 ] }, { "item": "nail", "charges": [ 4, 8 ] }, { "item": "splinter", "count": 1 } ]
+      "items": [
+        { "item": "2x4", "count": [ 1, 2 ] },
+        { "item": "nail", "charges": [ 4, 8 ] },
+        { "item": "splinter", "count": [ 5, 10 ] }
+      ]
     },
     "examine_action": "workbench",
     "workbench": { "multiplier": 1.1, "mass": 200000, "volume": "75L" }
@@ -34,9 +36,7 @@
     "coverage": 55,
     "required_str": -1,
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "CONTAINER", "PLACE_ITEM", "ORGANIC", "MOUNTABLE", "FLAT_SURF" ],
-    "deconstruct": {
-      "items": [ { "item": "2x4", "count": 3 }, { "item": "wood_panel", "count": 1 }, { "item": "nail", "charges": [ 6, 8 ] } ]
-    },
+    "deconstruct": { "items": [ { "item": "2x4", "count": 3 }, { "item": "wood_panel", "count": 2 }, { "item": "nail", "charges": 8 } ] },
     "bash": {
       "str_min": 8,
       "str_max": 30,
@@ -46,7 +46,7 @@
         { "item": "2x4", "count": [ 1, 3 ] },
         { "item": "wood_panel", "count": [ 0, 1 ] },
         { "item": "nail", "charges": [ 2, 6 ] },
-        { "item": "splinter", "count": 1 }
+        { "item": "splinter", "count": [ 5, 10 ] }
       ]
     },
     "examine_action": "workbench",
@@ -66,13 +66,18 @@
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "DOOR", "ORGANIC" ],
     "//connects_to": "COUNTER",
     "open": "f_counter_gate_o",
-    "deconstruct": { "items": [ { "item": "2x4", "count": 4 }, { "item": "wood_panel", "count": 1 }, { "item": "nail", "charges": 10 } ] },
+    "deconstruct": { "items": [ { "item": "2x4", "count": 6 }, { "item": "hinge", "count": 2 }, { "item": "nail", "charges": 10 } ] },
     "bash": {
       "str_min": 12,
       "str_max": 40,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [ { "item": "2x4", "count": [ 2, 6 ] }, { "item": "nail", "charges": [ 4, 8 ] }, { "item": "splinter", "count": 1 } ]
+      "items": [
+        { "item": "2x4", "count": [ 2, 6 ] },
+        { "item": "hinge", "charges": [ 0, 1 ] },
+        { "item": "nail", "charges": [ 4, 8 ] },
+        { "item": "splinter", "count": [ 5, 10 ] }
+      ]
     }
   },
   {
@@ -87,13 +92,18 @@
     "//connects_to": "COUNTER",
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "FLAT", "ROAD", "ORGANIC" ],
     "close": "f_counter_gate_c",
-    "deconstruct": { "items": [ { "item": "2x4", "count": 4 }, { "item": "wood_panel", "count": 1 }, { "item": "nail", "charges": 10 } ] },
+    "deconstruct": { "items": [ { "item": "2x4", "count": 6 }, { "item": "hinge", "count": 2 }, { "item": "nail", "charges": 10 } ] },
     "bash": {
       "str_min": 12,
       "str_max": 40,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [ { "item": "2x4", "count": [ 2, 6 ] }, { "item": "nail", "charges": [ 4, 8 ] }, { "item": "splinter", "count": 1 } ]
+      "items": [
+        { "item": "2x4", "count": [ 2, 6 ] },
+        { "item": "hinge", "charges": [ 0, 1 ] },
+        { "item": "nail", "charges": [ 4, 8 ] },
+        { "item": "splinter", "count": [ 5, 10 ] }
+      ]
     }
   },
   {
@@ -107,9 +117,7 @@
     "coverage": 45,
     "required_str": 5,
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "CONTAINER", "PLACE_ITEM", "ORGANIC", "MOUNTABLE", "FLAT_SURF" ],
-    "deconstruct": {
-      "items": [ { "item": "2x4", "count": 8 }, { "item": "wood_panel", "count": 1 }, { "item": "nail", "charges": [ 16, 24 ] } ]
-    },
+    "deconstruct": { "items": [ { "item": "2x4", "count": 8 }, { "item": "wood_panel", "count": 2 }, { "item": "nail", "charges": 24 } ] },
     "bash": {
       "str_min": 12,
       "str_max": 40,
@@ -258,9 +266,7 @@
     "coverage": 50,
     "required_str": 5,
     "flags": [ "TRANSPARENT", "FLAMMABLE", "ORGANIC", "MOUNTABLE", "SHORT", "FLAT_SURF" ],
-    "deconstruct": {
-      "items": [ { "item": "2x4", "count": 4 }, { "item": "wood_panel", "count": 1 }, { "item": "nail", "charges": [ 6, 8 ] } ]
-    },
+    "deconstruct": { "items": [ { "item": "2x4", "count": 4 }, { "item": "wood_panel", "count": 1 }, { "item": "nail", "charges": 8 } ] },
     "bash": {
       "str_min": 12,
       "str_max": 50,
@@ -288,9 +294,7 @@
     "coverage": 50,
     "required_str": 5,
     "flags": [ "TRANSPARENT", "FLAMMABLE", "ORGANIC", "MOUNTABLE", "SHORT", "FLAT_SURF" ],
-    "deconstruct": {
-      "items": [ { "item": "2x4", "count": 2 }, { "item": "wood_panel", "count": 1 }, { "item": "nail", "charges": [ 6, 8 ] } ]
-    },
+    "deconstruct": { "items": [ { "item": "2x4", "count": 2 }, { "item": "wood_panel", "count": 1 }, { "item": "nail", "charges": 8 } ] },
     "bash": {
       "str_min": 10,
       "str_max": 50,

--- a/data/json/furniture_and_terrain/furniture-tools.json
+++ b/data/json/furniture_and_terrain/furniture-tools.json
@@ -66,13 +66,13 @@
     "max_volume": "125 L",
     "crafting_pseudo_item": "char_kiln",
     "flags": [ "CONTAINER", "FIRE_CONTAINER", "PLACE_ITEM", "EASY_DECONSTRUCT", "MINEABLE" ],
-    "deconstruct": { "items": [ { "item": "rock", "count": [ 35, 40 ] } ] },
+    "deconstruct": { "items": [ { "item": "rock", "count": 40 }, { "item": "material_soil", "count": 2 } ] },
     "bash": {
       "str_min": 25,
       "str_max": 180,
       "sound": "crash!",
       "sound_fail": "whump!",
-      "items": [ { "item": "rock", "count": [ 15, 30 ] } ]
+      "items": [ { "item": "rock", "count": [ 15, 30 ] }, { "item": "material_soil", "count": [ 0, 1 ] } ]
     }
   },
   {
@@ -88,13 +88,13 @@
     "required_str": -1,
     "examine_action": "kiln_full",
     "flags": [ "NOITEM", "SEALED", "CONTAINER", "FIRE_CONTAINER", "SUPPRESS_SMOKE", "PLACE_ITEM", "EASY_DECONSTRUCT", "MINEABLE" ],
-    "deconstruct": { "items": [ { "item": "rock", "count": [ 30, 30 ] } ] },
+    "deconstruct": { "items": [ { "item": "rock", "count": 40 }, { "item": "material_soil", "count": 2 } ] },
     "bash": {
       "str_min": 25,
       "str_max": 180,
       "sound": "crash!",
       "sound_fail": "whump!",
-      "items": [ { "item": "rock", "count": [ 15, 30 ] } ]
+      "items": [ { "item": "rock", "count": [ 15, 30 ] }, { "item": "material_soil", "count": [ 0, 1 ] } ]
     }
   },
   {
@@ -111,7 +111,7 @@
     "max_volume": "125 L",
     "crafting_pseudo_item": "char_kiln",
     "flags": [ "CONTAINER", "FIRE_CONTAINER", "PLACE_ITEM" ],
-    "deconstruct": { "items": [ { "item": "metal_tank", "count": [ 1, 4 ] }, { "item": "pipe", "count": [ 2, 4 ] } ] },
+    "deconstruct": { "items": [ { "item": "metal_tank", "count": 4 }, { "item": "pipe", "count": 4 } ] },
     "bash": {
       "str_min": 12,
       "str_max": 40,
@@ -137,7 +137,7 @@
     "required_str": -1,
     "examine_action": "kiln_full",
     "flags": [ "NOITEM", "SEALED", "CONTAINER", "FIRE_CONTAINER", "SUPPRESS_SMOKE", "PLACE_ITEM" ],
-    "deconstruct": { "items": [ { "item": "metal_tank", "count": [ 1, 4 ] }, { "item": "pipe", "count": [ 2, 4 ] } ] },
+    "deconstruct": { "items": [ { "item": "metal_tank", "count": 4 }, { "item": "pipe", "count": 4 } ] },
     "bash": {
       "str_min": 12,
       "str_max": 40,
@@ -165,16 +165,36 @@
     "max_volume": "200 L",
     "crafting_pseudo_item": "arcfurnace",
     "flags": [ "CONTAINER", "FIRE_CONTAINER", "PLACE_ITEM" ],
-    "deconstruct": { "items": [ { "item": "metal_tank", "count": [ 1, 4 ] }, { "item": "pipe", "count": [ 2, 4 ] } ] },
+    "deconstruct": {
+      "items": [
+        { "item": "fire_brick", "count": 40 },
+        { "item": "cu_pipe", "count": 4 },
+        { "item": "cable", "count": 12 },
+        { "item": "pipe", "count": 4 },
+        { "item": "clamp", "count": 1 },
+        { "item": "motor_tiny", "count": 1 },
+        { "item": "medium_storage_battery", "count": 2 },
+        { "item": "frame", "count": 1 }
+      ]
+    },
     "bash": {
       "str_min": 18,
       "str_max": 40,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "items": [
-        { "item": "scrap", "count": [ 2, 4 ] },
-        { "item": "steel_chunk", "count": [ 0, 3 ] },
-        { "item": "pipe", "count": [ 0, 4 ] }
+        { "item": "fire_brick", "count": [ 10, 20 ] },
+        { "item": "rock", "count": [ 1, 10 ] },
+        { "item": "cu_pipe", "count": [ 1, 2 ] },
+        { "item": "scrap_copper", "count": [ 1, 4 ] },
+        { "item": "cable", "count": [ 6, 12 ] },
+        { "item": "pipe", "count": [ 0, 3 ] },
+        { "item": "clamp", "prob": 25 },
+        { "item": "motor_tiny", "prob": 25 },
+        { "item": "small_storage_battery", "count": [ 10, 20 ] },
+        { "item": "steel_lump", "count": [ 5, 10 ] },
+        { "item": "steel_chunk", "count": [ 5, 20 ] },
+        { "item": "scrap", "count": [ 10, 50 ] }
       ]
     }
   },
@@ -191,16 +211,36 @@
     "required_str": -1,
     "examine_action": "arcfurnace_full",
     "flags": [ "NOITEM", "SEALED", "CONTAINER", "FIRE_CONTAINER", "SUPPRESS_SMOKE", "PLACE_ITEM" ],
-    "deconstruct": { "items": [ { "item": "metal_tank", "count": [ 1, 4 ] }, { "item": "pipe", "count": [ 2, 4 ] } ] },
+    "deconstruct": {
+      "items": [
+        { "item": "fire_brick", "count": 40 },
+        { "item": "cu_pipe", "count": 4 },
+        { "item": "cable", "count": 12 },
+        { "item": "pipe", "count": 4 },
+        { "item": "clamp", "count": 1 },
+        { "item": "motor_tiny", "count": 1 },
+        { "item": "medium_storage_battery", "count": 2 },
+        { "item": "frame", "count": 1 }
+      ]
+    },
     "bash": {
       "str_min": 18,
       "str_max": 40,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "items": [
-        { "item": "scrap", "count": [ 2, 4 ] },
-        { "item": "steel_chunk", "count": [ 0, 3 ] },
-        { "item": "pipe", "count": [ 0, 4 ] }
+        { "item": "fire_brick", "count": [ 10, 20 ] },
+        { "item": "rock", "count": [ 1, 10 ] },
+        { "item": "cu_pipe", "count": [ 1, 2 ] },
+        { "item": "scrap_copper", "count": [ 1, 4 ] },
+        { "item": "cable", "count": [ 6, 12 ] },
+        { "item": "pipe", "count": [ 0, 3 ] },
+        { "item": "clamp", "prob": 25 },
+        { "item": "motor_tiny", "prob": 25 },
+        { "item": "small_storage_battery", "count": [ 10, 20 ] },
+        { "item": "steel_lump", "count": [ 5, 10 ] },
+        { "item": "steel_chunk", "count": [ 5, 20 ] },
+        { "item": "scrap", "count": [ 10, 50 ] }
       ]
     }
   },
@@ -304,14 +344,14 @@
     "required_str": -1,
     "crafting_pseudo_item": "char_forge",
     "flags": [ "SEALED", "CONTAINER", "NOITEM", "EASY_DECONSTRUCT", "MINEABLE" ],
-    "deconstruct": { "items": [ { "item": "rock", "count": 40 } ] },
+    "deconstruct": { "items": [ { "item": "rock", "count": 40 }, { "item": "material_soil", "count": 3 } ] },
     "examine_action": "reload_furniture",
     "bash": {
       "str_min": 18,
       "str_max": 50,
       "sound": "crash!",
       "sound_fail": "whump.",
-      "items": [ { "item": "rock", "count": [ 20, 30 ] } ]
+      "items": [ { "item": "rock", "count": [ 20, 30 ] }, { "item": "material_soil", "count": [ 0, 2 ] } ]
     }
   },
   {
@@ -783,10 +823,9 @@
     "deconstruct": {
       "items": [
         { "item": "2x4", "count": 14 },
-        { "item": "nail", "charges": [ 6, 12 ] },
+        { "item": "nail", "charges": 12 },
         { "item": "water_faucet", "count": 1 },
-        { "item": "sheet_metal_small", "count": [ 4, 10 ] },
-        { "item": "scrap", "count": [ 5, 10 ] }
+        { "item": "sheet_metal_small", "count": 12 }
       ]
     },
     "bash": {

--- a/data/json/recipes/basecamps/recipe_modular_canteen/recipe_modular_canteen_log.json
+++ b/data/json/recipes/basecamps/recipe_modular_canteen/recipe_modular_canteen_log.json
@@ -78,7 +78,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 216 ] ], [ [ "log", 24 ] ], [ [ "nail", 448 ] ], [ [ "wood_panel", 22 ] ] ]
+        "components": [ [ [ "2x4", 215 ] ], [ [ "log", 24 ] ], [ [ "nail", 446 ] ], [ [ "wood_panel", 22 ] ] ]
       }
     }
   },

--- a/data/json/recipes/basecamps/recipe_modular_canteen/recipe_modular_canteen_metal.json
+++ b/data/json/recipes/basecamps/recipe_modular_canteen/recipe_modular_canteen_metal.json
@@ -107,9 +107,9 @@
           [ { "id": "WRENCH", "level": 2 } ]
         ],
         "components": [
-          [ [ "2x4", 180 ] ],
+          [ [ "2x4", 179 ] ],
           [ [ "frame", 18 ], [ "pipe", 108 ], [ "xlframe", 30 ] ],
-          [ [ "nail", 544 ] ],
+          [ [ "nail", 542 ] ],
           [ [ "scrap", 420 ], [ "sheet_metal_small", 210 ] ],
           [ [ "wood_panel", 22 ] ]
         ]

--- a/data/json/recipes/basecamps/recipe_modular_canteen/recipe_modular_canteen_migo_resin.json
+++ b/data/json/recipes/basecamps/recipe_modular_canteen/recipe_modular_canteen_migo_resin.json
@@ -56,7 +56,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 180 ] ], [ [ "nail", 448 ] ], [ [ "alien_pod_resin", 12 ] ], [ [ "wood_panel", 22 ] ] ]
+        "components": [ [ [ "2x4", 179 ] ], [ [ "alien_pod_resin", 12 ] ], [ [ "nail", 446 ] ], [ [ "wood_panel", 22 ] ] ]
       }
     }
   },

--- a/data/json/recipes/basecamps/recipe_modular_canteen/recipe_modular_canteen_rammed_earth.json
+++ b/data/json/recipes/basecamps/recipe_modular_canteen/recipe_modular_canteen_rammed_earth.json
@@ -100,10 +100,10 @@
           [ { "id": "SMOOTH" } ]
         ],
         "components": [
-          [ [ "2x4", 180 ] ],
+          [ [ "2x4", 179 ] ],
           [ [ "concrete", 6 ], [ "material_quicklime", 120 ], [ "material_sand", 120 ] ],
           [ [ "material_soil", 600 ] ],
-          [ [ "nail", 448 ] ],
+          [ [ "nail", 446 ] ],
           [ [ "pointy_stick", 12 ], [ "spear_wood", 12 ] ],
           [ [ "water", 300 ], [ "water_clean", 300 ] ],
           [ [ "wood_panel", 22 ] ]

--- a/data/json/recipes/basecamps/recipe_modular_canteen/recipe_modular_canteen_rock.json
+++ b/data/json/recipes/basecamps/recipe_modular_canteen/recipe_modular_canteen_rock.json
@@ -83,9 +83,9 @@
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 180 ] ],
+          [ [ "2x4", 179 ] ],
           [ [ "mortar_adobe", 12 ], [ "mortar_build", 12 ] ],
-          [ [ "nail", 448 ] ],
+          [ [ "nail", 446 ] ],
           [ [ "pebble", 300 ] ],
           [ [ "rock", 144 ] ],
           [ [ "wood_panel", 22 ] ]

--- a/data/json/recipes/basecamps/recipe_modular_canteen/recipe_modular_canteen_wad.json
+++ b/data/json/recipes/basecamps/recipe_modular_canteen/recipe_modular_canteen_wad.json
@@ -107,7 +107,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 240 ] ],
+          [ [ "2x4", 239 ] ],
           [
             [ "cattail_stalk", 48 ],
             [ "dogbane", 48 ],
@@ -123,7 +123,7 @@
             [ "material_quicklime", 48 ],
             [ "material_soil", 240 ]
           ],
-          [ [ "nail", 448 ] ],
+          [ [ "nail", 446 ] ],
           [ [ "water", 60 ], [ "water_clean", 60 ] ],
           [ [ "wood_panel", 22 ] ]
         ]

--- a/data/json/recipes/basecamps/recipe_modular_canteen/recipe_modular_canteen_wood.json
+++ b/data/json/recipes/basecamps/recipe_modular_canteen/recipe_modular_canteen_wood.json
@@ -64,7 +64,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 240 ] ], [ [ "nail", 688 ] ], [ [ "wood_panel", 34 ] ] ]
+        "components": [ [ [ "2x4", 239 ] ], [ [ "nail", 686 ] ], [ [ "wood_panel", 34 ] ] ]
       }
     }
   },

--- a/data/json/recipes/basecamps/recipe_modular_saltworks/recipe_modular_saltworks_common.json
+++ b/data/json/recipes/basecamps/recipe_modular_saltworks/recipe_modular_saltworks_common.json
@@ -32,11 +32,11 @@
       "skills": [ [ "mechanics", 0 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
-        "qualities": [ [ { "id": "SAW_M" } ], [ { "id": "SAW_W" } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "WRENCH" } ] ],
+        "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_M" } ], [ { "id": "SAW_W" } ], [ { "id": "WRENCH" } ] ],
         "components": [
-          [ [ "2x4", 8 ] ],
+          [ [ "2x4", 7 ] ],
           [ [ "metal_tank", 1 ] ],
-          [ [ "nail", 16 ] ],
+          [ [ "nail", 14 ] ],
           [ [ "pipe", 13 ] ],
           [ [ "sheet_metal", 2 ] ],
           [ [ "still", 1 ] ],

--- a/data/json/recipes/basecamps/recipe_modular_saltworks/recipe_modular_saltworks_log.json
+++ b/data/json/recipes/basecamps/recipe_modular_saltworks/recipe_modular_saltworks_log.json
@@ -19,13 +19,13 @@
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 267 ] ],
+          [ [ "2x4", 266 ] ],
           [ [ "birchbark", 228 ], [ "pine_bough", 228 ] ],
           [ [ "glass_sheet", 3 ] ],
           [ [ "hinge", 2 ] ],
           [ [ "log", 118 ] ],
           [ [ "material_soil", 760 ] ],
-          [ [ "nail", 158 ] ],
+          [ [ "nail", 156 ] ],
           [ [ "wood_panel", 6 ] ]
         ]
       }

--- a/data/json/recipes/basecamps/recipe_modular_saltworks/recipe_modular_saltworks_metal.json
+++ b/data/json/recipes/basecamps/recipe_modular_saltworks/recipe_modular_saltworks_metal.json
@@ -26,10 +26,10 @@
           [ { "id": "SAW_W", "level": 2 } ]
         ],
         "components": [
-          [ [ "2x4", 71 ] ],
+          [ [ "2x4", 70 ] ],
           [ [ "glass_sheet", 3 ] ],
           [ [ "hinge", 2 ] ],
-          [ [ "nail", 158 ] ],
+          [ [ "nail", 156 ] ],
           [ [ "steel_plate", 80 ] ],
           [ [ "wood_panel", 6 ] ]
         ]

--- a/data/json/recipes/basecamps/recipe_modular_saltworks/recipe_modular_saltworks_migo_resin.json
+++ b/data/json/recipes/basecamps/recipe_modular_saltworks/recipe_modular_saltworks_migo_resin.json
@@ -18,7 +18,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W" } ], [ { "id": "SMOOTH" } ] ],
-        "components": [ [ [ "2x4", 12 ] ], [ [ "alien_pod_resin", 79 ] ], [ [ "nail", 32 ] ], [ [ "wood_panel", 5 ], [ "wood_sheet", 3 ] ] ]
+        "components": [ [ [ "2x4", 11 ] ], [ [ "alien_pod_resin", 79 ] ], [ [ "nail", 30 ] ], [ [ "wood_panel", 5 ], [ "wood_sheet", 3 ] ] ]
       }
     }
   },

--- a/data/json/recipes/basecamps/recipe_modular_saltworks/recipe_modular_saltworks_rammed_earth.json
+++ b/data/json/recipes/basecamps/recipe_modular_saltworks/recipe_modular_saltworks_rammed_earth.json
@@ -25,10 +25,10 @@
           [ { "id": "SMOOTH" } ]
         ],
         "components": [
-          [ [ "2x4", 211 ] ],
+          [ [ "2x4", 210 ] ],
           [ [ "concrete", 20 ], [ "material_quicklime", 400 ], [ "material_sand", 400 ] ],
           [ [ "material_soil", 2000 ] ],
-          [ [ "nail", 486 ] ],
+          [ [ "nail", 484 ] ],
           [ [ "pointy_stick", 40 ], [ "spear_wood", 40 ] ],
           [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
           [ [ "water", 1000 ], [ "water_clean", 1000 ] ],

--- a/data/json/recipes/basecamps/recipe_modular_saltworks/recipe_modular_saltworks_stone.json
+++ b/data/json/recipes/basecamps/recipe_modular_saltworks/recipe_modular_saltworks_stone.json
@@ -19,11 +19,11 @@
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 71 ] ],
+          [ [ "2x4", 70 ] ],
           [ [ "glass_sheet", 3 ] ],
           [ [ "hinge", 2 ] ],
           [ [ "mortar_adobe", 40 ], [ "mortar_build", 40 ] ],
-          [ [ "nail", 158 ] ],
+          [ [ "nail", 156 ] ],
           [ [ "pebble", 1000 ] ],
           [ [ "rock", 480 ] ],
           [ [ "wood_panel", 6 ] ]

--- a/data/json/recipes/basecamps/recipe_modular_saltworks/recipe_modular_saltworks_wad.json
+++ b/data/json/recipes/basecamps/recipe_modular_saltworks/recipe_modular_saltworks_wad.json
@@ -19,7 +19,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 381 ] ],
+          [ [ "2x4", 380 ] ],
           [
             [ "cattail_stalk", 172 ],
             [ "dogbane", 172 ],
@@ -35,7 +35,7 @@
             [ "material_quicklime", 172 ],
             [ "material_soil", 860 ]
           ],
-          [ [ "nail", 396 ] ],
+          [ [ "nail", 394 ] ],
           [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
           [ [ "water", 215 ], [ "water_clean", 215 ] ],
           [ [ "wood_panel", 22 ] ]

--- a/data/json/recipes/basecamps/recipe_modular_saltworks/recipe_modular_saltworks_wood.json
+++ b/data/json/recipes/basecamps/recipe_modular_saltworks/recipe_modular_saltworks_wood.json
@@ -18,7 +18,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 271 ] ], [ [ "glass_sheet", 3 ] ], [ [ "hinge", 2 ] ], [ [ "nail", 958 ] ], [ [ "wood_panel", 46 ] ] ]
+        "components": [ [ [ "2x4", 270 ] ], [ [ "glass_sheet", 3 ] ], [ [ "hinge", 2 ] ], [ [ "nail", 956 ] ], [ [ "wood_panel", 46 ] ] ]
       }
     }
   },

--- a/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop.rock.json
+++ b/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop.rock.json
@@ -50,11 +50,11 @@
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 131 ] ],
+          [ [ "2x4", 130 ] ],
           [ [ "glass_sheet", 1 ] ],
           [ [ "hinge", 2 ] ],
           [ [ "mortar_adobe", 12 ], [ "mortar_build", 12 ] ],
-          [ [ "nail", 394 ] ],
+          [ [ "nail", 392 ] ],
           [ [ "pebble", 300 ] ],
           [ [ "rock", 144 ] ],
           [ [ "wood_panel", 23 ] ]

--- a/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_log.json
+++ b/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_log.json
@@ -42,11 +42,11 @@
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 167 ] ],
+          [ [ "2x4", 166 ] ],
           [ [ "glass_sheet", 1 ] ],
           [ [ "hinge", 2 ] ],
           [ [ "log", 24 ] ],
-          [ [ "nail", 394 ] ],
+          [ [ "nail", 392 ] ],
           [ [ "wood_panel", 23 ] ]
         ]
       }

--- a/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_metal.json
+++ b/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_metal.json
@@ -61,10 +61,10 @@
           [ { "id": "WRENCH" } ]
         ],
         "components": [
-          [ [ "2x4", 113 ] ],
+          [ [ "2x4", 112 ] ],
           [ [ "glass_sheet", 1 ] ],
           [ [ "hinge", 2 ] ],
-          [ [ "nail", 274 ] ],
+          [ [ "nail", 272 ] ],
           [ [ "pipe", 36 ] ],
           [ [ "sheet_metal", 6 ] ],
           [ [ "steel_plate", 24 ] ],

--- a/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_migo_resin.json
+++ b/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_migo_resin.json
@@ -37,7 +37,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W" } ], [ { "id": "SMOOTH" } ] ],
-        "components": [ [ [ "2x4", 22 ] ], [ [ "alien_pod_resin", 35 ] ], [ [ "nail", 128 ] ], [ [ "wood_panel", 12 ], [ "wood_sheet", 6 ] ] ]
+        "components": [ [ [ "2x4", 21 ] ], [ [ "alien_pod_resin", 35 ] ], [ [ "nail", 126 ] ], [ [ "wood_panel", 12 ], [ "wood_sheet", 6 ] ] ]
       }
     }
   },

--- a/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_rammed_earth.json
+++ b/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_rammed_earth.json
@@ -61,10 +61,10 @@
           [ { "id": "SMOOTH" } ]
         ],
         "components": [
-          [ [ "2x4", 135 ] ],
+          [ [ "2x4", 134 ] ],
           [ [ "concrete", 6 ], [ "material_quicklime", 120 ], [ "material_sand", 120 ] ],
           [ [ "material_soil", 600 ] ],
-          [ [ "nail", 382 ] ],
+          [ [ "nail", 380 ] ],
           [ [ "pointy_stick", 12 ], [ "spear_wood", 12 ] ],
           [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
           [ [ "water", 300 ], [ "water_clean", 300 ] ],

--- a/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_wad.json
+++ b/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_wad.json
@@ -62,7 +62,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 185 ] ],
+          [ [ "2x4", 184 ] ],
           [
             [ "cattail_stalk", 52 ],
             [ "dogbane", 52 ],
@@ -78,7 +78,7 @@
             [ "material_quicklime", 52 ],
             [ "material_soil", 260 ]
           ],
-          [ [ "nail", 352 ] ],
+          [ [ "nail", 350 ] ],
           [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
           [ [ "water", 65 ], [ "water_clean", 65 ] ],
           [ [ "wood_panel", 22 ] ]

--- a/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_wood.json
+++ b/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_wood.json
@@ -56,7 +56,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 191 ] ], [ [ "glass_sheet", 1 ] ], [ [ "hinge", 2 ] ], [ [ "nail", 634 ] ], [ [ "wood_panel", 35 ] ] ]
+        "components": [ [ [ "2x4", 190 ] ], [ [ "glass_sheet", 1 ] ], [ [ "hinge", 2 ] ], [ [ "nail", 632 ] ], [ [ "wood_panel", 35 ] ] ]
       }
     }
   },


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

Please use a descriptive name for the PR title, so it's clear at a glance what the PR is about.
-->

## Summary
SUMMARY: Balance "Make deconstructing most constructable furniture not devour components at random"

<!--
This section should consist of exactly one line, formatted like the example above.

'Category' must be one of the following:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/

If the PR is a port or adaptation of DDA content, please indicate it to be so.
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This adjusts the deconstruct yields of more constructable furniture to return what you put into them, so you don't randomly lose components for no good reason just trying to rebuild something in another location. A good chunk of constructions already do this, so this is just enforcing that consistency a bit more for some of the real old stuff.

This should cover all instances in the `FURN` and `WORKSHOP` categories, since the list was getting decently long I figured I'd save an overview of constructables in the `CONSTRUCT` category for another time.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

Set consistent deconstruct yields for the following constructables:
* Grid RV kitchen unit
* Dresser
* Bookcase
* Entertainment center
* Wooden rack
* Warehouse shelf
* Coat rack
* Cupboard
* Counter
* Table
* Coffee table
* Chair
* Stool
* Bench
* Makeshift bed (still returns rags instead of sheets but now matches uncraft of 1 blanket)
* Straw bed
* Bunk bed
* Bed frame
* Arm chair
* Sofa
* Sign
* Fermenting vat
* Wooden barrel
* Desk
* Wardrobe
* Mailbox
* Planter
* Charcoal kiln
* Metal charcoal kiln
* Rock forge
* Counter gate
* Arc furnace (this one was ESPECIALLY wacky and had zero connection to the construction recipe)

Some of those changes also entailed a reduction in planks yielded from deconstruct or bashing, and/or an increase in splintered wood when bashed, since some furniture was transmutating wooden panels into extra planks.

MISC: Also reduced materials needed to construct a stool to 3 planks and 6 nails, so that it's actually less material than a basic chair instead of identical. The deconstruct entry was already set up with yields that implied this was the intended amount anyway.

MISC: Fixed decorative tree not being deconstuctable at all despite being fairly simple furniture with the `EASY_DECONSTRUCT` flag, and fixed it using `count` instead of `charges` for the nails dropped on bashing.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Making small, fiddly components like nails, copper wire, solder etc stay lossy. Most deconstructs that'd be affected by that (in particular grid furniture) already return 100% of wire or solder used as it is so we already seem to be erring on the side of non-lossy deconstruct yields there.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Checked affected files for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
