### PR TITLE
fix: update eye encumbrance, infravision when transforming items

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -487,7 +487,6 @@ Character::Character( Character &&source )  noexcept : Creature( std::move( sour
 
     worn = std::move( source.worn );
     damage_disinfected = source.damage_disinfected ;
-    nv_cached = source.nv_cached ;
     in_vehicle = source.in_vehicle ;
     hauling = source.hauling ;
 
@@ -645,7 +644,6 @@ noexcept
 
     worn = std::move( source.worn );
     damage_disinfected = source.damage_disinfected ;
-    nv_cached = source.nv_cached ;
     in_vehicle = source.in_vehicle ;
     hauling = source.hauling ;
 
@@ -1144,11 +1142,6 @@ int Character::get_perceived_pain() const
     }
 
     return std::max( get_pain() - get_painkiller(), 0 );
-}
-
-void Character::action_taken()
-{
-    nv_cached = false;
 }
 
 int Character::swim_speed() const
@@ -2029,7 +2022,9 @@ void Character::recalc_sight_limits()
         ( is_mounted() && mounted_creature->has_flag( MF_MECH_RECON_VISION ) ) ) {
         best_bonus_nv = std::max( best_bonus_nv, 10.0f );
     }
-    if( has_nv() ) {
+    if( worn_with_flag( flag_GNV_EFFECT ) ||
+        has_active_bionic( bio_night_vision ) ||
+        has_effect_with_flag( flag_EFFECT_NIGHT_VISION ) ) {
         vision_mode_cache.set( NV_GOGGLES );
         best_bonus_nv = std::max( best_bonus_nv, 10.0f );
     }
@@ -4151,20 +4146,6 @@ void Character::reset()
     recalculate_enchantment_cache();
     // TODO: Move reset_stats here, remove it from Creature
     Creature::reset();
-}
-
-bool Character::has_nv()
-{
-    static bool nv = false;
-
-    if( !nv_cached ) {
-        nv_cached = true;
-        nv = ( worn_with_flag( flag_GNV_EFFECT ) ||
-               has_active_bionic( bio_night_vision ) ||
-               has_effect_with_flag( flag_EFFECT_NIGHT_VISION ) );
-    }
-
-    return nv;
 }
 
 void Character::reset_encumbrance()

--- a/src/character.h
+++ b/src/character.h
@@ -413,8 +413,6 @@ class Character : public Creature, public location_visitable<Character>
         bool has_alarm_clock() const;
         /** Returns true if the player or their vehicle has a watch */
         bool has_watch() const;
-        /** Called after every action, invalidates player caches */
-        void action_taken();
         /** Returns true if the player is knocked over or has broken legs */
         bool is_on_ground() const override;
         /** Returns the player's speed for swimming across water tiles */
@@ -1584,9 +1582,6 @@ class Character : public Creature, public location_visitable<Character>
         /** Returns true if the player is immune to throws */
         bool is_throw_immune() const;
 
-        /** Returns true if the player has some form of night vision */
-        bool has_nv();
-
         /**
          * Returns >0 if character is sitting/lying and relatively inactive.
          * 1 represents sleep on comfortable bed, so anything above that should be rare.
@@ -1641,7 +1636,6 @@ class Character : public Creature, public location_visitable<Character>
 
         location_vector<item> worn;
         std::array<int, num_hp_parts> damage_bandaged, damage_disinfected;
-        bool nv_cached = false;
         // Means player sit inside vehicle on the tile he is now
         bool in_vehicle = false;
         bool hauling = false;

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -762,8 +762,6 @@ void Character::reset_stats()
 
     apply_skill_boost();
 
-    nv_cached = false;
-
     // Reset our stats to normal levels
     // Any persistent buffs/debuffs will take place in effects,
     // player::suffer(), etc.

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1457,7 +1457,6 @@ bool game::do_turn()
 
                 if( handle_action() ) {
                     ++moves_since_last_save;
-                    u.action_taken();
                 }
 
                 if( is_game_over() ) {

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -297,6 +297,8 @@ int iuse_transform::use( player &p, item &it, bool t, const tripoint &pos ) cons
     }
     it.item_counter = countdown > 0 ? countdown : it.type->countdown_interval;
     it.active = active || it.item_counter;
+    // Check for gaining or losing night vision, eye encumbrance effects, clairvoyance from transforming relics, etc.
+    p.recalc_sight_limits();
 
     return 0;
 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -123,7 +123,6 @@ player::player()
     lastconsumed = itype_id( "null" );
     death_drops = true;
 
-    nv_cached = false;
     volume = 0;
 
     set_value( "THIEF_MODE", "THIEF_ASK" );


### PR DESCRIPTION
## Purpose of change

This salvages another of the fixes from https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2965 and puts it in a separate PR.

## Describe the solution

In iuse_actor.cpp, set `iuse_transform::use` to include a call to `recalc_sight_limits` in case the transformation in question affects vision. Fixes vision items like infrared goggles requiring you to wait a turn after toggling them before the visual effects update. Also affects stuff like changing eye encumbrance restricting night vision, like raising or lowering the visor on the welding mask.

Per Olanti's suggestion, adjusted the way night vision is checked for to not use a weird cache that seems custom-made to do nothing but delay the night vision effect kicking in for a turn, via adjusting `recalc_sight_limits` to check for NV effects directly, same way that.

Leads to deleting various uses of `has_nv`, `nv_cached`, and `Character::action_taken` in the code as all of that was used solely for caching and delaying NV effects, and nothing else it seems.

## Describe alternatives you've considered

Adding the injections to `activity_handlers::spellcasting_finish` and `salvage_actor::cut_up` the above-linked PR added. The former would be useful for spells that give the player clairvoyance or night vision as those also need a turn to update.

The latter...not sure? It'd only matter if you have any sources of different vision modes that can be cut up, and it'd also depend on whether the time component of salvaging it is applied in an order that hides the problem. I tried editing light amp goggles to be cotton but it wouldn't let me cut it up, possibly since it's an active item.

Also, keeping all the now-unused shit in the code just in case some really obscure thing might break without it and just leaving its current only apparent usage orphaned.

## Testing

1. Compiled and load-tested.
2. Spawned in a pair of infrared goggles and used them.
3. Confirmed that the infrared effect (starter NPC being marked with a heat dot off in the distance) kicks in immediately when turned on and goes away immediately when turned off.
4. Also tested toggling a worn welding mask in the dark, it now correctly applies changing effects of eye encumbrance when toggled.
5. Created a save with worn light amp goggles prior to the removal of `has_nv` and `nv_cached` code.
6. Loaded it after stripping it out, no errors popped up.
7. Turned light amp goggles off, they now correctly update instantly, same when turned back on.
8. Checked affected files for astyle.

Clairvoyance from sources like mask of insight in Arcana still won't work, but that's because of other issues with delayed-effect relic fuckery, via `ench_effects` still being buried in the `activate_passive` function, as brought up in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3643
