### PR TITLE
feat(balance): Rebalanced occurrences of some specials

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -343,7 +343,7 @@
     "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "forest" ],
     "city_distance": [ 5, 60 ],
-    "occurrences": [ 0, 10 ],
+    "occurrences": [ 0, 4 ],
     "flags": [ "CLASSIC", "ELECTRIC_GRID" ]
   },
   {
@@ -859,9 +859,8 @@
       { "point": [ 0, 2, 1 ], "overmap": "prison_alcatraz_15_2f_north" }
     ],
     "locations": [ "lake_surface" ],
-    "city_distance": [ 3, -1 ],
-    "city_sizes": [ 4, 12 ],
-    "occurrences": [ 50, 100 ],
+    "city_distance": [ 12, -1 ],
+    "occurrences": [ 75, 100 ],
     "flags": [ "CLASSIC", "LAKE", "UNIQUE" ]
   },
   {
@@ -1467,7 +1466,7 @@
     ],
     "locations": [ "wilderness" ],
     "city_distance": [ 12, -1 ],
-    "occurrences": [ 33, 100 ],
+    "occurrences": [ 30, 100 ],
     "flags": [ "UNIQUE" ]
   },
   {
@@ -3054,7 +3053,7 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 3, -1 ],
     "city_sizes": [ 4, -1 ],
-    "occurrences": [ 75, 100 ],
+    "occurrences": [ 50, 100 ],
     "flags": [ "UNIQUE" ]
   },
   {
@@ -4119,7 +4118,7 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 3, -1 ],
     "city_sizes": [ 1, 16 ],
-    "occurrences": [ 33, 100 ],
+    "occurrences": [ 35, 100 ],
     "rotate": false,
     "flags": [ "UNIQUE", "ELECTRIC_GRID" ]
   },
@@ -4709,7 +4708,7 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 8, -1 ],
-    "occurrences": [ 50, 100 ],
+    "occurrences": [ 35, 100 ],
     "flags": [ "CLASSIC", "UNIQUE", "ELECTRIC_GRID" ]
   },
   {
@@ -4865,9 +4864,7 @@
       { "point": [ 5, 5, 0 ], "overmap": "lake_surface" }
     ],
     "locations": [ "lake_surface" ],
-    "city_distance": [ 3, -1 ],
-    "city_sizes": [ 4, 12 ],
-    "occurrences": [ 0, 1 ],
+    "occurrences": [ 0, 3 ],
     "flags": [ "CLASSIC", "LAKE", "WILDERNESS" ]
   },
   {
@@ -4912,9 +4909,7 @@
       { "point": [ 5, 5, 0 ], "overmap": "lake_surface" }
     ],
     "locations": [ "lake_surface" ],
-    "city_distance": [ 3, -1 ],
-    "city_sizes": [ 4, 12 ],
-    "occurrences": [ 0, 1 ],
+    "occurrences": [ 0, 3 ],
     "flags": [ "CLASSIC", "LAKE", "WILDERNESS" ]
   },
   {
@@ -4932,9 +4927,7 @@
       { "point": [ 2, 2, 0 ], "overmap": "lake_surface" }
     ],
     "locations": [ "lake_surface" ],
-    "city_distance": [ 3, -1 ],
-    "city_sizes": [ 4, 12 ],
-    "occurrences": [ 0, 1 ],
+    "occurrences": [ 0, 3 ],
     "flags": [ "CLASSIC", "LAKE", "WILDERNESS" ]
   },
   {
@@ -4985,9 +4978,7 @@
       { "point": [ 6, 5, 0 ], "overmap": "lake_surface" }
     ],
     "locations": [ "lake_surface" ],
-    "city_distance": [ 3, -1 ],
-    "city_sizes": [ 4, 12 ],
-    "occurrences": [ 0, 1 ],
+    "occurrences": [ 0, 3 ],
     "flags": [ "CLASSIC", "LAKE", "WILDERNESS" ]
   },
   {
@@ -5038,9 +5029,7 @@
       { "point": [ 6, 5, 0 ], "overmap": "lake_surface" }
     ],
     "locations": [ "lake_surface" ],
-    "city_distance": [ 3, -1 ],
-    "city_sizes": [ 4, 12 ],
-    "occurrences": [ 0, 1 ],
+    "occurrences": [ 0, 3 ],
     "flags": [ "CLASSIC", "LAKE", "WILDERNESS" ]
   },
   {
@@ -5091,9 +5080,7 @@
       { "point": [ 6, 5, 0 ], "overmap": "lake_surface" }
     ],
     "locations": [ "lake_surface" ],
-    "city_distance": [ 3, -1 ],
-    "city_sizes": [ 4, 12 ],
-    "occurrences": [ 0, 1 ],
+    "occurrences": [ 0, 3 ],
     "flags": [ "CLASSIC", "LAKE", "WILDERNESS" ]
   },
   {
@@ -5151,9 +5138,7 @@
       { "point": [ 6, 6, 0 ], "overmap": "lake_surface" }
     ],
     "locations": [ "lake_surface" ],
-    "city_distance": [ 3, -1 ],
-    "city_sizes": [ 4, 12 ],
-    "occurrences": [ 0, 1 ],
+    "occurrences": [ 0, 3 ],
     "flags": [ "CLASSIC", "LAKE", "WILDERNESS" ]
   },
   {
@@ -5187,9 +5172,7 @@
       { "point": [ 4, 4, 0 ], "overmap": "lake_surface" }
     ],
     "locations": [ "lake_surface" ],
-    "city_distance": [ 3, -1 ],
-    "city_sizes": [ 4, 12 ],
-    "occurrences": [ 0, 1 ],
+    "occurrences": [ 0, 3 ],
     "flags": [ "CLASSIC", "LAKE", "WILDERNESS" ]
   },
   {
@@ -5223,9 +5206,7 @@
       { "point": [ 4, 4, 0 ], "overmap": "lake_surface" }
     ],
     "locations": [ "lake_surface" ],
-    "city_distance": [ 3, -1 ],
-    "city_sizes": [ 4, 12 ],
-    "occurrences": [ 0, 1 ],
+    "occurrences": [ 0, 3 ],
     "flags": [ "CLASSIC", "LAKE", "WILDERNESS" ]
   },
   {
@@ -5259,9 +5240,7 @@
       { "point": [ 4, 4, 0 ], "overmap": "lake_surface" }
     ],
     "locations": [ "lake_surface" ],
-    "city_distance": [ 3, -1 ],
-    "city_sizes": [ 4, 12 ],
-    "occurrences": [ 0, 1 ],
+    "occurrences": [ 0, 3 ],
     "flags": [ "CLASSIC", "LAKE", "WILDERNESS" ]
   },
   {
@@ -5295,9 +5274,7 @@
       { "point": [ 4, 4, 0 ], "overmap": "lake_surface" }
     ],
     "locations": [ "lake_surface" ],
-    "city_distance": [ 3, -1 ],
-    "city_sizes": [ 4, 12 ],
-    "occurrences": [ 0, 1 ],
+    "occurrences": [ 0, 3 ],
     "flags": [ "CLASSIC", "LAKE", "WILDERNESS" ]
   },
   {
@@ -5321,9 +5298,7 @@
       { "point": [ 2, 2, 0 ], "overmap": "lake_surface" }
     ],
     "locations": [ "lake_surface" ],
-    "city_distance": [ 3, -1 ],
-    "city_sizes": [ 4, 12 ],
-    "occurrences": [ 0, 1 ],
+    "occurrences": [ 0, 4 ],
     "flags": [ "CLASSIC", "LAKE" ]
   },
   {
@@ -5370,9 +5345,7 @@
       { "point": [ 5, 5, 0 ], "overmap": "lake_surface" }
     ],
     "locations": [ "lake_surface" ],
-    "city_distance": [ 3, -1 ],
-    "city_sizes": [ 4, 12 ],
-    "occurrences": [ 0, 1 ],
+    "occurrences": [ 0, 3 ],
     "flags": [ "CLASSIC", "LAKE", "WILDERNESS" ]
   },
   {
@@ -5392,31 +5365,32 @@
       { "point": [ -1, 2, 0 ], "overmap": "lake_shore", "locations": [ "lake_shore" ] },
       { "point": [ -1, 1, 0 ], "overmap": "lake_surface", "locations": [ "lake_surface" ] },
       { "point": [ -1, 0, 0 ], "overmap": "lake_surface", "locations": [ "lake_surface" ] },
-      { "point": [ 4, 0, 0 ], "overmap": "marina_1_north", "locations": [ "lake_surface" ] },
-      { "point": [ 3, 0, 0 ], "overmap": "marina_2_north", "locations": [ "lake_surface" ] },
-      { "point": [ 2, 0, 0 ], "overmap": "marina_3_north", "locations": [ "lake_surface" ] },
-      { "point": [ 1, 0, 0 ], "overmap": "marina_4_north", "locations": [ "lake_surface" ] },
-      { "point": [ 0, 0, 0 ], "overmap": "marina_5_north", "locations": [ "lake_surface" ] },
-      { "point": [ 4, 1, 0 ], "overmap": "marina_6_north", "locations": [ "lake_surface" ] },
-      { "point": [ 3, 1, 0 ], "overmap": "marina_7_north", "locations": [ "lake_surface" ] },
-      { "point": [ 2, 1, 0 ], "overmap": "marina_8_north", "locations": [ "lake_surface" ] },
-      { "point": [ 1, 1, 0 ], "overmap": "marina_9_north", "locations": [ "lake_surface" ] },
-      { "point": [ 0, 1, 0 ], "overmap": "marina_10_north", "locations": [ "lake_surface" ] },
-      { "point": [ 4, 2, 0 ], "overmap": "marina_11_north", "locations": [ "lake_shore" ] },
-      { "point": [ 3, 2, 0 ], "overmap": "marina_12_north", "locations": [ "lake_shore" ] },
-      { "point": [ 2, 2, 0 ], "overmap": "marina_13_north", "locations": [ "lake_shore" ] },
-      { "point": [ 1, 2, 0 ], "overmap": "marina_14_north", "locations": [ "lake_shore" ] },
-      { "point": [ 0, 2, 0 ], "overmap": "marina_15_north", "locations": [ "lake_shore" ] },
+      { "point": [ 4, 0, 0 ], "overmap": "marina_1_north" },
+      { "point": [ 3, 0, 0 ], "overmap": "marina_2_north" },
+      { "point": [ 2, 0, 0 ], "overmap": "marina_3_north" },
+      { "point": [ 1, 0, 0 ], "overmap": "marina_4_north" },
+      { "point": [ 0, 0, 0 ], "overmap": "marina_5_north" },
+      { "point": [ 4, 1, 0 ], "overmap": "marina_6_north" },
+      { "point": [ 3, 1, 0 ], "overmap": "marina_7_north" },
+      { "point": [ 2, 1, 0 ], "overmap": "marina_8_north" },
+      { "point": [ 1, 1, 0 ], "overmap": "marina_9_north" },
+      { "point": [ 0, 1, 0 ], "overmap": "marina_10_north" },
+      { "point": [ 4, 2, 0 ], "overmap": "marina_11_north" },
+      { "point": [ 3, 2, 0 ], "overmap": "marina_12_north" },
+      { "point": [ 2, 2, 0 ], "overmap": "marina_13_north" },
+      { "point": [ 1, 2, 0 ], "overmap": "marina_14_north" },
+      { "point": [ 0, 2, 0 ], "overmap": "marina_15_north" },
       { "point": [ 4, 3, 0 ], "overmap": "marina_16_north", "locations": [ "land" ] },
       { "point": [ 3, 3, 0 ], "overmap": "marina_17_north", "locations": [ "land" ] },
       { "point": [ 2, 3, 0 ], "overmap": "marina_18_north", "locations": [ "land" ] },
       { "point": [ 1, 3, 0 ], "overmap": "marina_19_north", "locations": [ "land" ] },
       { "point": [ 0, 3, 0 ], "overmap": "marina_20_north", "locations": [ "land" ] }
     ],
+    "locations": [ "lake_surface", "lake_shore", "land" ],
     "city_sizes": [ 4, 20 ],
-    "occurrences": [ 0, 1 ],
+    "occurrences": [ 75, 100 ],
     "connections": [ { "point": [ 2, 4, 0 ], "connection": "local_road", "from": [ 2, 3, 0 ] } ],
-    "flags": [ "LAKE" ]
+    "flags": [ "LAKE", "UNIQUE" ]
   },
   {
     "type": "overmap_special",
@@ -6374,8 +6348,8 @@
       { "point": [ 29, 29, 0 ], "overmap": "forest_thick" }
     ],
     "locations": [ "land" ],
-    "city_distance": [ 5, -1 ],
-    "occurrences": [ 30, 100 ],
+    "city_distance": [ 15, -1 ],
+    "occurrences": [ 20, 100 ],
     "flags": [ "CLASSIC", "FARM", "UNIQUE" ]
   },
   {
@@ -6950,7 +6924,7 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 8, -1 ],
-    "occurrences": [ 50, 100 ],
+    "occurrences": [ 35, 100 ],
     "flags": [ "CLASSIC", "UNIQUE", "ELECTRIC_GRID" ]
   },
   {


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

Please use a descriptive name for the PR title, so it's clear at a glance what the PR is about.
-->

## Summary
SUMMARY: Balance "Rebalanced occurrences of some specials"

<!--
This section should consist of exactly one line, formatted like the example above.

'Category' must be one of the following:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/

If the PR is a port or adaptation of DDA content, please indicate it to be so.
-->

## Purpose of change
With latest changes some specials went way off balance, that an attempt to improve it.
For reference: [context](https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3520#issuecomment-1801283529), [documentation](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/5b43ade4b2f86fc48589e25a6521cf6d59723ab7/doc/src/content/docs/en/mod/json/reference/map/overmap.md#placement-rules).
There might be more things which need adjustments, feedback welcome.

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution
Lakes changes:
* All islands increased from 0-1 to 0-3, and untied from cities. Raw occurrences assumes a full lake overmap, so even with 0-3 lakes are desolated enough. And islands shouldn't care about cities at all.
* Island prison got bigger min distance from city - it won't noticeable restrict uniq thing, and just makes sense. Chances slightly increased to compensate land\water normalization.
* Marina become an uniq instead of 0-1, slightly increasing chances(50% to 75%), and also got more forgiving placement restrictions. We don't really care if it will be placed on bumpy coast, as long as edge is matching - inner terrain will be overridden anyway.
* Lighthouse increased from 0-1 to 0-4. That's the only non-uniq lake special worth a visit, some buff won't hurt it.

Land changes:
* Sugar House reduced from 0-10 to 0-4. That's a very bland special, which even paves a road to itself, just adding a mess for no good reason.
* Airports nerfed from 50% to 35%. There's two of them and total 70% seems good enough. Airports are cool, it makes them a bit more valuable.
* Refuge center nerfed from 75% to 50%. Huge ugly thing. Less is better.
* Isherwood got bigger min distance from city. This abomination often bigger than cities, better put in wilderness.
* Necropolist 33% -> 30%, Hub 01 33% -> 35%. Just rounding.
<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

## Describe alternatives you've considered
Leaving balancing to someone else.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing
Generated some overmaps.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
