### PR TITLE
fix(content): `NON_FOULING` flag not working due to typo

### DIFF
--- a/data/json/ammo_effects.json
+++ b/data/json/ammo_effects.json
@@ -376,10 +376,5 @@
     "id": "RECYCLED",
     "type": "ammo_effect",
     "//": "Nearly-immeasurable chance to fail to fire."
-  },
-  {
-    "id": "NON_FOULING",
-    "type": "ammo_effect",
-    "//": "Doesn't cause gunk to build up."
   }
 ]

--- a/data/json/ammo_effects.json
+++ b/data/json/ammo_effects.json
@@ -378,7 +378,7 @@
     "//": "Nearly-immeasurable chance to fail to fire."
   },
   {
-    "id": "NON-FOULING",
+    "id": "NON_FOULING",
     "type": "ammo_effect",
     "//": "Doesn't cause gunk to build up."
   }

--- a/data/json/ammo_effects_simple.json
+++ b/data/json/ammo_effects_simple.json
@@ -95,7 +95,7 @@
     "//": "Doesn't overkill."
   },
   {
-    "id": "NON-FOULING",
+    "id": "NON_FOULING",
     "type": "ammo_effect",
     "//": "Doesn't cause gunk to build up."
   },

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2068,7 +2068,7 @@
     "context": [  ]
   },
   {
-    "id": "NON-FOULING",
+    "id": "NON_FOULING",
     "type": "json_flag",
     "context": [  ]
   },

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2068,11 +2068,6 @@
     "context": [  ]
   },
   {
-    "id": "NON_FOULING",
-    "type": "json_flag",
-    "context": [  ]
-  },
-  {
     "id": "PUMP_RAIL_COMPATIBLE",
     "type": "json_flag",
     "context": [  ]

--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -278,7 +278,7 @@
     "to_hit": -1,
     "qualities": [ [ "HAMMER", 1 ] ],
     "dont_recover_one_in": 80,
-    "effects": [ "NEVER_MISFIRES", "NON-FOULING" ]
+    "effects": [ "NEVER_MISFIRES", "NON_FOULING" ]
   },
   {
     "type": "AMMO",
@@ -298,7 +298,7 @@
     "dispersion": 14,
     "loudness": 0,
     "count": 10,
-    "effects": [ "NEVER_MISFIRES", "NON-FOULING" ]
+    "effects": [ "NEVER_MISFIRES", "NON_FOULING" ]
   },
   {
     "type": "AMMO",
@@ -362,7 +362,7 @@
     "loudness": 0,
     "count": 50,
     "dont_recover_one_in": 1000,
-    "effects": [ "NEVER_MISFIRES", "NON-FOULING" ]
+    "effects": [ "NEVER_MISFIRES", "NON_FOULING" ]
   },
   {
     "type": "AMMO",
@@ -383,7 +383,7 @@
     "count": 500,
     "stack_size": 200,
     "loudness": 9,
-    "effects": [ "NOGIB", "NEVER_MISFIRES", "NON-FOULING" ]
+    "effects": [ "NOGIB", "NEVER_MISFIRES", "NON_FOULING" ]
   },
   {
     "type": "AMMO",
@@ -1080,7 +1080,7 @@
     "loudness": 0,
     "to_hit": -1,
     "dont_recover_one_in": 1000,
-    "effects": [ "NEVER_MISFIRES", "NON-FOULING" ]
+    "effects": [ "NEVER_MISFIRES", "NON_FOULING" ]
   },
   {
     "type": "AMMO",
@@ -1100,6 +1100,6 @@
     "loudness": 0,
     "count": 30,
     "dont_recover_one_in": 1000,
-    "effects": [ "NEVER_MISFIRES", "NON-FOULING" ]
+    "effects": [ "NEVER_MISFIRES", "NON_FOULING" ]
   }
 ]

--- a/data/json/items/ammo/metal_rail.json
+++ b/data/json/items/ammo/metal_rail.json
@@ -19,7 +19,7 @@
     "range": 20,
     "damage": { "damage_type": "stab", "amount": 60, "armor_penetration": 10 },
     "dispersion": 200,
-    "effects": [ "RECYCLED", "NON-FOULING" ]
+    "effects": [ "RECYCLED", "NON_FOULING" ]
   },
   {
     "id": "steel_rail",
@@ -35,7 +35,7 @@
     "material": [ "steel" ],
     "color": "light_gray",
     "dispersion": 100,
-    "effects": [ "NEVER_MISFIRES", "NON-FOULING" ],
+    "effects": [ "NEVER_MISFIRES", "NON_FOULING" ],
     "relative": { "range": 10, "damage": { "damage_type": "stab", "amount": -10, "armor_penetration": 20 } }
   }
 ]

--- a/data/json/items/ammo/nail.json
+++ b/data/json/items/ammo/nail.json
@@ -29,6 +29,6 @@
     "range": 3,
     "damage": { "damage_type": "stab", "amount": 4, "armor_penetration": 3 },
     "dispersion": 120,
-    "effects": [ "NON-FOULING" ]
+    "effects": [ "NON_FOULING" ]
   }
 ]

--- a/data/json/items/classes/gun.json
+++ b/data/json/items/classes/gun.json
@@ -163,7 +163,7 @@
     "name": { "str": "energy pistol" },
     "looks_like": "v29",
     "//": "No conventional faults because it uses non-conventional systems.",
-    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON-FOULING", "NEEDS_NO_LUBE" ],
+    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE" ],
     "valid_mod_locations": [
       [ "accessories", 2 ],
       [ "emitter", 1 ],
@@ -185,7 +185,7 @@
     "bashing": 7,
     "to_hit": -2,
     "//": "No conventional faults because it uses non-conventional systems.",
-    "flags": [ "RELOAD_ONE", "STR_RELOAD", "WATERPROOF_GUN", "UNDERWATER_GUN", "NEVER_JAMS", "NON-FOULING", "NEEDS_NO_LUBE" ],
+    "flags": [ "RELOAD_ONE", "STR_RELOAD", "WATERPROOF_GUN", "UNDERWATER_GUN", "NEVER_JAMS", "NON_FOULING", "NEEDS_NO_LUBE" ],
     "dispersion": 120,
     "reload": 600,
     "valid_mod_locations": [
@@ -287,7 +287,7 @@
     "name": { "str": "energy rifle" },
     "looks_like": "laser_rifle",
     "//": "No conventional faults because it uses non-conventional systems.",
-    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON-FOULING", "NEEDS_NO_LUBE" ],
+    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE" ],
     "valid_mod_locations": [
       [ "accessories", 4 ],
       [ "emitter", 1 ],
@@ -309,7 +309,7 @@
     "name": { "str": "magnetic rifle" },
     "looks_like": "laser_rifle",
     "//": "No conventional faults because it uses non-conventional systems.",
-    "flags": [ "NEVER_JAMS", "NON-FOULING", "NEEDS_NO_LUBE" ],
+    "flags": [ "NEVER_JAMS", "NON_FOULING", "NEEDS_NO_LUBE" ],
     "valid_mod_locations": [
       [ "accessories", 4 ],
       [ "grip", 1 ],
@@ -331,7 +331,7 @@
     "bashing": 8,
     "to_hit": -2,
     "//": "No conventional faults because it uses non-conventional systems.",
-    "flags": [ "RELOAD_ONE", "STR_RELOAD", "WATERPROOF_GUN", "UNDERWATER_GUN", "NEVER_JAMS", "NON-FOULING", "NEEDS_NO_LUBE" ],
+    "flags": [ "RELOAD_ONE", "STR_RELOAD", "WATERPROOF_GUN", "UNDERWATER_GUN", "NEVER_JAMS", "NON_FOULING", "NEEDS_NO_LUBE" ],
     "dispersion": 90,
     "reload": 700,
     "valid_mod_locations": [
@@ -353,7 +353,7 @@
     "name": { "str": "pneumatic rifle" },
     "bashing": 8,
     "//": "No conventional faults because it uses non-conventional systems.",
-    "flags": [ "NEVER_JAMS", "NON-FOULING", "NEEDS_NO_LUBE" ],
+    "flags": [ "NEVER_JAMS", "NON_FOULING", "NEEDS_NO_LUBE" ],
     "dispersion": 350,
     "reload": 600,
     "valid_mod_locations": [ [ "accessories", 3 ], [ "sling", 1 ], [ "grip", 1 ], [ "mechanism", 4 ], [ "stock", 1 ], [ "rail mount", 1 ] ],
@@ -488,7 +488,7 @@
     "bashing": 8,
     "reload": 200,
     "handling": 40,
-    "flags": [ "NO_UNLOAD", "NEVER_JAMS", "NON-FOULING" ],
+    "flags": [ "NO_UNLOAD", "NEVER_JAMS", "NON_FOULING" ],
     "faults": [  ]
   },
   {
@@ -501,7 +501,7 @@
     "bashing": 9,
     "skill": "launcher",
     "ammo": "chemical_spray",
-    "flags": [ "FIRE_50", "NEVER_JAMS", "NON-FOULING" ],
+    "flags": [ "FIRE_50", "NEVER_JAMS", "NON_FOULING" ],
     "valid_mod_locations": [
       [ "accessories", 4 ],
       [ "grip", 1 ],

--- a/data/json/items/gun/flammable.json
+++ b/data/json/items/gun/flammable.json
@@ -41,7 +41,7 @@
     "durability": 9,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "AUTO", "auto", 4 ] ],
     "valid_mod_locations": [ [ "accessories", 4 ], [ "rail", 1 ], [ "grip", 1 ], [ "sling", 1 ], [ "stock", 1 ], [ "underbarrel", 1 ] ],
-    "extend": { "flags": [ "FIRE_20", "MODE_BURST", "NON-FOULING" ] },
+    "extend": { "flags": [ "FIRE_20", "MODE_BURST", "NON_FOULING" ] },
     "delete": { "flags": [ "FIRE_100" ] },
     "magazines": [ [ "flammable", [ "rm4502", "rm4504" ] ] ]
   }

--- a/data/json/items/gun/misc.json
+++ b/data/json/items/gun/misc.json
@@ -32,7 +32,7 @@
     "description": "A water cannon from a fire truck.  Mounted on a vehicle, it could be used to stop fires or \"protesters\".  Or it could be loaded with something more corrosive, for a lot less firefighting and a lot more excessive force.",
     "price": 50000,
     "material": "steel",
-    "flags": [ "NEVER_JAMS", "MOUNTED_GUN", "NO_RELOAD", "NON-FOULING" ],
+    "flags": [ "NEVER_JAMS", "MOUNTED_GUN", "NO_RELOAD", "NON_FOULING" ],
     "ammo_effects": [ "JET", "BEANBAG", "NEVER_MISFIRES" ],
     "ammo": [ "water", "acid" ],
     "weight": "24500 g",

--- a/data/json/items/gun/paintball.json
+++ b/data/json/items/gun/paintball.json
@@ -11,7 +11,7 @@
     "price": 8000,
     "price_postapoc": 50,
     "material": [ "aluminum", "plastic" ],
-    "flags": [ "NEVER_JAMS", "NON-FOULING" ],
+    "flags": [ "NEVER_JAMS", "NON_FOULING" ],
     "skill": "smg",
     "ammo": "paintball",
     "weight": "1600 g",

--- a/data/json/items/gunmod/rail.json
+++ b/data/json/items/gunmod/rail.json
@@ -23,7 +23,7 @@
       "clip_size": 1
     },
     "dispersion_modifier": 60,
-    "flags": [ "STR_RELOAD", "NON-FOULING" ]
+    "flags": [ "STR_RELOAD", "NON_FOULING" ]
   },
   {
     "id": "gun_crossbow_mod",

--- a/data/json/items/ranged/spearguns.json
+++ b/data/json/items/ranged/spearguns.json
@@ -74,7 +74,7 @@
     "price": 25000,
     "price_postapoc": 1000,
     "material": [ "plastic", "steel" ],
-    "flags": [ "RELOAD_ONE", "STR_RELOAD", "WATERPROOF_GUN", "UNDERWATER_GUN", "NON-FOULING" ],
+    "flags": [ "RELOAD_ONE", "STR_RELOAD", "WATERPROOF_GUN", "UNDERWATER_GUN", "NON_FOULING" ],
     "skill": "rifle",
     "ammo": "fishspear",
     "weight": "3460 g",

--- a/data/json/obsoletion/items.json
+++ b/data/json/obsoletion/items.json
@@ -1748,7 +1748,7 @@
     "magazine_well": 1,
     "magazines": [ [ "flammable", [ "aux_pressurized_tank" ] ] ],
     "min_skills": [ [ "weapon", 2 ], [ "launcher", 1 ] ],
-    "flags": [ "FIRE_100", "PUMP_RAIL_COMPATIBLE", "NON-FOULING" ]
+    "flags": [ "FIRE_100", "PUMP_RAIL_COMPATIBLE", "NON_FOULING" ]
   },
   {
     "type": "recipe",
@@ -1892,7 +1892,7 @@
     "description": "A double-barreled pneumatic air shotgun handcrafted from scrap.  Though it's firepower is lacking compared to more conventional shotguns, this thing can still pack quite a punch.  That is, if your target is directly in front of you.",
     "price": 220000,
     "material": [ "steel", "wood" ],
-    "flags": [ "RELOAD_ONE", "STR_RELOAD", "NON-FOULING" ],
+    "flags": [ "RELOAD_ONE", "STR_RELOAD", "NON_FOULING" ],
     "skill": "shotgun",
     "ammo": "shotcanister",
     "weight": "3410 g",

--- a/data/mods/Aftershock/items/bioparts.json
+++ b/data/mods/Aftershock/items/bioparts.json
@@ -103,6 +103,6 @@
     "loudness": 4,
     "clip_size": 80,
     "ammo_effects": "ACIDBOMB",
-    "flags": [ "NO_UNLOAD", "NON-FOULING" ]
+    "flags": [ "NO_UNLOAD", "NON_FOULING" ]
   }
 ]

--- a/data/mods/Aftershock/items/gun/laser.json
+++ b/data/mods/Aftershock/items/gun/laser.json
@@ -15,7 +15,7 @@
     "dispersion": 500,
     "ups_charges": 25,
     "ammo_effects": [ "LASER", "BEANBAG" ],
-    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON-FOULING", "NEEDS_NO_LUBE" ]
+    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE" ]
   },
   {
     "id": "afs_sentinel_laser",
@@ -29,7 +29,7 @@
     "ups_charges": 30,
     "modes": [ [ "MULTI", "trilaser", 3 ] ],
     "ammo_effects": [ "LASER" ],
-    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON-FOULING", "NEEDS_NO_LUBE" ]
+    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE" ]
   },
   {
     "id": "afs_sentinel_laser_mon",
@@ -37,6 +37,6 @@
     "copy-from": "afs_sentinel_laser",
     "name": { "str": "wrist-trilaser" },
     "ups_charges": 0,
-    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON-FOULING", "NEEDS_NO_LUBE" ]
+    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE" ]
   }
 ]

--- a/data/mods/Aftershock/items/weapons.json
+++ b/data/mods/Aftershock/items/weapons.json
@@ -187,7 +187,7 @@
     "reload": 500,
     "valid_mod_locations": [ [ "accessories", 4 ], [ "sights", 1 ], [ "sling", 1 ], [ "stock", 1 ], [ "underbarrel", 1 ] ],
     "ammo_effects": [ "LASER", "DRAW_AS_LINE" ],
-    "flags": [ "NEVER_JAMS", "FIRE_20", "NON-FOULING" ],
+    "flags": [ "NEVER_JAMS", "FIRE_20", "NON_FOULING" ],
     "magazines": [
       [ "battery", [ "heavy_battery_cell", "heavy_plus_battery_cell", "heavy_atomic_battery_cell", "heavy_disposable_cell" ] ]
     ]
@@ -287,6 +287,6 @@
       [ "underbarrel mount", 1 ]
     ],
     "ammo_effects": [ "LASER", "INCENDIARY" ],
-    "flags": [ "NO_UNLOAD", "NON-FOULING", "NEEDS_NO_LUBE" ]
+    "flags": [ "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE" ]
   }
 ]

--- a/data/mods/CRT_EXPANSION/items/crt_gun.json
+++ b/data/mods/CRT_EXPANSION/items/crt_gun.json
@@ -33,7 +33,7 @@
       [ "underbarrel", 1 ]
     ],
     "ammo_effects": [ "LASER", "INCENDIARY" ],
-    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON-FOULING" ]
+    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING" ]
   },
   {
     "id": "crt_laser_gatling",
@@ -60,7 +60,7 @@
     "modes": [ [ "DEFAULT", "burst", 12 ] ],
     "valid_mod_locations": [ [ "accessories", 1 ], [ "emitter", 1 ], [ "grip", 1 ], [ "lens", 1 ], [ "rail", 1 ], [ "sights", 1 ], [ "stock", 1 ] ],
     "ammo_effects": [ "LASER", "INCENDIARY" ],
-    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON-FOULING" ]
+    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING" ]
   },
   {
     "id": "crt_laser_carbine",
@@ -96,7 +96,7 @@
       [ "underbarrel", 1 ]
     ],
     "ammo_effects": [ "LASER", "INCENDIARY" ],
-    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON-FOULING" ]
+    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING" ]
   },
   {
     "id": "crt_energy_rifle",
@@ -132,7 +132,7 @@
       [ "underbarrel", 1 ]
     ],
     "ammo_effects": [ "LASER", "INCENDIARY" ],
-    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON-FOULING" ]
+    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING" ]
   },
   {
     "id": "crt_cqb_si",
@@ -195,7 +195,7 @@
       [ "underbarrel", 1 ]
     ],
     "ammo_effects": [ "STREAM", "INCENDIARY" ],
-    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "UNARMED_WEAPON", "DURABLE_MELEE", "NON-FOULING", "PYROMANIAC_WEAPON" ]
+    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "UNARMED_WEAPON", "DURABLE_MELEE", "NON_FOULING", "PYROMANIAC_WEAPON" ]
   },
   {
     "id": "pelletgun",
@@ -209,7 +209,7 @@
     "price": 9900,
     "//": "You can get a decent Ruger .177 at walmart for $99",
     "material": [ "steel", "plastic" ],
-    "flags": [ "STR_RELOAD", "NON-FOULING", "NON-FOULING" ],
+    "flags": [ "STR_RELOAD", "NON_FOULING", "NON_FOULING" ],
     "skill": "rifle",
     "ammo": "pellets",
     "weight": "5023 g",
@@ -252,7 +252,7 @@
     "reload": 170,
     "valid_mod_locations": [ [ "accessories", 1 ], [ "grip", 1 ], [ "sights", 1 ] ],
     "ammo_effects": [ "PLASMA", "INCENDIARY", "DRAW_LASER_BEAM" ],
-    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON-FOULING", "PYROMANIAC_WEAPON" ]
+    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "PYROMANIAC_WEAPON" ]
   },
   {
     "id": "ds_rivet_gun",
@@ -308,7 +308,7 @@
     "modes": [ [ "DEFAULT", "semi-auto", 1 ] ],
     "valid_mod_locations": [ [ "accessories", 1 ], [ "grip", 1 ], [ "sights", 1 ] ],
     "ammo_effects": [ "WIDE", "LASER" ],
-    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "SLOW_WIELD", "NON-FOULING", "PYROMANIAC_WEAPON" ]
+    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "SLOW_WIELD", "NON_FOULING", "PYROMANIAC_WEAPON" ]
   },
   {
     "id": "ds_pulse_rifle",
@@ -335,7 +335,7 @@
     "reload": 15,
     "modes": [ [ "BURST", "3 rd.", 3 ] ],
     "valid_mod_locations": [ [ "accessories", 1 ], [ "grip", 1 ], [ "sights", 1 ], [ "stock", 1 ] ],
-    "ammo_effects": [ "NOGIB", "BEANBAG", "NON-FOULING" ],
+    "ammo_effects": [ "NOGIB", "BEANBAG", "NON_FOULING" ],
     "flags": [ "NEVER_JAMS" ]
   },
   {
@@ -364,6 +364,6 @@
     "reload": 450,
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "REACH", "em field saw", 5, [ "MELEE", "REACH_ATTACK" ] ] ],
     "ammo_effects": [ "LIGHTNING" ],
-    "flags": [ "NEVER_JAMS", "NON-FOULING" ]
+    "flags": [ "NEVER_JAMS", "NON_FOULING" ]
   }
 ]

--- a/data/mods/No_Hope/Items/gunmods.json
+++ b/data/mods/No_Hope/Items/gunmods.json
@@ -202,6 +202,6 @@
     },
     "dispersion_modifier": 60,
     "min_skills": [ [ "weapon", 2 ], [ "rifle", 1 ] ],
-    "flags": [ "STR_RELOAD", "NON-FOULING" ]
+    "flags": [ "STR_RELOAD", "NON_FOULING" ]
   }
 ]

--- a/data/mods/No_Hope/Items/guns.json
+++ b/data/mods/No_Hope/Items/guns.json
@@ -35,7 +35,7 @@
       [ "underbarrel mount", 1 ]
     ],
     "ammo_effects": [ "LASER", "INCENDIARY" ],
-    "flags": [ "NO_UNLOAD", "NON-FOULING", "NEEDS_NO_LUBE" ]
+    "flags": [ "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE" ]
   },
   {
     "id": "bio_blaster_gun",
@@ -503,7 +503,7 @@
     "description": "A double-barreled pneumatic air shotgun handcrafted from scrap.  Though it's firepower is lacking compared to more conventional shotguns, this thing can still pack quite a punch.  That is, if your target is directly in front of you.",
     "price": 220000,
     "material": [ "steel", "wood" ],
-    "flags": [ "RELOAD_ONE", "STR_RELOAD", "NON-FOULING" ],
+    "flags": [ "RELOAD_ONE", "STR_RELOAD", "NON_FOULING" ],
     "skill": "shotgun",
     "ammo": [ "shotcanister" ],
     "weight": "3410 g",

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -20,7 +20,7 @@
     "to_hit": -2,
     "qualities": [ [ "HAMMER", 1 ] ],
     "dont_recover_one_in": 80,
-    "effects": [ "NEVER_MISFIRES", "NON-FOULING" ]
+    "effects": [ "NEVER_MISFIRES", "NON_FOULING" ]
   },
   {
     "type": "GENERIC",

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -91,7 +91,7 @@ static const ammo_effect_str_id ammo_effect_LIGHTNING( "LIGHTNING" );
 static const ammo_effect_str_id ammo_effect_NO_CRIT( "NO_CRIT" );
 static const ammo_effect_str_id ammo_effect_NO_EMBED( "NO_EMBED" );
 static const ammo_effect_str_id ammo_effect_NO_ITEM_DAMAGE( "NO_ITEM_DAMAGE" );
-static const ammo_effect_str_id ammo_effect_NON_FOULING( "NON-FOULING" );
+static const ammo_effect_str_id ammo_effect_NON_FOULING( "NON_FOULING" );
 static const ammo_effect_str_id ammo_effect_PLASMA( "PLASMA" );
 static const ammo_effect_str_id ammo_effect_RECYCLED( "RECYCLED" );
 static const ammo_effect_str_id ammo_effect_SHATTER_SELF( "SHATTER_SELF" );


### PR DESCRIPTION
## Summary

SUMMARY: Bugfixes "Fix NON_FOULING flag not working due to typo"

## Purpose of change

- fixes #3645

DDA removed their accidental hyphen-based item flags to underscore based ones, BN didn't follow. Thus BN was using `NON-FOULING`. #3354 introduced `NON_FOULING`, which made the hardcoded flag look for `NON_FOULING`.

## Describe the solution

search and replace

## Describe alternatives you've considered

hecc.

## Testing

spawned and fired A7 laser rifle a lot.
before: got fouling
after: got no fouling