### PR TITLE
refactor(content): Convert slimepit special to mutable

### DIFF
--- a/data/json/overmap/overmap_mutable/slimepit.json
+++ b/data/json/overmap/overmap_mutable/slimepit.json
@@ -1,0 +1,63 @@
+[
+  {
+    "type": "overmap_special",
+    "id": "Slime Pit",
+    "subtype": "mutable",
+    "locations": [ "subterranean_empty" ],
+    "city_distance": [ 3, 30 ],
+    "occurrences": [ 0, 3 ],
+    "rotate": false,
+    "spawns": { "group": "GROUP_GOO", "population": [ 100, 200 ], "radius": [ 2, 10 ] },
+    "flags": [ "SLIME" ],
+    "check_for_locations": [
+      [ [ 0, 0, 0 ], [ "wilderness" ] ],
+      [ [ 0, 0, -1 ], [ "subterranean_empty" ] ],
+      [ [ 1, 0, -1 ], [ "subterranean_empty" ] ],
+      [ [ 0, 1, -1 ], [ "subterranean_empty" ] ],
+      [ [ -1, 0, -1 ], [ "subterranean_empty" ] ],
+      [ [ 0, -1, -1 ], [ "subterranean_empty" ] ]
+    ],
+    "joins": [ "slime_to_slime" ],
+    "overmaps": {
+      "surface": { "overmap": "slimepit_down", "below": "slime_to_slime", "locations": [ "wilderness" ] },
+      "slimepit": {
+        "overmap": "slimepit",
+        "above": { "id": "slime_to_slime", "type": "available" },
+        "north": "slime_to_slime",
+        "east": "slime_to_slime",
+        "south": "slime_to_slime",
+        "west": "slime_to_slime"
+      },
+      "slimepit_down": {
+        "overmap": "slimepit_down",
+        "below": "slime_to_slime",
+        "north": "slime_to_slime",
+        "east": "slime_to_slime",
+        "south": "slime_to_slime",
+        "west": "slime_to_slime"
+      },
+      "rock": {
+        "overmap": "rock",
+        "north": { "id": "slime_to_slime", "type": "available" },
+        "east": { "id": "slime_to_slime", "type": "available" },
+        "south": { "id": "slime_to_slime", "type": "available" },
+        "west": { "id": "slime_to_slime", "type": "available" }
+      }
+    },
+    "root": "surface",
+    "shared": { "size": [ 4, 10 ] },
+    "phases": [
+      [ { "overmap": "slimepit", "max": 1 } ],
+      [
+        { "overmap": "slimepit", "scale": "size", "max": { "poisson": 1 } },
+        {
+          "name": "stairs",
+          "chunk": [ { "overmap": "slimepit_down", "pos": [ 0, 0, 0 ] }, { "overmap": "slimepit", "pos": [ 0, 0, -1 ] } ],
+          "scale": "size",
+          "max": { "poisson": 0.1 }
+        }
+      ],
+      [ { "overmap": "rock" } ]
+    ]
+  }
+]

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -927,17 +927,6 @@
   },
   {
     "type": "overmap_special",
-    "id": "Slime Pit",
-    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "slimepit_down" } ],
-    "locations": [ "wilderness" ],
-    "city_distance": [ 3, 30 ],
-    "occurrences": [ 0, 3 ],
-    "rotate": false,
-    "spawns": { "group": "GROUP_GOO", "population": [ 100, 200 ], "radius": [ 2, 10 ] },
-    "flags": [ "SLIME" ]
-  },
-  {
-    "type": "overmap_special",
     "id": "Fungal Bloom",
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "fungal_bloom" } ],
     "locations": [ "wilderness" ],

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -4986,19 +4986,25 @@ void map::draw_slimepit( mapgendata &dat )
 {
     const oter_id &terrain_type = dat.terrain_type();
     if( is_ot_match( "slimepit", terrain_type, ot_match_type::prefix ) ) {
+        if( dat.zlevel() == 0 ) {
+            dat.fill_groundcover();
+        } else {
+            draw_fill_background( t_rock_floor );
+        }
+
+        for( int i = 0; i < 4; i++ ) {
+            if( !is_ot_match( "slimepit", dat.t_nesw[i], ot_match_type::prefix ) ) {
+                dat.set_dir( i, SEEX );
+            }
+        }
+
         for( int i = 0; i < SEEX * 2; i++ ) {
             for( int j = 0; j < SEEY * 2; j++ ) {
-                if( !one_in( 10 ) && ( j < dat.n_fac * SEEX ||
-                                       i < dat.w_fac * SEEX ||
-                                       j > SEEY * 2 - dat.s_fac * SEEY ||
-                                       i > SEEX * 2 - dat.e_fac * SEEX ) ) {
-                    ter_set( point( i, j ), ( !one_in( 10 ) ? t_slime : t_rock_floor ) );
-                } else if( rng( 0, SEEX ) > std::abs( i - SEEX ) && rng( 0, SEEY ) > std::abs( j - SEEY ) ) {
+                if( !one_in( 5 ) && ( rng( 0, dat.n_fac ) <= j &&
+                                      rng( 0, dat.w_fac ) <= i &&
+                                      SEEY * 2 - rng( 0, dat.s_fac ) > j &&
+                                      SEEX * 2 - rng( 0, dat.e_fac ) > i ) ) {
                     ter_set( point( i, j ), t_slime );
-                } else if( dat.zlevel() == 0 ) {
-                    ter_set( point( i, j ), t_dirt );
-                } else {
-                    ter_set( point( i, j ), t_rock_floor );
                 }
             }
         }

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -435,7 +435,6 @@ class overmap
 
         void build_city_street( const overmap_connection &connection, const point_om_omt &p, int cs,
                                 om_direction::type dir, const city &town, int block_width = 2 );
-        bool build_slimepit( const tripoint_om_omt &origin, int s );
         void build_mine( const tripoint_om_omt &origin, int s );
 
         // Connection laying
@@ -459,7 +458,6 @@ class overmap
                        const tripoint_om_omt &p ) const;
         bool check_overmap_special_type( const overmap_special_id &id,
                                          const tripoint_om_omt &location ) const;
-        void chip_rock( const tripoint_om_omt &p );
 
         void polish_rivers( const overmap *north, const overmap *east, const overmap *south,
                             const overmap *west );


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

Please use a descriptive name for the PR title, so it's clear at a glance what the PR is about.
-->

## Summary
SUMMARY: Content "Converted slimepit special to mutable"

<!--
This section should consist of exactly one line, formatted like the example above.

'Category' must be one of the following:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/

If the PR is a port or adaptation of DDA content, please indicate it to be so.
-->

## Purpose of change
Yet another step on my crusade to unhardcode specials.

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution
Slimepit have very simple layout, mutable one is pretty much identical.
Also, you might notice that i'm removing `oter_above == "forest_water"` -> `ter_set("cavern" )`. This thing does not work since `forest_water` is in `skip_above`. Some ancient relic.
<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

## Describe alternatives you've considered
DDA got fancy pit entrace with slopes, which can also be ported and integrated in mutable slimepit. That's a pure JSON thing, so it won't be difficult to port if someone likes it. I wasn't excited enough by its appearance to bother.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing
Generated few slimepits.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context
Slimepit used to merge with neighbors years ago, but it's been broken during one of very old refactors. Salvaged that by the way.
Before:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/544763/38ede210-ac1f-4591-afa0-5c59153ed423)

After:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/544763/7a537168-c538-49cd-a0ba-f3be44c8832d)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
