### PR TITLE
feat(content): Add sleepdebt effect

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,7 +14,7 @@ translation:
   - lang/**/*
 
 docs:
-  - docs/**/*
+  - doc/**/*
 
 scripts:
   - scripts/**/*

--- a/doc/src/content/docs/en/mod/json/reference/creatures/effects_json.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/effects_json.md
@@ -491,6 +491,15 @@ Valid arguments:
 "thirst_chance_bot"
 "thirst_tick"       - Defaults to every tick
 
+"sleepdebt_amount"     - Amount of sleep debt it can give/take.
+"sleepdebt_min"        - Minimal amount of sleep, certain effect will give/take
+"sleepdebt_max"        - if 0 or missing value will be exactly "sleepdebt_min"
+"sleepdebt_min_val"    - Defaults to 0, which means uncapped
+"sleepdebt_max_val"    - Defaults to 0, which means uncapped
+"sleepdebt_chance"     - Chance to give more sleep
+"sleepdebt_chance_bot" - Min chance, unsure, needs auditing
+"sleepdebt_tick"       - Defaults to every tick
+
 "fatigue_amount"    - Amount of fatigue it can give/take. After certain amount character will need to sleep.
 "fatigue_min"       - Minimal amount of fatigue, certain effect will give/take
 "fatigue_max"       - if 0 or missing value will be exactly "fatigue_min"

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -422,6 +422,16 @@ void Character::process_one_effect( effect &it, bool is_new )
         }
     }
 
+    // Handle sleep debt
+    val = get_effect( "SLEEPDEBT", reduced );
+    if( val != 0 ) {
+        mod = 1;
+        if( is_new || it.activated( calendar::turn, "SLEEPDEBT", val, reduced, mod ) ) {
+            mod_sleep_deprivation( bound_mod_to_vals( get_sleep_deprivation(), val, it.get_max_val( "SLEEPDEBT", reduced ),
+                                           it.get_min_val( "SLEEPDEBT", reduced ) ) );
+        }
+    }
+
     // Handle Radiation
     val = get_effect( "RAD", reduced );
     if( val != 0 ) {

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -427,8 +427,9 @@ void Character::process_one_effect( effect &it, bool is_new )
     if( val != 0 ) {
         mod = 1;
         if( is_new || it.activated( calendar::turn, "SLEEPDEBT", val, reduced, mod ) ) {
-            mod_sleep_deprivation( bound_mod_to_vals( get_sleep_deprivation(), val, it.get_max_val( "SLEEPDEBT", reduced ),
-                                           it.get_min_val( "SLEEPDEBT", reduced ) ) );
+            mod_sleep_deprivation( bound_mod_to_vals( get_sleep_deprivation(), val, it.get_max_val( "SLEEPDEBT",
+                                   reduced ),
+                                   it.get_min_val( "SLEEPDEBT", reduced ) ) );
         }
     }
 

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -367,6 +367,16 @@ bool effect_type::load_mod_data( const JsonObject &jo, const std::string &member
         extract_effect( j, mod_data, "fatigue_chance_bot", member, "FATIGUE",  "chance_bot" );
         extract_effect( j, mod_data, "fatigue_tick",      member, "FATIGUE",  "tick" );
 
+        // Then sleep debt
+        extract_effect( j, mod_data, "sleepdebt_amount",    member, "SLEEPDEBT",   "amount" );
+        extract_effect( j, mod_data, "sleepdebt_min",       member, "SLEEPDEBT",   "min" );
+        extract_effect( j, mod_data, "sleepdebt_max",       member, "SLEEPDEBT",   "max" );
+        extract_effect( j, mod_data, "sleepdebt_min_val",   member, "SLEEPDEBT",   "min_val" );
+        extract_effect( j, mod_data, "sleepdebt_max_val",   member, "SLEEPDEBT",   "max_val" );
+        extract_effect( j, mod_data, "sleepdebt_chance",    member, "SLEEPDEBT",   "chance_top" );
+        extract_effect( j, mod_data, "sleepdebt_chance_bot", member, "SLEEPDEBT",   "chance_bot" );
+        extract_effect( j, mod_data, "sleepdebt_tick",      member, "SLEEPDEBT",   "tick" );
+
         // Then stamina
         extract_effect( j, mod_data, "stamina_amount",    member, "STAMINA",  "amount" );
         extract_effect( j, mod_data, "stamina_min",       member, "STAMINA",  "min" );


### PR DESCRIPTION
## Purpose of change

We had no way of using effects to add or remove sleep deprivation, now we do.

## Describe the solution

It appears under effect.cpp adding a new "member" for SLEEPDEBT and the relevant json fields happen there, and under character_turn.cpp is the part that hooks into mod_sleep_deprivation to cause the relevant effect to change a players stats.

I don't know the underlying code, this was reworked from the thirst effect and modified to work for sleep.

## Describe alternatives you've considered

scream

## Testing

I loaded one of my old worlds from 0.4 stable and this change had no related bugs. I have successfully tested it using a spell effect from my mod. You can add the json field `"sleepdebt_min": [ -100 ]` to any effect you want on testing.

## Additional context

Here's some screenshots.

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/112293514/6da7b839-0422-435b-83fd-242de1e7d939)
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/112293514/113d581f-7c70-42e2-b91c-505f0d5c0ee3)

We need to update all effects documentation. That is out of scope right now.

## Checklist

If this is a C++ PR that modifies JSON loading or behavior:
- [x] Document the changes in the appropriate location in the `doc/` folder.
