### PR TITLE
fix: mass_grave map extras

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/map_extras.json
+++ b/data/json/itemgroups/Locations_MapExtras/map_extras.json
@@ -111,5 +111,10 @@
     "subtype": "distribution",
     "id": "map_extra_casings",
     "entries": [ { "item": "rag_bloody" }, { "item": "cigar_butt" }, { "item": "cig_butt" }, { "item": "can_drink_unsealed" } ]
+  },
+  {
+    "type": "item_group",
+    "id": "mass_grave_casings",
+    "items": [ [ "223_casing", 60 ], [ "308_casing", 20 ], [ "shot_hull", 20 ] ]
   }
 ]

--- a/data/json/mapgen/map_extras/mass_grave.json
+++ b/data/json/mapgen/map_extras/mass_grave.json
@@ -1,10 +1,5 @@
 [
   {
-    "id": "mass_grave_casings",
-    "type": "item_group",
-    "items": [ [ "223_casing", 60 ], [ "308_casing", 20 ], [ "shot_hull", 20 ] ]
-  },
-  {
     "type": "mapgen",
     "method": "json",
     "update_mapgen_id": "mx_mass_grave",
@@ -35,8 +30,7 @@
         " cccccccccccccccccccccc ",
         "                        "
       ],
-      "terrain": { "a": "t_pit_corpsed", "b": "t_fence_post", "c": "t_fence_barbed" },
-      "furniture": {  },
+      "terrain": { "a": ["t_pit_corpsed"], "b": ["t_fence_post"], "c": ["t_fence_barbed"] },
       "place_loot": [
         { "group": "everyday_corpse", "x": [ 4, 4 ], "y": [ 8, 8 ] },
         { "group": "everyday_corpse", "chance": 100, "repeat": [ 1 ], "x": [ 4, 4 ], "y": [ 10, 10 ] },

--- a/data/json/mapgen/map_extras/mass_grave.json
+++ b/data/json/mapgen/map_extras/mass_grave.json
@@ -30,7 +30,7 @@
         " cccccccccccccccccccccc ",
         "                        "
       ],
-      "terrain": { "a": ["t_pit_corpsed"], "b": ["t_fence_post"], "c": ["t_fence_barbed"] },
+      "terrain": { "a": [ "t_pit_corpsed" ], "b": [ "t_fence_post" ], "c": [ "t_fence_barbed" ] },
       "place_loot": [
         { "group": "everyday_corpse", "x": [ 4, 4 ], "y": [ 8, 8 ] },
         { "group": "everyday_corpse", "chance": 100, "repeat": [ 1 ], "x": [ 4, 4 ], "y": [ 10, 10 ] },


### PR DESCRIPTION
## Purpose of change
fix: mass_grave map extras because mass_grave doesn't appear correctly.

## Testing
Debug mass_grave and it looks correct.

## Additional context
Before:
<img width="960" alt="Capture d’écran 2023-11-15 193446" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/696c47b7-6b9b-4bca-9dcf-16bb42921668">
After:
<img width="960" alt="Capture d’écran 2023-11-15 192047" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/9278c1a3-209b-4851-bda1-438af79fe501">
