### PR TITLE
fix: sewer rework

### DIFF
--- a/data/json/overmap/overmap_connections.json
+++ b/data/json/overmap/overmap_connections.json
@@ -4,11 +4,11 @@
     "id": "local_road",
     "default_terrain": "road",
     "subtypes": [
+      { "terrain": "road_nesw_manhole", "locations": [  ] },
       { "terrain": "road", "locations": [ "field", "road" ] },
       { "terrain": "road", "locations": [ "forest_without_trail" ], "basic_cost": 20 },
       { "terrain": "road", "locations": [ "forest_trail" ], "basic_cost": 25 },
       { "terrain": "road", "locations": [ "swamp" ], "basic_cost": 40 },
-      { "terrain": "road_nesw_manhole", "locations": [  ] },
       { "terrain": "bridge", "locations": [ "water" ], "basic_cost": 120 }
     ]
   },

--- a/src/mapgen_functions.h
+++ b/src/mapgen_functions.h
@@ -64,10 +64,7 @@ void mapgen_open_air( mapgendata &dat );
 void mapgen_rift( mapgendata &dat );
 void mapgen_hellmouth( mapgendata &dat );
 void mapgen_subway( mapgendata &dat );
-void mapgen_sewer_curved( mapgendata &dat );
-void mapgen_sewer_four_way( mapgendata &dat );
-void mapgen_sewer_straight( mapgendata &dat );
-void mapgen_sewer_tee( mapgendata &dat );
+void mapgen_sewer( mapgendata &dat );
 void mapgen_tutorial( mapgendata &dat );
 void mapgen_lake_shore( mapgendata &dat );
 

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -434,7 +434,8 @@ class overmap
         void place_building( const tripoint_om_omt &p, om_direction::type dir, const city &town );
 
         void build_city_street( const overmap_connection &connection, const point_om_omt &p, int cs,
-                                om_direction::type dir, const city &town, int block_width = 2 );
+                                om_direction::type dir, const city &town, std::vector<tripoint_om_omt> &sewers,
+                                int block_width = 2 );
         void build_mine( const tripoint_om_omt &origin, int s );
 
         // Connection laying


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.


PR TITLE: Please follow conventional commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.

for example:
feat(content, mods): new item for <mod name>

for more on which category is available, see:
https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/

If the PR is a port or adaptation of DDA content, please indicate it by adding port in PR title, like:
feat(port): <feature name> from DDA
-->

## Purpose of change
Mostly to remove sewers generation from `generate_sub()`. To eventually(after mutable mines) remove whole that loop iterating over all overmap tiles.
And it also fixes few sewers-related bugs, such us when sewer entrance is disconnected from tunnel(due to missing end mapgen), or when sewer leads to the point with no entrance at all(due to lack of manhole in city center).
<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution
Sewer mapgens combined in one function, to implement mapgen for end tiles, and reduce clutter.
Roads used to override manholes due to terrains order in overmap_connections.json, fixed now. Chance to generate manhole reduced from 1/2 to 1/8 to compensate increased amount.
City centers now have manholes - sewer specials connects to center, so it need to way in. Also, all manholes generate subways during city generation, so it won't need to iterate whole map searching for manholes later on.
Each town have its own isolated sewer, with no connections between cities. Such connections makes some sense for subways, but definitely not for sewers. And it's not very fun if sewers and subways would had basically same layout.

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

## Describe alternatives you've considered
Building sewers connections right in `build_city_street()`. But this way it would steal undergrounds from potential basements, it's safer to juggle a vector around.
Porting jsonified sewer from DDA. That's... an option. But replacing 20 lines of code wth 1000 lines of json is... meh. I'd rather delegate it to lua eventually.
Joining sewers of overlapping cities. Still considering.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing
Generated bunch of overmaps.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context
Sewers of different cities: 
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/544763/696a873e-b56e-4a6c-ae10-2bd3b5060d71)
There's no cut tunnels, all of them ends with entrance of some kind(specials, manholes).

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
