### PR TITLE
ci: fix autofix bot not adding comments

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -31,11 +31,11 @@ jobs:
       - name: json formatting
         run: make style-all-json-parallel RELEASE=1
 
-      - uses: autofix-ci/action@d3e591514b99d0fca6779455ff8338516663f7cc
+      - uses: autofix-ci/action@bee19d72e71787c12ca0f29de72f2833e437e4c9
         if: ${{ always() }}
         with:
           commit-message: "style(autofix.ci): automated formatting"
-          commment: |
+          comment: |
             The Autofix app has automatically formatted this Pull Request.
 
             If you edit your PR on web UI, you can ignore this message.


### PR DESCRIPTION
## Purpose of change

fix #3395

there was a [typo in input field](https://github.com/autofix-ci/action/issues/9), which prevented the bot from adding comments when it made a commit.

## Describe the solution

- [bumped up action version with fixes](https://github.com/autofix-ci/action/issues/9#issuecomment-1812521148)
- renamed field name: `commment` -> `comment`