### PR TITLE
feat: Convert non-pistol only energy weapon mods to be compatible with all energy weapons.

### DIFF
--- a/data/json/items/gunmod/laser_gunmods.json
+++ b/data/json/items/gunmod/laser_gunmods.json
@@ -12,7 +12,7 @@
     "symbol": ":",
     "color": "light_gray",
     "location": "lens",
-    "mod_target_category": [ [ "ENERGY_WEAPONS", "PISTOLS" ], [ "ENERGY_WEAPONS", "RIFLES" ] ],
+    "mod_target_category": [ [ "ENERGY_WEAPONS" ] ],
     "range_modifier": -25,
     "damage_modifier": { "damage_type": "heat", "amount": 10 },
     "ammo_effects": [ "SHOT" ]
@@ -30,7 +30,7 @@
     "symbol": ":",
     "color": "light_gray",
     "location": "lens",
-    "mod_target_category": [ [ "ENERGY_WEAPONS", "PISTOLS" ], [ "ENERGY_WEAPONS", "RIFLES" ] ],
+    "mod_target_category": [ [ "ENERGY_WEAPONS" ] ],
     "range_modifier": 15,
     "damage_modifier": { "damage_type": "heat", "amount": 5 },
     "dispersion_modifier": 15
@@ -68,7 +68,7 @@
     "symbol": ":",
     "color": "light_gray",
     "location": "emitter",
-    "mod_target_category": [ [ "ENERGY_WEAPONS", "PISTOLS" ], [ "ENERGY_WEAPONS", "RIFLES" ] ],
+    "mod_target_category": [ [ "ENERGY_WEAPONS" ] ],
     "ups_charges_multiplier": 0.9
   },
   {
@@ -85,7 +85,7 @@
     "symbol": ":",
     "color": "light_gray",
     "location": "emitter",
-    "mod_target_category": [ [ "ENERGY_WEAPONS", "PISTOLS" ], [ "ENERGY_WEAPONS", "RIFLES" ] ],
+    "mod_target_category": [ [ "ENERGY_WEAPONS" ] ],
     "range_modifier": 5,
     "damage_modifier": { "damage_type": "heat", "amount": 10 },
     "ups_charges_multiplier": 2.0


### PR DESCRIPTION
## Purpose of change

Discord described issue with some non-pistol energy weapon mods not applying due to mod target category being narrow. Expanded it to all energy weapons as this doesn't change vanilla behavior but allows mods to use it in more versatile ways without overwriting it.

## Describe the solution

Trimmed down the mod target category to any weapon with energy weapons

## Describe alternatives you've considered

- Add machine gun category so that it fits more closely with original format that included both pistol and rifle skill using guns.
  - I can't see the harm in allowing it on SMG and Shotguns from mods. If/when we add new energy weapons we may then balance this at our leisure.

## Testing

- [x] Mods still installable in both A7 and v29

## Additional context

## Checklist