### PR TITLE
fix: another fix for anthill migration

### DIFF
--- a/data/json/obsoletion/terrains.json
+++ b/data/json/obsoletion/terrains.json
@@ -27,9 +27,7 @@
       "ants_larvae",
       "ants_larvae_acid",
       "ants_queen",
-      "ants_queen_acid",
-      "ants_larvae_acid_north",
-      "ants_queen_acid_north"
+      "ants_queen_acid"
     ]
   }
 ]

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -388,7 +388,7 @@ void overmap::convert_terrain(
             old == "fema_2_1" || old == "fema_2_2" || old == "fema_2_3" ||
             old == "fema_3_1" || old == "fema_3_2" || old == "fema_3_3" ||
             old == "mine_entrance" || old == "underground_sub_station" ||
-            old == "sewer_sub_station" || old == "anthill" || old == "acid_anthill" ||
+            old == "sewer_sub_station" || old == "anthill" ||
             old == "ants_larvae" || old == "ants_queen" || old == "ants_food" ) {
             ter_set( pos, oter_id( old + "_north" ) );
         } else if( old.compare( 0, 10, "mass_grave" ) == 0 ) {
@@ -399,12 +399,8 @@ void overmap::convert_terrain(
             ter_set( pos, oter_id( "acid_ants_larvae_north" ) );
         } else if( old == "ants_queen_acid" ) {
             ter_set( pos, oter_id( "acid_ants_queen_north" ) );
-        } else if( old == "ants_larvae_acid_north" ) {
-            // Fix for saves affected by messed migration, remove me in a while
-            ter_set( pos, oter_id( "acid_ants_larvae_north" ) );
-        } else if( old == "ants_queen_acid_north" ) {
-            // Fix for saves affected by messed migration, remove me in a while
-            ter_set( pos, oter_id( "acid_ants_queen_north" ) );
+        } else if( old == "acid_anthill" ) {
+            ter_set( pos, oter_id( "anthill_north" ) );
         }
 
         for( const auto &conv : nearby ) {


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods): new item for <mod name>
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change
Hotfix for migration hotfix(https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3661). To cover missing case(https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3666#issuecomment-1811692042).

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution
As per testing migrating of ill-migrated terrains doesn't really work - such OMT becomes "nothing" on load, without preserving old\converted IDs. Thus previously added crutches are not doing anything, and can be removed.

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

## Describe alternatives you've considered
None.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing
It builds, runs, and still didn't exploded my PC.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->