### PR TITLE
fix: Crash in npc activities

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1286,11 +1286,11 @@ bool Character::check_outbounds_activity( player_activity &act )
     return false;
 }
 
-bool Character::restore_outbounds_activity( std::unique_ptr<player_activity> &&act )
+bool Character::restore_outbounds_activity()
 {
-    if( check_outbounds_activity( *act ) ) {
+    if( check_outbounds_activity( *activity ) ) {
         // stash activity for when reloaded.
-        stashed_outbounds_activity = std::move( act );
+        stashed_outbounds_activity = std::move( activity );
         if( !backlog.empty() ) {
             stashed_outbounds_backlog = std::move( backlog.front() );
             backlog.pop_front();

--- a/src/character.h
+++ b/src/character.h
@@ -1715,7 +1715,7 @@ class Character : public Creature, public location_visitable<Character>
         void use_fire( int quantity );
         void assign_stashed_activity();
         bool check_outbounds_activity( player_activity &act );
-        bool restore_outbounds_activity( std::unique_ptr<player_activity> &&act );
+        bool restore_outbounds_activity();
         /** Legacy activity assignment, does not work for any activites using
          * the new activity_actor class and may cause issues with resuming.
          * TODO: delete this once migration of activites to the activity_actor system is complete

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -329,7 +329,7 @@ void player_activity::do_turn( player &p )
         }
     }
     int previous_stamina = p.get_stamina();
-    if( p.is_npc() && p.restore_outbounds_activity( p.remove_activity() ) ) {
+    if( p.is_npc() && p.restore_outbounds_activity() ) {
         // npc might be operating at the edge of the reality bubble.
         // or just now reloaded back into it, and their activity target might
         // be still unloaded, can cause infinite loops.


### PR DESCRIPTION
## Purpose of change

Fixes #3686.

## Describe the solution

Have restore_outbounds_activity use the players current activity rather than accepting an argument. 