### PR TITLE
refactor(content): convert mine special to mutable

### DIFF
--- a/data/json/overmap/overmap_mutable/lab.json
+++ b/data/json/overmap/overmap_mutable/lab.json
@@ -1,11 +1,11 @@
 [
   {
-    "//": "Nested special, does not spawn by itself",
     "type": "overmap_special",
     "id": "lab_basement",
     "subtype": "mutable",
     "locations": [ "subterranean_empty" ],
     "occurrences": [ 0, 0 ],
+    "flags": [ "RESTRICTED" ],
     "check_for_locations": [ [ [ 0, 0, 0 ], [ "subterranean_empty" ] ] ],
     "joins": [ "lab_to_lab" ],
     "overmaps": {

--- a/data/json/overmap/overmap_mutable/mine.json
+++ b/data/json/overmap/overmap_mutable/mine.json
@@ -1,0 +1,32 @@
+[
+  {
+    "type": "overmap_special",
+    "id": "mine_tunnel",
+    "subtype": "mutable",
+    "locations": [ "subterranean_empty" ],
+    "occurrences": [ 0, 0 ],
+    "flags": [ "RESTRICTED" ],
+    "check_for_locations": [ [ [ 0, 0, 0 ], [ "subterranean_empty" ] ], [ [ 0, 0, -1 ], [ "subterranean_empty" ] ] ],
+    "joins": [ "mine_to_mine", "mine_shaft" ],
+    "overmaps": {
+      "above_entrance": { "overmap": "empty_rock", "below": "mine_shaft" },
+      "straight_tunnel": { "overmap": "mine", "north": "mine_to_mine", "south": "mine_to_mine" },
+      "corner": { "overmap": "mine", "north": "mine_to_mine", "east": "mine_to_mine" },
+      "stairs_down": { "overmap": "mine_down", "north": "mine_to_mine", "below": "mine_shaft" },
+      "stairs_up": { "overmap": "mine", "north": "mine_to_mine", "above": "mine_shaft" },
+      "finale": { "overmap": "mine_finale", "north": "mine_to_mine" },
+      "fallback": { "overmap": "mine", "above": "mine_shaft" }
+    },
+    "root": "above_entrance",
+    "phases": [
+      [
+        { "overmap": "straight_tunnel", "max": { "poisson": 6 } },
+        { "overmap": "corner", "max": { "poisson": 6 } },
+        { "overmap": "stairs_down", "max": { "poisson": 3 } },
+        { "overmap": "stairs_up", "join": "mine_shaft" }
+      ],
+      [ { "overmap": "finale", "max": 1 } ],
+      [ { "overmap": "fallback" } ]
+    ]
+  }
+]

--- a/data/json/overmap/overmap_special/mine.json
+++ b/data/json/overmap/overmap_special/mine.json
@@ -18,6 +18,7 @@
       { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] },
       { "point": [ 1, -1, 0 ], "connection": "local_road", "from": [ 1, 0, 0 ] }
     ],
+    "place_nested": [ { "point": [ 0, 0, -1 ], "special": "mine_tunnel" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 10, 40 ],
     "city_sizes": [ 4, -1 ],
@@ -58,6 +59,7 @@
       { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] },
       { "point": [ 1, -1, 0 ], "connection": "local_road", "from": [ 1, 0, 0 ] }
     ],
+    "place_nested": [ { "point": [ 0, 0, -1 ], "special": "mine_tunnel" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 10, 40 ],
     "city_sizes": [ 4, -1 ],
@@ -92,6 +94,7 @@
       { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] },
       { "point": [ 1, -1, 0 ], "connection": "local_road", "from": [ 1, 0, 0 ] }
     ],
+    "place_nested": [ { "point": [ 0, 0, -1 ], "special": "mine_tunnel" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 10, 40 ],
     "city_sizes": [ 4, -1 ],
@@ -121,6 +124,7 @@
       { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] },
       { "point": [ 1, -1, 0 ], "connection": "local_road", "from": [ 1, 0, 0 ] }
     ],
+    "place_nested": [ { "point": [ 0, 0, -1 ], "special": "mine_tunnel" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 10, 40 ],
     "city_sizes": [ 4, -1 ],

--- a/doc/src/content/docs/en/mod/json/reference/json_flags.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_flags.md
@@ -1270,6 +1270,10 @@ These branches are also the valid entries for the categories of `dreams` in `dre
   contain any lake terrain.
 - `UNIQUE` Location is unique and will only occur once per overmap. `occurrences` is overridden to
   define a percent chance (e.g. `"occurrences" : [75, 100]` is 75%)
+- `ENDGAME` Location will have highest priority during special placement, and won't be affected by
+  any occurrences normalizations.
+- `RESTRICTED` Location will never be spawned as starting locations. Intended(but not limited) to
+  use with incomplete nested specials.
 
 ### Overmap terrains
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -4741,9 +4741,12 @@ void map::draw_mine( mapgendata &dat )
 
         for( int i = 0; i < SEEX * 2; i++ ) {
             for( int j = 0; j < SEEY * 2; j++ ) {
+                int i_reverse = SEEX * 2 - 1 - i;
+                int j_reverse = SEEY * 2 - 1 - j;
                 if( i >= dat.w_fac + rng( 0, 2 ) && i <= EAST_EDGE - dat.e_fac - rng( 0, 2 ) &&
                     j >= dat.n_fac + rng( 0, 2 ) && j <= SOUTH_EDGE - dat.s_fac - rng( 0, 2 ) &&
-                    i + j >= 4 && ( SEEX * 2 - i ) + ( SEEY * 2 - j ) >= 6 ) {
+                    i + j >= 3 && i_reverse + j_reverse >= 3 &&
+                    i + j_reverse >= 3 && j + i_reverse >= 3 ) {
                     ter_set( point( i, j ), t_rock_floor );
                 } else {
                     ter_set( point( i, j ), t_rock );

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -436,7 +436,6 @@ class overmap
         void build_city_street( const overmap_connection &connection, const point_om_omt &p, int cs,
                                 om_direction::type dir, const city &town, std::vector<tripoint_om_omt> &sewers,
                                 int block_width = 2 );
-        void build_mine( const tripoint_om_omt &origin, int s );
 
         // Connection laying
         pf::directed_path<point_om_omt> lay_out_connection(

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -231,6 +231,10 @@ tripoint_abs_omt start_location::find_player_initial_location() const
 
         // Look for special having that terrain
         for( const auto &special : overmap_specials::get_all() ) {
+            if( special.has_flag( "RESTRICTED" ) ) {
+                continue;
+            }
+
             const auto &terrains = special.all_terrains();
             if( std::none_of( terrains.begin(), terrains.end(),
             [&loc]( const oter_str_id & t ) {


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods): new item for <mod name>
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change
More unhardcding. That terrible loop in `generate_sub()` is now completely emptied, and removed.

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution
Mine layout is pretty much same as it used to be - one lengthy tunnel with stairs down and finale.
Mapgen function is *slightly* adjusted, to get rid of those ugly corners in 2x2 empty spaces. They always annoyed me. Now it's nice round support.
Nested mines special is a bit hacky(starts with solid rock above the tunnel) to make it resemble old mines as much as possible.
Added "RESTRICTED" special flag. Strictly speaking, this thing is *not* necessary, as nested things wouldn't be spawned as starting location anyway(not in default region at least), due to terrain checks. But. Game does not knows that, and would search for valid place anyway, which used to be painfully slow. It's very rare cases(e.g. lab\mine start on x0 specials density), but safeguard for that is also trivial, so it won't hurt to have.

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

## Describe alternatives you've considered
Porting JSONified mines from DDA. They *different*, and i don't want to remove current mines. They worth to be ported someday as alternative layout.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing
Generated bunch of mines, started Bottom of a Mine scenario.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context
Aforementioned adjustment to mapgen.
Before:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/544763/92c91e15-8b58-4b9b-84a6-84b197c367e5)
After:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/544763/b9852dc2-eba3-482e-9b15-d354e145b9d8)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist
- [x] Document the changes in the appropriate location in the `doc/` folder.
<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->