### PR TITLE
fix: Indefinite vehicle refill

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6903,7 +6903,7 @@ detached_ptr<item> Character::pour_into( vehicle &veh, detached_ptr<item> &&liqu
 
     auto &tank = veh_interact::select_part( veh, sel, title );
     if( !tank ) {
-        return detached_ptr<item>();
+        return std::move(liquid);
     }
 
     //~ $1 - vehicle name, $2 - part name, $3 - liquid type

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6903,7 +6903,7 @@ detached_ptr<item> Character::pour_into( vehicle &veh, detached_ptr<item> &&liqu
 
     auto &tank = veh_interact::select_part( veh, sel, title );
     if( !tank ) {
-        return std::move(liquid);
+        return std::move( liquid );
     }
 
     //~ $1 - vehicle name, $2 - part name, $3 - liquid type

--- a/src/rot.cpp
+++ b/src/rot.cpp
@@ -41,7 +41,6 @@ auto temperature_flag_for_location( const map &m, const item &loc ) -> temperatu
             }
             int cargo_index = veh->vehicle().part_with_feature( veh->part_index(), VPFLAG_CARGO, true );
             if( cargo_index < 0 ) {
-                debugmsg( "Expected cargo part at %d, %d, %d, but couldn't find any", pos.x, pos.y, pos.z );
                 return temperature_flag::TEMP_NORMAL;
             }
             return temperature_flag_for_part( veh->vehicle(), cargo_index );


### PR DESCRIPTION
## Purpose of change

Fixes #3634. Also removes a bad debugmsg.

## Describe the solution

Don't consume the liquid in the case it can't find a tank for it, pass it back as expected. Also the debugmsg would trigger when the item was in a tank rather than a cargo part.