### PR TITLE
fix: campground mapgen

### DIFF
--- a/data/json/mapgen/campground.json
+++ b/data/json/mapgen/campground.json
@@ -1,68 +1,10 @@
 [
   {
+    "type": "mapgen",
     "method": "json",
+    "om_terrain": [ [ "campground_1a", "campground_1b" ], [ "campground_2a", "campground_2b" ] ],
+    "weight": 100,
     "object": {
-      "items": {
-        ";": [
-          { "item": "dresser", "chance": 5, "repeat": [ 1, 2 ] },
-          { "item": "creepy", "chance": 2 },
-          { "item": "camping", "chance": 5 },
-          { "item": "archery", "chance": 2 }
-        ],
-        ",": [
-          { "item": "dresser", "chance": 5, "repeat": [ 1, 2 ] },
-          { "item": "creepy", "chance": 2 },
-          { "item": "camping", "chance": 5 },
-          { "item": "archery", "chance": 2 }
-        ],
-        "t": [
-          { "item": "barbecue", "chance": 5, "repeat": [ 1, 2 ] },
-          { "item": "misc_smoking", "chance": 2 },
-          { "item": "cannedfood", "chance": 2, "repeat": [ 1, 2 ] }
-        ]
-      },
-      "place_monsters": [
-        { "chance": 50, "density": 1, "monster": "CAMPERS", "x": [ 8, 18 ], "y": [ 7, 22 ] },
-        { "monster": "GROUP_PARK_ANIMAL", "x": [ 2, 17 ], "y": [ 2, 15 ], "repeat": [ 0, 2 ] },
-        { "chance": 50, "density": 1, "monster": "CAMPERS", "x": [ 3, 17 ], "y": [ 32, 46 ] },
-        { "monster": "GROUP_PARK_ANIMAL", "x": [ 2, 17 ], "y": [ 31, 46 ], "repeat": [ 0, 2 ] },
-        { "monster": "GROUP_PARK_ANIMAL", "x": [ 30, 46 ], "y": [ 31, 46 ], "repeat": [ 0, 2 ] }
-      ],
-      "place_vehicles": [
-        { "chance": 25, "fuel": 15, "rotation": 270, "status": -1, "vehicle": "campground_vehicles", "x": 16, "y": 2 },
-        { "chance": 25, "fuel": -1, "rotation": 180, "status": -1, "vehicle": "campground_vehicles", "x": 5, "y": 19 },
-        { "chance": 50, "fuel": 20, "rotation": 0, "status": -1, "vehicle": "lux_rv", "x": 43, "y": 18 },
-        {
-          "chance": 25,
-          "fuel": 15,
-          "rotation": 180,
-          "status": -1,
-          "vehicle": "campground_vehicles",
-          "x": 26,
-          "y": 14
-        },
-        {
-          "chance": 25,
-          "fuel": 15,
-          "rotation": 360,
-          "status": -1,
-          "vehicle": "campground_vehicles",
-          "x": 18,
-          "y": 32
-        },
-        { "chance": 25, "fuel": -1, "rotation": 0, "status": -1, "vehicle": "campground_vehicles", "x": 7, "y": 34 },
-        {
-          "chance": 25,
-          "fuel": -1,
-          "rotation": 270,
-          "status": -1,
-          "vehicle": "campground_vehicles",
-          "x": 17,
-          "y": 40
-        },
-        { "chance": 10, "fuel": -1, "rotation": 0, "status": -1, "vehicle": "rv", "x": 42, "y": 27 },
-        { "chance": 25, "fuel": 15, "rotation": 90, "status": -1, "vehicle": "campground_vehicles", "x": 35, "y": 43 }
-      ],
       "rows": [
         "_____________________ssssss_ss_......sssssssss__",
         "_______sssssssssssssssbbbbs__ss......|ww||||||||",
@@ -113,11 +55,45 @@
         "______________sssssss#####sssssssss____ssssss___",
         "____________________ssssss______________________"
       ],
-      "palettes": [ "campground_palette" ]
-    },
-    "om_terrain": [ [ "campground_1a", "campground_1b" ], [ "campground_2a", "campground_2b" ] ],
-    "type": "mapgen",
-    "weight": 100
+      "palettes": [ "campground_palette" ],
+      "items": {
+        ";": [
+          { "item": "dresser", "chance": 5, "repeat": [ 1, 2 ] },
+          { "item": "creepy", "chance": 2 },
+          { "item": "camping", "chance": 5 },
+          { "item": "archery", "chance": 2 }
+        ],
+        ",": [
+          { "item": "dresser", "chance": 5, "repeat": [ 1, 2 ] },
+          { "item": "creepy", "chance": 2 },
+          { "item": "camping", "chance": 5 },
+          { "item": "archery", "chance": 2 }
+        ],
+        "t": [
+          { "item": "barbecue", "chance": 5, "repeat": [ 1, 2 ] },
+          { "item": "misc_smoking", "chance": 2 },
+          { "item": "cannedfood", "chance": 2, "repeat": [ 1, 2 ] }
+        ]
+      },
+      "place_monsters": [
+        { "chance": 50, "density": 1, "monster": "CAMPERS", "x": [ 8, 18 ], "y": [ 7, 22 ] },
+        { "monster": "GROUP_PARK_ANIMAL", "x": [ 2, 17 ], "y": [ 2, 15 ], "repeat": [ 0, 2 ] },
+        { "chance": 50, "density": 1, "monster": "CAMPERS", "x": [ 3, 17 ], "y": [ 32, 46 ] },
+        { "monster": "GROUP_PARK_ANIMAL", "x": [ 2, 17 ], "y": [ 31, 46 ], "repeat": [ 0, 2 ] },
+        { "monster": "GROUP_PARK_ANIMAL", "x": [ 30, 46 ], "y": [ 31, 46 ], "repeat": [ 0, 2 ] }
+      ],
+      "place_vehicles": [
+        { "chance": 25, "fuel": 15, "rotation": 270, "status": -1, "vehicle": "campground_vehicles", "x": 16, "y": 5 },
+        { "chance": 25, "fuel": -1, "rotation": 180, "status": -1, "vehicle": "campground_vehicles", "x": 5, "y": 19 },
+        { "chance": 50, "fuel": 20, "rotation": 0, "status": -1, "vehicle": "lux_rv", "x": 42, "y": 18 },
+        { "chance": 25, "fuel": 15, "rotation": 180, "status": -1, "vehicle": "campground_vehicles", "x": 26, "y": 14 },
+        { "chance": 25, "fuel": 15, "rotation": 90, "status": -1, "vehicle": "campground_vehicles", "x": 22, "y": 31 },
+        { "chance": 25, "fuel": -1, "rotation": 0, "status": -1, "vehicle": "campground_vehicles", "x": 7, "y": 34 },
+        { "chance": 25, "fuel": -1, "rotation": 270, "status": -1, "vehicle": "campground_vehicles", "x": 17, "y": 41 },
+        { "chance": 10, "fuel": -1, "rotation": 0, "status": -1, "vehicle": "rv", "x": 42, "y": 27 },
+        { "chance": 25, "fuel": 15, "rotation": 90, "status": -1, "vehicle": "campground_vehicles", "x": 34, "y": 41 }
+      ]
+    }
   },
   {
     "method": "json",

--- a/data/json/mapgen/campground.json
+++ b/data/json/mapgen/campground.json
@@ -86,10 +86,26 @@
         { "chance": 25, "fuel": 15, "rotation": 270, "status": -1, "vehicle": "campground_vehicles", "x": 16, "y": 5 },
         { "chance": 25, "fuel": -1, "rotation": 180, "status": -1, "vehicle": "campground_vehicles", "x": 5, "y": 19 },
         { "chance": 50, "fuel": 20, "rotation": 0, "status": -1, "vehicle": "lux_rv", "x": 42, "y": 18 },
-        { "chance": 25, "fuel": 15, "rotation": 180, "status": -1, "vehicle": "campground_vehicles", "x": 26, "y": 14 },
+        {
+          "chance": 25,
+          "fuel": 15,
+          "rotation": 180,
+          "status": -1,
+          "vehicle": "campground_vehicles",
+          "x": 26,
+          "y": 14
+        },
         { "chance": 25, "fuel": 15, "rotation": 90, "status": -1, "vehicle": "campground_vehicles", "x": 22, "y": 31 },
         { "chance": 25, "fuel": -1, "rotation": 0, "status": -1, "vehicle": "campground_vehicles", "x": 7, "y": 34 },
-        { "chance": 25, "fuel": -1, "rotation": 270, "status": -1, "vehicle": "campground_vehicles", "x": 17, "y": 41 },
+        {
+          "chance": 25,
+          "fuel": -1,
+          "rotation": 270,
+          "status": -1,
+          "vehicle": "campground_vehicles",
+          "x": 17,
+          "y": 41
+        },
         { "chance": 10, "fuel": -1, "rotation": 0, "status": -1, "vehicle": "rv", "x": 42, "y": 27 },
         { "chance": 25, "fuel": 15, "rotation": 90, "status": -1, "vehicle": "campground_vehicles", "x": 34, "y": 41 }
       ]

--- a/data/json/mapgen_palettes/campground.json
+++ b/data/json/mapgen_palettes/campground.json
@@ -32,7 +32,6 @@
       "h": "f_chair",
       "H": "f_camp_chair",
       "#": "f_large_canvas_wall",
-      "&": "f_toilet",
       ";": "f_large_groundsheet",
       ",": "f_center_groundsheet",
       "B": "f_brazier",
@@ -42,6 +41,7 @@
       "t": "f_table",
       "n": "f_tourist_table",
       "o": "f_firering"
-    }
+    },
+    "toilets": { "&": {  } }
   }
 ]


### PR DESCRIPTION
## Purpose of change
Fix waterless toilets.
Fix vehicle placement to avoid vehicles placed on a tree, dead tree, young tree, tourist table, brazier, bush,...
#3692

## Describe the solution
Change the placement of some vehicles.

## Describe alternatives you've considered

## Testing
I reloaded the campground many times to make sure all the vehicles were placed correctly.
Think it's okay.
## Additional context
![Isaac Harrell __17-42-10_Paris, Madrid](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/df410105-3b4e-43e5-a67b-ada73d78a683)
![Isaac Harrell __17-42-22_Paris, Madrid](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/3de36019-ba64-4de3-92e7-02c61390e29d)
![Isaac Harrell __17-42-36_Paris, Madrid](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/1484cac3-d0e8-47c3-9674-69e5b8450f32)
![Isaac Harrell __17-42-47_Paris, Madrid](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/9c73c25b-c4c5-46a0-835c-011124c575be)
