### PR TITLE
feat(balance): adjust biodiesel recipe for more reasonable crafting time

### DIFF
--- a/data/json/recipes/chem/fuel.json
+++ b/data/json/recipes/chem/fuel.json
@@ -54,9 +54,9 @@
     "skill_used": "cooking",
     "difficulty": 6,
     "result_mult": 4,
-    "time": "420 m",
+    "time": "4 h",
     "book_learn": [ [ "textbook_biodiesel", 5 ] ],
-    "batch_time_factors": [ 83, 5 ],
+    "batch_time_factors": [ 99, 1 ],
     "qualities": [ { "id": "CHEM", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 100, "LIST" ] ] ],
     "components": [


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods): new item for <mod name>
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

Crafting time of biodiesel is currently just outrageous. Long base time plus stingy batch factors means a batch of 50 takes 
about 3 days to make. That doesn't make any sense since it's a chemical reaction that should have a more or less constant speed regardless of scale. Also, it's annoying.

## Describe the solution

1. Change batch time reduction to 99% at > 1. The process is obviously easily scalable, further confirmed by the fact DDA currently uses the same values.
2. Reduce base crafting time to 4 hours. This part is a bit arbitrary, but I couldn't find any hard data on why transesterification of fats has to take specifically 7 hours, no more and no less, and I suspect it was picked somewhat arbitrarily in the first place. Even if it has some basis in reality, having overly long crafting times for regularly used consumables isn't what I'd call quality of life, so may as well reduce it to something more reasonable. Also, lower base time means that remaining 1% is not as impactful.

As a result of these changes, we end up with a roughly 6 hour crafting time for a x50 batch, which is still only 50 liters of fuel. This is still by no means a fast process of fuel acquisition, so I don't think balance is disturbed overmuch.

## Describe alternatives you've considered

Leaving the base time alone, obviously. But 1% of 420 minutes is still a noticeable time, and it quickly adds up to annoying levels.

## Testing

Load up the game. Make sure the values displayed in crafting UI are correct.

## Additional context

The existing crafting framework doesn't work well with processes that require babysitting but don't need you to actually do anything for most of the time. IRL you'd at least be able to do some other crafts in parallel, thus saving the time. I believe it's justified to reduce the length of such crafts to compensate.

## Checklist

not applicable