### PR TITLE
fix: potential fix for liquid iexamine

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -3811,21 +3811,24 @@ void iexamine::trap( player &p, const tripoint &examp )
     }
 }
 //Note that these three functions are checked by pointer in map::water_from. Yes it's awful.
-void iexamine::water_source( player &, const tripoint &examp )
+void iexamine::water_source( player &, const tripoint & )
 {
-    liquid_handler::handle_liquid( examp );
+    liquid_handler::handle_liquid( item::spawn( "water", calendar::start_of_cataclysm,
+                                   item::INFINITE_CHARGES ) );
 }
 
 //Note that these three functions are checked by pointer in map::water_from. Yes it's awful.
-void iexamine::clean_water_source( player &, const tripoint &examp )
+void iexamine::clean_water_source( player &, const tripoint & )
 {
-    liquid_handler::handle_liquid( examp );
+    liquid_handler::handle_liquid( item::spawn( "water_clean", calendar::start_of_cataclysm,
+                                   item::INFINITE_CHARGES ) );
 }
 
 //Note that these three functions are checked by pointer in map::water_from. Yes it's awful.
 void iexamine::liquid_source( player &, const tripoint &examp )
 {
-    liquid_handler::handle_liquid( examp );
+    liquid_handler::handle_liquid( item::spawn( get_map().furn( examp ).obj().provides_liquids,
+                                   calendar::turn, item::INFINITE_CHARGES ) );
 }
 
 std::vector<itype> furn_t::crafting_pseudo_item_types() const

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -3811,10 +3811,10 @@ void iexamine::trap( player &p, const tripoint &examp )
     }
 }
 //Note that these three functions are checked by pointer in map::water_from. Yes it's awful.
-void iexamine::water_source( player &, const tripoint & )
+void iexamine::water_source( player &, const tripoint &examp )
 {
-    liquid_handler::handle_liquid( item::spawn( "water", calendar::start_of_cataclysm,
-                                   item::INFINITE_CHARGES ) );
+    // Routed to map::water_from to handle poison
+    liquid_handler::handle_liquid( examp );
 }
 
 //Note that these three functions are checked by pointer in map::water_from. Yes it's awful.

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4543,10 +4543,12 @@ detached_ptr<item> map::water_from( const tripoint &p )
     if( furn( p ).obj().examine == &iexamine::water_source ) {
         return item::spawn( "water", calendar::start_of_cataclysm, item::INFINITE_CHARGES );
     }
-    if( furn( p ).obj().examine == &iexamine::clean_water_source ) {
+    if( furn( p ).obj().examine == &iexamine::clean_water_source ||
+        terrain_id.obj().examine == &iexamine::clean_water_source ) {
         return item::spawn( "water_clean", calendar::start_of_cataclysm, item::INFINITE_CHARGES );
     }
     if( furn( p ).obj().examine == &iexamine::liquid_source ) {
+        // Terrains have no "provides_liquids" to work with generic source
         return item::spawn( furn( p ).obj().provides_liquids, calendar::turn, item::INFINITE_CHARGES );
     }
     return detached_ptr<item>();


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods): new item for <mod name>
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change
Might fix https://github.com/cataclysmbnteam/Cataclysm-BN/issues/3698
<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution
Working theory is that MSVC optimizes all three liquid iexamine functions intro one, as the are identical. And then when they compared - they all have *same* pointer, which breaks check in `map::water_from()`.
One of possible solutions - make those functions actually different.

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

## Describe alternatives you've considered
It's not the nicest solution, as i ended  duplicating code between `water_from()` and iexamine, but it's *simple* solution.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing
Can't properly test it. That bug seems to appear only on MSVC builds, which i can't build. On my MSYS2 build it works both with, and without this fix. So, best i can say - it's that it doesn't *seems* to break it worse.

* Important note for testing: iexamine will not call water_from() anymore, which have that problematic check. It's possible that this fix will work around bug, without *actually* fixing it.
Right way to make sure that problem is gone would be e.g. crafting "weak mixed alcohol" standing near beer pump.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/544763/e0c5006e-3b5a-4cdf-a798-5bb751ddbdab)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->