### PR TITLE
fix: farm mapgen

### DIFF
--- a/data/json/mapgen/farm.json
+++ b/data/json/mapgen/farm.json
@@ -129,9 +129,7 @@
         "                        ",
         "FFFFFFFFFFFFFFFFFFFFFFFF"
       ],
-      "terrain": {
-        "Q": "t_dirtfloor"
-      },
+      "terrain": { "Q": "t_dirtfloor" },
       "items": {
         ".": { "item": "trash", "chance": 20 },
         "B": [

--- a/data/json/mapgen/farm.json
+++ b/data/json/mapgen/farm.json
@@ -24,7 +24,7 @@
         "  #__2___________2__#   #_1__1_# -6..........H.- F  DDDDDDDDDDDDDDDD  F ",
         "  #__2___________2__#   #______# -u...----+----- F                    F ",
         "  #332___________233#   #______# --+---kh......- F  DDDDDDDDDDDDDDDD  F ",
-        "  #_____________1___#   #_1__1_# -...-.........w F                    F ",
+        "  #_____________1___#   #_1__1_# -b..-.........w F                    F ",
         "  W_________________W   #______# -b..+......BB.- F  DDDDDDDDDDDDDDDD  F ",
         "  W_________________W   #____ll# -.ST-.....dBBd- F                    F ",
         "  #lll__________O___#   ###++### --w------w----- F  DDDDDDDDDDDDDDDD  F ",
@@ -80,7 +80,6 @@
         "F                                                                     F ",
         "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF "
       ],
-      "place_items": [  ],
       "place_item": [
         { "item": "straw_pile", "x": [ 3, 5 ], "y": [ 5, 7 ], "amount": [ 0, 8 ] },
         { "item": "cattlefodder", "x": [ 3, 5 ], "y": [ 5, 7 ], "amount": [ 0, 4 ] },
@@ -90,11 +89,10 @@
         { "item": "cattlefodder", "x": [ 19, 19 ], "y": [ 10, 15 ], "amount": [ 2, 7 ] }
       ],
       "place_monsters": [
-        { "monster": "GROUP_ZOMBIE", "x": [ 4, 4 ], "y": [ 14, 14 ], "repeat": [ 1, 6 ], "density": 0.2 },
+        { "monster": "GROUP_ZOMBIE", "x": [ 9, 11 ], "y": [ 12, 14 ], "repeat": [ 1, 6 ], "density": 0.2 },
         { "monster": "GROUP_DOMESTIC", "x": [ 10, 12 ], "y": [ 15, 17 ], "repeat": [ 1, 2 ], "density": 0.2 }
       ],
       "sealed_item": { "D": { "item": { "item": "seed_corn" }, "furniture": "f_plant_seedling" } },
-      "place_nested": [ { "chunks": [ [ "NC_FARMER_spawn", 10 ], [ "null", 90 ] ], "x": 23, "y": 3 } ],
       "palettes": [ "farm" ]
     }
   },
@@ -123,7 +121,7 @@
         "#_1__1_# -6...........m-",
         "#__Q___# -u...----+-----",
         "#______# --+---mm....mm-",
-        "#_1__1_# -...-.........w",
+        "#_1__1_# -b..-.........w",
         "#______# -b..+......BB.-",
         "#____ll# -.ST-mm...dBBd-",
         "###++### --w------w-----",
@@ -131,6 +129,9 @@
         "                        ",
         "FFFFFFFFFFFFFFFFFFFFFFFF"
       ],
+      "terrain": {
+        "Q": "t_dirtfloor"
+      },
       "items": {
         ".": { "item": "trash", "chance": 20 },
         "B": [
@@ -164,6 +165,7 @@
         "u": [ { "item": "kitchen", "chance": 70 }, { "item": "cannedfood", "chance": 40 }, { "item": "softdrugs", "chance": 40 } ],
         "Q": { "item": "farming_tools", "chance": 15 }
       },
+      "place_nested": [ { "chunks": [ [ "NC_FARMER_spawn", 10 ], [ "null", 90 ] ], "x": 17, "y": 13 } ],
       "palettes": [ "farm" ]
     }
   },


### PR DESCRIPTION
## Purpose of change
Bathtub with two tiles instead of one in the house.
Place NPC farmer inside the house.
Move placement of zombie group to center of barn to avoid some of them appearing outside.
Replace the grass tile with a dirt tile in the building left of the house.

## Describe the solution

## Describe alternatives you've considered

## Testing
I didn't see any zombies appearing outside the barn during my tests.
The NPC is correctly placed inside the house.

## Additional context
NPC:
![Boyd Rees __20-32-35_Paris, Madrid](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/a623336b-69fd-4cc0-88aa-51e4b1b0d542)