### PR TITLE
fix: toxic dump mapgen

### DIFF
--- a/data/json/mapgen/toxic_dump.json
+++ b/data/json/mapgen/toxic_dump.json
@@ -53,6 +53,8 @@
         "+": "t_door_metal_pickable",
         "-": "t_wall",
         ".": "t_thconc_floor",
+        "R": "t_thconc_floor",
+        "A": "t_thconc_floor",
         "c": "t_chaingate_c",
         "|": "t_chainfence"
       },
@@ -68,6 +70,41 @@
         { "group": "toxic_waste", "x": [ 5, 20 ], "y": [ 5, 16 ], "chance": 40, "repeat": [ 3, 15 ] },
         { "item": "id_military", "x": 3, "y": [ 18, 20 ], "chance": 10 }
       ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": [ "toxic_dump_roof" ],
+    "object": {
+      "fill_ter": "t_flat_roof",
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "  ........              ",
+        "  ........              ",
+        "  ........              ",
+        "  ........              ",
+        "  ........              ",
+        "                        ",
+        "                        "
+      ],
+      "palettes": [ "roof_palette" ]
     }
   }
 ]

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -1088,7 +1088,10 @@
   {
     "type": "overmap_special",
     "id": "Toxic Waste Dump",
-    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "toxic_dump_north" } ],
+    "overmaps": [
+      { "point": [ 0, 0, 0 ], "overmap": "toxic_dump_north" },
+      { "point": [ 0, 0, 1 ], "overmap": "toxic_dump_roof_north" }
+    ],
     "locations": [ "land" ],
     "city_distance": [ 20, -1 ],
     "city_sizes": [ 8, -1 ],

--- a/data/json/overmap/overmap_terrain/overmap_terrain_waste_junk.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_waste_junk.json
@@ -69,6 +69,13 @@
   },
   {
     "type": "overmap_terrain",
+    "id": [ "toxic_dump_roof" ],
+    "name": "toxic waste dump roof",
+    "sym": "D",
+    "color": "pink"
+  },
+  {
+    "type": "overmap_terrain",
     "id": [
       "haz_sar_1_1",
       "haz_sar_1_2",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_waste_junk.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_waste_junk.json
@@ -69,7 +69,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": [ "toxic_dump_roof" ],
+    "id": "toxic_dump_roof",
     "name": "toxic waste dump roof",
     "sym": "D",
     "color": "pink"

--- a/data/json/overmap/overmap_terrain/overmap_terrain_waste_junk.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_waste_junk.json
@@ -72,7 +72,8 @@
     "id": "toxic_dump_roof",
     "name": "toxic waste dump roof",
     "sym": "D",
-    "color": "pink"
+    "color": "pink",
+    "see_cost": 2
   },
   {
     "type": "overmap_terrain",


### PR DESCRIPTION
## Purpose of change
Add a roof to the toxic waste dump.
Replace dirt tiles under furniture.
## Describe the solution

## Describe alternatives you've considered

## Testing

## Additional context
<img width="960" alt="Capture d’écran 2023-11-19 152727" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/e2637620-3066-4bf2-b8a1-cc5fc64ad727">
<img width="960" alt="Capture d’écran 2023-11-19 152822" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/0b4e9348-3cd0-4444-966b-a5c07e74eda4">
<img width="960" alt="Capture d’écran 2023-11-19 152952" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/03710539-a0af-49ae-aae7-4883112a365a">
