### PR TITLE
perf: specials placement optimizations

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -2454,6 +2454,8 @@ std::vector<overmap_special_terrain> overmap_special::preview_terrains() const
 
 std::vector<overmap_special_locations> overmap_special::required_locations() const
 {
+    // TODO: It's called a lot during mapgen, and should probably be cached
+    // instead of making thousands of copies
     std::vector<overmap_special_locations> result;
     switch( subtype_ ) {
         case overmap_special_subtype::fixed: {
@@ -5354,9 +5356,11 @@ std::vector<tripoint_om_omt> overmap::place_special(
             if( !linked && connection_cache ) {
                 // If no city present, try to link to closest connection
                 auto points = connection_cache->get_closests( elem.connection->id, rp.z(), rp.xy() );
+                int attempts = 0;
                 for( const point_om_omt &pos : points ) {
                     if( ( linked = build_connection( pos, rp.xy(), rp.z(), *elem.connection,
-                                                     must_be_unexplored, initial_dir ) ) ) {
+                                                     must_be_unexplored, initial_dir ) ) ||
+                        ++attempts > 10 ) {
                         break;
                     }
                 }
@@ -5364,13 +5368,15 @@ std::vector<tripoint_om_omt> overmap::place_special(
             if( !linked && !connection_cache ) {
                 // Cache is cleared once generation is done, if special is spawned via debug or for
                 // mission we'll need to perform search. It is slow, but that's a rare case
+                int attempts = 0;
                 for( const tripoint_om_omt &p : closest_points_first( rp, OMAPX ) ) {
                     if( !inbounds( p ) || std::find( result.begin(), result.end(), p ) != result.end() ||
                         !check_ot( elem.connection->id->default_terrain.str(), ot_match_type::type, p ) ) {
                         continue;
                     }
                     if( ( linked = build_connection( p.xy(), rp.xy(), rp.z(), *elem.connection,
-                                                     must_be_unexplored, initial_dir ) ) ) {
+                                                     must_be_unexplored, initial_dir ) ) ||
+                        ++attempts > 10 ) {
                         break;
                     }
                 }
@@ -5572,40 +5578,68 @@ void overmap::place_specials( overmap_special_batch &enabled_specials )
     const int RANGE = std::max( 0, get_option<int>( "SPECIALS_SPACING" ) );
     const float DENSITY = get_option<float>( "SPECIALS_DENSITY" );
 
+    static const overmap_location_id water( "water" );
+
+    // We have four zones with individual point pools:
+    // land surface, land underground, all lakes, all rivers
+    // not very consistent, but we don't have any underwater specials to bother
+    enum zone : int {
+        land,
+        land_under,
+        lake,
+        river,
+        last
+    };
+
     // Rough estimate how many space our specials about to take with
     // our range, density, and available specials, if we can't possibly
     // have that much - tune density down
-    float land_needed = 0;
-    float lake_needed = 0;
+    float area_needed[zone::last] = { 0 };
 
+    // We'll need to track locations of land surface specials
+    cata::flat_set<overmap_location_id> land_locs;
+
+    std::unordered_map<overmap_special_id, zone> special_zone;
     std::unordered_map<overmap_special_id, int> special_area;
     for( auto &iter : enabled_specials ) {
         const overmap_special &special = *iter.special_details;
+        const std::vector<overmap_special_locations> &locs = special.required_locations();
 
-        // preview_terrains() would give more accurate area, but
-        // since we don't taking in account cities, and assumes
-        // tight packig of terrains - some overestimation won't hurt
-        special_area[special.id] = special.required_locations().size();
+        // Check all locations to find out if that's river or underground special
+        cata::flat_set<overmap_location_id> this_locs;
+        int area[2] = { 0 };
+        for( const overmap_special_locations &loc : locs ) {
+            if( loc.p.z == 0 ) {
+                area[0]++;
+                // Only z0 locations are actually matched, other ones are ignored
+                this_locs.insert( loc.locations.begin(), loc.locations.end() );
+            } else {
+                area[1]++;
+            }
+        }
+
+        zone current = special.has_flag( "LAKE" ) ? zone::lake :
+                       this_locs.count( water ) ? zone::river :
+                       area[0] ? zone::land : zone::land_under;
+
+        if( current == zone::land ) {
+            land_locs.insert( this_locs.begin(), this_locs.end() );
+        }
+
         const numeric_interval<int> &o = special.get_constraints().occurrences;
 
         float average_amount = special.has_flag( "UNIQUE" ) ?
                                static_cast<float>( o.min ) / o.max :
                                static_cast<float>( o.min + o.max ) / 2;
 
-        float total_area = std::pow( std::sqrt( special_area[special.id] ) + RANGE, 2.0 ) *
+        special_area[special.id] = current == zone::land_under ? area[1] : area[0];
+        float this_range = current == zone::land_under ? 0 : RANGE;
+        float total_area = std::pow( std::sqrt( special_area[special.id] ) + this_range, 2.0 ) *
                            average_amount * DENSITY;
-        if( special.has_flag( "LAKE" ) ) {
-            lake_needed += total_area;
-        } else {
-            land_needed += total_area;
-        }
-    }
 
-    // Most of the setups should end with x1 multiplier, but some dire combinations
-    // of settings like maxed spacing and density may actually need adjusting to
-    // give a things on bottom of the list a chance to spawn
-    float lake_crowd_ratio = std::min( 1.0f, OMAPX * OMAPY / lake_needed );
-    float land_crowd_ratio = std::min( 1.0f, OMAPX * OMAPY / land_needed );
+        area_needed[current] += total_area;
+        special_zone[special.id] = current;
+    }
 
     // Sort specials be they sizes - placing big things is faster
     // and easier while we have most of map still empty, and also
@@ -5623,31 +5657,51 @@ void overmap::place_specials( overmap_special_batch &enabled_specials )
         return special_weight( a.special_details ) > special_weight( b.special_details );
     } );
 
-    // Prepare overmap points
-    std::vector<tripoint_om_omt> lake_points;
-    std::vector<tripoint_om_omt> land_points;
+    // Prepare vectors of points for all zones
+    std::vector<tripoint_om_omt> zone_points[zone::last];
     for( int x = 0; x < OMAPX; x++ ) {
         for( int y = 0; y < OMAPY; y++ ) {
             const tripoint_om_omt p = {x, y, 0};
-            if( ter( p )->is_lake() ) {
-                lake_points.push_back( p );
-            } else {
-                land_points.push_back( p );
+            const oter_id &t = ter( p );
+
+            zone current = t->is_lake() ? zone::lake :
+                           t->is_river() ? zone::river :
+                           zone::land_under;
+
+            // Grab all lakes, rivers, and undergrounds
+            zone_points[current].push_back( p );
+
+            if( current == zone::land_under && is_amongst_locations( t, land_locs ) ) {
+                // Points above undergrounds goes to land zone, but only if this location
+                // can be used by some special, this way we'll filter out city buildings
+                zone_points[zone::land].push_back( p );
             }
         }
     }
 
-    // Calculate water to land ratio to normalize specials occurencies
-    // we don't want to dump all specials on overmap covered by water
-    float lake_rate = lake_points.size() / static_cast<float>( OMAPX * OMAPY ) *
-                      lake_crowd_ratio * DENSITY;
-    float land_rate = land_points.size() / static_cast<float>( OMAPX * OMAPY ) *
-                      land_crowd_ratio * DENSITY;
+    static const float OMAP_AREA = static_cast<float>( OMAPX * OMAPY );
+    float zone_ratio[zone::last];
+    for( int i = 0; i < zone::river; i++ ) {
+        // Most of the setups should end with x1 multiplier, but some dire combinations
+        // of settings like maxed spacing and density may actually need adjusting to
+        // give a things on bottom of the list a chance to spawn
+        float crowd_ratio = std::min( 1.0f, OMAP_AREA / area_needed[i] );
 
-    specials_overlay lake( lake_points );
-    specials_overlay land( land_points );
+        // Calculate terrain ratio to normalize specials occurencies
+        // we don't want to dump all specials on overmap covered by water
+        zone_ratio[i] = ( zone_points[i].size() / OMAP_AREA ) * crowd_ratio * DENSITY;
+    }
+    // TODO: Yes, that's a hack. Calculatng real river ratio would require rebalancing occurences.
+    zone_ratio[zone::river] = zone_ratio[zone::land_under];
 
-    // And here we go
+    specials_overlay zone_overlay[zone::last] = {
+        specials_overlay( zone_points[0] ),
+        specials_overlay( zone_points[1] ),
+        specials_overlay( zone_points[2] ),
+        specials_overlay( zone_points[3] )
+    };
+
+    // Now all preparations is done, and we can start placing specials
     for( auto &iter : enabled_specials ) {
         const overmap_special &special = *iter.special_details;
         const overmap_special_placement_constraints &constraints = special.get_constraints();
@@ -5655,9 +5709,10 @@ void overmap::place_specials( overmap_special_batch &enabled_specials )
         const int min = constraints.occurrences.min;
         const int max = constraints.occurrences.max;
 
-        const bool is_lake = special.has_flag( "LAKE" );
+        zone current = special_zone[special.id];
+
         const float rate = is_true_center && special.has_flag( "ENDGAME" ) ? 1 :
-                           ( is_lake ? lake_rate : land_rate );
+                           zone_ratio[current];
 
         int amount_to_place;
         if( special.has_flag( "UNIQUE" ) ) {
@@ -5668,9 +5723,8 @@ void overmap::place_specials( overmap_special_batch &enabled_specials )
             float real_max = std::max( static_cast<float>( min ), max * rate );
             amount_to_place = roll_remainder( rng_float( min, real_max ) );
         }
-
         iter.instances_placed += place_special_attempt( special,
-                                 amount_to_place, ( is_lake ? lake : land ), false );
+                                 amount_to_place, zone_overlay[current], false );
     }
 }
 


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods): new item for <mod name>
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change
Better performance
<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution
Added two more placement overlays. River overlay prevents attempting of placing river specials on ground and vice versa. Underground overlay allows placing underground special(microlabs in vanilla game) within range of surface specials without conflicts.
Added locations check to land overlay to prevent expensive attempts of placing specials over existing cities.
Limited max amount of attempts to build connections. It could been *terribly* slow - i've seen minute long hangs during placing of *single* special, when it physically can't be connected anywhere, due to being on unreachable island, or fully surrounded by other buildings.

With all that generation speed of crowded maps with big cities will be magnitude faster than before. On default settings with plenty of empty space difference isn't that drastic.
As for result - with dedicated overlays land specials won't interfere with river and underground ones, which is nicer, but there isn't a lot of them to benefit from it, so produced overmaps looks pretty much same.

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

## Describe alternatives you've considered
Code would look a bit more consistent with *six* overlays, land\lake\river plus their underground counterparts. But since we don't have *any* underwater specials it would just increase operational costs for nothing.
Adding "RIVER" and "UNDERGROUND" specials flags, forcing them to respective overlays. First one would allow less hacky detection of river special(but would break all river specials in old mods), second one could be useful for thing like mining mod(but don't have any use in vanilla).
It might be beneficial to skip land locations check when map generated with no cities, but this case is already fast enough to bother too much.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing
Maps are generating, tests are passing.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->