### PR TITLE
fix(balance): repair chance rebalancing

### DIFF
--- a/data/json/items/tool/tailoring.json
+++ b/data/json/items/tool/tailoring.json
@@ -72,7 +72,7 @@
       "item_action_type": "repair_fabric",
       "materials": [ "cotton", "leather", "nylon", "wool", "fur", "faux_fur", "nomex", "kevlar", "gutskin" ],
       "skill": "tailor",
-      "tool_quality": -1,
+      "tool_quality": 1,
       "cost_scaling": 0.1,
       "move_cost": 1300
     },
@@ -101,7 +101,7 @@
       "item_action_type": "repair_fabric",
       "materials": [ "neoprene" ],
       "skill": "tailor",
-      "tool_quality": 0,
+      "tool_quality": 1,
       "cost_scaling": 0.1,
       "move_cost": 1200
     },
@@ -130,7 +130,7 @@
       "item_action_type": "repair_fabric",
       "materials": [ "cotton", "nylon", "leather", "wool", "fur", "faux_fur", "nomex", "gutskin" ],
       "skill": "tailor",
-      "tool_quality": -1,
+      "tool_quality": 0,
       "cost_scaling": 0.1,
       "move_cost": 1500
     },
@@ -160,7 +160,7 @@
       "item_action_type": "repair_fabric",
       "materials": [ "cotton", "leather", "nylon", "wool", "fur", "faux_fur", "nomex", "kevlar", "gutskin" ],
       "skill": "tailor",
-      "tool_quality": 0,
+      "tool_quality": 2,
       "cost_scaling": 0.1,
       "move_cost": 1000
     },
@@ -206,7 +206,7 @@
         "item_action_type": "repair_fabric",
         "materials": [ "cotton", "leather", "nylon", "wool", "fur", "faux_fur", "nomex", "kevlar", "neoprene", "gutskin" ],
         "skill": "tailor",
-        "tool_quality": 1,
+        "tool_quality": 3,
         "cost_scaling": 0.1,
         "move_cost": 800
       },

--- a/doc/src/content/docs/en/mod/json/reference/json_info.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_info.md
@@ -2414,7 +2414,29 @@ more structured function.
     "done_message": "Place the beartrap on the %s.", // The message that appears after the trap has been placed. %s is replaced with the terrain name of the place where the trap has been put.
     "practice": 4, // How much practice to the "traps" skill placing the trap gives.
     "moves": 10 // (optional, default is 100): the move points that are used by placing the trap.
-}
+},
+"use_action": {
+  {
+    "type": "repair_item",                // Repair items. Skill, tool quality, and minor impact from dexterit
+    "item_action_type": "repair_fabric",  // Points to an item_action JSON entry that determines the action's name in the use menu. Vanilla examples include repair_fabric and repair_metal.
+    "materials": [                        // What materials can be repaired by this item. Materials.json defines what item is consumed when repairing items of that material.
+      "cotton",
+      "leather",
+      "nylon",
+      "wool",
+      "fur",
+      "faux_fur",
+      "nomex",
+      "kevlar",
+      "neoprene",
+      "gutskin"
+    ],
+    "skill": "tailor",    // What skill determines chance of success vs. risk of damaging the item further.
+    "tool_quality": 3,    // Bonus from tool, 1.<X> times multiplier on skill.  With 8 Dex, 10 skill plus 2 or more tool_quality allows any item in the game to be fully reinforced.
+    "cost_scaling": 0.1,  // Reduces or increases how much raw material is needed per successful repair action, also affected by the item's volume.
+    "move_cost": 800      // How long between each roll for success or failure, 100 moves is 1 turn.
+  }
+},
 "use_action": {
     "type": "sew_advanced",  // Modify clothing
     "materials": [           // materials to deal with.

--- a/doc/src/content/docs/en/mod/json/reference/json_info.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_info.md
@@ -2417,7 +2417,7 @@ more structured function.
 },
 "use_action": {
   {
-    "type": "repair_item",                // Repair items. Skill, tool quality, and minor impact from dexterit
+    "type": "repair_item",                // Repair items. Skill, tool quality, and dexterity is checked against how hard that item is to craft/dissemble (which may be modified with repairs_like).
     "item_action_type": "repair_fabric",  // Points to an item_action JSON entry that determines the action's name in the use menu. Vanilla examples include repair_fabric and repair_metal.
     "materials": [                        // What materials can be repaired by this item. Materials.json defines what item is consumed when repairing items of that material.
       "cotton",

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -3296,7 +3296,7 @@ std::pair<float, float> repair_item_actor::repair_chance(
             break;
         case RT_REINFORCE:
             // Reinforcing is 50% harder than refitting
-            action_difficulty = fix.max_damage() / itype::damage_scale * 1.5;
+            action_difficulty = ( fix.max_damage() / itype::damage_scale ) + 2;
             break;
         case RT_PRACTICE:
             // Skill gain scales with recipe difficulty, so practice difficulty should too

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -3295,8 +3295,8 @@ std::pair<float, float> repair_item_actor::repair_chance(
             action_difficulty = fix.max_damage() / itype::damage_scale;
             break;
         case RT_REINFORCE:
-            // Reinforcing is at least as hard as refitting
-            action_difficulty = std::max( fix.max_damage() / itype::damage_scale, recipe_difficulty );
+            // Reinforcing is 50% harder than refitting
+            action_difficulty = fix.max_damage() / itype::damage_scale * 1.5;
             break;
         case RT_PRACTICE:
             // Skill gain scales with recipe difficulty, so practice difficulty should too
@@ -3315,9 +3315,11 @@ std::pair<float, float> repair_item_actor::repair_chance(
     // Duster |    2   |   5   |  5  |   10%   |   0%
     // Duster |    2   |   2   |  10 |   4%    |   1%
     // Duster | Refit  |   2   |  10 |   0%    |   N/A
-    float success_chance = ( 10 + 2 * skill - 2 * difficulty + tool_quality / 5.0f ) / 100.0f;
+    float success_chance = ( 10 + 2 * ( skill * ( 1 + tool_quality / 10.0f ) ) - 2 * difficulty ) /
+                           100.0f;
     /** @EFFECT_DEX reduces the chances of damaging an item when repairing */
-    float damage_chance = ( difficulty - skill - ( tool_quality + pl.dex_cur ) / 5.0f ) / 100.0f;
+    float damage_chance = ( difficulty - ( skill * ( 1 + tool_quality / 10.0f ) ) - pl.dex_cur /
+                            5.0f ) / 100.0f;
 
     damage_chance = std::max( 0.0f, std::min( 1.0f, damage_chance ) );
     success_chance = std::max( 0.0f, std::min( 1.0f - damage_chance, success_chance ) );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -3306,15 +3306,6 @@ std::pair<float, float> repair_item_actor::repair_chance(
     }
 
     const int difficulty = recipe_difficulty + action_difficulty;
-    // Sample numbers:
-    // Item   | Damage | Skill | Dex | Success | Failure
-    // Hoodie |    2   |   3   |  10 |   6%    |   0%
-    // Hazmat |    1   |   10  |  10 |   8%    |   0%
-    // Hazmat |    1   |   5   |  20 |   0%    |   2%
-    // t-shirt|    4   |   1   |  5  |   2%    |   3%
-    // Duster |    2   |   5   |  5  |   10%   |   0%
-    // Duster |    2   |   2   |  10 |   4%    |   1%
-    // Duster | Refit  |   2   |  10 |   0%    |   N/A
     float success_chance = ( 10 + 2 * ( skill * ( 1 + tool_quality / 10.0f ) ) - 2 * difficulty ) /
                            100.0f;
     /** @EFFECT_DEX reduces the chances of damaging an item when repairing */


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods): new item for <mod name>
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

It was pointed out in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3720 that you need literally superhuman tailoring skill to be able to reinforce uncraftable items (if they have no `repairs_like` defined), specifically level 16.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

C++ changes:
1. In iuse_actor.cpp, changed how `repair_item_actor::repair_chance` determines `action_difficulty` when reinforcing, from favoring `recipe_difficulty` to instead being 50% harder than the value used for refitting, which in turn is set to the difficulty of repairing a max-damage item. Since max damage would return a value of 4, this makes the `action_difficulty` always 6, instead of being anywhere from 4 to 10 depending on how easy it is to craft (when `recipe_difficulty` is already used later on so how easy it is to craft doesn't need to be taken into account twice over).
2. In the same function, changed how `tool_quality` is used to determine `success_chance` and `damage_chance`. Before 1 point of tool quality was worth one fifth a point in skill level. Now it's used as a multiplier on skill level, with a value of 0 meaning no impact on skill, and a quality of 10 doubling it. The aim here was to make tool quality more relevant instead of barely mattering at all, enough that at max level it's worth a full level's worth each. Making it a multiplier instead of just increasing the original bonus fivefold was so that it doesn't disproportionately impact repair difficulty at lower levels.

JSON changes:
1. Changed how the tool bonuses for tailoring tools scale. Instead of only ever being a range of -1 to +1, the wooden needle has a bonus of zero, the bone and curved needles (idea being bone needle is more work to obtain typically and finer point) has a bonus of 1, sewing kit has a bonus of 2, and tailor's kit has a bonus of 3. All other repair tools had a range of 4-10 for their tool qualities, so it stands out as odd that tailoring tools were so much vastly worse.

Doc updates:
1. Documented the basics of the `repair_item` use action in json_info.md

All these factors combined should mean:
* Repairs at level zero skill will be slightly harder, since your tool quality bonus is being multiplied against zero. We're talking less than a level's worth of difference however since the old fixed tool quality bonus was so low.
* Once you gain any level of skill, tool quality starts to have a more noticeable impact on repairs, some items potentially being in reach a bit easier than they used to be. Given how long repairs can take, it should be a reasonable change.
* Once you max out your skill, you'll be just in range to successfully reinforce an uncraftable item with the right tools. In the case of tailoring, makeshift sewing tools will still be inadequate, but a sewing kit or tailor's kit will do the job, while all the more advanced metalworking tools will be much more reliable at repairing anything.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Adding code that can check if an item would be literally impossible to refit with the current tool even at 10 repair skill, setting it to no longer count as a valid repair skill on the item's inventory screen, and making it say "this item is too hard for any human to reinforce, go get an exodii-made sewing kit" or something to that effect on trying to select such an item to reinforce.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON file for syntax and lint errors.
2. Compiled and load-tested.
3. Spawned in a moisture retention suit (an item I can currently confirm has maxed difficulty to repair) and debugged tailoring to 10.
4. Confirmed I can refit it with a bone sewing needle, but can't reinforce.
5. Confirmed a sewing kit bumps things up enough that I have a shot at reinforcing it.
6. Checked affected C++ file for astyle.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
