### PR TITLE
fix: specials spawned for missions will respect min range

### DIFF
--- a/src/mission_util.cpp
+++ b/src/mission_util.cpp
@@ -193,7 +193,7 @@ static std::optional<tripoint_abs_omt> find_or_create_om_terrain(
             if( params.overmap_special ) {
                 // ...then attempt to place the whole special.
                 const bool placed = overmap_buffer.place_special( *params.overmap_special, origin_pos,
-                                    params.search_range );
+                                    params.min_distance, params.search_range );
                 // If we succeeded in placing the special, then try and find the particular location
                 // we're interested in.
                 if( placed ) {

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1616,8 +1616,9 @@ bool overmapbuffer::place_special( const overmap_special_id &special_id,
         // search using the same radius value we used in placing it.
 
         std::vector<tripoint_om_omt> points_in_range;
-        for( const tripoint_abs_omt &p : closest_points_first( center, min_radius,
-                std::max( 1, max_radius - longest_side ) ) ) {
+        int max = std::max( 1, max_radius - longest_side );
+        int min = std::min( max, min_radius + longest_side );
+        for( const tripoint_abs_omt &p : closest_points_first( center, min, max ) ) {
             point_abs_om overmap;
             tripoint_om_omt omt_within_overmap;
             std::tie( overmap, omt_within_overmap ) = project_remain<coords::om>( p );

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1616,8 +1616,8 @@ bool overmapbuffer::place_special( const overmap_special_id &special_id,
         // search using the same radius value we used in placing it.
 
         std::vector<tripoint_om_omt> points_in_range;
-        int max = std::max( 1, max_radius - longest_side );
-        int min = std::min( max, min_radius + longest_side );
+        const int max = std::max( 1, max_radius - longest_side );
+        const int min = std::min( max, min_radius + longest_side );
         for( const tripoint_abs_omt &p : closest_points_first( center, min, max ) ) {
             point_abs_om overmap;
             tripoint_om_omt omt_within_overmap;

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1594,27 +1594,19 @@ std::optional<std::vector<tripoint_abs_omt>> overmapbuffer::place_special(
 }
 
 bool overmapbuffer::place_special( const overmap_special_id &special_id,
-                                   const tripoint_abs_omt &center, int radius )
+                                   const tripoint_abs_omt &center,
+                                   int min_radius, int max_radius )
 {
     // First find the requested special. If it doesn't exist, we're done here.
-    bool found = false;
-    overmap_special special;
-    for( const auto &elem : overmap_specials::get_all() ) {
-        if( elem.id == special_id ) {
-            special = elem;
-            found = true;
-            break;
-        }
-    }
-    if( !found ) {
+    if( !special_id.is_valid() ) {
         return false;
     }
-
+    const overmap_special &special = *special_id;
     const int longest_side = special.longest_side();
 
     // Get all of the overmaps within the defined radius of the center.
     for( const auto &om : get_overmaps_near(
-             project_to<coords::sm>( center ), omt_to_sm_copy( radius ) ) ) {
+             project_to<coords::sm>( center ), omt_to_sm_copy( max_radius ) ) ) {
 
         // We'll include points that within our radius. We reduce the radius by
         // the length of the longest side of our special so that we don't end up in a
@@ -1622,9 +1614,10 @@ bool overmapbuffer::place_special( const overmap_special_id &special_id,
         // rest of it is outside the radius (due to size, rotation, etc), which would
         // then result in us placing the special but then not finding it later if we
         // search using the same radius value we used in placing it.
+
         std::vector<tripoint_om_omt> points_in_range;
-        for( const tripoint_abs_omt &p : points_in_radius( center, std::max( 1,
-                radius - longest_side ) ) ) {
+        for( const tripoint_abs_omt &p : closest_points_first( center, min_radius,
+                std::max( 1, max_radius - longest_side ) ) ) {
             point_abs_om overmap;
             tripoint_om_omt omt_within_overmap;
             std::tie( overmap, omt_within_overmap ) = project_remain<coords::om>( p );

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -516,11 +516,12 @@ class overmapbuffer
          * @param special_id The id of overmap special to place.
          * @param center Used in conjunction with radius to search the specified and adjacent overmaps for
          * a valid placement location. Absolute overmap terrain coordinates.
-         * @param radius Used in conjunction with center. Absolute overmap terrain units.
+         * @param min_radius Used in conjunction with center. Absolute overmap terrain units.
+         * @param max_radius Used in conjunction with center. Absolute overmap terrain units.
          * @returns True if the special was placed, else false.
          */
         bool place_special( const overmap_special_id &special_id, const tripoint_abs_omt &center,
-                            int radius );
+                            int min_radius, int max_radius );
 
     private:
         /**

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -248,7 +248,7 @@ tripoint_abs_omt start_location::find_player_initial_location() const
             // that special is bad, no need to check all other overmaps for same thing
             const point_abs_om &omp = random_entry( overmaps );
             const tripoint_abs_omt abs_mid = project_combine( omp, om_mid );
-            if( overmap_buffer.place_special( special.id, abs_mid, OMAPX / 2 ) ) {
+            if( overmap_buffer.place_special( special.id, abs_mid, 0, OMAPX / 2 ) ) {
 
                 // Now try to find what we spawned
                 const tripoint_abs_omt start = overmap_buffer.find_closest( abs_mid, loc.first,


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods): new item for <mod name>
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change
Should fix https://github.com/cataclysmbnteam/Cataclysm-BN/issues/3730
<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution
Added min range argument to specials placement: https://github.com/cataclysmbnteam/Cataclysm-BN/issues/3730#issuecomment-1821450385
<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

## Describe alternatives you've considered
None.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing
Restarted few times as assassin with x0 specials(to make sure mission will actually need to spawn airport) as per https://github.com/cataclysmbnteam/Cataclysm-BN/issues/3730#issuecomment-1821555011. No more errors.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context
Piece of code that makes a copy of special shouldn't be needed now. It used to override occurrences with 1 before placement rework, but not anymore.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->