### PR TITLE
feat(balance): update capacity of power armor holsters

### DIFF
--- a/data/json/items/armor/holster.json
+++ b/data/json/items/armor/holster.json
@@ -18,7 +18,7 @@
     "material_thickness": 1,
     "use_action": {
       "type": "holster",
-      "max_volume": "9 L",
+      "max_volume": "10 L",
       "min_volume": "1500 ml",
       "draw_cost": 150,
       "skills": [ "smg", "shotgun", "rifle", "launcher" ]

--- a/data/json/items/armor/power_armor.json
+++ b/data/json/items/armor/power_armor.json
@@ -426,7 +426,7 @@
     "material_thickness": 1,
     "use_action": {
       "type": "holster",
-      "max_volume": "10 L",
+      "max_volume": "9 L",
       "min_volume": "1500 ml",
       "draw_cost": 150,
       "skills": [ "smg", "shotgun", "rifle", "launcher" ]
@@ -448,14 +448,14 @@
     "covers": [ "leg_either" ],
     "coverage": 5,
     "material_thickness": 1,
-    "use_action": { "type": "holster", "max_volume": "800 ml", "min_volume": "100 ml", "skills": [ "pistol", "smg", "shotgun" ] },
+    "use_action": { "type": "holster", "max_volume": "1 L", "min_volume": "250 ml", "skills": [ "pistol", "smg", "shotgun" ] },
     "flags": [ "POWERARMOR_MOD", "COMPACT", "WATERPROOF", "STURDY", "WAIST" ]
   },
   {
     "id": "power_armor_chest_rig",
     "type": "ARMOR",
-    "name": { "str": "power armor chest rig" },
-    "description": "A set of compartments capable of carrying three magazines close at hand.  Designed to interface with a military exoskeleton.  Activate to store/retrieve your magazines.",
+    "name": { "str": "power armor magazine carrier" },
+    "description": "A set of compartments capable of carrying two magazines close at hand, including larger drum mags or UPS batteries.  Designed to interface with a military exoskeleton.  Activate to store/retrieve your magazines.",
     "weight": "500 g",
     "volume": "500 ml",
     "price": 50000,
@@ -471,10 +471,11 @@
       "type": "holster",
       "holster_prompt": "Stash ammo",
       "holster_msg": "You stash your %s.",
-      "multi": 3,
-      "max_volume": "750 ml",
-      "draw_cost": 40,
-      "flags": [ "MAG_COMPACT" ]
+      "multi": 4,
+      "min_volume": "250 ml",
+      "max_volume": "1500 ml",
+      "draw_cost": 80,
+      "flags": [ "MAG_COMPACT", "MAG_BULKY" ]
     },
     "flags": [ "POWERARMOR_MOD", "COMPACT", "WATERPROOF", "STURDY", "BELTED", "WAIST" ]
   },

--- a/data/json/items/armor/power_armor.json
+++ b/data/json/items/armor/power_armor.json
@@ -426,7 +426,7 @@
     "material_thickness": 1,
     "use_action": {
       "type": "holster",
-      "max_volume": "9 L",
+      "max_volume": "10 L",
       "min_volume": "1500 ml",
       "draw_cost": 150,
       "skills": [ "smg", "shotgun", "rifle", "launcher" ]

--- a/data/json/items/armor/power_armor.json
+++ b/data/json/items/armor/power_armor.json
@@ -471,7 +471,7 @@
       "type": "holster",
       "holster_prompt": "Stash ammo",
       "holster_msg": "You stash your %s.",
-      "multi": 4,
+      "multi": 2,
       "min_volume": "250 ml",
       "max_volume": "1500 ml",
       "draw_cost": 80,


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods): new item for <mod name>
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Updates some items I overlooked back when I updated holster sizes in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3159, plus expand on one item's role.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Per Scarf's suggestion, increased max volume of back holster from 9 liters to 10 liters, matching that of power armor back holster.
2. Increased maximum volume of power armor holster from 800 ml to 1 liter and minimum volume from 100 ml to 250 ml, matching standard holster.
3. Altered the power armor chest rig a bit, renaming it to "power armor magazine carrier" to distinguish it from from the carry stats of the standard chest rig. Reduced its max mags down to only 2, but bumped its max volume to 1500 ml and allowed it to hold items with the `MAG_BULKY` flag. This gives it the ability to stash spare heavy batteries, like what a UPS loads.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Allowing the mag pouches to also hold ammo belts via adding a flag to it. 5.56 and 7.62 have a pretty massive volume when maxed out at 500 rounds, and even if toned down to 200 that'd require the mag carrier's capacity to be boosted a bit higher, while it'd hold a 200-round 5.56mm belt a 200-round 7.62mm belt is still just a hair over 2.5 liters.
2. Allowing more mag carrier items to hold `MAG_BULKY` items.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Checked affected file for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->