### PR TITLE
feat: monster armor for `cold` and `electric`

### DIFF
--- a/data/mods/Aftershock/mobs/robots.json
+++ b/data/mods/Aftershock/mobs/robots.json
@@ -104,6 +104,8 @@
     "armor_cut": 90,
     "armor_bullet": 72,
     "armor_fire": 36,
+    "armor_cold": 36,
+    "armor_electric": 72,
     "vision_day": 50,
     "revert_to_itype": "bot_tankbot",
     "starting_ammo": { "40x46mm_m433": 200, "556": 3000 },

--- a/doc/src/content/docs/en/mod/json/reference/creatures/monsters.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/monsters.md
@@ -280,11 +280,11 @@ was n zombies. A player with max(Str,Dex)<=n has no chance of breaking that grab
 
 Amount of cutting damage added to die roll on monster melee attack.
 
-## "armor_bash", "armor_cut", "armor_stab", "armor_acid", "armor_fire"
+## "armor_bash", "armor_cut", "armor_stab", "armor_acid", "armor_fire", "armor_cold", "armor_electric"
 
 (integer, optional)
 
-Monster protection from bashing, cutting, stabbing, acid and fire damage.
+Monster protection from bashing, cutting, stabbing, acid, fire, cold and electric damage.
 
 ## "vision_day", "vision_night"
 

--- a/src/damage.cpp
+++ b/src/damage.cpp
@@ -205,6 +205,8 @@ resistances::resistances( monster &monster ) : resistances()
     set_resist( DT_BULLET, monster.type->armor_bullet );
     set_resist( DT_ACID, monster.type->armor_acid );
     set_resist( DT_HEAT, monster.type->armor_fire );
+    set_resist( DT_COLD, monster.type->armor_cold );
+    set_resist( DT_ELECTRIC, monster.type->armor_electric );
 }
 void resistances::set_resist( damage_type dt, float amount )
 {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2114,8 +2114,9 @@ int monster::get_armor_type( damage_type dt, bodypart_id bp ) const
         case DT_HEAT:
             return worn_armor + static_cast<int>( type->armor_fire );
         case DT_COLD:
+            return worn_armor + static_cast<int>( type->armor_cold );
         case DT_ELECTRIC:
-            return worn_armor;
+            return worn_armor + static_cast<int>( type->armor_electric );
         case DT_NULL:
         case NUM_DT:
             // Let it error below

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -383,6 +383,12 @@ void MonsterGenerator::finalize_mtypes()
         if( mon.armor_fire < 0 ) {
             mon.armor_fire = 0;
         }
+        if( mon.armor_cold < 0 ) {
+            mon.armor_cold = 0;
+        }
+        if( mon.armor_electric < 0 ) {
+            mon.armor_electric = 0;
+        }
 
         // Lower bound for hp scaling
         mon.hp = std::max( mon.hp, 1 );
@@ -749,6 +755,8 @@ void mtype::load( const JsonObject &jo, const std::string &src )
     assign( jo, "armor_stab", armor_stab, strict, 0 );
     assign( jo, "armor_acid", armor_acid, strict, 0 );
     assign( jo, "armor_fire", armor_fire, strict, 0 );
+    assign( jo, "armor_cold", armor_cold, strict, 0 );
+    assign( jo, "armor_electric", armor_electric, strict, 0 );
 
     assign( jo, "vision_day", vision_day, strict, 0 );
     assign( jo, "vision_night", vision_night, strict, 0 );

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -298,12 +298,14 @@ struct mtype {
         int sk_dodge = 0;       /** dodge skill */
 
         /** If unset (-1) then values are calculated automatically from other properties */
-        int armor_bash = -1;    /** innate armor vs. bash */
-        int armor_cut  = -1;    /** innate armor vs. cut */
-        int armor_stab = -1;    /** innate armor vs. stabbing */
-        int armor_bullet = -1;  /** innate armor vs. bullet */
-        int armor_acid = -1;    /** innate armor vs. acid */
-        int armor_fire = -1;    /** innate armor vs. fire */
+        int armor_bash = -1;     /** innate armor vs. bash */
+        int armor_cut  = -1;     /** innate armor vs. cut */
+        int armor_stab = -1;     /** innate armor vs. stabbing */
+        int armor_bullet = -1;   /** innate armor vs. bullet */
+        int armor_acid = -1;     /** innate armor vs. acid */
+        int armor_fire = -1;     /** innate armor vs. fire */
+        int armor_cold = -1;     /** innate armor vs. cold */
+        int armor_electric = -1; /** innate armor vs. electrical */
 
         // Vision range is linearly scaled depending on lighting conditions
         int vision_day = 40;    /** vision range in bright light */


### PR DESCRIPTION
## Purpose of change

- resolves #3671 

## Describe the solution

- added `armor_cold` and `armor_electric`, by copy-pasting implementation of `armor_fire`.
- gave tankbot cold and electricity armor.

## Describe alternatives you've considered

a better JSON format to group monster armor together, but it seemed like too much endeavor.

## Testing
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/7277f701-08d7-4869-a28d-76136f3002f3)

1. added magiclysm.
2. spawned tank UGV and debug monster.
3. casted lighting bolt.
4. tankbot took much less damage than debug monster, due to their 72 electric armor.

## Additional context
spent 30 minutes figuring out why cold resistance wasn't working, then found out i was editing tankbot in _aftershock._ fun times.