### PR TITLE
feat: allow using `MOUNTABLE` terrains nearby when firing heavy weapon

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -778,6 +778,10 @@ namespace
 
 auto is_mountable( const map &m, const tripoint &pos ) -> bool
 {
+    if( m.impassable( pos ) ) {
+        return false;
+    }
+
     // usage of any attached bipod is dependent upon terrain
     if( m.has_flag_ter_or_furn( "MOUNTABLE", pos ) ) {
         return true;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -148,7 +148,6 @@ static constexpr int AIF_DURATION_LIMIT = 10;
 
 static projectile make_gun_projectile( const item &gun );
 static void cycle_action( item &weap, const tripoint &pos );
-bool can_use_heavy_weapon( const Character &who, const map &m, const tripoint &pos );
 dispersion_sources calculate_dispersion( const map &m, const Character &who, const item &gun,
         int at_recoil, bool burst );
 
@@ -773,31 +772,49 @@ void npc::pretend_fire( npc *source, int shots, item &gun )
     }
 }
 
-bool can_use_heavy_weapon( const Character &who, const map &m, const tripoint &pos )
-{
-    if( who.is_mounted() && who.mounted_creature->has_flag( MF_RIDEABLE_MECH ) ) {
-        return true;
-    }
 
+namespace
+{
+
+auto is_mountable( const map &m, const tripoint &pos ) -> bool
+{
     // usage of any attached bipod is dependent upon terrain
     if( m.has_flag_ter_or_furn( "MOUNTABLE", pos ) ) {
         return true;
     }
 
     if( const optional_vpart_position vp = m.veh_at( pos ) ) {
+        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
         return vp->vehicle().has_part( pos, "MOUNTABLE" );
     }
-
     return false;
 }
+
+auto is_mountable_nearby( const map &m, const tripoint &pos ) -> bool
+{
+    const auto &xs = closest_points_first( pos, 1 );
+    return std::any_of( xs.begin(), xs.end(),
+                        [&m]( const tripoint & x ) -> bool { return is_mountable( m, x ); } );
+}
+
+auto can_use_heavy_weapon( const Character &who, const map &m, const tripoint &pos ) -> bool
+{
+    if( who.is_mounted() && who.mounted_creature->has_flag( MF_RIDEABLE_MECH ) ) {
+        return true;
+    }
+    return is_mountable_nearby( m, pos );
+}
+
+} // namespace
+
 
 dispersion_sources calculate_dispersion( const map &m, const Character &who, const item &gun,
         int at_recoil, bool burst )
 {
-    bool bipod = can_use_heavy_weapon( who, m, who.pos() );
+    const bool bipod = can_use_heavy_weapon( who, m, who.pos() );
 
-    int gun_recoil = gun.gun_recoil( bipod );
-    int eff_recoil = at_recoil + ( burst ? ranged::burst_penalty( who, gun, gun_recoil ) : 0 );
+    const int gun_recoil = gun.gun_recoil( bipod );
+    const int eff_recoil = at_recoil + ( burst ? ranged::burst_penalty( who, gun, gun_recoil ) : 0 );
     dispersion_sources dispersion( ranged::get_weapon_dispersion( who, gun ) );
     dispersion.add_range( eff_recoil );
     return dispersion;
@@ -2072,6 +2089,7 @@ double ranged::recoil_vehicle( const Character &who )
 
     if( who.in_vehicle ) {
         if( const optional_vpart_position vp = get_map().veh_at( who.pos() ) ) {
+            // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
             return static_cast<double>( std::abs( vp->vehicle().velocity ) ) * 3 / 100;
         }
     }
@@ -3732,8 +3750,8 @@ bool ranged::gunmode_checks_common( avatar &you, const map &m, std::vector<std::
     return result;
 }
 
-bool ranged::gunmode_checks_weapon( avatar &you, const map &m, std::vector<std::string> &messages,
-                                    const gun_mode &gmode )
+auto ranged::gunmode_checks_weapon( avatar &you, const map &m, std::vector<std::string> &messages,
+                                    const gun_mode &gmode ) -> bool
 {
     bool result = true;
 


### PR DESCRIPTION
## Purpose of change

- resolves #3644

## Describe the solution

used `closest_points_first` to check for mountable terrain in 3x3 radius.

## Describe alternatives you've considered

taking direction into account, but this seemed simpler.

## Testing

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/f1797873-c580-4250-9d1a-02ac693a3336)

## Additional context

https://discord.com/channels/830879262763909202/830916329053487124/1173138811555946527