### PR TITLE
feat: mop 3x3 area around

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -5131,10 +5131,6 @@ int iuse::boltcutters( player *p, item *it, bool, const tripoint & )
 
 int iuse::mop( player *p, item *it, bool, const tripoint & )
 {
-    if( p->is_mounted() ) {
-        p->add_msg_if_player( m_info, _( "You cannot do that while mounted." ) );
-        return 0;
-    }
     const std::vector<field_type_id> to_check = {
         fd_blood,
         fd_blood_veggy,

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -5129,83 +5129,37 @@ int iuse::boltcutters( player *p, item *it, bool, const tripoint & )
     return it->type->charges_to_use();
 }
 
-int iuse::mop( player *p, item *it, bool, const tripoint & )
+namespace
 {
-    const std::vector<field_type_id> to_check = {
-        fd_blood,
-        fd_blood_veggy,
-        fd_blood_insect,
-        fd_blood_invertebrate,
-        fd_gibs_flesh,
-        fd_gibs_veggy,
-        fd_gibs_insect,
-        fd_gibs_invertebrate,
-        fd_bile,
-        fd_slime,
-        fd_sludge
-    };
-    const std::function<bool( const tripoint & )> f = [&to_check]( const tripoint & pnt ) {
-        if( !g->m.has_flag( "LIQUIDCONT", pnt ) && !g->m.has_flag( "SEALED", pnt ) ) {
-            map_stack items = g->m.i_at( pnt );
-            auto found = std::find_if( items.begin(), items.end(), []( const item * const & it ) {
-                return it->made_of( LIQUID );
-            } );
-            if( found != items.end() ) {
-                return true;
-            }
-        }
-        field &fld = g->m.field_at( pnt );
-        for( field_type_id fid : to_check ) {
-            if( fld.find_field_c( fid ) ) {
-                return true;
-            }
-        }
-        if( const optional_vpart_position vp = g->m.veh_at( pnt ) ) {
-            vehicle *const veh = &vp->vehicle();
-            std::vector<int> parts_here = veh->parts_at_relative( vp->mount(), true );
-            for( int elem : parts_here ) {
-                if( veh->part( elem ).blood > 0 ) {
-                    return true;
-                }
-                vehicle_stack items = veh->get_items( elem );
-                auto found = std::find_if( items.begin(), items.end(), []( const item * const & it ) {
-                    return it->made_of( LIQUID );
-                } );
-                if( found != items.end() ) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    };
 
-    const std::optional<tripoint> pnt_ = choose_adjacent_highlight(
-            _( "Mop where?" ), _( "There is nothing to mop nearby." ), f, false );
-    if( !pnt_ ) {
-        return 0;
-    }
-    const tripoint &pnt = *pnt_;
-    if( !f( pnt ) ) {
-        if( pnt == p->pos() ) {
-            p->add_msg_if_player( m_info, _( "You mop yourself up." ) );
-            p->add_msg_if_player( m_info, _( "The universe implodes and reforms around you." ) );
-        } else {
-            p->add_msg_if_player( m_bad, _( "There's nothing to mop there." ) );
-        }
-        return 0;
-    }
+auto mop_normal( const tripoint &pos ) -> bool
+{
+    return get_map().mop_spills( pos );
+}
+
+auto mop_blindly( const tripoint &pos ) -> bool
+{
+    return one_in( 3 ) && get_map().mop_spills( pos );
+}
+
+} // namespace
+
+auto iuse::mop( player *p, item *it, bool, const tripoint & ) -> int
+{
+    const auto mop = p->is_blind() ? mop_blindly : mop_normal;
+    const auto xs = closest_points_first( p->pos(), 1 );
+
+    const int mopped_tiles = std::count_if( xs.begin(), xs.end(), mop );
+
     if( p->is_blind() ) {
         p->add_msg_if_player( m_info, _( "You move the mop around, unsure whether it's doing any good." ) );
-        p->moves -= 15;
-        if( one_in( 3 ) ) {
-            g->m.mop_spills( pnt );
-        }
-    } else if( g->m.mop_spills( pnt ) ) {
-        p->add_msg_if_player( m_info, _( "You mop up the spill." ) );
-        p->moves -= 15;
+    } else if( mopped_tiles == 0 ) {
+        p->add_msg_if_player( m_bad, _( "There's nothing to mop there." ) );
     } else {
-        return 0;
+        p->add_msg_if_player( m_info, _( "You mop up the spill." ) );
     }
+
+    p->moves -= 15 * mopped_tiles;
     return it->type->charges_to_use();
 }
 


### PR DESCRIPTION
## Purpose of change

make mopping wide area a bit less painful.

## Describe the solution

- removed restriction on mounts because if one can play [polo](https://en.wikipedia.org/wiki/Polo), one can mop.
- removed tile validity check in `iuse::mop` as it was checked again in `map::mop_spills` anyways.
- counts mopped tiles and uses time accordingly multiplied. it doesn't for charges because that seemed overly wasteful.

## Describe alternatives you've considered

- zone for mopping? ~~that'd be too much work~~
- it's a bad news for some who like to draw zombie blood art using carefully coordinated application of mops

## Testing

### Regular 3x3 mopping

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/28538e0b-57e9-4b46-a6d5-01ef1d74d94e

### Mopping while blind

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/a18f9e6a-5a2e-46cc-a3f2-16efcad15e8c

## Additional context

[original discussion on discord](https://discord.com/channels/830879262763909202/830916329053487124/1159633141665902602)