### PR TITLE
fix: use env. resist for `stun`, `blind`, `sap`, `paralysis`

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -932,7 +932,7 @@ void Creature::deal_projectile_attack( Creature *source, dealt_projectile_attack
         add_effect( effect_paralyzepoison, 5_minutes );
     }
 
-    const int stun_strength = get_stun_srength( proj, get_size() );
+    const int stun_strength = get_stun_srength( proj, get_size() ) - get_env_resist( bp_hit );
     if( stun_strength > 0 ) {
         add_effect( effect_stunned, 1_turns * rng( stun_strength / 2, stun_strength ) );
     }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -919,15 +919,25 @@ void Creature::deal_projectile_attack( Creature *source, dealt_projectile_attack
         }
     }
 
-    if( bp_hit == bodypart_str_id( "head" ) && proj.has_effect( ammo_effect_BLINDS_EYES ) ) {
+    // at least `dealt_dam` doesn't get mutated after this point
+    const int total_damage = dealt_dam.total_damage();
+    const int env_resist = get_env_resist( bp_hit );
+
+    const int blind_strength = bp_hit == bodypart_str_id( "head" )
+                               && proj.has_effect( ammo_effect_BLINDS_EYES ) ? total_damage - env_resist : 0;
+    if( blind_strength > 0 ) {
         // TODO: Change this to require bp_eyes
         add_env_effect( effect_blind, bp_eyes, 5, rng( 3_turns, 10_turns ) );
     }
 
-    if( proj.has_effect( ammo_effect_APPLY_SAP ) ) {
-        add_effect( effect_sap, 1_turns * dealt_dam.total_damage() );
+    const int sap_strength = proj.has_effect( ammo_effect_APPLY_SAP ) ? total_damage - env_resist : 0;
+    if( sap_strength > 0 ) {
+        add_effect( effect_sap, 1_turns * sap_strength );
     }
-    if( proj.has_effect( ammo_effect_PARALYZEPOISON ) && dealt_dam.total_damage() > 0 ) {
+
+    const int paralysis_strength = proj.has_effect( ammo_effect_PARALYZEPOISON )
+                                   ? total_damage - env_resist : 0;
+    if( paralysis_strength > 0 ) {
         add_msg_if_player( m_bad, _( "You feel poison coursing through your body!" ) );
         add_effect( effect_paralyzepoison, 5_minutes );
     }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -720,6 +720,31 @@ dealt_damage_instance hit_with_aoe( Creature &target, Creature *source, const da
 
 } // namespace ranged
 
+namespace
+{
+
+auto get_stun_srength( const projectile &proj, m_size size ) -> int
+{
+    const int stun_strength = proj.has_effect( ammo_effect_BEANBAG ) ? 4
+                              : proj.has_effect( ammo_effect_LARGE_BEANBAG ) ? 16
+                              : 0;
+
+    switch( size ) {
+        case MS_TINY:
+            return stun_strength * 4;
+        case MS_SMALL:
+            return stun_strength * 2;
+        case MS_MEDIUM:
+        default:
+            return stun_strength;
+        case MS_LARGE:
+            return stun_strength / 2;
+        case MS_HUGE:
+            return stun_strength / 4;
+    }
+}
+} // namespace
+
 /**
  * Attempts to harm a creature with a projectile.
  *
@@ -907,31 +932,8 @@ void Creature::deal_projectile_attack( Creature *source, dealt_projectile_attack
         add_effect( effect_paralyzepoison, 5_minutes );
     }
 
-    int stun_strength = 0;
-    if( proj.has_effect( ammo_effect_BEANBAG ) ) {
-        stun_strength = 4;
-    }
-    if( proj.has_effect( ammo_effect_LARGE_BEANBAG ) ) {
-        stun_strength = 16;
-    }
+    const int stun_strength = get_stun_srength( proj, get_size() );
     if( stun_strength > 0 ) {
-        switch( get_size() ) {
-            case MS_TINY:
-                stun_strength *= 4;
-                break;
-            case MS_SMALL:
-                stun_strength *= 2;
-                break;
-            case MS_MEDIUM:
-            default:
-                break;
-            case MS_LARGE:
-                stun_strength /= 2;
-                break;
-            case MS_HUGE:
-                stun_strength /= 4;
-                break;
-        }
         add_effect( effect_stunned, 1_turns * rng( stun_strength / 2, stun_strength ) );
     }
 


### PR DESCRIPTION
## Purpose of change

- fixes #2702

## Describe the solution

- extracted stun strength calculation logic.
- made environmental resist apply to `stun`, `blind`, `sap`, `paralysis`, so power armor doesn't get pwned by riot control platform

## Describe alternatives you've considered

centralize all damage mechanism and screm

## Testing

1. spawn riot control platform
2. turn on debug invincibility and confirm it get stunned. (maybe should add a `Debug Effect Repellant` mutation?)
3. spawn and wear heavy power armor (env. protection: 16)
4. turn off debug invincibility and confirm no stun is applied.

### Without env protection

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/280ff91c-1fac-4396-8037-58e92bddaada

### With env protection

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/6093efb5-7d50-4d24-890c-0736ba893bd3
