### PR TITLE
feat(content): power armored profession

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -14,6 +14,15 @@
   {
     "type": "item_group",
     "subtype": "collection",
+    "id": "army_mags_power_armor",
+    "entries": [
+      { "item": "heavy_plus_battery_cell", "ammo-item": "battery", "charges": 1250 },
+      { "item": "heavy_plus_battery_cell", "ammo-item": "battery", "charges": 1250 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
     "id": "charged_flashlight",
     "entries": [ { "item": "light_disposable_cell", "ammo-item": "battery", "charges": 300, "container-item": "flashlight" } ]
   },
@@ -871,6 +880,33 @@
       },
       "male": [ "boxer_shorts" ],
       "female": [ "sports_bra", "boxer_shorts" ]
+    }
+  },
+  {
+    "type": "profession",
+    "id": "power_armor_soldier",
+    "name": "Power Armor Soldier",
+    "description": "Those new plutonium power banks they were rolling out never arrived, nevermind the experimental new weapons, but at least your unit received the latest generation of powered armor.  The rest of your squad has fallen, but your gear might see you through.",
+    "points": 8,
+    "traits": [ "PROF_MILITARY" ],
+    "skills": [
+      { "level": 2, "name": "gun" },
+      { "level": 1, "name": "rifle" },
+      { "level": 2, "name": "melee" },
+      { "level": 1, "name": "stabbing" },
+      { "level": 2, "name": "mechanics" }
+    ],
+    "items": {
+      "both": {
+        "items": [ "power_armor_light", "power_armor_helmet_light", "power_armor_frame" ],
+        "entries": [
+          { "item": "heavy_plus_battery_cell", "charges": 2500, "container-item": "UPS_off" },
+          { "item": "two_way_radio", "contents-item": [ "battery_ups" ] },
+          { "item": "power_armor_chest_rig", "contents-group": "army_mags_power_armor" },
+          { "item": "knife_combat", "container-item": "power_armor_sheath" },
+          { "item": "m240", "ammo-item": "762_51_incendiary", "charges": 500, "custom-flags": [ "auto_wield" ] }
+        ]
+      }
     }
   },
   {

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -580,6 +580,7 @@
     "professions": [
       "soldier",
       "specops",
+      "power_armor_soldier",
       "bio_soldier",
       "bio_sniper",
       "bionic_spy",
@@ -660,7 +661,17 @@
     "description": "Despite all the soldiers, guns and minefields, the base you were on got overrun by the dead.  Everyone was ordered to fall back to the armory, but during all the chaos you got lost and you are now stuck in the warehouse all alone.  You are not sure if anyone made it to the armory, or if you are the last man alive.",
     "start_name": "Military Base Warehouse",
     "allowed_locs": [ "sloc_military_base_warehouse" ],
-    "professions": [ "unemployed", "soldier", "specops", "bio_soldier", "bio_sniper", "labtech", "medic", "mili_pilot" ],
+    "professions": [
+      "unemployed",
+      "soldier",
+      "specops",
+      "power_armor_soldier",
+      "bio_soldier",
+      "bio_sniper",
+      "labtech",
+      "medic",
+      "mili_pilot"
+    ],
     "flags": [ "CHALLENGE", "LONE_START" ]
   },
   {


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods): new item for <mod name>
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Adds an idea I'd been tinkering with for a bit. Best reserved for after https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3758 is merged since it'll affect the balancing of this profession.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

Added power armor solder profession. Starts with light power armor and supplementary gear to fill the niches military recruits get (storage, knife, two-way radio, helmet will provide the ear-pro so no earplugs). Starting skills takes the basics of military recruit but swaps the dodging for mechanics skill.

Equipment includes an M240, UPS (implying that rollout of advanced UPS wasn't 100% complete by the time of the cataclysm, because advanced UPS' balance is in a weird state due to https://github.com/cataclysmbnteam/Cataclysm-BN/issues/3765 but will be both more powerful yet harder to keep running even if this was fixed, so figuring out how it balances would be hard), and spare batteries in a magazine carrier. Loadout will exceed weight limit of a default strength-8 character while the armor is inactive, so either activate the armor in a pinch, find a cart to stow the 240 in outside of combat, or just pick Strong Back in chargen.

Additionally added the profession to heli crash and overrun scenarios.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Picking a weapon loadout that just barely fits within the strength limit of a default character. An M249 with the lightweight furniture kit just barely does if you don't start the belt fully loaded. An M27 IAR plus a pair of 100-round STANAG mags (replacing one of the spare batteries) does as well.
2. Going in the opposite direction, going full Brotherhood of Steel memery and swapping in either an M134 minigun or M2 Browning. It'd certainly be amusing, though not very effective at low skill levels without using mountable terrain instead of trying to hip-fire it in active armor, and choosing the minigun would drain UPS even faster in the process.
3. Making the profession scenario-locked to Overrun and other relevant scenarios. Currently all vanilla military professions except post-apoc ones like the holdouts are available in standard scenarios.
4. Messing with point cost further. Currently it uses the same point cost as bionic sniper, which is currently the highest point cost any profession in vanilla uses.
5. Saving this idea for after the relevant rebalancing and fixing of power armor is merged.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Played around with profession back when I was writing the JSON to see how it looks and that the gear and weight are set up as expected.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->