### PR TITLE
feat(balance): ammo pouch storage adjustments

### DIFF
--- a/data/json/items/armor/ammo_pouch.json
+++ b/data/json/items/armor/ammo_pouch.json
@@ -78,7 +78,7 @@
     "id": "ammo_satchel",
     "type": "ARMOR",
     "name": { "str": "ammo satchel" },
-    "description": "A fabric ammo bag worn at the waist which is capable of holding a single large magazine close at hand.",
+    "description": "A fabric ammo bag worn at the waist which is capable of holding a single magazine or speedloader close at hand, of nearly any size.",
     "weight": "180 g",
     "volume": "500 ml",
     "price": 2000,
@@ -95,9 +95,10 @@
       "type": "holster",
       "holster_prompt": "Stash ammo",
       "holster_msg": "You stash your %s.",
-      "max_volume": "1500 ml",
+      "min_volume": "250 ml",
+      "max_volume": "2 L",
       "draw_cost": 40,
-      "flags": [ "MAG_COMPACT", "MAG_BULKY" ]
+      "flags": [ "MAG_COMPACT", "MAG_BULKY", "SPEEDLOADER" ]
     },
     "flags": [ "WATER_FRIENDLY", "WAIST" ]
   },
@@ -122,6 +123,7 @@
       "type": "holster",
       "holster_prompt": "Stash ammo",
       "holster_msg": "You stash your %s.",
+      "multi": 2,
       "max_volume": "750 ml",
       "draw_cost": 40,
       "flags": [ "MAG_COMPACT", "SPEEDLOADER" ]

--- a/data/json/items/armor/bandolier.json
+++ b/data/json/items/armor/bandolier.json
@@ -194,7 +194,7 @@
   {
     "id": "grenade_pouch",
     "type": "ARMOR",
-    "name": { "str": "grenade pouch", "str_pl": "grenade pouches" },
+    "name": { "str": "grenade ammo pouch", "str_pl": "grenade ammo pouches" },
     "description": "A small pouch for storing cartridge grenades with straps for attaching it to your belt or other webbing.",
     "weight": "90 g",
     "volume": "250 ml",
@@ -208,7 +208,7 @@
     "coverage": 10,
     "encumbrance": 4,
     "material_thickness": 1,
-    "use_action": { "type": "bandolier", "capacity": 4, "ammo": [ "40x46mm", "40x53mm" ], "draw_cost": 20 },
+    "use_action": { "type": "bandolier", "capacity": 6, "ammo": [ "40x46mm", "40x53mm" ], "draw_cost": 20 },
     "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE" ]
   },
   {
@@ -235,7 +235,7 @@
   {
     "id": "grenadebandolier",
     "type": "ARMOR",
-    "name": { "str": "large grenade pouch", "str_pl": "large grenade pouches" },
+    "name": { "str": "hand grenade pouch", "str_pl": "hand grenade pouches" },
     "description": "A pouch for holding up to four full-sized grenades of various types.",
     "weight": "600 g",
     "volume": "1250 ml",
@@ -246,7 +246,7 @@
     "symbol": "[",
     "looks_like": "leather_belt",
     "color": "dark_gray",
-    "covers": [ "torso" ],
+    "covers": [ "leg_either" ],
     "coverage": 15,
     "material_thickness": 2,
     "use_action": {
@@ -254,7 +254,8 @@
       "holster_prompt": "Stash grenades",
       "holster_msg": "You stash your %s.",
       "multi": 4,
-      "max_volume": "750 ml",
+      "min_volume": "250 ml",
+      "max_volume": "1 L",
       "draw_cost": 30,
       "flags": [ "GRENADE" ]
     },

--- a/data/json/items/magazine/8x40mm.json
+++ b/data/json/items/magazine/8x40mm.json
@@ -53,7 +53,8 @@
     "ammo_type": "8x40mm",
     "capacity": 250,
     "reliability": 10,
-    "reload_time": 60
+    "reload_time": 60,
+    "flags": [ "MAG_BULKY" ]
   },
   {
     "id": "8x40_25_mag",
@@ -89,7 +90,8 @@
     "color": "dark_gray",
     "ammo_type": "8x40mm",
     "capacity": 500,
-    "reliability": 10
+    "reliability": 10,
+    "flags": [ "MAG_BULKY" ]
   },
   {
     "id": "8x40_50_mag",

--- a/data/json/items/magazine/chemical_spray.json
+++ b/data/json/items/magazine/chemical_spray.json
@@ -15,6 +15,7 @@
     "ammo_type": "chemical_spray",
     "capacity": 800,
     "reliability": 9,
-    "reload_time": 3
+    "reload_time": 3,
+    "flags": [ "MAG_BULKY" ]
   }
 ]

--- a/data/json/items/magazine/liquid.json
+++ b/data/json/items/magazine/liquid.json
@@ -15,7 +15,8 @@
     "ammo_type": "flammable",
     "capacity": 3000,
     "reliability": 9,
-    "reload_time": 3
+    "reload_time": 3,
+    "flags": [ "MAG_BULKY" ]
   },
   {
     "id": "aux_pressurized_tank",
@@ -52,7 +53,8 @@
     "ammo_type": "flammable",
     "capacity": 2000,
     "reliability": 10,
-    "reload_time": 3
+    "reload_time": 3,
+    "flags": [ "MAG_BULKY" ]
   },
   {
     "id": "rm4504",
@@ -70,6 +72,7 @@
     "ammo_type": "flammable",
     "capacity": 4000,
     "reliability": 10,
-    "reload_time": 3
+    "reload_time": 3,
+    "flags": [ "MAG_BULKY" ]
   }
 ]

--- a/data/json/items/magazine/weldgas.json
+++ b/data/json/items/magazine/weldgas.json
@@ -16,7 +16,7 @@
     "capacity": 60,
     "count": 60,
     "reliability": 10,
-    "flags": [ "NO_UNLOAD", "NO_RELOAD" ]
+    "flags": [ "NO_UNLOAD", "NO_RELOAD", "MAG_BULKY" ]
   },
   {
     "id": "weldtank",
@@ -35,6 +35,6 @@
     "capacity": 240,
     "count": 240,
     "reliability": 10,
-    "flags": [ "NO_UNLOAD", "NO_RELOAD" ]
+    "flags": [ "NO_UNLOAD", "NO_RELOAD", "MAG_BULKY" ]
   }
 ]

--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -31,7 +31,7 @@
     "symbol": "*",
     "color": "yellow",
     "use_action": "ACIDBOMB_ACT",
-    "flags": [ "ACT_ON_RANGED_HIT", "NPC_THROWN" ]
+    "flags": [ "ACT_ON_RANGED_HIT", "NPC_THROWN", "GRENADE" ]
   },
   {
     "id": "can_bomb",
@@ -58,7 +58,7 @@
       "menu_text": "Light fuse",
       "type": "transform"
     },
-    "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB", "NO_REPAIR" ]
+    "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB", "NO_REPAIR", "GRENADE" ]
   },
   {
     "id": "can_bomb_act",
@@ -95,7 +95,8 @@
     "material": [ "plastic" ],
     "symbol": ";",
     "color": "light_gray",
-    "use_action": "C4"
+    "use_action": "C4",
+    "flags": [ "GRENADE" ]
   },
   {
     "id": "c4armed",
@@ -148,7 +149,7 @@
       "menu_text": "Light fuse",
       "type": "transform"
     },
-    "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB" ]
+    "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB", "GRENADE" ]
   },
   {
     "id": "dynamite_act",
@@ -208,7 +209,7 @@
       "menu_text": "Light fuse",
       "type": "transform"
     },
-    "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB" ]
+    "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB", "GRENADE" ]
   },
   {
     "id": "dynamite_bomb_act",
@@ -330,7 +331,8 @@
       "need_fire": 1,
       "menu_text": "Light fuse",
       "type": "transform"
-    }
+    },
+    "flags": [ "GRENADE" ]
   },
   {
     "id": "improvised_demolition_charge_act",
@@ -376,7 +378,8 @@
     "material": "paper",
     "symbol": ";",
     "color": "red",
-    "use_action": "FIRECRACKER"
+    "use_action": "FIRECRACKER",
+    "flags": [ "GRENADE" ]
   },
   {
     "id": "firecracker_act",
@@ -413,7 +416,8 @@
     "initial_charges": 25,
     "max_charges": 25,
     "charges_per_use": 1,
-    "use_action": "FIRECRACKER_PACK"
+    "use_action": "FIRECRACKER_PACK",
+    "flags": [ "GRENADE" ]
   },
   {
     "id": "firecracker_pack_act",
@@ -553,7 +557,7 @@
       "menu_text": "Arm",
       "type": "transform"
     },
-    "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB" ]
+    "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB", "GRENADE" ]
   },
   {
     "id": "gasbomb_makeshift_act",
@@ -858,7 +862,7 @@
     "type": "TOOL",
     "name": { "str": "improvised grenade" },
     "looks_like": "makeshift_grenade",
-    "description": "A improvised explosive device cobbled together from parts.  Use this item light the fuse.  You will then have some amount of time before it explodes; throwing it would be a good idea.",
+    "description": "A improvised explosive device cobbled together from parts.  Use this item to light the fuse.  You will then have some amount of time before it explodes; throwing it would be a good idea.",
     "weight": "400 g",
     "price": 750,
     "material": [ "aluminum", "iron" ],
@@ -879,7 +883,7 @@
       "menu_text": "Light fuse",
       "type": "transform"
     },
-    "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB", "NPC_ACTIVATE" ]
+    "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB", "NPC_ACTIVATE", "GRENADE" ]
   },
   {
     "id": "improvised_grenade_act",
@@ -921,7 +925,7 @@
     "symbol": "*",
     "color": "light_green",
     "use_action": "MININUKE",
-    "flags": [ "LEAK_DAM", "RADIOACTIVE", "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB", "CLOSES_PORTAL" ]
+    "flags": [ "LEAK_DAM", "RADIOACTIVE", "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB", "GRENADE", "CLOSES_PORTAL" ]
   },
   {
     "id": "mininuke_act",
@@ -981,7 +985,7 @@
       "menu_text": "Light rag",
       "type": "transform"
     },
-    "flags": [ "NPC_ACTIVATE", "NO_REPAIR" ]
+    "flags": [ "NPC_ACTIVATE", "NO_REPAIR", "GRENADE" ]
   },
   {
     "id": "molotov_lit",
@@ -1035,7 +1039,7 @@
       "menu_text": "Light fuse",
       "type": "transform"
     },
-    "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB", "NPC_ACTIVATE" ]
+    "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB", "NPC_ACTIVATE", "GRENADE" ]
   },
   {
     "id": "improvised_pipebomb_act",
@@ -1181,7 +1185,7 @@
       "menu_text": "Light fuse",
       "type": "transform"
     },
-    "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB" ]
+    "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB", "GRENADE" ]
   },
   {
     "id": "tool_anfo_charge_act",
@@ -1248,7 +1252,7 @@
       "menu_text": "Light fuse",
       "type": "transform"
     },
-    "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB" ]
+    "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB", "GRENADE" ]
   },
   {
     "id": "tool_small_improvised_fragmentation_device_act",
@@ -1317,7 +1321,7 @@
       "menu_text": "Light fuse",
       "type": "transform"
     },
-    "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB" ]
+    "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB", "GRENADE" ]
   },
   {
     "id": "tool_improvised_barrel_bomb_act",
@@ -1380,7 +1384,7 @@
       "menu_text": "Light candy",
       "type": "transform"
     },
-    "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB" ]
+    "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB", "GRENADE" ]
   },
   {
     "id": "tool_rocket_candy_act",


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods): new item for <mod name>
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Some misc things that came to mind while looking at items and pondering ideas.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Added `MAG_BULKY` to the 250-round and 500-round 8x40 magazines. Nothing in vanilla can hold the 500-rounder currently, but this enables mods that might add more options to support them, along with consistency since all other 8x40mm mags have storage flags.
2. Added `MAG_BULKY` to fuel tanks for welding gas, chemicals, flamethrower fuel, etc lacking the flag already. Consistent with other hardware with military uses, namely batteries, getting storage flags and some flamethrower tanks already being storable.
3. Expanded the size range of the generic crappy ammo satchel, allowing it to hold any magazine or speedloader from 250 ml up to 2 liters. Reasoning being it's a waist-slot item that only holds a single mag, for nearly any other purpose all other magazine storage items tend to be a better choice. Also means a few bulky mags previously impossible to store in vanilla gain an option.
4. Set chest ammo pouch to allow holding two magazines. Being the makeshift counterpart to the chest rig (much like the ammo satchel is to the tac vest and ammo satchel in different ways), it's rather underwhelming due to being a strapped-slot item with a relatively narrow magazine selection compared to the glorious tac vest.
5. Renamed grenade pouch to grenade ammo pouch to make it more clear what it's meant to hold, and increased capacity from 4 to 6. I'd buffed most bandoliers previously but overlooked this one, even after having similarly buffed wrist bandoliers from 4 to 6 as well.
6. Renamed large grenade pouch to hand grenade pouch to help distinguish their functions better, moved it to the leg slot like grenade ammo pouches and stone pouches, and increased its max size to 1 liter to stow EMP bombs and C-4. Given all of them are strapped-slot items, having a grenade pouch compete with your backback is less than ideal.
7. Added the grenade flag to most explosive items that lacked it, allowing the ones 750 ml or below to become stowable in the hand grenade pouch. Bigger ones to have gained the flag of course will be stowable should any mod add larger hand grenade pouches. Even the mininuke, should some lunatic design a pouch big enough for it. The EMP bomb was already given this flag despite being bigger than its capcity previously allowed.
8. MISC: Fixed a typo in description for makeshift grenade I spotted along the way.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Moving the chest ammo pouch and chest rig to waist slot, on the basis that the tac vest is basically better than either in every way, being able to hold a better selection of magazines and occupying the silver-medal spot of the torso waist instead of taking up the number one vital location of strapped-torso. We'd need to play around with number of mags stored and size ranges to make them more distinct if so.
2. Buffing capacity of hand grenade pouches too. Given it's geared to hold pretty big explosives I figured it's more reasonable for it to stay at only 4, as a contrast with the grenade ammo pouch which holds more but smaller ammo (40x53mm being a bit above 250ml each).

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Tested adding `MAG_BULKY` to the 500-round 8x40mm mag in my test build to make sure that an item that has a storage flag but can't be stowed in any item doesn't somehow do any weird shit.
2. Checked affected files for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Being able to chuck ammo belts in storage items might be nice. Only problem with that is their volume varies with how many links it has, so whether a belt will be stashable in any given pouch will vary wildly for reasons the player has to bend over backwards to consciously manipulate (reloading an ammo belt to an exact amount instead of stopping at the maximum attainable requires dropping an exact amount of links beforehand). Too few links on you and it won't be big enough to fit in your pouch, load too many and it'd quickly get too big...

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->