### PR TITLE
fix(content): update Joint Servo CBM descriptions

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1071,7 +1071,7 @@
     "id": "bio_jointservo",
     "type": "bionic",
     "name": { "str": "Joint Servo" },
-    "description": "Your leg joints have been equipped with servomotors that provide power-assisted movement.  They are optimized for running, but walking also requires less effort. When unpowered, the bionic still improves your speed slightly by balancing your gait and preventing incorrect or excessive movements.",
+    "description": "Your leg joints have been equipped with servomotors that provide power-assisted movement.  They are optimized for running, but walking also requires less effort.  When unpowered, the bionic still improves your speed slightly by balancing your gait and preventing incorrect or excessive movements.",
     "occupied_bodyparts": [ [ "leg_l", 12 ], [ "leg_r", 12 ] ],
     "flags": [ "BIONIC_TOGGLED" ],
     "trigger_cost": "35 J"

--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1071,7 +1071,7 @@
     "id": "bio_jointservo",
     "type": "bionic",
     "name": { "str": "Joint Servo" },
-    "description": "Your leg joints have been equipped with servomotors that provide power-assisted movement.  They are optimized for running, but walking also requires less effort when this bionic is online.  Even when they're offline, the servos balances your gait.",
+    "description": "Your leg joints have been equipped with servomotors that provide power-assisted movement.  They are optimized for running, but walking also requires less effort. When unpowered, the bionic still improves your speed slightly by balancing your gait and preventing incorrect or excessive movements.",
     "occupied_bodyparts": [ [ "leg_l", 12 ], [ "leg_r", 12 ] ],
     "flags": [ "BIONIC_TOGGLED" ],
     "trigger_cost": "35 J"

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -976,7 +976,7 @@
     "type": "BIONIC_ITEM",
     "name": { "str": "Joint Servo CBM" },
     "looks_like": "bio_int_enhancer",
-    "description": "A set of servomotors that get installed on leg joints to provide power-assisted movement.  They are optimized for running, but walking also requires less effort while this bionic is active. In passive mode, it provides a smaller benefit by enforcing optimal movement technique.",
+    "description": "A set of servomotors that get installed on leg joints to provide power-assisted movement.  They are optimized for running, but walking also requires less effort while this bionic is active.  In passive mode, it provides a smaller benefit by enforcing optimal movement technique.",
     "price": 450000,
     "weight": "1000 g",
     "difficulty": 4

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -976,7 +976,7 @@
     "type": "BIONIC_ITEM",
     "name": { "str": "Joint Servo CBM" },
     "looks_like": "bio_int_enhancer",
-    "description": "A set of servomotors that get installed on leg joints to provide power-assisted movement.  They are optimized for running, but walking also requires less effort while this bionic is active.  However, when it's offline it will hamper the user's movement.",
+    "description": "A set of servomotors that get installed on leg joints to provide power-assisted movement.  They are optimized for running, but walking also requires less effort while this bionic is active. In passive mode, it provides a smaller benefit by enforcing optimal movement technique.",
     "price": 450000,
     "weight": "1000 g",
     "difficulty": 4


### PR DESCRIPTION
## Purpose of change

#2694 made the Joint Servo CBM all-positive with no tradeoffs, but the item description doesn't reflect that.

## Describe the solution

Updated the description for the Joint Servo CBM's item form to make clear that it provides a lesser bonus instead of a malus when turned off. Also while at it, slightly changed the installed form's description to expand on the idea (which is that the system enforces correct running technique, so it's beneficial even when not directly providing extra power).

## Describe alternatives you've considered

Staying away from a useful upgrade due to misleading description.

## Testing

Made sure JSON syntax is not affected by the change. Made sure the game loads and the description changes are present.