### PR TITLE
feat(balance): assorted profession updates

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -23,6 +23,15 @@
   {
     "type": "item_group",
     "subtype": "collection",
+    "id": "army_mags_rm51",
+    "entries": [
+      { "item": "8x40_50_mag", "ammo-item": "8mm_caseless", "charges": 50 },
+      { "item": "8x40_50_mag", "ammo-item": "8mm_caseless", "charges": 50 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
     "id": "charged_flashlight",
     "entries": [ { "item": "light_disposable_cell", "ammo-item": "battery", "charges": 300, "container-item": "flashlight" } ]
   },
@@ -632,26 +641,15 @@
     "type": "profession",
     "id": "mechanic",
     "name": "Home Mechanic",
-    "description": "Although you never got your driver's license, you've always loved cars.  At least now you'll never be wanting for materials.",
+    "description": "You've always loved working on cars, and have been eager to tune up something special one of these days.  At least now you'll never be wanting for materials.",
     "points": 2,
     "skills": [ { "level": 3, "name": "mechanics" } ],
     "items": {
       "both": {
-        "items": [
-          "slingpack",
-          "tank_top",
-          "jeans",
-          "socks",
-          "boots_steel",
-          "duct_tape",
-          "smart_phone",
-          "screwdriver",
-          "wristwatch",
-          "mag_cars"
-        ],
+        "items": [ "slingpack", "tank_top", "jeans", "socks", "boots_steel", "duct_tape", "smart_phone", "wristwatch", "mag_cars" ],
         "entries": [
           { "item": "goggles_welding", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "wrench", "container-item": "tool_belt" },
+          { "item": "tool_belt", "contents-item": [ "wrench", "screwdriver" ] },
           { "item": "medium_battery_cell", "ammo-item": "battery", "charges": 500, "container-item": "welder" }
         ]
       },
@@ -795,8 +793,8 @@
   {
     "type": "profession",
     "id": "soldier",
-    "name": "Military Recruit",
-    "description": "You were a high school drop-out with one goal in mind: to join the military.  You finally got in, just in time for your training to get interrupted by a national emergency.  As far as you can tell, military command abandoned you in this hellhole when you missed the emergency evac.",
+    "name": "Military Rifleman",
+    "description": "You were hoping to see some action, only to get more than you bargained for deployed stateside responding to a national emergency.  As far as you can tell, military command abandoned you to this hellhole.",
     "points": 4,
     "traits": [ "PROF_MILITARY" ],
     "skills": [
@@ -810,22 +808,25 @@
       "both": {
         "items": [
           "pants_army",
-          "undershirt",
+          "tshirt",
           "jacket_army",
+          "helmet_liner",
           "helmet_army",
-          "mask_ski",
           "gloves_liner",
           "gloves_tactical",
           "socks",
           "boots_combat",
           "wristwatch",
+          "canteen",
           "molle_pack"
         ],
         "entries": [
           { "group": "charged_two_way_radio" },
-          { "item": "modularvest", "contents-group": "army_mags_m4" },
+          { "item": "modularvestceramic", "contents-group": "army_mags_m4" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
+          { "item": "e_tool", "container-item": "webbing_belt" },
           { "item": "knife_combat", "container-item": "sheath" },
+          { "item": "grenadebandolier", "contents-item": [ "grenade", "grenade" ] },
           { "item": "m4a1", "ammo-item": "556", "charges": 30, "contents-item": [ "shoulder_strap", "holo_sight" ] }
         ]
       },
@@ -901,6 +902,7 @@
         "items": [ "power_armor_light", "power_armor_helmet_light", "power_armor_frame" ],
         "entries": [
           { "item": "heavy_plus_battery_cell", "charges": 2500, "container-item": "UPS_off" },
+          { "item": "canteen", "custom-flags": [ "no_auto_equip" ] },
           { "item": "two_way_radio", "contents-item": [ "battery_ups" ] },
           { "item": "power_armor_chest_rig", "contents-group": "army_mags_power_armor" },
           { "item": "knife_combat", "container-item": "power_armor_sheath" },
@@ -1791,13 +1793,13 @@
     "type": "profession",
     "id": "electrician",
     "name": "Electrician",
-    "description": "You used to work for some small-time business owners doing minor electrical work, and you just so happened to be working on one of these jokes of an evac shelter when the Cataclysm struck.  Unfortunately, you didn't finish wiring anything up except the computer - fat lot of good it's doing you now.",
+    "description": "You used to work for some small-time business owners doing minor electrical work, and were on your way to another trivial job when the Cataclysm struck.  The power's out, but if you survive long enough you might be able to improvise.",
     "points": 1,
     "skills": [ { "level": 3, "name": "electronics" } ],
     "items": {
       "both": {
-        "items": [ "jumpsuit", "socks", "smart_phone", "boots", "tool_belt", "wristwatch" ],
-        "entries": [ { "group": "charged_flashlight" } ]
+        "items": [ "jumpsuit", "socks", "smart_phone", "boots", "wristwatch" ],
+        "entries": [ { "item": "tool_belt", "contents-item": [ "voltmeter", "soldering_iron" ] }, { "group": "charged_flashlight" } ]
       },
       "male": [ "boxer_briefs" ],
       "female": [ "bra", "panties" ]
@@ -2199,25 +2201,30 @@
       "both": {
         "items": [
           "winter_pants_army",
+          "tshirt",
           "winter_jacket_army",
           "winter_gloves_army",
           "mask_ski",
-          "tac_helmet",
+          "helmet_army",
           "socks",
           "boots_combat",
-          "wristwatch"
+          "wristwatch",
+          "canteen",
+          "rucksack"
         ],
         "entries": [
           { "group": "charged_two_way_radio" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "sheath", "contents-item": "knife_combat" },
+          { "item": "e_tool", "container-item": "webbing_belt" },
+          { "item": "knife_combat", "container-item": "sheath" },
+          { "item": "grenadebandolier", "contents-item": [ "grenade", "grenade_emp" ] },
           {
-            "item": "h&k416a5",
-            "ammo-item": "556",
-            "charges": 30,
+            "item": "rm51_assault_rifle",
+            "ammo-item": "8mm_caseless",
+            "charges": 50,
             "contents-item": [ "shoulder_strap", "acog_scope" ]
           },
-          { "item": "modularvestceramic", "contents-group": "army_mags_m4" }
+          { "item": "modularvestceramic", "contents-group": "army_mags_rm51" }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -2254,12 +2261,12 @@
       "both": {
         "items": [
           "winter_pants_army",
-          "army_top",
+          "tshirt",
           "winter_jacket_army",
-          "gloves_tactical",
+          "winter_gloves_army",
           "rucksack",
-          "cloak",
           "mask_ski",
+          "tac_helmet",
           "socks",
           "boots_combat",
           "canteen",
@@ -2273,17 +2280,16 @@
           { "item": "medium_plus_battery_cell", "ammo-item": "battery", "charges": 600, "container-item": "mil_mess_kit" },
           { "group": "charged_two_way_radio" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "hat_boonie", "custom-flags": [ "no_auto_equip" ] },
+          { "item": "knife_hunting", "container-item": "sheath" },
           {
-            "item": "m2010",
-            "ammo-item": "300_winmag",
-            "charges": 5,
-            "contents-item": [ "shoulder_strap", "rifle_scope", "bipod" ]
+            "item": "rm11b_sniper_rifle",
+            "ammo-item": "8mm_caseless",
+            "charges": 10,
+            "contents-item": [ "shoulder_strap", "bipod" ]
           },
           { "item": "usp_45", "ammo-item": "45_acp", "charges": 12, "container-item": "holster" },
-          { "item": "usp45mag", "ammo-item": "45_acp", "charges": 12 },
-          { "item": "usp45mag", "ammo-item": "45_acp", "charges": 12 },
-          { "item": "tacvest", "contents-group": [ "army_mags_m2010" ] }
+          { "item": "legpouch_large", "contents-group": "army_mags_usp45" },
+          { "item": "tacvest", "contents-group": [ "army_mags_rm11b" ] }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -3516,19 +3522,28 @@
         "items": [
           "socks",
           "pants_army",
+          "tshirt",
           "jacket_army",
-          "balclava",
           "boots_combat",
+          "gloves_liner",
           "gloves_tactical",
-          "tac_helmet",
+          "helmet_liner",
+          "helmet_army",
           "canteen",
           "wristwatch",
           "quikclot"
         ],
         "entries": [
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
+          { "item": "e_tool", "container-item": "webbing_belt" },
           { "item": "knife_combat", "container-item": "sheath" },
-          { "item": "m4a1", "ammo-item": "556", "contents-item": "shoulder_strap" },
+          { "item": "grenadebandolier", "contents-item": [ "grenade", "grenade" ] },
+          {
+            "item": "m4a1",
+            "ammo-item": "556",
+            "charges": [ 1, 30 ],
+            "contents-item": [ "shoulder_strap", "holo_sight" ]
+          },
           {
             "item": "medium_plus_battery_cell",
             "ammo-item": "battery",
@@ -3536,7 +3551,7 @@
             "container-item": "mil_mess_kit"
           },
           { "group": "charged_two_way_radio" },
-          { "item": "chestrig", "contents-group": "army_mags_m4" }
+          { "item": "modularvestceramic", "contents-group": "army_mags_m4" }
         ]
       },
       "male": [ "boxer_shorts" ],

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -1798,6 +1798,7 @@
     "skills": [ { "level": 3, "name": "electronics" } ],
     "items": {
       "both": {
+        "ammo": 100,
         "items": [ "jumpsuit", "socks", "smart_phone", "boots", "wristwatch" ],
         "entries": [ { "item": "tool_belt", "contents-item": [ "voltmeter", "soldering_iron" ] }, { "group": "charged_flashlight" } ]
       },

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -902,7 +902,6 @@
         "items": [ "power_armor_light", "power_armor_helmet_light", "power_armor_frame" ],
         "entries": [
           { "item": "heavy_plus_battery_cell", "charges": 2500, "container-item": "UPS_off" },
-          { "item": "canteen", "custom-flags": [ "no_auto_equip" ] },
           { "item": "two_way_radio", "contents-item": [ "battery_ups" ] },
           { "item": "power_armor_chest_rig", "contents-group": "army_mags_power_armor" },
           { "item": "knife_combat", "container-item": "power_armor_sheath" },

--- a/data/mods/Fuji_Mil_Prof/prof/army.json
+++ b/data/mods/Fuji_Mil_Prof/prof/army.json
@@ -1,42 +1,6 @@
 [
   {
     "type": "profession",
-    "id": "mil_rifleman",
-    "name": "Military Rifleman",
-    "description": "Frontline infantry, frontline infantry, frontline infantry, frontline infantry.",
-    "points": 2,
-    "traits": [ "PROF_MILITARY" ],
-    "skills": [ { "level": 1, "name": "survival" }, { "level": 1, "name": "gun" }, { "level": 1, "name": "rifle" } ],
-    "items": {
-      "both": {
-        "items": [
-          "tac_helmet",
-          "jacket_army",
-          "pants_army",
-          "longshirt",
-          "rucksack",
-          "glasses_bal",
-          "dump_pouch",
-          "knee_pads",
-          "elbow_pads",
-          "socks",
-          "boots_combat",
-          "gloves_tactical"
-        ],
-        "entries": [
-          { "item": "m4a1", "ammo-item": "556", "charges": 30, "contents-item": [ "shoulder_strap", "acog_scope", "grip" ] },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "modularvestceramic", "contents-group": "army_mags_m4" },
-          { "item": "knife_combat", "container-item": "sheath" },
-          { "item": "m17", "ammo-item": "9mm", "charges": 17, "container-item": "holster" }
-        ]
-      },
-      "male": [ "boxer_shorts" ],
-      "female": [ "boy_shorts", "sports_bra" ]
-    }
-  },
-  {
-    "type": "profession",
     "id": "mil_marksman",
     "name": "Military Marksman",
     "description": "You like to think you're a real sniper, but really you're just infantry with a bigger gun.",

--- a/data/mods/Fuji_Mil_Prof/scenarios.json
+++ b/data/mods/Fuji_Mil_Prof/scenarios.json
@@ -4,7 +4,6 @@
     "type": "scenario",
     "extend": {
       "professions": [
-        "mil_rifleman",
         "mil_marksman",
         "mil_auto_rifleman",
         "mil_grenadier",
@@ -23,7 +22,6 @@
     "type": "scenario",
     "extend": {
       "professions": [
-        "mil_rifleman",
         "mil_marksman",
         "mil_auto_rifleman",
         "mil_grenadier",


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Some assorted adjustments to professions for modernization and consistency. Also sets things up so in the future I can start adding some more military professions too.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Set it so that electrician spawns with a voltmeter, soldering iron in their toolbelt, those being the basic tools needed to expand a grid connection. Reworded the profession description to not be something that only makes sense in the evacuee scenario.
2. Stashed the home mechanic's screwdriver in their toolbelt. Updated description of home mechanic to not insist you don't have a driver's license. Profession doesn't start with driving skill, but the player can obviously start with points in the skill anyway, making it a weird detail to emphasis.
3. Renamed the military recruit to military rifleman, to reflavor as the basic bog-standard soldier profession. Tweaked its starting gear to fix some oddities, mainly swapping ski mask for helmet liner (as they don't spawn in a winter set) and t-shirt for undershirt (to not clash with underwear on female version, and because modern ACUs and MCCUUs can come with a plain t-shirt under the jacket/blouse), plus adding glove liners. Gave them a canteen as this is a basic utility item and a common soldier drop (empty for now, see below). Added a webbing belt with entrenching tool. Finally, added a hand grenade pouch with a pair of grenades in it. This now makes them start with all the basic gear that would be expected of typical bog-standard infantry.
4. Adjusted the uniforms of all other uninformed military professions accordingly (liner items unless the profession uses winter gear, t-shirt instead of undershirt, canteen, webbing belt where feasible, grenade pouch for basic grunts, etc). Bionic soldier in particular gets one frag grenade and one EMP grenade instead of two frag grenades.
5. Swapped the primary weapons of bionic soldier and bionic sniper to Rivtech guns, on the basis of them likely being the only ones who actually got a shot at running trials on 8x40mm weaponry before the Cataclysm hit, seeing as 8x40mm shows up in typical milspec itemgroups but not as a regular soldier drop. While a boost to their raw firepower, it also puts a handicap on them in the midgame via making them have to worry about finding a more commonly-used weapon before they run dry.
6. Deleted military rifleman from Fuji's mod as it's functionally redundant. Some of their professions will get mainlined later on and will need their gear modernized too.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Making electrician stay a 1-point profession while actually getting the basic tools they logically should've used to do a job on site, when home mechanic and blacksmith starts with some basic tools and accordingly are 2-point professions.
2. Also replacing the bionic sniper's pistol with the 5mm needle pistol so their gear is all futuretech, instead of a more balanced mix of futuretech primary with a standard sidearm.
3. Adjusting point cost of rifleman to match the 5-point cost of the Fujimod version. Would put it just under the bionic soldier though which gets a fair bit more, so hmm.
4. Standardizing MBR vests in professions around spawning with no plates instead of ceramic.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Loaded up a save with the Fujimod rifleman profession that I made prior to removing the profession, to confirm that doesn't cause any issues.
2. Checked affected files for syntax and lint errors.
3. Confirmed that electrician correctly spawns with a soldering iron and voltmeter that both have batteries in them.
4. Confirmed that home mechanic's tools spawn in tool belt.
5. Confirmed that military rifleman's gear looks as expected.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

There are some related DDA PRs we could take additional influence from:
1. https://github.com/CleverRaven/Cataclysm-DDA/pull/49142 by @Tairesh specifically gives military professions a filled canteen. Nice lil flavor bonus but most professions in the game don't get that benefit even when they (presumably) still require hydration while vibing in the limbo before game start, so it may seem inconsistent?
2. https://github.com/CleverRaven/Cataclysm-DDA/pull/45359 by @Beneficial-Insurance, in addition to being a partial mainlining of Fuji mod (mostly via having a redundant rifleman profession while still keeping recruit) and adding several new professions, buffed starting skills of military professions in the interest of realism. Reasonable arguably, but balanc-wise BN still cares about point cost so it may be a bit much for our taste without warranting tweaks to profession costs, plus it becomes inconsistent when all other professions have basically no skill investment at all.

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
