### PR TITLE
fix: repair nanobots not working at all on broken limbs

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -661,7 +661,7 @@
     "id": "bio_nanobots",
     "type": "bionic",
     "name": { "str": "Repair Nanobots" },
-    "description": "Inside your body is a fleet of tiny dormant robots.  While activated they will reduce the intensity of one bleed effect every 30 seconds, and heal all injured body parts by 1 HP (or broken limbs by 1%) every 2 minutes if you have 3 kJ bionic power and 5 kcal per body part.  Broken limbs must still be splinted (unless you have specific mutations) to benefit.  If you don't have enough, they will prioritize based on the resources you have.",
+    "description": "Inside your body is a fleet of tiny dormant robots.  While activated they will reduce the intensity of one bleed effect every 30 seconds, and heal all injured body parts by 1 HP (or broken limbs by 1%) every 2 minutes if you have 3 kJ bionic power and 5 kcal per body part.  If you don't have enough, they will prioritize based on the resources you have.",
     "occupied_bodyparts": [ [ "torso", 10 ] ],
     "flags": [ "BIONIC_TOGGLED", "BIONIC_NPC_USABLE", "BIONIC_SLEEP_FRIENDLY" ],
     "act_cost": "300 J",

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -610,7 +610,7 @@
     "type": "BIONIC_ITEM",
     "name": { "str": "Repair Nanobots CBM" },
     "looks_like": "bio_int_enhancer",
-    "description": "A fleet of tiny dormant robots.  While activated they will reduce the intensity of one bleed effect every 30 seconds, and heal all injured body parts by 1 HP (or broken limbs by 1%) every 2 minutes if you have 3 kJ bionic power and 5 kcal per body part.  Broken limbs must still be splinted (unless you have specific mutations) to benefit.  If you don't have enough, they will prioritize based on the resources you have.",
+    "description": "A fleet of tiny dormant robots.  While activated they will reduce the intensity of one bleed effect every 30 seconds, and heal all injured body parts by 1 HP (or broken limbs by 1%) every 2 minutes if you have 3 kJ bionic power and 5 kcal per body part.  If you don't have enough, they will prioritize based on the resources you have.",
     "price": "9500 USD",
     "weight": "200 g",
     "difficulty": 6

--- a/src/regen.cpp
+++ b/src/regen.cpp
@@ -1,0 +1,35 @@
+#include "regen.h"
+#include "character.h"
+#include "rng.h"
+
+const flag_id flag_SPLINT( "SPLINT" );
+
+namespace
+{
+
+/// Limb is broken without splint
+auto has_broken_limb_penalty( const Character &c, const bodypart_id &bp ) -> bool
+{
+    return c.is_limb_broken( bp )
+           && !c.worn_with_flag( flag_SPLINT, bp );
+}
+
+/// Broken limbs without splint heal slower up to 25%
+auto mending_modifier( const Character &c ) -> float
+{
+    return clamp( c.mutation_value( "mending_modifier" ), 0.25f, 1.0f );
+}
+
+} // namespace
+
+auto heal_adjusted( Character &c, const bodypart_id &bp, const int heal ) -> int
+{
+    const float broken_regen_mod = mending_modifier( c );
+    const int broken_heal = roll_remainder( heal * broken_regen_mod );
+    const bool is_broken = has_broken_limb_penalty( c, bp );
+    const int actual_heal = is_broken ? broken_heal : heal;
+
+    c.heal( bp, actual_heal );
+
+    return actual_heal;
+}

--- a/src/regen.h
+++ b/src/regen.h
@@ -1,0 +1,18 @@
+#pragma once
+#ifndef CATA_SRC_REGEN_H
+#define CATA_SRC_REGEN_H
+
+#include "type_id.h"
+
+class Character;
+
+/// like heal, but actually takes account of
+/// - whether limb suffers from being broken without splint
+/// - `mending_modifier`
+///
+/// @return actually healed amount. used for `mod_part_healed_total`
+///
+/// TODO: merge into `Character::heal`?
+auto heal_adjusted( Character &c, const bodypart_id &bp, const int heal ) -> int;
+
+#endif // CATA_SRC_REGEN_H


### PR DESCRIPTION
## Purpose of change

- fixes #3786 

## Describe the solution

1. removed mentions of repair nanobots requiring splints (so its behavior matches with #3054)
2. extracted `is_broken` logic into `has_broken_limb_penalty`. hidden ATM to encourage encap?sulation in future
3. extracted `broken_heal` logic into `heal_adjusted`. it takes account of whether limb gets penalty from being broken and not splinted.
4. made repair nanobot logic use `heal_adjusted`.

## Describe alternatives you've considered

- making `heal_adjusted` the default behavior of `character::heal`

## Testing

in both cases player waited ~6 hours with arms broken and repair nanobots active.

### Without Splints

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/a930e87e-d247-4581-9d1b-08602a442e11

it heals slowly.

### With Splints

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/8803bcc4-0aea-4606-a726-fca440bffa0b

it heals quickly.

## Additional context

- bodypart health logic is getting messier.
- spent 40 minutes figuring out why no changes/breakpoints was made after code changes, only to find out cmake changed emitting files from `./cataclysm-tiles` into `build/src/cataclysm-tiles`
- also hecc, i made the PR on my main branch