### PR TITLE
feat(balance): Make slimesprings avoid traps

### DIFF
--- a/data/json/monsters/slimes.json
+++ b/data/json/monsters/slimes.json
@@ -173,6 +173,6 @@
     "harvest": "exempt",
     "special_attacks": [ [ "SLIMESPRING", 15 ] ],
     "death_function": [ "ACID" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "GOODHEARING", "NOHEAD", "POISON", "VENOM", "WARM", "GUILT", "PATH_AVOID_DANGER_1" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "GOODHEARING", "NOHEAD", "POISON", "VENOM", "WARM", "GUILT", "PATH_AVOID_DANGER_2" ]
   }
 ]

--- a/data/json/monsters/slimes.json
+++ b/data/json/monsters/slimes.json
@@ -173,6 +173,6 @@
     "harvest": "exempt",
     "special_attacks": [ [ "SLIMESPRING", 15 ] ],
     "death_function": [ "ACID" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "GOODHEARING", "NOHEAD", "POISON", "VENOM", "WARM", "GUILT" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "GOODHEARING", "NOHEAD", "POISON", "VENOM", "WARM", "GUILT", "PATH_AVOID_DANGER_1" ]
   }
 ]


### PR DESCRIPTION
## Purpose of change

As pointed out by a member in the Discord, slimesprings don't currently avoid traps. Fixing this seems like a no-brainer to me, since I doubt it's intended for the cute lil guys to be walking into traps like that.

## Describe the solution

Adds `"PATH_AVOID_DANGER_1"` to the slimespring. This *should* fix the issue, assuming this flag does what I assume it does.

## Describe alternatives you've considered

None

## Testing

Admittedly, none. However, I hope this is a simple enough fix that, in the words of a certain man, "It just works."

## Additional context

Another user suggested [changing the aggression of the slimesprings](https://github.com/cataclysmbnteam/Cataclysm-BN/discussions/3794) so that they aren't so hostile towards non-hostile monsters, but I have no clue what the correct aggression value for that would be.
