### PR TITLE
feat: debug infinite stamina

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -6362,6 +6362,15 @@
   },
   {
     "type": "mutation",
+    "id": "DEBUG_STAMINA",
+    "name": { "str": "Debug Infinite Stamina" },
+    "points": 99,
+    "valid": false,
+    "description": "Lets you run forever (in other words, until you fix that bug).",
+    "debug": true
+  },
+  {
+    "type": "mutation",
     "id": "SQUEAMISH",
     "name": { "str": "Squeamish" },
     "points": -1,

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -227,6 +227,7 @@ static const trait_id trait_BADBACK( "BADBACK" );
 static const trait_id trait_CF_HAIR( "CF_HAIR" );
 static const trait_id trait_GLASSJAW( "GLASSJAW" );
 static const trait_id trait_DEBUG_NODMG( "DEBUG_NODMG" );
+static const trait_id trait_DEBUG_STAMINA( "DEBUG_STAMINA" );
 static const trait_id trait_DEFT( "DEFT" );
 static const trait_id trait_PROF_SKATER( "PROF_SKATER" );
 static const trait_id trait_QUILLS( "QUILLS" );
@@ -7578,6 +7579,10 @@ void Character::mod_rad( int mod )
 
 int Character::get_stamina() const
 {
+    if( has_trait( trait_DEBUG_STAMINA ) ) {
+        return get_stamina_max();
+    }
+
     return stamina;
 }
 


### PR DESCRIPTION
## Purpose of change

sometimes it's useful to have infinite stamina to test stuff (e.g testing marathon achievement).

## Describe the solution

added `Debug Infinite Stamina` trait, which lets you... have infinite stamina.

works by hooking into `Character::get_stamina` and returning max stamina

## Describe alternatives you've considered

might affect performance negatively.

## Testing

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/11c06153-566d-4301-96b3-67dec6b2de52)

ran some few hundred tiles. stamina was full.