### PR TITLE
fix: only increase noise when vehicle is airborne

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4051,7 +4051,7 @@ void vehicle::noise_and_smoke( int load, time_duration time )
         spew_field( mufflesmoke, exhaust_part, fd_smoke,
                     bad_filter ? fd_smoke.obj().get_max_intensity() : 1 );
     }
-    if( is_rotorcraft() ) {
+    if( is_flying && is_rotorcraft() ) {
         noise *= 2;
     }
     // Cap engine noise to avoid deafening.


### PR DESCRIPTION
## Purpose of change

- fix #3583

## Describe the solution

https://github.com/cataclysmbnteam/Cataclysm-BN/blob/2703a29ff42c6961cc57193c26dca6229804dde7/src/vehicle.cpp#L4054-L4056

make it only double noises if it's actually airborne.

## Describe alternatives you've considered

making the rotor toggleable, but i think this effectively achieves the same.

## Testing

### On ground

![Cataclysm: Bright Nights - 2703a29ff42c_01](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/72191836-138e-4d36-86c3-e46d2427ee2d)

### Airborne

![Cataclysm: Bright Nights - 2703a29ff42c_02](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/314d0dd4-7c62-4131-833f-60d60c729413)

## Additional context

cc @Krwak