### PR TITLE
feat(balance): NPCs can now help push vehicles, adjustments to wooden cart wheels

### DIFF
--- a/data/json/vehicleparts/wheel.json
+++ b/data/json/vehicleparts/wheel.json
@@ -617,7 +617,7 @@
     },
     "rolling_resistance": 2.15,
     "wheel_type": "rigid",
-    "contact_area": 60,
+    "contact_area": 100,
     "flags": [ "WHEEL", "NEEDS_JACKING" ],
     "damage_reduction": { "all": 14 }
   },

--- a/data/json/vehicles/military.json
+++ b/data/json/vehicles/military.json
@@ -631,9 +631,9 @@
       [ " H" ]
     ],
     "parts": [
-      { "x": 0, "y": 0, "parts": [ "frame_cross", "turret_mount", "mounted_3in_ordnance_rifle" ] },
-      { "x": 0, "y": -1, "parts": [ "frame_horizontal", "wheel_wood_b" ] },
-      { "x": 0, "y": 1, "parts": [ "frame_horizontal", "wheel_wood_b" ] },
+      { "x": 0, "y": 0, "parts": [ "frame_wood_cross", "turret_mount", "mounted_3in_ordnance_rifle" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_wood_horizontal", "wheel_wood_b" ] },
+      { "x": 0, "y": 1, "parts": [ "frame_wood_horizontal", "wheel_wood_b" ] },
       { "x": -1, "y": 0, "parts": [ "frame_wood_handle" ] }
     ]
   }

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -7,6 +7,7 @@
 
 #include "avatar.h"
 #include "character.h"
+#include "character_functions.h"
 #include "map.h"
 #include "messages.h"
 #include "monster.h"
@@ -156,13 +157,7 @@ bool game::grabbed_veh_move( const tripoint &dp )
     // for smaller vehicles, offroad_str_req_cap sanity-checks our results.
     int str_req = std::min( get_vehicle_str_requirement( grabbed_vehicle ),
                             offroad_str_req_cap( grabbed_vehicle ) );
-    int str = u.get_str();
-    if( u.is_mounted() ) {
-        auto mons = u.mounted_creature.get();
-        if( mons->has_flag( MF_RIDEABLE_MECH ) && mons->mech_str_addition() != 0 ) {
-            str = mons->mech_str_addition();
-        }
-    }
+    int str = character_funcs::get_lift_strength_with_helpers( u );
     add_msg( m_debug, "str_req: %d", str_req );
 
     //final strength check and outcomes


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Some things to balance out pushing around of vehicles on dirt, which have been a bit fucky every since I started messing with craterization but also had some other underlying issues. In particular, I aimed to balance things so that a more reasonable selection of vehicles can be pushed off-road if you have above-average strength, and make it possible for a weaker character to get a logical way around it...

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

C++ changes:
1. In grab.cpp, changed `game::grabbed_veh_move` so the strength function calls `character_funcs::get_lift_strength_with_helpers`. This not only automatically includes the check for ahauler mech's strength (allowing me to remove it here), but more importantly allows companion NPCs to participate in hauling vehicles.
2. Included character_functions.h in grab.cpp.

JSON changes:
1. Increased contact area of cart wheels from 60 to 100, on the basis of rail wheels having a whopping 80, plus this makes a thousand-pound vehicle relying on 2 cart wheels take under 20 strength to push on dirt, compare a 2600-pound car requiring only 9 or "literally barely above average" to push around singlehandedly. This in turn makes the traction value of cart wheels no longer much lower than casters, when shopping carts aren't the ones designed for rolling around on a muddy farm field.
2. Adjusted the cannon vehicle to use wooden frames instead of steel car frames. Combined with the above, its strength to move on dirt becomes 15, in range that a single beefed-up survivor could reasonably push it, or a more normal survivor can with friends.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Making NPC assistance strength count for only half for balance purposes, and/or because they presumably spend at least some of that movecost dicking around yelling at each other to get out of the way or other typical NPC things.
2. Make rigid wheels better in the actual code, their off-road penalty multiplier is 0.1 if I recall as opposed to 0.5 for normal tires.
3. Messing with some combination of weight, contact area, or offroad penalty code to ensure that a PC that isn't sufficiently strong needs to get a friend to help push a car around even on-road.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON files for syntax and lint errors.
2. Spawned in a cannon, observed in debug it now takes 15 strength to push offroad instead of 28, and offroad rating is now a bit higher than a shopping cart.
3. Spawned in a car, observed that strength to push offroad was still 9, confirmed recruiting starter NPC made a strength-8 character able to push it.
4. Tested pushing the car alone with strength 9 and assisted with strength 8, observed move cost is lower when getting assistance from fren.
5. Brought said fren to the cannon, can now push it around.
6. Checked affected C++ file for astyle.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Branch name mentions gatlings but my plan to add that got derailed by fixes instead. Another time prolly.

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
