### PR TITLE
fix: starting item sorting differently on mac

### DIFF
--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -464,9 +464,8 @@ std::vector<detached_ptr<item>> profession::items( bool male,
         }
     }
 
-    std::sort( result.begin(),
-               result.end(), []( detached_ptr<item> &first,
-    detached_ptr<item> &second ) {
+    std::stable_sort( result.begin(), result.end(),
+    []( const detached_ptr<item> &first, const detached_ptr<item> &second ) {
         return first->get_layer() < second->get_layer();
     } );
     return result;


### PR DESCRIPTION
## Purpose of change

- fix #3813

## Describe the solution
https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3814#issuecomment-1842917642

<!--
idk, just running test for mac only

## Describe alternatives you've considered

dsafsfddsfasfsd

## Testing

CI-sama, save us
-->