### PR TITLE
fix: `house_fence04` mapgen

### DIFF
--- a/data/json/mapgen/house/house_fence04.json
+++ b/data/json/mapgen/house/house_fence04.json
@@ -94,7 +94,7 @@
       "terrain": {
         "{": "t_chainfence",
         ",": "t_chaingate_c",
-        "`": "t_null",
+        "`": "t_floor",
         "/": "t_railing_h",
         "_": "t_linoleum_gray",
         "=": "t_carpet_purple",
@@ -110,7 +110,6 @@
         "₸": "t_floor_noroof",
         "&": "t_floor_noroof",
         "}": "t_door_o",
-        "[": "t_window_open",
         "]": "t_chaingate_o"
       },
       "furniture": { "&": "f_table", "?": [ "f_indoor_plant", "f_indoor_plant_y" ] },


### PR DESCRIPTION
## Purpose of change
Fix cat hoarder variant because concrete floor under cats, windows instead of trees.
## Describe the solution
JSON changes.
## Additional context
Before:
<img width="960" alt="Capture d’écran 2023-12-03 143417" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/8311a1f3-52fd-4d45-b65a-e582945417f7">
After:
<img width="960" alt="Capture d’écran 2023-12-03 150012" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/0ea19064-e907-48ff-99a6-c931a123ffb1">