### PR TITLE
fix: make debug spawned clothings fit to body

### DIFF
--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -16,6 +16,7 @@
 #include "color.h"
 #include "cursesdef.h"
 #include "debug.h"
+#include "flag.h"
 #include "flat_set.h"
 #include "game.h"
 #include "input.h"
@@ -666,7 +667,11 @@ void debug_menu::wishitem( player *p, const tripoint &pos )
     std::vector<std::pair<std::string, const itype *>> opts;
     for( const itype *i : item_controller->all() ) {
         //TODO!: push up
-        opts.emplace_back( item::spawn_temporary( i, calendar::start_of_cataclysm )->tname( 1, false ), i );
+        auto it = item::spawn_temporary( i, calendar::start_of_cataclysm );
+        if( it->has_flag( flag_VARSIZE ) ) {
+            it->set_flag( flag_FIT );
+        }
+        opts.emplace_back( it->tname( 1, false ), i );
     }
     std::sort( opts.begin(), opts.end(), localized_compare );
     std::vector<const itype *> itypes;
@@ -706,6 +711,9 @@ void debug_menu::wishitem( player *p, const tripoint &pos )
         bool did_amount_prompt = false;
         while( wmenu.ret >= 0 ) {
             detached_ptr<item> granted = item::spawn( opts[wmenu.ret].second );
+            if( granted->has_flag( flag_VARSIZE ) ) {
+                granted->set_flag( flag_FIT );
+            }
             if( cb.incontainer ) {
                 granted = item::in_its_container( std::move( granted ) );
             }


### PR DESCRIPTION
## Purpose of change

it's inconvenient that debug spawned clothings are always `(poor fit)`. together we can stop this.

## Describe the solution

terrible spaghetti duplicate code to set `FIT` flag if it's `VARSIZE`

## Describe alternatives you've considered

overhaul items to be immutable and configurable

## Testing

### Before

![Cataclysm: Bright Nights - f3d7db35815b_01](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/2a23c12f-f31d-4191-8a7b-d48e57586bac)

### After

![Cataclysm: Bright Nights - 5a44bedaa75e_01](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/2c7eb3b9-c628-493d-9f53-dc6e20c34218)

![Cataclysm: Bright Nights - 5a44bedaa75e_02](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/600e3218-bbd6-415f-80ca-3c636cf91e3e)

they all fit nicely.

## Additional context

quick PR while working on #3814
