### PR TITLE
feat(balance): replace smoke bomb recipe with a more realistic version

### DIFF
--- a/data/json/recipes/weapon/explosive.json
+++ b/data/json/recipes/weapon/explosive.json
@@ -287,8 +287,8 @@
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [
       [ [ "water", 1 ], [ "water_clean", 1 ], [ "salt_water", 1 ], [ "saline", 5 ] ],
-      [ [ "candy", 1 ], [ "cola", 1 ] ],
-      [ [ "vitamins", 10 ], [ "aspirin", 8 ], [ "chem_phenol", 80 ] ],
+      [ [ "sugar", 40 ] ],
+      [ [ "oxy_powder", 80 ], [ "chem_saltpetre", 20 ] ],
       [ [ "canister_empty", 1 ], [ "can_food_unsealed", 1 ], [ "clay_canister", 1 ], [ "can_drink_unsealed", 1 ] ],
       [ [ "superglue", 1 ] ]
     ]


### PR DESCRIPTION
## Purpose of change

The existing smoke bomb recipe is weird. I'm no chemist and can't say with certainty if it would or wouldn't work, but at the very least it's oddly specific and needlessly requires items player may be short on or have better use for. Meanwhile, a commonly known and definitely realistic recipe for a homemade smoke bomb exists but isn't available in the game.

## Describe the solution

Replaced components for the existing recipe with roughly 3 parts fuel (sugar) and 2 parts oxidizer (saltpeter or oxidizer powder), by volume. The recipe you can find online calls for saltpeter specifically but I added oxidizer powder as an alternative because it fits by description and is reasonably easy to make, while saltpeter can be less accessible. A smoke bomb is a situationally useful item, hardly an OP consumable, so it makes no sense for it to exclusively require scarce or gated ingredients.

## Describe alternatives you've considered

Adding a new recipe while keeping the original as is. But the latter is so weird, it just doesn't seem worth keeping.

## Testing

Made sure the new ingredients are reflected in the game.

## Additional context

This is roughly similar to the recipe DDA currently uses, but not exactly the same.