### PR TITLE
refactor(port): tidy specials data and mutable connections

### DIFF
--- a/data/json/overmap/overmap_mutable/lab.json
+++ b/data/json/overmap/overmap_mutable/lab.json
@@ -53,6 +53,7 @@
       },
       "lab_train_depot": {
         "overmap": "lab_train_depot",
+        "connections": { "north": { "connection": "subway_tunnel" } },
         "north": { "id": "lab_to_lab", "type": "reject" },
         "east": { "id": "lab_to_lab", "type": "optional" },
         "south": { "id": "lab_to_lab", "type": "optional" },
@@ -83,24 +84,8 @@
           "max": { "chance": 0.2 }
         }
       ],
-      [
-        {
-          "overmap": "lab_train_depot",
-          "z": -2,
-          "scale": "size",
-          "max": { "chance": 0.15 },
-          "connections": [ { "point": [ 0, -1, 0 ], "connection": "subway_tunnel", "from": [ 0, 0, 0 ] } ]
-        }
-      ],
-      [
-        {
-          "overmap": "lab_train_depot",
-          "z": -4,
-          "scale": "size",
-          "max": { "chance": 0.05 },
-          "connections": [ { "point": [ 0, -1, 0 ], "connection": "subway_tunnel", "from": [ 0, 0, 0 ] } ]
-        }
-      ],
+      [ { "overmap": "lab_train_depot", "z": -2, "scale": "size", "max": { "chance": 0.15 } } ],
+      [ { "overmap": "lab_train_depot", "z": -4, "scale": "size", "max": { "chance": 0.05 } } ],
       [ { "overmap": "lab", "z": "bottom", "scale": "size", "max": { "poisson": 1 } } ],
       [ { "overmap": "lab_finale", "z": "bottom", "max": 1 } ]
     ]
@@ -169,6 +154,7 @@
       },
       "lab_train_depot": {
         "overmap": "lab_train_depot",
+        "connections": { "north": { "connection": "subway_tunnel" } },
         "north": { "id": "lab_to_lab", "type": "reject" },
         "east": { "id": "lab_to_lab", "type": "optional" },
         "south": { "id": "lab_to_lab", "type": "optional" },
@@ -200,24 +186,8 @@
           "max": { "chance": 0.2 }
         }
       ],
-      [
-        {
-          "overmap": "lab_train_depot",
-          "z": -2,
-          "scale": "size",
-          "max": { "chance": 0.15 },
-          "connections": [ { "point": [ 0, -1, 0 ], "connection": "subway_tunnel", "from": [ 0, 0, 0 ] } ]
-        }
-      ],
-      [
-        {
-          "overmap": "lab_train_depot",
-          "z": -4,
-          "scale": "size",
-          "max": { "chance": 0.05 },
-          "connections": [ { "point": [ 0, -1, 0 ], "connection": "subway_tunnel", "from": [ 0, 0, 0 ] } ]
-        }
-      ],
+      [ { "overmap": "lab_train_depot", "z": -2, "scale": "size", "max": { "chance": 0.15 } } ],
+      [ { "overmap": "lab_train_depot", "z": -4, "scale": "size", "max": { "chance": 0.05 } } ],
       [ { "overmap": "ice_lab", "z": "bottom", "scale": "size", "max": { "poisson": 1 } } ],
       [ { "overmap": "ice_lab_finale", "z": "bottom", "max": 1 } ]
     ]
@@ -332,6 +302,7 @@
       },
       "central_lab_train_depot": {
         "overmap": "central_lab_train_depot",
+        "connections": { "north": { "connection": "subway_tunnel" } },
         "north": { "id": "lab_to_lab", "type": "reject" },
         "east": { "id": "lab_to_lab", "type": "optional" },
         "south": { "id": "lab_to_lab", "type": "optional" },
@@ -414,15 +385,7 @@
           "max": { "poisson": 50 }
         }
       ],
-      [
-        {
-          "overmap": "central_lab_train_depot",
-          "rotate": true,
-          "z": -4,
-          "max": [ 1, 3 ],
-          "connections": [ { "point": [ 0, -1, 0 ], "connection": "subway_tunnel", "from": [ 0, 0, 0 ] } ]
-        }
-      ],
+      [ { "overmap": "central_lab_train_depot", "rotate": true, "z": -4, "max": [ 1, 3 ] } ],
       [ { "overmap": "central_lab", "z": "bottom", "max": { "poisson": 3 } } ],
       [ { "overmap": "central_lab_finale", "z": "bottom", "max": 1 } ],
       [ { "overmap": "central_lab_finale", "z": [ -10, -5 ], "max": { "poisson": 2 } } ],

--- a/doc/src/content/docs/en/mod/json/reference/map/overmap.md
+++ b/doc/src/content/docs/en/mod/json/reference/map/overmap.md
@@ -488,8 +488,7 @@ above `dead_end` overmap can represent a dead end tunnel in any direction, but i
 the chosen OMT `ants_end_south` is consistent with the `north` join for the generated map to make
 sense.
 
-Overmaps can also specify connections.  For example, an overmap might be
-defined as:
+Overmaps can also specify connections. For example, an overmap might be defined as:
 
 ```json
 "where_road_connects": {
@@ -499,12 +498,10 @@ defined as:
 }
 ```
 
-Once the mutable special placement is complete, a `local_road` connection will
-be built from the north edge of this overmap (again, 'north' is a relative
-term, that will rotate as the overmap is rotated) in the same way as
-connections are built for fixed specials.  'Existing' connections are not
+Once the mutable special placement is complete, a `local_road` connection will be built from the
+north edge of this overmap (again, 'north' is a relative term, that will rotate as the overmap is
+rotated) in the same way as connections are built for fixed specials. 'Existing' connections are not
 supported for mutable specials.
-
 
 #### Layout phases
 

--- a/doc/src/content/docs/en/mod/json/reference/map/overmap.md
+++ b/doc/src/content/docs/en/mod/json/reference/map/overmap.md
@@ -488,6 +488,24 @@ above `dead_end` overmap can represent a dead end tunnel in any direction, but i
 the chosen OMT `ants_end_south` is consistent with the `north` join for the generated map to make
 sense.
 
+Overmaps can also specify connections.  For example, an overmap might be
+defined as:
+
+```json
+"where_road_connects": {
+  "overmap": "road_end_north",
+  "west": "parking_lot_to_road",
+  "connections": { "north": { "connection": "local_road" } }
+}
+```
+
+Once the mutable special placement is complete, a `local_road` connection will
+be built from the north edge of this overmap (again, 'north' is a relative
+term, that will rotate as the overmap is rotated) in the same way as
+connections are built for fixed specials.  'Existing' connections are not
+supported for mutable specials.
+
+
 #### Layout phases
 
 After all the joins and overmaps are defined, the manner in which the special is laid out is given
@@ -771,7 +789,6 @@ Alternatively it can be a JSON object with the following keys:
 | Identifier           | Description                                                                                                     |
 | -------------------- | --------------------------------------------------------------------------------------------------------------- |
 | `overmap` or `chunk` | Id of the `overmap` to place, chunk configuration.                                                              |
-| `connections`        | List of overmap connections and their relative `[ x, y, z ]` location to overmap or chunk.                      |
 | `join`               | Id of `join` which must be resolved during current phase.                                                       |
 | `z`                  | Z level restrictions for this phase.                                                                            |
 | `om_pos`             | Absolute coordinates `[ x, y ]` of the overmap (180x180 chunk of the world) this phase is allowed to run in.    |

--- a/src/cube_direction.h
+++ b/src/cube_direction.h
@@ -5,6 +5,8 @@
 
 #include "enum_traits.h"
 
+struct tripoint;
+
 namespace om_direction
 {
 enum class type : int;
@@ -41,5 +43,7 @@ cube_direction operator+( cube_direction, om_direction::type );
 cube_direction operator+( cube_direction, int i );
 cube_direction operator-( cube_direction, om_direction::type );
 cube_direction operator-( cube_direction, int i );
+
+tripoint displace( cube_direction d );
 
 #endif // CATA_SRC_CUBE_DIRECTION_H

--- a/src/om_direction.h
+++ b/src/om_direction.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "coordinates.h"
+#include "cube_direction.h"
 
 /** Direction on the overmap. */
 namespace om_direction
@@ -104,6 +105,8 @@ type random();
 
 /** Whether these directions are parallel. */
 bool are_parallel( type dir1, type dir2 );
+
+type from_cube( cube_direction, const std::string &error_msg );
 
 } // namespace om_direction
 

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -454,10 +454,10 @@ class overmap
     public:
         bool build_connection(
             const overmap_connection &connection, const pf::directed_path<point_om_omt> &path, int z,
-            const om_direction::type &initial_dir = om_direction::type::invalid );
+            cube_direction initial_dir = cube_direction::last );
         bool build_connection( const point_om_omt &source, const point_om_omt &dest, int z,
                                const overmap_connection &connection, bool must_be_unexplored,
-                               const om_direction::type &initial_dir = om_direction::type::invalid );
+                               cube_direction initial_dir = cube_direction::last );
         void connect_closest_points( const std::vector<point_om_omt> &points, int z,
                                      const overmap_connection &connection );
         // Polishing

--- a/src/overmap_special.h
+++ b/src/overmap_special.h
@@ -12,6 +12,7 @@
 #include <array>
 #include <string>
 
+#include "cube_direction.h"
 #include "flat_set.h"
 #include "memory_fast.h"
 #include "omdata.h"
@@ -78,7 +79,7 @@ struct overmap_special_terrain : overmap_special_locations {
 struct overmap_special_connection {
     tripoint p;
     std::optional<tripoint> from;
-    om_direction::type initial_dir = om_direction::type::invalid;
+    cube_direction initial_dir = cube_direction::last;
     overmap_connection_id connection;
     bool existing = false;
 


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change
Properly separate fixed and mutable data, and match mutable connections format with DDA.
<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution
Based on following PRs:
* https://github.com/CleverRaven/Cataclysm-DDA/pull/52234
* https://github.com/CleverRaven/Cataclysm-DDA/pull/59822

They got bunch of changes here and there, as BN expanded some of related coded, but overall this PR serve same purpose, and reduces distance between codebases for easier maintaining.
JSON format of mutable connections changed to what currently used in DDA. Implementation is a bit different as i didn't wanted to duplicate code, but now we're using same notation, which was the goal.
<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

## Describe alternatives you've considered
Changed connections comes with tiny regress. Old format was allowing to declare "disconnected connections", i.e. connections without `from` property. If that feature will be demanded it can be restored by adding about three lines of code, but for now i opted to drop that "feature", which wasn't used anyway.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing
Tests are passing, maps are generating.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context
At first glance it might seems that old connections used to support "existing" connections, and new ones doesn't - it's not exactly the case.
Neither of them doesn't supported "existing" connections in chunks scope same way as they works in specials scope. When special asked for existing connection it just prevents placing special on locations without adjacent road. Mutables doesn't know beforehand which chunks where will be placed, so it just can't do that. But. Pretty similar result can be achieved by messing with `check_for_locations` and\or chunks `into_locations` checks.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
