### PR TITLE
perf: `performance-avoid-endl`

### DIFF
--- a/src/catalua.cpp
+++ b/src/catalua.cpp
@@ -186,7 +186,7 @@ void debug_write_lua_backtrace( std::ostream &out )
     luaL_traceback( container.lua_state(), state->lua.lua_state(), "=== Lua backtrace report ===", 0 );
 
     std::string data = sol::stack::pop<std::string>( container );
-    out << data << std::endl;
+    out << data << '\n';
 }
 
 static sol::table get_mod_storage_table( lua_state &state )

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -698,7 +698,7 @@ void DebugFile::init( DebugOutput output_mode, const std::string &filename )
         break;
         default:
             std::cerr << "Unexpected debug output mode " << static_cast<int>( output_mode )
-                      << std::endl;
+                      << '\n';
             return;
     }
 
@@ -1162,7 +1162,7 @@ void debug_write_backtrace( std::ostream &out )
     static backtrace_state *bt_state = bt_create_state( nullptr, 0, bt_error );
     if( bt_state ) {
         bt_full( bt_state, 0, bt_full_print, bt_error );
-        out << std::endl;
+        out << '\n';
     } else {
         out << "\n\n    Failed to initialize libbacktrace\n";
     }
@@ -1356,21 +1356,21 @@ void output_repetitions( std::ostream &out )
         if( rep_folder.repeat_count > 1 ) {
             out << "[ Previous repeated " << ( rep_folder.repeat_count - 1 ) << " times ]";
         }
-        out << std::endl;
+        out << '\n';
         out << rep_folder.m_time << " ";
         // repetition folding is only done through realDebugmsg
         out << io::enum_to_string<DL>( DL::Error ) << " ";
         out << io::enum_to_string<DC>( DC::DebugMsg ) << " ";
         out << ": ";
         out << rep_folder.m_filename << ":" << rep_folder.m_line << " [" << rep_folder.m_funcname << "] " <<
-            rep_folder.m_text << std::endl;
+            rep_folder.m_text << '\n';
         rep_folder.reset();
     }
 }
 
 detail::DebugLogGuard::~DebugLogGuard()
 {
-    *s << std::endl;
+    *s << '\n';
 }
 
 detail::DebugLogGuard detail::realDebugLog( DL lev, DC cl, const char *filename,
@@ -1417,7 +1417,7 @@ detail::DebugLogGuard detail::realDebugLog( DL lev, DC cl, const char *filename,
             time_t after = time( nullptr );
             // Cool down for 60s between backtrace emissions.
             next_backtrace = after + 60;
-            out << "Backtrace emission took " << after - now << " seconds." << std::endl;
+            out << "Backtrace emission took " << after - now << " seconds." << '\n';
             cata::debug_write_lua_backtrace( out );
             out << "(continued from above) " << io::enum_to_string( lev ) << ": ";
         }

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -520,37 +520,37 @@ void character_edit_menu( Character &c )
     std::string nmenu_label;
     if( np != nullptr ) {
         std::stringstream data;
-        data << np->name << " " << ( np->male ? _( "Male" ) : _( "Female" ) ) << std::endl;
+        data << np->name << " " << ( np->male ? _( "Male" ) : _( "Female" ) ) << '\n';
         data << np->myclass.obj().get_name() << "; " <<
              npc_attitude_name( np->get_attitude() ) << "; " <<
              ( np->get_faction() ? np->get_faction()->name : _( "no faction" ) ) << "; " <<
              ( np->get_faction() ? np->get_faction()->currency->nname( 1 ) : _( "no currency" ) )
              << "; " <<
-             "api: " << np->get_faction_ver() << std::endl;
+             "api: " << np->get_faction_ver() << '\n';
         if( np->has_destination() ) {
             data << string_format(
                      _( "Destination: %s %s" ), np->goal.to_string(),
-                     overmap_buffer.ter( np->goal )->get_name() ) << std::endl;
+                     overmap_buffer.ter( np->goal )->get_name() ) << '\n';
         } else {
-            data << _( "No destination." ) << std::endl;
+            data << _( "No destination." ) << '\n';
         }
         data << string_format( _( "Trust: %d" ), np->op_of_u.trust ) << " "
              << string_format( _( "Fear: %d" ), np->op_of_u.fear ) << " "
              << string_format( _( "Value: %d" ), np->op_of_u.value ) << " "
              << string_format( _( "Anger: %d" ), np->op_of_u.anger ) << " "
-             << string_format( _( "Owed: %d" ), np->op_of_u.owed ) << std::endl;
+             << string_format( _( "Owed: %d" ), np->op_of_u.owed ) << '\n';
 
         data << string_format( _( "Aggression: %d" ),
                                static_cast<int>( np->personality.aggression ) ) << " "
              << string_format( _( "Bravery: %d" ), static_cast<int>( np->personality.bravery ) ) << " "
              << string_format( _( "Collector: %d" ), static_cast<int>( np->personality.collector ) ) << " "
-             << string_format( _( "Altruism: %d" ), static_cast<int>( np->personality.altruism ) ) << std::endl;
+             << string_format( _( "Altruism: %d" ), static_cast<int>( np->personality.altruism ) ) << '\n';
 
-        data << _( "Needs:" ) << std::endl;
+        data << _( "Needs:" ) << '\n';
         for( const auto &need : np->needs ) {
-            data << need << std::endl;
+            data << need << '\n';
         }
-        data << string_format( _( "Total morale: %d" ), np->get_morale_level() ) << std::endl;
+        data << string_format( _( "Total morale: %d" ), np->get_morale_level() ) << '\n';
 
         nmenu_label = data.str();
     } else {
@@ -1981,21 +1981,21 @@ void debug()
             int count = 0;
             for( const auto &elem : g->faction_manager_ptr->all() ) {
                 std::cout << std::to_string( count ) << " Faction_id key in factions map = " << elem.first.str() <<
-                          std::endl;
+                          '\n';
                 std::cout << std::to_string( count ) << " Faction name associated with this id is " <<
-                          elem.second.name << std::endl;
+                          elem.second.name << '\n';
                 std::cout << std::to_string( count ) << " the id of that faction object is " << elem.second.id.str()
-                          << std::endl;
+                          << '\n';
                 count++;
             }
-            std::cout << "Player faction is " << g->u.get_faction()->id.str() << std::endl;
+            std::cout << "Player faction is " << g->u.get_faction()->id.str() << '\n';
             break;
         }
         case DEBUG_PRINT_NPC_MAGIC: {
             for( npc &guy : g->all_npcs() ) {
                 const std::vector<spell_id> spells = guy.magic->spells();
                 if( spells.empty() ) {
-                    std::cout << guy.disp_name() << " does not know any spells." << std::endl;
+                    std::cout << guy.disp_name() << " does not know any spells." << '\n';
                     continue;
                 }
                 std::cout << guy.disp_name() << "knows : ";
@@ -2005,7 +2005,7 @@ void debug()
                     if( counter < static_cast<int>( spells.size() ) ) {
                         std::cout << "and ";
                     } else {
-                        std::cout << "." << std::endl;
+                        std::cout << "." << '\n';
                     }
                     counter++;
                 }
@@ -2123,7 +2123,7 @@ void debug()
         case DEBUG_RELOAD_TILES:
             std::ostringstream ss;
             g->reload_tileset( [&ss]( const std::string & str ) {
-                ss << str << std::endl;
+                ss << str << '\n';
             } );
             add_msg( ss.str() );
             break;

--- a/src/descriptions.cpp
+++ b/src/descriptions.cpp
@@ -178,16 +178,16 @@ std::string map_data_common_t::extended_description() const
 {
     std::stringstream ss;
     ss << "<header>" << string_format( _( "That is a %s." ), name() ) << "</header>" << '\n';
-    ss << description << std::endl;
+    ss << description << '\n';
     bool has_any_harvest = std::any_of( harvest_by_season.begin(), harvest_by_season.end(),
     []( const harvest_id & hv ) {
         return !hv.obj().empty();
     } );
 
     if( has_any_harvest ) {
-        ss << "--" << std::endl;
+        ss << "--" << '\n';
         int player_skill = get_avatar().get_skill_level( skill_survival );
-        ss << _( "You could harvest the following things from it:" ) << std::endl;
+        ss << _( "You could harvest the following things from it:" ) << '\n';
         // Group them by identical ids to avoid repeating same blocks of data
         // First, invert the mapping: season->id to id->seasons
         std::multimap<harvest_id, season_type> identical_harvest;
@@ -216,27 +216,27 @@ std::string map_data_common_t::extended_description() const
 
                 return "<dark>" + calendar::name_season( pr.second ) + "</dark>";
             } );
-            ss << ":" << std::endl;
+            ss << ":" << '\n';
             // List the drops
             // They actually describe what player can get from it now, so it isn't spoily
             // TODO: Allow spoily listing of everything
-            ss << range.first->first.obj().describe( player_skill ) << std::endl;
+            ss << range.first->first.obj().describe( player_skill ) << '\n';
             // Remove the range from the multimap so that it isn't listed twice
             identical_harvest.erase( range.first, range.second );
         }
 
-        ss << std::endl;
+        ss << '\n';
     }
 
     if( deconstruct.can_do ) {
         const auto items = item_group::every_possible_item_from( deconstruct.drop_group );
         if( !items.empty() ) {
-            ss << std::endl << _( "You could deconstruct it to get some of those items:" ) << std::endl;
+            ss << '\n' << _( "You could deconstruct it to get some of those items:" ) << '\n';
             for( const itype *it : items ) {
-                ss << "<good>" << item::nname( it->get_id() ) << "</good>" << std::endl;
+                ss << "<good>" << item::nname( it->get_id() ) << "</good>" << '\n';
             }
         } else {
-            ss << _( "It can be deconstructed, but won't yield any resources." ) << std::endl;
+            ss << _( "It can be deconstructed, but won't yield any resources." ) << '\n';
         }
     }
 

--- a/src/dump.cpp
+++ b/src/dump.cpp
@@ -38,7 +38,7 @@ bool game::dump_stats( const std::string &what, dump_mode mode,
     try {
         init::load_core_bn_modfiles();
     } catch( const std::exception &err ) {
-        std::cerr << "Error loading data from json: " << err.what() << std::endl;
+        std::cerr << "Error loading data from json: " << err.what() << '\n';
         return false;
     }
 
@@ -297,7 +297,7 @@ bool game::dump_stats( const std::string &what, dump_mode mode,
         }
 
     } else {
-        std::cerr << "unknown argument: " << what << std::endl;
+        std::cerr << "unknown argument: " << what << '\n';
         return false;
     }
 

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -511,7 +511,7 @@ bool can_write_to_dir( const std::string &dir_path )
 
     const auto writer = []( std::ostream & s ) {
         // Write at least something to check if there is free space on disk
-        s << CBN << std::endl;
+        s << CBN << '\n';
     };
 
     if( !write_to_file( dummy_file, writer, nullptr ) ) {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1075,11 +1075,11 @@ static void sleep()
     std::stringstream data;
     if( !active.empty() ) {
         as_m.selected = 2;
-        data << as_m.text << std::endl;
-        data << _( "You may want to extinguish or turn off:" ) << std::endl;
-        data << " " << std::endl;
+        data << as_m.text << '\n';
+        data << _( "You may want to extinguish or turn off:" ) << '\n';
+        data << " " << '\n';
         for( auto &a : active ) {
-            data << "<color_red>" << a << "</color>" << std::endl;
+            data << "<color_red>" << a << "</color>" << '\n';
         }
         as_m.text = data.str();
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1028,7 +1028,7 @@ bool init::check_mods_for_errors( loading_ui &ui, const std::vector<mod_id> &opt
         const std::vector<mod_id> mods_empty;
         WORLDPTR test_world = world_generator->make_new_world( mods_empty );
         if( !test_world ) {
-            std::cerr << "Failed to generate test world." << std::endl;
+            std::cerr << "Failed to generate test world." << '\n';
             return false;
         }
         world_generator->set_active_world( test_world );
@@ -1043,7 +1043,7 @@ bool init::check_mods_for_errors( loading_ui &ui, const std::vector<mod_id> &opt
         try {
             load_and_finalize_packs( ui, _( "Checking mods" ), mods_list );
         } catch( const std::exception &err ) {
-            std::cerr << "Error loading data: " << err.what() << std::endl;
+            std::cerr << "Error loading data: " << err.what() << '\n';
         }
 
         std::string world_name = world_generator->active_world->world_name;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -150,7 +150,7 @@ static void report_fatal_error( const std::string &msg )
 #if defined(TILES)
     if( test_mode ) {
 #endif
-        std::cerr << "Cataclysm BN: Fatal error" << std::endl << msg << std::endl;
+        std::cerr << "Cataclysm BN: Fatal error" << '\n' << msg << '\n';
 #if defined(TILES)
     } else {
         SDL_ShowSimpleMessageBox(
@@ -683,7 +683,7 @@ int main( int argc, char *argv[] )
             catacurses::init_interface();
         } catch( const std::exception &err ) {
             // can't use any curses function as it has not been initialized
-            std::cerr << "Error while initializing the interface: " << err.what() << std::endl;
+            std::cerr << "Error while initializing the interface: " << err.what() << '\n';
             DebugLog( DL::Error, DC::Main ) << "Error while initializing the interface: " << err.what();
             return 1;
         }

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -75,7 +75,7 @@ void game::serialize( std::ostream &fout )
      * To prevent (or encourage) confusion, there is no version 8. (cata 0.8 uses v7)
      */
     // Header
-    fout << "# version " << savegame_version << std::endl;
+    fout << "# version " << savegame_version << '\n';
 
     JsonOut json( fout, true ); // pretty-print
 
@@ -730,7 +730,7 @@ static void serialize_array_to_compacted_sequence( JsonOut &json,
 
 void overmap::serialize_view( std::ostream &fout ) const
 {
-    fout << "# version " << savegame_version << std::endl;
+    fout << "# version " << savegame_version << '\n';
 
     JsonOut json( fout, false );
     json.start_object();
@@ -741,7 +741,7 @@ void overmap::serialize_view( std::ostream &fout ) const
         json.start_array();
         serialize_array_to_compacted_sequence( json, layer[z].visible );
         json.end_array();
-        fout << std::endl;
+        fout << '\n';
     }
     json.end_array();
 
@@ -751,7 +751,7 @@ void overmap::serialize_view( std::ostream &fout ) const
         json.start_array();
         serialize_array_to_compacted_sequence( json, layer[z].explored );
         json.end_array();
-        fout << std::endl;
+        fout << '\n';
     }
     json.end_array();
 
@@ -767,7 +767,7 @@ void overmap::serialize_view( std::ostream &fout ) const
             json.write( i.dangerous );
             json.write( i.danger_radius );
             json.end_array();
-            fout << std::endl;
+            fout << '\n';
         }
         json.end_array();
     }
@@ -783,7 +783,7 @@ void overmap::serialize_view( std::ostream &fout ) const
             json.write( i.p.y() );
             json.write( i.id );
             json.end_array();
-            fout << std::endl;
+            fout << '\n';
         }
         json.end_array();
     }
@@ -857,7 +857,7 @@ void overmap::save_monster_groups( JsonOut &jout ) const
 
 void overmap::serialize( std::ostream &fout ) const
 {
-    fout << "# version " << savegame_version << std::endl;
+    fout << "# version " << savegame_version << '\n';
 
     JsonOut json( fout, false );
     json.start_object();
@@ -893,16 +893,16 @@ void overmap::serialize( std::ostream &fout ) const
         // End the z-level
         json.end_array();
         // Insert a newline occasionally so the file isn't totally unreadable.
-        fout << std::endl;
+        fout << '\n';
     }
     json.end_array();
 
     // temporary, to allow user to manually switch regions during play until regionmap is done.
     json.member( "region_id", settings->id );
-    fout << std::endl;
+    fout << '\n';
 
     save_monster_groups( json );
-    fout << std::endl;
+    fout << '\n';
 
     json.member( "cities" );
     json.start_array();
@@ -915,10 +915,10 @@ void overmap::serialize( std::ostream &fout ) const
         json.end_object();
     }
     json.end_array();
-    fout << std::endl;
+    fout << '\n';
 
     json.member( "connections_out", connections_out );
-    fout << std::endl;
+    fout << '\n';
 
     json.member( "radios" );
     json.start_array();
@@ -933,7 +933,7 @@ void overmap::serialize( std::ostream &fout ) const
         json.end_object();
     }
     json.end_array();
-    fout << std::endl;
+    fout << '\n';
 
     json.member( "monster_map" );
     json.start_array();
@@ -942,7 +942,7 @@ void overmap::serialize( std::ostream &fout ) const
         i.second.serialize( json );
     }
     json.end_array();
-    fout << std::endl;
+    fout << '\n';
 
     json.member( "tracked_vehicles" );
     json.start_array();
@@ -955,7 +955,7 @@ void overmap::serialize( std::ostream &fout ) const
         json.end_object();
     }
     json.end_array();
-    fout << std::endl;
+    fout << '\n';
 
     json.member( "scent_traces" );
     json.start_array();
@@ -967,7 +967,7 @@ void overmap::serialize( std::ostream &fout ) const
         json.end_object();
     }
     json.end_array();
-    fout << std::endl;
+    fout << '\n';
 
     json.member( "npcs" );
     json.start_array();
@@ -975,7 +975,7 @@ void overmap::serialize( std::ostream &fout ) const
         json.write( *i );
     }
     json.end_array();
-    fout << std::endl;
+    fout << '\n';
 
     json.member( "camps" );
     json.start_array();
@@ -983,7 +983,7 @@ void overmap::serialize( std::ostream &fout ) const
         json.write( i );
     }
     json.end_array();
-    fout << std::endl;
+    fout << '\n';
 
     // Condense the overmap special placements so that all placements of a given special
     // are grouped under a single key for that special.
@@ -1016,7 +1016,7 @@ void overmap::serialize( std::ostream &fout ) const
         json.end_object();
     }
     json.end_array();
-    fout << std::endl;
+    fout << '\n';
 
     json.member( "electric_grid_connections" );
     json.start_array();
@@ -1037,7 +1037,7 @@ void overmap::serialize( std::ostream &fout ) const
                 joins_used.begin(), joins_used.end() );
     json.member( "joins_used", flattened_joins_used );
     json.member( "mapgen_arg_storage", mapgen_arg_storage );
-    fout << std::endl;
+    fout << '\n';
     json.member( "mapgen_arg_index" );
     json.start_array();
     for( const std::pair<const tripoint_om_omt, int> &p : mapgen_args_index ) {
@@ -1047,10 +1047,10 @@ void overmap::serialize( std::ostream &fout ) const
         json.end_array();
     }
     json.end_array();
-    fout << std::endl;
+    fout << '\n';
 
     json.end_object();
-    fout << std::endl;
+    fout << '\n';
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -1189,7 +1189,7 @@ void mission::serialize_all( JsonOut &json )
 
 void game::serialize_master( std::ostream &fout )
 {
-    fout << "# version " << savegame_version << std::endl;
+    fout << "# version " << savegame_version << '\n';
     try {
         JsonOut json( fout, true ); // pretty-print
         json.start_object();

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -3250,10 +3250,10 @@ void veh_interact::complete_vehicle( player &p )
                 veh->remove_remote_part( vehicle_part );
             }
             if( veh->is_towing() || veh->is_towed() ) {
-                std::cout << "vehicle is towing/towed" << std::endl;
+                std::cout << "vehicle is towing/towed" << '\n';
                 vehicle *other_veh = veh->is_towing() ? veh->tow_data.get_towed() : veh->tow_data.get_towed_by();
                 if( other_veh ) {
-                    std::cout << "other veh exists" << std::endl;
+                    std::cout << "other veh exists" << '\n';
                     other_veh->remove_part( other_veh->part_with_feature( other_veh->get_tow_part(), "TOW_CABLE",
                                             true ) );
                     other_veh->tow_data.clear_towing();

--- a/src/weather_gen.cpp
+++ b/src/weather_gen.cpp
@@ -334,7 +334,7 @@ void weather_generator::test_weather( unsigned seed = 1000 ) const
     write_to_file( "weather.output", [&]( std::ostream & testfile ) {
         testfile <<
                  "|;year;season;day;hour;minute;temperature(F);humidity(%);pressure(mB);weatherdesc;windspeed(mph);winddirection"
-                 << std::endl;
+                 << '\n';
 
         const time_point begin = calendar::turn;
         const time_point end = begin + 2 * calendar::year_length();
@@ -354,7 +354,7 @@ void weather_generator::test_weather( unsigned seed = 1000 ) const
             }
             testfile << "|;" << year << ";" << season_of_year( i ) << ";" << day << ";" << hour << ";" << minute
                      << ";" << w.temperature << ";" << w.humidity << ";" << w.pressure << ";" << conditions->name << ";"
-                     << w.windpower << ";" << w.winddirection << std::endl;
+                     << w.windpower << ";" << w.winddirection << '\n';
         }
 
     }, "weather test file" );

--- a/tests/explosion_balance_test.cpp
+++ b/tests/explosion_balance_test.cpp
@@ -88,7 +88,7 @@ void check_lethality( const std::string &explosive_id, const int range, float le
             }
         }
         if( !survivors.empty() ) {
-            survivor_stats << std::endl;
+            survivor_stats << '\n';
         }
         for( int i = survivors.size(); i < num_subjects_this_time; ++i ) {
             victims.add( true );

--- a/tests/invlet_test.cpp
+++ b/tests/invlet_test.cpp
@@ -143,36 +143,36 @@ static std::string test_action_desc(
     const invlet_state final_first_invlet_state, const invlet_state final_second_invlet_state )
 {
     std::stringstream ss;
-    ss << "1. add 1st item to " << location_desc( to ) << std::endl;
-    ss << "2. add 2nd item to " << location_desc( to ) << std::endl;
-    ss << "3. set 1st item's invlet to " << invlet_state_desc( first_invlet_state ) << std::endl;
-    ss << "4. " << move_action_desc( 0, to, from ) << std::endl;
-    ss << "5. set 2nd item's invlet to " << invlet_state_desc( second_invlet_state ) << std::endl;
+    ss << "1. add 1st item to " << location_desc( to ) << '\n';
+    ss << "2. add 2nd item to " << location_desc( to ) << '\n';
+    ss << "3. set 1st item's invlet to " << invlet_state_desc( first_invlet_state ) << '\n';
+    ss << "4. " << move_action_desc( 0, to, from ) << '\n';
+    ss << "5. set 2nd item's invlet to " << invlet_state_desc( second_invlet_state ) << '\n';
     switch( action ) {
         case REMOVE_1ST_REMOVE_2ND_ADD_1ST_ADD_2ND:
-            ss << "6. " << move_action_desc( 1, to, from ) << std::endl;
-            ss << "7. " << move_action_desc( 0, from, to ) << std::endl;
-            ss << "8. " << move_action_desc( 1, from, to ) << std::endl;
+            ss << "6. " << move_action_desc( 1, to, from ) << '\n';
+            ss << "7. " << move_action_desc( 0, from, to ) << '\n';
+            ss << "8. " << move_action_desc( 1, from, to ) << '\n';
             break;
         case REMOVE_1ST_REMOVE_2ND_ADD_2ND_ADD_1ST:
-            ss << "6. " << move_action_desc( 1, to, from ) << std::endl;
-            ss << "7. " << move_action_desc( 1, from, to ) << std::endl;
-            ss << "8. " << move_action_desc( 0, from, to ) << std::endl;
+            ss << "6. " << move_action_desc( 1, to, from ) << '\n';
+            ss << "7. " << move_action_desc( 1, from, to ) << '\n';
+            ss << "8. " << move_action_desc( 0, from, to ) << '\n';
             break;
         case REMOVE_1ST_ADD_1ST:
-            ss << "6. " << move_action_desc( 0, from, to ) << std::endl;
+            ss << "6. " << move_action_desc( 0, from, to ) << '\n';
             break;
         default:
             return "unimplemented";
     }
     ss << "expect 1st item to have " << invlet_state_desc( expected_first_invlet_state ) << " invlet" <<
-       std::endl;
+       '\n';
     ss << "1st item actually has " << invlet_state_desc( final_first_invlet_state ) << " invlet" <<
-       std::endl;
+       '\n';
     ss << "expect 2nd item to have " << invlet_state_desc( expected_second_invlet_state ) << " invlet"
-       << std::endl;
+       << '\n';
     ss << "2nd item actually has " << invlet_state_desc( final_second_invlet_state ) << " invlet" <<
-       std::endl;
+       '\n';
 
     return ss.str();
 }
@@ -503,13 +503,13 @@ static void stack_invlet_test( player &dummy, inventory_location from, inventory
     move_item( dummy, tshirt1, from, to );
 
     std::stringstream ss;
-    ss << "1. add a stack of two same items to " << location_desc( from ) << std::endl;
-    ss << "2. assign the stack with an invlet" << std::endl;
-    ss << "3. " << move_action_desc( 0, from, to ) << std::endl;
-    ss << "expect the two items to have different invlets" << std::endl;
+    ss << "1. add a stack of two same items to " << location_desc( from ) << '\n';
+    ss << "2. assign the stack with an invlet" << '\n';
+    ss << "3. " << move_action_desc( 0, from, to ) << '\n';
+    ss << "expect the two items to have different invlets" << '\n';
     ss << "actually the two items have " <<
        ( tshirt1.invlet != tshirt2.invlet ? "different" : "the same" ) <<
-       " invlets" << std::endl;
+       " invlets" << '\n';
     INFO( ss.str() );
     // the wielded/worn item should have different invlet from the remaining item
     CHECK( tshirt1.invlet != tshirt2.invlet );
@@ -563,17 +563,17 @@ static void swap_invlet_test( player &dummy, inventory_location loc )
 
     std::stringstream ss;
     ss << "1. add two items of the same type to " << location_desc( loc ) <<
-       ", and ensure them do not stack" << std::endl;
-    ss << "2. assign different invlets to the two items" << std::endl;
+       ", and ensure them do not stack" << '\n';
+    ss << "2. assign different invlets to the two items" << '\n';
     ss << "3. swap the invlets by assign one of the items with the invlet of the other item" <<
-       std::endl;
-    ss << "4. move the items to " << location_desc( GROUND ) << std::endl;
-    ss << "5. move the items to " << location_desc( loc ) << " again" << std::endl;
-    ss << "expect the items to keep their swapped invlets" << std::endl;
+       '\n';
+    ss << "4. move the items to " << location_desc( GROUND ) << '\n';
+    ss << "5. move the items to " << location_desc( loc ) << " again" << '\n';
+    ss << "expect the items to keep their swapped invlets" << '\n';
     if( tshirt1.invlet == invlet_2 && tshirt2.invlet == invlet_1 ) {
-        ss << "the items actually keep their swapped invlets" << std::endl;
+        ss << "the items actually keep their swapped invlets" << '\n';
     } else {
-        ss << "the items actually does not keep their swapped invlets" << std::endl;
+        ss << "the items actually does not keep their swapped invlets" << '\n';
     }
     INFO( ss.str() );
     // invlets should not disappear and should still be swapped
@@ -637,16 +637,16 @@ static void merge_invlet_test( player &dummy, inventory_location from )
         char merged_invlet = merged_item.invlet;
 
         std::stringstream ss;
-        ss << "1. add two stackable items to the inventory and " << location_desc( from ) << std::endl;
+        ss << "1. add two stackable items to the inventory and " << location_desc( from ) << '\n';
         ss << "2. assign " << invlet_state_desc( first_invlet_state ) << " invlet " << invlet_1 <<
-           " to the item in the inventory " << std::endl;
+           " to the item in the inventory " << '\n';
         ss << "3. assign " << invlet_state_desc( second_invlet_state ) << " invlet " << invlet_2 <<
-           " to the " << location_desc( from ) << std::endl;
-        ss << "4. " << move_action_desc( 0, from, INVENTORY ) << std::endl;
+           " to the " << location_desc( from ) << '\n';
+        ss << "4. " << move_action_desc( 0, from, INVENTORY ) << '\n';
         ss << "expect the stack in the inventory to have " << invlet_state_desc(
-               expected_merged_invlet_state ) << " invlet " << expected_merged_invlet << std::endl;
+               expected_merged_invlet_state ) << " invlet " << expected_merged_invlet << '\n';
         ss << "the stack actually has " << invlet_state_desc( merged_invlet_state ) << " invlet " <<
-           merged_invlet << std::endl;
+           merged_invlet << '\n';
         INFO( ss.str() );
         REQUIRE( merged_item.typeId() == tshirt1.typeId() );
         CHECK( merged_invlet_state == expected_merged_invlet_state );

--- a/tests/line_test.cpp
+++ b/tests/line_test.cpp
@@ -88,9 +88,9 @@ static bool check_bresenham_far( const tripoint &source, const tripoint &destina
         return true;
     } );
     std::stringstream ss;
-    ss << std::endl;
+    ss << '\n';
     for( const tripoint &t : generated_path ) {
-        ss << t << std::endl;
+        ss << t << '\n';
     }
     std::string generated_points = ss.str();
 

--- a/tests/melee_test.cpp
+++ b/tests/melee_test.cpp
@@ -43,10 +43,10 @@ static float brute_special_probability( monster &attacker, Creature &target, con
 static std::string full_attack_details( const player &dude )
 {
     std::stringstream ss;
-    ss << "Details for " << dude.disp_name() << std::endl;
-    ss << "get_hit() == " << dude.get_hit() << std::endl;
-    ss << "get_melee_hit_base() == " << dude.get_melee_hit_base() << std::endl;
-    ss << "get_hit_weapon() == " << dude.get_hit_weapon( dude.primary_weapon() ) << std::endl;
+    ss << "Details for " << dude.disp_name() << '\n';
+    ss << "get_hit() == " << dude.get_hit() << '\n';
+    ss << "get_melee_hit_base() == " << dude.get_melee_hit_base() << '\n';
+    ss << "get_hit_weapon() == " << dude.get_hit_weapon( dude.primary_weapon() ) << '\n';
     return ss.str();
 }
 

--- a/tests/overmap_noise_test.cpp
+++ b/tests/overmap_noise_test.cpp
@@ -12,15 +12,15 @@ static void export_raw_noise( const std::string &filename, const om_noise::om_no
 {
     std::ofstream testfile;
     testfile.open( filename, std::ofstream::trunc );
-    testfile << "P2" << std::endl;
-    testfile << width << " " << height << std::endl;
-    testfile << "255" << std::endl;
+    testfile << "P2" << '\n';
+    testfile << width << " " << height << '\n';
+    testfile << "255" << '\n';
 
     for( int x = 0; x < width; x++ ) {
         for( int y = 0; y < height; y++ ) {
             testfile << static_cast<int>( noise.noise_at( {x, y} ) * 255 ) << " ";
         }
-        testfile << std::endl;
+        testfile << '\n';
     }
 
     testfile.close();
@@ -32,9 +32,9 @@ static void export_interpreted_noise(
 {
     std::ofstream testfile;
     testfile.open( filename, std::ofstream::trunc );
-    testfile << "P2" << std::endl;
-    testfile << width << " " << height << std::endl;
-    testfile << "255" << std::endl;
+    testfile << "P2" << '\n';
+    testfile << width << " " << height << '\n';
+    testfile << "255" << '\n';
 
     for( int x = 0; x < width; x++ ) {
         for( int y = 0; y < height; y++ ) {
@@ -44,7 +44,7 @@ static void export_interpreted_noise(
                 testfile << 0 << " ";
             }
         }
-        testfile << std::endl;
+        testfile << '\n';
     }
 
     testfile.close();

--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -64,13 +64,13 @@ std::ostream &operator <<( std::ostream &os, const std::vector<T> &v )
 std::ostream &operator<<( std::ostream &stream, const dispersion_sources &sources )
 {
     if( !sources.normal_sources.empty() ) {
-        stream << "Normal: " << sources.normal_sources << std::endl;
+        stream << "Normal: " << sources.normal_sources << '\n';
     }
     if( !sources.linear_sources.empty() ) {
-        stream << "Linear: " << sources.linear_sources << std::endl;
+        stream << "Linear: " << sources.linear_sources << '\n';
     }
     if( !sources.multipliers.empty() ) {
-        stream << "Mult: " << sources.multipliers << std::endl;
+        stream << "Mult: " << sources.multipliers << '\n';
     }
     return stream;
 }

--- a/tools/format/format.cpp
+++ b/tools/format/format.cpp
@@ -155,7 +155,7 @@ static void format( JsonIn &jsin, JsonOut &jsout, int depth, bool force_wrap )
             jsin.seek( i );
             std::cerr << jsin.peek();
         }
-        std::cerr << "\"" << std::endl;
+        std::cerr << "\"" << '\n';
     }
 }
 
@@ -172,7 +172,7 @@ int main( int argc, char *argv[] )
         if( argc == 2 ) {
             filename = argv[1];
         } else if( argc != 1 ) {
-            std::cout << "Supply a filename to style or no arguments." << std::endl;
+            std::cout << "Supply a filename to style or no arguments." << '\n';
             exit( EXIT_FAILURE );
         }
 
@@ -181,7 +181,7 @@ int main( int argc, char *argv[] )
         } else {
             std::ifstream fin( filename, std::ios::binary );
             if( !fin.good() ) {
-                std::cout << "Failed to open " << filename << std::endl;
+                std::cout << "Failed to open " << filename << '\n';
                 exit( EXIT_FAILURE );
             }
             in << fin.rdbuf();
@@ -199,7 +199,7 @@ int main( int argc, char *argv[] )
     }
 
     if( in.str().size() == 0 ) {
-        std::cout << "Error, input empty." << std::endl;
+        std::cout << "Error, input empty." << '\n';
         exit( EXIT_FAILURE );
     }
     JsonOut jsout( out, true );
@@ -207,7 +207,7 @@ int main( int argc, char *argv[] )
 
     format( jsin, jsout );
 
-    out << std::endl;
+    out << '\n';
 
     if( filename.empty() ) {
         std::cout << header;
@@ -231,8 +231,8 @@ int main( int argc, char *argv[] )
             std::ofstream fout( filename, std::ios::binary | std::ios::trunc );
             fout << out.str();
             fout.close();
-            std::cout << color_bad << "Needs linting : " << color_end << filename << std::endl;
-            std::cout << "Please read doc/JSON_STYLE.md" << std::endl;
+            std::cout << color_bad << "Needs linting : " << color_end << filename << '\n';
+            std::cout << "Please read doc/JSON_STYLE.md" << '\n';
             exit( EXIT_FAILURE );
         }
     }


### PR DESCRIPTION
## Purpose of change

https://clang.llvm.org/extra/clang-tidy/checks/performance/avoid-endl.html

## Describe the solution

found and replaced usages of `std::endl` to `\n`. this clang-tidy warning 

## Describe alternatives you've considered

also apply the fix to catch2.hpp but that'd cause huge rebuild.

## Additional context

this check is added in clang-tools 18.0.0