### PR TITLE
fix: allow mounting gun on climbables

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -778,18 +778,15 @@ namespace
 
 auto is_mountable( const map &m, const tripoint &pos ) -> bool
 {
-    if( m.impassable( pos ) ) {
-        return false;
-    }
-
     // usage of any attached bipod is dependent upon terrain
-    if( m.has_flag_ter_or_furn( "MOUNTABLE", pos ) ) {
+    // sandbag barricades are impassable but climbable
+    if( m.climb_difficulty( pos ) <= 5 && m.has_flag_ter_or_furn( "MOUNTABLE", pos ) ) {
         return true;
     }
 
     if( const optional_vpart_position vp = m.veh_at( pos ) ) {
         // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-        return vp->vehicle().has_part( pos, "MOUNTABLE" );
+        return m.passable( pos ) && vp->vehicle().has_part( pos, "MOUNTABLE" );
     }
     return false;
 }


### PR DESCRIPTION
## Purpose of change

continuation of #3751, it was not possible to use sandbags to stabilize guns, which was counterintuitive compared to real life.

## Describe the solution

- only check whether it's passable on vehicle parts.
- check climb difficulty on terrain/furniture instead

## Describe alternatives you've considered

make climb check functions sane and not spread throughout source code with slightly different usage and return value

## Testing

![Cataclysm: Bright Nights - d8f5cc5e2f4c_01](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/b21910b2-9f70-4bba-96ef-34a5b3bbdf76)
![Cataclysm: Bright Nights - d8f5cc5e2f4c_02](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/c0553687-44a9-484e-a9a6-75285b6dd63a)
![Cataclysm: Bright Nights - d8f5cc5e2f4c_03](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/515adc80-1a10-482e-ac15-e817b98a9946)
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/f03204ab-3eb7-4113-813a-cdf23f89b75b)
