### PR TITLE
feat(content): more holy books

### DIFF
--- a/data/json/itemgroups/books.json
+++ b/data/json/itemgroups/books.json
@@ -152,6 +152,7 @@
       { "item": "holybook_bible1", "prob": 1 },
       { "item": "holybook_bible2", "prob": 1 },
       { "item": "holybook_bible3", "prob": 1 },
+      { "item": "holybook_bible4", "prob": 1 },
       { "item": "holybook_quran", "prob": 1 },
       { "item": "holybook_hadith", "prob": 1 },
       { "item": "holybook_havamal", "prob": 1 },
@@ -168,7 +169,11 @@
       { "item": "holybook_slack", "prob": 1 },
       { "item": "holybook_kallisti", "prob": 1 },
       { "item": "holybook_scientology", "prob": 1 },
-      { "item": "holybook_satanic", "prob": 1 }
+      { "item": "holybook_satanic", "prob": 1 },
+      { "item": "holybook_taoism", "prob": 1 },
+      { "item": "holybook_confucianism", "prob": 1 },
+      { "item": "holybook_paganism", "prob": 1 },
+      { "item": "holybook_shamanism", "prob": 1 }
     ]
   },
   {

--- a/data/json/items/book/bloat.json
+++ b/data/json/items/book/bloat.json
@@ -21,6 +21,14 @@
     "copy-from": "holybook_bible1"
   },
   {
+    "id": "holybook_bible4",
+    "type": "BOOK",
+    "name": { "str": "Catholic Bible", "str_pl": "copies of Catholic Bible" },
+    "description": "An English copy of the Catholic Bible, including the whole 73 book canon recognized by the Catholic church.",
+    "looks_like": "holybook_bible1",
+    "copy-from": "holybook_bible1"
+  },
+  {
     "id": "holybook_granth",
     "type": "BOOK",
     "name": { "str": "The Guru Granth Sahib", "str_pl": "copies of The Guru Granth Sahib" },
@@ -140,6 +148,41 @@
     "type": "BOOK",
     "name": { "str": "Hávamál", "str_pl": "copies of Hávamál" },
     "description": "An English translation of several Old Norse poems.  The poems contain proverbs and stories attributed to the god Odin, many transcribed from oral history.",
+    "copy-from": "holybook_bible1"
+  },
+  {
+    "id": "holybook_taoism",
+    "type": "BOOK",
+    "name": { "str": "Tao Te Ching", "str_pl": "copies of Tao Te Ching" },
+    "description": "An English translation of the collection of poetry and sayings that guides Taoist thought and actions.",
+    "looks_like": "holybook_tripitaka",
+    "copy-from": "holybook_bible1"
+  },
+  {
+    "id": "holybook_confucianism",
+    "type": "BOOK",
+    "name": { "str": "Lunyu", "str_pl": "copies of the Lunyu" },
+    "description": "An English translation of the most-revered sacred scripture in the Confucian tradition, compiled by the succeeding generations of Confucius's disciples.  It is sometimes viewed as a philosophy and sometimes as a religion.",
+    "looks_like": "holybook_tripitaka",
+    "copy-from": "holybook_bible1",
+    "delete": { "flags": [ "INSPIRATIONAL" ] }
+  },
+  {
+    "id": "holybook_paganism",
+    "type": "BOOK",
+    "name": { "str": "Book of Pagan prayer", "str_pl": "copies of Book of Pagan prayer" },
+    "description": "A comprehensive selection of prayers to guide the reader on Pagan and Wiccan worship.",
+    "looks_like": "holybook_havamal",
+    "//": "ISBN 1-57863-255-2",
+    "copy-from": "holybook_bible1"
+  },
+  {
+    "id": "holybook_shamanism",
+    "type": "BOOK",
+    "name": { "str": "Book of shamanistic and folk practices", "str_pl": "copies of Book of shamanistic and folk practices" },
+    "description": "A comprehensive book detailing the practices of a single region of shamanistic or folk beliefs.",
+    "looks_like": "holybook_havamal",
+    "//": "There's hundreds of shamanistic religions and folk beliefs, we can't model them all.",
     "copy-from": "holybook_bible1"
   },
   {

--- a/data/mods/No_Religious_Books/modinfo.json
+++ b/data/mods/No_Religious_Books/modinfo.json
@@ -16,6 +16,7 @@
       "holybook_bible1",
       "holybook_bible2",
       "holybook_bible3",
+      "holybook_bible4",
       "holybook_quran",
       "holybook_hadith",
       "holybook_havamal",
@@ -32,7 +33,11 @@
       "holybook_slack",
       "holybook_kallisti",
       "holybook_scientology",
-      "holybook_satanic"
+      "holybook_satanic",
+      "holybook_taoism",
+      "holybook_confucianism",
+      "holybook_paganism",
+      "holybook_shamanism"
     ]
   }
 ]


### PR DESCRIPTION
## Purpose of change

We're missing a few holy books and I'm all for increased representation. There's also several mods that could possibly make use of calling for holy books, I.E. Arcana, my mod, and Phantasmagoria.

## Describe the solution

I added five new holy books, One for Taoism, Confucianism, Paganism/Wicca, a generic catch-all for Shamanism or folk beliefs due to there being hundreds of examples, and the Catholic bible.

I'll have probably forgot to represent something, I can do more later.

https://education.nationalgeographic.org/resource/taoism/
https://www.britannica.com/topic/Confucianism/The-Analects-as-the-embodiment-of-Confucian-ideas

Confucianism is seen sometimes as a philosophy and sometimes as a religion so it does not require spiritualist to read for the morale bonus. I've included the ISBN for the Paganism/Wicca book in a comment.

I also updated the No religious texts mod.

## Describe alternatives you've considered

Representation doesn't have an alternative. However, overhauling holybook itemgroups to have both canon and extra commentaries and other theology books is on the agenda for later.

## Testing

They were successfully added to the itemgroup and loaded into a world. No new itemgroups were added so this was trivial.

## Additional context

Maybe I should've checked the other fork first but it was faster to research than fiddle with github file searches.
