### PR TITLE
refactor!: remove usage of `g->u` and `g->m`

### DIFF
--- a/doxygen_doc/pages.h
+++ b/doxygen_doc/pages.h
@@ -14,7 +14,7 @@
  * have ever been created into memory and keeps them there in a list. It does not "sort" them into overmaps
  * or anything like that.
  *
- * Again parallel to this, there is \ref map and `g->m`. A map contains a 2D pointer-array of submaps, for instance
+ * Again parallel to this, there is \ref map and `get_map()`. A map contains a 2D pointer-array of submaps, for instance
  * 11x11 submaps. These are usually centered around the player, which is the reason the coordinate system shifts.
  * For all these submaps, it also caches additional data, such as lighting, scent, etc. This is basically
  * where all the "on-screen" processing happens. Most of the source code modifies terrain, monsters and so on only by

--- a/src/achievement.cpp
+++ b/src/achievement.cpp
@@ -12,7 +12,6 @@
 #include "enums.h"
 #include "event.h"
 #include "event_statistics.h"
-#include "game.h"
 #include "generic_factory.h"
 #include "json.h"
 #include "kill_tracker.h"

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -709,7 +709,8 @@ action_id handle_action_menu()
             action_weightings[ACTION_CYCLE_MOVE] = 400;
         }
         // Only prioritize fire weapon options if we're wielding a ranged weapon.
-        if( get_avatar().primary_weapon().is_gun() || get_avatar().primary_weapon().has_flag( flag_REACH_ATTACK ) ) {
+        if( get_avatar().primary_weapon().is_gun() ||
+            get_avatar().primary_weapon().has_flag( flag_REACH_ATTACK ) ) {
             action_weightings[ACTION_FIRE] = 350;
         }
     }

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -583,9 +583,9 @@ bool can_move_vertical_at( const tripoint &p, int movez )
     // TODO: unify this with game::move_vertical
     if( here.has_flag( flag_SWIMMABLE, p ) && here.has_flag( TFLAG_DEEP_WATER, p ) ) {
         if( movez == -1 ) {
-            return !g->u.is_underwater() && !g->u.worn_with_flag( flag_FLOTATION );
+            return !get_avatar().is_underwater() && !get_avatar().worn_with_flag( flag_FLOTATION );
         } else {
-            return g->u.swim_speed() < 500 || g->u.is_wearing( itype_id( "swim_fins" ) );
+            return get_avatar().swim_speed() < 500 || get_avatar().is_wearing( itype_id( "swim_fins" ) );
         }
     }
 
@@ -643,13 +643,13 @@ bool can_interact_at( action_id action, const tripoint &p )
     map &here = get_map();
     switch( action ) {
         case ACTION_OPEN:
-            return here.open_door( p, !here.is_outside( g->u.pos() ), true );
+            return here.open_door( p, !here.is_outside( get_avatar().pos() ), true );
         case ACTION_CLOSE: {
             const optional_vpart_position vp = here.veh_at( p );
             return ( vp &&
                      vp->vehicle().next_part_to_close( vp->part_index(),
-                             veh_pointer_or_null( here.veh_at( g->u.pos() ) ) != &vp->vehicle() ) >= 0 ) ||
-                   here.close_door( p, !here.is_outside( g->u.pos() ), true );
+                             veh_pointer_or_null( here.veh_at( get_avatar().pos() ) ) != &vp->vehicle() ) >= 0 ) ||
+                   here.close_door( p, !here.is_outside( get_avatar().pos() ), true );
         }
         case ACTION_BUTCHER:
             return can_butcher_at( p );
@@ -703,39 +703,39 @@ action_id handle_action_menu()
     std::map<action_id, int> action_weightings;
 
     // Check if we're in a potential combat situation, if so, sort a few actions to the top.
-    if( !g->u.get_hostile_creatures( 60 ).empty() ) {
+    if( !get_avatar().get_hostile_creatures( 60 ).empty() ) {
         // Only prioritize movement options if we're not driving.
-        if( !g->u.controlling_vehicle ) {
+        if( !get_avatar().controlling_vehicle ) {
             action_weightings[ACTION_CYCLE_MOVE] = 400;
         }
         // Only prioritize fire weapon options if we're wielding a ranged weapon.
-        if( g->u.primary_weapon().is_gun() || g->u.primary_weapon().has_flag( flag_REACH_ATTACK ) ) {
+        if( get_avatar().primary_weapon().is_gun() || get_avatar().primary_weapon().has_flag( flag_REACH_ATTACK ) ) {
             action_weightings[ACTION_FIRE] = 350;
         }
     }
 
     // If we're already running, make it simple to toggle running to off.
-    if( g->u.movement_mode_is( CMM_RUN ) ) {
+    if( get_avatar().movement_mode_is( CMM_RUN ) ) {
         action_weightings[ACTION_TOGGLE_RUN] = 300;
     }
     // If we're already crouching, make it simple to toggle crouching to off.
-    if( g->u.movement_mode_is( CMM_CROUCH ) ) {
+    if( get_avatar().movement_mode_is( CMM_CROUCH ) ) {
         action_weightings[ACTION_TOGGLE_CROUCH] = 300;
     }
 
     map &here = get_map();
     // Check if we're on a vehicle, if so, vehicle controls should be top.
-    if( here.veh_at( g->u.pos() ) ) {
+    if( here.veh_at( get_avatar().pos() ) ) {
         // Make it 300 to prioritize it before examining the vehicle.
         action_weightings[ACTION_CONTROL_VEHICLE] = 300;
     }
 
     // Check if we can perform one of our actions on nearby terrain. If so,
     // display that action at the top of the list.
-    for( const tripoint &pos : here.points_in_radius( g->u.pos(), 1 ) ) {
-        if( pos != g->u.pos() ) {
+    for( const tripoint &pos : here.points_in_radius( get_avatar().pos(), 1 ) ) {
+        if( pos != get_avatar().pos() ) {
             // Check for actions that work on nearby tiles, skipping tiles blocked by vehicles
-            if( here.obstructed_by_vehicle_rotation( g->u.pos(), pos ) ) {
+            if( here.obstructed_by_vehicle_rotation( get_avatar().pos(), pos ) ) {
                 continue;
             }
 
@@ -969,9 +969,9 @@ std::optional<tripoint> choose_direction( const std::string &message, const bool
         if( const std::optional<tripoint> vec = ctxt.get_direction( action ) ) {
             // Make player's sprite face left/right if interacting with something to the left or right
             if( vec->x > 0 ) {
-                g->u.facing = FD_RIGHT;
+                get_avatar().facing = FD_RIGHT;
             } else if( vec->x < 0 ) {
-                g->u.facing = FD_LEFT;
+                get_avatar().facing = FD_LEFT;
             }
             return vec;
         } else if( action == "pause" ) {
@@ -995,12 +995,12 @@ std::optional<tripoint> choose_adjacent( const std::string &message, const bool 
         return std::nullopt;
     }
 
-    if( get_map().obstructed_by_vehicle_rotation( g->u.pos(), *dir + g->u.pos() ) ) {
+    if( get_map().obstructed_by_vehicle_rotation( get_avatar().pos(), *dir + get_avatar().pos() ) ) {
         add_msg( _( "You can't reach through that vehicle's wall." ) );
         return std::nullopt;
     }
 
-    return *dir + g->u.pos();
+    return *dir + get_avatar().pos();
 }
 
 std::optional<tripoint> choose_adjacent_highlight( const std::string &message,
@@ -1021,8 +1021,8 @@ std::optional<tripoint> choose_adjacent_highlight(
     std::vector<tripoint> valid;
     map &here = get_map();
     if( allowed ) {
-        for( const tripoint &pos : here.points_in_radius( g->u.pos(), 1 ) ) {
-            if( !here.obstructed_by_vehicle_rotation( g->u.pos(), pos ) && allowed( pos ) ) {
+        for( const tripoint &pos : here.points_in_radius( get_avatar().pos(), 1 ) ) {
+            if( !here.obstructed_by_vehicle_rotation( get_avatar().pos(), pos ) && allowed( pos ) ) {
                 valid.emplace_back( pos );
             }
         }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -439,11 +439,12 @@ void dig_activity_actor::finish( player_activity &act, Character &who )
             here.spawn_item( location, itype_bone_human, rng( 5, 15 ) );
             here.furn_set( location, f_coffin_c );
         }
-        std::vector<item *> dropped = g->m.place_items( item_group_id( "allclothes" ), 50, location,
+        std::vector<item *> dropped = get_map().place_items( item_group_id( "allclothes" ), 50, location,
                                       location, false,
                                       calendar::turn );
-        g->m.place_items( item_group_id( "grave" ), 25, location, location, false, calendar::turn );
-        g->m.place_items( item_group_id( "jewelry_front" ), 20, location, location, false, calendar::turn );
+        get_map().place_items( item_group_id( "grave" ), 25, location, location, false, calendar::turn );
+        get_map().place_items( item_group_id( "jewelry_front" ), 20, location, location, false,
+                               calendar::turn );
         for( item * const &it : dropped ) {
             if( it->is_armor() ) {
                 it->set_flag( flag_FILTHY );
@@ -1107,14 +1108,14 @@ void lockpick_activity_actor::finish( player_activity &act, Character &who )
         return;
     }
 
-    const tripoint target = g->m.getlocal( this->target );
-    const ter_id ter_type = g->m.ter( target );
-    const furn_id furn_type = g->m.furn( target );
+    const tripoint target = get_map().getlocal( this->target );
+    const ter_id ter_type = get_map().ter( target );
+    const furn_id furn_type = get_map().furn( target );
     ter_id new_ter_type = t_null;
     furn_id new_furn_type = f_null;
     std::string open_message = _( "The lock opens…" );
 
-    if( g->m.has_furn( target ) ) {
+    if( get_map().has_furn( target ) ) {
         if( furn_type->lockpick_result.is_null() ) {
             debugmsg( "%s lockpick_result is null", furn_type.id().str() );
             return;
@@ -1149,13 +1150,13 @@ void lockpick_activity_actor::finish( player_activity &act, Character &who )
     int xp_gain = 0;
     if( perfect || ( pick_roll >= lock_roll ) ) {
         xp_gain += lock_roll;
-        g->m.has_furn( target ) ?
-        g->m.furn_set( target, new_furn_type ) :
-        static_cast<void>( g->m.ter_set( target, new_ter_type ) );
+        get_map().has_furn( target ) ?
+        get_map().furn_set( target, new_furn_type ) :
+        static_cast<void>( get_map().ter_set( target, new_ter_type ) );
         who.add_msg_if_player( m_good, open_message );
     } else if( furn_type == f_gunsafe_ml && lock_roll > ( 3 * pick_roll ) ) {
         who.add_msg_if_player( m_bad, _( "Your clumsy attempt jams the lock!" ) );
-        g->m.furn_set( target, furn_str_id( "f_gunsafe_mj" ) );
+        get_map().furn_set( target, furn_str_id( "f_gunsafe_mj" ) );
     } else if( lock_roll > ( 1.5 * pick_roll ) ) {
         if( it->inc_damage() ) {
             who.add_msg_if_player( m_bad,
@@ -1175,7 +1176,8 @@ void lockpick_activity_actor::finish( player_activity &act, Character &who )
     }
     who.practice( skill_mechanics, xp_gain );
 
-    if( !perfect && g->m.has_flag( "ALARMED", target ) && ( lock_roll + dice( 1, 30 ) ) > pick_roll ) {
+    if( !perfect && get_map().has_flag( "ALARMED", target ) &&
+        ( lock_roll + dice( 1, 30 ) ) > pick_roll ) {
         sounds::sound( who.pos(), 40, sounds::sound_t::alarm, _( "an alarm sound!" ),
                        true, "environment", "alarm" );
         if( !g->timed_events.queued( TIMED_EVENT_WANTED ) ) {
@@ -1191,8 +1193,8 @@ void lockpick_activity_actor::finish( player_activity &act, Character &who )
 
 bool lockpick_activity_actor::is_pickable( const tripoint &p )
 {
-    return g->m.has_furn( p ) ? !g->m.furn( p )->lockpick_result.is_null() :
-           !g->m.ter( p )->lockpick_result.is_null();
+    return get_map().has_furn( p ) ? !get_map().furn( p )->lockpick_result.is_null() :
+           !get_map().ter( p )->lockpick_result.is_null();
 }
 
 std::optional<tripoint> lockpick_activity_actor::select_location( avatar &you )
@@ -1212,7 +1214,7 @@ std::optional<tripoint> lockpick_activity_actor::select_location( avatar &you )
         return target;
     }
 
-    const ter_id terr_type = g->m.ter( *target );
+    const ter_id terr_type = get_map().ter( *target );
     if( *target == you.pos() ) {
         you.add_msg_if_player( m_info, _( "You pick your nose and your sinuses swing open." ) );
     } else if( g->critter_at<npc>( *target ) ) {

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1728,9 +1728,10 @@ void activity_handlers::game_do_turn( player_activity *act, player *p )
 void activity_handlers::hotwire_finish( player_activity *act, player *p )
 {
     //Grab this now, in case the vehicle gets shifted
-    if( const optional_vpart_position vp = g->m.veh_at( g->m.getlocal( tripoint( act->values[0],
-                                           act->values[1],
-                                           p->posz() ) ) ) ) {
+    if( const optional_vpart_position vp = get_map().veh_at( get_map().getlocal( tripoint(
+            act->values[0],
+            act->values[1],
+            p->posz() ) ) ) ) {
         vehicle *const veh = &vp->vehicle();
         const int mech_skill = act->values[2];
         if( mech_skill > static_cast<int>( rng( 1, 6 ) ) ) {
@@ -1795,7 +1796,7 @@ void activity_handlers::longsalvage_finish( player_activity *act, player *p )
 void activity_handlers::make_zlave_finish( player_activity *act, player *p )
 {
     act->set_to_null();
-    map_stack items = g->m.i_at( p->pos() );
+    map_stack items = get_map().i_at( p->pos() );
     const std::string corpse_name = act->str_values[0];
     item *body = nullptr;
 

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -716,7 +716,7 @@ static void set_up_butchery_activity( player_activity &act, player &u, const but
                                              _( "You try to look away, but this gruesome image will stay on your mind for some time." ) );
                         break;
                 }
-                g->u.add_morale( MORALE_BUTCHER, -50, 0, 2_days, 3_hours );
+                get_avatar().add_morale( MORALE_BUTCHER, -50, 0, 2_days, 3_hours );
             } else {
                 u.add_msg_if_player( m_good, _( "It needs a coffin, not a knife." ) );
                 act.targets.pop_back();
@@ -2148,7 +2148,7 @@ static bool magic_train( player_activity *act, player *p )
     }
     const spell_id &sp_id = spell_id( act->name );
     if( sp_id.is_valid() ) {
-        const bool knows = g->u.magic->knows_spell( sp_id );
+        const bool knows = get_avatar().magic->knows_spell( sp_id );
         if( knows ) {
             spell &studying = p->magic->get_spell( sp_id );
             const int expert_multiplier = act->values.empty() ? 0 : act->values[0];
@@ -2309,7 +2309,7 @@ void activity_handlers::start_engines_finish( player_activity *act, player *p )
     vehicle *veh = g->remoteveh();
     map &here = get_map();
     if( !veh ) {
-        const tripoint pos = act->placement + g->u.pos();
+        const tripoint pos = act->placement + get_avatar().pos();
         veh = veh_pointer_or_null( here.veh_at( pos ) );
         if( !veh ) {
             return;
@@ -3034,22 +3034,22 @@ void activity_handlers::wear_do_turn( player_activity *act, player *p )
 // This activity opens the menu (it's not meant to queue consumption of items)
 void activity_handlers::eat_menu_do_turn( player_activity *, player * )
 {
-    avatar_action::eat( g->u );
+    avatar_action::eat( get_avatar() );
 }
 
 void activity_handlers::consume_food_menu_do_turn( player_activity *, player * )
 {
-    avatar_action::eat( g->u, game_menus::inv::consume_food( g->u ) );
+    avatar_action::eat( get_avatar(), game_menus::inv::consume_food( get_avatar() ) );
 }
 
 void activity_handlers::consume_drink_menu_do_turn( player_activity *, player * )
 {
-    avatar_action::eat( g->u, game_menus::inv::consume_drink( g->u ) );
+    avatar_action::eat( get_avatar(), game_menus::inv::consume_drink( get_avatar() ) );
 }
 
 void activity_handlers::consume_meds_menu_do_turn( player_activity *, player * )
 {
-    avatar_action::eat( g->u, game_menus::inv::consume_meds( g->u ) );
+    avatar_action::eat( get_avatar(), game_menus::inv::consume_meds( get_avatar() ) );
 }
 
 void activity_handlers::move_loot_do_turn( player_activity *act, player *p )
@@ -3435,8 +3435,8 @@ void activity_handlers::operation_do_turn( player_activity *act, player *p )
     const bionic_id bid( act->str_values[cbm_id] );
     const bionic_id upbid = bid->upgraded_bionic;
     const bool autodoc = act->str_values[is_autodoc] == "true";
-    const bool u_see = g->u.sees( p->pos() ) && ( !g->u.has_effect( effect_narcosis ) ||
-                       g->u.has_bionic( bio_painkiller ) || g->u.has_trait( trait_NOPAIN ) );
+    const bool u_see = get_avatar().sees( p->pos() ) && ( !get_avatar().has_effect( effect_narcosis ) ||
+                       get_avatar().has_bionic( bio_painkiller ) || get_avatar().has_trait( trait_NOPAIN ) );
 
     const int difficulty = act->values.front();
 

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -865,8 +865,8 @@ static int move_cost_inv( const item &it, const tripoint &src, const tripoint &d
     const int mc_per_tile = 100;
 
     // only free inventory capacity
-    const int inventory_capacity = units::to_milliliter( g->u.volume_capacity() -
-                                   g->u.volume_carried() );
+    const int inventory_capacity = units::to_milliliter( get_avatar().volume_capacity() -
+                                   get_avatar().volume_carried() );
 
     const int item_volume = units::to_milliliter( it.volume() );
 
@@ -885,7 +885,7 @@ static int move_cost_cart( const item &it, const tripoint &src, const tripoint &
     const int MAX_COST = 500;
 
     // cost to move item into the cart
-    const int pickup_cost = pickup::cost_to_move_item( g->u, it );
+    const int pickup_cost = pickup::cost_to_move_item( get_avatar(), it );
 
     // cost to move item out of the cart
     const int drop_cost = pickup_cost;
@@ -908,8 +908,8 @@ static int move_cost_cart( const item &it, const tripoint &src, const tripoint &
 
 static int move_cost( const item &it, const tripoint &src, const tripoint &dest )
 {
-    if( g->u.get_grab_type() == OBJECT_VEHICLE ) {
-        tripoint cart_position = g->u.pos() + g->u.grab_point;
+    if( get_avatar().get_grab_type() == OBJECT_VEHICLE ) {
+        tripoint cart_position = get_avatar().pos() + get_avatar().grab_point;
 
         if( const std::optional<vpart_reference> vp = get_map().veh_at(
                     cart_position ).part_with_feature( "CARGO", false ) ) {
@@ -1373,7 +1373,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
             return activity_reason_info::fail( do_activity_reason::NO_ZONE );
         }
         // if the vehicle is moving or player is controlling it.
-        if( std::abs( veh->velocity ) > 100 || veh->player_in_control( g->u ) ) {
+        if( std::abs( veh->velocity ) > 100 || veh->player_in_control( get_avatar() ) ) {
             return activity_reason_info::fail( do_activity_reason::NO_ZONE );
         }
         for( const npc &guy : g->all_npcs() ) {
@@ -1387,8 +1387,8 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
             }
             // If their position or intended position or player position/intended position
             // then discount, don't need to move each other out of the way.
-            if( here.getlocal( g->u.activity->placement ) == src_loc ||
-                guy_work_spot == src_loc || guy.pos() == src_loc || ( p.is_npc() && g->u.pos() == src_loc ) ) {
+            if( here.getlocal( get_avatar().activity->placement ) == src_loc ||
+                guy_work_spot == src_loc || guy.pos() == src_loc || ( p.is_npc() && get_avatar().pos() == src_loc ) ) {
                 return activity_reason_info::fail( do_activity_reason::ALREADY_WORKING );
             }
             if( guy_work_spot != tripoint_zero ) {
@@ -1398,8 +1398,8 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
                     already_working_indexes.push_back( guy.activity_vehicle_part_index );
                 }
             }
-            if( g->u.activity_vehicle_part_index != -1 ) {
-                already_working_indexes.push_back( g->u.activity_vehicle_part_index );
+            if( get_avatar().activity_vehicle_part_index != -1 ) {
+                already_working_indexes.push_back( get_avatar().activity_vehicle_part_index );
             }
         }
         if( act == ACT_VEHICLE_DECONSTRUCTION ) {
@@ -3308,7 +3308,7 @@ bool find_auto_consume( player &p, const consume_type type )
     const auto dist = std::max( rl_dist( p.pos(), here.getlocal( current.loc ) ), 1 );
     p.mod_moves( -cost * dist );
 
-    avatar_action::eat( g->u, current.item_loc );
+    avatar_action::eat( get_avatar(), current.item_loc );
     // eat() may have removed the item, so check its still there.
     if( current.item_loc && current.item_loc->is_container() ) {
         current.item_loc->on_contents_changed();

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1388,7 +1388,8 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
             // If their position or intended position or player position/intended position
             // then discount, don't need to move each other out of the way.
             if( here.getlocal( get_avatar().activity->placement ) == src_loc ||
-                guy_work_spot == src_loc || guy.pos() == src_loc || ( p.is_npc() && get_avatar().pos() == src_loc ) ) {
+                guy_work_spot == src_loc || guy.pos() == src_loc || ( p.is_npc() &&
+                        get_avatar().pos() == src_loc ) ) {
                 return activity_reason_info::fail( do_activity_reason::ALREADY_WORKING );
             }
             if( guy_work_spot != tripoint_zero ) {
@@ -3263,7 +3264,7 @@ bool find_auto_consume( player &p, const consume_type type )
         if( loc.z != p.pos().z ) {
             continue;
         }
-        const optional_vpart_position vp = here.veh_at( g->m.getlocal( loc ) );
+        const optional_vpart_position vp = here.veh_at( get_map().getlocal( loc ) );
         if( vp ) {
             vehicle &veh = vp->vehicle();
             const int index = veh.part_with_feature( vp->part_index(), "CARGO", false );

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -237,7 +237,8 @@ void advanced_inventory::print_items( const advanced_inventory_pane &pane, bool 
         nc_color color = weight_carried > weight_capacity ? c_red : c_light_green;
         mvwprintz( window, point( hrightcol, 4 ), color, "%.1f", weight_carried );
         wprintz( window, c_light_gray, "/%.1f %s  ", weight_capacity, weight_units() );
-        color = get_avatar().volume_carried().value() > get_avatar().volume_capacity().value() ? c_red : c_light_green;
+        color = get_avatar().volume_carried().value() > get_avatar().volume_capacity().value() ? c_red :
+                c_light_green;
         wprintz( window, color, volume_carried );
         wprintz( window, c_light_gray, "/%s %s", volume_capacity, volume_units_abbr() );
     } else {
@@ -948,18 +949,19 @@ bool advanced_inventory::move_all_items( bool nested_call )
             if( dpane.get_area() == AIM_INVENTORY ) {
                 std::vector<pickup::pick_drop_selection> targets = pickup::optimize_pickup( target_items,
                         quantities );
-                get_avatar().assign_activity( std::make_unique<player_activity>( std::make_unique<pickup_activity_actor>(
-                                          targets,
-                                          panes[src].in_vehicle() ? std::nullopt : std::optional<tripoint>( get_avatar().pos() )
-                                      ) ) );
+                get_avatar().assign_activity( std::make_unique<player_activity>
+                                              ( std::make_unique<pickup_activity_actor>(
+                                                    targets,
+                                                    panes[src].in_vehicle() ? std::nullopt : std::optional<tripoint>( get_avatar().pos() )
+                                                ) ) );
             } else {
                 get_avatar().assign_activity( std::make_unique<player_activity>
-                                      ( std::make_unique<move_items_activity_actor>(
-                                            target_items,
-                                            quantities,
-                                            dpane.in_vehicle(),
-                                            relative_destination
-                                        ) ) );
+                                              ( std::make_unique<move_items_activity_actor>(
+                                                    target_items,
+                                                    quantities,
+                                                    dpane.in_vehicle(),
+                                                    relative_destination
+                                                ) ) );
             }
         }
 
@@ -1159,21 +1161,22 @@ void advanced_inventory::start_activity( const aim_location destarea,
         if( destarea == AIM_INVENTORY ) {
             std::vector<pickup::pick_drop_selection> targets = pickup::optimize_pickup( target_items,
                     quantities );
-            get_avatar().assign_activity( std::make_unique<player_activity>( std::make_unique<pickup_activity_actor>(
-                                      targets,
-                                      from_vehicle ? std::nullopt : std::optional<tripoint>( get_avatar().pos() )
-                                  ) ) );
+            get_avatar().assign_activity( std::make_unique<player_activity>
+                                          ( std::make_unique<pickup_activity_actor>(
+                                                targets,
+                                                from_vehicle ? std::nullopt : std::optional<tripoint>( get_avatar().pos() )
+                                            ) ) );
         } else {
             // Stash the destination
             const tripoint relative_destination = squares[destarea].off;
 
             get_avatar().assign_activity( std::make_unique<player_activity>
-                                  ( std::make_unique<move_items_activity_actor>(
-                                        target_items,
-                                        quantities,
-                                        to_vehicle,
-                                        relative_destination
-                                    ) ) );
+                                          ( std::make_unique<move_items_activity_actor>(
+                                                target_items,
+                                                quantities,
+                                                to_vehicle,
+                                                relative_destination
+                                            ) ) );
         }
     }
 }
@@ -1235,9 +1238,10 @@ bool advanced_inventory::action_move_item( advanced_inv_listitem *sitem,
             item *itm = &get_avatar().i_at( sitem->idx );
 
             drop_locations to_move = { drop_location( *itm, amount_to_move ) };
-            get_avatar().assign_activity( std::make_unique<player_activity>( std::make_unique<drop_activity_actor>
-                                  ( get_avatar(), to_move,
-                                    !to_vehicle, squares[destarea].off ) ) );
+            get_avatar().assign_activity( std::make_unique<player_activity>
+                                          ( std::make_unique<drop_activity_actor>
+                                            ( get_avatar(), to_move,
+                                              !to_vehicle, squares[destarea].off ) ) );
         }
         // exit so that the activity can be carried out
         exit = true;
@@ -1257,9 +1261,10 @@ bool advanced_inventory::action_move_item( advanced_inv_listitem *sitem,
             get_avatar().takeoff( *itm );
         } else {
             drop_locations to_move = { drop_location( *itm, amount_to_move ) };
-            get_avatar().assign_activity( std::make_unique<player_activity>( std::make_unique<drop_activity_actor>
-                                  ( get_avatar(), to_move,
-                                    !to_vehicle, squares[destarea].off ) ) );
+            get_avatar().assign_activity( std::make_unique<player_activity>
+                                          ( std::make_unique<drop_activity_actor>
+                                            ( get_avatar(), to_move,
+                                              !to_vehicle, squares[destarea].off ) ) );
         }
         // exit so that the activity can be carried out
         exit = true;

--- a/src/advanced_inv_area.cpp
+++ b/src/advanced_inv_area.cpp
@@ -15,7 +15,6 @@
 #include "enums.h"
 #include "field.h"
 #include "field_type.h"
-#include "game.h"
 #include "game_constants.h"
 #include "int_id.h"
 #include "inventory.h"

--- a/src/advanced_inv_area.cpp
+++ b/src/advanced_inv_area.cpp
@@ -35,9 +35,9 @@
 int advanced_inv_area::get_item_count() const
 {
     if( id == AIM_INVENTORY ) {
-        return g->u.inv_size();
+        return get_avatar().inv_size();
     } else if( id == AIM_WORN ) {
-        return g->u.worn.size();
+        return get_avatar().worn.size();
     } else if( id == AIM_ALL ) {
         return 0;
     } else if( id == AIM_DRAGGED ) {
@@ -62,7 +62,7 @@ advanced_inv_area::advanced_inv_area( aim_location id, point h, tripoint off,
 
 void advanced_inv_area::init()
 {
-    pos = g->u.pos() + off;
+    pos = get_avatar().pos() + off;
     veh = nullptr;
     vstor = -1;
     // must update in main function
@@ -76,15 +76,15 @@ void advanced_inv_area::init()
             canputitemsloc = true;
             break;
         case AIM_DRAGGED:
-            if( g->u.get_grab_type() != OBJECT_VEHICLE ) {
+            if( get_avatar().get_grab_type() != OBJECT_VEHICLE ) {
                 canputitemsloc = false;
                 desc[0] = _( "Not dragging any vehicle!" );
                 break;
             }
             // offset for dragged vehicles is not statically initialized, so get it
-            off = g->u.grab_point;
+            off = get_avatar().grab_point;
             // Reset position because offset changed
-            pos = g->u.pos() + off;
+            pos = get_avatar().pos() + off;
             if( const std::optional<vpart_reference> vp = here.veh_at( pos ).part_with_feature( "CARGO",
                     false ) ) {
                 veh = &vp->vehicle();
@@ -119,7 +119,7 @@ void advanced_inv_area::init()
             break;
         case AIM_ABOVE:
         case AIM_BELOW:
-            if( !g->m.has_zlevels() || !g->m.valid_move( g->u.pos(), pos ) ) {
+            if( !g->m.has_zlevels() || !g->m.valid_move( get_avatar().pos(), pos ) ) {
                 canputitemsloc = false;
                 break;
             }
@@ -176,7 +176,7 @@ void advanced_inv_area::init()
 
     // trap?
     const trap &tr = here.tr_at( pos );
-    if( tr.can_see( pos, g->u ) && !tr.is_benign() ) {
+    if( tr.can_see( pos, get_avatar() ) && !tr.is_benign() ) {
         flags.append( _( " TRAP" ) );
     }
 
@@ -203,7 +203,7 @@ units::volume advanced_inv_area::free_volume( bool in_vehicle ) const
     // should be a specific location instead
     assert( id != AIM_ALL );
     if( id == AIM_INVENTORY || id == AIM_WORN ) {
-        return g->u.volume_capacity() - g->u.volume_carried();
+        return get_avatar().volume_capacity() - get_avatar().volume_carried();
     }
     return in_vehicle ? veh->free_volume( vstor ) : get_map().free_volume( pos );
 }
@@ -254,7 +254,7 @@ item *advanced_inv_area::get_container( bool in_vehicle )
     if( uistate.adv_inv_container_location != -1 ) {
         // try to find valid container in the area
         if( uistate.adv_inv_container_location == AIM_INVENTORY ) {
-            const_invslice stacks = g->u.inv_const_slice();
+            const_invslice stacks = get_avatar().inv_const_slice();
 
             // check index first
             if( stacks.size() > static_cast<size_t>( uistate.adv_inv_container_index ) ) {
@@ -276,7 +276,7 @@ item *advanced_inv_area::get_container( bool in_vehicle )
                 }
             }
         } else if( uistate.adv_inv_container_location == AIM_WORN ) {
-            auto &worn = g->u.worn;
+            auto &worn = get_avatar().worn;
             size_t idx = static_cast<size_t>( uistate.adv_inv_container_index );
             if( worn.size() > idx ) {
                 auto iter = worn.begin();
@@ -407,12 +407,12 @@ void advanced_inv_area::set_container_position()
 {
     // update the offset of the container based on location
     if( uistate.adv_inv_container_location == AIM_DRAGGED ) {
-        off = g->u.grab_point;
+        off = get_avatar().grab_point;
     } else {
         off = aim_vector( static_cast<aim_location>( uistate.adv_inv_container_location ) );
     }
     // update the absolute position
-    pos = g->u.pos() + off;
+    pos = get_avatar().pos() + off;
     // update vehicle information
     if( const std::optional<vpart_reference> vp = get_map().veh_at( pos ).part_with_feature( "CARGO",
             false ) ) {

--- a/src/advanced_inv_area.cpp
+++ b/src/advanced_inv_area.cpp
@@ -119,7 +119,7 @@ void advanced_inv_area::init()
             break;
         case AIM_ABOVE:
         case AIM_BELOW:
-            if( !g->m.has_zlevels() || !g->m.valid_move( get_avatar().pos(), pos ) ) {
+            if( !get_map().has_zlevels() || !get_map().valid_move( get_avatar().pos(), pos ) ) {
                 canputitemsloc = false;
                 break;
             }

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -16,7 +16,6 @@
 #include "player.h"
 #include "point.h"
 #include "popup.h"
-#include "posix_time.h"
 #include "ranged.h"
 #include "translations.h"
 #include "type_id.h"
@@ -646,7 +645,7 @@ void game::draw_hit_mon( const tripoint &p, const monster &m, const bool dead )
 
 namespace
 {
-void draw_hit_player_curses( const game &g, const Character &p, const int dam )
+void draw_hit_player_curses( const game &, const Character &p, const int dam )
 {
     nc_color const col = !dam ? yellow_background( p.symbol_color() ) : red_background(
                              p.symbol_color() );
@@ -841,7 +840,7 @@ void draw_sct_curses( const game &g )
             continue;
         }
 
-        const bool is_old = text.getStep() >= SCT.iMaxSteps / 2;
+        const bool is_old = text.getStep() >= scrollingcombattext::iMaxSteps / 2;
 
         nc_color const col1 = msgtype_to_color( text.getMsgType( "first" ),  is_old );
         nc_color const col2 = msgtype_to_color( text.getMsgType( "second" ), is_old );

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -102,7 +102,7 @@ class wave_animation : public basic_animation
 
 bool is_point_visible( const tripoint &p, int margin = 0 )
 {
-    return g->is_in_viewport( p, margin ) && g->u.sees( p );
+    return g->is_in_viewport( p, margin ) && get_avatar().sees( p );
 }
 
 bool is_radius_visible( const tripoint &center, int radius )
@@ -137,7 +137,7 @@ void draw_explosion_curses( game &g, const tripoint &center, const int r,
         return;
     }
     // TODO: Make it look different from above/below
-    const tripoint p = relative_view_pos( g.u, center );
+    const tripoint p = relative_view_pos( get_avatar(), center );
 
     explosion_animation anim;
 
@@ -190,7 +190,7 @@ void draw_custom_explosion_curses( game &g,
                                    const std::list< std::map<tripoint, explosion_tile> > &layers )
 {
     // calculate screen offset relative to player + view offset position
-    const tripoint center = g.u.pos() + g.u.view_offset;
+    const tripoint center = get_avatar().pos() + get_avatar().view_offset;
     const tripoint topleft( center.x - getmaxx( g.w_terrain ) / 2,
                             center.y - getmaxy( g.w_terrain ) / 2, 0 );
 
@@ -330,17 +330,17 @@ void explosion_handler::draw_custom_explosion( const tripoint &,
 #if defined(TILES)
     if( !use_tiles ) {
         for( const auto &pr : all_area ) {
-            const tripoint relative_point = relative_view_pos( g->u, pr.first );
+            const tripoint relative_point = relative_view_pos( get_avatar(), pr.first );
             if( relative_point.z == 0 ) {
                 neighbors[pr.first] = explosion_tile{ N_NO_NEIGHBORS, pr.second };
             }
         }
     } else {
         // In tiles mode, the coordinates have to be absolute
-        const tripoint view_center = relative_view_pos( g->u, g->u.pos() );
+        const tripoint view_center = relative_view_pos( get_avatar(), get_avatar().pos() );
         for( const auto &pr : all_area ) {
             // Relative point is only used for z level check
-            const tripoint relative_point = relative_view_pos( g->u, pr.first );
+            const tripoint relative_point = relative_view_pos( get_avatar(), pr.first );
             if( relative_point.z == view_center.z ) {
                 neighbors[pr.first] = explosion_tile{ N_NO_NEIGHBORS, pr.second };
             }
@@ -348,7 +348,7 @@ void explosion_handler::draw_custom_explosion( const tripoint &,
     }
 #else
     for( const auto &pr : all_area ) {
-        const tripoint relative_point = relative_view_pos( g->u, pr.first );
+        const tripoint relative_point = relative_view_pos( get_avatar(), pr.first );
         if( relative_point.z == 0 ) {
             neighbors[pr.first] = explosion_tile{ N_NO_NEIGHBORS, pr.second };
         }
@@ -463,7 +463,7 @@ void draw_bullet_curses( map &m, const tripoint &t, const char bullet, const tri
         return;
     }
 
-    const tripoint vp = g->u.pos() + g->u.view_offset;
+    const tripoint vp = get_avatar().pos() + get_avatar().view_offset;
 
     if( vp.z != t.z ) {
         return;
@@ -650,7 +650,7 @@ void draw_hit_player_curses( const game &g, const Character &p, const int dam )
 {
     nc_color const col = !dam ? yellow_background( p.symbol_color() ) : red_background(
                              p.symbol_color() );
-    hit_animation( g.u, p.pos(), col, p.symbol() );
+    hit_animation( get_avatar(), p.pos(), col, p.symbol() );
 }
 } //namespace
 
@@ -700,9 +700,9 @@ void draw_line_curses( game &g, const tripoint &center, const std::vector<tripoi
         const auto critter = g.critter_at( p, true );
 
         // NPCs and monsters get drawn with inverted colors
-        if( critter && g.u.sees( *critter ) ) {
+        if( critter && get_avatar().sees( *critter ) ) {
             critter->draw( g.w_terrain, center, true );
-        } else if( noreveal && !g.u.sees( p ) ) {
+        } else if( noreveal && !get_avatar().sees( p ) ) {
             // Draw a meaningless symbol. Avoids revealing tile, but keeps feedback
             const char sym = '?';
             const nc_color col = c_dark_gray;
@@ -755,7 +755,7 @@ void draw_line_curses( game &g, const std::vector<tripoint> &points )
     }
 
     const tripoint p = points.empty() ? tripoint {POSX, POSY, 0} :
-                       relative_view_pos( g.u, points.back() );
+                       relative_view_pos( get_avatar(), points.back() );
     mvwputch( g.w_terrain, p.xy(), c_white, 'X' );
 }
 } //namespace
@@ -831,7 +831,7 @@ namespace
 {
 void draw_sct_curses( const game &g )
 {
-    const tripoint off = relative_view_pos( g.u, tripoint_zero );
+    const tripoint off = relative_view_pos( get_avatar(), tripoint_zero );
 
     for( const auto &text : SCT.vSCT ) {
         const int dy = off.y + text.getPosY();

--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -15,7 +15,6 @@
 #include "debug.h"
 #include "enums.h"
 #include "flag.h"
-#include "game.h"
 #include "game_inventory.h"
 #include "input.h"
 #include "inventory.h"

--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -100,7 +100,7 @@ void user_interface::show()
         tmpx += shortcut_print( w_header, point( tmpx, 0 ), c_white, c_light_green, _( "<M>ove" ) ) + 2;
         tmpx += shortcut_print( w_header, point( tmpx, 0 ), c_white, c_light_green, _( "<E>nable" ) ) + 2;
         tmpx += shortcut_print( w_header, point( tmpx, 0 ), c_white, c_light_green, _( "<D>isable" ) ) + 2;
-        if( !g->u.name.empty() ) {
+        if( !get_avatar().name.empty() ) {
             shortcut_print( w_header, point( tmpx, 0 ), c_white, c_light_green, _( "<T>est" ) );
         }
         tmpx = 0;
@@ -364,7 +364,7 @@ void user_interface::show()
                 iLine--;
                 iColumn = 1;
             }
-        } else if( action == "TEST_RULE" && currentPageNonEmpty && !g->u.name.empty() ) {
+        } else if( action == "TEST_RULE" && currentPageNonEmpty && !get_avatar().name.empty() ) {
             cur_rules[iLine].test_pattern();
         } else if( action == "SWITCH_AUTO_PICKUP_OPTION" ) {
             // TODO: Now that NPCs use this function, it could be used for them too
@@ -392,7 +392,7 @@ void player_settings::show()
 
     ui.title = _( " AUTO PICKUP MANAGER " );
     ui.tabs.emplace_back( _( "[<Global>]" ), global_rules );
-    if( !g->u.name.empty() ) {
+    if( !get_avatar().name.empty() ) {
         ui.tabs.emplace_back( _( "[<Character>]" ), character_rules );
     }
     ui.is_autopickup = true;
@@ -404,7 +404,7 @@ void player_settings::show()
     }
 
     save_global();
-    if( !g->u.name.empty() ) {
+    if( !get_avatar().name.empty() ) {
         save_character();
     }
     invalidate();

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -135,12 +135,12 @@ bool avatar::should_show_map_memory()
 
 bool avatar::save_map_memory()
 {
-    return player_map_memory->save( g->m.getabs( pos() ) );
+    return player_map_memory->save( get_map().getabs( pos() ) );
 }
 
 void avatar::load_map_memory()
 {
-    player_map_memory->load( g->m.getabs( pos() ) );
+    player_map_memory->load( get_map().getabs( pos() ) );
 }
 
 void avatar::prepare_map_memory_region( const tripoint &p1, const tripoint &p2 )

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -105,7 +105,7 @@ class JsonOut;
 
 static void skim_book_msg( const item &book, avatar &u );
 
-avatar &get_avatar()
+auto get_avatar() -> avatar &
 {
     return g->u;
 }

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -146,7 +146,7 @@ class avatar : public player
          * Helper function for player::read.
          *
          * @param book Book to read
-         * @param reasons Starting with g->u, for each player/NPC who cannot read, a message will be pushed back here.
+         * @param reasons Starting with get_avatar(), for each player/NPC who cannot read, a message will be pushed back here.
          * @returns nullptr, if neither the player nor his followers can read to the player, otherwise the player/NPC
          * who can read and can read the fastest
          */
@@ -276,6 +276,6 @@ class avatar : public player
         std::map<faction_id, std::pair<int, time_point>> warning_record;
 };
 
-avatar &get_avatar();
+auto get_avatar() -> avatar &;
 
 #endif // CATA_SRC_AVATAR_H

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -880,8 +880,8 @@ void avatar_action::eat( avatar &you, item *loc )
             add_msg( _( "You leave the empty %s." ), loc->tname() );
         }
     }
-    if( g->u.get_value( "THIEF_MODE_KEEP" ) != "YES" ) {
-        g->u.set_value( "THIEF_MODE", "THIEF_ASK" );
+    if( get_avatar().get_value( "THIEF_MODE_KEEP" ) != "YES" ) {
+        get_avatar().set_value( "THIEF_MODE", "THIEF_ASK" );
     }
 }
 

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -72,7 +72,7 @@ static void drop_or_embed_projectile( dealt_projectile_attack &attack )
 
     if( proj.has_effect( ammo_effect_SHATTER_SELF ) ) {
         // Drop the contents, not the thrown item
-        if( g->u.sees( pt ) ) {
+        if( get_avatar().sees( pt ) ) {
             add_msg( _( "The %s shatters!" ), drop_item.tname() );
         }
 
@@ -88,7 +88,7 @@ static void drop_or_embed_projectile( dealt_projectile_attack &attack )
 
     if( proj.has_effect( ammo_effect_BURST ) ) {
         // Drop the contents, not the thrown item
-        if( g->u.sees( pt ) ) {
+        if( get_avatar().sees( pt ) ) {
             add_msg( _( "The %s bursts!" ), drop_item.tname() );
         }
 
@@ -123,7 +123,7 @@ static void drop_or_embed_projectile( dealt_projectile_attack &attack )
 
     if( embed ) {
         mon->add_item( std::move( drop ) );
-        if( g->u.sees( *mon ) ) {
+        if( get_avatar().sees( *mon ) ) {
             add_msg( _( "The %1$s embeds in %2$s!" ), drop_item.tname(), mon->disp_name() );
         }
     } else {
@@ -349,7 +349,7 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
             }
         }
 
-        // Drawing the bullet uses player g->u, and not player p, because it's drawn
+        // Drawing the bullet uses player get_avatar(), and not player p, because it's drawn
         // relative to YOUR position, which may not be the gunman's position.
         if( do_animation && !do_draw_line ) {
             // TODO: Make this draw thrown item/launched grenade/arrow

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -715,7 +715,7 @@ bool basecamp_action_components::choose_components()
 {
     const auto filter = is_crafting_component;
     const requirement_data *req =
-        making_.deduped_requirements().select_alternative( g->u, base_._inv, filter, batch_size_ );
+        making_.deduped_requirements().select_alternative( get_avatar(), base_._inv, filter, batch_size_ );
     if( !req ) {
         return false;
     }
@@ -725,7 +725,7 @@ bool basecamp_action_components::choose_components()
     }
     for( const auto &it : req->get_components() ) {
         comp_selection<item_comp> is =
-            g->u.select_item_component( it, batch_size_, base_._inv, true, filter,
+            get_avatar().select_item_component( it, batch_size_, base_._inv, true, filter,
                                         !base_.by_radio );
         if( is.use_from == cancel ) {
             return false;
@@ -757,12 +757,12 @@ void basecamp_action_components::consume_components()
     }
     const tripoint &origin = target_map->getlocal( base_.get_dumping_spot() );
     for( const comp_selection<item_comp> &sel : item_selections_ ) {
-        g->u.consume_items( *target_map, sel, batch_size_, is_crafting_component, origin,
+        get_avatar().consume_items( *target_map, sel, batch_size_, is_crafting_component, origin,
                             basecamp::inv_range );
     }
     // this may consume pseudo-resources from fake items
     for( const comp_selection<tool_comp> &sel : tool_selections_ ) {
-        g->u.consume_tools( *target_map, sel, batch_size_, origin, basecamp::inv_range, &base_ );
+        get_avatar().consume_tools( *target_map, sel, batch_size_, origin, basecamp::inv_range, &base_ );
     }
     // go back and consume the actual resources
     for( basecamp_resource &bcp_r : base_.resources ) {

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -726,7 +726,7 @@ bool basecamp_action_components::choose_components()
     for( const auto &it : req->get_components() ) {
         comp_selection<item_comp> is =
             get_avatar().select_item_component( it, batch_size_, base_._inv, true, filter,
-                                        !base_.by_radio );
+                                                !base_.by_radio );
         if( is.use_from == cancel ) {
             return false;
         }
@@ -758,7 +758,7 @@ void basecamp_action_components::consume_components()
     const tripoint &origin = target_map->getlocal( base_.get_dumping_spot() );
     for( const comp_selection<item_comp> &sel : item_selections_ ) {
         get_avatar().consume_items( *target_map, sel, batch_size_, is_crafting_component, origin,
-                            basecamp::inv_range );
+                                    basecamp::inv_range );
     }
     // this may consume pseudo-resources from fake items
     for( const comp_selection<tool_comp> &sel : tool_selections_ ) {

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -931,7 +931,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
         if( target.has_value() ) {
             add_msg_activate();
             assign_activity( std::make_unique<player_activity>( lockpick_activity_actor::use_bionic(
-                                 item::spawn( bio.info().fake_item ), g->m.getabs( *target ) ) ) );
+                                 item::spawn( bio.info().fake_item ), get_map().getabs( *target ) ) ) );
             if( close_bionics_ui ) {
                 *close_bionics_ui = true;
             }
@@ -1068,7 +1068,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
 
     } else if( bio.id == bio_probability_travel ) {
         if( const std::optional<tripoint> pnt = choose_adjacent( _( "Tunnel in which direction?" ) ) ) {
-            if( g->m.impassable( *pnt ) ) {
+            if( get_map().impassable( *pnt ) ) {
                 add_msg_activate();
                 g->phasing_move( *pnt );
             } else {

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1678,8 +1678,9 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
     }
     if( get_avatar().controlling_vehicle ) {
         if( std::optional<tripoint> indicator_offset = g->get_veh_dir_indicator_location( true ) ) {
-            draw_from_id_string( "cursor", C_NONE, empty_string, indicator_offset->xy() + tripoint( get_avatar().posx(),
-                                 get_avatar().posy(), center.z ),
+            draw_from_id_string( "cursor", C_NONE, empty_string,
+                                 indicator_offset->xy() + tripoint( get_avatar().posx(),
+                                         get_avatar().posy(), center.z ),
                                  0, 0, lit_level::LIT, false, 0 );
         }
     }
@@ -2271,7 +2272,7 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
     // or has an idle animation and idle animations are enabled
     if( has_variations && variations_enabled ) {
         if( seed_from_map_coords ) {
-            seed = simple_point_hash( g->m.getabs( pos ) );
+            seed = simple_point_hash( get_map().getabs( pos ) );
         }
         static const auto rot32 = []( const unsigned int x, const int k ) {
             return ( x << k ) | ( x >> ( 32 - k ) );
@@ -2836,7 +2837,8 @@ bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3
                                         nv_goggles_activated, height_3d, z_drop );
         }
     }
-    if( overridden || ( !invisible[0] && neighborhood_overridden && tr.obj().can_see( p, get_avatar() ) ) ) {
+    if( overridden || ( !invisible[0] && neighborhood_overridden &&
+                        tr.obj().can_see( p, get_avatar() ) ) ) {
         // and then draw the override trap
         const trap_id &tr2 = overridden ? override->second : tr;
         if( tr2 ) {
@@ -3121,7 +3123,8 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
     } else {
         // invisible
         const Creature *critter = g->critter_at( p, true );
-        if( critter && ( get_avatar().sees_with_infrared( *critter ) || get_avatar().sees_with_specials( *critter ) ) ) {
+        if( critter && ( get_avatar().sees_with_infrared( *critter ) ||
+                         get_avatar().sees_with_specials( *critter ) ) ) {
             // try drawing infrared creature if invisible and not overridden
             // return directly without drawing overlay
             return draw_from_id_string( "infrared_creature", C_NONE, empty_string, p, 0, 0,

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1171,10 +1171,10 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
     const int max_row = s.y;
 
     //limit the render area to maximum view range (121x121 square centered on player)
-    const int min_visible_x = g->u.posx() % SEEX;
-    const int min_visible_y = g->u.posy() % SEEY;
-    const int max_visible_x = ( g->u.posx() % SEEX ) + ( MAPSIZE - 1 ) * SEEX;
-    const int max_visible_y = ( g->u.posy() % SEEY ) + ( MAPSIZE - 1 ) * SEEY;
+    const int min_visible_x = get_avatar().posx() % SEEX;
+    const int min_visible_y = get_avatar().posy() % SEEY;
+    const int max_visible_x = ( get_avatar().posx() % SEEX ) + ( MAPSIZE - 1 ) * SEEX;
+    const int max_visible_y = ( get_avatar().posy() % SEEY ) + ( MAPSIZE - 1 ) * SEEY;
 
     // Map memory should be at least the size of the view range
     // so that new tiles can be memorized, and at least the size of the display
@@ -1187,7 +1187,7 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
                                  std::max( s.x + o.x, max_visible_x ),
                                  std::max( s.y + o.y, max_visible_y )
                              );
-    g->u.prepare_map_memory_region(
+    get_avatar().prepare_map_memory_region(
         here.getabs( tripoint( min_mm_reg, center.z ) ),
         here.getabs( tripoint( max_mm_reg, center.z ) )
     );
@@ -1202,7 +1202,7 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
     }
 
     //retrieve night vision goggle status once per draw
-    auto vision_cache = g->u.get_vision_modes();
+    auto vision_cache = get_avatar().get_vision_modes();
     nv_goggles_activated = vision_cache[NV_GOGGLES];
 
     // check that the creature for which we'll draw the visibility map is still alive at that point
@@ -1438,8 +1438,8 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
                         }
                         for( int cz = pos.z; !invisible[0] && cz <= -center.z; cz++ ) {
                             const Creature *critter = g->critter_at( {pos.xy(), cz}, true );
-                            if( critter && ( g->u.sees_with_infrared( *critter ) ||
-                                             g->u.sees_with_specials( *critter ) ) ) {
+                            if( critter && ( get_avatar().sees_with_infrared( *critter ) ||
+                                             get_avatar().sees_with_specials( *critter ) ) ) {
                                 invisible[0] = true;
                             }
                         }
@@ -1670,16 +1670,16 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
         if( do_draw_cone_aoe ) {
             draw_cone_aoe_frame();
         }
-    } else if( g->u.view_offset != tripoint_zero && !g->u.in_vehicle ) {
+    } else if( get_avatar().view_offset != tripoint_zero && !get_avatar().in_vehicle ) {
         // check to see if player is located at ter
         draw_from_id_string( "cursor", C_NONE, empty_string,
                              tripoint( g->ter_view_p.xy(), center.z ), 0, 0, lit_level::LIT,
                              false, 0 );
     }
-    if( g->u.controlling_vehicle ) {
+    if( get_avatar().controlling_vehicle ) {
         if( std::optional<tripoint> indicator_offset = g->get_veh_dir_indicator_location( true ) ) {
-            draw_from_id_string( "cursor", C_NONE, empty_string, indicator_offset->xy() + tripoint( g->u.posx(),
-                                 g->u.posy(), center.z ),
+            draw_from_id_string( "cursor", C_NONE, empty_string, indicator_offset->xy() + tripoint( get_avatar().posx(),
+                                 get_avatar().posy(), center.z ),
                                  0, 0, lit_level::LIT, false, 0 );
         }
     }
@@ -2248,7 +2248,7 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
         default:
             // player
             if( string_starts_with( found_id, "player_" ) ) {
-                seed = g->u.name[0];
+                seed = get_avatar().name[0];
                 break;
             }
             // NPC
@@ -2582,7 +2582,7 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
         }
         const std::string &tname = t.id().str();
         if( here.check_seen_cache( p ) && t != t_open_air ) {
-            g->u.memorize_tile( here.getabs( p ), tname, subtile, rotation );
+            get_avatar().memorize_tile( here.getabs( p ), tname, subtile, rotation );
         }
         // draw the actual terrain if there's no override
         if( !neighborhood_overridden ) {
@@ -2629,8 +2629,8 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
 
 bool cata_tiles::has_memory_at( const tripoint &p ) const
 {
-    if( g->u.should_show_map_memory() ) {
-        const memorized_terrain_tile t = g->u.get_memorized_tile( get_map().getabs( p ) );
+    if( get_avatar().should_show_map_memory() ) {
+        const memorized_terrain_tile t = get_avatar().get_memorized_tile( get_map().getabs( p ) );
         return !t.tile.empty();
     }
     return false;
@@ -2638,8 +2638,8 @@ bool cata_tiles::has_memory_at( const tripoint &p ) const
 
 bool cata_tiles::has_terrain_memory_at( const tripoint &p ) const
 {
-    if( g->u.should_show_map_memory() ) {
-        const memorized_terrain_tile t = g->u.get_memorized_tile( get_map().getabs( p ) );
+    if( get_avatar().should_show_map_memory() ) {
+        const memorized_terrain_tile t = get_avatar().get_memorized_tile( get_map().getabs( p ) );
         if( string_starts_with( t.tile, "t_" ) ) {
             return true;
         }
@@ -2649,8 +2649,8 @@ bool cata_tiles::has_terrain_memory_at( const tripoint &p ) const
 
 bool cata_tiles::has_furniture_memory_at( const tripoint &p ) const
 {
-    if( g->u.should_show_map_memory() ) {
-        const memorized_terrain_tile t = g->u.get_memorized_tile( get_map().getabs( p ) );
+    if( get_avatar().should_show_map_memory() ) {
+        const memorized_terrain_tile t = get_avatar().get_memorized_tile( get_map().getabs( p ) );
         if( string_starts_with( t.tile, "f_" ) ) {
             return true;
         }
@@ -2660,8 +2660,8 @@ bool cata_tiles::has_furniture_memory_at( const tripoint &p ) const
 
 bool cata_tiles::has_trap_memory_at( const tripoint &p ) const
 {
-    if( g->u.should_show_map_memory() ) {
-        const memorized_terrain_tile t = g->u.get_memorized_tile( get_map().getabs( p ) );
+    if( get_avatar().should_show_map_memory() ) {
+        const memorized_terrain_tile t = get_avatar().get_memorized_tile( get_map().getabs( p ) );
         if( string_starts_with( t.tile, "tr_" ) ) {
             return true;
         }
@@ -2671,8 +2671,8 @@ bool cata_tiles::has_trap_memory_at( const tripoint &p ) const
 
 bool cata_tiles::has_vpart_memory_at( const tripoint &p ) const
 {
-    if( g->u.should_show_map_memory() ) {
-        const memorized_terrain_tile t = g->u.get_memorized_tile( get_map().getabs( p ) );
+    if( get_avatar().should_show_map_memory() ) {
+        const memorized_terrain_tile t = get_avatar().get_memorized_tile( get_map().getabs( p ) );
         if( string_starts_with( t.tile, "vp_" ) ) {
             return true;
         }
@@ -2682,8 +2682,8 @@ bool cata_tiles::has_vpart_memory_at( const tripoint &p ) const
 
 memorized_terrain_tile cata_tiles::get_terrain_memory_at( const tripoint &p ) const
 {
-    if( g->u.should_show_map_memory() ) {
-        const memorized_terrain_tile t = g->u.get_memorized_tile( get_map().getabs( p ) );
+    if( get_avatar().should_show_map_memory() ) {
+        const memorized_terrain_tile t = get_avatar().get_memorized_tile( get_map().getabs( p ) );
         if( string_starts_with( t.tile, "t_" ) ) {
             return t;
         }
@@ -2693,8 +2693,8 @@ memorized_terrain_tile cata_tiles::get_terrain_memory_at( const tripoint &p ) co
 
 memorized_terrain_tile cata_tiles::get_furniture_memory_at( const tripoint &p ) const
 {
-    if( g->u.should_show_map_memory() ) {
-        const memorized_terrain_tile t = g->u.get_memorized_tile( get_map().getabs( p ) );
+    if( get_avatar().should_show_map_memory() ) {
+        const memorized_terrain_tile t = get_avatar().get_memorized_tile( get_map().getabs( p ) );
         if( string_starts_with( t.tile, "f_" ) ) {
             return t;
         }
@@ -2704,8 +2704,8 @@ memorized_terrain_tile cata_tiles::get_furniture_memory_at( const tripoint &p ) 
 
 memorized_terrain_tile cata_tiles::get_trap_memory_at( const tripoint &p ) const
 {
-    if( g->u.should_show_map_memory() ) {
-        const memorized_terrain_tile t = g->u.get_memorized_tile( get_map().getabs( p ) );
+    if( get_avatar().should_show_map_memory() ) {
+        const memorized_terrain_tile t = get_avatar().get_memorized_tile( get_map().getabs( p ) );
         if( string_starts_with( t.tile, "tr_" ) ) {
             return t;
         }
@@ -2715,8 +2715,8 @@ memorized_terrain_tile cata_tiles::get_trap_memory_at( const tripoint &p ) const
 
 memorized_terrain_tile cata_tiles::get_vpart_memory_at( const tripoint &p ) const
 {
-    if( g->u.should_show_map_memory() ) {
-        const memorized_terrain_tile t = g->u.get_memorized_tile( get_map().getabs( p ) );
+    if( get_avatar().should_show_map_memory() ) {
+        const memorized_terrain_tile t = get_avatar().get_memorized_tile( get_map().getabs( p ) );
         if( string_starts_with( t.tile, "vp_" ) ) {
             return t;
         }
@@ -2753,7 +2753,7 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
         get_tile_values( f.to_i(), neighborhood, subtile, rotation );
         const std::string &fname = f.id().str();
         if( here.check_seen_cache( p ) ) {
-            g->u.memorize_tile( here.getabs( p ), fname, subtile, rotation );
+            get_avatar().memorize_tile( here.getabs( p ), fname, subtile, rotation );
         }
         // draw the actual furniture if there's no override
         if( !neighborhood_overridden ) {
@@ -2816,7 +2816,7 @@ bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3
     map &here = get_map();
     // first memorize the actual trap
     const trap_id &tr = here.tr_at( p ).loadid;
-    if( tr && !invisible[0] && tr.obj().can_see( p, g->u ) ) {
+    if( tr && !invisible[0] && tr.obj().can_see( p, get_avatar() ) ) {
         const int neighborhood[4] = {
             static_cast<int>( here.tr_at( p + point_south ).loadid ),
             static_cast<int>( here.tr_at( p + point_east ).loadid ),
@@ -2828,7 +2828,7 @@ bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3
         get_tile_values( tr.to_i(), neighborhood, subtile, rotation );
         const std::string trname = tr.id().str();
         if( here.check_seen_cache( p ) && tr != tr_ledge ) {
-            g->u.memorize_tile( here.getabs( p ), trname, subtile, rotation );
+            get_avatar().memorize_tile( here.getabs( p ), trname, subtile, rotation );
         }
         // draw the actual trap if there's no override
         if( !neighborhood_overridden ) {
@@ -2836,7 +2836,7 @@ bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3
                                         nv_goggles_activated, height_3d, z_drop );
         }
     }
-    if( overridden || ( !invisible[0] && neighborhood_overridden && tr.obj().can_see( p, g->u ) ) ) {
+    if( overridden || ( !invisible[0] && neighborhood_overridden && tr.obj().can_see( p, get_avatar() ) ) ) {
         // and then draw the override trap
         const trap_id &tr2 = overridden ? override->second : tr;
         if( tr2 ) {
@@ -2936,7 +2936,7 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
             mon_id = std::get<1>( it_override->second );
             hilite = std::get<2>( it_override->second );
             it_type = &*it_id;
-        } else if( !invisible[0] && here.sees_some_items( p, g->u ) ) {
+        } else if( !invisible[0] && here.sees_some_items( p, get_avatar() ) ) {
             const maptile &tile = here.maptile_at( p );
             const item &itm = tile.get_uppermost_item();
             const mtype *const mon = itm.get_mtype();
@@ -3059,8 +3059,8 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
         }
         const Creature &critter = *pcritter;
 
-        if( !g->u.sees( critter ) ) {
-            if( g->u.sees_with_infrared( critter ) || g->u.sees_with_specials( critter ) ) {
+        if( !get_avatar().sees( critter ) ) {
+            if( get_avatar().sees_with_infrared( critter ) || get_avatar().sees_with_specials( critter ) ) {
                 return draw_from_id_string( "infrared_creature", C_NONE, empty_string, p, 0, 0,
                                             lit_level::LIT, false, height_3d, z_drop );
             }
@@ -3103,7 +3103,7 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
                 }
                 result = draw_from_id_string( chosen_id, ent_category, ent_subcategory, p, subtile, rot_facing,
                                               ll, false, height_3d, z_drop );
-                sees_player = m->sees( g->u );
+                sees_player = m->sees( get_avatar() );
                 attitude = m->attitude_to( g-> u );
             }
         }
@@ -3121,7 +3121,7 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
     } else {
         // invisible
         const Creature *critter = g->critter_at( p, true );
-        if( critter && ( g->u.sees_with_infrared( *critter ) || g->u.sees_with_specials( *critter ) ) ) {
+        if( critter && ( get_avatar().sees_with_infrared( *critter ) || get_avatar().sees_with_specials( *critter ) ) ) {
             // try drawing infrared creature if invisible and not overridden
             // return directly without drawing overlay
             return draw_from_id_string( "infrared_creature", C_NONE, empty_string, p, 0, 0,
@@ -3177,7 +3177,7 @@ bool cata_tiles::draw_zombie_revival_indicators( const tripoint &pos, const lit_
 {
     map &here = get_map();
     if( tileset_ptr->find_tile_type( ZOMBIE_REVIVAL_INDICATOR ) && !invisible[0] &&
-        item_override.find( pos ) == item_override.end() && here.could_see_items( pos, g->u ) ) {
+        item_override.find( pos ) == item_override.end() && here.could_see_items( pos, get_avatar() ) ) {
         for( auto &i : here.i_at( pos ) ) {
             if( i->can_revive() ) {
                 return draw_from_id_string( ZOMBIE_REVIVAL_INDICATOR, C_NONE, empty_string, pos, 0, 0,
@@ -3622,7 +3622,7 @@ void cata_tiles::draw_line()
         return;
     }
     static std::string line_overlay = "animation_line";
-    if( !is_target_line || g->u.sees( line_pos ) ) {
+    if( !is_target_line || get_avatar().sees( line_pos ) ) {
         for( auto it = line_trajectory.begin(); it != line_trajectory.end() - 1; ++it ) {
             draw_from_id_string( line_overlay, *it, 0, 0, lit_level::LIT, false, 0 );
         }
@@ -3688,7 +3688,7 @@ void cata_tiles::draw_sct_frame( std::multimap<point, formatted_text> &overlay_s
 
                     if( tileset_ptr->find_tile_type( generic_id ) ) {
                         draw_from_id_string( generic_id, C_NONE, empty_string,
-                                             iD + tripoint( iOffsetX, iOffsetY, g->u.pos().z ), 0, 0, lit_level::LIT, false, 0 );
+                                             iD + tripoint( iOffsetX, iOffsetY, get_avatar().pos().z ), 0, 0, lit_level::LIT, false, 0 );
                     }
 
                     if( tile_iso ) {
@@ -3706,7 +3706,7 @@ void cata_tiles::draw_zones_frame()
     for( int iY = zone_start.y; iY <= zone_end.y; ++ iY ) {
         for( int iX = zone_start.x; iX <= zone_end.x; ++iX ) {
             draw_from_id_string( "highlight", C_NONE, empty_string,
-                                 zone_offset.xy() + tripoint( iX, iY, g->u.pos().z ),
+                                 zone_offset.xy() + tripoint( iX, iY, get_avatar().pos().z ),
                                  0, 0, lit_level::LIT, false, 0 );
         }
     }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3106,7 +3106,7 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
                 result = draw_from_id_string( chosen_id, ent_category, ent_subcategory, p, subtile, rot_facing,
                                               ll, false, height_3d, z_drop );
                 sees_player = m->sees( get_avatar() );
-                attitude = m->attitude_to( g-> u );
+                attitude = m->attitude_to( get_avatar() );
             }
         }
         const player *pl = dynamic_cast<const player *>( &critter );
@@ -3116,8 +3116,8 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
             if( pl->is_player() ) {
                 is_player = true;
             } else {
-                sees_player = pl->sees( g-> u );
-                attitude = pl->attitude_to( g-> u );
+                sees_player = pl->sees( get_avatar() );
+                attitude = pl->attitude_to( get_avatar() );
             }
         }
     } else {

--- a/src/catalua_console.cpp
+++ b/src/catalua_console.cpp
@@ -5,7 +5,6 @@
 #include "catalua_log.h"
 #include "catalua_impl.h"
 #include "cursesdef.h"
-#include "game.h"
 #include "init.h"
 #include "input.h"
 #include "output.h"

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -378,7 +378,7 @@ std::string enum_to_string<character_movemode>( character_movemode data )
 
 Character &get_player_character()
 {
-    return g->u;
+    return get_avatar();
 }
 
 // *INDENT-OFF*
@@ -1343,12 +1343,12 @@ void Character::mount_creature( monster &z )
     mounted_creature = mons;
     mons->mounted_player = this;
     if( is_avatar() ) {
-        if( g->u.is_hauling() ) {
-            g->u.stop_hauling();
+        if( get_avatar().is_hauling() ) {
+            get_avatar().stop_hauling();
         }
-        if( g->u.get_grab_type() != OBJECT_NONE ) {
+        if( get_avatar().get_grab_type() != OBJECT_NONE ) {
             add_msg( m_warning, _( "You let go of the grabbed object." ) );
-            g->u.grab( OBJECT_NONE );
+            get_avatar().grab( OBJECT_NONE );
         }
         g->place_player( pnt );
     } else {
@@ -1518,15 +1518,15 @@ void Character::forced_dismount()
         add_msg( m_debug, "Forced_dismount could not find a square to deposit player" );
     }
     if( is_avatar() ) {
-        if( g->u.get_grab_type() != OBJECT_NONE ) {
+        if( get_avatar().get_grab_type() != OBJECT_NONE ) {
             add_msg( m_warning, _( "You let go of the grabbed object." ) );
-            g->u.grab( OBJECT_NONE );
+            get_avatar().grab( OBJECT_NONE );
         }
         set_movement_mode( CMM_WALK );
-        if( g->u.is_auto_moving() || g->u.has_destination() || g->u.has_destination_activity() ) {
-            g->u.clear_destination();
+        if( get_avatar().is_auto_moving() || get_avatar().has_destination() || get_avatar().has_destination_activity() ) {
+            get_avatar().clear_destination();
         }
-        g->update_map( g->u );
+        g->update_map( get_avatar() );
     }
     if( activity ) {
         cancel_activity();
@@ -1553,9 +1553,9 @@ void Character::dismount()
             weapon.typeId() == critter->type->mech_weapon ) {
             remove_item( weapon );
         }
-        if( is_avatar() && g->u.get_grab_type() != OBJECT_NONE ) {
+        if( is_avatar() && get_avatar().get_grab_type() != OBJECT_NONE ) {
             add_msg( m_warning, _( "You let go of the grabbed object." ) );
-            g->u.grab( OBJECT_NONE );
+            get_avatar().grab( OBJECT_NONE );
         }
         critter->remove_effect( effect_ridden );
         critter->add_effect( effect_ai_waiting, 5_turns );
@@ -8617,7 +8617,7 @@ void Character::absorb_hit( const bodypart_id &bp, damage_instance &dam )
             }
 
             if( destroy ) {
-                if( g->u.sees( *this ) ) {
+                if( get_avatar().sees( *this ) ) {
                     SCT.add( point( posx(), posy() ), direction::NORTH, remove_color_tags( pre_damage_name ),
                              m_neutral, _( "destroyed" ), m_info );
                 }
@@ -8810,7 +8810,7 @@ void Character::on_hit( Creature *source, bodypart_id bp_hit,
         return;
     }
 
-    bool u_see = g->u.sees( *this );
+    bool u_see = get_avatar().sees( *this );
     units::energy trigger_cost_base = bio_ods->power_trigger;
     if( has_active_bionic( bio_ods ) && get_power_level() >= trigger_cost_base * 4 ) {
         if( is_player() ) {
@@ -8945,7 +8945,7 @@ void Character::apply_damage( Creature *source, bodypart_id hurt, int dam,
 
     if( is_dead_state() ) {
         // if the player killed himself, add it to the kill count list
-        if( !is_npc() && !get_killer() && source == g->u.as_character() ) {
+        if( !is_npc() && !get_killer() && source == get_avatar().as_character() ) {
             g->events().send<event_type::character_kills_character>( get_player_character().getID(), getID(),
                     get_name() );
         }
@@ -8983,7 +8983,7 @@ dealt_damage_instance Character::deal_damage( Creature *source, bodypart_id bp,
     int dam = dealt_dams.total_damage();
 
     // TODO: Pre or post blit hit tile onto "this"'s location here
-    if( dam > 0 && g->u.sees( pos() ) ) {
+    if( dam > 0 && get_avatar().sees( pos() ) ) {
         g->draw_hit_player( *this, dam );
 
         if( is_player() && source ) {
@@ -9020,10 +9020,10 @@ dealt_damage_instance Character::deal_damage( Creature *source, bodypart_id bp,
     }
 
     //Acid blood effects.
-    bool u_see = g->u.sees( *this );
+    bool u_see = get_avatar().sees( *this );
     int cut_dam = dealt_dams.type_damage( DT_CUT );
     if( source && has_trait( trait_ACIDBLOOD ) && !one_in( 3 ) &&
-        ( dam >= 4 || cut_dam > 0 ) && ( rl_dist( g->u.pos(), source->pos() ) <= 1 ) ) {
+        ( dam >= 4 || cut_dam > 0 ) && ( rl_dist( get_avatar().pos(), source->pos() ) <= 1 ) ) {
         if( is_player() ) {
             add_msg( m_good, _( "Your acidic blood splashes %s in mid-attack!" ),
                      source->disp_name() );
@@ -11592,7 +11592,7 @@ void Character::knock_back_to( const tripoint &to )
     // If we're still in the function at this point, we're actually moving a tile!
     if( g->m.has_flag( "LIQUID", to ) && g->m.has_flag( TFLAG_DEEP_WATER, to ) ) {
         if( !is_npc() ) {
-            avatar_action::swim( g->m, g->u, to );
+            avatar_action::swim( g->m, get_avatar(), to );
         }
         // TODO: NPCs can't swim!
     } else if( g->m.impassable( to ) ) { // Wait, it's a wall

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1523,7 +1523,8 @@ void Character::forced_dismount()
             get_avatar().grab( OBJECT_NONE );
         }
         set_movement_mode( CMM_WALK );
-        if( get_avatar().is_auto_moving() || get_avatar().has_destination() || get_avatar().has_destination_activity() ) {
+        if( get_avatar().is_auto_moving() || get_avatar().has_destination() ||
+            get_avatar().has_destination_activity() ) {
             get_avatar().clear_destination();
         }
         g->update_map( get_avatar() );
@@ -11427,7 +11428,7 @@ int Character::impact( const int force, const tripoint &p )
         // TODO: Modify based on something?
         mod = 1.0f;
         effective_force = force;
-    } else if( const optional_vpart_position vp = g->m.veh_at( p ) ) {
+    } else if( const optional_vpart_position vp = get_map().veh_at( p ) ) {
         // Slamming into vehicles
         // TODO: Integrate it with vehicle collision function somehow
         target_name = vp->vehicle().disp_name();
@@ -11445,17 +11446,17 @@ int Character::impact( const int force, const tripoint &p )
         }
     } else {
         // Slamming into terrain/furniture
-        target_name = g->m.disp_name( p );
-        int hard_ground = g->m.has_flag( TFLAG_DIGGABLE, p ) ? 0 : 3;
+        target_name = get_map().disp_name( p );
+        int hard_ground = get_map().has_flag( TFLAG_DIGGABLE, p ) ? 0 : 3;
         armor_eff = 0.25f; // Not much
         // Get cut by stuff
         // This isn't impalement on metal wreckage, more like flying through a closed window
-        cut = g->m.has_flag( TFLAG_SHARP, p ) ? 5 : 0;
+        cut = get_map().has_flag( TFLAG_SHARP, p ) ? 5 : 0;
         effective_force = force + hard_ground;
         mod = slam ? 1.0f : fall_damage_mod();
-        if( g->m.has_furn( p ) ) {
+        if( get_map().has_furn( p ) ) {
             // TODO: Make furniture matter
-        } else if( g->m.has_flag( TFLAG_SWIMMABLE, p ) ) {
+        } else if( get_map().has_flag( TFLAG_SWIMMABLE, p ) ) {
             // TODO: Some formula of swimming
             effective_force /= 4;
         }
@@ -11555,7 +11556,7 @@ void Character::knock_back_to( const tripoint &to )
         apply_damage( nullptr, bodypart_id( "torso" ), 3 );
         add_effect( effect_stunned, 2_turns );
         add_msg_player_or_npc( _( "You bounce off a %s!" ), _( "<npcname> bounces off a %s!" ),
-                               g->m.obstacle_name( intervening ) );
+                               get_map().obstacle_name( intervening ) );
         return;
     }
 
@@ -11590,19 +11591,19 @@ void Character::knock_back_to( const tripoint &to )
     }
 
     // If we're still in the function at this point, we're actually moving a tile!
-    if( g->m.has_flag( "LIQUID", to ) && g->m.has_flag( TFLAG_DEEP_WATER, to ) ) {
+    if( get_map().has_flag( "LIQUID", to ) && get_map().has_flag( TFLAG_DEEP_WATER, to ) ) {
         if( !is_npc() ) {
-            avatar_action::swim( g->m, get_avatar(), to );
+            avatar_action::swim( get_map(), get_avatar(), to );
         }
         // TODO: NPCs can't swim!
-    } else if( g->m.impassable( to ) ) { // Wait, it's a wall
+    } else if( get_map().impassable( to ) ) { // Wait, it's a wall
 
         // It's some kind of wall.
         // TODO: who knocked us back? Maybe that creature should be the source of the damage?
         apply_damage( nullptr, bodypart_id( "torso" ), 3 );
         add_effect( effect_stunned, 2_turns );
         add_msg_player_or_npc( _( "You bounce off a %s!" ), _( "<npcname> bounces off a %s!" ),
-                               g->m.obstacle_name( to ) );
+                               get_map().obstacle_name( to ) );
 
     } else { // It's no wall
         setpos( to );

--- a/src/character.h
+++ b/src/character.h
@@ -1914,7 +1914,7 @@ class Character : public Creature, public location_visitable<Character>
         /**
          * Returns all creatures that this player can see and that are in the given
          * range. This player object itself is never included.
-         * The player character (g->u) is checked and might be included (if applicable).
+         * The player character (get_avatar()) is checked and might be included (if applicable).
          * @param range The maximal distance (@ref rl_dist), creatures at this distance or less
          * are included.
          */

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -267,7 +267,7 @@ loot_options::query_loot_result loot_options::query_loot()
 
 plot_options::query_seed_result plot_options::query_seed()
 {
-    player &p = g->u;
+    player &p = get_avatar();
     map &here = get_map();
 
     std::vector<item *> seed_inv = p.items_with( []( const item & itm ) {

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -127,7 +127,7 @@ void computer_session::use()
                 return;
 
             case ynq::yes:
-                if( !hack_attempt( g->u ) ) {
+                if( !hack_attempt( get_avatar() ) ) {
                     if( comp.failures.empty() ) {
                         query_any( _( "Maximum login attempts exceeded.  Press any key…" ) );
                         reset_terminal();
@@ -174,7 +174,7 @@ void computer_session::use()
         if( current.security + comp.alerts > 0 ) {
             print_error( _( "Password required." ) );
             if( query_bool( _( "Hack into system?" ) ) ) {
-                if( !hack_attempt( g->u, current.security ) ) {
+                if( !hack_attempt( get_avatar(), current.security ) ) {
                     activate_random_failure();
                     reset_terminal();
                     return;
@@ -230,7 +230,7 @@ static item *pick_usb()
         return it.typeId() == itype_usb_drive;
     };
 
-    item *loc = game_menus::inv::titled_filter_menu( filter, g->u, _( "Choose drive:" ) );
+    item *loc = game_menus::inv::titled_filter_menu( filter, get_avatar(), _( "Choose drive:" ) );
     if( loc ) {
         return loc;
     }
@@ -242,9 +242,9 @@ static void remove_submap_turrets()
     map &here = get_map();
     for( monster &critter : g->all_monsters() ) {
         // Check 1) same overmap coords, 2) turret, 3) hostile
-        if( ms_to_omt_copy( here.getabs( critter.pos() ) ) == ms_to_omt_copy( here.getabs( g->u.pos() ) ) &&
+        if( ms_to_omt_copy( here.getabs( critter.pos() ) ) == ms_to_omt_copy( here.getabs( get_avatar().pos() ) ) &&
             critter.has_flag( MF_CONSOLE_DESPAWN ) &&
-            critter.attitude_to( g->u ) == Creature::Attitude::A_HOSTILE ) {
+            critter.attitude_to( get_avatar() ) == Creature::Attitude::A_HOSTILE ) {
             g->remove_zombie( critter );
         }
     }
@@ -307,7 +307,7 @@ void computer_session::activate_function( computer_action action )
     const auto it = computer_action_functions.find( action );
     if( it != computer_action_functions.end() ) {
         // Token move cost for any action, if an action takes longer decrement moves further.
-        g->u.moves -= 30;
+        get_avatar().moves -= 30;
         ( this->*( it->second ) )();
     }
 }
@@ -320,7 +320,7 @@ void computer_session::action_open_disarm()
 
 void computer_session::action_open()
 {
-    get_map().translate_radius( t_door_metal_locked, t_floor, 25.0, g->u.pos(), true );
+    get_map().translate_radius( t_door_metal_locked, t_floor, 25.0, get_avatar().pos(), true );
     query_any( _( "Doors opened.  Press any key…" ) );
 }
 
@@ -331,7 +331,7 @@ void computer_session::action_open()
 // player position to determine which terrain tiles to edit.
 void computer_session::action_lock()
 {
-    get_map().translate_radius( t_door_metal_c, t_door_metal_locked, 8.0, g->u.pos(), true );
+    get_map().translate_radius( t_door_metal_c, t_door_metal_locked, 8.0, get_avatar().pos(), true );
     query_any( _( "Lock enabled.  Press any key…" ) );
 }
 
@@ -343,21 +343,21 @@ void computer_session::action_unlock_disarm()
 
 void computer_session::action_unlock()
 {
-    get_map().translate_radius( t_door_metal_locked, t_door_metal_c, 8.0, g->u.pos(), true );
+    get_map().translate_radius( t_door_metal_locked, t_door_metal_c, 8.0, get_avatar().pos(), true );
     query_any( _( "Lock disabled.  Press any key…" ) );
 }
 
 //Toll is required for the church computer/mechanism to function
 void computer_session::action_toll()
 {
-    sounds::sound( g->u.pos(), 120, sounds::sound_t::music,
+    sounds::sound( get_avatar().pos(), 120, sounds::sound_t::music,
                    //~ the sound of a church bell ringing
                    _( "Bohm…  Bohm…  Bohm…" ), true, "environment", "church_bells" );
 }
 
 void computer_session::action_sample()
 {
-    g->u.moves -= 30;
+    get_avatar().moves -= 30;
     map &here = get_map();
     item *sewage = item::spawn_temporary( itype_sewage, calendar::turn );
     for( const tripoint &p : here.points_on_zlevel() ) {
@@ -394,9 +394,9 @@ void computer_session::action_sample()
 void computer_session::action_release()
 {
     g->events().send<event_type::releases_subspace_specimens>();
-    sounds::sound( g->u.pos(), 40, sounds::sound_t::alarm, _( "an alarm sound!" ), false, "environment",
+    sounds::sound( get_avatar().pos(), 40, sounds::sound_t::alarm, _( "an alarm sound!" ), false, "environment",
                    "alarm" );
-    get_map().translate_radius( t_reinforced_glass, t_thconc_floor, 25.0, g->u.pos(), true );
+    get_map().translate_radius( t_reinforced_glass, t_thconc_floor, 25.0, get_avatar().pos(), true );
     query_any( _( "Containment shields opened.  Press any key…" ) );
 }
 
@@ -408,9 +408,9 @@ void computer_session::action_release_disarm()
 
 void computer_session::action_release_bionics()
 {
-    sounds::sound( g->u.pos(), 40, sounds::sound_t::alarm, _( "an alarm sound!" ), false, "environment",
+    sounds::sound( get_avatar().pos(), 40, sounds::sound_t::alarm, _( "an alarm sound!" ), false, "environment",
                    "alarm" );
-    get_map().translate_radius( t_reinforced_glass, t_thconc_floor, 3.0, g->u.pos(), true );
+    get_map().translate_radius( t_reinforced_glass, t_thconc_floor, 3.0, get_avatar().pos(), true );
     query_any( _( "Containment shields opened.  Press any key…" ) );
 }
 
@@ -427,7 +427,7 @@ void computer_session::action_terminate()
               here.ter( p + tripoint_south ) == t_concrete_wall ) ||
             ( here.ter( p + tripoint_south ) == t_reinforced_glass &&
               here.ter( p + tripoint_north ) == t_concrete_wall ) ) {
-            mon->die( &g->u );
+            mon->die( &get_avatar() );
         }
     }
     query_any( _( "Subjects terminated.  Press any key…" ) );
@@ -462,12 +462,12 @@ void computer_session::action_cascade()
     g->events().send<event_type::causes_resonance_cascade>();
     map &here = get_map();
     std::vector<tripoint> cascade_points;
-    for( const tripoint &dest : here.points_in_radius( g->u.pos(), 10 ) ) {
+    for( const tripoint &dest : here.points_in_radius( get_avatar().pos(), 10 ) ) {
         if( here.ter( dest ) == t_radio_tower ) {
             cascade_points.push_back( dest );
         }
     }
-    explosion_handler::resonance_cascade( random_entry( cascade_points, g->u.pos() ) );
+    explosion_handler::resonance_cascade( random_entry( cascade_points, get_avatar().pos() ) );
 }
 
 void computer_session::action_research()
@@ -479,7 +479,7 @@ void computer_session::action_research()
     if( !log.has_value() ) {
         log = to_translation( "No data found." );
     } else {
-        g->u.moves -= 70;
+        get_avatar().moves -= 70;
     }
 
     print_text( "%s", log.value() );
@@ -497,7 +497,7 @@ void computer_session::action_research()
 
 void computer_session::action_radio_archive()
 {
-    g->u.moves -= 300;
+    get_avatar().moves -= 300;
     sfx::fade_audio_channel( sfx::channel::radio, 100 );
     sfx::play_ambient_variant_sound( "radio", "inaudible_chatter", 100, sfx::channel::radio,
                                      2000 );
@@ -579,7 +579,7 @@ void computer_session::action_miss_disarm()
 
 void computer_session::action_list_bionics()
 {
-    g->u.moves -= 30;
+    get_avatar().moves -= 30;
     std::vector<std::string> names;
     int more = 0;
     map &here = get_map();
@@ -627,7 +627,7 @@ void computer_session::action_amigara_log()
 {
     g->timed_events.add( timed_event_type::AMIGARA_WHISPERS, calendar::turn + 1_minutes );
 
-    g->u.moves -= 30;
+    get_avatar().moves -= 30;
     reset_terminal();
     print_line( _( "NEPower Mine(%d:%d) Log" ), g->get_levx(), g->get_levy() );
     print_text( "%s", SNIPPET.random_from_category( "amigara1" ).value_or( translation() ) );
@@ -635,7 +635,7 @@ void computer_session::action_amigara_log()
     if( !query_bool( _( "Continue reading?" ) ) ) {
         return;
     }
-    g->u.moves -= 30;
+    get_avatar().moves -= 30;
     reset_terminal();
     print_line( _( "NEPower Mine(%d:%d) Log" ), g->get_levx(), g->get_levy() );
     print_text( "%s", SNIPPET.random_from_category( "amigara2" ).value_or( translation() ) );
@@ -643,7 +643,7 @@ void computer_session::action_amigara_log()
     if( !query_bool( _( "Continue reading?" ) ) ) {
         return;
     }
-    g->u.moves -= 30;
+    get_avatar().moves -= 30;
     reset_terminal();
     print_line( _( "NEPower Mine(%d:%d) Log" ), g->get_levx(), g->get_levy() );
     print_text( "%s", SNIPPET.random_from_category( "amigara3" ).value_or( translation() ) );
@@ -664,7 +664,7 @@ void computer_session::action_amigara_log()
     if( !query_bool( _( "Continue reading?" ) ) ) {
         return;
     }
-    g->u.moves -= 30;
+    get_avatar().moves -= 30;
     reset_terminal();
     print_line( _( "SITE %d%d%d\n"
                    "PERTINENT FOREMAN LOGS WILL BE PREPENDED TO NOTES" ),
@@ -689,7 +689,7 @@ void computer_session::action_amigara_start()
 
 void computer_session::action_complete_disable_external_power()
 {
-    for( auto miss : g->u.get_active_missions() ) {
+    for( auto miss : get_avatar().get_active_missions() ) {
         static const mission_type_id commo_2 = mission_type_id( "MISSION_OLD_GUARD_NEC_COMMO_2" );
         if( miss->mission_id() == commo_2 ) {
             print_error( _( "--ACCESS GRANTED--" ) );
@@ -705,15 +705,15 @@ void computer_session::action_complete_disable_external_power()
 
 void computer_session::action_repeater_mod()
 {
-    if( g->u.has_amount( itype_radio_repeater_mod, 1 ) ) {
-        for( auto miss : g->u.get_active_missions() ) {
+    if( get_avatar().has_amount( itype_radio_repeater_mod, 1 ) ) {
+        for( auto miss : get_avatar().get_active_missions() ) {
             static const mission_type_id commo_3 = mission_type_id( "MISSION_OLD_GUARD_NEC_COMMO_3" ),
                                          commo_4 = mission_type_id( "MISSION_OLD_GUARD_NEC_COMMO_4" );
             if( miss->mission_id() == commo_3 || miss->mission_id() == commo_4 ) {
                 miss->step_complete( 1 );
                 print_error( _( "Repeater mod installed…" ) );
                 print_error( _( "Mission Complete!" ) );
-                g->u.use_amount( itype_radio_repeater_mod, 1 );
+                get_avatar().use_amount( itype_radio_repeater_mod, 1 );
                 query_any();
                 comp.options.clear();
                 activate_failure( COMPFAIL_SHUTDOWN );
@@ -734,7 +734,7 @@ void computer_session::action_download_software()
             debugmsg( _( "Computer couldn't find its mission!" ) );
             return;
         }
-        g->u.moves -= 30;
+        get_avatar().moves -= 30;
         detached_ptr<item> software = item::spawn( miss->get_item_id(), calendar::start_of_cataclysm );
         software->mission_id = comp.mission_id;
         usb->contents.clear_items();
@@ -748,9 +748,9 @@ void computer_session::action_download_software()
 
 void computer_session::action_blood_anal()
 {
-    g->u.moves -= 70;
+    get_avatar().moves -= 70;
     map &here = get_map();
-    for( const tripoint &dest : here.points_in_radius( g->u.pos(), 2 ) ) {
+    for( const tripoint &dest : here.points_in_radius( get_avatar().pos(), 2 ) ) {
         if( here.furn( dest ) == furn_str_id( "f_centrifuge" ) ) {
             map_stack items = here.i_at( dest );
             if( items.empty() ) {
@@ -794,9 +794,9 @@ void computer_session::action_blood_anal()
 
 void computer_session::action_data_anal()
 {
-    g->u.moves -= 30;
+    get_avatar().moves -= 30;
     map &here = get_map();
-    for( const tripoint &dest : here.points_in_radius( g->u.pos(), 2 ) ) {
+    for( const tripoint &dest : here.points_in_radius( get_avatar().pos(), 2 ) ) {
         if( here.ter( dest ) == t_floor_blue ) {
             print_error( _( "PROCESSING DATA" ) );
             map_stack items = here.i_at( dest );
@@ -813,7 +813,7 @@ void computer_session::action_data_anal()
             } else { // Success!
                 if( items.only_item().typeId() == itype_black_box ) {
                     print_line( _( "Memory Bank: Military Hexron Encryption\nPrinting Transcript\n" ) );
-                    here.add_item_or_charges( g->u.pos(), item::spawn( "black_box_transcript", calendar::turn ) );
+                    here.add_item_or_charges( get_avatar().pos(), item::spawn( "black_box_transcript", calendar::turn ) );
                 } else {
                     print_line( _( "Memory Bank: Unencrypted\nNothing of interest.\n" ) );
                 }
@@ -932,7 +932,7 @@ void computer_session::action_srcf_seal()
     for( const tripoint &p : here.points_on_zlevel() ) {
         if( here.ter( p ) == t_elevator || here.ter( p ) == t_vat ) {
             here.make_rubble( p, f_rubble_rock );
-            explosion_handler::explosion( p, &g->u, 40, 0.7, true );
+            explosion_handler::explosion( p, &get_avatar(), 40, 0.7, true );
         }
         if( here.ter( p ) == t_wall_glass ) {
             here.make_rubble( p, f_rubble_rock );
@@ -942,7 +942,7 @@ void computer_session::action_srcf_seal()
         }
         if( here.ter( p ) == t_sewage_pump ) {
             here.make_rubble( p, f_rubble_rock );
-            explosion_handler::explosion( p, &g->u, 50, 0.7, true );
+            explosion_handler::explosion( p, &get_avatar(), 50, 0.7, true );
         }
     }
     comp.options.clear(); // Disable the terminal.
@@ -951,7 +951,7 @@ void computer_session::action_srcf_seal()
 
 void computer_session::action_srcf_elevator()
 {
-    Character &player_character = g->u;
+    Character &player_character = get_avatar();
     map &here = g->m;
     tripoint surface_elevator;
     tripoint underground_elevator;
@@ -1019,17 +1019,17 @@ void computer_session::action_srcf_elevator()
 //irradiates food at t_rad_platform, adds radiation
 void computer_session::action_irradiator()
 {
-    g->u.moves -= 30;
+    get_avatar().moves -= 30;
     bool error = false;
     bool platform_exists = false;
     map &here = get_map();
-    for( const tripoint &dest : here.points_in_radius( g->u.pos(), 10 ) ) {
+    for( const tripoint &dest : here.points_in_radius( get_avatar().pos(), 10 ) ) {
         if( here.ter( dest ) == t_rad_platform ) {
             platform_exists = true;
             if( here.i_at( dest ).empty() ) {
                 print_error( _( "ERROR: Processing platform empty." ) );
             } else {
-                g->u.moves -= 300;
+                get_avatar().moves -= 300;
                 for( auto iter = here.i_at( dest ).begin(); iter != here.i_at( dest ).end(); ++iter ) {
                     // actual food processing
                     item *it = *iter;
@@ -1040,14 +1040,14 @@ void computer_session::action_irradiator()
                     // critical failure - radiation spike sets off electronic detonators
                     if( it->typeId() == itype_mininuke || it->typeId() == itype_mininuke_act ||
                         it->typeId() == itype_c4 ) {
-                        explosion_handler::explosion( dest, &g->u, 40 );
+                        explosion_handler::explosion( dest, &get_avatar(), 40 );
                         reset_terminal();
                         print_error( _( "WARNING [409]: Primary sensors offline!" ) );
                         print_error( _( "  >> Initialize secondary sensors: Geiger profiling…" ) );
                         print_error( _( "  >> Radiation spike detected!\n" ) );
                         print_error( _( "WARNING [912]: Catastrophic malfunction!  Contamination detected!" ) );
                         print_error( _( "EMERGENCY PROCEDURE [1]:  Evacuate.  Evacuate.  Evacuate.\n" ) );
-                        sounds::sound( g->u.pos(), 30, sounds::sound_t::alarm, _( "an alarm sound!" ), false, "environment",
+                        sounds::sound( get_avatar().pos(), 30, sounds::sound_t::alarm, _( "an alarm sound!" ), false, "environment",
                                        "alarm" );
                         here.i_rem( dest, it );
                         here.make_rubble( dest );
@@ -1059,9 +1059,9 @@ void computer_session::action_irradiator()
                                                    dest ) > 0 ? rl_dist( radorigin, dest ) : 1 ) );
                         }
                         if( here.pl_sees( dest, 10 ) ) {
-                            g->u.irradiate( rng_float( 50, 250 ) / rl_dist( g->u.pos(), dest ) );
+                            get_avatar().irradiate( rng_float( 50, 250 ) / rl_dist( get_avatar().pos(), dest ) );
                         } else {
-                            g->u.irradiate( rng_float( 20, 100 ) / rl_dist( g->u.pos(), dest ) );
+                            get_avatar().irradiate( rng_float( 20, 100 ) / rl_dist( get_avatar().pos(), dest ) );
                         }
                         query_any( _( "EMERGENCY SHUTDOWN!  Press any key…" ) );
                         error = true;
@@ -1076,7 +1076,7 @@ void computer_session::action_irradiator()
                     }
                     // if unshielded, rad source irradiates player directly, reduced by distance to source
                     if( here.pl_sees( dest, 10 ) ) {
-                        g->u.irradiate( rng_float( 5, 25 ) / rl_dist( g->u.pos(), dest ) );
+                        get_avatar().irradiate( rng_float( 5, 25 ) / rl_dist( get_avatar().pos(), dest ) );
                     }
                 }
                 if( !error && platform_exists ) {
@@ -1098,7 +1098,7 @@ void computer_session::action_irradiator()
 // geiger counter for irradiator, primary measurement at t_rad_platform, secondary at player loacation
 void computer_session::action_geiger()
 {
-    g->u.moves -= 30;
+    get_avatar().moves -= 30;
     tripoint platform;
     bool source_exists = false;
     int sum_rads = 0;
@@ -1106,7 +1106,7 @@ void computer_session::action_geiger()
     int tiles_counted = 0;
     map &here = get_map();
     print_error( _( "RADIATION MEASUREMENTS:" ) );
-    for( const tripoint &dest : here.points_in_radius( g->u.pos(), 10 ) ) {
+    for( const tripoint &dest : here.points_in_radius( get_avatar().pos(), 10 ) ) {
         if( here.ter( dest ) == t_rad_platform ) {
             source_exists = true;
             platform = dest;
@@ -1129,8 +1129,8 @@ void computer_session::action_geiger()
         print_error( _( "GEIGER COUNTER @ ZONE:… MAX %s mSv/h." ), peak_rad );
         print_newline();
     }
-    print_error( _( "GEIGER COUNTER @ CONSOLE:… %s mSv/h." ), here.get_radiation( g->u.pos() ) );
-    print_error( _( "PERSONAL DOSIMETRY:… %s mSv." ), g->u.get_rad() );
+    print_error( _( "GEIGER COUNTER @ CONSOLE:… %s mSv/h." ), here.get_radiation( get_avatar().pos() ) );
+    print_error( _( "PERSONAL DOSIMETRY:… %s mSv." ), get_avatar().get_rad() );
     print_newline();
     query_any( _( "Press any key…" ) );
 }
@@ -1139,7 +1139,7 @@ void computer_session::action_geiger()
 // ensure only bay of each type in range
 void computer_session::action_conveyor()
 {
-    g->u.moves -= 300;
+    get_avatar().moves -= 300;
     tripoint loading; // red tile = loading bay
     tripoint unloading; // green tile = unloading bay
     tripoint platform; // radiation platform = middle point
@@ -1147,7 +1147,7 @@ void computer_session::action_conveyor()
     bool u_exists = false;
     bool p_exists = false;
     map &here = get_map();
-    for( const tripoint &dest : here.points_in_radius( g->u.pos(), 10 ) ) {
+    for( const tripoint &dest : here.points_in_radius( get_avatar().pos(), 10 ) ) {
         if( here.ter( dest ) == t_rad_platform ) {
             platform = dest;
             p_exists = true;
@@ -1190,9 +1190,9 @@ void computer_session::action_conveyor()
 // toggles reinforced glass shutters open->closed and closed->open depending on their current state
 void computer_session::action_shutters()
 {
-    g->u.moves -= 300;
+    get_avatar().moves -= 300;
     get_map().translate_radius( t_reinforced_glass_shutter_open, t_reinforced_glass_shutter, 8.0,
-                                g->u.pos(),
+                                get_avatar().pos(),
                                 true, true );
     query_any( _( "Toggling shutters.  Press any key…" ) );
 }
@@ -1201,11 +1201,11 @@ void computer_session::action_shutters()
 void computer_session::action_extract_rad_source()
 {
     if( query_yn( _( "Operation irreversible.  Extract radioactive material?" ) ) ) {
-        g->u.moves -= 300;
+        get_avatar().moves -= 300;
         tripoint platform;
         bool p_exists = false;
         map &here = get_map();
-        for( const tripoint &dest : here.points_in_radius( g->u.pos(), 10 ) ) {
+        for( const tripoint &dest : here.points_in_radius( get_avatar().pos(), 10 ) ) {
             if( here.ter( dest ) == t_rad_platform ) {
                 platform = dest;
                 p_exists = true;
@@ -1213,7 +1213,7 @@ void computer_session::action_extract_rad_source()
         }
         if( p_exists ) {
             here.spawn_item( platform, itype_cobalt_60, rng( 8, 15 ) );
-            here.translate_radius( t_rad_platform, t_concrete, 8.0, g->u.pos(), true );
+            here.translate_radius( t_rad_platform, t_concrete, 8.0, get_avatar().pos(), true );
             comp.remove_option( COMPACT_IRRADIATOR );
             comp.remove_option( COMPACT_EXTRACT_RAD_SOURCE );
             query_any( _( "Extraction sequence complete…  Press any key." ) );
@@ -1226,11 +1226,11 @@ void computer_session::action_extract_rad_source()
 // remove shock vent fields; check for existing plutonium generators in radius
 void computer_session::action_deactivate_shock_vent()
 {
-    g->u.moves -= 30;
+    get_avatar().moves -= 30;
     bool has_vent = false;
     bool has_generator = false;
     map &here = get_map();
-    for( const tripoint &dest : here.points_in_radius( g->u.pos(), 10 ) ) {
+    for( const tripoint &dest : here.points_in_radius( get_avatar().pos(), 10 ) ) {
         if( here.get_field( dest, fd_shock_vent ) != nullptr ) {
             has_vent = true;
         }
@@ -1292,7 +1292,7 @@ void computer_session::failure_shutdown()
 {
     bool found_tile = false;
     map &here = get_map();
-    for( const tripoint &p : here.points_in_radius( g->u.pos(), 1 ) ) {
+    for( const tripoint &p : here.points_in_radius( get_avatar().pos(), 1 ) ) {
         if( here.has_flag( flag_CONSOLE, p ) ) {
             here.ter_set( p, t_console_broken );
             add_msg( m_bad, _( "The console shuts down." ) );
@@ -1312,12 +1312,12 @@ void computer_session::failure_shutdown()
 
 void computer_session::failure_alarm()
 {
-    g->events().send<event_type::triggers_alarm>( g->u.getID() );
-    sounds::sound( g->u.pos(), 60, sounds::sound_t::alarm, _( "an alarm sound!" ), false, "environment",
+    g->events().send<event_type::triggers_alarm>( get_avatar().getID() );
+    sounds::sound( get_avatar().pos(), 60, sounds::sound_t::alarm, _( "an alarm sound!" ), false, "environment",
                    "alarm" );
     if( g->get_levz() > 0 && !g->timed_events.queued( TIMED_EVENT_WANTED ) ) {
         g->timed_events.add( TIMED_EVENT_WANTED, calendar::turn + 30_minutes, 0,
-                             g->u.global_sm_location() );
+                             get_avatar().global_sm_location() );
     }
 }
 
@@ -1348,11 +1348,11 @@ void computer_session::failure_secubots()
 void computer_session::failure_damage()
 {
     add_msg( m_neutral, _( "The console shocks you." ) );
-    if( g->u.is_elec_immune() ) {
+    if( get_avatar().is_elec_immune() ) {
         add_msg( m_good, _( "You're protected from electric shocks." ) );
     } else {
         add_msg( m_bad, _( "Your body is damaged by the electric shock!" ) );
-        g->u.hurtall( rng( 1, 10 ), nullptr );
+        get_avatar().hurtall( rng( 1, 10 ), nullptr );
     }
 }
 
@@ -1402,7 +1402,7 @@ void computer_session::failure_pump_leak()
 void computer_session::failure_amigara()
 {
     g->timed_events.add( TIMED_EVENT_AMIGARA, calendar::turn + 30_seconds );
-    g->u.add_effect( effect_amigara, 2_minutes );
+    get_avatar().add_effect( effect_amigara, 2_minutes );
     explosion_handler::explosion( tripoint( rng( 0, MAPSIZE_X ), rng( 0, MAPSIZE_Y ), g->get_levz() ),
                                   nullptr,
                                   10,
@@ -1418,7 +1418,7 @@ void computer_session::failure_destroy_blood()
 {
     print_error( _( "ERROR: Disruptive Spin" ) );
     map &here = get_map();
-    for( const tripoint &dest : here.points_in_radius( g->u.pos(), 2 ) ) {
+    for( const tripoint &dest : here.points_in_radius( get_avatar().pos(), 2 ) ) {
         if( here.furn( dest ) == furn_str_id( "f_centrifuge" ) ) {
             map_stack items = here.i_at( dest );
             if( items.empty() ) {
@@ -1444,7 +1444,7 @@ void computer_session::failure_destroy_data()
 {
     print_error( _( "ERROR: ACCESSING DATA MALFUNCTION" ) );
     map &here = get_map();
-    for( const tripoint &p : here.points_in_radius( g->u.pos(), 2 ) ) {
+    for( const tripoint &p : here.points_in_radius( get_avatar().pos(), 2 ) ) {
         if( here.ter( p ) == t_floor_blue ) {
             map_stack items = here.i_at( p );
             if( items.empty() ) {
@@ -1475,8 +1475,8 @@ void computer_session::action_emerg_ref_center()
     tripoint_abs_omt mission_target;
     avatar &player_character = get_avatar();
     // Check completed missions too, so people can't repeatedly get the mission.
-    const std::vector<mission *> completed_missions = g->u.get_completed_missions();
-    std::vector<mission *> missions = g->u.get_active_missions();
+    const std::vector<mission *> completed_missions = get_avatar().get_completed_missions();
+    std::vector<mission *> missions = get_avatar().get_active_missions();
     missions.insert( missions.end(), completed_missions.begin(), completed_missions.end() );
 
     const bool has_mission = std::any_of( missions.begin(), missions.end(), [ &mission_type,
@@ -1491,7 +1491,7 @@ void computer_session::action_emerg_ref_center()
 
     if( !has_mission ) {
         const auto mission = mission::reserve_new( mission_type, character_id() );
-        mission->assign( g->u );
+        mission->assign( get_avatar() );
         mission_target = mission->get_target();
     }
 

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -242,7 +242,8 @@ static void remove_submap_turrets()
     map &here = get_map();
     for( monster &critter : g->all_monsters() ) {
         // Check 1) same overmap coords, 2) turret, 3) hostile
-        if( ms_to_omt_copy( here.getabs( critter.pos() ) ) == ms_to_omt_copy( here.getabs( get_avatar().pos() ) ) &&
+        if( ms_to_omt_copy( here.getabs( critter.pos() ) ) == ms_to_omt_copy( here.getabs(
+                    get_avatar().pos() ) ) &&
             critter.has_flag( MF_CONSOLE_DESPAWN ) &&
             critter.attitude_to( get_avatar() ) == Creature::Attitude::A_HOSTILE ) {
             g->remove_zombie( critter );
@@ -394,7 +395,8 @@ void computer_session::action_sample()
 void computer_session::action_release()
 {
     g->events().send<event_type::releases_subspace_specimens>();
-    sounds::sound( get_avatar().pos(), 40, sounds::sound_t::alarm, _( "an alarm sound!" ), false, "environment",
+    sounds::sound( get_avatar().pos(), 40, sounds::sound_t::alarm, _( "an alarm sound!" ), false,
+                   "environment",
                    "alarm" );
     get_map().translate_radius( t_reinforced_glass, t_thconc_floor, 25.0, get_avatar().pos(), true );
     query_any( _( "Containment shields opened.  Press any key…" ) );
@@ -408,7 +410,8 @@ void computer_session::action_release_disarm()
 
 void computer_session::action_release_bionics()
 {
-    sounds::sound( get_avatar().pos(), 40, sounds::sound_t::alarm, _( "an alarm sound!" ), false, "environment",
+    sounds::sound( get_avatar().pos(), 40, sounds::sound_t::alarm, _( "an alarm sound!" ), false,
+                   "environment",
                    "alarm" );
     get_map().translate_radius( t_reinforced_glass, t_thconc_floor, 3.0, get_avatar().pos(), true );
     query_any( _( "Containment shields opened.  Press any key…" ) );
@@ -813,7 +816,8 @@ void computer_session::action_data_anal()
             } else { // Success!
                 if( items.only_item().typeId() == itype_black_box ) {
                     print_line( _( "Memory Bank: Military Hexron Encryption\nPrinting Transcript\n" ) );
-                    here.add_item_or_charges( get_avatar().pos(), item::spawn( "black_box_transcript", calendar::turn ) );
+                    here.add_item_or_charges( get_avatar().pos(), item::spawn( "black_box_transcript",
+                                              calendar::turn ) );
                 } else {
                     print_line( _( "Memory Bank: Unencrypted\nNothing of interest.\n" ) );
                 }
@@ -952,7 +956,7 @@ void computer_session::action_srcf_seal()
 void computer_session::action_srcf_elevator()
 {
     Character &player_character = get_avatar();
-    map &here = g->m;
+    map &here = get_map();
     tripoint surface_elevator;
     tripoint underground_elevator;
     bool is_surface_elevator_on = false;
@@ -1047,7 +1051,8 @@ void computer_session::action_irradiator()
                         print_error( _( "  >> Radiation spike detected!\n" ) );
                         print_error( _( "WARNING [912]: Catastrophic malfunction!  Contamination detected!" ) );
                         print_error( _( "EMERGENCY PROCEDURE [1]:  Evacuate.  Evacuate.  Evacuate.\n" ) );
-                        sounds::sound( get_avatar().pos(), 30, sounds::sound_t::alarm, _( "an alarm sound!" ), false, "environment",
+                        sounds::sound( get_avatar().pos(), 30, sounds::sound_t::alarm, _( "an alarm sound!" ), false,
+                                       "environment",
                                        "alarm" );
                         here.i_rem( dest, it );
                         here.make_rubble( dest );
@@ -1129,7 +1134,8 @@ void computer_session::action_geiger()
         print_error( _( "GEIGER COUNTER @ ZONE:… MAX %s mSv/h." ), peak_rad );
         print_newline();
     }
-    print_error( _( "GEIGER COUNTER @ CONSOLE:… %s mSv/h." ), here.get_radiation( get_avatar().pos() ) );
+    print_error( _( "GEIGER COUNTER @ CONSOLE:… %s mSv/h." ),
+                 here.get_radiation( get_avatar().pos() ) );
     print_error( _( "PERSONAL DOSIMETRY:… %s mSv." ), get_avatar().get_rad() );
     print_newline();
     query_any( _( "Press any key…" ) );
@@ -1313,7 +1319,8 @@ void computer_session::failure_shutdown()
 void computer_session::failure_alarm()
 {
     g->events().send<event_type::triggers_alarm>( get_avatar().getID() );
-    sounds::sound( get_avatar().pos(), 60, sounds::sound_t::alarm, _( "an alarm sound!" ), false, "environment",
+    sounds::sound( get_avatar().pos(), 60, sounds::sound_t::alarm, _( "an alarm sound!" ), false,
+                   "environment",
                    "alarm" );
     if( g->get_levz() > 0 && !g->timed_events.queued( TIMED_EVENT_WANTED ) ) {
         g->timed_events.add( TIMED_EVENT_WANTED, calendar::turn + 30_minutes, 0,

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -184,7 +184,7 @@ void conditional_t<T>::set_u_has_mission( const JsonObject &jo )
 {
     const std::string &mission = jo.get_string( "u_has_mission" );
     condition = [mission]( const T & ) {
-        for( auto miss_it : g->u.get_active_missions() ) {
+        for( auto miss_it : get_avatar().get_active_missions() ) {
             if( miss_it->mission_id() == mission_type_id( mission ) ) {
                 return true;
             }
@@ -724,7 +724,7 @@ template<class T>
 void conditional_t<T>::set_npc_friend()
 {
     condition = []( const T & d ) {
-        return d.beta->is_friendly( g->u );
+        return d.beta->is_friendly( get_avatar() );
     };
 }
 
@@ -837,7 +837,7 @@ template<class T>
 void conditional_t<T>::set_u_has_camp()
 {
     condition = []( const T & ) {
-        return !g->u.camps.empty();
+        return !get_avatar().camps.empty();
     };
 }
 

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1010,7 +1010,8 @@ void place_construction( const construction_group_str_id &group )
     map &here = get_map();
     for( const tripoint &p : here.points_in_radius( get_avatar().pos(), 1 ) ) {
         for( const construction *con : cons ) {
-            if( p != get_avatar().pos() && can_construct( *con, p ) && player_can_build( get_avatar(), total_inv, *con ) ) {
+            if( p != get_avatar().pos() && can_construct( *con, p ) &&
+                player_can_build( get_avatar(), total_inv, *con ) ) {
                 valid[ p ] = con;
             }
         }
@@ -1455,7 +1456,8 @@ void construct::done_digormine_stair( const tripoint &p, bool dig )
     tmpmap.load( tripoint( pos_sm.xy(), pos_sm.z - 1 ), false );
     const tripoint local_tmp = tmpmap.getlocal( abs_pos );
 
-    bool dig_muts = get_avatar().has_trait( trait_PAINRESIST_TROGLO ) || get_avatar().has_trait( trait_STOCKY_TROGLO );
+    bool dig_muts = get_avatar().has_trait( trait_PAINRESIST_TROGLO ) ||
+                    get_avatar().has_trait( trait_STOCKY_TROGLO );
 
     int no_mut_penalty = dig_muts ? 10 : 0;
     int mine_penalty = dig ? 0 : 10;
@@ -1529,7 +1531,8 @@ void construct::done_mine_upstair( const tripoint &p )
         return;
     }
 
-    bool dig_muts = get_avatar().has_trait( trait_PAINRESIST_TROGLO ) || get_avatar().has_trait( trait_STOCKY_TROGLO );
+    bool dig_muts = get_avatar().has_trait( trait_PAINRESIST_TROGLO ) ||
+                    get_avatar().has_trait( trait_STOCKY_TROGLO );
 
     int no_mut_penalty = dig_muts ? 15 : 0;
     get_avatar().mod_stored_nutr( 20 + no_mut_penalty );

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1288,7 +1288,7 @@ bool Character::feed_furnace_with( item &it )
         return false;
     }
     if( it.is_favorite &&
-        !g->u.query_yn( _( "Are you sure you want to eat your favorited %s?" ), it.tname() ) ) {
+        !get_avatar().query_yn( _( "Are you sure you want to eat your favorited %s?" ), it.tname() ) ) {
         return false;
     }
 

--- a/src/coordinates.h
+++ b/src/coordinates.h
@@ -620,7 +620,7 @@ std::vector<coords::coord_point<Point, Origin, Scale>>
  * 'absolute' is defined as the -actual- submap x,y * SEEX + position in submap, and
  * can be obtained from map.getabs(x, y);
  *   usage:
- *    real_coords rc( g->m.getabs(get_avatar().posx(), get_avatar().posy() ) );
+ *    real_coords rc( get_map().getabs(get_avatar().posx(), get_avatar().posy() ) );
  */
 struct real_coords {
     static const int tiles_in_sub = SEEX;

--- a/src/coordinates.h
+++ b/src/coordinates.h
@@ -620,7 +620,7 @@ std::vector<coords::coord_point<Point, Origin, Scale>>
  * 'absolute' is defined as the -actual- submap x,y * SEEX + position in submap, and
  * can be obtained from map.getabs(x, y);
  *   usage:
- *    real_coords rc( g->m.getabs(g->u.posx(), g->u.posy() ) );
+ *    real_coords rc( g->m.getabs(get_avatar().posx(), get_avatar().posy() ) );
  */
 struct real_coords {
     static const int tiles_in_sub = SEEX;

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1556,7 +1556,8 @@ std::vector<detached_ptr<item>> player::consume_items( map &m, const comp_select
             ret.insert( ret.end(), std::make_move_iterator( tmp.begin() ),
                         std::make_move_iterator( tmp.end() ) );
         } else {
-            std::vector<detached_ptr<item>> tmp = g->m.use_amount( loc, radius, selected_comp.type, real_count,
+            std::vector<detached_ptr<item>> tmp = get_map().use_amount( loc, radius, selected_comp.type,
+                                                  real_count,
                                                   filter );
             std::vector<item *> as_p;
             as_p.reserve( tmp.size() );
@@ -2339,7 +2340,7 @@ static std::pair<bench_type, float> best_bench_here( const item &craft, const tr
         }
     }
 
-    if( g->m.furn( loc ).obj().workbench ) {
+    if( get_map().furn( loc ).obj().workbench ) {
         float furn_mult = workbench_crafting_speed_multiplier( craft, bench_location{bench_type::furniture, loc} );
         if( furn_mult > best_mult ) {
             best_type = bench_type::furniture;
@@ -2347,7 +2348,7 @@ static std::pair<bench_type, float> best_bench_here( const item &craft, const tr
         }
     }
 
-    if( const std::optional<vpart_reference> vp = g->m.veh_at(
+    if( const std::optional<vpart_reference> vp = get_map().veh_at(
                 loc ).part_with_feature( "WORKBENCH", true ) ) {
         float veh_mult = workbench_crafting_speed_multiplier( craft, bench_location{bench_type::vehicle, loc} );
         if( veh_mult > best_mult ) {
@@ -2366,9 +2367,9 @@ bench_location find_best_bench( const player &p, const item &craft )
     float best_bench_multi = bench_here.second;
     tripoint best_loc = p.pos();
     std::vector<tripoint> reachable( PICKUP_RANGE * PICKUP_RANGE );
-    g->m.reachable_flood_steps( reachable, p.pos(), PICKUP_RANGE, 1, 100 );
+    get_map().reachable_flood_steps( reachable, p.pos(), PICKUP_RANGE, 1, 100 );
     for( const tripoint &adj : reachable ) {
-        if( const cata::value_ptr<furn_workbench_info> &wb = g->m.furn( adj ).obj().workbench ) {
+        if( const cata::value_ptr<furn_workbench_info> &wb = get_map().furn( adj ).obj().workbench ) {
             if( wb->multiplier > best_bench_multi ) {
                 best_type = bench_type::furniture;
                 best_bench_multi = wb->multiplier;
@@ -2376,7 +2377,7 @@ bench_location find_best_bench( const player &p, const item &craft )
             }
         }
 
-        if( const std::optional<vpart_reference> vp = g->m.veh_at(
+        if( const std::optional<vpart_reference> vp = get_map().veh_at(
                     adj ).part_with_feature( "WORKBENCH", true ) ) {
             if( const std::optional<vpslot_workbench> &wb_info = vp->part().info().get_workbench_info() ) {
                 if( wb_info->multiplier > best_bench_multi ) {

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -32,7 +32,6 @@
 #include "faction.h"
 #include "flag.h"
 #include "flat_set.h"
-#include "game.h"
 #include "game_constants.h"
 #include "game_inventory.h"
 #include "handle_liquid.h"

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -20,7 +20,6 @@
 #include "character_functions.h"
 #include "crafting.h"
 #include "cursesdef.h"
-#include "game.h"
 #include "input.h"
 #include "inventory.h"
 #include "item.h"

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -359,7 +359,7 @@ bool Creature::sees( const tripoint &t, bool is_avatar, int range_mod ) const
         }
         if( is_avatar ) {
             // Special case monster -> player visibility, forcing it to be symmetric with player vision.
-            const float player_visibility_factor = g->u.visibility() / 100.0f;
+            const float player_visibility_factor = get_avatar().visibility() / 100.0f;
             int adj_range = std::floor( range * player_visibility_factor );
             return adj_range >= wanted_range &&
                    here.get_cache_ref( pos().z ).seen_cache[pos().x][pos().y] > LIGHT_TRANSPARENCY_SOLID;
@@ -389,7 +389,7 @@ static bool overlaps_vehicle( const std::set<tripoint> &veh_area, const tripoint
 Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area )
 {
     Creature *target = nullptr;
-    player &u = g->u; // Could easily protect something that isn't the player
+    player &u = get_avatar(); // Could easily protect something that isn't the player
     constexpr int hostile_adj = 2; // Priority bonus for hostile targets
     const int iff_dist = ( range + area ) * 3 / 2 + 6; // iff check triggers at this distance
     // iff safety margin (degrees). less accuracy, more paranoia
@@ -400,10 +400,10 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
     bool self_area_iff = false; // Need to check if the target is near the vehicle we're a part of
     bool area_iff = false;      // Need to check distance from target to player
     bool angle_iff = true;      // Need to check if player is in a cone between us and target
-    int pldist = rl_dist( pos(), g->u.pos() );
+    int pldist = rl_dist( pos(), get_avatar().pos() );
     map &here = get_map();
     vehicle *in_veh = is_fake() ? veh_pointer_or_null( here.veh_at( pos() ) ) : nullptr;
-    if( pldist < iff_dist && sees( g->u ) ) {
+    if( pldist < iff_dist && sees( get_avatar() ) ) {
         area_iff = area > 0;
         angle_iff = true;
         // Player inside vehicle won't be hit by shots from the roof,
@@ -431,7 +431,7 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
             // friendly to the player, not a target for us
             return static_cast<const npc *>( &critter )->get_attitude() == NPCATT_KILL;
         }
-        // TODO: what about g->u?
+        // TODO: what about get_avatar()?
         return false;
     } );
     for( auto &m : targets ) {
@@ -775,7 +775,7 @@ void Creature::deal_projectile_attack( Creature *source, dealt_projectile_attack
     projectile &proj = attack.proj;
     dealt_damage_instance &dealt_dam = attack.dealt_dam;
 
-    const bool u_see_this = g->u.sees( *this );
+    const bool u_see_this = get_avatar().sees( *this );
 
     const int avoid_roll = dodge_roll();
     // Do dice(10, speed) instead of dice(speed, 10) because speed could potentially be > 10000
@@ -788,7 +788,7 @@ void Creature::deal_projectile_attack( Creature *source, dealt_projectile_attack
         attack.missed_by = 1.0; // Arbitrary value
         // "Avoid" rather than "dodge", because it includes removing self from the line of fire
         //  rather than just Matrix-style bullet dodging
-        if( source != nullptr && g->u.sees( *source ) ) {
+        if( source != nullptr && get_avatar().sees( *source ) ) {
             add_msg_player_or_npc(
                 m_warning,
                 _( "You avoid %s projectile!" ),

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1386,7 +1386,7 @@ void debug()
     bool debug_menu_has_hotkey = hotkey_for_action( ACTION_DEBUG, false ) != -1;
     int action = debug_menu_uilist( debug_menu_has_hotkey );
     avatar &u = get_avatar();
-    map &m = g->m;
+    map &m = get_map();
     switch( action ) {
         case DEBUG_WISH:
             debug_menu::wishitem( &u );
@@ -2066,7 +2066,7 @@ void debug()
         break;
 
         case DEBUG_VEHICLE_BATTERY_CHARGE: {
-            optional_vpart_position v_part_pos = g->m.veh_at( u.pos() );
+            optional_vpart_position v_part_pos = get_map().veh_at( u.pos() );
             if( !v_part_pos ) {
                 add_msg( m_bad, _( "There's no vehicle there." ) );
                 break;
@@ -2089,7 +2089,7 @@ void debug()
             break;
         }
         case DEBUG_VEHICLE_EXPORT_JSON: {
-            const optional_vpart_position v_part_pos = g->m.veh_at( u.pos() );
+            const optional_vpart_position v_part_pos = get_map().veh_at( u.pos() );
             if( !v_part_pos ) {
                 add_msg( m_bad, _( "There's no vehicle there." ) );
                 break;

--- a/src/descriptions.cpp
+++ b/src/descriptions.cpp
@@ -1,23 +1,23 @@
 
 #include <algorithm>
 #include <sstream>
-#include <type_traits>
 #include <utility>
 
 #include "avatar.h"
 #include "calendar.h"
 #include "color.h"
 #include "harvest.h"
-#include "input.h"
 #include "map.h"
 #include "mapdata.h"
-#include "mod_manager.h"
 #include "output.h"
+#include "game.h"
 #include "string_formatter.h"
 #include "string_id.h"
 #include "string_utils.h"
-#include "translations.h"
 #include "ui_manager.h"
+#include "translations.h"
+#include "input.h"
+#include "mod_manager.h"
 #include "item_group.h"
 #include "itype.h"
 

--- a/src/descriptions.cpp
+++ b/src/descriptions.cpp
@@ -41,7 +41,7 @@ static bool debug_vision()
 static const Creature *seen_critter( const game &g, const tripoint &p )
 {
     const Creature *critter = g.critter_at( p, true );
-    if( critter != nullptr && g.u.sees( *critter ) ) {
+    if( critter != nullptr && get_avatar().sees( *critter ) ) {
         return critter;
     }
 

--- a/src/descriptions.cpp
+++ b/src/descriptions.cpp
@@ -1,4 +1,3 @@
-#include "game.h" // IWYU pragma: associated
 
 #include <algorithm>
 #include <sstream>

--- a/src/dialogue.h
+++ b/src/dialogue.h
@@ -222,7 +222,7 @@ struct talk_response {
 
 struct dialogue {
         /**
-         * The player character that speaks (always g->u).
+         * The player character that speaks (always get_avatar()).
          * TODO: make it a reference, not a pointer.
          */
         player *alpha = nullptr;

--- a/src/diary_ui.cpp
+++ b/src/diary_ui.cpp
@@ -1,4 +1,3 @@
-#include "game.h" // IWYU pragma: associated
 
 #include <algorithm>
 #include <map>

--- a/src/distribution_grid.cpp
+++ b/src/distribution_grid.cpp
@@ -323,7 +323,7 @@ void grid_furn_transform_queue::apply( mapbuffer &mb, distribution_grid_tracker 
         // TODO: this is copy-pasted from map.cpp
         if( old_t.active ) {
             sm->active_furniture.erase( p_within_sm );
-            // TODO: Only for g->m? Observer pattern?
+            // TODO: Only for get_map()? Observer pattern?
             grid_tracker.on_changed( qt.p );
         }
         if( new_t.active ) {

--- a/src/dump.cpp
+++ b/src/dump.cpp
@@ -30,6 +30,7 @@
 #include "vehicle.h"
 #include "vehicle_part.h"
 #include "vitamin.h"
+#include "game.h"
 
 bool game::dump_stats( const std::string &what, dump_mode mode,
                        const std::vector<std::string> &opts )

--- a/src/dump.cpp
+++ b/src/dump.cpp
@@ -1,4 +1,3 @@
-#include "game.h" // IWYU pragma: associated
 
 #include <algorithm>
 #include <cmath>

--- a/src/dump.cpp
+++ b/src/dump.cpp
@@ -84,7 +84,7 @@ bool game::dump_stats( const std::string &what, dump_mode mode,
         auto dump = [&rows, &bp]( const item & obj ) {
             std::vector<std::string> r;
             r.push_back( obj.tname( 1, false ) );
-            r.push_back( std::to_string( obj.get_encumber( g->u, convert_bp( bp ).id() ) ) );
+            r.push_back( std::to_string( obj.get_encumber( get_avatar(), convert_bp( bp ).id() ) ) );
             r.push_back( std::to_string( obj.get_warmth() ) );
             r.push_back( std::to_string( to_gram( obj.weight() ) ) );
             r.push_back( std::to_string( obj.get_storage() / units::legacy_volume_factor ) );
@@ -135,7 +135,7 @@ bool game::dump_stats( const std::string &what, dump_mode mode,
         for( const itype *e : item_controller->all() ) {
             item &food = *item::spawn_temporary( e, calendar::turn, item::solitary_tag {} );
 
-            if( food.is_food() && g->u.can_eat( food ).success() ) {
+            if( food.is_food() && get_avatar().can_eat( food ).success() ) {
                 dump( food );
             }
         }

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -260,7 +260,7 @@ bool editmap::eget_direction( tripoint &p, const std::string &action ) const
 {
     p = tripoint_zero;
     if( action == "CENTER" ) {
-        p = g->u.pos() - target;
+        p = get_avatar().pos() - target;
     } else if( action == "LEFT_WIDE" ) {
         p.x = -tmax.x / 2;
     } else if( action == "DOWN_WIDE" ) {
@@ -337,8 +337,8 @@ shared_ptr_fast<ui_adaptor> editmap::create_or_get_ui_adaptor()
 
 std::optional<tripoint> editmap::edit()
 {
-    restore_on_out_of_scope<tripoint> view_offset_prev( g->u.view_offset );
-    target = g->u.pos() + g->u.view_offset;
+    restore_on_out_of_scope<tripoint> view_offset_prev( get_avatar().view_offset );
+    target = get_avatar().pos() + get_avatar().view_offset;
     input_context ctxt( "EDITMAP" );
     ctxt.set_iso( true );
     ctxt.register_directions();
@@ -495,7 +495,7 @@ void editmap::uber_draw_ter( const catacurses::window &w, map *m )
 
 void editmap::do_ui_invalidation()
 {
-    g->u.view_offset = target - g->u.pos();
+    get_avatar().view_offset = target - get_avatar().pos();
     g->invalidate_main_ui_adaptor();
     create_or_get_ui_adaptor()->invalidate_ui();
 }
@@ -625,7 +625,7 @@ void editmap::draw_main_ui_overlay()
                     g->draw_trap_override( map_p, tmpmap.tr_at( tmp_p ).loadid );
                     g->draw_field_override( map_p, tmpmap.field_at( tmp_p ).displayed_field_type() );
                     const maptile &tile = tmpmap.maptile_at( tmp_p );
-                    if( tmpmap.sees_some_items( tmp_p, g->u.pos() - origin_p ) ) {
+                    if( tmpmap.sees_some_items( tmp_p, get_avatar().pos() - origin_p ) ) {
                         const item &itm = tile.get_uppermost_item();
                         const mtype *const mon = itm.get_mtype();
                         g->draw_item_override( map_p, itm.typeId(), mon ? mon->id : mtype_id::NULL_ID(),

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -1554,7 +1554,7 @@ void explosion_funcs::flashbang( const queued_explosion &qe )
                 flash_mod = 3; // Not really proper flash protection, but better than nothing
             }
             get_avatar().add_env_effect( effect_blind, bp_eyes, ( 12 - flash_mod - dist ) / 2,
-                                 time_duration::from_turns( 10 - dist ) );
+                                         time_duration::from_turns( 10 - dist ) );
         }
     }
     for( monster &critter : g->all_monsters() ) {
@@ -1776,7 +1776,8 @@ void explosion_funcs::resonance_cascade( const queued_explosion &qe )
     map &here = get_map();
     const tripoint &p = qe.pos;
 
-    const time_duration maxglow = time_duration::from_turns( 100 - 5 * trig_dist( p, get_avatar().pos() ) );
+    const time_duration maxglow = time_duration::from_turns( 100 - 5 * trig_dist( p,
+                                  get_avatar().pos() ) );
     if( maxglow > 0_turns ) {
         const time_duration minglow = std::max( 0_turns, time_duration::from_turns( 60 - 5 * trig_dist( p,
                                                 get_avatar().pos() ) ) );

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -568,15 +568,15 @@ int npc::faction_display( const catacurses::window &fac_w, const int width ) con
     nc_color see_color;
 
     static const flag_id json_flag_TWO_WAY_RADIO( "TWO_WAY_RADIO" );
-    bool u_has_radio = g->u.has_item_with_flag( json_flag_TWO_WAY_RADIO, true );
+    bool u_has_radio = get_avatar().has_item_with_flag( json_flag_TWO_WAY_RADIO, true );
     bool guy_has_radio = has_item_with_flag( json_flag_TWO_WAY_RADIO, true );
     // is the NPC even in the same area as the player?
     if( rl_dist( player_abspos, global_omt_location() ) > 3 ||
-        ( rl_dist( g->u.pos(), pos() ) > SEEX * 2 || !g->u.sees( pos() ) ) ) {
+        ( rl_dist( get_avatar().pos(), pos() ) > SEEX * 2 || !get_avatar().sees( pos() ) ) ) {
         if( u_has_radio && guy_has_radio ) {
             // TODO: better range calculation than just elevation.
             int max_range = 200;
-            max_range *= ( 1 + ( g->u.pos().z * 0.1 ) );
+            max_range *= ( 1 + ( get_avatar().pos().z * 0.1 ) );
             max_range *= ( 1 + ( pos().z * 0.1 ) );
             if( is_stationed ) {
                 // if camp that NPC is at, has a radio tower
@@ -586,14 +586,14 @@ int npc::faction_display( const catacurses::window &fac_w, const int width ) con
             }
             // if camp that player is at, has a radio tower
             std::optional<basecamp *> player_camp =
-                overmap_buffer.find_camp( g->u.global_omt_location().xy() );
+                overmap_buffer.find_camp( get_avatar().global_omt_location().xy() );
             if( player_camp ) {
                 if( ( *player_camp )->has_provides( "radio_tower" ) ) {
                     max_range *= 5;
                 }
             }
-            if( ( ( g->u.pos().z >= 0 && pos().z >= 0 ) || ( g->u.pos().z == pos().z ) ) &&
-                square_dist( g->u.global_sm_location(), global_sm_location() ) <= max_range ) {
+            if( ( ( get_avatar().pos().z >= 0 && pos().z >= 0 ) || ( get_avatar().pos().z == pos().z ) ) &&
+                square_dist( get_avatar().global_sm_location(), global_sm_location() ) <= max_range ) {
                 retval = 2;
                 can_see = _( "Within radio range" );
                 see_color = c_light_green;
@@ -860,7 +860,7 @@ void faction_manager::display() const
         camp = nullptr;
         // create a list of faction camps
         camps.clear();
-        for( tripoint_abs_omt elem : g->u.camps ) {
+        for( tripoint_abs_omt elem : get_avatar().camps ) {
             std::optional<basecamp *> p = overmap_buffer.find_camp( elem.xy() );
             if( !p ) {
                 continue;

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -485,7 +485,7 @@ static bool update_time_left( std::string &entry, const comp_list &npc_list )
             entry = entry + " [" +
                     to_string( comp->companion_mission_time_ret - calendar::turn ) +
                     _( " left]\n" );
-            avail = g->u.has_trait( trait_DEBUG_HS );
+            avail = get_avatar().has_trait( trait_DEBUG_HS );
         }
     }
     entry = entry + _( "\n\nDo you wish to bring your allies back into your party?" );
@@ -647,7 +647,7 @@ void talk_function::basecamp_mission( npc &p )
         return;
     }
     basecamp *bcp = *temp_camp;
-    bcp->set_by_radio( g->u.dialogue_by_radio );
+    bcp->set_by_radio( get_avatar().dialogue_by_radio );
     if( bcp->get_dumping_spot() == tripoint_zero ) {
         map &here = get_map();
         auto &mgr = zone_manager::get_manager();
@@ -1995,7 +1995,7 @@ void basecamp::start_setup_hide_site()
                               omt_pos, true );
     if( forest != tripoint_abs_omt( -999, -999, -999 ) ) {
         int dist = rl_dist( forest.xy(), omt_pos.xy() );
-        std::vector<item *> pos_inv = g->u.items_with( []( const item & itm ) {
+        std::vector<item *> pos_inv = get_avatar().items_with( []( const item & itm ) {
             return !itm.can_revive();
         } );
         if( !pos_inv.empty() ) {
@@ -2037,7 +2037,7 @@ void basecamp::start_relay_hide_site()
                               omt_pos, true );
     if( forest != tripoint_abs_omt( -999, -999, -999 ) ) {
         int dist = rl_dist( forest.xy(), omt_pos.xy() );
-        std::vector<item *> pos_inv = g->u.items_with( []( const item & itm ) {
+        std::vector<item *> pos_inv = get_avatar().items_with( []( const item & itm ) {
             return !itm.can_revive();
         } );
         std::vector<item *> losing_equipment;
@@ -2363,7 +2363,7 @@ static std::pair<size_t, std::string> farm_action( const tripoint_abs_omt &omt_t
                             int seed_cnt = std::max( 1, rng( plant_cnt / 4, plant_cnt / 2 ) );
                             for( auto &i : iexamine::get_harvest_items( *( *seed )->type, plant_cnt,
                                     seed_cnt, true ) ) {
-                                here.add_item_or_charges( g->u.pos(), std::move( i ) );
+                                here.add_item_or_charges( get_avatar().pos(), std::move( i ) );
                             }
                             seed = map_stack::iterator();
                             farm_map.i_clear( pos );
@@ -2866,9 +2866,9 @@ void basecamp::recruit_return( const std::string &task, int score )
     }
     // Time durations always subtract from camp food supply
     camp_food_supply( 1_days * food_desire );
-    recruit->spawn_at_precise( { g->get_levx(), g->get_levy() }, g->u.pos() + point( -4, -4 ) );
+    recruit->spawn_at_precise( { g->get_levx(), g->get_levy() }, get_avatar().pos() + point( -4, -4 ) );
     overmap_buffer.insert_npc( recruit );
-    recruit->form_opinion( g->u );
+    recruit->form_opinion( get_avatar() );
     recruit->mission = NPC_MISSION_NULL;
     recruit->add_new_mission( mission::reserve_random( ORIGIN_ANY_NPC,
                               recruit->global_omt_location(),
@@ -2983,7 +2983,7 @@ bool basecamp::farm_return( const std::string &task, const tripoint_abs_omt &omt
 
     for( detached_ptr<item> &it : comp->companion_mission_inv.dump_remove() ) {
         if( it->charges > 0 ) {
-            g->u.i_add( std::move( it ) );
+            get_avatar().i_add( std::move( it ) );
         }
     }
     finish_return( *comp, true, msg, "survival", 2 );
@@ -3450,7 +3450,7 @@ bool om_set_hide_site( npc &comp, const tripoint_abs_omt &omt_tgt,
         comp.companion_mission_inv.add_item( target_bay.i_rem( point( 11, 10 ), i ) );
     }
     for( auto i : itms ) {
-        std::vector<detached_ptr<item>> res = g->u.use_amount( i->typeId(), 1 );
+        std::vector<detached_ptr<item>> res = get_avatar().use_amount( i->typeId(), 1 );
         target_bay.add_item_or_charges( point( 11, 10 ), std::move( res.front() ) );
     }
     target_bay.save();
@@ -3587,7 +3587,7 @@ bool basecamp::validate_sort_points()
         mgr.cache_vzones();
     }
     tripoint src_loc = here.getlocal( bb_pos ) + point_north;
-    const tripoint abspos = here.getabs( g->u.pos() );
+    const tripoint abspos = here.getabs( get_avatar().pos() );
     if( !mgr.has_near( zone_type_camp_storage, abspos, 60 ) ||
         !mgr.has_near( zone_type_camp_food, abspos, 60 ) ) {
         if( query_yn( _( "You do not have sufficient sort zones.  Do you want to add them?" ) ) ) {
@@ -3722,7 +3722,7 @@ int basecamp::recruit_evaluation( int &sbase, int &sexpansions, int &sfaction, i
     }
     //More machine than man
     //Bionics count > 10, respect > 75
-    if( g->u.get_bionics().size() > 10 && camp_discipline() > 75 ) {
+    if( get_avatar().get_bionics().size() > 10 && camp_discipline() > 75 ) {
         sbonus += 10;
     }
     //Survival of the fittest
@@ -3856,7 +3856,7 @@ std::string camp_car_description( vehicle *car )
 // food supply
 int camp_food_supply( int change, bool return_days )
 {
-    faction *yours = g->u.get_faction();
+    faction *yours = get_avatar().get_faction();
     yours->food_supply += change;
     if( yours->food_supply < 0 ) {
         yours->likes_u += yours->food_supply / 1250;
@@ -3968,14 +3968,14 @@ bool basecamp::distribute_food()
 // morale
 int camp_discipline( int change )
 {
-    faction *yours = g->u.get_faction();
+    faction *yours = get_avatar().get_faction();
     yours->respects_u += change;
     return yours->respects_u;
 }
 
 int camp_morale( int change )
 {
-    faction *yours = g->u.get_faction();
+    faction *yours = get_avatar().get_faction();
     yours->likes_u += change;
     return yours->likes_u;
 }
@@ -3995,7 +3995,7 @@ void basecamp::place_results( detached_ptr<item> &&result )
         if( here.check_vehicle_zones( g->get_levz() ) ) {
             mgr.cache_vzones();
         }
-        const auto abspos = here.getabs( g->u.pos() );
+        const auto abspos = here.getabs( get_avatar().pos() );
         if( mgr.has_near( zone_type_camp_storage, abspos ) ) {
             const auto &src_set = mgr.get_near( zone_type_camp_storage, abspos );
             const auto &src_sorted = get_sorted_tiles_by_distance( abspos, src_set );
@@ -4006,8 +4006,8 @@ void basecamp::place_results( detached_ptr<item> &&result )
             apply_camp_ownership( src_loc, 10 );
             //or dump them at players feet
         } else {
-            here.add_item_or_charges( g->u.pos(), std::move( result ), true );
-            apply_camp_ownership( g->u.pos(), 0 );
+            here.add_item_or_charges( get_avatar().pos(), std::move( result ), true );
+            apply_camp_ownership( get_avatar().pos(), 0 );
         }
     }
 }
@@ -4019,7 +4019,7 @@ void apply_camp_ownership( const tripoint &camp_pos, int radius )
             camp_pos + point( radius, radius ) ) ) {
         auto items = here.i_at( p.xy() );
         for( item * const &elem : items ) {
-            elem->set_owner( g->u );
+            elem->set_owner( get_avatar() );
         }
     }
 }

--- a/src/fungal_effects.cpp
+++ b/src/fungal_effects.cpp
@@ -65,9 +65,11 @@ fungal_effects::fungal_effects( game &g, map &mp )
 
 void fungal_effects::fungalize( const tripoint &p, Creature *origin, double spore_chance )
 {
+    auto &you = get_avatar();
+
     if( monster *const mon_ptr = g->critter_at<monster>( p ) ) {
         monster &critter = *mon_ptr;
-        if( gm.u.sees( p ) &&
+        if( you.sees( p ) &&
             !critter.type->in_species( FUNGUS ) ) {
             add_msg( _( "The %s is covered in tiny spores!" ), critter.name() );
         }
@@ -76,25 +78,24 @@ void fungal_effects::fungalize( const tripoint &p, Creature *origin, double spor
             critter.add_effect( effect_stunned, rng( 1_turns, 3_turns ) );
             critter.apply_damage( origin, bodypart_id( "torso" ), rng( 25, 50 ) );
         }
-    } else if( gm.u.pos() == p && gm.u.get_effect_int( effect_fungus ) < 3 ) {
+    } else if( you.pos() == p && you.get_effect_int( effect_fungus ) < 3 ) {
         // TODO: Make this accept NPCs when they understand fungals
-        player &pl = gm.u;
         ///\EFFECT_DEX increases chance of knocking fungal spores away with your TAIL_CATTLE
         ///\EFFECT_MELEE increases chance of knocking fungal sports away with your TAIL_CATTLE
-        if( pl.has_trait( trait_TAIL_CATTLE ) &&
-            one_in( 20 - pl.dex_cur - pl.get_skill_level( skill_melee ) ) ) {
-            pl.add_msg_if_player(
+        if( you.has_trait( trait_TAIL_CATTLE ) &&
+            one_in( 20 - you.dex_cur - you.get_skill_level( skill_melee ) ) ) {
+            you.add_msg_if_player(
                 _( "The spores land on you, but you quickly swat them off with your tail!" ) );
             return;
         }
         // Spores hit the player--is there any hope?
         bool hit = false;
-        hit |= one_in( 4 ) && pl.add_env_effect( effect_spores, bp_head, 3, 9_minutes, bp_head );
-        hit |= one_in( 2 ) && pl.add_env_effect( effect_spores, bp_torso, 3, 9_minutes, bp_torso );
-        hit |= one_in( 4 ) && pl.add_env_effect( effect_spores, bp_arm_l, 3, 9_minutes, bp_arm_l );
-        hit |= one_in( 4 ) && pl.add_env_effect( effect_spores, bp_arm_r, 3, 9_minutes, bp_arm_r );
-        hit |= one_in( 4 ) && pl.add_env_effect( effect_spores, bp_leg_l, 3, 9_minutes, bp_leg_l );
-        hit |= one_in( 4 ) && pl.add_env_effect( effect_spores, bp_leg_r, 3, 9_minutes, bp_leg_r );
+        hit |= one_in( 4 ) && you.add_env_effect( effect_spores, bp_head, 3, 9_minutes, bp_head );
+        hit |= one_in( 2 ) && you.add_env_effect( effect_spores, bp_torso, 3, 9_minutes, bp_torso );
+        hit |= one_in( 4 ) && you.add_env_effect( effect_spores, bp_arm_l, 3, 9_minutes, bp_arm_l );
+        hit |= one_in( 4 ) && you.add_env_effect( effect_spores, bp_arm_r, 3, 9_minutes, bp_arm_r );
+        hit |= one_in( 4 ) && you.add_env_effect( effect_spores, bp_leg_l, 3, 9_minutes, bp_leg_l );
+        hit |= one_in( 4 ) && you.add_env_effect( effect_spores, bp_leg_r, 3, 9_minutes, bp_leg_r );
         if( hit ) {
             add_msg( m_warning, _( "You're covered in tiny spores!" ) );
         }
@@ -104,7 +105,7 @@ void fungal_effects::fungalize( const tripoint &p, Creature *origin, double spor
             if( origin_mon != nullptr ) {
                 spore->make_ally( *origin_mon );
             } else if( origin != nullptr && origin->is_player() &&
-                       gm.u.has_trait( trait_THRESH_MYCUS ) ) {
+                       you.has_trait( trait_THRESH_MYCUS ) ) {
                 spore->friendly = 1000;
             }
         }
@@ -139,6 +140,8 @@ void fungal_effects::marlossify( const tripoint &p )
 
 void fungal_effects::spread_fungus_one_tile( const tripoint &p, const int growth )
 {
+    auto &you = get_avatar();
+
     bool converted = false;
     // Terrain conversion
     if( m.has_flag_ter( flag_DIGGABLE, p ) ) {
@@ -169,7 +172,7 @@ void fungal_effects::spread_fungus_one_tile( const tripoint &p, const int growth
             if( m.get_field_intensity( p, fd_fungal_haze ) != 0 ) {
                 if( x_in_y( growth * 10, 800 ) ) { // young trees are vulnerable
                     m.ter_set( p, t_fungus );
-                    if( gm.place_critter_at( mon_fungal_blossom, p ) && gm.u.sees( p ) ) {
+                    if( gm.place_critter_at( mon_fungal_blossom, p ) && you.sees( p ) ) {
                         add_msg( m_warning, _( "The young tree blooms forth into a fungal blossom!" ) );
                     }
                 } else if( x_in_y( growth * 10, 400 ) ) {
@@ -185,7 +188,7 @@ void fungal_effects::spread_fungus_one_tile( const tripoint &p, const int growth
             if( m.get_field_intensity( p, fd_fungal_haze ) != 0 ) {
                 if( x_in_y( growth * 10, 100 ) ) {
                     m.ter_set( p, t_fungus );
-                    if( gm.place_critter_at( mon_fungal_blossom, p ) && gm.u.sees( p ) ) {
+                    if( gm.place_critter_at( mon_fungal_blossom, p ) && you.sees( p ) ) {
                         add_msg( m_warning, _( "The tree blooms forth into a fungal blossom!" ) );
                     }
                 } else if( x_in_y( growth * 10, 600 ) ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -294,7 +294,7 @@ bool is_valid_in_w_terrain( point p )
 static void achievement_attained( const achievement *a )
 {
     get_avatar().add_msg_if_player( m_good, _( "You completed the achievement \"%s\"." ),
-                            a->name() );
+                                    a->name() );
 }
 
 // This is the main game set-up process.
@@ -3072,7 +3072,8 @@ static shared_ptr_fast<game::draw_callback_t> create_zone_callback(
             }
         }
         if( zone_blink && zone_start && zone_end ) {
-            const point offset2( get_avatar().view_offset.xy() + point( get_avatar().posx() - getmaxx( g->w_terrain ) / 2,
+            const point offset2( get_avatar().view_offset.xy() + point( get_avatar().posx() - getmaxx(
+                                     g->w_terrain ) / 2,
                                  get_avatar().posy() - getmaxy( g->w_terrain ) / 2 ) );
 
             tripoint offset;
@@ -4973,7 +4974,7 @@ void game::save_cyborg( item *cyborg, const tripoint &couch_pos, player &install
         add_msg( m_good, _( "Successfully removed Personality override." ) );
         add_msg( m_bad, _( "Autodoc immediately destroys the CBM upon removal." ) );
 
-        delete_cyborg_item( g->m, couch_pos, cyborg );
+        delete_cyborg_item( get_map(), couch_pos, cyborg );
 
         const string_id<npc_template> npc_cyborg( "cyborg_rescued" );
         shared_ptr_fast<npc> tmp = make_shared_fast<npc>();
@@ -5004,7 +5005,7 @@ void game::save_cyborg( item *cyborg, const tripoint &couch_pos, player &install
             case 5:
                 add_msg( m_info, _( "The removal is a catastrophe." ) );
                 add_msg( m_bad, _( "The body is destroyed!" ) );
-                delete_cyborg_item( g->m, couch_pos, cyborg );
+                delete_cyborg_item( get_map(), couch_pos, cyborg );
                 break;
             default:
                 break;

--- a/src/game.h
+++ b/src/game.h
@@ -8,7 +8,6 @@
 #include <functional>
 #include <iosfwd>
 #include <list>
-#include <map>
 #include <memory>
 #include <optional>
 #include <set>
@@ -36,15 +35,6 @@ class item;
 class monster;
 class spell_events;
 class drop_token_provider;
-
-static constexpr int DEFAULT_TILESET_ZOOM = 16;
-
-static const std::string SAVE_MASTER( "master.gsav" );
-static const std::string SAVE_ARTIFACTS( "artifacts.gsav" );
-static const std::string SAVE_EXTENSION( ".sav" );
-static const std::string SAVE_EXTENSION_LOG( ".log" );
-static const std::string SAVE_EXTENSION_WEATHER( ".weather" );
-static const std::string SAVE_EXTENSION_SHORTCUTS( ".shortcuts" );
 
 // The reference to the one and only game instance.
 class game;

--- a/src/game.h
+++ b/src/game.h
@@ -956,9 +956,9 @@ class game
         pimpl<distribution_grid_tracker> grid_tracker_ptr;
         pimpl<weather_manager> weather_manager_ptr;
 
-    public:
         map &m;
         avatar &u;
+    public:
         scent_map &scent;
         timed_event_manager &timed_events;
 

--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -2,7 +2,8 @@
 #ifndef CATA_SRC_GAME_CONSTANTS_H
 #define CATA_SRC_GAME_CONSTANTS_H
 
-#include "units.h"
+#include "units_mass.h"
+#include "units_temperature.h"
 
 // Fixed window sizes.
 static constexpr int HP_HEIGHT = 14;
@@ -176,5 +177,6 @@ constexpr float very_obese = 35.0f;
 constexpr float morbidly_obese = 40.0f;
 } // namespace character_weight_category
 
+static constexpr int DEFAULT_TILESET_ZOOM = 16;
 
 #endif // CATA_SRC_GAME_CONSTANTS_H

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -528,7 +528,7 @@ class comestible_inventory_preset : public inventory_selector_preset
             }, _( "VOLUME" ) );
 
             append_cell( [this]( const item * loc ) {
-                if( g->u.can_estimate_rot() ) {
+                if( get_avatar().can_estimate_rot() ) {
                     const islot_comestible item = get_edible_comestible( loc );
                     if( item.spoils > 0_turns ) {
                         return get_freshness( loc );
@@ -539,7 +539,7 @@ class comestible_inventory_preset : public inventory_selector_preset
             }, _( "FRESHNESS" ) );
 
             append_cell( [ this ]( const item * loc ) {
-                if( g->u.can_estimate_rot() ) {
+                if( get_avatar().can_estimate_rot() ) {
                     const islot_comestible item = get_edible_comestible( loc );
                     if( item.spoils > 0_turns ) {
                         if( !get_consumable_item( loc ).rotten() ) {
@@ -735,8 +735,8 @@ static std::string get_consume_needs_hint( player &p )
 
 item *game_menus::inv::consume( player &p )
 {
-    if( !g->u.has_activity( ACT_EAT_MENU ) ) {
-        g->u.assign_activity( ACT_EAT_MENU );
+    if( !get_avatar().has_activity( ACT_EAT_MENU ) ) {
+        get_avatar().assign_activity( ACT_EAT_MENU );
     }
 
     return inv_internal( p, comestible_inventory_preset( p ),
@@ -762,8 +762,8 @@ class comestible_filtered_inventory_preset : public comestible_inventory_preset
 
 item *game_menus::inv::consume_food( player &p )
 {
-    if( !g->u.has_activity( ACT_CONSUME_FOOD_MENU ) ) {
-        g->u.assign_activity( ACT_CONSUME_FOOD_MENU );
+    if( !get_avatar().has_activity( ACT_CONSUME_FOOD_MENU ) ) {
+        get_avatar().assign_activity( ACT_CONSUME_FOOD_MENU );
     }
 
     return inv_internal( p, comestible_filtered_inventory_preset( p, []( const item & it ) {
@@ -777,8 +777,8 @@ item *game_menus::inv::consume_food( player &p )
 
 item *game_menus::inv::consume_drink( player &p )
 {
-    if( !g->u.has_activity( ACT_CONSUME_DRINK_MENU ) ) {
-        g->u.assign_activity( ACT_CONSUME_DRINK_MENU );
+    if( !get_avatar().has_activity( ACT_CONSUME_DRINK_MENU ) ) {
+        get_avatar().assign_activity( ACT_CONSUME_DRINK_MENU );
     }
 
     return inv_internal( p, comestible_filtered_inventory_preset( p, []( const item & it ) {
@@ -792,8 +792,8 @@ item *game_menus::inv::consume_drink( player &p )
 
 item *game_menus::inv::consume_meds( player &p )
 {
-    if( !g->u.has_activity( ACT_CONSUME_MEDS_MENU ) ) {
-        g->u.assign_activity( ACT_CONSUME_MEDS_MENU );
+    if( !get_avatar().has_activity( ACT_CONSUME_MEDS_MENU ) ) {
+        get_avatar().assign_activity( ACT_CONSUME_MEDS_MENU );
     }
 
     return inv_internal( p, comestible_filtered_inventory_preset( p, []( const item & it ) {
@@ -1913,7 +1913,7 @@ class bionic_install_preset: public inventory_selector_preset
                                        skill_electronics,
                                        -1 );
 
-            if( g->u.has_trait( trait_DEBUG_BIONICS ) ) {
+            if( get_avatar().has_trait( trait_DEBUG_BIONICS ) ) {
                 chance_of_failure = 0;
             } else {
                 chance_of_failure = has_install_program ? 1 : 100 - bionic_manip_cos( adjusted_skill, difficulty );
@@ -2004,7 +2004,7 @@ class bionic_install_surgeon_preset : public inventory_selector_preset
                                        skill_electronics,
                                        20 );
 
-            if( g->u.has_trait( trait_DEBUG_BIONICS ) ) {
+            if( get_avatar().has_trait( trait_DEBUG_BIONICS ) ) {
                 chance_of_failure = 0;
             } else {
                 chance_of_failure = 100 - bionic_manip_cos( adjusted_skill, difficulty );
@@ -2088,7 +2088,7 @@ class bionic_uninstall_preset : public inventory_selector_preset
                                        skill_electronics,
                                        -1 );
 
-            if( g->u.has_trait( trait_DEBUG_BIONICS ) ) {
+            if( get_avatar().has_trait( trait_DEBUG_BIONICS ) ) {
                 chance_of_failure = 0;
             } else {
                 chance_of_failure = 100 - bionic_manip_cos( adjusted_skill, difficulty );

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -595,7 +595,7 @@ class comestible_inventory_preset : public inventory_selector_preset
             const item &med = !( *loc ).is_container_empty() && ( *loc ).get_contained().is_medication() &&
                               ( *loc ).get_contained().type->has_use() ? ( *loc ).get_contained() : *loc;
 
-            if( loc->made_of( LIQUID ) && !g->m.has_flag( flag_LIQUIDCONT, loc->position() ) ) {
+            if( loc->made_of( LIQUID ) && !get_map().has_flag( flag_LIQUIDCONT, loc->position() ) ) {
                 return _( "Can't drink spilt liquids" );
             }
 

--- a/src/game_utils.cpp
+++ b/src/game_utils.cpp
@@ -1,0 +1,7 @@
+#include "game.h"
+#include "game_utils.h"
+
+auto has_game() -> bool
+{
+    return g != nullptr;
+}

--- a/src/game_utils.h
+++ b/src/game_utils.h
@@ -1,0 +1,8 @@
+#pragma once
+#ifndef CATA_SRC_HAS_GAME_H
+#define CATA_SRC_HAS_GAME_H
+
+/// Checks whether global unique game `g` is initialized.
+auto has_game() -> bool;
+
+#endif // CATA_SRC_HAS_GAME_H

--- a/src/gamemode_defense.cpp
+++ b/src/gamemode_defense.cpp
@@ -303,7 +303,8 @@ void defense_game::init_map()
     player_character.sety( SEEY );
 
     g->update_map( g-> u );
-    monster *const generator = g->place_critter_around( mtype_id( "mon_generator" ), get_avatar().pos(), 2 );
+    monster *const generator = g->place_critter_around( mtype_id( "mon_generator" ), get_avatar().pos(),
+                               2 );
     assert( generator );
     generator->friendly = -1;
 }

--- a/src/gamemode_defense.cpp
+++ b/src/gamemode_defense.cpp
@@ -302,7 +302,7 @@ void defense_game::init_map()
     player_character.setx( SEEX );
     player_character.sety( SEEY );
 
-    g->update_map( g-> u );
+    g->update_map( get_avatar() );
     monster *const generator = g->place_critter_around( mtype_id( "mon_generator" ), get_avatar().pos(),
                                2 );
     assert( generator );

--- a/src/gamemode_tutorial.cpp
+++ b/src/gamemode_tutorial.cpp
@@ -165,25 +165,25 @@ void tutorial_game::per_turn()
     add_message( tut_lesson::LESSON_MOVE );
     add_message( tut_lesson::LESSON_LOOK );
 
-    if( g->light_level( g->u.posz() ) == 1 ) {
-        if( g->u.has_amount( itype_flashlight, 1 ) ) {
+    if( g->light_level( get_avatar().posz() ) == 1 ) {
+        if( get_avatar().has_amount( itype_flashlight, 1 ) ) {
             add_message( tut_lesson::LESSON_DARK );
         } else {
             add_message( tut_lesson::LESSON_DARK_NO_FLASH );
         }
     }
 
-    if( g->u.get_pain() > 0 ) {
+    if( get_avatar().get_pain() > 0 ) {
         add_message( tut_lesson::LESSON_PAIN );
     }
 
-    if( g->u.recoil >= MAX_RECOIL ) {
+    if( get_avatar().recoil >= MAX_RECOIL ) {
         add_message( tut_lesson::LESSON_RECOIL );
     }
 
     map &here = get_map();
     if( !tutorials_seen[tut_lesson::LESSON_BUTCHER] ) {
-        for( const item * const &it : here.i_at( point( g->u.posx(), g->u.posy() ) ) ) {
+        for( const item * const &it : here.i_at( point( get_avatar().posx(), get_avatar().posy() ) ) ) {
             if( it->is_corpse() ) {
                 add_message( tut_lesson::LESSON_BUTCHER );
                 break;
@@ -191,7 +191,7 @@ void tutorial_game::per_turn()
         }
     }
 
-    for( const tripoint &p : here.points_in_radius( g->u.pos(), 1 ) ) {
+    for( const tripoint &p : here.points_in_radius( get_avatar().pos(), 1 ) ) {
         if( here.ter( p ) == t_door_o ) {
             add_message( tut_lesson::LESSON_OPEN );
             break;
@@ -213,7 +213,7 @@ void tutorial_game::per_turn()
         }
     }
 
-    if( !here.i_at( point( g->u.posx(), g->u.posy() ) ).empty() ) {
+    if( !here.i_at( point( get_avatar().posx(), get_avatar().posy() ) ).empty() ) {
         add_message( tut_lesson::LESSON_PICKUP );
     }
 }
@@ -236,10 +236,10 @@ void tutorial_game::post_action( action_id act )
 {
     switch( act ) {
         case ACTION_RELOAD_WEAPON:
-            if( g->u.primary_weapon().is_gun() && !tutorials_seen[tut_lesson::LESSON_GUN_FIRE] ) {
-                g->place_critter_at( mon_zombie, tripoint( g->u.posx(), g->u.posy() - 6, g->u.posz() ) );
-                g->place_critter_at( mon_zombie, tripoint( g->u.posx() + 2, g->u.posy() - 5, g->u.posz() ) );
-                g->place_critter_at( mon_zombie, tripoint( g->u.posx() - 2, g->u.posy() - 5, g->u.posz() ) );
+            if( get_avatar().primary_weapon().is_gun() && !tutorials_seen[tut_lesson::LESSON_GUN_FIRE] ) {
+                g->place_critter_at( mon_zombie, tripoint( get_avatar().posx(), get_avatar().posy() - 6, get_avatar().posz() ) );
+                g->place_critter_at( mon_zombie, tripoint( get_avatar().posx() + 2, get_avatar().posy() - 5, get_avatar().posz() ) );
+                g->place_critter_at( mon_zombie, tripoint( get_avatar().posx() - 2, get_avatar().posy() - 5, get_avatar().posz() ) );
                 add_message( tut_lesson::LESSON_GUN_FIRE );
             }
             break;
@@ -253,11 +253,11 @@ void tutorial_game::post_action( action_id act )
             break;
 
         case ACTION_USE: {
-            if( g->u.has_amount( itype_grenade_act, 1 ) ) {
+            if( get_avatar().has_amount( itype_grenade_act, 1 ) ) {
                 add_message( tut_lesson::LESSON_ACT_GRENADE );
             }
             map &here = get_map();
-            for( const tripoint &dest : here.points_in_radius( g->u.pos(), 1 ) ) {
+            for( const tripoint &dest : here.points_in_radius( get_avatar().pos(), 1 ) ) {
                 if( here.tr_at( dest ).id == trap_str_id( "tr_bubblewrap" ) ) {
                     add_message( tut_lesson::LESSON_ACT_BUBBLEWRAP );
                 }
@@ -266,17 +266,17 @@ void tutorial_game::post_action( action_id act )
         break;
 
         case ACTION_EAT:
-            if( g->u.last_item == itype_codeine ) {
+            if( get_avatar().last_item == itype_codeine ) {
                 add_message( tut_lesson::LESSON_TOOK_PAINKILLER );
-            } else if( g->u.last_item == itype_cig ) {
+            } else if( get_avatar().last_item == itype_cig ) {
                 add_message( tut_lesson::LESSON_TOOK_CIG );
-            } else if( g->u.last_item == itype_water ) {
+            } else if( get_avatar().last_item == itype_water ) {
                 add_message( tut_lesson::LESSON_DRANK_WATER );
             }
             break;
 
         case ACTION_WEAR: {
-            item &it = *item::spawn_temporary( g->u.last_item, calendar::start_of_cataclysm );
+            item &it = *item::spawn_temporary( get_avatar().last_item, calendar::start_of_cataclysm );
             if( it.is_armor() ) {
                 if( it.get_avg_coverage() >= 2 || it.get_thickness() >= 2 ) {
                     add_message( tut_lesson::LESSON_WORE_ARMOR );
@@ -292,7 +292,7 @@ void tutorial_game::post_action( action_id act )
         break;
 
         case ACTION_WIELD:
-            if( g->u.primary_weapon().is_gun() ) {
+            if( get_avatar().primary_weapon().is_gun() ) {
                 add_message( tut_lesson::LESSON_GUN_LOAD );
             }
             break;
@@ -301,7 +301,7 @@ void tutorial_game::post_action( action_id act )
             add_message( tut_lesson::LESSON_INTERACT );
         /* fallthrough */
         case ACTION_PICKUP: {
-            item &it = *item::spawn_temporary( g->u.last_item, calendar::start_of_cataclysm );
+            item &it = *item::spawn_temporary( get_avatar().last_item, calendar::start_of_cataclysm );
             if( it.is_armor() ) {
                 add_message( tut_lesson::LESSON_GOT_ARMOR );
             } else if( it.is_gun() ) {

--- a/src/gamemode_tutorial.cpp
+++ b/src/gamemode_tutorial.cpp
@@ -237,9 +237,12 @@ void tutorial_game::post_action( action_id act )
     switch( act ) {
         case ACTION_RELOAD_WEAPON:
             if( get_avatar().primary_weapon().is_gun() && !tutorials_seen[tut_lesson::LESSON_GUN_FIRE] ) {
-                g->place_critter_at( mon_zombie, tripoint( get_avatar().posx(), get_avatar().posy() - 6, get_avatar().posz() ) );
-                g->place_critter_at( mon_zombie, tripoint( get_avatar().posx() + 2, get_avatar().posy() - 5, get_avatar().posz() ) );
-                g->place_critter_at( mon_zombie, tripoint( get_avatar().posx() - 2, get_avatar().posy() - 5, get_avatar().posz() ) );
+                g->place_critter_at( mon_zombie, tripoint( get_avatar().posx(), get_avatar().posy() - 6,
+                                     get_avatar().posz() ) );
+                g->place_critter_at( mon_zombie, tripoint( get_avatar().posx() + 2, get_avatar().posy() - 5,
+                                     get_avatar().posz() ) );
+                g->place_critter_at( mon_zombie, tripoint( get_avatar().posx() - 2, get_avatar().posy() - 5,
+                                     get_avatar().posz() ) );
                 add_message( tut_lesson::LESSON_GUN_FIRE );
             }
             break;

--- a/src/gates.cpp
+++ b/src/gates.cpp
@@ -220,7 +220,7 @@ void gates::toggle_gate( const tripoint &pos )
         }
     }
 
-    if( g->u.sees( pos ) ) {
+    if( get_avatar().sees( pos ) ) {
         if( open ) {
             add_msg( gate.open_message );
         } else if( close ) {

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -20,7 +20,7 @@
 #include "rng.h"
 #include "tileray.h"
 #include "translations.h"
-#include "units.h"
+#include "game.h"
 
 static const efftype_id effect_harnessed( "harnessed" );
 
@@ -100,11 +100,14 @@ bool game::grabbed_veh_move( const tripoint &dp )
         u.grab( OBJECT_NONE );
         return false;
     }
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     vehicle *grabbed_vehicle = &grabbed_vehicle_vp->vehicle();
     if( !grabbed_vehicle ||
         !grabbed_vehicle->handle_potential_theft( u ) ) {
         return false;
     }
+
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     const int grabbed_part = grabbed_vehicle_vp->part_index();
     for( int part_index = 0; part_index < grabbed_vehicle->part_count(); ++part_index ) {
         monster *mon = grabbed_vehicle->get_pet( part_index );

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -1,5 +1,4 @@
 #include "enums.h"
-#include "game.h" // IWYU pragma: associated
 
 #include <cstdlib>
 #include <algorithm>

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -398,7 +398,7 @@ input_context game::get_player_input( std::string &action )
 
 inline static void rcdrive( point d )
 {
-    player &u = g->u;
+    player &u = get_avatar();
     map &here = get_map();
     std::string car_location_string = u.get_value( "remote_controlling" );
 
@@ -451,7 +451,7 @@ static void pldrive( const tripoint &p )
     if( !g->check_safe_mode_allowed() ) {
         return;
     }
-    player &u = g->u;
+    player &u = get_avatar();
     vehicle *veh = g->remoteveh();
     bool remote = true;
     int part = -1;
@@ -516,7 +516,7 @@ inline static void pldrive( point d )
 
 static void open()
 {
-    player &u = g->u;
+    player &u = get_avatar();
     const std::optional<tripoint> openp_ = choose_adjacent_highlight( _( "Open where?" ),
                                            pgettext( "no door, gate, curtain, etc.", "There is nothing that can be opened nearby." ),
                                            ACTION_OPEN, false );
@@ -597,14 +597,14 @@ static void close()
     if( const std::optional<tripoint> pnt = choose_adjacent_highlight( _( "Close where?" ),
                                             pgettext( "no door, gate, etc.", "There is nothing that can be closed nearby." ),
                                             ACTION_CLOSE, false ) ) {
-        doors::close_door( get_map(), g->u, *pnt );
+        doors::close_door( get_map(), get_avatar(), *pnt );
     }
 }
 
 // Establish or release a grab on a vehicle
 static void grab()
 {
-    avatar &you = g->u;
+    avatar &you = get_avatar();
     map &here = get_map();
 
     if( you.get_grab_type() != OBJECT_NONE ) {
@@ -654,7 +654,7 @@ static void grab()
 
 static void haul()
 {
-    player &u = g->u;
+    player &u = get_avatar();
     map &here = get_map();
 
     if( u.is_hauling() ) {
@@ -676,7 +676,7 @@ static void haul()
 
 static void smash()
 {
-    player &u = g->u;
+    player &u = get_avatar();
     map &here = get_map();
     if( u.is_mounted() ) {
         auto mons = u.mounted_creature.get();
@@ -853,7 +853,7 @@ static void smash()
 static int try_set_alarm()
 {
     uilist as_m;
-    const bool already_set = g->u.has_effect( effect_alarm_clock );
+    const bool already_set = get_avatar().has_effect( effect_alarm_clock );
 
     as_m.text = already_set ?
                 _( "You already have an alarm set.  What do you want to do?" ) :
@@ -874,7 +874,7 @@ static void wait()
 {
     std::map<int, time_duration> durations;
     uilist as_m;
-    player &u = g->u;
+    player &u = get_avatar();
     bool setting_alarm = false;
     map &here = get_map();
 
@@ -917,7 +917,7 @@ static void wait()
         }
 
     } else {
-        if( g->u.get_stamina() < g->u.get_stamina_max() ) {
+        if( get_avatar().get_stamina() < get_avatar().get_stamina_max() ) {
             as_m.addentry( 12, true, 'w', _( "Wait until you catch your breath" ) );
             durations.emplace( 12, 15_minutes ); // to hide it from showing
         }
@@ -1096,7 +1096,7 @@ static void sleep()
 
     time_duration try_sleep_dur = 24_hours;
     std::string deaf_text;
-    if( g->u.is_deaf() ) {
+    if( get_avatar().is_deaf() ) {
         deaf_text = _( "<color_c_red> (DEAF!)</color>" );
     }
     if( u.has_alarm_clock() ) {
@@ -1148,7 +1148,7 @@ static void loot()
         MultiMining = 8192
     };
 
-    player &u = g->u;
+    player &u = get_avatar();
     int flags = 0;
     auto &mgr = zone_manager::get_manager();
     const bool has_fertilizer = u.has_item_with_flag( flag_FERTILIZER );
@@ -1274,7 +1274,7 @@ static void loot()
 
 static void wear()
 {
-    avatar &u = g->u;
+    avatar &u = get_avatar();
     item *loc = game_menus::inv::wear( u );
 
     if( loc ) {
@@ -1287,7 +1287,7 @@ static void wear()
 
 static void takeoff()
 {
-    avatar &u = g->u;
+    avatar &u = get_avatar();
     item *loc = game_menus::inv::take_off( u );
 
     if( loc ) {
@@ -1300,7 +1300,7 @@ static void takeoff()
 
 static void read()
 {
-    avatar &u = g->u;
+    avatar &u = get_avatar();
     // Can read items from inventory or within one tile (including in vehicles)
     item *loc = game_menus::inv::read( u );
 
@@ -1331,7 +1331,7 @@ static void reach_attack( avatar &you )
 
 static void fire()
 {
-    avatar &u = g->u;
+    avatar &u = get_avatar();
     map &here = get_map();
 
     // Use vehicle turret or draw a pistol from a holster if unarmed
@@ -1400,7 +1400,7 @@ static void fire()
 
 static void open_movement_mode_menu()
 {
-    avatar &u = g->u;
+    avatar &u = get_avatar();
     uilist as_m;
 
     as_m.text = _( "Change to which movement mode?" );
@@ -1423,7 +1423,7 @@ static void open_movement_mode_menu()
 
 static void cast_spell()
 {
-    player &u = g->u;
+    player &u = get_avatar();
 
     std::vector<spell_id> spells = u.magic->spells();
 
@@ -2078,11 +2078,11 @@ bool game::handle_action()
                 break;
 
             case ACTION_MEND:
-                avatar_action::mend( g->u, nullptr );
+                avatar_action::mend( get_avatar(), nullptr );
                 break;
 
             case ACTION_THROW: {
-                avatar_action::plthrow( g->u, nullptr );
+                avatar_action::plthrow( get_avatar(), nullptr );
                 break;
             }
 
@@ -2442,24 +2442,24 @@ bool game::handle_action()
                 break;
 
             case ACTION_TOGGLE_THIEF_MODE:
-                if( g->u.get_value( "THIEF_MODE" ) == "THIEF_ASK" ) {
+                if( get_avatar().get_value( "THIEF_MODE" ) == "THIEF_ASK" ) {
                     u.set_value( "THIEF_MODE", "THIEF_HONEST" );
                     u.set_value( "THIEF_MODE_KEEP", "YES" );
                     //~ Thief mode cycled between THIEF_ASK/THIEF_HONEST/THIEF_STEAL
                     add_msg( _( "You will not pick up other peoples belongings." ) );
-                } else if( g->u.get_value( "THIEF_MODE" ) == "THIEF_HONEST" ) {
+                } else if( get_avatar().get_value( "THIEF_MODE" ) == "THIEF_HONEST" ) {
                     u.set_value( "THIEF_MODE", "THIEF_STEAL" );
                     u.set_value( "THIEF_MODE_KEEP", "YES" );
                     //~ Thief mode cycled between THIEF_ASK/THIEF_HONEST/THIEF_STEAL
                     add_msg( _( "You will pick up also those things that belong to others!" ) );
-                } else if( g->u.get_value( "THIEF_MODE" ) == "THIEF_STEAL" ) {
+                } else if( get_avatar().get_value( "THIEF_MODE" ) == "THIEF_STEAL" ) {
                     u.set_value( "THIEF_MODE", "THIEF_ASK" );
                     u.set_value( "THIEF_MODE_KEEP", "NO" );
                     //~ Thief mode cycled between THIEF_ASK/THIEF_HONEST/THIEF_STEAL
                     add_msg( _( "You will be reminded not to steal." ) );
                 } else {
                     // ERROR
-                    add_msg( _( "THIEF_MODE CONTAINED BAD VALUE [ %s ]!" ), g->u.get_value( "THIEF_MODE" ) );
+                    add_msg( _( "THIEF_MODE CONTAINED BAD VALUE [ %s ]!" ), get_avatar().get_value( "THIEF_MODE" ) );
                 }
                 break;
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -776,7 +776,7 @@ static void smash()
         return; // don't smash terrain if we've smashed a corpse
     }
 
-    vehicle *veh = veh_pointer_or_null( g->m.veh_at( smashp ) );
+    vehicle *veh = veh_pointer_or_null( get_map().veh_at( smashp ) );
     if( veh != nullptr ) {
         if( !veh->handle_potential_theft( get_avatar() ) ) {
             return;

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -127,7 +127,7 @@ static bool get_liquid_target( item &liquid, const int radius, liquid_dest_opt &
     std::vector<std::function<void()>> actions;
 
     if( get_avatar().can_consume( liquid ) && ( !liquid.is_loaded() ||
-                                        liquid.where() != item_location_type::monster ) ) {
+            liquid.where() != item_location_type::monster ) ) {
         if( get_avatar().can_consume_for_bionic( liquid ) ) {
             menu.addentry( -1, true, 'e', _( "Fuel bionic with it" ) );
         } else {

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -19,7 +19,6 @@
 #include "debug.h"
 #include "enums.h"
 #include "fstream_utils.h"
-#include "game.h"
 #include "game_inventory.h"
 #include "iexamine.h"
 #include "item.h"

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -376,11 +376,11 @@ void iexamine::translocator( player &, const tripoint &examp )
     avatar &player_character = get_avatar();
     const bool activated = player_character.translocators->knows_translocator( omt_loc );
     if( !activated ) {
-        g->u.translocators->activate_teleporter( omt_loc, examp );
+        get_avatar().translocators->activate_teleporter( omt_loc, examp );
         add_msg( m_info, _( "Translocator gate active." ) );
     } else {
         if( query_yn( _( "Do you want to deactivate this active Translocator?" ) ) ) {
-            g->u.translocators->deactivate_teleporter( omt_loc, examp );
+            get_avatar().translocators->deactivate_teleporter( omt_loc, examp );
         }
     }
 }
@@ -1093,7 +1093,7 @@ void iexamine::chainfence( player &p, const tripoint &examp )
             return;
         }
         p.moves += climb * 10;
-        sfx::play_variant_sound( "plmove", "clear_obstacle", sfx::get_heard_volume( g->u.pos() ) );
+        sfx::play_variant_sound( "plmove", "clear_obstacle", sfx::get_heard_volume( get_avatar().pos() ) );
     }
     if( p.in_vehicle ) {
         here.unboard_vehicle( p.pos() );
@@ -2214,7 +2214,7 @@ void iexamine::plant_seed( player &p, const tripoint &examp, const itype_id &see
 void iexamine::dirtmound( player &p, const tripoint &examp )
 {
 
-    if( !warm_enough_to_plant( g->u.pos() ) ) {
+    if( !warm_enough_to_plant( get_avatar().pos() ) ) {
         add_msg( m_info, _( "It is too cold to plant anything now." ) );
         return;
     }
@@ -3256,7 +3256,7 @@ void iexamine::keg( player &p, const tripoint &examp )
         drink->charges = 0;
         bool keg_full = false;
         for( int i = 0; i < charges_held && !keg_full; i++ ) {
-            g->u.use_charges( drink->typeId(), 1 );
+            get_avatar().use_charges( drink->typeId(), 1 );
             drink->charges++;
             keg_full = drink->volume() >= keg_cap;
         }
@@ -3577,8 +3577,8 @@ void iexamine::tree_maple_tapped( player &p, const tripoint &examp )
         }
 
         case REMOVE_CONTAINER: {
-            g->u.assign_activity( std::make_unique<player_activity>( std::make_unique<pickup_activity_actor>(
-            std::vector<pickup::pick_drop_selection> { { container, std::nullopt, {} } }, g->u.pos() ) ) );
+            get_avatar().assign_activity( std::make_unique<player_activity>( std::make_unique<pickup_activity_actor>(
+            std::vector<pickup::pick_drop_selection> { { container, std::nullopt, {} } }, get_avatar().pos() ) ) );
             return;
         }
 
@@ -3917,8 +3917,8 @@ void iexamine::reload_furniture( player &p, const tripoint &examp )
             auto items = here.i_at( examp );
             for( auto &itm : items ) {
                 if( itm->type == cur_ammo ) {
-                    g->u.assign_activity( std::make_unique<player_activity>( std::make_unique<pickup_activity_actor>(
-                    std::vector<pickup::pick_drop_selection> { { itm, std::nullopt, {} } }, g->u.pos() ) ) );
+                    get_avatar().assign_activity( std::make_unique<player_activity>( std::make_unique<pickup_activity_actor>(
+                    std::vector<pickup::pick_drop_selection> { { itm, std::nullopt, {} } }, get_avatar().pos() ) ) );
                     return;
                 }
             }
@@ -4045,7 +4045,7 @@ void iexamine::use_furn_fake_item( player &p, const tripoint &examp )
     p.invoke_item( &fake_item );
 
     // HACK: Evil hack incoming
-    activity_handlers::repair_activity_hack::patch_activity_for_furniture( *g->u.activity, examp,
+    activity_handlers::repair_activity_hack::patch_activity_for_furniture( *get_avatar().activity, examp,
             cur_tool.get_id() );
 
     const int discharged_ammo = original_charges - fake_item.charges;
@@ -4258,7 +4258,7 @@ static int findBestGasDiscount( player &p )
 
 static std::string str_to_illiterate_str( std::string s )
 {
-    if( !g->u.has_trait( trait_ILLITERATE ) ) {
+    if( !get_avatar().has_trait( trait_ILLITERATE ) ) {
         return s;
     } else {
         for( auto &i : s ) {
@@ -4809,7 +4809,7 @@ static player &best_installer( player &p, player &null_player, int difficulty )
             player &ally = *g->critter_by_id<player>( e->getID() );
             int ally_cos = bionic_manip_cos( ally_skills[ i ].first, difficulty );
             if( e->has_effect( effect_sleep ) ) {
-                if( !g->u.query_yn(
+                if( !get_avatar().query_yn(
                         //~ %1$s is the name of the ally
                         _( "<color_white>%1$s is asleep, but has a <color_green>%2$d<color_white> chance of success compared to your <color_red>%3$d<color_white> chance of success.  Continue with a higher risk of failure?</color>" ),
                         ally.disp_name(), ally_cos, player_cos ) ) {
@@ -5059,14 +5059,14 @@ void iexamine::autodoc( player &p, const tripoint &examp )
                         bionic_to_uninstall->set_flag( flag_IN_CBM );
                         bionic_to_uninstall->set_flag( flag_NO_STERILE );
                         bionic_to_uninstall->set_flag( flag_NO_PACKED );
-                        g->u.i_add( std::move( bionic_to_uninstall ) );
+                        get_avatar().i_add( std::move( bionic_to_uninstall ) );
                     }
                 }
             }
 
             const item *bionic = game_menus::inv::uninstall_bionic( p, patient );
             if( !bionic ) {
-                g->u.remove_items_with( []( detached_ptr<item> &&it ) { // remove cbm items from inventory
+                get_avatar().remove_items_with( []( detached_ptr<item> &&it ) { // remove cbm items from inventory
                     if( it->has_flag( flag_IN_CBM ) ) {
                         detached_ptr<item> del = std::move( it ); //This acts as a delete
                     }
@@ -5078,7 +5078,7 @@ void iexamine::autodoc( player &p, const tripoint &examp )
             const itype *itemtype = it->type;
             const bionic_id &bid = itemtype->bionic->id;
 
-            g->u.remove_items_with( []( detached_ptr<item> &&it ) { // remove cbm items from inventory
+            get_avatar().remove_items_with( []( detached_ptr<item> &&it ) { // remove cbm items from inventory
                 if( it->has_flag( flag_IN_CBM ) ) {
                     detached_ptr<item> del = std::move( it ); //This acts as a delete
                 }
@@ -5654,7 +5654,7 @@ static void smoker_load_food( player &p, const tripoint &examp,
     comps.emplace_back( what->typeId(), amount );
 
     // select from where to get the items from and place them
-    inv.form_from_map( g->u.pos(), PICKUP_RANGE, &g->u );
+    inv.form_from_map( get_avatar().pos(), PICKUP_RANGE, &get_avatar() );
     inv.remove_items_with( []( const item & it ) {
         return it.rotten();
     } );
@@ -5763,7 +5763,7 @@ static void mill_load_food( player &p, const tripoint &examp,
     comps.emplace_back( what->typeId(), amount );
 
     // select from where to get the items from and place them
-    inv.form_from_map( g->u.pos(), PICKUP_RANGE, &g->u );
+    inv.form_from_map( get_avatar().pos(), PICKUP_RANGE, &get_avatar() );
     inv.remove_items_with( []( const item & it ) {
         return it.rotten();
     } );
@@ -5787,7 +5787,7 @@ void iexamine::on_smoke_out( const tripoint &examp, const time_point &start_time
     map &here = get_map();
     if( here.furn( examp ) == furn_str_id( "f_smoking_rack_active" ) ||
         here.furn( examp ) == furn_str_id( "f_metal_smoking_rack_active" ) ) {
-        smoker_finalize( g->u, examp, start_time );
+        smoker_finalize( get_avatar(), examp, start_time );
     }
 }
 

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -13,7 +13,6 @@
 #include "debug.h"
 #include "diary.h"
 #include "distribution_grid.h"
-#include "game.h"
 #include "iexamine.h"
 #include "locations.h"
 #include "magic_enchantment.h"

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -270,7 +270,7 @@ char inventory::find_usable_cached_invlet( const itype_id &item_type )
             continue;
         }
         // Check if anything is using this invlet.
-        if( g->u.invlet_to_item( invlet ) != nullptr ) {
+        if( get_avatar().invlet_to_item( invlet ) != nullptr ) {
             continue;
         }
         return invlet;
@@ -303,7 +303,7 @@ item &inventory::add_item( item &newit, bool keep_invlet, bool assign_invlet, bo
             } else if( keep_invlet && assign_invlet && it->invlet == newit.invlet &&
                        it->invlet != '\0' ) {
                 // If keep_invlet is true, we'll be forcing other items out of their current invlet.
-                assign_empty_invlet( *it, g->u );
+                assign_empty_invlet( *it, get_avatar() );
             }
         }
     }
@@ -356,7 +356,7 @@ item &inventory::add_item_by_items_type_cache( item &newit, bool keep_invlet, bo
             } else if( keep_invlet && assign_invlet && it_ref->invlet == newit.invlet &&
                        it_ref->invlet != '\0' ) {
                 // If keep_invlet is true, we'll be forcing other items out of their current invlet.
-                assign_empty_invlet( *it_ref, g->u );
+                assign_empty_invlet( *it_ref, get_avatar() );
             }
         }
     }
@@ -1009,7 +1009,7 @@ void inventory::rust_iron_items()
                                     elem_stack_iter->base_volume().value() ) / 250 ) ) ) ) &&
                 //                       ^season length   ^14/5*0.75/pi (from volume of sphere)
                 //Freshwater without oxygen rusts slower than air
-                g->m.water_from( g->u.pos() )->typeId() == itype_salt_water ) {
+                g->m.water_from( get_avatar().pos() )->typeId() == itype_salt_water ) {
                 elem_stack_iter->inc_damage( DT_ACID ); // rusting never completely destroys an item
                 add_msg( m_bad, _( "Your %s is damaged by rust." ), elem_stack_iter->tname() );
             }
@@ -1190,7 +1190,7 @@ void inventory::assign_empty_invlet( item &it, const Character &p, const bool fo
     if( cur_inv.count() < inv_chars.size() ) {
         // XXX YUCK I don't know how else to get the keybindings
         // FIXME: Find a better way to get bound keys
-        avatar &u = g->u;
+        avatar &u = get_avatar();
         inventory_selector selector( u );
 
         std::vector<char> binds = selector.all_bound_keys();
@@ -1257,7 +1257,7 @@ void inventory::update_invlet( item &newit, bool assign_invlet )
     if( newit.invlet ) {
         char tmp_invlet = newit.invlet;
         newit.invlet = '\0';
-        if( g->u.invlet_to_item( tmp_invlet ) == nullptr ) {
+        if( get_avatar().invlet_to_item( tmp_invlet ) == nullptr ) {
             newit.invlet = tmp_invlet;
         }
     }
@@ -1270,7 +1270,7 @@ void inventory::update_invlet( item &newit, bool assign_invlet )
 
         // Give the item an invlet if it has none
         if( !newit.invlet ) {
-            assign_empty_invlet( newit, g->u );
+            assign_empty_invlet( newit, get_avatar() );
         }
     }
 }

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -466,7 +466,7 @@ void inventory::form_from_map( const tripoint &origin, int range, const Characte
                                bool assign_invlet,
                                bool clear_path )
 {
-    form_from_map( g->m, origin, range, pl, assign_invlet, clear_path );
+    form_from_map( get_map(), origin, range, pl, assign_invlet, clear_path );
 }
 
 void inventory::form_from_zone( map &m, std::unordered_set<tripoint> &zone_pts, const Character *pl,
@@ -1009,7 +1009,7 @@ void inventory::rust_iron_items()
                                     elem_stack_iter->base_volume().value() ) / 250 ) ) ) ) &&
                 //                       ^season length   ^14/5*0.75/pi (from volume of sphere)
                 //Freshwater without oxygen rusts slower than air
-                g->m.water_from( get_avatar().pos() )->typeId() == itype_salt_water ) {
+                get_map().water_from( get_avatar().pos() )->typeId() == itype_salt_water ) {
                 elem_stack_iter->inc_damage( DT_ACID ); // rusting never completely destroys an item
                 add_msg( m_bad, _( "Your %s is damaged by rust." ), elem_stack_iter->tname() );
             }

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -652,7 +652,7 @@ void inventory_column::set_stack_favorite( const item *location, bool favorite )
             get_avatar().inv_set_stack_favorite( position, !selected_item->is_favorite ); // in inventory
         }
     } else if( location->where() == item_location_type::map ) {
-        auto items = g->m.i_at( location->position() );
+        auto items = get_map().i_at( location->position() );
 
         for( auto &item : items ) {
             if( item->stacks_with( *selected_item ) ) {
@@ -663,7 +663,7 @@ void inventory_column::set_stack_favorite( const item *location, bool favorite )
             item->set_favorite( favorite );
         }
     } else if( location->where() == item_location_type::vehicle ) {
-        const std::optional<vpart_reference> vp = g->m.veh_at(
+        const std::optional<vpart_reference> vp = get_map().veh_at(
                     location->position() ).part_with_feature( "CARGO", true );
         assert( vp );
 
@@ -1209,9 +1209,9 @@ void inventory_selector::add_character_items( Character &character )
 
 void inventory_selector::add_map_items( const tripoint &target )
 {
-    if( g->m.accessible_items( target ) ) {
-        const auto items = g->m.i_at( target );
-        const std::string name = to_upper_case( g->m.name( target ) );
+    if( get_map().accessible_items( target ) ) {
+        const auto items = get_map().i_at( target );
+        const std::string name = to_upper_case( get_map().name( target ) );
         const item_category map_cat( name, no_translation( name ), 100 );
 
         add_items( map_column, []( item * it ) {
@@ -1222,7 +1222,8 @@ void inventory_selector::add_map_items( const tripoint &target )
 
 void inventory_selector::add_vehicle_items( const tripoint &target )
 {
-    const std::optional<vpart_reference> vp = g->m.veh_at( target ).part_with_feature( "CARGO", true );
+    const std::optional<vpart_reference> vp = get_map().veh_at( target ).part_with_feature( "CARGO",
+            true );
     if( !vp ) {
         return;
     }
@@ -1244,7 +1245,7 @@ void inventory_selector::add_nearby_items( int radius )
     if( radius >= 0 ) {
         for( const tripoint &pos : closest_points_first( u.pos(), radius ) ) {
             // can not reach this -> can not access its contents
-            if( u.pos() != pos && !g->m.clear_path( u.pos(), pos, rl_dist( u.pos(), pos ), 1, 100 ) ) {
+            if( u.pos() != pos && !get_map().clear_path( u.pos(), pos, rl_dist( u.pos(), pos ), 1, 100 ) ) {
                 continue;
             }
             add_map_items( pos );

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -5,7 +5,6 @@
 #include "catacharset.h"
 #include "character.h"
 #include "debug.h"
-#include "game.h"
 #include "ime.h"
 #include "inventory.h"
 #include "item.h"

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -122,7 +122,7 @@ class selection_column_preset : public inventory_selector_preset
             if( entry.is_item() ) {
                 if( get_player_character().is_wielding( *entry.any_item() ) ) {
                     return c_light_blue;
-                } else if( g->u.is_worn( *entry.any_item() ) ) {
+                } else if( get_avatar().is_worn( *entry.any_item() ) ) {
                     return c_cyan;
                 }
             }
@@ -176,7 +176,7 @@ nc_color inventory_entry::get_invlet_color() const
 {
     if( !is_selectable() ) {
         return c_dark_gray;
-    } else if( g->u.inv_assigned_invlet().count( get_invlet() ) ) {
+    } else if( get_avatar().inv_assigned_invlet().count( get_invlet() ) ) {
         return c_yellow;
     } else {
         return c_white;
@@ -238,8 +238,8 @@ bool inventory_selector_preset::sort_compare( const inventory_entry &lhs,
         const inventory_entry &rhs ) const
 {
     // Place items with an assigned inventory letter first, since the player cared enough to assign them
-    const bool left_fav  = g->u.inv_assigned_invlet().count( lhs.any_item()->invlet );
-    const bool right_fav = g->u.inv_assigned_invlet().count( rhs.any_item()->invlet );
+    const bool left_fav  = get_avatar().inv_assigned_invlet().count( lhs.any_item()->invlet );
+    const bool right_fav = get_avatar().inv_assigned_invlet().count( rhs.any_item()->invlet );
     if( left_fav == right_fav ) {
         return lhs.cached_name.compare( rhs.cached_name ) < 0; // Simple alphabetic order
     } else if( left_fav ) {
@@ -644,12 +644,12 @@ void inventory_column::set_stack_favorite( const item *location, bool favorite )
     std::list<item *> to_favorite;
 
     if( location->where() == item_location_type::character ) {
-        int position = g->u.get_item_position( selected_item );
+        int position = get_avatar().get_item_position( selected_item );
 
         if( position < 0 ) {
-            g->u.i_at( position ).set_favorite( !selected_item->is_favorite ); // worn/wielded
+            get_avatar().i_at( position ).set_favorite( !selected_item->is_favorite ); // worn/wielded
         } else {
-            g->u.inv_set_stack_favorite( position, !selected_item->is_favorite ); // in inventory
+            get_avatar().inv_set_stack_favorite( position, !selected_item->is_favorite ); // in inventory
         }
     } else if( location->where() == item_location_type::map ) {
         auto items = g->m.i_at( location->position() );
@@ -2222,7 +2222,7 @@ drop_locations inventory_drop_selector::execute()
             const auto filter_to_nonfavorite_and_nonworn = []( const inventory_entry & entry ) {
                 return entry.is_item() &&
                        !entry.any_item()->is_favorite &&
-                       !g->u.is_worn( *entry.any_item() );
+                       !get_avatar().is_worn( *entry.any_item() );
             };
 
             const auto selected( get_active_column().get_entries( filter_to_nonfavorite_and_nonworn ) );

--- a/src/item.h
+++ b/src/item.h
@@ -646,7 +646,7 @@ class item : public location_visitable<item>, public game_object<item>
          */
         double effective_dps( const player &guy, const monster &mon ) const;
         /**
-         * calculate effective dps against a stock set of monsters.  by default, assume g->u
+         * calculate effective dps against a stock set of monsters.  by default, assume get_avatar()
          * is wielding
         * for_display - include monsters intended for display purposes
          * for_calc - include monsters intended for evaluation purposes

--- a/src/item_action.cpp
+++ b/src/item_action.cpp
@@ -15,7 +15,6 @@
 #include "clone_ptr.h"
 #include "cursesdef.h"
 #include "debug.h"
-#include "game.h"
 #include "input.h"
 #include "inventory.h"
 #include "item.h"

--- a/src/item_action.cpp
+++ b/src/item_action.cpp
@@ -2,18 +2,17 @@
 
 #include <algorithm>
 #include <iterator>
-#include <list>
 #include <memory>
 #include <set>
 #include <tuple>
 #include <unordered_set>
 #include <utility>
 
+#include "game.h"
 #include "avatar.h"
 #include "calendar.h"
 #include "catacharset.h"
 #include "clone_ptr.h"
-#include "cursesdef.h"
 #include "debug.h"
 #include "input.h"
 #include "inventory.h"

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -698,7 +698,7 @@ int iuse::fungicide( player *p, item *it, bool, const tripoint & )
                 x_in_y( spore_count, 8 ) ) {
                 if( monster *const mon_ptr = g->critter_at<monster>( dest ) ) {
                     monster &critter = *mon_ptr;
-                    if( g->u.sees( dest ) &&
+                    if( get_avatar().sees( dest ) &&
                         !critter.type->in_species( FUNGUS ) ) {
                         add_msg( m_warning, _( "The %s is covered in tiny spores!" ),
                                  critter.name() );
@@ -1773,7 +1773,7 @@ static bool good_fishing_spot( tripoint pos )
     std::string om_id = cur_omt.id().c_str();
     if( fishables.empty() && !g->m.has_flag( "CURRENT", pos ) &&
         om_id.find( "river_" ) == std::string::npos && !cur_omt->is_lake() && !cur_omt->is_lake_shore() ) {
-        g->u.add_msg_if_player( m_info, _( "You doubt you will have much luck catching fish here" ) );
+        get_avatar().add_msg_if_player( m_info, _( "You doubt you will have much luck catching fish here" ) );
         return false;
     }
     return true;
@@ -1967,14 +1967,14 @@ int iuse::extinguisher( player *p, item *it, bool, const tripoint & )
             blind = true;
             critter.add_effect( effect_blind, rng( 1_minutes, 2_minutes ) );
         }
-        if( g->u.sees( critter ) ) {
+        if( get_avatar().sees( critter ) ) {
             p->add_msg_if_player( _( "The %s is sprayed!" ), critter.name() );
             if( blind ) {
                 p->add_msg_if_player( _( "The %s looks blinded." ), critter.name() );
             }
         }
         if( critter.made_of( LIQUID ) ) {
-            if( g->u.sees( critter ) ) {
+            if( get_avatar().sees( critter ) ) {
                 p->add_msg_if_player( _( "The %s is frozen!" ), critter.name() );
             }
             critter.apply_damage( p, bodypart_id( "torso" ), rng( 20, 60 ) );
@@ -2407,7 +2407,7 @@ int iuse::hammer( player *p, item *it, bool, const tripoint & )
     };
 
     const std::function<bool( const tripoint & )> f = [&allowed_ter_id]( const tripoint & pnt ) {
-        if( pnt == g->u.pos() ) {
+        if( pnt == get_avatar().pos() ) {
             return false;
         }
         const ter_id ter = g->m.ter( pnt );
@@ -2717,21 +2717,21 @@ int iuse::dig( player *p, item *it, bool t, const tripoint & )
     }
 
     if( grave ) {
-        if( g->u.has_trait( trait_SPIRITUAL ) && !g->u.has_trait( trait_PSYCHOPATH ) &&
-            g->u.query_yn( _( "Would you really touch the sacred resting place of the dead?" ) ) ) {
+        if( get_avatar().has_trait( trait_SPIRITUAL ) && !get_avatar().has_trait( trait_PSYCHOPATH ) &&
+            get_avatar().query_yn( _( "Would you really touch the sacred resting place of the dead?" ) ) ) {
             add_msg( m_info, _( "Exhuming a grave is really against your beliefs." ) );
-            g->u.add_morale( MORALE_GRAVEDIGGER, -50, -100, 48_hours, 12_hours );
+            get_avatar().add_morale( MORALE_GRAVEDIGGER, -50, -100, 48_hours, 12_hours );
             if( one_in( 3 ) ) {
-                g->u.vomit();
+                get_avatar().vomit();
             }
-        } else if( g->u.has_trait( trait_PSYCHOPATH ) ) {
+        } else if( get_avatar().has_trait( trait_PSYCHOPATH ) ) {
             p->add_msg_if_player( m_good,
                                   _( "Exhuming a grave is fun now, where there is no one to object." ) );
-            g->u.add_morale( MORALE_GRAVEDIGGER, 25, 50, 2_hours, 1_hours );
-        } else if( !g->u.has_trait( trait_EATDEAD ) &&
-                   !g->u.has_trait( trait_SAPROVORE ) ) {
+            get_avatar().add_morale( MORALE_GRAVEDIGGER, 25, 50, 2_hours, 1_hours );
+        } else if( !get_avatar().has_trait( trait_EATDEAD ) &&
+                   !get_avatar().has_trait( trait_SAPROVORE ) ) {
             p->add_msg_if_player( m_bad, _( "Exhuming this grave is utterly disgusting!" ) );
-            g->u.add_morale( MORALE_GRAVEDIGGER, -25, -50, 2_hours, 1_hours );
+            get_avatar().add_morale( MORALE_GRAVEDIGGER, -25, -50, 2_hours, 1_hours );
             if( one_in( 5 ) ) {
                 p->vomit();
             }
@@ -2844,7 +2844,7 @@ int iuse::fill_pit( player *p, item *it, bool t, const tripoint & )
     };
 
     const std::function<bool( const tripoint & )> f = [&allowed_ter_id]( const tripoint & pnt ) {
-        if( pnt == g->u.pos() ) {
+        if( pnt == get_avatar().pos() ) {
             return false;
         }
         const ter_id type = g->m.ter( pnt );
@@ -2949,7 +2949,7 @@ int iuse::siphon( player *p, item *it, bool, const tripoint & )
 
     vehicle *v = nullptr;
     bool found_more_than_one = false;
-    for( const tripoint &pos : g->m.points_in_radius( g->u.pos(), 1 ) ) {
+    for( const tripoint &pos : g->m.points_in_radius( get_avatar().pos(), 1 ) ) {
         const optional_vpart_position vp = g->m.veh_at( pos );
         if( !vp ) {
             continue;
@@ -3440,7 +3440,7 @@ int iuse::geiger( player *p, item *it, bool t, const tripoint &pos )
                 return 0;
             }
             const tripoint &pnt = *pnt_;
-            if( pnt == g->u.pos() ) {
+            if( pnt == get_avatar().pos() ) {
                 p->add_msg_if_player( m_info, _( "Your radiation level: %d mSv (%d mSv from items)" ), p->get_rad(),
                                       p->leak_level( flag_RADIOACTIVE ) );
                 break;
@@ -3504,7 +3504,7 @@ int iuse::can_goo( player *p, item *it, bool, const tripoint & )
     }
     if( monster *const mon_ptr = g->critter_at<monster>( goop ) ) {
         monster &critter = *mon_ptr;
-        if( g->u.sees( goop ) ) {
+        if( get_avatar().sees( goop ) ) {
             add_msg( _( "Black goo emerges from the canister and envelopes a %s!" ),
                      critter.name() );
         }
@@ -3513,7 +3513,7 @@ int iuse::can_goo( player *p, item *it, bool, const tripoint & )
         critter.set_speed_base( critter.get_speed_base() - rng( 5, 25 ) );
         critter.set_hp( critter.get_speed() );
     } else {
-        if( g->u.sees( goop ) ) {
+        if( get_avatar().sees( goop ) ) {
             add_msg( _( "Living black goo emerges from the canister!" ) );
         }
         if( monster *const goo = g->place_critter_at( mon_blob, goop ) ) {
@@ -3530,7 +3530,7 @@ int iuse::can_goo( player *p, item *it, bool, const tripoint & )
             found = g->m.passable( goop ) && g->m.tr_at( goop ).is_null();
         } while( !found && tries < 10 );
         if( found ) {
-            if( g->u.sees( goop ) ) {
+            if( get_avatar().sees( goop ) ) {
                 add_msg( m_warning, _( "A nearby splatter of goo forms into a goo pit." ) );
             }
             g->m.trap_set( goop, tr_goo );
@@ -3627,21 +3627,21 @@ int iuse::granade_act( player *p, item *it, bool t, const tripoint &pos )
                         buff_stat( person->int_max, rng( 0, person->int_max / 2 ) );
                         /** @EFFECT_PER_MAX increases possible granade per buff for NPCs */
                         buff_stat( person->per_max, rng( 0, person->per_max / 2 ) );
-                    } else if( g->u.pos() == dest ) {
+                    } else if( get_avatar().pos() == dest ) {
                         /** @EFFECT_STR_MAX increases possible granade str buff */
-                        buff_stat( g->u.str_max, rng( 0, g->u.str_max / 2 ) );
+                        buff_stat( get_avatar().str_max, rng( 0, get_avatar().str_max / 2 ) );
                         /** @EFFECT_DEX_MAX increases possible granade dex buff */
-                        buff_stat( g->u.dex_max, rng( 0, g->u.dex_max / 2 ) );
+                        buff_stat( get_avatar().dex_max, rng( 0, get_avatar().dex_max / 2 ) );
                         /** @EFFECT_INT_MAX increases possible granade int buff */
-                        buff_stat( g->u.int_max, rng( 0, g->u.int_max / 2 ) );
+                        buff_stat( get_avatar().int_max, rng( 0, get_avatar().int_max / 2 ) );
                         /** @EFFECT_PER_MAX increases possible granade per buff */
-                        buff_stat( g->u.per_max, rng( 0, g->u.per_max / 2 ) );
-                        g->u.recalc_hp();
-                        for( const bodypart_id &bp : g->u.get_all_body_parts() ) {
-                            g->u.set_part_hp_cur( bp, g->u.get_part_hp_cur( bp ) * rng_float( 1, 1.2 ) );
-                            const int hp_max = g->u.get_part_hp_max( bp );
-                            if( g->u.get_part_hp_cur( bp ) > hp_max ) {
-                                g->u.set_part_hp_cur( bp, hp_max );
+                        buff_stat( get_avatar().per_max, rng( 0, get_avatar().per_max / 2 ) );
+                        get_avatar().recalc_hp();
+                        for( const bodypart_id &bp : get_avatar().get_all_body_parts() ) {
+                            get_avatar().set_part_hp_cur( bp, get_avatar().get_part_hp_cur( bp ) * rng_float( 1, 1.2 ) );
+                            const int hp_max = get_avatar().get_part_hp_max( bp );
+                            if( get_avatar().get_part_hp_cur( bp ) > hp_max ) {
+                                get_avatar().set_part_hp_cur( bp, hp_max );
                             }
                         }
                     }
@@ -3667,20 +3667,20 @@ int iuse::granade_act( player *p, item *it, bool t, const tripoint &pos )
                         person->int_max -= rng( 0, person->int_max / 2 );
                         /** @EFFECT_PER_MAX increases possible granade per debuff for NPCs (NEGATIVE) */
                         person->per_max -= rng( 0, person->per_max / 2 );
-                    } else if( g->u.pos() == dest ) {
+                    } else if( get_avatar().pos() == dest ) {
                         /** @EFFECT_STR_MAX increases possible granade str debuff (NEGATIVE) */
-                        g->u.str_max -= rng( 0, g->u.str_max / 2 );
+                        get_avatar().str_max -= rng( 0, get_avatar().str_max / 2 );
                         /** @EFFECT_DEX_MAX increases possible granade dex debuff (NEGATIVE) */
-                        g->u.dex_max -= rng( 0, g->u.dex_max / 2 );
+                        get_avatar().dex_max -= rng( 0, get_avatar().dex_max / 2 );
                         /** @EFFECT_INT_MAX increases possible granade int debuff (NEGATIVE) */
-                        g->u.int_max -= rng( 0, g->u.int_max / 2 );
+                        get_avatar().int_max -= rng( 0, get_avatar().int_max / 2 );
                         /** @EFFECT_PER_MAX increases possible granade per debuff (NEGATIVE) */
-                        g->u.per_max -= rng( 0, g->u.per_max / 2 );
-                        g->u.recalc_hp();
-                        for( const bodypart_id &bp : g->u.get_all_body_parts() ) {
-                            const int hp_cur = g->u.get_part_hp_cur( bp );
+                        get_avatar().per_max -= rng( 0, get_avatar().per_max / 2 );
+                        get_avatar().recalc_hp();
+                        for( const bodypart_id &bp : get_avatar().get_all_body_parts() ) {
+                            const int hp_cur = get_avatar().get_part_hp_cur( bp );
                             if( hp_cur > 0 ) {
-                                g->u.set_part_hp_cur( bp, rng( 1, hp_cur ) );
+                                get_avatar().set_part_hp_cur( bp, rng( 1, hp_cur ) );
                             }
                         }
                     }
@@ -3699,9 +3699,9 @@ int iuse::granade_act( player *p, item *it, bool t, const tripoint &pos )
                         critter.clear_effects();
                     } else if( npc *const person = g->critter_at<npc>( dest ) ) {
                         person->environmental_revert_effect();
-                    } else if( g->u.pos() == dest ) {
-                        g->u.environmental_revert_effect();
-                        do_purify( g->u );
+                    } else if( get_avatar().pos() == dest ) {
+                        get_avatar().environmental_revert_effect();
+                        do_purify( get_avatar() );
                     }
                 }
                 break;
@@ -3961,7 +3961,7 @@ int iuse::pheromone( player *p, item *it, bool, const tripoint &pos )
         }
     }
 
-    if( g->u.sees( *p ) ) {
+    if( get_avatar().sees( *p ) ) {
         if( converts == 0 ) {
             add_msg( _( "…but nothing happens." ) );
         } else if( converts == 1 ) {
@@ -4601,7 +4601,7 @@ int iuse::dog_whistle( player *p, item *it, bool, const tripoint & )
     p->add_msg_if_player( _( "You blow your dog whistle." ) );
     for( monster &critter : g->all_monsters() ) {
         if( critter.friendly != 0 && critter.has_flag( MF_DOGFOOD ) ) {
-            bool u_see = g->u.sees( critter );
+            bool u_see = get_avatar().sees( critter );
             if( critter.has_effect( effect_docile ) ) {
                 if( u_see ) {
                     p->add_msg_if_player( _( "Your %s looks ready to attack." ), critter.name() );
@@ -4816,7 +4816,7 @@ int iuse::chop_tree( player *p, item *it, bool t, const tripoint & )
         return 0;
     }
     const std::function<bool( const tripoint & )> f = []( const tripoint & pnt ) {
-        if( pnt == g->u.pos() ) {
+        if( pnt == get_avatar().pos() ) {
             return false;
         }
         return g->m.has_flag( "TREE", pnt );
@@ -4936,7 +4936,7 @@ int iuse::oxytorch( player *p, item *it, bool, const tripoint & )
 
     const std::function<bool( const tripoint & )> f = [&allowed_ter_id,
     &allowed_furn_id]( const tripoint & pnt ) {
-        if( pnt == g->u.pos() ) {
+        if( pnt == get_avatar().pos() ) {
             return false;
         }
         const ter_id ter = g->m.ter( pnt );
@@ -5026,7 +5026,7 @@ int iuse::hacksaw( player *p, item *it, bool t, const tripoint & )
     };
     const std::function<bool( const tripoint & )> f = [&allowed_ter_id,
     &allowed_furn_id]( const tripoint & pnt ) {
-        if( pnt == g->u.pos() ) {
+        if( pnt == get_avatar().pos() ) {
             return false;
         }
         const ter_id ter = g->m.ter( pnt );
@@ -5086,7 +5086,7 @@ int iuse::boltcutters( player *p, item *it, bool, const tripoint & )
         t_chainfence
     };
     const std::function<bool( const tripoint & )> f = [&allowed_ter_id]( const tripoint & pnt ) {
-        if( pnt == g->u.pos() ) {
+        if( pnt == get_avatar().pos() ) {
             return false;
         }
         const ter_id ter = g->m.ter( pnt );
@@ -5254,7 +5254,7 @@ int iuse::artifact( player *p, item *it, bool, const tripoint & )
                 bool blood = false;
                 for( const tripoint &tmp : g->m.points_in_radius( p->pos(), 4 ) ) {
                     if( !one_in( 4 ) && g->m.add_field( tmp, fd_blood, 3 ) &&
-                        ( blood || g->u.sees( tmp ) ) ) {
+                        ( blood || get_avatar().sees( tmp ) ) ) {
                         blood = true;
                     }
                 }
@@ -5826,7 +5826,7 @@ int iuse::talking_doll( player *p, item *it, bool, const tripoint & )
 
 int iuse::gun_clean( player *p, item *, bool, const tripoint & )
 {
-    item *loc = game_menus::inv::titled_menu( g->u, ( "Select the firearm to clean or mend" ) );
+    item *loc = game_menus::inv::titled_menu( get_avatar(), ( "Select the firearm to clean or mend" ) );
     if( !loc ) {
         p->add_msg_if_player( m_info, _( "You do not have that item!" ) );
         return 0;
@@ -5867,7 +5867,7 @@ int iuse::gun_repair( player *p, item *it, bool, const tripoint & )
         p->add_msg_if_player( m_info, _( "You need a mechanics skill of 2 to use this repair kit." ) );
         return 0;
     }
-    item *loc = game_menus::inv::titled_menu( g->u, ( "Select the firearm to repair" ) );
+    item *loc = game_menus::inv::titled_menu( get_avatar(), ( "Select the firearm to repair" ) );
     if( !loc ) {
         p->add_msg_if_player( m_info, _( "You do not have that item!" ) );
         return 0;
@@ -7163,7 +7163,7 @@ static extended_photo_def photo_def_for_camera_point( const tripoint &aim_point,
             Creature *creature;
             if( mon && mon->has_effect( effect_ridden ) ) {
                 // only player can ride, see monexamine::mount_pet
-                guy = &g->u;
+                guy = &get_avatar();
                 description_figures_appearance[ mon->name() ] = "\"" + mon->type->get_description() + "\"";
             }
 
@@ -8309,7 +8309,7 @@ int iuse::remoteveh( player *p, item *it, bool t, const tripoint &pos )
         return 0;
     }
 
-    point p2( g->u.view_offset.xy() );
+    point p2( get_avatar().view_offset.xy() );
 
     vehicle *veh = pickveh( pos, choice == 0 );
 
@@ -8322,7 +8322,7 @@ int iuse::remoteveh( player *p, item *it, bool t, const tripoint &pos )
     }
 
     if( choice == 0 ) {
-        if( g->u.has_trait( trait_WAYFARER ) ) {
+        if( get_avatar().has_trait( trait_WAYFARER ) ) {
             add_msg( m_info,
                      _( "Despite using a controller, you still refuse to take control of this vehicle." ) );
         } else {
@@ -8343,8 +8343,8 @@ int iuse::remoteveh( player *p, item *it, bool t, const tripoint &pos )
         }
     }
 
-    g->u.view_offset.x = p2.x;
-    g->u.view_offset.y = p2.y;
+    get_avatar().view_offset.x = p2.x;
+    get_avatar().view_offset.y = p2.y;
     return it->type->charges_to_use();
 }
 
@@ -8559,7 +8559,7 @@ int iuse::multicooker( player *p, item *it, bool t, const tripoint &pos )
 
             std::vector<const recipe *> dishes;
 
-            inventory crafting_inv = g->u.crafting_inventory();
+            inventory crafting_inv = get_avatar().crafting_inventory();
             //add some tools and qualities. we can't add this qualities to json, because multicook must be used only by activating, not as component other crafts.
             const time_point bday = calendar::start_of_cataclysm;
 
@@ -8572,7 +8572,7 @@ int iuse::multicooker( player *p, item *it, bool t, const tripoint &pos )
 
             int counter = 0;
 
-            for( const auto &r : g->u.get_learned_recipes().in_category( "CC_FOOD" ) ) {
+            for( const auto &r : get_avatar().get_learned_recipes().in_category( "CC_FOOD" ) ) {
                 if( multicooked_subcats.count( r->subcategory ) > 0 ) {
                     dishes.push_back( r );
                     const bool can_make = r->deduped_requirements().can_make_with_inventory(
@@ -8645,7 +8645,7 @@ int iuse::multicooker( player *p, item *it, bool t, const tripoint &pos )
 
             bool has_tools = true;
 
-            const inventory &cinv = g->u.crafting_inventory();
+            const inventory &cinv = get_avatar().crafting_inventory();
 
             if( !cinv.has_amount( itype_soldering_iron, 1 ) ) {
                 p->add_msg_if_player( m_warning, _( "You need a %s." ),

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -763,7 +763,7 @@ map::apparent_light_info map::apparent_light_helper( const level_cache &map_cach
 
 lit_level map::apparent_light_at( const tripoint &p, const visibility_variables &cache ) const
 {
-    const int dist = rl_dist( g->u.pos(), p );
+    const int dist = rl_dist( get_avatar().pos(), p );
 
     // Clairvoyance overrides everything.
     if( dist <= cache.u_clairvoyance ) {
@@ -774,7 +774,7 @@ lit_level map::apparent_light_at( const tripoint &p, const visibility_variables 
 
     // Unimpaired range is an override to strictly limit vision range based on various conditions,
     // but the player can still see light sources.
-    if( dist > g->u.unimpaired_range() ) {
+    if( dist > get_avatar().unimpaired_range() ) {
         if( !a.obstructed && map_cache.sm[p.x][p.y] > 0.0 ) {
             return lit_level::BRIGHT_ONLY;
         } else {
@@ -815,15 +815,15 @@ bool map::pl_sees( const tripoint &t, const int max_range ) const
         return false;
     }
 
-    if( max_range >= 0 && square_dist( t, g->u.pos() ) > max_range ) {
+    if( max_range >= 0 && square_dist( t, get_avatar().pos() ) > max_range ) {
         return false;    // Out of range!
     }
 
     const auto &map_cache = get_cache_ref( t.z );
     const apparent_light_info a = apparent_light_helper( map_cache, t );
-    const float light_at_player = map_cache.lm[g->u.posx()][g->u.posy()].max();
+    const float light_at_player = map_cache.lm[get_avatar().posx()][get_avatar().posy()].max();
     return !a.obstructed &&
-           ( a.apparent_light >= g->u.get_vision_threshold( light_at_player ) ||
+           ( a.apparent_light >= get_avatar().get_vision_threshold( light_at_player ) ||
              map_cache.sm[t.x][t.y] > 0.0 );
 }
 
@@ -833,7 +833,7 @@ bool map::pl_line_of_sight( const tripoint &t, const int max_range ) const
         return false;
     }
 
-    if( max_range >= 0 && square_dist( t, g->u.pos() ) > max_range ) {
+    if( max_range >= 0 && square_dist( t, get_avatar().pos() ) > max_range ) {
         // Out of range!
         return false;
     }

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1582,7 +1582,7 @@ class spellcasting_callback : public uilist_callback
                 int invlet = 0;
                 invlet = popup_getkey( _( "Choose a new hotkey for this spell." ) );
                 if( inv_chars.valid( invlet ) ) {
-                    const bool invlet_set = g->u.magic->set_invlet( known_spells[entnum]->id(), invlet,
+                    const bool invlet_set = get_avatar().magic->set_invlet( known_spells[entnum]->id(), invlet,
                                             reserved_invlets );
                     if( !invlet_set ) {
                         popup( _( "Hotkey already used." ) );
@@ -1592,7 +1592,7 @@ class spellcasting_callback : public uilist_callback
                     }
                 } else {
                     popup( _( "Hotkey removed." ) );
-                    g->u.magic->rem_invlet( known_spells[entnum]->id() );
+                    get_avatar().magic->rem_invlet( known_spells[entnum]->id() );
                 }
                 return true;
             }
@@ -1706,7 +1706,7 @@ void spellcasting_callback::draw_spell_info( const spell &sp, const uilist *menu
                         string_format( "%s: %d", _( "Max Level" ), sp.get_max_level() ) );
 
     print_colored_text( w_menu, point( h_col1, line ), gray, gray,
-                        sp.colorized_fail_percent( g->u ) );
+                        sp.colorized_fail_percent( get_avatar() ) );
     print_colored_text( w_menu, point( h_col2, line++ ), gray, gray,
                         string_format( "%s: %d", _( "Difficulty" ), sp.get_difficulty() ) );
 
@@ -1720,21 +1720,21 @@ void spellcasting_callback::draw_spell_info( const spell &sp, const uilist *menu
         line++;
     }
 
-    const bool cost_encumb = energy_cost_encumbered( sp, g->u );
+    const bool cost_encumb = energy_cost_encumbered( sp, get_avatar() );
     std::string cost_string = cost_encumb ? _( "Casting Cost (impeded)" ) : _( "Casting Cost" );
     std::string energy_cur = sp.energy_source() == hp_energy ? "" : string_format( _( " (%s current)" ),
-                             sp.energy_cur_string( g->u ) );
-    if( !sp.can_cast( g->u ) ) {
+                             sp.energy_cur_string( get_avatar() ) );
+    if( !sp.can_cast( get_avatar() ) ) {
         cost_string = colorize( _( "Not Enough Energy" ), c_red );
         energy_cur = "";
     }
     print_colored_text( w_menu, point( h_col1, line++ ), gray, gray,
                         string_format( "%s: %s %s%s", cost_string,
-                                       sp.energy_cost_string( g->u ), sp.energy_string(), energy_cur ) );
-    const bool c_t_encumb = casting_time_encumbered( sp, g->u );
+                                       sp.energy_cost_string( get_avatar() ), sp.energy_string(), energy_cur ) );
+    const bool c_t_encumb = casting_time_encumbered( sp, get_avatar() );
     print_colored_text( w_menu, point( h_col1, line++ ), gray, gray, colorize(
                             string_format( "%s: %s", c_t_encumb ? _( "Casting Time (impeded)" ) : _( "Casting Time" ),
-                                           moves_to_string( sp.casting_time( g->u ) ) ),
+                                           moves_to_string( sp.casting_time( get_avatar() ) ) ),
                             c_t_encumb  ? c_red : c_light_gray ) );
 
     if( line <= win_height * 3 / 4 ) {
@@ -2170,7 +2170,7 @@ void spell_events::notify( const cata::event &e )
                 std::string learn_spell_id = it->first;
                 int learn_at_level = it->second;
                 if( learn_at_level == slvl ) {
-                    g->u.magic->learn_spell( learn_spell_id, g->u );
+                    get_avatar().magic->learn_spell( learn_spell_id, get_avatar() );
                     spell_type spell_learned = spell_factory.obj( spell_id( learn_spell_id ) );
                     add_msg(
                         _( "Your experience and knowledge in creating and manipulating magical energies to cast %s have opened your eyes to new possibilities, you can now cast %s." ),

--- a/src/make_static.h
+++ b/src/make_static.h
@@ -23,7 +23,7 @@
  */
 #define STATIC(expr) \
     (([]()-> const auto &{ \
-        using CachedType = std::conditional_t<std::is_same<std::decay_t<decltype(expr)>, const char*>::value, \
+        using CachedType = std::conditional_t<std::is_same_v<std::decay_t<decltype(expr)>, const char*>, \
                            std::string, std::decay_t<decltype(expr)>>; \
         static const CachedType _cached_expr = (expr); \
         return _cached_expr; \

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -141,7 +141,7 @@ static level_cache        nullcache;         // Dummy cache for z-levels outside
 
 bool disable_mapgen = false;
 
-map &get_map()
+auto get_map() -> map &
 {
     return g->m;
 }
@@ -759,7 +759,8 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &fac
     veh.check_falling_or_floating();
     // If the PC is in the currently moved vehicle, adjust the
     //  view offset.
-    if( get_avatar().controlling_vehicle && veh_pointer_or_null( veh_at( get_avatar().pos() ) ) == &veh ) {
+    if( get_avatar().controlling_vehicle &&
+        veh_pointer_or_null( veh_at( get_avatar().pos() ) ) == &veh ) {
         g->calc_driving_offset( &veh );
         if( veh.skidding && can_move ) {
             // TODO: Make skid recovery in air hard
@@ -1444,7 +1445,8 @@ void map::furn_set( const tripoint &p, const furn_id &new_furniture,
     const furn_t &new_t = new_furniture.obj();
 
     // If player has grabbed this furniture and it's no longer grabbable, release the grab.
-    if( get_avatar().get_grab_type() == OBJECT_FURNITURE && get_avatar().grab_point == p && !new_t.is_movable() ) {
+    if( get_avatar().get_grab_type() == OBJECT_FURNITURE && get_avatar().grab_point == p &&
+        !new_t.is_movable() ) {
         add_msg( _( "The %s you were grabbing is destroyed!" ), old_t.name() );
         get_avatar().grab( OBJECT_NONE );
     }
@@ -1491,7 +1493,7 @@ void map::furn_set( const tripoint &p, const furn_id &new_furniture,
 
     if( old_t.active ) {
         current_submap->active_furniture.erase( point_sm_ms( l ) );
-        // TODO: Only for g->m? Observer pattern?
+        // TODO: Only for get_map()? Observer pattern?
         get_distribution_grid_tracker().on_changed( tripoint_abs_ms( getabs( p ) ) );
     }
     if( new_t.active || new_active ) {
@@ -5373,7 +5375,8 @@ void map::disarm_trap( const tripoint &p )
     ///\EFFECT_DEX increases chance of disarming trap
 
     ///\EFFECT_TRAPS increases chance of disarming trap
-    while( ( rng( 5, 20 ) < get_avatar().per_cur || rng( 1, 20 ) < get_avatar().dex_cur ) && roll < 50 ) {
+    while( ( rng( 5, 20 ) < get_avatar().per_cur || rng( 1, 20 ) < get_avatar().dex_cur ) &&
+           roll < 50 ) {
         roll++;
     }
     if( roll >= diff ) {
@@ -5839,7 +5842,7 @@ visibility_type map::get_visibility( const lit_level ll,
 static bool has_memory_at( const tripoint &p )
 {
     if( get_avatar().should_show_map_memory() ) {
-        int t = get_avatar().get_memorized_symbol( g->m.getabs( p ) );
+        int t = get_avatar().get_memorized_symbol( get_map().getabs( p ) );
         return t != 0;
     }
     return false;
@@ -5848,7 +5851,7 @@ static bool has_memory_at( const tripoint &p )
 static int get_memory_at( const tripoint &p )
 {
     if( get_avatar().should_show_map_memory() ) {
-        return get_avatar().get_memorized_symbol( g->m.getabs( p ) );
+        return get_avatar().get_memorized_symbol( get_map().getabs( p ) );
     }
     return ' ';
 }
@@ -5883,8 +5886,8 @@ void map::draw( const catacurses::window &w, const tripoint &center )
                                  std::max( MAPSIZE_Y, offs.y + wnd_h )
                              );
     get_avatar().prepare_map_memory_region(
-        g->m.getabs( tripoint( min_mm_reg, center.z ) ),
-        g->m.getabs( tripoint( max_mm_reg, center.z ) )
+        get_map().getabs( tripoint( min_mm_reg, center.z ) ),
+        get_map().getabs( tripoint( max_mm_reg, center.z ) )
     );
 
     const auto draw_background = [&]( const tripoint & p ) {
@@ -6130,7 +6133,8 @@ bool map::draw_maptile( const catacurses::window &w, const tripoint &p,
     std::string item_sym;
 
     // If there are items here, draw those instead
-    if( param.show_items() && curr_maptile.get_item_count() > 0 && sees_some_items( p, get_avatar() ) ) {
+    if( param.show_items() && curr_maptile.get_item_count() > 0 &&
+        sees_some_items( p, get_avatar() ) ) {
         // if there's furniture/terrain/trap/fields (sym!='.')
         // and we should not override it, then only highlight the square
         if( sym != '.' && sym != '%' && !draw_item_sym ) {

--- a/src/map.h
+++ b/src/map.h
@@ -461,10 +461,10 @@ class map
 
         /** Draw a visible part of the map into `w`.
          *
-         * This method uses `g->u.posx()/posy()` for visibility calculations, so it can
+         * This method uses `get_avatar().posx()/posy()` for visibility calculations, so it can
          * not be used for anything but the player's viewport. Likewise, only
          * `g->m` and maps with equivalent coordinates can be used, as other maps
-         * would have coordinate systems incompatible with `g->u.posx()`
+         * would have coordinate systems incompatible with `get_avatar().posx()`
          *
          * @param w Window we are drawing in
          * @param center The coordinate of the center of the viewport, this can
@@ -1592,7 +1592,7 @@ class map
         // End of light/transparency
 
         /**
-         * Whether the player character (g->u) can see the given square (local map coordinates).
+         * Whether the player character (get_avatar()) can see the given square (local map coordinates).
          * This only checks the transparency of the path to the target, the light level is not
          * checked.
          * @param t Target point to look at

--- a/src/map.h
+++ b/src/map.h
@@ -463,7 +463,7 @@ class map
          *
          * This method uses `get_avatar().posx()/posy()` for visibility calculations, so it can
          * not be used for anything but the player's viewport. Likewise, only
-         * `g->m` and maps with equivalent coordinates can be used, as other maps
+         * `get_map()` and maps with equivalent coordinates can be used, as other maps
          * would have coordinate systems incompatible with `get_avatar().posx()`
          *
          * @param w Window we are drawing in
@@ -2063,7 +2063,7 @@ class map
         bool dont_draw_lower_floor( const tripoint &p );
 };
 
-map &get_map();
+auto get_map() -> map &;
 
 template<int SIZE, int MULTIPLIER>
 void shift_bitset_cache( std::bitset<SIZE *SIZE> &cache, point s );

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1000,25 +1000,25 @@ void map::process_fields_in_submap( submap *const current_submap,
                             if( !valid.empty() ) {
                                 tripoint newp = random_entry( valid );
                                 add_item_or_charges( newp, std::move( detached ) );
-                                if( g->u.pos() == newp ) {
+                                if( get_avatar().pos() == newp ) {
                                     add_msg( m_bad, _( "A %s hits you!" ), tmp.tname() );
-                                    const bodypart_id hit = g->u.get_random_body_part();
-                                    g->u.deal_damage( nullptr, hit, damage_instance( DT_BASH, 6 ) );
-                                    g->u.check_dead_state();
+                                    const bodypart_id hit = get_avatar().get_random_body_part();
+                                    get_avatar().deal_damage( nullptr, hit, damage_instance( DT_BASH, 6 ) );
+                                    get_avatar().check_dead_state();
                                 }
 
                                 if( npc *const p = g->critter_at<npc>( newp ) ) {
                                     // TODO: combine with player character code above
-                                    const bodypart_id hit = g->u.get_random_body_part();
+                                    const bodypart_id hit = get_avatar().get_random_body_part();
                                     p->deal_damage( nullptr, hit, damage_instance( DT_BASH, 6 ) );
-                                    if( g->u.sees( newp ) ) {
+                                    if( get_avatar().sees( newp ) ) {
                                         add_msg( _( "A %1$s hits %2$s!" ), tmp.tname(), p->name );
                                     }
                                     p->check_dead_state();
                                 } else if( monster *const mon = g->critter_at<monster>( newp ) ) {
                                     mon->apply_damage( nullptr, bodypart_id( "torso" ),
                                                        6 - mon->get_armor_bash( bodypart_id( "torso" ) ) );
-                                    if( g->u.sees( newp ) ) {
+                                    if( get_avatar().sees( newp ) ) {
                                         add_msg( _( "A %1$s hits the %2$s!" ), tmp.tname(), mon->name() );
                                     }
                                     mon->check_dead_state();
@@ -1118,12 +1118,12 @@ void map::process_fields_in_submap( submap *const current_submap,
                         cur.set_field_intensity( 0 );
                     } else {
                         // Bees chase the player if in range, wander randomly otherwise.
-                        if( !g->u.is_underwater() &&
-                            rl_dist( p, g->u.pos() ) < 10 &&
-                            clear_path( p, g->u.pos(), 10, 1, 100 ) ) {
+                        if( !get_avatar().is_underwater() &&
+                            rl_dist( p, get_avatar().pos() ) < 10 &&
+                            clear_path( p, get_avatar().pos(), 10, 1, 100 ) ) {
 
                             std::vector<point> candidate_positions =
-                                squares_in_direction( p.xy(), point( g->u.posx(), g->u.posy() ) );
+                                squares_in_direction( p.xy(), point( get_avatar().posx(), get_avatar().posy() ) );
                             for( point candidate_position : candidate_positions ) {
                                 field &target_field = get_field( tripoint( candidate_position, p.z ) );
                                 // Only shift if there are no bees already there.

--- a/src/map_selector.cpp
+++ b/src/map_selector.cpp
@@ -4,7 +4,7 @@
 #include <optional>
 #include <vector>
 
-#include "game.h"
+#include "game_utils.h"
 #include "game_constants.h"
 #include "map.h"
 #include "map_iterator.h"
@@ -59,9 +59,9 @@ std::optional<tripoint> random_point( const tripoint_range<tripoint> &range,
     return random_entry( suitable );
 }
 
-map_cursor::map_cursor( const tripoint &pos ) : pos_( g ? get_map().getabs( pos ) : pos ) { }
+map_cursor::map_cursor( const tripoint &pos ) : pos_( has_game() ? get_map().getabs( pos ) : pos ) { }
 
 map_cursor::operator tripoint() const
 {
-    return g ? get_map().getlocal( pos_ ) : pos_;
+    return has_game() ? get_map().getlocal( pos_ ) : pos_;
 }

--- a/src/map_selector.cpp
+++ b/src/map_selector.cpp
@@ -1,11 +1,10 @@
 #include "map_selector.h"
 
-#include <algorithm>
 #include <functional>
-#include <memory>
 #include <optional>
 #include <vector>
 
+#include "game.h"
 #include "game_constants.h"
 #include "map.h"
 #include "map_iterator.h"

--- a/src/map_selector.cpp
+++ b/src/map_selector.cpp
@@ -6,7 +6,6 @@
 #include <optional>
 #include <vector>
 
-#include "game.h"
 #include "game_constants.h"
 #include "map.h"
 #include "map_iterator.h"

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -153,9 +153,9 @@ bool leap_actor::call( monster &z ) const
 
     z.moves -= move_cost;
     const tripoint chosen = random_entry( options );
-    bool seen = g->u.sees( z ); // We can see them jump...
+    bool seen = get_avatar().sees( z ); // We can see them jump...
     z.setpos( chosen );
-    seen |= g->u.sees( z ); // ... or we can see them land
+    seen |= get_avatar().sees( z ); // ... or we can see them land
     if( seen ) {
         add_msg( _( "The %s leaps!" ), z.name() );
     }
@@ -216,7 +216,7 @@ bool mon_spellcasting_actor::call( monster &mon ) const
         target_name = target_monster->disp_name();
     }
 
-    if( g->u.sees( target ) ) {
+    if( get_avatar().sees( target ) ) {
         add_msg( spell_data.message(), mon.disp_name(), spell_data.name(), target_name );
     }
 
@@ -348,7 +348,7 @@ void melee_actor::on_damage( monster &z, Creature &target, dealt_damage_instance
                                  sfx::get_heard_angle( z.pos() ) );
         sfx::do_player_death_hurt( dynamic_cast<player &>( target ), false );
     }
-    auto msg_type = target.attitude_to( g->u ) == Creature::A_FRIENDLY ? m_bad : m_neutral;
+    auto msg_type = target.attitude_to( get_avatar() ) == Creature::A_FRIENDLY ? m_bad : m_neutral;
     const body_part bp = dealt.bp_hit;
     target.add_msg_player_or_npc( msg_type, hit_dmg_u, hit_dmg_npc, z.name(),
                                   body_part_name_accusative( bp ) );
@@ -566,7 +566,7 @@ bool gun_actor::call( monster &z ) const
         int hostiles; // hostiles which cannot be engaged without risking friendly fire
         target = z.auto_find_hostile_target( max_range, hostiles );
         if( !target ) {
-            if( hostiles > 0 && g->u.sees( z ) ) {
+            if( hostiles > 0 && get_avatar().sees( z ) ) {
                 add_msg( m_warning, vgettext( "Pointed in your direction, the %s emits an IFF warning beep.",
                                               "Pointed in your direction, the %s emits %d annoyed sounding beeps.",
                                               hostiles ),
@@ -613,7 +613,7 @@ bool gun_actor::call( monster &z ) const
 bool gun_actor::try_target( monster &z, Creature &target ) const
 {
     if( require_sunlight && !g->is_in_sunlight( z.pos() ) ) {
-        if( one_in( 3 ) && g->u.sees( z ) ) {
+        if( one_in( 3 ) && get_avatar().sees( z ) ) {
             add_msg( _( failure_msg ), z.name() );
         }
         return false;
@@ -692,7 +692,7 @@ void gun_actor::shoot( monster &z, const tripoint &target, const gun_mode_id &mo
     tmp.set_primary_weapon( std::move( gun ) );
     tmp.i_add( item::spawn( "UPS_off", calendar::turn, 1000 ) );
 
-    if( g->u.sees( z ) ) {
+    if( get_avatar().sees( z ) ) {
         add_msg( m_warning, _( description ), z.name(), tmp.primary_weapon().tname() );
     }
 

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -484,7 +484,7 @@ void Character::melee_attack( Creature &t, bool allow_special, const matec_id *f
             } else {
                 add_msg( _( "You miss." ) );
             }
-        } else if( g->u.sees( *this ) ) {
+        } else if( get_avatar().sees( *this ) ) {
             if( stumble_pen >= 60 ) {
                 add_msg( _( "%s misses and stumbles with the momentum." ), name );
             } else if( stumble_pen >= 10 ) {
@@ -510,7 +510,7 @@ void Character::melee_attack( Creature &t, bool allow_special, const matec_id *f
     } else {
         melee::melee_stats.hit_count += 1;
         // Remember if we see the monster at start - it may change
-        const bool seen = g->u.sees( t );
+        const bool seen = get_avatar().sees( t );
         // Start of attacks.
         const bool critical_hit = scored_crit( t.dodge_roll(), cur_weapon );
         if( critical_hit ) {
@@ -602,7 +602,7 @@ void Character::melee_attack( Creature &t, bool allow_special, const matec_id *f
             }
 
             // Treat monster as seen if we see it before or after the attack
-            if( seen || g->u.sees( t ) ) {
+            if( seen || get_avatar().sees( t ) ) {
                 std::string message = melee_message( technique, *this, dealt_dam );
                 player_hit_message( this, message, t, dam, critical_hit );
             } else {
@@ -1491,7 +1491,7 @@ void Character::perform_technique( const ma_technique &technique, Creature &t, d
                 ( to_swimmable && to_deepwater ) || // Dive into deep water
                 is_mounted() ||
                 ( veh0 != nullptr && std::abs( veh0->velocity ) > 100 ) || // Diving from moving vehicle
-                ( veh0 != nullptr && veh0->player_in_control( g->u ) ) || // Player is driving
+                ( veh0 != nullptr && veh0->player_in_control( get_avatar() ) ) || // Player is driving
                 has_effect( effect_amigara );
 
             if( !move_issue ) {
@@ -2220,7 +2220,7 @@ void player_hit_message( Character *attacker, const std::string &message,
         msgtype = m_neutral;
     } else if(
         crit ) { //Player won't see exact numbers of damage dealt by NPC unless player has DEBUG_NIGHTVISION trait
-        if( attacker->is_npc() && !g->u.has_trait( trait_DEBUG_NIGHTVISION ) ) {
+        if( attacker->is_npc() && !get_avatar().has_trait( trait_DEBUG_NIGHTVISION ) ) {
             //~ NPC hits something (critical)
             msg = string_format( _( "%s. Critical!" ), message );
         } else {
@@ -2230,7 +2230,7 @@ void player_hit_message( Character *attacker, const std::string &message,
         sSCTmod = _( "Critical!" );
         gmtSCTcolor = m_critical;
     } else {
-        if( attacker->is_npc() && !g->u.has_trait( trait_DEBUG_NIGHTVISION ) ) {
+        if( attacker->is_npc() && !get_avatar().has_trait( trait_DEBUG_NIGHTVISION ) ) {
             //~ NPC hits something
             msg = string_format( _( "%s." ), message );
         } else {

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -302,7 +302,7 @@ bool Character::handle_melee_wear( item &shield, float wear_multiplier )
             if( comp->typeId() == big_comp && !is_armed() ) {
                 wield( std::move( comp ) );
             } else {
-                g->m.add_item_or_charges( pos(), std::move( comp ) );
+                get_map().add_item_or_charges( pos(), std::move( comp ) );
             }
         }
     } else {
@@ -707,7 +707,7 @@ void Character::reach_attack( const tripoint &p )
         } else if( here.impassable( path_point ) &&
                    // Fences etc. Spears can stab through those
                    !( primary_weapon().has_flag( flag_SPEAR ) &&
-                      g->m.has_flag( "THIN_OBSTACLE", path_point ) &&
+                      get_map().has_flag( "THIN_OBSTACLE", path_point ) &&
                       x_in_y( skill, 10 ) ) ) {
             /** @EFFECT_STR increases bash effects when reach attacking past something */
             here.bash( path_point, str_cur + primary_weapon().damage_melee( DT_BASH ) );
@@ -862,7 +862,7 @@ float Character::get_dodge() const
 
     if( has_effect( effect_grabbed ) ) {
         int zed_number = 0;
-        for( auto &dest : g->m.points_in_radius( pos(), 1, 0 ) ) {
+        for( auto &dest : get_map().points_in_radius( pos(), 1, 0 ) ) {
             const monster *const mon = g->critter_at<monster>( dest );
             if( mon && mon->has_effect( effect_grabbing ) ) {
                 zed_number++;
@@ -1166,7 +1166,7 @@ matec_id Character::pick_technique( Creature &t, const item &weap,
 
     bool downed = t.has_effect( effect_downed );
     bool stunned = t.has_effect( effect_stunned );
-    bool wall_adjacent = g->m.is_wall_adjacent( pos() );
+    bool wall_adjacent = get_map().is_wall_adjacent( pos() );
 
     // first add non-aoe tecs
     for( const matec_id &tec_id : all ) {
@@ -1349,7 +1349,7 @@ bool Character::valid_aoe_technique( Creature &t, const ma_technique &technique,
     }
 
     if( targets.empty() && technique.aoe == "spin" ) {
-        for( const tripoint &tmp : g->m.points_in_radius( pos(), 1 ) ) {
+        for( const tripoint &tmp : get_map().points_in_radius( pos(), 1 ) ) {
             if( tmp == t.pos() ) {
                 continue;
             }
@@ -1480,10 +1480,10 @@ void Character::perform_technique( const ma_technique &technique, Creature &t, d
         }
         // This technique makes the player follow into the tile the target was knocked from
         if( technique.knockback_follow ) {
-            const optional_vpart_position vp0 = g->m.veh_at( pos() );
+            const optional_vpart_position vp0 = get_map().veh_at( pos() );
             vehicle *const veh0 = veh_pointer_or_null( vp0 );
-            bool to_swimmable = g->m.has_flag( "SWIMMABLE", prev_pos );
-            bool to_deepwater = g->m.has_flag( TFLAG_DEEP_WATER, prev_pos );
+            bool to_swimmable = get_map().has_flag( "SWIMMABLE", prev_pos );
+            bool to_deepwater = get_map().has_flag( TFLAG_DEEP_WATER, prev_pos );
 
             // Check if it's possible to move to the new tile
             bool move_issue =
@@ -1518,7 +1518,7 @@ void Character::perform_technique( const ma_technique &technique, Creature &t, d
     }
 
     if( technique.disarms && p != nullptr && p->is_armed() ) {
-        g->m.add_item_or_charges( p->pos(), p->remove_primary_weapon() );
+        get_map().add_item_or_charges( p->pos(), p->remove_primary_weapon() );
         if( p->is_player() ) {
             add_msg_if_npc( _( "<npcname> disarms you!" ) );
         } else {
@@ -2414,7 +2414,7 @@ void avatar_funcs::try_disarm_npc( avatar &you, npc &target )
             add_msg( _( "You grab at %s and pull with all your force, but it drops nearby!" ),
                      it.tname() );
             const tripoint tp = target.pos() + tripoint( rng( -1, 1 ), rng( -1, 1 ), 0 );
-            g->m.add_item_or_charges( tp, it.detach( ) );
+            get_map().add_item_or_charges( tp, it.detach( ) );
             you.mod_moves( -100 );
         } else {
             add_msg( _( "You grab at %s and pull with all your force, but in vain!" ), it.tname() );
@@ -2431,7 +2431,7 @@ void avatar_funcs::try_disarm_npc( avatar &you, npc &target )
         add_msg( _( "You smash %s with all your might forcing their %s to drop down nearby!" ),
                  target.name, it.tname() );
         const tripoint tp = target.pos() + tripoint( rng( -1, 1 ), rng( -1, 1 ), 0 );
-        g->m.add_item_or_charges( tp, it.detach( ) );
+        get_map().add_item_or_charges( tp, it.detach( ) );
     } else {
         add_msg( _( "You smash %s with all your might but %s remains in their hands!" ),
                  target.name, it.tname() );

--- a/src/memorial_logger.cpp
+++ b/src/memorial_logger.cpp
@@ -96,13 +96,13 @@ void memorial_logger::clear()
 void memorial_logger::add( const std::string &male_msg,
                            const std::string &female_msg )
 {
-    const std::string &msg = g->u.male ? male_msg : female_msg;
+    const std::string &msg = get_avatar().male ? male_msg : female_msg;
 
     if( msg.empty() ) {
         return;
     }
 
-    const oter_id &cur_ter = overmap_buffer.ter( g->u.global_omt_location() );
+    const oter_id &cur_ter = overmap_buffer.ter( get_avatar().global_omt_location() );
     const std::string &location = cur_ter->get_name();
 
     std::string log_message = "| " + to_string( calendar::turn ) + " | " + location + " | " + msg;
@@ -149,7 +149,7 @@ std::string memorial_logger::dump() const
 
 void memorial_logger::write( std::ostream &file, const std::string &epitaph ) const
 {
-    avatar &u = g->u;
+    avatar &u = get_avatar();
     static const char *eol = cata_files::eol();
 
     //Size of indents in the memorial file
@@ -369,7 +369,7 @@ void memorial_logger::notify( const cata::event &e )
     switch( e.type() ) {
         case event_type::activates_artifact: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 std::string item_name = e.get<cata_variant_type::string>( "item_name" );
                 //~ %s is artifact name
                 add( pgettext( "memorial_male", "Activated the %s." ),
@@ -380,7 +380,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::activates_mininuke: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 add( pgettext( "memorial_male", "Activated a mininuke." ),
                      pgettext( "memorial_female", "Activated a mininuke." ) );
             }
@@ -388,7 +388,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::administers_mutagen: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 mutagen_technique technique = e.get<mutagen_technique>( "technique" );
                 switch( technique ) {
                     case mutagen_technique::consumed_mutagen:
@@ -429,7 +429,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::becomes_wanted: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 add( pgettext( "memorial_male", "Became wanted by the police!" ),
                      pgettext( "memorial_female", "Became wanted by the police!" ) );
             }
@@ -437,7 +437,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::broken_bone_mends: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 body_part part = e.get<body_part>( "part" );
                 //~ %s is bodypart
                 add( pgettext( "memorial_male", "Broken %s began to mend." ),
@@ -448,7 +448,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::buries_corpse: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 const mtype &corpse_type = e.get<mtype_id>( "corpse_type" ).obj();
                 std::string corpse_name = e.get<cata_variant_type::string>( "corpse_name" );
                 if( corpse_name.empty() ) {
@@ -473,7 +473,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::character_gains_effect: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 const effect_type &type = e.get<efftype_id>( "effect" ).obj();
                 const std::string message = type.get_apply_memorial_log();
                 if( !message.empty() ) {
@@ -485,11 +485,11 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::character_kills_character: {
             character_id ch = e.get<character_id>( "killer" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 std::string name = e.get<cata_variant_type::string>( "victim_name" );
-                bool cannibal = g->u.has_trait( trait_CANNIBAL );
-                bool psycho = g->u.has_trait( trait_PSYCHOPATH );
-                if( g->u.has_trait( trait_SAPIOVORE ) ) {
+                bool cannibal = get_avatar().has_trait( trait_CANNIBAL );
+                bool psycho = get_avatar().has_trait( trait_PSYCHOPATH );
+                if( get_avatar().has_trait( trait_SAPIOVORE ) ) {
                     add( pgettext( "memorial_male",
                                    "Caught and killed an ape.  Prey doesn't have a name." ),
                          pgettext( "memorial_female",
@@ -524,7 +524,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::character_kills_monster: {
             character_id ch = e.get<character_id>( "killer" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 mtype_id victim_type = e.get<mtype_id>( "victim_type" );
                 if( victim_type->difficulty >= 30 ) {
                     add( pgettext( "memorial_male", "Killed a %s." ),
@@ -536,7 +536,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::character_loses_effect: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 const effect_type &type = e.get<efftype_id>( "effect" ).obj();
                 const std::string message = type.get_remove_memorial_log();
                 if( !message.empty() ) {
@@ -548,7 +548,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::character_triggers_trap: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 trap_str_id trap = e.get<trap_str_id>( "trap" );
                 if( trap == tr_bubblewrap ) {
                     add( pgettext( "memorial_male", "Stepped on bubble wrap." ),
@@ -637,7 +637,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::consumes_marloss_item: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 itype_id it = e.get<cata_variant_type::itype_id>( "itype" );
                 std::string itname = it->nname( 1 );
                 add( pgettext( "memorial_male", "Consumed a %s." ),
@@ -647,7 +647,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::crosses_marloss_threshold: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 add( pgettext( "memorial_male", "Opened the Marloss Gateway." ),
                      pgettext( "memorial_female", "Opened the Marloss Gateway." ) );
             }
@@ -655,7 +655,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::crosses_mutation_threshold: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 mutation_category_id category_id =
                     e.get<cata_variant_type::mutation_category_id>( "category" );
                 const mutation_category_trait &category =
@@ -667,7 +667,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::crosses_mycus_threshold: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 add( pgettext( "memorial_male", "Became one with the Mycus." ),
                      pgettext( "memorial_female", "Became one with the Mycus." ) );
             }
@@ -675,7 +675,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::dermatik_eggs_hatch: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 add( pgettext( "memorial_male", "Dermatik eggs hatched." ),
                      pgettext( "memorial_female", "Dermatik eggs hatched." ) );
             }
@@ -683,7 +683,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::dermatik_eggs_injected: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 add( pgettext( "memorial_male", "Injected with dermatik eggs." ),
                      pgettext( "memorial_female", "Injected with dermatik eggs." ) );
             }
@@ -696,7 +696,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::dies_from_asthma_attack: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 add( pgettext( "memorial_male", "Succumbed to an asthma attack." ),
                      pgettext( "memorial_female", "Succumbed to an asthma attack." ) );
             }
@@ -704,7 +704,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::dies_from_drug_overdose: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 efftype_id effect = e.get<efftype_id>( "effect" );
                 if( effect == effect_datura ) {
                     add( pgettext( "memorial_male", "Died of datura overdose." ),
@@ -727,7 +727,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::dies_of_infection: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 add( pgettext( "memorial_male", "Succumbed to the infection." ),
                      pgettext( "memorial_female", "Succumbed to the infection." ) );
             }
@@ -735,7 +735,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::dies_of_starvation: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 add( pgettext( "memorial_male", "Died of starvation." ),
                      pgettext( "memorial_female", "Died of starvation." ) );
             }
@@ -743,7 +743,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::dies_of_thirst: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 add( pgettext( "memorial_male", "Died of thirst." ),
                      pgettext( "memorial_female", "Died of thirst." ) );
             }
@@ -766,7 +766,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::evolves_mutation: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 trait_id from = e.get<trait_id>( "from_trait" );
                 trait_id to = e.get<trait_id>( "to_trait" );
                 add( pgettext( "memorial_male", "'%s' mutation turned into '%s'" ),
@@ -777,7 +777,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::exhumes_grave: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 add( pgettext( "memorial_male", "Exhumed a grave." ),
                      pgettext( "memorial_female", "Exhumed a grave." ) );
             }
@@ -785,7 +785,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::fails_to_install_cbm: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 std::string cbm_name = e.get<bionic_id>( "bionic" )->name.translated();
                 add( pgettext( "memorial_male", "Failed install of bionic: %s." ),
                      pgettext( "memorial_female", "Failed install of bionic: %s." ),
@@ -795,7 +795,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::fails_to_remove_cbm: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 std::string cbm_name = e.get<bionic_id>( "bionic" )->name.translated();
                 add( pgettext( "memorial_male", "Failed to remove bionic: %s." ),
                      pgettext( "memorial_female", "Failed to remove bionic: %s." ),
@@ -805,7 +805,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::falls_asleep_from_exhaustion: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 add( pgettext( "memorial_male", "Succumbed to lack of sleep." ),
                      pgettext( "memorial_female", "Succumbed to lack of sleep." ) );
             }
@@ -820,7 +820,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::gains_addiction: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 add_type type = e.get<add_type>( "add_type" );
                 const std::string &type_name = addiction_type_name( type );
                 //~ %s is addiction name
@@ -832,7 +832,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::gains_mutation: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 trait_id trait = e.get<trait_id>( "trait" );
                 add( pgettext( "memorial_male", "Gained the mutation '%s'." ),
                      pgettext( "memorial_female", "Gained the mutation '%s'." ),
@@ -842,7 +842,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::gains_skill_level: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 skill_id skill = e.get<skill_id>( "skill" );
                 int new_level = e.get<int>( "new_level" );
                 if( new_level % 4 == 0 ) {
@@ -863,11 +863,11 @@ void memorial_logger::notify( const cata::event &e )
             if( suicide ) {
                 add( pgettext( "memorial_male", "%s committed suicide." ),
                      pgettext( "memorial_female", "%s committed suicide." ),
-                     g->u.name );
+                     get_avatar().name );
             } else {
                 add( pgettext( "memorial_male", "%s was killed." ),
                      pgettext( "memorial_female", "%s was killed." ),
-                     g->u.name );
+                     get_avatar().name );
             }
             if( !last_words.empty() ) {
                 add( pgettext( "memorial_male", "Last words: %s" ),
@@ -880,12 +880,12 @@ void memorial_logger::notify( const cata::event &e )
             add( //~ %s is player name
                 pgettext( "memorial_male", "%s began their journey into the Cataclysm." ),
                 pgettext( "memorial_female", "%s began their journey into the Cataclysm." ),
-                g->u.name );
+                get_avatar().name );
             break;
         }
         case event_type::installs_cbm: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 std::string cbm_name = e.get<bionic_id>( "bionic" )->name.translated();
                 add( pgettext( "memorial_male", "Installed bionic: %s." ),
                      pgettext( "memorial_female", "Installed bionic: %s." ),
@@ -895,7 +895,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::installs_faulty_cbm: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 std::string cbm_name = e.get<bionic_id>( "bionic" )->name.translated();
                 add( pgettext( "memorial_male", "Installed bad bionic: %s." ),
                      pgettext( "memorial_female", "Installed bad bionic: %s." ),
@@ -905,7 +905,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::learns_martial_art: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 matype_id mastyle = e.get<matype_id>( "martial_art" );
                 //~ %s is martial art
                 add( pgettext( "memorial_male", "Learned %s." ),
@@ -916,7 +916,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::loses_addiction: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 add_type type = e.get<add_type>( "add_type" );
                 const std::string &type_name = addiction_type_name( type );
                 //~ %s is addiction name
@@ -957,7 +957,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::removes_cbm: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 std::string cbm_name = e.get<bionic_id>( "bionic" )->name.translated();
                 add( pgettext( "memorial_male", "Removed bionic: %s." ),
                      pgettext( "memorial_female", "Removed bionic: %s." ),
@@ -972,7 +972,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::telefrags_creature: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 std::string victim_name = e.get<cata_variant_type::string>( "victim_name" );
                 add( pgettext( "memorial_male", "Telefragged a %s." ),
                      pgettext( "memorial_female", "Telefragged a %s." ),
@@ -982,7 +982,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::teleglow_teleports: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 add( pgettext( "memorial_male", "Spontaneous teleport." ),
                      pgettext( "memorial_female", "Spontaneous teleport." ) );
             }
@@ -990,7 +990,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::teleports_into_wall: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 std::string obstacle_name = e.get<cata_variant_type::string>( "obstacle_name" );
                 add( pgettext( "memorial_male", "Teleported into a %s." ),
                      pgettext( "memorial_female", "Teleported into a %s." ),
@@ -1005,7 +1005,7 @@ void memorial_logger::notify( const cata::event &e )
         }
         case event_type::throws_up: {
             character_id ch = e.get<character_id>( "character" );
-            if( ch == g->u.getID() ) {
+            if( ch == get_avatar().getID() ) {
                 add( pgettext( "memorial_male", "Threw up." ),
                      pgettext( "memorial_female", "Threw up." ) );
             }

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -152,7 +152,7 @@ void mission::on_creature_death( Creature &poor_dead_dude )
     npc *p = dynamic_cast<npc *>( &poor_dead_dude );
     if( p == nullptr ) {
         // Must be the player
-        for( auto &miss : g->u.get_active_missions() ) {
+        for( auto &miss : get_avatar().get_active_missions() ) {
             // mission is free and can be reused
             miss->player_id = character_id();
         }
@@ -240,8 +240,8 @@ void mission::assign( avatar &u )
 void mission::fail()
 {
     status = mission_status::failure;
-    if( g->u.getID() == player_id ) {
-        g->u.on_mission_finished( *this );
+    if( get_avatar().getID() == player_id ) {
+        get_avatar().on_mission_finished( *this );
     }
 
     type->fail( this );
@@ -279,7 +279,7 @@ void mission::step_complete( const int _step )
 
 void mission::wrap_up()
 {
-    auto &u = g->u;
+    auto &u = get_avatar();
     if( u.getID() != player_id ) {
         // This is called from npctalk.cpp, the npc should only offer the option to wrap up mission
         // that have been assigned to the current player.
@@ -348,7 +348,7 @@ bool mission::is_complete( const character_id &_npc_id ) const
         return true;
     }
 
-    auto &u = g->u;
+    auto &u = get_avatar();
     switch( type->goal ) {
         case MGOAL_GO_TO: {
             const tripoint_abs_omt cur_pos = u.global_omt_location();
@@ -356,7 +356,7 @@ bool mission::is_complete( const character_id &_npc_id ) const
         }
 
         case MGOAL_GO_TO_TYPE: {
-            const auto cur_ter = overmap_buffer.ter( g->u.global_omt_location() );
+            const auto cur_ter = overmap_buffer.ter( get_avatar().global_omt_location() );
             return is_ot_match( type->target_id.str(), cur_ter, ot_match_type::type );
         }
 
@@ -451,7 +451,7 @@ bool mission::is_complete( const character_id &_npc_id ) const
             cc.beta = n;
 
             for( auto &mission : n->chatbin.missions_assigned ) {
-                if( mission->get_assigned_player_id() == g->u.getID() ) {
+                if( mission->get_assigned_player_id() == get_avatar().getID() ) {
                     cc.missions_assigned.push_back( mission );
                 }
             }

--- a/src/mission_end.cpp
+++ b/src/mission_end.cpp
@@ -26,6 +26,6 @@ void mission_end::deposit_box( mission *miss )
     } else if( one_in( 3 ) ) {
         itemName = "m4a1";
     }
-    g->u.i_add( item::spawn( itemName, calendar::start_of_cataclysm ) );
+    get_avatar().i_add( item::spawn( itemName, calendar::start_of_cataclysm ) );
     add_msg( m_good, _( "%s gave you an item from the deposit box." ), p->name );
 }

--- a/src/mission_start.cpp
+++ b/src/mission_start.cpp
@@ -59,7 +59,7 @@ void mission_start::place_dog( mission *miss )
         debugmsg( "Couldn't find NPC!  %d", miss->npc_id.get_value() );
         return;
     }
-    g->u.i_add( item::spawn( "dog_whistle", calendar::start_of_cataclysm ) );
+    get_avatar().i_add( item::spawn( "dog_whistle", calendar::start_of_cataclysm ) );
     add_msg( _( "%s gave you a dog whistle." ), dev->name );
 
     miss->target = house;
@@ -192,7 +192,7 @@ void mission_start::place_npc_software( mission *miss )
         debugmsg( "Couldn't find NPC!  %d", miss->npc_id.get_value() );
         return;
     }
-    g->u.i_add( item::spawn( "usb_drive", calendar::start_of_cataclysm ) );
+    get_avatar().i_add( item::spawn( "usb_drive", calendar::start_of_cataclysm ) );
     add_msg( _( "%s gave you a USB drive." ), dev->name );
 
     std::string type = "house";

--- a/src/mission_util.cpp
+++ b/src/mission_util.cpp
@@ -59,7 +59,7 @@ static void reveal_target( mission *miss, const std::string &omter_id )
                  oter->get_name() );
         miss->set_target( destination );
         if( one_in( 3 ) &&
-            mission_util::reveal_road( g->u.global_omt_location(), destination, overmap_buffer ) ) {
+            mission_util::reveal_road( get_avatar().global_omt_location(), destination, overmap_buffer ) ) {
             add_msg( _( "%s also marks the road that leads to it…" ), p->name );
         }
     }
@@ -124,7 +124,7 @@ tripoint_abs_omt mission_util::random_house_in_closest_city()
     const city_reference cref = overmap_buffer.closest_city( center );
     if( !cref ) {
         debugmsg( "could not find closest city" );
-        return g->u.global_omt_location();
+        return get_avatar().global_omt_location();
     }
     return random_house_in_city( cref );
 }
@@ -330,12 +330,12 @@ tripoint_abs_omt mission_util::target_om_ter_random( const std::string &omter, i
         mission *miss, bool must_see, int range, tripoint_abs_omt loc )
 {
     if( loc == overmap::invalid_tripoint ) {
-        loc = g->u.global_omt_location();
+        loc = get_avatar().global_omt_location();
     }
 
     auto places = overmap_buffer.find_all( loc, omter, range, must_see );
     if( places.empty() ) {
-        return g->u.global_omt_location();
+        return get_avatar().global_omt_location();
     }
     const overmap *loc_om = overmap_buffer.get_existing_om_global( loc ).om;
     assert( loc_om );
@@ -522,7 +522,7 @@ bool mission_type::parse_funcs( const JsonObject &jo, std::function<void( missio
         if( d.beta == nullptr ) {
             d.beta = &default_npc;
         }
-        d.alpha = &g->u;
+        d.alpha = &get_avatar();
         for( const talk_effect_fun_t &effect : talk_effects.effects ) {
             effect( d );
         }

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -100,7 +100,7 @@ void mdeath::normal( monster &z )
         sfx::play_variant_sound( "mon_death", "zombie_death", sfx::get_heard_volume( z.pos() ) );
     }
 
-    if( g->u.sees( z ) ) {
+    if( get_avatar().sees( z ) ) {
         //Currently it is possible to get multiple messages that a monster died.
         add_msg( m_good, _( "The %s dies!" ), z.name() );
     }
@@ -261,7 +261,7 @@ void mdeath::splatter( monster &z )
 
 void mdeath::acid( monster &z )
 {
-    if( g->u.sees( z ) ) {
+    if( get_avatar().sees( z ) ) {
         if( z.type->dies.size() ==
             1 ) { //If this death function is the only function. The corpse gets dissolved.
             add_msg( m_mixed, _( "The %s's body dissolves into acid." ), z.name() );
@@ -284,8 +284,8 @@ void mdeath::boomer( monster &z )
         }
     }
 
-    if( rl_dist( z.pos(), g->u.pos() ) == 1 ) {
-        g->u.add_env_effect( effect_boomered, bp_eyes, 2, 24_turns );
+    if( rl_dist( z.pos(), get_avatar().pos() ) == 1 ) {
+        get_avatar().add_env_effect( effect_boomered, bp_eyes, 2, 24_turns );
     }
 
     g->m.propagate_field( z.pos(), fd_bile, 15, 1 );
@@ -377,7 +377,7 @@ void mdeath::vine_cut( monster &z )
 
 void mdeath::triffid_heart( monster &z )
 {
-    if( g->u.sees( z ) ) {
+    if( get_avatar().sees( z ) ) {
         add_msg( m_warning, _( "The surrounding roots begin to crack and crumble." ) );
     }
     g->timed_events.add( TIMED_EVENT_ROOTS_DIE, calendar::turn + 10_minutes );
@@ -401,14 +401,14 @@ void mdeath::fungus( monster &z )
 
 void mdeath::disintegrate( monster &z )
 {
-    if( g->u.sees( z ) ) {
+    if( get_avatar().sees( z ) ) {
         add_msg( m_good, _( "The %s disintegrates!" ), z.name() );
     }
 }
 
 void mdeath::worm( monster &z )
 {
-    if( g->u.sees( z ) ) {
+    if( get_avatar().sees( z ) ) {
         if( z.type->dies.size() == 1 ) {
             add_msg( m_good, _( "The %s splits in two!" ), z.name() );
         } else {
@@ -424,7 +424,7 @@ void mdeath::worm( monster &z )
 
 void mdeath::disappear( monster &z )
 {
-    if( g->u.sees( z ) ) {
+    if( get_avatar().sees( z ) ) {
         add_msg( m_good, _( "The %s disappears." ), z.name() );
     }
 }
@@ -443,11 +443,11 @@ void mdeath::guilt( monster &z )
     guilt_tresholds[50] = _( "You regret killing %s." );
     guilt_tresholds[25] = _( "You feel remorse for killing %s." );
 
-    if( g->u.has_trait( trait_PSYCHOPATH ) || g->u.has_trait_flag( trait_flag_PRED3 ) ||
-        g->u.has_trait_flag( trait_flag_PRED4 ) || g->u.has_trait( trait_KILLER ) ) {
+    if( get_avatar().has_trait( trait_PSYCHOPATH ) || get_avatar().has_trait_flag( trait_flag_PRED3 ) ||
+        get_avatar().has_trait_flag( trait_flag_PRED4 ) || get_avatar().has_trait( trait_KILLER ) ) {
         return;
     }
-    if( rl_dist( z.pos(), g->u.pos() ) > MAX_GUILT_DISTANCE ) {
+    if( rl_dist( z.pos(), get_avatar().pos() ) > MAX_GUILT_DISTANCE ) {
         // Too far away, we can deal with it.
         return;
     }
@@ -464,8 +464,8 @@ void mdeath::guilt( monster &z )
         }
         return;
 
-    } else if( ( g->u.has_trait_flag( trait_flag_PRED1 ) ) ||
-               ( g->u.has_trait_flag( trait_flag_PRED1 ) ) ) {
+    } else if( ( get_avatar().has_trait_flag( trait_flag_PRED1 ) ) ||
+               ( get_avatar().has_trait_flag( trait_flag_PRED1 ) ) ) {
         msg = ( _( "Culling the weak is distasteful, but necessary." ) );
         msgtype = m_neutral;
     } else {
@@ -486,15 +486,15 @@ void mdeath::guilt( monster &z )
     time_duration decayDelay = 3_minutes * ( 1.0 - ( static_cast<float>( kill_count ) / maxKills ) );
     if( z.type->in_species( ZOMBIE ) ) {
         moraleMalus /= 10;
-        if( g->u.has_trait( trait_PACIFIST ) ) {
+        if( get_avatar().has_trait( trait_PACIFIST ) ) {
             moraleMalus *= 5;
-        } else if( g->u.has_trait_flag( trait_flag_PRED1 ) ) {
+        } else if( get_avatar().has_trait_flag( trait_flag_PRED1 ) ) {
             moraleMalus /= 4;
-        } else if( g->u.has_trait_flag( trait_flag_PRED2 ) ) {
+        } else if( get_avatar().has_trait_flag( trait_flag_PRED2 ) ) {
             moraleMalus /= 5;
         }
     }
-    g->u.add_morale( MORALE_KILLED_MONSTER, moraleMalus, maxMalus, duration, decayDelay );
+    get_avatar().add_morale( MORALE_KILLED_MONSTER, moraleMalus, maxMalus, duration, decayDelay );
 
 }
 
@@ -503,13 +503,13 @@ void mdeath::blobsplit( monster &z )
     int speed = z.get_speed() - rng( 30, 50 );
     g->m.spawn_item( z.pos(), "slime_scrap", 1, 0, calendar::turn );
     if( z.get_speed() <= 0 ) {
-        if( g->u.sees( z ) ) {
+        if( get_avatar().sees( z ) ) {
             // TODO: Add vermin-tagged tiny versions of the splattered blob  :)
             add_msg( m_good, _( "The %s splatters apart." ), z.name() );
         }
         return;
     }
-    if( g->u.sees( z ) ) {
+    if( get_avatar().sees( z ) ) {
         if( z.type->dies.size() == 1 ) {
             add_msg( m_good, _( "The %s splits in two!" ), z.name() );
         } else {
@@ -544,7 +544,7 @@ void mdeath::jackson( monster &z )
             critter.poly( mon_zombie_hulk );
             critter.remove_effect( effect_ai_controlled );
         }
-        if( g->u.sees( z ) ) {
+        if( get_avatar().sees( z ) ) {
             add_msg( m_warning, _( "The music stops!" ) );
         }
     }
@@ -552,7 +552,7 @@ void mdeath::jackson( monster &z )
 
 void mdeath::melt( monster &z )
 {
-    if( g->u.sees( z ) ) {
+    if( get_avatar().sees( z ) ) {
         add_msg( m_good, _( "The %s melts away." ), z.name() );
     }
 }
@@ -570,8 +570,8 @@ void mdeath::amigara( monster &z )
     }
 
     // We were the last!
-    if( g->u.has_effect( effect_amigara ) ) {
-        g->u.remove_effect( effect_amigara );
+    if( get_avatar().has_effect( effect_amigara ) ) {
+        get_avatar().remove_effect( effect_amigara );
         add_msg( _( "Your obsession with the fault fades away…" ) );
     }
 
@@ -623,7 +623,7 @@ void mdeath::focused_beam( monster &z )
 
     if( !z.get_items().empty() ) {
 
-        if( g->u.sees( z ) ) {
+        if( get_avatar().sees( z ) ) {
             add_msg( m_warning, _( "As the final light is destroyed, it erupts in a blinding flare!" ) );
         }
 
@@ -712,17 +712,17 @@ void mdeath::broken( monster &z )
     }
 
     // TODO: make mdeath::splatter work for robots
-    if( ( broken_mon_ref.damage() >= broken_mon_ref.max_damage() ) && g->u.sees( z.pos() ) ) {
+    if( ( broken_mon_ref.damage() >= broken_mon_ref.max_damage() ) && get_avatar().sees( z.pos() ) ) {
         add_msg( m_good, _( "The %s is destroyed!" ), z.name() );
-    } else if( g->u.sees( z.pos() ) ) {
+    } else if( get_avatar().sees( z.pos() ) ) {
         add_msg( m_good, _( "The %s collapses!" ), z.name() );
     }
 }
 
 void mdeath::ratking( monster &z )
 {
-    g->u.remove_effect( effect_rat );
-    if( g->u.sees( z ) ) {
+    get_avatar().remove_effect( effect_rat );
+    if( get_avatar().sees( z ) ) {
         add_msg( m_warning, _( "Rats suddenly swarm into view." ) );
     }
 
@@ -733,8 +733,8 @@ void mdeath::ratking( monster &z )
 
 void mdeath::darkman( monster &z )
 {
-    g->u.remove_effect( effect_darkness );
-    if( g->u.sees( z ) ) {
+    get_avatar().remove_effect( effect_darkness );
+    if( get_avatar().sees( z ) ) {
         add_msg( m_good, _( "The %s melts away." ), z.name() );
     }
 }
@@ -757,7 +757,7 @@ void mdeath::fungalburst( monster &z )
 {
     // If the fungus died from anti-fungal poison, don't pouf
     if( g->m.get_field_intensity( z.pos(), fd_fungicidal_gas ) ) {
-        if( g->u.sees( z ) ) {
+        if( get_avatar().sees( z ) ) {
             add_msg( m_good, _( "The %s inflates and melts away." ), z.name() );
         }
         return;
@@ -792,7 +792,7 @@ void mdeath::jabberwock( monster &z )
 void mdeath::gameover( monster &z )
 {
     add_msg( m_bad, _( "The %s was destroyed!  GAME OVER!" ), z.name() );
-    g->u.set_part_hp_cur( bodypart_id( "torso" ), 0 );
+    get_avatar().set_part_hp_cur( bodypart_id( "torso" ), 0 );
 }
 
 void mdeath::kill_breathers( monster &/*z*/ )
@@ -851,7 +851,7 @@ void mdeath::detonate( monster &z )
         }
     }
 
-    if( g->u.sees( z ) ) {
+    if( get_avatar().sees( z ) ) {
         if( dets.empty() ) {
             add_msg( m_info,
                      //~ %s is the possessive form of the monster's name
@@ -879,7 +879,7 @@ void mdeath::detonate( monster &z )
 
 void mdeath::broken_ammo( monster &z )
 {
-    if( g->u.sees( z.pos() ) ) {
+    if( get_avatar().sees( z.pos() ) ) {
         //~ %s is the possessive form of the monster's name
         add_msg( m_info, _( "The %s's interior compartment sizzles with destructive energy." ),
                  z.name() );
@@ -957,7 +957,7 @@ void mdeath::preg_roach( monster &z )
     int num_roach = rng( 1, 3 );
     while( num_roach > 0 && g->place_critter_around( mon_giant_cockroach_nymph, z.pos(), 1 ) ) {
         num_roach--;
-        if( g->u.sees( z ) ) {
+        if( get_avatar().sees( z ) ) {
             add_msg( m_warning, _( "A cockroach nymph crawls out of the pregnant giant cockroach corpse." ) );
         }
     }

--- a/src/mondefense.cpp
+++ b/src/mondefense.cpp
@@ -15,7 +15,6 @@
 #include "bodypart.h"
 #include "creature.h"
 #include "damage.h"
-#include "game.h"
 #include "map.h"
 #include "map_iterator.h"
 #include "dispersion.h"

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -15,7 +15,6 @@
 #include "damage.h"
 #include "debug.h"
 #include "enum_conversions.h"
-#include "game.h"
 #include "generic_factory.h"
 #include "item.h"
 #include "item_group.h"

--- a/src/morale.cpp
+++ b/src/morale.cpp
@@ -19,7 +19,6 @@
 #include "effect.h"
 #include "enum_conversions.h"
 #include "enums.h"
-#include "game.h"
 #include "input.h"
 #include "int_id.h"
 #include "item.h"

--- a/src/morale.cpp
+++ b/src/morale.cpp
@@ -954,7 +954,7 @@ void player_morale::on_worn_item_washed( const item &it )
     const body_part_set covered( it.get_covered_body_parts() );
 
     if( covered.any() ) {
-        for( const bodypart_id &bp : g->u.get_all_body_parts() ) {
+        for( const bodypart_id &bp : get_avatar().get_all_body_parts() ) {
             if( covered.test( bp.id() ) ) {
                 update_body_part( body_parts[bp] );
             }
@@ -1012,7 +1012,7 @@ void player_morale::set_worn( const item &it, bool worn )
     const body_part_set covered( it.get_covered_body_parts() );
 
     if( covered.any() ) {
-        for( const bodypart_id &bp : g->u.get_all_body_parts() ) {
+        for( const bodypart_id &bp : get_avatar().get_all_body_parts() ) {
             if( covered.test( bp.id() ) ) {
                 update_body_part( body_parts[bp] );
             }

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -581,7 +581,7 @@ void Character::activate_mutation( const trait_id &mut )
     } else if( !mdata.ranged_mutation.is_empty() ) {
         add_msg_if_player( mdata.ranged_mutation_message() );
         //TODO!: check later
-        avatar_action::fire_ranged_mutation( g->u, item::spawn( mdata.ranged_mutation ) );
+        avatar_action::fire_ranged_mutation( get_avatar(), item::spawn( mdata.ranged_mutation ) );
         tdata.powered = false;
         return;
     }

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -8,6 +8,7 @@
 #include <numeric>
 #include <unordered_set>
 
+#include "avatar.h"
 #include "avatar_action.h"
 #include "basecamp.h"
 #include "bionics.h"
@@ -27,9 +28,7 @@
 #include "make_static.h"
 #include "magic_enchantment.h"
 #include "map.h"
-#include "map_iterator.h"
 #include "mapdata.h"
-#include "math_defines.h"
 #include "memorial_logger.h"
 #include "monster.h"
 #include "omdata.h"
@@ -38,9 +37,9 @@
 #include "overmapbuffer.h"
 #include "player_activity.h"
 #include "rng.h"
+#include "map_iterator.h" // IWYU pragma: associated
 #include "string_id.h"
 #include "translations.h"
-#include "units.h"
 #include "weighted_list.h"
 
 static const activity_id ACT_TREE_COMMUNION( "ACT_TREE_COMMUNION" );

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -484,7 +484,7 @@ void Character::activate_mutation( const trait_id &mut )
     }
 
     if( mut == trait_WEB_WEAVER ) {
-        g->m.add_field( pos(), fd_web, 1 );
+        get_map().add_field( pos(), fd_web, 1 );
         add_msg_if_player( _( "You start spinning web with your spinnerets!" ) );
     } else if( mut == trait_BURROW ) {
         tdata.powered = false;
@@ -544,8 +544,8 @@ void Character::activate_mutation( const trait_id &mut )
         }
         // Check for adjacent trees.
         bool adjacent_tree = false;
-        for( const tripoint &p2 : g->m.points_in_radius( pos(), 1 ) ) {
-            if( g->m.has_flag( "TREE", p2 ) ) {
+        for( const tripoint &p2 : get_map().points_in_radius( pos(), 1 ) ) {
+            if( get_map().has_flag( "TREE", p2 ) ) {
                 adjacent_tree = true;
             }
         }
@@ -1501,7 +1501,7 @@ static mutagen_rejection try_reject_mutagen( Character &guy, const item &it, boo
         if( guy.has_trait( trait_M_SPORES ) || guy.has_trait( trait_M_FERTILE ) ||
             guy.has_trait( trait_M_BLOSSOMS ) || guy.has_trait( trait_M_BLOOM ) ) {
             guy.add_msg_if_player( m_good, _( "We decontaminate it with spores." ) );
-            g->m.ter_set( guy.pos(), t_fungus );
+            get_map().ter_set( guy.pos(), t_fungus );
             if( guy.is_avatar() ) {
                 g->memorial().add(
                     pgettext( "memorial_male", "Destroyed a harmful invader." ),

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2458,7 +2458,7 @@ void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomo
     if( moved ) {
         const tripoint old_pos = pos();
         setpos( p );
-        set_underwater( g->m.is_divable( p ) );
+        set_underwater( get_map().is_divable( p ) );
         if( old_pos.x - p.x < 0 ) {
             facing = FD_RIGHT;
         } else {

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -102,7 +102,7 @@ void talk_function::assign_mission( npc &p )
         debugmsg( "assign_mission: mission_selected == nullptr" );
         return;
     }
-    miss->assign( g->u );
+    miss->assign( get_avatar() );
     p.chatbin.missions_assigned.push_back( miss );
     const auto it = std::find( p.chatbin.missions.begin(), p.chatbin.missions.end(), miss );
     p.chatbin.missions.erase( it );
@@ -328,7 +328,7 @@ void talk_function::goto_location( npc &p )
         return;
     }
     if( index == static_cast<int>( camps.size() ) ) {
-        destination = g->u.global_omt_location();
+        destination = get_avatar().global_omt_location();
     } else {
         auto selected_camp = camps[index];
         destination = selected_camp->camp_omt_pos();
@@ -450,7 +450,7 @@ void talk_function::insult_combat( npc &p )
 
 void talk_function::bionic_install( npc &p )
 {
-    item *bionic = game_menus::inv::install_bionic( g->u, g->u, true );
+    item *bionic = game_menus::inv::install_bionic( get_avatar(), get_avatar(), true );
 
     if( !bionic ) {
         return;
@@ -465,15 +465,15 @@ void talk_function::bionic_install( npc &p )
     }
 
     //Makes the doctor awesome at installing but not perfect
-    if( g->u.can_install_bionics( it, p, false, 20 ) ) {
+    if( get_avatar().can_install_bionics( it, p, false, 20 ) ) {
         bionic->detach();
-        g->u.install_bionics( it, p, false, 20 );
+        get_avatar().install_bionics( it, p, false, 20 );
     }
 }
 
 void talk_function::bionic_remove( npc &p )
 {
-    const bionic_collection all_bio = *g->u.my_bionics;
+    const bionic_collection all_bio = *get_avatar().my_bionics;
     if( all_bio.empty() ) {
         popup( _( "You don't have any bionics installed…" ) );
         return;
@@ -517,9 +517,9 @@ void talk_function::bionic_remove( npc &p )
     }
 
     //Makes the doctor awesome at installing but not perfect
-    if( g->u.can_uninstall_bionic( bionic_id( bionic_types[bionic_index].str() ), p, false ) ) {
-        g->u.amount_of( bionic_types[bionic_index] ); // ??? this does nothing, it just queries the count
-        g->u.uninstall_bionic( bionic_id( bionic_types[bionic_index].str() ), p, false );
+    if( get_avatar().can_uninstall_bionic( bionic_id( bionic_types[bionic_index].str() ), p, false ) ) {
+        get_avatar().amount_of( bionic_types[bionic_index] ); // ??? this does nothing, it just queries the count
+        get_avatar().uninstall_bionic( bionic_id( bionic_types[bionic_index].str() ), p, false );
     }
 
 }
@@ -546,8 +546,8 @@ void talk_function::give_equipment( npc &p )
     }
     item &it = *giving[chosen].locs.front();
     popup( _( "%1$s gives you a %2$s" ), p.name, it.tname() );
-    g->u.i_add( giving[chosen].locs.front()->detach() );
-    it.set_owner( g->u );
+    get_avatar().i_add( giving[chosen].locs.front()->detach() );
+    it.set_owner( get_avatar() );
     p.op_of_u.owed -= giving[chosen].price;
     p.add_effect( effect_asked_for_item, 3_hours );
 }
@@ -613,7 +613,7 @@ static void generic_barber( const std::string &mut_type )
     std::vector<trait_id> hair_muts = get_mutations_in_type( mut_type );
     trait_id cur_hair;
     for( auto elem : hair_muts ) {
-        if( g->u.has_trait( elem ) ) {
+        if( get_avatar().has_trait( elem ) ) {
             cur_hair = elem;
         }
         index += 1;
@@ -622,10 +622,10 @@ static void generic_barber( const std::string &mut_type )
     hair_menu.query();
     int choice = hair_menu.ret;
     if( choice != 0 ) {
-        if( g->u.has_trait( cur_hair ) ) {
-            g->u.remove_mutation( cur_hair, true );
+        if( get_avatar().has_trait( cur_hair ) ) {
+            get_avatar().remove_mutation( cur_hair, true );
         }
-        g->u.set_mutation( hair_muts[ choice - 1 ] );
+        get_avatar().set_mutation( hair_muts[ choice - 1 ] );
         add_msg( m_info, _( "You get a trendy new cut!" ) );
     }
 }
@@ -642,35 +642,35 @@ void talk_function::barber_hair( npc &/*p*/ )
 
 void talk_function::buy_haircut( npc &p )
 {
-    g->u.add_morale( MORALE_HAIRCUT, 5, 5, 720_minutes, 3_minutes );
+    get_avatar().add_morale( MORALE_HAIRCUT, 5, 5, 720_minutes, 3_minutes );
     const int moves = to_moves<int>( 20_minutes );
-    g->u.assign_activity( ACT_WAIT_NPC, moves );
-    g->u.activity->str_values.push_back( p.name );
+    get_avatar().assign_activity( ACT_WAIT_NPC, moves );
+    get_avatar().activity->str_values.push_back( p.name );
     add_msg( m_good, _( "%s gives you a decent haircut…" ), p.name );
 }
 
 void talk_function::buy_shave( npc &p )
 {
-    g->u.add_morale( MORALE_SHAVE, 10, 10, 360_minutes, 3_minutes );
+    get_avatar().add_morale( MORALE_SHAVE, 10, 10, 360_minutes, 3_minutes );
     const int moves = to_moves<int>( 5_minutes );
-    g->u.assign_activity( ACT_WAIT_NPC, moves );
-    g->u.activity->str_values.push_back( p.name );
+    get_avatar().assign_activity( ACT_WAIT_NPC, moves );
+    get_avatar().activity->str_values.push_back( p.name );
     add_msg( m_good, _( "%s gives you a decent shave…" ), p.name );
 }
 
 void talk_function::morale_chat( npc &p )
 {
-    g->u.add_morale( MORALE_CHAT, rng( 3, 10 ), 10, 200_minutes, 5_minutes / 2 );
+    get_avatar().add_morale( MORALE_CHAT, rng( 3, 10 ), 10, 200_minutes, 5_minutes / 2 );
     add_msg( m_good, _( "That was a pleasant conversation with %s…" ), p.disp_name() );
 }
 
 void talk_function::morale_chat_activity( npc &p )
 {
     const int moves = to_moves<int>( 10_minutes );
-    g->u.assign_activity( ACT_SOCIALIZE, moves );
-    g->u.activity->str_values.push_back( p.name );
+    get_avatar().assign_activity( ACT_SOCIALIZE, moves );
+    get_avatar().activity->str_values.push_back( p.name );
     add_msg( m_good, _( "That was a pleasant conversation with %s." ), p.disp_name() );
-    g->u.add_morale( MORALE_CHAT, rng( 3, 10 ), 10, 200_minutes, 5_minutes / 2 );
+    get_avatar().add_morale( MORALE_CHAT, rng( 3, 10 ), 10, 200_minutes, 5_minutes / 2 );
 }
 
 void talk_function::buy_10_logs( npc &p )
@@ -732,7 +732,7 @@ void talk_function::follow( npc &p )
     g->add_npc_follower( p.getID() );
     p.set_attitude( NPCATT_FOLLOW );
     p.set_fac( faction_id( "your_followers" ) );
-    g->u.cash += p.cash;
+    get_avatar().cash += p.cash;
     p.cash = 0;
 }
 
@@ -772,7 +772,7 @@ void talk_function::hostile( npc &p )
         return;
     }
 
-    if( p.sees( g->u ) ) {
+    if( p.sees( get_avatar() ) ) {
         add_msg( _( "%s turns hostile!" ), p.name );
     }
 
@@ -829,16 +829,16 @@ void talk_function::stranger_neutral( npc &p )
 void talk_function::drop_stolen_item( npc &p )
 {
     map &here = get_map();
-    for( auto &elem : g->u.inv_dump() ) {
+    for( auto &elem : get_avatar().inv_dump() ) {
         if( elem->is_old_owner( p ) ) {
             detached_ptr<item> to_drop = elem->detach( );
             to_drop->remove_old_owner();
             to_drop->set_owner( p );
-            here.add_item_or_charges( g->u.pos(), std::move( to_drop ) );
+            here.add_item_or_charges( get_avatar().pos(), std::move( to_drop ) );
         }
     }
-    if( g->u.is_hauling() ) {
-        g->u.stop_hauling();
+    if( get_avatar().is_hauling() ) {
+        get_avatar().stop_hauling();
     }
     p.set_attitude( NPCATT_NULL );
 }
@@ -870,19 +870,19 @@ void talk_function::drop_weapon( npc &p )
 
 void talk_function::player_weapon_away( npc &/*p*/ )
 {
-    g->u.i_add( g->u.remove_primary_weapon() );
+    get_avatar().i_add( get_avatar().remove_primary_weapon() );
 }
 
 void talk_function::player_weapon_drop( npc &/*p*/ )
 {
-    get_map().add_item_or_charges( g->u.pos(), g->u.remove_primary_weapon() );
+    get_map().add_item_or_charges( get_avatar().pos(), get_avatar().remove_primary_weapon() );
 }
 
 void talk_function::lead_to_safety( npc &p )
 {
     const auto mission = mission::reserve_new( mission_type_id( "MISSION_REACH_SAFETY" ),
                          character_id() );
-    mission->assign( g->u );
+    mission->assign( get_avatar() );
     p.goal = mission->get_target();
     p.set_attitude( NPCATT_LEAD );
 }
@@ -906,21 +906,21 @@ void talk_function::start_training( npc &p )
     const matype_id &style = p.chatbin.style;
     const spell_id &sp_id = p.chatbin.dialogue_spell;
     int expert_multiplier = 1;
-    if( skill.is_valid() && g->u.get_skill_level( skill ) < p.get_skill_level( skill ) ) {
+    if( skill.is_valid() && get_avatar().get_skill_level( skill ) < p.get_skill_level( skill ) ) {
         cost = calc_skill_training_cost( p, skill );
         time = calc_skill_training_time( p, skill );
         name = skill.str();
-    } else if( p.chatbin.style.is_valid() && !g->u.martial_arts_data->has_martialart( style ) ) {
+    } else if( p.chatbin.style.is_valid() && !get_avatar().martial_arts_data->has_martialart( style ) ) {
         cost = calc_ma_style_training_cost( p, style );
         time = calc_ma_style_training_time( p, style );
         name = p.chatbin.style.str();
         // already checked if can learn this spell in npctalk.cpp
     } else if( p.chatbin.dialogue_spell.is_valid() ) {
         const spell &temp_spell = p.magic->get_spell( sp_id );
-        const bool knows = g->u.magic->knows_spell( sp_id );
+        const bool knows = get_avatar().magic->knows_spell( sp_id );
         cost = p.calc_spell_training_cost( knows, temp_spell.get_difficulty(), temp_spell.get_level() );
         name = temp_spell.id().str();
-        expert_multiplier = knows ? temp_spell.get_level() - g->u.magic->get_spell( sp_id ).get_level() : 1;
+        expert_multiplier = knows ? temp_spell.get_level() - get_avatar().magic->get_spell( sp_id ).get_level() : 1;
         // quicker to learn with instruction as opposed to books.
         // if this is a known spell, then there is a set time to gain some exp.
         // if player doesn't know this spell, then the NPC will teach all of it
@@ -930,7 +930,7 @@ void talk_function::start_training( npc &p )
         if( knows ) {
             time = 1_hours;
         } else {
-            int seconds = g->u.magic->time_to_learn_spell( g->u, sp_id ) / 50;
+            int seconds = get_avatar().magic->time_to_learn_spell( get_avatar(), sp_id ) / 50;
             time = time_duration::from_seconds( clamp( seconds, 7200, 21600 ) );
         }
     } else {
@@ -939,8 +939,8 @@ void talk_function::start_training( npc &p )
     }
 
     mission *miss = p.chatbin.mission_selected;
-    if( miss != nullptr && miss->get_assigned_player_id() == g->u.getID() &&
-        miss->is_complete( g->u.getID() ) ) {
+    if( miss != nullptr && miss->get_assigned_player_id() == get_avatar().getID() &&
+        miss->is_complete( get_avatar().getID() ) ) {
         clear_mission( p );
     } else if( !npc_trading::pay_npc( p, cost ) ) {
         return;
@@ -949,7 +949,7 @@ void talk_function::start_training( npc &p )
                                            to_moves<int>( time ),
                                            p.getID().get_value(), 0, name );
     act->values.push_back( expert_multiplier );
-    g->u.assign_activity( std::move( act ) );
+    get_avatar().assign_activity( std::move( act ) );
 
     p.add_effect( effect_asked_to_train, 6_hours );
 }
@@ -960,7 +960,7 @@ npc *pick_follower()
     std::vector<tripoint> locations;
 
     for( npc &guy : g->all_npcs() ) {
-        if( guy.is_player_ally() && g->u.sees( guy ) ) {
+        if( guy.is_player_ally() && get_avatar().sees( guy ) ) {
             followers.push_back( &guy );
             locations.push_back( guy.pos() );
         }

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -518,7 +518,8 @@ void talk_function::bionic_remove( npc &p )
 
     //Makes the doctor awesome at installing but not perfect
     if( get_avatar().can_uninstall_bionic( bionic_id( bionic_types[bionic_index].str() ), p, false ) ) {
-        get_avatar().amount_of( bionic_types[bionic_index] ); // ??? this does nothing, it just queries the count
+        get_avatar().amount_of(
+            bionic_types[bionic_index] ); // ??? this does nothing, it just queries the count
         get_avatar().uninstall_bionic( bionic_id( bionic_types[bionic_index].str() ), p, false );
     }
 
@@ -910,7 +911,8 @@ void talk_function::start_training( npc &p )
         cost = calc_skill_training_cost( p, skill );
         time = calc_skill_training_time( p, skill );
         name = skill.str();
-    } else if( p.chatbin.style.is_valid() && !get_avatar().martial_arts_data->has_martialart( style ) ) {
+    } else if( p.chatbin.style.is_valid() &&
+               !get_avatar().martial_arts_data->has_martialart( style ) ) {
         cost = calc_ma_style_training_cost( p, style );
         time = calc_ma_style_training_time( p, style );
         name = p.chatbin.style.str();
@@ -920,7 +922,8 @@ void talk_function::start_training( npc &p )
         const bool knows = get_avatar().magic->knows_spell( sp_id );
         cost = p.calc_spell_training_cost( knows, temp_spell.get_difficulty(), temp_spell.get_level() );
         name = temp_spell.id().str();
-        expert_multiplier = knows ? temp_spell.get_level() - get_avatar().magic->get_spell( sp_id ).get_level() : 1;
+        expert_multiplier = knows ? temp_spell.get_level() - get_avatar().magic->get_spell(
+                                sp_id ).get_level() : 1;
         // quicker to learn with instruction as opposed to books.
         // if this is a known spell, then there is a set time to gain some exp.
         // if player doesn't know this spell, then the NPC will teach all of it

--- a/src/npctrade.cpp
+++ b/src/npctrade.cpp
@@ -232,8 +232,8 @@ void trading_window::setup_trade( int cost, npc &np )
     // Note that the NPC's barter skill is factored into these prices.
     // TODO: Recalc item values every time a new item is selected
     // Trading is not linear - starving NPC may pay $100 for 3 jerky, but not $100000 for 300 jerky
-    theirs = npc_trading::init_buying( g->u, np, true );
-    yours = npc_trading::init_buying( np, g->u, false );
+    theirs = npc_trading::init_buying( get_avatar(), np, true );
+    yours = npc_trading::init_buying( np, get_avatar(), false );
 
     if( np.will_exchange_items_freely() ) {
         your_balance = 0;
@@ -322,7 +322,7 @@ void trading_window::update_win( npc &np, const std::string &deal )
         const std::vector<item_pricing> &list = they ? theirs : yours;
         const size_t &offset = they ? them_off : you_off;
         const player &person = they ? static_cast<player &>( np ) :
-                               static_cast<player &>( g->u );
+                               static_cast<player &>( get_avatar() );
         catacurses::window &w_whose = they ? w_them : w_you;
         int win_w = getmaxx( w_whose );
         // Borders
@@ -336,7 +336,7 @@ void trading_window::update_win( npc &np, const std::string &deal )
             std::string itname = it->display_name();
 
             if( np.will_exchange_items_freely() && ip.locs.front()->where() != item_location_type::character ) {
-                itname = itname + " (" + ip.locs.front()->describe_location( &g->u ) + ")";
+                itname = itname + " (" + ip.locs.front()->describe_location( &get_avatar() ) + ")";
                 color = c_light_blue;
             }
 
@@ -689,13 +689,13 @@ bool npc_trading::trade( npc &np, int cost, const std::string &deal )
     if( traded ) {
         int practice = 0;
 
-        npc_trading::transfer_items( trade_win.yours, g->u, np, false );
-        npc_trading::transfer_items( trade_win.theirs, np, g->u, true );
+        npc_trading::transfer_items( trade_win.yours, get_avatar(), np, false );
+        npc_trading::transfer_items( trade_win.theirs, np, get_avatar(), true );
 
         // NPCs will remember debts, to the limit that they'll extend credit or previous debts
         if( !np.will_exchange_items_freely() ) {
             trade_win.update_npc_owed( np );
-            g->u.practice( skill_barter, practice / 10000 );
+            get_avatar().practice( skill_barter, practice / 10000 );
         }
     }
     return traded;

--- a/src/npctrade.cpp
+++ b/src/npctrade.cpp
@@ -17,7 +17,6 @@
 #include "cursesdef.h"
 #include "debug.h"
 #include "faction.h"
-#include "game.h"
 #include "game_constants.h"
 #include "input.h"
 #include "item.h"

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -618,7 +618,7 @@ static tripoint_abs_omt show_notes_manager( const tripoint_abs_omt &origin )
     tripoint_abs_omt selected = origin;
     sort_mode_t sort_mode = sort_mode_t::name;
 
-    const tripoint_abs_omt p_player = g->u.global_omt_location();
+    const tripoint_abs_omt p_player = get_avatar().global_omt_location();
 
     bool quit = false;
     while( !quit ) {
@@ -2228,7 +2228,7 @@ void ui::omap::display_distribution_grids()
 {
     overmap_ui::draw_data_t data;
     data.debug_grids = true;
-    overmap_ui::display( g->u.global_omt_location(), data );
+    overmap_ui::display( get_avatar().global_omt_location(), data );
 }
 
 void ui::omap::display_editor()

--- a/src/path_info.h
+++ b/src/path_info.h
@@ -4,6 +4,13 @@
 
 #include <string>
 
+static const std::string SAVE_MASTER( "master.gsav" );
+static const std::string SAVE_ARTIFACTS( "artifacts.gsav" );
+static const std::string SAVE_EXTENSION( ".sav" );
+static const std::string SAVE_EXTENSION_LOG( ".log" );
+static const std::string SAVE_EXTENSION_WEATHER( ".weather" );
+static const std::string SAVE_EXTENSION_SHORTCUTS( ".shortcuts" );
+
 enum class holiday : int;
 
 namespace PATH_INFO

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -145,7 +145,7 @@ static pickup_answer handle_problematic_pickup( const item &it, bool &offered_sw
         return CANCEL;
     }
 
-    player &u = g->u;
+    player &u = get_avatar();
 
     uilist amenu;
 
@@ -187,7 +187,7 @@ static pickup_answer handle_problematic_pickup( const item &it, bool &offered_sw
 
 bool pickup::query_thief()
 {
-    player &u = g->u;
+    player &u = get_avatar();
     const bool force_uc = get_option<bool>( "FORCE_CAPITAL_YN" );
     const auto &allow_key = force_uc ? input_context::disallow_lower_case
                             : input_context::allow_all_keys;
@@ -241,7 +241,7 @@ static bool pick_one_up( pickup::pick_drop_selection &selection, bool &got_water
     item *loc = &*selection.target;
 
     const std::optional<int> &quantity = selection.quantity;
-    if( !loc->is_owned_by( g->u, true ) ) {
+    if( !loc->is_owned_by( get_avatar(), true ) ) {
         // Has the player given input on if stealing is ok?
         if( u.get_value( "THIEF_MODE" ) == "THIEF_ASK" ) {
             pickup::query_thief();
@@ -634,7 +634,7 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
 
     if( min == -1 ) {
         // Recursively pick up adjacent items if that option is on.
-        if( get_option<bool>( "AUTO_PICKUP_ADJACENT" ) && g->u.pos() == p ) {
+        if( get_option<bool>( "AUTO_PICKUP_ADJACENT" ) && get_avatar().pos() == p ) {
             //Autopickup adjacent
             direction adjacentDir[8] = {direction::NORTH, direction::NORTHEAST, direction::EAST, direction::SOUTHEAST, direction::SOUTH, direction::SOUTHWEST, direction::WEST, direction::NORTHWEST};
             for( auto &elem : adjacentDir ) {
@@ -657,13 +657,13 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
     // Not many items, just grab them
     if( static_cast<int>( here.size() ) <= min && min != -1 ) {
         if( from_vehicle ) {
-            g->u.assign_activity( std::make_unique<player_activity>( std::make_unique<pickup_activity_actor>(
+            get_avatar().assign_activity( std::make_unique<player_activity>( std::make_unique<pickup_activity_actor>(
             std::vector<pickup::pick_drop_selection> { { *here.front(), std::nullopt, {} } },
             std::nullopt ) ) );
         } else {
-            g->u.assign_activity( std::make_unique<player_activity>( std::make_unique<pickup_activity_actor>(
+            get_avatar().assign_activity( std::make_unique<player_activity>( std::make_unique<pickup_activity_actor>(
             std::vector<pickup::pick_drop_selection> { { *here.front(), std::nullopt, {} } },
-            g->u.pos() ) ) );
+            get_avatar().pos() ) ) );
         }
         return;
     }
@@ -887,7 +887,7 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
                     }
 
                     // if the item does not belong to your fraction then add the stolen symbol
-                    if( !this_item.is_owned_by( g->u, true ) ) {
+                    if( !this_item.is_owned_by( get_avatar(), true ) ) {
                         item_name = string_format( "<color_light_red>!</color> %s", item_name );
                     }
 
@@ -916,13 +916,13 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
 
             const std::string fmted_weight_predict = colorize(
                         string_format( "%.1f", round_up( convert_weight( weight_predict ), 1 ) ),
-                        weight_predict > g->u.weight_capacity() ? c_red : c_white );
+                        weight_predict > get_avatar().weight_capacity() ? c_red : c_white );
             const std::string fmted_weight_capacity = string_format(
-                        "%.1f", round_up( convert_weight( g->u.weight_capacity() ), 1 ) );
+                        "%.1f", round_up( convert_weight( get_avatar().weight_capacity() ), 1 ) );
             const std::string fmted_volume_predict = colorize(
                         format_volume( volume_predict ),
-                        volume_predict > g->u.volume_capacity() ? c_red : c_white );
-            const std::string fmted_volume_capacity = format_volume( g->u.volume_capacity() );
+                        volume_predict > get_avatar().volume_capacity() ? c_red : c_white );
+            const std::string fmted_volume_capacity = format_volume( get_avatar().volume_capacity() );
 
             trim_and_print( w_pickup, point_zero, pickupW, c_white,
                             string_format( _( "PICK Wgt %1$s/%2$s  Vol %3$s/%4$s" ),
@@ -1140,8 +1140,8 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
                     }
                 }
 
-                weight_predict = g->u.weight_carried() + weight_picked_up;
-                volume_predict = g->u.volume_carried() + volume_picked_up;
+                weight_predict = get_avatar().weight_carried() + weight_picked_up;
+                volume_predict = get_avatar().volume_carried() + volume_picked_up;
             }
 
             ui_manager::redraw();
@@ -1202,12 +1202,12 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
     }
 
     std::vector<pickup::pick_drop_selection> targets = pickup::optimize_pickup( locations, quantities );
-    g->u.assign_activity( std::make_unique<player_activity>( std::make_unique<pickup_activity_actor>
+    get_avatar().assign_activity( std::make_unique<player_activity>( std::make_unique<pickup_activity_actor>
                           ( targets,
-                            g->u.pos() ) ) );
+                            get_avatar().pos() ) ) );
     if( min == -1 ) {
         // Auto pickup will need to auto resume since there can be several of them on the stack.
-        g->u.activity->auto_resume = true;
+        get_avatar().activity->auto_resume = true;
     }
 
     g->reenter_fullscreen();

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "game.h"
 #include "action.h"
 #include "activity_handlers.h"
 #include "ammo.h"

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -32,7 +32,6 @@
 #include "fault.h"
 #include "flag.h"
 #include "field_type.h"
-#include "game.h"
 #include "game_inventory.h"
 #include "gun_mode.h"
 #include "handle_liquid.h"

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -174,7 +174,7 @@ static void eff_fun_fungus( player &u, effect &it )
             break;
         case 3: {
             // Permanent symptoms
-            bool is_fungal_ter = g->m.has_flag_ter( "FUNGUS", u.pos() );
+            bool is_fungal_ter = get_map().has_flag_ter( "FUNGUS", u.pos() );
             if( !is_fungal_ter && one_in( 600 + 4 * bonus ) ) {
                 u.add_effect( effect_nausea, 5_minutes );
             }
@@ -699,9 +699,9 @@ void Character::hardcoded_effects( effect &it )
             }
             if( one_in( 7200 - ( intense * 250 ) ) ) {
                 add_msg_if_player( m_bad, _( "You are beset with a vision of a prowling beast." ) );
-                for( const tripoint &dest : g->m.points_in_radius( pos(), 6 ) ) {
-                    if( g->m.is_cornerfloor( dest ) ) {
-                        g->m.add_field( dest, fd_tindalos_rift, 3 );
+                for( const tripoint &dest : get_map().points_in_radius( pos(), 6 ) ) {
+                    if( get_map().is_cornerfloor( dest ) ) {
+                        get_map().add_field( dest, fd_tindalos_rift, 3 );
                         add_msg_if_player( m_info, _( "Your surroundings are permeated with a foul scent." ) );
                         break;
                     }
@@ -729,8 +729,8 @@ void Character::hardcoded_effects( effect &it )
                     }
                 } while( g->critter_at( dest ) );
                 if( tries < 10 ) {
-                    if( g->m.impassable( dest ) ) {
-                        g->m.make_rubble( dest, f_rubble_rock );
+                    if( get_map().impassable( dest ) ) {
+                        get_map().make_rubble( dest, f_rubble_rock );
                     }
                     MonsterGroupResult spawn_details = MonsterGroupManager::GetResultFromGroup(
                                                            GROUP_NETHER );
@@ -911,7 +911,7 @@ void Character::hardcoded_effects( effect &it )
     } else if( id == effect_grabbed ) {
         set_num_blocks_bonus( get_num_blocks_bonus() - 1 );
         int zed_number = 0;
-        for( auto &dest : g->m.points_in_radius( pos(), 1, 0 ) ) {
+        for( auto &dest : get_map().points_in_radius( pos(), 1, 0 ) ) {
             const monster *const mon = g->critter_at<monster>( dest );
             if( mon && mon->has_effect( effect_grabbing ) ) {
                 zed_number += mon->get_grab_strength();
@@ -1080,7 +1080,7 @@ void Character::hardcoded_effects( effect &it )
         // TODO: Move this to update_needs when NPCs can mutate
         if( calendar::once_every( 10_minutes ) && ( has_trait( trait_CHLOROMORPH ) ||
                 has_trait( trait_M_SKIN3 ) || has_trait( trait_WATERSLEEP ) ) &&
-            g->m.is_outside( pos() ) ) {
+            get_map().is_outside( pos() ) ) {
             if( has_trait( trait_CHLOROMORPH ) ) {
                 // Hunger and thirst fall before your Chloromorphic physiology!
                 if( g->natural_light_level( posz() ) >= 12 &&
@@ -1095,7 +1095,7 @@ void Character::hardcoded_effects( effect &it )
             }
             if( has_trait( trait_M_SKIN3 ) ) {
                 // Spores happen!
-                if( g->m.has_flag_ter_or_furn( "FUNGUS", pos() ) ) {
+                if( get_map().has_flag_ter_or_furn( "FUNGUS", pos() ) ) {
                     if( get_fatigue() >= 0 ) {
                         mod_fatigue( -5 ); // Local guides need less sleep on fungal soil
                     }
@@ -1153,7 +1153,7 @@ void Character::hardcoded_effects( effect &it )
                     trait_SEESLEEP ) ) { // People who can see while sleeping are acclimated to the light.
                 if( has_trait( trait_HEAVYSLEEPER2 ) && !has_trait( trait_HIBERNATE ) ) {
                     // So you can too sleep through noon
-                    if( ( tirednessVal * 1.25 ) < g->m.ambient_light_at( pos() ) && ( get_fatigue() < 10 ||
+                    if( ( tirednessVal * 1.25 ) < get_map().ambient_light_at( pos() ) && ( get_fatigue() < 10 ||
                             one_in( get_fatigue() / 2 ) ) ) {
                         add_msg_if_player( _( "It's too bright to sleep." ) );
                         // Set ourselves up for removal
@@ -1162,14 +1162,14 @@ void Character::hardcoded_effects( effect &it )
                     }
                     // Ursine hibernators would likely do so indoors.  Plants, though, might be in the sun.
                 } else if( has_trait( trait_HIBERNATE ) ) {
-                    if( ( tirednessVal * 5 ) < g->m.ambient_light_at( pos() ) && ( get_fatigue() < 10 ||
+                    if( ( tirednessVal * 5 ) < get_map().ambient_light_at( pos() ) && ( get_fatigue() < 10 ||
                             one_in( get_fatigue() / 2 ) ) ) {
                         add_msg_if_player( _( "It's too bright to sleep." ) );
                         // Set ourselves up for removal
                         it.set_duration( 0_turns );
                         woke_up = true;
                     }
-                } else if( tirednessVal < g->m.ambient_light_at( pos() ) && ( get_fatigue() < 10 ||
+                } else if( tirednessVal < get_map().ambient_light_at( pos() ) && ( get_fatigue() < 10 ||
                            one_in( get_fatigue() / 2 ) ) ) {
                     add_msg_if_player( _( "It's too bright to sleep." ) );
                     // Set ourselves up for removal
@@ -1225,12 +1225,12 @@ void Character::hardcoded_effects( effect &it )
                 } else {
                     int max_count = rng( 1, 3 );
                     int count = 0;
-                    for( const tripoint &mp : g->m.points_in_radius( pos(), 1 ) ) {
+                    for( const tripoint &mp : get_map().points_in_radius( pos(), 1 ) ) {
                         if( mp == pos() ) {
                             continue;
                         }
-                        if( g->m.has_flag( "FLAT", mp ) &&
-                            g->m.pl_sees( mp, 2 ) ) {
+                        if( get_map().has_flag( "FLAT", mp ) &&
+                            get_map().pl_sees( mp, 2 ) ) {
                             g->spawn_hallucination( mp );
                             if( ++count > max_count ) {
                                 break;

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -552,8 +552,8 @@ void Character::hardcoded_effects( effect &it )
             if( !is_npc() ) {
                 //~ %s is bodypart in accusative.
                 add_msg( m_warning, _( "You start scratching your %s!" ), body_part_name_accusative( bp ) );
-                g->u.cancel_activity();
-            } else if( g->u.sees( pos() ) ) {
+                get_avatar().cancel_activity();
+            } else if( get_avatar().sees( pos() ) ) {
                 //~ 1$s is NPC name, 2$s is bodypart in accusative.
                 add_msg( _( "%1$s starts scratching their %2$s!" ), name, body_part_name_accusative( bp ) );
             }
@@ -735,7 +735,7 @@ void Character::hardcoded_effects( effect &it )
                     MonsterGroupResult spawn_details = MonsterGroupManager::GetResultFromGroup(
                                                            GROUP_NETHER );
                     g->place_critter_at( spawn_details.name, dest );
-                    if( g->u.sees( dest ) ) {
+                    if( get_avatar().sees( dest ) ) {
                         g->cancel_activity_or_ignore_query( distraction_type::hostile_spotted_far,
                                                             _( "A monster appears nearby!" ) );
                         add_msg( m_warning, _( "A portal opens nearby, and a monster crawls through!" ) );

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -7,7 +7,6 @@
 
 #include "ammo_effect.h"
 #include "explosion.h"
-#include "game.h"
 #include "json.h"
 #include "item.h"
 #include "map.h"

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -18,7 +18,6 @@
 #include "color.h"
 #include "crafting.h"
 #include "debug.h"
-#include "game.h"
 #include "generic_factory.h"
 #include "inventory.h"
 #include "item.h"

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -701,7 +701,7 @@ std::vector<std::string> requirement_data::get_folded_tools_list( int width, nc_
 bool requirement_data::can_make_with_inventory( const inventory &crafting_inv,
         const std::function<bool( const item & )> &filter, int batch, cost_adjustment flags ) const
 {
-    if( g->u.has_trait( trait_DEBUG_HS ) ) {
+    if( get_avatar().has_trait( trait_DEBUG_HS ) ) {
         return true;
     }
 
@@ -763,7 +763,7 @@ bool quality_requirement::has(
     const inventory &crafting_inv, const std::function<bool( const item & )> &, int,
     cost_adjustment, const std::function<void( int )> & ) const
 {
-    if( g->u.has_trait( trait_DEBUG_HS ) ) {
+    if( get_avatar().has_trait( trait_DEBUG_HS ) ) {
         return true;
     }
     return crafting_inv.has_quality( type, level, count );
@@ -782,7 +782,7 @@ bool tool_comp::has(
     const inventory &crafting_inv, const std::function<bool( const item & )> &filter, int batch,
     cost_adjustment flags, std::function<void( int )> visitor ) const
 {
-    if( g->u.has_trait( trait_DEBUG_HS ) ) {
+    if( get_avatar().has_trait( trait_DEBUG_HS ) ) {
         return true;
     }
     if( !by_charges() ) {
@@ -816,7 +816,7 @@ bool item_comp::has(
     const inventory &crafting_inv, const std::function<bool( const item & )> &filter, int batch,
     cost_adjustment, const std::function<void( int )> & ) const
 {
-    if( g->u.has_trait( trait_DEBUG_HS ) ) {
+    if( get_avatar().has_trait( trait_DEBUG_HS ) ) {
         return true;
     }
     const int cnt = std::abs( count ) * batch;

--- a/src/runtime_handlers.cpp
+++ b/src/runtime_handlers.cpp
@@ -2,6 +2,7 @@
 #include "cursesdef.h"
 #include "debug.h"
 #include "init.h"
+#include "game.h"
 
 [[ noreturn ]]
 void exit_handler( int status )

--- a/src/runtime_handlers.cpp
+++ b/src/runtime_handlers.cpp
@@ -2,7 +2,6 @@
 #include "cursesdef.h"
 #include "debug.h"
 #include "init.h"
-#include "game.h"
 
 [[ noreturn ]]
 void exit_handler( int status )

--- a/src/safe_reference.cpp
+++ b/src/safe_reference.cpp
@@ -91,7 +91,7 @@ void deserialize<item>( safe_reference<item> &out, JsonIn &js )
                 obj.read( "character", who_id );
             } else {
                 // This is for migrating saves before npc item locations were supported and all
-                // character item locations were assumed to be on g->u
+                // character item locations were assumed to be on get_avatar()
                 who_id = get_avatar().getID();
             }
 

--- a/src/safemode_ui.cpp
+++ b/src/safemode_ui.cpp
@@ -202,7 +202,7 @@ void safemode::show( const std::string &custom_name_in, bool is_safemode_in )
 
         auto &current_tab = ( tab == GLOBAL_TAB ) ? global_rules : character_rules;
 
-        if( tab == CHARACTER_TAB && g->u.name.empty() ) {
+        if( tab == CHARACTER_TAB && get_avatar().name.empty() ) {
             character_rules.clear();
             mvwprintz( w, point( 15, 8 ), c_white, _( "Please load a character first to use this page!" ) );
         } else if( empty() ) {
@@ -270,7 +270,7 @@ void safemode::show( const std::string &custom_name_in, bool is_safemode_in )
             line = 0;
         } else if( action == "QUIT" ) {
             break;
-        } else if( tab == CHARACTER_TAB && g->u.name.empty() ) {
+        } else if( tab == CHARACTER_TAB && get_avatar().name.empty() ) {
             //Only allow loaded games to use the char sheet
         } else if( action == "DOWN" ) {
             line++;
@@ -308,7 +308,7 @@ void safemode::show( const std::string &custom_name_in, bool is_safemode_in )
             current_tab.push_back( current_tab[line] );
             line = current_tab.size() - 1;
         } else if( action == "SWAP_RULE_GLOBAL_CHAR" && !current_tab.empty() ) {
-            if( ( tab == GLOBAL_TAB && !g->u.name.empty() ) || tab == CHARACTER_TAB ) {
+            if( ( tab == GLOBAL_TAB && !get_avatar().name.empty() ) || tab == CHARACTER_TAB ) {
                 changes_made = true;
                 //copy over
                 auto &temp_rules_from = ( tab == GLOBAL_TAB ) ? global_rules : character_rules;
@@ -467,7 +467,7 @@ void safemode::show( const std::string &custom_name_in, bool is_safemode_in )
     if( query_yn( _( "Save changes?" ) ) ) {
         if( is_safemode_in ) {
             save_global();
-            if( !g->u.name.empty() ) {
+            if( !get_avatar().name.empty() ) {
                 save_character();
             }
         } else {
@@ -489,7 +489,7 @@ void safemode::test_pattern( const int tab_in, const int row_in )
         return;
     }
 
-    if( g->u.name.empty() ) {
+    if( get_avatar().name.empty() ) {
         popup( _( "No monsters loaded.  Please start a game first." ) );
         return;
     }

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -4,12 +4,11 @@
 #include <map>
 #include <sstream>
 #include <string>
-#include <type_traits>
 #include <unordered_map>
-#include <unordered_set>
 #include <utility>
 #include <vector>
 
+#include "path_info.h"
 #include "achievement.h"
 #include "avatar.h"
 #include "basecamp.h"
@@ -18,8 +17,6 @@
 #include "creature_tracker.h"
 #include "debug.h"
 #include "drop_token.h"
-#include "enum_conversions.h"
-#include "faction.h"
 #include "hash_utils.h"
 #include "int_id.h"
 #include "json.h"
@@ -39,7 +36,6 @@
 #include "regional_settings.h"
 #include "scent_map.h"
 #include "stats_tracker.h"
-#include "string_id.h"
 #include "translations.h"
 #include "ui_manager.h"
 #include "weather.h"

--- a/src/scent_map.cpp
+++ b/src/scent_map.cpp
@@ -14,6 +14,7 @@
 #include "map.h"
 #include "output.h"
 #include "string_id.h"
+#include "game.h"
 
 static constexpr int SCENT_RADIUS = 40;
 
@@ -157,13 +158,15 @@ void scent_map::update( const tripoint &center, map &m )
         return;
     }
 
+    constexpr int SCENT_RADIUS_X2 = SCENT_RADIUS * 2;
+
     //the block and reduce scent properties are folded into a single scent_transfer value here
     //block=0 reduce=1 normal=5
     scent_array<char> scent_transfer;
 
-    std::array < std::array < int, 3 + SCENT_RADIUS * 2 >, 1 + SCENT_RADIUS * 2 > new_scent;
-    std::array < std::array < int, 3 + SCENT_RADIUS * 2 >, 1 + SCENT_RADIUS * 2 > sum_3_scent_y;
-    std::array < std::array < char, 3 + SCENT_RADIUS * 2 >, 1 + SCENT_RADIUS * 2 > squares_used_y;
+    std::array < std::array < int, 3 + SCENT_RADIUS_X2 >, 1 + SCENT_RADIUS_X2 > new_scent;
+    std::array < std::array < int, 3 + SCENT_RADIUS_X2 >, 1 + SCENT_RADIUS_X2 > sum_3_scent_y;
+    std::array < std::array < char, 3 + SCENT_RADIUS_X2 >, 1 + SCENT_RADIUS_X2 > squares_used_y;
 
     diagonal_blocks( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = m.access_cache(
                 center.z ).vehicle_obstructed_cache;
@@ -178,15 +181,16 @@ void scent_map::update( const tripoint &center, map &m )
     m.scent_blockers( scent_transfer, point( scentmap_minx - 1, scentmap_miny - 1 ),
                       point( scentmap_maxx + 1, scentmap_maxy + 1 ) );
 
-    for( int x = 0; x < SCENT_RADIUS * 2 + 3; ++x ) {
+
+    for( int x = 0; x < SCENT_RADIUS_X2 + 3; ++x ) {
         sum_3_scent_y[0][x] = 0;
         squares_used_y[0][x] = 0;
-        sum_3_scent_y[SCENT_RADIUS * 2][x] = 0;
-        squares_used_y[SCENT_RADIUS * 2][x] = 0;
+        sum_3_scent_y[SCENT_RADIUS_X2][x] = 0;
+        squares_used_y[SCENT_RADIUS_X2][x] = 0;
     }
 
-    for( int x = 0; x < SCENT_RADIUS * 2 + 3; ++x ) {
-        for( int y = 0; y < SCENT_RADIUS * 2 + 1; ++y ) {
+    for( int x = 0; x < SCENT_RADIUS_X2 + 3; ++x ) {
+        for( int y = 0; y < SCENT_RADIUS_X2 + 1; ++y ) {
 
             point abs( x + scentmap_minx - 1, y + scentmap_miny );
 
@@ -200,8 +204,8 @@ void scent_map::update( const tripoint &center, map &m )
         }
     }
 
-    for( int x = 1; x < SCENT_RADIUS * 2 + 2; ++x ) {
-        for( int y = 0; y < SCENT_RADIUS * 2 + 1; ++y ) {
+    for( int x = 1; x < SCENT_RADIUS_X2 + 2; ++x ) {
+        for( int y = 0; y < SCENT_RADIUS_X2 + 1; ++y ) {
             const point abs( x + scentmap_minx - 1, y + scentmap_miny );
 
             int squares_used = squares_used_y[y][x - 1] + squares_used_y[y][x] + squares_used_y[y][x + 1];
@@ -235,8 +239,8 @@ void scent_map::update( const tripoint &center, map &m )
 
         }
     }
-    for( int x = 1; x < SCENT_RADIUS * 2 + 2; ++x ) {
-        for( int y = 0; y < SCENT_RADIUS * 2 + 1; ++y ) {
+    for( int x = 1; x < SCENT_RADIUS_X2 + 2; ++x ) {
+        for( int y = 0; y < SCENT_RADIUS_X2 + 1; ++y ) {
             grscent[x + scentmap_minx - 1 ][y + scentmap_miny] = new_scent[y][x];
         }
     }

--- a/src/scent_map.cpp
+++ b/src/scent_map.cpp
@@ -10,7 +10,6 @@
 #include "cuboid_rectangle.h"
 #include "cursesdef.h"
 #include "debug.h"
-#include "game.h"
 #include "generic_factory.h"
 #include "map.h"
 #include "output.h"

--- a/src/scent_map.h
+++ b/src/scent_map.h
@@ -68,7 +68,7 @@ class scent_map
         /**
          * Get the scent value at the given position.
          * An invalid position is allows and will yield a 0 value.
-         * The coordinate system is the same as the @ref map (`g->m`) uses.
+         * The coordinate system is the same as the @ref map (`get_map()`) uses.
          */
         /**@{*/
         void set( const tripoint &p, int value, const scenttype_id &type = scenttype_id() );

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1982,7 +1982,8 @@ input_context touch_input_context;
 
 std::string get_quick_shortcut_name( const std::string &category )
 {
-    if( category == "DEFAULTMODE" && g->check_zone( zone_type_id( "NO_AUTO_PICKUP" ), get_avatar().pos() ) &&
+    if( category == "DEFAULTMODE" &&
+        g->check_zone( zone_type_id( "NO_AUTO_PICKUP" ), get_avatar().pos() ) &&
         get_option<bool>( "ANDROID_SHORTCUT_ZONE" ) ) {
         return "DEFAULTMODE____SHORTCUTS";
     }

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1552,7 +1552,7 @@ void cata_cursesport::curses_drawwindow( const catacurses::window &w )
         clear_window_area( w );
         tilecontext->draw_minimap(
             point( win->pos.x * fontwidth, win->pos.y * fontheight ),
-            tripoint( g->u.pos().xy(), g->ter_view_p.z ),
+            tripoint( get_avatar().pos().xy(), g->ter_view_p.z ),
             win->width * font->width, win->height * font->height );
         update = true;
 
@@ -1982,7 +1982,7 @@ input_context touch_input_context;
 
 std::string get_quick_shortcut_name( const std::string &category )
 {
-    if( category == "DEFAULTMODE" && g->check_zone( zone_type_id( "NO_AUTO_PICKUP" ), g->u.pos() ) &&
+    if( category == "DEFAULTMODE" && g->check_zone( zone_type_id( "NO_AUTO_PICKUP" ), get_avatar().pos() ) &&
         get_option<bool>( "ANDROID_SHORTCUT_ZONE" ) ) {
         return "DEFAULTMODE____SHORTCUTS";
     }
@@ -2240,10 +2240,10 @@ void remove_stale_inventory_quick_shortcuts()
             valid = inv_chars.valid( key );
             in_inventory = false;
             if( valid ) {
-                in_inventory = g->u.inv_invlet_to_position( key ) != INT_MIN;
+                in_inventory = get_avatar().inv_invlet_to_position( key ) != INT_MIN;
                 if( !in_inventory ) {
                     // We couldn't find this item in the inventory, let's check worn items
-                    for( const auto &item : g->u.worn ) {
+                    for( const auto &item : get_avatar().worn ) {
                         if( item->invlet == key ) {
                             in_inventory = true;
                             break;
@@ -2252,7 +2252,7 @@ void remove_stale_inventory_quick_shortcuts()
                 }
                 if( !in_inventory ) {
                     // We couldn't find it in worn items either, check weapon held
-                    if( g->u.primary_weapon().invlet == key ) {
+                    if( get_avatar().primary_weapon().invlet == key ) {
                         in_inventory = true;
                     }
                 }
@@ -2373,10 +2373,10 @@ void draw_quick_shortcuts()
         if( show_hint ) {
             if( touch_input_context.get_category() == "INVENTORY" && inv_chars.valid( key ) ) {
                 // Special case for inventory items - show the inventory item name as help text
-                hint_text = g->u.inv_find_item( g->u.inv_invlet_to_position( key ) ).display_name();
+                hint_text = get_avatar().inv_find_item( get_avatar().inv_invlet_to_position( key ) ).display_name();
                 if( hint_text == "none" ) {
                     // We couldn't find this item in the inventory, let's check worn items
-                    for( const auto &item : g->u.worn ) {
+                    for( const auto &item : get_avatar().worn ) {
                         if( item->invlet == key ) {
                             hint_text = item->display_name();
                             break;
@@ -2385,8 +2385,8 @@ void draw_quick_shortcuts()
                 }
                 if( hint_text == "none" ) {
                     // We couldn't find it in worn items either, must be weapon held
-                    if( g->u.primary_weapon().invlet == key ) {
-                        hint_text = g->u.primary_weapon().display_name();
+                    if( get_avatar().primary_weapon().invlet == key ) {
+                        hint_text = get_avatar().primary_weapon().display_name();
                     }
                 }
             } else {
@@ -2760,24 +2760,24 @@ static void CheckMessages()
                 std::set<action_id> actions_remove;
 
                 // Check if we're in a potential combat situation, if so, sort a few actions to the top.
-                if( !g->u.get_hostile_creatures( 60 ).empty() ) {
+                if( !get_avatar().get_hostile_creatures( 60 ).empty() ) {
                     // Only prioritize movement options if we're not driving.
-                    if( !g->u.controlling_vehicle ) {
+                    if( !get_avatar().controlling_vehicle ) {
                         actions.insert( ACTION_CYCLE_MOVE );
                     }
                     // Only prioritize fire weapon options if we're wielding a ranged weapon.
-                    if( g->u.primary_weapon().is_gun() ||
-                        g->u.primary_weapon().has_flag( STATIC( flag_id( "REACH_ATTACK" ) ) ) ) {
+                    if( get_avatar().primary_weapon().is_gun() ||
+                        get_avatar().primary_weapon().has_flag( STATIC( flag_id( "REACH_ATTACK" ) ) ) ) {
                         actions.insert( ACTION_FIRE );
                     }
                 }
 
                 // If we're already running, make it simple to toggle running to off.
-                if( g->u.movement_mode_is( CMM_RUN ) ) {
+                if( get_avatar().movement_mode_is( CMM_RUN ) ) {
                     actions.insert( ACTION_TOGGLE_RUN );
                 }
                 // If we're already crouching, make it simple to toggle crouching to off.
-                if( g->u.movement_mode_is( CMM_CROUCH ) ) {
+                if( get_avatar().movement_mode_is( CMM_CROUCH ) ) {
                     actions.insert( ACTION_TOGGLE_CROUCH );
                 }
 
@@ -2791,9 +2791,9 @@ static void CheckMessages()
                 // display that action at the top of the list.
                 for( int dx = -1; dx <= 1; dx++ ) {
                     for( int dy = -1; dy <= 1; dy++ ) {
-                        int x = g->u.posx() + dx;
-                        int y = g->u.posy() + dy;
-                        int z = g->u.posz();
+                        int x = get_avatar().posx() + dx;
+                        int y = get_avatar().posy() + dy;
+                        int z = get_avatar().posz();
                         const tripoint pos( x, y, z );
 
                         // Check if we're near a vehicle, if so, vehicle controls should be top.
@@ -2890,13 +2890,13 @@ static void CheckMessages()
                 }
 
                 // Check if we're significantly hungry or thirsty - if so, add eat
-                if( g->u.max_stored_kcal() - g->u.get_stored_kcal() > 1000 ||
-                    g->u.get_thirst() > thirst_levels::thirsty ) {
+                if( get_avatar().max_stored_kcal() - get_avatar().get_stored_kcal() > 1000 ||
+                    get_avatar().get_thirst() > thirst_levels::thirsty ) {
                     actions.insert( ACTION_EAT );
                 }
 
                 // Check if we're dead tired - if so, add sleep
-                if( g->u.get_fatigue() > fatigue_levels::dead_tired ) {
+                if( get_avatar().get_fatigue() > fatigue_levels::dead_tired ) {
                     actions.insert( ACTION_SLEEP );
                 }
 

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1109,7 +1109,7 @@ sfx::sound_thread::sound_thread( const tripoint &source, const tripoint &target,
     const int heard_volume = get_heard_volume( source );
     const player *p = g->critter_at<npc>( source );
     if( !p ) {
-        p = &g->u;
+        p = &get_avatar();
         // sound comes from the same place as the player is, calculation of angle wouldn't work
         ang_src = 0_degrees;
         vol_src = heard_volume;
@@ -1128,7 +1128,7 @@ sfx::sound_thread::sound_thread( const tripoint &source, const tripoint &target,
 void sfx::sound_thread::operator()() const
 {
     // This is function is run in a separate thread. One must be careful and not access game data
-    // that might change (e.g. g->u.weapon, the character could switch weapons while this thread
+    // that might change (e.g. get_avatar().weapon, the character could switch weapons while this thread
     // runs).
     std::this_thread::sleep_for( std::chrono::milliseconds( rng( 1, 2 ) ) );
     std::string variant_used;
@@ -1492,13 +1492,13 @@ void sfx::do_footstep()
             start_sfx_timestamp = std::chrono::high_resolution_clock::now();
         };
 
-        auto veh_displayed_part = g->m.veh_at( g->u.pos() ).part_displayed();
+        auto veh_displayed_part = g->m.veh_at( get_avatar().pos() ).part_displayed();
 
         if( !veh_displayed_part && ( water.count( terrain ) > 0 ) ) {
             play_plmove_sound_variant( "walk_water" );
             return;
         }
-        if( !g->u.wearing_something_on( bodypart_id( bp_foot_l ) ) ) {
+        if( !get_avatar().wearing_something_on( bodypart_id( bp_foot_l ) ) ) {
             play_plmove_sound_variant( "walk_barefoot" );
             return;
         }

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1492,7 +1492,7 @@ void sfx::do_footstep()
             start_sfx_timestamp = std::chrono::high_resolution_clock::now();
         };
 
-        auto veh_displayed_part = g->m.veh_at( get_avatar().pos() ).part_displayed();
+        auto veh_displayed_part = get_map().veh_at( get_avatar().pos() ).part_displayed();
 
         if( !veh_displayed_part && ( water.count( terrain ) > 0 ) ) {
             play_plmove_sound_variant( "walk_water" );

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -171,9 +171,9 @@ static void board_up( map &m, const tripoint_range<tripoint> &range )
             continue;
         }
         // If the furniture is movable and the character can move it, use it to barricade
-        // g->u is workable here as NPCs by definition are not starting the game.  (Let's hope.)
+        // get_avatar() is workable here as NPCs by definition are not starting the game.  (Let's hope.)
         ///\EFFECT_STR determines what furniture might be used as a starting area barricade
-        if( m.furn( p ).obj().is_movable() && m.furn( p ).obj().move_str_req < g->u.get_str() ) {
+        if( m.furn( p ).obj().is_movable() && m.furn( p ).obj().move_str_req < get_avatar().get_str() ) {
             if( m.furn( p ).obj().movecost == 0 ) {
                 // Obstacles are better, prefer them
                 furnitures1.push_back( p );
@@ -407,7 +407,7 @@ void start_location::burn( const tripoint_abs_omt &omtstart, const size_t count,
     tinymap m;
     m.load( player_location, false );
     m.build_outside_cache( m.get_abs_sub().z );
-    const point u( g->u.posx() % HALF_MAPSIZE_X, g->u.posy() % HALF_MAPSIZE_Y );
+    const point u( get_avatar().posx() % HALF_MAPSIZE_X, get_avatar().posy() % HALF_MAPSIZE_Y );
     std::vector<tripoint> valid;
     for( const tripoint &p : m.points_on_zlevel() ) {
         if( !( m.has_flag_ter( "DOOR", p ) ||

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -339,7 +339,7 @@ static int rate_location( map &m, const tripoint &p, const bool must_be_inside,
 void start_location::place_player( player &u ) const
 {
     // Need the "real" map with it's inside/outside cache and the like.
-    map &m = g->m;
+    map &m = get_map();
     // Start us off somewhere in the center of the map
     u.setx( HALF_MAPSIZE_X );
     u.sety( HALF_MAPSIZE_Y );

--- a/src/start_location.h
+++ b/src/start_location.h
@@ -45,7 +45,7 @@ class start_location
          */
         void prepare_map( const tripoint_abs_omt &omtstart ) const;
         /**
-         * Place the player somewhere in the reality bubble (g->m).
+         * Place the player somewhere in the reality bubble (get_map()).
          */
         void place_player( player &u ) const;
         /**

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -632,7 +632,7 @@ void Character::suffer_from_asthma( const int current_stim )
 
     if( in_sleep_state() && !has_effect( effect_narcosis ) ) {
         inventory map_inv;
-        map_inv.form_from_map( g->u.pos(), 2, &g->u );
+        map_inv.form_from_map( get_avatar().pos(), 2, &get_avatar() );
         // check if an inhaler is somewhere near
         bool nearby_use = auto_use || oxygenator || map_inv.has_charges( itype_inhaler, 1 ) ||
                           map_inv.has_charges( itype_oxygen_tank, 1 ) ||
@@ -655,11 +655,11 @@ void Character::suffer_from_asthma( const int current_stim )
             // create new variable to resolve a reference issue
             int amount = 1;
             map &here = get_map();
-            if( !here.use_charges( g->u.pos(), 2, itype_inhaler, amount ).empty() ) {
+            if( !here.use_charges( get_avatar().pos(), 2, itype_inhaler, amount ).empty() ) {
                 add_msg_if_player( m_info, _( "You use your inhaler and go back to sleep." ) );
                 add_effect( effect_took_antiasthmatic, rng( 1_hours, 2_hours ) );
-            } else if( !here.use_charges( g->u.pos(), 2, itype_oxygen_tank, amount ).empty() ||
-                       !here.use_charges( g->u.pos(), 2, itype_smoxygen_tank, amount ).empty() ) {
+            } else if( !here.use_charges( get_avatar().pos(), 2, itype_oxygen_tank, amount ).empty() ||
+                       !here.use_charges( get_avatar().pos(), 2, itype_smoxygen_tank, amount ).empty() ) {
                 add_msg_if_player( m_info, _( "You take a deep breath from your oxygen tank "
                                               "and go back to sleep." ) );
             }
@@ -1301,7 +1301,7 @@ void Character::suffer_from_bad_bionics()
         add_msg_if_player( m_bad, _( "You suffer a burning acidic discharge!" ) );
         hurtall( 1, nullptr );
         sfx::play_variant_sound( "bionics", "acid_discharge", 100 );
-        sfx::do_player_death_hurt( g->u, false );
+        sfx::do_player_death_hurt( get_avatar(), false );
     }
     if( has_bionic( bio_drain ) && get_power_level() > 24_kJ && one_turn_in( 1_hours ) ) {
         add_msg_if_player( m_bad, _( "Your batteries discharge slightly." ) );

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -90,7 +90,7 @@ bool teleport::teleport( Creature &critter, int min_distance, int max_distance, 
                                           poor_soul->disp_name() );
                 g->events().send<event_type::telefrags_creature>( p->getID(), poor_soul->get_name() );
             } else {
-                if( g->u.sees( *poor_soul ) ) {
+                if( get_avatar().sees( *poor_soul ) ) {
                     add_msg( m_good, _( "%1$s teleports into %2$s, killing them!" ),
                              critter.disp_name(), poor_soul->disp_name() );
                 }

--- a/src/timed_event.cpp
+++ b/src/timed_event.cpp
@@ -76,14 +76,15 @@ void timed_event::actualize()
                 pgettext( "memorial_male", "Drew the attention of more dark wyrms!" ),
                 pgettext( "memorial_female", "Drew the attention of more dark wyrms!" ) );
             // 50% chance to spawn a dark wyrm near every orifice on the level.
-            for( const tripoint &p : g->m.points_on_zlevel() ) {
-                if( g->m.ter( p ) == ter_id( "t_orifice" ) ) {
+            for( const tripoint &p : get_map().points_on_zlevel() ) {
+                if( get_map().ter( p ) == ter_id( "t_orifice" ) ) {
                     g->place_critter_around( mon_dark_wyrm, p, 1 );
                 }
             }
             // You could drop the flag, you know.
             if( get_avatar().has_amount( itype_petrified_eye, 1 ) ) {
-                sounds::sound( get_avatar().pos(), 60, sounds::sound_t::alert, _( "a tortured scream!" ), false, "shout",
+                sounds::sound( get_avatar().pos(), 60, sounds::sound_t::alert, _( "a tortured scream!" ), false,
+                               "shout",
                                "scream_tortured" );
                 if( !get_avatar().is_deaf() ) {
                     add_msg( _( "The eye you're carrying lets out a tortured scream!" ) );
@@ -98,10 +99,11 @@ void timed_event::actualize()
             int num_horrors = rng( 3, 5 );
             std::optional<tripoint> fault_point;
             bool horizontal = false;
-            for( const tripoint &p : g->m.points_on_zlevel() ) {
-                if( g->m.ter( p ) == t_fault ) {
+            for( const tripoint &p : get_map().points_on_zlevel() ) {
+                if( get_map().ter( p ) == t_fault ) {
                     fault_point = p;
-                    horizontal = g->m.ter( p + tripoint_east ) == t_fault || g->m.ter( p + tripoint_west ) == t_fault;
+                    horizontal = get_map().ter( p + tripoint_east ) == t_fault ||
+                                 get_map().ter( p + tripoint_west ) == t_fault;
                     break;
                 }
             }
@@ -111,7 +113,7 @@ void timed_event::actualize()
                     if( horizontal ) {
                         monp.x = rng( fault_point->x, fault_point->x + 2 * SEEX - 8 );
                         for( int n = -1; n <= 1; n++ ) {
-                            if( g->m.ter( point( monp.x, fault_point->y + n ) ) == t_rock_floor ) {
+                            if( get_map().ter( point( monp.x, fault_point->y + n ) ) == t_rock_floor ) {
                                 monp.y = fault_point->y + n;
                             }
                         }
@@ -119,7 +121,7 @@ void timed_event::actualize()
                         // Vertical fault
                         monp.y = rng( fault_point->y, fault_point->y + 2 * SEEY - 8 );
                         for( int n = -1; n <= 1; n++ ) {
-                            if( g->m.ter( point( fault_point->x + n, monp.y ) ) == t_rock_floor ) {
+                            if( get_map().ter( point( fault_point->x + n, monp.y ) ) == t_rock_floor ) {
                                 monp.x = fault_point->x + n;
                             }
                         }
@@ -134,9 +136,9 @@ void timed_event::actualize()
 
         case TIMED_EVENT_ROOTS_DIE:
             g->events().send<event_type::destroys_triffid_grove>();
-            for( const tripoint &p : g->m.points_on_zlevel() ) {
-                if( g->m.ter( p ) == t_root_wall && one_in( 3 ) ) {
-                    g->m.ter_set( p, t_underbrush );
+            for( const tripoint &p : get_map().points_on_zlevel() ) {
+                if( get_map().ter( p ) == t_root_wall && one_in( 3 ) ) {
+                    get_map().ter_set( p, t_underbrush );
                 }
             }
             break;
@@ -144,9 +146,9 @@ void timed_event::actualize()
         case TIMED_EVENT_TEMPLE_OPEN: {
             g->events().send<event_type::opens_temple>();
             bool saw_grate = false;
-            for( const tripoint &p : g->m.points_on_zlevel() ) {
-                if( g->m.ter( p ) == t_grate ) {
-                    g->m.ter_set( p, t_stairs_down );
+            for( const tripoint &p : get_map().points_on_zlevel() ) {
+                if( get_map().ter( p ) == t_grate ) {
+                    get_map().ter_set( p, t_stairs_down );
                     if( !saw_grate && get_avatar().sees( p ) ) {
                         saw_grate = true;
                     }
@@ -162,14 +164,14 @@ void timed_event::actualize()
             bool flooded = false;
 
             ter_id flood_buf[MAPSIZE_X][MAPSIZE_Y];
-            for( const tripoint &p : g->m.points_on_zlevel() ) {
-                flood_buf[p.x][p.y] = g->m.ter( p );
+            for( const tripoint &p : get_map().points_on_zlevel() ) {
+                flood_buf[p.x][p.y] = get_map().ter( p );
             }
-            for( const tripoint &p : g->m.points_on_zlevel() ) {
-                if( g->m.ter( p ) == t_water_sh ) {
+            for( const tripoint &p : get_map().points_on_zlevel() ) {
+                if( get_map().ter( p ) == t_water_sh ) {
                     bool deepen = false;
                     for( const tripoint &w : points_in_radius( p, 1 ) ) {
-                        if( g->m.ter( w ) == t_water_dp ) {
+                        if( get_map().ter( w ) == t_water_dp ) {
                             deepen = true;
                             break;
                         }
@@ -178,10 +180,10 @@ void timed_event::actualize()
                         flood_buf[p.x][p.y] = t_water_dp;
                         flooded = true;
                     }
-                } else if( g->m.ter( p ) == t_rock_floor ) {
+                } else if( get_map().ter( p ) == t_rock_floor ) {
                     bool flood = false;
                     for( const tripoint &w : points_in_radius( p, 1 ) ) {
-                        if( g->m.ter( w ) == t_water_dp || g->m.ter( w ) == t_water_sh ) {
+                        if( get_map().ter( w ) == t_water_dp || get_map().ter( w ) == t_water_sh ) {
                             flood = true;
                             break;
                         }
@@ -197,7 +199,7 @@ void timed_event::actualize()
                 return;
             }
             // Check if we should print a message
-            if( flood_buf[get_avatar().posx()][get_avatar().posy()] != g->m.ter( get_avatar().pos() ) ) {
+            if( flood_buf[get_avatar().posx()][get_avatar().posy()] != get_map().ter( get_avatar().pos() ) ) {
                 if( flood_buf[get_avatar().posx()][get_avatar().posy()] == t_water_sh ) {
                     add_msg( m_warning, _( "Water quickly floods up to your knees." ) );
                     g->memorial().add(
@@ -209,12 +211,12 @@ void timed_event::actualize()
                     g->memorial().add(
                         pgettext( "memorial_male", "Water level reached the ceiling." ),
                         pgettext( "memorial_female", "Water level reached the ceiling." ) );
-                    avatar_action::swim( g->m, get_avatar(), get_avatar().pos() );
+                    avatar_action::swim( get_map(), get_avatar(), get_avatar().pos() );
                 }
             }
-            // flood_buf is filled with correct tiles; now copy them back to g->m
-            for( const tripoint &p : g->m.points_on_zlevel() ) {
-                g->m.ter_set( p, flood_buf[p.x][p.y] );
+            // flood_buf is filled with correct tiles; now copy them back to get_map()
+            for( const tripoint &p : get_map().points_on_zlevel() ) {
+                get_map().ter_set( p, flood_buf[p.x][p.y] );
             }
             g->timed_events.add( TIMED_EVENT_TEMPLE_FLOOD,
                                  calendar::turn + rng( 2_turns, 3_turns ) );
@@ -243,7 +245,7 @@ void timed_event::per_turn()
         case TIMED_EVENT_WANTED: {
             // About once every 5 minutes. Suppress in classic zombie mode.
             if( g->get_levz() >= 0 && one_in( 50 ) && !get_option<bool>( "DISABLE_ROBOT_RESPONSE" ) ) {
-                point place = g->m.random_outdoor_tile();
+                point place = get_map().random_outdoor_tile();
                 if( place.x == -1 && place.y == -1 ) {
                     // We're safely indoors!
                     return;
@@ -263,7 +265,8 @@ void timed_event::per_turn()
                 when -= 1_turns;
                 return;
             }
-            if( calendar::once_every( time_duration::from_seconds( rng( 2, 3 ) ) ) && !get_avatar().is_deaf() ) {
+            if( calendar::once_every( time_duration::from_seconds( rng( 2, 3 ) ) ) &&
+                !get_avatar().is_deaf() ) {
                 add_msg( m_warning, _( "You hear screeches from the rock above and around you!" ) );
             }
             break;
@@ -276,8 +279,8 @@ void timed_event::per_turn()
 
         case timed_event_type::AMIGARA_WHISPERS: {
             bool faults = false;
-            for( const tripoint &p : g->m.points_on_zlevel() ) {
-                if( g->m.ter( p ) == t_fault ) {
+            for( const tripoint &p : get_map().points_on_zlevel() ) {
+                if( get_map().ter( p ) == t_fault ) {
                     faults = true;
                     break;
                 }

--- a/src/timed_event.cpp
+++ b/src/timed_event.cpp
@@ -56,14 +56,14 @@ void timed_event::actualize()
             break;
 
         case TIMED_EVENT_ROBOT_ATTACK: {
-            const auto u_pos = g->u.global_sm_location();
+            const auto u_pos = get_avatar().global_sm_location();
             if( rl_dist( u_pos, map_point ) <= 4 ) {
                 const mtype_id &robot_type = one_in( 2 ) ? mon_copbot : mon_riotbot;
 
-                g->events().send<event_type::becomes_wanted>( g->u.getID() );
+                g->events().send<event_type::becomes_wanted>( get_avatar().getID() );
                 point rob( u_pos.x > map_point.x ? 0 - SEEX * 2 : SEEX * 4,
                            u_pos.y > map_point.y ? 0 - SEEY * 2 : SEEY * 4 );
-                g->place_critter_at( robot_type, tripoint( rob, g->u.posz() ) );
+                g->place_critter_at( robot_type, tripoint( rob, get_avatar().posz() ) );
             }
         }
         break;
@@ -82,12 +82,12 @@ void timed_event::actualize()
                 }
             }
             // You could drop the flag, you know.
-            if( g->u.has_amount( itype_petrified_eye, 1 ) ) {
-                sounds::sound( g->u.pos(), 60, sounds::sound_t::alert, _( "a tortured scream!" ), false, "shout",
+            if( get_avatar().has_amount( itype_petrified_eye, 1 ) ) {
+                sounds::sound( get_avatar().pos(), 60, sounds::sound_t::alert, _( "a tortured scream!" ), false, "shout",
                                "scream_tortured" );
-                if( !g->u.is_deaf() ) {
+                if( !get_avatar().is_deaf() ) {
                     add_msg( _( "The eye you're carrying lets out a tortured scream!" ) );
-                    g->u.add_morale( MORALE_SCREAM, -15, 0, 30_minutes, 30_seconds );
+                    get_avatar().add_morale( MORALE_SCREAM, -15, 0, 30_minutes, 30_seconds );
                 }
             }
         }
@@ -107,7 +107,7 @@ void timed_event::actualize()
             }
             for( int i = 0; fault_point && i < num_horrors; i++ ) {
                 for( int tries = 0; tries < 10; ++tries ) {
-                    tripoint monp = g->u.pos();
+                    tripoint monp = get_avatar().pos();
                     if( horizontal ) {
                         monp.x = rng( fault_point->x, fault_point->x + 2 * SEEX - 8 );
                         for( int n = -1; n <= 1; n++ ) {
@@ -147,7 +147,7 @@ void timed_event::actualize()
             for( const tripoint &p : g->m.points_on_zlevel() ) {
                 if( g->m.ter( p ) == t_grate ) {
                     g->m.ter_set( p, t_stairs_down );
-                    if( !saw_grate && g->u.sees( p ) ) {
+                    if( !saw_grate && get_avatar().sees( p ) ) {
                         saw_grate = true;
                     }
                 }
@@ -197,8 +197,8 @@ void timed_event::actualize()
                 return;
             }
             // Check if we should print a message
-            if( flood_buf[g->u.posx()][g->u.posy()] != g->m.ter( g->u.pos() ) ) {
-                if( flood_buf[g->u.posx()][g->u.posy()] == t_water_sh ) {
+            if( flood_buf[get_avatar().posx()][get_avatar().posy()] != g->m.ter( get_avatar().pos() ) ) {
+                if( flood_buf[get_avatar().posx()][get_avatar().posy()] == t_water_sh ) {
                     add_msg( m_warning, _( "Water quickly floods up to your knees." ) );
                     g->memorial().add(
                         pgettext( "memorial_male", "Water level reached knees." ),
@@ -209,7 +209,7 @@ void timed_event::actualize()
                     g->memorial().add(
                         pgettext( "memorial_male", "Water level reached the ceiling." ),
                         pgettext( "memorial_female", "Water level reached the ceiling." ) );
-                    avatar_action::swim( g->m, g->u, g->u.pos() );
+                    avatar_action::swim( g->m, get_avatar(), get_avatar().pos() );
                 }
             }
             // flood_buf is filled with correct tiles; now copy them back to g->m
@@ -227,7 +227,7 @@ void timed_event::actualize()
                 }
             };
             const mtype_id &montype = random_entry( temple_monsters );
-            g->place_critter_around( montype, g->u.pos(), 2 );
+            g->place_critter_around( montype, get_avatar().pos(), 2 );
         }
         break;
 
@@ -248,8 +248,8 @@ void timed_event::per_turn()
                     // We're safely indoors!
                     return;
                 }
-                g->place_critter_at( mon_eyebot, tripoint( place, g->u.posz() ) );
-                if( g->u.sees( tripoint( place, g->u.posz() ) ) ) {
+                g->place_critter_at( mon_eyebot, tripoint( place, get_avatar().posz() ) );
+                if( get_avatar().sees( tripoint( place, get_avatar().posz() ) ) ) {
                     add_msg( m_warning, _( "An eyebot swoops down nearby!" ) );
                 }
                 // One eyebot per trigger is enough, really
@@ -263,7 +263,7 @@ void timed_event::per_turn()
                 when -= 1_turns;
                 return;
             }
-            if( calendar::once_every( time_duration::from_seconds( rng( 2, 3 ) ) ) && !g->u.is_deaf() ) {
+            if( calendar::once_every( time_duration::from_seconds( rng( 2, 3 ) ) ) && !get_avatar().is_deaf() ) {
                 add_msg( m_warning, _( "You hear screeches from the rock above and around you!" ) );
             }
             break;
@@ -318,7 +318,7 @@ void timed_event_manager::process()
 void timed_event_manager::add( const timed_event_type type, const time_point &when,
                                const int faction_id )
 {
-    add( type, when, faction_id, g->u.global_sm_location() );
+    add( type, when, faction_id, get_avatar().global_sm_location() );
 }
 
 void timed_event_manager::add( const timed_event_type type, const time_point &when,

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -65,7 +65,7 @@ static const mtype_id mon_shadow_snake( "mon_shadow_snake" );
 static float pit_effectiveness( const tripoint &p )
 {
     units::volume corpse_volume = 0_ml;
-    for( auto &pit_content : g->m.i_at( p ) ) {
+    for( auto &pit_content : get_map().i_at( p ) ) {
         if( pit_content->is_corpse() ) {
             corpse_volume += pit_content->volume();
         }
@@ -96,7 +96,7 @@ bool trapfunc::bubble( const tripoint &p, Creature *c, item * )
         }
     }
     sounds::sound( p, 18, sounds::sound_t::alarm, _( "Pop!" ), false, "trap", "bubble_wrap" );
-    g->m.remove_trap( p );
+    get_map().remove_trap( p );
     return true;
 }
 
@@ -122,7 +122,7 @@ bool trapfunc::glass( const tripoint &p, Creature *c, item * )
         }
     }
     sounds::sound( p, 10, sounds::sound_t::combat, _( "glass cracking!" ), false, "trap", "glass" );
-    g->m.remove_trap( p );
+    get_map().remove_trap( p );
     return true;
 }
 
@@ -145,7 +145,7 @@ bool trapfunc::beartrap( const tripoint &p, Creature *c, item * )
         return false;
     }
     sounds::sound( p, 8, sounds::sound_t::combat, _( "SNAP!" ), false, "trap", "bear_trap" );
-    g->m.remove_trap( p );
+    get_map().remove_trap( p );
     if( c != nullptr ) {
         // What got hit?
         const bodypart_id hit = one_in( 2 ) ? bodypart_id( "leg_l" ) : bodypart_id( "leg_r" );
@@ -164,7 +164,7 @@ bool trapfunc::beartrap( const tripoint &p, Creature *c, item * )
         c->deal_damage( nullptr, hit, d );
         c->check_dead_state();
     } else {
-        g->m.spawn_item( p, "beartrap" );
+        get_map().spawn_item( p, "beartrap" );
     }
     return true;
 }
@@ -253,7 +253,7 @@ bool trapfunc::caltrops_glass( const tripoint &p, Creature *c, item * )
         sounds::sound( p, 8, sounds::sound_t::combat, _( "glass cracking!" ), false, "trap",
                        "glass_caltrops" );
     }
-    g->m.remove_trap( p );
+    get_map().remove_trap( p );
     return true;
 }
 
@@ -274,7 +274,7 @@ bool trapfunc::tripwire( const tripoint &p, Creature *c, item * )
         if( z->has_effect( effect_ridden ) ) {
             add_msg( m_bad, _( "Your %s trips over a tripwire!" ), z->get_name() );
             std::vector<tripoint> valid;
-            for( const tripoint &jk : g->m.points_in_radius( p, 1 ) ) {
+            for( const tripoint &jk : get_map().points_in_radius( p, 1 ) ) {
                 if( g->is_empty( jk ) ) {
                     valid.push_back( jk );
                 }
@@ -293,7 +293,7 @@ bool trapfunc::tripwire( const tripoint &p, Creature *c, item * )
         }
     } else if( n != nullptr ) {
         std::vector<tripoint> valid;
-        for( const tripoint &jk : g->m.points_in_radius( p, 1 ) ) {
+        for( const tripoint &jk : get_map().points_in_radius( p, 1 ) ) {
             if( g->is_empty( jk ) ) {
                 valid.push_back( jk );
             }
@@ -402,11 +402,11 @@ bool trapfunc::crossbow( const tripoint &p, Creature *c, item * )
         }
         c->check_dead_state();
     }
-    g->m.remove_trap( p );
-    g->m.spawn_item( p, "crossbow" );
-    g->m.spawn_item( p, "string_36" );
+    get_map().remove_trap( p );
+    get_map().spawn_item( p, "crossbow" );
+    get_map().spawn_item( p, "string_36" );
     if( add_bolt ) {
-        g->m.spawn_item( p, "bolt_steel", 1, 1 );
+        get_map().spawn_item( p, "bolt_steel", 1, 1 );
     }
     return true;
 }
@@ -414,7 +414,7 @@ bool trapfunc::crossbow( const tripoint &p, Creature *c, item * )
 bool trapfunc::shotgun( const tripoint &p, Creature *c, item * )
 {
     sounds::sound( p, 60, sounds::sound_t::combat, _( "Kerblam!" ), false, "fire_gun",
-                   g->m.tr_at( p ).loadid == tr_shotgun_1 ? "shotgun_s" : "shotgun_d" );
+                   get_map().tr_at( p ).loadid == tr_shotgun_1 ? "shotgun_s" : "shotgun_d" );
     int shots = 1;
     if( c != nullptr ) {
         if( c->has_effect( effect_ridden ) ) {
@@ -427,7 +427,7 @@ bool trapfunc::shotgun( const tripoint &p, Creature *c, item * )
         if( n != nullptr ) {
             ///\EFFECT_STR_MAX increases chance of two shots from shotgun trap
             shots = ( one_in( 8 ) || one_in( 20 - n->str_max ) ? 2 : 1 );
-            if( g->m.tr_at( p ).loadid != tr_shotgun_2 ) {
+            if( get_map().tr_at( p ).loadid != tr_shotgun_2 ) {
                 shots = 1;
             }
             ///\EFFECT_DODGE reduces chance of being hit by shotgun trap
@@ -491,7 +491,7 @@ bool trapfunc::shotgun( const tripoint &p, Creature *c, item * )
                     break;
             }
             shots = ( one_in( 8 ) || one_in( chance ) ? 2 : 1 );
-            if( g->m.tr_at( p ).loadid != tr_shotgun_2 ) {
+            if( get_map().tr_at( p ).loadid != tr_shotgun_2 ) {
                 shots = 1;
             }
             if( seen ) {
@@ -503,9 +503,9 @@ bool trapfunc::shotgun( const tripoint &p, Creature *c, item * )
         c->check_dead_state();
     }
 
-    g->m.spawn_item( p, g->m.tr_at( p ).loadid == tr_shotgun_1 ? "shotgun_s" : "shotgun_d" );
-    g->m.spawn_item( p, "string_36" );
-    g->m.remove_trap( p );
+    get_map().spawn_item( p, get_map().tr_at( p ).loadid == tr_shotgun_1 ? "shotgun_s" : "shotgun_d" );
+    get_map().spawn_item( p, "string_36" );
+    get_map().remove_trap( p );
     return true;
 }
 
@@ -530,7 +530,7 @@ bool trapfunc::blade( const tripoint &, Creature *c, item * )
 bool trapfunc::snare_light( const tripoint &p, Creature *c, item * )
 {
     sounds::sound( p, 2, sounds::sound_t::combat, _( "Snap!" ), false, "trap", "snare" );
-    g->m.remove_trap( p );
+    get_map().remove_trap( p );
     if( c == nullptr ) {
         return false;
     }
@@ -556,7 +556,7 @@ bool trapfunc::snare_light( const tripoint &p, Creature *c, item * )
 bool trapfunc::snare_heavy( const tripoint &p, Creature *c, item * )
 {
     sounds::sound( p, 4, sounds::sound_t::combat, _( "Snap!" ), false, "trap", "snare" );
-    g->m.remove_trap( p );
+    get_map().remove_trap( p );
     if( c == nullptr ) {
         return false;
     }
@@ -621,7 +621,7 @@ bool trapfunc::landmine( const tripoint &p, Creature *c, item * )
                                   _( "<npcname> triggers a land mine!" ) );
     }
     explosion_handler::explosion( p, get_basic_explosion_data(), nullptr );
-    g->m.remove_trap( p );
+    get_map().remove_trap( p );
     return true;
 }
 
@@ -632,7 +632,7 @@ bool trapfunc::boobytrap( const tripoint &p, Creature *c, item * )
                                   _( "<npcname> triggers a booby trap!" ) );
     }
     explosion_handler::explosion( p, get_basic_explosion_data(), nullptr );
-    g->m.remove_trap( p );
+    get_map().remove_trap( p );
     return true;
 }
 
@@ -656,7 +656,7 @@ bool trapfunc::telepad( const tripoint &p, Creature *c, item * )
 
 bool trapfunc::goo( const tripoint &p, Creature *c, item * )
 {
-    g->m.remove_trap( p );
+    get_map().remove_trap( p );
     if( c == nullptr ) {
         return false;
     }
@@ -870,11 +870,11 @@ bool trapfunc::pit_spikes( const tripoint &p, Creature *c, item * )
         if( get_avatar().sees( p ) ) {
             add_msg( _( "The spears break!" ) );
         }
-        g->m.ter_set( p, t_pit );
+        get_map().ter_set( p, t_pit );
         // 4 spears to a pit
         for( int i = 0; i < 4; i++ ) {
             if( one_in( 3 ) ) {
-                g->m.spawn_item( p, "pointy_stick" );
+                get_map().spawn_item( p, "pointy_stick" );
             }
         }
     }
@@ -953,11 +953,11 @@ bool trapfunc::pit_glass( const tripoint &p, Creature *c, item * )
         if( get_avatar().sees( p ) ) {
             add_msg( _( "The shards shatter!" ) );
         }
-        g->m.ter_set( p, t_pit );
+        get_map().ter_set( p, t_pit );
         // 20 shards in a pit.
         for( int i = 0; i < 20; i++ ) {
             if( one_in( 3 ) ) {
-                g->m.spawn_item( p, "glass_shard" );
+                get_map().spawn_item( p, "glass_shard" );
             }
         }
     }
@@ -970,7 +970,7 @@ bool trapfunc::lava( const tripoint &p, Creature *c, item * )
         return false;
     }
     c->add_msg_player_or_npc( m_bad, _( "The %s burns you horribly!" ), _( "The %s burns <npcname>!" ),
-                              g->m.tername( p ) );
+                              get_map().tername( p ) );
     monster *z = dynamic_cast<monster *>( c );
     player *n = dynamic_cast<player *>( c );
     if( n != nullptr ) {
@@ -1045,7 +1045,7 @@ static bool sinkhole_safety_roll( player *p, const itype_id &itemname, const int
     }
 
     std::vector<tripoint> safe;
-    for( const tripoint &tmp : g->m.points_in_radius( p->pos(), 1 ) ) {
+    for( const tripoint &tmp : get_map().points_in_radius( p->pos(), 1 ) ) {
         if( here.passable( tmp ) && !here.obstructed_by_vehicle_rotation( p->pos(), tmp ) &&
             here.tr_at( tmp ).loadid != tr_pit ) {
             safe.push_back( tmp );
@@ -1100,8 +1100,8 @@ bool trapfunc::sinkhole( const tripoint &p, Creature *c, item *i )
         pl->add_msg_player_or_npc( m_warning, _( "The sinkhole collapses!" ),
                                    _( "A sinkhole under <npcname> collapses!" ) );
         if( success ) {
-            g->m.remove_trap( p );
-            g->m.ter_set( p, t_pit );
+            get_map().remove_trap( p );
+            get_map().ter_set( p, t_pit );
             return true;
         }
         pl->add_msg_player_or_npc( m_bad, _( "You fall into the sinkhole!" ),
@@ -1109,8 +1109,8 @@ bool trapfunc::sinkhole( const tripoint &p, Creature *c, item *i )
     } else {
         return false;
     }
-    g->m.remove_trap( p );
-    g->m.ter_set( p, t_pit );
+    get_map().remove_trap( p );
+    get_map().ter_set( p, t_pit );
     c->moves -= 100;
     pit( p, c, i );
     return true;
@@ -1125,7 +1125,7 @@ bool trapfunc::ledge( const tripoint &p, Creature *c, item * )
     if( m != nullptr && m->flies() ) {
         return false;
     }
-    if( !g->m.has_zlevels() ) {
+    if( !get_map().has_zlevels() ) {
         if( c == &get_avatar() ) {
             add_msg( m_warning, _( "You fall down a level!" ) );
             g->vertical_move( -1, true );
@@ -1158,7 +1158,7 @@ bool trapfunc::ledge( const tripoint &p, Creature *c, item * )
     tripoint where = p;
     tripoint below = where;
     below.z--;
-    while( g->m.valid_move( where, below, false, true ) ) {
+    while( get_map().valid_move( where, below, false, true ) ) {
         where.z--;
         if( g->critter_at( where ) != nullptr ) {
             where.z++;
@@ -1177,7 +1177,7 @@ bool trapfunc::ledge( const tripoint &p, Creature *c, item * )
         }
 
         std::vector<tripoint> valid;
-        for( const tripoint &pt : g->m.points_in_radius( below, 1 ) ) {
+        for( const tripoint &pt : get_map().points_in_radius( below, 1 ) ) {
             if( g->is_empty( pt ) ) {
                 valid.push_back( pt );
             }
@@ -1237,8 +1237,8 @@ bool trapfunc::temple_flood( const tripoint &p, Creature *c, item * )
         int &j = tmp.y;
         for( i = 0; i < MAPSIZE_X; i++ ) {
             for( j = 0; j < MAPSIZE_Y; j++ ) {
-                if( g->m.tr_at( tmp ).loadid == tr_temple_flood ) {
-                    g->m.remove_trap( tmp );
+                if( get_map().tr_at( tmp ).loadid == tr_temple_flood ) {
+                    get_map().remove_trap( tmp );
                 }
             }
         }
@@ -1253,29 +1253,29 @@ bool trapfunc::temple_toggle( const tripoint &p, Creature *c, item * )
     // Monsters and npcs are completely ignored here, should they?
     if( c == &get_avatar() ) {
         add_msg( _( "You hear the grinding of shifting rock." ) );
-        const ter_id type = g->m.ter( p );
+        const ter_id type = get_map().ter( p );
         tripoint tmp = p;
         int &i = tmp.x;
         int &j = tmp.y;
         for( i = 0; i < MAPSIZE_X; i++ ) {
             for( j = 0; j < MAPSIZE_Y; j++ ) {
                 if( type == t_floor_red ) {
-                    if( g->m.ter( tmp ) == t_rock_green ) {
-                        g->m.ter_set( tmp, t_floor_green );
-                    } else if( g->m.ter( tmp ) == t_floor_green ) {
-                        g->m.ter_set( tmp, t_rock_green );
+                    if( get_map().ter( tmp ) == t_rock_green ) {
+                        get_map().ter_set( tmp, t_floor_green );
+                    } else if( get_map().ter( tmp ) == t_floor_green ) {
+                        get_map().ter_set( tmp, t_rock_green );
                     }
                 } else if( type == t_floor_green ) {
-                    if( g->m.ter( tmp ) == t_rock_blue ) {
-                        g->m.ter_set( tmp, t_floor_blue );
-                    } else if( g->m.ter( tmp ) == t_floor_blue ) {
-                        g->m.ter_set( tmp, t_rock_blue );
+                    if( get_map().ter( tmp ) == t_rock_blue ) {
+                        get_map().ter_set( tmp, t_floor_blue );
+                    } else if( get_map().ter( tmp ) == t_floor_blue ) {
+                        get_map().ter_set( tmp, t_rock_blue );
                     }
                 } else if( type == t_floor_blue ) {
-                    if( g->m.ter( tmp ) == t_rock_red ) {
-                        g->m.ter_set( tmp, t_floor_red );
-                    } else if( g->m.ter( tmp ) == t_floor_red ) {
-                        g->m.ter_set( tmp, t_rock_red );
+                    if( get_map().ter( tmp ) == t_rock_red ) {
+                        get_map().ter_set( tmp, t_floor_red );
+                    } else if( get_map().ter( tmp ) == t_floor_red ) {
+                        get_map().ter_set( tmp, t_rock_red );
                     }
                 }
             }
@@ -1360,13 +1360,13 @@ bool trapfunc::shadow( const tripoint &p, Creature *c, item * )
             monp.x = p.x + ( one_in( 2 ) ? -5 : +5 );
             monp.y = p.y + rng( -5, +5 );
         }
-        if( !g->m.sees( monp, p, 10 ) ) {
+        if( !get_map().sees( monp, p, 10 ) ) {
             continue;
         }
         if( monster *const spawned = g->place_critter_at( mon_shadow, monp ) ) {
             spawned->add_msg_if_npc( m_warning, _( "A shadow forms nearby." ) );
             spawned->reset_special_rng( "DISAPPEAR" );
-            g->m.remove_trap( p );
+            get_map().remove_trap( p );
             break;
         }
     }
@@ -1417,11 +1417,11 @@ bool trapfunc::cast_spell( const tripoint &p, Creature *critter, item * )
     if( critter == nullptr ) {
         return false;
     }
-    const spell trap_spell = g->m.tr_at( p ).spell_data.get_spell( 0 );
+    const spell trap_spell = get_map().tr_at( p ).spell_data.get_spell( 0 );
     npc dummy;
     trap_spell.cast_all_effects( dummy, critter->pos() );
     trap_spell.make_sound( p, 20 );
-    g->m.remove_trap( p );
+    get_map().remove_trap( p );
     return true;
 }
 
@@ -1430,7 +1430,7 @@ bool trapfunc::snake( const tripoint &p, Creature *, item * )
     //~ the sound a snake makes
     sounds::sound( p, 10, sounds::sound_t::movement, _( "ssssssss" ), false, "misc", "snake_hiss" );
     if( one_in( 6 ) ) {
-        g->m.remove_trap( p );
+        get_map().remove_trap( p );
     }
     if( one_in( 3 ) ) {
         for( int tries = 0; tries < 10; tries++ ) {
@@ -1442,13 +1442,13 @@ bool trapfunc::snake( const tripoint &p, Creature *, item * )
                 monp.x = p.x + ( one_in( 2 ) ? -5 : +5 );
                 monp.y = p.y + rng( -5, +5 );
             }
-            if( !g->m.sees( monp, p, 10 ) ) {
+            if( !get_map().sees( monp, p, 10 ) ) {
                 continue;
             }
             if( monster *const spawned = g->place_critter_at( mon_shadow_snake, monp ) ) {
                 spawned->add_msg_if_npc( m_warning, _( "A shadowy snake forms nearby." ) );
                 spawned->reset_special_rng( "DISAPPEAR" );
-                g->m.remove_trap( p );
+                get_map().remove_trap( p );
                 break;
             }
         }

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -184,7 +184,7 @@ bool trapfunc::board( const tripoint &, Creature *c, item * )
     if( z != nullptr ) {
         if( z->has_effect( effect_ridden ) ) {
             add_msg( m_warning, _( "Your %s stepped on a spiked board!" ), c->get_name() );
-            g->u.moves -= 80;
+            get_avatar().moves -= 80;
         } else {
             z->moves -= 80;
         }
@@ -213,7 +213,7 @@ bool trapfunc::caltrops( const tripoint &, Creature *c, item * )
     if( z != nullptr ) {
         if( z->has_effect( effect_ridden ) ) {
             add_msg( m_warning, _( "Your %s steps on a sharp metal caltrop!" ), c->get_name() );
-            g->u.moves -= 80;
+            get_avatar().moves -= 80;
         } else {
             z->moves -= 80;
         }
@@ -248,7 +248,7 @@ bool trapfunc::caltrops_glass( const tripoint &p, Creature *c, item * )
         c->deal_damage( nullptr, bodypart_id( "foot_r" ), damage_instance( DT_CUT, rng( 9, 30 ) ) );
     }
     c->check_dead_state();
-    if( g->u.sees( p ) ) {
+    if( get_avatar().sees( p ) ) {
         add_msg( _( "The shards shatter!" ) );
         sounds::sound( p, 8, sounds::sound_t::combat, _( "glass cracking!" ), false, "trap",
                        "glass_caltrops" );
@@ -280,11 +280,11 @@ bool trapfunc::tripwire( const tripoint &p, Creature *c, item * )
                 }
             }
             if( !valid.empty() ) {
-                g->u.setpos( random_entry( valid ) );
-                z->setpos( g->u.pos() );
+                get_avatar().setpos( random_entry( valid ) );
+                z->setpos( get_avatar().pos() );
             }
-            g->u.moves -= 150;
-            g->update_map( g->u );
+            get_avatar().moves -= 150;
+            g->update_map( get_avatar() );
         } else {
             z->stumble();
         }
@@ -302,8 +302,8 @@ bool trapfunc::tripwire( const tripoint &p, Creature *c, item * )
             n->setpos( random_entry( valid ) );
         }
         n->moves -= 150;
-        if( c == &g->u ) {
-            g->update_map( g->u );
+        if( c == &get_avatar() ) {
+            g->update_map( get_avatar() );
         }
         if( !n->is_mounted() ) {
             ///\EFFECT_DEX decreases chance of taking damage from a tripwire trap
@@ -368,7 +368,7 @@ bool trapfunc::crossbow( const tripoint &p, Creature *c, item * )
                                           _( "<npcname> dodges the shot!" ) );
             }
         } else if( z != nullptr ) {
-            bool seen = g->u.sees( *z );
+            bool seen = get_avatar().sees( *z );
             int chance = 0;
             // adapted from shotgun code - chance of getting hit depends on size
             switch( z->type->size ) {
@@ -469,7 +469,7 @@ bool trapfunc::shotgun( const tripoint &p, Creature *c, item * )
                                           _( "<npcname> dodges the shot!" ) );
             }
         } else if( z != nullptr ) {
-            bool seen = g->u.sees( *z );
+            bool seen = get_avatar().sees( *z );
             int chance = 0;
             switch( z->type->size ) {
                 case MS_TINY:
@@ -643,10 +643,10 @@ bool trapfunc::telepad( const tripoint &p, Creature *c, item * )
     if( c == nullptr ) {
         return false;
     }
-    if( c == &g->u ) {
+    if( c == &get_avatar() ) {
         c->add_msg_if_player( m_warning, _( "The air shimmers around you…" ) );
     } else {
-        if( g->u.sees( p ) ) {
+        if( get_avatar().sees( p ) ) {
             add_msg( _( "The air shimmers around %s…" ), c->disp_name() );
         }
     }
@@ -676,7 +676,7 @@ bool trapfunc::goo( const tripoint &p, Creature *c, item * )
         return true;
     } else if( z != nullptr ) {
         if( z->has_effect( effect_ridden ) ) {
-            g->u.forced_dismount();
+            get_avatar().forced_dismount();
         }
         //All monsters except for blobs get a speed decrease
         if( z->type->id != mon_blob ) {
@@ -725,7 +725,7 @@ bool trapfunc::dissector( const tripoint &p, Creature *c, item * )
             ch->deal_damage( nullptr, bodypart_id( "leg_r" ), damage_instance( DT_CUT, 12 ) );
             ch->deal_damage( nullptr, bodypart_id( "foot_l" ), damage_instance( DT_CUT, 10 ) );
             ch->deal_damage( nullptr, bodypart_id( "foot_r" ), damage_instance( DT_CUT, 10 ) );
-            if( g->u.sees( p ) ) {
+            if( get_avatar().sees( p ) ) {
                 ch->add_msg_player_or_npc( m_bad, _( "Electrical beams emit from the floor and slice your flesh!" ),
                                            _( "Electrical beams emit from the floor and slice <npcname>s flesh!" ) );
             }
@@ -735,7 +735,7 @@ bool trapfunc::dissector( const tripoint &p, Creature *c, item * )
 
     //~ the sound of a dissector dissecting
     sounds::sound( p, 10, sounds::sound_t::combat, _( "BRZZZAP!" ), false, "trap", "dissector" );
-    if( g->u.sees( p ) ) {
+    if( get_avatar().sees( p ) ) {
         add_msg( m_bad, _( "Electrical beams emit from the floor and slice the %s!" ), c->get_name() );
     }
     c->deal_damage( nullptr, bodypart_id( "head" ), damage_instance( DT_CUT, 15 ) );
@@ -793,7 +793,7 @@ bool trapfunc::pit( const tripoint &p, Creature *c, item * )
     } else if( z != nullptr ) {
         if( z->has_effect( effect_ridden ) ) {
             add_msg( m_bad, _( "Your %s falls into a pit!" ), z->get_name() );
-            g->u.forced_dismount();
+            get_avatar().forced_dismount();
         }
         z->deal_damage( nullptr, bodypart_id( "leg_l" ), damage_instance( DT_BASH, eff * rng( 10, 20 ) ) );
         z->deal_damage( nullptr, bodypart_id( "leg_r" ), damage_instance( DT_BASH, eff * rng( 10, 20 ) ) );
@@ -861,13 +861,13 @@ bool trapfunc::pit_spikes( const tripoint &p, Creature *c, item * )
     } else if( z != nullptr ) {
         if( z->has_effect( effect_ridden ) ) {
             add_msg( m_bad, _( "Your %s falls into a pit!" ), z->get_name() );
-            g->u.forced_dismount();
+            get_avatar().forced_dismount();
         }
         z->deal_damage( nullptr, bodypart_id( "torso" ), damage_instance( DT_CUT, rng( 20, 50 ) ) );
     }
     c->check_dead_state();
     if( one_in( 4 ) ) {
-        if( g->u.sees( p ) ) {
+        if( get_avatar().sees( p ) ) {
             add_msg( _( "The spears break!" ) );
         }
         g->m.ter_set( p, t_pit );
@@ -944,13 +944,13 @@ bool trapfunc::pit_glass( const tripoint &p, Creature *c, item * )
     } else if( z != nullptr ) {
         if( z->has_effect( effect_ridden ) ) {
             add_msg( m_bad, _( "Your %s falls into a pit!" ), z->get_name() );
-            g->u.forced_dismount();
+            get_avatar().forced_dismount();
         }
         z->deal_damage( nullptr, bodypart_id( "torso" ), damage_instance( DT_CUT, rng( 20, 50 ) ) );
     }
     c->check_dead_state();
     if( one_in( 5 ) ) {
-        if( g->u.sees( p ) ) {
+        if( get_avatar().sees( p ) ) {
             add_msg( _( "The shards shatter!" ) );
         }
         g->m.ter_set( p, t_pit );
@@ -1060,7 +1060,7 @@ static bool sinkhole_safety_roll( player *p, const itype_id &itemname, const int
         p->add_msg_player_or_npc( m_good, _( "You pull yourself to safety!" ),
                                   _( "<npcname> steps on a sinkhole, but manages to pull themselves to safety." ) );
         p->setpos( random_entry( safe ) );
-        if( p == &g->u ) {
+        if( p == &get_avatar() ) {
             g->update_map( *p );
         }
 
@@ -1079,7 +1079,7 @@ bool trapfunc::sinkhole( const tripoint &p, Creature *c, item *i )
     if( z != nullptr ) {
         if( z->has_effect( effect_ridden ) ) {
             add_msg( m_bad, _( "Your %s falls into a sinkhole!" ), z->get_name() );
-            g->u.forced_dismount();
+            get_avatar().forced_dismount();
         }
     } else if( pl != nullptr ) {
         bool success = false;
@@ -1126,19 +1126,19 @@ bool trapfunc::ledge( const tripoint &p, Creature *c, item * )
         return false;
     }
     if( !g->m.has_zlevels() ) {
-        if( c == &g->u ) {
+        if( c == &get_avatar() ) {
             add_msg( m_warning, _( "You fall down a level!" ) );
             g->vertical_move( -1, true );
-            if( g->u.has_trait( trait_WINGS_BIRD ) || ( one_in( 2 ) &&
-                    g->u.has_trait( trait_WINGS_BUTTERFLY ) ) ) {
+            if( get_avatar().has_trait( trait_WINGS_BIRD ) || ( one_in( 2 ) &&
+                    get_avatar().has_trait( trait_WINGS_BUTTERFLY ) ) ) {
                 add_msg( _( "You flap your wings and flutter down gracefully." ) );
-            } else if( g->u.has_trait( trait_WEB_RAPPEL ) ) {
+            } else if( get_avatar().has_trait( trait_WEB_RAPPEL ) ) {
                 add_msg( _( "You quickly spin a line of silk and rappel down." ) );
-            } else if( g->u.has_active_bionic( bio_shock_absorber ) ) {
+            } else if( get_avatar().has_active_bionic( bio_shock_absorber ) ) {
                 add_msg( m_info,
                          _( "You hit the ground hard, but your shock absorbers handle the impact admirably!" ) );
             } else {
-                g->u.impact( 20, p );
+                get_avatar().impact( 20, p );
             }
         } else {
             c->add_msg_if_npc( _( "<npcname> falls down a level!" ) );
@@ -1230,7 +1230,7 @@ bool trapfunc::ledge( const tripoint &p, Creature *c, item * )
 bool trapfunc::temple_flood( const tripoint &p, Creature *c, item * )
 {
     // Monsters and npcs are completely ignored here, should they?
-    if( c == &g->u ) {
+    if( c == &get_avatar() ) {
         add_msg( m_warning, _( "You step on a loose tile, and water starts to flood the room!" ) );
         tripoint tmp = p;
         int &i = tmp.x;
@@ -1251,7 +1251,7 @@ bool trapfunc::temple_flood( const tripoint &p, Creature *c, item * )
 bool trapfunc::temple_toggle( const tripoint &p, Creature *c, item * )
 {
     // Monsters and npcs are completely ignored here, should they?
-    if( c == &g->u ) {
+    if( c == &get_avatar() ) {
         add_msg( _( "You hear the grinding of shifting rock." ) );
         const ter_id type = g->m.ter( p );
         tripoint tmp = p;
@@ -1300,7 +1300,7 @@ bool trapfunc::glow( const tripoint &p, Creature *c, item * )
         if( z->has_effect( effect_ridden ) ) {
             if( one_in( 3 ) ) {
                 add_msg( m_bad, _( "You're bathed in radiation!" ) );
-                g->u.irradiate( rng( 10, 30 ) );
+                get_avatar().irradiate( rng( 10, 30 ) );
             } else if( one_in( 4 ) ) {
                 add_msg( m_bad, _( "A blinding flash strikes you!" ) );
                 explosion_handler::flashbang( p, false, "explosion" );
@@ -1347,7 +1347,7 @@ bool trapfunc::hum( const tripoint &p, Creature *, item * )
 
 bool trapfunc::shadow( const tripoint &p, Creature *c, item * )
 {
-    if( c != &g->u ) {
+    if( c != &get_avatar() ) {
         return false;
     }
     // Monsters and npcs are completely ignored here, should they?

--- a/src/turret.cpp
+++ b/src/turret.cpp
@@ -392,7 +392,8 @@ bool vehicle::turrets_aim( std::vector<vehicle_part *> &turrets )
     }
 
     // Get target
-    target_handler::trajectory trajectory = target_handler::mode_turrets( get_avatar(), *this, turrets );
+    target_handler::trajectory trajectory = target_handler::mode_turrets( get_avatar(), *this,
+                                            turrets );
 
     bool got_target = !trajectory.empty();
     if( got_target ) {

--- a/src/turret.cpp
+++ b/src/turret.cpp
@@ -8,7 +8,6 @@
 #include "creature.h"
 #include "debug.h"
 #include "enums.h"
-#include "game.h"
 #include "gun_mode.h"
 #include "item.h"
 #include "itype.h"

--- a/src/turret.cpp
+++ b/src/turret.cpp
@@ -392,7 +392,7 @@ bool vehicle::turrets_aim( std::vector<vehicle_part *> &turrets )
     }
 
     // Get target
-    target_handler::trajectory trajectory = target_handler::mode_turrets( g->u, *this, turrets );
+    target_handler::trajectory trajectory = target_handler::mode_turrets( get_avatar(), *this, turrets );
 
     bool got_target = !trajectory.empty();
     if( got_target ) {
@@ -405,7 +405,7 @@ bool vehicle::turrets_aim( std::vector<vehicle_part *> &turrets )
         }
 
         ///\EFFECT_INT speeds up aiming of vehicle turrets
-        g->u.moves = std::min( 0, g->u.moves - 100 + ( 5 * g->u.int_cur ) );
+        get_avatar().moves = std::min( 0, get_avatar().moves - 100 + ( 5 * get_avatar().int_cur ) );
     }
     return got_target;
 }
@@ -562,8 +562,8 @@ int vehicle::automatic_fire_turret( vehicle_part &pt )
         area += area == 1 ? 1 : 2;
     }
 
-    const bool u_see = g->u.sees( pos );
-    const bool u_hear = !g->u.is_deaf();
+    const bool u_see = get_avatar().sees( pos );
+    const bool u_hear = !get_avatar().is_deaf();
     // The current target of the turret.
     auto &target = pt.target;
     if( target.first == target.second ) {
@@ -614,7 +614,7 @@ int vehicle::automatic_fire_turret( vehicle_part &pt )
 
     shots = gun.fire( *cpu, targ );
 
-    if( shots && u_see && !g->u.sees( targ ) ) {
+    if( shots && u_see && !get_avatar().sees( targ ) ) {
         add_msg( _( "The %1$s fires its %2$s!" ), name, pt.name() );
     }
 

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -985,10 +985,10 @@ struct pointmenu_cb::impl_t {
 pointmenu_cb::impl_t::impl_t( const std::vector<tripoint> &pts ) : points( pts )
 {
     last = INT_MIN;
-    last_view = g->u.view_offset;
+    last_view = get_avatar().view_offset;
     terrain_draw_cb = make_shared_fast<game::draw_callback_t>( [this]() {
         if( last >= 0 && static_cast<size_t>( last ) < points.size() ) {
-            g->draw_trail_to_square( g->u.view_offset, true );
+            g->draw_trail_to_square( get_avatar().view_offset, true );
         }
     } );
     g->add_draw_callback( terrain_draw_cb );
@@ -996,7 +996,7 @@ pointmenu_cb::impl_t::impl_t( const std::vector<tripoint> &pts ) : points( pts )
 
 pointmenu_cb::impl_t::~impl_t()
 {
-    g->u.view_offset = last_view;
+    get_avatar().view_offset = last_view;
 }
 
 void pointmenu_cb::impl_t::select( uilist *const menu )
@@ -1006,12 +1006,12 @@ void pointmenu_cb::impl_t::select( uilist *const menu )
     }
     last = menu->selected;
     if( menu->selected < 0 || menu->selected >= static_cast<int>( points.size() ) ) {
-        g->u.view_offset = tripoint_zero;
+        get_avatar().view_offset = tripoint_zero;
     } else {
         const tripoint &center = points[menu->selected];
-        g->u.view_offset = center - g->u.pos();
+        get_avatar().view_offset = center - get_avatar().pos();
         // TODO: Remove this line when it's safe
-        g->u.view_offset.z = 0;
+        get_avatar().view_offset.z = 0;
     }
     g->invalidate_main_ui_adaptor();
 }

--- a/src/units.h
+++ b/src/units.h
@@ -2,7 +2,6 @@
 #ifndef CATA_SRC_UNITS_H
 #define CATA_SRC_UNITS_H
 
-#include <limits>
 #include <ostream>
 #include <string>
 #include <utility>

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -638,7 +638,7 @@ class vehicle
          * @param handler A class that receives various callbacks, e.g. for placing items.
          * This handler is different when called during mapgen (when items need to be placed
          * on the temporary mapgen map), and when called during normal game play (when items
-         * go on the main map g->m).
+         * go on the main map get_map()).
          */
         bool remove_part( int p, RemovePartHandler &handler );
         bool remove_part( int p );

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1464,7 +1464,8 @@ bool vehicle::check_on_ramp( int idir, const tripoint &offset ) const
     for( auto &prt : get_all_parts() ) {
         tripoint partPoint = global_pos3() + offset + prt.part().precalc[idir];
 
-        if( g->m.has_flag( TFLAG_RAMP_UP, partPoint ) || g->m.has_flag( TFLAG_RAMP_DOWN, partPoint ) ) {
+        if( get_map().has_flag( TFLAG_RAMP_UP, partPoint ) ||
+            get_map().has_flag( TFLAG_RAMP_DOWN, partPoint ) ) {
             return true;
         }
     }

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -643,7 +643,7 @@ bool vehicle::can_enable( const vehicle_part &pt, bool alert ) const
         return false;
     }
 
-    if( pt.info().has_flag( "PLANTER" ) && !warm_enough_to_plant( g->u.pos() ) ) {
+    if( pt.info().has_flag( "PLANTER" ) && !warm_enough_to_plant( get_avatar().pos() ) ) {
         if( alert ) {
             add_msg( m_bad, _( "It is too cold to plant anything now." ) );
         }

--- a/src/vpart_position.h
+++ b/src/vpart_position.h
@@ -82,8 +82,8 @@ class vpart_position
          * Returns the position of this part in the coordinates system that @ref game::m uses.
          * Postcondition (if the vehicle cache of the map is correct and if there are un-removed
          * parts at this positions):
-         * `g->m.veh_at( this->pos() )` (there is a vehicle there)
-         * `g->m.veh_at( this->pos() )->vehicle() == this->vehicle()` (it's this one)
+         * `get_map().veh_at( this->pos() )` (there is a vehicle there)
+         * `get_map().veh_at( this->pos() )->vehicle() == this->vehicle()` (it's this one)
          */
         // Name chosen to match Creature::pos
         tripoint pos() const;

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -76,7 +76,8 @@ static bool is_player_outside()
 void glare( const weather_type_id &w )
 {
     //General prepequisites for glare
-    if( !is_player_outside() || !g->is_in_sunlight( get_avatar().pos() ) || get_avatar().in_sleep_state() ||
+    if( !is_player_outside() || !g->is_in_sunlight( get_avatar().pos() ) ||
+        get_avatar().in_sleep_state() ||
         get_avatar().worn_with_flag( json_flag_SUN_GLASSES ) ||
         get_avatar().has_bionic( bio_sunglasses ) ||
         get_avatar().is_blind() ) {
@@ -322,7 +323,7 @@ static void fill_funnels( int rain_depth_mm_per_hour, bool acid, const trap &tr 
 {
     const double turns_per_charge = tr.funnel_turns_per_charge( rain_depth_mm_per_hour );
     // Give each funnel on the map a chance to collect the rain.
-    const std::vector<tripoint> &funnel_locs = g->m.trap_locations( tr.loadid );
+    const std::vector<tripoint> &funnel_locs = get_map().trap_locations( tr.loadid );
     for( const tripoint &loc : funnel_locs ) {
         units::volume maxcontains = 0_ml;
         if( one_in( turns_per_charge ) ) {
@@ -331,7 +332,7 @@ static void fill_funnels( int rain_depth_mm_per_hour, bool acid, const trap &tr 
             // This funnel has collected some rain! Put the rain in the largest
             // container here which is either empty or contains some mixture of
             // impure water and acid.
-            map_stack items = g->m.i_at( loc );
+            map_stack items = get_map().i_at( loc );
             auto container = items.end();
             for( auto candidate_container = items.begin(); candidate_container != items.end();
                  ++candidate_container ) {
@@ -464,7 +465,8 @@ void weather_effect::light_acid( int intensity )
 {
     if( calendar::once_every( time_duration::from_seconds( intensity ) ) && is_player_outside() ) {
         if( get_avatar().primary_weapon().has_flag( json_flag_RAIN_PROTECT ) && !one_in( 3 ) ) {
-            add_msg( _( "Your %s protects you from the acidic drizzle." ), get_avatar().primary_weapon().tname() );
+            add_msg( _( "Your %s protects you from the acidic drizzle." ),
+                     get_avatar().primary_weapon().tname() );
         } else {
             if( get_avatar().worn_with_flag( json_flag_RAINPROOF ) && !one_in( 4 ) ) {
                 add_msg( _( "Your clothing protects you from the acidic drizzle." ) );
@@ -541,7 +543,7 @@ void handle_weather_effects( const weather_type_id &w )
             decay_time = 45_turns;
             wetness = 60;
         }
-        g->m.decay_fields_and_scent( decay_time );
+        get_map().decay_fields_and_scent( decay_time );
         weather_effect::wet_player( wetness );
     }
     glare( w );
@@ -969,7 +971,7 @@ double get_local_windpower( double windpower, const oter_id &omter, const tripoi
 
 bool is_wind_blocker( const tripoint &location )
 {
-    return g->m.has_flag( "BLOCK_WIND", location );
+    return get_map().has_flag( "BLOCK_WIND", location );
 }
 
 // Description of Wind Speed - https://en.wikipedia.org/wiki/Beaufort_scale
@@ -1131,7 +1133,7 @@ int weather_manager::get_temperature( const tripoint &location ) const
                        : temperature ) +
                      ( g->new_game
                        ? 0
-                       : g->m.get_temperature( location ) + temp_mod );
+                       : get_map().get_temperature( location ) + temp_mod );
 
     temperature_cache.emplace( location, temp );
     return temp;

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -761,7 +761,7 @@ void debug_menu::wishitem( player *p, const tripoint &pos )
                     }
                     p->invalidate_crafting_inventory();
                 } else if( pos.x >= 0 && pos.y >= 0 ) {
-                    g->m.add_item_or_charges( pos, item::spawn( *granted ) );
+                    get_map().add_item_or_charges( pos, item::spawn( *granted ) );
                     wmenu.ret = -1;
                 }
                 if( amount > 0 ) {

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -19,7 +19,6 @@
 #include "enums.h"
 #include "filesystem.h"
 #include "fstream_utils.h"
-#include "game.h"
 #include "ime.h"
 #include "input.h"
 #include "json.h"

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -21,7 +21,6 @@
 #include "enums.h"
 #include "filesystem.h"
 #include "fstream_utils.h"
-#include "game.h"
 #include "ime.h"
 #include "input.h"
 #include "json.h"

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -4,14 +4,12 @@
 #include <array>
 #include <cstdio>
 #include <cstdlib>
-#include <fstream>
 #include <iterator>
 #include <memory>
 #include <set>
 #include <unordered_map>
 #include <utility>
 
-#include "cata_utility.h"
 #include "catacharset.h"
 #include "catalua.h"
 #include "char_validity_check.h"
@@ -21,6 +19,7 @@
 #include "enums.h"
 #include "filesystem.h"
 #include "fstream_utils.h"
+#include "game.h"
 #include "ime.h"
 #include "input.h"
 #include "json.h"
@@ -327,7 +326,7 @@ void worldfactory::init()
             for( auto &origin_file : get_files_from_path( ".", origin_path, false ) ) {
                 std::string filename = origin_file.substr( origin_file.find_last_of( "/\\" ) );
 
-                rename( origin_file.c_str(), ( newworld->folder_path() + filename ).c_str() );
+                ( void )rename( origin_file.c_str(), ( newworld->folder_path() + filename ).c_str() );
             }
             newworld->world_saves = old_world.world_saves;
             newworld->WORLD_OPTIONS = old_world.WORLD_OPTIONS;
@@ -570,7 +569,7 @@ WORLDPTR worldfactory::pick_world( bool show_prompt, bool empty_only )
             } while( world_pages[selpage].empty() );
         } else if( action == "CONFIRM" ) {
             WORLDPTR world = get_world( world_pages[selpage][sel] );
-            if( !( world->needs_lua() && !cata::has_lua() ) ) {
+            if( !world->needs_lua() || cata::has_lua() ) {
                 return world;
             }
         }

--- a/tests/active_item_cache_test.cpp
+++ b/tests/active_item_cache_test.cpp
@@ -17,11 +17,11 @@ TEST_CASE( "place_active_item_at_various_coordinates", "[item]" )
     for( int z = -OVERMAP_DEPTH; z < OVERMAP_HEIGHT; ++z ) {
         for( int x = 0; x < MAPSIZE_X; ++x ) {
             for( int y = 0; y < MAPSIZE_Y; ++y ) {
-                g->m.i_clear( { x, y, z } );
+                get_map().i_clear( { x, y, z } );
             }
         }
     }
-    REQUIRE( g->m.get_submaps_with_active_items().empty() );
+    REQUIRE( get_map().get_submaps_with_active_items().empty() );
     // An arbitrary active item.
     item &active = *item::spawn_temporary( "firecracker_act", calendar::start_of_cataclysm,
                                            item::default_charges_tag() );
@@ -31,22 +31,22 @@ TEST_CASE( "place_active_item_at_various_coordinates", "[item]" )
     int z = 0;
     for( int x = 0; x < MAPSIZE_X; ++x ) {
         for( int y = 0; y < MAPSIZE_Y; ++y ) {
-            REQUIRE( g->m.i_at( { x, y, z } ).empty() );
+            REQUIRE( get_map().i_at( { x, y, z } ).empty() );
             CAPTURE( x, y, z );
-            tripoint abs_loc = g->m.get_abs_sub() + tripoint( x / SEEX, y / SEEY, z );
+            tripoint abs_loc = get_map().get_abs_sub() + tripoint( x / SEEX, y / SEEY, z );
             CAPTURE( abs_loc.x, abs_loc.y, abs_loc.z );
-            REQUIRE( g->m.get_submaps_with_active_items().empty() );
-            REQUIRE( g->m.get_submaps_with_active_items().find( abs_loc ) ==
-                     g->m.get_submaps_with_active_items().end() );
+            REQUIRE( get_map().get_submaps_with_active_items().empty() );
+            REQUIRE( get_map().get_submaps_with_active_items().find( abs_loc ) ==
+                     get_map().get_submaps_with_active_items().end() );
             detached_ptr<item> n = item::spawn( active );
             item &item_ref = *n;
-            g->m.add_item( { x, y, z }, std::move( n ) );
+            get_map().add_item( { x, y, z }, std::move( n ) );
             REQUIRE( item_ref.active );
-            REQUIRE_FALSE( g->m.get_submaps_with_active_items().empty() );
-            REQUIRE( g->m.get_submaps_with_active_items().find( abs_loc ) !=
-                     g->m.get_submaps_with_active_items().end() );
-            REQUIRE_FALSE( g->m.i_at( { x, y, z } ).empty() );
-            g->m.i_clear( { x, y, z } );
+            REQUIRE_FALSE( get_map().get_submaps_with_active_items().empty() );
+            REQUIRE( get_map().get_submaps_with_active_items().find( abs_loc ) !=
+                     get_map().get_submaps_with_active_items().end() );
+            REQUIRE_FALSE( get_map().i_at( { x, y, z } ).empty() );
+            get_map().i_clear( { x, y, z } );
         }
     }
 }

--- a/tests/active_item_cache_test.cpp
+++ b/tests/active_item_cache_test.cpp
@@ -4,7 +4,6 @@
 #include <set>
 
 #include "calendar.h"
-#include "game.h"
 #include "game_constants.h"
 #include "item.h"
 #include "map.h"

--- a/tests/basecamp_test.cpp
+++ b/tests/basecamp_test.cpp
@@ -3,8 +3,6 @@
 #include "calendar.h"
 #include "clzones.h"
 #include "faction.h"
-#include "game.h"
-#include "game_constants.h"
 #include "map.h"
 #include "overmapbuffer.h"
 #include "point.h"

--- a/tests/basecamp_test.cpp
+++ b/tests/basecamp_test.cpp
@@ -56,20 +56,20 @@ TEST_CASE( "distribute_food" )
     clear_all_state();
     constexpr tripoint origin( 60, 60, 0 );
     constexpr tripoint thirty_steps_rd = tripoint( 30, 30, 0 );
-    g->u.setpos( origin );
+    get_avatar().setpos( origin );
     const tripoint origin_abs = get_map().getabs( origin );
-    const tripoint_abs_omt omt_pos = g->u.global_omt_location();
+    const tripoint_abs_omt omt_pos = get_avatar().global_omt_location();
     g->m.add_camp( omt_pos, "faction_camp_for_distribute" );
     basecamp *bcp = overmap_buffer.find_camp( omt_pos.xy() ).value();
     bcp->set_bb_pos( origin_abs + tripoint_east );
     zone_manager &zmgr = zone_manager::get_manager();
-    const faction *yours = g->u.get_faction();
+    const faction *yours = get_avatar().get_faction();
     zmgr.add( "Zone for dumping food", zone_type_id( "CAMP_FOOD" ),
-              g->u.get_faction()->id, false, true,
+              get_avatar().get_faction()->id, false, true,
               origin_abs - thirty_steps_rd,
               origin_abs + thirty_steps_rd );
     zmgr.add( "Storage zone", zone_type_id( "CAMP_STORAGE" ),
-              g->u.get_faction()->id, false, true,
+              get_avatar().get_faction()->id, false, true,
               origin_abs - thirty_steps_rd,
               origin_abs + thirty_steps_rd );
 

--- a/tests/char_stamina_test.cpp
+++ b/tests/char_stamina_test.cpp
@@ -125,7 +125,7 @@ static float actual_regen_rate( player &dummy, int moves )
 TEST_CASE( "stamina movement cost modifier", "[stamina][cost]" )
 {
     clear_all_state();
-    player &dummy = g->u;
+    player &dummy = get_avatar();
 
     SECTION( "running cost is double walking cost for the same stamina level" ) {
         CHECK( move_cost_mod( dummy, CMM_RUN, 1.0 ) == 2 * move_cost_mod( dummy, CMM_WALK, 1.0 ) );
@@ -167,7 +167,7 @@ TEST_CASE( "stamina movement cost modifier", "[stamina][cost]" )
 TEST_CASE( "modify character stamina", "[stamina][modify]" )
 {
     clear_all_state();
-    player &dummy = g->u;
+    player &dummy = get_avatar();
     clear_character( dummy );
     REQUIRE_FALSE( dummy.is_npc() );
 
@@ -229,7 +229,7 @@ TEST_CASE( "modify character stamina", "[stamina][modify]" )
 TEST_CASE( "stamina burn for movement", "[stamina][burn][move]" )
 {
     clear_all_state();
-    player &dummy = g->u;
+    player &dummy = get_avatar();
 
     // Defined in game_balance.json
     const int normal_burn_rate = get_option<int>( "PLAYER_BASE_STAMINA_BURN_RATE" );
@@ -293,7 +293,7 @@ TEST_CASE( "stamina burn for movement", "[stamina][burn][move]" )
 TEST_CASE( "burning stamina when overburdened may cause pain", "[stamina][burn][pain]" )
 {
     clear_all_state();
-    player &dummy = g->u;
+    player &dummy = get_avatar();
     int pain_before;
     int pain_after;
 
@@ -337,7 +337,7 @@ TEST_CASE( "burning stamina when overburdened may cause pain", "[stamina][burn][
 TEST_CASE( "stamina regeneration rate", "[stamina][update][regen]" )
 {
     clear_all_state();
-    player &dummy = g->u;
+    player &dummy = get_avatar();
     clear_character( dummy, false );
     int turn_moves = to_moves<int>( 1_turns );
 
@@ -356,7 +356,7 @@ TEST_CASE( "stamina regeneration rate", "[stamina][update][regen]" )
 TEST_CASE( "stamina regen in different movement modes", "[stamina][update][regen][mode]" )
 {
     clear_all_state();
-    player &dummy = g->u;
+    player &dummy = get_avatar();
     clear_character( dummy );
 
     int turn_moves = to_moves<int>( 1_turns );
@@ -389,7 +389,7 @@ TEST_CASE( "stamina regen in different movement modes", "[stamina][update][regen
 TEST_CASE( "stamina regen with mouth encumbrance", "[stamina][update][regen][encumbrance]" )
 {
     clear_all_state();
-    player &dummy = g->u;
+    player &dummy = get_avatar();
     clear_character( dummy );
 
     int turn_moves = to_moves<int>( 1_turns );

--- a/tests/char_stamina_test.cpp
+++ b/tests/char_stamina_test.cpp
@@ -1,19 +1,15 @@
 #include "catch/catch.hpp"
 
-#include <memory>
-
 #include "avatar.h"
 #include "bodypart.h"
 #include "calendar.h"
 #include "character.h"
-#include "game.h"
 #include "item.h"
 #include "options.h"
 #include "player.h"
 #include "player_helpers.h"
 #include "state_helpers.h"
 #include "type_id.h"
-#include "units.h"
 
 // These test cases cover stamina-related functions in the `Character` class, including:
 //

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -312,7 +312,7 @@ static void prep_craft( const recipe_id &rid, std::vector<detached_ptr<item>> &t
     }
     // and just in case "used" skill difficulty is higher, set that too
     get_avatar().set_skill_level( r.skill_used, std::max( r.difficulty,
-                          get_avatar().get_skill_level( r.skill_used ) ) );
+                                  get_avatar().get_skill_level( r.skill_used ) ) );
 
     const inventory &crafting_inv = get_avatar().crafting_inventory();
     bool can_craft = r.deduped_requirements().can_make_with_inventory(

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -298,23 +298,23 @@ static void prep_craft( const recipe_id &rid, std::vector<detached_ptr<item>> &t
 {
     clear_avatar();
     const tripoint test_origin( 60, 60, 0 );
-    g->u.setpos( test_origin );
-    g->u.wear_item( item::spawn( "backpack" ), false );
+    get_avatar().setpos( test_origin );
+    get_avatar().wear_item( item::spawn( "backpack" ), false );
     for( detached_ptr<item> &gear : tools ) {
-        g->u.i_add( std::move( gear ) );
+        get_avatar().i_add( std::move( gear ) );
     }
 
     const recipe &r = rid.obj();
 
     // Ensure adequate skill for all "required" skills
     for( const std::pair<const skill_id, int> &skl : r.required_skills ) {
-        g->u.set_skill_level( skl.first, skl.second );
+        get_avatar().set_skill_level( skl.first, skl.second );
     }
     // and just in case "used" skill difficulty is higher, set that too
-    g->u.set_skill_level( r.skill_used, std::max( r.difficulty,
-                          g->u.get_skill_level( r.skill_used ) ) );
+    get_avatar().set_skill_level( r.skill_used, std::max( r.difficulty,
+                          get_avatar().get_skill_level( r.skill_used ) ) );
 
-    const inventory &crafting_inv = g->u.crafting_inventory();
+    const inventory &crafting_inv = get_avatar().crafting_inventory();
     bool can_craft = r.deduped_requirements().can_make_with_inventory(
                          crafting_inv, r.get_component_filter() );
     REQUIRE( can_craft == expect_craftable );
@@ -535,21 +535,21 @@ static void verify_inventory( const std::vector<std::string> &has,
 {
     std::ostringstream os;
     os << "Inventory:\n";
-    for( const item *i : g->u.inv_dump() ) {
+    for( const item *i : get_avatar().inv_dump() ) {
         os << "  " << i->typeId().str() << " (" << i->charges << ")\n";
     }
-    os << "Wielded:\n" << g->u.primary_weapon().tname() << "\n";
+    os << "Wielded:\n" << get_avatar().primary_weapon().tname() << "\n";
     INFO( os.str() );
     for( const std::string &i : has ) {
         INFO( "expecting " << i );
         const bool has_item =
-            player_has_item_of_type( i ) || g->u.primary_weapon().type->get_id() == itype_id( i );
+            player_has_item_of_type( i ) || get_avatar().primary_weapon().type->get_id() == itype_id( i );
         REQUIRE( has_item );
     }
     for( const std::string &i : hasnt ) {
         INFO( "not expecting " << i );
         const bool hasnt_item =
-            !player_has_item_of_type( i ) && !( g->u.primary_weapon().type->get_id() == itype_id( i ) );
+            !player_has_item_of_type( i ) && !( get_avatar().primary_weapon().type->get_id() == itype_id( i ) );
         REQUIRE( hasnt_item );
     }
 }

--- a/tests/creature_in_field_test.cpp
+++ b/tests/creature_in_field_test.cpp
@@ -1,8 +1,5 @@
 #include "catch/catch.hpp"
 
-#include <memory>
-
-#include "game.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "monster.h"

--- a/tests/effective_dps_test.cpp
+++ b/tests/effective_dps_test.cpp
@@ -5,7 +5,6 @@
 #include <memory>
 
 #include "avatar.h"
-#include "game.h"
 #include "item.h"
 #include "melee.h"
 #include "monster.h"

--- a/tests/effective_dps_test.cpp
+++ b/tests/effective_dps_test.cpp
@@ -104,7 +104,7 @@ static void check_accuracy_dps( avatar &attacker, monster &defender, item &wpn1,
 TEST_CASE( "effective damage per second", "[effective][dps]" )
 {
     clear_all_state();
-    avatar &dummy = g->u;
+    avatar &dummy = get_avatar();
     clear_character( dummy );
 
     item &clumsy_sword = *item::spawn_temporary( "test_clumsy_sword" );
@@ -168,7 +168,7 @@ TEST_CASE( "effective damage per second", "[effective][dps]" )
 TEST_CASE( "effective vs actual damage per second", "[actual][dps][!mayfail]" )
 {
     clear_all_state();
-    avatar &dummy = g->u;
+    avatar &dummy = get_avatar();
     clear_character( dummy );
 
     monster soldier( mtype_id( "mon_zombie_soldier" ) );
@@ -201,7 +201,7 @@ TEST_CASE( "effective vs actual damage per second", "[actual][dps][!mayfail]" )
 TEST_CASE( "accuracy increases success", "[accuracy][dps]" )
 {
     clear_all_state();
-    avatar &dummy = g->u;
+    avatar &dummy = get_avatar();
     clear_character( dummy );
 
     monster soldier( mtype_id( "mon_zombie_soldier" ) );

--- a/tests/encumbrance_test.cpp
+++ b/tests/encumbrance_test.cpp
@@ -11,7 +11,6 @@
 #include "bodypart.h"
 #include "character.h"
 #include "character_encumbrance.h"
-#include "game.h"
 #include "item.h"
 #include "material.h"
 #include "npc.h"

--- a/tests/encumbrance_test.cpp
+++ b/tests/encumbrance_test.cpp
@@ -50,7 +50,7 @@ static void test_encumbrance_items(
 )
 {
     // Test NPC first because NPC code can accidentally end up using properties
-    // of g->u, and such bugs are hidden if we test the other way around.
+    // of get_avatar(), and such bugs are hidden if we test the other way around.
     SECTION( "testing on npc" ) {
         npc example_npc;
         test_encumbrance_on( example_npc, clothing, body_part, expected_encumbrance, tweak_player );

--- a/tests/explosion_balance_test.cpp
+++ b/tests/explosion_balance_test.cpp
@@ -39,7 +39,7 @@ void set_off_explosion( item &explosive, const tripoint &origin )
 {
     explosion_handler::get_explosion_queue().clear();
     explosive.charges = 0;
-    explosive.type->invoke( g->u, explosive, origin );
+    explosive.type->invoke( get_avatar(), explosive, origin );
     explosion_handler::get_explosion_queue().execute();
 }
 

--- a/tests/explosion_balance_test.cpp
+++ b/tests/explosion_balance_test.cpp
@@ -184,7 +184,7 @@ TEST_CASE( "shrapnel behind wall", "[grenade][explosion][balance]" )
 
     for( const tripoint &pt : closest_points_first( origin, 2 ) ) {
         if( square_dist( origin, pt ) > 1 ) {
-            g->m.ter_set( pt, t_wall_metal );
+            get_map().ter_set( pt, t_wall_metal );
         }
     }
 

--- a/tests/item_tname_test.cpp
+++ b/tests/item_tname_test.cpp
@@ -256,7 +256,7 @@ TEST_CASE( "weapon fouling", "[item][tname][fouling][dirt]" )
 
         // Ensure the player and gun are normal size to prevent "too big" or "too small" suffix in tname
         get_avatar().clear_mutations();
-        REQUIRE( gun.get_sizing( g-> u ) == item::sizing::ignore );
+        REQUIRE( gun.get_sizing( get_avatar() ) == item::sizing::ignore );
         REQUIRE_FALSE( gun.has_flag( flag_OVERSIZE ) );
         REQUIRE_FALSE( gun.has_flag( flag_UNDERSIZE ) );
 

--- a/tests/item_tname_test.cpp
+++ b/tests/item_tname_test.cpp
@@ -39,7 +39,7 @@ static const skill_id skill_survival( "survival" );
 TEST_CASE( "food with hidden effects", "[item][tname][hidden]" )
 {
     clear_all_state();
-    g->u.clear_mutations();
+    get_avatar().clear_mutations();
 
     GIVEN( "food with hidden poison" ) {
         item &coffee = *item::spawn_temporary( "coffee_pod" );
@@ -47,8 +47,8 @@ TEST_CASE( "food with hidden effects", "[item][tname][hidden]" )
         REQUIRE( coffee.has_flag( flag_HIDDEN_POISON ) );
 
         WHEN( "avatar has level 2 survival skill" ) {
-            g->u.set_skill_level( skill_survival, 2 );
-            REQUIRE( g->u.get_skill_level( skill_survival ) == 2 );
+            get_avatar().set_skill_level( skill_survival, 2 );
+            REQUIRE( get_avatar().get_skill_level( skill_survival ) == 2 );
 
             THEN( "they cannot see it is poisonous" ) {
                 CHECK( coffee.tname() == "Kentucky coffee pod" );
@@ -56,8 +56,8 @@ TEST_CASE( "food with hidden effects", "[item][tname][hidden]" )
         }
 
         WHEN( "avatar has level 3 survival skill" ) {
-            g->u.set_skill_level( skill_survival, 3 );
-            REQUIRE( g->u.get_skill_level( skill_survival ) == 3 );
+            get_avatar().set_skill_level( skill_survival, 3 );
+            REQUIRE( get_avatar().get_skill_level( skill_survival ) == 3 );
 
             THEN( "they see it is poisonous" ) {
                 CHECK( coffee.tname() == "Kentucky coffee pod (poisonous)" );
@@ -72,8 +72,8 @@ TEST_CASE( "food with hidden effects", "[item][tname][hidden]" )
         REQUIRE( mushroom.has_flag( flag_HIDDEN_HALLU ) );
 
         WHEN( "avatar has level 4 survival skill" ) {
-            g->u.set_skill_level( skill_survival, 4 );
-            REQUIRE( g->u.get_skill_level( skill_survival ) == 4 );
+            get_avatar().set_skill_level( skill_survival, 4 );
+            REQUIRE( get_avatar().get_skill_level( skill_survival ) == 4 );
 
             THEN( "they cannot see it is hallucinogenic" ) {
                 CHECK( mushroom.tname() == "mushroom (fresh)" );
@@ -81,8 +81,8 @@ TEST_CASE( "food with hidden effects", "[item][tname][hidden]" )
         }
 
         WHEN( "avatar has level 5 survival skill" ) {
-            g->u.set_skill_level( skill_survival, 5 );
-            REQUIRE( g->u.get_skill_level( skill_survival ) == 5 );
+            get_avatar().set_skill_level( skill_survival, 5 );
+            REQUIRE( get_avatar().get_skill_level( skill_survival ) == 5 );
 
             THEN( "they see it is hallucinogenic" ) {
                 CHECK( mushroom.tname() == "mushroom (hallucinogenic) (fresh)" );
@@ -255,7 +255,7 @@ TEST_CASE( "weapon fouling", "[item][tname][fouling][dirt]" )
         item &gun = *item::spawn_temporary( "hk_mp5" );
 
         // Ensure the player and gun are normal size to prevent "too big" or "too small" suffix in tname
-        g->u.clear_mutations();
+        get_avatar().clear_mutations();
         REQUIRE( gun.get_sizing( g-> u ) == item::sizing::ignore );
         REQUIRE_FALSE( gun.has_flag( flag_OVERSIZE ) );
         REQUIRE_FALSE( gun.has_flag( flag_UNDERSIZE ) );

--- a/tests/item_tname_test.cpp
+++ b/tests/item_tname_test.cpp
@@ -5,7 +5,6 @@
 #include <string>
 
 #include "avatar.h"
-#include "game.h"
 #include "flag.h"
 #include "item.h"
 #include "itype.h"

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include "avatar.h"
-#include "game.h"
 #include "item.h"
 #include "iteminfo_query.h"
 #include "itype.h"

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -43,7 +43,7 @@ void test_info_equals( const item &i, const iteminfo_query &q,
                        const std::string &reference,
                        temperature_flag temperature = temperature_flag::TEMP_NORMAL )
 {
-    g->u.clear_mutations();
+    get_avatar().clear_mutations();
     std::string info = i.info_string( q, 1, temperature );
     CAPTURE( escape_newlines( info ) );
     CAPTURE( escape_newlines( reference ) );
@@ -61,7 +61,7 @@ void test_info_equals( std::string item_name, const iteminfo_query &q,
 void test_info_contains( const item &i, const iteminfo_query &q,
                          const std::string &reference )
 {
-    g->u.clear_mutations();
+    get_avatar().clear_mutations();
     std::string info = i.info_string( q, 1 );
     using Catch::Matchers::Contains;
     REQUIRE_THAT( info, Contains( reference ) );
@@ -114,7 +114,7 @@ TEST_CASE( "item owner, price, and barter value", "[item][iteminfo][price]" )
 
     SECTION( "owner and price" ) {
         detached_ptr<item> my_rock = item::spawn( "test_rock" );
-        my_rock->set_owner( g->u );
+        my_rock->set_owner( get_avatar() );
         test_info_equals(
             *my_rock, q,
             "Owner: Your Followers\n"
@@ -124,7 +124,7 @@ TEST_CASE( "item owner, price, and barter value", "[item][iteminfo][price]" )
 
     SECTION( "owner, price and barter value" ) {
         detached_ptr<item> my_pipe = item::spawn( "test_pipe" );
-        my_pipe->set_owner( g->u );
+        my_pipe->set_owner( get_avatar() );
         test_info_equals(
             *my_pipe, q,
             "Owner: Your Followers\n"
@@ -184,8 +184,8 @@ TEST_CASE( "weapon attack ratings and moves", "[item][iteminfo][weapon]" )
 {
     clear_all_state();
     // new DPS calculations depend on the avatar's stats, so make sure they're consistent
-    REQUIRE( g->u.get_str() == 8 );
-    REQUIRE( g->u.get_dex() == 8 );
+    REQUIRE( get_avatar().get_str() == 8 );
+    REQUIRE( get_avatar().get_dex() == 8 );
     iteminfo_query q = q_vec( { iteminfo_parts::BASE_DAMAGE, iteminfo_parts::BASE_TOHIT,
                                 iteminfo_parts::BASE_MOVES
                               } );
@@ -753,8 +753,8 @@ TEST_CASE( "food freshness and lifetime", "[item][iteminfo][food]" )
     iteminfo_query q = q_vec( { iteminfo_parts::FOOD_ROT, iteminfo_parts::FOOD_ROT_STORAGE} );
 
     // Ensure test character has no skill estimating spoilage
-    g->u.clear_skills();
-    REQUIRE_FALSE( g->u.can_estimate_rot() );
+    get_avatar().clear_skills();
+    REQUIRE_FALSE( get_avatar().can_estimate_rot() );
 
     SECTION( "food is fresh" ) {
         test_info_equals(
@@ -947,13 +947,13 @@ TEST_CASE( "show available recipes with item as an ingredient", "[item][iteminfo
     clear_all_state();
     iteminfo_query q = q_vec( { iteminfo_parts::DESCRIPTION_APPLICABLE_RECIPES } );
     const recipe *purtab = &recipe_id( "pur_tablets" ).obj();
-    g->u.clear_mutations();
+    get_avatar().clear_mutations();
 
     GIVEN( "character has a potassium iodide tablet and no skill" ) {
         detached_ptr<item> det = item::spawn( "iodine" );
         item &iodine = *det;
-        g->u.i_add( std::move( det ) );
-        g->u.clear_skills();
+        get_avatar().i_add( std::move( det ) );
+        get_avatar().clear_skills();
 
         THEN( "nothing is craftable from it" ) {
             test_info_equals(
@@ -962,8 +962,8 @@ TEST_CASE( "show available recipes with item as an ingredient", "[item][iteminfo
         }
 
         WHEN( "they acquire the needed skills" ) {
-            g->u.set_skill_level( purtab->skill_used, purtab->difficulty );
-            REQUIRE( g->u.get_skill_level( purtab->skill_used ) == purtab->difficulty );
+            get_avatar().set_skill_level( purtab->skill_used, purtab->difficulty );
+            REQUIRE( get_avatar().get_skill_level( purtab->skill_used ) == purtab->difficulty );
 
             THEN( "still nothing is craftable from it" ) {
                 test_info_equals(
@@ -972,8 +972,8 @@ TEST_CASE( "show available recipes with item as an ingredient", "[item][iteminfo
             }
 
             WHEN( "they have no book, but have the recipe memorized" ) {
-                g->u.learn_recipe( purtab );
-                REQUIRE( g->u.knows_recipe( purtab ) );
+                get_avatar().learn_recipe( purtab );
+                REQUIRE( get_avatar().knows_recipe( purtab ) );
 
                 THEN( "they can use potassium iodide tablets to craft it" ) {
                     test_info_equals(
@@ -985,7 +985,7 @@ TEST_CASE( "show available recipes with item as an ingredient", "[item][iteminfo
             }
 
             WHEN( "they have the recipe in a book, but not memorized" ) {
-                g->u.i_add( item::spawn( "textbook_chemistry" ) );
+                get_avatar().i_add( item::spawn( "textbook_chemistry" ) );
 
                 THEN( "they can use potassium iodide tablets to craft it" ) {
                     test_info_equals(

--- a/tests/itemname_test.cpp
+++ b/tests/itemname_test.cpp
@@ -15,7 +15,7 @@ TEST_CASE( "item sizing display", "[item][iteminfo][display_name][sizing]" )
 {
     clear_all_state();
     GIVEN( "player is a normal size" ) {
-        g->u.clear_mutations();
+        get_avatar().clear_mutations();
 
         WHEN( "the item is a normal size" ) {
             std::string name = item::spawn_temporary( "bookplate" )->display_name();
@@ -38,7 +38,7 @@ TEST_CASE( "item sizing display", "[item][iteminfo][display_name][sizing]" )
             std::string name = i.display_name();
 
             THEN( "we have the correct sizing" ) {
-                const item::sizing sizing_level = i.get_sizing( g->u );
+                const item::sizing sizing_level = i.get_sizing( get_avatar() );
                 CHECK( sizing_level == item::sizing::small_sized_human_char );
             }
 
@@ -50,8 +50,8 @@ TEST_CASE( "item sizing display", "[item][iteminfo][display_name][sizing]" )
     }
 
     GIVEN( "player is a huge size" ) {
-        g->u.clear_mutations();
-        g->u.toggle_trait( trait_id( "HUGE_OK" ) );
+        get_avatar().clear_mutations();
+        get_avatar().toggle_trait( trait_id( "HUGE_OK" ) );
 
         WHEN( "the item is a normal size" ) {
             std::string name = item::spawn_temporary( "bookplate" )->display_name();
@@ -74,7 +74,7 @@ TEST_CASE( "item sizing display", "[item][iteminfo][display_name][sizing]" )
             std::string name = i.display_name();
 
             THEN( "we have the correct sizing" ) {
-                const item::sizing sizing_level = i.get_sizing( g->u );
+                const item::sizing sizing_level = i.get_sizing( get_avatar() );
                 CHECK( sizing_level == item::sizing::small_sized_big_char );
             }
 
@@ -86,8 +86,8 @@ TEST_CASE( "item sizing display", "[item][iteminfo][display_name][sizing]" )
     }
 
     GIVEN( "player is a small size" ) {
-        g->u.clear_mutations();
-        g->u.toggle_trait( trait_id( "SMALL_OK" ) );
+        get_avatar().clear_mutations();
+        get_avatar().toggle_trait( trait_id( "SMALL_OK" ) );
 
         WHEN( "the item is a normal size" ) {
             std::string name = item::spawn_temporary( "bookplate" )->display_name();
@@ -110,7 +110,7 @@ TEST_CASE( "item sizing display", "[item][iteminfo][display_name][sizing]" )
             std::string name = i.display_name();
 
             THEN( "we have the correct sizing" ) {
-                const item::sizing sizing_level = i.get_sizing( g->u );
+                const item::sizing sizing_level = i.get_sizing( get_avatar() );
                 CHECK( sizing_level == item::sizing::small_sized_small_char );
             }
 

--- a/tests/itemname_test.cpp
+++ b/tests/itemname_test.cpp
@@ -6,7 +6,6 @@
 #include "avatar.h"
 #include "flag.h"
 #include "flat_set.h"
-#include "game.h"
 #include "item.h"
 #include "type_id.h"
 #include "state_helpers.h"

--- a/tests/iuse_actor_test.cpp
+++ b/tests/iuse_actor_test.cpp
@@ -42,7 +42,7 @@ static monster *find_adjacent_monster( const tripoint &pos )
 TEST_CASE( "manhack", "[iuse_actor][manhack]" )
 {
     clear_all_state();
-    player &dummy = g->u;
+    player &dummy = get_avatar();
 
     g->clear_zombies();
     detached_ptr<item> det = item::spawn( "bot_manhack", calendar::start_of_cataclysm,

--- a/tests/magic_spell_test.cpp
+++ b/tests/magic_spell_test.cpp
@@ -475,7 +475,7 @@ TEST_CASE( "spell effect - target_attack", "[magic][spell][effect][target_attack
     int after_hp = 0;
 
     // Avatar/spellcaster
-    avatar &dummy = g->u;
+    avatar &dummy = get_avatar();
     clear_character( dummy );
     dummy.setpos( dummy_loc );
     REQUIRE( dummy.pos() == dummy_loc );
@@ -523,7 +523,7 @@ TEST_CASE( "spell effect - summon", "[magic][spell][effect][summon]" )
     const tripoint dummy_loc = { 60, 60, 0 };
     const tripoint mummy_loc = { 61, 60, 0 };
 
-    avatar &dummy = g->u;
+    avatar &dummy = get_avatar();
     clear_character( dummy );
     dummy.setpos( dummy_loc );
     REQUIRE( dummy.pos() == dummy_loc );
@@ -563,7 +563,7 @@ TEST_CASE( "spell effect - recover_energy", "[magic][spell][effect][recover_ener
     // For that, "target_attack" with a negative damage is used.
 
     // Yer a wizard, ya dummy
-    player &dummy = g->u;
+    player &dummy = get_avatar();
     clear_character( dummy );
     SECTION( "recover stamina" ) {
         spell_id montage_id( "test_spell_montage" );

--- a/tests/map_helpers.cpp
+++ b/tests/map_helpers.cpp
@@ -25,8 +25,8 @@
 // Remove all vehicles from the map
 void clear_vehicles()
 {
-    for( wrapped_vehicle &veh : g->m.get_vehicles() ) {
-        g->m.destroy_vehicle( veh.v );
+    for( wrapped_vehicle &veh : get_map().get_vehicles() ) {
+        get_map().destroy_vehicle( veh.v );
     }
 }
 
@@ -38,13 +38,13 @@ void wipe_map_terrain()
         ter_id terrain = z == 0 ? t_grass : z < 0 ? t_rock : t_open_air;
         for( int x = 0; x < mapsize; ++x ) {
             for( int y = 0; y < mapsize; ++y ) {
-                g->m.set( { x, y, z}, terrain, f_null );
+                get_map().set( { x, y, z}, terrain, f_null );
             }
         }
     }
     clear_vehicles();
-    g->m.invalidate_map_cache( 0 );
-    g->m.build_map_cache( 0, true );
+    get_map().invalidate_map_cache( 0 );
+    get_map().build_map_cache( 0, true );
 }
 
 void clear_creatures()
@@ -65,16 +65,16 @@ void clear_npcs()
 
 void clear_fields( const int zlevel )
 {
-    const int mapsize = g->m.getmapsize() * SEEX;
+    const int mapsize = get_map().getmapsize() * SEEX;
     for( int x = 0; x < mapsize; ++x ) {
         for( int y = 0; y < mapsize; ++y ) {
             const tripoint p( x, y, zlevel );
             std::vector<field_type_id> fields;
-            for( auto &pr : g->m.field_at( p ) ) {
+            for( auto &pr : get_map().field_at( p ) ) {
                 fields.push_back( pr.second.get_field_type() );
             }
             for( field_type_id f : fields ) {
-                g->m.remove_field( p, f );
+                get_map().remove_field( p, f );
             }
         }
     }
@@ -82,10 +82,10 @@ void clear_fields( const int zlevel )
 
 void clear_items( const int zlevel )
 {
-    const int mapsize = g->m.getmapsize() * SEEX;
+    const int mapsize = get_map().getmapsize() * SEEX;
     for( int x = 0; x < mapsize; ++x ) {
         for( int y = 0; y < mapsize; ++y ) {
-            g->m.i_clear( { x, y, zlevel } );
+            get_map().i_clear( { x, y, zlevel } );
         }
     }
 }
@@ -106,7 +106,7 @@ void clear_map()
     wipe_map_terrain();
     clear_npcs();
     clear_creatures();
-    g->m.clear_traps();
+    get_map().clear_traps();
     for( int z = -2; z <= 0; ++z ) {
         clear_items( z );
     }
@@ -129,16 +129,16 @@ monster &spawn_test_monster( const std::string &monster_type, const tripoint &st
 // terrain, and no furniture, traps, or items.
 void build_test_map( const ter_id &terrain )
 {
-    for( const tripoint &p : g->m.points_in_rectangle( tripoint_zero,
+    for( const tripoint &p : get_map().points_in_rectangle( tripoint_zero,
             tripoint( MAPSIZE * SEEX, MAPSIZE * SEEY, 0 ) ) ) {
-        g->m.furn_set( p, furn_id( "f_null" ) );
-        g->m.ter_set( p, terrain );
-        g->m.trap_set( p, trap_id( "tr_null" ) );
-        g->m.i_clear( p );
+        get_map().furn_set( p, furn_id( "f_null" ) );
+        get_map().ter_set( p, terrain );
+        get_map().trap_set( p, trap_id( "tr_null" ) );
+        get_map().i_clear( p );
     }
 
-    g->m.invalidate_map_cache( 0 );
-    g->m.build_map_cache( 0, true );
+    get_map().invalidate_map_cache( 0 );
+    get_map().build_map_cache( 0, true );
 }
 
 void build_water_test_map( const ter_id &surface, const ter_id &mid, const ter_id &bottom )
@@ -168,7 +168,7 @@ void set_time( const time_point &time )
     calendar::turn = time;
     g->reset_light_level();
     int z = get_avatar().posz();
-    g->m.update_visibility_cache( z );
-    g->m.invalidate_map_cache( z );
-    g->m.build_map_cache( z );
+    get_map().update_visibility_cache( z );
+    get_map().invalidate_map_cache( z );
+    get_map().build_map_cache( z );
 }

--- a/tests/map_helpers.cpp
+++ b/tests/map_helpers.cpp
@@ -115,7 +115,7 @@ void clear_map()
 void put_player_underground()
 {
     // Make sure the player doesn't block the path of the monster being tested.
-    g->u.setpos( { 0, 0, -2 } );
+    get_avatar().setpos( { 0, 0, -2 } );
 }
 
 monster &spawn_test_monster( const std::string &monster_type, const tripoint &start )
@@ -167,7 +167,7 @@ void set_time( const time_point &time )
 {
     calendar::turn = time;
     g->reset_light_level();
-    int z = g->u.posz();
+    int z = get_avatar().posz();
     g->m.update_visibility_cache( z );
     g->m.invalidate_map_cache( z );
     g->m.build_map_cache( z );

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -19,15 +19,15 @@ TEST_CASE( "destroy_grabbed_furniture" )
     GIVEN( "Furniture grabbed by the player" ) {
         const tripoint test_origin( 60, 60, 0 );
         map &here = get_map();
-        g->u.setpos( test_origin );
+        get_avatar().setpos( test_origin );
         const tripoint grab_point = test_origin + tripoint_east;
         here.furn_set( grab_point, furn_id( "f_chair" ) );
-        g->u.grab( OBJECT_FURNITURE, grab_point );
+        get_avatar().grab( OBJECT_FURNITURE, grab_point );
         WHEN( "The furniture grabbed by the player is destroyed" ) {
             here.destroy( grab_point );
             THEN( "The player's grab is released" ) {
-                CHECK( g->u.get_grab_type() == OBJECT_NONE );
-                CHECK( g->u.grab_point == tripoint_zero );
+                CHECK( get_avatar().get_grab_type() == OBJECT_NONE );
+                CHECK( get_avatar().grab_point == tripoint_zero );
             }
         }
     }

--- a/tests/melee_dodge_hit_test.cpp
+++ b/tests/melee_dodge_hit_test.cpp
@@ -77,7 +77,7 @@ TEST_CASE( "monster::get_hit_base", "[monster][melee][hit]" )
 TEST_CASE( "Character::get_hit_base", "[character][melee][hit][dex]" )
 {
     clear_all_state();
-    avatar &dummy = g->u;
+    avatar &dummy = get_avatar();
     clear_character( dummy );
 
     SECTION( "character get_hit_base increases by 1/4 for each point of DEX" ) {
@@ -103,7 +103,7 @@ TEST_CASE( "monster::get_dodge_base", "[monster][melee][dodge]" )
 TEST_CASE( "Character::get_dodge_base", "[character][melee][dodge][dex][skill]" )
 {
     clear_all_state();
-    avatar &dummy = g->u;
+    avatar &dummy = get_avatar();
     clear_character( dummy );
 
     // Character::get_dodge_base is simply DEXTERITY / 2 + DODGE_SKILL
@@ -193,7 +193,7 @@ TEST_CASE( "monster::get_dodge with effects", "[monster][melee][dodge][effect]" 
 TEST_CASE( "Character::get_dodge", "[player][melee][dodge]" )
 {
     clear_all_state();
-    avatar &dummy = g->u;
+    avatar &dummy = get_avatar();
     clear_character( dummy );
 
     const float base_dodge = dummy.get_dodge_base();
@@ -215,7 +215,7 @@ TEST_CASE( "Character::get_dodge", "[player][melee][dodge]" )
 TEST_CASE( "Character::get_dodge with effects", "[player][melee][dodge][effect]" )
 {
     clear_all_state();
-    avatar &dummy = g->u;
+    avatar &dummy = get_avatar();
     clear_character( dummy );
 
     // Compare all effects against base dodge ability
@@ -272,7 +272,7 @@ TEST_CASE( "Character::get_dodge with effects", "[player][melee][dodge][effect]"
 TEST_CASE( "player::get_dodge while grabbed", "[player][melee][dodge][grab]" )
 {
     clear_all_state();
-    avatar &dummy = g->u;
+    avatar &dummy = get_avatar();
     clear_character( dummy );
 
     // Base dodge rate when not grabbed

--- a/tests/memorial_test.cpp
+++ b/tests/memorial_test.cpp
@@ -57,8 +57,8 @@ TEST_CASE( "memorials" )
     m.clear();
     event_bus &b = g->events();
 
-    character_id ch = g->u.getID();
-    std::string u_name = g->u.name;
+    character_id ch = get_avatar().getID();
+    std::string u_name = get_avatar().name;
     character_id ch2 = character_id( ch.get_value() + 1 );
     mutagen_technique mutagen = mutagen_technique::injected_purifier;
     mtype_id mon( "mon_zombie_kevlar_2" );

--- a/tests/modify_morale_test.cpp
+++ b/tests/modify_morale_test.cpp
@@ -8,7 +8,6 @@
 
 #include "avatar.h"
 #include "flag.h"
-#include "game.h"
 #include "item.h"
 #include "map.h"
 #include "map_helpers.h"

--- a/tests/monster_grab_balance_test.cpp
+++ b/tests/monster_grab_balance_test.cpp
@@ -27,7 +27,7 @@
 TEST_CASE( "Monster losing grabbing effect", "[player][melee][grab]" )
 {
     clear_all_state();
-    avatar &dummy = g->u;
+    avatar &dummy = get_avatar();
     clear_character( dummy );
 
     // Four nearby spots

--- a/tests/monster_vision_test.cpp
+++ b/tests/monster_vision_test.cpp
@@ -1,9 +1,6 @@
 #include "catch/catch.hpp"
 
-#include <memory>
-
 #include "calendar.h"
-#include "game.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "mapdata.h"

--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -31,7 +31,7 @@
 
 int get_remaining_charges( const std::string &tool_id )
 {
-    const inventory crafting_inv = g->u.crafting_inventory();
+    const inventory crafting_inv = get_avatar().crafting_inventory();
     std::vector<item *> items =
     crafting_inv.items_with( [tool_id]( const item & i ) {
         return i.typeId() == itype_id( tool_id );
@@ -46,7 +46,7 @@ int get_remaining_charges( const std::string &tool_id )
 bool player_has_item_of_type( const std::string &type )
 {
 
-    std::vector<item *> inv_items = g->u.inv_dump();
+    std::vector<item *> inv_items = get_avatar().inv_dump();
 
     return std::any_of( inv_items.begin(), inv_items.end(), [&]( const item * const & i ) {
         return i->type->get_id() == itype_id( type );
@@ -133,7 +133,7 @@ void clear_character( player &dummy, bool debug_storage )
 
 void clear_avatar()
 {
-    clear_character( g->u );
+    clear_character( get_avatar() );
 }
 
 void process_activity( player &dummy )

--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -149,7 +149,7 @@ void process_activity( player &dummy )
 npc &spawn_npc( const point &p, const std::string &npc_class )
 {
     const string_id<npc_template> test_guy( npc_class );
-    const character_id model_id = g->m.place_npc( p, test_guy, true );
+    const character_id model_id = get_map().place_npc( p, test_guy, true );
     g->load_npcs();
 
     npc *guy = g->find_npc( model_id );

--- a/tests/ranged_aiming_test.cpp
+++ b/tests/ranged_aiming_test.cpp
@@ -31,13 +31,13 @@ static constexpr tripoint shooter_pos( 60, 60, 0 );
 static void set_up_player_vision()
 {
     g->place_player( shooter_pos );
-    g->u.worn.clear();
+    get_avatar().worn.clear();
     g->reset_light_level();
 
-    REQUIRE( !g->u.is_blind() );
-    REQUIRE( !g->u.in_sleep_state() );
+    REQUIRE( !get_avatar().is_blind() );
+    REQUIRE( !get_avatar().in_sleep_state() );
 
-    g->u.recalc_sight_limits();
+    get_avatar().recalc_sight_limits();
 
     calendar::turn = calendar::turn_zero + 12_hours;
 
@@ -53,7 +53,7 @@ TEST_CASE( "Aiming at a clearly visible target", "[ranged][aiming]" )
 {
     clear_all_state();
     set_up_player_vision();
-    player &shooter = g->u;
+    player &shooter = get_avatar();
     arm_character( shooter, "glock_19" );
     int max_range = shooter.primary_weapon().gun_range( &shooter );
     REQUIRE( max_range >= 10 );
@@ -101,7 +101,7 @@ TEST_CASE( "Aiming at a clearly visible target", "[ranged][aiming]" )
 TEST_CASE( "Aiming at a target behind wall", "[ranged][aiming]" )
 {
     clear_all_state();
-    player &shooter = g->u;
+    player &shooter = get_avatar();
     clear_character( shooter, true );
     shooter.add_effect( efftype_id( "debug_clairvoyance" ), 1_seconds );
     arm_character( shooter, "glock_19" );
@@ -142,7 +142,7 @@ TEST_CASE( "Aiming at a target behind bars", "[ranged][aiming]" )
 {
     clear_all_state();
     set_up_player_vision();
-    player &shooter = g->u;
+    player &shooter = get_avatar();
     arm_character( shooter, "glock_19" );
     int max_range = shooter.primary_weapon().gun_range( &shooter );
     REQUIRE( max_range >= 5 );
@@ -176,7 +176,7 @@ TEST_CASE( "Aiming a turret from a solid vehicle", "[ranged][aiming]" )
 {
     clear_all_state();
     set_up_player_vision();
-    avatar &shooter = g->u;
+    avatar &shooter = get_avatar();
     shooter.setpos( shooter_pos );
     arm_character( shooter, "glock_19" );
     int max_range = shooter.primary_weapon().gun_range( &shooter );

--- a/tests/reload_magazine_test.cpp
+++ b/tests/reload_magazine_test.cpp
@@ -8,7 +8,6 @@
 
 #include "avatar.h"
 #include "calendar.h"
-#include "game.h"
 #include "inventory.h"
 #include "item.h"
 #include "player.h"

--- a/tests/reload_magazine_test.cpp
+++ b/tests/reload_magazine_test.cpp
@@ -34,7 +34,7 @@ TEST_CASE( "reload_magazine", "[magazine] [visitable] [item] [item_location]" )
     CHECK( mag_id != bad_mag );
     CHECK( mag_cap > 0 );
 
-    player &p = g->u;
+    player &p = get_avatar();
     p.worn.clear();
     p.inv_clear();
     p.remove_primary_weapon();
@@ -63,7 +63,7 @@ TEST_CASE( "reload_magazine", "[magazine] [visitable] [item] [item_location]" )
             det = item::spawn( bad_ammo );
             item &ammo = *det;
             p.i_add( std::move( det ) );
-            bool ok = mag.reload( g->u, ammo, mag.ammo_capacity() );
+            bool ok = mag.reload( get_avatar(), ammo, mag.ammo_capacity() );
             THEN( "reloading should fail" ) {
                 REQUIRE_FALSE( ok );
                 REQUIRE( mag.ammo_remaining() == 0 );
@@ -76,7 +76,7 @@ TEST_CASE( "reload_magazine", "[magazine] [visitable] [item] [item_location]" )
             p.i_add( std::move( det ) );
             REQUIRE( ammo.charges == mag_cap + 5 );
 
-            bool ok = mag.reload( g->u, ammo, mag.ammo_capacity() );
+            bool ok = mag.reload( get_avatar(), ammo, mag.ammo_capacity() );
             THEN( "reloading is successful" ) {
                 REQUIRE( ok );
 
@@ -108,7 +108,7 @@ TEST_CASE( "reload_magazine", "[magazine] [visitable] [item] [item_location]" )
             p.i_add( std::move( det ) );
             REQUIRE( ammo.charges == mag_cap - 2 );
 
-            bool ok = mag.reload( g->u, ammo, mag.ammo_capacity() );
+            bool ok = mag.reload( get_avatar(), ammo, mag.ammo_capacity() );
             THEN( "reloading is successful" ) {
                 REQUIRE( ok == true );
 
@@ -139,7 +139,7 @@ TEST_CASE( "reload_magazine", "[magazine] [visitable] [item] [item_location]" )
                 REQUIRE( ammo.charges == 10 );
                 REQUIRE( mag.ammo_remaining() == mag_cap - 2 );
 
-                bool ok = mag.reload( g->u, ammo, mag.ammo_capacity() );
+                bool ok = mag.reload( get_avatar(), ammo, mag.ammo_capacity() );
                 THEN( "further reloading is successful" ) {
                     REQUIRE( ok );
 
@@ -165,7 +165,7 @@ TEST_CASE( "reload_magazine", "[magazine] [visitable] [item] [item_location]" )
                 det = item::spawn( alt_ammo );
                 item &ammo = *det;
                 p.i_add( std::move( det ) );
-                bool ok = mag.reload( g->u, ammo, mag.ammo_capacity() );
+                bool ok = mag.reload( get_avatar(), ammo, mag.ammo_capacity() );
                 THEN( "further reloading should fail" ) {
                     REQUIRE_FALSE( ok );
                     REQUIRE( mag.ammo_remaining() == mag_cap - 2 );
@@ -176,7 +176,7 @@ TEST_CASE( "reload_magazine", "[magazine] [visitable] [item] [item_location]" )
                 det = item::spawn( bad_ammo );
                 item &ammo = *det;
                 p.i_add( std::move( det ) );
-                bool ok = mag.reload( g->u, ammo, mag.ammo_capacity() );
+                bool ok = mag.reload( get_avatar(), ammo, mag.ammo_capacity() );
                 THEN( "further reloading should fail" ) {
                     REQUIRE_FALSE( ok );
                     REQUIRE( mag.ammo_remaining() == mag_cap - 2 );
@@ -208,7 +208,7 @@ TEST_CASE( "reload_magazine", "[magazine] [visitable] [item] [item_location]" )
             det = item::spawn( bad_mag );
             item &mag = *det;
             p.i_add( std::move( det ) );
-            bool ok = gun.reload( g->u, mag, 1 );
+            bool ok = gun.reload( get_avatar(), mag, 1 );
             THEN( "reloading should fail" ) {
                 REQUIRE_FALSE( ok );
                 REQUIRE_FALSE( gun.magazine_current() );
@@ -218,7 +218,7 @@ TEST_CASE( "reload_magazine", "[magazine] [visitable] [item] [item_location]" )
         WHEN( "the gun is reloaded with an empty compatible magazine" ) {
             CHECK( mag.ammo_remaining() == 0 );
 
-            bool ok = gun.reload( g->u, mag, 1 );
+            bool ok = gun.reload( get_avatar(), mag, 1 );
             THEN( "reloading is successful" ) {
                 REQUIRE( ok );
                 REQUIRE( gun.magazine_current() );
@@ -245,7 +245,7 @@ TEST_CASE( "reload_magazine", "[magazine] [visitable] [item] [item_location]" )
             CHECK( mag.ammo_current() == ammo_id );
             CHECK( mag.ammo_remaining() == mag_cap - 2 );
 
-            bool ok = gun.reload( g->u, mag, 1 );
+            bool ok = gun.reload( get_avatar(), mag, 1 );
             THEN( "reloading is successful" ) {
                 REQUIRE( ok );
                 REQUIRE( gun.magazine_current() );
@@ -269,7 +269,7 @@ TEST_CASE( "reload_magazine", "[magazine] [visitable] [item] [item_location]" )
                     det = item::spawn( alt_ammo, calendar::turn, 10 );
                     item &ammo = *det;
                     p.i_add( std::move( det ) );
-                    bool ok = gun.magazine_current()->reload( g->u, ammo, 10 );
+                    bool ok = gun.magazine_current()->reload( get_avatar(), ammo, 10 );
                     THEN( "further reloading should fail" ) {
                         REQUIRE_FALSE( ok );
                         REQUIRE( gun.ammo_remaining() == mag_cap - 2 );
@@ -280,7 +280,7 @@ TEST_CASE( "reload_magazine", "[magazine] [visitable] [item] [item_location]" )
                     det = item::spawn( bad_ammo, calendar::turn, 10 );
                     item &ammo = *det;
                     p.i_add( std::move( det ) );
-                    bool ok = gun.magazine_current()->reload( g->u, ammo, 10 );
+                    bool ok = gun.magazine_current()->reload( get_avatar(), ammo, 10 );
                     THEN( "further reloading should fail" ) {
                         REQUIRE_FALSE( ok );
                         REQUIRE( gun.ammo_remaining() == mag_cap - 2 );
@@ -293,7 +293,7 @@ TEST_CASE( "reload_magazine", "[magazine] [visitable] [item] [item_location]" )
                     p.i_add( std::move( det ) );
                     REQUIRE( ammo.charges == 10 );
 
-                    bool ok = gun.magazine_current()->reload( g->u, ammo, 10 );
+                    bool ok = gun.magazine_current()->reload( get_avatar(), ammo, 10 );
                     THEN( "further reloading is successful" ) {
                         REQUIRE( ok );
 

--- a/tests/state_helpers.cpp
+++ b/tests/state_helpers.cpp
@@ -5,7 +5,6 @@
 #include "rng.h"
 #include "calendar.h"
 #include "weather.h"
-#include "game.h"
 #include "map.h"
 #include "name.h"
 

--- a/tests/stats_tracker_test.cpp
+++ b/tests/stats_tracker_test.cpp
@@ -28,7 +28,7 @@ TEST_CASE( "stats_tracker_count_events", "[stats]" )
     event_bus b;
     b.subscribe( &s );
 
-    const character_id u_id = g->u.getID();
+    const character_id u_id = get_avatar().getID();
     const mtype_id mon1( "mon_zombie" );
     const mtype_id mon2( "mon_zombie_brute" );
     const cata::event kill1 = cata::event::make<event_type::character_kills_monster>( u_id, mon1 );
@@ -54,7 +54,7 @@ TEST_CASE( "stats_tracker_total_events", "[stats]" )
     event_bus b;
     b.subscribe( &s );
 
-    const character_id u_id = g->u.getID();
+    const character_id u_id = get_avatar().getID();
     character_id other_id = u_id;
     ++other_id;
     const cata::event::data_type damage_to_any{};
@@ -237,7 +237,7 @@ TEST_CASE( "stats_tracker_with_event_statistics", "[stats]" )
     }
 
     SECTION( "kills" ) {
-        const character_id u_id = g->u.getID();
+        const character_id u_id = get_avatar().getID();
         character_id other_id = u_id;
         ++other_id;
         const mtype_id mon_zombie( "mon_zombie" );
@@ -272,7 +272,7 @@ TEST_CASE( "stats_tracker_with_event_statistics", "[stats]" )
     }
 
     SECTION( "damage" ) {
-        const character_id u_id = g->u.getID();
+        const character_id u_id = get_avatar().getID();
         const cata::event avatar_2_damage =
             cata::event::make<event_type::character_takes_damage>( u_id, 2 );
         const string_id<score> damage_taken( "score_damage_taken" );
@@ -411,7 +411,7 @@ TEST_CASE( "stats_tracker_watchers", "[stats]" )
     }
 
     SECTION( "kills" ) {
-        const character_id u_id = g->u.getID();
+        const character_id u_id = get_avatar().getID();
         character_id other_id = u_id;
         ++other_id;
         const mtype_id mon_zombie( "mon_zombie" );
@@ -444,7 +444,7 @@ TEST_CASE( "stats_tracker_watchers", "[stats]" )
     }
 
     SECTION( "damage" ) {
-        const character_id u_id = g->u.getID();
+        const character_id u_id = get_avatar().getID();
         const cata::event avatar_2_damage =
             cata::event::make<event_type::character_takes_damage>( u_id, 2 );
         const string_id<event_statistic> damage_taken( "avatar_damage_taken" );
@@ -476,7 +476,7 @@ TEST_CASE( "achievements_tracker", "[stats]" )
 
     SECTION( "time" ) {
         calendar::turn = calendar::start_of_game;
-        const character_id u_id = g->u.getID();
+        const character_id u_id = get_avatar().getID();
 
         const cata::event avatar_wakes_up =
             cata::event::make<event_type::character_wakes_up>( u_id );
@@ -496,7 +496,7 @@ TEST_CASE( "achievements_tracker", "[stats]" )
     }
 
     SECTION( "hidden_kills" ) {
-        const character_id u_id = g->u.getID();
+        const character_id u_id = get_avatar().getID();
         const mtype_id mon_zombie( "mon_zombie" );
         const cata::event avatar_zombie_kill =
             cata::event::make<event_type::character_kills_monster>( u_id, mon_zombie );
@@ -520,7 +520,7 @@ TEST_CASE( "achievements_tracker", "[stats]" )
         CAPTURE( time_since_game_start );
         calendar::turn = calendar::start_of_game + time_since_game_start;
 
-        const character_id u_id = g->u.getID();
+        const character_id u_id = get_avatar().getID();
         const mtype_id mon_zombie( "mon_zombie" );
         const cata::event avatar_zombie_kill =
             cata::event::make<event_type::character_kills_monster>( u_id, mon_zombie );
@@ -626,7 +626,7 @@ TEST_CASE( "achievements_tracker", "[stats]" )
             string_id<achievement> a_marathon( "achievement_marathon" );
 
             GIVEN( "a new game" ) {
-                const character_id u_id = g->u.getID();
+                const character_id u_id = get_avatar().getID();
                 b.send<event_type::game_start>( u_id );
                 CHECK( achievements_completed.empty() );
 
@@ -645,7 +645,7 @@ TEST_CASE( "achievements_tracker", "[stats]" )
             string_id<achievement> a_traverse_sharp_terrain( "achievement_traverse_sharp_terrain" );
 
             GIVEN( "a new game" ) {
-                const character_id u_id = g->u.getID();
+                const character_id u_id = get_avatar().getID();
                 b.send<event_type::game_start>( u_id );
                 CHECK( achievements_completed.empty() );
 
@@ -664,7 +664,7 @@ TEST_CASE( "achievements_tracker", "[stats]" )
             string_id<achievement> a_swim_merit_badge( "achievement_swim_merit_badge" );
 
             GIVEN( "a new game" ) {
-                const character_id u_id = g->u.getID();
+                const character_id u_id = get_avatar().getID();
                 b.send<event_type::game_start>( u_id );
                 CHECK( achievements_completed.empty() );
 
@@ -687,7 +687,7 @@ TEST_CASE( "achievements_tracker", "[stats]" )
             string_id<achievement> a_reach_max_z_level( "achievement_reach_max_z_level" );
 
             GIVEN( "a new game" ) {
-                const character_id u_id = g->u.getID();
+                const character_id u_id = get_avatar().getID();
                 b.send<event_type::game_start>( u_id );
                 CHECK( achievements_completed.empty() );
 
@@ -704,7 +704,7 @@ TEST_CASE( "achievements_tracker", "[stats]" )
             string_id<achievement> a_reach_min_z_level( "achievement_reach_min_z_level" );
 
             GIVEN( "a new game" ) {
-                const character_id u_id = g->u.getID();
+                const character_id u_id = get_avatar().getID();
                 b.send<event_type::game_start>( u_id );
                 CHECK( achievements_completed.empty() );
 

--- a/tests/stomach_contents_test.cpp
+++ b/tests/stomach_contents_test.cpp
@@ -8,7 +8,6 @@
 #include "avatar.h"
 #include "calendar.h"
 #include "catch/catch.hpp"
-#include "game.h"
 #include "item.h"
 #include "player.h"
 #include "player_helpers.h"

--- a/tests/stomach_contents_test.cpp
+++ b/tests/stomach_contents_test.cpp
@@ -23,7 +23,7 @@ static const efftype_id effect_bloated( "bloated" );
 static void reset_time()
 {
     calendar::turn = calendar::start_of_cataclysm;
-    player &p = g->u;
+    player &p = get_avatar();
     p.set_stored_kcal( p.max_stored_kcal() );
 }
 
@@ -74,7 +74,7 @@ static void eat_all_nutrients( player &p )
 TEST_CASE( "starve_test", "[starve][slow]" )
 {
     clear_all_state();
-    player &dummy = g->u;
+    player &dummy = get_avatar();
     reset_time();
     clear_stomach( dummy );
 
@@ -109,7 +109,7 @@ TEST_CASE( "starve_test", "[starve][slow]" )
 TEST_CASE( "starve_test_hunger3", "[starve][slow]" )
 {
     clear_all_state();
-    player &dummy = g->u;
+    player &dummy = get_avatar();
     reset_time();
     clear_stomach( dummy );
     while( !( dummy.has_trait( trait_id( "HUNGER3" ) ) ) ) {
@@ -152,7 +152,7 @@ TEST_CASE( "all_nutrition_starve_test", "[!mayfail][starve][slow]" )
     clear_all_state();
     // change this bool when editing the test
     const bool print_tests = false;
-    player &dummy = g->u;
+    player &dummy = get_avatar();
     reset_time();
     clear_stomach( dummy );
     eat_all_nutrients( dummy );
@@ -194,7 +194,7 @@ TEST_CASE( "tape_worm_halves_nutrients" )
     clear_all_state();
     const efftype_id effect_tapeworm( "tapeworm" );
     const bool print_tests = false;
-    player &dummy = g->u;
+    player &dummy = get_avatar();
     reset_time();
     clear_stomach( dummy );
     eat_all_nutrients( dummy );
@@ -212,7 +212,7 @@ TEST_CASE( "tape_worm_halves_nutrients" )
 TEST_CASE( "One day of waiting at full calories eats up about bmr of stored calories", "[stomach]" )
 {
     clear_all_state();
-    player &dummy = g->u;
+    player &dummy = get_avatar();
     reset_time();
     clear_stomach( dummy );
     int kcal_before = dummy.get_stored_kcal();
@@ -225,7 +225,7 @@ TEST_CASE( "Stomach calories become stored calories after less than 1 day", "[st
 {
     clear_all_state();
     constexpr time_duration test_time = 1_days;
-    player &dummy = g->u;
+    player &dummy = get_avatar();
     reset_time();
     clear_stomach( dummy );
     int kcal_before = dummy.max_stored_kcal() - dummy.bmr();
@@ -248,7 +248,7 @@ TEST_CASE( "Stomach calories become stored calories after less than 1 day", "[st
 TEST_CASE( "Eating food fills up stomach calories", "[stomach]" )
 {
     clear_all_state();
-    player &dummy = g->u;
+    player &dummy = get_avatar();
     reset_time();
     clear_stomach( dummy );
     dummy.set_stored_kcal( 100 );
@@ -265,7 +265,7 @@ TEST_CASE( "Eating food fills up stomach calories", "[stomach]" )
 TEST_CASE( "Eating above max kcal causes bloating", "[stomach]" )
 {
     clear_all_state();
-    player &dummy = g->u;
+    player &dummy = get_avatar();
     reset_time();
     clear_stomach( dummy );
     dummy.set_stored_kcal( dummy.max_stored_kcal() - 10 );

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -158,8 +158,8 @@ static void init_global_game_state( const std::vector<mod_id> &mods,
     loading_ui ui( false );
     init::load_world_modfiles( ui, g->get_world_base_save_path() + "/" + SAVE_ARTIFACTS );
 
-    g->u = avatar();
-    g->u.create( character_type::NOW );
+    get_avatar() = avatar();
+    get_avatar().create( character_type::NOW );
 
     g->m = map( get_option<bool>( "ZLEVELS" ) );
     disable_mapgen = true;

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -161,11 +161,11 @@ static void init_global_game_state( const std::vector<mod_id> &mods,
     get_avatar() = avatar();
     get_avatar().create( character_type::NOW );
 
-    g->m = map( get_option<bool>( "ZLEVELS" ) );
+    get_map() = map( get_option<bool>( "ZLEVELS" ) );
     disable_mapgen = true;
 
-    g->m.load( tripoint( g->get_levx(), g->get_levy(), g->get_levz() ), false );
-    get_distribution_grid_tracker().load( g->m );
+    get_map().load( tripoint( g->get_levx(), g->get_levy(), g->get_levz() ), false );
+    get_distribution_grid_tracker().load( get_map() );
 
     get_weather().update_weather();
 }

--- a/tests/throwing_test.cpp
+++ b/tests/throwing_test.cpp
@@ -172,7 +172,7 @@ constexpr throw_test_pstats hi_skill_athlete_stats = { MAX_SKILL, 12, 12, 12 };
 TEST_CASE( "basic_throwing_sanity_tests", "[throwing],[balance]" )
 {
     clear_all_state();
-    player &p = g->u;
+    player &p = get_avatar();
 
     SECTION( "test_player_vs_zombie_rock_basestats" ) {
         test_throwing_player_versus( p, "mon_zombie", "rock", 1, lo_skill_base_stats, { 0.99, 0.10 }, { 10, 3 } );
@@ -217,7 +217,7 @@ TEST_CASE( "basic_throwing_sanity_tests", "[throwing],[balance]" )
 TEST_CASE( "throwing_skill_impact_test", "[throwing],[balance]" )
 {
     clear_all_state();
-    player &p = g->u;
+    player &p = get_avatar();
     // we already cover low stats in the sanity tests and we only cover a few
     // ranges here because what we're really trying to capture is the effect
     // the throwing skill has while the sanity tests are more explicit.
@@ -237,7 +237,7 @@ TEST_CASE( "throwing_skill_impact_test", "[throwing],[balance]" )
 TEST_CASE( "time_to_throw_independent_of_number_of_projectiles", "[throwing],[balance]" )
 {
     clear_all_state();
-    player &p = g->u;
+    player &p = get_avatar();
 
     detached_ptr<item> det = item::spawn( "throwing_stick", calendar::turn, 10 );
     item &thrown = *det;

--- a/tests/vehicle_drag_test.cpp
+++ b/tests/vehicle_drag_test.cpp
@@ -8,7 +8,6 @@
 #include "avatar.h"
 #include "bodypart.h"
 #include "calendar.h"
-#include "game.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "point.h"

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -48,10 +48,10 @@ static void clear_game( const ter_id &terrain )
     clear_vehicles();
 
     // Move player somewhere safe
-    REQUIRE_FALSE( g->u.in_vehicle );
-    g->u.setpos( tripoint_zero );
+    REQUIRE_FALSE( get_avatar().in_vehicle );
+    get_avatar().setpos( tripoint_zero );
     // Blind the player to avoid needless drawing-related overhead
-    g->u.add_effect( effect_blind, 365_days, num_bp );
+    get_avatar().add_effect( effect_blind, 365_days, num_bp );
 
     build_test_map( terrain );
 }

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -15,7 +15,6 @@
 #include "bodypart.h"
 #include "calendar.h"
 #include "enums.h"
-#include "game.h"
 #include "item.h"
 #include "itype.h"
 #include "line.h"

--- a/tests/vehicle_interact_test.cpp
+++ b/tests/vehicle_interact_test.cpp
@@ -54,8 +54,9 @@ static void test_repair( std::vector<detached_ptr<item>> &tools, bool expect_cra
     // Bust cache on crafting_inventory()
     get_avatar().mod_moves( 1 );
     inventory crafting_inv = get_avatar().crafting_inventory();
-    bool can_repair = vp.repair_requirements().can_make_with_inventory( get_avatar().crafting_inventory(),
-                      is_crafting_component );
+    bool can_repair = vp.repair_requirements().can_make_with_inventory(
+                          get_avatar().crafting_inventory(),
+                          is_crafting_component );
     CHECK( can_repair == expect_craftable );
 }
 

--- a/tests/vehicle_interact_test.cpp
+++ b/tests/vehicle_interact_test.cpp
@@ -24,10 +24,10 @@ static void test_repair( std::vector<detached_ptr<item>> &tools, bool expect_cra
 {
 
     const tripoint test_origin( 60, 60, 0 );
-    g->u.setpos( test_origin );
-    g->u.wear_item( item::spawn( "backpack" ), false );
+    get_avatar().setpos( test_origin );
+    get_avatar().wear_item( item::spawn( "backpack" ), false );
     for( detached_ptr<item> &gear : tools ) {
-        g->u.i_add( std::move( gear ) );
+        get_avatar().i_add( std::move( gear ) );
     }
 
     const tripoint vehicle_origin = test_origin + tripoint_south_east;
@@ -52,9 +52,9 @@ static void test_repair( std::vector<detached_ptr<item>> &tools, bool expect_cra
 
     requirement_data reqs = vp.repair_requirements();
     // Bust cache on crafting_inventory()
-    g->u.mod_moves( 1 );
-    inventory crafting_inv = g->u.crafting_inventory();
-    bool can_repair = vp.repair_requirements().can_make_with_inventory( g->u.crafting_inventory(),
+    get_avatar().mod_moves( 1 );
+    inventory crafting_inv = get_avatar().crafting_inventory();
+    bool can_repair = vp.repair_requirements().can_make_with_inventory( get_avatar().crafting_inventory(),
                       is_crafting_component );
     CHECK( can_repair == expect_craftable );
 }

--- a/tests/vehicle_interact_test.cpp
+++ b/tests/vehicle_interact_test.cpp
@@ -6,7 +6,6 @@
 
 #include "avatar.h"
 #include "calendar.h"
-#include "game.h"
 #include "inventory.h"
 #include "item.h"
 #include "map.h"

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -9,7 +9,6 @@
 #include "bodypart.h"
 #include "calendar.h"
 #include "flag.h"
-#include "game.h"
 #include "item.h"
 #include "map.h"
 #include "map_helpers.h"

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -181,8 +181,9 @@ TEST_CASE( "Vehicle charging station", "[vehicle][power]" )
 
     GIVEN( "Vehicle with a charged battery and an active recharging station on a box" ) {
         const tripoint vehicle_origin = tripoint( 10, 10, 0 );
-        vehicle *veh_ptr = g->m.add_vehicle( vproto_id( "recharge_test" ), vehicle_origin, 0_degrees, 100,
-                                             0 );
+        vehicle *veh_ptr = get_map().add_vehicle( vproto_id( "recharge_test" ), vehicle_origin, 0_degrees,
+                           100,
+                           0 );
         REQUIRE( veh_ptr != nullptr );
         REQUIRE( veh_ptr->fuel_left( fuel_type_battery ) > 1000 );
         veh_ptr->update_time( calendar::turn_zero );
@@ -205,7 +206,7 @@ TEST_CASE( "Vehicle charging station", "[vehicle][power]" )
             WHEN( "An hour passes" ) {
                 // Should use vehicle::update_time, but that doesn't do charging...
                 for( int i = 0; i < to_turns<int>( 1_hours ); i++ ) {
-                    g->m.process_items();
+                    get_map().process_items();
                 }
 
                 THEN( "The battery is fully charged" ) {
@@ -228,7 +229,7 @@ TEST_CASE( "Vehicle charging station", "[vehicle][power]" )
             veh_ptr->add_item( cargo_part, std::move( det ) );
             WHEN( "An hour passes" ) {
                 for( int i = 0; i < to_turns<int>( 1_hours ); i++ ) {
-                    g->m.process_items();
+                    get_map().process_items();
                 }
 
                 THEN( "The battery is fully charged" ) {

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -224,7 +224,7 @@ TEST_CASE( "Vehicle charging station", "[vehicle][power]" )
             det = item::spawn( "soldering_iron" );
             item &tool = *det;
             REQUIRE( tool.magazine_current() == nullptr );
-            tool.reload( g->u, battery, 1 );
+            tool.reload( get_avatar(), battery, 1 );
             veh_ptr->add_item( cargo_part, std::move( det ) );
             WHEN( "An hour passes" ) {
                 for( int i = 0; i < to_turns<int>( 1_hours ); i++ ) {

--- a/tests/vehicle_turrets_test.cpp
+++ b/tests/vehicle_turrets_test.cpp
@@ -8,7 +8,6 @@
 
 #include "ammo.h"
 #include "avatar.h"
-#include "game.h"
 #include "item.h"
 #include "itype.h"
 #include "map.h"

--- a/tests/visitable_remove_test.cpp
+++ b/tests/visitable_remove_test.cpp
@@ -62,14 +62,14 @@ TEST_CASE( "visitable_remove", "[visitable]" )
     const auto suitable = []( const tripoint & pos, const int radius ) {
         std::vector<tripoint> tiles = closest_points_first( pos, radius );
         return std::all_of( tiles.begin(), tiles.end(), []( const tripoint & e ) {
-            if( !g->m.inbounds( e ) ) {
+            if( !get_map().inbounds( e ) ) {
                 return false;
             }
-            if( const optional_vpart_position vp = g->m.veh_at( e ) ) {
-                g->m.destroy_vehicle( &vp->vehicle() );
+            if( const optional_vpart_position vp = get_map().veh_at( e ) ) {
+                get_map().destroy_vehicle( &vp->vehicle() );
             }
-            g->m.i_clear( e );
-            return g->m.passable( e );
+            get_map().i_clear( e );
+            return get_map().passable( e );
         } );
     };
 
@@ -344,11 +344,11 @@ TEST_CASE( "visitable_remove", "[visitable]" )
             if( i == 0 || tiles.empty() ) {
                 // always place at least one bottle on player tile
                 our++;
-                g->m.add_item( p.pos(), item::spawn( obj ) );
+                get_map().add_item( p.pos(), item::spawn( obj ) );
             } else {
                 // randomly place bottles on adjacent tiles
                 adj++;
-                g->m.add_item( random_entry( tiles ), item::spawn( obj ) );
+                get_map().add_item( random_entry( tiles ), item::spawn( obj ) );
             }
         }
         REQUIRE( our + adj == count );
@@ -471,13 +471,14 @@ TEST_CASE( "visitable_remove", "[visitable]" )
         std::vector<tripoint> tiles = closest_points_first( p.pos(), 1 );
         tiles.erase( tiles.begin() ); // player tile
         tripoint veh = random_entry( tiles );
-        REQUIRE( g->m.add_vehicle( vproto_id( "shopping_cart" ), veh, 0_degrees, 0, 0 ) );
+        REQUIRE( get_map().add_vehicle( vproto_id( "shopping_cart" ), veh, 0_degrees, 0, 0 ) );
 
         REQUIRE( std::count_if( tiles.begin(), tiles.end(), []( const tripoint & e ) {
-            return static_cast<bool>( g->m.veh_at( e ) );
+            return static_cast<bool>( get_map().veh_at( e ) );
         } ) == 1 );
 
-        const std::optional<vpart_reference> vp = g->m.veh_at( veh ).part_with_feature( "CARGO", true );
+        const std::optional<vpart_reference> vp = get_map().veh_at( veh ).part_with_feature( "CARGO",
+                true );
         REQUIRE( vp );
         vehicle *const v = &vp->vehicle();
         const int part = vp->part_index();

--- a/tests/visitable_remove_test.cpp
+++ b/tests/visitable_remove_test.cpp
@@ -51,7 +51,7 @@ TEST_CASE( "visitable_remove", "[visitable]" )
     REQUIRE( item::spawn_temporary( container_id )->is_container() );
     REQUIRE( item::spawn_temporary( worn_id )->is_container() );
 
-    player &p = g->u;
+    player &p = get_avatar();
     p.worn.clear();
     p.inv_clear();
     p.remove_primary_weapon();

--- a/tests/visitable_remove_test.cpp
+++ b/tests/visitable_remove_test.cpp
@@ -10,7 +10,6 @@
 #include "avatar.h"
 #include "calendar.h"
 #include "catch/catch.hpp"
-#include "game.h"
 #include "inventory.h"
 #include "item.h"
 #include "item_contents.h"


### PR DESCRIPTION
## Purpose of change

first step of removing header inclusion for god objects as mentioned in #3200 and #3152

## Describe the solution

### Step 1

use find and replace to replace
- `g->u` -> `get_avatar()`
- `g->m` -> `get_map()`

this changes removes 26 "game.h" and adds 12 new "game.h".

### Step 2

https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3845/commits/015579eaaef4210f68d571295abefb53dad2d08d

- removed constants declaration from `game.h` and moved them to `path_info.h` and `game_constants.h`
- created `game_utils.h` with `has_game` function, to prevent pulling whole `"game.h"` just to check whether `g` exists

this changes removes 22 "game.h" and adds 1 new "game.h".

### Step 3

made visibility of `u` and `m` private. this prevents accidental usage of `g->u` or `g->m`.

### Summary

total 35 "game.h" header inclusions are removed.

## Describe alternatives you've considered, e.g `critter_at`

- extract more API from game.h
- group multiple usages of `get_avatar()` or `get_map()` into single local variable

## Testing

built locally. CI should pass since it has no functional differences.

## Additional context

recompilation is _fun_