### PR TITLE
feat: open wiki in menu

### DIFF
--- a/data/raw/keybindings/keybindings.json
+++ b/data/raw/keybindings/keybindings.json
@@ -2016,6 +2016,13 @@
   },
   {
     "type": "keybinding",
+    "name": "Open Wiki",
+    "category": "DEFAULTMODE",
+    "id": "open_wiki",
+    "bindings": [ { "input_method": "keyboard", "key": "w" } ]
+  },
+  {
+    "type": "keybinding",
     "name": "View Help",
     "category": "DEFAULTMODE",
     "id": "help",

--- a/doc/src/content/docs/en/index.mdx
+++ b/doc/src/content/docs/en/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Welcome to Cataclysm: Bright Nights reference"
-description: Get started building your docs site with Starlight.
+description: Comprehensive reference for gameplay, modding, and development.
 template: splash
 hero:
   tagline: Learn how to contribute to the project!

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -263,6 +263,8 @@ std::string action_ident( action_id act )
             return "morale";
         case ACTION_MESSAGES:
             return "messages";
+        case ACTION_OPEN_WIKI:
+            return "open_wiki";
         case ACTION_HELP:
             return "help";
         case ACTION_DEBUG:
@@ -386,6 +388,7 @@ bool can_action_change_worldstate( const action_id act )
         case ACTION_FACTIONS:
         case ACTION_MORALE:
         case ACTION_MESSAGES:
+        case ACTION_OPEN_WIKI:
         case ACTION_HELP:
         case ACTION_MAIN_MENU:
         case ACTION_KEYBINDINGS:
@@ -799,7 +802,7 @@ action_id handle_action_menu()
             register_actions( { ACTION_SAVE } );
             register_action_if_hotkey_assigned( ACTION_QUICKLOAD );
             register_action_if_hotkey_assigned( ACTION_SUICIDE );
-            register_actions( { ACTION_HELP } );
+            register_actions( { ACTION_OPEN_WIKI, ACTION_HELP } );
             if( ( entry = &entries.back() ) ) {
                 // help _is_a menu.
                 entry->txt += "…";
@@ -923,7 +926,7 @@ action_id handle_main_menu()
     const auto register_actions = make_register_actions( entries, ctxt );
 
     register_actions( {
-        ACTION_HELP, ACTION_KEYBINDINGS, ACTION_OPTIONS, ACTION_AUTOPICKUP, ACTION_AUTONOTES,
+        ACTION_OPEN_WIKI, ACTION_HELP, ACTION_KEYBINDINGS, ACTION_OPTIONS, ACTION_AUTOPICKUP, ACTION_AUTONOTES,
         ACTION_SAFEMODE, ACTION_DISTRACTION_MANAGER, ACTION_COLOR, ACTION_WORLD_MODS,
         ACTION_ACTIONMENU, ACTION_QUICKSAVE, ACTION_SAVE, ACTION_DEBUG, ACTION_LUA_CONSOLE,
         ACTION_LUA_RELOAD

--- a/src/action.h
+++ b/src/action.h
@@ -245,6 +245,8 @@ enum action_id : int {
     ACTION_MORALE,
     /** Display messages screen */
     ACTION_MESSAGES,
+    /** Open external Wiki webpage */
+    ACTION_OPEN_WIKI,
     /** Display help screen */
     ACTION_HELP,
     /** Display main menu */

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2219,6 +2219,7 @@ input_context get_default_mode_input_context()
     ctxt.register_action( "debug" );
     ctxt.register_action( "lua_console" );
     ctxt.register_action( "lua_reload" );
+    ctxt.register_action( "open_wiki" );
     ctxt.register_action( "debug_scent" );
     ctxt.register_action( "debug_scent_type" );
     ctxt.register_action( "debug_temp" );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -85,6 +85,7 @@
 #include "translations.h"
 #include "ui.h"
 #include "ui_manager.h"
+#include "url_utility.h"
 #include "units.h"
 #include "veh_type.h"
 #include "vehicle.h"
@@ -2341,6 +2342,11 @@ bool game::handle_action()
 
             case ACTION_MESSAGES:
                 Messages::display_messages();
+                break;
+
+            case ACTION_OPEN_WIKI:
+                // TODO: un-hardcode URL
+                open_url( "https://docs.cataclysmbn.org" );
                 break;
 
             case ACTION_HELP:


### PR DESCRIPTION
## Purpose of change

- resolves #3844

## Describe the solution

added shortcut `w` to open [documentation page](https://docs.cataclysmbn.org/) (you could call it wiki).

## Describe alternatives you've considered

- move its position to bottom?
- use other shortcuts?

## Testing

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/0ad62648-d89b-4be4-9fab-db42e2431a5a

### Notes

- footage taken before changing shortcut from `-` to `w`
- wiki redirects path without locale by country, thus korean UI