### PR TITLE
feat(balance): necromancers and masters spawn late instead of evolving

### DIFF
--- a/data/json/mapgen/motel.json
+++ b/data/json/mapgen/motel.json
@@ -11,7 +11,9 @@
     "default": "mon_zombie",
     "monsters": [
       { "monster": "mon_zombie_swimmer", "freq": 500, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_child", "freq": 150, "cost_multiplier": 1 }
+      { "monster": "mon_zombie_child", "freq": 150, "cost_multiplier": 1 },
+      { "monster": "mon_zombie_necro", "freq": 8, "cost_multiplier": 20, "starts": 500 },
+      { "monster": "mon_zombie_master", "freq": 2, "cost_multiplier": 25, "starts": 1000 }
     ]
   },
   {

--- a/data/json/mapgen/necropolis/necropolis.json
+++ b/data/json/mapgen/necropolis/necropolis.json
@@ -19,7 +19,9 @@
       { "monster": "mon_zombie_soldier", "freq": 50, "cost_multiplier": 1 },
       { "monster": "mon_irradiated_wanderer_1", "freq": 90, "cost_multiplier": 1 },
       { "monster": "mon_irradiated_wanderer_2", "freq": 10, "cost_multiplier": 1 },
-      { "monster": "mon_irradiated_wanderer_3", "freq": 1, "cost_multiplier": 1 }
+      { "monster": "mon_irradiated_wanderer_3", "freq": 1, "cost_multiplier": 1 },
+      { "monster": "mon_zombie_necro", "freq": 8, "cost_multiplier": 20, "starts": 500 },
+      { "monster": "mon_zombie_master", "freq": 2, "cost_multiplier": 25, "starts": 1000 }
     ]
   },
   {

--- a/data/json/mapgen/necropolis/necropolisB1.json
+++ b/data/json/mapgen/necropolis/necropolisB1.json
@@ -15,7 +15,9 @@
       { "monster": "mon_irradiated_wanderer_4", "freq": 1, "cost_multiplier": 1 },
       { "monster": "mon_centipede_giant", "freq": 100, "cost_multiplier": 1 },
       { "monster": "mon_chud", "freq": 50, "cost_multiplier": 1 },
-      { "monster": "mon_one_eye", "freq": 25, "cost_multiplier": 1 }
+      { "monster": "mon_one_eye", "freq": 25, "cost_multiplier": 1 },
+      { "monster": "mon_zombie_necro", "freq": 8, "cost_multiplier": 20, "starts": 500 },
+      { "monster": "mon_zombie_master", "freq": 2, "cost_multiplier": 25, "starts": 1000 }
     ]
   },
   {
@@ -32,7 +34,9 @@
       { "monster": "mon_irradiated_wanderer_2", "freq": 100, "cost_multiplier": 1 },
       { "monster": "mon_irradiated_wanderer_3", "freq": 75, "cost_multiplier": 1 },
       { "monster": "mon_irradiated_wanderer_4", "freq": 25, "cost_multiplier": 1 },
-      { "monster": "mon_charred_nightmare", "freq": 5, "cost_multiplier": 1 }
+      { "monster": "mon_charred_nightmare", "freq": 5, "cost_multiplier": 1 },
+      { "monster": "mon_zombie_necro", "freq": 8, "cost_multiplier": 20, "starts": 500 },
+      { "monster": "mon_zombie_master", "freq": 2, "cost_multiplier": 25, "starts": 1000 }
     ]
   },
   {

--- a/data/json/mapgen/ws_fire_lookout_tower.json
+++ b/data/json/mapgen/ws_fire_lookout_tower.json
@@ -6,7 +6,9 @@
     "monsters": [
       { "monster": "mon_zombie_cop", "freq": 500, "cost_multiplier": 2 },
       { "monster": "mon_zombie_soldier", "freq": 150, "cost_multiplier": 1 },
-      { "monster": "mon_zombie_survivor", "freq": 150, "cost_multiplier": 1 }
+      { "monster": "mon_zombie_survivor", "freq": 150, "cost_multiplier": 1 },
+      { "monster": "mon_zombie_necro", "freq": 8, "cost_multiplier": 20, "starts": 500 },
+      { "monster": "mon_zombie_master", "freq": 2, "cost_multiplier": 25, "starts": 1000 }
     ]
   },
   {

--- a/data/json/monstergroups/military.json
+++ b/data/json/monstergroups/military.json
@@ -85,7 +85,9 @@
       { "monster": "mon_zombie_scorched", "freq": 25, "cost_multiplier": 2 },
       { "monster": "mon_zombie_soldier", "freq": 200, "cost_multiplier": 2 },
       { "monster": "mon_zombie_military_pilot", "freq": 5, "cost_multiplier": 1 },
-      { "monster": "mon_zombie_flamer", "freq": 1, "cost_multiplier": 30 }
+      { "monster": "mon_zombie_flamer", "freq": 1, "cost_multiplier": 30 },
+      { "monster": "mon_zombie_necro", "freq": 8, "cost_multiplier": 20, "starts": 500 },
+      { "monster": "mon_zombie_master", "freq": 2, "cost_multiplier": 25, "starts": 1000 }
     ]
   },
   {

--- a/data/json/monstergroups/resort.json
+++ b/data/json/monstergroups/resort.json
@@ -21,7 +21,9 @@
       { "monster": "mon_zombie_resort_staff", "freq": 20, "cost_multiplier": 2, "pack_size": [ 1, 3 ] },
       { "monster": "mon_zombie_tough", "freq": 10, "cost_multiplier": 2, "pack_size": [ 1, 3 ] },
       { "monster": "mon_zombie_brute_shocker", "freq": 1, "cost_multiplier": 35 },
-      { "monster": "mon_zombie_brute", "freq": 3, "cost_multiplier": 20 }
+      { "monster": "mon_zombie_brute", "freq": 3, "cost_multiplier": 20 },
+      { "monster": "mon_zombie_necro", "freq": 8, "cost_multiplier": 20, "starts": 500 },
+      { "monster": "mon_zombie_master", "freq": 2, "cost_multiplier": 25, "starts": 1000 }
     ]
   },
   {
@@ -31,19 +33,29 @@
     "monsters": [
       { "monster": "mon_zombie_resort_dancer", "freq": 20, "cost_multiplier": 2, "pack_size": [ 1, 3 ] },
       { "monster": "mon_zombie_resort_bouncer", "freq": 20, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_resort_staff", "freq": 70, "cost_multiplier": 3, "pack_size": [ 1, 4 ] }
+      { "monster": "mon_zombie_resort_staff", "freq": 70, "cost_multiplier": 3, "pack_size": [ 1, 4 ] },
+      { "monster": "mon_zombie_necro", "freq": 8, "cost_multiplier": 20, "starts": 500 },
+      { "monster": "mon_zombie_master", "freq": 2, "cost_multiplier": 25, "starts": 1000 }
     ]
   },
   {
     "name": "GROUP_RESORT_STAFF",
     "type": "monstergroup",
     "default": "mon_zombie",
-    "monsters": [ { "monster": "mon_zombie_resort_staff", "freq": 200, "cost_multiplier": 2, "pack_size": [ 1, 4 ] } ]
+    "monsters": [
+      { "monster": "mon_zombie_resort_staff", "freq": 200, "cost_multiplier": 2, "pack_size": [ 1, 4 ] },
+      { "monster": "mon_zombie_necro", "freq": 8, "cost_multiplier": 20, "starts": 500 },
+      { "monster": "mon_zombie_master", "freq": 2, "cost_multiplier": 25, "starts": 1000 }
+    ]
   },
   {
     "name": "GROUP_RESORT_BOUNCER",
     "type": "monstergroup",
     "default": "mon_zombie",
-    "monsters": [ { "monster": "mon_zombie_resort_bouncer", "freq": 200, "cost_multiplier": 3, "pack_size": [ 1, 4 ] } ]
+    "monsters": [
+      { "monster": "mon_zombie_resort_bouncer", "freq": 200, "cost_multiplier": 3, "pack_size": [ 1, 4 ] },
+      { "monster": "mon_zombie_necro", "freq": 8, "cost_multiplier": 20, "starts": 500 },
+      { "monster": "mon_zombie_master", "freq": 2, "cost_multiplier": 25, "starts": 1000 }
+    ]
   }
 ]

--- a/data/json/monstergroups/zombie_upgrades.json
+++ b/data/json/monstergroups/zombie_upgrades.json
@@ -27,10 +27,8 @@
       { "monster": "mon_zombie_biter", "freq": 15, "cost_multiplier": 5 },
       { "monster": "mon_zombie_shrieker", "freq": 45, "cost_multiplier": 5 },
       { "monster": "mon_zombie_acidic", "freq": 45, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_necro", "freq": 8, "cost_multiplier": 25 },
       { "monster": "mon_boomer", "freq": 45, "cost_multiplier": 5 },
       { "monster": "mon_zombie_brute", "freq": 23, "cost_multiplier": 15 },
-      { "monster": "mon_zombie_master", "freq": 2, "cost_multiplier": 30 },
       { "monster": "mon_zombie_hollow", "freq": 3, "cost_multiplier": 10 },
       { "monster": "mon_zombie_thorny", "freq": 13, "cost_multiplier": 5 },
       { "monster": "mon_zombie_nurse", "freq": 10, "cost_multiplier": 3 }

--- a/data/json/monstergroups/zombies.json
+++ b/data/json/monstergroups/zombies.json
@@ -116,6 +116,8 @@
       { "monster": "mon_zombie_nurse", "freq": 25, "cost_multiplier": 3, "pack_size": [ 1, 2 ] },
       { "monster": "mon_zombie_brainless", "freq": 65, "cost_multiplier": 1 },
       { "monster": "mon_zombie_brainless", "freq": 65, "cost_multiplier": 1 },
+      { "monster": "mon_zombie_necro", "freq": 8, "cost_multiplier": 20, "starts": 500 },
+      { "monster": "mon_zombie_master", "freq": 2, "cost_multiplier": 25, "starts": 1000 },
       { "monster": "mon_feral_human_pipe", "starts": 250, "freq": 20, "cost_multiplier": 2, "pack_size": [ 1, 2 ] },
       { "monster": "mon_feral_human_crowbar", "starts": 250, "freq": 20, "cost_multiplier": 2, "pack_size": [ 1, 2 ] },
       { "monster": "mon_feral_human_axe", "starts": 250, "freq": 8, "cost_multiplier": 2, "pack_size": [ 1, 2 ] },
@@ -165,6 +167,8 @@
       { "monster": "mon_zombie_static", "freq": 30, "cost_multiplier": 5 },
       { "monster": "mon_zombie_survivor", "freq": 1, "cost_multiplier": 25 },
       { "monster": "mon_zombie_survivor_elite", "freq": 1, "cost_multiplier": 25, "starts": 1440 },
+      { "monster": "mon_zombie_necro", "freq": 8, "cost_multiplier": 20, "starts": 500 },
+      { "monster": "mon_zombie_master", "freq": 2, "cost_multiplier": 25, "starts": 1000 },
       { "monster": "mon_feral_survivalist", "starts": 250, "freq": 5, "cost_multiplier": 1 },
       { "monster": "mon_feral_prepper", "starts": 500, "freq": 4, "cost_multiplier": 5 },
       { "monster": "mon_feral_militia", "starts": 500, "freq": 1, "cost_multiplier": 10 }
@@ -191,7 +195,9 @@
       { "monster": "mon_zombie_swimmer", "freq": 20, "cost_multiplier": 2 },
       { "monster": "mon_zombie_static", "freq": 30, "cost_multiplier": 5 },
       { "monster": "mon_zombie_survivor", "freq": 1, "cost_multiplier": 25 },
-      { "monster": "mon_zombie_survivor_elite", "freq": 1, "cost_multiplier": 25, "starts": 1440 }
+      { "monster": "mon_zombie_survivor_elite", "freq": 1, "cost_multiplier": 25, "starts": 1440 },
+      { "monster": "mon_zombie_necro", "freq": 8, "cost_multiplier": 20, "starts": 500 },
+      { "monster": "mon_zombie_master", "freq": 2, "cost_multiplier": 25, "starts": 1000 }
     ]
   },
   {
@@ -202,6 +208,8 @@
       { "monster": "mon_zombie_tough", "freq": 180, "cost_multiplier": 0 },
       { "monster": "mon_zombie_survivor", "freq": 400, "cost_multiplier": 0 },
       { "monster": "mon_zombie_survivor_elite", "freq": 20, "cost_multiplier": 25, "starts": 1440 },
+      { "monster": "mon_zombie_necro", "freq": 8, "cost_multiplier": 20, "starts": 500 },
+      { "monster": "mon_zombie_master", "freq": 2, "cost_multiplier": 25, "starts": 1000 },
       { "monster": "mon_feral_survivalist", "starts": 250, "freq": 5, "cost_multiplier": 1 },
       { "monster": "mon_feral_prepper", "starts": 500, "freq": 4, "cost_multiplier": 5 },
       { "monster": "mon_feral_militia", "starts": 500, "freq": 1, "cost_multiplier": 10 }
@@ -231,6 +239,8 @@
       { "monster": "mon_zombie_survivor_elite", "freq": 1, "cost_multiplier": 25, "starts": 1440 },
       { "monster": "mon_zombie_nurse", "freq": 50, "cost_multiplier": 2 },
       { "monster": "mon_zombie_runner", "freq": 130, "cost_multiplier": 3 },
+      { "monster": "mon_zombie_necro", "freq": 8, "cost_multiplier": 20, "starts": 500 },
+      { "monster": "mon_zombie_master", "freq": 2, "cost_multiplier": 25, "starts": 1000 },
       { "monster": "mon_feral_survivalist", "starts": 250, "freq": 1, "cost_multiplier": 1 },
       { "monster": "mon_feral_prepper", "starts": 500, "freq": 1, "cost_multiplier": 5 },
       { "monster": "mon_feral_militia", "starts": 500, "freq": 1, "cost_multiplier": 10 }
@@ -258,6 +268,8 @@
       { "monster": "mon_zombie_static", "freq": 180, "cost_multiplier": 5 },
       { "monster": "mon_zombie_survivor", "freq": 1, "cost_multiplier": 25 },
       { "monster": "mon_zombie_survivor_elite", "freq": 1, "cost_multiplier": 25, "starts": 1440 },
+      { "monster": "mon_zombie_necro", "freq": 8, "cost_multiplier": 20, "starts": 500 },
+      { "monster": "mon_zombie_master", "freq": 2, "cost_multiplier": 25, "starts": 1000 },
       { "monster": "mon_feral_survivalist", "starts": 250, "freq": 1, "cost_multiplier": 1 },
       { "monster": "mon_feral_prepper", "starts": 500, "freq": 1, "cost_multiplier": 5 },
       { "monster": "mon_feral_militia", "starts": 500, "freq": 1, "cost_multiplier": 10 }
@@ -285,6 +297,8 @@
       { "monster": "mon_zombie_static", "freq": 30, "cost_multiplier": 5 },
       { "monster": "mon_zombie_survivor", "freq": 1, "cost_multiplier": 25 },
       { "monster": "mon_zombie_survivor_elite", "freq": 1, "cost_multiplier": 25, "starts": 1440 },
+      { "monster": "mon_zombie_necro", "freq": 8, "cost_multiplier": 20, "starts": 500 },
+      { "monster": "mon_zombie_master", "freq": 2, "cost_multiplier": 25, "starts": 1000 },
       { "monster": "mon_feral_survivalist", "starts": 250, "freq": 1, "cost_multiplier": 1 },
       { "monster": "mon_feral_prepper", "starts": 500, "freq": 1, "cost_multiplier": 5 },
       { "monster": "mon_feral_militia", "starts": 500, "freq": 1, "cost_multiplier": 10 }
@@ -387,7 +401,9 @@
       { "monster": "mon_zombie_tough", "freq": 75, "cost_multiplier": 3 },
       { "monster": "mon_zombie_child", "freq": 75, "cost_multiplier": 1 },
       { "monster": "mon_zombie_rot", "freq": 50, "cost_multiplier": 3 },
-      { "monster": "mon_zombie_crawler", "freq": 25, "cost_multiplier": 3 }
+      { "monster": "mon_zombie_crawler", "freq": 25, "cost_multiplier": 3 },
+      { "monster": "mon_zombie_necro", "freq": 8, "cost_multiplier": 20, "starts": 500 },
+      { "monster": "mon_zombie_master", "freq": 2, "cost_multiplier": 25, "starts": 1000 }
     ]
   },
   {
@@ -424,6 +440,8 @@
       { "monster": "mon_zombie_swat", "freq": 5, "cost_multiplier": 3 },
       { "monster": "mon_zombie_static", "freq": 5, "cost_multiplier": 5 },
       { "monster": "mon_zombie_runner", "freq": 10, "cost_multiplier": 5, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_zombie_necro", "freq": 8, "cost_multiplier": 20, "starts": 500 },
+      { "monster": "mon_zombie_master", "freq": 2, "cost_multiplier": 25, "starts": 1000 },
       { "monster": "mon_feral_maid_broom", "freq": 10, "cost_multiplier": 1 },
       { "monster": "mon_feral_maid_candlestick", "freq": 10, "cost_multiplier": 1 },
       { "monster": "mon_feral_maid_knife", "freq": 10, "cost_multiplier": 1 },
@@ -522,7 +540,9 @@
       { "monster": "mon_zombie_cop", "freq": 10, "cost_multiplier": 2 },
       { "monster": "mon_zombie_swat", "freq": 5, "cost_multiplier": 2 },
       { "monster": "mon_zombie_child", "freq": 20, "cost_multiplier": 1 },
-      { "monster": "mon_zombie_crawler", "freq": 10, "cost_multiplier": 1 }
+      { "monster": "mon_zombie_crawler", "freq": 10, "cost_multiplier": 1 },
+      { "monster": "mon_zombie_necro", "freq": 8, "cost_multiplier": 20, "starts": 500 },
+      { "monster": "mon_zombie_master", "freq": 2, "cost_multiplier": 25, "starts": 1000 }
     ]
   },
   {
@@ -534,14 +554,20 @@
       { "monster": "mon_zombie_swat", "freq": 125, "cost_multiplier": 2 },
       { "monster": "mon_zombie", "freq": 150, "cost_multiplier": 1 },
       { "monster": "mon_zombie_swimmer", "freq": 100, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_nurse", "freq": 10, "cost_multiplier": 2 }
+      { "monster": "mon_zombie_nurse", "freq": 10, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_necro", "freq": 8, "cost_multiplier": 20, "starts": 500 },
+      { "monster": "mon_zombie_master", "freq": 2, "cost_multiplier": 25, "starts": 1000 }
     ]
   },
   {
     "type": "monstergroup",
     "name": "GROUP_ZOMBIE_SEXSHOP_B",
     "default": "mon_zombie",
-    "monsters": [ { "monster": "mon_zombie_swimmer", "freq": 500, "cost_multiplier": 2 } ]
+    "monsters": [
+      { "monster": "mon_zombie_swimmer", "freq": 500, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_necro", "freq": 8, "cost_multiplier": 20, "starts": 500 },
+      { "monster": "mon_zombie_master", "freq": 2, "cost_multiplier": 25, "starts": 1000 }
+    ]
   },
   {
     "name": "GROUP_FIRE",
@@ -639,6 +665,8 @@
       { "monster": "mon_dog_zombie_rot", "freq": 15, "cost_multiplier": 2 },
       { "monster": "mon_zombie_survivor", "freq": 100, "cost_multiplier": 1 },
       { "monster": "mon_zombie_survivor_elite", "freq": 50, "cost_multiplier": 5, "starts": 1440 },
+      { "monster": "mon_zombie_necro", "freq": 8, "cost_multiplier": 20, "starts": 500 },
+      { "monster": "mon_zombie_master", "freq": 2, "cost_multiplier": 25, "starts": 1000 },
       { "monster": "mon_feral_survivalist", "starts": 250, "freq": 40, "cost_multiplier": 1 },
       { "monster": "mon_feral_prepper", "starts": 500, "freq": 30, "cost_multiplier": 5 },
       { "monster": "mon_feral_militia", "starts": 500, "freq": 30, "cost_multiplier": 10 }


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Alternative solution to https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3725

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Moved zombie necromancers and masters out of `GROUP_ZOMBIE_UPGRADE`...
2. And instead, put spawns of them at equivalent weights in all monstergroups that had `mon_zombie` as the default spawn, with `starts` values set to 500 and 1000 respectively. Cost multiplier nudged down a bit since total potential spawns are getting a bit more concentrated in a few fewer groups.

<details>
<summary>Affected monstergroups:</summary>

* GROUP_ZOMBIE_POOL
* GROUP_NECROPOLIS
* GROUP_NECROPOLIS_SEWERS
* GROUP_NECROPOLIS_VAULT
* GROUP_ZOMBIE_FIRELOOKOUTTOWER
* GROUP_MIL_BASE_CIVILIAN
* GROUP_RESORT_MIXED
* GROUP_RESORT_MIXED_STAFF
* GROUP_RESORT_STAFF
* GROUP_RESORT_BOUNCER
* GROUP_ZOMBIE
* GROUP_POLICE
* GROUP_HOUSE
* GROUP_PREPPER_HOUSE
* GROUP_PHARM
* GROUP_ELECTRO
* GROUP_GROCERY
* GROUP_CHURCH_ZOMBIE
* GROUP_MANSION
* GROUP_MALL
* GROUP_ZOMBIE_SEXSHOP_A
* GROUP_ZOMBIE_SEXSHOP_B
* GROUP_ZOMBIE_GUNSTORE

</details>

Only cases of "default is just a regular zed" I didn't add them too was `GROUP_VANILLA` and `GROUP_PLAIN`, for obvious reasons.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Waiting for the author of the other PR to respond to proposed feedback.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
