### PR TITLE
fix: apply clang-tidy `modernize-type-traits`

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -379,7 +379,7 @@ struct time_info {
         using char_t = typename Stream::char_type;
         using base   = std::basic_ostream<char_t>;
 
-        static_assert( std::is_base_of<base, Stream>::value, "" );
+        static_assert( std::is_base_of_v<base, Stream>, "" );
 
         out << std::setfill( '0' );
         out << std::setw( 2 ) << t.hours << ':' << std::setw( 2 ) << t.minutes << ':' <<

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -536,7 +536,7 @@ bool is_set_value( const trait_id &mut, float val )
 }
 
 template <float mutation_branch::*First, float mutation_branch::* ...Rest,
-          typename std::enable_if<( sizeof...( Rest ) > 0 ), bool>::type NonEmpty = false >
+          std::enable_if_t<( sizeof...( Rest ) > 0 ), bool>NonEmpty = false >
                   bool is_set_value( const trait_id &mut, float val )
 {
     return ( *mut ).*First == val && is_set_value<Rest...>( mut, val );

--- a/src/make_static.h
+++ b/src/make_static.h
@@ -23,7 +23,7 @@
  */
 #define STATIC(expr) \
     (([]()-> const auto &{ \
-        using CachedType = std::conditional_t<std::is_same<std::decay_t<decltype(expr)>, const char*>::value, \
+        using CachedType = std::conditional_t<std::is_same_v<std::decay_t<decltype(expr)>, const char*>, \
                            std::string, std::decay_t<decltype(expr)>>; \
         static const CachedType _cached_expr = (expr); \
         return _cached_expr; \

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -985,7 +985,7 @@ class mapgen_value
         using StringId = to_string_id_t<Id>;
         struct void_;
         using Id_unless_string =
-            std::conditional_t<std::is_same<Id, std::string>::value, void_, Id>;
+            std::conditional_t<std::is_same_v<Id, std::string>, void_, Id>;
 
         struct value_source {
             virtual ~value_source() = default;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5101,8 +5101,8 @@ namespace distribution_graph
 {
 
 template <bool IsConst,
-          typename Vehicle = typename std::conditional<IsConst, const vehicle, vehicle>::type,
-          typename Grid = typename std::conditional<IsConst, const distribution_grid, distribution_grid>::type>
+          typename Vehicle = std::conditional_t<IsConst, const vehicle, vehicle>,
+          typename Grid = std::conditional_t<IsConst, const distribution_grid, distribution_grid>>
 struct vehicle_or_grid {
     enum class type_t : char {
         vehicle,
@@ -5140,7 +5140,7 @@ void traverse( StartPoint &start,
                VehFunc veh_action, GridFunc grid_action )
 {
     using tvr = traverse_visitor_result;
-    constexpr bool IsConst = std::is_const<StartPoint>::value;
+    constexpr bool IsConst = std::is_const_v<StartPoint>;
     struct hash {
         const std::hash<char> char_hash = std::hash<char>();
         const std::hash<size_t> ptr_hash = std::hash<size_t>();


### PR DESCRIPTION
## Purpose of change

resolve https://clang.llvm.org/extra/clang-tidy/checks/modernize/type-traits.html warnings

## Describe the solution

use `_v` variants

## Describe alternatives you've considered

None.

## Testing

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/2875eff8-329a-4a04-91ad-d417372ef18b)
