### PR TITLE
fix: No Hope megastore palette

### DIFF
--- a/data/mods/No_Hope/Mapgen/megastore.json
+++ b/data/mods/No_Hope/Mapgen/megastore.json
@@ -62,6 +62,7 @@
       "U": "f_cupboard",
       "x": "f_crate_o",
       "X": "f_crate_c",
+      "[": "f_glass_freezer",
       ":": "f_shredder"
     },
     "toilets": { "&": { "amount": [ 0, 50 ] } },


### PR DESCRIPTION
## Purpose of change
Add "[": "f_glass_freezer" because missing in the megastore palette in No Hope.
## Describe the solution
Add "[" missing from the palette.
## Describe alternatives you've considered
None
## Testing

## Additional context
