### PR TITLE
fix: freshwater research terrain fixes

### DIFF
--- a/data/json/furniture_and_terrain/furniture-storage.json
+++ b/data/json/furniture_and_terrain/furniture-storage.json
@@ -983,111 +983,12 @@
   },
   {
     "type": "furniture",
-    "id": "f_metal_crate_r",
-    "name": "riveted metal crate",
-    "looks_like": "f_metal_crate_c",
-    "description": "This huge box is made of a dull metal, riveted together.  There is no obvious opening mechanism, and the rivets don't match any of your tools.  The only way in would be to smash it.",
-    "//": "To-do: There should be an exodii riveting tool that can convert this to f_metal_crate_c",
-    "symbol": "X",
-    "color": "light_gray",
-    "move_cost_mod": 5,
-    "coverage": 80,
-    "required_str": 12,
-    "max_volume": "1000 L",
-    "flags": [ "CONTAINER", "SEALED", "BLOCKSDOOR", "MOUNTABLE" ],
-    "bash": {
-      "str_min": 30,
-      "str_max": 150,
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "scrap", "count": [ 8, 12 ] },
-        { "item": "pipe", "count": [ 0, 3 ] },
-        { "item": "sheet_metal", "count": [ 0, 3 ] },
-        { "item": "sheet_metal_small", "count": [ 2, 10 ] }
-      ]
-    }
-  },
-  {
-    "type": "furniture",
-    "id": "f_metal_crate_c",
-    "name": "sealed metal crate",
-    "looks_like": "t_crate_c",
-    "description": "This is a huge, tightly sealed storage crate made from welded and riveted sheet metal.  The sealing mechanism is too tight to open bare-handed and would need some kind of prying instrument to release.",
-    "symbol": "X",
-    "color": "light_gray",
-    "move_cost_mod": 5,
-    "coverage": 80,
-    "required_str": 12,
-    "max_volume": "1000 L",
-    "flags": [ "CONTAINER", "SEALED", "BLOCKSDOOR", "MOUNTABLE", "FLAT_SURF" ],
-    "bash": {
-      "str_min": 30,
-      "str_max": 150,
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "scrap", "count": [ 8, 12 ] },
-        { "item": "pipe", "count": [ 0, 3 ] },
-        { "item": "sheet_metal", "count": [ 0, 3 ] },
-        { "item": "sheet_metal_small", "count": [ 2, 10 ] }
-      ]
-    }
-  },
-  {
-    "type": "furniture",
-    "id": "f_metal_crate_o",
-    "name": "open metal crate",
-    "looks_like": "f_metal_crate_c",
-    "description": "This large metal crate’s lid is unsealed, and hinges open easily to reveal a number of storage shelves inside.  Once open, the side panels also swing wider for easy access.",
-    "symbol": "X",
-    "color": "light_gray",
-    "move_cost_mod": 5,
-    "coverage": 80,
-    "required_str": 12,
-    "max_volume": "1000 L",
-    "flags": [ "CONTAINER", "PLACE_ITEM", "NO_SIGHT", "HIDE_PLACE", "BLOCKSDOOR", "MOUNTABLE" ],
-    "bash": {
-      "str_min": 30,
-      "str_max": 150,
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "scrap", "count": [ 8, 12 ] },
-        { "item": "pipe", "count": [ 0, 3 ] },
-        { "item": "sheet_metal", "count": [ 0, 3 ] },
-        { "item": "sheet_metal_small", "count": [ 2, 10 ] }
-      ]
-    }
-  },
-  {
-    "type": "furniture",
-    "id": "f_chest",
-    "description": "A sealed wooden storage container.  Lacking any labels, it could hold just about anything inside.  It has a simple metal latch.",
-    "name": "wooden chest",
-    "symbol": "X",
-    "color": "white",
-    "move_cost_mod": -1,
-    "coverage": 60,
-    "required_str": 12,
-    "looks_like": "f_crate_c",
-    "flags": [ "TRANSPARENT", "CONTAINER", "FLAMMABLE", "PLACE_ITEM", "ORGANIC", "MOUNTABLE", "SHORT" ],
-    "deconstruct": {
-      "items": [ { "item": "wood_panel", "count": 5 }, { "item": "hinge", "count": 2 }, { "item": "nail", "charges": [ 6, 10 ] } ]
-    },
-    "bash": {
-      "str_min": 12,
-      "str_max": 40,
-      "sound": "smash!",
-      "sound_fail": "wham!",
-      "items": [ { "item": "2x4", "count": [ 1, 5 ] }, { "item": "hinge", "count": 2 }, { "item": "nail", "charges": [ 2, 10 ] } ]
-    }
-  },
-  {
-    "type": "furniture",
     "id": "f_foot_locker",
     "name": "metal foot locker",
-    "description": "An metal stoarge box, capable of holding any number of things.  The lid has has a small lock.",
+    "description": "An metal storage box, capable of holding any number of things.  The lid has has a small lock.",
     "symbol": "O",
     "color": "white",
-    "move_cost_mod": -1,
+    "move_cost_mod": 2,
     "coverage": 60,
     "required_str": 10,
     "looks_like": "f_crate_c",

--- a/data/json/furniture_and_terrain/terrain-doors.json
+++ b/data/json/furniture_and_terrain/terrain-doors.json
@@ -2558,7 +2558,7 @@
     "move_cost": 2,
     "coverage": 95,
     "roof": "t_metal_flat_roof",
-    "flags": [ "NOITEM", "DOOR", "CONNECT_TO_WALL", "MINEABLE", "BLOCK_WIND" ],
+    "flags": [ "TRANSPARENT", "INDOORS", "FLAT", "ROAD" ],
     "close": "t_door_metal_bulkhead_c",
     "bash": {
       "str_min": 80,

--- a/data/json/furniture_and_terrain/terrain-liquids.json
+++ b/data/json/furniture_and_terrain/terrain-liquids.json
@@ -325,14 +325,13 @@
   {
     "type": "terrain",
     "id": "t_bulkhead_floor",
-    "//": "for eventual use with water z levels.  Currently non-functional.  Roof for submerged structures.",
     "name": "bulkhead",
-    "description": "The bottom of a submerged structure.",
+    "description": "The interior of a submerged structure.  At least this part hasn't flooded yet.",
     "symbol": "#",
     "looks_like": "t_metal_floor",
     "color": "light_gray",
-    "move_cost": 8,
-    "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "INDOORS", "FLAT", "ROAD", "MINEABLE" ],
+    "move_cost": 2,
+    "flags": [ "TRANSPARENT", "INDOORS", "FLAT", "ROAD" ],
     "bash": {
       "sound": "thump",
       "ter_set": "t_null",


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Fixes some issues with terrain ported over for the underwater research station.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Fixed bulkhead floors and related terrain counting as slow terrain, by giving it the same flags as metal floors.
2. Fixed open bulkhead doors still blocking vision, replacing its flags with that of open metal doors.
3. Removed the exodii crates, those aren't used in the research station and we aren't planning to port over aliens who invented bionics.
4. Also removed the unused wooden chests. We can always re-add them later for buried treasure or something like that when we actually want to use them.
5. Made it possible to walk onto foot lockers at a move cost penalty instead of blocking movement outright.
6. Also edited description of bulkhead floors to make it clear how it's being used currently.
7. Fixed typo in description of foot lockers.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Removing references to the exodii with metal crates, fixing the ability to climb into sealed crates, making them pryable with halligan bars, and actually spawning them somewhere. Not worth the effort in my opinion.
2. Obsoleting the offending unused furniture instead. Not used in anything in vanilla or in-repo mods so removing these should only cause problems if someone was debugging.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested and spawned in a research station, confirmed things are acting as expected.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Checked DDA and while they at some point fixed foot lockers, but floors and doors still seem to be busted in all the exact same ways, right down to open bulkhead doors still blocking vision.

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
