### PR TITLE
fix: remove house_fence07 flying roofs

### DIFF
--- a/data/json/mapgen/house/house_fence07.json
+++ b/data/json/mapgen/house/house_fence07.json
@@ -100,6 +100,8 @@
       "terrain": {
         "#": "t_brick_wall",
         ",": "t_concrete",
+        "]": "t_concrete",
+        ")": "t_concrete",
         "/": "t_concrete_railing",
         "_": "t_linoleum_gray",
         "₸": "t_concrete",


### PR DESCRIPTION
## Purpose of change
Place concrete floor instead of waxed floor under the planters, because waxed floor creates flying roofs on the level above.

## Describe the solution
JSON changes.
## Describe alternatives you've considered
None.

## Additional context
Before:
<img width="960" alt="Capture d’écran 2023-12-12 185220" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/bf84a894-92bb-40a7-9f95-f9ece8432b29">
After:
<img width="960" alt="Capture d’écran 2023-12-12 191421" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/cbe98c29-98fc-4e6e-b8e8-ab6549c2ace9">
