### PR TITLE
chore: rename `upload` branch to `main`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,19 +13,19 @@ body:
 
         ### Open Options (ESC) -> Debug Menu
 
-        ![](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/contribute/img/readme-bug1.png?raw=true)
+        ![](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/doc/src/content/docs/en/contribute/img/readme-bug1.png?raw=true)
 
         ### Open Info (i)
 
-        ![](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/contribute/img/readme-bug2.png?raw=true)
+        ![](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/doc/src/content/docs/en/contribute/img/readme-bug2.png?raw=true)
 
         ### Submit a bug report on github (U)
 
-        ![](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/contribute/img/readme-bug3.png?raw=true)
+        ![](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/doc/src/content/docs/en/contribute/img/readme-bug3.png?raw=true)
 
         ### Fill the form and submit
 
-        ![](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/src/content/docs/en/contribute/img/readme-bug4.png?raw=true)
+        ![](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/doc/src/content/docs/en/contribute/img/readme-bug4.png?raw=true)
 
   - type: textarea
     id: describe-bug

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,7 +3,7 @@ name: Cataclysm Android build
 on:
   pull_request:
     branches:
-      - upload
+      - main
     paths-ignore:
       - "build-data/osx/**"
       - "doc/**"

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -2,10 +2,10 @@ name: Clang-tidy (clang-12, tiles)
 
 on:
   push:
-    branches: [upload]
+    branches: [main]
     paths: [ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "build-scripts/**","tools/clang-tidy-plugin/**", ".github/workflows/clang-tidy.yml", "**/.clang-tidy" ]
   pull_request:
-    branches: [upload]
+    branches: [main]
     paths: [ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "build-scripts/**", "tools/clang-tidy-plugin/**", ".github/workflows/clang-tidy.yml", "**/.clang-tidy" ]
 
 # We only care about the latest revision of a PR, so cancel all previous instances.
@@ -51,7 +51,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install libncursesw5-dev clang-12 libclang-12-dev llvm-12-dev llvm-12-tools \
             libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libpulse-dev ccache \
-            libflac-dev gettext 
+            libflac-dev gettext
 
       - name: prepare
         run: bash ./build-scripts/requirements.sh

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,7 +2,7 @@ name: Deploy starlight documentation to GitHub Pages
 
 on:
   push:
-    branches: [upload]
+    branches: [main]
     paths: [doc/**]
   workflow_dispatch:
 

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -3,20 +3,20 @@ name: General build matrix
 on:
   push:
     branches:
-      - upload
+      - main
     paths-ignore:
       - doc/**
       - 'scripts/**'
   merge_group:
   pull_request:
     branches:
-      - upload
+      - main
     paths-ignore:
       - doc/**
       - 'scripts/**'
 
 # Cancel all previous instances in favor of latest revision of a PR.
-# Allow running upload builds to complete to help with ccache refreshes.
+# Allow running main builds to complete to help with ccache refreshes.
 concurrency:
   group: general-build-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -58,9 +58,9 @@ jobs:
     steps:
       - id: matrix_vars
         run: |
-          echo "fail_fast=$([ "$GITHUB_REF_NAME" = "upload" ] && echo false || echo true)" >> $GITHUB_OUTPUT
-          echo "skip_tests=$([ "$GITHUB_REF_NAME" = "upload" ] && echo true || echo false)" >> $GITHUB_OUTPUT
-          echo "max_parallel=$([ "$GITHUB_REF_NAME" = "upload" ] && echo 20 || echo 1)" >> $GITHUB_OUTPUT
+          echo "fail_fast=$([ "$GITHUB_REF_NAME" = "main" ] && echo false || echo true)" >> $GITHUB_OUTPUT
+          echo "skip_tests=$([ "$GITHUB_REF_NAME" = "main" ] && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "max_parallel=$([ "$GITHUB_REF_NAME" = "main" ] && echo 20 || echo 1)" >> $GITHUB_OUTPUT
 
   varied_builds:
     needs: [ skip-duplicates-code, skip-duplicates-data, matrix-variables ]
@@ -235,7 +235,7 @@ jobs:
           path: ${{ steps.get-ccache-vars.outputs.ccache-path }}
           # double-dash after compiler is not a typo, it is to disambiguate between g++-<date> and g++-11-<date> for restore key prefix matching
           key: ccache-${{ github.ref_name }}-${{ matrix.ccache_key }}--${{ steps.get-ccache-vars.outputs.datetime }}
-          restore-keys: ccache-upload-${{ matrix.ccache_key }}--
+          restore-keys: ccache-main-${{ matrix.ccache_key }}--
 
       - name: ccache info
         if: ${{ env.SKIP == 'false' && steps.cache.outputs.cache-hit != 'true' }}
@@ -258,7 +258,7 @@ jobs:
           ccache --show-stats --verbose
 
       - name: clear ccache on PRs
-        if: ${{ github.ref_name != 'upload' && env.SKIP == 'false' && !failure() && (runner.os == 'Linux' || runner.os == 'macOS') }}
+        if: ${{ github.ref_name != 'main' && env.SKIP == 'false' && !failure() && (runner.os == 'Linux' || runner.os == 'macOS') }}
         run: ccache --clear
 
       - name: run tests

--- a/.github/workflows/msvc-full-features-cmake.yml
+++ b/.github/workflows/msvc-full-features-cmake.yml
@@ -3,7 +3,7 @@ name: Cataclysm Windows build (CMake + MSVC)
 on:
   push:
     branches:
-    - upload
+    - main
     paths-ignore:
     - 'android/**'
     - 'build-data/osx/**'

--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -3,7 +3,7 @@ name: Cataclysm Windows build (MSVC)
 on:
   push:
     branches:
-    - upload
+    - main
     paths-ignore:
     - 'android/**'
     - 'build-data/osx/**'
@@ -18,7 +18,7 @@ on:
     - 'scripts/**'
   pull_request:
     branches:
-    - upload
+    - main
     paths-ignore:
     - 'android/**'
     - 'build-data/osx/**'

--- a/.github/workflows/msys2-cmake.yml
+++ b/.github/workflows/msys2-cmake.yml
@@ -3,7 +3,7 @@ name: Windows build (CMake + MSYS2)
 on:
   push:
     branches:
-    - upload
+    - main
     paths-ignore:
     - 'android/**'
     - 'build-data/osx/**'

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -3,7 +3,7 @@ name: Windows build (MSYS2)
 on:
   push:
     branches:
-    - upload
+    - main
     paths-ignore:
     - 'android/**'
     - 'build-data/osx/**'

--- a/.github/workflows/pull-translations.yml
+++ b/.github/workflows/pull-translations.yml
@@ -33,7 +33,7 @@ jobs:
           token: ${{ secrets.TX_PR_CREATOR }}
           branch: i18n
           delete-branch: true
-          base: upload
+          base: main
           title: "feat(i18n): routine i18n updates on ${{ steps.get-timestamp.outputs.time }}"
           body: ""
           labels: Translation

--- a/data/raw/generate_docs.lua
+++ b/data/raw/generate_docs.lua
@@ -159,7 +159,7 @@ sidebar:
 This page is auto-generated from [`data/raw/generate_docs.lua`][generate_docs]
 and should not be edited directly.
 
-[generate_docs]: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/data/raw/generate_docs.lua
+[generate_docs]: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/data/raw/generate_docs.lua
 
 :::
 

--- a/doc/astro.config.ts
+++ b/doc/astro.config.ts
@@ -51,7 +51,7 @@ export default defineConfig({
         "./src/styles/theme.css",
         "./src/styles/capitalize.css",
       ],
-      editLink: { baseUrl: `${github}/edit/upload/doc` },
+      editLink: { baseUrl: `${github}/edit/main/doc` },
       lastUpdated: true,
       navbar: {
         game: {

--- a/doc/src/content/docs/en/contribute/contributing.md
+++ b/doc/src/content/docs/en/contribute/contributing.md
@@ -49,11 +49,11 @@ irrevocable.
 There are a couple of guidelines we suggest sticking to:
 
 - Add this repository as an `upstream` remote.
-- Keep your `upload` branch clean. This means you can easily pull changes made to this repository
+- Keep your `main` branch clean. This means you can easily pull changes made to this repository
   into yours.
 - Create a new branch for each new feature or set of related bug fixes.
-- Never merge from your local branches into your `upload` branch. Only update that by pulling from
-  `upstream/upload`.
+- Never merge from your local branches into your `main` branch. Only update that by pulling from
+  `upstream/main`.
 
 ## Code Style
 
@@ -198,28 +198,28 @@ For further details about commit message guidelines please visit:
 - [chris.beams.io](https://chris.beams.io/posts/git-commit/)
 - [help.github.com](https://help.github.com/articles/closing-issues-using-keywords/)
 
-### Update your `upload` branch
+### Update your `main` branch
 
-1. Make sure you have your `upload` branch checked out.
-
-```sh
-$ git checkout upload
-```
-
-2. Pull the changes from the `upstream/upload` branch.
+1. Make sure you have your `main` branch checked out.
 
 ```sh
-$ git pull --ff-only upstream upload
-# gets changes from "upload" branch on the "upstream" remote
+$ git checkout main
 ```
 
-> **Note** If this gives you an error, it means you have committed directly to your local `upload`
+2. Pull the changes from the `upstream/main` branch.
+
+```sh
+$ git pull --ff-only upstream main
+# gets changes from "main" branch on the "upstream" remote
+```
+
+> **Note** If this gives you an error, it means you have committed directly to your local `main`
 > branch.
 > [Click here for instructions on how to fix this issue](#why-does-git-pull---ff-only-result-in-an-error).
 
 ### Make your changes
 
-0. Update your `upload` branch, if you haven't already.
+0. Update your `main` branch, if you haven't already.
 
 1. For each new feature or bug fix, create a new branch.
 
@@ -238,7 +238,7 @@ $ git push origin new_feature
 ```
 
 3. Once you're finished working on your branch, and have committed and pushed all your changes,
-   submit a pull request from your `new_feature` branch to this repository's `upload` branch.
+   submit a pull request from your `new_feature` branch to this repository's `main` branch.
 
 > **Note** any new commits to the `new_feature` branch on GitHub will automatically be included in
 > the pull request, so make sure to only commit related changes to the same branch.
@@ -312,16 +312,16 @@ These guidelines aren't essential, but they can make keeping things in order muc
 
 ### Using remote tracking branches
 
-Remote tracking branches allow you to easily stay in touch with this repository's `upload` branch,
+Remote tracking branches allow you to easily stay in touch with this repository's `main` branch,
 as they automatically know which remote branch to get changes from.
 
 ```sh
 $ git branch -vv
-* upload      xxxx [origin/upload] ....
+* main        xxxx [origin/main] ....
   new_feature xxxx ....
 ```
 
-Here you can see we have two branches; `upload` which is tracking `origin/upload`, and `new_feature`
+Here you can see we have two branches; `main` which is tracking `origin/main`, and `new_feature`
 which isn't tracking any branch. In practice, what this means is that git won't know where to get
 changes from.
 
@@ -333,12 +333,12 @@ There is no tracking information for the current branch.
 Please specify which branch you want to merge with.
 ```
 
-In order to easily pull changes from `upstream/upload` into the `new_feature` branch, we can tell
-git which branch it should track. (You can even do this for your local upload branch.)
+In order to easily pull changes from `upstream/main` into the `new_feature` branch, we can tell
+git which branch it should track. (You can even do this for your local main branch.)
 
 ```sh
-$ git branch -u upstream/upload new_feature
-Branch new_feature set up to track remote branch upload from upstream.
+$ git branch -u upstream/main new_feature
+Branch new_feature set up to track remote branch main from upstream.
 $ git pull
 Updating xxxx..xxxx
 ....
@@ -347,13 +347,13 @@ Updating xxxx..xxxx
 You can also set the tracking information at the same time as creating the branch.
 
 ```sh
-$ git branch new_feature_2 --track upstream/upload
-Branch new_feature_2 set up to track remote branch upload from upstream.
+$ git branch new_feature_2 --track upstream/main
+Branch new_feature_2 set up to track remote branch main from upstream.
 ```
 
-> **Note**: Although this makes it easier to pull from `upstream/upload`, it doesn't change anything
+> **Note**: Although this makes it easier to pull from `upstream/main`, it doesn't change anything
 > with regards to pushing. `git push` fails because you don't have permission to push to
-> `upstream/upload`.
+> `upstream/main`.
 
 ```sh
 $ git push
@@ -421,28 +421,28 @@ debug menu.
 ### Why does `git pull --ff-only` result in an error?
 
 If `git pull --ff-only` shows an error, it means that you've committed directly to your local
-`upload` branch. To fix this, we create a new branch with these commits, find the point at which we
-diverged from `upstream/upload`, and then reset `upload` to that point.
+`main` branch. To fix this, we create a new branch with these commits, find the point at which we
+diverged from `upstream/main`, and then reset `main` to that point.
 
 ```sh
-$ git pull --ff-only upstream upload
+$ git pull --ff-only upstream main
 From https://github.com/cataclysmbnteam/Cataclysm-BN
- * branch            upload     -> FETCH_HEAD
+ * branch            main     -> FETCH_HEAD
 fatal: Not possible to fast-forward, aborting.
-$ git branch new_branch upload          # mark the current commit with a tmp branch
-$ git merge-base upload upstream/upload
-cc31d0... # the last commit before we committed directly to upload
+$ git branch new_branch main          # mark the current commit with a tmp branch
+$ git merge-base main upstream/main
+cc31d0... # the last commit before we committed directly to main
 $ git reset --hard cc31d0....
 HEAD is now at cc31d0... ...
 ```
 
-Now that `upload` has been cleaned up, we can easily pull from `upstream/upload`, and then continue
+Now that `main` has been cleaned up, we can easily pull from `upstream/main`, and then continue
 working on `new_branch`.
 
 ```sh
-$ git pull --ff-only upstream upload
-# gets changes from the "upstream" remote for the matching branch, in this case "upload"
+$ git pull --ff-only upstream main
+# gets changes from the "upstream" remote for the matching branch, in this case "main"
 $ git checkout new_branch
 ```
 
-For more frequently asked questions, see the [developer FAQ](../dev/reference/FAQ).
+For more frequently asked questions, see the [developer FAQ](../dev/reference/faq.md).

--- a/doc/src/content/docs/en/contribute/contributing.md
+++ b/doc/src/content/docs/en/contribute/contributing.md
@@ -49,8 +49,8 @@ irrevocable.
 There are a couple of guidelines we suggest sticking to:
 
 - Add this repository as an `upstream` remote.
-- Keep your `main` branch clean. This means you can easily pull changes made to this repository
-  into yours.
+- Keep your `main` branch clean. This means you can easily pull changes made to this repository into
+  yours.
 - Create a new branch for each new feature or set of related bug fixes.
 - Never merge from your local branches into your `main` branch. Only update that by pulling from
   `upstream/main`.
@@ -312,8 +312,8 @@ These guidelines aren't essential, but they can make keeping things in order muc
 
 ### Using remote tracking branches
 
-Remote tracking branches allow you to easily stay in touch with this repository's `main` branch,
-as they automatically know which remote branch to get changes from.
+Remote tracking branches allow you to easily stay in touch with this repository's `main` branch, as
+they automatically know which remote branch to get changes from.
 
 ```sh
 $ git branch -vv
@@ -333,8 +333,8 @@ There is no tracking information for the current branch.
 Please specify which branch you want to merge with.
 ```
 
-In order to easily pull changes from `upstream/main` into the `new_feature` branch, we can tell
-git which branch it should track. (You can even do this for your local main branch.)
+In order to easily pull changes from `upstream/main` into the `new_feature` branch, we can tell git
+which branch it should track. (You can even do this for your local main branch.)
 
 ```sh
 $ git branch -u upstream/main new_feature
@@ -420,9 +420,9 @@ debug menu.
 
 ### Why does `git pull --ff-only` result in an error?
 
-If `git pull --ff-only` shows an error, it means that you've committed directly to your local
-`main` branch. To fix this, we create a new branch with these commits, find the point at which we
-diverged from `upstream/main`, and then reset `main` to that point.
+If `git pull --ff-only` shows an error, it means that you've committed directly to your local `main`
+branch. To fix this, we create a new branch with these commits, find the point at which we diverged
+from `upstream/main`, and then reset `main` to that point.
 
 ```sh
 $ git pull --ff-only upstream main

--- a/doc/src/content/docs/en/dev/guides/building/makefile.md
+++ b/doc/src/content/docs/en/dev/guides/building/makefile.md
@@ -388,7 +388,7 @@ builds the SDL version with all features enabled, including tiles, sound and loc
 - SDL2_image (tested with 2.0.3)
 
 The Gradle build process automatically installs dependencies from
-[deps.zip](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/android/app/deps.zip).
+[deps.zip](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/android/app/deps.zip).
 
 ### Setup
 

--- a/doc/src/content/docs/en/dev/guides/working_with_both_bn_and_dda_in_git.md
+++ b/doc/src/content/docs/en/dev/guides/working_with_both_bn_and_dda_in_git.md
@@ -53,14 +53,14 @@ git checkout ddamaster
 git pull
 ```
 
-This shouldn't result in any conflicts. If it did, you probably committed changes to the upload
+This shouldn't result in any conflicts. If it did, you probably committed changes to the main
 branch. In this case you may want to back them up:
 
 ```
 git checkout -b temp-branch-name
 ```
 
-And reset the upload branch to the remote:
+And reset the main branch to the remote:
 
 ```
 git branch -f ddamaster dda/master
@@ -70,7 +70,7 @@ git branch -f ddamaster dda/master
 
 ```
 # Switch to BN branch
-git checkout upload
+git checkout main
 # Update local content
 git pull
 # Create new branch for your changes

--- a/doc/src/content/docs/en/dev/reference/tooling.md
+++ b/doc/src/content/docs/en/dev/reference/tooling.md
@@ -82,7 +82,7 @@ manager and then configure it the same way.
 1. Go to `Tools` - `Options` - `AStyle Formatter` - `General`.
 
 2. Import
-   `https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/msvc-full-features/AStyleExtension-Cataclysm-BN.cfg`
+   `https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/msvc-full-features/AStyleExtension-Cataclysm-BN.cfg`
    on `Export/Import` tab using `Import` button:
 
 ![image](./img/VS_Astyle_Step_1.png)
@@ -117,7 +117,7 @@ rule in the `Makefile` to do this for you; just run `make ctags` or `make etags`
 ## clang-tidy
 
 Cataclysm has a
-[clang-tidy configuration file](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/.clang-tidy)
+[clang-tidy configuration file](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/.clang-tidy)
 and if you have `clang-tidy` available you can run it to perform static analysis of the codebase. We
 test with `clang-tidy` from LLVM 12.0.0 with CI, so for the most consistent results, you might want
 to use that version.

--- a/doc/src/content/docs/en/mod/json/guides/map/mapgen.md
+++ b/doc/src/content/docs/en/mod/json/guides/map/mapgen.md
@@ -34,14 +34,14 @@ ground floor mapgen, so it is good practice to include dedicated downstairs if y
 ## The Files & their purpose:
 
 1. You will add a new mapgen file in:
-   [data/json/mapgen](https://github.com/cataclysmbnteam/Cataclysm-BN/tree/upload/data/json/mapgen)
+   [data/json/mapgen](https://github.com/cataclysmbnteam/Cataclysm-BN/tree/main/data/json/mapgen)
    or one of its sub-folders. If you are using an existing foundation shape for the building, you
    may append it to that building's file.
    - This is the blueprint for the building. It can also hold all the building’s data for adding
      furniture and loot (see palette for an alternative).
 
 2. You will add entries for each z level you create in the appropriate overmap_terrain file
-   ([data/json/overmap/overmap_terrain](https://github.com/cataclysmbnteam/Cataclysm-BN/tree/upload/data/json/overmap/overmap_terrain)).
+   ([data/json/overmap/overmap_terrain](https://github.com/cataclysmbnteam/Cataclysm-BN/tree/main/data/json/overmap/overmap_terrain)).
    - These entries will define what your building looks like in the overmap, its symbol, color, and
      spawn requirements like adding sidewalks, it will also control flags for some mapgen functions.
 
@@ -494,12 +494,12 @@ sample roof:
    "t_shingle_flat_roof" in this mapgen which will override the palettes entry for
    `".": "t_flat_roof"`. (more on this in advanced mapgen).
 
-I have a separate roof document at: [JSON_ROOF_MAPGEN](../JSON_ROOF_MAPGEN).
+I have a separate roof document at: [JSON_ROOF_MAPGEN](../json_roof_mapgen.md).
 
 ## Linking various mapgen maps using multitile_city_buildings.json
 
 This file is found at:
-[data/json/overmap/multitile_city_buildings.json](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/data/json/overmap/multitile_city_buildings.json).
+[data/json/overmap/multitile_city_buildings.json](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/data/json/overmap/multitile_city_buildings.json).
 
 _Remember this file is for city buildings only, not specials_
 
@@ -537,7 +537,7 @@ A standard entry:
 
 ## Setting overmap spawns using regional_map_settings.json
 
-[data/json/regional_map_settings.json](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/data/json/regional_map_settings.json)
+[data/json/regional_map_settings.json](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/data/json/regional_map_settings.json)
 
 1. For city buildings and houses you'll scroll down to the `"city":` flag.
 2. Find your appropriate subtag, `"houses"` or `"shops"` usually.
@@ -548,7 +548,7 @@ A standard entry:
 ## Linking and spawning specials:
 
 Put the entry in:
-[data/json/overmap/overmap_special/specials.json](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/data/json/overmap/overmap_special/specials.json).
+[data/json/overmap/overmap_special/specials.json](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/data/json/overmap/overmap_special/specials.json).
 
 This entry does the job of both the regional_map_settings and multitile_city_buildings plus other
 fun overmap stuff.
@@ -596,14 +596,14 @@ Example:
    percentage so `[ 1, 10 ]` wouldn't be 1 to 10 times per overmap but a 1 in 10% chance to spawn on
    the overmap. So 10% chance to spawn once per overmap.
 8. `"flags"`: These are flags you can use to further define the special. For a list of flags see:
-   [JSON_FLAGS](../../reference/JSON_FLAGS).
+   [JSON_FLAGS](../../reference/json_flags.md).
 
-Read: [OVERMAP](../../reference/map/OVERMAP) for more details.
+Read: [OVERMAP](../../reference/map/overmap.md) for more details.
 
 ## Overmap_terrain entries:
 
 Choose a file for your building type at:
-[data/json/overmap/overmap_terrain](https://github.com/cataclysmbnteam/Cataclysm-BN/tree/upload/data/json/overmap/overmap_terrain).
+[data/json/overmap/overmap_terrain](https://github.com/cataclysmbnteam/Cataclysm-BN/tree/main/data/json/overmap/overmap_terrain).
 
 This set of entries defines how your building will look on the overmap. It supports copy-from.
 Example:
@@ -727,13 +727,13 @@ Everything else will look like a series of object entries, for example the roof_
 ```
 
 If you want to look at more complex palettes, the standard_domestic_palette in
-[data/json/mapgen_palettes/house_general_palette.json](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/data/json/mapgen_palettes/house_general_palette.json)
+[data/json/mapgen_palettes/house_general_palette.json](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/data/json/mapgen_palettes/house_general_palette.json)
 is a good look at a palette designed to work across all CDDA houses. It includes the loot spawns and
 accounts for most furniture that will be used in a house. I also left a list of symbols open to be
 used in the mapgen file for specific location needs.
 
 Finally, the series of house_w palettes at
-[data/json/mapgen_palettes/house_w_palette.json](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/data/json/mapgen_palettes/house_w_palette.json)
+[data/json/mapgen_palettes/house_w_palette.json](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/data/json/mapgen_palettes/house_w_palette.json)
 are designed to work together for houses using nested mapgen. There is a palette devoted to the
 foundation, another for the nests, and finally another one I've designed for domestic outdoor nested
 chunks.

--- a/doc/src/content/docs/en/mod/json/guides/map/mapgen.md
+++ b/doc/src/content/docs/en/mod/json/guides/map/mapgen.md
@@ -34,9 +34,9 @@ ground floor mapgen, so it is good practice to include dedicated downstairs if y
 ## The Files & their purpose:
 
 1. You will add a new mapgen file in:
-   [data/json/mapgen](https://github.com/cataclysmbnteam/Cataclysm-BN/tree/main/data/json/mapgen)
-   or one of its sub-folders. If you are using an existing foundation shape for the building, you
-   may append it to that building's file.
+   [data/json/mapgen](https://github.com/cataclysmbnteam/Cataclysm-BN/tree/main/data/json/mapgen) or
+   one of its sub-folders. If you are using an existing foundation shape for the building, you may
+   append it to that building's file.
    - This is the blueprint for the building. It can also hold all the building’s data for adding
      furniture and loot (see palette for an alternative).
 

--- a/doc/src/content/docs/en/mod/json/reference/items/json_inheritance.md
+++ b/doc/src/content/docs/en/mod/json/reference/items/json_inheritance.md
@@ -131,18 +131,18 @@ The following types currently support inheritance:
 To find out if a types supports copy-from, you need to know if it has implemented generic_factory.
 To find out if this is the case, do the following:
 
-- Open [init.cpp](https://github.com/cataclysmbnteam/Cataclysm-BN/tree/upload/src/init.cpp)
+- Open [init.cpp](https://github.com/cataclysmbnteam/Cataclysm-BN/tree/main/src/init.cpp)
 - Find the line that mentions your type, for example `add( "gate", &gates::load );`
 - Copy the load function, in this case it would be _gates::load_
 - Use this in
   [the search bar on github](https://github.com/cataclysmbnteam/Cataclysm-BN/search?q=%22gates%3A%3Aload%22&unscoped_q=%22gates%3A%3Aload%22&type=Code)
   to find the file that contains _gates::load_
 - In the search results you find
-  [gates.cpp](https://github.com/cataclysmbnteam/Cataclysm-BN/tree/upload/src/gates.cpp). open it.
+  [gates.cpp](https://github.com/cataclysmbnteam/Cataclysm-BN/tree/main/src/gates.cpp). open it.
 - In gates.cpp, find the generic_factory line, it looks like this:
   `generic_factory<gate_data> gates_data( "gate type", "handle", "other_handles" );`
 - Since the generic_factory line is present, you can now conclude that it supports copy-from.
 - If you don't find generic_factoy present, it does not support copy-from, as is the case for type
   vitamin (repeat the above steps and find that
-  [vitamin.cpp](https://github.com/cataclysmbnteam/Cataclysm-BN/tree/upload/src/vitamin.cpp) does
+  [vitamin.cpp](https://github.com/cataclysmbnteam/Cataclysm-BN/tree/main/src/vitamin.cpp) does
   not contain generic_factoy)

--- a/doc/src/content/docs/en/mod/json/reference/items/json_inheritance.md
+++ b/doc/src/content/docs/en/mod/json/reference/items/json_inheritance.md
@@ -144,5 +144,5 @@ To find out if this is the case, do the following:
 - Since the generic_factory line is present, you can now conclude that it supports copy-from.
 - If you don't find generic_factoy present, it does not support copy-from, as is the case for type
   vitamin (repeat the above steps and find that
-  [vitamin.cpp](https://github.com/cataclysmbnteam/Cataclysm-BN/tree/main/src/vitamin.cpp) does
-  not contain generic_factoy)
+  [vitamin.cpp](https://github.com/cataclysmbnteam/Cataclysm-BN/tree/main/src/vitamin.cpp) does not
+  contain generic_factoy)

--- a/doc/src/content/docs/en/mod/json/reference/json_info.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_info.md
@@ -970,7 +970,7 @@ Any or all of the following alterations can be made to the event stream:
 
 - Add new fields to each event based on event field transformations. The event field transformations
   can be found in
-  [`event_field_transformation.cpp`](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/src/event_field_transformations.cpp).
+  [`event_field_transformation.cpp`](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/src/event_field_transformations.cpp).
 - Filter events based on the values they contain to produce a stream containing some subset of the
   input stream.
 - Drop some fields which are not of interest in the output stream.

--- a/doc/src/content/docs/en/mod/lua/reference/lua.md
+++ b/doc/src/content/docs/en/mod/lua/reference/lua.md
@@ -12,7 +12,7 @@ sidebar:
 This page is auto-generated from [`data/raw/generate_docs.lua`][generate_docs] and should not be
 edited directly.
 
-[generate_docs]: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/data/raw/generate_docs.lua
+[generate_docs]: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/data/raw/generate_docs.lua
 
 :::
 

--- a/doc/src/content/docs/ko/contribute/contributing.md
+++ b/doc/src/content/docs/ko/contribute/contributing.md
@@ -30,8 +30,8 @@ http://creativecommons.org/licenses/by-sa/3.0/ 를 참고해주세요. 그 말�
 몇 가지 지켰으면 하는 가이드라인이 있습니다:
 
 - 이 저장소를 `upstream` [리모트][remote]로 추가해주세요.
-- `main` 브랜치를 수정사항 없이 깨끗하게 유지해주세요. 원격 저장소의 최신 변경사항을 바로 끌어올
-  수 있게 하기 위함입니다.
+- `main` 브랜치를 수정사항 없이 깨끗하게 유지해주세요. 원격 저장소의 최신 변경사항을 바로 끌어올 수
+  있게 하기 위함입니다.
 - 새 기능이나 버그 수정을 할 때마다 새 브랜치를 만들어주세요.
 - 절대로 `main` 브랜치에 로컬 브랜치를 병합하지 마세요. `upstream/main`에서 끌어오기만 해주세요.
 
@@ -286,8 +286,8 @@ Infrastructure, Build, I18N이 있습니다.
 
 ### 원격 추적 브랜치 사용하기
 
-원본 저장소의 `main` 브랜치에
-대한 원격 추적 브랜치를 설정하면 쉽게 최신 변경사항을 가져올 수 있습니다.
+원본 저장소의 `main` 브랜치에 대한 원격 추적 브랜치를 설정하면 쉽게 최신 변경사항을 가져올 수
+있습니다.
 
 ```sh
 $ git branch -vv
@@ -295,9 +295,8 @@ $ git branch -vv
   new_feature xxxx ....
 ```
 
-`main` 브랜치는 `origin/main` 브랜치를 추적하고 있고, `new_feature` 브랜치는 아무 브랜치도
-추적하고 있지 않습니다. 그 말은 git이 어디에서 `new_feature` 에 대한 변경사항을 가져올지 모른다는
-뜻입니다.
+`main` 브랜치는 `origin/main` 브랜치를 추적하고 있고, `new_feature` 브랜치는 아무 브랜치도 추적하고
+있지 않습니다. 그 말은 git이 어디에서 `new_feature` 에 대한 변경사항을 가져올지 모른다는 뜻입니다.
 
 ```sh
 $ git checkout new_feature
@@ -406,8 +405,8 @@ $ git reset --hard cc31d0....
 HEAD is now at cc31d0... ...
 ```
 
-이제 `main`가 정리되었으니 `upstream/main`에서 변경 내역을 끌어오고, `new_branch`에서 계속
-작업할 수 있습니다.
+이제 `main`가 정리되었으니 `upstream/main`에서 변경 내역을 끌어오고, `new_branch`에서 계속 작업할 수
+있습니다.
 
 ```sh
 $ git pull --ff-only upstream main

--- a/doc/src/content/docs/ko/contribute/contributing.md
+++ b/doc/src/content/docs/ko/contribute/contributing.md
@@ -30,10 +30,10 @@ http://creativecommons.org/licenses/by-sa/3.0/ 를 참고해주세요. 그 말�
 몇 가지 지켰으면 하는 가이드라인이 있습니다:
 
 - 이 저장소를 `upstream` [리모트][remote]로 추가해주세요.
-- `upload` 브랜치를 수정사항 없이 깨끗하게 유지해주세요. 원격 저장소의 최신 변경사항을 바로 끌어올
+- `main` 브랜치를 수정사항 없이 깨끗하게 유지해주세요. 원격 저장소의 최신 변경사항을 바로 끌어올
   수 있게 하기 위함입니다.
 - 새 기능이나 버그 수정을 할 때마다 새 브랜치를 만들어주세요.
-- 절대로 `upload` 브랜치에 로컬 브랜치를 병합하지 마세요. `upstream/upload`에서 끌어오기만 해주세요.
+- 절대로 `main` 브랜치에 로컬 브랜치를 병합하지 마세요. `upstream/main`에서 끌어오기만 해주세요.
 
 [remote]: https://docs.github.com/ko/pull-requests/collaborating-with-pull-requests/working-with-forks/configuring-a-remote-repository-for-a-fork
 
@@ -173,27 +173,27 @@ $ git remote add -f upstream https://github.com/cataclysmbnteam/Cataclysm-BN.git
 - [chris.beams.io](https://chris.beams.io/posts/git-commit/)
 - [help.github.com](https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
 
-### `upload` 브랜치 업데이트하기
+### `main` 브랜치 업데이트하기
 
-1. `upload` 브랜치가 체크아웃 되어 있는지 확인해주세요.
-
-```sh
-$ git checkout upload
-```
-
-2. `upstream/upload` 브랜치에서 변경사항을 가져옵니다.
+1. `main` 브랜치가 체크아웃 되어 있는지 확인해주세요.
 
 ```sh
-$ git pull --ff-only upstream upload
-# "upstream" 원격 저장소의 "upload" 브랜치에서 변경사항을 가져옵니다.
+$ git checkout main
 ```
 
-> **Note** 오류가 발생했다면, 로컬 `upload` 브랜치에 직접 커밋을 했다는 뜻입니다.
+2. `upstream/main` 브랜치에서 변경사항을 가져옵니다.
+
+```sh
+$ git pull --ff-only upstream main
+# "upstream" 원격 저장소의 "main" 브랜치에서 변경사항을 가져옵니다.
+```
+
+> **Note** 오류가 발생했다면, 로컬 `main` 브랜치에 직접 커밋을 했다는 뜻입니다.
 > [이 문제를 해결하는 방법을 보려면 여기를 클릭하세요](#git-pull---ff-only을-했더니-에러가-나요).
 
 ### 변경사항 만들기
 
-0. 아직 `upload` 브랜치를 업데이트하지 않았다면, 업데이트하세요.
+0. 아직 `main` 브랜치를 업데이트하지 않았다면, 업데이트하세요.
 
 1. 기능 추가나 버그 수정을 하려 할 때마다, 새 브랜치를 만들어주세요.
 
@@ -212,7 +212,7 @@ $ git push origin new_feature
 ```
 
 3. 브랜치에서 작업을 마치고, 모든 변경사항을 커밋하고 푸시했다면, `new_feature` 브랜치에서 이
-   저장소의 `upload` 브랜치로 풀 리퀘스트를 보내주세요.
+   저장소의 `main` 브랜치로 풀 리퀘스트를 보내주세요.
 
 > **Note** 깃허브의 `new_feature` 브랜치에 새 커밋이 생기면, 풀 리퀘스트에 자동으로 포함됩니다.
 > 따라서 같은 브랜치에 관련된 변경사항만 커밋해주세요.
@@ -278,7 +278,7 @@ Infrastructure, Build, I18N이 있습니다.
 ## 개발 도구 지원
 
 코딩 스타일을 지키도록 도와주는 여러 도구들이 있습니다. 자세한 내용은
-[DEVELOPER_TOOLING](../dev/reference/tooling)을 참고해주세요.
+[DEVELOPER_TOOLING](../dev/reference/tooling.md)을 참고해주세요.
 
 ## 고급
 
@@ -286,17 +286,16 @@ Infrastructure, Build, I18N이 있습니다.
 
 ### 원격 추적 브랜치 사용하기
 
-Remote tracking branches allow you to easily stay in touch with this repository's `upload` branch,
-as they automatically know which remote branch to get changes from. 원본 저장소의 `upload` 브랜치에
+원본 저장소의 `main` 브랜치에
 대한 원격 추적 브랜치를 설정하면 쉽게 최신 변경사항을 가져올 수 있습니다.
 
 ```sh
 $ git branch -vv
-* upload      xxxx [origin/upload] ....
+* main        xxxx [origin/main] ....
   new_feature xxxx ....
 ```
 
-`upload` 브랜치는 `origin/upload` 브랜치를 추적하고 있고, `new_feature` 브랜치는 아무 브랜치도
+`main` 브랜치는 `origin/main` 브랜치를 추적하고 있고, `new_feature` 브랜치는 아무 브랜치도
 추적하고 있지 않습니다. 그 말은 git이 어디에서 `new_feature` 에 대한 변경사항을 가져올지 모른다는
 뜻입니다.
 
@@ -308,12 +307,12 @@ $ git pull
 어떤 브랜치를 대상으로 병합할지 지정하십시오.
 ```
 
-`new_feature` 브랜치에서 `upstream/upload` 브랜치의 변경사항을 쉽게 가져오려면, git에 어떤 브랜치를
-추적할지 알려줘야 합니다. (로컬 `upload` 브랜치에도 적용할 수 있습니다.)
+`new_feature` 브랜치에서 `upstream/main` 브랜치의 변경사항을 쉽게 가져오려면, git에 어떤 브랜치를
+추적할지 알려줘야 합니다. (로컬 `main` 브랜치에도 적용할 수 있습니다.)
 
 ```sh
-$ git branch -u upstream/upload new_feature
-Branch new_feature set up to track remote branch upload from upstream.
+$ git branch -u upstream/main new_feature
+Branch new_feature set up to track remote branch main from upstream.
 $ git pull
 Updating xxxx..xxxx
 ....
@@ -322,12 +321,12 @@ Updating xxxx..xxxx
 브랜치를 생성할 때 추적 정보를 설정할 수도 있습니다.
 
 ```sh
-$ git branch new_feature_2 --track upstream/upload
-Branch new_feature_2 set up to track remote branch upload from upstream.
+$ git branch new_feature_2 --track upstream/main
+Branch new_feature_2 set up to track remote branch main from upstream.
 ```
 
-> **Note** : 이렇게 하면 `upstream/upload` 브랜치에서 변경사항을 가져오는 것은 쉬워지지만,
-> `git push`는 여전히 실패합니다. `git push`는 `upstream/upload` 브랜치에 변경사항을 푸시할 권한이
+> **Note** : 이렇게 하면 `upstream/main` 브랜치에서 변경사항을 가져오는 것은 쉬워지지만,
+> `git push`는 여전히 실패합니다. `git push`는 `upstream/main` 브랜치에 변경사항을 푸시할 권한이
 > 없기 때문입니다.
 
 ```sh
@@ -390,30 +389,30 @@ The test took 41.772 seconds
 
 ### `git pull --ff-only`을 했더니 에러가 나요
 
-`git pull --ff-only`를 실행했더니 에러가 났다면, `upload` 브랜치에 직접 커밋을 했기 때문입니다. 그
-이유는 `upload` 브랜치의 내용이 원격과 로컬에서 각각 달라졌기 때문에, git이 원격과 로컬 중 무엇을
-유지하고 무엇을 버릴 지 모르기 때문입니다. 이를 고치려면, 새 브랜치를 만들고, `upstream/upload`
-브랜치와 분기된 지점을 찾은 다음, `upload` 브랜치를 그 지점으로 되돌려야 합니다.
+`git pull --ff-only`를 실행했더니 에러가 났다면, `main` 브랜치에 직접 커밋을 했기 때문입니다. 그
+이유는 `main` 브랜치의 내용이 원격과 로컬에서 각각 달라졌기 때문에, git이 원격과 로컬 중 무엇을
+유지하고 무엇을 버릴 지 모르기 때문입니다. 이를 고치려면, 새 브랜치를 만들고, `upstream/main`
+브랜치와 분기된 지점을 찾은 다음, `main` 브랜치를 그 지점으로 되돌려야 합니다.
 
 ```sh
-$ git pull --ff-only upstream upload
+$ git pull --ff-only upstream main
 From https://github.com/cataclysmbnteam/Cataclysm-BN
- * branch            upload     -> FETCH_HEAD
+ * branch            main     -> FETCH_HEAD
 fatal: Not possible to fast-forward, aborting.
-$ git branch new_branch upload          # 현재 커밋 내역을 임시 브랜치에 백업합니다
-$ git merge-base upload upstream/upload
-cc31d0... # upload에 커밋하기 직전 가장 마지막 커밋
+$ git branch new_branch main          # 현재 커밋 내역을 임시 브랜치에 백업합니다
+$ git merge-base main upstream/main
+cc31d0... # main에 커밋하기 직전 가장 마지막 커밋
 $ git reset --hard cc31d0....
 HEAD is now at cc31d0... ...
 ```
 
-이제 `upload`가 정리되었으니 `upstream/upload`에서 변경 내역을 끌어오고, `new_branch`에서 계속
+이제 `main`가 정리되었으니 `upstream/main`에서 변경 내역을 끌어오고, `new_branch`에서 계속
 작업할 수 있습니다.
 
 ```sh
-$ git pull --ff-only upstream upload
-# "upstream" 원격 저장소에서 "upload" 브랜치의 변경사항을 가져옵니다
+$ git pull --ff-only upstream main
+# "upstream" 원격 저장소에서 "main" 브랜치의 변경사항을 가져옵니다
 $ git checkout new_branch
 ```
 
-더 자주 묻는 질문은 [개발자 FAQ](../dev/reference/FAQ)를 참고해주세요.
+더 자주 묻는 질문은 [개발자 FAQ](../dev/reference/faq.md)를 참고해주세요.


### PR DESCRIPTION
## Purpose of change

- resolves #673

## Describe the solution

renamed all references of `upload` to `main`.

## Describe alternatives you've considered

none.

## Testing

old links should work.

## Additional context

https://github.com/github/renaming