### PR TITLE
fix: id, description of concrete floor without roof

### DIFF
--- a/data/json/furniture_and_terrain/terrain-floors-outdoors.json
+++ b/data/json/furniture_and_terrain/terrain-floors-outdoors.json
@@ -414,5 +414,28 @@
     "move_cost": 0,
     "roof": "t_rock_floor_no_roof",
     "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL" ]
+  },
+  {
+    "type": "terrain",
+    "id": "t_thconc_floor_no_roof",
+    "name": "concrete floor",
+    "description": "A bare and cold concrete floor.",
+    "symbol": ".",
+    "color": "cyan",
+    "looks_like": "t_thconc_floor",
+    "move_cost": 2,
+    "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
+    "bash": {
+      "sound": "SMASH!",
+      "ter_set": "t_null",
+      "str_min": 100,
+      "str_max": 400,
+      "str_min_supported": 150,
+      "items": [
+        { "item": "rock", "count": [ 5, 10 ] },
+        { "item": "scrap", "count": [ 5, 8 ] },
+        { "item": "rebar", "count": [ 0, 2 ] }
+      ]
+    }
   }
 ]

--- a/data/json/mapgen/trail_small.json
+++ b/data/json/mapgen/trail_small.json
@@ -91,7 +91,7 @@
       ],
       "terrain": {
         "#": "t_underbrush_harvested_spring",
-        "&": "t_thconc_floor_nofloor",
+        "&": "t_thconc_floor_no_roof",
         "-": "t_railing_v",
         ".": "t_grass",
         "1": "t_tree_young",
@@ -104,7 +104,7 @@
         "W": "t_water_dp",
         "_": "t_dirt",
         "a": "t_tree_hickory",
-        "b": "t_thconc_floor_nofloor",
+        "b": "t_thconc_floor_no_roof",
         "c": "t_chainfence_posts",
         "d": "t_shrub_strawberry_harvested",
         "e": "t_tree_apple",

--- a/data/json/mapgen/trail_small.json
+++ b/data/json/mapgen/trail_small.json
@@ -111,7 +111,7 @@
         "f": "t_tree_hickory_dead",
         "g": "t_tree_cherry_harvested",
         "s": "t_sidewalk",
-        "t": "t_thconc_floor_nofloor",
+        "t": "t_thconc_floor_no_roof",
         "u": "t_underbrush_harvested_autumn",
         "w": "t_water_sh",
         "|": "t_chainfence_v"

--- a/data/json/mapgen_palettes/acidia_commercial_destroyed_palette.json
+++ b/data/json/mapgen_palettes/acidia_commercial_destroyed_palette.json
@@ -1,28 +1,5 @@
 [
   {
-    "type": "terrain",
-    "id": "t_thconc_floor_nofloor",
-    "name": "concrete floor",
-    "description": "A bare and cold concrete floor with matching roof, could still insulate from the outdoors but roof collapse is possible if supporting walls are broken down.",
-    "symbol": ".",
-    "color": "cyan",
-    "looks_like": "t_thconc_floor",
-    "move_cost": 2,
-    "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
-    "bash": {
-      "sound": "SMASH!",
-      "ter_set": "t_null",
-      "str_min": 100,
-      "str_max": 400,
-      "str_min_supported": 150,
-      "items": [
-        { "item": "rock", "count": [ 5, 10 ] },
-        { "item": "scrap", "count": [ 5, 8 ] },
-        { "item": "rebar", "count": [ 0, 2 ] }
-      ]
-    }
-  },
-  {
     "type": "palette",
     "id": "acidia_commercial_destroyed_palette",
     "furniture": {
@@ -92,7 +69,7 @@
         "t_door_locked_interior"
       ],
       "2": "t_linoleum_white",
-      "3": "t_thconc_floor_nofloor",
+      "3": "t_thconc_floor_no_roof",
       "4": "t_linoleum_white",
       "5": [ "t_door_bar_locked", "t_door_bar_locked", "t_door_bar_locked", "t_door_bar_locked", "t_door_bar_o" ],
       "6": "t_console_broken",


### PR DESCRIPTION
## Purpose of change
Rename id "t_thconc_floor_nofloor" of concrete floor without roof for consistency.
Remove the "roof" part of the terrain description.
## Describe the solution
Replace id with "t_thconc_floor_no_roof".
## Describe alternatives you've considered
None
## Testing

## Additional context
<img width="665" alt="Capture d’écran 2023-12-13 145534" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/fcf75f89-0f73-4bd3-b12a-4265dbca07aa">