### PR TITLE
fix: `debug_clairvoyance` not working on reading and vehicle modification

### DIFF
--- a/src/character_functions.cpp
+++ b/src/character_functions.cpp
@@ -164,7 +164,9 @@ float fine_detail_vision_mod( const Character &who )
 
 float fine_detail_vision_mod( const Character &who, const tripoint &p )
 {
-    if( who.has_effect_with_flag( flag_EFFECT_SUPER_CLAIRVOYANCE ) ) {
+    if( who.has_effect_with_flag( flag_EFFECT_SUPER_CLAIRVOYANCE )
+        || who.has_effect_with_flag( flag_EFFECT_CLAIRVOYANCE )
+        || who.has_effect_with_flag( flag_EFFECT_CLAIRVOYANCE_PLUS ) ) {
         return 1.0f;
     }
 

--- a/src/character_functions.cpp
+++ b/src/character_functions.cpp
@@ -164,6 +164,10 @@ float fine_detail_vision_mod( const Character &who )
 
 float fine_detail_vision_mod( const Character &who, const tripoint &p )
 {
+    if( who.has_effect_with_flag( flag_EFFECT_SUPER_CLAIRVOYANCE ) ) {
+        return 1.0f;
+    }
+
     // PER_SLIME_OK implies you can get enough eyes around the bile
     // that you can generally see.  There still will be the haze, but
     // it's annoying rather than limiting.


### PR DESCRIPTION
## Purpose of change

- fix #3898 

## Describe the solution

make `fine_detail_vision_mod` which is used to check everything related to vision.

## Describe alternatives you've considered

screm

## Testing

1. spawned architect's cube.
2. light level went bright.
3. was able to read books.
4. was able to install vehicle parts.