### PR TITLE
feat(content): wheels for apache helicopter

### DIFF
--- a/data/json/vehicles/helicopters.json
+++ b/data/json/vehicles/helicopters.json
@@ -1163,7 +1163,10 @@
       { "x": -1, "y": -1, "part": "plating_military" },
       { "x": 3, "y": -2, "part": "plating_military" },
       { "x": 4, "y": -1, "part": "plating_military" },
-      { "x": 3, "y": 0, "part": "plating_military" }
+      { "x": 3, "y": 0, "part": "plating_military" },
+      { "x": -10, "y": -1, "part": "wheel_10" },
+      { "x": -2, "y": 0, "part": "wheel_10" },
+      { "x": -2, "y": -2, "part": "wheel_10" }
     ],
     "items": [
       { "x": -1, "y": -1, "chance": 7, "item_groups": [ "drugs_soldier" ] },
@@ -1312,7 +1315,9 @@
       { "x": -1, "y": -1, "part": "plating_military" },
       { "x": 3, "y": -2, "part": "plating_military" },
       { "x": 4, "y": -1, "part": "plating_military" },
-      { "x": 3, "y": 0, "part": "plating_military" }
+      { "x": 3, "y": 0, "part": "plating_military" },
+      { "x": -2, "y": 0, "part": "wheel_10" },
+      { "x": -2, "y": -2, "part": "wheel_10" }
     ],
     "items": [
       { "x": -1, "y": -1, "chance": 7, "item_groups": [ "drugs_soldier" ] },


### PR DESCRIPTION
## Purpose of change

1. intact apache helicopters can be found in aircraft carrier(#3892)
2. they are hard to use because they lack wheels

## Describe the solution

![Cataclysm: Bright Nights - 0 C-56948-g6dc6c1ca82b8-dirty_01](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/96ca7aee-88a6-4e93-891c-99279587b756)

added wheels to apache helicopter so it can be drived.

## Describe alternatives you've considered

- adding wheels to other helicopters, but there's rather a large amount of them

## Testing

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/96ad520b-0ec8-412a-afaa-98870064117f)
