### PR TITLE
feat(UI): display mouse cursor position on examine

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6751,7 +6751,10 @@ look_around_result game::look_around( bool show_window, tripoint &center,
                          pixel_minimap_text );
 #endif // TILES
 
-            int first_line = 1;
+            // print current position
+            center_print( w_info, 1, c_white, string_format( _( "Cursor At: (%d,%d,%d)" ), lx, ly, lz ) );
+
+            int first_line = 2;
             const int last_line = getmaxy( w_info ) - 3;
             pre_print_all_tile_info( lp, w_info, first_line, last_line, cache );
 


### PR DESCRIPTION
## Purpose of change

make it easier to debug position related bugs (e.g #3892)

## Describe the solution

display mouse cursor point on e`x`amine

## Describe alternatives you've considered

the location and display format could change.

## Testing

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/8c6a3001-a3f3-47a3-976e-7eb2f6851519

