### PR TITLE
ci: ignore `no_hope` and `aftershock` on all mods test

### DIFF
--- a/build-scripts/mod_test_blacklist
+++ b/build-scripts/mod_test_blacklist
@@ -1,3 +1,4 @@
+no_hope
 crt_expansion
 Graphical_Overmap
 no_medieval_items

--- a/build-scripts/mod_test_blacklist
+++ b/build-scripts/mod_test_blacklist
@@ -1,4 +1,5 @@
 no_hope
+aftershock
 crt_expansion
 Graphical_Overmap
 no_medieval_items


### PR DESCRIPTION
## Purpose of change

- resolves #3896
- fixes test failure introduced by #3876
