### PR TITLE
ci: simplify tag and release name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,49 +9,42 @@ env:
   VCPKG_BINARY_SOURCES: "default"
 
 jobs:
-  commits:
+  metadata:
     runs-on: ubuntu-latest
     outputs:
-      count: ${{ steps.yesterday.outputs.count }}
+      count: ${{ steps.env_vars.outputs.count }}
+      tag_name: ${{ steps.env_vars.outputs.tag_name }}
+      release_name: ${{ steps.env_vars.outputs.release_name }}
     steps:
       - uses: actions/checkout@v3
-      - id: yesterday
+      - id: env_vars
         run: |
-          COMMITS=$(git log --oneline --since=$(date -u --iso-8601 --date='1 day ago') | wc -l)
-          
+          COMMITS=$(git log --oneline --since="$(date -u --iso-8601 --date='1 day ago')" | wc -l)
+          TAG_NAME=$(date -u --iso-8601=date)
+          RELEASE_NAME="Experimental $TAG_NAME"
+
           echo "commits yesterday: $COMMITS" >> "$GITHUB_STEP_SUMMARY"
 
           echo "count=$COMMITS" >> "$GITHUB_OUTPUT"
+          echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
+          echo "release_name=$RELEASE_NAME" >> "$GITHUB_OUTPUT"
 
   release:
-    needs: commits
+    needs: metadata
     name: Create Release
     runs-on: ubuntu-22.04
-    if: fromJson(needs.commits.outputs.count) > 0
+
+    if: fromJson(needs.metadata.outputs.count) > 0
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
-      timestamp: ${{ steps.get-timestamp.outputs.time }}
       release_already_exists: ${{ steps.tag_check.outputs.exists }}
 
     steps:
-      - name: Get build timestamp
-        id: get-timestamp
-        uses: nanzm/get-time-action@v1.1
-        with:
-          timeZone: 0
-          format: "YYYY-MM-DD-HHmm"
-
-      - name: Generate environmental variables
-        id: generate_env_vars
-        run: |
-          echo "tag_name=cbn-experimental-${{ steps.get-timestamp.outputs.time }}" >> $GITHUB_OUTPUT
-          echo "release_name=Cataclysm-BN experimental build ${{ steps.get-timestamp.outputs.time }}" >> $GITHUB_OUTPUT
-
       - name: Check if there is existing git tag
         id: tag_check
         uses: mukunku/tag-exists-action@v1.4.0
         with:
-          tag: ${{ steps.generate_env_vars.outputs.tag_name }}
+          tag: ${{ needs.metadata.outputs.tag_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -63,12 +56,12 @@ jobs:
         uses: mathieudutour/github-tag-action@v5.5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          custom_tag: ${{ steps.generate_env_vars.outputs.tag_name }}
+          custom_tag: ${{ needs.metadata.outputs.tag_name }}
           tag_prefix: ""
 
       - uses: actions/checkout@v3
 
-      - run: git fetch origin tag ${{ steps.generate_env_vars.outputs.tag_name }} --no-tags
+      - run: git fetch origin tag ${{ needs.metadata.outputs.tag_name }} --no-tags
 
       - name: Build Changelog
         id: build_changelog
@@ -85,8 +78,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.generate_env_vars.outputs.tag_name }}
-          release_name: ${{ steps.generate_env_vars.outputs.release_name }}
+          tag_name: ${{ needs.metadata.outputs.tag_name }}
+          release_name: ${{ needs.metadata.outputs.release_name }}
           body: |
             ${{ steps.build_changelog.outputs.changelog }}
             These are the outputs for the experimental build of commit [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})
@@ -94,7 +87,7 @@ jobs:
           prerelease: true
 
   builds:
-    needs: release
+    needs: [metadata, release]
     if: ${{ needs.release.outputs.release_already_exists == 'false' }}
     strategy:
       fail-fast: false
@@ -192,7 +185,7 @@ jobs:
         run: |
           cat >VERSION.txt <<EOL
           build type: ${{ matrix.artifact }}
-          build number: ${{ needs.release.outputs.timestamp }}
+          build number: ${{ needs.metadata.outputs.tag_name }}
           commit sha: ${{ github.sha }}
           commit url: https://github.com/${{ github.repository }}/commit/${{ github.sha }}
           EOL
@@ -258,7 +251,7 @@ jobs:
         if: runner.os == 'Linux' && matrix.mxe == 'none' && matrix.android == 'none'
         run: |
           make -j$((`nproc`+0)) TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} LUA=1 RELEASE=1 LANGUAGES=all PCH=0 bindist
-          mv cataclysmbn-unstable.tar.gz cbn-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.tar.gz
+          mv cataclysmbn-unstable.tar.gz cbn-${{ matrix.artifact }}-${{ needs.metadata.outputs.tag_name }}.tar.gz
 
       - name: Build CBN (windows)
         if: matrix.mxe != 'none'
@@ -266,7 +259,7 @@ jobs:
           PLATFORM: /opt/mxe/usr/bin/${{ matrix.mxe }}-w64-mingw32.static.gcc11-
         run: |
           make -j$((`nproc`+0)) CROSS="${PLATFORM}" TILES=1 SOUND=1 LUA=1 RELEASE=1 LANGUAGES=all PCH=0 bindist
-          mv cataclysmbn-unstable.zip cbn-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.zip
+          mv cataclysmbn-unstable.zip cbn-${{ matrix.artifact }}-${{ needs.metadata.outputs.tag_name }}.zip
 
       - name: Build CBN (windows msvc)
         if: runner.os == 'Windows'
@@ -275,13 +268,13 @@ jobs:
         run: |
           msbuild -m -p:Configuration=Release -p:Platform=${{ matrix.arch }} "-target:Cataclysm-vcpkg-static;JsonFormatter-vcpkg-static" msvc-full-features\Cataclysm-vcpkg-static.sln
           .\build-scripts\windist.ps1
-          mv cataclysmbn.zip cbn-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.zip
+          mv cataclysmbn.zip cbn-${{ matrix.artifact }}-${{ needs.metadata.outputs.tag_name }}.zip
 
       - name: Build CBN (osx)
         if: runner.os == 'macOS'
         run: |
           make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} LUA=1 RELEASE=1 LANGUAGES=all USE_HOME_DIR=1 OSX_MIN=11 PCH=0 dmgdist COMPILER=clang++
-          mv CataclysmBN-unstable.dmg cbn-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.dmg
+          mv CataclysmBN-unstable.dmg cbn-${{ matrix.artifact }}-${{ needs.metadata.outputs.tag_name }}.dmg
 
       - name: Set up JDK 11 (android)
         if: runner.os == 'Linux' && matrix.android != 'none' && matrix.mxe == 'none'
@@ -309,15 +302,15 @@ jobs:
           if [ ${{ matrix.android }} = arm64 ]
           then
                ./gradlew -Pj=$((`nproc`+0)) -Pabi_arm_32=false assembleExperimentalRelease
-               mv ./app/build/outputs/apk/experimental/release/*.apk ../cbn-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.apk
+               mv ./app/build/outputs/apk/experimental/release/*.apk ../cbn-${{ matrix.artifact }}-${{ needs.metadata.outputs.tag_name }}.apk
           elif [ ${{ matrix.android }} = arm32 ]
           then
                ./gradlew -Pj=$((`nproc`+0)) -Pabi_arm_64=false assembleExperimentalRelease
-               mv ./app/build/outputs/apk/experimental/release/*.apk ../cbn-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.apk
+               mv ./app/build/outputs/apk/experimental/release/*.apk ../cbn-${{ matrix.artifact }}-${{ needs.metadata.outputs.tag_name }}.apk
           elif [ ${{ matrix.android }} = bundle ]
           then
                ./gradlew -Pj=$((`nproc`+0)) bundleExperimentalRelease
-               mv ./app/build/outputs/bundle/experimentalRelease/*.aab ../cbn-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.aab
+               mv ./app/build/outputs/bundle/experimentalRelease/*.aab ../cbn-${{ matrix.artifact }}-${{ needs.metadata.outputs.tag_name }}.aab
           fi
 
       - name: Upload release asset
@@ -327,6 +320,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
-          asset_path: cbn-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.${{ matrix.ext }}
-          asset_name: cbn-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.${{ matrix.ext }}
+          asset_path: cbn-${{ matrix.artifact }}-${{ needs.metadata.outputs.tag_name }}.${{ matrix.ext }}
+          asset_name: cbn-${{ matrix.artifact }}-${{ needs.metadata.outputs.tag_name }}.${{ matrix.ext }}
           asset_content_type: ${{ matrix.content }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,9 @@ jobs:
       - id: yesterday
         run: |
           COMMITS=$(git log --oneline --since=$(date -u --iso-8601 --date='1 day ago') | wc -l)
+          
           echo "commits yesterday: $COMMITS" >> "$GITHUB_STEP_SUMMARY"
+
           echo "count=$COMMITS" >> "$GITHUB_OUTPUT"
 
   release:
@@ -30,6 +32,7 @@ jobs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
       timestamp: ${{ steps.get-timestamp.outputs.time }}
       release_already_exists: ${{ steps.tag_check.outputs.exists }}
+
     steps:
       - name: Get build timestamp
         id: get-timestamp
@@ -37,11 +40,13 @@ jobs:
         with:
           timeZone: 0
           format: "YYYY-MM-DD-HHmm"
+
       - name: Generate environmental variables
         id: generate_env_vars
         run: |
           echo "tag_name=cbn-experimental-${{ steps.get-timestamp.outputs.time }}" >> $GITHUB_OUTPUT
           echo "release_name=Cataclysm-BN experimental build ${{ steps.get-timestamp.outputs.time }}" >> $GITHUB_OUTPUT
+
       - name: Check if there is existing git tag
         id: tag_check
         uses: mukunku/tag-exists-action@v1.4.0
@@ -49,17 +54,22 @@ jobs:
           tag: ${{ steps.generate_env_vars.outputs.tag_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: actions/checkout@v3
+
       - name: Push tag
+        if: ${{ steps.tag_check.outputs.exists == 'false' }}
         id: tag_version
         uses: mathieudutour/github-tag-action@v5.5
-        if: ${{ steps.tag_check.outputs.exists == 'false' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ steps.generate_env_vars.outputs.tag_name }}
           tag_prefix: ""
+
       - uses: actions/checkout@v3
+
       - run: git fetch origin tag ${{ steps.generate_env_vars.outputs.tag_name }} --no-tags
+
       - name: Build Changelog
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v2.1.0
@@ -67,10 +77,11 @@ jobs:
           configuration: "changelog.json"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create release
+        if: ${{ steps.tag_check.outputs.exists == 'false' }}
         id: create_release
         uses: actions/create-release@v1
-        if: ${{ steps.tag_check.outputs.exists == 'false' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -81,6 +92,7 @@ jobs:
             These are the outputs for the experimental build of commit [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})
           draft: false
           prerelease: true
+
   builds:
     needs: release
     if: ${{ needs.release.outputs.release_already_exists == 'false' }}
@@ -167,8 +179,10 @@ jobs:
             artifact: android-bundle
             ext: aab
             content: application/aap
+
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+
     env:
       ZSTD_CLEVEL: 17
     steps:
@@ -182,21 +196,26 @@ jobs:
           commit sha: ${{ github.sha }}
           commit url: https://github.com/${{ github.repository }}/commit/${{ github.sha }}
           EOL
+
       - name: Install MSBuild (windows msvc)
         if: runner.os == 'Windows'
         uses: microsoft/setup-msbuild@v1.3.1
+
       - name: Install stable CMake
         uses: lukka/get-cmake@latest
+
       - name: Install vcpkg
         uses: lukka/run-vcpkg@v11
         id: runvcpkg
         with:
           vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
           vcpkgGitCommitId: "66444e13a86da7087ee24c342f91801cc6eb9877"
+
       - name: Integrate vcpkg
         if: runner.os == 'Windows'
         run: |
           vcpkg integrate install
+
       - name: Install dependencies (windows mxe)
         if: matrix.mxe != 'none'
         run: |
@@ -204,6 +223,7 @@ jobs:
           sudo apt install astyle autoconf automake autopoint bash bison bzip2 cmake flex gettext git g++ gperf intltool \
             libffi-dev libgdk-pixbuf2.0-dev libtool libltdl-dev libssl-dev libxml-parser-perl lzip make mingw-w64 openssl \
             p7zip-full patch perl pkg-config python ruby scons sed unzip wget xz-utils g++-multilib libc6-dev-i386 libtool-bin
+
       - name: Install MXE
         if: matrix.mxe != 'none'
         run: |
@@ -214,27 +234,32 @@ jobs:
           curl -L -o libbacktrace-${{ matrix.mxe }}-w64-mingw32.tar.gz https://github.com/Qrox/libbacktrace/releases/download/2020-01-03/libbacktrace-${{ matrix.mxe }}-w64-mingw32.tar.gz
           shasum -a 256 -c ./build-scripts/libbacktrace-${{ matrix.mxe }}-w64-mingw32-sha256
           sudo tar -xzf libbacktrace-${{ matrix.mxe }}-w64-mingw32.tar.gz --exclude=LICENSE -C /opt/mxe/usr/${{ matrix.mxe }}-w64-mingw32.static.gcc11
+
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux' && matrix.mxe == 'none' && matrix.android == 'none'
         run: |
           sudo apt-get update
           sudo apt-get install libncursesw5-dev libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev \
             libsdl2-mixer-dev libpulse-dev ccache gettext parallel
+
       - name: Install dependencies (mac)
         if: runner.os == 'macOS'
         run: |
           HOMEBREW_NO_AUTO_UPDATE=yes HOMEBREW_NO_INSTALL_CLEANUP=yes brew install sdl2 sdl2_image sdl2_ttf sdl2_mixer gettext ccache parallel
           pip3 install mac_alias==2.2.0 dmgbuild==1.6.1 biplist
+
       - name: Compile translations (windows)
         if: runner.os == 'Windows'
         shell: bash
         run: |
           lang/compile_mo.sh all
+
       - name: Build CBN (linux)
         if: runner.os == 'Linux' && matrix.mxe == 'none' && matrix.android == 'none'
         run: |
           make -j$((`nproc`+0)) TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} LUA=1 RELEASE=1 LANGUAGES=all PCH=0 bindist
           mv cataclysmbn-unstable.tar.gz cbn-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.tar.gz
+
       - name: Build CBN (windows)
         if: matrix.mxe != 'none'
         env:
@@ -242,6 +267,7 @@ jobs:
         run: |
           make -j$((`nproc`+0)) CROSS="${PLATFORM}" TILES=1 SOUND=1 LUA=1 RELEASE=1 LANGUAGES=all PCH=0 bindist
           mv cataclysmbn-unstable.zip cbn-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.zip
+
       - name: Build CBN (windows msvc)
         if: runner.os == 'Windows'
         env:
@@ -250,22 +276,26 @@ jobs:
           msbuild -m -p:Configuration=Release -p:Platform=${{ matrix.arch }} "-target:Cataclysm-vcpkg-static;JsonFormatter-vcpkg-static" msvc-full-features\Cataclysm-vcpkg-static.sln
           .\build-scripts\windist.ps1
           mv cataclysmbn.zip cbn-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.zip
+
       - name: Build CBN (osx)
         if: runner.os == 'macOS'
         run: |
           make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} LUA=1 RELEASE=1 LANGUAGES=all USE_HOME_DIR=1 OSX_MIN=11 PCH=0 dmgdist COMPILER=clang++
           mv CataclysmBN-unstable.dmg cbn-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.dmg
+
       - name: Set up JDK 11 (android)
         if: runner.os == 'Linux' && matrix.android != 'none' && matrix.mxe == 'none'
         uses: actions/setup-java@v3
         with:
           java-version: "11"
           distribution: "adopt"
+
       - name: Setup Build and Dependencies (android)
         if: runner.os == 'Linux' && matrix.android != 'none' && matrix.mxe == 'none'
         run: |
           sudo apt-get update
           sudo apt-get install gettext
+
       - name: Build CBN (android)
         if: runner.os == 'Linux' && matrix.android != 'none' && matrix.mxe == 'none'
         working-directory: ./android
@@ -289,6 +319,7 @@ jobs:
                ./gradlew -Pj=$((`nproc`+0)) bundleExperimentalRelease
                mv ./app/build/outputs/bundle/experimentalRelease/*.aab ../cbn-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.aab
           fi
+
       - name: Upload release asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,11 @@ jobs:
       - uses: actions/checkout@v3
       - id: env_vars
         run: |
-          COMMITS=$(git log --oneline --since="$(date -u --iso-8601 --date='1 day ago')" | wc -l)
-          TAG_NAME=$(date -u --iso-8601=date)
+          TAG_NAME=$(date -u --iso-8601 --date='1 day ago')
+          COMMITS=$(git log --oneline --since="$TAG_NAME" | wc -l)
           RELEASE_NAME="Experimental $TAG_NAME"
 
-          echo "commits yesterday: $COMMITS" >> "$GITHUB_STEP_SUMMARY"
+          echo "commits yesterday ($TAG_NAME): $COMMITS" >> "$GITHUB_STEP_SUMMARY"
 
           echo "count=$COMMITS" >> "$GITHUB_OUTPUT"
           echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Purpose of change

- resolves #3895

## Describe the solution

- tag format: `cbn-experimental-YYYY-MM-DD-HHmm` -> `YYYY-MM-DD`
- release format: `Cataclysm-BN experimental build YYYY-MM-DD-HHmm` -> `Experimental YYYY-MM-DD`

tag name aligns with date range of commits. for example, release with commits from `2023-12-26T00:00:00Z/2023-12-26T23:59:59Z` will be named
- before: `cbn-experimental-2023-12-27-0036` (36 seconds is due to CI delay)
- after: `2023-12-26`

## Describe alternatives you've considered

- keeping it as-is, but this has disadvantages of not being able to locate daily release without using github API, such as: `https://github.com/cataclysmbnteam/Cataclysm-BN/releases/tag/2023-12-17`
- alternative tag prefix? `v2023-12-17`, `cbn-2023-12-17`
- use yesterday as release name? currently release `2023-12-18` contains commits from `2023-12-17`.

## Testing

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/84ef7c9f-1caa-4bf2-ae9f-dbe3d3389bcf)

https://github.com/scarf005/Cataclysm-BN/actions/runs/7237790887/job/19717922050

runs on fork. android failure is due to lack of keyring.

## Additional context
