### PR TITLE
feat: remove option to not use z-levels

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -481,11 +481,7 @@ void game::setup()
 
     init::load_world_modfiles( ui, get_world_base_save_path() + "/" + SAVE_ARTIFACTS );
 
-    if( get_option<bool>( "ELEVATED_BRIDGES" ) && !get_option<bool>( "ZLEVELS" ) ) {
-        debugmsg( "\"Elevated bridges\" mod requires z-levels to be ENABLED to work properly!" );
-    }
-
-    m = map( get_option<bool>( "ZLEVELS" ) );
+    m = map();
 
     next_npc_id = character_id( 1 );
     next_mission_id = 1;

--- a/src/map.h
+++ b/src/map.h
@@ -387,7 +387,7 @@ class map
 
     public:
         // Constructors & Initialization
-        map( int mapsize = MAPSIZE, bool zlev = false );
+        map( int mapsize = MAPSIZE, bool zlev = true );
         explicit map( bool zlev ) : map( MAPSIZE, zlev ) { }
         virtual ~map();
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2380,13 +2380,6 @@ void options_manager::add_options_world_default()
 
     add_empty_line();
 
-    add( "ZLEVELS", world_default, translate_marker( "Z-levels" ),
-         translate_marker( "If true, enables several features related to vertical movement, such as hauling items up stairs, climbing downspouts, flying aircraft and ramps.  May cause problems if toggled mid-game." ),
-         true
-       );
-
-    add_empty_line();
-
     add( "CHARACTER_POINT_POOLS", world_default, translate_marker( "Character point pools" ),
          translate_marker( "Allowed point pools for character generation." ),
     { { "any", translate_marker( "Any" ) }, { "multi_pool", translate_marker( "Multi-pool only" ) }, { "no_freeform", translate_marker( "No freeform" ) } },

--- a/tests/ground_destroy_test.cpp
+++ b/tests/ground_destroy_test.cpp
@@ -1,6 +1,5 @@
 #include "catch/catch.hpp"
 
-#include <memory>
 #include <set>
 #include <vector>
 
@@ -20,15 +19,12 @@
 // Destroying pavement with a pickaxe should not leave t_flat_roof.
 // See issue #24707:
 // https://github.com/CleverRaven/Cataclysm-DDA/issues/24707
-// Behavior may depend on ZLEVELS being set.
 TEST_CASE( "pavement_destroy", "[.]" )
 {
     clear_all_state();
     const ter_id flat_roof_id = ter_id( "t_flat_roof" );
     REQUIRE( flat_roof_id != t_null );
 
-    const bool zlevels_set = get_option<bool>( "ZLEVELS" );
-    INFO( "ZLEVELS is " << zlevels_set );
     put_player_underground();
     map &here = get_map();
     // Populate the map with pavement.
@@ -47,15 +43,11 @@ TEST_CASE( "pavement_destroy", "[.]" )
 // Ground-destroying explosions on dirt or grass shouldn't leave t_flat_roof.
 // See issue #23250:
 // https://github.com/CleverRaven/Cataclysm-DDA/issues/23250
-// Behavior may depend on ZLEVELS being set.
 TEST_CASE( "explosion_on_ground", "[.]" )
 {
     clear_all_state();
     ter_id flat_roof_id = ter_id( "t_flat_roof" );
     REQUIRE( flat_roof_id != t_null );
-
-    const bool zlevels_set = get_option<bool>( "ZLEVELS" );
-    INFO( "ZLEVELS is " << zlevels_set );
 
     put_player_underground();
     std::vector<ter_id> test_terrain_id = {
@@ -95,7 +87,6 @@ TEST_CASE( "explosion_on_ground", "[.]" )
 // Ground-destroying explosions on t_floor with a t_rock_floor basement
 // below should create some t_open_air, not just t_flat_roof (which is
 // the defined roof of a t_rock-floor).
-// Behavior depends on ZLEVELS being set.
 TEST_CASE( "explosion_on_floor_with_rock_floor_basement", "[.]" )
 {
     clear_all_state();
@@ -108,9 +99,6 @@ TEST_CASE( "explosion_on_floor_with_rock_floor_basement", "[.]" )
     REQUIRE( floor_id != t_null );
     REQUIRE( rock_floor_id != t_null );
     REQUIRE( open_air_id != t_null );
-
-    const bool zlevels_set = get_option<bool>( "ZLEVELS" );
-    INFO( "ZLEVELS is " << zlevels_set );
 
     put_player_underground();
 
@@ -155,7 +143,6 @@ TEST_CASE( "explosion_on_floor_with_rock_floor_basement", "[.]" )
 
 // Destroying interior floors shouldn't cause the roofs above to collapse.
 // Destroying supporting walls should cause the roofs above to collapse.
-// Behavior may depend on ZLEVELS being set.
 TEST_CASE( "collapse_checks", "[.]" )
 {
     clear_all_state();
@@ -171,8 +158,6 @@ TEST_CASE( "collapse_checks", "[.]" )
     REQUIRE( wall_id != t_null );
     REQUIRE( open_air_id != t_null );
 
-    const bool zlevels_set = get_option<bool>( "ZLEVELS" );
-    INFO( "ZLEVELS is " << zlevels_set );
     put_player_underground();
 
     map &here = get_map();

--- a/tests/monster_vision_test.cpp
+++ b/tests/monster_vision_test.cpp
@@ -26,8 +26,7 @@ static const time_point midday = calendar::turn_zero + 12_hours;
 TEST_CASE( "monsters shouldn't see through floors", "[vision]" )
 {
     clear_all_state();
-    override_option opt( "ZLEVELS", "true" );
-    override_option opt2( "FOV_3D", "true" );
+    override_option opt( "FOV_3D", "true" );
     bool old_fov_3d = fov_3d;
     fov_3d = true;
     calendar::turn = midday;

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -161,7 +161,7 @@ static void init_global_game_state( const std::vector<mod_id> &mods,
     g->u = avatar();
     g->u.create( character_type::NOW );
 
-    g->m = map( get_option<bool>( "ZLEVELS" ) );
+    g->m = map();
     disable_mapgen = true;
 
     g->m.load( tripoint( g->get_levx(), g->get_levy(), g->get_levz() ), false );


### PR DESCRIPTION
## Purpose of change

- fixes #3906
- fixes #3907

## Describe the solution

remove mentions of `get_option<bool>( "ZLEVELS" )`. also referenced https://github.com/CleverRaven/Cataclysm-DDA/pull/41707

## Describe alternatives you've considered

keeping the system as-is, however not having one causes issues like #3096 and complicates z-level features like elevated bridges.

## Testing

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/ee65553d-90be-4f87-8bc0-baaa90769de9)

was able to load, z-levels were present.

## Additional context

this change was approved by players via poll in #3533.