### PR TITLE
fix: Stack cbc item contents

### DIFF
--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -30,20 +30,20 @@ bool item_contents::empty() const
 
 ret_val<bool> item_contents::insert_item( detached_ptr<item> &&it )
 {
-	bool stacked=false;
-	if(it->count_by_charges()){
-	    for(item * check : items){
-			// NOLINTNEXTLINE(bugprone-use-after-move)
-			if(check->merge_charges(std::move(it))){
-				stacked=true;
-				break;
-			}
-		}
-	}
+    bool stacked = false;
+    if( it->count_by_charges() ) {
+        for( item *check : items ) {
+            // NOLINTNEXTLINE(bugprone-use-after-move)
+            if( check->merge_charges( std::move( it ) ) ) {
+                stacked = true;
+                break;
+            }
+        }
+    }
 
-    if(!stacked){
-		items.push_back( std::move( it ) );
-	}
+    if( !stacked ) {
+        items.push_back( std::move( it ) );
+    }
 
     return ret_val<bool>::make_success();
 }

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -42,6 +42,7 @@ ret_val<bool> item_contents::insert_item( detached_ptr<item> &&it )
     }
 
     if( !stacked ) {
+        // NOLINTNEXTLINE(bugprone-use-after-move)
         items.push_back( std::move( it ) );
     }
 

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -30,7 +30,21 @@ bool item_contents::empty() const
 
 ret_val<bool> item_contents::insert_item( detached_ptr<item> &&it )
 {
-    items.push_back( std::move( it ) );
+	bool stacked=false;
+	if(it->count_by_charges()){
+	    for(item * check : items){
+			// NOLINTNEXTLINE(bugprone-use-after-move)
+			if(check->merge_charges(std::move(it))){
+				stacked=true;
+				break;
+			}
+		}
+	}
+
+    if(!stacked){
+		items.push_back( std::move( it ) );
+	}
+
     return ret_val<bool>::make_success();
 }
 


### PR DESCRIPTION
## Purpose of change

Fixes #3763 and generally makes item contents stack when appropriate. 

## Describe the solution

Tries to merge things before adding it.

## Additional context

I think this was present in 0.4 as well. 