### PR TITLE
fix: cufflinks are fancy!

### DIFF
--- a/data/json/items/armor/jewelry.json
+++ b/data/json/items/armor/jewelry.json
@@ -361,7 +361,8 @@
     "price_postapoc": "10 cent",
     "material": [ "silver" ],
     "symbol": "[",
-    "color": "light_gray"
+    "color": "light_gray",
+    "flags": [ "FANCY" ]
   },
   {
     "id": "cufflinks_intricate",
@@ -374,7 +375,8 @@
     "price_postapoc": "50 cent",
     "material": [ "silver", "gold" ],
     "symbol": "[",
-    "color": "light_gray"
+    "color": "light_gray",
+    "flags": [ "SUPER_FANCY" ]
   },
   {
     "id": "garnet_gold_cufflinks",


### PR DESCRIPTION
## Purpose of change

Regular non-jeweled cufflinks and intricate cufflinks are missing their rightful fancy flag. 0/10, literally unplayable.

## Describe the solution

- Made regular cufflinks `FANCY`. Duh
- Made intricate cufflinks `SUPER_FANCY`. There's precious few "very fancy" items that stylish characters can wear for that sweet sweet morale boost that don't also make you look like a deranged psycho given the circumstances. Let's provide at least one more sane alternative to killing zombies in a wedding dress.

## Describe alternatives you've considered

Killing zombies in a wedding dress. While also wearing a top hat and a monocle. Because that's what you call "stylish".

## Testing

Made sure the JSON changes are reflected in the game.
