### PR TITLE
ci: prevent JSON PRs skipping tests

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -166,13 +166,6 @@ jobs:
         run: |
             sudo apt-get install libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libpulse-dev libflac-dev
 
-      - name: check compiler (mac)
-        if: ${{ env.SKIP == 'false' && runner.os == 'macOS' }}
-        run: |
-          ${{ matrix.compiler }} --version
-          # Ensure that it is actually needed version
-          ${{ matrix.compiler }} --version | grep -q -E "${{ matrix.grep_clang_version_rxp }}"
-
       - name: set up a mock GCC toolchain root for Clang (Ubuntu)
         if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && (matrix.compiler == 'clang++-14') }}
         run: |
@@ -185,6 +178,10 @@ jobs:
       - name: install dependencies (mac)
         if: ${{ env.SKIP == 'false' && runner.os == 'macOS' }}
         run: |
+          ${{ matrix.compiler }} --version
+          # Ensure that it is actually needed version
+          ${{ matrix.compiler }} --version | grep -q -E "${{ matrix.grep_clang_version_rxp }}"
+          
           HOMEBREW_NO_AUTO_UPDATE=yes HOMEBREW_NO_INSTALL_CLEANUP=yes brew install sdl2 sdl2_image sdl2_ttf sdl2_mixer gettext ccache parallel
 
       - name: prepare

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -126,12 +126,12 @@ jobs:
       ZSTD_CLEVEL: 17
       CMAKE: ${{ matrix.cmake }}
       COMPILER: ${{ matrix.compiler }}
-      CXXFLAGS: ${{ matrix.cxxflags }}
+      # CXXFLAGS: ${{ matrix.cxxflags }}
       OS: ${{ matrix.os }}
       TILES: ${{ matrix.tiles }}
       SOUND: ${{ matrix.sound }}
       LUA: ${{ matrix.lua }}
-      SANITIZE: ${{ matrix.sanitize }}
+      # SANITIZE: ${{ matrix.sanitize }}
       TEST_STAGE: ${{ matrix.test-stage }}
       LANGUAGES: ${{ matrix.languages }}
       LIBBACKTRACE: ${{ matrix.libbacktrace }}
@@ -166,14 +166,15 @@ jobs:
         run: |
             sudo apt-get install libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libpulse-dev libflac-dev
 
-      - name: set up a mock GCC toolchain root for Clang (Ubuntu)
-        if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && (matrix.compiler == 'clang++-14') }}
-        run: |
-          sudo mkdir /opt/mock-gcc-11
-          sudo ln -s /usr/include /opt/mock-gcc-11/include
-          sudo ln -s /usr/bin /opt/mock-gcc-11/bin
-          sudo mkdir -p /opt/mock-gcc-11/lib/gcc/x86_64-linux-gnu
-          sudo ln -s /usr/lib/gcc/x86_64-linux-gnu/11 /opt/mock-gcc-11/lib/gcc/x86_64-linux-gnu/11
+      # === Temporarily disabled because of #3664 ===
+      # - name: set up a mock GCC toolchain root for Clang (Ubuntu)
+      #   if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && (matrix.compiler == 'clang++-14') }}
+      #   run: |
+      #     sudo mkdir /opt/mock-gcc-11
+      #     sudo ln -s /usr/include /opt/mock-gcc-11/include
+      #     sudo ln -s /usr/bin /opt/mock-gcc-11/bin
+      #     sudo mkdir -p /opt/mock-gcc-11/lib/gcc/x86_64-linux-gnu
+      #     sudo ln -s /usr/lib/gcc/x86_64-linux-gnu/11 /opt/mock-gcc-11/lib/gcc/x86_64-linux-gnu/11
 
       - name: install dependencies (mac)
         if: ${{ env.SKIP == 'false' && runner.os == 'macOS' }}
@@ -181,7 +182,7 @@ jobs:
           ${{ matrix.compiler }} --version
           # Ensure that it is actually needed version
           ${{ matrix.compiler }} --version | grep -q -E "${{ matrix.grep_clang_version_rxp }}"
-          
+
           HOMEBREW_NO_AUTO_UPDATE=yes HOMEBREW_NO_INSTALL_CLEANUP=yes brew install sdl2 sdl2_image sdl2_ttf sdl2_mixer gettext ccache parallel
 
       - name: prepare

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -22,32 +22,24 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  skip-duplicates-code:
+  skip-duplicates:
     continue-on-error: true
     runs-on: ubuntu-22.04
-    # Map a step output to a job output
     outputs:
-      should_skip_code: ${{ steps.skip_check.outputs.should_skip }}
+      should_skip_code: ${{ steps.skip_code_check.outputs.should_skip }}
+      should_skip_data: ${{ steps.skip_data_check.outputs.should_skip }}
     steps:
-      - id: skip_check
+      - id: skip_code_check
         uses: fkirc/skip-duplicate-actions@master
         with:
           paths_ignore: '["android/**", "build-data/osx/**", "doc/**", "doxygen_doc/**", "msvc-**", "tools/**", "utilities/**", "scripts/**", "data/**", "lang/**"]'
-
-  skip-duplicates-data:
-    continue-on-error: true
-    runs-on: ubuntu-22.04
-    # Map a step output to a job output
-    outputs:
-      should_skip_data: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
+      - id: skip_data_check
         uses: fkirc/skip-duplicate-actions@master
         with:
           paths_ignore: '["android/**", "build-data/osx/**", "doc/**", "doxygen_doc/**", "msvc-**", "tools/**", "utilities/**", "scripts/**"]'
 
   varied_builds:
-    needs: [ skip-duplicates-code, skip-duplicates-data ]
+    needs: skip-duplicates
     strategy:
       fail-fast: ${{ github.ref_name == 'main' }}
       max-parallel: ${{ github.ref_name == 'main' && 20 || 1 }}
@@ -156,7 +148,7 @@ jobs:
       CCACHE_HARDLINK: true
       CCACHE_NOCOMPRESS: true
 
-      SKIP: ${{ ( github.event.pull_request.draft == true && matrix.run-on-draft == 'true' ) || ( needs.skip-duplicates-code.outputs.should_skip_code == 'true' ) || ( needs.skip-duplicates-data.outputs.should_skip_data == 'true' ) }}
+      SKIP: ${{ ( github.event.pull_request.draft == true && matrix.run-on-draft == 'true' ) || ( needs.skip-duplicates.outputs.should_skip_code == 'true' ) || ( needs.skip-duplicates.outputs.should_skip_data == 'true' ) }}
 
     steps:
       - name: checkout repository

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -53,13 +53,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       fail_fast: ${{ steps.matrix_vars.outputs.fail_fast }}
-      skip_tests: ${{ steps.matrix_vars.outputs.skip_tests }}
       max_parallel: ${{ steps.matrix_vars.outputs.max_parallel }}
     steps:
       - id: matrix_vars
         run: |
           echo "fail_fast=$([ "$GITHUB_REF_NAME" = "main" ] && echo false || echo true)" >> $GITHUB_OUTPUT
-          echo "skip_tests=$([ "$GITHUB_REF_NAME" = "main" ] && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "max_parallel=$([ "$GITHUB_REF_NAME" = "main" ] && echo 20 || echo 1)" >> $GITHUB_OUTPUT
 
   varied_builds:
@@ -173,7 +171,6 @@ jobs:
       CCACHE_NOCOMPRESS: true
 
       SKIP: ${{ ( github.event.pull_request.draft == true && matrix.run-on-draft == 'true' ) || ( needs.skip-duplicates-code.outputs.should_skip_code == 'true' ) || ( needs.skip-duplicates-data.outputs.should_skip_data == 'true' ) }}
-      SKIP_TESTS: ${{ needs.matrix-variables.outputs.skip_tests }}
 
     steps:
       - name: checkout repository
@@ -262,7 +259,7 @@ jobs:
         run: ccache --clear
 
       - name: run tests
-        if: ${{ env.SKIP == 'false' && env.SKIP_TESTS == 'false' }}
+        if: ${{ github.ref_name != 'main' && env.SKIP == 'false' }}
         run: bash ./build-scripts/gha_test_only.sh
 
       - name: emit success artifact

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches: [main]
     paths-ignore: [doc/**, scripts/**]
+    types: [opened, reopened, synchronize, ready_for_review]
 
 # Cancel all previous instances in favor of latest revision of a PR.
 # Allow running main builds to complete to help with ccache refreshes.

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -46,23 +46,11 @@ jobs:
         with:
           paths_ignore: '["android/**", "build-data/osx/**", "doc/**", "doxygen_doc/**", "msvc-**", "tools/**", "utilities/**", "scripts/**"]'
 
-  matrix-variables:
-    permissions:
-      contents: none
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    outputs:
-      max_parallel: ${{ steps.matrix_vars.outputs.max_parallel }}
-    steps:
-      - id: matrix_vars
-        run: |
-          echo "max_parallel=$([ "$GITHUB_REF_NAME" = "main" ] && echo 20 || echo 1)" >> $GITHUB_OUTPUT
-
   varied_builds:
-    needs: [ skip-duplicates-code, skip-duplicates-data, matrix-variables ]
+    needs: [ skip-duplicates-code, skip-duplicates-data ]
     strategy:
       fail-fast: ${{ github.ref_name == 'main' }}
-      max-parallel: ${{ fromJSON(needs.matrix-variables.outputs.max_parallel) }}
+      max-parallel: ${{ github.ref_name == 'main' && 20 || 1 }}
       matrix:
         include:
           - title: GCC 12, Ubuntu, Curses

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -2,18 +2,11 @@ name: General build matrix
 
 on:
   push:
-    branches:
-      - main
-    paths-ignore:
-      - doc/**
-      - 'scripts/**'
-  merge_group:
+    branches: [main]
+    paths-ignore: [doc/**, scripts/**]
   pull_request:
-    branches:
-      - main
-    paths-ignore:
-      - doc/**
-      - 'scripts/**'
+    branches: [main]
+    paths-ignore: [doc/**, scripts/**]
 
 # Cancel all previous instances in favor of latest revision of a PR.
 # Allow running main builds to complete to help with ccache refreshes.

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -52,6 +52,7 @@ jobs:
             ccache_limit: 2G
             ccache_key: linux-gcc-12
             run-on-draft: true
+            always-test: true
 
           - title: GCC 12, Ubuntu, Tiles, Sound, Lua, CMake, Languages
             compiler: g++-12
@@ -142,7 +143,9 @@ jobs:
       CCACHE_HARDLINK: true
       CCACHE_NOCOMPRESS: true
 
-      SKIP: ${{ ( github.event.pull_request.draft == true && matrix.run-on-draft == 'true' ) || ( needs.skip-duplicates.outputs.should_skip_code == 'true' ) || ( needs.skip-duplicates.outputs.should_skip_data == 'true' ) }}
+      SKIP: ${{ ( github.event.pull_request.draft == true && matrix.run-on-draft != 'true' ) ||
+                ( matrix.always-test != 'true' && needs.skip-duplicates.outputs.should_skip_code == 'true' ) ||
+                ( matrix.always-test != 'true' && needs.skip-duplicates.outputs.should_skip_data == 'true' ) }}
 
     steps:
       - name: checkout repository

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -52,18 +52,16 @@ jobs:
     continue-on-error: true
     runs-on: ubuntu-latest
     outputs:
-      fail_fast: ${{ steps.matrix_vars.outputs.fail_fast }}
       max_parallel: ${{ steps.matrix_vars.outputs.max_parallel }}
     steps:
       - id: matrix_vars
         run: |
-          echo "fail_fast=$([ "$GITHUB_REF_NAME" = "main" ] && echo false || echo true)" >> $GITHUB_OUTPUT
           echo "max_parallel=$([ "$GITHUB_REF_NAME" = "main" ] && echo 20 || echo 1)" >> $GITHUB_OUTPUT
 
   varied_builds:
     needs: [ skip-duplicates-code, skip-duplicates-data, matrix-variables ]
     strategy:
-      fail-fast: ${{ fromJSON(needs.matrix-variables.outputs.fail_fast) }}
+      fail-fast: ${{ github.ref_name == 'main' }}
       max-parallel: ${{ fromJSON(needs.matrix-variables.outputs.max_parallel) }}
       matrix:
         include:


### PR DESCRIPTION
## Purpose of change

- fix #3560 

## Describe the solution

- add `always-test` flag 
- fix incorrect boolean logic that made matrix marked as 'always run on draft' _skip_ draft PRs
- simplified environment variables

## Describe alternatives you've considered

currently there's not much point in separating build step and test step because we don't cache executable and test binary.

1. also release tests binary daily (probably on separate repo?)
2. create separate workflow for C++ changes and JSON changes
3. make JSON workflow download [recent binary from releases](https://github.com/marketplace/actions/release-downloader) and use the binary for quick testing

## Testing

should build on CI

## Additional context

at least one CI will run tests regardless of state.