### PR TITLE
refactor: fahrenheit to celsius, part 2

### DIFF
--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -244,8 +244,7 @@
     "charges": 2,
     "category": "chems",
     "flags": [ "UNSAFE_CONSUME" ],
-    "fun": -30,
-    "freezing_point": -108
+    "fun": -30
   },
   {
     "type": "COMESTIBLE",
@@ -434,7 +433,6 @@
     "phase": "liquid",
     "category": "chems",
     "fun": -45,
-    "freezing_point": 25,
     "drop_action": { "type": "emit_actor", "emits": [ "emit_acid_splash" ], "scale_qty": true },
     "ammo_data": { "ammo_type": "acid", "damage": { "damage_type": "acid", "amount": 3 }, "effects": [ "ACID_TRAIL" ] }
   },
@@ -573,7 +571,6 @@
     "effects": [ "ACID_TRAIL_WEAK" ],
     "phase": "liquid",
     "container": "bottle_glass",
-    "//freezing_point": 25,
     "drop_action": { "type": "emit_actor", "emits": [ "emit_acid_drop" ], "scale_qty": true }
   },
   {
@@ -595,7 +592,6 @@
     "effects": [ "ACID_TRAIL_WEAK" ],
     "phase": "liquid",
     "container": "bottle_glass",
-    "//freezing_point": 25,
     "drop_action": { "type": "emit_actor", "emits": [ "emit_acid_drop" ], "scale_qty": true }
   },
   {
@@ -617,7 +613,6 @@
     "effects": [ "ACID_TRAIL_WEAK" ],
     "phase": "liquid",
     "container": "bottle_glass",
-    "//freezing_point": -44,
     "drop_action": { "type": "emit_actor", "emits": [ "emit_acid_drop" ], "scale_qty": true }
   },
   {

--- a/data/json/items/classes/comestible.json
+++ b/data/json/items/classes/comestible.json
@@ -12,7 +12,6 @@
     "container": "bag_plastic",
     "material": "powder",
     "symbol": "%",
-    "charges": 100,
-    "freezing_point": -490
+    "charges": 100
   }
 ]

--- a/data/json/items/comestibles/alcohol.json
+++ b/data/json/items/comestibles/alcohol.json
@@ -23,8 +23,7 @@
     "phase": "liquid",
     "charges": 5,
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD", "MYCUS_OK" ],
-    "fun": 25,
-    "freezing_point": 17
+    "fun": 25
   },
   {
     "type": "COMESTIBLE",
@@ -51,8 +50,7 @@
     "phase": "liquid",
     "charges": 5,
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "fun": 15,
-    "freezing_point": 17
+    "fun": 15
   },
   {
     "type": "COMESTIBLE",
@@ -79,8 +77,7 @@
     "phase": "liquid",
     "charges": 5,
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "fun": 15,
-    "freezing_point": 17
+    "fun": 15
   },
   {
     "type": "COMESTIBLE",
@@ -105,8 +102,7 @@
     "volume": "250 ml",
     "phase": "liquid",
     "charges": 5,
-    "fun": 15,
-    "freezing_point": 17
+    "fun": 15
   },
   {
     "type": "COMESTIBLE",
@@ -132,8 +128,7 @@
     "phase": "liquid",
     "charges": 5,
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "fun": 16,
-    "freezing_point": 15
+    "fun": 16
   },
   {
     "type": "COMESTIBLE",
@@ -159,8 +154,7 @@
     "phase": "liquid",
     "charges": 5,
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "fun": 15,
-    "freezing_point": 17
+    "fun": 15
   },
   {
     "type": "COMESTIBLE",
@@ -186,8 +180,7 @@
     "phase": "liquid",
     "charges": 5,
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "fun": 15,
-    "freezing_point": 17
+    "fun": 15
   },
   {
     "type": "COMESTIBLE",
@@ -213,7 +206,6 @@
     "volume": "250 ml",
     "phase": "liquid",
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "freezing_point": 23,
     "fun": 14,
     "vitamins": [ [ "calcium", 1 ] ]
   },
@@ -240,7 +232,6 @@
     "material": "alcohol",
     "volume": "250 ml",
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "freezing_point": -22,
     "phase": "liquid",
     "charges": 7,
     "fun": 15
@@ -269,7 +260,6 @@
     "phase": "liquid",
     "charges": 7,
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD", "NUTRIENT_OVERRIDE" ],
-    "freezing_point": -22,
     "fun": 15
   },
   {
@@ -296,7 +286,6 @@
     "phase": "liquid",
     "charges": 7,
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "freezing_point": -22,
     "fun": 15
   },
   {
@@ -323,8 +312,7 @@
     "phase": "liquid",
     "charges": 7,
     "fun": 15,
-    "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "freezing_point": -22
+    "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ]
   },
   {
     "type": "COMESTIBLE",
@@ -350,8 +338,7 @@
     "phase": "liquid",
     "charges": 7,
     "fun": 18,
-    "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "freezing_point": -22
+    "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ]
   },
   {
     "type": "COMESTIBLE",
@@ -375,7 +362,6 @@
     "material": "alcohol",
     "volume": "250 ml",
     "flags": [ "UNSAFE_CONSUME" ],
-    "freezing_point": 0,
     "phase": "liquid",
     "charges": 7,
     "fun": 10
@@ -405,8 +391,7 @@
     "phase": "liquid",
     "charges": 7,
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "fun": 10,
-    "freezing_point": 22
+    "fun": 10
   },
   {
     "type": "COMESTIBLE",
@@ -431,7 +416,6 @@
     "phase": "liquid",
     "charges": 7,
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "freezing_point": -22,
     "fun": 5
   },
   {
@@ -458,7 +442,6 @@
     "volume": "250 ml",
     "phase": "liquid",
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD", "NUTRIENT_OVERRIDE" ],
-    "freezing_point": -22,
     "fun": 4
   },
   {
@@ -486,8 +469,7 @@
     "phase": "liquid",
     "charges": 7,
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "fun": 2,
-    "freezing_point": 20
+    "fun": 2
   },
   {
     "type": "COMESTIBLE",
@@ -511,7 +493,6 @@
     "material": "alcohol",
     "volume": "250 ml",
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "freezing_point": -22,
     "phase": "liquid",
     "charges": 7,
     "fun": 12
@@ -594,7 +575,6 @@
     "volume": "250 ml",
     "phase": "liquid",
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "freezing_point": -29,
     "fun": 20,
     "vitamins": [ [ "vitA", 2 ], [ "vitC", 118 ], [ "calcium", 2 ], [ "iron", 1 ] ]
   },
@@ -622,7 +602,6 @@
     "volume": "250 ml",
     "phase": "liquid",
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "freezing_point": -29,
     "fun": 20,
     "vitamins": [ [ "vitC", 135 ], [ "calcium", 1 ], [ "iron", 1 ] ]
   },
@@ -650,7 +629,6 @@
     "volume": "250 ml",
     "phase": "liquid",
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "freezing_point": -22,
     "fun": 20
   },
   {
@@ -676,7 +654,6 @@
     "volume": "250 ml",
     "phase": "liquid",
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "freezing_point": 23,
     "fun": 10,
     "vitamins": [ [ "calcium", 1 ] ]
   },
@@ -704,7 +681,6 @@
     "phase": "liquid",
     "charges": 7,
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "freezing_point": 23,
     "fun": 14
   },
   {
@@ -732,8 +708,7 @@
     "phase": "liquid",
     "charges": 7,
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "fun": 16,
-    "freezing_point": 25
+    "fun": 16
   },
   {
     "type": "COMESTIBLE",
@@ -759,8 +734,7 @@
     "phase": "liquid",
     "charges": 7,
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "fun": 16,
-    "freezing_point": 25
+    "fun": 16
   },
   {
     "type": "COMESTIBLE",
@@ -787,7 +761,6 @@
     "phase": "liquid",
     "charges": 7,
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "freezing_point": 23,
     "fun": 12
   },
   {
@@ -813,7 +786,6 @@
     "volume": "250 ml",
     "phase": "liquid",
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "freezing_point": 23,
     "fun": 8,
     "vitamins": [ [ "calcium", 1 ] ]
   },
@@ -841,7 +813,6 @@
     "phase": "liquid",
     "charges": 7,
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "freezing_point": -49,
     "fun": 12
   },
   {
@@ -868,7 +839,6 @@
     "volume": "250 ml",
     "phase": "liquid",
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "freezing_point": 23,
     "fun": 10,
     "vitamins": [ [ "calcium", 1 ] ]
   },
@@ -896,7 +866,6 @@
     "volume": "250 ml",
     "phase": "liquid",
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "freezing_point": 23,
     "fun": 14,
     "vitamins": [ [ "calcium", 1 ] ]
   },
@@ -924,7 +893,6 @@
     "volume": "250 ml",
     "phase": "liquid",
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "freezing_point": 23,
     "fun": 14,
     "vitamins": [ [ "calcium", 1 ] ]
   },
@@ -951,7 +919,6 @@
     "primary_material": "alcohol",
     "volume": "250 ml",
     "phase": "liquid",
-    "freezing_point": 23,
     "fun": 14,
     "vitamins": [ [ "calcium", 1 ], [ "iron", 1 ] ],
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ]
@@ -980,7 +947,6 @@
     "volume": "250 ml",
     "phase": "liquid",
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "freezing_point": 23,
     "fun": 14,
     "vitamins": [ [ "calcium", 1 ] ]
   },
@@ -1009,8 +975,7 @@
     "phase": "liquid",
     "fun": 18,
     "vitamins": [ [ "calcium", 1 ], [ "iron", 1 ] ],
-    "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "freezing_point": 23
+    "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ]
   },
   {
     "type": "COMESTIBLE",
@@ -1038,8 +1003,7 @@
     "charges": 6,
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
     "fun": 8,
-    "vitamins": [ [ "vitC", 20 ] ],
-    "freezing_point": -22
+    "vitamins": [ [ "vitC", 20 ] ]
   },
   {
     "type": "COMESTIBLE",
@@ -1067,8 +1031,7 @@
     "charges": 6,
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
     "fun": -12,
-    "vitamins": [ [ "vitC", 20 ] ],
-    "freezing_point": -22
+    "vitamins": [ [ "vitC", 20 ] ]
   },
   {
     "type": "COMESTIBLE",
@@ -1093,7 +1056,6 @@
     "material": "alcohol",
     "volume": "250 ml",
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "freezing_point": -22,
     "phase": "liquid",
     "charges": 7,
     "fun": 17
@@ -1150,7 +1112,6 @@
     "material": "alcohol",
     "volume": "250 ml",
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "freezing_point": -22,
     "phase": "liquid",
     "charges": 7,
     "fun": 17
@@ -1200,7 +1161,6 @@
     "phase": "liquid",
     "charges": 5,
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "freezing_point": -27,
     "fun": 20
   },
   {
@@ -1228,7 +1188,6 @@
     "phase": "liquid",
     "charges": 2,
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "freezing_point": -22,
     "fun": 20
   },
   {
@@ -1254,7 +1213,6 @@
     "volume": "500 ml",
     "phase": "liquid",
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "freezing_point": -22,
     "fun": 20
   },
   {
@@ -1280,7 +1238,6 @@
     "volume": "250 ml",
     "phase": "liquid",
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "freezing_point": -22,
     "fun": 20
   },
   {
@@ -1361,8 +1318,7 @@
     "charges": 2,
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
     "fun": 20,
-    "vitamins": [ [ "vitA", 5 ], [ "vitC", 3 ], [ "calcium", 12 ], [ "iron", 2 ] ],
-    "freezing_point": 12
+    "vitamins": [ [ "vitA", 5 ], [ "vitC", 3 ], [ "calcium", 12 ], [ "iron", 2 ] ]
   },
   {
     "type": "COMESTIBLE",
@@ -1388,7 +1344,6 @@
     "charges": 5,
     "phase": "liquid",
     "flags": [ "UNSAFE_CONSUME", "EATEN_COLD" ],
-    "freezing_point": -22,
     "fun": 20
   }
 ]

--- a/data/json/items/comestibles/drink.json
+++ b/data/json/items/comestibles/drink.json
@@ -970,8 +970,7 @@
     "material": "water",
     "volume": "250 ml",
     "phase": "liquid",
-    "fun": 2,
-    "freezing_point": 22
+    "fun": 2
   },
   {
     "type": "COMESTIBLE",

--- a/data/json/items/comestibles/drink_other.json
+++ b/data/json/items/comestibles/drink_other.json
@@ -44,8 +44,7 @@
     "fun": 1,
     "flags": [ "EATEN_COLD", "RAW" ],
     "phase": "liquid",
-    "vitamins": [  ],
-    "freezing_point": 30
+    "vitamins": [  ]
   },
   {
     "id": "mayonnaise",
@@ -65,8 +64,7 @@
     "spoils_in": "6 days 16 hours",
     "charges": 16,
     "fun": -1,
-    "phase": "liquid",
-    "freezing_point": 25
+    "phase": "liquid"
   },
   {
     "id": "ketchup",
@@ -179,8 +177,7 @@
     "phase": "liquid",
     "charges": 16,
     "calories": 3,
-    "fun": -10,
-    "freezing_point": 28
+    "fun": -10
   },
   {
     "type": "COMESTIBLE",
@@ -203,8 +200,7 @@
     "phase": "liquid",
     "fun": -25,
     "flags": [ "NUTRIENT_OVERRIDE" ],
-    "vitamins": [  ],
-    "freezing_point": 14
+    "vitamins": [  ]
   },
   {
     "type": "COMESTIBLE",
@@ -235,8 +231,7 @@
     "charges": 4,
     "fun": 2,
     "flags": [ "USE_EAT_VERB" ],
-    "vitamins": [ [ "calcium", 18 ], [ "iron", 23 ] ],
-    "freezing_point": -20
+    "vitamins": [ [ "calcium", 18 ], [ "iron", 23 ] ]
   },
   {
     "id": "horseradish",

--- a/data/json/items/comestibles/junkfood.json
+++ b/data/json/items/comestibles/junkfood.json
@@ -411,8 +411,7 @@
     "phase": "liquid",
     "charges": 16,
     "fun": 5,
-    "vitamins": [ [ "calcium", 2 ] ],
-    "freezing_point": -70
+    "vitamins": [ [ "calcium", 2 ] ]
   },
   {
     "type": "COMESTIBLE",

--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -436,7 +436,6 @@
     "phase": "liquid",
     "charges": 4,
     "flags": [ "EATEN_COLD" ],
-    "freezing_point": -49,
     "fun": 30
   },
   {

--- a/data/json/items/comestibles/mutagen.json
+++ b/data/json/items/comestibles/mutagen.json
@@ -20,8 +20,7 @@
     "addiction_type": "mutagen",
     "flags": [ "NUTRIENT_OVERRIDE" ],
     "vitamins": [  ],
-    "material": "water",
-    "freezing_point": 17
+    "material": "water"
   },
   {
     "abstract": "iv_mutagen_flavor",

--- a/data/json/items/comestibles/nuts.json
+++ b/data/json/items/comestibles/nuts.json
@@ -432,8 +432,7 @@
     "phase": "liquid",
     "charges": 4,
     "flags": [ "EATEN_HOT" ],
-    "fun": 5,
-    "freezing_point": -80
+    "fun": 5
   },
   {
     "type": "COMESTIBLE",

--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -245,7 +245,6 @@
     "price_postapoc": "0 cent",
     "material": "cardboard",
     "volume": "250 ml",
-    "freezing_point": -490,
     "charges": 10,
     "fun": -20
   },

--- a/data/json/items/comestibles/seed.json
+++ b/data/json/items/comestibles/seed.json
@@ -680,7 +680,6 @@
     "primary_material": "dried_vegetable",
     "volume": "250 ml",
     "flags": [ "SMOKED" ],
-    "freezing_point": -490,
     "charges": 4,
     "fun": 3
   },

--- a/data/json/items/comestibles/spice.json
+++ b/data/json/items/comestibles/spice.json
@@ -127,7 +127,6 @@
     "charges": 10,
     "healthy": -1,
     "fun": -15,
-    "freezing_point": -22,
     "phase": "liquid"
   },
   {

--- a/data/mods/Aftershock/items/comestibles.json
+++ b/data/mods/Aftershock/items/comestibles.json
@@ -16,7 +16,6 @@
     "charges": 5,
     "looks_like": "vitamins",
     "fun": -8,
-    "freezing_point": -490,
     "vitamins": [ [ "calcium", 24, 48 ], [ "iron", 24, 48 ], [ "vitA", 24, 48 ], [ "vitB", 24, 48 ], [ "vitC", 24, 48 ] ]
   },
   {
@@ -47,8 +46,7 @@
     "looks_like": "diesel",
     "container": "flask_glass",
     "stim": 4,
-    "flags": [ "LIGHT_2", "EATEN_HOT" ],
-    "freezing_point": -490
+    "flags": [ "LIGHT_2", "EATEN_HOT" ]
   },
   {
     "id": "afs_sungel",

--- a/data/mods/Aftershock/items/comestibles/cheap_food.json
+++ b/data/mods/Aftershock/items/comestibles/cheap_food.json
@@ -16,7 +16,6 @@
     "charges": 5,
     "looks_like": "vitamins",
     "fun": -8,
-    "freezing_point": -490,
     "vitamins": [
       [ "calcium", 24, 48 ],
       [ "iron", 24, 48 ],
@@ -63,8 +62,7 @@
     "fun": 10,
     "stim": 4,
     "vitamins": [ [ "bad_food", -6 ] ],
-    "flags": [ "LIGHT_2", "EATEN_HOT" ],
-    "freezing_point": -490
+    "flags": [ "LIGHT_2", "EATEN_HOT" ]
   },
   {
     "id": "afs_h2o",
@@ -87,7 +85,6 @@
     "charges": 2,
     "description": "Smoothly blended edibles, neatly shaped into cubes for maximum enjoyment.",
     "fun": 2,
-    "freezing_point": -490,
     "vitamins": [ [ "calcium", 30 ], [ "iron", 30 ], [ "vitA", 30 ], [ "vitB", 30 ], [ "vitC", 30 ], [ "bad_food", 1 ] ]
   },
   {
@@ -102,8 +99,7 @@
     "healthy": 3,
     "charges": 2,
     "description": "Foodplace™ easy-storage Food-to-go™ the choice Food™ for the contemporary Foodman™.",
-    "fun": 2,
-    "freezing_point": -490
+    "fun": 2
   },
   {
     "id": "afs_loop_fruit",
@@ -116,7 +112,6 @@
     "healthy": 3,
     "description": "Rings of caramelized yellow colorant, tasting not exactly like apple.",
     "fun": 2,
-    "freezing_point": -490,
     "vitamins": [ [ "iron", 1 ], [ "vitA", 1 ], [ "vitC", 10 ] ]
   },
   {
@@ -132,7 +127,6 @@
     "charges": 3,
     "description": "Smooth crackers colored grayish-green.  Used to be perfectly edible seaweed, or so the wrapper claims.",
     "fun": 2,
-    "freezing_point": -490,
     "vitamins": [ [ "calcium", 5 ], [ "iron", 5 ], [ "vitC", 10 ], [ "bad_food", 1 ] ]
   },
   {
@@ -148,7 +142,6 @@
     "description": "Soy or pureed rat?  Better not to know.\n(But its probably both.) ",
     "fun": 0,
     "charges": 2,
-    "freezing_point": -490,
     "vitamins": [ [ "calcium", 5 ], [ "iron", 5 ], [ "vitC", 10 ], [ "vitB", 10 ], [ "bad_food", 1 ] ]
   },
   {
@@ -163,7 +156,6 @@
     "healthy": 3,
     "description": "Yellow chunks float on creamy liquid, like flotsam on a filthy summer pond.  Branding implies at least 26 other flavors, but you have neither seen or heard about any of them.",
     "fun": 0,
-    "freezing_point": -490,
     "vitamins": [ [ "calcium", 1 ], [ "iron", 10 ], [ "vitC", 5 ], [ "vitB", 10 ], [ "vitA", 5 ], [ "bad_food", 1 ] ]
   },
   {
@@ -176,7 +168,6 @@
     "healthy": -3,
     "description": "A dark and soapy beverage, pre-brewed and loaded with synthetic caffeine.",
     "fun": 6,
-    "freezing_point": -490,
     "vitamins": [ [ "bad_food", 1 ] ]
   }
 ]

--- a/data/mods/Magiclysm/items/alchemy_items.json
+++ b/data/mods/Magiclysm/items/alchemy_items.json
@@ -190,8 +190,7 @@
     "flags": [ "TRADER_AVOID", "INEDIBLE" ],
     "container": "flask_glass",
     "charges": 1,
-    "phase": "liquid",
-    "freezing_point": -100
+    "phase": "liquid"
   },
   {
     "id": "stirge_proboscis",

--- a/data/mods/Magiclysm/items/cast_spell_items.json
+++ b/data/mods/Magiclysm/items/cast_spell_items.json
@@ -18,8 +18,7 @@
     "comestible_type": "DRINK",
     "flags": [ "EATEN_COLD", "NUTRIENT_OVERRIDE" ],
     "phase": "liquid",
-    "price": "25 USD",
-    "freezing_point": 40
+    "price": "25 USD"
   },
   {
     "id": "mana_potion",
@@ -55,8 +54,7 @@
     "comestible_type": "DRINK",
     "flags": [ "EATEN_COLD", "NUTRIENT_OVERRIDE" ],
     "phase": "liquid",
-    "price": "30 USD",
-    "freezing_point": 40
+    "price": "30 USD"
   },
   {
     "id": "ogres_strength_potion",
@@ -138,8 +136,7 @@
     "comestible_type": "DRINK",
     "flags": [ "TRADER_AVOID", "NUTRIENT_OVERRIDE" ],
     "phase": "liquid",
-    "price": "25 USD",
-    "freezing_point": 10
+    "price": "25 USD"
   },
   {
     "id": "twisted_restore_potion_improved",

--- a/data/mods/Magiclysm/items/mutagen.json
+++ b/data/mods/Magiclysm/items/mutagen.json
@@ -20,7 +20,6 @@
     "charges": 2,
     "use_action": { "type": "mutagen_iv", "mutation_category": "MANATOUCHED" },
     "flags": [ "EATEN_COLD", "NUTRIENT_OVERRIDE" ],
-    "freezing_point": -22,
     "fun": -15
   }
 ]

--- a/doc/src/content/docs/en/mod/json/reference/json_info.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_info.md
@@ -1749,7 +1749,6 @@ CBMs can be defined like this:
 "charges" : 4,              // Number of uses when spawned
 "stack_size" : 8,           // (Optional) How many uses are in the above-defined volume. If omitted, is the same as 'charges'
 "fun" : 50                  // Morale effects when used
-"freezing_point": 32,       // (Optional) Temperature in F at which item freezes, default is water (32F/0C)
 "cooks_like": "meat_cooked" // (Optional) If the item is used in a recipe, replaces it with its cooks_like
 "parasites": 10,            // (Optional) Probability of becoming parasitised when eating
 "contamination": [ { "disease": "bad_food", "probability": 5 } ],         // (Optional) List of diseases carried by this comestible and their associated probability. Values must be in the [0, 100] range.

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -985,7 +985,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
                            print_temperature(
                                get_local_windchill( units::to_fahrenheit( weatherPoint.temperature ),
                                        weatherPoint.humidity,
-                                       windpower / 100 ) + player_local_temp ) );
+                                       windpower / 100 ) + units::to_fahrenheit( player_local_temp ) ) );
         std::string dirstring = get_dirstring( weather.winddirection );
         add_msg_if_player( m_info, _( "Wind Direction: From the %s." ), dirstring );
     } else if( bio.id == bio_remote ) {

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1,3 +1,4 @@
+#include "units_temperature.h"
 #if defined(TILES)
 #include "cata_tiles.h"
 
@@ -1298,29 +1299,27 @@ void cata_tiles::draw( point dest, const tripoint &center, int width, int height
 
             // Add temperature value to the overlay_strings list for every visible tile when displaying temperature
             if( g->display_overlay_state( ACTION_DISPLAY_TEMPERATURE ) && !invis ) {
-                int temp_value = get_weather().get_temperature( {temp_x, temp_y, center.z} );
-                int ctemp = units::fahrenheit_to_celsius( temp_value );
+                const auto temp = get_weather().get_temperature( tripoint_abs_omt{temp_x, temp_y, center.z} );
                 short color;
                 const short bold = 8;
-                if( ctemp > 40 ) {
+                if( temp > 40_c ) {
                     color = catacurses::red;
-                } else if( ctemp > 25 ) {
+                } else if( temp > 25_c ) {
                     color = catacurses::yellow + bold;
-                } else if( ctemp > 10 ) {
+                } else if( temp > 10_c ) {
                     color = catacurses::green + bold;
-                } else if( ctemp > 0 ) {
+                } else if( temp > 0_c ) {
                     color = catacurses::white + bold;
-                } else if( ctemp > -10 ) {
+                } else if( temp > -10_c ) {
                     color = catacurses::cyan + bold;
                 } else {
                     color = catacurses::blue + bold;
                 }
-                if( get_option<std::string>( "USE_CELSIUS" ) == "celsius" ) {
-                    temp_value = units::fahrenheit_to_celsius( temp_value );
-                } else if( get_option<std::string>( "USE_CELSIUS" ) == "kelvin" ) {
-                    temp_value = units::fahrenheit_to_kelvin( temp_value );
+                const auto display_option = get_option<std::string>( "USE_CELSIUS" );
+                const int temp_value = display_option == "kelvin" ? units::to_kelvins( temp )
+                                       : display_option == "fahrenheit" ? units::to_fahrenheit( temp )
+                                       : units::to_celsius( temp );
 
-                }
                 overlay_strings.emplace( player_to_screen( point( temp_x, temp_y ) ) + point( tile_width / 2, 0 ),
                                          formatted_text( std::to_string( temp_value ), color,
                                                  direction::NORTH ) );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5757,7 +5757,7 @@ void Character::update_bodytemp( const map &m, const weather_manager &weather )
 
     const int lying_warmth = use_floor_warmth ? floor_warmth( pos() ) : 0;
     const int water_temperature_raw =
-        100 * units::fahrenheit_to_celsius( weather.get_water_temperature( pos() ) );
+        100 * weather.get_water_temperature( pos() ).value();
     // Rescale so that 0C is 0 (FREEZING) and 30C is 5k (NORM).
     const int water_temperature = water_temperature_raw * 5 / 3;
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5478,7 +5478,8 @@ needs_rates Character::calc_needs_rates() const
 
     if( has_trait( trait_TRANSPIRATION ) ) {
         // Transpiration, the act of moving nutrients with evaporating water, can take a very heavy toll on your thirst when it's really hot.
-        rates.thirst *= ( ( get_weather().get_temperature( pos() ) - 32.5f ) / 40.0f );
+        rates.thirst *= ( ( units::to_fahrenheit( get_weather().get_temperature(
+                                pos() ) ) - 32.5f ) / 40.0f );
     }
 
     if( is_npc() ) {
@@ -5724,7 +5725,7 @@ void Character::update_bodytemp( const map &m, const weather_manager &weather )
     const auto player_local_temp = weather.get_temperature( pos() );
     // NOTE : visit weather.h for some details on the numbers used
     // In Celsius / 100
-    int Ctemperature = static_cast<int>( 100 * units::fahrenheit_to_celsius( player_local_temp ) );
+    int Ctemperature = units::to_millidegree_celsius( player_local_temp ) / 10;
     const w_point &weather_point = get_weather().get_precise();
     int vehwindspeed = 0;
     const optional_vpart_position vp = m.veh_at( pos() );
@@ -5892,7 +5893,7 @@ void Character::update_bodytemp( const map &m, const weather_manager &weather )
         // Calculate windchill
         int windchill = submerged_bp
                         ? 0
-                        : get_local_windchill( player_local_temp,
+                        : get_local_windchill( units::to_fahrenheit( player_local_temp ),
                                                air_humidity,
                                                bp_windpower );
 
@@ -6069,7 +6070,8 @@ void Character::update_bodytemp( const map &m, const weather_manager &weather )
             // Warmth gives a slight buff to temperature resistance
             // Wetness gives a heavy nerf to temperature resistance
             double adjusted_warmth = warmth_per_bp.at( bp ) - wetness_percentage;
-            int Ftemperature = static_cast<int>( player_local_temp + 0.2 * adjusted_warmth );
+            int Ftemperature = static_cast<int>( units::to_fahrenheit( player_local_temp ) + 0.2 *
+                                                 adjusted_warmth );
             // Windchill reduced by your armor
             int FBwindPower = static_cast<int>(
                                   total_windpower * ( 1 - wind_res_per_bp[ bp ] / 100.0 ) );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -98,6 +98,7 @@
 #include "trap.h"
 #include "ui.h"
 #include "ui_manager.h"
+#include "units_temperature.h"
 #include "units_utility.h"
 #include "value_ptr.h"
 #include "veh_interact.h"
@@ -5757,7 +5758,7 @@ void Character::update_bodytemp( const map &m, const weather_manager &weather )
 
     const int lying_warmth = use_floor_warmth ? floor_warmth( pos() ) : 0;
     const int water_temperature_raw =
-        100 * weather.get_water_temperature( pos() ).value();
+        units::to_millidegree_celsius( weather.get_water_temperature( pos() ) ) / 10;
     // Rescale so that 0C is 0 (FREEZING) and 30C is 5k (NORM).
     const int water_temperature = water_temperature_raw * 5 / 3;
 

--- a/src/character.h
+++ b/src/character.h
@@ -47,6 +47,7 @@
 #include "string_formatter.h"
 #include "type_id.h"
 #include "units.h"
+#include "units_temperature.h"
 #include "visitable.h"
 #include "weighted_list.h"
 
@@ -2139,7 +2140,7 @@ class Character : public Creature, public location_visitable<Character>
         /** Drenches the player with water, saturation is the percent gotten wet */
         void drench( int saturation, const body_part_set &flags, bool ignore_waterproof );
         /** Recalculates morale penalty/bonus from wetness based on mutations, equipment and temperature */
-        void apply_wetness_morale( int temperature );
+        void apply_wetness_morale( const units::temperature &temperature );
         std::vector<std::string> short_description_parts() const;
         std::string short_description() const;
         int print_info( const catacurses::window &w, int vStart, int vLines, int column ) const override;

--- a/src/character_display.cpp
+++ b/src/character_display.cpp
@@ -814,7 +814,7 @@ static void draw_speed_tab( const catacurses::window &w_speed,
     if( temperature_speed_modifier != 0 ) {
         nc_color pen_color;
         std::string pen_sign;
-        const auto player_local_temp = get_weather().get_temperature( you.pos() );
+        const auto player_local_temp = units::to_fahrenheit( get_weather().get_temperature( you.pos() ) );
         if( you.has_trait( trait_id( "COLDBLOOD4" ) ) && player_local_temp > 65 ) {
             pen_color = c_green;
             pen_sign = "+";

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -23,6 +23,7 @@
 #include "rng.h"
 #include "submap.h"
 #include "trap.h"
+#include "units_temperature.h"
 #include "veh_type.h"
 #include "vehicle.h"
 #include "vehicle_part.h"
@@ -137,7 +138,7 @@ void Character::recalc_speed_bonus()
         }
         const float temperature_speed_modifier = mutation_value( "temperature_speed_modifier" );
         if( temperature_speed_modifier != 0 ) {
-            const auto player_local_temp = get_weather().get_temperature( pos() );
+            const auto player_local_temp = units::to_fahrenheit( get_weather().get_temperature( pos() ) );
             if( has_trait( trait_COLDBLOOD4 ) || player_local_temp < 65 ) {
                 mod_speed_bonus( ( player_local_temp - 65 ) * temperature_speed_modifier );
             }

--- a/src/gamemode_defense.cpp
+++ b/src/gamemode_defense.cpp
@@ -98,7 +98,7 @@ defense_game::defense_game()
 bool defense_game::init()
 {
     calendar::turn = calendar::turn_zero + 12_hours; // Start at noon
-    get_weather().temperature = 65;
+    get_weather().update_weather();
     if( !g->u.create( character_type::CUSTOM ) ) {
         return false;
     }

--- a/src/gamemode_tutorial.cpp
+++ b/src/gamemode_tutorial.cpp
@@ -113,7 +113,7 @@ bool tutorial_game::init()
     calendar::turn = calendar::turn_zero + 12_hours;
     tutorials_seen.clear();
     g->scent.reset();
-    get_weather().temperature = 65;
+    get_weather().update_weather();
     // We use a Z-factor of 10 so that we don't plop down tutorial rooms in the
     // middle of the "real" game world
     character_funcs::normalize( you );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9016,7 +9016,7 @@ detached_ptr<item>  item::process_rot( detached_ptr<item> &&self, const bool sea
     // note we're also gated by item::processing_speed
     constexpr time_duration smallest_interval = 10_minutes;
 
-    units::temperature temp = units::from_fahrenheit( weather.get_temperature( pos ) );
+    units::temperature temp = weather.get_temperature( pos );
     temp = clip_by_temperature_flag( temp, flag );
 
     time_point time = self->last_rot_check;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5582,8 +5582,10 @@ auto get_hourly_rotpoints_at_temp( const units::temperature temp ) -> int
     if( temp > 40_c ) {
         return 21240;
     }
-    const int temp_c = units::to_celsius( temp );
-    return rot_chart[temp_c];
+    // HACK: due to frequent fahrenheit <-> celsius conversion, 18C is actually 17.777C
+    // remove rounding after most of temperatures passed around are in `units::temperature`
+    const float temp_c = static_cast<float>( units::to_millidegree_celsius( temp ) ) / 1000;
+    return rot_chart[std::round( temp_c )];
 }
 
 auto item::calc_rot( time_point time, const units::temperature temp ) const -> time_duration

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2175,7 +2175,6 @@ void Item_factory::load( islot_comestible &slot, const JsonObject &jo, const std
     assign( jo, "healthy", slot.healthy, strict );
     assign( jo, "parasites", slot.parasites, strict, 0 );
     assign( jo, "radiation", slot.radiation, strict );
-    assign( jo, "freezing_point", slot.freeze_point, strict );
     assign( jo, "spoils_in", slot.spoils, strict, 1_hours );
     assign( jo, "cooks_like", slot.cooks_like, strict );
     assign( jo, "smoking_result", slot.smoking_result, strict );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -9101,7 +9101,7 @@ int iuse::weather_tool( player *p, item *it, bool, const tripoint & )
                 get_local_windchill( units::to_fahrenheit( weatherPoint.temperature ),
                                      weatherPoint.humidity,
                                      windpower / 100 ) +
-                player_local_temp ) );
+                units::to_fahrenheit( player_local_temp ) ) );
         std::string dirstring = get_dirstring( weather.winddirection );
         p->add_msg_if_player( m_neutral, _( "Wind Direction: From the %s." ), dirstring );
     }

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -55,6 +55,7 @@
 #include "translations.h"
 #include "type_id.h"
 #include "units.h"
+#include "units_temperature.h"
 #include "weather.h"
 
 static const bionic_id bio_dis_acid( "bio_dis_acid" );
@@ -1756,7 +1757,7 @@ void Character::drench( int saturation, const body_part_set &flags, bool ignore_
     }
 }
 
-void Character::apply_wetness_morale( int temperature )
+void Character::apply_wetness_morale( const units::temperature &celsius_temperature )
 {
     // First, a quick check if we have any wetness to calculate morale from
     // Faster than checking all worn items for friendliness
@@ -1767,8 +1768,10 @@ void Character::apply_wetness_morale( int temperature )
         return;
     }
 
+    int temperature = units::celsius_to_fahrenheit( celsius_temperature.value() );
     // Normalize temperature to [-1.0,1.0]
-    temperature = std::max( 0, std::min( 100, temperature ) );
+    temperature = std::clamp( temperature, 0, 100 );
+
     const double global_temperature_mod = -1.0 + ( 2.0 * temperature / 100.0 );
 
     int total_morale = 0;

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -811,10 +811,11 @@ void Character::suffer_in_sunlight()
         const bool has_hat = wearing_something_on( bodypart_id( "head" ) );
         const float weather_factor = ( get_weather().weather_id->sun_intensity >=
                                        sun_intensity_type::normal ) ? 1.0 : 0.5;
-        const int player_local_temp = get_weather().get_temperature( pos() );
-        const int flux = ( player_local_temp - 65 ) / 2;
 
         int sunlight_nutrition = 0;
+        const int player_local_temp = units::to_fahrenheit( get_weather().get_temperature( pos() ) );
+        const int flux = ( player_local_temp - 65 ) / 2;
+
         if( !has_hat ) {
             sunlight_nutrition += ( 100 + flux ) * weather_factor;
         }

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1757,7 +1757,7 @@ void Character::drench( int saturation, const body_part_set &flags, bool ignore_
     }
 }
 
-void Character::apply_wetness_morale( const units::temperature &celsius_temperature )
+void Character::apply_wetness_morale( const units::temperature &temperature )
 {
     // First, a quick check if we have any wetness to calculate morale from
     // Faster than checking all worn items for friendliness
@@ -1768,11 +1768,11 @@ void Character::apply_wetness_morale( const units::temperature &celsius_temperat
         return;
     }
 
-    int temperature = units::celsius_to_fahrenheit( celsius_temperature.value() );
+    int normalized_temperature = units::to_fahrenheit( temperature );
     // Normalize temperature to [-1.0,1.0]
-    temperature = std::clamp( temperature, 0, 100 );
+    normalized_temperature = std::clamp( normalized_temperature, 0, 100 );
 
-    const double global_temperature_mod = -1.0 + ( 2.0 * temperature / 100.0 );
+    const double global_temperature_mod = -1.0 + ( 2.0 * normalized_temperature / 100.0 );
 
     int total_morale = 0;
     const auto wet_friendliness = exclusive_flag_coverage( flag_WATER_FRIENDLY );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1,6 +1,7 @@
 #include "character.h"
 #include "vehicle.h"
 #include "vehicle_part.h" // IWYU pragma: associated
+#include "units_temperature.h"
 
 #include <algorithm>
 #include <array>
@@ -955,7 +956,7 @@ double vehicle::engine_cold_factor( const int e ) const
         return 0.0;
     }
 
-    int eff_temp = get_weather().get_temperature( g->u.pos() );
+    int eff_temp = units::to_fahrenheit( get_weather().get_temperature( g->u.pos() ) );
     if( !parts[ engines[ e ] ].faults().count( fault_glowplug ) ) {
         eff_temp = std::min( eff_temp, 20 );
     }

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -1032,12 +1032,12 @@ rl_vec2d convert_wind_to_coord( const int angle )
 bool warm_enough_to_plant( const tripoint &pos )
 {
     // semi-appropriate temperature for most plants
-    return get_weather().get_temperature( pos ) >= 50;
+    return get_weather().get_temperature( pos ) >= 10_c;
 }
 
 bool warm_enough_to_plant( const tripoint_abs_omt &pos )
 {
-    return get_weather().get_temperature( pos ) >= 50;
+    return get_weather().get_temperature( pos ) >= 10_c;
 }
 
 weather_manager::weather_manager()
@@ -1111,7 +1111,7 @@ void weather_manager::set_nextweather( time_point t )
     update_weather();
 }
 
-int weather_manager::get_temperature( const tripoint &location ) const
+auto weather_manager::get_temperature( const tripoint &location ) const -> units::temperature
 {
     const auto &cached = temperature_cache.find( location );
     if( cached != temperature_cache.end() ) {
@@ -1125,25 +1125,28 @@ int weather_manager::get_temperature( const tripoint &location ) const
         temp_mod += get_heat_radiation( location, false );
         temp_mod += get_convection_temperature( location );
     }
-    const int temp = units::to_fahrenheit( location.z < 0 ? temperatures::annual_average : temperature )
-                     + ( g->new_game ? 0 : g->m.get_temperature( location ) + temp_mod );
 
-    temperature_cache.emplace( location, temp );
-    return temp;
+    const int added_f = g->new_game ? 0 : g->m.get_temperature( location ) + temp_mod;
+    const int base_f = units::to_fahrenheit(
+                           location.z < 0 ? temperatures::annual_average : temperature );
+
+    // Hack: adding temperatures between temperatures makes no sense
+    return units::from_celsius( std::round( units::fahrenheit_to_celsius( base_f + added_f ) ) );
 }
 
-int weather_manager::get_temperature( const tripoint_abs_omt &location )
+auto weather_manager::get_temperature( const tripoint_abs_omt &location ) const ->
+units::temperature
 {
     if( location.z() < 0 ) {
-        return units::to_fahrenheit( temperatures::annual_average );
+        return temperatures::annual_average;
     }
 
     tripoint abs_ms = project_to<coords::ms>( location ).raw();
     w_point w = get_cur_weather_gen().get_weather( abs_ms, calendar::turn, g->get_seed() );
-    return units::to_fahrenheit( w.temperature );
+    return w.temperature;
 }
 
-units::temperature weather_manager::get_water_temperature( const tripoint & ) const
+auto weather_manager::get_water_temperature( const tripoint & ) const -> units::temperature
 {
     return water_temperature;
 }

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -1100,10 +1100,9 @@ void weather_manager::update_weather()
         get_map().set_seen_cache_dirty( tripoint_zero );
     }
 
-    water_temperature = units::to_fahrenheit(
-                            weather_gen.get_water_temperature(
-                                tripoint_abs_ms( g->u.global_square_location() ),
-                                calendar::turn, calendar::config, g->get_seed() ) );
+    water_temperature = weather_gen.get_water_temperature(
+                            tripoint_abs_ms( g->u.global_square_location() ),
+                            calendar::turn, calendar::config, g->get_seed() ) ;
 }
 
 void weather_manager::set_nextweather( time_point t )
@@ -1148,7 +1147,7 @@ int weather_manager::get_temperature( const tripoint_abs_omt &location )
     return units::to_fahrenheit( w.temperature );
 }
 
-int weather_manager::get_water_temperature( const tripoint & ) const
+units::temperature weather_manager::get_water_temperature( const tripoint & ) const
 {
     return water_temperature;
 }

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -1045,7 +1045,7 @@ weather_manager::weather_manager()
     lightning_active = false;
     weather_override = weather_type_id::NULL_ID();
     nextweather = calendar::before_time_starts;
-    temperature = 0;
+    temperature = 0_c;
     weather_id = weather_type_id::NULL_ID();
 }
 
@@ -1076,7 +1076,7 @@ void weather_manager::update_weather()
     }
 
     sfx::do_ambient();
-    temperature = units::to_fahrenheit( w.temperature );
+    temperature = w.temperature;
     lightning_active = false;
     // Check weather every few turns, instead of every turn.
     // TODO: predict when the weather changes and use that time.
@@ -1125,12 +1125,8 @@ int weather_manager::get_temperature( const tripoint &location ) const
         temp_mod += get_heat_radiation( location, false );
         temp_mod += get_convection_temperature( location );
     }
-    const int temp = ( location.z < 0
-                       ? units::to_fahrenheit( temperatures::annual_average )
-                       : temperature ) +
-                     ( g->new_game
-                       ? 0
-                       : g->m.get_temperature( location ) + temp_mod );
+    const int temp = units::to_fahrenheit( location.z < 0 ? temperatures::annual_average : temperature )
+                     + ( g->new_game ? 0 : g->m.get_temperature( location ) + temp_mod );
 
     temperature_cache.emplace( location, temp );
     return temp;

--- a/src/weather.h
+++ b/src/weather.h
@@ -203,14 +203,14 @@ class weather_manager
         // The time at which weather will shift next.
         time_point nextweather;
 
-        /** temperature cache, cleared every turn, sparse map of map tripoints to temperatures in Fahrenheit */
-        mutable std::unordered_map< tripoint, int > temperature_cache;
-        // Returns outdoor or indoor temperature of given location (in local coords) in Fahrenheit.
-        int get_temperature( const tripoint &location ) const;
+        /** temperature cache, cleared every turn, sparse map of map tripoints to temperatures */
+        mutable std::unordered_map< tripoint, units::temperature > temperature_cache;
+        // Returns outdoor or indoor temperature of given location (in local coords).
+        auto get_temperature( const tripoint &location ) const -> units::temperature;
         // Returns outdoor or indoor temperature of given location
-        int get_temperature( const tripoint_abs_omt &location );
+        auto get_temperature( const tripoint_abs_omt &location ) const -> units::temperature;
         // Returns water temperature of given location (in local coords).
-        units::temperature get_water_temperature( const tripoint &location ) const;
+        auto get_water_temperature( const tripoint &location ) const -> units::temperature;
         void clear_temp_cache();
 
         // Get precise weather data

--- a/src/weather.h
+++ b/src/weather.h
@@ -184,8 +184,8 @@ class weather_manager
 
         // Updates the temperature and weather pattern
         void update_weather();
-        // The air temperature in Fahrenheit
-        int temperature = 0;
+        // The air temperature
+        units::temperature temperature = 0_c;
         units::temperature water_temperature = 0_c;
         bool lightning_active = false;
         // Weather pattern

--- a/src/weather.h
+++ b/src/weather.h
@@ -186,8 +186,7 @@ class weather_manager
         void update_weather();
         // The air temperature in Fahrenheit
         int temperature = 0;
-        // The water temperature in Fahrenheit
-        int water_temperature = 0;
+        units::temperature water_temperature = 0_c;
         bool lightning_active = false;
         // Weather pattern
         weather_type_id weather_id = weather_type_id::NULL_ID();
@@ -210,8 +209,8 @@ class weather_manager
         int get_temperature( const tripoint &location ) const;
         // Returns outdoor or indoor temperature of given location
         int get_temperature( const tripoint_abs_omt &location );
-        // Returns water temperature of given location (in local coords) in Fahrenheit.
-        int get_water_temperature( const tripoint &location ) const;
+        // Returns water temperature of given location (in local coords).
+        units::temperature get_water_temperature( const tripoint &location ) const;
         void clear_temp_cache();
 
         // Get precise weather data

--- a/tests/behavior_test.cpp
+++ b/tests/behavior_test.cpp
@@ -153,7 +153,7 @@ TEST_CASE( "check_npc_behavior_tree", "[npc][behavior]" )
     CHECK( npc_needs.tick( &oracle ) == "idle" );
     SECTION( "Freezing" ) {
         weather_manager &weather = get_weather();
-        weather.temperature = -100;
+        weather.temperature = -70_c;
         weather.clear_temp_cache();
         test_npc.update_bodytemp( get_map(), weather );
         CHECK( npc_needs.tick( &oracle ) == "idle" );

--- a/tests/behavior_test.cpp
+++ b/tests/behavior_test.cpp
@@ -153,7 +153,7 @@ TEST_CASE( "check_npc_behavior_tree", "[npc][behavior]" )
     CHECK( npc_needs.tick( &oracle ) == "idle" );
     SECTION( "Freezing" ) {
         weather_manager &weather = get_weather();
-        weather.temperature = -70_c;
+        weather.temperature = -100_c;
         weather.clear_temp_cache();
         test_npc.update_bodytemp( get_map(), weather );
         CHECK( npc_needs.tick( &oracle ) == "idle" );

--- a/tests/player_test.cpp
+++ b/tests/player_test.cpp
@@ -195,7 +195,7 @@ static void test_temperature_spread( player &p,
 {
     const auto thresholds = bodytemp_voronoi();
     for( int i = 0; i < 7; i++ ) {
-        get_weather().temperature = to_fahrenheit( air_temperatures[i] );
+        get_weather().temperature = air_temperatures[i];
         get_weather().clear_temp_cache();
         CAPTURE( air_temperatures[i] );
         CAPTURE( get_weather().temperature );
@@ -321,7 +321,7 @@ static std::array<units::temperature, bodytemps.size()> find_temperature_points(
     std::vector<temperatures_wrapper> all_converged_temperatures;
     all_converged_temperatures.resize( max_air_temp - min_air_temp, temperatures_wrapper( {} ) );
     for( int i = min_air_temp; i < max_air_temp; i++ ) {
-        get_weather().temperature = i;
+        get_weather().temperature = units::from_fahrenheit( i );
         get_weather().clear_temp_cache();
         all_converged_temperatures[i - min_air_temp] = converge_temperature( p, 10000 );
         int converged_torso_temp = all_converged_temperatures[i - min_air_temp][0];

--- a/tests/player_test.cpp
+++ b/tests/player_test.cpp
@@ -9,6 +9,7 @@
 #include "avatar_action.h"
 #include "catch/catch.hpp"
 #include "player.h"
+#include "units_temperature.h"
 #include "weather.h"
 #include "bodypart.h"
 #include "calendar.h"
@@ -407,9 +408,10 @@ static int find_converging_water_temp( player &p, int expected_water, int expect
     int step = 2 * 128;
     do {
         step /= 2;
-        get_weather().water_temperature = actual_water;
+        get_weather().water_temperature = units::from_fahrenheit( actual_water );
         get_weather().clear_temp_cache();
-        const int actual_temperature = get_weather().get_water_temperature( p.pos() );
+        const int actual_temperature = units::celsius_to_fahrenheit( get_weather().get_water_temperature(
+                                           p.pos() ).value() );
         REQUIRE( actual_temperature == actual_water );
 
         int converged_temperature = converge_temperature( p, 10000 )[0];
@@ -480,7 +482,7 @@ TEST_CASE( "Player body temperatures in water.", "[.][bodytemp]" )
 static void hypothermia_check( player &p, int water_temperature, time_duration expected_time,
                                int expected_temperature )
 {
-    get_weather().water_temperature = water_temperature;
+    get_weather().water_temperature = units::from_fahrenheit( water_temperature );
     get_weather().clear_temp_cache();
     int expected_turns = to_turns<int>( expected_time );
     int lower_bound = expected_turns * 0.8f;

--- a/tests/player_test.cpp
+++ b/tests/player_test.cpp
@@ -321,7 +321,7 @@ static std::array<units::temperature, bodytemps.size()> find_temperature_points(
     std::vector<temperatures_wrapper> all_converged_temperatures;
     all_converged_temperatures.resize( max_air_temp - min_air_temp, temperatures_wrapper( {} ) );
     for( int i = min_air_temp; i < max_air_temp; i++ ) {
-        get_weather().temperature = units::from_fahrenheit( i );
+        get_weather().temperature = units::from_millidegree_celsius( i * 500 );
         get_weather().clear_temp_cache();
         all_converged_temperatures[i - min_air_temp] = converge_temperature( p, 10000 );
         int converged_torso_temp = all_converged_temperatures[i - min_air_temp][0];

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -9,13 +9,14 @@
 #include "map_helpers.h"
 #include "game.h" // Just for get_convection_temperature(), TODO: Remove
 #include "point.h"
+#include "units_temperature.h"
 #include "weather.h"
 
 static const furn_str_id f_atomic_freezer( "f_atomic_freezer" );
 
 static void set_map_temperature( weather_manager &weather, int new_temperature )
 {
-    weather.temperature = new_temperature;
+    weather.temperature = units::from_fahrenheit( new_temperature );
     weather.clear_temp_cache();
 }
 

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -14,9 +14,9 @@
 
 static const furn_str_id f_atomic_freezer( "f_atomic_freezer" );
 
-static void set_map_temperature( weather_manager &weather, int new_temperature )
+static void set_map_temperature( weather_manager &weather, units::temperature new_temperature )
 {
-    weather.temperature = units::from_fahrenheit( new_temperature );
+    weather.temperature = new_temperature;
     weather.clear_temp_cache();
 }
 
@@ -46,9 +46,9 @@ TEST_CASE( "Rate of rotting" )
         detached_ptr<item> freeze_item = item::spawn( "offal_canned" );
         detached_ptr<item> sealed_item = item::in_its_container( item::spawn( "offal_canned" ) );
 
-        set_map_temperature( weather, 65 ); // 18,3 C
+        set_map_temperature( weather, 18_c );
         ensure_no_temperature_mods( tripoint_zero );
-        REQUIRE( weather.get_temperature( tripoint_zero ) == Approx( 65 ) );
+        REQUIRE( weather.get_temperature( tripoint_zero ) == Approx( 64 ) );
 
         normal_item = item::process( std::move( normal_item ), nullptr, tripoint_zero, false,
                                      temperature_flag::TEMP_NORMAL, weather );
@@ -169,7 +169,7 @@ TEST_CASE( "Items don't rot away on map load if in a freezer" )
     detached_ptr<item> sealed_item_d = item::in_its_container( item::spawn( "offal_canned" ) );
     item &sealed_item = *sealed_item_d;
 
-    set_map_temperature( weather, 65 ); // 18,3 C
+    set_map_temperature( weather, 18_c );
 
     m.i_clear( freezer_pnt );
     m.i_clear( sealed_pnt );

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -48,7 +48,7 @@ TEST_CASE( "Rate of rotting" )
 
         set_map_temperature( weather, 18_c );
         ensure_no_temperature_mods( tripoint_zero );
-        REQUIRE( weather.get_temperature( tripoint_zero ) == Approx( 64 ) );
+        REQUIRE( weather.get_temperature( tripoint_zero ) == 18_c );
 
         normal_item = item::process( std::move( normal_item ), nullptr, tripoint_zero, false,
                                      temperature_flag::TEMP_NORMAL, weather );


### PR DESCRIPTION
## Purpose of change

part 2 of #2570

## Describe the solution

- migrated `weather` class to use Celsius.
- removed legacy usage of `freezing_point`.

## Describe alternatives you've considered

remove discrete temperatures and manage it via enums (`temperature_flag`)

## Testing

- (to my surprise) local tests passed.
- was able to load items with/without `freezing_point` field.

## Additional context

- after 5 months we're back.
- TIL adding temperatures with temperatures makes no sense (hence C + C != F + F)