### PR TITLE
ci: fix always run flag not working

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -51,8 +51,7 @@ jobs:
             native: linux64
             ccache_limit: 2G
             ccache_key: linux-gcc-12
-            run-on-draft: true
-            always-test: true
+            always-run: true
 
           - title: GCC 12, Ubuntu, Tiles, Sound, Lua, CMake, Languages
             compiler: g++-12
@@ -143,9 +142,7 @@ jobs:
       CCACHE_HARDLINK: true
       CCACHE_NOCOMPRESS: true
 
-      SKIP: ${{ ( github.event.pull_request.draft == true && matrix.run-on-draft != 'true' ) ||
-                ( matrix.always-test != 'true' && needs.skip-duplicates.outputs.should_skip_code == 'true' ) ||
-                ( matrix.always-test != 'true' && needs.skip-duplicates.outputs.should_skip_data == 'true' ) }}
+      SKIP: ${{ matrix.always-run != true && ( github.event.pull_request.draft == true || needs.skip-duplicates.outputs.should_skip_code == true || needs.skip-duplicates.outputs.should_skip_data == true ) }}
 
     steps:
       - name: checkout repository


### PR DESCRIPTION
## Purpose of change

- fixes #3560 (again)

## Describe the solution

`true != 'true'` always evaluates to `true`. this causes tests to always skip.

https://github.com/cataclysmbnteam/Cataclysm-BN/blob/ce5c66744d1eea231629c43554ffd2e26d356520/.github/workflows/matrix.yml#L146-L148

matrix was comparing [`true` (boolean)](https://github.com/cataclysmbnteam/Cataclysm-BN/actions/runs/7237118999/job/19717827424#step:1:154) to [`'true'` (string)](https://github.com/cataclysmbnteam/Cataclysm-BN/actions/runs/7237118999/job/19717827424#step:1:156), always resulting in `true`.

## Describe alternatives you've considered

- separate matrix into jobs per os for easier management
- host a server solely dedicated to run JSON tests built daily
- screm

## Testing

should work (really)

## Additional context

while a bit verbose, https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging helped a lot.