### PR TITLE
fix: correct the model name for MP5 SMG

### DIFF
--- a/data/json/items/gun/9mm.json
+++ b/data/json/items/gun/9mm.json
@@ -94,7 +94,7 @@
     "//": "Tileset whitelist for SMGs",
     "copy-from": "smg_base",
     "type": "GUN",
-    "name": { "str": "H&K MP5A2" },
+    "name": { "str": "H&K MP5A4" },
     "description": "The Heckler & Koch MP5 is one of the most widely-used submachine guns in the world, and has been adopted by special police forces and militaries alike.  Its high degree of accuracy and low recoil are universally praised.",
     "weight": "2730 g",
     "volume": "1025 ml",

--- a/tests/item_tname_test.cpp
+++ b/tests/item_tname_test.cpp
@@ -262,7 +262,7 @@ TEST_CASE( "weapon fouling", "[item][tname][fouling][dirt]" )
 
         WHEN( "it is perfectly clean" ) {
             gun.set_var( "dirt", 0 );
-            CHECK( gun.tname() == "H&K MP5A2" );
+            CHECK( gun.tname() == "H&K MP5A4" );
         }
 
         WHEN( "it is fouled" ) {
@@ -273,37 +273,37 @@ TEST_CASE( "weapon fouling", "[item][tname][fouling][dirt]" )
 
             THEN( "minimal fouling is not indicated" ) {
                 gun.set_var( "dirt", 1000 );
-                CHECK( gun.tname() == "H&K MP5A2" );
+                CHECK( gun.tname() == "H&K MP5A4" );
             }
 
             // U+2581 'Lower one eighth block'
             THEN( "20%% fouling is indicated with a thin white bar" ) {
                 gun.set_var( "dirt", 2000 );
-                CHECK( gun.tname() == "<color_white>\u2581</color>H&K MP5A2" );
+                CHECK( gun.tname() == "<color_white>\u2581</color>H&K MP5A4" );
             }
 
             // U+2583 'Lower three eighths block'
             THEN( "40%% fouling is indicated with a slight gray bar" ) {
                 gun.set_var( "dirt", 4000 );
-                CHECK( gun.tname() == "<color_light_gray>\u2583</color>H&K MP5A2" );
+                CHECK( gun.tname() == "<color_light_gray>\u2583</color>H&K MP5A4" );
             }
 
             // U+2585 'Lower five eighths block'
             THEN( "60%% fouling is indicated with a medium gray bar" ) {
                 gun.set_var( "dirt", 6000 );
-                CHECK( gun.tname() == "<color_light_gray>\u2585</color>H&K MP5A2" );
+                CHECK( gun.tname() == "<color_light_gray>\u2585</color>H&K MP5A4" );
             }
 
             // U+2585 'Lower seven eighths block'
             THEN( "80%% fouling is indicated with a tall dark gray bar" ) {
                 gun.set_var( "dirt", 8000 );
-                CHECK( gun.tname() == "<color_dark_gray>\u2587</color>H&K MP5A2" );
+                CHECK( gun.tname() == "<color_dark_gray>\u2587</color>H&K MP5A4" );
             }
 
             // U+2588 'Full block'
             THEN( "100%% fouling is indicated with a full brown bar" ) {
                 gun.set_var( "dirt", 10000 );
-                CHECK( gun.tname() == "<color_brown>\u2588</color>H&K MP5A2" );
+                CHECK( gun.tname() == "<color_brown>\u2588</color>H&K MP5A4" );
             }
         }
     }


### PR DESCRIPTION
## Purpose of change

It came to my attention that the model designation MP5A2 used in the game cannot be correct, since the A2 modification does not feature 3-round burst firing mode.

## Describe the solution

Rename the gun to MP5A4, which is the same thing but with 4-position trigger group.

## Describe alternatives you've considered

Clobbering myself over the noggin until I forget this little bit of gun trivia so the discrepancy stops bugging me.

## Testing

Made sure the new name is reflected in the game.