### PR TITLE
feat(content,port): JSONize terrain flag requirement for plants.

### DIFF
--- a/data/json/furniture_and_terrain/terrain-liquids.json
+++ b/data/json/furniture_and_terrain/terrain-liquids.json
@@ -7,7 +7,7 @@
     "symbol": "~",
     "color": "light_blue",
     "move_cost": 5,
-    "flags": [ "TRANSPARENT", "LIQUID", "NO_SCENT", "SWIMMABLE", "FISHABLE" ],
+    "flags": [ "TRANSPARENT", "LIQUID", "NO_SCENT", "SWIMMABLE", "FISHABLE", "SHALLOW_WATER" ],
     "connects_to": "WATER",
     "examine_action": "water_source"
   },

--- a/data/json/furniture_and_terrain/terrain-liquids.json
+++ b/data/json/furniture_and_terrain/terrain-liquids.json
@@ -147,7 +147,7 @@
     "looks_like": "t_water_sh",
     "color": "light_blue",
     "move_cost": 5,
-    "flags": [ "TRANSPARENT", "LIQUID", "NO_SCENT", "SWIMMABLE", "SALT_WATER", "FISHABLE" ],
+    "flags": [ "TRANSPARENT", "LIQUID", "NO_SCENT", "SWIMMABLE", "SALT_WATER", "FISHABLE", "SHALLOW_WATER" ],
     "connects_to": "WATER",
     "examine_action": "water_source"
   },

--- a/data/json/items/comestibles/seed.json
+++ b/data/json/items/comestibles/seed.json
@@ -240,8 +240,14 @@
     "copy-from": "seed",
     "name": { "str_sp": "cattail seeds" },
     "color": "green",
-    "description": "Some cattail seeds.",
-    "seed_data": { "plant_name": "cattail", "fruit": "cattail_stalk", "byproducts": [ "cattail_rhizome" ], "grow": "14 days" }
+    "description": "Some cattail seeds.  Must be planted in shallow water.",
+    "seed_data": {
+      "plant_name": "cattail",
+      "fruit": "cattail_stalk",
+      "byproducts": [ "cattail_rhizome" ],
+      "grow": "14 days",
+      "required_terrain_flag": "SHALLOW_WATER"
+    }
   },
   {
     "type": "COMESTIBLE",

--- a/doc/src/content/docs/en/mod/json/reference/json_info.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_info.md
@@ -2011,6 +2011,9 @@ can be planted:
     "grow" : 91 // A time duration: how long it takes for a plant to fully mature. Based around a 91 day season length (roughly a real world season) to give better accuracy for longer season lengths
                 // Note that growing time is later converted based upon the season_length option, basing it around 91 is just for accuracy purposes
                 // A value 91 means 3 full seasons, a value of 30 would mean 1 season.
+    "required_terrain_flag": "PLANTABLE" // A tag that terrain and furniture would need to have in order for the seed to be plantable there.
+					 // Default is "PLANTABLE", and using this will cause any terain the plant is wrown on to turn into dirt once the plant is planted, unless furniture is used.
+					 // Using any other tag will not turn the terrain into dirt.
 }
 ```
 

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -3580,10 +3580,12 @@ void activity_handlers::plant_seed_finish( player_activity *act, player *p )
         }
         used_seed.front()->set_flag( flag_HIDDEN_ITEM );
         here.add_item_or_charges( examp, std::move( used_seed.front() ) );
-        if( here.has_flag_furn( flag_PLANTABLE, examp ) ) {
+        if( here.has_flag_furn( seed_id->seed->required_terrain_flag, examp ) ) {
             here.furn_set( examp, furn_str_id( here.furn( examp )->plant->transform ) );
-        } else {
+        } else if( seed_id->seed->required_terrain_flag == flag_PLANTABLE ) {
             here.set( examp, t_dirt, f_plant_seed );
+        } else {
+            here.furn_set( examp, f_plant_seed );
         }
         p->add_msg_player_or_npc( _( "You plant some %s." ), _( "<npcname> plants some %s." ),
                                   item::nname( seed_id ) );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -141,7 +141,6 @@ static const std::string flag_BUTCHER_EQ( "BUTCHER_EQ" );
 static const std::string flag_FISHABLE( "FISHABLE" );
 static const std::string flag_GROWTH_HARVEST( "GROWTH_HARVEST" );
 static const std::string flag_PLANT( "PLANT" );
-static const std::string flag_PLANTABLE( "PLANTABLE" );
 static const std::string flag_PLOWABLE( "PLOWABLE" );
 static const std::string flag_TREE( "TREE" );
 
@@ -1619,6 +1618,8 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
         zones = mgr.get_zones( zone_type_FARM_PLOT,
                                here.getabs( src_loc ) );
         for( const zone_data &zone : zones ) {
+            const plot_options &options = dynamic_cast<const plot_options &>( zone.get_options() );
+            const itype_id seed = options.get_seed();
             if( here.has_flag_furn( flag_GROWTH_HARVEST, src_loc ) ) {
                 // simple work, pulling up plants, nothing else required.
                 return activity_reason_info::ok( do_activity_reason::NEEDS_HARVESTING );
@@ -1630,14 +1631,12 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
                     // we need a shovel/hoe
                     return activity_reason_info::fail( do_activity_reason::NEEDS_TILLING );
                 }
-            } else if( here.has_flag_ter_or_furn( flag_PLANTABLE, src_loc ) &&
+            } else if( here.has_flag_ter_or_furn( seed->seed->required_terrain_flag, src_loc ) &&
                        warm_enough_to_plant( src_loc ) ) {
                 if( here.has_items( src_loc ) ) {
                     return activity_reason_info::fail( do_activity_reason::BLOCKING_TILE );
                 } else {
                     // do we have the required seed on our person?
-                    const plot_options &options = dynamic_cast<const plot_options &>( zone.get_options() );
-                    const itype_id seed = options.get_seed();
                     // If its a farm zone with no specified seed, and we've checked for tilling and harvesting.
                     // then it means no further work can be done here
                     if( seed.is_empty() ) {
@@ -2901,8 +2900,7 @@ static bool generic_multi_activity_do( player &p, const activity_id &act_id,
         p.backlog.emplace_front( std::make_unique<player_activity>( act_id ) );
         p.activity->placement = src;
         return false;
-    } else if( reason == do_activity_reason::NEEDS_PLANTING &&
-               here.has_flag_ter_or_furn( flag_PLANTABLE, src_loc ) ) {
+    } else if( reason == do_activity_reason::NEEDS_PLANTING ) {
         std::vector<zone_data> zones = mgr.get_zones( zone_type_FARM_PLOT,
                                        here.getabs( src_loc ) );
         for( const zone_data &zone : zones ) {
@@ -2914,6 +2912,9 @@ static bool generic_multi_activity_do( player &p, const activity_id &act_id,
             // we don't have the required seed, even though we should at this point.
             // move onto the next tile, and if need be that will prompt a fetch seeds activity.
             if( seed_inv.empty() ) {
+                continue;
+            }
+            if( !here.has_flag_ter_or_furn( seed->seed->required_terrain_flag, src_loc ) ) {
                 continue;
             }
             iexamine::plant_seed( p, src_loc, itype_id( seed ) );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2247,6 +2247,11 @@ void iexamine::dirtmound( player &p, const tripoint &examp )
     }
     const auto &seed_id = std::get<0>( seed_entries[seed_index] );
 
+    if( !here.has_flag_ter_or_furn( seed_id->seed->required_terrain_flag, examp ) ) {
+        add_msg( _( "This type of seed can not be planted in this location." ) );
+        return;
+    }
+
     plant_seed( p, examp, seed_id );
 }
 

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2310,6 +2310,7 @@ void Item_factory::load( islot_seed &slot, const JsonObject &jo, const std::stri
     assign( jo, "fruit", slot.fruit_id );
     assign( jo, "seeds", slot.spawn_seeds );
     assign( jo, "byproducts", slot.byproducts );
+    assign( jo, "required_terrain_flag", slot.required_terrain_flag );
 }
 
 void Item_factory::load( islot_container &slot, const JsonObject &jo, const std::string & )

--- a/src/itype.h
+++ b/src/itype.h
@@ -21,6 +21,7 @@
 #include "explosion.h"
 #include "game_constants.h"
 #include "iuse.h" // use_function
+#include "mapdata.h"
 #include "pldata.h" // add_type
 #include "shape.h"
 #include "stomach.h"
@@ -765,7 +766,10 @@ struct islot_seed {
      * Additionally items (a list of their item ids) that will spawn when harvesting the plant.
      */
     std::vector<itype_id> byproducts;
-
+    /**
+     * Terrain tag required to plant the seed.
+     */
+    std::string required_terrain_flag = "PLANTABLE";
     islot_seed() = default;
 };
 


### PR DESCRIPTION
## Purpose of change

Ports https://github.com/CleverRaven/Cataclysm-DDA/pull/68664 which will set cattails as growing in shallow water and It also makes it so that different plants can have different terrain requirements for farming.

## Describe the solution

To quote the original PR: 

"seed_data" has a new optional field, "required_terrain_flag". This is set to "PLANTABLE" by default. In order to plant a seed somewhere, the terrain or furniture there needs to have the given flag.
If this flag is set to anything other than "PLANTABLE", the terrain will not turn into dirt after the seed is planted. This is to prevent the water to turn into dirt when you plant stuff in it.
Places that previously checked for the "PLANTABLE" tag now instead checks for the tag specified by the "seed_data".
Cattail seeds are set to have "required_terrain_flag": "SHALLOW_WATER".
Documentation is updated to match.
A new hardcoded message string is added for when you're trying to plant a seed in an invalid spot; add_msg( _( "This type of seed can not be planted in this location." ) );. This might need translation.

I had to add "SHALLOW_WATER" flag to fresh shallow water and salt shallow water, as we were missing that terrain flag from DDA.

## Describe alternatives you've considered

None

## Testing

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/112293514/9e846c9b-5dac-4d8e-aff7-1c21a4c078ff)
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/112293514/627d3d5b-3ddd-497d-9ce6-df4689c98283)
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/112293514/207f48d5-5c67-42d8-8133-dcc760749b1e)



## Additional context

This could've gone smoother, but it's ok in the end.

## Checklist

If this is a C++ PR that modifies JSON loading or behavior:
- [x] Document the changes in the appropriate location in the `doc/` folder.
- [x] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [x] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [x] If applicable, add checks on game load that would validate the loaded data.
