### PR TITLE
feat: JSONize some trap features

### DIFF
--- a/data/json/items/tool/traps.json
+++ b/data/json/items/tool/traps.json
@@ -219,10 +219,10 @@
     "id": "shotgun_trap",
     "type": "GENERIC",
     "category": "tools",
-    "name": { "str": "shotgun trap" },
-    "description": "This is a simple tripwire is attached to the trigger of a loaded double-barreled shotgun.  When pulled, the shotgun fires.  Two shells are loaded; the first time the trigger is pulled, one or both shells may be discharged.",
-    "weight": "2922 g",
-    "volume": "1750 ml",
+    "name": { "str": "double-barreled shotgun trap" },
+    "description": "This is a simple tripwire is attached to the trigger of a loaded double-barreled shotgun.  When pulled, the shotgun fires, discharging both barrels into the target.",
+    "weight": "3500 g",
+    "volume": "3 L",
     "price": "250 USD",
     "price_postapoc": "10 USD",
     "to_hit": -2,
@@ -233,6 +233,22 @@
     "use_action": {
       "type": "place_trap",
       "trap": "tr_shotgun_2",
+      "moves": 225,
+      "practice": 5,
+      "done_message": "You set the shotgun trap."
+    }
+  },
+  {
+    "id": "shotgun_trap_single",
+    "copy-from": "shotgun_trap",
+    "type": "GENERIC",
+    "name": { "str": "shotgun trap" },
+    "description": "This is a simple tripwire is attached to the trigger of a loaded single-barreled shotgun.  When pulled, the shotgun fires.",
+    "weight": "2600 g",
+    "volume": "2500 ml",
+    "use_action": {
+      "type": "place_trap",
+      "trap": "tr_shotgun_1",
       "moves": 225,
       "practice": 5,
       "done_message": "You set the shotgun trap."

--- a/data/json/obsoletion/uncategorized.json
+++ b/data/json/obsoletion/uncategorized.json
@@ -437,5 +437,30 @@
       ]
     },
     "examine_action": "clean_water_source"
+  },
+  {
+    "type": "trap",
+    "id": "tr_shotgun_2_1",
+    "trigger_weight": "200 g",
+    "name": "half-empty shotgun trap",
+    "color": "red",
+    "symbol": "^",
+    "visibility": 4,
+    "avoidance": 5,
+    "difficulty": 6,
+    "action": "shotgun",
+    "remove_on_trigger": true,
+    "trigger_items": [ "tripwire", "shotgun_d", { "item": "shot_hull", "quantity": 2, "charges": 1 } ],
+    "drops": [ "tripwire", "shotgun_d", { "item": "shot_00", "quantity": 1, "charges": 1 } ],
+    "vehicle_data": {
+      "chance": 70,
+      "damage": 300,
+      "sound_volume": 60,
+      "sound": "Bang!",
+      "sound_type": "fire_gun",
+      "sound_variant": "shotgun_d",
+      "remove_trap": true,
+      "spawn_items": [ "shotgun_d", "string_6" ]
+    }
   }
 ]

--- a/data/json/recipes/other/traps.json
+++ b/data/json/recipes/other/traps.json
@@ -137,11 +137,11 @@
     "reversible": true,
     "decomp_learn": 2,
     "autolearn": true,
-    "components": [ [ [ "tripwire", 1 ] ], [ [ "crossbow", 1 ] ], [ [ "bolt_steel", 1 ], [ "bolt_wood", 4 ] ] ]
+    "components": [ [ [ "tripwire", 1 ] ], [ [ "crossbow", 1 ] ], [ [ "bolt_steel", 1 ], [ "bolt_wood", 1 ] ] ]
   },
   {
     "type": "recipe",
-    "result": "shotgun_trap",
+    "result": "shotgun_trap_single",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_TRAPS",
     "skill_used": "traps",
@@ -150,6 +150,20 @@
     "time": "5 m",
     "reversible": true,
     "decomp_learn": 2,
+    "autolearn": true,
+    "components": [ [ [ "tripwire", 1 ] ], [ [ "shotgun_s", 1 ] ], [ [ "shot_00", 1 ], [ "shot_slug", 1 ], [ "shot_flechette", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "shotgun_trap",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TRAPS",
+    "skill_used": "traps",
+    "skills_required": [ "mechanics", 1 ],
+    "difficulty": 4,
+    "time": "5 m",
+    "reversible": true,
+    "decomp_learn": 3,
     "autolearn": true,
     "components": [ [ [ "tripwire", 1 ] ], [ [ "shotgun_d", 1 ] ], [ [ "shot_00", 2 ], [ "shot_slug", 2 ], [ "shot_flechette", 2 ] ] ]
   },

--- a/data/json/traps.json
+++ b/data/json/traps.json
@@ -146,6 +146,7 @@
     "visibility": 2,
     "avoidance": 7,
     "difficulty": 3,
+    "//": "trigger_items and remove_on_trigger don't apply to this action, since trap behavior is tied to the target freeing themselves.",
     "action": "beartrap",
     "drops": [ "beartrap" ],
     "vehicle_data": {
@@ -168,6 +169,7 @@
     "visibility": 9,
     "avoidance": 8,
     "difficulty": 4,
+    "//": "trigger_items and remove_on_trigger don't apply to this action, since trap behavior is tied to the target freeing themselves.",
     "action": "beartrap",
     "drops": [ "beartrap" ],
     "vehicle_data": {
@@ -244,6 +246,7 @@
     "difficulty": 5,
     "action": "spell",
     "spell_data": { "id": "spell_trap_can_alarm_trigger" },
+    "trigger_items": [ "can_alarm_trap" ],
     "drops": [ "can_alarm_trap" ],
     "vehicle_data": { "sound_volume": 25, "sound": "empty cans clattering!" }
   },
@@ -258,6 +261,8 @@
     "avoidance": 4,
     "difficulty": 5,
     "action": "crossbow",
+    "//": "Ammo spawn on activation is still hardcoded, as it has a randomized chance to drop intact.",
+    "trigger_items": [ "tripwire", "crossbow" ],
     "drops": [ "tripwire", "crossbow", "bolt_steel" ],
     "vehicle_data": {
       "chance": 30,
@@ -274,13 +279,15 @@
     "type": "trap",
     "id": "tr_shotgun_2",
     "trigger_weight": "200 g",
-    "name": "shotgun trap",
+    "name": "double-barrel shotgun trap",
     "color": "red",
     "symbol": "^",
     "visibility": 4,
     "avoidance": 5,
     "difficulty": 6,
     "action": "shotgun",
+    "//": "trigger_items here only matters if the trap rolls to fire both barrels, otherwise it becomes tr_shotgun_2_1 instead",
+    "trigger_items": [ "tripwire", "shotgun_d" ],
     "drops": [ "tripwire", "shotgun_d", { "item": "shot_00", "quantity": 2, "charges": 1 } ],
     "vehicle_data": {
       "chance": 70,
@@ -296,13 +303,14 @@
     "type": "trap",
     "id": "tr_shotgun_2_1",
     "trigger_weight": "200 g",
-    "name": "shotgun trap",
+    "name": "half-empty shotgun trap",
     "color": "red",
     "symbol": "^",
     "visibility": 4,
     "avoidance": 5,
     "difficulty": 6,
     "action": "shotgun",
+    "trigger_items": [ "tripwire", "shotgun_d" ],
     "drops": [ "tripwire", "shotgun_d", { "item": "shot_00", "quantity": 1, "charges": 1 } ],
     "vehicle_data": {
       "chance": 70,
@@ -326,6 +334,7 @@
     "avoidance": 5,
     "difficulty": 6,
     "action": "shotgun",
+    "trigger_items": [ "tripwire", "shotgun_s" ],
     "drops": [ "tripwire", "shotgun_s", { "item": "shot_00", "quantity": 1, "charges": 1 } ],
     "vehicle_data": {
       "chance": 70,
@@ -477,6 +486,7 @@
     "visibility": 0,
     "avoidance": 8,
     "difficulty": 99,
+    "//": "trigger_items isn't used here since the spikes breaking occurs at random, and comes with converting the terrain type when triggered.",
     "action": "pit_spikes",
     "vehicle_data": { "damage": 500 }
   },
@@ -630,6 +640,7 @@
     "visibility": 0,
     "avoidance": 8,
     "difficulty": 99,
+    "//": "trigger_items isn't used here since the spikes breaking occurs at random, and comes with converting the terrain type when triggered.",
     "action": "pit_glass",
     "vehicle_data": { "damage": 500 }
   },

--- a/data/json/traps.json
+++ b/data/json/traps.json
@@ -21,6 +21,7 @@
     "avoidance": 8,
     "difficulty": 0,
     "action": "bubble",
+    "remove_on_trigger": true,
     "drops": [ "bubblewrap" ],
     "vehicle_data": { "sound_volume": 18, "sound": "Pop!" }
   },
@@ -34,6 +35,7 @@
     "avoidance": 8,
     "difficulty": 0,
     "action": "glass",
+    "remove_on_trigger": true,
     "drops": [ "glass_shard" ],
     "vehicle_data": { "sound_volume": 10, "sound": "Crunch!" }
   },
@@ -146,8 +148,9 @@
     "visibility": 2,
     "avoidance": 7,
     "difficulty": 3,
-    "//": "trigger_items and remove_on_trigger don't apply to this action, since trap behavior is tied to the target freeing themselves.",
     "action": "beartrap",
+    "//": "trigger_items isn't needed for this action, since trap behavior is tied to the target freeing themselves.",
+    "remove_on_trigger": true,
     "drops": [ "beartrap" ],
     "vehicle_data": {
       "damage": 300,
@@ -169,8 +172,9 @@
     "visibility": 9,
     "avoidance": 8,
     "difficulty": 4,
-    "//": "trigger_items and remove_on_trigger don't apply to this action, since trap behavior is tied to the target freeing themselves.",
     "action": "beartrap",
+    "//": "trigger_items isn't needed for this action, since trap behavior is tied to the target freeing themselves.",
+    "remove_on_trigger": true,
     "drops": [ "beartrap" ],
     "vehicle_data": {
       "damage": 300,
@@ -218,6 +222,8 @@
     "avoidance": 6,
     "difficulty": 0,
     "action": "caltrops_glass",
+    "remove_on_trigger": true,
+    "trigger_items": [ { "item": "glass_shard", "quantity": 3 } ],
     "drops": [ "caltrops_glass" ],
     "vehicle_data": { "damage": 300 }
   },
@@ -246,6 +252,7 @@
     "difficulty": 5,
     "action": "spell",
     "spell_data": { "id": "spell_trap_can_alarm_trigger" },
+    "remove_on_trigger": true,
     "trigger_items": [ "can_alarm_trap" ],
     "drops": [ "can_alarm_trap" ],
     "vehicle_data": { "sound_volume": 25, "sound": "empty cans clattering!" }
@@ -261,6 +268,7 @@
     "avoidance": 4,
     "difficulty": 5,
     "action": "crossbow",
+    "remove_on_trigger": true,
     "//": "Ammo spawn on activation is still hardcoded, as it has a randomized chance to drop intact.",
     "trigger_items": [ "tripwire", "crossbow" ],
     "drops": [ "tripwire", "crossbow", "bolt_steel" ],
@@ -286,8 +294,9 @@
     "avoidance": 5,
     "difficulty": 6,
     "action": "shotgun",
-    "//": "trigger_items here only matters if the trap rolls to fire both barrels, otherwise it becomes tr_shotgun_2_1 instead",
-    "trigger_items": [ "tripwire", "shotgun_d" ],
+    "//": "trigger_items and remove_on_trigger only matters here if it fires both barrels, otherwise it converts to tr_shotgun_2_1",
+    "remove_on_trigger": true,
+    "trigger_items": [ "tripwire", "shotgun_d", { "item": "shot_hull", "quantity": 2, "charges": 1 } ],
     "drops": [ "tripwire", "shotgun_d", { "item": "shot_00", "quantity": 2, "charges": 1 } ],
     "vehicle_data": {
       "chance": 70,
@@ -310,7 +319,8 @@
     "avoidance": 5,
     "difficulty": 6,
     "action": "shotgun",
-    "trigger_items": [ "tripwire", "shotgun_d" ],
+    "remove_on_trigger": true,
+    "trigger_items": [ "tripwire", "shotgun_d", { "item": "shot_hull", "quantity": 2, "charges": 1 } ],
     "drops": [ "tripwire", "shotgun_d", { "item": "shot_00", "quantity": 1, "charges": 1 } ],
     "vehicle_data": {
       "chance": 70,
@@ -334,7 +344,8 @@
     "avoidance": 5,
     "difficulty": 6,
     "action": "shotgun",
-    "trigger_items": [ "tripwire", "shotgun_s" ],
+    "remove_on_trigger": true,
+    "trigger_items": [ "tripwire", "shotgun_s", { "item": "shot_hull", "quantity": 1, "charges": 1 } ],
     "drops": [ "tripwire", "shotgun_s", { "item": "shot_00", "quantity": 1, "charges": 1 } ],
     "vehicle_data": {
       "chance": 70,
@@ -384,6 +395,7 @@
     "avoidance": 14,
     "difficulty": 10,
     "action": "landmine",
+    "remove_on_trigger": true,
     "drops": [ "landmine" ],
     "vehicle_data": {
       "do_explosion": true,
@@ -406,6 +418,7 @@
     "avoidance": 14,
     "difficulty": 10,
     "action": "landmine",
+    "remove_on_trigger": true,
     "drops": [ "landmine" ],
     "vehicle_data": {
       "do_explosion": true,
@@ -439,7 +452,8 @@
     "visibility": 0,
     "avoidance": 15,
     "difficulty": 15,
-    "action": "goo"
+    "action": "goo",
+    "remove_on_trigger": true
   },
   {
     "type": "trap",
@@ -463,6 +477,7 @@
     "avoidance": 14,
     "difficulty": 99,
     "action": "sinkhole",
+    "remove_on_trigger": true,
     "vehicle_data": { "damage": 500 }
   },
   {
@@ -537,6 +552,7 @@
     "avoidance": 4,
     "difficulty": 7,
     "action": "boobytrap",
+    "remove_on_trigger": true,
     "drops": [ "boobytrap" ],
     "vehicle_data": {
       "do_explosion": true,

--- a/data/json/traps.json
+++ b/data/json/traps.json
@@ -294,7 +294,6 @@
     "avoidance": 5,
     "difficulty": 6,
     "action": "shotgun",
-    "//": "trigger_items and remove_on_trigger only matters here if it fires both barrels, otherwise it converts to tr_shotgun_2_1",
     "remove_on_trigger": true,
     "trigger_items": [ "tripwire", "shotgun_d", { "item": "shot_hull", "quantity": 2, "charges": 1 } ],
     "drops": [ "tripwire", "shotgun_d", { "item": "shot_00", "quantity": 2, "charges": 1 } ],
@@ -306,31 +305,6 @@
       "sound_type": "fire_gun",
       "sound_variant": "shotgun_d",
       "set_trap": "tr_shotgun_2_1"
-    }
-  },
-  {
-    "type": "trap",
-    "id": "tr_shotgun_2_1",
-    "trigger_weight": "200 g",
-    "name": "half-empty shotgun trap",
-    "color": "red",
-    "symbol": "^",
-    "visibility": 4,
-    "avoidance": 5,
-    "difficulty": 6,
-    "action": "shotgun",
-    "remove_on_trigger": true,
-    "trigger_items": [ "tripwire", "shotgun_d", { "item": "shot_hull", "quantity": 2, "charges": 1 } ],
-    "drops": [ "tripwire", "shotgun_d", { "item": "shot_00", "quantity": 1, "charges": 1 } ],
-    "vehicle_data": {
-      "chance": 70,
-      "damage": 300,
-      "sound_volume": 60,
-      "sound": "Bang!",
-      "sound_type": "fire_gun",
-      "sound_variant": "shotgun_d",
-      "remove_trap": true,
-      "spawn_items": [ "shotgun_d", "string_6" ]
     }
   },
   {

--- a/src/trap.cpp
+++ b/src/trap.cpp
@@ -129,6 +129,24 @@ void trap::load( const JsonObject &jo, const std::string & )
         looks_like = jo.get_string( "copy-from" );
     }
     jo.read( "looks_like", looks_like );
+    for( const JsonValue entry : jo.get_array( "trigger_items" ) ) {
+        itype_id item_type;
+        int quantity = 0;
+        int charges = 0;
+        if( entry.test_object() ) {
+            JsonObject jc = entry.get_object();
+            jc.read( "item", item_type, true );
+            quantity = jc.get_int( "quantity", 1 );
+            charges = jc.get_int( "charges", 1 );
+        } else {
+            entry.read( item_type, true );
+            quantity = 1;
+            charges = 1;
+        }
+        if( !item_type.is_empty() && quantity > 0 && charges > 0 ) {
+            trigger_components.emplace_back( item_type, quantity, charges );
+        }
+    }
     for( const JsonValue entry : jo.get_array( "drops" ) ) {
         itype_id item_type;
         int quantity = 0;

--- a/src/trap.cpp
+++ b/src/trap.cpp
@@ -279,6 +279,17 @@ bool trap::is_funnel() const
     return !is_null() && funnel_radius_mm > 0;
 }
 
+
+void trap::trigger_aftermath( map &m, const tripoint &p ) const
+{
+    for( auto &i : m.tr_at( p ).trigger_components ) {
+        const itype_id &item_type = std::get<0>( i );
+        const int quantity = std::get<1>( i );
+        const int charges = std::get<2>( i );
+        m.spawn_item( p.xy(), item_type, quantity, charges );
+    }
+}
+
 void trap::on_disarmed( map &m, const tripoint &p ) const
 {
     for( auto &i : components ) {

--- a/src/trap.cpp
+++ b/src/trap.cpp
@@ -119,6 +119,7 @@ void trap::load( const JsonObject &jo, const std::string & )
 
     optional( jo, was_loaded, "map_regen", map_regen, "none" );
     optional( jo, was_loaded, "benign", benign, false );
+    optional( jo, was_loaded, "remove_on_trigger", remove_on_trigger, false );
     optional( jo, was_loaded, "always_invisible", always_invisible, false );
     optional( jo, was_loaded, "funnel_radius", funnel_radius_mm, 0 );
     optional( jo, was_loaded, "comfort", comfort, 0 );
@@ -287,6 +288,9 @@ void trap::trigger_aftermath( map &m, const tripoint &p ) const
         const int quantity = std::get<1>( i );
         const int charges = std::get<2>( i );
         m.spawn_item( p.xy(), item_type, quantity, charges );
+    }
+    if( m.tr_at( p ).remove_trap_when_triggered() ) {
+        m.remove_trap( p );
     }
 }
 

--- a/src/trap.h
+++ b/src/trap.h
@@ -111,7 +111,9 @@ struct trap {
          */
         units::mass trigger_weight = units::mass( -1, units::mass::unit_type{} );
         int funnel_radius_mm = 0;
-        // For disassembly?
+        // Items optionally yielded after the trap goes off
+        std::vector<std::pair<itype_id, double>> trigger_components;
+        // Items optionally yielded after the trap is disarmed
         std::vector<std::tuple<itype_id, int, int>> components;
     public:
         // data required for trapfunc::spell()

--- a/src/trap.h
+++ b/src/trap.h
@@ -186,7 +186,7 @@ struct trap {
         bool triggered_by_item( const item &itm ) const;
         /**
          * Cleanup after a trap has been triggered, spawns items (if any) and.
-         * if trigger_remove is set to true removes the trap via
+         * if remove_on_trigger is set to true removes the trap via
          * @ref map::remove_trap.
          */
         void trigger_aftermath( map &m, const tripoint &p ) const;

--- a/src/trap.h
+++ b/src/trap.h
@@ -101,6 +101,7 @@ struct trap {
         // 0 to ??, trap radius
         int trap_radius = 0;
         bool benign = false;
+        bool remove_on_trigger = false;
         bool always_invisible = false;
         // a valid overmap id, for map_regen action traps
         std::string map_regen;
@@ -161,6 +162,13 @@ struct trap {
          */
         bool is_benign() const {
             return benign;
+        }
+        /**
+         * If true, remove this trap during trap::trigger_aftermath when the trap is set off.
+         * Warning: won't affect underlying terrain, so not worth using for things like t_pit.
+         */
+        bool remove_trap_when_triggered() const {
+            return remove_on_trigger;
         }
         /** Player has not yet seen the trap and returns the variable chance, at this moment,
          of whether the trap is seen or not. */

--- a/src/trap.h
+++ b/src/trap.h
@@ -112,7 +112,7 @@ struct trap {
         units::mass trigger_weight = units::mass( -1, units::mass::unit_type{} );
         int funnel_radius_mm = 0;
         // Items optionally yielded after the trap goes off
-        std::vector<std::pair<itype_id, double>> trigger_components;
+        std::vector<std::tuple<itype_id, int, int>> trigger_components;
         // Items optionally yielded after the trap is disarmed
         std::vector<std::tuple<itype_id, int, int>> components;
     public:
@@ -184,6 +184,12 @@ struct trap {
          * If the given item is throw onto the trap, does it trigger the trap?
          */
         bool triggered_by_item( const item &itm ) const;
+        /**
+         * Cleanup after a trap has been triggered, spawns items (if any) and.
+         * if trigger_remove is set to true removes the trap via
+         * @ref map::remove_trap.
+         */
+        void trigger_aftermath( map &m, const tripoint &p ) const;
         /**
          * Called when a trap at the given point in the map has been disarmed.
          * It should spawn trap items (if any) and remove the trap from the map via

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -479,7 +479,7 @@ bool trapfunc::shotgun( const tripoint &p, Creature *c, item * )
             }
             if( shots > 1 ) {
                 z->deal_damage( nullptr, bodypart_id( "torso" ), damage_instance( DT_BULLET, rng( 60,
-                            80 ), 0, 1.5f ) );
+                                80 ), 0, 1.5f ) );
             }
             z->deal_damage( nullptr, bodypart_id( "torso" ), damage_instance( DT_BULLET, rng( 60,
                             80 ), 0, 1.5f ) );

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -77,6 +77,16 @@ static float pit_effectiveness( const tripoint &p )
     return std::max( 0.0f, 1.0f - corpse_volume / filled_volume );
 }
 
+void trapfunc::trigger_aftermath( map &m, const tripoint &p ) const
+{
+    for( auto &i : m.tr_at( p ).trigger_components ) {
+        const itype_id &item_type = std::get<0>( i );
+        const int quantity = std::get<1>( i );
+        const int charges = std::get<2>( i );
+        m.spawn_item( p.xy(), item_type, quantity, charges );
+    }
+}
+
 bool trapfunc::none( const tripoint &, Creature *, item * )
 {
     return false;
@@ -1423,6 +1433,7 @@ bool trapfunc::cast_spell( const tripoint &p, Creature *critter, item * )
     npc dummy;
     trap_spell.cast_all_effects( dummy, critter->pos() );
     trap_spell.make_sound( p );
+    trigger_aftermath( get_map(), p );
     g->m.remove_trap( p );
     return true;
 }


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

The continues the work started with https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3939 to improve trap-related code and add some more eventually. WIP for now.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->
C++ changes:
1. In trap.cpp and trap.h, defined support for `trigger_items` JSON in `trap::load`. Uses the same format as `drops`, instead being items that spawn when the trap is triggered (as opposed to disarmed like `drops`).
2. Also in trap.cpp and trap.h, defined function `trap::trigger_aftermath`. This is used to provide final cleanup for traps, in particular dropping any items on trigger defined in the trap JSON's `trigger_items` section.
3. In trapfunc.cpp, converted all trap functions that return `true` to use `trigger_aftermath` in them, and removed most hardcoded instances of spawning items or calling `remove_trap` in them. The random chance of dropping ammo in `trapfunc::crossbow`, and chance of spears breaking in `trapfunc::pit_spikes` and `trapfunc::pit_glass` were also kept special-cased in the function since not yet added to `trigger_items`. Meanwhile, `trapfunc::beartrap`, `trapfunc::snare_light`, and `trapfunc::snare_heavy` still use the whole "trap is removed early and item is only spawned when the victim is freed" thing, but they still have support for trap cleanup effects if desired.
4. Per feedback, set it so that double-barrel shotgun traps always unload both barrels instead of picking how many to fire at random based on size/strength. In exchange, it's now done as two separate damage instances, so armor gets applies for both shots.
5. Added support for the `remove_on_trigger` bool. If present in a trap's JSON, it will remove the trap when `trigger_aftermath` applies, so whether any given trap effect is single-use or reusable is fully JSONized (barring stuff like pits turning into other pits, sinkholes converting into pits, and other interactions with trap-conversion or terrain alteration).
6. Per feedback from Kheir, changed `trapfunc::sinkhole` so that successfully grappling out of it returns without converting the trap into a pit or other standard cleanup, so that it doesn't spawn a pit in a different tile without leaving the sinkhole still intact.
7. Modernized damage of shotgun trap based on the base damage of slugs as the minimum, and base damage of buckshot as the maximum. Rigged it to use zero arpen like buckshot but 1.5x damage multiplier like slugs. Also separates the two hits of damage instance instead of pooling it together in one big hit.
8. Modernized damage of crossbow trap to use stab damage, and use values closer to the base damage of the crossbow with intended bolts.

JSON changes:
1. In traps.json, converted all the vanilla drops that used to drop hardcoded items when triggered to use `trigger_items`, with comments pointing out any case where something is still hardcoded in.
2. In addition, set it so that can alarm traps drop themselves when activated instead of vanishing entirely.
3. Updated names of shotgun traps to make them easier to tell apart.
4. Added use of `remove_on_trigger` to all relevant traps.
5. Set it so that glass caltrops drop 3 of the component glass shards when triggered.
6. . Fixed recipe for crossbow trap using 4 times as many bolts if you pick wooden ones.
7. Added item and recipe definition for a single-barrel variant of the shotgun trap, updating weights and volumes to be closer to the guns they use.
8. Bumped recipe for double-barrel shotgun trap up a level to level 4, on the basis of it taking a bit more effort to rig it to pull both triggers. Also shifts things so there's a more even spread of trapping options across levels.
9. Obsoleted half-empty double-barrel trap.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Letting crossbow traps drop their bolts 100% of the time and adding it to `trigger_items`, on the basis that it already does this 90% of the time anyway.
2. Renaming `drops` to `disarm_items` for clarity?

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON files for syntax and lint errors.
2. Compiled and load-tested.
3. Got some zeds to blunder into crossbow, single shotty, and can alarm traps, expected items drop as a result.
4. Got a zed to wander into a double-barrel shotgun trap, as expected the trap sometimes drops a double shotty and tripwire, sometimes converts to a partially-depleted shotgun trap instead, and when that's triggered it drops as expected.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Support for pipe shotgun traps to be added eventually.

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
