### PR TITLE
fix: blood sample origin being lost

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4641,6 +4641,7 @@ int iuse::blood_draw( player *p, item *it, bool, const tripoint & )
         return 0;
     }
 
+    const mtype *mt = nullptr;
     bool drew_blood = false;
     bool acid_blood = false;
     for( auto &map_it : g->m.i_at( point( p->posx(), p->posy() ) ) ) {
@@ -4652,7 +4653,10 @@ int iuse::blood_draw( player *p, item *it, bool, const tripoint & )
             auto bloodtype( map_it->get_mtype()->bloodType() );
             if( bloodtype.obj().has_acid ) {
                 acid_blood = true;
+            } else {
+                mt = map_it->get_mtype();
             }
+            break;
         }
     }
 
@@ -4690,6 +4694,9 @@ int iuse::blood_draw( player *p, item *it, bool, const tripoint & )
     }
 
     detached_ptr<item> blood = item::spawn( "blood", calendar::turn );
+    if ( mt != nullptr ) {
+        blood->set_mtype( mt );
+    }
     if( !liquid_handler::handle_liquid( std::move( blood ), 1 ) ) {
         // NOLINTNEXTLINE(bugprone-use-after-move)
         it->put_in( std::move( blood ) );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4694,7 +4694,7 @@ int iuse::blood_draw( player *p, item *it, bool, const tripoint & )
     }
 
     detached_ptr<item> blood = item::spawn( "blood", calendar::turn );
-    if ( mt != nullptr ) {
+    if( mt != nullptr ) {
         blood->set_mtype( mt );
     }
     if( !liquid_handler::handle_liquid( std::move( blood ), 1 ) ) {


### PR DESCRIPTION
## Purpose of change

- Fixes #3946

It seems the code responsible for assigning source reference to blood got lost somehow, so all samples that are not acid would always turn out to be clean "human blood" instead of "%monster_name% blood". This leads to the Refugee Center quest "Analyze Zombie Blood" being impossible to complete.

## Describe the solution

- Modify `iuse::blood_draw` to store source body `mtype` and assign it to produced sample.
- Additionally, when using blood draw kit on a tile with multiple bodies, break the loop and prevent subsequent prompts after picking a corpse to draw from.

## Describe alternatives you've considered

Hoping someone else fixes this eventually.

## Testing

Spawned and killed a bunch of zombies, including an acidic one, a monster, a feral human, and an NPC.
Tried using blood draw kit on each corpse, on myself, on none, with bodies piled up and individually.
Tried analyzing the samples in a centrifuge. Made sure zombie blood produces downloadable data.