### PR TITLE
test(port): non-lethal JSON errors for missing mapgen key

### DIFF
--- a/src/json.cpp
+++ b/src/json.cpp
@@ -212,6 +212,16 @@ void JsonObject::throw_error( const std::string &err, const std::string &name ) 
     jsin->error( err );
 }
 
+void JsonArray::string_error( const std::string &err, int idx, int offset )
+{
+    if( jsin && idx >= 0 && static_cast<size_t>( idx ) < positions.size() ) {
+        jsin->seek( positions[idx] );
+        jsin->string_error( err, offset );
+    } else {
+        throw_error( err );
+    }
+}
+
 void JsonArray::throw_error( const std::string &err )
 {
     if( !jsin ) {

--- a/src/json.h
+++ b/src/json.h
@@ -1149,6 +1149,8 @@ class JsonArray
         std::string str(); // copy array json as string
         [[noreturn]] void throw_error( const std::string &err );
         [[noreturn]] void throw_error( const std::string &err, int idx );
+        // See JsonIn::string_error
+        [[noreturn]] void string_error( const std::string &err, int idx, int offset );
         void show_warning( const std::string &err );
         void show_warning( const std::string &err, int idx );
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3523,21 +3523,21 @@ bool mapgen_function_json_base::setup_common( const JsonObject &jo )
                 const bool has_placing = fpi != format_placings.end();
 
                 if( !has_terrain && !fallback_terrain_exists ) {
-                    parray.throw_error(
+                    parray.string_error(
                         string_format( "format: rows: row %d column %d: "
                                        "'%s' is not in 'terrain', and no 'fill_ter' is set!",
-                                       c + 1, i + 1, key.str ) );
+                                       c + 1, i + 1, key.str ), c, i + 1 );
                 }
-                if( test_mode && !has_terrain && !has_placing &&
+                if( !has_terrain && !has_placing &&
                     key.str != " " && key.str != "." ) {
-                    // TODO: Once all the in-tree mods don't report this error,
-                    // it should be changed to happen in regular games (not
-                    // just test_mode) and be non-fatal, so that mappers find
-                    // out about their issues before they PR their changes.
-                    parray.throw_error(
-                        string_format( "format: rows: row %d column %d: "
-                                       "'%s' has no terrain, furniture, or other definition",
-                                       c + 1, i + 1, key.str ) );
+                    try {
+                        parray.string_error(
+                            string_format( "format: rows: row %d column %d: "
+                                           "'%s' has no terrain, furniture, or other definition",
+                                           c + 1, i + 1, key.str ), c, i + 1 );
+                    } catch( const JsonError &e ) {
+                        debugmsg( "(json-error)\n%s", e.what() );
+                    }
                 }
                 if( has_placing ) {
                     jmapgen_place where( p );


### PR DESCRIPTION
## Purpose of change

- closes #3927

## Describe the solution

port non-lethal errors commit of https://github.com/CleverRaven/Cataclysm-DDA/pull/46337 by @Qrox 

## Describe alternatives you've considered

- also migrate to typescript, but dependencies order resolution was a bit more involved and existing script works.
- also fix related JSON errors, but the amount of reported errors are massive

## Testing

should work in CI.
