### PR TITLE
fix: `NON_FOULING` weapon stacking broken by `'dirt'` var

### DIFF
--- a/src/avatar_functions.cpp
+++ b/src/avatar_functions.cpp
@@ -231,6 +231,9 @@ void mend_item( avatar &you, item &obj, bool interactive )
     if( mending_options.empty() ) {
         if( interactive ) {
             add_msg( m_info, _( "The %s doesn't have any faults to mend." ), obj.tname() );
+            if( obj.has_flag( flag_NON_FOULING ) && obj.has_var( "dirt" ) ) {
+                obj.erase_var( "dirt" );
+            }
             if( obj.damage() > 0 ) {
                 const std::set<itype_id> &rep = obj.repaired_with();
                 if( !rep.empty() ) {


### PR DESCRIPTION
## Purpose of change

Guns with `NON_FOULING` flag can still spawn in fouled state (or could until recently? I think there has been a fix for that). They can be cleaned, but due to  `dirt` property being defined, will still refuse to stack with other identical weapons.

## Describe the solution

On (m)end attempt, if no faults are found, check the item for `NON_FOULING` flag and erase the `dirt` var if present.
This is a bit of a crutch code-wise, but should be good enough for a save compatibility fix.

## Describe alternatives you've considered

- Also checking and removing faults themselves if an overriding flag is present. Felt like a bit too much work for an edge case, assuming the core issue has been fixed and those incorrectly generated guns can only be found in older saves
- Changing the cleaning process to erase `dirt` property instead of setting to 0. Not sure what side effects that would bring, also would break stacking for most guns until re-cleaned, which for most players would be more noticeable than the actual issue being fixed here

## Testing

- Had two BB guns that wouldn't stack, one correctly spawned, the other found as fouled and cleaned
- Tried to (m)end the second one
- The gun lost its `dirt` property and now stacks with the first one