### PR TITLE
fix: make autodoc message generic

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -2920,7 +2920,7 @@ void Character::introduce_into_anesthesia( const time_duration &duration, player
                                _( "You feel excited as the Autodoc slices painlessly into you.  You enjoy the sight of scalpels slicing you apart." ) );
         } else {
             add_msg_if_player( m_mixed,
-                               _( "You stay very, very still, focusing intently on an interesting stain on the ceiling, as the Autodoc slices painlessly into you." ) );
+                               _( "You stay very, very still, intently staring off into space, as the Autodoc slices painlessly into you." ) );
         }
     }
 


### PR DESCRIPTION
## Purpose of change

- fix #3914

## Describe the solution

made the sentence generic enough

## Describe alternatives you've considered

actually taking acoount of map and vehicle roof, but api for that isn't straightforward

## Testing

should work since it's only string changes
