### PR TITLE
fix: account for charges on salvage

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1708,7 +1708,7 @@ int salvage_actor::cut_up( player &p, item &it, item &cut ) const
                 }
             } else {
                 for( int i = 0; i < amount; i++ ) {
-                    here.spawn_an_item( pos.xy(), item::spawn( result ), amount, 0 );
+                    here.add_item_or_charges( pos, item::spawn( result ) );
                 }
             }
         } else {


### PR DESCRIPTION
## Purpose of change

- fix #3547

## Describe the solution

use `add_item_or_charges` in the loop

## Describe alternatives you've considered

make everything stackable so we don't suffer

## Testing

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/1cd3a4ac-e049-4ecf-8801-ccff9824aea8)

local tests pass

## Additional context

ripped off from #3489 because after month i wasn't able to figure out the reason of drastic changes in vehicle distance test
