### PR TITLE
fix(content): Update ergonomic grips to work for shotguns

### DIFF
--- a/data/json/items/gunmod/grip.json
+++ b/data/json/items/gunmod/grip.json
@@ -53,6 +53,7 @@
       [ "RIFLES" ],
       [ "MACHINE_GUNS" ],
       [ "GATLING_GUNS" ],
+      [ "SHOTGUNS" ],
       [ "BOWS" ],
       [ "S_XBOWS" ],
       [ "M_XBOWS" ],


### PR DESCRIPTION
Fixes oversight missed in original weapon category commit in #2541 . Manually checkd rest of the entries, only gunmod that got missed for shotguns.
