### PR TITLE
feat(content): shoulder holsters

### DIFF
--- a/data/json/itemgroups/Clothing_Gear/clothing.json
+++ b/data/json/itemgroups/Clothing_Gear/clothing.json
@@ -3409,7 +3409,8 @@
       { "item": "wristholster", "prob": 1 },
       { "item": "bow_sling", "prob": 5 },
       { "item": "bscabbard", "prob": 5 },
-      { "item": "holster", "prob": 20 },
+      { "item": "holster", "prob": 15 },
+      { "item": "shoulder_holster", "prob": 5 },
       { "item": "scabbard", "prob": 10 },
       { "item": "sheath", "prob": 25 },
       { "item": "sholster", "prob": 5 }

--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -337,6 +337,7 @@
       [ "bandolier_shotgun", 8 ],
       [ "torso_bandolier_shotgun", 3 ],
       [ "holster", 8 ],
+      [ "shoulder_holster", 4 ],
       [ "bootstrap", 2 ],
       [ "wristholster", 1 ],
       [ "bholster", 5 ],

--- a/data/json/itemgroups/Locations_MapExtras/locations_mapextras.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_mapextras.json
@@ -59,6 +59,7 @@
       [ "backpack", 38 ],
       [ "backpack_leather", 28 ],
       [ "holster", 8 ],
+      [ "shoulder_holster", 4 ],
       [ "bholster", 2 ],
       [ "armguard_soft", 40 ],
       [ "chestguard_hard", 20 ],

--- a/data/json/items/armor/holster.json
+++ b/data/json/items/armor/holster.json
@@ -147,6 +147,19 @@
     "flags": [ "SKINTIGHT", "COMPACT", "WATER_FRIENDLY" ]
   },
   {
+    "id": "shoulder_holster",
+    "copy-from": "holster",
+    "type": "ARMOR",
+    "name": { "str": "shoulder holster" },
+    "description": "A shoulder holster designed to be worn under a jacket or coat that allows a gun to hang comfortably beneath the arm.  Activate to holster/draw a gun.",
+    "weight": "320 g",
+    "volume": "750 ml",
+    "price": "100 USD",
+    "price_postapoc": "8 USD",
+    "covers": [ "arm_either" ],
+    "flags": [ "WAIST" ]
+  },
+  {
     "id": "survivor_vest",
     "type": "ARMOR",
     "name": { "str": "survivor harness", "str_pl": "survivor harnesses" },

--- a/data/json/items/armor/holster.json
+++ b/data/json/items/armor/holster.json
@@ -157,7 +157,7 @@
     "price": "100 USD",
     "price_postapoc": "8 USD",
     "covers": [ "arm_either" ],
-    "flags": [ "WAIST" ]
+    "flags": [ "BELTED", "COMPACT", "OVERSIZE" ]
   },
   {
     "id": "survivor_vest",

--- a/data/json/monsterdrops/zombie_cop.json
+++ b/data/json/monsterdrops/zombie_cop.json
@@ -35,6 +35,7 @@
       [ "tacvest", 5 ],
       [ "heavy_flashlight", 35 ],
       [ "holster", 25 ],
+      [ "shoulder_holster", 10 ],
       [ "kevlar", 35 ],
       [ "bholster", 3 ],
       [ "legpouch_large", 5 ],

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -407,6 +407,19 @@
     "components": [ [ [ "leather", 6 ] ], [ [ "filament", 10, "LIST" ] ] ]
   },
   {
+    "result": "shoulder_holster",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_STORAGE",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "skills_required": [ "gun", 1 ],
+    "time": "15 m",
+    "autolearn": true,
+    "qualities": [ { "id": "SEW", "level": 1 } ],
+    "components": [ [ [ "holster", 1 ] ], [ [ "shoulder_strap", 1 ] ], [ [ "filament", 10, "LIST" ] ] ]
+  },
+  {
     "result": "jerrypack",
     "type": "recipe",
     "category": "CC_ARMOR",


### PR DESCRIPTION
## Purpose of change

Adds the ability to create and find shoulder holsters like a cool 90s cop and/or super spy.

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/84274761/b1964e3e-ca23-4324-8aae-0a1e15787e17)

## Describe the solution

You can make a holster that sits under your arm. Copied mostly from the existing holster item with some caveats:

- I tried to make it so that we make use of existing items in the game - you can craft a shoulder holster from a normal holster, some standard sewing filament (10), and a shoulder strap. 
- Volume, weight and cost are all increased to account for the inclusion of the shoulder strap.
- Moved to the strapped layer instead of waist, compact and oversize are preserved so mutants can make these and it doesn't interfere with other strapped arm armor.
- Added to the accessory_weaponcarry so every zombie has a chance to have this (less chances than a normal holster), also added to the pawnshop and drugdealer item distribution groups, which is where you can find normal holsters. Also added these to the zombie cop death drops. Did *not* add these to military zombies, they have holsters put in with a 100% rate, so this might be overkill.

## Describe alternatives you've considered

This is too cool not to have in the game.

## Testing

- Debugged a character in, can be crafted 
- Killed some mobs, can be found. 

## Additional context

Reviewers - may need to your assistance to make sure I've put in the correct values for distribution, not too familiar with those jsons.