### PR TITLE
feat(content): make fire lookout tower higher

### DIFF
--- a/data/json/mapgen/ws_fire_lookout_tower.json
+++ b/data/json/mapgen/ws_fire_lookout_tower.json
@@ -201,11 +201,7 @@
         "                        ",
         "                        "
       ],
-      "terrain": {
-        "X": "t_concrete_wall",
-        "<": "t_ladder_up",
-        ">": "t_ladder_down"
-      }
+      "terrain": { "X": "t_concrete_wall", "<": "t_ladder_up", ">": "t_ladder_down" }
     }
   },
   {
@@ -240,11 +236,7 @@
         "                        ",
         "                        "
       ],
-      "terrain": {
-        "X": "t_concrete_wall",
-        "<": "t_ladder_up",
-        ">": "t_ladder_down"
-      }
+      "terrain": { "X": "t_concrete_wall", "<": "t_ladder_up", ">": "t_ladder_down" }
     }
   },
   {

--- a/data/json/mapgen/ws_fire_lookout_tower.json
+++ b/data/json/mapgen/ws_fire_lookout_tower.json
@@ -173,6 +173,84 @@
     "type": "mapgen",
     "method": "json",
     "om_terrain": [ "ws_fire_lookout_tower_f1" ],
+    "object": {
+      "fill_ter": "t_open_air",
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "       XX      XX       ",
+        "       XX      XX       ",
+        "                        ",
+        "          XXXX          ",
+        "          X>>X          ",
+        "          X<<X          ",
+        "          XXXX          ",
+        "                        ",
+        "       XX      XX       ",
+        "       XX      XX       ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "terrain": {
+        "X": "t_concrete_wall",
+        "<": "t_ladder_up",
+        ">": "t_ladder_down"
+      }
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": [ "ws_fire_lookout_tower_f2" ],
+    "object": {
+      "fill_ter": "t_open_air",
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "       XX      XX       ",
+        "       XX      XX       ",
+        "                        ",
+        "          XXXX          ",
+        "          X<<X          ",
+        "          X>>X          ",
+        "          XXXX          ",
+        "                        ",
+        "       XX      XX       ",
+        "       XX      XX       ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "terrain": {
+        "X": "t_concrete_wall",
+        "<": "t_ladder_up",
+        ">": "t_ladder_down"
+      }
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": [ "ws_fire_lookout_tower_f3" ],
     "weight": 1000,
     "object": {
       "rows": [
@@ -269,7 +347,7 @@
   {
     "type": "mapgen",
     "method": "json",
-    "om_terrain": [ "ws_fire_lookout_tower_f2" ],
+    "om_terrain": [ "ws_fire_lookout_tower_f4" ],
     "weight": 1000,
     "object": {
       "rows": [
@@ -324,7 +402,7 @@
   {
     "type": "mapgen",
     "method": "json",
-    "om_terrain": [ "ws_fire_lookout_tower_f3" ],
+    "om_terrain": [ "ws_fire_lookout_tower_f5" ],
     "weight": 1000,
     "object": {
       "rows": [

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -3095,7 +3095,9 @@
       { "point": [ 0, 0, 0 ], "overmap": "ws_fire_lookout_tower_base_north" },
       { "point": [ 0, 0, 1 ], "overmap": "ws_fire_lookout_tower_f1_north" },
       { "point": [ 0, 0, 2 ], "overmap": "ws_fire_lookout_tower_f2_north" },
-      { "point": [ 0, 0, 3 ], "overmap": "ws_fire_lookout_tower_f3_north" }
+      { "point": [ 0, 0, 3 ], "overmap": "ws_fire_lookout_tower_f3_north" },
+      { "point": [ 0, 0, 4 ], "overmap": "ws_fire_lookout_tower_f4_north" },
+      { "point": [ 0, 0, 5 ], "overmap": "ws_fire_lookout_tower_f5_north" }
     ],
     "locations": [ "wilderness" ],
     "city_distance": [ 20, 40 ],

--- a/data/json/overmap/overmap_terrain/overmap_terrain_military.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_military.json
@@ -140,7 +140,14 @@
   },
   {
     "type": "overmap_terrain",
-    "id": [ "ws_fire_lookout_tower_base", "ws_fire_lookout_tower_f1", "ws_fire_lookout_tower_f2", "ws_fire_lookout_tower_f3", "ws_fire_lookout_tower_f4", "ws_fire_lookout_tower_f5" ],
+    "id": [
+      "ws_fire_lookout_tower_base",
+      "ws_fire_lookout_tower_f1",
+      "ws_fire_lookout_tower_f2",
+      "ws_fire_lookout_tower_f3",
+      "ws_fire_lookout_tower_f4",
+      "ws_fire_lookout_tower_f5"
+    ],
     "copy-from": "generic_city_building_no_sidewalk",
     "name": "fire lookout tower",
     "sym": "T",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_military.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_military.json
@@ -140,7 +140,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": [ "ws_fire_lookout_tower_base", "ws_fire_lookout_tower_f1", "ws_fire_lookout_tower_f2", "ws_fire_lookout_tower_f3" ],
+    "id": [ "ws_fire_lookout_tower_base", "ws_fire_lookout_tower_f1", "ws_fire_lookout_tower_f2", "ws_fire_lookout_tower_f3", "ws_fire_lookout_tower_f4", "ws_fire_lookout_tower_f5" ],
     "copy-from": "generic_city_building_no_sidewalk",
     "name": "fire lookout tower",
     "sym": "T",


### PR DESCRIPTION
## Purpose of change
Add two more levels to the tower to make it a more interesting observation point.
## Describe the solution
Increase its height by 2 levels.
## Describe alternatives you've considered
Do nothing.
## Testing

## Additional context
"ws_fire_lookout_tower_f1":
<img width="960" alt="Capture d’écran 2023-12-26 164923" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/2eb943e2-35c9-4100-ad0f-e851e465cad6">
"ws_fire_lookout_tower_f2":
<img width="960" alt="Capture d’écran 2023-12-26 164938" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/67a034ce-d0eb-482d-861f-ea6a13b4225b">
