### PR TITLE
fix: id used for jewelry in regional_map_settings

### DIFF
--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -896,7 +896,7 @@
         "home_improvement": 200,
         "s_lot": 400,
         "s_arcade": 200,
-        "s_jewelry": 200,
+        "s_jewelry_shop": 200,
         "s_antique": 200,
         "s_gardening": 200,
         "museum": 100,


### PR DESCRIPTION
## Purpose of change
Replace "s_jewelry" with "s_jewelry_shop".
## Describe the solution
JSON changes.
## Describe alternatives you've considered
none
## Testing
1. Go into town.
2. The jewelry store and its roof appear without problem.