### PR TITLE
feat(balance): adjust effective CBM chance of lower-tier profession zeds

### DIFF
--- a/data/json/itemgroups/Monsters_Animals_Lairs/monster_drops_advtech.json
+++ b/data/json/itemgroups/Monsters_Animals_Lairs/monster_drops_advtech.json
@@ -124,17 +124,17 @@
     "id": "cyborg_harvest_uncommon",
     "type": "item_group",
     "subtype": "distribution",
-    "//": "Lab mutant spawns, 10% of them will roll for either components or a single CBM.",
+    "//": "Lab mutant spawns, 40% of them will roll for either components or a single CBM, effectively 20% odds of getting a bionic.",
     "entries": [
-      { "item": "null", "prob": 90 },
+      { "item": "null", "prob": 60 },
       {
         "distribution": [
           { "group": "bionic_salvage_junk", "prob": 25 },
           { "item": "burnt_out_bionic", "prob": 25 },
-          { "group": "bionic_power_storage_civ", "prob": 25 },
-          { "group": "bionics_broken_cyborg", "prob": 25 }
+          { "group": "bionic_power_storage_civ", "prob": 10 },
+          { "group": "bionics_broken_cyborg", "prob": 40 }
         ],
-        "prob": 10
+        "prob": 40
       }
     ]
   },
@@ -275,16 +275,16 @@
     "id": "harvest_maybe_sci",
     "type": "item_group",
     "subtype": "distribution",
-    "//": "Non-cyborg medical/science spawns, 5% of them will roll for either components or a single CBM.",
+    "//": "Non-cyborg medical/science spawns, 20% of them will roll for either components or a single CBM, effectively 10% odds of getting a bionic.",
     "entries": [
-      { "item": "null", "prob": 95 },
+      { "item": "null", "prob": 80 },
       {
         "distribution": [
           { "group": "bionic_salvage_junk", "prob": 50 },
-          { "group": "bionic_power_storage_civ", "prob": 25 },
-          { "group": "bionics_sci", "prob": 25 }
+          { "group": "bionic_power_storage_civ", "prob": 10 },
+          { "group": "bionics_sci", "prob": 40 }
         ],
-        "prob": 5
+        "prob": 20
       }
     ]
   },
@@ -292,16 +292,16 @@
     "id": "harvest_maybe_tech",
     "type": "item_group",
     "subtype": "distribution",
-    "//": "Non-cyborg industrial/technician spawns, 5% of them will roll for either components or a single CBM.",
+    "//": "Non-cyborg industrial/technician spawns, effective chance of getting a CBM is 10%.",
     "entries": [
-      { "item": "null", "prob": 95 },
+      { "item": "null", "prob": 80 },
       {
         "distribution": [
           { "group": "bionic_salvage_junk", "prob": 50 },
-          { "group": "bionic_power_storage_civ", "prob": 25 },
-          { "group": "bionics_tech", "prob": 25 }
+          { "group": "bionic_power_storage_civ", "prob": 10 },
+          { "group": "bionics_tech", "prob": 40 }
         ],
-        "prob": 5
+        "prob": 20
       }
     ]
   },
@@ -309,16 +309,16 @@
     "id": "harvest_maybe_survivalist",
     "type": "item_group",
     "subtype": "distribution",
-    "//": "Non-cyborg survivalist/police spawns, 5% of them will roll for either components or a single CBM.",
+    "//": "Non-cyborg survivalist/police spawns, effective chance of getting a CBM is 10%.",
     "entries": [
-      { "item": "null", "prob": 95 },
+      { "item": "null", "prob": 80 },
       {
         "distribution": [
           { "group": "bionic_salvage_junk", "prob": 50 },
-          { "group": "bionic_power_storage_civ", "prob": 25 },
-          { "group": "bionics_survivalist", "prob": 25 }
+          { "group": "bionic_power_storage_civ", "prob": 10 },
+          { "group": "bionics_survivalist", "prob": 40 }
         ],
-        "prob": 5
+        "prob": 20
       }
     ]
   },
@@ -336,17 +336,17 @@
     "id": "harvest_maybe_military",
     "type": "item_group",
     "subtype": "distribution",
-    "//": "Non-cyborg military spawns, 10% of them will roll for either components or a single CBM.",
+    "//": "Non-cyborg military spawns, effective chance of getting a CBM is 10%.",
     "entries": [
-      { "item": "null", "prob": 90 },
+      { "item": "null", "prob": 80 },
       {
         "distribution": [
           { "group": "bionic_salvage_junk_mil", "prob": 50 },
-          { "group": "bionic_power_storage_mil", "prob": 25 },
-          { "group": "bionics_mil", "prob": 15 },
-          { "group": "bionics_heavy_mil", "prob": 10 }
+          { "group": "bionic_power_storage_mil", "prob": 10 },
+          { "group": "bionics_mil", "prob": 20 },
+          { "group": "bionics_heavy_mil", "prob": 20 }
         ],
-        "prob": 10
+        "prob": 20
       }
     ]
   },
@@ -354,16 +354,16 @@
     "id": "harvest_maybe_military_heavy",
     "type": "item_group",
     "subtype": "distribution",
-    "//": "Non-cyborg heavy military spawns, 25% of them will roll for either components or a CBM from heavy-mil itemgroup.",
+    "//": "Non-cyborg heavy military spawns, effectively 20% chance of spawning a CBM.",
     "entries": [
-      { "item": "null", "prob": 75 },
+      { "item": "null", "prob": 60 },
       {
         "distribution": [
           { "group": "bionic_salvage_junk_mil", "prob": 50 },
-          { "group": "bionic_power_storage_mil", "prob": 25 },
-          { "group": "bionics_heavy_mil", "prob": 25 }
+          { "group": "bionic_power_storage_mil", "prob": 10 },
+          { "group": "bionics_heavy_mil", "prob": 40 }
         ],
-        "prob": 25
+        "prob": 40
       }
     ]
   }


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Some adjustments to the lowered spawn rates of bionics per experience with playtesting. General thing I found was that the new lower-tier harvest entries were much rarer than intended because of how both regular CBMs and power storage are merged into a single harvest roll, whereas the traditional cyborg zeds tend to have a separate roll for power storage.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Elevated the total chance of getting anything out of `cyborg_harvest_uncommon` from 10% to 40%, as all its potential yield is merged into a single roll. Additionally weighted the CBM portion more towards bionics over power storage. This makes the total chance of getting a CBM from lab mutants and armored zombies 20%, compare two shots at 50% chance each for lab cyborgs and bio-operators.
2. Likewise bumped the following groups from a mere 5% (10% in the case of soldiers) chance to 20% and weighted them more towards their utility CBMs: `harvest_maybe_sci`, `harvest_maybe_tech`, `harvest_maybe_survivalist`, and `harvest_maybe_military`. This makes the effective odds of getting a bionic out of them 10%.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Creating "maybe power storage" itemgroups and having all the "usually a civilian profession zed but some of them are secretly cyborgs" harvest entries get a separate roll for power storage like proper cyborg zeds.
2. Eliminating the 1/3 tier of bionic spawns and making the CBM spawn rate 50% for shocker zombies, technicians, and zombie scientists like it is for more "elite" cyborg zeds.
3. Implementing the "any rando zed can have like a baby-tier 1% chance to generate something" idea to give players extra anxiety if they don't have a bionic scanner. I feel like keeping the focus on profession zeds that might reasonably have the occasional augmented member is a better approach, so early-game players without scanners can still intuit that certain zeds are more likely to be augmented than others, instead of incentivizing dissecting every last zombie in the game in the hope you'll stike gold eventually.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected file for syntax and lint errors.
2. Actually remembered to do the math on what the effective chance of getting a CBM is, instead of trusting that it won't end up being something stupid like effectively 2.5%.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
