### PR TITLE
ci: cache deno dependencies

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -7,6 +7,9 @@ on:
 permissions:
   contents: read
 
+env:
+  DENO_DIR: '~/.cache/deno'
+
 jobs:
   autofix:
     runs-on: ubuntu-22.04
@@ -21,6 +24,12 @@ jobs:
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
+
+      - name: cache deno dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.DENO_DIR }}
+          key: deno-${{ hashFiles('deno.lock') }}
 
       - name: format C++ files
         run: make astyle


### PR DESCRIPTION
## Purpose of change

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/b9dd1d46-4fed-4f59-a94b-5b4738cd2834)

https://github.com/cataclysmbnteam/Cataclysm-BN/actions/runs/7340681630/job/19987088515?pr=3992#step:10:282

prevent network failure halting the whole CI pipeline

## Describe the solution

use [actions/cache](https://github.com/actions/cache) to [cache deno dependencies](https://docs.deno.com/runtime/manual/advanced/continuous_integration#caching-dependencies).

## Describe alternatives you've considered

screm

## Additional context

found while investigating CI failure on #3992