### PR TITLE
revert: "refactor: use `std::clamp`"

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3381,7 +3381,7 @@ void try_fuel_fire( player_activity &act, player &p, const bool starting_fire )
         }
     }
     if( found ) {
-        const int quantity = std::clamp( found->charges, 1, found->charges_per_volume( 250_ml ) );
+        const int quantity = std::max( 1, std::min( found->charges, found->charges_per_volume( 250_ml ) ) );
         // Note: move_item() handles messages (they're the generic "you drop x")
         move_item( p, *found, quantity, *refuel_spot, *best_fire );
     }


### PR DESCRIPTION
## Purpose of change

- fix #4005 

## Describe the solution

due to `item::charges_per_volume` returning 0 when no charges fit in given volume, `std::clamp(10, 1, 0)` will return 0, which will always move entire stack of items.
previous expression, `std::max(1, std::min(10, 0))` will return 1 and work correctly here

## Describe alternatives you've considered

_cri_

## Testing

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/89a39852-09b3-4fc6-b367-751675183b3b)

was able to use plank to light up oven.

## Additional context

urgent fix for 0.5.1