### PR TITLE
fix: prevent full ownership transfer when trading with partial charges of item

### DIFF
--- a/src/npctrade.cpp
+++ b/src/npctrade.cpp
@@ -51,12 +51,15 @@ void npc_trading::transfer_items( std::vector<item_pricing> &stuff, player &,
         }
 
         item &gift = *ip.locs.front();
-        gift.set_owner( receiver );
-        int charges = npc_gives ? ip.u_charges : ip.npc_charges;
+        const int charges = npc_gives ? ip.u_charges : ip.npc_charges;
 
         if( ip.charges ) {
-            receiver.i_add( gift.split( charges ) );
+            auto to_give = gift.split( charges );
+            to_give->set_owner( receiver );
+
+            receiver.i_add( std::move( to_give ) );
         } else {
+            gift.set_owner( receiver );
             for( item *&it : ip.locs ) {
                 receiver.i_add( it->detach() );
             }


### PR DESCRIPTION
## Purpose of change

- fixes #4006 

## Describe the solution

only set ownership for splitted item if item is counted using charges.

## Describe alternatives you've considered

_cri more_

## Testing

![Cataclysm: Bright Nights - 957428c3486c_01](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/fb255926-e72a-4bfd-b0ad-3b3066c0fcf8)

traded with 1 of 100 hub gold coins. ownership for 99 coins was intact.

## Additional context

we should really make everything stackable and remove this unholy mess.