### PR TITLE
fix: bike rack merging vehicle merging after loading from save

### DIFF
--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -76,6 +76,7 @@ void vehicle_part::refresh_locations_hack( vehicle *veh )
 
 void vehicle_part::copy_static_from( const vehicle_part &source )
 {
+    carry_names = source.carry_names;
     mount = source.mount;
     precalc = source.precalc;
     blood = source.blood;


### PR DESCRIPTION
## Purpose of change

- fixes #3933

## Describe the solution

https://github.com/cataclysmbnteam/Cataclysm-BN/blob/37586353b31a28ec0f4a7ad71e7ad844e52ad0ec/src/savegame_json.cpp#L2499-L2503

running debugger for an hour has shown that despite `carry_names` properly being loaded in `vehicle_part::deserialize`,

https://github.com/cataclysmbnteam/Cataclysm-BN/blob/37586353b31a28ec0f4a7ad71e7ad844e52ad0ec/src/vehicle.cpp#L2150

it was always empty on `vehicle::remove_carried_vehicle`.

https://github.com/cataclysmbnteam/Cataclysm-BN/blob/37586353b31a28ec0f4a7ad71e7ad844e52ad0ec/src/vehicle_part.cpp#L77

found out `vehicle_part::copy_static_from` was the culprit. it wasn't copying `carry_names`.

## Describe alternatives you've considered

rewrite vehicle logic from scratch

## Testing

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/5a2e78da-9627-4e23-8044-e827edf5cfa4

1. mount bike to vehicle with bike rack.
2. save and reload.
3. while extremely buggy, it doesn't meld.

## Additional context

words cannot describe how i hate C++.