### PR TITLE
fix(content): Fix holsters holding multiple items

### DIFF
--- a/data/json/monsterdrops/feral_humans.json
+++ b/data/json/monsterdrops/feral_humans.json
@@ -511,7 +511,8 @@
     "magazine": 100,
     "ammo": 20,
     "entries": [
-      { "item": "holster", "contents-group": "military_standard_pistols", "damage": [ 1, 4 ] },
+      { "item": "holster" },
+      { "group": "military_standard_pistols", "prob": 30, "damage": [ 0, 2 ], "dirt": [ 0, 1500 ] },
       { "item": "kevlar", "prob": 50, "damage": [ 2, 4 ] },
       { "item": "wearable_light", "prob": 100, "charges": [ 0, 100 ], "damage": [ 1, 4 ] },
       { "group": "feral_autogun", "prob": 100, "damage": [ 1, 4 ] },

--- a/data/json/monsterdrops/zombie_military_pilot.json
+++ b/data/json/monsterdrops/zombie_military_pilot.json
@@ -7,7 +7,8 @@
     "ammo": 60,
     "entries": [
       { "group": "clothing_military_pilot", "damage": [ 1, 4 ] },
-      { "item": "holster", "contents-group": "military_standard_pistols" },
+      { "item": "holster" },
+      { "group": "military_standard_pistols", "prob": 30, "damage": [ 0, 2 ], "dirt": [ 0, 1500 ] },
       { "item": "two_way_radio", "prob": 90 },
       { "item": "adderall", "prob": 40 },
       { "item": "id_military", "prob": 25 },


### PR DESCRIPTION


## Purpose of change

As part of #3090 this requires all weapon groups to be taken out of holsters as this could spawn guns AND ammo, which doesn't make sense in a holster that can normally only hold 1 item. Fixes #3982 .

## Describe the solution

Copied zombie soldier military death drop pistol chances to both feral militia and zombie military pilot death drops, which are the only two monsters to have the pistol group in their holsters creating multiple items. Copied from normal military soldier zombies so 30% probability to spawn. 

## Describe alternatives you've considered

None, this was outlined in #3090 - all weapon groups must be outside their holsters otherwise things get weird.

## Testing

Yup, dropped this into my test world and.... now I have an empty holster as well as the problem holster with multiple items in it. What. This doesn't make sense. @chaosvolt pls
