### PR TITLE
fix: adds  "SHALLOW_WATER" flag where appropriate

### DIFF
--- a/data/json/furniture_and_terrain/terrain-liquids.json
+++ b/data/json/furniture_and_terrain/terrain-liquids.json
@@ -63,7 +63,7 @@
     "color": "light_blue",
     "looks_like": "t_water_sh",
     "move_cost": 5,
-    "flags": [ "TRANSPARENT", "LIQUID", "NO_SCENT", "SWIMMABLE", "FISHABLE" ],
+    "flags": [ "TRANSPARENT", "LIQUID", "NO_SCENT", "SWIMMABLE", "FISHABLE", "SHALLOW_WATER" ],
     "connects_to": "WATER",
     "examine_action": "water_source"
   },
@@ -91,7 +91,7 @@
     "symbol": "~",
     "color": "light_blue",
     "move_cost": 6,
-    "flags": [ "TRANSPARENT", "LIQUID", "NO_SCENT", "SWIMMABLE", "FISHABLE", "CURRENT" ],
+    "flags": [ "TRANSPARENT", "LIQUID", "NO_SCENT", "SWIMMABLE", "FISHABLE", "CURRENT", "SHALLOW_WATER" ],
     "connects_to": "WATER",
     "examine_action": "water_source"
   },


### PR DESCRIPTION
## Purpose of change

I was more focused on getting JSONized plant terrain data out the door than worrying if cattails could grow on flowing water and murky water. Now they can.

## Describe the solution

Added the flag to flowing water and murky water. All shallow waters besides nasty chlorinated pool water can grow cattails now.

## Describe alternatives you've considered

None

## Testing

Same flag as the other terrains

## Additional context
