### PR TITLE
fix: floor under counters in Luna park

### DIFF
--- a/data/json/mapgen/miniature_railway/miniature_railway.json
+++ b/data/json/mapgen/miniature_railway/miniature_railway.json
@@ -196,7 +196,8 @@
         "L": [ "t_sandbox" ],
         "M": [ "t_monkey_bars" ],
         "#": [ "t_slide" ],
-        "*": [ "t_railroad_track_small" ]
+        "*": [ "t_railroad_track_small" ],
+        "C": "t_floor"
       },
       "furniture": { "b": [ "f_bench" ], "B": [ "f_birdbath" ], "C": [ "f_counter" ] },
       "monsters": { "u": { "monster": "GROUP_SCHOOL", "chance": 1, "density": 0.001 } },


### PR DESCRIPTION
## Purpose of change
Replace sidewalks under counters with wooden floors.
## Describe the solution
JSON changes.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="539" alt="Capture d’écran 2023-12-30 102601" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/8b105d1c-0969-4b76-9672-79f729e5a43b">
After:
<img width="685" alt="Capture d’écran 2023-12-30 102921" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/215a1f7d-78b4-4e1c-a0cd-847704874e2d">