### PR TITLE
fix: pawn shop outdoor terrain

### DIFF
--- a/data/json/mapgen/pawn_shop.json
+++ b/data/json/mapgen/pawn_shop.json
@@ -33,8 +33,8 @@
         "..............'U<U''U''."
       ],
       "terrain": {
-        ".": [ "t_grass", "t_grass", "t_grass", "t_grass", "t_dirt" ],
-        "]": "t_dirt",
+        ".": "t_region_groundcover_urban",
+        "]": "t_region_groundcover_urban",
         " ": "t_floor",
         "'": "t_pavement",
         "U": "t_pavement",
@@ -154,7 +154,7 @@
         ".|y                  y|.",
         ".|{  ##############  }|.",
         ".|{                  }|.",
-        ".|{  ##############  }| ",
+        ".|{  ##############  }|.",
         ".|{                  }|.",
         ".|{  ##############  }|.",
         ".|{                  }|.",
@@ -175,8 +175,8 @@
         "......8U8888<U8........."
       ],
       "terrain": {
-        ".": [ "t_grass", "t_grass", "t_grass", "t_grass", "t_dirt" ],
-        "]": "t_dirt",
+        ".": "t_region_groundcover_urban",
+        "]": "t_region_groundcover_urban",
         " ": "t_floor",
         "'": "t_sidewalk",
         "^": "t_door_c",
@@ -322,8 +322,8 @@
         "........................"
       ],
       "terrain": {
-        ".": [ "t_grass", "t_grass", "t_grass", "t_grass", "t_dirt" ],
-        "]": "t_dirt",
+        ".": "t_region_groundcover_urban",
+        "]": "t_region_groundcover_urban",
         " ": "t_floor",
         "{": "t_floor",
         "}": "t_floor",


### PR DESCRIPTION
## Purpose of change
Use "t_region_groundcover_urban" for outside.
Also remove outdoor wooden floor on "pawn_1".
## Describe the solution
JSON changes.
## Describe alternatives you've considered
none
## Additional context
Before:
"pawn_1":
<img width="683" alt="Capture d’écran 2023-12-30 111319" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/d464fa14-24c5-45c0-8873-d73fac22206b">
After:
"pawn_1":
<img width="587" alt="Capture d’écran 2023-12-30 121719" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/fe0587af-8c5f-4b35-ab27-6c5b86a2a0fb">