### PR TITLE
fix: internet cafe outdoor and roof

### DIFF
--- a/data/json/mapgen/cs_internet_cafe.json
+++ b/data/json/mapgen/cs_internet_cafe.json
@@ -63,10 +63,10 @@
         "...4...................."
       ],
       "terrain": {
-        ".": [ [ "t_grass", 5 ], "t_dirt" ],
+        ".": "t_region_groundcover_urban",
         ",": "t_floor",
         "|": "t_wall_w",
-        "'": "t_dirt",
+        "'": "t_region_groundcover_urban",
         "s": "t_sidewalk",
         "P": "t_console_broken",
         "D": "t_door_c",
@@ -146,7 +146,8 @@
         "D": "t_door_locked",
         "g": "t_wall_glass_alarm",
         "&": "t_flat_roof",
-        "=": "t_flat_roof"
+        "=": "t_flat_roof",
+        "A": "t_flat_roof"
       },
       "place_loot": [ { "item": "television", "x": 14, "y": 9, "chance": 100 }, { "item": "stepladder", "x": 5, "y": 10, "chance": 100 } ],
       "items": {


### PR DESCRIPTION
## Purpose of change
Use "t_region_groundcover_urban" for outside.
Place a flat roof under the cooling units on the roof.
## Describe the solution
JSON changes.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="647" alt="image1" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/53634d92-9b76-4876-b269-a470ff5646df">
After:
<img width="627" alt="image2" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/832ee806-09c7-4208-9a47-004a1679ab49">