### PR TITLE
fix: mi-go scout tower

### DIFF
--- a/data/json/mapgen/mi-go/mi-go_nested.json
+++ b/data/json/mapgen/mi-go/mi-go_nested.json
@@ -397,6 +397,26 @@
   {
     "type": "mapgen",
     "method": "json",
+    "nested_mapgen_id": "mi-go_encampment1_room17",
+    "//": "Large monster holding cell",
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "rotation": [ 0, 3 ],
+      "rows": [
+        "@|||@@",
+        "|| +@@",
+        "|##|||",
+        "|1  P|",
+        "|  1||",
+        "|||||v"
+      ],
+      "palettes": [ "mi-go_palette" ],
+      "place_monsters": [ { "monster": "GROUP_ZOMBIE_BRUTE", "x": [ 1, 3 ], "y": [ 3, 4 ], "repeat": [ 1, 2 ] } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
     "nested_mapgen_id": "mi-go_scout_tower_cells",
     "//": "Mi-go surgical suite and prisoner cells for upper z levels",
     "object": {

--- a/data/json/mapgen/mi-go/mi-go_scout_tower.json
+++ b/data/json/mapgen/mi-go/mi-go_scout_tower.json
@@ -107,7 +107,7 @@
       "palettes": [ "mi-go_palette" ],
       "place_nested": [
         { "chunks": [ "mi-go_scout_tower_cells" ], "x": 4, "y": 3 },
-        { "chunks": [ "mi-go_encampment1_room14" ], "x": 1, "y": 14 }
+        { "chunks": [ "mi-go_encampment1_room17" ], "x": 1, "y": 14 }
       ],
       "place_monsters": [ { "monster": "GROUP_MI-GO_SCOUT_TOWER", "density": 0.1, "x": 12, "y": 12 } ]
     }


### PR DESCRIPTION
## Purpose of change
Fix a flying terrain tile in the "mi-go_scout_tower_3" mapgen.
## Describe the solution
JSON changes:
Create a copy of the nested mapgen "mi-go_encampment1_room14", adapted to level 2 of the tower.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/5d24a341-34b3-4c07-a1bf-5f0ef52786dd">
After:
<img width="960" alt="image2" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/774776e8-bbbe-4bf6-882f-3c561fa9929e">