### PR TITLE
fix: leashing animal using entire stack of rope

### DIFF
--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -831,7 +831,7 @@ void monexamine::add_leash( monster &z )
         return;
     }
     item *rope_item = rope_inv[index - 1];
-    z.set_tied_item( rope_item->detach( ) );
+    z.set_tied_item( rope_item->split( 1 ) );
     z.add_effect( effect_leashed, 1_turns );
     z.get_effect( effect_leashed ).set_permanent();
     add_msg( _( "You add a leash to your %s." ), z.get_name() );


### PR DESCRIPTION
## Purpose of change

- fix #4031 

## Describe the solution

use [`item::split`](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/578117ae7b3051bb2be8dd8a9c127eab1ecddbbe/src/item.h#L368) instead of [`game_object::detach`](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/578117ae7b3051bb2be8dd8a9c127eab1ecddbbe/src/game_object.h#L51)

## Describe alternatives you've considered

~~unify charges for the 100th time~~

## Testing

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/4e208d79-8e84-4d6a-9c56-c36deeb9abec

## Additional context

_end of 2023 with fixing bugs lol_