### PR TITLE
fix: candy shop roof

### DIFF
--- a/data/json/mapgen/s_candy.json
+++ b/data/json/mapgen/s_candy.json
@@ -132,10 +132,9 @@
         "               -.....-  ",
         "               -------  ",
         "                        ",
-        "........................"
+        "                        "
       ],
       "palettes": [ "roof_palette" ],
-      "furniture": { "A": "f_air_conditioner" },
       "place_items": [ { "item": "roof_trash", "x": [ 3, 19 ], "y": [ 11, 16 ], "chance": 50, "repeat": [ 1, 3 ] } ],
       "place_nested": [
         {


### PR DESCRIPTION
## Purpose of change
Small fix on "candy_shop_roof" mapgen.
## Describe alternatives you've considered
none
## Additional context
"candy_shop_roof":
<img width="960" alt="image1" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/c26d7109-e55e-43b3-bb74-e6d9bea9c4b4">