### PR TITLE
fix: roadstop, public washroom, roadside foodcart

### DIFF
--- a/data/json/mapgen/roadstop.json
+++ b/data/json/mapgen/roadstop.json
@@ -5,6 +5,7 @@
     "om_terrain": [ "roadstop" ],
     "weight": 333,
     "object": {
+      "fill_ter": "t_floor",
       "rotation": 2,
       "rows": [
         "........................",
@@ -33,15 +34,12 @@
         ".......2222..2222......."
       ],
       "terrain": {
-        " ": "t_floor",
         "#": "t_wall_log",
-        ".": "t_grass",
+        ".": "t_region_groundcover_urban",
         "2": "t_dirt",
         "3": "t_door_c",
-        "6": "t_floor",
-        "7": "t_floor",
+        "6": "t_dirt",
         "8": "t_dirt",
-        "A": "t_floor",
         "S": "t_sidewalk"
       },
       "furniture": { "6": "f_table", "7": "f_toilet", "8": "f_trashcan", "A": "f_sink" },
@@ -95,6 +93,7 @@
     "om_terrain": [ "roadstop_a" ],
     "weight": 333,
     "object": {
+      "fill_ter": "t_floor",
       "rotation": 2,
       "rows": [
         "........................",
@@ -102,13 +101,13 @@
         "........................",
         "........................",
         "........................",
-        "......o........oo.......",
+        "........................",
         ".....##############.....",
         ".t.t.#A  37##73  A#.t.t.",
         ".....#A  ######  A#.....",
-        ".t.t.#A  39##73  A#.t.t.",
+        ".t.t.#A  37##73  A#.t.t.",
         ".....#A  ######  A#.....",
-        ".t.t.#   37##93   #.t.t.",
+        ".t.t.#   37##73   #.t.t.",
         ".....# ########## #.....",
         ".t.t.#    ####    #.t.t.",
         ".....####3#88#3####.....",
@@ -123,34 +122,28 @@
         "......2222....2222......"
       ],
       "terrain": {
-        " ": "t_floor",
         "#": "t_wall_log",
-        ".": "t_grass",
+        ".": "t_region_groundcover_urban",
         "2": "t_dirt",
         "3": "t_door_c",
-        "6": "t_floor",
-        "7": "t_floor",
         "8": "t_dirt",
-        "9": "t_floor",
-        "A": "t_floor",
         "S": "t_sidewalk",
         "i": "t_dirt",
-        "o": "t_dirt",
         "t": "t_tree"
       },
-      "furniture": { "6": "f_table", "7": "f_toilet", "8": "f_trashcan", "9": "f_toilet", "A": "f_sink", "i": "f_sign", "o": "f_crate_c" },
+      "furniture": { "7": "f_toilet", "8": "f_trashcan", "A": "f_sink", "i": "f_sign" },
       "signs": {
         "i": {
           "signage": "This was once an information map for the <city> area, but it has long since eroded beyond usefulness.  There are small holders for tourist maps attached."
         }
       },
-      "toilets": { "7": {  }, "9": { "amount": 500 } },
+      "toilets": { "7": {  } },
       "place_items": [
         { "item": "trash", "x": [ 11, 12 ], "y": 14, "chance": 80 },
         { "item": "trash", "x": [ 6, 18 ], "y": [ 8, 15 ], "chance": 60 },
         { "item": "methlab", "x": [ 6, 18 ], "y": [ 8, 15 ], "chance": 50 }
       ],
-      "place_item": [ { "item": "touristmap", "x": [ 11, 12 ], "y": 22, "chance": 50, "amount": 1 } ]
+      "place_item": [ { "item": "touristmap", "x": [ 11, 12 ], "y": 21, "chance": 50, "amount": 1 } ]
     }
   },
   {
@@ -195,14 +188,13 @@
     "om_terrain": [ "roadstop_b" ],
     "weight": 333,
     "object": {
+      "fill_ter": "t_floor",
       "rotation": 2,
       "rows": [
         "........................",
         "........................",
         "........................",
         "........................",
-        "........................",
-        "......o........oo.......",
         ".....##############.....",
         ".t.t.# 77A7i779995#.t.t.",
         ".....3           5#.....",
@@ -216,29 +208,24 @@
         ".2222222222222222222222.",
         ".2222222222222222222222.",
         ".2222222222222222222222.",
+        ".2222222222222222222222.",
         ".,,,,,222222222222,,,,,.",
         ".2222222222222222222222.",
         ".2222222222222222222222.",
         ".2222222222222222222222.",
-        ".,,,,,2222....2222,,,,,."
+        ".2222222222222222222222.",
+        ".,,,,,222222222222,,,,,."
       ],
       "terrain": {
-        " ": "t_floor",
         "#": "t_wall_w",
         ",": "t_pavement_y",
-        ".": [ [ "t_grass", 5 ], [ "t_grass_long", 2 ], "t_dirt", "t_shrub" ],
+        ".": [ [ "t_region_groundcover_urban", 8 ], "t_shrub" ],
         "2": "t_pavement",
         "3": "t_door_c",
         "4": "t_sidewalk",
-        "5": "t_floor",
         "6": "t_sidewalk",
-        "7": "t_floor",
         "8": "t_sidewalk",
-        "9": "t_floor",
-        "A": "t_floor",
         "S": "t_sidewalk",
-        "i": "t_dirt",
-        "o": "t_dirt",
         "t": "t_tree",
         "|": "t_sidewalk"
       },
@@ -250,17 +237,16 @@
         "8": "f_trashcan",
         "9": "f_fridge",
         "A": "f_sink",
-        "i": "f_oven",
-        "o": "f_crate_c"
+        "i": "f_oven"
       },
       "place_items": [
-        { "item": "kitchen", "x": 9, "y": [ 9, 14 ], "chance": 80 },
+        { "item": "kitchen", "x": [ 9, 13 ], "y": 7, "chance": 80 },
+        { "item": "trash", "x": 6, "y": 5, "chance": 80 },
         { "item": "trash", "x": 6, "y": 7, "chance": 80 },
-        { "item": "trash", "x": 6, "y": 9, "chance": 80 },
-        { "item": "trash", "x": 6, "y": 14, "chance": 80 },
-        { "item": "fridge", "x": [ 7, 8 ], "y": 9, "chance": 80 },
-        { "item": "coffee_fridge", "x": [ 14, 16 ], "y": 7, "chance": 80 },
-        { "item": "trash", "x": 17, "y": 14, "chance": 80 }
+        { "item": "trash", "x": 6, "y": 12, "chance": 80 },
+        { "item": "fridge", "x": [ 7, 8 ], "y": 7, "chance": 80 },
+        { "item": "coffee_fridge", "x": [ 14, 16 ], "y": 5, "chance": 80 },
+        { "item": "trash", "x": 17, "y": 12, "chance": 80 }
       ]
     }
   },
@@ -284,13 +270,13 @@
         "                        ",
         "                        ",
         "                        ",
+        "                        ",
+        "                        ",
         "     ..............     ",
         "     ........&.....     ",
         "     ....A.........     ",
         "     ...........:..     ",
         "     ..............     ",
-        "                        ",
-        "                        ",
         "                        ",
         "                        ",
         "                        ",

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -1942,7 +1942,7 @@
     "type": "overmap_special",
     "id": "rest_stop",
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "roadstop_north" }, { "point": [ 0, 0, 1 ], "overmap": "roadstop_roof_north" } ],
-    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true, "from": [ 0, 0, 0 ] } ],
     "locations": [ "land" ],
     "city_distance": [ 10, 200 ],
     "occurrences": [ 0, 4 ],
@@ -1955,7 +1955,7 @@
       { "point": [ 0, 0, 0 ], "overmap": "roadstop_a_north" },
       { "point": [ 0, 0, 1 ], "overmap": "roadstop_a_roof_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true, "from": [ 0, 0, 0 ] } ],
     "locations": [ "land" ],
     "city_distance": [ 10, 200 ],
     "occurrences": [ 0, 4 ],
@@ -1968,7 +1968,7 @@
       { "point": [ 0, 0, 0 ], "overmap": "roadstop_b_north" },
       { "point": [ 0, 0, 1 ], "overmap": "roadstop_b_roof_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true, "from": [ 0, 0, 0 ] } ],
     "locations": [ "land" ],
     "city_distance": [ 10, 200 ],
     "occurrences": [ 0, 4 ],

--- a/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
@@ -112,8 +112,7 @@
     "name": "roadstop",
     "sym": "^",
     "color": "light_blue",
-    "mondensity": 2,
-    "flags": [ "SIDEWALK" ]
+    "mondensity": 2
   },
   {
     "type": "overmap_terrain",
@@ -121,8 +120,7 @@
     "name": "public washroom",
     "sym": "^",
     "color": "light_blue",
-    "mondensity": 2,
-    "flags": [ "SIDEWALK" ]
+    "mondensity": 2
   },
   {
     "type": "overmap_terrain",
@@ -130,8 +128,7 @@
     "name": "roadside foodcart",
     "sym": "^",
     "color": "magenta",
-    "mondensity": 2,
-    "flags": [ "SIDEWALK" ]
+    "mondensity": 2
   },
   {
     "type": "overmap_terrain",


### PR DESCRIPTION
## Purpose of change
Connect roadstop, public washroom, roadside foodcart to the road and remove their "SIDEWALK" flag.
Modify roadside foodcart parking.
Change the placement of some objects, use "t_region_groundcover_urban" for the outside terrain, and remove useless crates.
## Describe the solution
JSON changes.
## Describe alternatives you've considered
Do nothing.
## Additional context
Before:
<img width="960" alt="image4" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/b012ab3c-53d1-4e31-bf54-8973d27eb337">
<img width="960" alt="image5" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/fda6fc4a-705f-4334-8cc8-f8ca77bc87e2">
After:
"roadstop":
<img width="960" alt="image1" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/4bcbaea0-1618-4254-ab8d-6ec7a424a6ef">
"roadstop_a":
<img width="960" alt="image2" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/085ae86c-3614-4321-a764-5bc761496418">
"roadstop_b":
<img width="960" alt="image3" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/2c45a704-1432-466f-925d-ba12ce63499b">