### PR TITLE
fix: "candy_shop_roof" mapgen

### DIFF
--- a/data/json/mapgen/s_candy.json
+++ b/data/json/mapgen/s_candy.json
@@ -132,10 +132,9 @@
         "               -.....-  ",
         "               -------  ",
         "                        ",
-        "........................"
+        "                        "
       ],
       "palettes": [ "roof_palette" ],
-      "furniture": { "A": "f_air_conditioner" },
       "place_items": [ { "item": "roof_trash", "x": [ 3, 19 ], "y": [ 11, 16 ], "chance": 50, "repeat": [ 1, 3 ] } ],
       "place_nested": [
         {


### PR DESCRIPTION
## Purpose of change
I redo #4042.
Fix "candy_shop_roof" because a line forgotten during #3779 places a flat roof line that shouldn't be there.
Delete line 138 because "A": "f_air_conditioner" is in the "roof_palette".
## Describe the solution
JSON changes.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/6aedcc57-a42b-4e42-a010-378f09afbaff">
After:
<img width="960" alt="image2" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/761dbd09-7ede-4800-b742-12ac1520881f">