### PR TITLE
fix: replace stairs with ladders on city block roof

### DIFF
--- a/data/json/mapgen/city_blocks/city_block_2.json
+++ b/data/json/mapgen/city_blocks/city_block_2.json
@@ -208,7 +208,7 @@
         "                                                                                                "
       ],
       "palettes": [ "roof_palette" ],
-      "terrain": { ">": "t_stairs_down" },
+      "terrain": { ">": "t_ladder_down" },
       "nested": {
         "E": {
           "chunks": [


### PR DESCRIPTION
## Purpose of change
Replace stairs with ladders on the roof of the city block, because ladders are more appropriate here.
## Describe the solution
JSON change:
Replace "t_stairs_down" with "t_ladder_down".
## Describe alternatives you've considered
Do nothing.
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/e4a41531-2bf3-41f2-8729-1e3329363560">
<img width="960" alt="image2" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/68ce2116-311f-4785-8dab-24768c96240c">
After:
<img width="743" alt="image3" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/0df2b25b-d9ae-40e0-bb8c-e0171c37cbde">
<img width="750" alt="image4" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/75bf7cd4-b04a-4efc-a375-314e114c3f59">