### PR TITLE
fix: change `ranch_camp` overmap symbols

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain_ranch_camp.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_ranch_camp.json
@@ -18,7 +18,6 @@
       "ranch_camp_7",
       "ranch_camp_8",
       "ranch_camp_74",
-      "ranch_camp_74_roof",
       "ranch_camp_79",
       "ranch_camp_80"
     ],
@@ -49,7 +48,6 @@
       "ranch_camp_46",
       "ranch_camp_54",
       "ranch_camp_55",
-      "ranch_camp_57_roof",
       "ranch_camp_63",
       "ranch_camp_64",
       "ranch_camp_72"
@@ -121,17 +119,9 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "ranch_camp_57",
+    "id": [ "ranch_camp_57", "ranch_camp_57_roof", "ranch_camp_57_silo" ],
     "name": "silo",
-    "sym": "#",
-    "color": "i_brown",
-    "see_cost": 2
-  },
-  {
-    "type": "overmap_terrain",
-    "id": "ranch_camp_57_silo",
-    "name": "silo",
-    "sym": "│",
+    "sym": "O",
     "color": "brown",
     "see_cost": 2
   },
@@ -139,16 +129,16 @@
     "type": "overmap_terrain",
     "id": "ranch_camp_57_silocap",
     "name": "silo cap",
-    "sym": "│",
+    "sym": "O",
     "color": "brown",
     "see_cost": 2
   },
   {
     "type": "overmap_terrain",
-    "id": "ranch_camp_65_roof",
+    "id": [ "ranch_camp_65_roof", "ranch_camp_74_roof", "ranch_camp_75_roof" ],
     "name": "barn roof",
-    "sym": "#",
-    "color": "brown",
+    "sym": ".",
+    "color": "blue",
     "see_cost": 2
   },
   {
@@ -201,7 +191,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": [ "ranch_camp_75", "ranch_camp_75_roof", "ranch_camp_81" ],
+    "id": [ "ranch_camp_75", "ranch_camp_81" ],
     "name": "field",
     "sym": "┘",
     "color": "brown",


### PR DESCRIPTION
## Purpose of change
silo with `|` or `#` as symbol doesn't fit.

## Describe the solution

Change some of the ranch symbols in overmap_terrain_ranch_camp.json to make the ranch look good on the map and be consistent.

## Describe alternatives you've considered
Do nothing.
## Additional context
Before:
<img width="736" alt="image1" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/1b34f247-64d6-4129-a9b6-c0de0bade0fe">
<img width="735" alt="image2" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/97549e1e-3f86-414e-924a-fe9323d52138">
<img width="782" alt="image3" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/185b3fa7-b6fb-4cf2-8c5f-b80f3e264a43">
<img width="737" alt="image4" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/66f3beb6-641d-4453-b09e-8cb95e36671d">
After:
<img width="800" alt="image5" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/7ded2577-f60a-47cf-af86-20c183e068de">
<img width="787" alt="image6" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/437085c8-3661-44de-a274-4459a06a3abb">
<img width="824" alt="image7" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/a0e30a8d-1dbb-4071-b22d-a6eaea46762e">
<img width="770" alt="image8" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/ade4e37d-3cf7-49ce-ad63-abec64a7464b">