### PR TITLE
fix: crashed airliner

### DIFF
--- a/data/json/mapgen/airliner.json
+++ b/data/json/mapgen/airliner.json
@@ -361,6 +361,7 @@
         "AAAAAAAAAAAAAAAAAAAAAAAA",
         "AAAAAAAAAAAAAAAAAAAAAAAA"
       ],
+      "terrain": { ".": "t_metal_flat_roof" },
       "palettes": [ "airliner_palette" ]
     }
   },


### PR DESCRIPTION
## Purpose of change
The metal floor "t_metal_floor" used for the roof of the crashed airliner must be replaced by something else, because the metal floor places a flat roof on the upper level, level 2.
## Describe the solution
JSON change.
Use "t_metal_flat_roof" instead of "t_metal_floor" for "airliner_2a_1", "airliner_2b_1", "airliner_2c_1".
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/4c957d7a-d45e-4ba5-abf2-be247ff42e8a">
After:
<img width="960" alt="image2" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/21f3d385-2780-4c7f-a9eb-eb507db32498">