### PR TITLE
refactor: Decouple attitude from creature

### DIFF
--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -2,8 +2,8 @@
 
 #include "avatar.h"
 #include "character.h"
-#include "creature.h"
 #include "cursesdef.h"
+#include "enums.h"
 #include "explosion.h"
 #include "game.h"
 #include "game_constants.h"
@@ -1038,7 +1038,7 @@ void game::draw_below_override( const tripoint &, const bool )
 
 #if defined(TILES)
 void game::draw_monster_override( const tripoint &p, const mtype_id &id, const int count,
-                                  const bool more, const Creature::Attitude att )
+                                  const bool more, const Attitude att )
 {
     if( use_tiles ) {
         tilecontext->init_draw_monster_override( p, id, count, more, att );
@@ -1046,7 +1046,7 @@ void game::draw_monster_override( const tripoint &p, const mtype_id &id, const i
 }
 #else
 void game::draw_monster_override( const tripoint &, const mtype_id &, const int,
-                                  const bool, const Creature::Attitude )
+                                  const bool, const Attitude )
 {
 }
 #endif

--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -724,7 +724,7 @@ void show_armor_layers_ui( Character &who )
                 you.add_msg_if_npc( m_bad, _( "%s is too far to sort armor." ), who.name );
                 return;
             }
-            if( you.attitude_to( you ) != Creature::A_FRIENDLY ) {
+            if( you.attitude_to( you ) != Attitude::A_FRIENDLY ) {
                 you.add_msg_if_npc( m_bad, _( "%s is not friendly!" ), who.name );
                 return;
             }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3038,7 +3038,7 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
     bool result;
     bool is_player;
     bool sees_player;
-    Creature::Attitude attitude;
+    Attitude attitude;
     const auto override = monster_override.find( p );
     if( override != monster_override.end() ) {
         const mtype_id id = std::get<0>( override->second );
@@ -3070,7 +3070,7 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
         result = false;
         sees_player = false;
         is_player = false;
-        attitude = Creature::A_ANY;
+        attitude = Attitude::A_ANY;
         const monster *m = dynamic_cast<const monster *>( &critter );
         if( m != nullptr ) {
             const auto ent_category = C_MONSTER;
@@ -3361,7 +3361,7 @@ void cata_tiles::init_draw_below_override( const tripoint &p, const bool draw )
     draw_below_override.emplace( p, draw );
 }
 void cata_tiles::init_draw_monster_override( const tripoint &p, const mtype_id &id, const int count,
-        const bool more, const Creature::Attitude att )
+        const bool more, const Attitude att )
 {
     monster_override.emplace( p, std::make_tuple( id, count, more, att ) );
 }

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -12,7 +12,6 @@
 #include <vector>
 
 #include "animation.h"
-#include "creature.h"
 #include "enums.h"
 #include "lightmap.h"
 #include "line.h"
@@ -602,7 +601,7 @@ class cata_tiles
         void void_draw_below_override();
 
         void init_draw_monster_override( const tripoint &p, const mtype_id &id, int count,
-                                         bool more, Creature::Attitude att );
+                                         bool more, Attitude att );
         void void_monster_override();
 
         bool has_draw_override( const tripoint &p ) const;
@@ -754,7 +753,7 @@ class cata_tiles
         std::map<tripoint, std::tuple<vpart_id, int, units::angle, bool, point>> vpart_override;
         std::map<tripoint, bool> draw_below_override;
         // int represents spawn count
-        std::map<tripoint, std::tuple<mtype_id, int, bool, Creature::Attitude>> monster_override;
+        std::map<tripoint, std::tuple<mtype_id, int, bool, Attitude>> monster_override;
         pimpl<std::vector<tile_render_info>> draw_points_cache;
 
     private:

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1381,7 +1381,7 @@ bool Character::check_mount_will_move( const tripoint &dest_loc )
     if( mounted_creature && mounted_creature->type->has_fear_trigger( mon_trigger::HOSTILE_CLOSE ) ) {
         for( const monster &critter : g->all_monsters() ) {
             Attitude att = critter.attitude_to( *this );
-            if( att == A_HOSTILE && sees( critter ) && rl_dist( pos(), critter.pos() ) <= 15 &&
+            if( att == Attitude::A_HOSTILE && sees( critter ) && rl_dist( pos(), critter.pos() ) <= 15 &&
                 rl_dist( dest_loc, critter.pos() ) < rl_dist( pos(), critter.pos() ) ) {
                 add_msg_if_player( _( "You fail to budge your %s!" ), mounted_creature->get_name() );
                 return false;
@@ -1411,7 +1411,7 @@ bool Character::check_mount_is_spooked()
             double chance = 1.0;
             Attitude att = critter.attitude_to( *this );
             // actually too close now - horse might spook.
-            if( att == A_HOSTILE && sees( critter ) && rl_dist( pos(), critter.pos() ) <= 10 ) {
+            if( att == Attitude::A_HOSTILE && sees( critter ) && rl_dist( pos(), critter.pos() ) <= 10 ) {
                 chance += 10 - rl_dist( pos(), critter.pos() );
                 if( critter.get_size() >= mount_size ) {
                     chance *= 2;
@@ -10801,7 +10801,7 @@ std::vector<Creature *> Character::get_hostile_creatures( int range ) const
         // Fixes circular distance range for ranged attacks
         float dist_to_creature = std::round( rl_dist_exact( pos(), critter.pos() ) );
         return this != &critter && pos() != critter.pos() && // TODO: get rid of fake npcs (pos() check)
-        dist_to_creature <= range && critter.attitude_to( *this ) == A_HOSTILE
+        dist_to_creature <= range && critter.attitude_to( *this ) == Attitude::A_HOSTILE
         && sees( critter );
     } );
 }
@@ -10947,12 +10947,12 @@ int Character::get_lowest_hp() const
     return lowest_hp;
 }
 
-Creature::Attitude Character::attitude_to( const Creature &other ) const
+Attitude Character::attitude_to( const Creature &other ) const
 {
     const auto m = dynamic_cast<const monster *>( &other );
     if( m != nullptr ) {
         if( m->friendly != 0 ) {
-            return A_FRIENDLY;
+            return Attitude::A_FRIENDLY;
         }
         switch( m->attitude( const_cast<Character *>( this ) ) ) {
             // player probably does not want to harm them, but doesn't care much at all.
@@ -10960,36 +10960,36 @@ Creature::Attitude Character::attitude_to( const Creature &other ) const
             case MATT_FPASSIVE:
             case MATT_IGNORE:
             case MATT_FLEE:
-                return A_NEUTRAL;
+                return Attitude::A_NEUTRAL;
             // player does not want to harm those.
             case MATT_FRIEND:
             case MATT_ZLAVE:
                 // Don't want to harm your zlave!
-                return A_FRIENDLY;
+                return Attitude::A_FRIENDLY;
             case MATT_ATTACK:
-                return A_HOSTILE;
+                return Attitude::A_HOSTILE;
             case MATT_NULL:
             case NUM_MONSTER_ATTITUDES:
                 break;
         }
 
-        return A_NEUTRAL;
+        return Attitude::A_NEUTRAL;
     }
 
     const auto p = dynamic_cast<const npc *>( &other );
     if( p != nullptr ) {
         if( p->is_enemy() ) {
-            return A_HOSTILE;
+            return Attitude::A_HOSTILE;
         } else if( p->is_player_ally() ) {
-            return A_FRIENDLY;
+            return Attitude::A_FRIENDLY;
         } else {
-            return A_NEUTRAL;
+            return Attitude::A_NEUTRAL;
         }
     } else if( &other == this ) {
-        return A_FRIENDLY;
+        return Attitude::A_FRIENDLY;
     }
 
-    return A_NEUTRAL;
+    return Attitude::A_NEUTRAL;
 }
 
 bool Character::sees( const tripoint &t, bool, int ) const

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -13,7 +13,6 @@
 #include "character_id.h"
 #include "color.h"
 #include "coordinate_conversions.h"
-#include "creature.h"
 #include "debug.h"
 #include "enums.h"
 #include "event.h"
@@ -244,7 +243,7 @@ static void remove_submap_turrets()
         // Check 1) same overmap coords, 2) turret, 3) hostile
         if( ms_to_omt_copy( here.getabs( critter.pos() ) ) == ms_to_omt_copy( here.getabs( g->u.pos() ) ) &&
             critter.has_flag( MF_CONSOLE_DESPAWN ) &&
-            critter.attitude_to( g->u ) == Creature::Attitude::A_HOSTILE ) {
+            critter.attitude_to( g->u ) == Attitude::A_HOSTILE ) {
             g->remove_zombie( critter );
         }
     }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -507,7 +507,7 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
             // Helps avoid (possibly expensive) attitude calculation
             continue;
         }
-        if( m->attitude_to( u ) == A_HOSTILE ) {
+        if( m->attitude_to( u ) == Attitude::A_HOSTILE ) {
             target_rating = ( mon_rating + hostile_adj ) / dist;
             if( maybe_boo ) {
                 boo_hoo++;
@@ -2016,11 +2016,11 @@ void Creature::check_dead_state()
 std::string Creature::attitude_raw_string( Attitude att )
 {
     switch( att ) {
-        case Creature::A_HOSTILE:
+        case Attitude::A_HOSTILE:
             return "hostile";
-        case Creature::A_NEUTRAL:
+        case Attitude::A_NEUTRAL:
             return "neutral";
-        case Creature::A_FRIENDLY:
+        case Attitude::A_FRIENDLY:
             return "friendly";
         default:
             return "other";

--- a/src/creature.h
+++ b/src/creature.h
@@ -158,20 +158,6 @@ class Creature
         virtual float stability_roll() const = 0;
 
         /**
-         * Simplified attitude towards any creature:
-         * hostile - hate, want to kill, etc.
-         * neutral - anything between.
-         * friendly - avoid harming it, maybe even help.
-         * any - any of the above, used in safemode_ui
-         */
-        enum Attitude : int {
-            A_HOSTILE,
-            A_NEUTRAL,
-            A_FRIENDLY,
-            A_ANY
-        };
-
-        /**
          * Simplified attitude string for unlocalized needs.
          */
         static std::string attitude_raw_string( Attitude att );

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -653,7 +653,7 @@ void editmap::draw_main_ui_overlay()
                 }
             }
             // int: count, bool: more than 1 spawn data
-            std::map<tripoint, std::tuple<mtype_id, int, bool, Creature::Attitude>> spawns;
+            std::map<tripoint, std::tuple<mtype_id, int, bool, Attitude>> spawns;
             for( int x = 0; x < 2; x++ ) {
                 for( int y = 0; y < 2; y++ ) {
                     submap *sm = tmpmap.get_submap_at_grid( { x, y, target.z } );
@@ -663,7 +663,7 @@ void editmap::draw_main_ui_overlay()
                             const tripoint spawn_p = sm_origin + sp.pos;
                             const auto spawn_it = spawns.find( spawn_p );
                             if( spawn_it == spawns.end() ) {
-                                const Creature::Attitude att = sp.friendly ? Creature::A_FRIENDLY : Creature::A_ANY;
+                                const Attitude att = sp.friendly ? Attitude::A_FRIENDLY : Attitude::A_ANY;
                                 spawns.emplace( spawn_p, std::make_tuple( sp.type, sp.count, false, att ) );
                             } else {
                                 std::get<2>( spawn_it->second ) = true;

--- a/src/enums.h
+++ b/src/enums.h
@@ -10,6 +10,20 @@ constexpr inline int sgn( const T x )
     return x < 0 ? -1 : ( x > 0 ? 1 : 0 );
 }
 
+/**
+ * Simplified attitude towards any creature:
+ * hostile - hate, want to kill, etc.
+ * neutral - anything between.
+ * friendly - avoid harming it, maybe even help.
+ * any - any of the above, used in safemode_ui
+ */
+enum Attitude : int {
+    A_HOSTILE,
+    A_NEUTRAL,
+    A_FRIENDLY,
+    A_ANY
+};
+
 enum class bionic_ui_sort_mode : int {
     NONE   = 0,
     POWER  = 1,

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3609,7 +3609,7 @@ Creature *game::is_hostile_very_close()
 Creature *game::is_hostile_within( int distance )
 {
     for( auto &critter : u.get_visible_creatures( distance ) ) {
-        if( u.attitude_to( *critter ) == Creature::A_HOSTILE ) {
+        if( u.attitude_to( *critter ) == Attitude::A_HOSTILE ) {
             return critter;
         }
     }
@@ -5528,7 +5528,7 @@ void game::examine( const tripoint &examp )
                 if( monexamine::pay_bot( *mon ) ) {
                     return;
                 }
-            } else if( mon->attitude_to( u ) == Creature::A_FRIENDLY && !u.is_mounted() ) {
+            } else if( mon->attitude_to( u ) == Attitude::A_FRIENDLY && !u.is_mounted() ) {
                 if( monexamine::mfriend_menu( *mon ) ) {
                     return;
                 }
@@ -7824,7 +7824,7 @@ game::vmenu_ret game::list_monsters( const std::vector<Creature *> &monster_list
     ctxt.register_action( "HELP_KEYBINDINGS" );
 
     // first integer is the row the attitude category string is printed in the menu
-    std::map<int, Creature::Attitude> mSortCategory;
+    std::map<int, Attitude> mSortCategory;
 
     for( int i = 0, last_attitude = -1; i < static_cast<int>( monster_list.size() ); i++ ) {
         const auto attitude = monster_list[i]->attitude_to( u );
@@ -7919,7 +7919,7 @@ game::vmenu_ret game::list_monsters( const std::vector<Creature *> &monster_list
                         const std::string monName = is_npc ? get_safemode().npc_type_name() : m->name();
 
                         std::string sSafemode;
-                        if( get_safemode().has_rule( monName, Creature::A_ANY ) ) {
+                        if( get_safemode().has_rule( monName, Attitude::A_ANY ) ) {
                             sSafemode = _( "<R>emove from safemode Blacklist" );
                         } else {
                             sSafemode = _( "<A>dd to safemode Blacklist" );
@@ -8027,15 +8027,15 @@ game::vmenu_ret game::list_monsters( const std::vector<Creature *> &monster_list
             const auto m = dynamic_cast<monster *>( cCurMon );
             const std::string monName = ( m != nullptr ) ? m->name() : "human";
 
-            if( get_safemode().has_rule( monName, Creature::A_ANY ) ) {
-                get_safemode().remove_rule( monName, Creature::A_ANY );
+            if( get_safemode().has_rule( monName, Attitude::A_ANY ) ) {
+                get_safemode().remove_rule( monName, Attitude::A_ANY );
             }
         } else if( action == "SAFEMODE_BLACKLIST_ADD" ) {
             if( !get_safemode().empty() ) {
                 const auto m = dynamic_cast<monster *>( cCurMon );
                 const std::string monName = ( m != nullptr ) ? m->name() : "human";
 
-                get_safemode().add_rule( monName, Creature::A_ANY, get_option<int>( "SAFEMODEPROXIMITY" ),
+                get_safemode().add_rule( monName, Attitude::A_ANY, get_option<int>( "SAFEMODEPROXIMITY" ),
                                          RULE_BLACKLISTED );
             }
         } else if( action == "look" ) {

--- a/src/game.h
+++ b/src/game.h
@@ -689,7 +689,7 @@ class game
                                   units::angle veh_dir, bool hilite, point mount );
         void draw_below_override( const tripoint &p, bool draw );
         void draw_monster_override( const tripoint &p, const mtype_id &id, int count,
-                                    bool more, Creature::Attitude att );
+                                    bool more, Attitude att );
 
         bool is_in_viewport( const tripoint &p, int margin = 0 ) const;
         /**

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2267,7 +2267,7 @@ bool game::handle_action()
 
             case ACTION_WHITELIST_ENEMY:
                 if( safe_mode == SAFE_MODE_STOP && !get_safemode().empty() ) {
-                    get_safemode().add_rule( get_safemode().lastmon_whitelist, Creature::A_ANY, 0, RULE_WHITELISTED );
+                    get_safemode().add_rule( get_safemode().lastmon_whitelist, Attitude::A_ANY, 0, RULE_WHITELISTED );
                     add_msg( m_info, _( "Creature whitelisted: %s" ), get_safemode().lastmon_whitelist );
                     set_safe_mode( SAFE_MODE_ON );
                     mostseen = 0;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -38,7 +38,6 @@
 #include "construction_partial.h"
 #include "coordinate_conversions.h"
 #include "craft_command.h"
-#include "creature.h"
 #include "cursesdef.h"
 #include "damage.h"
 #include "debug.h"
@@ -937,7 +936,7 @@ void iexamine::cardreader( player &p, const tripoint &examp )
             // Check 1) same overmap coords, 2) turret, 3) hostile
             if( ms_to_omt_copy( here.getabs( critter.pos() ) ) == ms_to_omt_copy( here.getabs( examp ) ) &&
                 critter.has_flag( MF_ID_CARD_DESPAWN ) &&
-                critter.attitude_to( p ) == Creature::Attitude::A_HOSTILE ) {
+                critter.attitude_to( p ) == Attitude::A_HOSTILE ) {
                 g->remove_zombie( critter );
             }
         }

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -997,9 +997,9 @@ bool spell::is_valid_target( const Creature &caster, const tripoint &p ) const
 {
     bool valid = false;
     if( Creature *const cr = g->critter_at<Creature>( p ) ) {
-        Creature::Attitude cr_att = cr->attitude_to( caster );
-        valid = valid || ( cr_att != Creature::A_FRIENDLY && is_valid_target( target_hostile ) );
-        valid = valid || ( cr_att == Creature::A_FRIENDLY && is_valid_target( target_ally ) &&
+        Attitude cr_att = cr->attitude_to( caster );
+        valid = valid || ( cr_att != Attitude::A_FRIENDLY && is_valid_target( target_hostile ) );
+        valid = valid || ( cr_att == Attitude::A_FRIENDLY && is_valid_target( target_ally ) &&
                            p != caster.pos() );
         valid = valid || ( is_valid_target( target_self ) && p == caster.pos() );
         valid = valid && target_by_monster_id( p );

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -664,9 +664,9 @@ static void spell_move( const spell &sp, const Creature &caster,
 
     if( can_target_creature ) {
         if( Creature *victim = g->critter_at<Creature>( from ) ) {
-            Creature::Attitude cr_att = victim->attitude_to( get_avatar() );
-            bool valid = cr_att != Creature::A_FRIENDLY && sp.is_valid_effect_target( target_hostile );
-            valid |= cr_att == Creature::A_FRIENDLY && sp.is_valid_effect_target( target_ally );
+            Attitude cr_att = victim->attitude_to( get_avatar() );
+            bool valid = cr_att != Attitude::A_FRIENDLY && sp.is_valid_effect_target( target_hostile );
+            valid |= cr_att == Attitude::A_FRIENDLY && sp.is_valid_effect_target( target_ally );
             valid |= victim == &caster && sp.is_valid_effect_target( target_self );
             if( valid ) {
                 victim->knock_back_to( to );

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -348,7 +348,7 @@ void melee_actor::on_damage( monster &z, Creature &target, dealt_damage_instance
                                  sfx::get_heard_angle( z.pos() ) );
         sfx::do_player_death_hurt( dynamic_cast<player &>( target ), false );
     }
-    auto msg_type = target.attitude_to( g->u ) == Creature::A_FRIENDLY ? m_bad : m_neutral;
+    auto msg_type = target.attitude_to( g->u ) == Attitude::A_FRIENDLY ? m_bad : m_neutral;
     const body_part bp = dealt.bp_hit;
     target.add_msg_player_or_npc( msg_type, hit_dmg_u, hit_dmg_npc, z.name(),
                                   body_part_name_accusative( bp ) );
@@ -594,7 +594,7 @@ bool gun_actor::call( monster &z ) const
     }
 
     // One last check to make sure we're not firing on a friendly
-    if( target && z.attitude_to( *target ) == Creature::A_FRIENDLY ) {
+    if( target && z.attitude_to( *target ) == Attitude::A_FRIENDLY ) {
         return false;
     }
     int dist = rl_dist( z.pos(), aim_at );

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -1042,7 +1042,7 @@ bool mattack::resurrect( monster *z )
         const bool allies = g->get_creature_if( [&]( const Creature & critter ) {
             const monster *const zed = dynamic_cast<const monster *>( &critter );
             return zed && zed != z && zed->type->has_flag( MF_REVIVES ) && zed->type->in_species( ZOMBIE ) &&
-                   z->attitude_to( *zed ) == Creature::Attitude::A_FRIENDLY  &&
+                   z->attitude_to( *zed ) == Attitude::A_FRIENDLY  &&
                    within_target_range( z, zed, 10 );
         } );
         if( !allies ) {
@@ -1472,7 +1472,7 @@ bool mattack::growplants( monster *z )
         Creature *critter = g->critter_at( p );
         // Don't grow under friends (and self)
         if( critter != nullptr &&
-            z->attitude_to( *critter ) == Creature::A_FRIENDLY ) {
+            z->attitude_to( *critter ) == Attitude::A_FRIENDLY ) {
             continue;
         }
 
@@ -1503,7 +1503,7 @@ bool mattack::growplants( monster *z )
         }
 
         Creature *critter = g->critter_at( p );
-        if( critter != nullptr && z->attitude_to( *critter ) == Creature::A_FRIENDLY ) {
+        if( critter != nullptr && z->attitude_to( *critter ) == Attitude::A_FRIENDLY ) {
             // Don't buff terrain below friends (and self)
             continue;
         }
@@ -1565,7 +1565,7 @@ bool mattack::vine( monster *z )
     z->moves -= 100;
     for( const tripoint &dest : g->m.points_in_radius( z->pos(), 1 ) ) {
         Creature *critter = g->critter_at( dest );
-        if( critter != nullptr && z->attitude_to( *critter ) == Creature::Attitude::A_HOSTILE ) {
+        if( critter != nullptr && z->attitude_to( *critter ) == Attitude::A_HOSTILE ) {
             if( critter->uncanny_dodge() ) {
                 return true;
             }
@@ -3002,7 +3002,7 @@ bool mattack::nurse_assist( monster *z )
 
     if( found_target ) {
         if( target->is_wearing( itype_badge_doctor ) ||
-            z->attitude_to( *target ) == Creature::Attitude::A_FRIENDLY ) {
+            z->attitude_to( *target ) == Attitude::A_FRIENDLY ) {
             sounds::sound( z->pos(), 8, sounds::sound_t::electronic_speech,
                            string_format(
                                _( "a soft robotic voice say, \"Welcome doctor %s.  I'll be your assistant today.\"" ),
@@ -3027,7 +3027,7 @@ bool mattack::nurse_operate( monster *z )
     }
 
     if( ( ( g->u.is_wearing( itype_badge_doctor ) ||
-            z->attitude_to( g->u ) == Creature::Attitude::A_FRIENDLY ) && u_see ) && one_in( 100 ) ) {
+            z->attitude_to( g->u ) == Attitude::A_FRIENDLY ) && u_see ) && one_in( 100 ) ) {
 
         add_msg( m_info, _( "The %s doesn't seem to register you as a doctor." ), z->name() );
     }
@@ -3056,7 +3056,7 @@ bool mattack::nurse_operate( monster *z )
             }
         }
     }
-    if( found_target && z->attitude_to( g->u ) == Creature::Attitude::A_FRIENDLY ) {
+    if( found_target && z->attitude_to( g->u ) == Attitude::A_FRIENDLY ) {
         // 50% chance to not turn hostile again
         if( one_in( 2 ) ) {
             return false;
@@ -3311,7 +3311,7 @@ void mattack::taze( monster *z, Creature *target )
         return;
     }
 
-    auto m_type = target->attitude_to( g->u ) == Creature::A_FRIENDLY ? m_bad : m_neutral;
+    auto m_type = target->attitude_to( g->u ) == Attitude::A_FRIENDLY ? m_bad : m_neutral;
     target->add_msg_player_or_npc( m_type,
                                    _( "The %s shocks you!" ),
                                    _( "The %s shocks <npcname>!" ),
@@ -3874,7 +3874,7 @@ bool mattack::chickenbot( monster *z )
     // Only monster-types for now - assuming humans are smart enough not to make it obvious
     // Unless damaged - then everything is hostile
     if( z->get_hp() <= z->get_hp_max() ||
-        ( mon != nullptr && mon->attitude_to( *z ) == Creature::Attitude::A_HOSTILE ) ) {
+        ( mon != nullptr && mon->attitude_to( *z ) == Attitude::A_HOSTILE ) ) {
         cap += 2;
     }
 
@@ -3956,7 +3956,7 @@ bool mattack::multi_robot( monster *z )
     // Only monster-types for now - assuming humans are smart enough not to make it obvious
     // Unless damaged - then everything is hostile
     if( z->get_hp() <= z->get_hp_max() ||
-        ( mon != nullptr && mon->attitude_to( *z ) == Creature::Attitude::A_HOSTILE ) ) {
+        ( mon != nullptr && mon->attitude_to( *z ) == Attitude::A_HOSTILE ) ) {
         cap += 2;
     }
 
@@ -4056,7 +4056,7 @@ bool mattack::upgrade( monster *z )
         // Check this first because it is a relatively cheap check
         if( zed.can_upgrade() ) {
             // Then do the more expensive ones
-            if( z->attitude_to( zed ) != Creature::Attitude::A_HOSTILE &&
+            if( z->attitude_to( zed ) != Attitude::A_HOSTILE &&
                 within_target_range( z, &zed, 10 ) ) {
                 targets.push_back( &zed );
             }
@@ -5716,7 +5716,7 @@ bool mattack::grenadier( monster *const z )
     // Only can actively target the player right now. Once we have the ability to grab targets that we aren't
     // actively attacking change this to use that instead.
     Creature *const target = static_cast<Creature *>( &g->u );
-    if( z->attitude_to( *target ) == Creature::A_FRIENDLY ) {
+    if( z->attitude_to( *target ) == Attitude::A_FRIENDLY ) {
         return false;
     }
     int ret = grenade_helper( z, target, 30, 60, grenades );
@@ -5751,7 +5751,7 @@ bool mattack::grenadier_elite( monster *const z )
     // Only can actively target the player right now. Once we have the ability to grab targets that we aren't
     // actively attacking change this to use that instead.
     Creature *const target = static_cast<Creature *>( &g->u );
-    if( z->attitude_to( *target ) == Creature::A_FRIENDLY ) {
+    if( z->attitude_to( *target ) == Attitude::A_FRIENDLY ) {
         return false;
     }
     int ret = grenade_helper( z, target, 30, 60, grenades );

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -993,13 +993,13 @@ void monster::move()
 
             const Creature *target = g->critter_at( candidate, is_hallucination() );
             if( target != nullptr ) {
-                const Creature::Attitude att = attitude_to( *target );
-                if( att == A_HOSTILE ) {
+                const Attitude att = attitude_to( *target );
+                if( att == Attitude::A_HOSTILE ) {
                     // When attacking an adjacent enemy, we're direct.
                     moved = true;
                     next_step = candidate_abs;
                     break;
-                } else if( att == A_FRIENDLY && ( target->is_player() || target->is_npc() ) ) {
+                } else if( att == Attitude::A_FRIENDLY && ( target->is_player() || target->is_npc() ) ) {
                     continue; // Friendly firing the player or an NPC is illegal for gameplay reasons
                 } else if( !has_flag( MF_ATTACKMON ) && !has_flag( MF_PUSH_MON ) ) {
                     // Bail out if there's a non-hostile monster in the way and we're not pushy.
@@ -1408,7 +1408,7 @@ bool monster::bash_at( const tripoint &p )
 
     // Don't bash if a friendly monster is standing there
     monster *target = g->critter_at<monster>( p );
-    if( target != nullptr && attitude_to( *target ) == A_FRIENDLY ) {
+    if( target != nullptr && attitude_to( *target ) == Attitude::A_FRIENDLY ) {
         return false;
     }
 
@@ -1525,7 +1525,7 @@ bool monster::attack_at( const tripoint &p )
 
         auto attitude = attitude_to( mon );
         // MF_ATTACKMON == hulk behavior, whack everything in your way
-        if( attitude == A_HOSTILE || has_flag( MF_ATTACKMON ) ) {
+        if( attitude == Attitude::A_HOSTILE || has_flag( MF_ATTACKMON ) ) {
             melee_attack( mon );
             return true;
         }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1195,7 +1195,7 @@ Creature *monster::attack_target()
 
     Creature *target = g->critter_at( move_target() );
     if( target == nullptr || target == this ||
-        attitude_to( *target ) == Creature::A_FRIENDLY || !sees( *target ) ) {
+        attitude_to( *target ) == Attitude::A_FRIENDLY || !sees( *target ) ) {
         return nullptr;
     }
 
@@ -1214,13 +1214,13 @@ bool monster::is_fleeing( player &u ) const
     return att == MATT_FLEE || ( att == MATT_FOLLOW && rl_dist( pos(), u.pos() ) <= 4 );
 }
 
-Creature::Attitude monster::attitude_to( const Creature &other ) const
+Attitude monster::attitude_to( const Creature &other ) const
 {
     const monster *m = other.is_monster() ? static_cast< const monster *>( &other ) : nullptr;
     const player *p = other.as_player();
     if( m != nullptr ) {
         if( m == this ) {
-            return A_FRIENDLY;
+            return Attitude::A_FRIENDLY;
         }
 
         static const string_id<monfaction> faction_zombie( "zombie" );
@@ -1229,42 +1229,42 @@ Creature::Attitude monster::attitude_to( const Creature &other ) const
             ( friendly == 0 && m->friendly == 0 && faction_att == MFA_FRIENDLY ) ) {
             // Friendly (to player) monsters are friendly to each other
             // Unfriendly monsters go by faction attitude
-            return A_FRIENDLY;
+            return Attitude::A_FRIENDLY;
         } else if( g->u.has_trait( trait_PROF_FERAL ) && ( faction == faction_zombie ||
                    type->in_species( ZOMBIE ) ) && ( m->faction == faction_zombie ||
                            m->type->in_species( ZOMBIE ) ) ) {
             // Zombies ignoring a feral survivor aren't quite the same as friendly
             // Ignore actually-friendly zombies/ferals but not other friendlies like reprogramed bots
-            return A_FRIENDLY;
+            return Attitude::A_FRIENDLY;
         } else if( ( friendly == 0 && m->friendly == 0 && faction_att == MFA_HATE ) ) {
             // Stuff that hates a specific faction will always attack that faction
-            return A_HOSTILE;
+            return Attitude::A_HOSTILE;
         } else if( ( friendly == 0 && m->friendly == 0 && faction_att == MFA_NEUTRAL ) ||
                    morale < 0 || anger < 10 ) {
             // Stuff that won't attack is neutral to everything
-            return A_NEUTRAL;
+            return Attitude::A_NEUTRAL;
         } else {
-            return A_HOSTILE;
+            return Attitude::A_HOSTILE;
         }
     } else if( p != nullptr ) {
         switch( attitude( const_cast<player *>( p ) ) ) {
             case MATT_FRIEND:
             case MATT_ZLAVE:
-                return A_FRIENDLY;
+                return Attitude::A_FRIENDLY;
             case MATT_FPASSIVE:
             case MATT_FLEE:
             case MATT_IGNORE:
             case MATT_FOLLOW:
-                return A_NEUTRAL;
+                return Attitude::A_NEUTRAL;
             case MATT_ATTACK:
-                return A_HOSTILE;
+                return Attitude::A_HOSTILE;
             case MATT_NULL:
             case NUM_MONSTER_ATTITUDES:
                 break;
         }
     }
     // Should not happen!, creature should be either player or monster
-    return A_NEUTRAL;
+    return Attitude::A_NEUTRAL;
 }
 
 monster_attitude monster::attitude( const Character *u ) const
@@ -1613,7 +1613,7 @@ void monster::melee_attack( Creature &target, float accuracy )
     int hitspread = target.deal_melee_attack( this, melee::melee_hit_range( accuracy ) );
 
     if( target.is_player() ||
-        ( target.is_npc() && g->u.attitude_to( target ) == A_FRIENDLY ) ) {
+        ( target.is_npc() && g->u.attitude_to( target ) == Attitude::A_FRIENDLY ) ) {
         // Make us a valid target for a few turns
         add_effect( effect_hit_by_player, 3_turns );
     }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2141,15 +2141,15 @@ bool npc::is_travelling() const
     return mission == NPC_MISSION_TRAVELLING;
 }
 
-Creature::Attitude npc::attitude_to( const Creature &other ) const
+Attitude npc::attitude_to( const Creature &other ) const
 {
     if( other.is_npc() || other.is_player() ) {
         const player &guy = dynamic_cast<const player &>( other );
         // check faction relationships first
         if( has_faction_relationship( guy, npc_factions::kill_on_sight ) ) {
-            return A_HOSTILE;
+            return Attitude::A_HOSTILE;
         } else if( has_faction_relationship( guy, npc_factions::watch_your_back ) ) {
-            return A_FRIENDLY;
+            return Attitude::A_FRIENDLY;
         }
     }
 
@@ -2160,11 +2160,11 @@ Creature::Attitude npc::attitude_to( const Creature &other ) const
 
     if( other.is_npc() ) {
         // Hostile NPCs are also hostile towards player's allies
-        if( is_enemy() && other.attitude_to( g->u ) == A_FRIENDLY ) {
-            return A_HOSTILE;
+        if( is_enemy() && other.attitude_to( g->u ) == Attitude::A_FRIENDLY ) {
+            return Attitude::A_HOSTILE;
         }
 
-        return A_NEUTRAL;
+        return Attitude::A_NEUTRAL;
     } else if( other.is_player() ) {
         // For now, make it symmetric.
         return other.attitude_to( *this );
@@ -2177,18 +2177,18 @@ Creature::Attitude npc::attitude_to( const Creature &other ) const
         case MATT_FPASSIVE:
         case MATT_IGNORE:
         case MATT_FLEE:
-            return A_NEUTRAL;
+            return Attitude::A_NEUTRAL;
         case MATT_FRIEND:
         case MATT_ZLAVE:
-            return A_FRIENDLY;
+            return Attitude::A_FRIENDLY;
         case MATT_ATTACK:
-            return A_HOSTILE;
+            return Attitude::A_HOSTILE;
         case MATT_NULL:
         case NUM_MONSTER_ATTITUDES:
             break;
     }
 
-    return A_NEUTRAL;
+    return Attitude::A_NEUTRAL;
 }
 
 void npc::npc_dismount()

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -445,7 +445,7 @@ void npc::assess_danger()
 
         if( has_faction_relationship( guy, npc_factions::watch_your_back ) ) {
             ai_cache.friends.emplace_back( g->shared_from( guy ) );
-        } else if( attitude_to( guy ) != A_NEUTRAL && sees( guy.pos() ) ) {
+        } else if( attitude_to( guy ) != Attitude::A_NEUTRAL && sees( guy.pos() ) ) {
             hostile_guys.emplace_back( g->shared_from( guy ) );
         }
     }
@@ -459,11 +459,11 @@ void npc::assess_danger()
 
     for( const monster &critter : g->all_monsters() ) {
         auto att = critter.attitude_to( *this );
-        if( att == A_FRIENDLY ) {
+        if( att == Attitude::A_FRIENDLY ) {
             ai_cache.friends.emplace_back( g->shared_from( critter ) );
             continue;
         }
-        if( att != A_HOSTILE && ( critter.friendly || !is_enemy() ) ) {
+        if( att != Attitude::A_HOSTILE && ( critter.friendly || !is_enemy() ) ) {
             continue;
         }
         if( !sees( critter ) ) {
@@ -2330,7 +2330,7 @@ void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomo
             return;
         }
         const auto att = attitude_to( *critter );
-        if( att == A_HOSTILE ) {
+        if( att == Attitude::A_HOSTILE ) {
             if( !no_bashing ) {
                 warn_about( "cant_flee", 5_turns + rng( 0, 5 ) * 1_turns );
                 melee_attack( *critter, true );

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2130,7 +2130,7 @@ std::vector<Creature *> targetable_creatures( const Character &c, const int rang
         }
 
         // TODO: get rid of fake npcs (pos() check)
-        if( &c == &critter || c.pos() == critter.pos() || c.attitude_to( critter ) == Creature::Attitude::A_FRIENDLY )
+        if( &c == &critter || c.pos() == critter.pos() || c.attitude_to( critter ) == Attitude::A_FRIENDLY )
         {
             return false;
         }
@@ -2895,10 +2895,10 @@ std::vector<weak_ptr_fast<Creature>> target_ui::list_friendlies_in_lof()
         if( p != dst && p != src ) {
             Creature *cr = g->critter_at( p, true );
             if( cr && you->sees( *cr ) ) {
-                Creature::Attitude a = cr->attitude_to( *this->you );
+                Attitude a = cr->attitude_to( *this->you );
                 if(
-                    ( cr->is_npc() && a != Creature::A_HOSTILE ) ||
-                    ( !cr->is_npc() && a == Creature::A_FRIENDLY )
+                    ( cr->is_npc() && a != Attitude::A_HOSTILE ) ||
+                    ( !cr->is_npc() && a == Attitude::A_FRIENDLY )
                 ) {
                     ret.emplace_back( g->shared_from( *cr ) );
                 }

--- a/src/safemode_ui.cpp
+++ b/src/safemode_ui.cpp
@@ -284,14 +284,14 @@ void safemode::show( const std::string &custom_name_in, bool is_safemode_in )
             }
         } else if( action == "ADD_DEFAULT_RULESET" ) {
             changes_made = true;
-            current_tab.emplace_back( "*", true, false, Creature::A_HOSTILE,
+            current_tab.emplace_back( "*", true, false, Attitude::A_HOSTILE,
                                       get_option<int>( "SAFEMODEPROXIMITY" )
                                       , HOSTILE_SPOTTED );
-            current_tab.emplace_back( "*", true, true, Creature::A_HOSTILE, 5, SOUND );
+            current_tab.emplace_back( "*", true, true, Attitude::A_HOSTILE, 5, SOUND );
             line = current_tab.size() - 1;
         } else if( action == "ADD_RULE" ) {
             changes_made = true;
-            current_tab.emplace_back( "", true, false, Creature::A_HOSTILE,
+            current_tab.emplace_back( "", true, false, Attitude::A_HOSTILE,
                                       get_option<int>( "SAFEMODEPROXIMITY" ), HOSTILE_SPOTTED );
             line = current_tab.size() - 1;
         } else if( action == "REMOVE_RULE" && !current_tab.empty() ) {
@@ -390,17 +390,17 @@ void safemode::show( const std::string &custom_name_in, bool is_safemode_in )
             } else if( column == COLUMN_ATTITUDE ) {
                 auto &attitude = current_tab[line].attitude;
                 switch( attitude ) {
-                    case Creature::A_HOSTILE:
-                        attitude = Creature::A_NEUTRAL;
+                    case Attitude::A_HOSTILE:
+                        attitude = Attitude::A_NEUTRAL;
                         break;
-                    case Creature::A_NEUTRAL:
-                        attitude = Creature::A_FRIENDLY;
+                    case Attitude::A_NEUTRAL:
+                        attitude = Attitude::A_FRIENDLY;
                         break;
-                    case Creature::A_FRIENDLY:
-                        attitude = Creature::A_ANY;
+                    case Attitude::A_FRIENDLY:
+                        attitude = Attitude::A_ANY;
                         break;
-                    case Creature::A_ANY:
-                        attitude = Creature::A_HOSTILE;
+                    case Attitude::A_ANY:
+                        attitude = Attitude::A_HOSTILE;
                 }
             } else if( column == COLUMN_PROXIMITY && ( current_tab[line].category == SOUND ||
                        !current_tab[line].whitelist ) ) {
@@ -595,7 +595,7 @@ void safemode::test_pattern( const int tab_in, const int row_in )
     }
 }
 
-void safemode::add_rule( const std::string &rule_in, const Creature::Attitude attitude_in,
+void safemode::add_rule( const std::string &rule_in, const Attitude attitude_in,
                          const int proximity_in,
                          const rule_state state_in )
 {
@@ -610,7 +610,7 @@ void safemode::add_rule( const std::string &rule_in, const Creature::Attitude at
     }
 }
 
-bool safemode::has_rule( const std::string &rule_in, const Creature::Attitude attitude_in )
+bool safemode::has_rule( const std::string &rule_in, const Attitude attitude_in )
 {
     for( auto &elem : character_rules ) {
         if( rule_in.length() == elem.rule.length()
@@ -622,7 +622,7 @@ bool safemode::has_rule( const std::string &rule_in, const Creature::Attitude at
     return false;
 }
 
-void safemode::remove_rule( const std::string &rule_in, const Creature::Attitude attitude_in )
+void safemode::remove_rule( const std::string &rule_in, const Attitude attitude_in )
 {
     for( auto it = character_rules.begin();
          it != character_rules.end(); ++it ) {
@@ -680,11 +680,11 @@ void safemode::add_rules( const std::vector<rules_class> &rules_in )
 
 void safemode::set_rule( const rules_class &rule_in, const std::string &name_in, rule_state rs_in )
 {
-    static std::vector<Creature::Attitude> attitude_any = { {Creature::A_HOSTILE, Creature::A_NEUTRAL, Creature::A_FRIENDLY} };
+    static std::vector<Attitude> attitude_any = { {Attitude::A_HOSTILE, Attitude::A_NEUTRAL, Attitude::A_FRIENDLY} };
     switch( rule_in.category ) {
         case HOSTILE_SPOTTED:
             if( !rule_in.rule.empty() && rule_in.active && wildcard_match( name_in, rule_in.rule ) ) {
-                if( rule_in.attitude == Creature::A_ANY ) {
+                if( rule_in.attitude == Attitude::A_ANY ) {
                     for( auto &att : attitude_any ) {
                         safemode_rules_hostile[name_in][att] = rule_state_class( rs_in, rule_in.proximity,
                                                                HOSTILE_SPOTTED );
@@ -704,7 +704,7 @@ void safemode::set_rule( const rules_class &rule_in, const std::string &name_in,
 }
 
 rule_state safemode::check_monster( const std::string &creature_name_in,
-                                    const Creature::Attitude attitude_in,
+                                    const Attitude attitude_in,
                                     const int proximity_in ) const
 {
     const auto iter = safemode_rules_hostile.find( creature_name_in );
@@ -845,7 +845,7 @@ void safemode::deserialize( JsonIn &jsin )
         const std::string rule = jo.get_string( "rule" );
         const bool active = jo.get_bool( "active" );
         const bool whitelist = jo.get_bool( "whitelist" );
-        const Creature::Attitude attitude = static_cast<Creature::Attitude>( jo.get_int( "attitude" ) );
+        const Attitude attitude = static_cast<Attitude>( jo.get_int( "attitude" ) );
         const int proximity = jo.get_int( "proximity" );
         const Categories cat = jo.has_member( "category" ) ? static_cast<Categories>
                                ( jo.get_int( "category" ) ) : HOSTILE_SPOTTED;

--- a/src/safemode_ui.h
+++ b/src/safemode_ui.h
@@ -33,14 +33,14 @@ class safemode
                 std::string rule;
                 bool active;
                 bool whitelist;
-                Creature::Attitude attitude;
+                Attitude attitude;
                 int proximity;
                 Categories category;
 
-                rules_class() : active( false ), whitelist( false ), attitude( Creature::A_HOSTILE ),
+                rules_class() : active( false ), whitelist( false ), attitude( Attitude::A_HOSTILE ),
                     proximity( 0 ), category( Categories::HOSTILE_SPOTTED ) {}
                 rules_class( const std::string &rule_in, bool active_in, bool whitelist_in,
-                             Creature::Attitude attitude_in, int proximity_in, Categories cat ) : rule( rule_in ),
+                             Attitude attitude_in, int proximity_in, Categories cat ) : rule( rule_in ),
                     active( active_in ), whitelist( whitelist_in ),
                     attitude( attitude_in ), proximity( proximity_in ), category( cat ) {}
         };
@@ -86,12 +86,12 @@ class safemode
     public:
         std::string lastmon_whitelist;
 
-        bool has_rule( const std::string &rule_in, Creature::Attitude attitude_in );
-        void add_rule( const std::string &rule_in, Creature::Attitude attitude_in,
+        bool has_rule( const std::string &rule_in, Attitude attitude_in );
+        void add_rule( const std::string &rule_in, Attitude attitude_in,
                        int proximity_in, rule_state state_in );
-        void remove_rule( const std::string &rule_in, Creature::Attitude attitude_in );
+        void remove_rule( const std::string &rule_in, Attitude attitude_in );
         void clear_character_rules();
-        rule_state check_monster( const std::string &creature_name_in, Creature::Attitude attitude_in,
+        rule_state check_monster( const std::string &creature_name_in, Attitude attitude_in,
                                   int proximity_in ) const;
 
         bool is_sound_safe( const std::string &sound_name_in, int proximity_in ) const;

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1250,7 +1250,7 @@ void sfx::do_danger_music()
     audio_muted = false;
     int hostiles = 0;
     for( auto &critter : player_character.get_visible_creatures( 40 ) ) {
-        if( player_character.attitude_to( *critter ) == Creature::A_HOSTILE ) {
+        if( player_character.attitude_to( *critter ) == Attitude::A_HOSTILE ) {
             hostiles++;
         }
     }


### PR DESCRIPTION
## Purpose of change

Decouple creature attitude from creature so as to reduce the inclusion of `creature.h`.

## Describe the solution

Changed Attitude from being an internal enum of Creature to simply being an enum, now defined in `enums.h`. Fixed code after this refactor by bash scripts: `for FILE in $(find ./ -name '*.cpp' -or -name '*.h'); do sed -i -E 's@(Creature::)*(Attitude::)*(A_HOSTILE|A_NEUTRAL|A_FRIENDLY|A_ANY)@Attitude::\3@g' $FILE; done
`, `for FILE in $(find ./ -name '*.cpp' -or -name '*.h'); do sed -i -E 's@Creature::Attitude@Attitude@g' $FILE; done` and `for FILE in $(find ./ -name '*.cpp' -or -name '*.h'); do sed -i -E 's@MFAttitude::@MF@g' $FILE; done`.

## Describe alternatives you've considered

None.

## Testing

Tested if the code compiles by `make LUA=0 TILES=1 SOUND=1 RELEASE=1`.