### PR TITLE
fix: sugar house outdoor terrain

### DIFF
--- a/data/json/mapgen/sugar_house.json
+++ b/data/json/mapgen/sugar_house.json
@@ -3,7 +3,6 @@
     "type": "mapgen",
     "method": "json",
     "om_terrain": [ "sugar_house" ],
-    "weight": 300,
     "object": {
       "fill_ter": "t_floor",
       "rows": [
@@ -32,15 +31,10 @@
         ".-------++------------.M",
         "........................"
       ],
-      "set": [
-        { "point": "terrain", "id": "t_grass", "x": 0, "y": [ 0, 23 ], "repeat": [ 5, 10 ] },
-        { "point": "terrain", "id": "t_grass", "x": [ 0, 21 ], "y": 0, "repeat": [ 5, 10 ] },
-        { "point": "terrain", "id": "t_grass", "x": [ 0, 21 ], "y": 23, "repeat": [ 5, 10 ] }
-      ],
       "terrain": {
         "+": "t_door_c",
         "-": "t_wall_g",
-        ".": "t_dirt",
+        ".": "t_region_groundcover",
         ";": "t_door_c",
         "M": "t_tree_maple_tapped",
         "v": "t_window",


### PR DESCRIPTION
## Purpose of change
Replace the outdoor sugar house terrain with something better.
Remove "weight".
## Describe the solution
Use "t_region_groundcover" and delete unnecessary "set" lines.
## Describe alternatives you've considered
Do nothing.
## Testing
1. Changes didn't crash my game.
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/e1c9348c-0914-41d4-a48f-c4c7c49c4209">
After:
<img width="960" alt="image2" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/6468818c-fdf8-437c-8c83-742bc729a363">