### PR TITLE
fix: better define how NPCs generate starting weapon

### DIFF
--- a/data/json/npcs/items_generic.json
+++ b/data/json/npcs/items_generic.json
@@ -313,18 +313,70 @@
   },
   {
     "type": "item_group",
+    "id": "npc_bashing",
+    "items": [ { "group": "survivor_bashing", "prob": 100 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "npc_cutting",
+    "items": [ { "group": "survivor_cutting", "prob": 100 } ]
+  },
+  {
+    "type": "item_group",
     "id": "npc_stabbing",
     "items": [ { "group": "survivor_knife", "prob": 20 }, { "group": "survivor_stabbing", "prob": 80 } ]
   },
   {
     "type": "item_group",
+    "id": "npc_pistol",
+    "items": [ { "group": "guns_pistol_common", "prob": 75 }, { "group": "guns_pistol_improvised", "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "npc_shotgun",
+    "items": [ { "group": "guns_shotgun_common", "prob": 75 }, { "group": "guns_shotgun_improvised", "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "npc_rifle",
+    "items": [
+      [ "crossbow", 15 ],
+      [ "compcrossbow", 10 ],
+      { "group": "guns_rifle_common", "prob": 50 },
+      { "group": "guns_rifle_improvised", "prob": 25 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "npc_smg",
+    "items": [ { "group": "guns_smg_common", "prob": 50 }, { "group": "guns_smg_improvised", "prob": 50 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "npc_launcher",
+    "items": [ { "group": "guns_launcher_improvised", "prob": 100 } ]
+  },
+  {
+    "type": "item_group",
     "id": "npc_throw",
-    "items": [ [ "throwing_knife", 7 ], [ "throwing_axe", 4 ] ]
+    "items": [
+      [ "slingshot", 15 ],
+      [ "wristrocket", 10 ],
+      [ "sling", 15 ],
+      [ "staff_sling", 10 ],
+      [ "throwing_knife", 30 ],
+      [ "throwing_axe", 20 ]
+    ]
   },
   {
     "type": "item_group",
     "id": "npc_archery",
-    "items": [ [ "crossbow", 50 ] ]
+    "items": [ [ "shortbow", 50 ], [ "compbow", 50 ] ]
+  },
+  {
+    "type": "item_group",
+    "id": "npc_unarmed",
+    "items": [ [ "knuckle_brass", 50 ], [ "punch_dagger", 50 ] ]
   },
   {
     "type": "item_group",

--- a/data/json/npcs/items_generic.json
+++ b/data/json/npcs/items_generic.json
@@ -349,12 +349,12 @@
   {
     "type": "item_group",
     "id": "npc_smg",
-    "items": [ { "group": "guns_smg_common", "prob": 50 }, { "group": "guns_smg_improvised", "prob": 50 } ]
+    "items": [ { "group": "guns_smg_common", "prob": 25 }, { "group": "guns_smg_improvised", "prob": 25 }, [ "null", 50 ] ]
   },
   {
     "type": "item_group",
     "id": "npc_launcher",
-    "items": [ { "group": "guns_launcher_improvised", "prob": 100 } ]
+    "items": [ { "group": "guns_launcher_improvised", "prob": 15 }, [ "m79", 10 ], [ "null", 75 ] ]
   },
   {
     "type": "item_group",
@@ -376,7 +376,7 @@
   {
     "type": "item_group",
     "id": "npc_unarmed",
-    "items": [ [ "knuckle_brass", 50 ], [ "punch_dagger", 50 ] ]
+    "items": [ [ "knuckle_brass", 25 ], [ "punch_dagger", 25 ], [ "null", 50 ] ]
   },
   {
     "type": "item_group",

--- a/data/json/skills.json
+++ b/data/json/skills.json
@@ -129,7 +129,7 @@
     "id": "archery",
     "name": { "str": "archery" },
     "description": "Your skill in using bow weapons, from hand-carved self bows to complex compound bows.  Quiet and effective, they require strength of body and sight to wield, and are not terribly accurate over a long distance.",
-    "tags": [ "combat_skill" ],
+    "tags": [ "combat_skill", "weapon_skill" ],
     "time_to_attack": { "min_time": 20, "base_time": 80, "time_reduction_per_level": 6 },
     "companion_combat_rank_factor": 1,
     "companion_survival_rank_factor": 1,
@@ -156,7 +156,7 @@
     "id": "launcher",
     "name": { "str": "launchers" },
     "description": "Your skill in using heavy weapons like rocket, grenade or missile launchers.  These weapons have a variety of applications and may carry immense destructive power, but they are cumbersome and hard to manage.",
-    "tags": [ "combat_skill" ],
+    "tags": [ "combat_skill", "weapon_skill" ],
     "time_to_attack": { "min_time": 30, "base_time": 100, "time_reduction_per_level": 7 },
     "display_category": "display_ranged"
   },
@@ -165,7 +165,7 @@
     "id": "pistol",
     "name": { "str": "handguns" },
     "description": "Handguns have poor accuracy compared to rifles, but are usually quick to fire and reload faster than other guns.  They are very effective at close quarters, though unsuited for long range engagement.",
-    "tags": [ "combat_skill" ],
+    "tags": [ "combat_skill", "weapon_skill" ],
     "time_to_attack": { "min_time": 10, "base_time": 80, "time_reduction_per_level": 7 },
     "display_category": "display_ranged",
     "companion_skill_practice": [ { "skill": "hunting", "weight": 25 } ]
@@ -175,7 +175,7 @@
     "id": "rifle",
     "name": { "str": "rifles" },
     "description": "Rifles have terrific range and accuracy compared to other firearms, but may be slow to fire and reload, and can prove difficult to use in close quarters.  Fully automatic rifles can fire rapidly, but are harder to handle properly.",
-    "tags": [ "combat_skill" ],
+    "tags": [ "combat_skill", "weapon_skill" ],
     "time_to_attack": { "min_time": 15, "base_time": 75, "time_reduction_per_level": 6 },
     "display_category": "display_ranged",
     "companion_skill_practice": [ { "skill": "hunting", "weight": 45 } ]
@@ -185,7 +185,7 @@
     "id": "shotgun",
     "name": { "str": "shotguns" },
     "description": "Shotguns are easy to shoot and can inflict massive damage, but their effectiveness and accuracy decline rapidly with range.  Slugs can be loaded into shotguns to provide greater range, though they are somewhat inaccurate.",
-    "tags": [ "combat_skill" ],
+    "tags": [ "combat_skill", "weapon_skill" ],
     "time_to_attack": { "min_time": 15, "base_time": 75, "time_reduction_per_level": 6 },
     "display_category": "display_ranged",
     "companion_skill_practice": [ { "skill": "hunting", "weight": 25 } ]
@@ -195,7 +195,7 @@
     "id": "smg",
     "name": { "str": "submachine guns" },
     "description": "Comprised of an automatic rifle carbine designed to fire a pistol cartridge, submachine guns can reload and fire quickly, sometimes in bursts, but they are relatively inaccurate and may be prone to mechanical failures.",
-    "tags": [ "combat_skill" ],
+    "tags": [ "combat_skill", "weapon_skill" ],
     "time_to_attack": { "min_time": 20, "base_time": 80, "time_reduction_per_level": 6 },
     "display_category": "display_ranged",
     "companion_skill_practice": [ { "skill": "hunting", "weight": 25 } ]
@@ -205,7 +205,7 @@
     "id": "throw",
     "name": { "str": "throwing" },
     "description": "Your skill in throwing objects over a distance.  Skill increases accuracy, and at higher levels, the range of a throw.",
-    "tags": [ "combat_skill" ],
+    "tags": [ "combat_skill", "weapon_skill" ],
     "time_to_attack": { "min_time": 50, "base_time": 220, "time_reduction_per_level": 25 },
     "display_category": "display_ranged"
   },
@@ -232,7 +232,7 @@
     "id": "bashing",
     "name": { "str": "bashing weapons" },
     "description": "Your skill in fighting with blunt weaponry, from rocks and sticks to baseball bats and the butts of rifles.  Skill increases damage, and higher levels will improve the accuracy of an attack.",
-    "tags": [ "combat_skill" ],
+    "tags": [ "combat_skill", "weapon_skill" ],
     "companion_combat_rank_factor": 1,
     "display_category": "display_melee",
     "companion_skill_practice": [ { "skill": "hunting", "weight": 10 }, { "skill": "combat", "weight": 10 } ]
@@ -242,7 +242,7 @@
     "id": "cutting",
     "name": { "str": "cutting weapons" },
     "description": "Your skill in fighting with weaponry designed to cut, hack and slash an opponent.  Lower levels of skill increase accuracy and damage, while higher levels will help to bypass heavy armor and thick hides.",
-    "tags": [ "combat_skill" ],
+    "tags": [ "combat_skill", "weapon_skill" ],
     "companion_combat_rank_factor": 1,
     "display_category": "display_melee",
     "companion_skill_practice": [ { "skill": "hunting", "weight": 10 }, { "skill": "combat", "weight": 10 } ]
@@ -260,7 +260,7 @@
     "id": "stabbing",
     "name": { "str": "piercing weapons" },
     "description": "Your skill in fighting with knives, spears and other such stabbing implements.  Skill increases attack accuracy as well as the chance of inflicting a deadly and critical blow.",
-    "tags": [ "combat_skill" ],
+    "tags": [ "combat_skill", "weapon_skill" ],
     "companion_combat_rank_factor": 1,
     "display_category": "display_melee",
     "companion_skill_practice": [ { "skill": "hunting", "weight": 10 }, { "skill": "combat", "weight": 10 } ]
@@ -270,7 +270,7 @@
     "id": "unarmed",
     "name": { "str": "unarmed combat" },
     "description": "Your skill in hand-to-hand fighting.  For the unskilled, it's a good way to get hurt, but those with enough practice can perform special blows and techniques to quickly dispatch enemies.",
-    "tags": [ "combat_skill" ],
+    "tags": [ "combat_skill", "weapon_skill" ],
     "companion_combat_rank_factor": 1,
     "companion_survival_rank_factor": 1,
     "display_category": "display_melee",

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -103,12 +103,14 @@ static const skill_id skill_archery( "archery" );
 static const skill_id skill_barter( "barter" );
 static const skill_id skill_bashing( "bashing" );
 static const skill_id skill_cutting( "cutting" );
+static const skill_id skill_launcher( "launcher" );
 static const skill_id skill_pistol( "pistol" );
 static const skill_id skill_rifle( "rifle" );
 static const skill_id skill_shotgun( "shotgun" );
 static const skill_id skill_smg( "smg" );
 static const skill_id skill_stabbing( "stabbing" );
 static const skill_id skill_throw( "throw" );
+static const skill_id skill_unarmed( "unarmed" );
 
 static const bionic_id bio_eye_optic( "bio_eye_optic" );
 static const bionic_id bio_memory( "bio_memory" );
@@ -790,7 +792,7 @@ skill_id npc::best_skill() const
     skill_id highest_skill( skill_id::NULL_ID() );
 
     for( const auto &p : *_skills ) {
-        if( p.first.obj().is_combat_skill() ) {
+        if( p.first.obj().is_weapon_skill() ) {
             const int level = p.second.level();
             if( level > highest_level ) {
                 highest_level = level;
@@ -827,25 +829,29 @@ void npc::starting_weapon( const npc_class_id &type )
 
     const skill_id best = best_skill();
 
-    // if NPC has no suitable skills default to stabbing weapon
-    if( !best || best == skill_stabbing ) {
-        set_primary_weapon( random_item_from( type, "stabbing", item_group_id( "survivor_stabbing" ) ) );
-    } else if( best == skill_bashing ) {
-        set_primary_weapon( random_item_from( type, "bashing",  item_group_id( "survivor_bashing" ) ) );
+    if( best == skill_bashing ) {
+        set_primary_weapon( random_item_from( type, "bashing" ) );
     } else if( best == skill_cutting ) {
-        set_primary_weapon( random_item_from( type, "cutting",  item_group_id( "survivor_cutting" ) ) );
+        set_primary_weapon( random_item_from( type, "cutting" ) );
+    } else if( best == skill_unarmed ) {
+        set_primary_weapon( random_item_from( type, "unarmed" ) );
     } else if( best == skill_throw ) {
         set_primary_weapon( random_item_from( type, "throw" ) );
     } else if( best == skill_archery ) {
         set_primary_weapon( random_item_from( type, "archery" ) );
+    } else if( best == skill_launcher ) {
+        set_primary_weapon( random_item_from( type, "launcher" ) );
     } else if( best == skill_pistol ) {
-        set_primary_weapon( random_item_from( type, "pistol",  item_group_id( "guns_pistol_common" ) ) );
+        set_primary_weapon( random_item_from( type, "pistol" ) );
     } else if( best == skill_shotgun ) {
-        set_primary_weapon( random_item_from( type, "shotgun",  item_group_id( "guns_shotgun_common" ) ) );
+        set_primary_weapon( random_item_from( type, "shotgun" ) );
     } else if( best == skill_smg ) {
-        set_primary_weapon( random_item_from( type, "smg",  item_group_id( "guns_smg_common" ) ) );
+        set_primary_weapon( random_item_from( type, "smg" ) );
     } else if( best == skill_rifle ) {
-        set_primary_weapon( random_item_from( type, "rifle",  item_group_id( "guns_rifle_common" ) ) );
+        set_primary_weapon( random_item_from( type, "rifle" ) );
+    } else {
+        // if NPC has no suitable skills default to stabbing weapon
+        set_primary_weapon( random_item_from( type, "stabbing" ) );
     }
 
     if( primary_weapon().is_gun() ) {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -820,6 +820,33 @@ int npc::best_skill_level() const
     return highest_level;
 }
 
+namespace
+{
+
+const std::map<skill_id, std::string> skill_to_weapons = {
+    { skill_bashing, "bashing" },
+    { skill_cutting, "cutting" },
+    { skill_unarmed, "unarmed" },
+    { skill_throw, "throw" },
+    { skill_archery, "archery" },
+    { skill_launcher, "launcher" },
+    { skill_pistol, "pistol" },
+    { skill_shotgun, "shotgun" },
+    { skill_smg, "smg" },
+    { skill_rifle, "rifle" },
+    { skill_stabbing, "stabbing" }
+};
+
+/// if NPC has no suitable skills default to stabbing weapon
+auto best_weapon_category( const skill_id &best_skill ) -> std::string
+{
+    const auto &res = skill_to_weapons.find( best_skill );
+
+    return res != skill_to_weapons.end() ? res->second : "stabbing";
+}
+
+} // namespace
+
 void npc::starting_weapon( const npc_class_id &type )
 {
     if( item_group::group_is_defined( type->weapon_override ) ) {
@@ -828,31 +855,8 @@ void npc::starting_weapon( const npc_class_id &type )
     }
 
     const skill_id best = best_skill();
-
-    if( best == skill_bashing ) {
-        set_primary_weapon( random_item_from( type, "bashing" ) );
-    } else if( best == skill_cutting ) {
-        set_primary_weapon( random_item_from( type, "cutting" ) );
-    } else if( best == skill_unarmed ) {
-        set_primary_weapon( random_item_from( type, "unarmed" ) );
-    } else if( best == skill_throw ) {
-        set_primary_weapon( random_item_from( type, "throw" ) );
-    } else if( best == skill_archery ) {
-        set_primary_weapon( random_item_from( type, "archery" ) );
-    } else if( best == skill_launcher ) {
-        set_primary_weapon( random_item_from( type, "launcher" ) );
-    } else if( best == skill_pistol ) {
-        set_primary_weapon( random_item_from( type, "pistol" ) );
-    } else if( best == skill_shotgun ) {
-        set_primary_weapon( random_item_from( type, "shotgun" ) );
-    } else if( best == skill_smg ) {
-        set_primary_weapon( random_item_from( type, "smg" ) );
-    } else if( best == skill_rifle ) {
-        set_primary_weapon( random_item_from( type, "rifle" ) );
-    } else {
-        // if NPC has no suitable skills default to stabbing weapon
-        set_primary_weapon( random_item_from( type, "stabbing" ) );
-    }
+    const std::string category = best_weapon_category( best );
+    set_primary_weapon( random_item_from( type, category ) );
 
     if( primary_weapon().is_gun() ) {
         primary_weapon().ammo_set( primary_weapon().ammo_default() );

--- a/src/skill.cpp
+++ b/src/skill.cpp
@@ -221,6 +221,13 @@ bool Skill::is_contextual_skill() const
     return _tags.count( contextual_skill ) > 0;
 }
 
+// used to check NPC weapon skills for determining starting weapon
+bool Skill::is_weapon_skill() const
+{
+    static const std::string weapon_skill( "weapon_skill" );
+    return _tags.count( weapon_skill ) > 0;
+}
+
 void SkillLevel::train( int amount, bool skip_scaling )
 {
     // Working off rust to regain levels goes twice as fast as reaching levels in the first place

--- a/src/skill.h
+++ b/src/skill.h
@@ -101,6 +101,7 @@ class Skill
 
         bool is_combat_skill() const;
         bool is_contextual_skill() const;
+        bool is_weapon_skill() const;
 
         // Required for LUA
         inline bool operator<( const Skill &rhs ) const {


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This aims to fix up some flaws with the hardcoded way in which NPCs generate their default starting weapons, clearing the way for better NPC gear variety in the future.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

C++ changes:
1. In npc.cpp, updated `npc::best_skill` to only check for what counts as weapon skills, to prevent weird shit like an NPC how has high marksmanship skill than their pistol skill or whatever generating unarmed because by the code's logic their best skill isn't a weapon skill. Uses a neat bool as outlined below.
2. Also in npc.cpp, updated the logic `npc::starting_weapon` a bit. Now it probably checks for all the skills in-repo that might reasonably qualify as a weapon skill, and fixed the fallback behavior to actually properly kick in as a default result and not being skippable if the NPC's top skill was an unexpected combat skill (as the fallback was only kicking in if combat skills were entirely absent). Now comes with the ability to define unarmed weapon groups and launchers for NPC classes. Additionally, axed the existing choices in fallback itemgroups in favor of always using `npc_X` itemgroups, as that allows bettr ability to define custom itemgroup choices.
3. In skill.cpp and skill.h, defined `Skill::is_weapon_skill` which defines an additional tag for skill JSON, for defining all skills that presently qualify as a weapon skill.

JSON changes:
1. Added `weapon_skill` tag to archery, launchers, handguns, rifles, shotguns, submachine guns, throwing, bashing weapons, cutting weapons, piercing weapons, and unarmed combat.
2. Defined proper fallback itemgroups for all potential resulting NPC weapon choices, additionally fixing NPCs picking a crossbow (which has used rifle skill for ages) as their default if they have archery skill. Comes with some potential calls to improvised gun itemgroups, crossbows returning to rifle users where they belong, and some better selection of defaults for throwing NPCs. SMG, launcher, and unarmed groups all come with some chance to still generate the NPC unarmed (especially for launchers given how !!FUN!! an NPC spawning with a rocket launcher could be).

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. We could support custom skills in mods if we were to figure out a way to smush `npc::starting_weapon` such that it feeds the ID of its skill to `random_item_from` automatically in place of the pre-defined strings. We may in the process also want to force it to construct the fallback itemgroup IDs in the same way instad of using predefined ones.
2. Picking a better name for the `weapon_skill` tag that in some way better clarifies it's mainly used by NPC generation?
3. Hardcoding the "filter out non-weapon skills" stuff directly into `npc::best_skill`, via explicitly telling it to exclude melee, marksmanship, and dodging.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON files for syntax and lint errors.
2. Compiled and load-tested.
3. Checked affected C++ files for astyle.

<details>
<summary>Screenshots:</summary>

This starter NPC spawned with a slingshot:
![1](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/c29a6361-d7d2-455e-bc49-177c0b19a190)

They had 7 marksmanship skill and only 5 in throwing, if not for the new property they would've defaulted to stabbing under current logic, and just spawned unarmed in current master.


All of these bandits generated armed for once, some had homemade hand cannons and the like mixed in with the standard glocks:
![2](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/58c931d1-345c-47da-acd2-d9b19ee0f202)

The two thugs still generated with melee weapons instead of guns since their skill is higher in that.



</details>

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
