### PR TITLE
fix(port): shopping carts in `s_clothes` mapgen

### DIFF
--- a/data/json/mapgen/s_clothing.json
+++ b/data/json/mapgen/s_clothing.json
@@ -10,11 +10,11 @@
       "rows": [
         "...........--..........'",
         "...........--...........",
-        "..##:::::::**:::::::##..",
-        "..# y         &y&y(y #..",
-        "..#b         ||||||||#..",
-        "..#J    &y&     c s  #..",
-        "..#J            c   D#..",
+        "..#::::::::**::::::::#..",
+        "..#y          y&y(y&y#..",
+        "..#b          |||||||#..",
+        "..#J    &y&     c    #..",
+        "..#J            cs  D#..",
         "..#J            c   y#..",
         "..#J    CyC     ccc  o..",
         "..#K                b#..",
@@ -36,7 +36,7 @@
       "palettes": [ "standard_building_palette", "clothes_store_palette" ],
       "terrain": { "'": "t_region_groundcover_urban" },
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 0, 0 ], "y": [ 23, 23 ], "chance": 2, "repeat": [ 2, 3 ] } ],
-      "vehicles": { ".": { "vehicle": "shopping_cart", "chance": 1, "status": 0 } }
+      "vehicles": { " ": { "vehicle": "shopping_cart", "chance": 1, "status": 0 } }
     }
   },
   {

--- a/data/json/mapgen/s_clothing.json
+++ b/data/json/mapgen/s_clothing.json
@@ -36,7 +36,7 @@
       "palettes": [ "standard_building_palette", "clothes_store_palette" ],
       "terrain": { "'": "t_region_groundcover_urban" },
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 0, 0 ], "y": [ 23, 23 ], "chance": 2, "repeat": [ 2, 3 ] } ],
-      "vehicles": { " ": { "vehicle": "shopping_cart", "chance": 1, "status": 0 } }
+      "vehicles": { " ": { "vehicle": "shopping_cart", "chance": 1, "status": 1 } }
     }
   },
   {


### PR DESCRIPTION
## Purpose of change
Fix because shopping carts in "s_clothes" are placed outside on the grass and appear "like new" constantly.
## Describe the solution
Port https://github.com/CleverRaven/Cataclysm-DDA/pull/51178
Set "status" to 1 for shopping carts.
## Describe alternatives you've considered
Do nothing.
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/f7648893-46f1-46a8-95c2-70939a40c9ad">
After:
<img width="960" alt="image2" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/6c09eeff-3de2-41a3-b504-68377ffe3b82">