### PR TITLE
fix(mods/DinoMod): Fix Dinomod overwriting various egg-based food recipes

### DIFF
--- a/data/mods/DinoMod/recipes/food_egg.json
+++ b/data/mods/DinoMod/recipes/food_egg.json
@@ -2,6 +2,7 @@
   {
     "type": "recipe",
     "result": "scrambled_eggs",
+	"id_suffix": "from_dino",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_OTHER",
     "skill_used": "cooking",
@@ -17,6 +18,7 @@
   {
     "type": "recipe",
     "result": "scrambled_eggs",
+	"id_suffix": "from_large_dino",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_OTHER",
     "skill_used": "cooking",
@@ -74,6 +76,7 @@
   {
     "type": "recipe",
     "result": "deluxe_eggs",
+	"id_suffix": "from_dino",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_OTHER",
     "skill_used": "cooking",
@@ -88,6 +91,7 @@
   {
     "type": "recipe",
     "result": "pancakes",
+	"id_suffix": "from_dino",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREAD",
     "skill_used": "cooking",
@@ -109,6 +113,7 @@
   {
     "type": "recipe",
     "result": "fruit_pancakes",
+	"id_suffix": "from_dino",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_VEGGI",
     "skill_used": "cooking",
@@ -131,6 +136,7 @@
   {
     "type": "recipe",
     "result": "choc_pancakes",
+	"id_suffix": "from_dino",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREAD",
     "skill_used": "cooking",
@@ -153,6 +159,7 @@
   {
     "type": "recipe",
     "result": "frenchtoast",
+	"id_suffix": "from_dino",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREAD",
     "skill_used": "cooking",
@@ -172,6 +179,7 @@
   {
     "type": "recipe",
     "result": "waffles",
+	"id_suffix": "from_dino",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREAD",
     "skill_used": "cooking",
@@ -193,6 +201,7 @@
   {
     "type": "recipe",
     "result": "fruit_waffles",
+	"id_suffix": "from_dino",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_VEGGI",
     "skill_used": "cooking",
@@ -215,6 +224,7 @@
   {
     "type": "recipe",
     "result": "choc_waffles",
+	"id_suffix": "from_dino",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREAD",
     "skill_used": "cooking",
@@ -237,6 +247,7 @@
   {
     "type": "recipe",
     "result": "powder_eggs",
+	"id_suffix": "from_dino",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_DRY",
     "skill_used": "cooking",
@@ -251,20 +262,7 @@
   {
     "type": "recipe",
     "result": "powder_eggs",
-    "category": "CC_FOOD",
-    "subcategory": "CSC_FOOD_DRY",
-    "skill_used": "cooking",
-    "difficulty": 2,
-    "charges": 30,
-    "time": "34 m",
-    "autolearn": true,
-    "batch_time_factors": [ 67, 5 ],
-    "tools": [ [ [ "dehydrator", 60 ], [ "char_smoker", 60 ] ], [ [ "surface_heat", 15, "LIST" ] ] ],
-    "components": [ [ [ "eggs_dino", 1, "LIST" ] ] ]
-  },
-  {
-    "type": "recipe",
-    "result": "powder_eggs",
+	"id_suffix": "from_large_dino",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_DRY",
     "skill_used": "cooking",
@@ -274,20 +272,6 @@
     "autolearn": true,
     "batch_time_factors": [ 67, 5 ],
     "tools": [ [ [ "dehydrator", 140 ], [ "char_smoker", 140 ] ] ],
-    "components": [ [ [ "eggs_dino_large", 1, "LIST" ] ] ]
-  },
-  {
-    "type": "recipe",
-    "result": "powder_eggs",
-    "category": "CC_FOOD",
-    "subcategory": "CSC_FOOD_DRY",
-    "skill_used": "cooking",
-    "difficulty": 2,
-    "charges": 70,
-    "time": "60 m",
-    "autolearn": true,
-    "batch_time_factors": [ 67, 5 ],
-    "tools": [ [ [ "dehydrator", 140 ], [ "char_smoker", 140 ] ], [ [ "surface_heat", 35, "LIST" ] ] ],
     "components": [ [ [ "eggs_dino_large", 1, "LIST" ] ] ]
   }
 ]

--- a/data/mods/DinoMod/recipes/food_egg.json
+++ b/data/mods/DinoMod/recipes/food_egg.json
@@ -2,7 +2,7 @@
   {
     "type": "recipe",
     "result": "scrambled_eggs",
-	"id_suffix": "from_dino",
+    "id_suffix": "from_dino",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_OTHER",
     "skill_used": "cooking",
@@ -18,7 +18,7 @@
   {
     "type": "recipe",
     "result": "scrambled_eggs",
-	"id_suffix": "from_large_dino",
+    "id_suffix": "from_large_dino",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_OTHER",
     "skill_used": "cooking",
@@ -76,7 +76,7 @@
   {
     "type": "recipe",
     "result": "deluxe_eggs",
-	"id_suffix": "from_dino",
+    "id_suffix": "from_dino",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_OTHER",
     "skill_used": "cooking",
@@ -91,7 +91,7 @@
   {
     "type": "recipe",
     "result": "pancakes",
-	"id_suffix": "from_dino",
+    "id_suffix": "from_dino",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREAD",
     "skill_used": "cooking",
@@ -113,7 +113,7 @@
   {
     "type": "recipe",
     "result": "fruit_pancakes",
-	"id_suffix": "from_dino",
+    "id_suffix": "from_dino",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_VEGGI",
     "skill_used": "cooking",
@@ -136,7 +136,7 @@
   {
     "type": "recipe",
     "result": "choc_pancakes",
-	"id_suffix": "from_dino",
+    "id_suffix": "from_dino",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREAD",
     "skill_used": "cooking",
@@ -159,7 +159,7 @@
   {
     "type": "recipe",
     "result": "frenchtoast",
-	"id_suffix": "from_dino",
+    "id_suffix": "from_dino",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREAD",
     "skill_used": "cooking",
@@ -179,7 +179,7 @@
   {
     "type": "recipe",
     "result": "waffles",
-	"id_suffix": "from_dino",
+    "id_suffix": "from_dino",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREAD",
     "skill_used": "cooking",
@@ -201,7 +201,7 @@
   {
     "type": "recipe",
     "result": "fruit_waffles",
-	"id_suffix": "from_dino",
+    "id_suffix": "from_dino",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_VEGGI",
     "skill_used": "cooking",
@@ -224,7 +224,7 @@
   {
     "type": "recipe",
     "result": "choc_waffles",
-	"id_suffix": "from_dino",
+    "id_suffix": "from_dino",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREAD",
     "skill_used": "cooking",
@@ -247,7 +247,7 @@
   {
     "type": "recipe",
     "result": "powder_eggs",
-	"id_suffix": "from_dino",
+    "id_suffix": "from_dino",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_DRY",
     "skill_used": "cooking",
@@ -262,7 +262,7 @@
   {
     "type": "recipe",
     "result": "powder_eggs",
-	"id_suffix": "from_large_dino",
+    "id_suffix": "from_large_dino",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_DRY",
     "skill_used": "cooking",


### PR DESCRIPTION
## Purpose of change

Fixes an issue occurring regarding Dinomod overwriting the egg-based food recipes to only use dinomod eggs.

## Describe the solution

Adds an appropriate id_suffix to the relevant recipes.
Also removes the random extra powdered egg recipes that just had a slight time difference and the ability to use surface_heat, just for the sake of making sure they aren't overwriting anything (though those might have been the intended proper recipes)

## Describe alternatives you've considered

- Leaving those tasty bird and other egg types unable to be cooked

- Instead removing the other pair of powdered egg recipes, and keeping the ones with surface_heat
I just have no clue what the purpose of the ones with surface_heat was, and thus I chose to keep the ones consistent with vanilla.

## Testing

Loaded in, confirmed that everything was working

## Additional context

Down with the dino-egg monopoly on egg items!

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/30732426/cb40804a-f6cd-4e84-923f-064ee747f1cd)
