### PR TITLE
fix: serving area interface terrain

### DIFF
--- a/data/json/mapgen/sai.json
+++ b/data/json/mapgen/sai.json
@@ -36,7 +36,7 @@
         "#": "t_sai_box",
         "+": "t_chaingate_c",
         "-": "t_chainfence_h",
-        ".": "t_grass",
+        ".": "t_region_groundcover",
         "x": "t_chainfence_posts",
         "|": "t_chainfence_v"
       },


### PR DESCRIPTION
## Purpose of change
Change the terrain around the serving area interface with something better.
## Describe the solution
Use "t_region_groundcover".
## Describe alternatives you've considered
Do nothing.
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/10f3ea98-8d35-4aa9-84fa-6f3c16af7876">
After:
<img width="960" alt="image2" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/3c0b188c-8772-4bc1-87d7-64b1032fa771">