### PR TITLE
feat(balance): more consistent bash results for plants and stone

### DIFF
--- a/data/json/furniture_and_terrain/furniture-terrains.json
+++ b/data/json/furniture_and_terrain/furniture-terrains.json
@@ -798,7 +798,12 @@
       "str_max": 40,
       "sound": "smash!",
       "sound_fail": "thump.",
-      "items": [ { "item": "rock", "count": [ 16, 32 ] }, { "item": "sharp_rock", "count": [ 0, 6 ] } ]
+      "items": [
+        { "item": "rock", "count": [ 16, 32 ] },
+        { "item": "sharp_rock", "count": [ 0, 6 ] },
+        { "item": "material_limestone", "charges": [ 3, 8 ], "prob": 80 },
+        { "group": "rock_mining_extra", "prob": 8 }
+      ]
     }
   },
   {
@@ -818,7 +823,12 @@
       "str_max": 80,
       "sound": "smash!",
       "sound_fail": "thump.",
-      "items": [ { "item": "rock", "count": [ 35, 50 ] }, { "item": "sharp_rock", "count": [ 3, 7 ] } ]
+      "items": [
+        { "item": "rock", "count": [ 35, 50 ] },
+        { "item": "sharp_rock", "count": [ 3, 7 ] },
+        { "item": "material_limestone", "charges": [ 5, 15 ], "prob": 80 },
+        { "group": "rock_mining_extra", "prob": 15 }
+      ]
     }
   },
   {
@@ -838,12 +848,10 @@
       "sound": "smash!",
       "sound_fail": "thump.",
       "items": [
-        { "item": "rock", "count": [ 65, 85 ] },
-        { "item": "sharp_rock", "count": [ 5, 9 ] },
-        { "item": "material_limestone", "charges": [ 2, 5 ], "prob": 30 },
-        { "item": "material_rocksalt", "count": [ 0, 1 ], "prob": 10 },
-        { "item": "material_rhodonite", "count": [ 0, 1 ], "prob": 1 },
-        { "item": "material_zincite", "count": [ 0, 5 ], "prob": 2 }
+        { "item": "rock", "count": [ 50, 70 ] },
+        { "item": "sharp_rock", "count": [ 4, 7 ] },
+        { "item": "material_limestone", "charges": [ 8, 20 ], "prob": 80 },
+        { "group": "rock_mining_extra", "prob": 20 }
       ]
     }
   },

--- a/data/json/furniture_and_terrain/terrain-flora.json
+++ b/data/json/furniture_and_terrain/terrain-flora.json
@@ -348,7 +348,7 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 0, 5 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 1, 4 ] } ]
     }
   },
   {
@@ -1266,7 +1266,7 @@
       "sound": "crunch.",
       "sound_fail": "brush.",
       "ter_set": "t_dirt",
-      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+      "items": [ { "item": "withered", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -1297,7 +1297,7 @@
       "sound": "crunch.",
       "sound_fail": "brush.",
       "ter_set": "t_dirt",
-      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+      "items": [ { "item": "withered", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -1328,7 +1328,7 @@
       "sound": "crunch.",
       "sound_fail": "brush.",
       "ter_set": "t_dirt",
-      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+      "items": [ { "item": "withered", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -1359,7 +1359,7 @@
       "sound": "crunch.",
       "sound_fail": "brush.",
       "ter_set": "t_dirt",
-      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+      "items": [ { "item": "withered", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -1390,7 +1390,7 @@
       "sound": "crunch.",
       "sound_fail": "brush.",
       "ter_set": "t_dirt",
-      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+      "items": [ { "item": "withered", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -1409,7 +1409,7 @@
       "sound": "crunch.",
       "sound_fail": "brush.",
       "ter_set": "t_dirt",
-      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+      "items": [ { "item": "withered", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -1433,7 +1433,7 @@
       "sound": "crunch.",
       "sound_fail": "brush.",
       "ter_set": "t_dirt",
-      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+      "items": [ { "item": "withered", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -1455,7 +1455,7 @@
       "sound": "crunch.",
       "sound_fail": "brush.",
       "ter_set": "t_dirt",
-      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+      "items": [ { "item": "withered", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -1486,7 +1486,7 @@
       "sound": "crunch.",
       "sound_fail": "brush.",
       "ter_set": "t_dirt",
-      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+      "items": [ { "item": "withered", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -1508,7 +1508,7 @@
       "sound": "crunch.",
       "sound_fail": "brush.",
       "ter_set": "t_dirt",
-      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+      "items": [ { "item": "withered", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -1539,7 +1539,7 @@
       "sound": "crunch.",
       "sound_fail": "brush.",
       "ter_set": "t_dirt",
-      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+      "items": [ { "item": "withered", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -1561,7 +1561,7 @@
       "sound": "crunch.",
       "sound_fail": "brush.",
       "ter_set": "t_dirt",
-      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+      "items": [ { "item": "withered", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -1592,7 +1592,7 @@
       "sound": "crunch.",
       "sound_fail": "brush.",
       "ter_set": "t_dirt",
-      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+      "items": [ { "item": "withered", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -1614,7 +1614,7 @@
       "sound": "crunch.",
       "sound_fail": "brush.",
       "ter_set": "t_dirt",
-      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+      "items": [ { "item": "withered", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -1645,7 +1645,7 @@
       "sound": "crunch.",
       "sound_fail": "brush.",
       "ter_set": "t_dirt",
-      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+      "items": [ { "item": "withered", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -1667,7 +1667,7 @@
       "sound": "crunch.",
       "sound_fail": "brush.",
       "ter_set": "t_dirt",
-      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+      "items": [ { "item": "withered", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -1698,7 +1698,7 @@
       "sound": "crunch.",
       "sound_fail": "brush.",
       "ter_set": "t_dirt",
-      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+      "items": [ { "item": "withered", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -1720,7 +1720,7 @@
       "sound": "crunch.",
       "sound_fail": "brush.",
       "ter_set": "t_dirt",
-      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+      "items": [ { "item": "withered", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -1753,7 +1753,7 @@
       "sound": "crunch.",
       "sound_fail": "brush.",
       "ter_set": "t_dirt",
-      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+      "items": [ { "item": "withered", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -1775,7 +1775,7 @@
       "sound": "crunch.",
       "sound_fail": "brush.",
       "ter_set": "t_dirt",
-      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+      "items": [ { "item": "withered", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -1799,7 +1799,7 @@
       "sound": "crunch.",
       "sound_fail": "brush.",
       "ter_set": "t_dirt",
-      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+      "items": [ { "item": "withered", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -1821,7 +1821,7 @@
       "sound": "crunch.",
       "sound_fail": "brush.",
       "ter_set": "t_dirt",
-      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+      "items": [ { "item": "withered", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -1844,7 +1844,7 @@
       "sound": "crunch.",
       "sound_fail": "brush.",
       "ter_set": "t_dirt",
-      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+      "items": [ { "item": "withered", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -1866,7 +1866,7 @@
       "sound": "crunch.",
       "sound_fail": "brush.",
       "ter_set": "t_dirt",
-      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+      "items": [ { "item": "withered", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -1889,7 +1889,7 @@
       "sound": "crunch.",
       "sound_fail": "brush.",
       "ter_set": "t_dirt",
-      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+      "items": [ { "item": "withered", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -1911,7 +1911,7 @@
       "sound": "crunch.",
       "sound_fail": "brush.",
       "ter_set": "t_dirt",
-      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+      "items": [ { "item": "withered", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -2081,7 +2081,7 @@
       "sound": "crunch.",
       "sound_fail": "whish.",
       "ter_set": "t_dirt",
-      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+      "items": [ { "item": "withered", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -2103,7 +2103,7 @@
       "sound": "crunch.",
       "sound_fail": "whish.",
       "ter_set": "t_dirt",
-      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+      "items": [ { "item": "withered", "count": [ 1, 2 ] } ]
     }
   },
   {
@@ -2175,7 +2175,7 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 0, 5 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 1, 4 ] } ]
     }
   },
   {
@@ -2196,7 +2196,7 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 0, 5 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 1, 4 ] } ]
     }
   }
 ]

--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -15,6 +15,17 @@
     ]
   },
   {
+    "type": "item_group",
+    "id": "rock_mining_extra",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "material_rocksalt", "prob": 50 },
+      { "item": "coal_lump", "charges": [ 250, 500 ], "prob": 30 },
+      { "item": "material_zincite", "count": [ 1, 4 ], "prob": 10 },
+      { "item": "material_rhodonite", "prob": 10 }
+    ]
+  },
+  {
     "type": "terrain",
     "id": "t_wall",
     "alias": [ "t_wall_h", "t_wall_v" ],
@@ -343,7 +354,8 @@
       "items": [
         { "item": "rock", "count": [ 35, 50 ] },
         { "item": "sharp_rock", "count": [ 3, 7 ] },
-        { "item": "material_rocksalt", "count": [ 0, 1 ], "prob": 10 }
+        { "item": "material_limestone", "charges": [ 5, 15 ], "prob": 80 },
+        { "item": "material_rocksalt", "prob": 10 }
       ]
     }
   },
@@ -1193,11 +1205,8 @@
       "items": [
         { "item": "rock", "count": [ 65, 85 ] },
         { "item": "sharp_rock", "count": [ 5, 9 ] },
-        { "item": "coal_lump", "charges": [ 250, 500 ], "prob": 10 },
         { "item": "material_limestone", "charges": [ 10, 25 ], "prob": 80 },
-        { "item": "material_rocksalt", "count": [ 0, 1 ], "prob": 20 },
-        { "item": "material_rhodonite", "count": [ 0, 1 ], "prob": 3 },
-        { "item": "material_zincite", "count": [ 0, 5 ], "prob": 5 }
+        { "group": "rock_mining_extra", "prob": 25 }
       ]
     }
   },
@@ -1217,7 +1226,12 @@
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_rock_floor",
-      "items": [ { "item": "rock", "count": [ 35, 50 ] }, { "item": "sharp_rock", "count": [ 3, 7 ] } ]
+      "items": [
+        { "item": "rock", "count": [ 35, 50 ] },
+        { "item": "sharp_rock", "count": [ 3, 7 ] },
+        { "item": "material_limestone", "charges": [ 5, 15 ], "prob": 80 },
+        { "item": "material_rocksalt", "prob": 10 }
+      ]
     }
   },
   {
@@ -1236,7 +1250,12 @@
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_rock_floor",
-      "items": [ { "item": "rock", "count": [ 35, 50 ] }, { "item": "sharp_rock", "count": [ 3, 7 ] } ]
+      "items": [
+        { "item": "rock", "count": [ 35, 50 ] },
+        { "item": "sharp_rock", "count": [ 3, 7 ] },
+        { "item": "material_limestone", "charges": [ 5, 15 ], "prob": 80 },
+        { "item": "material_rocksalt", "prob": 10 }
+      ]
     }
   },
   {
@@ -1255,7 +1274,12 @@
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_rock_floor",
-      "items": [ { "item": "rock", "count": [ 35, 50 ] }, { "item": "sharp_rock", "count": [ 3, 7 ] } ]
+      "items": [
+        { "item": "rock", "count": [ 35, 50 ] },
+        { "item": "sharp_rock", "count": [ 3, 7 ] },
+        { "item": "material_limestone", "charges": [ 5, 15 ], "prob": 80 },
+        { "item": "material_rocksalt", "prob": 10 }
+      ]
     }
   },
   {


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This consistency-checks and tweaks some bash and related yields from certain terrain innawoods to make some aspects a bit less annoying. In particular this also makes it a bit more reliable getting the basic trickle of limestone needed to start mining without already having access to mining (or using Mining Mod).

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Set young trees and related (coca) to yield 1-4 long sticks instead of 0-5, allowing you to always get long sticks out of a tree in exchange for a lower max possible yield (in my experience you seem to encounter the annoyance of trees dropping no sticks way more often).
2. Removed the 50% chance of getting nothing out of bashing underbrush and all related terrain that bash into withered plants outright. Cutting/digging grass for straw is already noticeably better as a way to get cordage en mass anyway so not vital to nerf I feel.
3. Converted the yield of all misc mineral materials from mining rock walls from a bunch of tiny RNG rolls to a call to a new itemgroup, `rock_mining_extra`. Additionally took out the janky 0-1 hindrance to spawning rock salt and rhodonite, and changed range of zincite from 0-5 to 1-4.
4. Set smoothed rock to have its potential bonus rock salt at just straight 10% chance instead of 10% chance to spawn 0-1 rock salt, and added a chance to spawn limestone (with amount scaled down based on its rock yield relative to solid rock).
5. Gave strange temple rocks the same possible results given they seem to be more or less smoothed rock in all but their anomalous puzzle properties.
6. Updated boulders so all types give limestone 80% of the time just as solid rock does, instead scaling min and max amounts based on how much lower their rock yield is. Additionally they can all call a result from `rock_mining_extra`, and that gets its chance to spawn scaled by how fewer rocks you get from the boulder. Medium boulders get the same amount of limestone as smoothed rock since same amount of basic rocks.
7. Large boulders have had their standard rock yield scaled down to be about 80% that of solid rock walls, making it nice and consistent to have their limestone yield and chance of extra minerals likewise be 80% that of solid rock.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Adding a wider variety of ore items to boulder and solid rock results. Dunno which would really fit for random New England rock content so.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Did math :<
3. Load-tested, smashed boulders, obtained limestone.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
