### PR TITLE
fix: Prevents reloading from deleting containers

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8186,7 +8186,7 @@ bool item::reload( player &u, item &loc, int qty )
             }
         }
 
-        detached_ptr<item> to_reload = ammo->split(qty);
+        detached_ptr<item> to_reload = ammo->split( qty );
         bool merged = false;
         for( item *it : contents.all_items_top() ) {
             if( it->merge_charges( std::move( to_reload ) ) ) {
@@ -8244,15 +8244,15 @@ bool item::reload( player &u, item &loc, int qty )
             ammo->charges -= qty;
             charges += qty;
         }
-		// we have transfered ammo from the container to the item
-		// therefore, we erase the 0-charge item inside container
-		// TODO: why don't we just remove 0-charge items?
-		if( ammo->charges == 0 && !ammo->has_flag( flag_SPEEDLOADER ) ) {
-			ammo->detach();
-			if(container!=nullptr){
-				u.inv_restack();
-			}
-	    }
+        // we have transfered ammo from the container to the item
+        // therefore, we erase the 0-charge item inside container
+        // TODO: why don't we just remove 0-charge items?
+        if( ammo->charges == 0 && !ammo->has_flag( flag_SPEEDLOADER ) ) {
+            ammo->detach();
+            if( container != nullptr ) {
+                u.inv_restack();
+            }
+        }
     }
 
     return true;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8186,9 +8186,7 @@ bool item::reload( player &u, item &loc, int qty )
             }
         }
 
-        detached_ptr<item> to_reload = item::spawn( *ammo );
-        to_reload->charges = qty;
-        ammo->charges -= qty;
+        detached_ptr<item> to_reload = ammo->split(qty);
         bool merged = false;
         for( item *it : contents.all_items_top() ) {
             if( it->merge_charges( std::move( to_reload ) ) ) {
@@ -8246,19 +8244,17 @@ bool item::reload( player &u, item &loc, int qty )
             ammo->charges -= qty;
             charges += qty;
         }
+		// we have transfered ammo from the container to the item
+		// therefore, we erase the 0-charge item inside container
+		// TODO: why don't we just remove 0-charge items?
+		if( ammo->charges == 0 && !ammo->has_flag( flag_SPEEDLOADER ) ) {
+			ammo->detach();
+			if(container!=nullptr){
+				u.inv_restack();
+			}
+	    }
     }
 
-    // we have transfered ammo from the container to the item
-    // therefore, we erase the 0-charge item inside container
-    // TODO: why don't we just remove 0-charge items?
-    if( ammo->charges == 0 && !ammo->has_flag( flag_SPEEDLOADER ) ) {
-        if( container != nullptr && !container->contents.empty() ) {
-            container->remove_item( container->contents.front() );
-            u.inv_restack( ); // emptied containers do not stack with non-empty ones
-        } else {
-            loc.detach();
-        }
-    }
     return true;
 }
 


### PR DESCRIPTION
## Purpose of change

Fixes #4068.

## Describe the solution

Moves magazine reloading to the new safer stack splitting system and moves the old charges==0 check to the one branch that still uses the old stuff. 

## Describe alternatives you've considered

Cleaning it up further, moving that last branch to the newer stuff and sorting out whatever's going on with speedloaders is probably a good idea at some point. 

## Testing

The reported bug (i.e. reloading liquids), reloading magazines, reloading singles and reloading with a speedloader. 