### PR TITLE
fix: stops linoleum from granting 1500 nails per tile

### DIFF
--- a/data/json/deconstruction.json
+++ b/data/json/deconstruction.json
@@ -140,7 +140,7 @@
     "required_skills": [ [ "fabrication", 2 ] ],
     "time": "10 m",
     "using": [ [ "linoleum_removal_standard", 1 ] ],
-    "byproducts": [ { "item": "splinter", "count": [ 0, 3 ] }, { "item": "nail", "count": [ 8, 15 ] } ],
+    "byproducts": [ { "item": "splinter", "count": [ 0, 3 ] }, { "item": "nail", "charges": [ 8, 15 ] } ],
     "pre_terrain": "t_linoleum_white",
     "post_terrain": "t_thconc_floor",
     "group": "remove_linoleum_tiles"
@@ -153,7 +153,7 @@
     "required_skills": [ [ "fabrication", 2 ] ],
     "time": "10 m",
     "using": [ [ "linoleum_removal_standard", 1 ] ],
-    "byproducts": [ { "item": "splinter", "count": [ 0, 3 ] }, { "item": "nail", "count": [ 8, 15 ] } ],
+    "byproducts": [ { "item": "splinter", "count": [ 0, 3 ] }, { "item": "nail", "charges": [ 8, 15 ] } ],
     "pre_terrain": "t_linoleum_gray",
     "post_terrain": "t_thconc_floor",
     "group": "remove_linoleum_tiles"


### PR DESCRIPTION
## Purpose of change

Someone used count for nails instead of charges when deconstructing linoleum. I noticed this because I'm the proud owner of about 6000 nails from partially renovating an evac shelter.

## Describe the solution

I replaced count with charges.

## Describe alternatives you've considered

Creating a typhoon of nails.

## Testing

Backported to my game so I could actually renovate my evac shelter.

## Additional context
Before
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/112293514/b32143b5-7154-4375-9222-d0edcf53bb2e)
After
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/112293514/01e02d42-0d43-4bcc-b867-0403be111dd1)
