### PR TITLE
docs: add info for mutation enchantments

### DIFF
--- a/doc/src/content/docs/en/mod/json/reference/creatures/effects_json.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/effects_json.md
@@ -84,6 +84,34 @@ have an additional field:
 If a creature successfully damages the player and their chance roll succeeds they will apply all of
 the listed effects to the player. The effects are added one after another.
 
+### Mutations
+
+Mutations can give effects with the field "enchantments", the following mutation grants a special attack.
+The enchant provided after the ink gland mutation permanently affects armor values on the player.
+
+{
+    "type": "mutation",
+    "id": "INK_GLANDS",
+    "name": { "str": "Ink glands" },
+    "points": 1,
+    "visibility": 1,
+    "ugliness": 1,
+    "description": "Several ink glands have grown onto your torso.  They can be used to spray defensive ink and blind an attacker in an emergency, as long as the torso isn't covered.",
+    "enchantments": [ "MEP_INK_GLAND_SPRAY" ],
+    "category": [ "CEPHALOPOD" ]
+  },
+  {
+    "type": "enchantment",
+    "id": "ENCH_BIO_CARBON",
+    "condition": "ALWAYS",
+    "values": [
+      { "value": "ARMOR_BASH", "multiply": -0.05 },
+      { "value": "ARMOR_CUT", "multiply": -0.1 },
+      { "value": "ARMOR_STAB", "multiply": -0.08 },
+      { "value": "ARMOR_BULLET", "multiply": -0.15 }
+    ]
+  }
+
 ## Required fields
 
 ```json

--- a/doc/src/content/docs/en/mod/json/reference/creatures/effects_json.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/effects_json.md
@@ -89,6 +89,7 @@ the listed effects to the player. The effects are added one after another.
 Mutations can give effects with the field "enchantments", the following mutation grants a special
 attack. The enchant provided after the ink gland mutation permanently affects armor values on the
 player.
+
 ```json
 {
     "type": "mutation",
@@ -113,6 +114,7 @@ player.
     ]
   }
 ```
+
 ## Required fields
 
 ```json

--- a/doc/src/content/docs/en/mod/json/reference/creatures/effects_json.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/effects_json.md
@@ -86,31 +86,17 @@ the listed effects to the player. The effects are added one after another.
 
 ### Mutations
 
-Mutations can give effects with the field "enchantments", the following mutation grants a special attack.
-The enchant provided after the ink gland mutation permanently affects armor values on the player.
+Mutations can give effects with the field "enchantments", the following mutation grants a special
+attack. The enchant provided after the ink gland mutation permanently affects armor values on the
+player.
 
-{
-    "type": "mutation",
-    "id": "INK_GLANDS",
-    "name": { "str": "Ink glands" },
-    "points": 1,
-    "visibility": 1,
-    "ugliness": 1,
-    "description": "Several ink glands have grown onto your torso.  They can be used to spray defensive ink and blind an attacker in an emergency, as long as the torso isn't covered.",
-    "enchantments": [ "MEP_INK_GLAND_SPRAY" ],
-    "category": [ "CEPHALOPOD" ]
-  },
-  {
-    "type": "enchantment",
-    "id": "ENCH_BIO_CARBON",
-    "condition": "ALWAYS",
-    "values": [
-      { "value": "ARMOR_BASH", "multiply": -0.05 },
-      { "value": "ARMOR_CUT", "multiply": -0.1 },
-      { "value": "ARMOR_STAB", "multiply": -0.08 },
-      { "value": "ARMOR_BULLET", "multiply": -0.15 }
-    ]
-  }
+{ "type": "mutation", "id": "INK_GLANDS", "name": { "str": "Ink glands" }, "points": 1,
+"visibility": 1, "ugliness": 1, "description": "Several ink glands have grown onto your torso. They
+can be used to spray defensive ink and blind an attacker in an emergency, as long as the torso isn't
+covered.", "enchantments": [ "MEP_INK_GLAND_SPRAY" ], "category": [ "CEPHALOPOD" ] }, { "type":
+"enchantment", "id": "ENCH_BIO_CARBON", "condition": "ALWAYS", "values": [ { "value": "ARMOR_BASH",
+"multiply": -0.05 }, { "value": "ARMOR_CUT", "multiply": -0.1 }, { "value": "ARMOR_STAB",
+"multiply": -0.08 }, { "value": "ARMOR_BULLET", "multiply": -0.15 } ] }
 
 ## Required fields
 

--- a/doc/src/content/docs/en/mod/json/reference/creatures/effects_json.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/effects_json.md
@@ -89,15 +89,30 @@ the listed effects to the player. The effects are added one after another.
 Mutations can give effects with the field "enchantments", the following mutation grants a special
 attack. The enchant provided after the ink gland mutation permanently affects armor values on the
 player.
-
-{ "type": "mutation", "id": "INK_GLANDS", "name": { "str": "Ink glands" }, "points": 1,
-"visibility": 1, "ugliness": 1, "description": "Several ink glands have grown onto your torso. They
-can be used to spray defensive ink and blind an attacker in an emergency, as long as the torso isn't
-covered.", "enchantments": [ "MEP_INK_GLAND_SPRAY" ], "category": [ "CEPHALOPOD" ] }, { "type":
-"enchantment", "id": "ENCH_BIO_CARBON", "condition": "ALWAYS", "values": [ { "value": "ARMOR_BASH",
-"multiply": -0.05 }, { "value": "ARMOR_CUT", "multiply": -0.1 }, { "value": "ARMOR_STAB",
-"multiply": -0.08 }, { "value": "ARMOR_BULLET", "multiply": -0.15 } ] }
-
+```json
+{
+    "type": "mutation",
+    "id": "INK_GLANDS",
+    "name": { "str": "Ink glands" },
+    "points": 1,
+    "visibility": 1,
+    "ugliness": 1,
+    "description": "Several ink glands have grown onto your torso.  They can be used to spray defensive ink and blind an attacker in an emergency, as long as the torso isn't covered.",
+    "enchantments": [ "MEP_INK_GLAND_SPRAY" ],
+    "category": [ "CEPHALOPOD" ]
+  },
+  {
+    "type": "enchantment",
+    "id": "ENCH_BIO_CARBON",
+    "condition": "ALWAYS",
+    "values": [
+      { "value": "ARMOR_BASH", "multiply": -0.05 },
+      { "value": "ARMOR_CUT", "multiply": -0.1 },
+      { "value": "ARMOR_STAB", "multiply": -0.08 },
+      { "value": "ARMOR_BULLET", "multiply": -0.15 }
+    ]
+  }
+```
 ## Required fields
 
 ```json

--- a/doc/src/content/docs/en/mod/json/reference/json_info.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_info.md
@@ -1282,6 +1282,7 @@ wake up for the first time after 24 hours into the game.
                "msg_transform": "You turn your photophore OFF.", // message displayed upon transformation
                "active": false , // Will the target mutation start powered ( turn ON ).
                "moves": 100 // how many moves this costs. (default: 0)
+"enchantments": [ "MEP_INK_GLAND_SPRAY" ], // Applies this enchantment to the player. See magic.md and effects_json.md
 }
 ```
 


### PR DESCRIPTION
## Purpose of change

There was poor documentation for adding effects via mutation, I added documentation for doing this with mutation enchantments.

## Describe the solution

In json_info.md The field for enchantments is added.

in effects_json.md I gave an in-repo example of a mutation that grants an enchantment, and an example of an enchantment that grants a permanent effect.

## Describe alternatives you've considered

Keeping it a mystery because that's funnier. Bugging others.

## Testing

It's docs.

## Additional context

Pain