### PR TITLE
fix: `2storymodern04` garage

### DIFF
--- a/data/json/mapgen/house/2storymodern04.json
+++ b/data/json/mapgen/house/2storymodern04.json
@@ -106,9 +106,10 @@
         "ᨖ": "t_carpet_red",
         "₸": "t_sidewalk",
         "K": "t_sidewalk",
-        "U": "t_concrete",
-        "N": "t_concrete",
-        "q": "t_concrete"
+        "`": "t_thconc_floor",
+        "U": "t_thconc_floor",
+        "N": "t_thconc_floor",
+        "q": "t_thconc_floor"
       },
       "furniture": { "֎": "f_counter", "₸": "f_deckchair" },
       "items": { "֎": { "item": "liquor_and_spirits", "chance": 30 } },


### PR DESCRIPTION
## Purpose of change
Just like the bungalow02 garage, the "t_concrete" terrain used in the garage doesn't have the INDOORS flag and must be replaced because it's weird to be able to see the sky in the garage or to be glared by the sun inside.
## Describe the solution
Replace "t_concrete" with "t_thconc_floor".
## Describe alternatives you've considered
Creates "t_concrete" with an INDOORS flag.
Do nothing.
## Testing
1. Check the JSON for errors.
2. No errors when starting a new character.
## Additional context

Before:

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/40c89db5-508f-42b5-9b7c-c2ea6c25ec6a

<img width="960" alt="image1" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/a8dd793a-515e-4c22-8d6f-8ab39e8c58d6">
After:

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/4bfdd1bb-1895-4520-bb69-30ae57b1de4d

<img width="960" alt="image2" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/69624655-0790-46a3-bddd-7249aa8c4ea0">