### PR TITLE
fix: `pick_safe_adjacent_tile` returning invalid position

### DIFF
--- a/src/character_functions.cpp
+++ b/src/character_functions.cpp
@@ -648,7 +648,7 @@ std::optional<tripoint> pick_safe_adjacent_tile( const Character &who )
         }
     }
 
-    return random_entry( ret );
+    return random_entry_opt( ret );
 }
 
 bool is_bp_immune_to( const Character &who, body_part bp, damage_unit dam )


### PR DESCRIPTION
## Purpose of change

- fixes #4137 

## Describe the solution

return `std::nullopt` instead of default initialized value

## Describe alternatives you've considered

RIIR

## Testing

worked in my machine

## Additional context

prerequisite for patches i'm making in #4125