### PR TITLE
fix: road connection for rural gas station

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -212,7 +212,7 @@
       { "point": [ 0, 0, 0 ], "overmap": "s_gas_rural_north" },
       { "point": [ 0, 0, 1 ], "overmap": "s_gas_rural_roof_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true, "from": [ 0, 0, 0 ] } ],
     "locations": [ "land" ],
     "city_distance": [ 20, -1 ],
     "occurrences": [ 0, 2 ],

--- a/data/json/overmap/overmap_terrain/overmap_terrain_commercial.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_commercial.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "overmap_terrain",
-    "id": [ "s_gas", "s_gas_1", "s_gas_rural" ],
+    "id": [ "s_gas", "s_gas_1" ],
     "copy-from": "generic_city_building",
     "name": "gas station",
     "color": "light_blue",
@@ -9,8 +9,23 @@
   },
   {
     "type": "overmap_terrain",
-    "id": [ "s_gas_roof_1", "s_gas_rural_roof" ],
+    "id": "s_gas_roof_1",
     "copy-from": "generic_city_building",
+    "name": "gas station roof",
+    "color": "light_blue"
+  },
+  {
+    "type": "overmap_terrain",
+    "id": "s_gas_rural",
+    "copy-from": "generic_city_building_no_sidewalk",
+    "name": "gas station",
+    "color": "light_blue",
+    "extend": { "flags": [ "SOURCE_FUEL", "SOURCE_VEHICLES" ] }
+  },
+  {
+    "type": "overmap_terrain",
+    "id": "s_gas_rural_roof",
+    "copy-from": "generic_city_building_no_sidewalk",
     "name": "gas station roof",
     "color": "light_blue"
   },


### PR DESCRIPTION
## Purpose of change
Connect the rural gas station to the road.
## Describe the solution
Modify overmap_terrain_commercial.json to remove the sidewalk of the rural gas station.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/cebd9347-d23d-44db-a926-549685958d89">
After:
<img width="960" alt="image2" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/2b776d31-4b69-41d0-bcb2-7ba8ecfb6038">