### PR TITLE
fix: give the SIDEWALK flag to the augmentation clinic

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain_afs.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_afs.json
@@ -67,6 +67,7 @@
     "spawns": { "group": "AFS_GROUP_AUG_CLINIC", "population": [ 4, 10 ], "chance": 80 },
     "sym": "A",
     "color": "yellow",
-    "see_cost": 3
+    "see_cost": 3,
+    "flags": [ "SIDEWALK" ]
   }
 ]


### PR DESCRIPTION
## Purpose of change
Fix because sometimes the clinic entrance is not connected to the sidewalk.
## Describe the solution
Give the SIDEWALK flag to the clinic.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/c2499526-cba1-4dc0-80b2-76b9a21b128a">
After:
<img width="960" alt="image2" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/9a25a3c3-e693-4e63-a578-b5f25b67ca15">