### PR TITLE
fix: `s_grocery_1` outdoor terrain

### DIFF
--- a/data/json/mapgen/s_grocery.json
+++ b/data/json/mapgen/s_grocery.json
@@ -180,8 +180,8 @@
     "object": {
       "fill_ter": "t_floor",
       "rows": [
-        "                       '",
-        "                        ",
+        "           ss          '",
+        "           ss           ",
         "  ---:::---++---:::---  ",
         "  |..................|  ",
         "  |..................|  ",
@@ -206,14 +206,15 @@
         "                        "
       ],
       "terrain": {
-        " ": [ "t_grass", "t_grass", "t_grass", "t_dirt" ],
-        "'": "t_dirt",
+        " ": "t_region_groundcover_urban",
+        "'": "t_region_groundcover_urban",
         "+": "t_door_c",
         "-": "t_wall_w",
         ".": "t_floor",
         ":": "t_window",
         "4": "t_gutter_downspout",
-        "|": "t_wall_w"
+        "|": "t_wall_w",
+        "s": "t_sidewalk"
       },
       "furniture": {
         "'": "f_street_light",


### PR DESCRIPTION
## Purpose of change
Fix `s_grocery_1` outdoor terrain.
## Describe the solution
Use "t_region_groundcover_urban" and connect the grocery store to the sidewalk.
## Describe alternatives you've considered
Do nothing.
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/965a0fae-5442-4cc9-8ed4-440fa974c9ad">
After:
<img width="960" alt="image2" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/358f3089-dd50-440e-b045-f87907d9c018">