### PR TITLE
fix: uaf in safe references

### DIFF
--- a/src/safe_reference.h
+++ b/src/safe_reference.h
@@ -154,6 +154,7 @@ class safe_reference
                 } else {
                     rec->mem_count--;
                     rec = rec->target.redirect;
+                    rec->mem_count++;
                 }
             }
         }
@@ -368,13 +369,12 @@ class safe_reference
             if( sec_rec->id == ID_NONE ) {
                 sec_rec->id = REDIRECTED_MASK;
                 sec_rec->target.redirect = pri_rec;
-            }
-
-            //They both have an id
-            if( pri_rec->id != ID_NONE && sec_rec->id != ID_NONE ) {
+                pri_rec->mem_count++;
+            }else{
                 //This is the worse case, we actually need a redirect
                 sec_rec->id = sec_rec->id | REDIRECTED_MASK;
                 sec_rec->target.redirect = pri_rec;
+                pri_rec->mem_count++;
             }
         }
 

--- a/src/safe_reference.h
+++ b/src/safe_reference.h
@@ -370,7 +370,7 @@ class safe_reference
                 sec_rec->id = REDIRECTED_MASK;
                 sec_rec->target.redirect = pri_rec;
                 pri_rec->mem_count++;
-            }else{
+            } else {
                 //This is the worse case, we actually need a redirect
                 sec_rec->id = sec_rec->id | REDIRECTED_MASK;
                 sec_rec->target.redirect = pri_rec;


### PR DESCRIPTION
## Purpose of change

Fixes #4108.

## Describe the solution

Counts the references correctly. It was missing the increment on redirect resolution and wasn't counting the redirected entries themselves. 

## Testing

Works on the save in the linked issue, tried 3 times without a crash when the crash rate was 100% before. 
