### PR TITLE
fix: orchard processing, stall roof

### DIFF
--- a/data/json/mapgen/orchard_apple.json
+++ b/data/json/mapgen/orchard_apple.json
@@ -73,6 +73,42 @@
   {
     "type": "mapgen",
     "method": "json",
+    "om_terrain": "orchard_processing_roof",
+    "object": {
+      "fill_ter": "t_metal_flat_roof",
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "   ..................   ",
+        "   ..................   ",
+        "   ..................   ",
+        "   ..................   ",
+        "   ..................   ",
+        "   ..................   ",
+        "   ..................   ",
+        "   ..................   ",
+        "   ..................   ",
+        "   ..................   ",
+        "   ..................   ",
+        "   ..................   ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "palettes": [ "roof_palette" ],
+      "terrain": { ".": "t_metal_flat_roof" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
     "om_terrain": [ "orchard_stall" ],
     "weight": 500,
     "object": {
@@ -152,6 +188,41 @@
         { "monster": "GROUP_ZOMBIE", "x": [ 1, 22 ], "y": [ 1, 22 ], "chance": 45 }
       ],
       "place_vehicles": [ { "vehicle": "suburban_home", "x": 4, "y": 17, "chance": 50, "rotation": -90 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": "orchard_stall_roof",
+    "object": {
+      "fill_ter": "t_flat_roof",
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "            ..........  ",
+        "            ..........  ",
+        "            ..........  ",
+        "            ..........  ",
+        "            ..........  ",
+        "            ..........  ",
+        "            ..........  ",
+        "            ..........  ",
+        "            ..........  ",
+        "                        ",
+        "                        "
+      ],
+      "palettes": [ "roof_palette" ]
     }
   },
   {

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -2122,10 +2122,12 @@
     "id": "Apple Orchard",
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "orchard_processing_north" },
+      { "point": [ 0, 0, 1 ], "overmap": "orchard_processing_roof_north" },
       { "point": [ 1, 0, 0 ], "overmap": "orchard_tree_apple_north" },
       { "point": [ 2, 0, 0 ], "overmap": "orchard_tree_apple_north" },
       { "point": [ 3, 0, 0 ], "overmap": "orchard_tree_apple_north" },
       { "point": [ 0, 1, 0 ], "overmap": "orchard_stall_north" },
+      { "point": [ 0, 1, 1 ], "overmap": "orchard_stall_roof_north" },
       { "point": [ 1, 1, 0 ], "overmap": "orchard_tree_apple_north" },
       { "point": [ 2, 1, 0 ], "overmap": "orchard_tree_apple_north" },
       { "point": [ 3, 1, 0 ], "overmap": "orchard_tree_apple_north" },

--- a/data/json/overmap/overmap_terrain/overmap_terrain_agricultural.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_agricultural.json
@@ -285,12 +285,28 @@
   },
   {
     "type": "overmap_terrain",
+    "id": "orchard_processing_roof",
+    "copy-from": "generic_rural_building",
+    "name": "orchard processing roof",
+    "sym": "T",
+    "color": "i_light_green"
+  },
+  {
+    "type": "overmap_terrain",
     "id": "orchard_stall",
     "copy-from": "generic_rural_building",
     "name": "orchard stall",
     "sym": "T",
     "color": "i_light_green",
     "mondensity": 3
+  },
+  {
+    "type": "overmap_terrain",
+    "id": "orchard_stall_roof",
+    "copy-from": "generic_rural_building",
+    "name": "orchard stall roof",
+    "sym": "T",
+    "color": "i_light_green"
   },
   {
     "type": "overmap_terrain",


### PR DESCRIPTION
## Purpose of change
Put a roof over `orchard_processing`, `orchard_stall` mapgen.
## Describe the solution
Create roofs.
## Describe alternatives you've considered
Terrain can place roofs over them with "roof" in their JSON, but this is not a good solution.
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/7cf71032-d12a-4f22-a417-749303836fbb">
<img width="960" alt="image2" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/1a773a2d-495c-4231-a85a-3463d6af117c">
After:
<img width="960" alt="image3" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/6f777466-4693-48da-b460-6a812fc5984f">
<img width="960" alt="image4" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/7fcc9aa4-8952-41e1-8a3d-ef7ab58d43aa">