### PR TITLE
fix: tapping maple trees

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -3576,7 +3576,7 @@ void iexamine::tree_maple_tapped( player &p, const tripoint &examp )
         }
 
         case HARVEST_SAP: {
-            liquid_handler::handle_liquid( *container, PICKUP_RANGE );
+            liquid_handler::handle_liquid( container->contents.front(), PICKUP_RANGE );
             return;
         }
 


### PR DESCRIPTION
## Purpose of change

Fixes #4101.

## Describe the solution

It was handling the container rather than the contents. Note that the check that the contents exists is done before enabling that menu option. 
