### PR TITLE
fix: wielded weapon show correct ammocount when selecting gunmod, default firemode name for gunmods

### DIFF
--- a/src/character_functions.cpp
+++ b/src/character_functions.cpp
@@ -434,7 +434,7 @@ std::string fmt_wielded_weapon( const Character &who )
     }
     const item &weapon = who.primary_weapon();
     if( weapon.is_gun() ) {
-        std::string str = string_format( "(%d) [%s] %s", weapon.ammo_remaining(),
+        std::string str = string_format( "(%d) [%s] %s", weapon.gun_current_mode()->ammo_remaining(),
                                          weapon.gun_current_mode().tname(), weapon.type_name() );
         // Is either the base item or at least one auxiliary gunmod loaded (includes empty magazines)
         bool base = weapon.ammo_capacity() > 0 && !weapon.has_flag( flag_RELOAD_AND_SHOOT );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -172,7 +172,9 @@ namespace
 // TODO: add explicit action field to gun definitions
 auto defmode_name( itype &obj )
 {
-    if( obj.gun->clip == 1 ) {
+    if( obj.mod ) {
+        return translate_marker( "gunmod" ); // grenade launchers
+    } else if( obj.gun->clip == 1 ) {
         return translate_marker( "manual" ); // break-type actions
     } else if( obj.gun->skill_used == skill_id( "pistol" ) && obj.has_flag( flag_RELOAD_ONE ) ) {
         return translate_marker( "revolver" );


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This helps make it a bit more visible when your wielded weapon is currently set to fire an attached gunmod, because it's easy to look at the wield query after flipping past full-auto, forgetting that the next fire mode is an M203 and not returning to semi-auto, and oops I exploded again.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. In character_functions.cpp, set `fmt_wielded_weapon` so that the ammo counter for the currently wielded weapon actually matches the ammo count of the current fire mode used, meaning the number of shots shown will properly change when you switch from a gun's normal firing modes to any attached gunmods.
2. In item_factory.cpp, set `defmode_name` so that gunmods will generate a default fire mode name telling you at a glance that the selected fire mode has you switched to a gunmod. This can of course be override by any gunmods that define their own fire modes, such as with bayonets.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Also someday coding in minimum arming distance for muh realisms.
2. Figuring out how to make ammo counter say `n/a` instead of zero when a bayonet is selected.
3. Continuing to blow myself up :<

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Spawned in as a grenadier, confirmed that switching my M4 to use the M203 shows the correct ammo count and says the fire mode is `gunmod`
3. Swapped the M203 out for a bayonet and switched fire mode to it, confirmed it doesn't do anything weird. Shows no ammo since bayonet is melee, and fire mode listed is `bayonet` instead of `gunmod` since not a default fire mode name.
4. Checked affected file for syntax and lint errors.

![1](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/fd111b8e-b54b-4d21-9d85-086585341892)

![2](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/d769729f-72b3-460a-8250-95182548a354)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Having stuff like more than one shootable gunmod installed (like an M203 and a rail-mounted crossbow for example) can still potentially confuse the player since chances are they'll both show as `(1) [gunmod] etcetc` but it's still more information than the player got previously. :3

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
