### PR TITLE
fix: `garden_3x3_2`, `garden_3x3_3` nested mapgen

### DIFF
--- a/data/json/mapgen/nested/house_nested.json
+++ b/data/json/mapgen/nested/house_nested.json
@@ -1829,6 +1829,7 @@
         "111"
       ],
       "palettes": [ "house_w_nest_garden_palette" ],
+      "terrain": { "1": "t_dirtfloor_no_roof" },
       "place_items": [
         { "item": "farming_tools", "x": [ 0, 2 ], "y": [ 0, 2 ], "chance": 5, "repeat": [ 1, 3 ] },
         { "item": "farming_seeds", "x": [ 0, 2 ], "y": [ 0, 2 ], "chance": 75, "repeat": [ 1, 3 ] }
@@ -1848,7 +1849,8 @@
         "1Z1",
         "111"
       ],
-      "palettes": [ "house_w_nest_garden_palette" ]
+      "palettes": [ "house_w_nest_garden_palette" ],
+      "terrain": { "1": "t_dirtfloor_no_roof" }
     }
   },
   {


### PR DESCRIPTION
## Purpose of change
Fix because "t_dirtfloor" used under the planters of these two nested mapgen should not be used outdoors.
## Describe the solution
Use "t_dirtfloor_no_roof".
## Describe alternatives you've considered
none
## Additional context
Before:
`garden_3x3_3` used around the cathedral.
<img width="960" alt="image1" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/10e1fe22-d6f2-4510-bf4f-04fc320e0cce">
After:
<img width="960" alt="image2" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/ca0399eb-1215-4d85-a8b4-21471e123cb8">