### PR TITLE
fix: don't spawn grenade launchers installed on magazines

### DIFF
--- a/data/json/itemgroups/Clothing_Gear/clothing.json
+++ b/data/json/itemgroups/Clothing_Gear/clothing.json
@@ -388,7 +388,7 @@
       { "item": "legpouch_large", "prob": 75 },
       { "item": "legrig", "prob": 50 },
       { "item": "dump_pouch", "prob": 50 },
-      { "item": "grenadebandolier", "prob": 25 },
+      { "item": "grenade_pouch", "prob": 25 },
       { "item": "grenadebandolier", "prob": 25 }
     ]
   },

--- a/data/json/itemgroups/Weapons_Mods_Ammo/everydaycarry_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/everydaycarry_guns.json
@@ -896,6 +896,18 @@
     "entries": [ { "item": "m4a1", "charges-min": 0, "charges-max": 30 }, { "item": "stanag30" }, { "item": "stanag30", "prob": 50 } ]
   },
   {
+    "id": "everyday_m4a1_grenadier",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack.  Grenadier variant",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "m4a1", "charges-min": 0, "charges-max": 30, "contents-group": "military_accessories_grenadier" },
+      { "item": "stanag30" },
+      { "item": "stanag30", "prob": 50 }
+    ]
+  },
+  {
     "id": "everyday_m1918",
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
@@ -940,6 +952,18 @@
     ]
   },
   {
+    "id": "everyday_h&k416a5_grenadier",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack.  Grenadier variant",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "h&k416a5", "charges-min": 0, "charges-max": 30, "contents-group": "military_accessories_grenadier" },
+      { "item": "stanag30" },
+      { "item": "stanag30", "prob": 50 }
+    ]
+  },
+  {
     "id": "everyday_m27iar",
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
@@ -961,6 +985,18 @@
       { "item": "stanag100", "ammo-item": "556_incendiary", "container-item": "m27iar", "charges-min": 0, "charges-max": 100 },
       { "item": "stanag100", "ammo-item": "556_incendiary" },
       { "item": "stanag100", "prob": 50, "ammo-item": "556_incendiary" }
+    ]
+  },
+  {
+    "id": "everyday_m27iar_grenadier",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack.  Grenadier variant",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "m27iar", "charges-min": 0, "charges-max": 30, "contents-group": "military_accessories_grenadier" },
+      { "item": "stanag30" },
+      { "item": "stanag30", "prob": 50 }
     ]
   },
   {
@@ -1085,6 +1121,18 @@
       { "item": "scar_h", "charges-min": 0, "charges-max": 20 },
       { "item": "scarhmag" },
       { "item": "scarhmag", "prob": 50 }
+    ]
+  },
+  {
+    "id": "everyday_scar_h_grenadier",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack.  Grenadier variant",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "scar_h", "charges-min": 0, "charges-max": 30, "contents-group": "military_accessories_grenadier" },
+      { "item": "stanag30" },
+      { "item": "stanag30", "prob": 50 }
     ]
   },
   {

--- a/data/json/itemgroups/Weapons_Mods_Ammo/everydaycarry_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/everydaycarry_guns.json
@@ -1130,9 +1130,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "scar_h", "charges-min": 0, "charges-max": 30, "contents-group": "military_accessories_grenadier" },
-      { "item": "stanag30" },
-      { "item": "stanag30", "prob": 50 }
+      { "item": "scar_h", "charges-min": 0, "charges-max": 20, "contents-group": "military_accessories_grenadier" },
+      { "item": "scarhmag" },
+      { "item": "scarhmag", "prob": 50 }
     ]
   },
   {

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -86,7 +86,15 @@
     "entries": [
       {
         "collection": [
-          { "group": "military_standard_assault_rifles", "contents-group": "military_accessories_grenadier" },
+          {
+            "distribution": [
+              { "group": "everyday_m4a1_grenadier", "prob": 75, "charges": [ 0, 30 ] },
+              { "group": "everyday_m27iar_grenadier", "prob": 10, "charges": [ 0, 30 ] },
+              { "group": "everyday_h&k416a5_grenadier", "prob": 5, "charges": [ 0, 30 ] },
+              { "group": "everyday_scar_h_grenadier", "prob": 5, "charges": [ 0, 30 ] },
+              { "item": "m16a4", "prob": 5, "charges": [ 0, 30 ], "contents-group": "military_accessories_grenadier" }
+            ]
+          },
           { "group": "on_hand_40x46mm" }
         ],
         "prob": 90


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

So recently I spotted a weird lil error: when a gun spawn (like zombie soldier drops) generates the grenadier variant, it also spawns M203s attached to the spare magazines that spawn, leading to this oddity when you try to unload them:
![e](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/1a19cec9-c721-4e09-92a3-e5eb0df5b421)

Along the way I spotted another smol mistake that I figured is minor enough to bundle in this.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Redefined contents of `military_standard_grenadier` to define grenadier-specific versions of the sub-itemgroups in `military_standard_assault_rifles` instead of using the itemgroup wholesale, so it won't also apply the gunmod to the spare mags derp.
2. Defined the above-mentioned variants of the relevant everyday-carry itemgroups, which spawn the relevant gun with `military_accessories_grenadier` added to them, then the relevant spare mags.
3. Misc: Fixed `clothing_tactical_leg` having two calls to spawn hand grenade pouches instead of one call to that and a call to grenade ammo pouches.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Screaming.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Ported JSON changes to test build, spawned in and debug-killed a bunch of zombie soldiers.
4. Sifted through for grenadier-variant weapon drops, confirmed the rifles correctly have a grenade launcher attatched while the spare STANAG mags don't let me unload M203s off them.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
