### PR TITLE
fix: hides after being smoked get merged into one

### DIFF
--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -2263,6 +2263,7 @@
     "weight": "100 g",
     "volume": "125 ml",
     "category": "spare_parts",
+    "stackable":true,
     "to_hit": -1
   },
   {
@@ -2279,6 +2280,7 @@
     "weight": "114 g",
     "volume": "170 ml",
     "category": "spare_parts",
+    "stackable":true,
     "to_hit": -1
   },
   {

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -2263,7 +2263,7 @@
     "weight": "100 g",
     "volume": "125 ml",
     "category": "spare_parts",
-    "stackable":true,
+    "stackable": true,
     "to_hit": -1
   },
   {
@@ -2280,7 +2280,7 @@
     "weight": "114 g",
     "volume": "170 ml",
     "category": "spare_parts",
-    "stackable":true,
+    "stackable": true,
     "to_hit": -1
   },
   {


### PR DESCRIPTION
## Purpose of change

After being smoked, the hides and felts get a correct number.

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution

Put the field `"stackable":true`

Then it looks fixed at all.


<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

## Describe alternatives you've considered

screm

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

### Before

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/129575271/d99d9af9-43bd-484f-824c-3ec15006ec09)


### After

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/129575271/8456787c-ac41-4aa8-9b47-3c84ad26cfd2)



<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
