### PR TITLE
feat(balance): further standardize and increase use of ranged bash info

### DIFF
--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -38,7 +38,7 @@
         { "item": "cu_pipe", "count": [ 1, 4 ] },
         { "item": "scrap_copper", "count": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 50 }
+      "ranged": { "reduction": [ 9, 18 ], "destroy_threshold": 50 }
     }
   },
   {
@@ -79,7 +79,7 @@
         { "item": "e_scrap", "count": [ 5, 10 ] },
         { "item": "plastic_chunk", "count": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 50 }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 50 }
     }
   },
   {
@@ -124,7 +124,7 @@
         { "item": "cu_pipe", "count": [ 1, 4 ] },
         { "item": "scrap_copper", "count": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 9, 18 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -165,7 +165,7 @@
         { "item": "element", "count": [ 1, 3 ] },
         { "item": "cable", "charges": [ 1, 15 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 9, 18 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -292,7 +292,7 @@
         { "item": "cable", "charges": [ 1, 4 ] },
         { "item": "plastic_chunk", "count": [ 2, 4 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 100, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 100, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -367,7 +367,7 @@
         { "item": "glass_shard", "count": [ 2, 4 ] },
         { "item": "motor_tiny", "prob": 25 }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 50 }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 50 }
     }
   },
   {
@@ -512,7 +512,7 @@
         { "item": "cu_pipe", "count": [ 1, 4 ] },
         { "item": "scrap_copper", "count": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 50 }
+      "ranged": { "reduction": [ 9, 18 ], "destroy_threshold": 50 }
     }
   },
   {
@@ -555,7 +555,7 @@
         { "item": "cu_pipe", "count": [ 1, 4 ] },
         { "item": "scrap_copper", "count": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 9, 18 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -587,7 +587,7 @@
         { "item": "cable", "charges": [ 1, 3 ] },
         { "item": "pilot_light", "count": 1 }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 30, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 30, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -622,7 +622,7 @@
         { "item": "water_faucet", "count": 1 },
         { "item": "pot", "count": [ 0, 1 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 30, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 30, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -657,7 +657,7 @@
         { "item": "scrap", "count": [ 0, 6 ] },
         { "item": "wire", "count": [ 1, 3 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 30, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 30, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -695,7 +695,7 @@
         { "item": "scrap", "count": [ 10, 20 ] },
         { "item": "pipe", "count": [ 1, 3 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 30, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 30, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -774,7 +774,7 @@
         { "item": "e_scrap", "count": [ 20, 50 ] },
         { "item": "cable", "charges": [ 2, 8 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 50 }
+      "ranged": { "reduction": [ 8, 16 ], "destroy_threshold": 40 }
     }
   },
   {
@@ -817,7 +817,7 @@
         { "item": "cable", "charges": [ 1, 15 ] },
         { "item": "scrap_copper", "count": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 50 }
+      "ranged": { "reduction": [ 9, 18 ], "destroy_threshold": 50 }
     }
   },
   {
@@ -935,7 +935,8 @@
         { "item": "cable", "charges": [ 2, 8 ] },
         { "item": "small_storage_battery", "count": [ 4, 16 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 16, "block_unaimed_chance": "50%" }
+      "//": "destroy_threshold equal to str_min instead of str_max due to delicate electronics",
+      "ranged": { "reduction": [ 8, 16 ], "destroy_threshold": 16, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -976,7 +977,8 @@
         { "item": "cable", "charges": [ 2, 8 ] },
         { "item": "small_storage_battery", "count": [ 20, 80 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 16, "block_unaimed_chance": "75%" }
+      "//": "destroy_threshold equal to str_min instead of str_max due to delicate electronics",
+      "ranged": { "reduction": [ 8, 16 ], "destroy_threshold": 16, "block_unaimed_chance": "75%" }
     }
   },
   {
@@ -1016,7 +1018,8 @@
         { "item": "cable", "charges": [ 2, 8 ] },
         { "item": "small_storage_battery", "count": [ 40, 160 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 16 }
+      "//": "destroy_threshold equal to str_min instead of str_max due to delicate electronics",
+      "ranged": { "reduction": [ 8, 16 ], "destroy_threshold": 16 }
     }
   },
   {
@@ -1171,7 +1174,7 @@
         { "item": "scrap", "count": [ 1, 4 ] },
         { "item": "cable", "charges": [ 2, 8 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 8, 16 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -1265,7 +1268,7 @@
         { "item": "plastic_chunk", "count": [ 1, 2 ] },
         { "item": "frame", "count": [ 0, 1 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 30, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 2, 4 ], "destroy_threshold": 30, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -1334,7 +1337,7 @@
         { "item": "cable", "charges": [ 1, 4 ] },
         { "item": "element", "count": [ 2, 6 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 30, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 30, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -1512,7 +1515,7 @@
         { "charges": 0, "item": "food_processor", "prob": 50 },
         { "charges": 0, "item": "press", "prob": 50 }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 9, 18 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -1613,7 +1616,7 @@
         { "item": "cable", "charges": [ 2, 8 ] },
         { "item": "frame", "count": [ 0, 1 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 30, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 30, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -1680,7 +1683,7 @@
         { "item": "scrap_copper", "count": [ 1, 2 ] },
         { "item": "motor_tiny", "prob": 25 }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 50 }
+      "ranged": { "reduction": [ 9, 18 ], "destroy_threshold": 50 }
     }
   },
   {
@@ -1802,7 +1805,7 @@
         { "item": "hose", "prob": 50 },
         { "item": "motor_tiny", "prob": 25 }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 50, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 9, 18 ], "destroy_threshold": 50, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -1892,7 +1895,7 @@
         { "item": "sheet_metal", "count": [ 1, 4 ] },
         { "item": "cable", "charges": [ 1, 1 ] }
       ],
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -2080,7 +2083,8 @@
         { "item": "plut_cell", "charges": [ 0, 3 ] },
         { "item": "lead", "charges": [ 12, 18 ] }
       ],
-      "ranged": { "reduction": [ 25, 50 ], "destroy_threshold": 75, "block_unaimed_chance": "50%" }
+      "//": "destroy_threshold equal to str_min instead of str_max due to delicate electronics",
+      "ranged": { "reduction": [ 25, 50 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
     },
     "deconstruct": {
       "items": [

--- a/data/json/furniture_and_terrain/furniture-barriers.json
+++ b/data/json/furniture_and_terrain/furniture-barriers.json
@@ -13,12 +13,12 @@
     "examine_action": "chainfence",
     "deconstruct": { "items": [ { "item": "2x4", "count": 6 }, { "item": "nail", "charges": 12 } ] },
     "bash": {
-      "str_min": 3,
+      "str_min": 6,
       "str_max": 40,
       "sound": "smash!",
       "sound_fail": "whump.",
       "items": [ { "item": "2x4", "count": [ 2, 6 ] }, { "item": "nail", "charges": [ 4, 8 ] }, { "item": "splinter", "count": 1 } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 3, 6 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -51,7 +51,8 @@
       "sound": "rrrip!",
       "sound_fail": "whump.",
       "items": [ { "item": "bag_canvas", "count": [ 10, 16 ] }, { "item": "material_soil", "charges": [ 40, 48 ] } ],
-      "ranged": { "reduction": [ 75, 75 ], "destroy_threshold": 75, "block_unaimed_chance": "50%" }
+      "//": "reduction and destroy_threshold equal to str_max of full-sized wall version, designed for ballistic protection",
+      "ranged": { "reduction": [ 80, 80 ], "destroy_threshold": 80, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -74,7 +75,8 @@
       "sound_fail": "whump.",
       "furn_set": "f_earthbag_half",
       "items": [ { "item": "bag_canvas", "count": [ 15, 20 ] }, { "item": "material_soil", "charges": [ 50, 60 ] } ],
-      "ranged": { "reduction": [ 100, 100 ], "destroy_threshold": 100 }
+      "//": "reduction equal to str_max due to being designed for ballistic protection",
+      "ranged": { "reduction": [ 80, 80 ], "destroy_threshold": 80 }
     }
   },
   {
@@ -124,7 +126,8 @@
       "sound": "rrrip!",
       "sound_fail": "whump.",
       "items": [ { "item": "bag_canvas", "count": [ 10, 16 ] }, { "item": "material_sand", "charges": [ 800, 960 ] } ],
-      "ranged": { "reduction": [ 75, 75 ], "destroy_threshold": 75, "block_unaimed_chance": "50%" }
+      "//": "reduction and destroy_threshold equal to str_max of full-sized wall version, designed for ballistic protection",
+      "ranged": { "reduction": [ 80, 80 ], "destroy_threshold": 80, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -146,7 +149,8 @@
       "sound_fail": "whump.",
       "furn_set": "f_sandbag_half",
       "items": [ { "item": "bag_canvas", "count": [ 15, 20 ] }, { "item": "material_sand", "charges": [ 1000, 1200 ] } ],
-      "ranged": { "reduction": [ 100, 100 ], "destroy_threshold": 100 }
+      "//": "reduction equal to str_max due to being designed for ballistic protection",
+      "ranged": { "reduction": [ 80, 80 ], "destroy_threshold": 80 }
     }
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-decorative.json
+++ b/data/json/furniture_and_terrain/furniture-decorative.json
@@ -18,7 +18,8 @@
       "sound_vol": 16,
       "furn_set": "f_bigmirror_b",
       "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 5 }
+      "//": "destroy_threshold equal to str_min as fragile glass breaks into standing mirror frame, reduction matches that of broken mirror",
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 5 }
     }
   },
   {
@@ -38,7 +39,7 @@
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "items": [ { "item": "scrap", "count": [ 2, 4 ] } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 30 }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 30 }
     }
   },
   {
@@ -117,7 +118,8 @@
       "sound": "smash!",
       "sound_fail": "thump.",
       "items": [ { "item": "rock", "count": [ 1, 6 ] } ],
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 30, "block_unaimed_chance": "50%" }
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 16, 32 ], "destroy_threshold": 32, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -137,7 +139,7 @@
       "sound": "smash!",
       "sound_fail": "whump.",
       "items": [ { "item": "splinter", "count": [ 9, 12 ] } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 3, 6 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -157,7 +159,8 @@
       "sound": "smash!",
       "sound_fail": "thump.",
       "items": [ { "item": "rock", "count": [ 1, 6 ] }, { "item": "rebar", "count": [ 1, 2 ] } ],
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 15, "block_unaimed_chance": "25%" }
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 16, 32 ], "destroy_threshold": 32, "block_unaimed_chance": "25%" }
     }
   },
   {

--- a/data/json/furniture_and_terrain/furniture-fireplaces.json
+++ b/data/json/furniture_and_terrain/furniture-fireplaces.json
@@ -17,7 +17,8 @@
       "sound": "crash!",
       "sound_fail": "whump!",
       "items": [ { "item": "rock", "count": [ 15, 30 ] } ],
-      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 80, "block_unaimed_chance": "75%" }
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 50, 100 ], "destroy_threshold": 100, "block_unaimed_chance": "75%" }
     }
   },
   {
@@ -39,7 +40,7 @@
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "items": [ { "item": "scrap", "count": [ 3, 6 ] }, { "item": "pipe", "prob": 50 } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 30, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 30, "block_unaimed_chance": "50%" }
     },
     "deconstruct": { "items": [ { "item": "metal_tank", "count": 1 }, { "item": "pipe", "count": 1 } ] }
   },
@@ -66,7 +67,7 @@
         { "item": "steel_chunk", "count": [ 2, 6 ] },
         { "item": "sheet_metal_small", "count": [ 2, 6 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 30, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 30, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -118,7 +119,7 @@
         { "item": "sheet_metal_small", "count": [ 3, 10 ] },
         { "item": "sheet_metal", "count": [ 0, 1 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 30, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 30, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -145,7 +146,7 @@
         { "item": "sheet_metal_small", "count": [ 2, 5 ] },
         { "item": "sheet_metal", "count": [ 0, 1 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 30, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 30, "block_unaimed_chance": "25%" }
     }
   },
   {

--- a/data/json/furniture_and_terrain/furniture-graves.json
+++ b/data/json/furniture_and_terrain/furniture-graves.json
@@ -17,6 +17,7 @@
       "sound": "smash!",
       "sound_fail": "thump.",
       "items": [ { "item": "rock", "count": [ 2, 7 ] } ],
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
       "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
     }
   },
@@ -38,7 +39,8 @@
       "sound": "crash!",
       "sound_fail": "thump!",
       "items": [ { "item": "rock", "count": [ 2, 4 ] } ],
-      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 80, "block_unaimed_chance": "25%" }
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 50, 100 ], "destroy_threshold": 100, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -59,7 +61,8 @@
       "sound": "crash!",
       "sound_fail": "thump!",
       "items": [ { "item": "rock", "count": [ 8, 14 ] } ],
-      "ranged": { "reduction": [ 50, 100 ], "destroy_threshold": 100, "block_unaimed_chance": "50%" }
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 60, 120 ], "destroy_threshold": 120, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -79,7 +82,8 @@
       "sound": "crash!",
       "sound_fail": "thump!",
       "items": [ { "item": "rock", "count": [ 5, 10 ] } ],
-      "ranged": { "reduction": [ 30, 60 ], "destroy_threshold": 60, "block_unaimed_chance": "25%" }
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 80, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -99,7 +103,8 @@
       "sound": "crash!",
       "sound_fail": "thunk!",
       "items": [ { "item": "rock", "count": [ 18, 30 ] } ],
-      "ranged": { "reduction": [ 60, 120 ], "destroy_threshold": 120 }
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 80, 160 ], "destroy_threshold": 160 }
     }
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-industrial.json
+++ b/data/json/furniture_and_terrain/furniture-industrial.json
@@ -27,7 +27,7 @@
         { "item": "plastic_chunk", "count": [ 10, 12 ] },
         { "item": "scrap", "count": [ 6, 8 ] }
       ],
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 150, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 150, "block_unaimed_chance": "25%" }
     },
     "deconstruct": {
       "items": [
@@ -68,7 +68,7 @@
         { "item": "jerrycan", "count": [ 0, 2 ] },
         { "item": "metal_tank", "count": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 150, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 150, "block_unaimed_chance": "25%" }
     },
     "deconstruct": {
       "items": [
@@ -123,7 +123,7 @@
         { "item": "scrap", "count": [ 2, 5 ] },
         { "item": "motor", "prob": 30 }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 45, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 45, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -156,7 +156,7 @@
         { "item": "steel_chunk", "count": [ 120, 240 ] },
         { "item": "scrap", "count": [ 120, 240 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 75, "block_unaimed_chance": "75%" }
+      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 150, "block_unaimed_chance": "75%" }
     }
   },
   {

--- a/data/json/furniture_and_terrain/furniture-medical.json
+++ b/data/json/furniture_and_terrain/furniture-medical.json
@@ -38,7 +38,8 @@
         { "item": "plastic_chunk", "count": [ 4, 10 ], "prob": 50 },
         { "item": "scrap", "count": [ 2, 6 ], "prob": 50 }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 75, "block_unaimed_chance": "25%" }
+      "//": "destroy_threshold equal to str_min instead of str_max due to delicate electronics",
+      "ranged": { "reduction": [ 8, 16 ], "destroy_threshold": 16, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -67,7 +68,8 @@
         { "item": "splinter", "count": [ 1, 2 ] },
         { "item": "rag", "count": [ 20, 30 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 20, "block_unaimed_chance": "25%" }
+      "//": "destroy_threshold equal to str_min instead of str_max due to delicate electronics",
+      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 10, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -107,7 +109,7 @@
         { "item": "cu_pipe", "count": [ 1, 4 ] },
         { "item": "scrap_copper", "count": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -193,7 +195,7 @@
         { "item": "cable", "charges": [ 1, 3 ] },
         { "item": "cu_pipe", "count": 1 }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 80, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 18, 35 ], "destroy_threshold": 80, "block_unaimed_chance": "50%" }
     },
     "examine_action": "workbench",
     "workbench": { "multiplier": 1.15, "mass": "300 kg", "volume": "100L" }
@@ -243,7 +245,7 @@
         { "item": "glass_shard", "count": [ 3, 6 ] },
         { "item": "cable", "charges": [ 1, 2 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 60, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 13, 25 ], "destroy_threshold": 60, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -283,7 +285,7 @@
         { "item": "element", "count": [ 1, 3 ] },
         { "item": "cable", "charges": [ 1, 15 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 60, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 13, 25 ], "destroy_threshold": 60, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -387,7 +389,7 @@
         { "item": "e_scrap", "count": [ 5, 10 ] },
         { "item": "plastic_chunk", "count": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 50, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 9, 18 ], "destroy_threshold": 50, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -433,7 +435,7 @@
         { "item": "e_scrap", "count": [ 5, 10 ] },
         { "item": "plastic_chunk", "count": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 70, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 11, 22 ], "destroy_threshold": 70, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -475,7 +477,7 @@
         { "item": "e_scrap", "count": [ 5, 10 ] },
         { "item": "plastic_chunk", "count": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 70, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 12, 24 ], "destroy_threshold": 70, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -516,7 +518,7 @@
         { "item": "e_scrap", "count": [ 5, 10 ] },
         { "item": "plastic_chunk", "count": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 70, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 19, 38 ], "destroy_threshold": 70, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -557,7 +559,7 @@
         { "item": "e_scrap", "count": [ 5, 10 ] },
         { "item": "plastic_chunk", "count": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 70, "block_unaimed_chance": "75%" }
+      "ranged": { "reduction": [ 18, 35 ], "destroy_threshold": 70, "block_unaimed_chance": "75%" }
     }
   },
   {
@@ -599,7 +601,7 @@
         { "item": "e_scrap", "count": [ 5, 10 ] },
         { "item": "plastic_chunk", "count": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 80, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 80, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -641,7 +643,7 @@
         { "item": "e_scrap", "count": [ 5, 10 ] },
         { "item": "plastic_chunk", "count": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 80, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 80, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -677,7 +679,7 @@
         { "item": "sheet_metal", "count": [ 1, 2 ] },
         { "item": "plastic_chunk", "count": [ 5, 10 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 50, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 9, 18 ], "destroy_threshold": 50, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -724,7 +726,7 @@
         { "item": "e_scrap", "count": [ 5, 10 ] },
         { "item": "plastic_chunk", "count": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 50, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 9, 18 ], "destroy_threshold": 50, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -769,7 +771,7 @@
         { "item": "e_scrap", "count": [ 5, 10 ] },
         { "item": "plastic_chunk", "count": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 9, 18 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -814,7 +816,7 @@
         { "item": "e_scrap", "count": [ 5, 10 ] },
         { "item": "plastic_chunk", "count": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 50, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 9, 18 ], "destroy_threshold": 50, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -907,7 +909,7 @@
       ]
     },
     "bash": {
-      "str_min": 3,
+      "str_min": 12,
       "str_max": 45,
       "sound": "crunch!",
       "sound_fail": "whack!",
@@ -919,7 +921,8 @@
         { "item": "sheet_metal", "count": [ 1, 3 ] },
         { "item": "cable", "charges": [ 1, 15 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 20, "block_unaimed_chance": "25%" }
+      "//": "destroy_threshold equal to str_min instead of str_max due to delicate electronics",
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 12, "block_unaimed_chance": "25%" }
     }
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-migo.json
+++ b/data/json/furniture_and_terrain/furniture-migo.json
@@ -40,7 +40,7 @@
       "sound_fail": "whump!",
       "furn_set": "f_alien_scar_small",
       "items": [ { "item": "fetid_goop", "count": [ 3, 7 ], "prob": 100 } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 26, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 7, 13 ], "destroy_threshold": 26, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -63,7 +63,7 @@
       "sound_fail": "whump!",
       "furn_set": "f_alien_scar_small",
       "items": [ { "item": "fetid_goop", "count": [ 15, 25 ], "prob": 100 } ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 60, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 60, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -100,7 +100,8 @@
       "sound": "splorch!",
       "sound_fail": "splat!",
       "items": [ { "item": "fetid_goop", "count": [ 6, 13 ], "prob": 100 } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 300, "block_unaimed_chance": "25%" }
+      "//": "reduction matches that of weakest furniture that turns into this when destroyed",
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 600, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -143,7 +144,7 @@
       "sound": "splorch!",
       "sound_fail": "whump.",
       "items": [ { "item": "fetid_goop", "count": [ 5, 10 ], "prob": 100 }, { "group": "migo_pod_storage", "prob": 50 } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -165,7 +166,7 @@
       "sound": "splorch!",
       "sound_fail": "whump.",
       "items": [ { "group": "migo_pod_samples", "prob": 75, "count": [ 1, 2 ] } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -186,7 +187,7 @@
       "sound": "splorch!",
       "sound_fail": "whump.",
       "items": [ { "item": "alien_pod_resin", "count": [ 1, 2 ] } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -207,7 +208,7 @@
       "sound": "splorch!",
       "sound_fail": "whump.",
       "furn_set": "f_alien_scar",
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 60, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 23, 45 ], "destroy_threshold": 60, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -232,7 +233,7 @@
       "sound_fail": "whump!",
       "furn_set": "f_alien_scar",
       "items": [ { "item": "fetid_goop", "count": [ 3, 5 ], "prob": 100 } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
     }
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-plumbing.json
+++ b/data/json/furniture_and_terrain/furniture-plumbing.json
@@ -23,7 +23,8 @@
         { "item": "water_faucet", "prob": 50 },
         { "item": "ceramic_shard", "count": [ 6, 18 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 12, "block_unaimed_chance": "25%" }
+      "//": "ceramic obstacles have destroy_threshold equal to str_min since more fragile",
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 12, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -50,7 +51,8 @@
         { "item": "ceramic_shard", "count": [ 2, 6 ] },
         { "item": "glass_shard", "count": [ 1, 2 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 6, "block_unaimed_chance": "25%" }
+      "//": "ceramic obstacles have destroy_threshold equal to str_min since more fragile",
+      "ranged": { "reduction": [ 3, 6 ], "destroy_threshold": 6, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -74,7 +76,8 @@
         { "item": "water_faucet", "prob": 50 },
         { "item": "ceramic_shard", "count": [ 2, 8 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 8, "block_unaimed_chance": "25%" }
+      "//": "ceramic obstacles have destroy_threshold equal to str_min since more fragile",
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 8, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -95,7 +98,8 @@
       "sound": "porcelain breaking!",
       "sound_fail": "whunk!",
       "items": [ { "item": "cu_pipe", "prob": 50 }, { "item": "ceramic_shard", "count": [ 2, 8 ] }, { "item": "wax", "count": 1 } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 8, "block_unaimed_chance": "25%" }
+      "//": "ceramic obstacles have destroy_threshold equal to str_min since more fragile",
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 8, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -117,7 +121,7 @@
       "sound": "reality shattering!",
       "sound_fail": "whunk!",
       "items": [ { "item": "cu_pipe", "prob": 50 }, { "item": "sheet_metal", "count": [ 2, 8 ] }, { "item": "pipe", "count": 1 } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 30, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 30, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -164,7 +168,7 @@
         { "item": "scrap_copper", "count": [ 0, 2 ] },
         { "item": "water_faucet", "count": [ 0, 1 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 9, 18 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -244,7 +248,7 @@
         { "item": "plastic_chunk", "count": [ 0, 2 ] },
         { "item": "cu_pipe", "count": [ 1, 3 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 50, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 8, 15 ], "destroy_threshold": 50, "block_unaimed_chance": "25%" }
     }
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-recreation.json
+++ b/data/json/furniture_and_terrain/furniture-recreation.json
@@ -29,7 +29,7 @@
         { "item": "pipe", "count": 1 },
         { "item": "lead", "charges": [ 1000, 2000 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 60, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 9, 18 ], "destroy_threshold": 60, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -80,7 +80,7 @@
         { "item": "splinter", "count": 1 },
         { "item": "felt_patch", "count": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -119,6 +119,7 @@
       "sound": "clang!",
       "sound_fail": "ting.",
       "items": [ { "item": "steel_plate", "count": 1 }, { "item": "pipe", "count": [ 1, 3 ] } ],
+      "//": "reduction equal to str_max due to being designed to soak up bullets",
       "ranged": { "reduction": [ 40, 40 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
     }
   },
@@ -160,7 +161,7 @@
         { "item": "power_supply", "prob": 50 },
         { "item": "RAM", "count": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 35, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 3, 6 ], "destroy_threshold": 35, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -208,7 +209,7 @@
         { "item": "plastic_chunk", "count": [ 1, 3 ] },
         { "item": "bearing", "charges": [ 0, 16 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -314,7 +315,7 @@
         { "item": "leather", "count": [ 4, 12 ] },
         { "item": "rag", "count": [ 4, 18 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 20, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 8, 15 ], "destroy_threshold": 20, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -352,7 +353,7 @@
         { "item": "splinter", "count": 1 },
         { "item": "plastic_chunk", "count": [ 1, 5 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -392,7 +393,7 @@
         { "item": "e_scrap", "prob": 25 },
         { "item": "plastic_chunk", "count": [ 0, 1 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 20, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 20, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -453,7 +454,7 @@
         { "item": "felt_patch", "count": [ 0, 2 ] },
         { "item": "scrap", "count": [ 0, 1 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -495,7 +496,7 @@
         { "item": "steel_chunk", "count": [ 1, 4 ] },
         { "item": "cable", "count": [ 1, 3 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40 }
+      "ranged": { "reduction": [ 8, 16 ], "destroy_threshold": 40 }
     }
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-roof.json
+++ b/data/json/furniture_and_terrain/furniture-roof.json
@@ -66,11 +66,12 @@
     "deconstruct": { "items": [ { "item": "sheet_metal", "count": 2 }, { "item": "brick", "count": 30 } ] },
     "bash": {
       "str_min": 15,
-      "str_max": 25,
+      "str_max": 50,
       "sound": "whack!",
       "sound_fail": "whump!",
       "items": [ { "item": "brick", "count": [ 5, 30 ] }, { "item": "scrap", "count": [ 3, 6 ] } ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 20, "block_unaimed_chance": "25%" }
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 30, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -137,7 +138,7 @@
       "sound": "whack!",
       "sound_fail": "clang!",
       "items": [ { "item": "sheet_metal_small", "count": [ 1, 5 ] }, { "item": "scrap", "count": [ 3, 6 ] } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 15, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 12, "block_unaimed_chance": "25%" }
     }
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-seats.json
+++ b/data/json/furniture_and_terrain/furniture-seats.json
@@ -20,7 +20,7 @@
       "sound": "smash!",
       "sound_fail": "whump.",
       "items": [ { "item": "2x4", "count": [ 1, 3 ] }, { "item": "nail", "charges": [ 2, 6 ] }, { "item": "splinter", "count": 1 } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -49,7 +49,7 @@
         { "item": "splinter", "count": 1 },
         { "item": "rag", "count": [ 20, 30 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -80,7 +80,7 @@
         { "item": "rag", "count": [ 20, 30 ] },
         { "item": "rope_6" }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -104,7 +104,7 @@
       "sound": "smash!",
       "sound_fail": "whump.",
       "items": [ { "item": "2x4", "count": [ 1, 3 ] }, { "item": "nail", "charges": [ 2, 6 ] }, { "item": "splinter", "count": 1 } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 20, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 3, 6 ], "destroy_threshold": 20, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -132,7 +132,7 @@
         { "item": "splinter", "count": [ 1, 2 ] },
         { "item": "rag", "count": [ 20, 30 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -156,7 +156,7 @@
       "sound": "smash!",
       "sound_fail": "whump.",
       "items": [ { "item": "2x4", "count": 1 }, { "item": "nail", "charges": [ 1, 5 ] }, { "item": "splinter", "count": 3 } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 20, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 3, 6 ], "destroy_threshold": 20, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -200,7 +200,7 @@
       "sound": "smash!",
       "sound_fail": "whump.",
       "items": [ { "item": "splinter", "count": [ 2, 6 ] } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -235,7 +235,7 @@
         { "item": "nail", "charges": [ 1, 3 ] },
         { "item": "rag", "count": [ 5, 10 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 3, 5 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -262,7 +262,7 @@
         { "item": "sheet_metal", "count": [ 0, 1 ] },
         { "item": "pipe", "count": [ 0, 4 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 200, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 7, 15 ], "destroy_threshold": 200, "block_unaimed_chance": "25%" }
     },
     "deconstruct": { "items": [ { "item": "scrap", "count": 3 }, { "item": "sheet_metal", "count": 1 }, { "item": "pipe", "count": 4 } ] }
   }

--- a/data/json/furniture_and_terrain/furniture-signs.json
+++ b/data/json/furniture_and_terrain/furniture-signs.json
@@ -13,7 +13,7 @@
     "examine_action": "bulletin_board",
     "deconstruct": { "items": [ { "item": "2x4", "count": 4 }, { "item": "nail", "charges": 8 } ] },
     "bash": {
-      "str_min": 3,
+      "str_min": 6,
       "str_max": 40,
       "sound": "crunch!",
       "sound_fail": "whump.",
@@ -22,7 +22,7 @@
         { "item": "nail", "charges": [ 4, 6 ] },
         { "item": "splinter", "count": [ 1, 4 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "75%" }
+      "ranged": { "reduction": [ 3, 6 ], "destroy_threshold": 40, "block_unaimed_chance": "75%" }
     }
   },
   {
@@ -44,7 +44,7 @@
       "sound": "smash!",
       "sound_fail": "whump.",
       "items": [ { "item": "2x4", "count": [ 1, 2 ] }, { "item": "nail", "charges": [ 2, 4 ] }, { "item": "splinter", "count": 2 } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 3, 6 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -67,7 +67,7 @@
       "sound": "smash!",
       "sound_fail": "whump.",
       "items": [ { "item": "2x4", "count": [ 1, 2 ] }, { "item": "nail", "charges": [ 2, 4 ] }, { "item": "splinter", "count": 2 } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 3, 6 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
     }
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-sleep.json
+++ b/data/json/furniture_and_terrain/furniture-sleep.json
@@ -25,7 +25,7 @@
         { "item": "rag", "count": [ 40, 55 ] },
         { "item": "scrap", "count": [ 10, 20 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -55,7 +55,7 @@
         { "item": "rag", "count": [ 80, 110 ] },
         { "item": "scrap", "count": [ 20, 40 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -91,7 +91,7 @@
         { "item": "rag", "count": [ 120, 160 ] },
         { "item": "scrap", "count": [ 60, 100 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 60, "block_unaimed_chance": "75%" }
+      "ranged": { "reduction": [ 13, 25 ], "destroy_threshold": 60, "block_unaimed_chance": "75%" }
     }
   },
   {
@@ -196,7 +196,7 @@
         { "item": "splinter", "count": [ 1, 4 ] },
         { "item": "rag", "count": [ 20, 30 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 30, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 30, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -223,7 +223,7 @@
         { "item": "straw_pile", "count": [ 7, 8 ] },
         { "item": "splinter", "count": [ 1, 2 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 20, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 3, 6 ], "destroy_threshold": 20, "block_unaimed_chance": "25%" }
     }
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-storage.json
+++ b/data/json/furniture_and_terrain/furniture-storage.json
@@ -22,7 +22,7 @@
         { "item": "nail", "charges": [ 4, 12 ] },
         { "item": "splinter", "count": [ 5, 10 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40 }
+      "ranged": { "reduction": [ 3, 6 ], "destroy_threshold": 40 }
     }
   },
   {
@@ -50,7 +50,7 @@
         { "item": "splinter", "count": [ 6, 10 ] },
         { "item": "wood_panel", "count": [ 0, 1 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40 }
+      "ranged": { "reduction": [ 3, 6 ], "destroy_threshold": 40 }
     }
   },
   {
@@ -97,7 +97,7 @@
         { "item": "nail", "charges": [ 2, 10 ] },
         { "item": "rag", "count": [ 8, 12 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
     },
     "pry": {
       "success_message": "You wedge open the coffin.",
@@ -139,7 +139,7 @@
         { "item": "nail", "charges": [ 2, 10 ] },
         { "item": "rag", "count": [ 8, 12 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -171,7 +171,7 @@
       "sound": "smash!",
       "sound_fail": "wham!",
       "items": [ { "item": "2x4", "count": [ 1, 5 ] }, { "item": "nail", "charges": [ 2, 10 ] } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
     },
     "pry": {
       "success_message": "You pop open the crate.",
@@ -200,7 +200,7 @@
       "sound": "smash!",
       "sound_fail": "wham!",
       "items": [ { "item": "2x4", "count": [ 1, 5 ] }, { "item": "nail", "charges": [ 2, 10 ] } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -261,7 +261,7 @@
         { "item": "nail", "charges": [ 4, 8 ] },
         { "item": "splinter", "count": [ 5, 10 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -298,7 +298,7 @@
         { "item": "glass_shard", "count": [ 1, 10 ] },
         { "item": "scrap", "count": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -325,6 +325,7 @@
         { "item": "scrap", "count": [ 1, 5 ] },
         { "item": "rock", "count": [ 1, 2 ] }
       ],
+      "//": "double the expected damage reduction",
       "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 200, "block_unaimed_chance": "75%" }
     }
   },
@@ -352,6 +353,7 @@
         { "item": "scrap", "count": [ 1, 5 ] },
         { "item": "rock", "count": [ 1, 2 ] }
       ],
+      "//": "double the expected damage reduction",
       "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 200, "block_unaimed_chance": "75%" }
     }
   },
@@ -381,6 +383,7 @@
         { "item": "scrap", "count": [ 1, 5 ] },
         { "item": "rock", "count": [ 1, 2 ] }
       ],
+      "//": "double the expected damage reduction",
       "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 200, "block_unaimed_chance": "75%" }
     }
   },
@@ -408,6 +411,7 @@
         { "item": "scrap", "count": [ 1, 5 ] },
         { "item": "rock", "count": [ 1, 2 ] }
       ],
+      "//": "double the expected damage reduction",
       "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 200, "block_unaimed_chance": "75%" }
     }
   },
@@ -436,6 +440,7 @@
         { "item": "scrap", "count": [ 1, 5 ] },
         { "item": "rock", "count": [ 1, 2 ] }
       ],
+      "//": "double the expected damage reduction",
       "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 200, "block_unaimed_chance": "75%" }
     }
   },
@@ -463,7 +468,7 @@
         { "item": "sheet_metal_small", "count": [ 4, 8 ] },
         { "item": "pipe", "count": [ 0, 1 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40 }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 40 }
     }
   },
   {
@@ -557,7 +562,7 @@
         { "item": "sheet_metal_small", "count": [ 4, 8 ] },
         { "item": "pipe", "count": 1 }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 30, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 3, 6 ], "destroy_threshold": 30, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -580,7 +585,7 @@
       "sound": "smash!",
       "sound_fail": "whump.",
       "items": [ { "item": "2x4", "count": [ 2, 6 ] }, { "item": "nail", "charges": [ 20, 40 ] }, { "item": "splinter", "count": 12 } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 3, 6 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -622,7 +627,7 @@
       "sound": "smash!",
       "sound_fail": "whump.",
       "items": [ { "item": "plastic_chunk", "count": [ 2, 7 ] }, { "item": "pipe", "count": [ 1, 2 ] } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 30, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 30, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -650,6 +655,7 @@
         { "item": "scrap", "count": [ 1, 5 ] },
         { "item": "rock", "count": [ 1, 2 ] }
       ],
+      "//": "double the expected damage reduction",
       "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 200, "block_unaimed_chance": "25%" }
     }
   },
@@ -678,6 +684,7 @@
         { "item": "scrap", "count": [ 1, 5 ] },
         { "item": "rock", "count": [ 1, 2 ] }
       ],
+      "//": "double the expected damage reduction",
       "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 200, "block_unaimed_chance": "25%" }
     }
   },
@@ -705,6 +712,7 @@
         { "item": "scrap", "count": [ 1, 5 ] },
         { "item": "rock", "count": [ 1, 2 ] }
       ],
+      "//": "double the expected damage reduction",
       "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 200, "block_unaimed_chance": "25%" }
     }
   },
@@ -760,7 +768,7 @@
         { "item": "pipe", "count": [ 0, 1 ] },
         { "item": "scrap", "count": [ 2, 5 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40 }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 40 }
     }
   },
   {
@@ -789,7 +797,7 @@
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "items": [ { "item": "scrap", "count": [ 0, 6 ] }, { "item": "sheet_metal", "count": [ 0, 4 ] } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 30, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 30, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -823,7 +831,7 @@
         { "item": "sheet_metal_small", "count": [ 1, 4 ] },
         { "item": "pipe", "count": 1 }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 30, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 8, 16 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -852,7 +860,7 @@
         { "item": "sheet_metal_small", "count": [ 4, 8 ] },
         { "item": "pipe", "count": 4 }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 40 }
+      "ranged": { "reduction": [ 8, 16 ], "destroy_threshold": 40 }
     }
   },
   {
@@ -890,7 +898,7 @@
         { "item": "scrap", "count": [ 10, 20 ] },
         { "item": "splinter", "count": 1 }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -914,7 +922,8 @@
       "sound_fail_vol": 12,
       "furn_set": "f_displaycase_b",
       "items": [ { "item": "glass_shard", "count": [ 1, 5 ] } ],
-      "ranged": { "reduction": [ 1, 6 ], "destroy_threshold": 5, "block_unaimed_chance": "75%" }
+      "//": "reduction matches that of the underlying broken case, destroy_threshold matches str_min since glass might shatter",
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 6, "block_unaimed_chance": "75%" }
     }
   },
   {
@@ -935,7 +944,7 @@
       "sound": "crunch!",
       "sound_fail": "whump.",
       "items": [ { "item": "2x4", "count": [ 3, 6 ] }, { "item": "splinter", "count": [ 2, 4 ] } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 30, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 30, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -982,7 +991,7 @@
         { "item": "steel_chunk", "count": [ 1, 3 ] },
         { "item": "pipe", "count": [ 1, 2 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 45, "block_unaimed_chance": "75%" }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 45, "block_unaimed_chance": "75%" }
     }
   },
   {
@@ -1013,7 +1022,7 @@
         { "item": "scrap", "count": [ 10, 20 ] },
         { "item": "splinter", "count": [ 1, 20 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 50, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 50, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -1042,7 +1051,7 @@
         { "item": "scrap", "count": [ 2, 6 ] },
         { "item": "hinge", "charges": 2 }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 30, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
     }
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-surfaces.json
+++ b/data/json/furniture_and_terrain/furniture-surfaces.json
@@ -21,7 +21,7 @@
         { "item": "nail", "charges": [ 4, 8 ] },
         { "item": "splinter", "count": [ 5, 10 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
     },
     "examine_action": "workbench",
     "workbench": { "multiplier": 1.1, "mass": "200 kg", "volume": "75L" }
@@ -49,7 +49,7 @@
         { "item": "nail", "charges": [ 2, 6 ] },
         { "item": "splinter", "count": [ 5, 10 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 30, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 30, "block_unaimed_chance": "50%" }
     },
     "examine_action": "workbench",
     "workbench": { "multiplier": 1.1, "mass": "200 kg", "volume": "75L" }
@@ -80,7 +80,7 @@
         { "item": "nail", "charges": [ 4, 8 ] },
         { "item": "splinter", "count": [ 5, 10 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -132,7 +132,7 @@
         { "item": "nail", "charges": [ 10, 16 ] },
         { "item": "splinter", "count": [ 4, 12 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
     },
     "examine_action": "workbench",
     "workbench": { "multiplier": 1.1, "mass": "200 kg", "volume": "75L" }
@@ -162,7 +162,7 @@
         { "item": "steel_chunk", "count": [ 4, 8 ] },
         { "item": "scrap", "count": [ 12, 24 ] }
       ],
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 80, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 18, 35 ], "destroy_threshold": 80, "block_unaimed_chance": "50%" }
     },
     "examine_action": "workbench",
     "workbench": { "multiplier": 1.2, "mass": "500 kg", "volume": "200L" }
@@ -257,7 +257,7 @@
         { "item": "pipe", "count": [ 1, 3 ] },
         { "item": "sheet_metal_small", "count": [ 4, 8 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 8, 16 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
     },
     "examine_action": "workbench",
     "workbench": { "multiplier": 1.05, "mass": "100 kg", "volume": "35L" }
@@ -285,7 +285,7 @@
         { "item": "nail", "charges": [ 4, 8 ] },
         { "item": "splinter", "count": 1 }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
     },
     "examine_action": "workbench",
     "workbench": { "multiplier": 1.1, "mass": "200 kg", "volume": "75L" }

--- a/data/json/furniture_and_terrain/furniture-terrains.json
+++ b/data/json/furniture_and_terrain/furniture-terrains.json
@@ -804,7 +804,8 @@
         { "item": "material_limestone", "charges": [ 3, 8 ], "prob": 80 },
         { "group": "rock_mining_extra", "prob": 8 }
       ],
-      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 16, 32 ], "destroy_threshold": 32, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -830,7 +831,7 @@
         { "item": "material_limestone", "charges": [ 5, 15 ], "prob": 80 },
         { "group": "rock_mining_extra", "prob": 15 }
       ],
-      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 80, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 32, 64 ], "destroy_threshold": 64, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -855,7 +856,7 @@
         { "item": "material_limestone", "charges": [ 8, 20 ], "prob": 80 },
         { "group": "rock_mining_extra", "prob": 20 }
       ],
-      "ranged": { "reduction": [ 80, 160 ], "destroy_threshold": 160 }
+      "ranged": { "reduction": [ 64, 128 ], "destroy_threshold": 128 }
     }
   },
   {
@@ -893,7 +894,7 @@
         { "item": "cable", "charges": [ 1, 2 ] },
         { "item": "plastic_chunk", "count": [ 2, 4 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 100, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 100, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -921,7 +922,7 @@
         { "item": "cable", "charges": [ 1, 3 ] },
         { "item": "scrap", "count": [ 3, 12 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 100, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 100, "block_unaimed_chance": "25%" }
     }
   },
   {

--- a/data/json/furniture_and_terrain/furniture-tools.json
+++ b/data/json/furniture_and_terrain/furniture-tools.json
@@ -44,7 +44,7 @@
         { "item": "plastic_chunk", "count": [ 4, 10 ], "prob": 50 },
         { "item": "scrap", "count": [ 2, 6 ], "prob": 50 }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 150, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 8, 16 ], "destroy_threshold": 150, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -93,7 +93,8 @@
         { "item": "plastic_chunk", "count": [ 4, 10 ], "prob": 50 },
         { "item": "scrap", "count": [ 2, 6 ], "prob": 50 }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 8, "block_unaimed_chance": "50%" }
+      "//": "reduction equal to broken version, but destroy_threshold equal to str_min since fragile",
+      "ranged": { "reduction": [ 8, 16 ], "destroy_threshold": 8, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -116,7 +117,7 @@
       "sound": "crunch!",
       "sound_fail": "whump.",
       "items": [ { "item": "char_forge", "count": 1 } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 8, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 2, 4 ], "destroy_threshold": 8, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -138,6 +139,7 @@
       "sound": "crunch!",
       "sound_fail": "whump.",
       "items": [ { "item": "anvil", "count": 1 } ],
+      "//": "reduction equal to str_max since solid steel object",
       "ranged": { "reduction": [ 40, 40 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
     }
   },
@@ -161,7 +163,7 @@
       "sound": "crunch!",
       "sound_fail": "whump.",
       "items": [ { "item": "still", "count": 1 } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 20, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 2, 4 ], "destroy_threshold": 8, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -185,7 +187,8 @@
       "sound": "crash!",
       "sound_fail": "whump!",
       "items": [ { "item": "rock", "count": [ 15, 30 ] }, { "item": "material_soil", "count": [ 0, 1 ] } ],
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 30 }
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 25, 50 ], "destroy_threshold": 50 }
     }
   },
   {
@@ -208,7 +211,8 @@
       "sound": "crash!",
       "sound_fail": "whump!",
       "items": [ { "item": "rock", "count": [ 15, 30 ] }, { "item": "material_soil", "count": [ 0, 1 ] } ],
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 30 }
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 25, 50 ], "destroy_threshold": 50 }
     }
   },
   {
@@ -236,7 +240,7 @@
         { "item": "steel_chunk", "count": [ 0, 3 ] },
         { "item": "pipe", "count": [ 0, 4 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 40 }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 40 }
     }
   },
   {
@@ -263,7 +267,7 @@
         { "item": "steel_chunk", "count": [ 0, 3 ] },
         { "item": "pipe", "count": [ 0, 4 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 40 }
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 40 }
     }
   },
   {
@@ -312,7 +316,7 @@
         { "item": "steel_chunk", "count": [ 5, 20 ] },
         { "item": "scrap", "count": [ 10, 50 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 40 }
+      "ranged": { "reduction": [ 9, 18 ], "destroy_threshold": 40 }
     }
   },
   {
@@ -359,7 +363,7 @@
         { "item": "steel_chunk", "count": [ 5, 20 ] },
         { "item": "scrap", "count": [ 10, 50 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 40 }
+      "ranged": { "reduction": [ 9, 18 ], "destroy_threshold": 40 }
     }
   },
   {
@@ -470,7 +474,8 @@
       "sound": "crash!",
       "sound_fail": "whump.",
       "items": [ { "item": "rock", "count": [ 20, 30 ] }, { "item": "material_soil", "count": [ 0, 2 ] } ],
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 30, "block_unaimed_chance": "25%" }
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 18, 36 ], "destroy_threshold": 36, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -493,7 +498,8 @@
       "sound": "crunch!",
       "sound_fail": "whump.",
       "items": [ { "item": "rock", "count": [ 20, 30 ] } ],
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 30, "block_unaimed_chance": "25%" }
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 18, 36 ], "destroy_threshold": 36, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -543,7 +549,7 @@
         { "item": "steel_chunk", "count": [ 2, 4 ] },
         { "item": "steel_plate", "count": [ 1, 2 ] }
       ],
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 150 }
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 150 }
     },
     "deconstruct": {
       "items": [
@@ -579,7 +585,7 @@
         { "item": "plastic_chunk", "count": [ 4, 10 ] },
         { "item": "steel_plate", "count": [ 2, 4 ] }
       ],
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 150, "block_unaimed_chance": "75%" }
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 150, "block_unaimed_chance": "75%" }
     },
     "deconstruct": {
       "items": [
@@ -618,7 +624,7 @@
         { "item": "plastic_chunk", "count": [ 4, 10 ] },
         { "item": "steel_plate", "count": [ 2, 4 ] }
       ],
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 150, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 150, "block_unaimed_chance": "50%" }
     },
     "deconstruct": {
       "items": [
@@ -657,7 +663,7 @@
         { "item": "plastic_chunk", "count": [ 4, 10 ] },
         { "item": "steel_plate", "count": [ 2, 4 ] }
       ],
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 150, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 150, "block_unaimed_chance": "25%" }
     },
     "deconstruct": {
       "items": [
@@ -695,7 +701,7 @@
         { "item": "plastic_chunk", "count": [ 4, 10 ] },
         { "item": "steel_plate", "count": [ 2, 4 ] }
       ],
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 150, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 150, "block_unaimed_chance": "50%" }
     },
     "deconstruct": {
       "items": [
@@ -733,7 +739,7 @@
         { "item": "plastic_chunk", "count": [ 4, 10 ] },
         { "item": "steel_plate", "count": [ 2, 4 ] }
       ],
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 150, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 150, "block_unaimed_chance": "50%" }
     },
     "deconstruct": {
       "items": [
@@ -771,7 +777,7 @@
         { "item": "plastic_chunk", "count": [ 4, 10 ] },
         { "item": "steel_plate", "count": [ 2, 4 ] }
       ],
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 150, "block_unaimed_chance": "25%" }
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 150, "block_unaimed_chance": "25%" }
     },
     "deconstruct": {
       "items": [
@@ -809,7 +815,7 @@
         { "item": "plastic_chunk", "count": [ 4, 10 ] },
         { "item": "steel_plate", "count": [ 2, 4 ] }
       ],
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 150, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 150, "block_unaimed_chance": "50%" }
     },
     "deconstruct": {
       "items": [
@@ -847,7 +853,7 @@
         { "item": "steel_lump", "count": [ 1, 2 ] },
         { "item": "steel_plate", "count": [ 1, 2 ] }
       ],
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 150, "block_unaimed_chance": "75%" }
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 150, "block_unaimed_chance": "75%" }
     },
     "deconstruct": {
       "items": [
@@ -884,7 +890,7 @@
         { "item": "steel_chunk", "count": [ 2, 4 ] },
         { "item": "steel_lump", "count": [ 1, 2 ] }
       ],
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 150, "block_unaimed_chance": "75%" }
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 150, "block_unaimed_chance": "75%" }
     },
     "deconstruct": {
       "items": [
@@ -937,7 +943,7 @@
         { "item": "e_scrap", "count": [ 5, 10 ] },
         { "item": "plastic_chunk", "count": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 50, "block_unaimed_chance": "75%" }
+      "ranged": { "reduction": [ 9, 18 ], "destroy_threshold": 50, "block_unaimed_chance": "75%" }
     }
   },
   {
@@ -1193,6 +1199,7 @@
       "sound": "glass breaking!",
       "sound_fail": "whack!",
       "furn_set": "f_aut_gas_console_o",
+      "//": "reduction equal to broken version, but destroy_threshold equal to str_min since fragile",      
       "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 7, "block_unaimed_chance": "25%", "flammable": true }
     }
   },
@@ -1209,7 +1216,7 @@
     "required_str": 20,
     "flags": [ "BLOCKSDOOR", "TRANSPARENT" ],
     "bash": {
-      "str_min": 5,
+      "str_min": 10,
       "str_max": 45,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
@@ -1247,7 +1254,7 @@
         { "item": "sheet_metal", "count": [ 0, 2 ] },
         { "item": "steel_chunk", "count": [ 1, 5 ] }
       ],
-      "ranged": { "reduction": [ 50, 100 ], "destroy_threshold": 520 }
+      "ranged": { "reduction": [ 75, 150 ], "destroy_threshold": 520 }
     }
   },
   {
@@ -1272,7 +1279,8 @@
       "sound_fail_vol": 12,
       "furn_set": "f_vending_o",
       "items": [ { "item": "glass_shard", "count": [ 1, 3 ] } ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 20 }
+      "//": "reduction equal to broken version, but destroy_threshold equal to str_min since fragile",
+      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 20 }
     }
   },
   {
@@ -1299,7 +1307,7 @@
         { "item": "cu_pipe", "count": [ 1, 4 ] },
         { "item": "scrap_copper", "count": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 50 }
+      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 50 }
     }
   },
   {

--- a/data/json/furniture_and_terrain/furniture-tools.json
+++ b/data/json/furniture_and_terrain/furniture-tools.json
@@ -1199,7 +1199,7 @@
       "sound": "glass breaking!",
       "sound_fail": "whack!",
       "furn_set": "f_aut_gas_console_o",
-      "//": "reduction equal to broken version, but destroy_threshold equal to str_min since fragile",      
+      "//": "reduction equal to broken version, but destroy_threshold equal to str_min since fragile",
       "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 7, "block_unaimed_chance": "25%", "flammable": true }
     }
   },

--- a/data/json/furniture_and_terrain/terrain-doors.json
+++ b/data/json/furniture_and_terrain/terrain-doors.json
@@ -19,7 +19,9 @@
       "sound_vol": 20,
       "sound_fail_vol": 14,
       "ter_set": "t_mdoor_frame",
-      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] }, { "item": "scrap", "count": [ 3, 5 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] }, { "item": "scrap", "count": [ 3, 5 ] } ],
+      "//": "half that of ballistic glass doors",
+      "ranged": { "reduction": [ 20, 20 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 20 }
     }
   },
   {
@@ -65,7 +67,9 @@
       "sound_vol": 20,
       "sound_fail_vol": 14,
       "ter_set": "t_mdoor_frame",
-      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] }, { "item": "scrap", "count": [ 3, 5 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] }, { "item": "scrap", "count": [ 3, 5 ] } ],
+      "//": "matches that of the other ballistic glass doors",
+      "ranged": { "reduction": [ 40, 40 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 40 }
     }
   },
   {
@@ -112,6 +116,7 @@
       "sound_fail_vol": 14,
       "ter_set": "t_mdoor_frame",
       "items": [ { "item": "glass_shard", "count": [ 3, 6 ] }, { "item": "wire", "prob": 20 }, { "item": "scrap", "count": [ 3, 5 ] } ],
+      "//": "reduction and destroy_threshold both match str_min for ballistic/reinforced glass doors",
       "ranged": { "reduction": [ 40, 40 ], "reduction_laser": [ 0, 8 ], "destroy_threshold": 40 }
     }
   },
@@ -135,7 +140,9 @@
       "sound_vol": 20,
       "sound_fail_vol": 14,
       "ter_set": "t_thconc_floor",
-      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] }, { "item": "wire", "prob": 20 }, { "item": "scrap", "count": [ 3, 5 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] }, { "item": "wire", "prob": 20 }, { "item": "scrap", "count": [ 3, 5 ] } ],
+      "//": "reduction and destroy_threshold both match str_min for ballistic/reinforced glass doors",
+      "ranged": { "reduction": [ 40, 40 ], "reduction_laser": [ 0, 8 ], "destroy_threshold": 40 }
     }
   },
   {
@@ -181,7 +188,9 @@
       "sound_vol": 20,
       "sound_fail_vol": 14,
       "ter_set": "t_thconc_floor",
-      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] }, { "item": "wire", "prob": 20 }, { "item": "scrap", "count": [ 3, 5 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] }, { "item": "wire", "prob": 20 }, { "item": "scrap", "count": [ 3, 5 ] } ],
+      "//": "reduction and destroy_threshold both match str_min for ballistic/reinforced glass doors",
+      "ranged": { "reduction": [ 40, 40 ], "reduction_laser": [ 0, 8 ], "destroy_threshold": 40 }
     }
   },
   {
@@ -219,7 +228,7 @@
         { "item": "splinter", "count": [ 1, 2 ] },
         { "item": "nail", "charges": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 80 }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 80 }
     }
   },
   {
@@ -1069,7 +1078,7 @@
         { "item": "splinter", "count": [ 1, 4 ] },
         { "item": "hinge", "count": [ 1, 2 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 80, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 3, 5 ], "destroy_threshold": 70, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -1446,7 +1455,7 @@
         { "item": "splinter", "count": [ 1, 2 ] },
         { "item": "nail", "charges": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 80 }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 80 }
     },
     "pry": {
       "success_message": "You pry open the door.",
@@ -1507,7 +1516,7 @@
         { "item": "splinter", "count": [ 1, 2 ] },
         { "item": "nail", "charges": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 80 }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 80 }
     },
     "pry": {
       "success_message": "You pry open the door.",
@@ -1558,7 +1567,7 @@
         { "item": "splinter", "count": [ 1, 2 ] },
         { "item": "nail", "charges": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 80 }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 80 }
     },
     "pry": {
       "success_message": "You pry open the door.",
@@ -1841,7 +1850,7 @@
         { "item": "nail", "charges": [ 2, 10 ] },
         { "item": "splinter", "count": [ 1, 2 ] }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 80 }
+      "ranged": { "reduction": [ 8, 15 ], "destroy_threshold": 80 }
     }
   },
   {
@@ -1927,7 +1936,7 @@
         { "item": "nail", "charges": [ 1, 8 ] },
         { "item": "splinter", "count": 1 }
       ],
-      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 60 }
+      "ranged": { "reduction": [ 13, 25 ], "destroy_threshold": 60 }
     }
   },
   {
@@ -2432,6 +2441,7 @@
       "sound_fail_vol": 10,
       "ter_set": "t_door_frame",
       "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
       "ranged": { "reduction": [ 1, 6 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 6 }
     }
   },

--- a/data/json/furniture_and_terrain/terrain-manufactured.json
+++ b/data/json/furniture_and_terrain/terrain-manufactured.json
@@ -43,7 +43,8 @@
       "sound_fail": "clang!",
       "ter_set": "t_gas_pump_smashed",
       "items": [ { "item": "scrap", "count": 1 } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 8, "flammable": true, "block_unaimed_chance": "50%" }
+      "//": "reduction equal to broken version but destroy_threshold matches str_min since fragile",
+      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 8, "flammable": true, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -63,7 +64,9 @@
       "explosive": 40,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "ter_set": "t_gas_tank_smashed"
+      "ter_set": "t_gas_tank_smashed",
+      "//": "destroy_threshold matches str_min since breaks into broken fuel tank",
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 40, "flammable": true, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -88,7 +91,8 @@
         { "item": "steel_lump", "count": [ 1, 4 ] },
         { "item": "steel_chunk", "count": [ 1, 4 ] },
         { "item": "scrap", "count": [ 3, 7 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 100, "flammable": true, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -103,7 +107,17 @@
     "move_cost": 0,
     "coverage": 65,
     "flags": [ "TRANSPARENT", "FLAMMABLE", "NOITEM", "SEALED", "CONTAINER", "REDUCE_SCENT" ],
-    "examine_action": "gaspump"
+    "examine_action": "gaspump",
+    "bash": {
+      "str_min": 8,
+      "str_max": 150,
+      "sound": "crunch!",
+      "sound_fail": "clang!",
+      "ter_set": "t_gas_pump_smashed",
+      "items": [ { "item": "scrap", "count": 1 } ],
+      "//": "reduction equal to broken version but destroy_threshold matches str_min since fragile",
+      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 8, "flammable": true, "block_unaimed_chance": "50%" }
+    }
   },
   {
     "type": "terrain",
@@ -127,7 +141,8 @@
         { "item": "steel_lump", "prob": 50 },
         { "item": "steel_chunk", "count": [ 1, 4 ] },
         { "item": "scrap", "count": [ 3, 7 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 150, "flammable": true, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -148,7 +163,9 @@
       "sound": "crunch!",
       "sound_fail": "clang!",
       "ter_set": "t_diesel_pump_smashed",
-      "items": [ { "item": "scrap", "count": 1 } ]
+      "items": [ { "item": "scrap", "count": 1 } ],
+      "//": "reduction equal to broken version but destroy_threshold matches str_min since fragile",
+      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 8, "flammable": true, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -173,7 +190,8 @@
         { "item": "steel_lump", "prob": 50 },
         { "item": "steel_chunk", "count": [ 1, 4 ] },
         { "item": "scrap", "count": [ 3, 7 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 150, "flammable": true, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -194,7 +212,9 @@
       "sound": "Critical failure imminent, self destruct activated.  Have a nice day!",
       "sound_fail": "clang!",
       "ter_set": "t_floor",
-      "items": [ { "item": "steel_chunk", "count": [ 1, 3 ] }, { "item": "scrap", "count": [ 4, 8 ] } ]
+      "items": [ { "item": "steel_chunk", "count": [ 1, 3 ] }, { "item": "scrap", "count": [ 4, 8 ] } ],
+      "//": "destroy_threshold matches str_min since delicate electronics",
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 40, "flammable": true, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -398,7 +418,9 @@
         { "item": "amplifier", "prob": 25 },
         { "item": "plastic_chunk", "count": [ 4, 10 ], "prob": 50 },
         { "item": "scrap", "count": [ 2, 6 ], "prob": 50 }
-      ]
+      ],
+      "//": "reduction equal to broken console but destroy_threshold matches str_min since fragile",
+      "ranged": { "reduction": [ 8, 16 ], "destroy_threshold": 8, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -467,7 +489,7 @@
     "coverage": 65,
     "flags": [ "NOITEM", "WALL", "PERMEABLE" ],
     "bash": {
-      "str_min": 6,
+      "str_min": 50,
       "str_max": 150,
       "sound": "crunch!",
       "sound_fail": "whack!",
@@ -476,7 +498,9 @@
         { "item": "e_scrap", "count": [ 1, 4 ], "prob": 50 },
         { "item": "circuit", "count": [ 1, 6 ], "prob": 50 },
         { "item": "scrap", "count": [ 2, 8 ], "prob": 50 }
-      ]
+      ],
+      "//": "destroy_threshold matches str_min since delicate electronics",
+      "ranged": { "reduction": [ 25, 50 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -508,7 +532,9 @@
         { "item": "amplifier", "prob": 25 },
         { "item": "plastic_chunk", "count": [ 4, 10 ], "prob": 50 },
         { "item": "scrap", "count": [ 2, 6 ], "prob": 50 }
-      ]
+      ],
+      "//": "reduction equal to broken console, but destroy_threshold equal to str_min since fragile",
+      "ranged": { "reduction": [ 8, 16 ], "destroy_threshold": 8, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -539,7 +565,8 @@
         { "item": "cable", "charges": [ 250, 500 ] },
         { "item": "circuit", "count": [ 1, 6 ] },
         { "item": "scrap", "count": [ 12, 18 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 60, 120 ], "destroy_threshold": 150 }
     }
   },
   {
@@ -571,7 +598,9 @@
         { "item": "amplifier", "prob": 25 },
         { "item": "plastic_chunk", "count": [ 4, 10 ], "prob": 50 },
         { "item": "scrap", "count": [ 2, 6 ], "prob": 50 }
-      ]
+      ],
+      "//": "reduction equal to broken console, but destroy_threshold equal to str_min since fragile",
+      "ranged": { "reduction": [ 8, 16 ], "destroy_threshold": 8, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -595,6 +624,7 @@
       "sound_fail_vol": 12,
       "ter_set": "t_floor",
       "items": [ { "item": "glass_shard", "count": [ 3, 6 ] }, { "item": "scrap", "count": [ 0, 2 ] } ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
       "ranged": { "reduction": [ 1, 6 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 6, "block_unaimed_chance": "75%" }
     }
   },
@@ -678,7 +708,9 @@
         { "item": "steel_chunk", "count": [ 1, 6 ] },
         { "item": "plut_cell", "charges": [ 0, 3 ] },
         { "item": "lead", "charges": [ 12, 18 ] }
-      ]
+      ],
+      "//": "destroy_threshold equal to str_min instead of str_max due to delicate electronics",
+      "ranged": { "reduction": [ 25, 50 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
     },
     "deconstruct": { "ter_set": "t_concrete", "items": [ { "item": "plut_generator_item", "count": 1 } ] }
   },

--- a/data/json/furniture_and_terrain/terrain-mechanisms.json
+++ b/data/json/furniture_and_terrain/terrain-mechanisms.json
@@ -42,7 +42,8 @@
         { "item": "amplifier", "prob": 25 },
         { "item": "plastic_chunk", "count": [ 4, 10 ], "prob": 50 },
         { "item": "scrap", "count": [ 2, 6 ], "prob": 50 }
-      ]
+      ],
+      "ranged": { "reduction": [ 8, 16 ], "destroy_threshold": 150, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -89,7 +90,9 @@
         { "item": "amplifier", "prob": 25 },
         { "item": "plastic_chunk", "count": [ 4, 10 ], "prob": 50 },
         { "item": "scrap", "count": [ 2, 6 ], "prob": 50 }
-      ]
+      ],
+      "//": "reduction equal to broken console but destroy_threshold matches str_min since fragile",
+      "ranged": { "reduction": [ 8, 16 ], "destroy_threshold": 8, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -470,7 +473,9 @@
         { "item": "amplifier", "prob": 25 },
         { "item": "plastic_chunk", "count": [ 4, 10 ], "prob": 50 },
         { "item": "scrap", "count": [ 2, 6 ], "prob": 50 }
-      ]
+      ],
+      "//": "destroy_threshold matches str_min since fragile",
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -510,7 +515,9 @@
         { "item": "amplifier", "prob": 25 },
         { "item": "plastic_chunk", "count": [ 4, 10 ], "prob": 50 },
         { "item": "scrap", "count": [ 2, 6 ], "prob": 50 }
-      ]
+      ],
+      "//": "destroy_threshold matches str_min since fragile",
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
     }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -701,7 +701,7 @@
         { "item": "nail", "charges": [ 4, 10 ] },
         { "item": "splinter", "count": [ 1, 5 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 110, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 2, 4 ], "destroy_threshold": 110, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -781,7 +781,7 @@
       "sound_fail": "whump!",
       "ter_set": "t_null",
       "items": [ { "item": "splinter", "count": [ 10, 20 ] } ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 150, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 150, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -948,7 +948,8 @@
       "sound_fail_vol": 10,
       "ter_set": "t_floor",
       "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ],
-      "ranged": { "reduction": [ 1, 4 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 5 }
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 4 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 4 }
     }
   },
   {
@@ -972,7 +973,8 @@
       "sound_fail_vol": 10,
       "ter_set": "t_floor",
       "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ],
-      "ranged": { "reduction": [ 1, 4 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 5 }
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 4 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 4 }
     }
   },
   {
@@ -996,6 +998,7 @@
       "sound_fail_vol": 14,
       "ter_set": "t_floor",
       "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ],
+      "//": "half that of ballistic glass doors",
       "ranged": { "reduction": [ 20, 20 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 20 }
     }
   },
@@ -1020,6 +1023,7 @@
       "sound_fail_vol": 14,
       "ter_set": "t_floor",
       "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ],
+      "//": "matches that of ballistic glass doors",
       "ranged": { "reduction": [ 40, 40 ], "reduction_laser": [ 0, 8 ], "destroy_threshold": 40 }
     }
   },
@@ -1043,6 +1047,7 @@
       "sound_fail_vol": 14,
       "ter_set": "t_floor",
       "items": [ { "item": "glass_shard", "count": [ 3, 6 ] }, { "item": "wire", "prob": 20 } ],
+      "//": "matches that of ballistic glass doors",
       "ranged": { "reduction": [ 40, 40 ], "reduction_laser": [ 0, 8 ], "destroy_threshold": 40 }
     }
   },
@@ -1066,6 +1071,7 @@
       "sound_fail_vol": 14,
       "ter_set": "t_floor",
       "items": [ { "item": "glass_shard", "count": [ 3, 6 ] }, { "item": "wire", "prob": 20 }, { "item": "scrap", "count": [ 3, 5 ] } ],
+      "//": "matches that of ballistic glass doors, increased laser protection since closed shutters",
       "ranged": { "reduction": [ 40, 40 ], "reduction_laser": [ 1, 10 ], "destroy_threshold": 40 }
     }
   },
@@ -1090,6 +1096,7 @@
       "sound_fail_vol": 14,
       "ter_set": "t_floor",
       "items": [ { "item": "glass_shard", "count": [ 3, 6 ] }, { "item": "wire", "prob": 20 }, { "item": "scrap", "count": [ 3, 5 ] } ],
+      "//": "matches that of ballistic glass doors",
       "ranged": { "reduction": [ 40, 40 ], "reduction_laser": [ 0, 8 ], "destroy_threshold": 40 }
     }
   },

--- a/data/json/furniture_and_terrain/terrain-windows.json
+++ b/data/json/furniture_and_terrain/terrain-windows.json
@@ -20,6 +20,7 @@
       "sound_fail_vol": 10,
       "ter_set": "t_window_frame",
       "items": [ { "item": "glass_shard", "count": [ 1, 5 ] } ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
       "ranged": { "reduction": [ 1, 3 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 3 }
     }
   },
@@ -37,7 +38,8 @@
     "bash": {
       "str_min": 6,
       "str_max": 12,
-      "ranged": { "reduction": [ 1, 3 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 3 }
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 6 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 6 }
     }
   },
   {
@@ -346,6 +348,7 @@
       "sound_fail_vol": 10,
       "ter_set": "t_window_frame",
       "items": [ { "item": "splinter", "count": [ 0, 2 ] }, { "item": "glass_shard", "count": [ 1, 4 ] } ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
       "ranged": { "reduction": [ 1, 3 ], "destroy_threshold": 3 }
     }
   },


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This does a bit of standardizing and cleanup for ballistic resistance of furniture and terrain before I work on applying the feature to more stuff.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. In general, all standard terrain and furniture with `ranged` bash data already specified now have their reduction properly set to an amount ranging from half their `str_min` (rounded up if needed) to `str_min`. Before I used arbitrary ranges that kinda sorta peaked at close to `bash_min`, but often I was using 5-10 values for basically anything with less than 15 bash_min, 10-20 for stuff in the 10-25 range, etc. This made very fragile terrain a bit tankier as ballistic protection than probably desirable, made a few substantially solid obstacles no better than some that could reasonably be considered more fragile, not to mention looked more arbitrary and weird.
2. Fixed a few oddball destroy thresholds.
3. Beefed up str_min of road barricades, centrifuges, CVD body, and bulletin boards a bit to justify more fitting ranged bash values.
4. Likewise, beefed up str_max of brick chimneys to ensure the destroy thresh was still fittingly lower.
5. Any case where an object's `reduction` or `destroy_threshold` does not match the current conventions for bash info now has a comment to bring it up and why it's like that.
6. Applied ballistic resistance to a few more terrain obstacles and the like. Basically just finishing up applying these stats to furniture and terrain types that already had these partially implemented. Still haven't covered all doors and windows yet because jfc so many of them weh.
7. Misc: fixed variant gas pump being magically indestructible.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Eternal screaming.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Ported JSON changes over to test build and load-tested.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
