### PR TITLE
ci: test msvc on PRs

### DIFF
--- a/.github/workflows/msvc-full-features-cmake.yml
+++ b/.github/workflows/msvc-full-features-cmake.yml
@@ -16,6 +16,21 @@ on:
     - '!tools/format/**'
     - 'utilities/**'
     - 'scripts/**'
+  pull_request:
+    branches:
+    - main
+    paths-ignore:
+    - 'android/**'
+    - 'build-data/osx/**'
+    - 'doc/**'
+    - 'doxygen_doc/**'
+    - 'gfx/**'
+    - 'lang/**'
+    - 'lgtm/**'
+    - 'tools/**'
+    - '!tools/format/**'
+    - 'utilities/**'
+    - 'scripts/**'
 
 # We only care about the latest revision, so cancel previous instances.
 concurrency:


### PR DESCRIPTION
## Purpose of change

- fix #4199

tests for windows aren't running in PRs because 
1. I disabled MSVC+vcpkg workflow
2. believing MSVC+cmake workflow would run instead
3. turns out it lacked a trigger for PRs (probably because it's WIP by the time (and still is) olanti added them)

## Describe the solution

copy and paste the same trigger used by MSVC

## Describe alternatives you've considered

turn back on MSVC+vcpkg action

## Testing

help me, CIIIIIII!

## Additional Context

didn't enable MSYS2 + cmake one as it didn't seem very popular