### PR TITLE
feat(content): adds an entry-level launcher weapon

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
@@ -954,7 +954,8 @@
     "//": "Makeshift or otherwise poor quality grenade and rocket launchers",
     "items": [
       { "item": "launcher_simple", "prob": 100 },
-      { "item": "triple_launcher_simple", "prob": 15, "charges-min": 0, "charges-max": 3 }
+      { "item": "triple_launcher_simple", "prob": 15, "charges-min": 0, "charges-max": 3 },
+      { "item": "slingshot_cannon", "prob": 30 }
     ]
   },
   {

--- a/data/json/items/ranged/slings.json
+++ b/data/json/items/ranged/slings.json
@@ -83,5 +83,30 @@
     "range": 8,
     "dispersion": 45,
     "durability": 7
+  },
+  {
+    "id": "slingshot_cannon",
+    "copy-from": "rifle_elastic",
+    "type": "GUN",
+    "weapon_category": [ "SLINGSHOTS", "ELASTIC" ],
+    "color": "brown",
+    "looks_like": "LAW",
+    "name": { "str": "slingshot cannon" },
+    "description": "Somewhere between a bullet crossbow and a slingshot on steroids, this shoulder-mounted weapon uses a winch to keep several elastic bands under tension.  It fires full-size rocks with much more power and range than pebbles out of a normal slingshot.  High strength will make it faster to reload.",
+    "price": "115 USD",
+    "price_postapoc": "15 USD",
+    "material": [ "wood", "plastic" ],
+    "ammo": "rock",
+    "weight": "8 kg",
+    "volume": "4 L",
+    "skill": "launcher",
+    "ranged_damage": { "damage_type": "bash", "amount": 20 },
+    "dispersion": 60,
+    "range": 24,
+    "reload": 800,
+    "durability": 6,
+    "clip_size": 1,
+    "valid_mod_locations": [ [ "accessories", 2 ], [ "sights", 1 ], [ "sling", 1 ] ],
+    "delete": { "flags": [ "WATERPROOF_GUN", "UNDERWATER_GUN" ] }
   }
 ]

--- a/data/json/recipes/weapon/ranged.json
+++ b/data/json/recipes/weapon/ranged.json
@@ -1214,5 +1214,25 @@
     "book_learn": [ [ "manual_luty", 4 ] ],
     "qualities": [ { "id": "SAW_M_FINE", "level": 1 }, { "id": "SCREW_FINE", "level": 1 } ],
     "components": [ [ [ "pipe", 2 ] ], [ [ "scrap", 3 ] ], [ [ "spring", 1 ] ], [ [ "2x4", 2 ] ], [ [ "sheet_metal", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "slingshot_cannon",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_RANGED",
+    "skill_used": "fabrication",
+    "skills_required": [ [ "mechanics", 2 ] ],
+    "difficulty": 4,
+    "time": "30 m",
+    "autolearn": true,
+    "book_learn": [ [ "manual_fabrication", 3 ], [ "textbook_fabrication", 3 ], [ "manual_launcher", 2 ] ],
+    "using": [ [ "wood_structural", 2 ], [ "steel_tiny", 1 ] ],
+    "qualities": [
+      { "id": "CUT", "level": 1 },
+      { "id": "HAMMER", "level": 2 },
+      { "id": "SCREW", "level": 1 },
+      { "id": "SAW_W", "level": 1 }
+    ],
+    "components": [ [ [ "hose", 4 ] ], [ [ "foot_crank", 1 ] ], [ [ "spring", 1 ] ] ]
   }
 ]

--- a/data/json/vehicleparts/turret.json
+++ b/data/json/vehicleparts/turret.json
@@ -461,5 +461,22 @@
     "breaks_into": [ { "item": "scrap", "count": 28 }, { "item": "steel_chunk", "count": 20 }, { "item": "steel_lump", "count": 12 } ],
     "requirements": { "install": { "skills": [ [ "mechanics", 4 ], [ "rifle", 2 ] ] }, "removal": { "skills": [ [ "mechanics", 3 ] ] } },
     "description": "A rotary firearm from the 19th Century driving multiple barrels with a hand crank for sustained fire."
+  },
+  {
+    "id": "mounted_slingshot_cannon",
+    "copy-from": "turret",
+    "type": "vehicle_part",
+    "name": { "str": "mounted slingshot cannon" },
+    "item": "slingshot_cannon",
+    "looks_like": "tow_launcher",
+    "color": "brown",
+    "broken_color": "light_gray",
+    "breaks_into": [
+      { "item": "steel_chunk", "count": [ 1, 2 ] },
+      { "item": "scrap", "count": [ 0, 2 ] },
+      { "item": "splinter", "count": [ 8, 16 ] },
+      { "item": "hose", "count": [ 0, 2 ] }
+    ],
+    "requirements": { "install": { "skills": [ [ "mechanics", 3 ], [ "launcher", 1 ] ] }, "removal": { "skills": [ [ "mechanics", 1 ] ] } }
   }
 ]


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This adds a weapon geared towards a higher-power upgrade step beyond slings and staff slings, with the added bonus of a design that can reasonably justify being a launcher-skill, in turn making it possible to break into entry-level launcher skill without spending valuable 40mm rounds on practice.

Also, as can probably be guessed, inspired by the over-the-top creations devised by Joerg Sprave (https://www.youtube.com/@Slingshotchannel).

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Adds item definition for a slingshot cannon. Geared towards being a signifigant step up in raw damage over the staff sling, a more modest step up in range, and accuracy comparable to baseline slingshots, using the launcher skill. Notably bulkier, high reload rate instead of being a reload-and-shoot weapon, `STR_RELOAD` can help with it.
2. Added recipe for the aforementioned weapon. I placed it a step up above the staff sling, requiring a bit more fabrication skill as well as low-level mechanics skill, now a bit more obtainable. Comparable to and in some ways the inverse of the skill requirements for the weaker spearguns (one can assume more of the power and fabrication demand both come from a frame built to keep the rubber at much higher tension, whereas the spearguns only likely draw back enough to comfortably hook them into place by hand).
3. Added a vehiclepart version to allow mounting them as turrets.
4. For bonus fun, added the new item to `guns_launcher_improvised`.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Making it reload faster in exchange for only being a bit stronger than a staff sling.
2. Finding some way to justify it having more than one shot to increase its utility.
3. Basing it more off one of Joerg's blursed gatling slingshot launchers instead, making them much weaker and limited back to pebbles in exchange for multiple shots and/or burst fire.
5. Focusing on reviving early-game homemade flamethrowers instead as the go-to way to potentially bootstrap launcher skill.
6. Axing the requirement for launcher skill from the recipe for grenade ammo pouches since it's probably the only instance where not having launcher skill will ever actually be an annoyance for players.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Ported file changes to compiled test build and load-tested.
3. Played about a bit with it, can just barely two-shot basic zeds with crits. With basic hits it's more of a 4-shot. Requires one to either make good use of its range or be mindful about kiting with reload rate, upgrading to lead sling bullets makes things easier but that adds even more weight of course. :3

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
