### PR TITLE
fix: description and id of `t_thconc_floor_nofloor`

### DIFF
--- a/data/json/furniture_and_terrain/terrain-floors-outdoors.json
+++ b/data/json/furniture_and_terrain/terrain-floors-outdoors.json
@@ -505,5 +505,29 @@
         { "item": "rebar", "count": [ 0, 2 ] }
       ]
     }
+  },
+  {
+    "type": "terrain",
+    "id": "t_thconc_floor_no_roof",
+    "alias": "t_thconc_floor_nofloor",
+    "name": "concrete floor",
+    "description": "A bare and cold concrete floor.",
+    "symbol": ".",
+    "color": "cyan",
+    "looks_like": "t_thconc_floor",
+    "move_cost": 2,
+    "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
+    "bash": {
+      "sound": "SMASH!",
+      "ter_set": "t_null",
+      "str_min": 100,
+      "str_max": 400,
+      "str_min_supported": 150,
+      "items": [
+        { "item": "rock", "count": [ 5, 10 ] },
+        { "item": "scrap", "count": [ 5, 8 ] },
+        { "item": "rebar", "count": [ 0, 2 ] }
+      ]
+    }
   }
 ]

--- a/data/json/mapgen_palettes/acidia_commercial_destroyed_palette.json
+++ b/data/json/mapgen_palettes/acidia_commercial_destroyed_palette.json
@@ -1,28 +1,5 @@
 [
   {
-    "type": "terrain",
-    "id": "t_thconc_floor_nofloor",
-    "name": "concrete floor",
-    "description": "A bare and cold concrete floor with matching roof, could still insulate from the outdoors but roof collapse is possible if supporting walls are broken down.",
-    "symbol": ".",
-    "color": "cyan",
-    "looks_like": "t_thconc_floor",
-    "move_cost": 2,
-    "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
-    "bash": {
-      "sound": "SMASH!",
-      "ter_set": "t_null",
-      "str_min": 100,
-      "str_max": 400,
-      "str_min_supported": 150,
-      "items": [
-        { "item": "rock", "count": [ 5, 10 ] },
-        { "item": "scrap", "count": [ 5, 8 ] },
-        { "item": "rebar", "count": [ 0, 2 ] }
-      ]
-    }
-  },
-  {
     "type": "palette",
     "id": "acidia_commercial_destroyed_palette",
     "furniture": {


### PR DESCRIPTION
## Purpose of change
Redo #3891.
Change description and id of `t_thconc_floor_nofloor`.
## Describe the solution
Remove `t_thconc_floor_nofloor` from acidia_commercial_destroyed_palette.json
Create `t_thconc_floor_no_roof` with `t_thconc_floor_nofloor` as "alias" in terrain-floors-outdoors.json
## Describe alternatives you've considered
Change only the description.
## Testing
1. Took a save file made before these changes.
2. Load the save file in another game, which contains these changes in the JSON.
3. No errors.
## Additional context
none