### PR TITLE
fix: use `STAB` flag for items that don't need `SPEAR`

### DIFF
--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -63,7 +63,7 @@
     "to_hit": 2,
     "cutting": 8,
     "techniques": "PRECISE",
-    "flags": [ "TRADER_AVOID", "NO_DROP", "UNBREAKABLE_MELEE", "SPEAR" ],
+    "flags": [ "TRADER_AVOID", "NO_DROP", "UNBREAKABLE_MELEE", "STAB" ],
     "qualities": [ [ "CUT", 1 ], [ "CUT_FINE", 5 ], [ "BUTCHER", 50 ] ]
   },
   {

--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -601,7 +601,7 @@
     "volume": "1500 ml",
     "bashing": 38,
     "cutting": 6,
-    "flags": [ "DURABLE_MELEE", "SPEAR", "NONCONDUCTIVE" ],
+    "flags": [ "DURABLE_MELEE", "STAB", "NONCONDUCTIVE" ],
     "price": "1200 USD",
     "price_postapoc": "80 USD",
     "qualities": [ [ "HAMMER", 1 ] ]
@@ -617,7 +617,7 @@
     "material": [ "budget_steel", "wood" ],
     "bashing": 26,
     "cutting": 1,
-    "flags": [ "SPEAR", "NONCONDUCTIVE" ],
+    "flags": [ "STAB", "NONCONDUCTIVE" ],
     "price": "120 USD",
     "price_postapoc": "10 USD"
   },
@@ -632,7 +632,7 @@
     "material": [ "aluminum", "wood" ],
     "bashing": 26,
     "cutting": 1,
-    "flags": [ "SPEAR", "NONCONDUCTIVE", "FRAGILE_MELEE" ],
+    "flags": [ "STAB", "NONCONDUCTIVE", "FRAGILE_MELEE" ],
     "price": "120 USD",
     "price_postapoc": "5 USD",
     "qualities": [  ]
@@ -902,7 +902,7 @@
     "//": "Craftable from steel, shouldn't be silver.  A warhammer is essentially one end of a pickaxe with balancing weight on the other and crushes/pierces the armor.",
     "material": [ "iron", "wood" ],
     "techniques": [ "WBLOCK_1", "BRUTAL", "SWEEP" ],
-    "flags": [ "DURABLE_MELEE", "SPEAR", "NONCONDUCTIVE", "BELT_CLIP" ],
+    "flags": [ "DURABLE_MELEE", "STAB", "NONCONDUCTIVE", "BELT_CLIP" ],
     "volume": "1250 ml",
     "bashing": 22,
     "cutting": 23,

--- a/data/json/items/tool/med.json
+++ b/data/json/items/tool/med.json
@@ -97,7 +97,7 @@
     "color": "light_gray",
     "techniques": "PRECISE",
     "qualities": [ [ "CUT", 1 ], [ "CUT_FINE", 3 ] ],
-    "flags": [ "SPEAR", "SHEATH_KNIFE" ]
+    "flags": [ "STAB", "SHEATH_KNIFE" ]
   },
   {
     "id": "smoxygen_tank",
@@ -189,7 +189,7 @@
     "seals": true,
     "watertight": true,
     "use_action": "BLOOD_DRAW",
-    "flags": [ "SPEAR" ]
+    "flags": [ "STAB" ]
   },
   {
     "id": "wrapped_rad_badge",

--- a/data/json/items/tool/tailoring.json
+++ b/data/json/items/tool/tailoring.json
@@ -16,7 +16,7 @@
     "symbol": ";",
     "color": "yellow",
     "qualities": [ [ "LEATHER_AWL", 1 ] ],
-    "flags": [ "SPEAR", "BELT_CLIP", "FRAGILE_MELEE" ]
+    "flags": [ "STAB", "BELT_CLIP", "FRAGILE_MELEE" ]
   },
   {
     "id": "awl_steel",

--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -690,7 +690,7 @@
     "color": "dark_gray",
     "use_action": "PICKAXE",
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "SPEAR", "DURABLE_MELEE", "NONCONDUCTIVE", "DIG_TOOL", "SHEATH_AXE" ]
+    "flags": [ "STAB", "DURABLE_MELEE", "NONCONDUCTIVE", "DIG_TOOL", "SHEATH_AXE" ]
   },
   {
     "id": "pin_reamer",
@@ -799,7 +799,7 @@
     "symbol": ";",
     "color": "yellow",
     "qualities": [ [ "SCREW", 1 ] ],
-    "flags": [ "SPEAR", "BELT_CLIP" ]
+    "flags": [ "STAB", "BELT_CLIP" ]
   },
   {
     "id": "screwdriver_set",
@@ -889,7 +889,7 @@
       },
       { "flame": false, "type": "cauterize" }
     ],
-    "flags": [ "SPEAR", "BELT_CLIP", "ALLOWS_REMOTE_USE" ],
+    "flags": [ "STAB", "BELT_CLIP", "ALLOWS_REMOTE_USE" ],
     "magazines": [
       [
         "battery",
@@ -1147,7 +1147,7 @@
     "color": "light_gray",
     "techniques": "PRECISE",
     "qualities": [ [ "CUT", 1 ], [ "CUT_FINE", 2 ] ],
-    "flags": [ "SPEAR", "SHEATH_KNIFE" ]
+    "flags": [ "STAB", "SHEATH_KNIFE" ]
   },
   {
     "id": "wrench",

--- a/data/mods/Magiclysm/items/alchemy_items.json
+++ b/data/mods/Magiclysm/items/alchemy_items.json
@@ -205,7 +205,7 @@
     "to_hit": -1,
     "material": [ "flesh" ],
     "cutting": 7,
-    "flags": [ "SPEAR", "SHEATH_KNIFE" ]
+    "flags": [ "STAB", "SHEATH_KNIFE" ]
   },
   {
     "type": "GENERIC",
@@ -250,7 +250,7 @@
     "material": [ "flesh" ],
     "volume": "250 ml",
     "cutting": 8,
-    "flags": [ "SPEAR", "SHEATH_KNIFE" ],
+    "flags": [ "STAB", "SHEATH_KNIFE" ],
     "price": "15 USD"
   },
   {

--- a/data/mods/Magiclysm/items/weapons.json
+++ b/data/mods/Magiclysm/items/weapons.json
@@ -38,7 +38,7 @@
     "description": "This weapon measures about 3 feet in length and is fletched like an arrow for better accuracy.  The business end of the javelin has wicked-looking barbs which could cause significant bleeding.",
     "weight": "2500 g",
     "volume": "2830 ml",
-    "flags": [ "SPEAR", "SHEATH_SPEAR", "JAVELIN", "TRADER_AVOID", "NO_REPAIR" ]
+    "flags": [ "STAB", "SHEATH_SPEAR", "JAVELIN", "TRADER_AVOID", "NO_REPAIR" ]
   },
   {
     "id": "lizardfolk_javelin_gun",

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -191,7 +191,7 @@
     "symbol": ";",
     "color": "yellow",
     "qualities": [ [ "SCREW", 2 ], [ "SCREW_FINE", 1 ], [ "WRENCH", 1 ], [ "PRY", 2 ], [ "LOCKPICK", 30 ] ],
-    "flags": [ "SPEAR", "BELT_CLIP" ]
+    "flags": [ "STAB", "BELT_CLIP" ]
   },
   {
     "id": "test_soldering_iron",
@@ -219,7 +219,7 @@
       },
       { "flame": false, "type": "cauterize" }
     ],
-    "flags": [ "SPEAR", "BELT_CLIP", "ALLOWS_REMOTE_USE" ],
+    "flags": [ "STAB", "BELT_CLIP", "ALLOWS_REMOTE_USE" ],
     "magazines": [
       [
         "battery",


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This is essentially a parallel update to https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4211 because turns out I can't just check out the remote and yeet the results of a quick search-in-folder at them if they PR'd from the master branch.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

Replaced use of the `SPEAR` flag with `STAB` for all items I found that do not use reach attacks and therefore have no need to use the former flag, since the above-mentioned PR is set to make `STAB` the only source of the cutting-to-stabbing DT conversion and `SPEAR` will be reserved for solely the "reach attacks can bypass obstacles" effect. Affects:
* autonomous surgical scalpels
* morningstar
* morningstar replica
* morningstar fake
* war hammer
* scalpel
* blood draw kit
* bone sewing awl
* pickaxe
* screwdriver
* soldering iron
* X-Acto knife
* stirge proboscis
* demon spider fang
* barbed javelin
* TEST sonic screwdriver
* TEST soldering iron

Test screwdriver already covered by the related PR.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Used eyes, discord chat rushed me into going "weh" and committing this before I could run all of them through the online linter but fuck it we have autoformat now.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
