### PR TITLE
fix: stop requiring plastic bags for coffee powder crafting

### DIFF
--- a/data/json/recipes/food/other.json
+++ b/data/json/recipes/food/other.json
@@ -265,9 +265,8 @@
     "difficulty": 1,
     "time": "3 m",
     "autolearn": true,
-    "contained": true,
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "components": [ [ [ "roasted_coffee_bean", 1 ] ], [ [ "bag_plastic", 1 ] ] ]
+    "components": [ [ [ "roasted_coffee_bean", 1 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
## Purpose of change

To craft coffee powder, you require a plastic bag to contain the coffee powder which gives you a plastic bag full of coffee powder. You then have to manually Unload the coffee powder to get your plastic bag back. This stops the tedium.

## Describe the solution

Removed the contained field, as well as the plastic bag component.

## Describe alternatives you've considered

I am fine with requiring a plastic bag as a tool, but currently this is the ONLY recipe in the game I'm aware of that requires this, starch doesn't but starch still requires a hammer.

## Testing

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/112293514/eaf03bde-1786-4048-b230-3cb3828248dd)


## Additional context

WTF WHY?
