### PR TITLE
fix: don't assign piercing damage to weapons that were previously cutting

### DIFF
--- a/data/json/items/melee/spears_and_polearms.json
+++ b/data/json/items/melee/spears_and_polearms.json
@@ -334,7 +334,7 @@
     "color": "light_gray",
     "techniques": "WBLOCK_1",
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", -42 ] ],
-    "flags": [ "REACH_ATTACK", "POLEARM", "NONCONDUCTIVE", "SHEATH_SPEAR", "FRAGILE_MELEE", "SPEAR", "STAB" ]
+    "flags": [ "REACH_ATTACK", "POLEARM", "NONCONDUCTIVE", "SHEATH_SPEAR", "FRAGILE_MELEE", "SPEAR" ]
   },
   {
     "id": "glaive",
@@ -348,7 +348,7 @@
     "price": "500 USD",
     "material": [ "steel", "wood" ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", -28 ] ],
-    "flags": [ "DURABLE_MELEE", "REACH_ATTACK", "NONCONDUCTIVE", "POLEARM", "SHEATH_SPEAR", "ALWAYS_TWOHAND", "SPEAR", "STAB" ],
+    "flags": [ "DURABLE_MELEE", "REACH_ATTACK", "NONCONDUCTIVE", "POLEARM", "SHEATH_SPEAR", "ALWAYS_TWOHAND", "SPEAR" ],
     "techniques": [ "WIDE", "WBLOCK_1" ],
     "weight": "2100 g",
     "volume": "2500 ml",
@@ -372,7 +372,7 @@
     "bashing": 7,
     "cutting": 45,
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", -24 ] ],
-    "flags": [ "DURABLE_MELEE", "REACH_ATTACK", "NONCONDUCTIVE", "POLEARM", "SHEATH_SPEAR", "ALWAYS_TWOHAND", "SPEAR", "STAB" ],
+    "flags": [ "DURABLE_MELEE", "REACH_ATTACK", "NONCONDUCTIVE", "POLEARM", "SHEATH_SPEAR", "ALWAYS_TWOHAND", "SPEAR" ],
     "price": "800 USD",
     "price_postapoc": "95 USD"
   },
@@ -385,7 +385,7 @@
     "material": [ "budget_steel", "wood" ],
     "bashing": 29,
     "cutting": 11,
-    "flags": [ "REACH_ATTACK", "NONCONDUCTIVE", "POLEARM", "SHEATH_SPEAR", "ALWAYS_TWOHAND", "SPEAR", "STAB" ],
+    "flags": [ "REACH_ATTACK", "NONCONDUCTIVE", "POLEARM", "SHEATH_SPEAR", "ALWAYS_TWOHAND", "SPEAR" ],
     "price_postapoc": "15 USD"
   },
   {
@@ -399,7 +399,7 @@
     "bashing": 12,
     "cutting": 2,
     "to_hit": 1,
-    "flags": [ "REACH_ATTACK", "NONCONDUCTIVE", "POLEARM", "SHEATH_SPEAR", "ALWAYS_TWOHAND", "FRAGILE_MELEE" ],
+    "flags": [ "REACH_ATTACK", "NONCONDUCTIVE", "POLEARM", "SHEATH_SPEAR", "ALWAYS_TWOHAND", "FRAGILE_MELEE", "SPEAR" ],
     "price": "80 USD",
     "price_postapoc": "5 USD",
     "qualities": [  ]
@@ -589,6 +589,6 @@
     "symbol": "/",
     "color": "yellow",
     "techniques": [ "WBLOCK_1", "DEF_DISARM" ],
-    "flags": [ "DURABLE_MELEE", "POLEARM", "REACH_ATTACK", "ALWAYS_TWOHAND", "NONCONDUCTIVE", "SHEATH_SPEAR", "SPEAR", "STAB" ]
+    "flags": [ "DURABLE_MELEE", "POLEARM", "REACH_ATTACK", "ALWAYS_TWOHAND", "NONCONDUCTIVE", "SHEATH_SPEAR", "SPEAR" ]
   }
 ]

--- a/data/mods/Magiclysm/items/alchemy_items.json
+++ b/data/mods/Magiclysm/items/alchemy_items.json
@@ -205,7 +205,7 @@
     "to_hit": -1,
     "material": [ "flesh" ],
     "cutting": 7,
-    "flags": [ "SPEAR", "SHEATH_KNIFE" ]
+    "flags": [ "STAB", "SHEATH_KNIFE" ]
   },
   {
     "type": "GENERIC",
@@ -250,7 +250,7 @@
     "material": [ "flesh" ],
     "volume": "250 ml",
     "cutting": 8,
-    "flags": [ "SPEAR", "SHEATH_KNIFE" ],
+    "flags": [ "STAB", "SHEATH_KNIFE" ],
     "price": "15 USD"
   },
   {

--- a/data/mods/Magiclysm/items/enchanted_melee.json
+++ b/data/mods/Magiclysm/items/enchanted_melee.json
@@ -805,7 +805,7 @@
     "color": "light_gray",
     "techniques": [ "WBLOCK_1", "IMPALE" ],
     "qualities": [ [ "COOK", 1 ] ],
-    "flags": [ "SPEAR", "REACH_ATTACK", "DURABLE_MELEE", "SHEATH_SPEAR", "TRADER_AVOID", "MAGIC_FOCUS" ]
+    "flags": [ "STAB", "SPEAR", "REACH_ATTACK", "DURABLE_MELEE", "SHEATH_SPEAR", "TRADER_AVOID", "MAGIC_FOCUS" ]
   },
   {
     "id": "rune_technomancer_weapon",

--- a/data/mods/Magiclysm/items/ethereal_items.json
+++ b/data/mods/Magiclysm/items/ethereal_items.json
@@ -276,6 +276,7 @@
     "flags": [
       "UNBREAKABLE_MELEE",
       "REACH_ATTACK",
+      "STAB",
       "SPEAR",
       "NONCONDUCTIVE",
       "SHEATH_SPEAR",

--- a/data/mods/Magiclysm/items/weapons.json
+++ b/data/mods/Magiclysm/items/weapons.json
@@ -25,7 +25,7 @@
     "techniques": [ "WBLOCK_2", "DEF_DISARM", "IMPALE" ],
     "volume": "3 L",
     "cutting": 29,
-    "flags": [ "SPEAR", "REACH_ATTACK", "NONCONDUCTIVE", "DURABLE_MELEE", "SHEATH_SPEAR" ],
+    "flags": [ "STAB", "SPEAR", "REACH_ATTACK", "NONCONDUCTIVE", "DURABLE_MELEE", "SHEATH_SPEAR" ],
     "price": "150 USD"
   },
   {
@@ -38,7 +38,7 @@
     "description": "This weapon measures about 3 feet in length and is fletched like an arrow for better accuracy.  The business end of the javelin has wicked-looking barbs which could cause significant bleeding.",
     "weight": "2500 g",
     "volume": "2830 ml",
-    "flags": [ "SPEAR", "SHEATH_SPEAR", "JAVELIN", "TRADER_AVOID", "NO_REPAIR" ]
+    "flags": [ "STAB", "SHEATH_SPEAR", "JAVELIN", "TRADER_AVOID", "NO_REPAIR" ]
   },
   {
     "id": "lizardfolk_javelin_gun",

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -191,7 +191,7 @@
     "symbol": ";",
     "color": "yellow",
     "qualities": [ [ "SCREW", 2 ], [ "SCREW_FINE", 1 ], [ "WRENCH", 1 ], [ "PRY", 2 ], [ "LOCKPICK", 30 ] ],
-    "flags": [ "SPEAR", "BELT_CLIP" ]
+    "flags": [ "STAB", "BELT_CLIP" ]
   },
   {
     "id": "test_soldering_iron",
@@ -219,7 +219,7 @@
       },
       { "flame": false, "type": "cauterize" }
     ],
-    "flags": [ "SPEAR", "BELT_CLIP", "ALLOWS_REMOTE_USE" ],
+    "flags": [ "STAB", "BELT_CLIP", "ALLOWS_REMOTE_USE" ],
     "magazines": [
       [
         "battery",


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

So, https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4214 was implemented by a script that accidentally converted some polearms from cutting damage to piercing damage.

In addition, mods folder wasn't touched by that PR.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Fixed makeshift glaive, glaive, naginata, naginata replica, and ji accidentally being converted into piercing weapons. Kept `SPEAR` flag on them for now.
2. Added `SPEAR` flag to naginata fake because the other variants have it. How the fuck the automation script missed that when the item is basically identical to the other two flag-wise is beyond me.
3. Updated items in mods that I had already set up to fix in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4212. Swapped `SPEAR` for `STAB` for stirge proboscis, demon spider fang, barbed javelin, TEST sonic screwdriver, and TEST soldering iron
4, Additionally added `STAB` flag to fix Biomancer spear, Wicked Bonespear, and wood trident.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. It's debatable whether ji should have the `SPEAR` flag or not, and if so whether halberds are still too bulky to justify it, but I left things as they are for now and just fixed the actual mistakes.
2. Fixing the migration script. I don't know what actually went wrong with it so.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Used my eyes to confirm I actually removed and/or added the flags I intended to add.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
