### PR TITLE
feat(balance): finish extending ranged bash info to windows, doors, and other half-implemented terrain; some window fixes

### DIFF
--- a/data/json/furniture_and_terrain/furniture-plumbing.json
+++ b/data/json/furniture_and_terrain/furniture-plumbing.json
@@ -194,7 +194,8 @@
         { "item": "pipe", "count": [ 0, 2 ] },
         { "item": "hose", "count": 1 },
         { "item": "water_faucet", "count": 1 }
-      ]
+      ],
+      "ranged": { "reduction": [ 8, 15 ], "destroy_threshold": 80, "block_unaimed_chance": "50%" }
     },
     "deconstruct": {
       "items": [

--- a/data/json/furniture_and_terrain/furniture-triffid.json
+++ b/data/json/furniture_and_terrain/furniture-triffid.json
@@ -34,7 +34,8 @@
       "str_max": 60,
       "sound": "smash",
       "sound_fail": "whump.",
-      "items": [ { "item": "splinter", "count": [ 10, 15 ] } ]
+      "items": [ { "item": "splinter", "count": [ 10, 15 ] } ],
+      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 60, "block_unaimed_chance": "50%" }
     }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-doors.json
+++ b/data/json/furniture_and_terrain/terrain-doors.json
@@ -188,9 +188,7 @@
       "sound_vol": 20,
       "sound_fail_vol": 14,
       "ter_set": "t_thconc_floor",
-      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] }, { "item": "wire", "prob": 20 }, { "item": "scrap", "count": [ 3, 5 ] } ],
-      "//": "reduction and destroy_threshold both match str_min for ballistic/reinforced glass doors",
-      "ranged": { "reduction": [ 40, 40 ], "reduction_laser": [ 0, 8 ], "destroy_threshold": 40 }
+      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] }, { "item": "wire", "prob": 20 }, { "item": "scrap", "count": [ 3, 5 ] } ]
     }
   },
   {
@@ -266,7 +264,8 @@
         { "item": "wood_panel", "prob": 10 },
         { "item": "splinter", "count": [ 1, 2 ] },
         { "item": "nail", "charges": [ 0, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 80 }
     }
   },
   {
@@ -304,7 +303,8 @@
         { "item": "wood_panel", "prob": 10 },
         { "item": "splinter", "count": [ 1, 2 ] },
         { "item": "nail", "charges": [ 0, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 80 }
     }
   },
   {
@@ -342,7 +342,8 @@
         { "item": "wood_panel", "prob": 10 },
         { "item": "splinter", "count": [ 1, 2 ] },
         { "item": "nail", "charges": [ 0, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 80 }
     }
   },
   {
@@ -380,7 +381,8 @@
         { "item": "wood_panel", "prob": 10 },
         { "item": "splinter", "count": [ 1, 2 ] },
         { "item": "nail", "charges": [ 0, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 80 }
     }
   },
   {
@@ -418,7 +420,8 @@
         { "item": "wood_panel", "prob": 10 },
         { "item": "splinter", "count": [ 1, 2 ] },
         { "item": "nail", "charges": [ 0, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 80 }
     }
   },
   {
@@ -602,7 +605,8 @@
         { "item": "nail", "charges": [ 1, 4 ] },
         { "item": "splinter", "count": [ 1, 4 ] },
         { "item": "hinge", "count": [ 1, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 3, 5 ], "destroy_threshold": 70, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -638,7 +642,8 @@
         { "item": "nail", "charges": [ 1, 4 ] },
         { "item": "splinter", "count": [ 1, 4 ] },
         { "item": "hinge", "count": [ 1, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 3, 5 ], "destroy_threshold": 70, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -674,7 +679,8 @@
         { "item": "nail", "charges": [ 1, 4 ] },
         { "item": "splinter", "count": [ 1, 4 ] },
         { "item": "hinge", "count": [ 1, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 3, 5 ], "destroy_threshold": 70, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -710,7 +716,8 @@
         { "item": "nail", "charges": [ 1, 4 ] },
         { "item": "splinter", "count": [ 1, 4 ] },
         { "item": "hinge", "count": [ 1, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 3, 5 ], "destroy_threshold": 70, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -834,7 +841,9 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_door_red_frame",
-      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 6 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 6 }
     }
   },
   {
@@ -882,7 +891,9 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_door_white_frame",
-      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 6 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 6 }
     }
   },
   {
@@ -906,7 +917,9 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_door_gray_frame",
-      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 6 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 6 }
     }
   },
   {
@@ -1041,7 +1054,8 @@
         { "item": "2x4", "prob": 25 },
         { "item": "splinter", "count": [ 1, 2 ] },
         { "item": "nail", "charges": [ 0, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 80 }
     }
   },
   {
@@ -1114,7 +1128,8 @@
         { "item": "nail", "charges": [ 1, 4 ] },
         { "item": "splinter", "count": [ 1, 4 ] },
         { "item": "hinge", "count": [ 1, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 3, 5 ], "destroy_threshold": 70, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -1152,7 +1167,8 @@
         { "item": "nail", "charges": [ 1, 4 ] },
         { "item": "splinter", "count": [ 1, 4 ] },
         { "item": "hinge", "count": [ 1, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 3, 5 ], "destroy_threshold": 70, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -1295,7 +1311,8 @@
         { "item": "2x4", "count": [ 1, 4 ] },
         { "item": "splinter", "count": [ 2, 4 ] },
         { "item": "nail", "charges": [ 4, 12 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 9, 18 ], "destroy_threshold": 100 }
     }
   },
   {
@@ -1331,7 +1348,8 @@
         { "item": "nail", "charges": [ 4, 18 ] },
         { "item": "splinter", "count": [ 2, 4 ] },
         { "item": "hinge", "count": [ 0, 1 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 90, "block_unaimed_chance": "75%" }
     }
   },
   {
@@ -1394,7 +1412,8 @@
         { "item": "wood_panel", "prob": 10 },
         { "item": "splinter", "count": [ 1, 2 ] },
         { "item": "nail", "charges": [ 0, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 80 }
     },
     "pry": {
       "success_message": "You pry open the door.",
@@ -1650,7 +1669,8 @@
         { "item": "rope_makeshift_6", "count": [ 0, 1 ] },
         { "item": "withered", "count": [ 2, 12 ] },
         { "item": "splinter", "count": [ 5, 10 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 2, 4 ], "destroy_threshold": 20 }
     }
   },
   {
@@ -1907,7 +1927,8 @@
         { "item": "2x4", "count": [ 1, 3 ] },
         { "item": "nail", "charges": [ 2, 10 ] },
         { "item": "splinter", "count": [ 1, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 8, 15 ], "destroy_threshold": 80 }
     }
   },
   {
@@ -1965,7 +1986,7 @@
         { "item": "splinter", "count": 1 },
         { "item": "hinge", "count": [ 0, 1 ] }
       ],
-      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 50 }
+      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 50 }
     }
   },
   {
@@ -1995,7 +2016,8 @@
         { "item": "nail", "charges": [ 2, 20 ] },
         { "item": "splinter", "count": 1 },
         { "item": "hinge", "count": [ 1, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 40 }
     }
   },
   {
@@ -2026,7 +2048,8 @@
         { "item": "scrap", "count": [ 12, 24 ] },
         { "item": "steel_plate", "prob": 75 },
         { "item": "hinge", "count": [ 1, 3 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 250 }
     }
   },
   {
@@ -2047,7 +2070,8 @@
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "ter_set": "t_mdoor_frame",
-      "items": [ { "item": "scrap", "count": [ 12, 24 ] }, { "item": "steel_plate", "prob": 75 } ]
+      "items": [ { "item": "scrap", "count": [ 12, 24 ] }, { "item": "steel_plate", "prob": 75 } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 250 }
     }
   },
   {
@@ -2087,7 +2111,8 @@
         { "item": "scrap", "count": [ 12, 24 ] },
         { "item": "steel_plate", "prob": 75 },
         { "item": "hinge", "count": [ 1, 3 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 250 }
     }
   },
   {
@@ -2165,7 +2190,8 @@
         { "item": "scrap", "count": [ 12, 24 ] },
         { "item": "steel_plate", "prob": 75 },
         { "item": "hinge", "count": [ 1, 3 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 250 }
     }
   },
   {
@@ -2222,7 +2248,8 @@
         { "item": "scrap", "count": [ 12, 24 ] },
         { "item": "steel_plate", "prob": 75 },
         { "item": "hinge", "count": [ 1, 3 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 250 }
     }
   },
   {
@@ -2308,7 +2335,8 @@
         { "item": "scrap", "count": [ 12, 24 ] },
         { "item": "steel_plate", "prob": 75 },
         { "item": "hinge", "count": [ 1, 3 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 250 }
     },
     "pry": {
       "success_message": "You pry open the door.",
@@ -2475,7 +2503,9 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_thconc_floor",
-      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 6 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 6 }
     }
   },
   {
@@ -2593,7 +2623,8 @@
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "ter_set": "t_mdoor_frame",
-      "items": [ { "item": "scrap", "count": [ 12, 24 ] }, { "item": "steel_plate", "prob": 75 } ]
+      "items": [ { "item": "scrap", "count": [ 12, 24 ] }, { "item": "steel_plate", "prob": 75 } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 250 }
     }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -68,7 +68,8 @@
         { "item": "wood_panel", "count": [ 0, 1 ] },
         { "item": "nail", "charges": [ 0, 5 ] },
         { "item": "splinter", "count": [ 5, 10 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 70, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -102,7 +103,8 @@
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_null",
-      "items": "wall_bash_results"
+      "items": "wall_bash_results",
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 20, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -267,7 +269,9 @@
       "sound": "crash!",
       "sound_fail": "bash!",
       "ter_set": "t_null",
-      "items": [ { "item": "rock", "count": [ 5, 8 ] }, { "item": "brick", "count": [ 1, 3 ] } ]
+      "items": [ { "item": "rock", "count": [ 5, 8 ] }, { "item": "brick", "count": [ 1, 3 ] } ],
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 30, 60 ], "destroy_threshold": 60, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -329,7 +333,9 @@
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_null",
-      "items": [ { "item": "rock", "count": [ 3, 8 ] } ]
+      "items": [ { "item": "rock", "count": [ 3, 8 ] } ],
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 80, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -376,7 +382,9 @@
       "sound": "crash!",
       "sound_fail": "bash!",
       "ter_set": "t_null",
-      "items": [ { "item": "material_soil", "count": [ 4, 10 ] }, { "item": "adobe_brick", "count": [ 1, 3 ] } ]
+      "items": [ { "item": "material_soil", "count": [ 4, 10 ] }, { "item": "adobe_brick", "count": [ 1, 3 ] } ],
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 40, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -514,7 +522,9 @@
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_pit_shallow",
-      "items": [ { "item": "rock", "count": [ 5, 11 ] } ]
+      "items": [ { "item": "rock", "count": [ 5, 11 ] } ],
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 80, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -555,7 +565,9 @@
       "sound": "scrrrash!",
       "sound_fail": "whump!",
       "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 5, 11 ] } ]
+      "items": [ { "item": "rock", "count": [ 5, 11 ] } ],
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 80, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -625,7 +637,8 @@
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "ter_set": "t_pit_shallow",
-      "items": [ { "item": "steel_chunk", "count": [ 5, 11 ] } ]
+      "items": [ { "item": "steel_chunk", "count": [ 5, 11 ] } ],
+      "ranged": { "reduction": [ 25, 50 ], "destroy_threshold": 130, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -721,7 +734,8 @@
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_null",
-      "items": [ { "item": "splinter", "count": [ 10, 20 ] } ]
+      "items": [ { "item": "splinter", "count": [ 10, 20 ] } ],
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 120, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -837,7 +851,8 @@
       "ter_set": "t_null",
       "sound": "crash!",
       "sound_fail": "whump!",
-      "items": [ { "item": "2x4", "count": [ 0, 3 ] }, { "item": "splinter", "count": [ 3, 6 ] } ]
+      "items": [ { "item": "2x4", "count": [ 0, 3 ] }, { "item": "splinter", "count": [ 3, 6 ] } ],
+      "ranged": { "reduction": [ 2, 4 ], "destroy_threshold": 110, "block_unaimed_chance": "50%" }
     },
     "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "NOITEM", "SUPPORTS_ROOF", "REDUCE_SCENT", "PERMEABLE", "CONNECT_TO_WALL" ]
   },
@@ -856,7 +871,8 @@
       "ter_set": "t_null",
       "sound": "crunch!",
       "sound_fail": "whump!",
-      "items": [ { "item": "2x4", "count": [ 1, 3 ] }, { "item": "splinter", "count": [ 6, 6 ] } ]
+      "items": [ { "item": "2x4", "count": [ 1, 3 ] }, { "item": "splinter", "count": [ 6, 6 ] } ],
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 75, "block_unaimed_chance": "50%" }
     },
     "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "NOITEM", "REDUCE_SCENT", "MOUNTABLE" ]
   },
@@ -1305,7 +1321,9 @@
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_null",
-      "items": [ { "item": "rock", "count": [ 1, 3 ] }, { "item": "rebar", "count": [ 0, 2 ] } ]
+      "items": [ { "item": "rock", "count": [ 1, 3 ] }, { "item": "rebar", "count": [ 0, 2 ] } ],
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 80, "block_unaimed_chance": "75%" }
     }
   },
   {
@@ -1316,6 +1334,7 @@
     "symbol": "*",
     "color": "light_gray",
     "move_cost": 5,
+    "coverage": 80,
     "flags": [ "TRANSPARENT", "NOITEM", "MOUNTABLE", "PERMEABLE", "MINEABLE" ],
     "connects_to": "WALL",
     "bash": {
@@ -1324,7 +1343,9 @@
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 5, 11 ] } ]
+      "items": [ { "item": "rock", "count": [ 5, 11 ] } ],
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 60, 120 ], "destroy_threshold": 120, "block_unaimed_chance": "75%" }
     }
   },
   {
@@ -1450,7 +1471,9 @@
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_null",
-      "items": [ { "item": "rock", "count": [ 3, 8 ] }, { "item": "pebble", "count": [ 20, 38 ] } ]
+      "items": [ { "item": "rock", "count": [ 3, 8 ] }, { "item": "pebble", "count": [ 20, 38 ] } ],
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 30, 60 ], "destroy_threshold": 60, "block_unaimed_chance": "50%" }
     }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-windows.json
+++ b/data/json/furniture_and_terrain/terrain-windows.json
@@ -136,7 +136,11 @@
     "move_cost": 4,
     "extend": { "flags": [ "OPENCLOSE_INSIDE", "MOUNTABLE", "BLOCK_WIND", "THIN_OBSTACLE", "SMALL_PASSAGE", "PERMEABLE" ] },
     "close": "t_window_no_curtains",
-    "bash": { "items": [ { "item": "glass_shard", "count": [ 1, 3 ] } ] }
+    "bash": {
+      "items": [ { "item": "glass_shard", "count": [ 1, 3 ] } ],
+      "//": "This is purely to override hidden inherited range data so open windows won't catch bullets that should fly through uninterrupted",
+      "ranged": { "block_unaimed_chance": "0%" }
+    }
   },
   {
     "type": "terrain",
@@ -194,7 +198,9 @@
         { "item": "sheet", "count": 2 },
         { "item": "stick", "count": 1 },
         { "item": "string_36", "count": 1 }
-      ]
+      ],
+      "//": "This is purely to override hidden inherited range data so open windows won't catch bullets that should fly through uninterrupted",
+      "ranged": { "block_unaimed_chance": "0%" }
     }
   },
   {
@@ -348,8 +354,7 @@
       "sound_fail_vol": 10,
       "ter_set": "t_window_frame",
       "items": [ { "item": "splinter", "count": [ 0, 2 ] }, { "item": "glass_shard", "count": [ 1, 4 ] } ],
-      "//": "reduction and destroy_threshold are lower for plain glass",
-      "ranged": { "reduction": [ 1, 3 ], "destroy_threshold": 3 }
+      "ranged": { "reduction": [ 2, 3 ], "destroy_threshold": 30 }
     }
   },
   {
@@ -372,7 +377,8 @@
       "sound_vol": 14,
       "sound_fail_vol": 10,
       "ter_set": "t_window_empty",
-      "items": [ { "item": "splinter", "count": [ 0, 2 ] } ]
+      "items": [ { "item": "splinter", "count": [ 0, 2 ] } ],
+      "ranged": { "reduction": [ 2, 3 ], "destroy_threshold": 30 }
     }
   },
   {
@@ -393,7 +399,8 @@
       "sound": "crash!",
       "sound_fail": "wham!",
       "ter_set": "t_window_boarded",
-      "items": [ { "item": "splinter", "count": [ 0, 8 ] } ]
+      "items": [ { "item": "splinter", "count": [ 0, 8 ] } ],
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 30 }
     }
   },
   {
@@ -414,7 +421,8 @@
       "sound": "crash!",
       "sound_fail": "wham!",
       "ter_set": "t_window_boarded_noglass",
-      "items": [ { "item": "splinter", "count": [ 0, 8 ] } ]
+      "items": [ { "item": "splinter", "count": [ 0, 8 ] } ],
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 30 }
     }
   },
   {
@@ -446,7 +454,8 @@
       "sound": "crash!",
       "sound_fail": "wham!",
       "ter_set": "t_window_reinforced",
-      "items": [ { "item": "spike", "count": [ 0, 2 ] }, { "item": "sheet_metal", "count": [ 1, 3 ] } ]
+      "items": [ { "item": "spike", "count": [ 0, 2 ] }, { "item": "sheet_metal", "count": [ 1, 3 ] } ],
+      "ranged": { "reduction": [ 9, 18 ], "destroy_threshold": 40 }
     }
   },
   {
@@ -478,7 +487,8 @@
       "sound": "crash!",
       "sound_fail": "wham!",
       "ter_set": "t_window_reinforced_noglass",
-      "items": [ { "item": "spike", "count": [ 0, 2 ] }, { "item": "sheet_metal", "count": [ 1, 3 ] } ]
+      "items": [ { "item": "spike", "count": [ 0, 2 ] }, { "item": "sheet_metal", "count": [ 1, 3 ] } ],
+      "ranged": { "reduction": [ 9, 18 ], "destroy_threshold": 40 }
     }
   },
   {
@@ -562,7 +572,9 @@
         { "item": "sheet", "count": 2 },
         { "item": "stick", "count": 1 },
         { "item": "string_36", "count": 1 }
-      ]
+      ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 3 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 3 }
     }
   },
   {
@@ -607,7 +619,9 @@
         { "item": "sheet", "count": 2 },
         { "item": "stick", "count": 1 },
         { "item": "string_36", "count": 1 }
-      ]
+      ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 3 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 3 }
     }
   },
   {
@@ -626,7 +640,9 @@
       "sound": "glass breaking!",
       "sound_fail": "whack!",
       "ter_set": "t_rock_floor",
-      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ],
+      "//": "Treated as laminated glass in terms of reduction and threshold",
+      "ranged": { "reduction": [ 20, 20 ], "reduction_laser": [ 1, 10 ], "destroy_threshold": 20 }
     }
   },
   {
@@ -645,7 +661,9 @@
       "sound": "glass breaking!",
       "sound_fail": "whack!",
       "ter_set": "t_rock_floor",
-      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ],
+      "//": "Treated as laminated glass in terms of reduction and threshold",
+      "ranged": { "reduction": [ 20, 20 ], "reduction_laser": [ 1, 10 ], "destroy_threshold": 20 }
     }
   },
   {
@@ -664,14 +682,16 @@
       "sound": "glass breaking!",
       "sound_fail": "whack!",
       "ter_set": "t_rock_floor",
-      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ],
+      "//": "Treated as laminated glass in terms of reduction and threshold",
+      "ranged": { "reduction": [ 20, 20 ], "reduction_laser": [ 1, 10 ], "destroy_threshold": 20 }
     }
   },
   {
     "type": "terrain",
     "id": "t_metal_grate_window",
     "name": "Window with metal grate",
-    "description": "Metal bars made into a grate for a window, Highly durability and will stand against any foe",
+    "description": "Metal bars made into a grate for a window, highly durable and will stand against any foe.",
     "looks_like": "t_window_bars",
     "symbol": "#",
     "color": "light_gray",
@@ -713,14 +733,15 @@
         { "item": "steel_chunk", "count": [ 1, 4 ] },
         { "item": "scrap", "count": [ 1, 5 ] },
         { "item": "glass_shard", "count": [ 5, 12 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 50, 75 ], "destroy_threshold": 75 }
     }
   },
   {
     "type": "terrain",
     "id": "t_metal_grate_window_with_curtain",
     "name": "Window with metal grate",
-    "description": "Metal bars made into a grate for a window with a closed curtain, Highly durability and will stand against any foe",
+    "description": "Metal bars made into a grate for a window with a closed curtain, highly durable and will stand against any foe.",
     "looks_like": "t_window_bars_curtains",
     "symbol": "#",
     "color": "light_gray",
@@ -756,14 +777,15 @@
         { "item": "steel_chunk", "count": [ 1, 4 ] },
         { "item": "scrap", "count": [ 1, 5 ] },
         { "item": "glass_shard", "count": [ 5, 12 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 25, 50 ], "destroy_threshold": 75 }
     }
   },
   {
     "type": "terrain",
     "id": "t_metal_grate_window_with_curtain_open",
     "name": "Window with metal grate",
-    "description": "Metal bars made into a grate for a window with a opened curtain, Highly durability and will stand against any foe",
+    "description": "Metal bars made into a grate for a window with a opened curtain, highly durable and will stand against any foe.",
     "looks_like": "t_window_bars_domestic",
     "symbol": "#",
     "color": "light_gray",
@@ -808,14 +830,15 @@
         { "item": "steel_chunk", "count": [ 1, 4 ] },
         { "item": "scrap", "count": [ 1, 5 ] },
         { "item": "glass_shard", "count": [ 5, 12 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 50, 75 ], "destroy_threshold": 75 }
     }
   },
   {
     "type": "terrain",
     "id": "t_metal_grate_window_noglass",
     "name": "Window with metal grate",
-    "description": "Metal bars made into a grate for a window, Highly durability and will stand against any foe",
+    "description": "Metal bars made into a grate for a window, highly durable and will stand against any foe.",
     "looks_like": "t_window_bars",
     "symbol": "#",
     "color": "light_gray",
@@ -848,14 +871,15 @@
         { "item": "steel_chunk", "count": [ 1, 4 ] },
         { "item": "scrap", "count": [ 1, 5 ] },
         { "item": "glass_shard", "count": [ 5, 12 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 50, 75 ], "destroy_threshold": 75 }
     }
   },
   {
     "type": "terrain",
     "id": "t_metal_grate_window_with_curtain_noglass",
     "name": "Window with metal grate",
-    "description": "Metal bars made into a grate for a window with a closed curtain, Highly durability and will stand against any foe",
+    "description": "Metal bars made into a grate for a window with a closed curtain, highly durable and will stand against any foe.",
     "looks_like": "t_window_bars_curtains",
     "symbol": "#",
     "color": "light_gray",
@@ -891,7 +915,8 @@
         { "item": "steel_chunk", "count": [ 1, 4 ] },
         { "item": "scrap", "count": [ 1, 5 ] },
         { "item": "glass_shard", "count": [ 5, 12 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 50, 75 ], "destroy_threshold": 75 }
     }
   },
   {
@@ -943,7 +968,8 @@
         { "item": "steel_chunk", "count": [ 1, 4 ] },
         { "item": "scrap", "count": [ 1, 5 ] },
         { "item": "glass_shard", "count": [ 5, 12 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 50, 75 ], "destroy_threshold": 75 }
     }
   },
   {
@@ -982,7 +1008,9 @@
         { "item": "stick", "count": 1 },
         { "item": "nail", "charges": [ 3, 4 ] },
         { "item": "glass_shard", "count": [ 3, 8 ] }
-      ]
+      ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 2 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 2 }
     }
   },
   {
@@ -1067,7 +1095,9 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_window_frame",
-      "items": [ { "item": "glass_shard", "count": [ 3, 8 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 8 ] } ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 2 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 2 }
     }
   },
   {
@@ -1113,7 +1143,9 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_window_frame",
-      "items": [ { "item": "glass_shard", "count": [ 3, 8 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 8 ] } ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 2 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 2 }
     }
   },
   {
@@ -1199,7 +1231,9 @@
         { "item": "stick", "count": 1 },
         { "item": "nail", "charges": [ 3, 4 ] },
         { "item": "glass_shard", "count": [ 3, 8 ] }
-      ]
+      ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 12 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 12 }
     }
   },
   {
@@ -1284,7 +1318,9 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_window_frame",
-      "items": [ { "item": "glass_shard", "count": [ 3, 8 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 8 ] } ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 12 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 12 }
     }
   },
   {
@@ -1330,7 +1366,9 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_window_frame",
-      "items": [ { "item": "glass_shard", "count": [ 3, 8 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 8 ] } ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 12 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 12 }
     }
   },
   {
@@ -1416,7 +1454,9 @@
         { "item": "stick", "count": 1 },
         { "item": "nail", "charges": [ 3, 4 ] },
         { "item": "glass_shard", "count": [ 3, 8 ] }
-      ]
+      ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 3 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 3 }
     }
   },
   {
@@ -1501,7 +1541,9 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_window_frame",
-      "items": [ { "item": "glass_shard", "count": [ 3, 8 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 8 ] } ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 3 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 3 }
     }
   },
   {
@@ -1547,7 +1589,9 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_window_frame",
-      "items": [ { "item": "glass_shard", "count": [ 3, 8 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 8 ] } ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 3 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 3 }
     }
   },
   {
@@ -1633,7 +1677,9 @@
         { "item": "stick", "count": 1 },
         { "item": "nail", "charges": [ 3, 4 ] },
         { "item": "glass_shard", "count": [ 3, 8 ] }
-      ]
+      ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 12 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 12 }
     }
   },
   {
@@ -1719,7 +1765,9 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_window_frame",
-      "items": [ { "item": "glass_shard", "count": [ 3, 8 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 8 ] } ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 12 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 12 }
     }
   },
   {
@@ -1730,7 +1778,7 @@
     "looks_like": "t_window_domestic",
     "symbol": "|",
     "color": "light_cyan",
-    "move_cost": 4,
+    "move_cost": 0,
     "coverage": 60,
     "roof": "t_flat_roof",
     "flags": [
@@ -1768,7 +1816,9 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_window_frame",
-      "items": [ { "item": "glass_shard", "count": [ 3, 8 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 8 ] } ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 12 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 12 }
     }
   },
   {
@@ -1854,7 +1904,9 @@
         { "item": "stick", "count": 1 },
         { "item": "nail", "charges": [ 3, 4 ] },
         { "item": "glass_shard", "count": [ 5, 12 ] }
-      ]
+      ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 4 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 4 }
     }
   },
   {
@@ -1939,7 +1991,9 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_window_frame",
-      "items": [ { "item": "glass_shard", "count": [ 5, 12 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 5, 12 ] } ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 4 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 4 }
     }
   },
   {
@@ -1985,13 +2039,15 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_window_frame",
-      "items": [ { "item": "glass_shard", "count": [ 3, 8 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 8 ] } ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 4 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 4 }
     }
   },
   {
     "type": "terrain",
     "id": "t_triple_pane_glass_with_curtain_open",
-    "name": "Triple-pane glass window With a curtain",
+    "name": "Triple-pane glass window with a curtain",
     "description": "A triple glazed window with fancy curtains on the inside that can be drawn closed to block visibility and shut out any light.",
     "looks_like": "t_window_open",
     "symbol": "|",
@@ -2071,7 +2127,9 @@
         { "item": "stick", "count": 1 },
         { "item": "nail", "charges": [ 3, 4 ] },
         { "item": "glass_shard", "count": [ 5, 12 ] }
-      ]
+      ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 12 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 12 }
     }
   },
   {
@@ -2156,7 +2214,9 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_window_frame",
-      "items": [ { "item": "glass_shard", "count": [ 5, 12 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 5, 12 ] } ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 12 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 12 }
     }
   },
   {
@@ -2167,7 +2227,7 @@
     "looks_like": "t_window_domestic",
     "symbol": "|",
     "color": "light_cyan",
-    "move_cost": 4,
+    "move_cost": 0,
     "coverage": 60,
     "roof": "t_flat_roof",
     "flags": [
@@ -2205,7 +2265,9 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_window_frame",
-      "items": [ { "item": "glass_shard", "count": [ 3, 8 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 8 ] } ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 12 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 12 }
     }
   },
   {
@@ -2291,7 +2353,9 @@
         { "item": "stick", "count": 1 },
         { "item": "nail", "charges": [ 3, 4 ] },
         { "item": "glass_shard", "count": [ 10, 20 ] }
-      ]
+      ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 5 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 5 }
     }
   },
   {
@@ -2374,7 +2438,9 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_window_frame",
-      "items": [ { "item": "glass_shard", "count": [ 10, 20 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 10, 20 ] } ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 5 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 5 }
     }
   },
   {
@@ -2420,13 +2486,15 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_window_frame",
-      "items": [ { "item": "glass_shard", "count": [ 3, 8 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 8 ] } ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 5 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 5 }
     }
   },
   {
     "type": "terrain",
     "id": "t_quadruple_pane_glass_with_curtain_open",
-    "name": "Quadruple glazed glass window With a curtain",
+    "name": "Quadruple glazed glass window with a curtain",
     "description": "A quadruple glazed window with fancy curtains on the inside that can be drawn closed to block visibility and shut out any light.",
     "looks_like": "t_window_open",
     "symbol": "|",
@@ -2506,7 +2574,9 @@
         { "item": "stick", "count": 1 },
         { "item": "nail", "charges": [ 3, 4 ] },
         { "item": "glass_shard", "count": [ 10, 20 ] }
-      ]
+      ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 12 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 12 }
     }
   },
   {
@@ -2591,7 +2661,9 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_window_frame",
-      "items": [ { "item": "glass_shard", "count": [ 10, 20 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 10, 20 ] } ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 12 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 12 }
     }
   },
   {
@@ -2602,7 +2674,7 @@
     "looks_like": "t_window_domestic",
     "symbol": "|",
     "color": "light_cyan",
-    "move_cost": 4,
+    "move_cost": 0,
     "coverage": 60,
     "roof": "t_flat_roof",
     "flags": [
@@ -2639,13 +2711,15 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_window_frame",
-      "items": [ { "item": "glass_shard", "count": [ 3, 8 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 8 ] } ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 12 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 12 }
     }
   },
   {
     "type": "terrain",
     "id": "t_reinforced_quadruple_pane_glass_with_curtain_open",
-    "name": "Reinforced quadruple glazed glass window With a curtain",
+    "name": "Reinforced quadruple glazed glass window with a curtain",
     "description": "A reinforced quadruple glazed window with fancy curtains on the inside that can be drawn closed to block visibility and shut out any light.",
     "looks_like": "t_window_open",
     "symbol": "|",
@@ -2722,7 +2796,8 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_window_frame",
-      "items": [ { "item": "stick", "count": 1 }, { "item": "nail", "charges": [ 3, 4 ] }, { "item": "plastic_sheet", "count": 1 } ]
+      "items": [ { "item": "stick", "count": 1 }, { "item": "nail", "charges": [ 3, 4 ] }, { "item": "plastic_sheet", "count": 1 } ],
+      "ranged": { "reduction": [ 2, 3 ], "destroy_threshold": 5 }
     }
   },
   {
@@ -2765,7 +2840,7 @@
     "type": "terrain",
     "id": "t_plastic_window_with_curtain",
     "name": "Plastic window with a curtain",
-    "description": "A makeshift window with a closed curtain.  comprising a sheet of translucent, rigid plastic secured in a wooden frame.  There are sheets drawn across it to block the light.  It'll do in a pinch.",
+    "description": "A makeshift window with a closed curtain.  Comprising a sheet of translucent, rigid plastic secured in a wooden frame.  There are sheets drawn across it to block the light.  It'll do in a pinch.",
     "looks_like": "t_curtains",
     "symbol": "|",
     "color": "light_blue",
@@ -2803,14 +2878,15 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_window_frame",
-      "items": [ { "item": "stick", "count": 1 }, { "item": "nail", "charges": [ 3, 4 ] }, { "item": "plastic_sheet", "count": 1 } ]
+      "items": [ { "item": "stick", "count": 1 }, { "item": "nail", "charges": [ 3, 4 ] }, { "item": "plastic_sheet", "count": 1 } ],
+      "ranged": { "reduction": [ 2, 3 ], "destroy_threshold": 5 }
     }
   },
   {
     "type": "terrain",
     "id": "t_plastic_window_with_curtain_open_window_closed",
     "name": "Plastic window with a curtain",
-    "description": "A makeshift window with a opened curtain.  comprising a sheet of translucent, rigid plastic secured in a wooden frame, with sheets strung about it to block the light as required.  It'll do in a pinch.",
+    "description": "A makeshift window with a opened curtain.  Comprising a sheet of translucent, rigid plastic secured in a wooden frame, with sheets strung about it to block the light as required.  It'll do in a pinch.",
     "looks_like": "t_window_domestic",
     "symbol": "|",
     "color": "light_blue",
@@ -2849,14 +2925,15 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_window_frame",
-      "items": [ { "item": "stick", "count": 1 }, { "item": "nail", "charges": [ 3, 4 ] }, { "item": "plastic_sheet", "count": 1 } ]
+      "items": [ { "item": "stick", "count": 1 }, { "item": "nail", "charges": [ 3, 4 ] }, { "item": "plastic_sheet", "count": 1 } ],
+      "ranged": { "reduction": [ 2, 3 ], "destroy_threshold": 5 }
     }
   },
   {
     "type": "terrain",
     "id": "t_plastic_window_with_curtain_open",
-    "name": "Plastic window With a curtain",
-    "description": "An opened makeshift window with a opened curtain.  comprising a sheet of translucent, rigid plastic secured in a wooden frame, with sheets strung about it to block the light as required.  It'll do in a pinch.",
+    "name": "Plastic window with a curtain",
+    "description": "An opened makeshift window with a opened curtain.  Comprising a sheet of translucent, rigid plastic secured in a wooden frame, with sheets strung about it to block the light as required.  It'll do in a pinch.",
     "looks_like": "t_window_open",
     "symbol": "|",
     "color": "light_blue",
@@ -2935,7 +3012,8 @@
         { "item": "stick", "count": 1 },
         { "item": "nail", "charges": [ 3, 4 ] },
         { "item": "plastic_sheet", "count": [ 1, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 15 }
     }
   },
   {
@@ -2975,14 +3053,15 @@
         { "item": "stick", "count": 1 },
         { "item": "nail", "charges": [ 3, 4 ] },
         { "item": "plastic_sheet", "count": [ 1, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 15 }
     }
   },
   {
     "type": "terrain",
     "id": "t_reinforced_plastic_window_with_curtain",
     "name": "Reinforced plastic window with a curtain",
-    "description": "A makeshift window with a closed curtain.  comprising three sheets of translucent, rigid plastic secured in a wooden frame.  It'll do in a pinch.",
+    "description": "A makeshift window with a closed curtain.  Comprising three sheets of translucent, rigid plastic secured in a wooden frame.  It'll do in a pinch.",
     "looks_like": "t_curtains",
     "symbol": "|",
     "color": "light_blue",
@@ -3024,14 +3103,15 @@
         { "item": "stick", "count": 1 },
         { "item": "nail", "charges": [ 3, 4 ] },
         { "item": "plastic_sheet", "count": [ 1, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 15 }
     }
   },
   {
     "type": "terrain",
     "id": "t_reinforced_plastic_window_with_curtain_open_window_closed",
     "name": "Reinforced plastic window with a curtain",
-    "description": "A makeshift window with a opened curtain.  comprising three sheets of translucent, rigid plastic secured in a wooden frame.  It'll do in a pinch.",
+    "description": "A makeshift window with a opened curtain.  Comprising three sheets of translucent, rigid plastic secured in a wooden frame.  It'll do in a pinch.",
     "looks_like": "t_window_domestic",
     "symbol": "|",
     "color": "light_blue",
@@ -3074,14 +3154,15 @@
         { "item": "stick", "count": 1 },
         { "item": "nail", "charges": [ 3, 4 ] },
         { "item": "plastic_sheet", "count": [ 1, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 15 }
     }
   },
   {
     "type": "terrain",
     "id": "t_reinforced_plastic_window_with_curtain_open",
     "name": "Reinforced plastic window With a curtain",
-    "description": "An open makeshift window with a opened curtain.  comprising three sheets of translucent, rigid plastic secured in a wooden frame.  It'll do in a pinch.",
+    "description": "An open makeshift window with a opened curtain.  Comprising three sheets of translucent, rigid plastic secured in a wooden frame.  It'll do in a pinch.",
     "looks_like": "t_window_open",
     "symbol": "|",
     "color": "light_blue",
@@ -3183,7 +3264,9 @@
         { "item": "stick", "count": 1 },
         { "item": "nail", "charges": [ 3, 4 ] },
         { "item": "glass_shard", "count": [ 3, 8 ] }
-      ]
+      ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 15 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 15 }
     }
   },
   {
@@ -3267,7 +3350,9 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_window_frame",
-      "items": [ { "item": "glass_shard", "count": [ 3, 8 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 8 ] } ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 15 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 15 }
     }
   },
   {
@@ -3313,7 +3398,9 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_window_frame",
-      "items": [ { "item": "glass_shard", "count": [ 3, 8 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 8 ] } ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 15 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 15 }
     }
   },
   {
@@ -3385,7 +3472,8 @@
         { "item": "steel_chunk", "count": [ 1, 4 ] },
         { "item": "scrap", "count": [ 1, 5 ] },
         { "item": "glass_shard", "count": [ 20, 50 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 25, 50 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 75 }
     }
   }
 ]


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This finally applies ranged bash info to the remaining doors and windows that already had `ranged` data partially in use.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Belatedly added ranged data to triffid furniture that was added while the original implementation of furniture ranged bash info was being worked on.
2. Finally gave all the variations on closed doors ranged bash info instead of only the basic ones having it, derp.
3. Fixed one case of mistakening giving an open door ranged data.
4. Gave ranged bashed info to all other transparent walls that lacked this, the rest will come next PR.
5. Misc: gave half-built columns a coverage value.
6. Updated windows with some missing ranged data.
7. Important: I learned that for some reason bash info isn't fully overriden when specified. Windows seem to be deliberately using this to not have to copy strength and noise and such, but it had a side effect of allowing open windows to ALWAYS catch bullets as if they were closed windows. To fix that I found one can slap a new `ranged` bit on these that specify a 0% intercept chance.
8. Minor: typofixes.
9. Minor: fixed being able to walk into a closed window variant or two.

Side note: metal grate windows are WEIRD. They seem to be flavored like barred windows but they oxytorch/deconstruct into up-armored BOARDED UP windows, yet you can see through them as if they were just barred windows. But those windows can be easily smashed into a version that is then tougher but no longer has glass, while this smash into an empty window frame but take massive punishment. These were also where all the typo fixes came in, the descriptions all had a copypasted line that was malformed in the same way every time.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.
3. Tested that setting intercept chance of open windows to 0% fixes the issue of them being shot apart as if they were closed windows.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
