### PR TITLE
feat(balance): ranged bash info for solid walls

### DIFF
--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -43,7 +43,8 @@
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_null",
-      "items": "wall_bash_results"
+      "items": "wall_bash_results",
+      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 210 }
     }
   },
   {
@@ -123,7 +124,8 @@
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_null",
-      "items": "wall_bash_results"
+      "items": "wall_bash_results",
+      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 210 }
     }
   },
   {
@@ -144,7 +146,8 @@
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_null",
-      "items": "wall_bash_results"
+      "items": "wall_bash_results",
+      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 210 }
     }
   },
   {
@@ -165,7 +168,8 @@
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_null",
-      "items": "wall_bash_results"
+      "items": "wall_bash_results",
+      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 210 }
     }
   },
   {
@@ -186,7 +190,8 @@
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_null",
-      "items": "wall_bash_results"
+      "items": "wall_bash_results",
+      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 210 }
     }
   },
   {
@@ -207,7 +212,8 @@
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_null",
-      "items": "wall_bash_results"
+      "items": "wall_bash_results",
+      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 210 }
     }
   },
   {
@@ -227,7 +233,8 @@
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_null",
-      "items": "wall_bash_results"
+      "items": "wall_bash_results",
+      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 210 }
     }
   },
   {
@@ -248,7 +255,8 @@
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_null",
-      "items": "wall_bash_results"
+      "items": "wall_bash_results",
+      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 210 }
     }
   },
   {
@@ -288,7 +296,9 @@
       "sound": "crash!",
       "sound_fail": "bash!",
       "ter_set": "t_null",
-      "items": [ { "item": "rock", "count": [ 8, 15 ] }, { "item": "brick", "count": [ 2, 6 ] } ]
+      "items": [ { "item": "rock", "count": [ 8, 15 ] }, { "item": "brick", "count": [ 2, 6 ] } ],
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 60, 120 ], "destroy_threshold": 120 }
     }
   },
   {
@@ -309,7 +319,9 @@
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_null",
-      "items": [ { "item": "rock", "count": [ 8, 18 ] } ]
+      "items": [ { "item": "rock", "count": [ 8, 18 ] } ],
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 80, 160 ], "destroy_threshold": 160 }
     }
   },
   {
@@ -356,7 +368,9 @@
         { "item": "sharp_rock", "count": [ 3, 7 ] },
         { "item": "material_limestone", "charges": [ 5, 15 ], "prob": 80 },
         { "item": "material_rocksalt", "prob": 10 }
-      ]
+      ],
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 120, 240 ], "destroy_threshold": 240 }
     }
   },
   {
@@ -397,7 +411,9 @@
       "sound": "crash!",
       "sound_fail": "bash!",
       "ter_set": "t_null",
-      "items": [ { "item": "material_soil", "count": [ 8, 20 ] }, { "item": "adobe_brick", "count": [ 2, 6 ] } ]
+      "items": [ { "item": "material_soil", "count": [ 8, 20 ] }, { "item": "adobe_brick", "count": [ 2, 6 ] } ],
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 80 }
     }
   },
   {
@@ -418,7 +434,9 @@
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
+      "items": [ { "item": "rock", "count": [ 10, 22 ] } ],
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 70, 140 ], "destroy_threshold": 140 }
     }
   },
   {
@@ -448,7 +466,8 @@
         { "item": "steel_lump", "count": [ 1, 4 ] },
         { "item": "steel_chunk", "count": [ 3, 12 ] },
         { "item": "scrap", "count": [ 9, 36 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 100, 200 ], "destroy_threshold": 600 }
     }
   },
   {
@@ -473,7 +492,8 @@
         { "item": "steel_lump", "count": [ 1, 4 ] },
         { "item": "steel_chunk", "count": [ 3, 12 ] },
         { "item": "scrap", "count": [ 9, 36 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 100, 200 ], "destroy_threshold": 600 }
     }
   },
   {
@@ -494,7 +514,9 @@
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_pit_shallow",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
+      "items": [ { "item": "rock", "count": [ 10, 22 ] } ],
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 90, 180 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -535,7 +557,9 @@
       "sound": "scrrrash!",
       "sound_fail": "whump!",
       "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
+      "items": [ { "item": "rock", "count": [ 10, 22 ] } ],
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 120, 240 ], "destroy_threshold": 240 }
     }
   },
   {
@@ -606,7 +630,8 @@
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "ter_set": "t_pit_shallow",
-      "items": [ { "item": "steel_chunk", "count": [ 10, 22 ] } ]
+      "items": [ { "item": "steel_chunk", "count": [ 10, 22 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 200 }
     }
   },
   {
@@ -651,7 +676,8 @@
         { "item": "wood_panel", "count": [ 0, 2 ] },
         { "item": "nail", "charges": [ 1, 5 ] },
         { "item": "splinter", "count": [ 1, 4 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 150 }
     }
   },
   {
@@ -676,7 +702,8 @@
         { "item": "wood_panel", "count": [ 0, 2 ] },
         { "item": "nail", "charges": [ 1, 3 ] },
         { "item": "splinter", "count": [ 1, 4 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 150 }
     }
   },
   {
@@ -742,7 +769,8 @@
       "sound": "crunch!",
       "sound_fail": "whump!",
       "ter_set": "t_wall_log_chipped",
-      "items": [ { "item": "splinter", "count": [ 5, 10 ] } ]
+      "items": [ { "item": "splinter", "count": [ 5, 10 ] } ],
+      "ranged": { "reduction": [ 30, 60 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -762,7 +790,8 @@
       "sound": "crunch!",
       "sound_fail": "whump!",
       "ter_set": "t_wall_log_broken",
-      "items": [ { "item": "splinter", "count": [ 5, 10 ] } ]
+      "items": [ { "item": "splinter", "count": [ 5, 10 ] } ],
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 160 }
     }
   },
   {
@@ -800,7 +829,8 @@
       "sound": "crunch!",
       "sound_fail": "whump!",
       "ter_set": "t_null",
-      "items": [ { "item": "splinter", "count": [ 10, 30 ] } ]
+      "items": [ { "item": "splinter", "count": [ 10, 30 ] } ],
+      "ranged": { "reduction": [ 18, 35 ], "destroy_threshold": 150 }
     }
   },
   {
@@ -819,7 +849,8 @@
       "ter_set": "t_wall_wattle_broken",
       "sound": "crunch!",
       "sound_fail": "whump!",
-      "items": [ { "item": "2x4", "count": [ 0, 3 ] }, { "item": "splinter", "count": [ 0, 6 ] } ]
+      "items": [ { "item": "2x4", "count": [ 0, 3 ] }, { "item": "splinter", "count": [ 0, 6 ] } ],
+      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 140 }
     },
     "flags": [ "FLAMMABLE_HARD", "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "BLOCK_WIND" ]
   },
@@ -883,7 +914,8 @@
         { "item": "scrap", "count": [ 1, 40 ] },
         { "item": "sheet_metal", "count": [ 1, 2 ] },
         { "item": "steel_chunk", "count": [ 1, 30 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 30, 60 ], "destroy_threshold": 200 }
     }
   },
   {
@@ -903,7 +935,9 @@
       "sound": "heavy rumbling!",
       "sound_fail": "thump",
       "ter_set": "t_fence_post",
-      "items": [ { "item": "material_soil", "count": [ 50, 75 ] } ]
+      "items": [ { "item": "material_soil", "count": [ 50, 75 ] } ],
+      "//": "reduction equal to str_max as with sandbags",
+      "ranged": { "reduction": [ 200, 200 ], "destroy_threshold": 200 }
     }
   },
   {
@@ -924,7 +958,8 @@
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "ter_set": "t_floor",
-      "items": [ { "item": "pipe", "count": [ 1, 2 ] }, { "item": "scrap", "count": [ 1, 40 ] } ]
+      "items": [ { "item": "pipe", "count": [ 1, 2 ] }, { "item": "scrap", "count": [ 1, 40 ] } ],
+      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 200 }
     }
   },
   {
@@ -1167,7 +1202,8 @@
       "sound": "crunch!",
       "sound_fail": "whump!",
       "ter_set": "t_null",
-      "items": [ { "item": "splinter", "count": [ 2, 5 ] } ]
+      "items": [ { "item": "splinter", "count": [ 2, 5 ] } ],
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 150 }
     }
   },
   {
@@ -1187,7 +1223,8 @@
       "sound": "crunch!",
       "sound_fail": "whump!",
       "ter_set": "t_floor_wax",
-      "items": [ { "item": "wax", "count": [ 3, 5 ] } ]
+      "items": [ { "item": "wax", "count": [ 3, 5 ] } ],
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 150 }
     }
   },
   {
@@ -1213,7 +1250,9 @@
         { "item": "sharp_rock", "count": [ 5, 9 ] },
         { "item": "material_limestone", "charges": [ 10, 25 ], "prob": 80 },
         { "group": "rock_mining_extra", "prob": 25 }
-      ]
+      ],
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 100, 200 ], "destroy_threshold": 200 }
     }
   },
   {
@@ -1237,7 +1276,9 @@
         { "item": "sharp_rock", "count": [ 3, 7 ] },
         { "item": "material_limestone", "charges": [ 5, 15 ], "prob": 80 },
         { "item": "material_rocksalt", "prob": 10 }
-      ]
+      ],
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 100, 200 ], "destroy_threshold": 200 }
     }
   },
   {
@@ -1261,7 +1302,9 @@
         { "item": "sharp_rock", "count": [ 3, 7 ] },
         { "item": "material_limestone", "charges": [ 5, 15 ], "prob": 80 },
         { "item": "material_rocksalt", "prob": 10 }
-      ]
+      ],
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 100, 200 ], "destroy_threshold": 200 }
     }
   },
   {
@@ -1285,7 +1328,9 @@
         { "item": "sharp_rock", "count": [ 3, 7 ] },
         { "item": "material_limestone", "charges": [ 5, 15 ], "prob": 80 },
         { "item": "material_rocksalt", "prob": 10 }
-      ]
+      ],
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 100, 200 ], "destroy_threshold": 200 }
     }
   },
   {
@@ -1339,11 +1384,13 @@
     "flags": [ "WALL", "PERMEABLE", "MINEABLE" ],
     "bash": {
       "str_min": 120,
-      "str_max": 200,
+      "str_max": 460,
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
+      "items": [ { "item": "rock", "count": [ 10, 22 ] } ],
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 120, 240 ], "destroy_threshold": 240 }
     }
   },
   {
@@ -1367,7 +1414,8 @@
         { "item": "steel_lump", "count": [ 0, 2 ] },
         { "item": "steel_chunk", "count": [ 2, 6 ] },
         { "item": "scrap", "count": [ 5, 18 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 200 }
     },
     "deconstruct": {
       "ter_set": "t_concrete",
@@ -1400,7 +1448,8 @@
         { "item": "steel_lump", "prob": 50 },
         { "item": "steel_chunk", "count": [ 1, 3 ] },
         { "item": "scrap", "count": [ 2, 9 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 200 }
     },
     "deconstruct": {
       "ter_set": "t_concrete",
@@ -1430,7 +1479,9 @@
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_null",
-      "items": [ { "item": "rock", "count": [ 8, 18 ] }, { "item": "pebble", "count": [ 20, 38 ] } ]
+      "items": [ { "item": "rock", "count": [ 8, 18 ] }, { "item": "pebble", "count": [ 20, 38 ] } ],
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 50, 100 ], "destroy_threshold": 100 }
     }
   },
   {
@@ -1466,11 +1517,13 @@
     "flags": [ "WALL", "PERMEABLE", "MINEABLE" ],
     "bash": {
       "str_min": 120,
-      "str_max": 200,
+      "str_max": 350,
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_reb_cage",
-      "items": [ { "item": "rock", "count": [ 10, 22 ] } ]
+      "items": [ { "item": "rock", "count": [ 10, 22 ] } ],
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 120, 240 ], "destroy_threshold": 240 }
     }
   },
   {


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This is in parallel with https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4219, while that finishes up adding ranged bash info to doors and other stuff that had ranged bash info partially implemented, this sets aside the addition of ranged data to solid walls.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Added ranged info to all non-transparent items in terrain-walls.json. Transparent stuff (i.e. half-built and damaged walls) meanwhile are covered by the above PR.
2. Also bumped up `str_max` of finished columns to match that of half-built ones, so the destroy thresh of its ranged info won't be higher than its max bash resist.
3. Likewise bumped `str_max` of concrete supports to match that of simple concrete walls, in between little and large concrete columns, for the same reason.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. First, tested firing a composite longbow at a mundane `t_wall` with full strength prior to implementing these changes. A few arrows later and it destroyed the wall.
2. Checked affected files for syntax and lint errors.
3. Load-tested in test build.
4. Repeated above test firing arrows from a composite longbow at a mundane interior wall. Hit it with 20-30 arrows and it stayed intact.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Side note, we could in the future give mundane walls a damaged state that allows knocking holes in the drywall while making the underlying support stay as hard to destroy as they are now. :3

An additional thought I had: it might be better for the code that checks `destroy_threshold` to check the projectile damage before applying damage reduction. This would allow for things like the previously-mentioned ability to knock down steel targets that bounce off the plate, and in general support terrain being wrecked by a shot it otherwise fully absorbs. Current behavior by contrast makes any terrain that fully absorbs the damage of a shot entirely impossible to destroy.

Only problem there is we'd have to either hardcode some randomness in the `destroy_threshold` check, or convert it to an array like `reduction` already is. The former would be hacky, but the latter would require I go back over every terrain and furniture in the repo and pick new minimum vulnerability values which is just auuugh. Not adding any randomness to it would mean that a given ammo will only ever always destroy the terrain it hits or never do so.

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
