### PR TITLE
chore(mods/magiclysm): Remove myself as Magiclysm Maintainer

### DIFF
--- a/data/mods/Magiclysm/modinfo.json
+++ b/data/mods/Magiclysm/modinfo.json
@@ -4,7 +4,7 @@
     "id": "magiclysm",
     "name": "Magiclysm",
     "authors": [ "KorGgenT", "Aptronym", "LaVeyanFiend" ],
-    "maintainers": [ ],
+    "maintainers": [  ],
     "description": "Cataclysm but with magic spells, BN Edition!",
     "category": "content",
     "dependencies": [ "bn" ]

--- a/data/mods/Magiclysm/modinfo.json
+++ b/data/mods/Magiclysm/modinfo.json
@@ -4,7 +4,7 @@
     "id": "magiclysm",
     "name": "Magiclysm",
     "authors": [ "KorGgenT", "Aptronym", "LaVeyanFiend" ],
-    "maintainers": [ "Robbietheneko" ],
+    "maintainers": [ "none" ],
     "description": "Cataclysm but with magic spells, BN Edition!",
     "category": "content",
     "dependencies": [ "bn" ]

--- a/data/mods/Magiclysm/modinfo.json
+++ b/data/mods/Magiclysm/modinfo.json
@@ -4,7 +4,7 @@
     "id": "magiclysm",
     "name": "Magiclysm",
     "authors": [ "KorGgenT", "Aptronym", "LaVeyanFiend" ],
-    "maintainers": [ "none" ],
+    "maintainers": [ ],
     "description": "Cataclysm but with magic spells, BN Edition!",
     "category": "content",
     "dependencies": [ "bn" ]


### PR DESCRIPTION
## Purpose of change

I'm not actually maintaining or updating Magiclysm anymore.

## Describe the solution

Removes myself from the list of maintainers in the modinfo file, replaces it with "none"

## Describe alternatives you've considered

- PR'ing moving Magical Nights in-repo
Not _**yet**_. But later, perhaps ;3

## Testing

N/A

## Additional context

I'd strongly suggest people interested in updated content that's actually getting maintained check out Magical Nights instead.

