### PR TITLE
feat(balance): allow pulping `zombify_into` corpses

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1926,7 +1926,8 @@ void activity_handlers::pulp_do_turn( player_activity *act, player *p )
     map_stack corpse_pile = here.i_at( pos );
     for( item *&corpse : corpse_pile ) {
         const mtype *corpse_mtype = corpse->get_mtype();
-        if( !corpse->is_corpse() || !corpse_mtype->has_flag( MF_REVIVES ) || !corpse_mtype->zombify_into ||
+        if( !corpse->is_corpse() || ( !corpse_mtype->has_flag( MF_REVIVES ) &&
+                                      !corpse_mtype->zombify_into ) ||
             ( std::find( act->str_values.begin(), act->str_values.end(), "auto_pulp_no_acid" ) !=
               act->str_values.end() && corpse_mtype->bloodType().obj().has_acid ) ) {
             // Don't smash non-rezing corpses //don't smash acid zombies when auto pulping

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1926,7 +1926,7 @@ void activity_handlers::pulp_do_turn( player_activity *act, player *p )
     map_stack corpse_pile = here.i_at( pos );
     for( item *&corpse : corpse_pile ) {
         const mtype *corpse_mtype = corpse->get_mtype();
-        if( !corpse->is_corpse() || !corpse_mtype->has_flag( MF_REVIVES ) ||
+        if( !corpse->is_corpse() || !corpse_mtype->has_flag( MF_REVIVES ) || !corpse_mtype->zombify_into ||
             ( std::find( act->str_values.begin(), act->str_values.end(), "auto_pulp_no_acid" ) !=
               act->str_values.end() && corpse_mtype->bloodType().obj().has_acid ) ) {
             // Don't smash non-rezing corpses //don't smash acid zombies when auto pulping

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -32,6 +32,7 @@
 #include "debug.h"
 #include "field.h"
 #include "field_type.h"
+#include "flag.h"
 #include "fstream_utils.h"
 #include "game.h"
 #include "game_constants.h"
@@ -3180,9 +3181,11 @@ bool cata_tiles::draw_zombie_revival_indicators( const tripoint &pos, const lit_
     if( tileset_ptr->find_tile_type( ZOMBIE_REVIVAL_INDICATOR ) && !invisible[0] &&
         item_override.find( pos ) == item_override.end() && here.could_see_items( pos, g->u ) ) {
         for( auto &i : here.i_at( pos ) ) {
-            if( i->can_revive() ) {
-                return draw_from_id_string( ZOMBIE_REVIVAL_INDICATOR, C_NONE, empty_string, pos, 0, 0,
-                                            lit_level::LIT, false, z_drop );
+            if( i->is_corpse() ) {
+                if( i->can_revive() || ( i->get_mtype()->zombify_into && !i->has_flag( flag_PULPED ) ) ) {
+                    return draw_from_id_string( ZOMBIE_REVIVAL_INDICATOR, C_NONE, empty_string, pos, 0, 0,
+                                                lit_level::LIT, false, z_drop );
+                }
             }
         }
     }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -756,7 +756,8 @@ static void smash()
 
     bool should_pulp = false;
     for( const item * const &it : here.i_at( smashp ) ) {
-        if( it->is_corpse() && it->damage() < it->max_damage() && it->can_revive() ) {
+        if( it->is_corpse() && it->damage() < it->max_damage() && ( it->can_revive() ||
+                it->get_mtype()->zombify_into ) ) {
             if( it->get_mtype()->bloodType()->has_acid ) {
                 if( query_yn( _( "Are you sure you want to pulp an acid filled corpse?" ) ) ) {
                     should_pulp = true;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4104,7 +4104,7 @@ nc_color item::color_in_inventory( const player &p ) const
     } else if( active && !is_food() && !is_food_container() && !is_corpse() ) {
         // Active items show up as yellow
         ret = c_yellow;
-    } else if( is_corpse() && ( can_revive() || corpse->zombify_into ) ) {
+    } else if( is_corpse() && ( can_revive() || corpse->zombify_into ) && !has_flag( flag_PULPED ) ) {
         // Only reviving corpses are yellow
         ret = c_yellow;
     } else if( const item *food = get_food() ) {
@@ -9146,7 +9146,7 @@ detached_ptr<item> item::process_corpse( detached_ptr<item> &&self, player *carr
     if( self->corpse == nullptr || self->damage() >= self->max_damage() ) {
         return std::move( self );
     }
-    if( self->corpse->zombify_into && self->rotten() && self->damage() >= self->max_damage() ) {
+    if( self->corpse->zombify_into && self->rotten() && !self->has_flag( flag_PULPED ) ) {
         self->rot -= self->get_shelf_life();
         self->corpse = &*self->corpse->zombify_into;
         return std::move( self );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4104,7 +4104,7 @@ nc_color item::color_in_inventory( const player &p ) const
     } else if( active && !is_food() && !is_food_container() && !is_corpse() ) {
         // Active items show up as yellow
         ret = c_yellow;
-    } else if( is_corpse() && can_revive() ) {
+    } else if( is_corpse() && ( can_revive() || corpse->zombify_into ) ) {
         // Only reviving corpses are yellow
         ret = c_yellow;
     } else if( const item *food = get_food() ) {
@@ -9146,7 +9146,7 @@ detached_ptr<item> item::process_corpse( detached_ptr<item> &&self, player *carr
     if( self->corpse == nullptr || self->damage() >= self->max_damage() ) {
         return std::move( self );
     }
-    if( self->corpse->zombify_into && self->rotten() ) {
+    if( self->corpse->zombify_into && self->rotten() && self->damage() >= self->max_damage() ) {
         self->rot -= self->get_shelf_life();
         self->corpse = &*self->corpse->zombify_into;
         return std::move( self );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3093,7 +3093,8 @@ void map::smash_items( const tripoint &p, const int power, const std::string &ca
         if( will_explode_on_impact( power ) && it->will_explode_in_fire() ) {
             return item::detonate( std::move( it ), p, contents );
         }
-        if( ( power < min_destroy_threshold || !do_destroy ) && !it->can_revive() ) {
+        if( ( power < min_destroy_threshold || !do_destroy ) && !it->can_revive() &&
+            !it->get_mtype()->zombify_into ) {
             return std::move( it );
         }
         bool is_active_explosive = it->active && it->type->get_use( "explosion" ) != nullptr;


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This change aims to make it so you can pulp dead feral humans to keep them from reviving like you would with regular zombies, instead of the only option being to butcher them (or wait for them to revive, kill their zombie form, them pulp that).

WIP because I'm out and about on laptop currently, will test then mark as ready when I get home.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. In activity_handlers.cpp, set it so `activity_handlers::pulp_do_turn` treats coprses with `zombify_into` as valid to pulp.
2. In cata_tiles.cpp, set `cata_tiles::draw_zombie_revival_indicators` to also check for unpulped monsters with `zombify_into` set for the sake of displaying the "stuff that should be pulped" indicator. Nested in a check for is_corpse to avoid potential access violation shenanigans I encountered during initial testing.
3. In handle_action.cpp, also set it so `smash` considers corpses that have `zombify_into` valid to pulp.
4. In item.cpp, changed `item::color_in_inventory` so that corpses with `zombify_into` show as yellow, just as ones with `REVIVES` do, and set it so the corpse being pulped reliably invalidates this.
5. Also in item.cpp, changed `item::process_corpse` so the part that handles `zombify_into` also checks that the corpse isn't pulped before changing monster type.
6. In map.cpp, set it so `map::smash_items` can correctly spot corpses with `zombify_into` for smashing.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Started with a benchmark test in my playthrough build by debug-killing a bunch of feral humans, changing time forward 5 days, then waiting 5 minutes. As expected, they soon all converted into un-revived zombie corpses and started to get back up.

1. Compiled and load-tested.
2. Spawned in some feral humans and debug-killed them.
3. Observed that the bodies now show as yellow.
4. Pulped half of the bodies, they can now be pulped, stop showing as yellow afterward and can only be pulped once.
5. Advanced time forward 5 days.
7. Waited five minutes, only the intact feral human corpses converted into zombies and reanimated.
8. Also spawned in some regular zombies and repeated above tests, to confirm that they still displayed, pulped, and reanimated as normal.
9. Tested a save with Dinomod, spawned in a pair of T. Rexes and confirmed they show as pulpable when slain, and pulping them works.
10. Checked affected files for astyle.

<details>
<summary>Screenshots:</summary>

![1](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/bd15c69a-1e3e-4802-9c70-26fc8342721c)

![2](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/622a488b-54c6-45f9-913d-2ea5e4a84b4e)

![1](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/4e8cd212-bc28-4b3c-a808-af5d545106f1)

![2](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/bfb85c5a-7855-4038-ab90-a83c0eb084da)

<details>

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

I'm 90% certain DDA does this too but dunno what PR it is nor if there's any difference in how they do it.

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
