### PR TITLE
fix: Changed 'Mature Plant' to 'Maturing Plant'

### DIFF
--- a/data/json/furniture_and_terrain/furniture-domestic_plants.json
+++ b/data/json/furniture_and_terrain/furniture-domestic_plants.json
@@ -89,7 +89,7 @@
     "type": "furniture",
     "id": "f_plant_mature",
     "name": "maturing plant",
-    "description": "This plant is flowering.",
+    "description": "This plant is maturing.",
     "symbol": "#",
     "color": "green",
     "move_cost_mod": 0,

--- a/data/json/furniture_and_terrain/furniture-domestic_plants.json
+++ b/data/json/furniture_and_terrain/furniture-domestic_plants.json
@@ -88,8 +88,8 @@
   {
     "type": "furniture",
     "id": "f_plant_mature",
-    "name": "mature plant",
-    "description": "This plant has matured.",
+    "name": "maturing plant",
+    "description": "This plant is flowering.",
     "symbol": "#",
     "color": "green",
     "move_cost_mod": 0,
@@ -198,7 +198,7 @@
   {
     "type": "furniture",
     "id": "f_planter_mature",
-    "name": "planter with mature plant",
+    "name": "planter with maturing plant",
     "description": "A garden planter full of soil and slatted to allow adequate drainage.  Can be used for planting crops.  This one contains a planted seed",
     "symbol": "#",
     "color": "green",


### PR DESCRIPTION
## Purpose of change

As pointed out by a member of the Discord, it's a *little* confusing how "Mature" plants aren't actually ready to harvest yet. Thus, this change is for clarity and to make it perfectly clear that it's not yet harvestable

## Describe the solution

Changed "Mature" to "Maturing" in the JSON file containing the single furniture id that every plant secretly points to when in the mature stage (and also changed the one for plants in planters too of course)

## Describe alternatives you've considered

- Flowering
Considering how this name change would affect **every** plant, not sensible. Would work decently well if we ever rework the plants system for some reason though.

## Testing

Checked to make sure the game didn't yell at me, and that it indeed does what it should. Should be auto-linted since I moved to VSCode where I can use the plugin.

## Additional context

Change suggested by Cürt in the Discord.

Left the ids themselves alone because changing them would be too much work and they still work perfectly fine given the simplicity of the change.

No clue what to mark this PR as other than chore, but that didn't really feel right so I went with next best thing of fix
