### PR TITLE
fix: remove root wall from survivor bunker

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -2635,5 +2635,97 @@
       { "item": "chem_black_powder", "charges": [ 100, 2500 ], "container-item": "wooden_barrel_small", "prob": 50 },
       { "item": "4570_low", "charges": [ 1, 240 ], "prob": 50 }
     ]
+  },
+  {
+    "type": "item_group",
+    "id": "oa_ig_sb_food",
+    "items": [
+      { "item": "veggy_pickled", "prob": 30, "charges": 2, "container-item": "jar_glass_sealed" },
+      { "item": "fish_pickled", "prob": 26, "charges": 2, "container-item": "jar_glass_sealed" },
+      { "item": "meat_pickled", "prob": 20, "charges": 2, "container-item": "jar_glass_sealed" },
+      [ "dry_meat", 20 ],
+      [ "dry_veggy", 20 ],
+      [ "carrot", 20 ],
+      [ "water_clean", 80 ],
+      [ "water_mineral", 5 ],
+      [ "cola", 70 ],
+      [ "creamsoda", 60 ],
+      [ "lemonlime", 60 ],
+      [ "orangesoda", 60 ],
+      [ "crispycran", 40 ],
+      [ "colamdew", 60 ],
+      [ "choc_drink", 30 ],
+      [ "jerky", 55 ],
+      [ "salted_fish", 35 ],
+      [ "porkstick", 55 ],
+      [ "cheese_hard", 15 ],
+      [ "can_beans", 40 ],
+      [ "can_corn", 35 ],
+      [ "can_spam", 30 ],
+      [ "salt", 10 ],
+      [ "seasoning_salt", 5 ],
+      [ "jar_sauerkraut_pickled", 20 ],
+      [ "lutefisk", 20 ],
+      [ "pemmican", 20 ]
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "oa_ig_sb_equipment",
+    "items": [
+      [ "flask_hip", 20 ],
+      [ "shortbow", 20 ],
+      [ "arrow_wood_heavy", 20 ],
+      [ "arrow_fire_hardened_fletched", 20 ],
+      [ "quiver_birchbark", 30 ],
+      [ "fire_drill", 30 ],
+      [ "lighter", 30 ],
+      [ "matches", 30 ],
+      [ "sunglasses", 30 ],
+      [ "fitover_sunglasses", 20 ],
+      [ "ax", 10 ],
+      [ "saw", 10 ],
+      [ "backpack", 30 ],
+      [ "backpack_leather", 30 ],
+      [ "quiver", 20 ],
+      [ "canteen", 20 ],
+      [ "knife_hunting", 30 ],
+      [ "shovel", 30 ],
+      { "group": "ammo_pocket_batteries_full", "prob": 30 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "oa_ig_sb_rare",
+    "items": [
+      { "item": "gasoline", "prob": 5, "charges-min": 450, "charges-max": 2000, "container-item": "jug_plastic" },
+      { "item": "gasoline", "prob": 5, "charges-min": 450, "charges-max": 4000, "container-item": "jerrycan" },
+      { "item": "gasoline", "prob": 5, "charges-min": 450, "charges-max": 10000, "container-item": "jerrycan_big" },
+      [ "gasoline_lantern", 15 ],
+      [ "electric_lantern", 15 ],
+      [ "oil_lamp", 15 ],
+      [ "lamp_oil", 15 ],
+      [ "compbow", 20 ],
+      [ "binoculars", 20 ],
+      [ "ref_lighter", 30 ],
+      [ "e_tool", 30 ],
+      [ "jackhammer", 5 ],
+      [ "elec_jackhammer", 5 ]
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "oa_ig_sb_books",
+    "items": [ [ "book_archery", 20 ] ]
+  },
+  {
+    "type": "item_group",
+    "id": "oa_ig_sb_wood",
+    "items": [ [ "2x4", 20 ], [ "stick", 20 ], [ "pointy_stick", 10 ], [ "log", 20 ] ]
+  },
+  {
+    "type": "item_group",
+    "id": "oa_ig_sb_water",
+    "items": [ { "item": "water", "prob": 30, "charges-min": 0, "charges-max": 200, "container-item": "keg" } ]
   }
 ]

--- a/data/json/mapgen/ws_survivor_bunker.json
+++ b/data/json/mapgen/ws_survivor_bunker.json
@@ -78,13 +78,7 @@
         "########################",
         "########################"
       ],
-      "terrain": {
-        "#": "t_rock",
-        "<": "t_ladder_up",
-        "-": "t_wall_wood",
-        "|": "t_wall_wood",
-        "D": "t_door_locked_interior"
-      },
+      "terrain": { "#": "t_rock", "<": "t_ladder_up", "-": "t_wall_wood", "|": "t_wall_wood", "D": "t_door_locked_interior" },
       "furniture": {
         "r": "f_rubble_rock",
         "s": "f_sandbag_half",

--- a/data/json/mapgen/ws_survivor_bunker.json
+++ b/data/json/mapgen/ws_survivor_bunker.json
@@ -1,108 +1,5 @@
 [
   {
-    "type": "monstergroup",
-    "name": "GROUP_ZOMBIE_BUNKER",
-    "default": "mon_zombie_survivor",
-    "monsters": [
-      { "monster": "mon_zombie_survivor", "freq": 250, "cost_multiplier": 0 },
-      { "monster": "mon_zombie_child", "freq": 100, "cost_multiplier": 0 },
-      { "monster": "mon_zombie_dog", "freq": 150, "cost_multiplier": 0 },
-      { "monster": "mon_dog_zombie_rot", "freq": 150, "cost_multiplier": 0 }
-    ]
-  },
-  {
-    "type": "item_group",
-    "id": "oa_ig_sb_food",
-    "items": [
-      { "item": "veggy_pickled", "prob": 30, "charges": 2, "container-item": "jar_glass_sealed" },
-      { "item": "fish_pickled", "prob": 26, "charges": 2, "container-item": "jar_glass_sealed" },
-      { "item": "meat_pickled", "prob": 20, "charges": 2, "container-item": "jar_glass_sealed" },
-      [ "dry_meat", 20 ],
-      [ "dry_veggy", 20 ],
-      [ "carrot", 20 ],
-      [ "water_clean", 80 ],
-      [ "water_mineral", 5 ],
-      [ "cola", 70 ],
-      [ "creamsoda", 60 ],
-      [ "lemonlime", 60 ],
-      [ "orangesoda", 60 ],
-      [ "crispycran", 40 ],
-      [ "colamdew", 60 ],
-      [ "choc_drink", 30 ],
-      [ "jerky", 55 ],
-      [ "salted_fish", 35 ],
-      [ "porkstick", 55 ],
-      [ "cheese_hard", 15 ],
-      [ "can_beans", 40 ],
-      [ "can_corn", 35 ],
-      [ "can_spam", 30 ],
-      [ "salt", 10 ],
-      [ "seasoning_salt", 5 ],
-      [ "jar_sauerkraut_pickled", 20 ],
-      [ "lutefisk", 20 ],
-      [ "pemmican", 20 ]
-    ]
-  },
-  {
-    "type": "item_group",
-    "id": "oa_ig_sb_equipment",
-    "items": [
-      [ "flask_hip", 20 ],
-      [ "shortbow", 20 ],
-      [ "arrow_wood_heavy", 20 ],
-      [ "arrow_fire_hardened_fletched", 20 ],
-      [ "quiver_birchbark", 30 ],
-      [ "fire_drill", 30 ],
-      [ "lighter", 30 ],
-      [ "matches", 30 ],
-      [ "sunglasses", 30 ],
-      [ "fitover_sunglasses", 20 ],
-      [ "ax", 10 ],
-      [ "saw", 10 ],
-      [ "backpack", 30 ],
-      [ "backpack_leather", 30 ],
-      [ "quiver", 20 ],
-      [ "canteen", 20 ],
-      [ "knife_hunting", 30 ],
-      [ "shovel", 30 ],
-      { "group": "ammo_pocket_batteries_full", "prob": 30 }
-    ]
-  },
-  {
-    "type": "item_group",
-    "id": "oa_ig_sb_rare",
-    "items": [
-      { "item": "gasoline", "prob": 5, "charges-min": 450, "charges-max": 2000, "container-item": "jug_plastic" },
-      { "item": "gasoline", "prob": 5, "charges-min": 450, "charges-max": 4000, "container-item": "jerrycan" },
-      { "item": "gasoline", "prob": 5, "charges-min": 450, "charges-max": 10000, "container-item": "jerrycan_big" },
-      [ "gasoline_lantern", 15 ],
-      [ "electric_lantern", 15 ],
-      [ "oil_lamp", 15 ],
-      [ "lamp_oil", 15 ],
-      [ "compbow", 20 ],
-      [ "binoculars", 20 ],
-      [ "ref_lighter", 30 ],
-      [ "e_tool", 30 ],
-      [ "jackhammer", 5 ],
-      [ "elec_jackhammer", 5 ]
-    ]
-  },
-  {
-    "type": "item_group",
-    "id": "oa_ig_sb_books",
-    "items": [ [ "book_archery", 20 ] ]
-  },
-  {
-    "type": "item_group",
-    "id": "oa_ig_sb_wood",
-    "items": [ [ "2x4", 20 ], [ "stick", 20 ], [ "pointy_stick", 10 ], [ "log", 20 ] ]
-  },
-  {
-    "type": "item_group",
-    "id": "oa_ig_sb_water",
-    "items": [ { "item": "water", "prob": 30, "charges-min": 0, "charges-max": 200, "container-item": "keg" } ]
-  },
-  {
     "type": "mapgen",
     "method": "json",
     "om_terrain": [ "ws_survivor_bunker_f0" ],
@@ -137,7 +34,6 @@
       "terrain": {
         ".": "t_grass",
         ",": "t_dirt",
-        "O": "t_pit_shallow",
         "T": "t_tree",
         "Y": "t_tree_young",
         "b": "t_underbrush",
@@ -155,52 +51,39 @@
     "om_terrain": [ "ws_survivor_bunker_f-1" ],
     "weight": 1000,
     "object": {
+      "fill_ter": "t_rock_floor",
       "rows": [
-        "####R#####R########RRR##",
-        "###RRR#########R####R###",
-        "########RRR#r##R########",
-        "####R####R#rrrRRR###R###",
-        "##RRR####Rrr<rR#####R###",
-        "####R######r2r####RRRR##",
-        "###RRRR####r1r#R####R###",
-        "#####R####r1.r#RRR######",
-        "#R###R####SsSRRR#####R##",
-        "#R###RRR##.1.##RRR###RR#",
-        "#R###R###--D--##R#####R#",
-        "###RRR###|b.t|RRRRR###R#",
-        "####R##R#|..h|###R###RR#",
-        "####RR#RR|k.W|#R#R####RR",
-        "####R##R#|C.B|RRR#####R#",
-        "#########|C.B|#R########",
-        "########R--D--#R#R######",
-        "###RRR####r.ssrr#RR#R###",
-        "####R######rr.rrr###R###",
-        "####RR#R####rr.rrr##R###",
-        "####R##RR#####rr####RR##",
-        "#######R######RR########",
-        "#####RRRR####RRRRR######",
-        "######R#########R#######"
+        "########################",
+        "########################",
+        "############r###########",
+        "###########rrr##########",
+        "##########rr<r##########",
+        "###########r2r##########",
+        "###########r1r##########",
+        "##########r1.r##########",
+        "##########SsS###########",
+        "##########.1.###########",
+        "#########--D--##########",
+        "#########|b.t|##########",
+        "#########|..h|##########",
+        "#########|k.W|##########",
+        "#########|C.B|##########",
+        "#########|C.B|##########",
+        "#########--D--##########",
+        "##########r.ssrr########",
+        "###########rr.rrr#######",
+        "############rr.rrr######",
+        "##############rr########",
+        "########################",
+        "########################",
+        "########################"
       ],
       "terrain": {
         "#": "t_rock",
         "<": "t_ladder_up",
         "-": "t_wall_wood",
         "|": "t_wall_wood",
-        ".": "t_rock_floor",
-        "D": "t_door_locked_interior",
-        "R": "t_root_wall",
-        "S": "t_rock_floor",
-        "s": "t_rock_floor",
-        "r": "t_rock_floor",
-        "1": "t_rock_floor",
-        "2": "t_rock_floor",
-        "k": "t_rock_floor",
-        "b": "t_rock_floor",
-        "t": "t_rock_floor",
-        "C": "t_rock_floor",
-        "B": "t_rock_floor",
-        "W": "t_rock_floor",
-        "h": "t_rock_floor"
+        "D": "t_door_locked_interior"
       },
       "furniture": {
         "r": "f_rubble_rock",
@@ -220,7 +103,7 @@
         "k": { "item": "oa_ig_sb_water", "chance": 60 },
         "W": { "item": "oa_ig_sb_wood", "chance": 70 }
       },
-      "add": [
+      "place_loot": [
         { "item": "ash", "chance": 2, "x": 12, "y": 13, "repeat": 2 },
         { "item": "charcoal", "chance": 3, "x": 12, "y": 13 },
         { "item": "survnote", "chance": 2, "x": 12, "y": 11 }

--- a/data/json/monstergroups/zombies.json
+++ b/data/json/monstergroups/zombies.json
@@ -725,5 +725,16 @@
       { "monster": "mon_zombie_necro", "freq": 8, "cost_multiplier": 20, "starts": 500 },
       { "monster": "mon_zombie_master", "freq": 2, "cost_multiplier": 25, "starts": 1000 }
     ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_ZOMBIE_BUNKER",
+    "default": "mon_zombie_survivor",
+    "monsters": [
+      { "monster": "mon_zombie_survivor", "freq": 250, "cost_multiplier": 0 },
+      { "monster": "mon_zombie_child", "freq": 100, "cost_multiplier": 0 },
+      { "monster": "mon_zombie_dog", "freq": 150, "cost_multiplier": 0 },
+      { "monster": "mon_dog_zombie_rot", "freq": 150, "cost_multiplier": 0 }
+    ]
   }
 ]


### PR DESCRIPTION
## Purpose of change
Remove the root walls from the survivor's bunker, because this terrain should logically only be found in the Triffid grove.
## Describe the solution
Remove root walls from `ws_survivor_bunker_f-1`.
Also moved "monstergroup" and "item_group" in ws_survivor_bunker.json to the appropriate JSON file.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/172a1ff3-e476-4e70-9370-e8a68daa8be8">
After:
<img width="960" alt="image2" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/02349fbe-a50a-4263-8085-0f8ad88a4c88">