### PR TITLE
feat(content): Add all bandage types to blindfold recipe

### DIFF
--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -78,7 +78,7 @@
         [ "scarf_fur_long_loose", 1 ],
         [ "knit_scarf_loose", 1 ],
         [ "long_knit_scarf_loose", 1 ],
-        [ "bandages", 2 ]
+        [ "bandages_all", 2, "LIST" ]
       ]
     ],
     "flags": [ "BLIND_EASY", "NO_RESIZE" ]

--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -253,7 +253,7 @@
     "components": [ [ [ "bone", 1 ], [ "bone_human", 1 ] ] ]
   },
   {
-    "id": "bandage_all",
+    "id": "bandages_all",
     "type": "requirement",
     "//": "Any kind of bandages, improvised or not, where quality does not matter for non-medical use",
     "components": [ [ [ "bandages", 1 ], [ "bandages_makeshift", 1 ], [ "bandages_makeshift_bleached", 1 ], [ "bandages_makeshift_boiled", 1 ] ] ]

--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -256,6 +256,13 @@
     "id": "bandages_all",
     "type": "requirement",
     "//": "Any kind of bandages, improvised or not, where quality does not matter for non-medical use",
-    "components": [ [ [ "bandages", 1 ], [ "bandages_makeshift", 1 ], [ "bandages_makeshift_bleached", 1 ], [ "bandages_makeshift_boiled", 1 ] ] ]
+    "components": [
+      [
+        [ "bandages", 1 ],
+        [ "bandages_makeshift", 1 ],
+        [ "bandages_makeshift_bleached", 1 ],
+        [ "bandages_makeshift_boiled", 1 ]
+      ]
+    ]
   }
 ]

--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -251,5 +251,11 @@
     "type": "requirement",
     "//": "Any kind of bones, human or not.  Tainted bones are too brittle and won't work for this purpose.",
     "components": [ [ [ "bone", 1 ], [ "bone_human", 1 ] ] ]
+  },
+  {
+    "id": "bandage_all",
+    "type": "requirement",
+    "//": "Any kind of bandages, improvised or not, where quality does not matter for non-medical use",
+    "components": [ [ [ "bandages", 1 ], [ "bandages_makeshift", 1 ], [ "bandages_makeshift_bleached", 1 ], [ "bandages_makeshift_boiled", 1 ] ] ]
   }
 ]


### PR DESCRIPTION
## Purpose of change

Add makeshift bandage types to blindfold recipe via a requirement group as no reason they cannot be used for a blindfold.

## Describe the solution

- Create requirement group bandages_all which has bandages, makeshift bandages, boiled makeshift bandages and bleached makeshift bandages in
- Add requirement group to blindfold recipe

## Describe alternatives you've considered

Leaving blindfold recipe alone.

## Testing

Loaded into base game and tested.

## Additional context

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/91185016/30a3b52b-c704-452b-a9bf-7b27d3c610a7)


