### PR TITLE
fix: add limits and side effects to `ABSORBS_SPLITS` behavior

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -278,6 +278,15 @@
     "desc": [ "AI tag used for monsters pushing each other.  This is a bug if you have it." ]
   },
   {
+    "type": "effect_type",
+    "id": "mon_mitosis",
+    "name": [ "Recently Split" ],
+    "desc": [
+      "AI tag for ABSORBS_SPLITS monsters having recently divided, forcing a cooldown between splits.  This is a bug if you have it."
+    ],
+    "max_duration": "1 m"
+  },
+  {
     "//": "ACTUAL PLAYER EFFECTS START HERE",
     "type": "effect_type",
     "id": "downed",

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -808,7 +808,7 @@
     "special_attacks": [ [ "PARROT", 40 ] ],
     "death_function": [ "MELT" ],
     "regenerates": 50,
-    "regeneration_modifiers": [ { "effect": "onfire", "base_mod": -0.3, "scaling_mod": -0.15 } ],
+    "regeneration_modifiers": [ { "effect": "onfire", "base_mod": -0.3, "scaling_mod": -0.15 }, { "effect": "mon_mitosis", "base_mod": -1.0 } ],
     "regen_morale": true,
     "flags": [ "SEES", "SMELLS", "SWIMS", "PLASTIC", "SLUDGEPROOF", "ACID_BLOOD", "ACIDPROOF", "NOHEAD", "ABSORBS_SPLITS", "NOGIB" ]
   },


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This finally implements some sanity-checking of shoggoth item absorption and splitting behavior so they won't be as much of a menace to society.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

C++ changes:
1. In monmove.cpp, changed `monster::move` so `ABSORBS_SPLITS` behavior gets a bit of sanity-checking. It now only does the split if it lacks a new status effect that's doled out to both monsters on a successful split, effectively implementing a cooldown on absorbing items. Splitting now also takes a bit out of both monsters, meaning some potential future items absorbed go into recovering from this loss of HP (until regen kicks back in, see below). They'll still absorb items to stockpile HP up to a point however, if they're still recovering from splitting they'll stop absorbing items once they're at 3 times max HP.

JSON changes:
1. Defined the effect JSON for the new effect.
2. Set shoggoths to have a regen modifier where the new effect disables regen entirely.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Ideally I'd like to have the absorption behavior only check for and remove items that have low acid resistance or aren't flammable (the latter is a bit more usable without material sanity-checking than the former since we haven't had acid item damage in years and the values are all over the place), but this requires using something with more finesse than `i_clear` and I could fucking could NOT figure out how to get `erase` or `use_amount` how to work right. I'm not used to this item identity stuff...

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON for syntax and lint errors.
2. Compiled and load-tested.
3. Let a shoggoth eat deer corpses until it split, confirmed the copy has less than full HP.
4. Confirmed that the new shoggoth has 300/400 HP, and that neither is regenerating.
5. Let the original shoggoth absorb a third deer, confirmed it now stays at over 800 HP but hasn't split due to the cooldown.
6. Placed more items under the shoggoth to feed it until it was over 1200 HP, observed it no longer wants to delete items.
7. Confirmed the other shoggoth is happy to eat items because HP isn't at 1200 yet.
8. Checked affected C++ for astyle.

He monch:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/b2d72719-e315-4281-b700-b965a8bcf7f6)

He do not monch because too full and can't split yet:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/5f162e40-3bfc-4e95-9119-8fe08102cdf3)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

DDA did this via special attack stuff if I recall, I was actually gonna do that too (without really bothering to look at how they did it and port it over) but item identity stuff tripped me up too much.

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
