### PR TITLE
fix: spiked pit on surface of survivor's bunker

### DIFF
--- a/data/json/mapgen/ws_survivor_bunker.json
+++ b/data/json/mapgen/ws_survivor_bunker.json
@@ -38,11 +38,9 @@
         "Y": "t_tree_young",
         "b": "t_underbrush",
         ">": "t_ladder_down",
-        "p": "t_dirt",
+        "p": "t_pit_spiked",
         "w": "t_dirt"
-      },
-      "furniture": {  },
-      "traps": { "p": { "trap": "tr_spike_pit" } }
+      }
     }
   },
   {


### PR DESCRIPTION
## Purpose of change
Fix because it's the trap that's used, not the terrain.
## Describe the solution
Use "t_pit_spiked" terrain instead of "tr_spike_pit" trap.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image2" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/f6a9ffb4-8408-42ad-996d-d1035677c0f1">
After:
<img width="960" alt="image1" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/d86263a3-165a-42b5-8f63-28e80788f249">