### PR TITLE
feat: Add ability to spawn items as active

### DIFF
--- a/data/json/mapgen/shelter.json
+++ b/data/json/mapgen/shelter.json
@@ -1,5 +1,12 @@
 [
   {
+    "id": "test_grenade",
+    "type": "item_group",
+    "subtype": "collection",
+    "//": "For testing active item spawns",
+    "items": [ { "item": "grenade_act", "prob": 100, "active": true } ]
+  },
+  {
     "id": "shelter_supplies",
     "type": "item_group",
     "subtype": "collection",
@@ -109,7 +116,10 @@
         "5": "t_gutter_drop"
       },
       "furniture": { ":": "f_standing_tank", "#": "f_solar_unit", "&": "f_roof_turbine_vent" },
-      "place_items": [ { "item": "roof_trash", "x": [ 5, 17 ], "y": [ 9, 22 ], "chance": 50, "repeat": [ 1, 3 ] } ],
+      "place_items": [
+        { "item": "roof_trash", "x": [ 5, 17 ], "y": [ 9, 22 ], "chance": 50, "repeat": [ 1, 3 ] },
+        { "item": "test_grenade", "x": 12, "y": 12, "chance": 100, "repeat": 1 }
+      ],
       "place_item": [ { "item": "grenade_act", "x": 15, "y": 15, "chance": 100, "active": true } ]
     }
   },
@@ -194,7 +204,10 @@
         "5": "t_gutter_drop"
       },
       "furniture": { ":": "f_standing_tank", "#": "f_solar_unit", "&": "f_roof_turbine_vent" },
-      "place_items": [ { "item": "roof_trash", "x": [ 5, 17 ], "y": [ 11, 22 ], "chance": 50, "repeat": [ 1, 3 ] } ],
+      "place_items": [
+        { "item": "roof_trash", "x": [ 5, 17 ], "y": [ 11, 22 ], "chance": 50, "repeat": [ 1, 3 ] },
+        { "item": "test_grenade", "x": 12, "y": 12, "chance": 100, "repeat": 1 }
+      ],
       "place_item": [ { "item": "grenade_act", "x": 15, "y": 15, "chance": 100, "active": true } ]
     }
   },
@@ -289,7 +302,10 @@
         "5": "t_gutter_drop"
       },
       "furniture": { ":": "f_standing_tank", "#": "f_solar_unit", "&": "f_roof_turbine_vent" },
-      "place_items": [ { "item": "roof_trash", "x": [ 8, 15 ], "y": [ 7, 22 ], "chance": 50, "repeat": [ 1, 3 ] } ],
+      "place_items": [
+        { "item": "roof_trash", "x": [ 8, 15 ], "y": [ 7, 22 ], "chance": 50, "repeat": [ 1, 3 ] },
+        { "item": "test_grenade", "x": 12, "y": 12, "chance": 100, "repeat": 1 }
+      ],
       "place_item": [ { "item": "grenade_act", "x": 15, "y": 15, "chance": 100, "active": true } ]
     }
   },

--- a/data/json/mapgen/shelter.json
+++ b/data/json/mapgen/shelter.json
@@ -109,7 +109,8 @@
         "5": "t_gutter_drop"
       },
       "furniture": { ":": "f_standing_tank", "#": "f_solar_unit", "&": "f_roof_turbine_vent" },
-      "place_items": [ { "item": "roof_trash", "x": [ 5, 17 ], "y": [ 9, 22 ], "chance": 50, "repeat": [ 1, 3 ] } ]
+      "place_items": [ { "item": "roof_trash", "x": [ 5, 17 ], "y": [ 9, 22 ], "chance": 50, "repeat": [ 1, 3 ] } ],
+      "place_item": [ { "item": "grenade_act", "x": 15, "y": 15, "chance": 100, "active": true } ]
     }
   },
   {
@@ -193,7 +194,8 @@
         "5": "t_gutter_drop"
       },
       "furniture": { ":": "f_standing_tank", "#": "f_solar_unit", "&": "f_roof_turbine_vent" },
-      "place_items": [ { "item": "roof_trash", "x": [ 5, 17 ], "y": [ 11, 22 ], "chance": 50, "repeat": [ 1, 3 ] } ]
+      "place_items": [ { "item": "roof_trash", "x": [ 5, 17 ], "y": [ 11, 22 ], "chance": 50, "repeat": [ 1, 3 ] } ],
+      "place_item": [ { "item": "grenade_act", "x": 15, "y": 15, "chance": 100, "active": true } ]
     }
   },
   {
@@ -287,7 +289,8 @@
         "5": "t_gutter_drop"
       },
       "furniture": { ":": "f_standing_tank", "#": "f_solar_unit", "&": "f_roof_turbine_vent" },
-      "place_items": [ { "item": "roof_trash", "x": [ 8, 15 ], "y": [ 7, 22 ], "chance": 50, "repeat": [ 1, 3 ] } ]
+      "place_items": [ { "item": "roof_trash", "x": [ 8, 15 ], "y": [ 7, 22 ], "chance": 50, "repeat": [ 1, 3 ] } ],
+      "place_item": [ { "item": "grenade_act", "x": 15, "y": 15, "chance": 100, "active": true } ]
     }
   },
   {

--- a/doc/src/content/docs/en/mod/json/reference/items/item_spawn.md
+++ b/doc/src/content/docs/en/mod/json/reference/items/item_spawn.md
@@ -112,7 +112,8 @@ item. This allows water, that contains a book, that contains a steel frame, that
 or ammo/magazine capacity. Setting max too high will decrease it to maximum capacity. Not setting
 min will set it to 0 when max is set.
 
-`active`: Will spawn the item active if true, note that this _does not work_ for itemgroups, only individual items _within_ itemgroups.
+`active`: Will spawn the item active if true, note that this _does not work_ for itemgroups, only
+individual items _within_ itemgroups.
 
 ```json
 "damage-min": 0,

--- a/doc/src/content/docs/en/mod/json/reference/items/item_spawn.md
+++ b/doc/src/content/docs/en/mod/json/reference/items/item_spawn.md
@@ -94,6 +94,7 @@ item(s):
 "charges": <number>|<array>,
 "charges-min": <number>,
 "charges-max": <number>,
+"active": "<bool>"
 "contents-item": "<item-id>" (can be a string or an array of strings),
 "contents-group": "<group-id>" (can be a string or an array of strings),
 "ammo-item": "<ammo-item-id>",
@@ -110,6 +111,8 @@ item. This allows water, that contains a book, that contains a steel frame, that
 `charges`: Setting only min, not max will make the game calculate the max charges based on container
 or ammo/magazine capacity. Setting max too high will decrease it to maximum capacity. Not setting
 min will set it to 0 when max is set.
+
+`active`: Will spawn the item active if true, note that this _does not work_ for itemgroups, only individual items _within_ itemgroups.
 
 ```json
 "damage-min": 0,

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2987,6 +2987,16 @@ bool load_min_max( std::pair<T, T> &pa, const JsonObject &obj, const std::string
     return result;
 }
 
+bool Item_factory::load_active( bool &ac, const JsonObject &obj )
+{
+    bool result = false;
+    if( obj.has_bool( "active" ) ) {
+        ac = obj.get_bool( "active" );
+        result |= ac;
+    }
+    return result;
+}
+
 bool Item_factory::load_sub_ref( std::unique_ptr<Item_spawn_data> &ptr, const JsonObject &obj,
                                  const std::string &name, const Item_group &parent )
 {
@@ -3110,6 +3120,7 @@ void Item_factory::add_entry( Item_group &ig, const JsonObject &obj )
     use_modifier |= load_sub_ref( modifier.ammo, obj, "ammo", ig );
     use_modifier |= load_sub_ref( modifier.container, obj, "container", ig );
     use_modifier |= load_sub_ref( modifier.contents, obj, "contents", ig );
+    use_modifier |= load_active( modifier.spawn_active, obj );
 
     std::vector<std::string> custom_flags;
     use_modifier |= load_string( custom_flags, obj, "custom-flags" );

--- a/src/item_factory.h
+++ b/src/item_factory.h
@@ -329,6 +329,11 @@ class Item_factory
          */
         bool load_sub_ref( std::unique_ptr<Item_spawn_data> &ptr, const JsonObject &obj,
                            const std::string &name, const Item_group &parent );
+        /**
+         * Loads whether an item should be spawned active or not into modifiers.
+         * DO NOT attempt to apply to itemgroups.
+         */
+        bool load_active( bool &ac, const JsonObject &obj );
         bool load_string( std::vector<std::string> &vec, const JsonObject &obj, const std::string &name );
         void add_entry( Item_group &ig, const JsonObject &obj );
 

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -374,6 +374,11 @@ detached_ptr<item> Item_modifier::modify( detached_ptr<item> &&new_item ) const
     for( const flag_id &flag : custom_flags ) {
         new_item->set_flag( flag );
     }
+
+    if( spawn_active ) {
+        new_item->activate();
+    }
+
     return std::move( new_item );
 }
 

--- a/src/item_group.h
+++ b/src/item_group.h
@@ -186,6 +186,11 @@ class Item_modifier
          */
         std::vector<flag_id> custom_flags;
 
+        /**
+        * Whether the item spawns active or not.
+        */
+        bool spawn_active = false;
+
         Item_modifier();
         Item_modifier( Item_modifier && ) = default;
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4302,7 +4302,7 @@ void map::spawn_natural_artifact( const tripoint &p, artifact_natural_property p
 
 void map::spawn_item( const tripoint &p, const itype_id &type_id,
                       const unsigned quantity, const int charges,
-                      const time_point &birthday, const int damlevel )
+                      const time_point &birthday, const int damlevel, bool spawn_active )
 {
     if( type_id.is_null() ) {
         return;
@@ -4314,6 +4314,9 @@ void map::spawn_item( const tripoint &p, const itype_id &type_id,
     for( size_t i = 0; i < quantity; i++ ) {
         // spawn the item
         detached_ptr<item> new_item = item::spawn( type_id, birthday );
+        if( spawn_active ) {
+            new_item->activate();
+        }
         if( one_in( 3 ) && new_item->has_flag( flag_VARSIZE ) ) {
             new_item->set_flag( flag_FIT );
         }

--- a/src/map.h
+++ b/src/map.h
@@ -1204,24 +1204,30 @@ class map
         void spawn_natural_artifact( const tripoint &p, artifact_natural_property prop );
         void spawn_item( const tripoint &p, const itype_id &type_id,
                          unsigned quantity = 1, int charges = 0,
-                         const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0 );
+                         const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0,
+                         const bool spawn_active = false );
         void spawn_item( point p, const itype_id &type_id,
                          unsigned quantity = 1, int charges = 0,
-                         const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0 ) {
-            spawn_item( tripoint( p, abs_sub.z ), type_id, quantity, charges, birthday, damlevel );
+                         const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0,
+                         const bool spawn_active = false ) {
+            spawn_item( tripoint( p, abs_sub.z ), type_id, quantity, charges, birthday, damlevel,
+                        spawn_active );
         }
 
         // FIXME: remove these overloads and require spawn_item to take an
         // itype_id
         void spawn_item( const tripoint &p, const std::string &type_id,
                          unsigned quantity = 1, int charges = 0,
-                         const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0 ) {
-            spawn_item( p, itype_id( type_id ), quantity, charges, birthday, damlevel );
+                         const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0,
+                         const bool spawn_active = false ) {
+            spawn_item( p, itype_id( type_id ), quantity, charges, birthday, damlevel, spawn_active );
         }
         void spawn_item( point p, const std::string &type_id,
                          unsigned quantity = 1, int charges = 0,
-                         const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0 ) {
-            spawn_item( tripoint( p, abs_sub.z ), type_id, quantity, charges, birthday, damlevel );
+                         const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0,
+                         const bool spawn_active = false ) {
+            spawn_item( tripoint( p, abs_sub.z ), type_id, quantity, charges, birthday, damlevel,
+                        spawn_active );
         }
         units::volume max_volume( const tripoint &p );
         units::volume free_volume( const tripoint &p );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -2181,11 +2181,13 @@ class jmapgen_spawn_item : public jmapgen_piece
         mapgen_value<itype_id> type;
         jmapgen_int amount;
         jmapgen_int chance;
+        bool spawn_active;
         jmapgen_spawn_item( const JsonObject &jsi ) :
             type( jsi.get_member( "item" ) )
             , amount( jsi, "amount", 1, 1 )
             , chance( jsi, "chance", 100, 100 ) {
             repeat = jmapgen_int( jsi, "repeat", 1, 1 );
+            spawn_active = jsi.get_bool( "active", false );
         }
         void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y
                   ) const override {
@@ -2203,7 +2205,8 @@ class jmapgen_spawn_item : public jmapgen_piece
             const float spawn_rate = get_option<float>( "ITEM_SPAWNRATE" );
             int spawn_count = ( c == 100 ) ? 1 : roll_remainder( c * spawn_rate / 100.0f );
             for( int i = 0; i < spawn_count; i++ ) {
-                dat.m.spawn_item( point( x.get(), y.get() ), chosen_id, amount.get() );
+                dat.m.spawn_item( point( x.get(), y.get() ), chosen_id, amount.get(), 0,
+                                  calendar::start_of_cataclysm, 0, spawn_active );
             }
         }
 


### PR DESCRIPTION
## Purpose of change

- Did not like how #4073 activates items on placement. Envisioned a more elegant solution where you could define that objects be selectively spawned active on mapgen rather than a blanket flag that applies every time an object is spawned.

## Describe the solution

Add optional variable to spawn items as active. It works in both `place_item` (for individual items) and within item groups for `place_items`.

## Describe alternatives you've considered

- #4073 

## Testing

- [x] Spawn into evac shelter, there should be two active grenades on the roof. Both should detonate after 5 turns.

## Additional context

Will probably add it to atomic lights and atomic nightlights since them being on doesn't consume power but adds a good example of what can be done.

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
