### PR TITLE
feat(balance): make matchhead powder recipe more granular, related fixes for mortar and pestle recipes

### DIFF
--- a/data/json/recipes/chem/chemicals.json
+++ b/data/json/recipes/chem/chemicals.json
@@ -483,6 +483,7 @@
     "subcategory": "CSC_CHEM_CHEMICALS",
     "charges": 100,
     "time": "5 m",
+    "batch_time_factors": [ 50, 3 ],
     "autolearn": true,
     "tools": [ [ [ "mortar_pestle", -1 ] ] ],
     "components": [ [ [ "chem_ammonium_nitrate_pellets", 100 ] ] ]

--- a/data/json/recipes/chem/other.json
+++ b/data/json/recipes/chem/other.json
@@ -76,9 +76,11 @@
     "category": "CC_CHEM",
     "subcategory": "CC_CHEM_OTHER",
     "skill_used": "fabrication",
-    "time": "8 m",
+    "time": "1 m",
+    "batch_time_factors": [ 50, 3 ],
+    "charges": 1,
     "autolearn": true,
-    "tools": [ [ [ "matches", 20 ] ], [ [ "mortar_pestle", -1 ] ] ]
+    "tools": [ [ [ "matches", 1 ] ], [ [ "mortar_pestle", -1 ] ] ]
   },
   {
     "result": "lye",

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -636,6 +636,7 @@
     "difficulty": 1,
     "charges": 1562,
     "time": "5 m",
+    "batch_time_factors": [ 50, 3 ],
     "autolearn": true,
     "tools": [ [ [ "mortar_pestle", -1 ] ] ],
     "qualities": [ { "id": "HAMMER", "level": 1 } ],


### PR DESCRIPTION

<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This implements some tweaks to how match head powder is make to make it less clunky to use, along with some related changes to some other mortar and pestle recipes once I noticed that a few of the recipes to use mortar and pestle lack batch time savings when most have it.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Set match head powder recipe to make 1 charge at a time, per 1 matchbook charge consumed. This makes it more granular, though more efficient as a side effect. Given match head powder isn't used for much besides primers (and are used en masse in that case) I feel it's not too wacky balance-wise. Time taken also reduced from 8 minutes to 1 minute, and to compensate for this increase in time per unit made it now uses the same batch time factor most other mortar and pestle recipes use.
2. Misc: Gave the ammonium nitrate and sulfur grinding recipes batch time multipliers too. Again used the same scaling nearly all recipes involving mortar and pestle use.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Chitin meal is literally the only mortar and pestle recipe to use a time factor of 83-3 instead of 50-3, we could tweak that.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Ported JSON changes to test build, confirmed I make match head powder 1 unit at a time now and for 1 charge of matchbook each.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
