### PR TITLE
feat: spawn active items on mapgen

### DIFF
--- a/data/json/mapgen/shelter.json
+++ b/data/json/mapgen/shelter.json
@@ -1,5 +1,12 @@
 [
   {
+    "id": "test_grenade",
+    "type": "item_group",
+    "subtype": "collection",
+    "//": "For testing active item spawns",
+    "items": [ { "item": "grenade_act", "prob": 100, "active": true } ]
+  },
+  {
     "id": "shelter_supplies",
     "type": "item_group",
     "subtype": "collection",
@@ -109,7 +116,10 @@
         "5": "t_gutter_drop"
       },
       "furniture": { ":": "f_standing_tank", "#": "f_solar_unit", "&": "f_roof_turbine_vent" },
-      "place_items": [ { "item": "roof_trash", "x": [ 5, 17 ], "y": [ 9, 22 ], "chance": 50, "repeat": [ 1, 3 ] } ],
+      "place_items": [
+        { "item": "roof_trash", "x": [ 5, 17 ], "y": [ 9, 22 ], "chance": 50, "repeat": [ 1, 3 ] },
+        { "item": "test_grenade", "x": 12, "y": 12, "chance": 100, "repeat": 1 }
+      ],
       "place_item": [ { "item": "grenade_act", "x": 15, "y": 15, "chance": 100, "active": true } ]
     }
   },
@@ -194,7 +204,10 @@
         "5": "t_gutter_drop"
       },
       "furniture": { ":": "f_standing_tank", "#": "f_solar_unit", "&": "f_roof_turbine_vent" },
-      "place_items": [ { "item": "roof_trash", "x": [ 5, 17 ], "y": [ 11, 22 ], "chance": 50, "repeat": [ 1, 3 ] } ],
+      "place_items": [
+        { "item": "roof_trash", "x": [ 5, 17 ], "y": [ 11, 22 ], "chance": 50, "repeat": [ 1, 3 ] },
+        { "item": "test_grenade", "x": 12, "y": 12, "chance": 100, "repeat": 1 }
+      ],
       "place_item": [ { "item": "grenade_act", "x": 15, "y": 15, "chance": 100, "active": true } ]
     }
   },
@@ -289,7 +302,10 @@
         "5": "t_gutter_drop"
       },
       "furniture": { ":": "f_standing_tank", "#": "f_solar_unit", "&": "f_roof_turbine_vent" },
-      "place_items": [ { "item": "roof_trash", "x": [ 8, 15 ], "y": [ 7, 22 ], "chance": 50, "repeat": [ 1, 3 ] } ],
+      "place_items": [
+        { "item": "roof_trash", "x": [ 8, 15 ], "y": [ 7, 22 ], "chance": 50, "repeat": [ 1, 3 ] },
+        { "item": "test_grenade", "x": 12, "y": 12, "chance": 100, "repeat": 1 }
+      ],
       "place_item": [ { "item": "grenade_act", "x": 15, "y": 15, "chance": 100, "active": true } ]
     }
   },

--- a/data/json/mapgen/shelter.json
+++ b/data/json/mapgen/shelter.json
@@ -1,12 +1,5 @@
 [
   {
-    "id": "test_grenade",
-    "type": "item_group",
-    "subtype": "collection",
-    "//": "For testing active item spawns",
-    "items": [ { "item": "grenade_act", "prob": 100, "active": true } ]
-  },
-  {
     "id": "shelter_supplies",
     "type": "item_group",
     "subtype": "collection",
@@ -116,11 +109,7 @@
         "5": "t_gutter_drop"
       },
       "furniture": { ":": "f_standing_tank", "#": "f_solar_unit", "&": "f_roof_turbine_vent" },
-      "place_items": [
-        { "item": "roof_trash", "x": [ 5, 17 ], "y": [ 9, 22 ], "chance": 50, "repeat": [ 1, 3 ] },
-        { "item": "test_grenade", "x": 12, "y": 12, "chance": 100, "repeat": 1 }
-      ],
-      "place_item": [ { "item": "grenade_act", "x": 15, "y": 15, "chance": 100, "active": true } ]
+      "place_items": [ { "item": "roof_trash", "x": [ 5, 17 ], "y": [ 9, 22 ], "chance": 50, "repeat": [ 1, 3 ] } ]
     }
   },
   {
@@ -204,11 +193,7 @@
         "5": "t_gutter_drop"
       },
       "furniture": { ":": "f_standing_tank", "#": "f_solar_unit", "&": "f_roof_turbine_vent" },
-      "place_items": [
-        { "item": "roof_trash", "x": [ 5, 17 ], "y": [ 11, 22 ], "chance": 50, "repeat": [ 1, 3 ] },
-        { "item": "test_grenade", "x": 12, "y": 12, "chance": 100, "repeat": 1 }
-      ],
-      "place_item": [ { "item": "grenade_act", "x": 15, "y": 15, "chance": 100, "active": true } ]
+      "place_items": [ { "item": "roof_trash", "x": [ 5, 17 ], "y": [ 11, 22 ], "chance": 50, "repeat": [ 1, 3 ] } ]
     }
   },
   {
@@ -302,11 +287,7 @@
         "5": "t_gutter_drop"
       },
       "furniture": { ":": "f_standing_tank", "#": "f_solar_unit", "&": "f_roof_turbine_vent" },
-      "place_items": [
-        { "item": "roof_trash", "x": [ 8, 15 ], "y": [ 7, 22 ], "chance": 50, "repeat": [ 1, 3 ] },
-        { "item": "test_grenade", "x": 12, "y": 12, "chance": 100, "repeat": 1 }
-      ],
-      "place_item": [ { "item": "grenade_act", "x": 15, "y": 15, "chance": 100, "active": true } ]
+      "place_items": [ { "item": "roof_trash", "x": [ 8, 15 ], "y": [ 7, 22 ], "chance": 50, "repeat": [ 1, 3 ] } ]
     }
   },
   {

--- a/data/json/mapgen/shelter.json
+++ b/data/json/mapgen/shelter.json
@@ -109,7 +109,8 @@
         "5": "t_gutter_drop"
       },
       "furniture": { ":": "f_standing_tank", "#": "f_solar_unit", "&": "f_roof_turbine_vent" },
-      "place_items": [ { "item": "roof_trash", "x": [ 5, 17 ], "y": [ 9, 22 ], "chance": 50, "repeat": [ 1, 3 ] } ]
+      "place_items": [ { "item": "roof_trash", "x": [ 5, 17 ], "y": [ 9, 22 ], "chance": 50, "repeat": [ 1, 3 ] } ],
+      "place_item": [ { "item": "grenade_act", "x": 15, "y": 15, "chance": 100, "active": true } ]
     }
   },
   {
@@ -193,7 +194,8 @@
         "5": "t_gutter_drop"
       },
       "furniture": { ":": "f_standing_tank", "#": "f_solar_unit", "&": "f_roof_turbine_vent" },
-      "place_items": [ { "item": "roof_trash", "x": [ 5, 17 ], "y": [ 11, 22 ], "chance": 50, "repeat": [ 1, 3 ] } ]
+      "place_items": [ { "item": "roof_trash", "x": [ 5, 17 ], "y": [ 11, 22 ], "chance": 50, "repeat": [ 1, 3 ] } ],
+      "place_item": [ { "item": "grenade_act", "x": 15, "y": 15, "chance": 100, "active": true } ]
     }
   },
   {
@@ -287,7 +289,8 @@
         "5": "t_gutter_drop"
       },
       "furniture": { ":": "f_standing_tank", "#": "f_solar_unit", "&": "f_roof_turbine_vent" },
-      "place_items": [ { "item": "roof_trash", "x": [ 8, 15 ], "y": [ 7, 22 ], "chance": 50, "repeat": [ 1, 3 ] } ]
+      "place_items": [ { "item": "roof_trash", "x": [ 8, 15 ], "y": [ 7, 22 ], "chance": 50, "repeat": [ 1, 3 ] } ],
+      "place_item": [ { "item": "grenade_act", "x": 15, "y": 15, "chance": 100, "active": true } ]
     }
   },
   {

--- a/doc/src/content/docs/en/mod/json/reference/items/item_spawn.md
+++ b/doc/src/content/docs/en/mod/json/reference/items/item_spawn.md
@@ -112,8 +112,32 @@ item. This allows water, that contains a book, that contains a steel frame, that
 or ammo/magazine capacity. Setting max too high will decrease it to maximum capacity. Not setting
 min will set it to 0 when max is set.
 
-`active`: Will spawn the item active if true, note that this _does not work_ for itemgroups, only
+`active`: If true, activates the item on spawn. Note that this _does not work_ for itemgroups, only
 individual items _within_ itemgroups.
+
+#### `active` Usage example
+
+```json
+[
+  {
+    "id": "test_grenade",
+    "type": "item_group",
+    "subtype": "collection",
+    "items": [{ "item": "grenade_act", "prob": 100, "active": true }]
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": "shelter_roof",
+    "weight": 100,
+    "object": {
+      // ...
+      "place_items": [{ "item": "test_grenade", "x": 12, "y": 12, "chance": 100, "repeat": 1 }],
+      "place_item": [{ "item": "grenade_act", "x": 15, "y": 15, "chance": 100, "active": true }]
+    }
+  }
+]
+```
 
 ```json
 "damage-min": 0,

--- a/doc/src/content/docs/en/mod/json/reference/items/item_spawn.md
+++ b/doc/src/content/docs/en/mod/json/reference/items/item_spawn.md
@@ -94,6 +94,7 @@ item(s):
 "charges": <number>|<array>,
 "charges-min": <number>,
 "charges-max": <number>,
+"active": "<bool>"
 "contents-item": "<item-id>" (can be a string or an array of strings),
 "contents-group": "<group-id>" (can be a string or an array of strings),
 "ammo-item": "<ammo-item-id>",
@@ -110,6 +111,9 @@ item. This allows water, that contains a book, that contains a steel frame, that
 `charges`: Setting only min, not max will make the game calculate the max charges based on container
 or ammo/magazine capacity. Setting max too high will decrease it to maximum capacity. Not setting
 min will set it to 0 when max is set.
+
+`active`: Will spawn the item active if true, note that this _does not work_ for itemgroups, only
+individual items _within_ itemgroups.
 
 ```json
 "damage-min": 0,

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -3129,7 +3129,7 @@ auto load_active( std::vector<ItemFn> &xs, const JsonObject &obj ) -> bool
     if( result ) {
         xs.emplace_back( []( detached_ptr<item> &&it ) {
             it->activate();
-            return it;
+            return std::move(it);
         } );
     }
     return result;

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -3129,7 +3129,7 @@ auto load_active( std::vector<ItemFn> &xs, const JsonObject &obj ) -> bool
     if( result ) {
         xs.emplace_back( []( detached_ptr<item> &&it ) {
             it->activate();
-            return std::move(it);
+            return std::move( it );
         } );
     }
     return result;

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -3121,6 +3121,22 @@ bool Item_factory::load_string( std::vector<std::string> &vec, const JsonObject 
     return result;
 }
 
+namespace
+{
+auto load_active( std::vector<ItemFn> &xs, const JsonObject &obj ) -> bool
+{
+    const bool result = obj.has_bool( "active" ) && obj.get_bool( "active" );
+    if( result ) {
+        xs.emplace_back( []( detached_ptr<item> &&it ) {
+            it->activate();
+            return it;
+        } );
+    }
+    return result;
+}
+
+} // namespace
+
 void Item_factory::add_entry( Item_group &ig, const JsonObject &obj )
 {
     std::unique_ptr<Item_group> gptr;
@@ -3164,6 +3180,7 @@ void Item_factory::add_entry( Item_group &ig, const JsonObject &obj )
     use_modifier |= load_sub_ref( modifier.ammo, obj, "ammo", ig );
     use_modifier |= load_sub_ref( modifier.container, obj, "container", ig );
     use_modifier |= load_sub_ref( modifier.contents, obj, "contents", ig );
+    use_modifier |= load_active( modifier.postprocess_fns, obj );
 
     std::vector<std::string> custom_flags;
     use_modifier |= load_string( custom_flags, obj, "custom-flags" );

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -374,6 +374,10 @@ detached_ptr<item> Item_modifier::modify( detached_ptr<item> &&new_item ) const
     for( const flag_id &flag : custom_flags ) {
         new_item->set_flag( flag );
     }
+
+    for( const auto &fn : postprocess_fns ) {
+        new_item = fn( std::move( new_item ) );
+    }
     return std::move( new_item );
 }
 

--- a/src/item_group.h
+++ b/src/item_group.h
@@ -145,7 +145,7 @@ class Item_spawn_data
         int probability;
 };
 
-using ItemFn = std::function < auto( detached_ptr<item> &&it ) -> detached_ptr<item> >;
+using ItemFn = std::function < detached_ptr<item> ( detached_ptr<item> &&it ) >;
 
 /**
  * Creates a single item, but can change various aspects

--- a/src/item_group.h
+++ b/src/item_group.h
@@ -144,6 +144,9 @@ class Item_spawn_data
         /** probability, used by the parent object. */
         int probability;
 };
+
+using ItemFn = std::function < auto( detached_ptr<item> &&it ) -> detached_ptr<item> >;
+
 /**
  * Creates a single item, but can change various aspects
  * of the created item.
@@ -185,6 +188,11 @@ class Item_modifier
          * Custom flags to be added to the item.
          */
         std::vector<flag_id> custom_flags;
+
+        /**
+         * Custom functions to be applied to the item after its creation.
+         */
+        std::vector<ItemFn> postprocess_fns;
 
         Item_modifier();
         Item_modifier( Item_modifier && ) = default;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4303,6 +4303,10 @@ std::vector<detached_ptr<item>> map::i_clear( const tripoint &p )
 detached_ptr<item> map::spawn_an_item( const tripoint &p, detached_ptr<item> &&new_item,
                                        const int charges, const int damlevel )
 {
+    if( one_in( 3 ) && new_item->has_flag( flag_VARSIZE ) ) {
+        new_item->set_flag( flag_FIT );
+    }
+
     if( charges && new_item->charges > 0 ) {
         //let's fail silently if we specify charges for an item that doesn't support it
         new_item->charges = charges;
@@ -4364,9 +4368,6 @@ void map::spawn_item( const tripoint &p, const itype_id &type_id,
     for( size_t i = 0; i < quantity; i++ ) {
         // spawn the item
         detached_ptr<item> new_item = item::spawn( type_id, birthday );
-        if( one_in( 3 ) && new_item->has_flag( flag_VARSIZE ) ) {
-            new_item->set_flag( flag_FIT );
-        }
 
         spawn_an_item( p, std::move( new_item ), charges, damlevel );
     }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -2164,26 +2164,21 @@ class jmapgen_vehicle : public jmapgen_piece
             type.check( oter_name, parameters );
         }
 };
-/**
- * Place a specific item.
- * "item": id of item type to spawn.
- * "chance": chance of spawning it (1 = always, otherwise one_in(chance)).
- * "amount": amount of items to spawn.
- * "repeat": number of times to apply this piece
- */
+
+/// Place a specific item.
 class jmapgen_spawn_item : public jmapgen_piece
 {
     public:
-        mapgen_value<itype_id> type;
-        jmapgen_int amount;
-        jmapgen_int chance;
-        bool spawn_active;
+        mapgen_value<itype_id> type; //< id of item type to spawn.
+        jmapgen_int amount;          //< amount of items to spawn.
+        jmapgen_int chance;          //< chance of spawning it (1 = always, otherwise one_in(chance)).
+        bool activate_on_spawn;      //< whether to activate the item on spawn.
         jmapgen_spawn_item( const JsonObject &jsi ) :
             type( jsi.get_member( "item" ) )
             , amount( jsi, "amount", 1, 1 )
             , chance( jsi, "chance", 100, 100 ) {
             repeat = jmapgen_int( jsi, "repeat", 1, 1 );
-            spawn_active = jsi.get_bool( "active", false );
+            activate_on_spawn = jsi.get_bool( "active", false );
         }
         void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y
                   ) const override {
@@ -2211,7 +2206,7 @@ class jmapgen_spawn_item : public jmapgen_piece
             for( int i = 0; i < spawn_count; i++ ) {
                 for( int j = 0; j < quantity; j++ ) {
                     detached_ptr<item> new_item = item::spawn( chosen_id, calendar::start_of_cataclysm );
-                    if( spawn_active ) {
+                    if( activate_on_spawn ) {
                         new_item->activate();
                     }
 


### PR DESCRIPTION
## Purpose of change

- wanted to prevent header modification in #4266 as it triggered ~300 file rebuilds.

## Describe the solution

cherry-picked solutions from #4073 and #4266:

- for individual items: inlined `map::spawn_item` in `src/mapgen.cpp` and replaced with `map::spawn_an_item` as it allows passing item ptr (so we can activate it first)
- ~~for item groups: sent `ACTIVATE_ON_PLACE` flag to `Item_modifier.custom_flags` in `src/item_factory.cpp` and checked its presence in `src/item_group.cpp`.~~
- added `postprocess_fns: vector<detached_ptr -> detached_ptr>` field in `Item_modifier` class that lets you postprocess spawned item in [Command pattern](https://gameprogrammingpatterns.com/command.html).

## Describe alternatives you've considered

- [x] send lambdas in item modifier to make sending messages less hacky. skipped for this one as this meant header modification and this would have been the only usage.
- unify item and item groups spawning by spawning single items via item groups

## Testing

![Cataclysm: Bright Nights - 0 C-57204-g083f635262fe-dirty_01](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/f93cc6e3-b015-449b-b349-4b25875bad10)
![Cataclysm: Bright Nights - 0 C-57204-g083f635262fe-dirty_02](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/e21a72ca-ba6d-43a2-aa60-12649f3f68ae)

- spawned grenades on top of shelter, one via individual item and one via item group. both are activated. 
- have to write a test to ensure it gets activated but i'm not sure which API to use.
- to test, revert last commit and load a evac shelter in fresh map.

## Checklist

- [x] Document the changes in the appropriate location in the `doc/` folder.
- [x] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

