### PR TITLE
fix: damage the clothes of the `house_dogs` dog fight victim

### DIFF
--- a/data/json/mapgen/house/house_dogs.json
+++ b/data/json/mapgen/house/house_dogs.json
@@ -13,12 +13,12 @@
     "type": "item_group",
     "subtype": "collection",
     "entries": [
-      { "item": "postman_shirt" },
-      { "item": "postman_shorts" },
-      { "item": "postman_hat" },
-      { "group": "underwear" },
-      { "item": "dress_shoes" },
-      { "item": "corpse" }
+      { "item": "postman_shirt", "damage": [ 1, 4 ] },
+      { "item": "postman_shorts", "damage": [ 1, 4 ] },
+      { "item": "postman_hat", "damage": [ 1, 4 ] },
+      { "group": "underwear", "damage": [ 1, 4 ] },
+      { "item": "dress_shoes", "damage": [ 1, 4 ] },
+      { "item": "corpse", "damage": 3 }
     ]
   },
   {


### PR DESCRIPTION
## Purpose of change
Make the victim clothes damaged, because logically if this person has been killed by dogs his clothes shouldn't be undamaged.
## Describe the solution
"damage": [ 1, 4 ] for all clothing and "damage": 3 for the body in `dogfight` `item_group`.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/6f31eb78-13fd-4fd2-8945-9fff5f563c42">
After:
<img width="960" alt="image2" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/365f1942-05f3-410b-9519-211a4522ac81">