### PR TITLE
test: ignore flaky ranged balance test

### DIFF
--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -225,7 +225,7 @@ static void assert_encumbrance( npc &shooter, int encumbrance )
 
 static constexpr tripoint shooter_pos( 60, 60, 0 );
 
-TEST_CASE( "unskilled_shooter_accuracy", "[ranged] [balance] [slow]" )
+TEST_CASE( "unskilled_shooter_accuracy", "[ranged][balance][slow][!mayfail]" )
 {
     clear_all_state();
     standard_npc shooter( "Shooter", shooter_pos, {}, 0, 8, 8, 8, 7 );


### PR DESCRIPTION
## Purpose of change

the tests are very flaky, and [fails unrelated PRs without much benefits](https://github.com/cataclysmbnteam/Cataclysm-BN/actions/runs/8125019849/job/22207142965?pr=4286#step:14:1917).
for the time being, it'd make more sense to ignore its failure.

## Describe the solution

https://github.com/catchorg/Catch2/blob/devel/docs/test-cases-and-sections.md#special-tags

mark `unskilled_shooter_accuracy` as `[!mayfail]`.

## Describe alternatives you've considered

- mark all other ranged balance tests as flaky

## Testing

should work as it effectively removes tests
