### PR TITLE
fix: mingw builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -582,6 +582,7 @@ ifeq ($(TARGETSYSTEM),WINDOWS)
   BINDIST_CMD = $(W32BINDIST_CMD)
   ODIR = $(W32ODIR)
   ODIRLUA = $(W32ODIRLUA)
+  OTHER += -Wa,-mbig-obj
   ifeq ($(DYNAMIC_LINKING), 1)
     # Windows isn't sold with programming support, these are static to remove MinGW dependency.
     LDFLAGS += -static-libgcc -static-libstdc++

--- a/src/catalua_luna_doc.h
+++ b/src/catalua_luna_doc.h
@@ -81,7 +81,7 @@ LUNA_DOC( bool, "bool" );
 LUNA_DOC( int, "int" );
 LUNA_DOC( unsigned int, "int" );
 LUNA_DOC( std::int64_t, "int" );
-LUNA_DOC( size_t, "int" );
+//LUNA_DOC( size_t, "int" ); This conflicts with the previous unsigned int def on some systems
 LUNA_DOC( float, "double" );
 LUNA_DOC( double, "double" );
 LUNA_DOC( void, "nil" );


### PR DESCRIPTION
## Purpose of change

This attempts to fix the mingw windows builds. It's 2 different fixes for 32 and 64 bit and I'm not sure either will work. Note it's the mingw builds I'm looking at here rather than the translation problems affecting the msvc build.

## Describe the solution

The 32 bit fix gets rid of size_t from the lua doc because it's internally the same type as unsigned int and so conflicted. The 64 bit fix adds "-Wa,-mbig-obj" to the build flags so it won't complain that the output is too big.

## Testing

None, I don't have a windows machine. I'm hoping to test it in the pipeline. 