### PR TITLE
fix: `OTHERS` typo in mingw build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -582,7 +582,7 @@ ifeq ($(TARGETSYSTEM),WINDOWS)
   BINDIST_CMD = $(W32BINDIST_CMD)
   ODIR = $(W32ODIR)
   ODIRLUA = $(W32ODIRLUA)
-  OTHER += -Wa,-mbig-obj
+  OTHERS += -Wa,-mbig-obj
   ifeq ($(DYNAMIC_LINKING), 1)
     # Windows isn't sold with programming support, these are static to remove MinGW dependency.
     LDFLAGS += -static-libgcc -static-libstdc++


### PR DESCRIPTION
## Purpose of change

followup of #4290

## Describe the solution

rename `OTHER` variable to `OTHERS`

## Describe alternatives you've considered

cry

## Testing

will test in `main` CI

## Additional context


https://digitalkarabela.com/mingw-w64-how-to-fix-file-too-big-too-many-sections/