### PR TITLE
fix: crashing when viewing armor item with undefined resitances

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6209,7 +6209,7 @@ int item::fire_resist( bool to_self, int base_env_resist ) const
     float mod = get_clothing_mod_val( clothing_mod_type_fire );
 
     std::optional<resistances> overriden_resistance = damage_resistance_override();
-    if (overriden_resistance && overriden_resistance->flat.count(DT_ACID)) {
+    if( overriden_resistance && overriden_resistance->flat.count( DT_ACID ) ) {
         return std::lround( overriden_resistance->flat[DT_HEAT] + mod );
     }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6209,7 +6209,7 @@ int item::fire_resist( bool to_self, int base_env_resist ) const
     float mod = get_clothing_mod_val( clothing_mod_type_fire );
 
     std::optional<resistances> overriden_resistance = damage_resistance_override();
-    if( overriden_resistance && overriden_resistance->flat.count( DT_ACID ) ) {
+    if( overriden_resistance && overriden_resistance->flat.count( DT_HEAT ) ) {
         return std::lround( overriden_resistance->flat[DT_HEAT] + mod );
     }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6170,7 +6170,7 @@ int item::acid_resist( bool to_self, int base_env_resist ) const
     float mod = get_clothing_mod_val( clothing_mod_type_acid );
 
     std::optional<resistances> overriden_resistance = damage_resistance_override();
-    if( overriden_resistance->flat.count( DT_ACID ) ) {
+    if( overriden_resistance && overriden_resistance->flat.count( DT_ACID ) ) {
         return std::lround( overriden_resistance->flat[DT_ACID] + mod );
     }
 
@@ -6209,7 +6209,7 @@ int item::fire_resist( bool to_self, int base_env_resist ) const
     float mod = get_clothing_mod_val( clothing_mod_type_fire );
 
     std::optional<resistances> overriden_resistance = damage_resistance_override();
-    if( overriden_resistance->flat.count( DT_HEAT ) ) {
+    if (overriden_resistance && overriden_resistance->flat.count(DT_ACID)) {
         return std::lround( overriden_resistance->flat[DT_HEAT] + mod );
     }
 


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change
fix #4302 

Items that are categorized as armor but don't have defined resistances will crash the game upon view. 

## Describe the solution
This was previously crash safe because we were using a null check, but the behavior was wrong. Added the null check back.

## Describe alternatives you've considered
letting chaos scream and cry

## Testing
Loaded up game, scrolled through entire debug spawner for items, no crash. Item resistance values look fine.

## Additional context
Not a fix for INT_MIN physical resistance on some smaller items; I can't reproduce that issue on windows.
