### PR TITLE
feat: extend `add_spawn()` to handle creating pets

### DIFF
--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -663,7 +663,7 @@ void editmap::draw_main_ui_overlay()
                             const tripoint spawn_p = sm_origin + sp.pos;
                             const auto spawn_it = spawns.find( spawn_p );
                             if( spawn_it == spawns.end() ) {
-                                const Attitude att = sp.friendly ? Attitude::A_FRIENDLY : Attitude::A_ANY;
+                                const Attitude att = sp.is_friendly() ? Attitude::A_FRIENDLY : Attitude::A_ANY;
                                 spawns.emplace( spawn_p, std::make_tuple( sp.type, sp.count, false, att ) );
                             } else {
                                 std::get<2>( spawn_it->second ) = true;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7320,7 +7320,9 @@ void map::rotten_item_spawn( const item &item, const tripoint &pnt )
                                          get_option<float>( "CARRION_SPAWNRATE" ) );
     if( rng( 0, 100 ) < chance ) {
         MonsterGroupResult spawn_details = MonsterGroupManager::GetResultFromGroup( mgroup );
-        add_spawn( spawn_details.name, 1, pnt, item.has_own_flag( flag_SPAWN_FRIENDLY ) );
+        const spawn_disposition disposition = item.has_own_flag( flag_SPAWN_FRIENDLY ) ?
+                                              spawn_disposition::SpawnDisp_Pet : spawn_disposition::SpawnDisp_Default;
+        add_spawn( spawn_details.name, 1, pnt, disposition );
         if( g->u.sees( pnt ) ) {
             if( item.is_seed() ) {
                 add_msg( m_warning, _( "Something has crawled out of the %s plants!" ), item.get_plant_name() );
@@ -7888,7 +7890,7 @@ void map::spawn_monsters_submap( const tripoint &gp, bool ignore_sight )
             if( i.name != "NONE" ) {
                 tmp.unique_name = i.name;
             }
-            if( i.friendly ) {
+            if( i.is_friendly() ) {
                 tmp.friendly = -1;
             }
 
@@ -7902,6 +7904,9 @@ void map::spawn_monsters_submap( const tripoint &gp, bool ignore_sight )
                 monster *const placed = g->place_critter_at( make_shared_fast<monster>( tmp ), p );
                 if( placed ) {
                     placed->on_load();
+                    if( i.disposition == spawn_disposition::SpawnDisp_Pet ) {
+                        placed->make_pet();
+                    }
                 }
             };
 

--- a/src/map.h
+++ b/src/map.h
@@ -36,6 +36,7 @@
 #include "type_id.h"
 #include "units.h"
 
+enum class spawn_disposition;
 struct scent_block;
 template <typename T> class string_id;
 
@@ -1559,6 +1560,9 @@ class map
         void apply_faction_ownership( point p1, point p2, const faction_id &id );
         void add_spawn( const mtype_id &type, int count, const tripoint &p,
                         bool friendly = false, int faction_id = -1, int mission_id = -1,
+                        const std::string &name = "NONE" ) const;
+        void add_spawn( const mtype_id &type, int count, const tripoint &p,
+                        spawn_disposition disposition, int faction_id = -1, int mission_id = -1,
                         const std::string &name = "NONE" ) const;
         void do_vehicle_caching( int z );
         // Note: in 3D mode, will actually build caches on ALL z-levels

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -6288,6 +6288,14 @@ std::vector<item *> map::put_items_from_loc( const item_group_id &loc, const tri
 void map::add_spawn( const mtype_id &type, int count, const tripoint &p, bool friendly,
                      int faction_id, int mission_id, const std::string &name ) const
 {
+    add_spawn( type, count, p, spawn_point::friendly_to_spawn_disposition( friendly ), faction_id,
+               mission_id, name );
+}
+
+void map::add_spawn( const mtype_id &type, int count, const tripoint &p,
+                     spawn_disposition disposition,
+                     int faction_id, int mission_id, const std::string &name ) const
+{
     if( p.x < 0 || p.x >= SEEX * my_MAPSIZE || p.y < 0 || p.y >= SEEY * my_MAPSIZE ) {
         debugmsg( "Bad add_spawn(%s, %d, %d, %d)", type.c_str(), count, p.x, p.y );
         return;
@@ -6303,7 +6311,7 @@ void map::add_spawn( const mtype_id &type, int count, const tripoint &p, bool fr
     if( MonsterGroupManager::monster_is_blacklisted( type ) ) {
         return;
     }
-    spawn_point tmp( type, count, offset, faction_id, mission_id, friendly, name );
+    spawn_point tmp( type, count, offset, faction_id, mission_id, disposition, name );
     place_on_submap->spawns.push_back( tmp );
 }
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -58,6 +58,7 @@
 #include "string_formatter.h"
 #include "string_id.h"
 #include "string_utils.h"
+#include "submap.h"
 #include "text_snippets.h"
 #include "translations.h"
 #include "trap.h"
@@ -509,16 +510,16 @@ void monster::try_reproduce()
 
         chance += 2;
 
-        // wildlife creatures that are friendly to the player will spawn friendly offspring
-        const bool friendly_parent = type->in_category( "WILDLIFE" ) &&
-                                     attitude_to( get_player_character() ) == Attitude::A_FRIENDLY;
+        // wildlife creatures that are pets of the player will spawn pet offspring
+        const spawn_disposition disposition = is_pet() ? spawn_disposition::SpawnDisp_Pet :
+                                              spawn_disposition::SpawnDisp_Default;
         if( season_match && female && one_in( chance ) ) {
             int spawn_cnt = rng( 1, type->baby_count );
             if( type->baby_monster ) {
-                g->m.add_spawn( type->baby_monster, spawn_cnt, pos(), friendly_parent );
+                g->m.add_spawn( type->baby_monster, spawn_cnt, pos(), disposition );
             } else {
                 detached_ptr<item> item_to_spawn = item::spawn( type->baby_egg, *baby_timer, spawn_cnt );
-                if( friendly_parent ) {
+                if( disposition == spawn_disposition::SpawnDisp_Pet ) {
                     item_to_spawn->set_flag( flag_SPAWN_FRIENDLY );
                 }
                 g->m.add_item_or_charges( pos(), std::move( item_to_spawn ), true );
@@ -2938,6 +2939,11 @@ void monster::make_pet()
     friendly = -1;
     g->critter_tracker->update_faction( *this );
     add_effect( effect_pet, 1_turns, num_bp );
+}
+
+bool monster::is_pet() const
+{
+    return ( friendly == -1 && has_effect( effect_pet ) );
 }
 
 bool monster::is_hallucination() const

--- a/src/monster.h
+++ b/src/monster.h
@@ -433,6 +433,8 @@ class monster : public Creature, public location_visitable<monster>
         void make_ally( const monster &z );
         // makes this monster a pet of the player
         void make_pet();
+        // check if this monster is a pet of the player
+        bool is_pet() const;
         // Add an item to inventory
         void add_item( detached_ptr<item> &&it );
         // check mech power levels and modify it.

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3922,7 +3922,7 @@ void submap::store( JsonOut &jsout ) const
         jsout.write( elem.pos.y );
         jsout.write( elem.faction_id );
         jsout.write( elem.mission_id );
-        jsout.write( elem.friendly );
+        jsout.write( elem.is_friendly() );
         jsout.write( elem.name );
         jsout.end_array();
     }
@@ -4166,7 +4166,8 @@ void submap::load( JsonIn &jsin, const std::string &member_name, int version,
             bool friendly = jsin.get_bool();
             std::string name = jsin.get_string();
             jsin.end_array();
-            spawn_point tmp( type, count, p, faction_id, mission_id, friendly, name );
+            spawn_point tmp( type, count, p, faction_id, mission_id,
+                             spawn_point::friendly_to_spawn_disposition( friendly ), name );
             spawns.push_back( tmp );
         }
     } else if( member_name == "vehicles" ) {

--- a/src/submap.h
+++ b/src/submap.h
@@ -19,6 +19,7 @@
 #include "game_constants.h"
 #include "item.h"
 #include "type_id.h"
+#include "monster.h"
 #include "point.h"
 #include "poly_serialized.h"
 
@@ -31,19 +32,41 @@ struct ter_t;
 struct furn_t;
 class vehicle;
 
+// enum defines the initial disposition of the monster that is to be spawned
+enum class spawn_disposition {
+    SpawnDisp_Default,
+    SpawnDisp_Friendly,
+    SpawnDisp_Pet,
+};
+
 struct spawn_point {
     point pos;
     int count;
     mtype_id type;
     int faction_id;
     int mission_id;
-    bool friendly;
+    spawn_disposition disposition;
     std::string name;
     spawn_point( const mtype_id &T = mtype_id::NULL_ID(), int C = 0, point P = point_zero,
-                 int FAC = -1, int MIS = -1, bool F = false,
+                 int FAC = -1, int MIS = -1, spawn_disposition DISP = spawn_disposition::SpawnDisp_Default,
                  const std::string &N = "NONE" ) :
         pos( P ), count( C ), type( T ), faction_id( FAC ),
-        mission_id( MIS ), friendly( F ), name( N ) {}
+        mission_id( MIS ), disposition( DISP ), name( N ) {}
+
+    // helper function to convert internal disposition into a binary bool value.
+    // This is required to preserve save game compatibility because submaps store/load
+    // their spawn_points using a boolean flag.
+    bool is_friendly( void ) const {
+        return disposition != spawn_disposition::SpawnDisp_Default;
+    }
+
+    // helper function to convert binary bool friendly value to internal disposition.
+    // This is required to preserve save game compatibility because submaps store/load
+    // their spawn_points using a boolean flag.
+    static spawn_disposition friendly_to_spawn_disposition( bool friendly ) {
+        return friendly ? spawn_disposition::SpawnDisp_Friendly
+               : spawn_disposition::SpawnDisp_Default;
+    }
 };
 
 template<int sx, int sy>


### PR DESCRIPTION
So far map::add_spawn() and the underlying spawn_point struct have been operating on the binary notion that a spawn can be friendly or not. This PR extends those APIs to also support generating monsters that are pets of the player, while also honoring backwards compatibility with parts of the codebase that still want to operate on the binary friendly notion, such as the save/load system for submaps.

<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

This is a followup to previous PRs (#4287, #4289) that made it possible for friendly wildlife creatures to spawn friendly offspring, mostly as a QoL improvement for farm players. As chaosvolt point out, this ended up creating friendly offspring, not pets. Hence several functions such as slaughter, milk, etc were still not allowed for friendly offspring - the player has to manually tame the friendly creatures to make them full blown pets. This PR addresses that so that wildlife pets of the player will actually spawn offspring that are full blown pets.
<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution
The map::add_spawn() API, backed up by the spawn_point structure, operated under the binary notion of spawning friendly or not friendly monsters. `spawn_point` and `submap::spawns` in general is used to keep track of monsters that are about to be spawned by haven't spawned yet - e.g. spawning creatures while loading new submap for first time or spawning baby chicken from egg, etc.

This PR takes care to extend this API with an enum while also preserving backwards compatibility with legacy systems such as the save/load part of submaps which need to keep operating with a binary notion of friendly so as to not break old save games. However, this doesn't prevent us from extending the API in order to be able to handle creating pet -or even monsters with other, unique dispositions- in the future via map::add_spawn().

The only corner-case where this patch wouldn't work as expected is in the unlikely corner-case where a creature is added to submap::spawns but is not spawned yet and the player saves+exits the game, at which point fine grained information of disposition is lost and we just save the 'spawn' in the submap save file as either friendly or not friendly in order to be backwards compatible.

IMHO the patch is as noninvasive as it can possibly be while still accomplishing the desired effect, looking forward to feedback though.
<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

## Describe alternatives you've considered

I've considered extending the attitude enum with a pet disposition and using that in spawn_point struct, but it seemed like a bad idea. I think a more narrowly scoped enum makes more sense for this case.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing

I've tested creating offspring with this patch and then ensuring that when they spawn, in the pet menu i can actually do things like 'slaughter' which I couldn't before since they just spawned as friendly.

This commit has been used to ease testing by making offspring spawn during submap load(), it applies on top of this patch. https://github.com/cataclysmbnteam/Cataclysm-BN/commit/be944e81df4e7fad6afec76de4ef7633b5fb0606

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
