### PR TITLE
feat: use mount's speed when mounted

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4638,6 +4638,9 @@ int get_speedydex_bonus( const int dex )
 
 int Character::get_speed() const
 {
+    if( is_mounted() ) {
+        return mounted_creature.get()->get_speed();
+    }
     return Creature::get_speed();
 }
 


### PR DESCRIPTION
## Purpose of change

riding horse should be fast.

- <https://gall.dcinside.com/board/view/?id=rlike&no=456342>

## Describe the solution

use mounted animal's speed instead when mounted.

## Describe alternatives you've considered

also take overburden or other stuff into account but was lazy.

## Testing

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/755153ea-9bdb-49a7-82de-b18efdc38a25)

1. spawn `horse`, `cattle fodder`, `horse tack`
2. ride on horse
3. speed is now 300
4. dismount from horse
5. speed is now 100