### PR TITLE
feat: stack comestibles regardless of rot

### DIFF
--- a/src/cached_item_options.cpp
+++ b/src/cached_item_options.cpp
@@ -1,0 +1,5 @@
+#include "cached_item_options.h"
+
+merge_comestible_t merge_comestible_mode = merge_comestible_t::merge_legacy;
+
+float relative_rot_threshold;

--- a/src/cached_item_options.cpp
+++ b/src/cached_item_options.cpp
@@ -2,4 +2,4 @@
 
 merge_comestible_t merge_comestible_mode = merge_comestible_t::merge_legacy;
 
-float relative_rot_threshold;
+float similarity_threshold;

--- a/src/cached_item_options.h
+++ b/src/cached_item_options.h
@@ -1,0 +1,21 @@
+#pragma once
+#ifndef CATA_SRC_CACHED_ITEM_OPTIONS_H
+#define CATA_SRC_CACHED_ITEM_OPTIONS_H
+
+enum class merge_comestible_t {
+    merge_legacy,
+    merge_liquid,
+    merge_all,
+};
+
+/**
+ * Merge similar comestibles.  Legacy: default behavior.  Liquid: Merge only liquid comestibles.  All: Merge all comestibles.
+ */
+extern merge_comestible_t merge_comestible_mode;
+
+/**
+ * Only merge comestibles fresher than given threshold. Lower value means stricter merging. 0.0 is fresh, 1.0 is rotten.
+ */
+extern float relative_rot_threshold;
+
+#endif // CATA_SRC_CACHED_ITEM_OPTIONS_H

--- a/src/cached_item_options.h
+++ b/src/cached_item_options.h
@@ -14,8 +14,11 @@ enum class merge_comestible_t {
 extern merge_comestible_t merge_comestible_mode;
 
 /**
- * Only merge comestibles fresher than given threshold. Lower value means stricter merging. 0.0 is fresh, 1.0 is rotten.
+ * Limit maximum allowed staleness difference when merging comestibles.
+ * The lower the value, the more similar the items must be to merge.
+ * 0.0: Only merge identical items.
+ * 1.0: Merge comestibles regardless of its freshness.
  */
-extern float relative_rot_threshold;
+extern float similarity_threshold;
 
 #endif // CATA_SRC_CACHED_ITEM_OPTIONS_H

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1015,6 +1015,11 @@ bool item::stacks_with( const item &rhs, bool check_components, bool skip_type_c
                     return false;
                 }
             }
+            case merge_comestible_t::merge_liquid: {
+                if( !made_of( LIQUID ) || !rhs.made_of( LIQUID ) ) {
+                    return false;
+                }
+            }
             default: {
                 if( get_relative_rot() > relative_rot_threshold ||
                     rhs.get_relative_rot() > relative_rot_threshold ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1746,7 +1746,7 @@ void item::basic_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
                 info.emplace_back( "BASE", _( "rot (turns): " ),
                                    "", iteminfo::lower_is_better,
                                    to_turns<int>( food->rot ) );
-                info.emplace_back( "BASE", space + _( "max rot (turns): " ),
+                info.emplace_back( "BASE", space + _( "shelf life (turns): " ),
                                    "", iteminfo::lower_is_better,
                                    to_turns<int>( food->get_shelf_life() ) );
                 info.emplace_back( "BASE", _( "last rot: " ),
@@ -3520,7 +3520,7 @@ void item::combat_info( std::vector<iteminfo> &info, const iteminfo_query *parts
 }
 
 void item::contents_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch,
-                          bool /*debug*/ ) const
+                          bool debug ) const
 {
     if( contents.empty() || !parts->test( iteminfo_parts::DESCRIPTION_CONTENTS ) ) {
         return;
@@ -3597,6 +3597,22 @@ void item::contents_info( std::vector<iteminfo> &info, const iteminfo_query *par
                                            c_light_blue ) );
                 }
                 info.emplace_back( "DESCRIPTION", description.translated() );
+            }
+
+            if( debug && contents_item && contents_item->goes_bad() ) {
+                info.emplace_back( "CONTAINER", space );
+                info.emplace_back( "CONTAINER", _( "age (turns): " ),
+                                   "", iteminfo::lower_is_better,
+                                   to_turns<int>( contents_item->age() ) );
+                info.emplace_back( "CONTAINER", _( "rot (turns): " ),
+                                   "", iteminfo::lower_is_better,
+                                   to_turns<int>( contents_item->rot ) );
+                info.emplace_back( "CONTAINER", space + _( "shelf life (turns): " ),
+                                   "", iteminfo::lower_is_better,
+                                   to_turns<int>( contents_item->get_shelf_life() ) );
+                info.emplace_back( "CONTAINER", _( "last rot: " ),
+                                   "", iteminfo::lower_is_better,
+                                   to_turn<int>( contents_item->last_rot_check ) );
             }
         }
     }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1003,13 +1003,26 @@ bool item::stacks_with( const item &rhs, bool check_components, bool skip_type_c
     if( goes_bad() && rhs.goes_bad() ) {
         // Stack items that fall into the same "bucket" of freshness.
         // Distant buckets are larger than near ones.
-        // std::pair<int, clipped_unit> my_clipped_time_to_rot =
-        //     clipped_time( get_shelf_life() - rot );
-        // std::pair<int, clipped_unit> other_clipped_time_to_rot =
-        //     clipped_time( rhs.get_shelf_life() - rhs.rot );
-        // if( my_clipped_time_to_rot != other_clipped_time_to_rot ) {
-        //     return false;
-        // }
+
+        // TODO: cache merging options?
+        const auto merge_mode = get_option<std::string>( "MERGE_COMESTIBLES" );
+
+        // actually 0 is fresh and 1 is rotten so we invert value
+        const float freshness_threshold = 1 - get_option<float>( "MERGE_COMESTIBLES_FRESHNESS" );
+
+        if( merge_mode == "legacy" ) {
+            std::pair<int, clipped_unit> my_clipped_time_to_rot =
+                clipped_time( get_shelf_life() - rot );
+            std::pair<int, clipped_unit> other_clipped_time_to_rot =
+                clipped_time( rhs.get_shelf_life() - rhs.rot );
+            if( my_clipped_time_to_rot != other_clipped_time_to_rot ) {
+                return false;
+            }
+        } else if( merge_mode == "all" ) {
+            if( get_relative_rot() > freshness_threshold || rhs.get_relative_rot() > freshness_threshold ) {
+                return false;
+            }
+        }
         if( rotten() != rhs.rotten() ) {
             // just to be safe that rotten and unrotten food is *never* stacked.
             return false;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1022,12 +1022,8 @@ bool item::stacks_with( const item &rhs, bool check_components, bool skip_type_c
                 }
             }
             [[fallthrough]];
-            default: {
-                if( get_relative_rot() > relative_rot_threshold ||
-                    rhs.get_relative_rot() > relative_rot_threshold ) {
-                    return false;
-                }
-            }
+            default:
+                return std::abs( get_relative_rot() - rhs.get_relative_rot() ) <= similarity_threshold;
         }
 
         if( rotten() != rhs.rotten() ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1021,6 +1021,7 @@ bool item::stacks_with( const item &rhs, bool check_components, bool skip_type_c
                     return false;
                 }
             }
+            [[fallthrough]];
             default: {
                 if( get_relative_rot() > relative_rot_threshold ||
                     rhs.get_relative_rot() > relative_rot_threshold ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1015,6 +1015,7 @@ bool item::stacks_with( const item &rhs, bool check_components, bool skip_type_c
                     return false;
                 }
             }
+            break;
             case merge_comestible_t::merge_liquid: {
                 if( !made_of( LIQUID ) || !rhs.made_of( LIQUID ) ) {
                     return false;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1003,13 +1003,13 @@ bool item::stacks_with( const item &rhs, bool check_components, bool skip_type_c
     if( goes_bad() && rhs.goes_bad() ) {
         // Stack items that fall into the same "bucket" of freshness.
         // Distant buckets are larger than near ones.
-        std::pair<int, clipped_unit> my_clipped_time_to_rot =
-            clipped_time( get_shelf_life() - rot );
-        std::pair<int, clipped_unit> other_clipped_time_to_rot =
-            clipped_time( rhs.get_shelf_life() - rhs.rot );
-        if( my_clipped_time_to_rot != other_clipped_time_to_rot ) {
-            return false;
-        }
+        // std::pair<int, clipped_unit> my_clipped_time_to_rot =
+        //     clipped_time( get_shelf_life() - rot );
+        // std::pair<int, clipped_unit> other_clipped_time_to_rot =
+        //     clipped_time( rhs.get_shelf_life() - rhs.rot );
+        // if( my_clipped_time_to_rot != other_clipped_time_to_rot ) {
+        //     return false;
+        // }
         if( rotten() != rhs.rotten() ) {
             // just to be safe that rotten and unrotten food is *never* stacked.
             return false;
@@ -1059,6 +1059,10 @@ bool item::merge_charges( detached_ptr<item> &&rhs, bool force )
     safe_reference<item>::merge( this, &*rhs );
     detached_ptr<item> del = std::move( rhs );
 
+    const int base_charges = charges + obj.charges;
+    const auto weighted_averaged_rot =
+        base_charges > 0 ? ( rot * charges + obj.rot * obj.charges ) / base_charges :  0_seconds;
+
     // Prevent overflow when either item has "near infinite" charges.
     if( charges >= INFINITE_CHARGES / 2 || obj.charges >= INFINITE_CHARGES / 2 ) {
         charges = INFINITE_CHARGES;
@@ -1070,6 +1074,10 @@ bool item::merge_charges( detached_ptr<item> &&rhs, bool force )
                          ( obj.item_counter ) * obj.charges ) / ( charges + obj.charges );
     }
     charges += obj.charges;
+
+    rot = weighted_averaged_rot;
+    set_age( std::max( age(), obj.age() ) );
+
     return true;
 }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1234,6 +1234,27 @@ void options_manager::add_options_general()
 
     add_empty_line();
 
+    add_option_group( general, Group( "comestible_merging",
+                                      to_translation( "Merge similar comestibles" ),
+                                      to_translation( "Configure how similar items are stacked." ) ),
+    [&]( auto & page_id ) {
+        add( "MERGE_COMESTIBLES", page_id, translate_marker( "Merging Mode" ),
+        translate_marker( "Merge similar comestibles.  Legacy: default behavior.  Liquid: Merge only liquid comestibles.  All: Merge all comestibles." ), {
+            { "legacy", to_translation( "Legacy" ) },
+            // { "liquid", to_translation( "Liquid" ) },
+            { "all", to_translation( "All" ) }
+        }, "all" );
+
+        add( "MERGE_COMESTIBLES_FRESHNESS", general, translate_marker( "Freshness Threshold" ),
+             translate_marker( "Only merge comestibles fresher than given threshold."
+                               "  0 is rotten, 1 is fresh." ),
+             0.0, 1.0, 0.75, 0.05 );
+
+        get_option( "MERGE_COMESTIBLES_FRESHNESS" ).setPrerequisite( "MERGE_COMESTIBLES", "all" );
+    } );
+
+    add_empty_line();
+
     add( "AUTO_PICKUP", general, translate_marker( "Auto pickup enabled" ),
          translate_marker( "Enable item auto pickup.  Change pickup rules with the Auto Pickup Manager." ),
          false

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1246,12 +1246,15 @@ void options_manager::add_options_general()
             { "all", to_translation( "All" ) }
         }, "all" );
 
-        add( "MERGE_COMESTIBLES_FRESHNESS", general, translate_marker( "Freshness Threshold" ),
-             translate_marker( "Only merge comestibles fresher than given threshold."
-                               "  1.0 is fresh, 0.0 is rotten." ),
-             0.0, 1.0, 0.75, 0.05 );
+        add( "MERGE_COMESTIBLES_THRESHOLD", general, translate_marker( "Freshness similarity threshold" ),
+             translate_marker( "Limit maximum allowed staleness difference when merging comestibles."
+                               "  The lower the value, the more similar the items must be to merge."
+                               "  0.0: Only merge identical items."
+                               "  1.0: Merge comestibles regardless of its freshness."
+                             ),
+             0.0, 1.0, 0.25, 0.05 );
 
-        get_option( "MERGE_COMESTIBLES_FRESHNESS" ).setPrerequisites( "MERGE_COMESTIBLES", {"liquid", "all"} );
+        get_option( "MERGE_COMESTIBLES_THRESHOLD" ).setPrerequisites( "MERGE_COMESTIBLES", {"liquid", "all"} );
     } );
 
     add_empty_line();
@@ -3399,9 +3402,7 @@ void options_manager::cache_to_globals()
         : merge_comestible_t::merge_all;
     } )();
 
-    // actually 0.0 is fresh and 1.0 is rotten so we invert value
-    relative_rot_threshold =
-        1.0f - ::get_option<float>( "MERGE_COMESTIBLES_FRESHNESS" );
+    similarity_threshold = ::get_option<float>( "MERGE_COMESTIBLES_THRESHOLD" );
 
 #if defined(SDL_SOUND)
     sounds::sound_enabled = ::get_option<bool>( "SOUND_ENABLED" );

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -165,7 +165,7 @@ TEST_CASE( "stacking_over_time", "[item]" )
 
     GIVEN( "Two items with the same birthday (stack mode: all)" ) {
         merge_comestible_mode = merge_comestible_t::merge_all;
-        relative_rot_threshold = 1.0f;
+        similarity_threshold = 1.0f;
 
         REQUIRE( A.stacks_with( B ) );
         WHEN( "the items are aged different numbers of seconds" ) {

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -12,6 +12,7 @@
 #include "math_defines.h"
 #include "units.h"
 #include "value_ptr.h"
+#include "cached_item_options.h"
 
 TEST_CASE( "item_volume", "[item]" )
 {
@@ -69,7 +70,9 @@ TEST_CASE( "stacking_over_time", "[item]" )
     item &A = *item::spawn_temporary( "bologna" );
     item &B = *item::spawn_temporary( "bologna" );
 
-    GIVEN( "Two items with the same birthday" ) {
+    GIVEN( "Two items with the same birthday (stack mode: legacy)" ) {
+        merge_comestible_mode = merge_comestible_t::merge_legacy;
+
         REQUIRE( A.stacks_with( B ) );
         WHEN( "the items are aged different numbers of seconds" ) {
             A.mod_rot( A.type->comestible->spoils - 1_turns );
@@ -159,7 +162,102 @@ TEST_CASE( "stacking_over_time", "[item]" )
             }
         }
     }
+
+    GIVEN( "Two items with the same birthday (stack mode: all)" ) {
+        merge_comestible_mode = merge_comestible_t::merge_all;
+        relative_rot_threshold = 1.0f;
+
+        REQUIRE( A.stacks_with( B ) );
+        WHEN( "the items are aged different numbers of seconds" ) {
+            A.mod_rot( A.type->comestible->spoils - 1_turns );
+            B.mod_rot( B.type->comestible->spoils - 3_turns );
+            THEN( "they stack" ) {
+                CHECK( A.stacks_with( B ) );
+            }
+        }
+        WHEN( "the items are aged the same to the minute but different numbers of seconds" ) {
+            A.mod_rot( A.type->comestible->spoils - 5_minutes );
+            B.mod_rot( B.type->comestible->spoils - 5_minutes );
+            B.mod_rot( -5_turns );
+            THEN( "they stack" ) {
+                CHECK( A.stacks_with( B ) );
+            }
+        }
+        WHEN( "the items are aged a few seconds different but different minutes" ) {
+            A.mod_rot( A.type->comestible->spoils - 5_minutes );
+            B.mod_rot( B.type->comestible->spoils - 5_minutes );
+            B.mod_rot( 5_turns );
+            THEN( "they stack" ) {
+                CHECK( A.stacks_with( B ) );
+            }
+        }
+        WHEN( "the items are aged the same to the hour but different numbers of minutes" ) {
+            A.mod_rot( A.type->comestible->spoils - 5_hours );
+            B.mod_rot( B.type->comestible->spoils - 5_hours );
+            B.mod_rot( -5_minutes );
+            THEN( "they stack" ) {
+                CHECK( A.stacks_with( B ) );
+            }
+        }
+        WHEN( "the items are aged a few seconds different but different hours" ) {
+            A.mod_rot( A.type->comestible->spoils - 5_hours );
+            B.mod_rot( B.type->comestible->spoils - 5_hours );
+            B.mod_rot( 5_turns );
+            THEN( "they stack" ) {
+                CHECK( A.stacks_with( B ) );
+            }
+        }
+        WHEN( "the items are aged the same to the day but different numbers of seconds" ) {
+            A.mod_rot( A.type->comestible->spoils - 3_days );
+            B.mod_rot( B.type->comestible->spoils - 3_days );
+            B.mod_rot( -5_turns );
+            THEN( "they stack" ) {
+                CHECK( A.stacks_with( B ) );
+            }
+        }
+        WHEN( "the items are aged a few seconds different but different days" ) {
+            A.mod_rot( A.type->comestible->spoils - 3_days );
+            B.mod_rot( B.type->comestible->spoils - 3_days );
+            B.mod_rot( 5_turns );
+            THEN( "they stack" ) {
+                CHECK( A.stacks_with( B ) );
+            }
+        }
+        WHEN( "the items are aged the same to the week but different numbers of seconds" ) {
+            A.mod_rot( A.type->comestible->spoils - 7_days );
+            B.mod_rot( B.type->comestible->spoils - 7_days );
+            B.mod_rot( -5_turns );
+            THEN( "they stack" ) {
+                CHECK( A.stacks_with( B ) );
+            }
+        }
+        WHEN( "the items are aged a few seconds different but different weeks" ) {
+            A.mod_rot( A.type->comestible->spoils - 7_days );
+            B.mod_rot( B.type->comestible->spoils - 7_days );
+            B.mod_rot( 5_turns );
+            THEN( "they stack" ) {
+                CHECK( A.stacks_with( B ) );
+            }
+        }
+        WHEN( "the items are aged the same to the season but different numbers of seconds" ) {
+            A.mod_rot( A.type->comestible->spoils - calendar::season_length() );
+            B.mod_rot( B.type->comestible->spoils - calendar::season_length() );
+            B.mod_rot( -5_turns );
+            THEN( "they stack" ) {
+                CHECK( A.stacks_with( B ) );
+            }
+        }
+        WHEN( "the items are aged a few seconds different but different seasons" ) {
+            A.mod_rot( A.type->comestible->spoils - calendar::season_length() );
+            B.mod_rot( B.type->comestible->spoils - calendar::season_length() );
+            B.mod_rot( 5_turns );
+            THEN( "they stack" ) {
+                CHECK( A.stacks_with( B ) );
+            }
+        }
+    }
 }
+
 
 TEST_CASE( "magazine_copyfrom_extends", "[item]" )
 {


### PR DESCRIPTION
## Purpose of change

- improve QOL by allowing 10h and 11h old pancakes to stack
- improve performance a tiny bit by not having 123 kinds of slightly different food around

## Describe the solution

- Added option group to configure comestible merging.
	- the new stacking strategy is enabled by default.
	- you can rollback to previous strategy via setting it `legacy`
	- ~~by default, only comestibles that's up to 75% fresh can be merged (tweakable)~~
	- by default, comestibles that has up to 25% similar freshness can be merged (tweakable)
- On item merging, the rot is set to weighted average of their rotness and charges
	- mixing small fresh food with huge amount of near rotten food won't make it much fresher and vice versa

## Describe alternatives you've considered

- [x] allow mixing two items not by freshness compared to shelf life, but similarities between the two?

## Testing

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/e1ec9e05-d220-4fe1-9fb4-a8f5c79a3840)

### Solid comestible

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/2e755378-e5b7-46ed-81f9-cb0f95a6a0e6

### Liquid comestible

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/ada331c4-7bb1-47a7-bd07-44c49fe8cac1

have to change the option before testing.

also updated `stacking_over_time` test to test both legacy and new behavior.

## Additional context

related: #3057