### PR TITLE
test: add `no_hope` to mod test blocklist

### DIFF
--- a/build-scripts/mod_test_blacklist
+++ b/build-scripts/mod_test_blacklist
@@ -1,3 +1,4 @@
+no_hope
 crt_expansion
 Graphical_Overmap
 no_medieval_items


### PR DESCRIPTION
## Purpose of change

1. the mod overrides many things such as palettes.
2. due to this, it causes countless test failures (like in #4312)
3. we lack staff to maintain it.

## Describe the solution

ignore `no_hope` from testing for the time being.

## Describe alternatives you've considered

extract the mod into third-party mod (`cataclysmbn/no_hope`)?
