### PR TITLE
ci: bump outdated actions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up JDK 11 (android)
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4.1.0
         with:
           java-version: "11"
           distribution: "adopt"

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - run: sudo apt-get install astyle
 

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: install dependencies

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -22,7 +22,7 @@ jobs:
     environment: github-pages
     steps:
       - name: Checkout your repository using git
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install, build, and upload site
         uses: withastro/action@v0
         with:

--- a/.github/workflows/i18n-extraction.yml
+++ b/.github/workflows/i18n-extraction.yml
@@ -21,7 +21,7 @@ jobs:
           sudo apt-get install gettext python3-pip
           sudo pip3 install polib luaparser
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Check that translation template extraction works
         run: lang/update_pot.sh

--- a/.github/workflows/i18n-printf-format.yml
+++ b/.github/workflows/i18n-printf-format.yml
@@ -16,7 +16,7 @@ jobs:
           sudo apt-get install python3-pip
           sudo pip3 install polib
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Check printf format string in translations"
         run: ./tools/check_po_printf_format.py

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -279,7 +279,7 @@ jobs:
           fi
       - name: Upload release asset
         id: upload-release-asset
-        uses: actions/upload-release-asset@v1
+        uses: shogo82148/actions-upload-release-asset@v1.7.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -32,7 +32,7 @@ jobs:
           tag: ${{ steps.generate_env_vars.outputs.tag_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Push tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v5.5
@@ -41,7 +41,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ steps.generate_env_vars.outputs.tag_name }}
           tag_prefix: ""
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: git fetch origin tag ${{ steps.generate_env_vars.outputs.tag_name }} --no-tags
       - name: Build Changelog
         id: build_changelog
@@ -155,7 +155,7 @@ jobs:
     env:
       ZSTD_CLEVEL: 17
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Create VERSION.TXT
         shell: bash
         run: |

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -27,7 +27,7 @@ jobs:
           echo "release_name=Cataclysm-BN ${{ env.VERSION }}" >> $GITHUB_OUTPUT
       - name: Check if there is existing git tag
         id: tag_check
-        uses: mukunku/tag-exists-action@v1.4.0
+        uses: mukunku/tag-exists-action@v1.6.0
         with:
           tag: ${{ steps.generate_env_vars.outputs.tag_name }}
         env:

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -45,7 +45,7 @@ jobs:
       - run: git fetch origin tag ${{ steps.generate_env_vars.outputs.tag_name }} --no-tags
       - name: Build Changelog
         id: build_changelog
-        uses: mikepenz/release-changelog-builder-action@v2.1.0
+        uses: mikepenz/release-changelog-builder-action@v4.2.0
         with:
           configuration: "changelog.json"
         env:

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -246,7 +246,7 @@ jobs:
           mv CataclysmBN-${{ env.VERSION }}.dmg cbn-${{ matrix.artifact }}-${{ env.VERSION }}.dmg
       - name: Set up JDK 11 (android)
         if: runner.os == 'Linux' && matrix.android != 'none' && matrix.mxe == 'none'
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4.1.0
         with:
           java-version: "11"
           distribution: "adopt"

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -52,13 +52,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create release
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2.0.2
         if: ${{ steps.tag_check.outputs.exists == 'false' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.generate_env_vars.outputs.tag_name }}
-          release_name: ${{ steps.generate_env_vars.outputs.release_name }}
+          name: ${{ steps.generate_env_vars.outputs.release_name }}
           body: |
             ${{ steps.build_changelog.outputs.changelog }}
             These are the outputs for the manually triggered build of commit [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Push tag
         id: tag_version
-        uses: mathieudutour/github-tag-action@v5.5
+        uses: mathieudutour/github-tag-action@v6.2
         if: ${{ steps.tag_check.outputs.exists == 'false' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -147,7 +147,7 @@ jobs:
     steps:
       - name: checkout repository
         if: ${{ env.SKIP == 'false' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 

--- a/.github/workflows/msvc-full-features-cmake.yml
+++ b/.github/workflows/msvc-full-features-cmake.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
     - name: checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 1
 

--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
     - name: checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 1
 

--- a/.github/workflows/msys2-cmake.yml
+++ b/.github/workflows/msys2-cmake.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
     - name: checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 1
 

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
     - name: checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 1
 

--- a/.github/workflows/pull-translations.yml
+++ b/.github/workflows/pull-translations.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           curl -sL https://github.com/transifex/cli/releases/download/v1.6.7/tx-linux-amd64.tar.gz | sudo tar zxvf - -C /usr/bin tx
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: "Get current date"
         uses: nanzm/get-time-action@v1.1
         id: get-timestamp

--- a/.github/workflows/push-translation-template.yml
+++ b/.github/workflows/push-translation-template.yml
@@ -27,7 +27,7 @@ jobs:
           sudo apt install python3-pip
           sudo pip3 install polib luaparser
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: "Generate translation template"
         run: |
           lang/update_pot.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,7 +282,7 @@ jobs:
 
       - name: Set up JDK 11 (android)
         if: runner.os == 'Linux' && matrix.android != 'none' && matrix.mxe == 'none'
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4.1.0
         with:
           java-version: "11"
           distribution: "adopt"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Push tag
         if: ${{ steps.tag_check.outputs.exists == 'false' }}
         id: tag_version
-        uses: mathieudutour/github-tag-action@v5.5
+        uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ needs.metadata.outputs.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Build Changelog
         id: build_changelog
-        uses: mikepenz/release-changelog-builder-action@v2.1.0
+        uses: mikepenz/release-changelog-builder-action@v4.2.0
         with:
           configuration: "changelog.json"
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: Check if there is existing git tag
         id: tag_check
-        uses: mukunku/tag-exists-action@v1.4.0
+        uses: mukunku/tag-exists-action@v1.6.0
         with:
           tag: ${{ needs.metadata.outputs.tag_name }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       tag_name: ${{ steps.env_vars.outputs.tag_name }}
       release_name: ${{ steps.env_vars.outputs.release_name }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: env_vars
         run: |
           TAG_NAME=$(date -u --iso-8601 --date='1 day ago')
@@ -48,7 +48,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Push tag
         if: ${{ steps.tag_check.outputs.exists == 'false' }}
@@ -59,7 +59,7 @@ jobs:
           custom_tag: ${{ needs.metadata.outputs.tag_name }}
           tag_prefix: ""
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - run: git fetch origin tag ${{ needs.metadata.outputs.tag_name }} --no-tags
 
@@ -179,7 +179,7 @@ jobs:
     env:
       ZSTD_CLEVEL: 17
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Create VERSION.TXT
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,12 +74,12 @@ jobs:
       - name: Create release
         if: ${{ steps.tag_check.outputs.exists == 'false' }}
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ needs.metadata.outputs.tag_name }}
-          release_name: ${{ needs.metadata.outputs.release_name }}
+          name: ${{ needs.metadata.outputs.release_name }}
           body: |
             ${{ steps.build_changelog.outputs.changelog }}
             These are the outputs for the experimental build of commit [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -319,7 +319,7 @@ jobs:
 
       - name: Upload release asset
         id: upload-release-asset
-        uses: actions/upload-release-asset@v1
+        uses: shogo82148/actions-upload-release-asset@v1.7.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Purpose of change

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/58805367-858d-4b94-8162-9a0449f0a7f5)

bump outdated actions. fixes:

- node16 deprecation warning
- set-output deprecation warning

## Describe the solution

- https://github.com/actions/create-release -> https://github.com/softprops/action-gh-release (deprecated)
- https://github.com/actions/upload-release-asset -> https://github.com/shogo82148/actions-upload-release-asset (deprecated)
- everything else: bumped to latest version

## Describe alternatives you've considered

get spammed with deprecation warning

## Testing

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/df9307e4-6453-4dec-9a67-1679879b9e66)

[works in fork.](https://github.com/scarf005/Cataclysm-BN/actions/runs/8266883425) (androids fail due to missing gnupg keyring)

https://github.com/scarf005/Cataclysm-BN/releases/tag/2024-03-12