### PR TITLE
feat(UI): move item notes to be with description, move `MAGIC_FOCUS` flag description to flag section

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -990,7 +990,7 @@
     "id": "MAGIC_FOCUS",
     "type": "json_flag",
     "context": [ "item" ],
-    "//": "You can cast spells with this item in your hand."
+    "info": "This item is a <info>magical focus</info>.  You can cast spells with it in your hand."
   },
   {
     "id": "HOSTILE_SUMMON",

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1679,7 +1679,7 @@ void item::basic_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
             }
             if( use_actor ) {
                 //~ %1$s: gerund (e.g. carved), %2$s: item name, %3$s: inscription text
-                ntext = string_format( pgettext( "carving", "%1$s on the %2$s is: %3$s" ),
+                ntext = string_format( pgettext( "carving", "<info>%1$s on the %2$s is:</info> %3$s" ),
                                        use_actor->gerund, tname(), item_note->second );
             } else {
                 //~ %1$s: inscription text
@@ -1687,7 +1687,7 @@ void item::basic_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
             }
             info.emplace_back( "DESCRIPTION", ntext );
         }
-            insert_separation_line( info );
+        insert_separation_line( info );
     }
 
     insert_separation_line( info );


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This implements a lil streamlining of some item UI stuff.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

C++ changes:
1. In item.cpp, removed the special bit in `item::basic_info` that places a description for the `MAGIC_FOCUS` flag directly above the item's description, as this is almost never actually important enough to be given such prominant placement.
2. Meanwhile, moved the check for notes inscribed on items out of `item::final_info` and into `item::basic_info` immediately below the item's basic description. This places it where you'd expect flavor text of this sort to be instead of being way down in its own dedicated section, separated by horizontal rules.

JSON changes:
1. Gave the `MAGIC_FOCUS` flag its orignal hardcoded text as its flag description.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Keeping item incriptions isolated by separators but still move them to directly below item description. I slapped some `<info>` on it so it doesn't blend in with the description though, so should be fine.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON change for syntax and lint errors.
2. Compiled and load-tested.
3. Started up a world with Magiclysm added, spawned in a lesser staff of the magi.
4. Confirmed the magic focus text is now in the flag section, and that item description format hasn't been screwed up.
5. Spawned in a gun and checked that its description is normal, added a note to it and confirmed it correctly displays right under the description.
6. Spawned in a survivor's note, confirmed it shows the snippet correctly, and that slapping an inscription on it with a marker doesn't break anything.
7. Checked affected C++ changes for astyle.

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/df722a29-d17f-47a1-aea0-09e556afdcdb)

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/103febc3-1fb6-4e34-96a7-0a153f8cc638)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
