### PR TITLE
fix: nets should not deal damage

### DIFF
--- a/data/json/ammo_effects.json
+++ b/data/json/ammo_effects.json
@@ -332,6 +332,11 @@
     "//": "Can't crit. Can still graze."
   },
   {
+    "id": "NO_DAMAGE",
+    "type": "ammo_effect",
+    "//": "Does not actually deal damage; meant for ammo that applies effects."
+  },
+  {
     "id": "NO_DAMAGE_SCALING",
     "type": "ammo_effect",
     "//": "Can't crit or graze, all hits have 100% damage modifier from accuracy."

--- a/data/json/ammo_effects_simple.json
+++ b/data/json/ammo_effects_simple.json
@@ -105,6 +105,11 @@
     "//": "Can't crit. Can still graze."
   },
   {
+    "id": "NO_DAMAGE",
+    "type": "ammo_effect",
+    "//": "Does not actually deal damage; meant for ammo that applies effects."
+  },
+  {
     "id": "NO_DAMAGE_SCALING",
     "type": "ammo_effect",
     "//": "Can't crit or graze, all hits have 100% damage modifier from accuracy."

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -1622,6 +1622,11 @@
     "context": [  ]
   },
   {
+    "id": "NO_DAMAGE",
+    "type": "json_flag",
+    "context": [  ]
+  },
+  {
     "id": "NO_DISPLAY",
     "type": "json_flag",
     "context": [  ]

--- a/data/json/items/ranged/throwing.json
+++ b/data/json/items/ranged/throwing.json
@@ -14,7 +14,7 @@
     "color": "blue",
     "to_hit": -1,
     "ammo_type": "thrown",
-    "flags": [ "NOGIB", "TANGLE", "PRIMITIVE_RANGED_WEAPON" ]
+    "flags": [ "NO_DAMAGE", "TANGLE", "PRIMITIVE_RANGED_WEAPON" ]
   },
   {
     "type": "GENERIC",

--- a/data/json/items/ranged/throwing.json
+++ b/data/json/items/ranged/throwing.json
@@ -63,7 +63,7 @@
     "color": "white",
     "to_hit": -2,
     "ammo_type": "thrown",
-    "flags": [ "NOGIB", "TANGLE", "PRIMITIVE_RANGED_WEAPON" ]
+    "flags": [ "NO_DAMAGE", "TANGLE", "PRIMITIVE_RANGED_WEAPON" ]
   },
   {
     "type": "GENERIC",

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -59,11 +59,11 @@ static const ammo_effect_str_id ammo_effect_INCENDIARY( "INCENDIARY" );
 static const ammo_effect_str_id ammo_effect_LARGE_BEANBAG( "LARGE_BEANBAG" );
 static const ammo_effect_str_id ammo_effect_magic( "magic" );
 static const ammo_effect_str_id ammo_effect_NO_CRIT( "NO_CRIT" );
+static const ammo_effect_str_id ammo_effect_NO_DAMAGE( "NO_DAMAGE" );
 static const ammo_effect_str_id ammo_effect_NO_DAMAGE_SCALING( "NO_DAMAGE_SCALING" );
 static const ammo_effect_str_id ammo_effect_NOGIB( "NOGIB" );
 static const ammo_effect_str_id ammo_effect_PARALYZEPOISON( "PARALYZEPOISON" );
 static const ammo_effect_str_id ammo_effect_TANGLE( "TANGLE" );
-
 
 static const efftype_id effect_blind( "blind" );
 static const efftype_id effect_bounced( "bounced" );
@@ -878,6 +878,11 @@ void Creature::deal_projectile_attack( Creature *source, dealt_projectile_attack
             impact.mult_damage( 1.0f / dmg_ratio );
         }
     }
+
+    if( proj.has_effect( ammo_effect_NO_DAMAGE ) ) {
+        impact.mult_damage( 0.0f );
+    }
+
     // If we have a shield, it might passively block ranged impacts
     block_ranged_hit( source, bp_hit, impact );
     dealt_dam = deal_damage( source, bp_hit, impact );

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -197,6 +197,7 @@ const flag_id flag_NONCONDUCTIVE( "NONCONDUCTIVE" );
 const flag_id flag_NON_FOULING( "NON_FOULING" );
 const flag_id flag_NO_BLOAT( "NO_BLOAT" );
 const flag_id flag_NO_CVD( "NO_CVD" );
+const flag_id flag_NO_DAMAGE( "NO_DAMAGE" );
 const flag_id flag_NO_DISPLAY( "NO_DISPLAY" );
 const flag_id flag_NO_DROP( "NO_DROP" );
 const flag_id flag_NO_INGEST( "NO_INGEST" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -201,6 +201,7 @@ extern const flag_id flag_NONCONDUCTIVE;
 extern const flag_id flag_NON_FOULING;
 extern const flag_id flag_NO_BLOAT;
 extern const flag_id flag_NO_CVD;
+extern const flag_id flag_NO_DAMAGE;
 extern const flag_id flag_NO_DISPLAY;
 extern const flag_id flag_NO_DROP;
 extern const flag_id flag_NO_INGEST;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -89,6 +89,7 @@ static const ammo_effect_str_id ammo_effect_IGNITE( "IGNITE" );
 static const ammo_effect_str_id ammo_effect_LASER( "LASER" );
 static const ammo_effect_str_id ammo_effect_LIGHTNING( "LIGHTNING" );
 static const ammo_effect_str_id ammo_effect_NO_CRIT( "NO_CRIT" );
+static const ammo_effect_str_id ammo_effect_NO_DAMAGE( "NO_DAMAGE" );
 static const ammo_effect_str_id ammo_effect_NO_EMBED( "NO_EMBED" );
 static const ammo_effect_str_id ammo_effect_NO_ITEM_DAMAGE( "NO_ITEM_DAMAGE" );
 static const ammo_effect_str_id ammo_effect_NON_FOULING( "NON_FOULING" );
@@ -1259,6 +1260,10 @@ dealt_projectile_attack throw_item( Character &who, const tripoint &target,
     // handling for tangling thrown items
     if( thrown.has_flag( flag_TANGLE ) ) {
         proj.add_effect( ammo_effect_TANGLE );
+    }
+
+    if( thrown.has_flag( flag_NO_DAMAGE ) ) {
+        proj.add_effect( ammo_effect_NO_DAMAGE );
     }
 
     Creature *critter = g->critter_at( target, true );


### PR DESCRIPTION
As the title implies, nets should not be dealing damage to the monsters they envelop. No matter how hard you throw a net, you are just throwing a net, it shouldn't kill a chicken in 2 throws.

Introduce NO_DAMAGE flag to deal with projectiles that should apply effects but not actually deal damage using typical logic.

<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

Currently throwing a net to envelop a creature actually deals damage using regular damage formula, albeit with the NOGIB flag preventing overkill. However just 1 throw can severely injure a small creature (e.g. chicken) and I have managed to kill chickens in a couple of throws just by throwing nets.

In several video-games nets are typically just effect-applying items, not damage dealing items. Also throwing a net so hard you kill something is silly and unfun - ask me how I know.

This change prevents nets from dealing damage - they still deal the tangle effect, same as before.

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution

Solution works by introducing a new flag called NO_DAMAGE. This flag gets applied to projectile and we simply check if it's present in Creature::deal_projectile_damage(). If it is present, we just nullify the impact damage of the projectile.

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

## Describe alternatives you've considered

Considered applying this flag to bolas item too but was on the fence. On one hand, it's a much more violent thrown item compared to a net so it could deal damage - on the other hand, it's annoying to kill what you are trying to capture. Open to feedback on this.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing

Character with all stats at 12, throwing at 10 - many nets.
Use net to 'tangle' monster. Tangle still works ok.
Throw 10 nets at chicken. Chicken takes no damage.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context
![catch-a-chicken-net](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/4570952/affccab8-a78b-4dc5-89a5-91c351cfe512)


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
