### PR TITLE
ci: use explicit tag range on changelog generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,8 +64,6 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - run: git fetch origin tag ${{ needs.metadata.outputs.tag_name }} --no-tags
-
       - name: Build Changelog
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v4.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,13 @@ jobs:
       count: ${{ steps.env_vars.outputs.count }}
       tag_name: ${{ steps.env_vars.outputs.tag_name }}
       release_name: ${{ steps.env_vars.outputs.release_name }}
+      yesterday_tag_name: ${{ steps.env_vars.outputs.yesterday_tag_name }}
     steps:
       - uses: actions/checkout@v4
       - id: env_vars
         run: |
           TAG_NAME=$(date -u --iso-8601 --date='1 day ago')
+          YESTERDAY_TAG_NAME=$(date -u --iso-8601 --date='2 day ago')
           COMMITS=$(git log --oneline --since="$TAG_NAME" | wc -l)
           RELEASE_NAME="Experimental $TAG_NAME"
 
@@ -27,6 +29,7 @@ jobs:
 
           echo "count=$COMMITS" >> "$GITHUB_OUTPUT"
           echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
+          echo "yesterday_tag_name=$YESTERDAY_TAG_NAME" >> "$GITHUB_OUTPUT"
           echo "release_name=$RELEASE_NAME" >> "$GITHUB_OUTPUT"
 
   release:
@@ -68,6 +71,8 @@ jobs:
         uses: mikepenz/release-changelog-builder-action@v4.2.0
         with:
           configuration: "changelog.json"
+          fromTag: ${{ needs.metadata.outputs.yesterday_tag_name }}
+          toTag: ${{ needs.metadata.outputs.tag_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,8 +62,6 @@ jobs:
           custom_tag: ${{ needs.metadata.outputs.tag_name }}
           tag_prefix: ""
 
-      - uses: actions/checkout@v4
-
       - name: Build Changelog
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v4.2.0


### PR DESCRIPTION
## Purpose of change

fix experimental releases having 'no changelog' despite having commits

## Describe the solution

explicitly give tag range

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/75b04e61-d8ad-406c-a4e4-70401434486b)

https://github.com/scarf005/Cataclysm-BN/actions/runs/8308252005/job/22738302800#step:5:41

worked in fork.
