### PR TITLE
feat(content): the armored wheel is now off-road

### DIFF
--- a/data/json/items/vehicle/wheel.json
+++ b/data/json/items/vehicle/wheel.json
@@ -86,7 +86,7 @@
     "id": "wheel_armor",
     "category": "veh_parts",
     "name": { "str": "armored wheel" },
-    "description": "A wide military grade wheel. Performs well off-road.",
+    "description": "A wide military grade wheel.  Performs well off-road.",
     "weight": "24500 g",
     "volume": "17500 ml",
     "price": "340 USD",

--- a/data/json/items/vehicle/wheel.json
+++ b/data/json/items/vehicle/wheel.json
@@ -86,7 +86,7 @@
     "id": "wheel_armor",
     "category": "veh_parts",
     "name": { "str": "armored wheel" },
-    "description": "A wide military grade wheel.",
+    "description": "A wide military grade wheel. Performs well off-road.",
     "weight": "24500 g",
     "volume": "17500 ml",
     "price": "340 USD",

--- a/data/json/vehicleparts/wheel.json
+++ b/data/json/vehicleparts/wheel.json
@@ -218,7 +218,7 @@
       { "item": "chunk_rubber", "count": [ 2, 3 ] }
     ],
     "rolling_resistance": 0.6,
-    "wheel_type": "standard",
+    "wheel_type": "off-road",
     "contact_area": 480,
     "requirements": {
       "install": { "skills": [ [ "mechanics", 0 ] ], "time": "20 m", "using": [ [ "vehicle_bolt", 1 ] ] },

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -449,8 +449,8 @@ TEST_CASE( "vehicle_efficiency", "[vehicle] [engine]" )
     test_vehicle( "fire_truck", 6319523, 410700, 83850, 19080, 4063 );
     test_vehicle( "truck_swat", 5966006, 682900, 131700, 29610, 7604 );
     test_vehicle( "tractor_plow", 725658, 681200, 681200, 132400, 132400 );
-    test_vehicle( "apc", 5805459, 2103310, 1453820, 110600, 75190 );
-    test_vehicle( "humvee", 5506381, 767900, 306900, 25620, 9171 );
+    test_vehicle( "apc", 5805459, 2103310, 2124343, 110600, 110657 );
+    test_vehicle( "humvee", 5506381, 767900, 564679, 25620, 18343 );
     test_vehicle( "road_roller", 8831804, 602500, 147100, 22760, 6925 );
     test_vehicle( "golf_cart", 319630, 49585, 47185, 22700, 12745 );
 


### PR DESCRIPTION
## Purpose of change

The 32' armored wheel looks like so: 
![](https://upload.wikimedia.org/wikipedia/commons/4/41/Irish_Army_RG-32M_Light_Tactical_Armoured_Vehicle_LTAV_(4520429843).jpg)

It is off-road.

It's also the best wheel the base game has to offer for your typical mobile base. It's difficult to find, difficult to take off and difficult to install. 

## Describe the solution

Changing the type from normal to off-road.

## Describe alternatives you've considered

A mod. I have a mod doing it, but it makes sense for this to be in the base game.

## Testing

Drive a vehicle with 32' armored wheels on rough terrain and compare the max speed/acceleration.
