### PR TITLE
fix: make count-by-charges vehiclepart installable

### DIFF
--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -254,7 +254,7 @@ double vehicle_part::damage_percent() const
 /** parts are considered broken at zero health */
 bool vehicle_part::is_broken() const
 {
-    return base->damage() >= base->max_damage();
+    return base->count_by_charges() ? false : base->damage() >= base->max_damage();
 }
 
 bool vehicle_part::is_unavailable( const bool carried ) const


### PR DESCRIPTION
## Purpose of change

- fixes #4012 

## Describe the solution

make count-by-charges vehicleparts invincible.

## Describe alternatives you've considered

make a proper damage system for CBC items, but this hack works...

## Testing

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/d524074c-d100-4e6b-8876-cfb356987e97

1. spawn a car.
2. uninstall seatbelt.
3. the seatbelt item is correctly dropped.

## Additional context

- wanted to also write a test for it but can't figure out which API to use.
- with this fix maybe we could continue #3489?
- we also need a recipe for seatbelt.