### PR TITLE
fix: dead state persisting between worlds

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2557,6 +2557,7 @@ bool game::load( const save_t &name )
     // Now load up the master game data; factions (and more?)
     load_master();
     u = avatar();
+    u.recalc_hp();
     u.set_save_id( name.decoded_name() );
     u.name = name.decoded_name();
     if( !read_from_file( playerpath + SAVE_EXTENSION, std::bind( &game::unserialize, this, _1 ) ) ) {


### PR DESCRIPTION
## Purpose of change

- fix #4022

## Describe the solution

on loading player character, reset its `cached_dead_state`.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing

1. kill yourself.
2. load another character in other world.
3. check that the character is alive.
