### PR TITLE
test: check negative calories

### DIFF
--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -275,7 +275,7 @@
     "name": { "str_sp": "commercial fertilizer" },
     "weight": "350 g",
     "color": "yellow",
-    "flags": [ "FERTILIZER", "UNSAFE_CONSUME" ],
+    "flags": [ "FERTILIZER", "UNSAFE_CONSUME", "NUTRIENT_OVERRIDE" ],
     "use_action": "PLANTBLECH",
     "container": "bag_canvas",
     "comestible_type": "FOOD",

--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -190,7 +190,8 @@
     "material": "powder",
     "volume": "250 ml",
     "charges": 4,
-    "fun": -10
+    "fun": -10,
+    "flags": [ "NUTRIENT_OVERRIDE" ]
   },
   {
     "type": "COMESTIBLE",

--- a/tests/test_statistics.h
+++ b/tests/test_statistics.h
@@ -79,7 +79,7 @@ class statistics
         // Outside of this class, this should only be used for debugging
         // purposes.
         template<typename U = T>
-        typename std::enable_if< std::is_same< U, bool >::value, double >::type
+        std::enable_if_t< std::is_same_v< U, bool >, double >
         margin_of_error() {
             if( _error != invalid_err ) {
                 return _error;
@@ -101,7 +101,7 @@ class statistics
         // Outside of this class, this should only be used for debugging purposes.
         // https://measuringu.com/ci-five-steps/
         template<typename U = T>
-        typename std::enable_if < ! std::is_same< U, bool >::value, double >::type
+        std::enable_if_t < ! std::is_same_v< U, bool >, double >
         margin_of_error() {
             if( _error != invalid_err ) {
                 return _error;


### PR DESCRIPTION
## Purpose of change

- automate calories testing more
- prevent #4317 from happening again
- make it easier to see why the test failed
- fix item stats accordingly

## Describe the solution

- `data/json/items/chemicals_and_resources.json`, `data/json/items/comestibles/other.json`: overriden item stats to pass the test.
- `tests/test_statistics.h`: applied clang-tidy suggestions.
- `tests/comestible_test.cpp`:
	- improved error output to show ingredients and result item on error.
	- made it not skip calories check when there's only one recipe.
	- forbidden non-drink comestibles to have zero calories (always has to be overriden).

## Describe alternatives you've considered

also output min and max kcal for each components, but it gets more complicated. might worth a followup PR.

## Testing

example test output:

```
FAILED:
  CHECK( mystats.calories.min() > 0 )
with expansion:
  -333 > 0
with message:
  recipe id: dry_rice
    used:
      [raw wild rice (1)]
    result: dry_rice

FAILED:
  CHECK( mystats.calories.min() > 0 )
with expansion:
  0 > 0
with message:
  recipe id: meal_bone
    used:
      [bone (1) or human bone (1)]
    result: meal_bone

FAILED:
  CHECK( mystats.calories.min() > 0 )
with expansion:
  0 > 0
with message:
  recipe id: fertilizer_commercial_simple
    used:
      [ammonium nitrate pellets (350)]
    result: fertilizer_commercial
```


