### PR TITLE
ci: fix lang file compilation in manual release

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -165,6 +165,17 @@ jobs:
           commit sha: ${{ github.sha }}
           commit url: https://github.com/${{ github.repository }}/commit/${{ github.sha }}
           EOL
+
+      - name: Setup msys2 (windows msvc)
+        if: runner.os == 'Windows'
+        uses: msys2/setup-msys2@v2
+        with: { msystem: mingw64, install: gettext }
+
+      - name: Compile translations (windows msvc)
+        if: runner.os == 'Windows'
+        shell: msys2 {0}
+        run: lang/compile_mo.sh all
+
       - name: Install dependencies (windows msvc) (1/3)
         if: runner.os == 'Windows'
         uses: microsoft/setup-msbuild@v1.3.1
@@ -214,11 +225,7 @@ jobs:
         run: |
           HOMEBREW_NO_AUTO_UPDATE=yes HOMEBREW_NO_INSTALL_CLEANUP=yes brew install sdl2 sdl2_image sdl2_ttf sdl2_mixer gettext ccache parallel
           pip3 install mac_alias==2.2.0 dmgbuild==1.6.1 biplist
-      - name: Compile translations (windows)
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          lang/compile_mo.sh all
+
       - name: Build CBN (linux)
         if: runner.os == 'Linux' && matrix.mxe == 'none' && matrix.android == 'none'
         run: |


### PR DESCRIPTION
## Purpose of change

fix manual release having no MSVC releases (like in [`v0.6.0`](https://github.com/cataclysmbnteam/Cataclysm-BN/releases/tag/v0.6.0))

## Describe the solution

same as #4298.

## Describe alternatives you've considered

unify experimental and manual release together.

## Testing

should work in CI.

https://github.com/scarf005/Cataclysm-BN/actions/runs/8370243414