### PR TITLE
fix: Tactical Tonfa (off) didn't clip to belts

### DIFF
--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -882,7 +882,7 @@
     "copy-from": "shocktonfa_off",
     "type": "TOOL",
     "name": { "str": "tactical tonfa (on)", "str_pl": "tactical tonfas (on)" },
-    "description": "This is a reinforced plastic tonfa; the core is hollowed out and is filled with capacitors and a high-yield rechargeable storage battery.  When a switch on the handle is pressed, a high-voltage current is transmitted to the two electrodes mounted in the end of the weapon, and by extension to anyone unfortunate enough to be in contact with them.  It also has a nifty flashlight, which is currently active.",
+    "description": "This is a reinforced plastic tonfa; the core is hollowed out and is filled with capacitors and a high-yield rechargeable storage battery.  When a switch on the handle is pressed, a high-voltage current is transmitted to the two electrodes mounted in the end of the tonfa, and by extension to anyone unfortunate enough to be in contact with them.  It also has a nifty flashlight, which is currently active.",
     "revert_to": "shocktonfa_off",
     "use_action": "SHOCKTONFA_ON",
     "extend": { "flags": [ "LIGHT_20", "TRADER_AVOID" ] },

--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -868,7 +868,7 @@
     "ammo": "battery",
     "charges_per_use": 1,
     "use_action": "SHOCKTONFA_OFF",
-    "flags": [ "DURABLE_MELEE", "NONCONDUCTIVE" ],
+    "flags": [ "DURABLE_MELEE", "NONCONDUCTIVE", "BELT_CLIP" ],
     "magazines": [
       [
         "battery",
@@ -885,7 +885,7 @@
     "description": "This is a reinforced plastic tonfa; the core is hollowed out and is filled with capacitors and a high-yield rechargeable storage battery.  When a switch on the handle is pressed, a high-voltage current is transmitted to the two electrodes mounted in the end of the weapon, and by extension to anyone unfortunate enough to be in contact with them.  It also has a nifty flashlight, which is currently active.",
     "revert_to": "shocktonfa_off",
     "use_action": "SHOCKTONFA_ON",
-    "flags": [ "LIGHT_20", "DURABLE_MELEE", "TRADER_AVOID", "NONCONDUCTIVE", "BELT_CLIP" ],
+    "extend": { "flags": [ "LIGHT_20", "TRADER_AVOID" ] },
     "magazine_well": "500 ml"
   },
   {


### PR DESCRIPTION
## Purpose of change

Tactical Tonfa (off) did not have the BELT_CLIP flag like other tonfas and its own (on) version. 

## Describe the solution

Added the missing flag and then reformatted the (on) version so it would just add its new flags to the base when turned on instead of overwriting them. Also changed a difference in the description of the two modes so they match.

## Describe alternatives you've considered

Tactical Tonfa (off) could have the intended flags by just inheriting the flags of the copyfrom and adding NONCONDUCTIVE using the "extend" command.
Tactical Tonfa (on)'s formatting could have been left unchanged and it would still have the correct flags, the actual belt clip flag bug only concerned Tactical Tonfa (off).

## Testing

Tested by downloading the modified bludgeons.json and running it.