### PR TITLE
feat(UI): display flags in debug mode

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1754,10 +1754,15 @@ void item::basic_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
                                active );
             info.emplace_back( "BASE", _( "burn: " ), "", iteminfo::lower_is_better,
                                burnt );
-            const std::string tags_listed = enumerate_as_string( item_tags, []( const flag_id & f ) {
-                return f.str();
-            }, enumeration_conjunction::none );
+
+            static const auto f = []( const flag_id & f ) -> std::string { return f.str(); };
+            const std::string itype_tags_listed = enumerate_as_string( type->item_tags, f,
+                                                  enumeration_conjunction::none );
+            info.emplace_back( "BASE", string_format( _( "itype tags: %s" ), itype_tags_listed ) );
+
+            const std::string tags_listed = enumerate_as_string( item_tags, f, enumeration_conjunction::none );
             info.emplace_back( "BASE", string_format( _( "tags: %s" ), tags_listed ) );
+
             for( auto const &imap : item_vars ) {
                 info.emplace_back( "BASE",
                                    string_format( _( "item var: %s, %s" ), imap.first,


### PR DESCRIPTION
## Purpose of change

make it easier to debug flags.

## Describe the solution

also show itype's flags.

## Describe alternatives you've considered

just unify all flags into one?

## Testing

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/42c415a1-4d7b-4dea-a6e4-17bd5a1dce13)

1. turn on debug mode (F12)
2. examine an item.
3. itype's flag is also displayed.