### PR TITLE
fix(balance): Recipe changes to address land mine component inconsistencies

### DIFF
--- a/data/json/recipes/other/traps.json
+++ b/data/json/recipes/other/traps.json
@@ -238,7 +238,11 @@
         [ "stable_explosive", 75, "LIST" ],
         [ "military_explosive", 75, "LIST" ]
       ],
-      [ [ "delay_fuze", 1 ], [ "fuse", 1 ] ]
+      [ 
+        [ "delay_fuze", 1 ],
+        [ "impact_fuze", 1 ],
+        [ "fuse", 1 ]
+      ]
     ]
   },
   {

--- a/data/json/recipes/other/traps.json
+++ b/data/json/recipes/other/traps.json
@@ -238,11 +238,7 @@
         [ "stable_explosive", 75, "LIST" ],
         [ "military_explosive", 75, "LIST" ]
       ],
-      [ 
-        [ "delay_fuze", 1 ],
-        [ "impact_fuze", 1 ],
-        [ "fuse", 1 ]
-      ]
+      [ [ "delay_fuze", 1 ], [ "impact_fuze", 1 ], [ "fuse", 1 ] ]
     ]
   },
   {

--- a/data/json/recipes/other/traps.json
+++ b/data/json/recipes/other/traps.json
@@ -233,7 +233,11 @@
         [ "bismuth", 70 ],
         [ "shrapnel", 40 ]
       ],
-      [ [ "volatile_explosive", 75, "LIST" ], [ "stable_explosive", 75, "LIST" ], [ "military_explosive", 75, "LIST" ] ],
+      [
+        [ "volatile_explosive", 75, "LIST" ],
+        [ "stable_explosive", 75, "LIST" ],
+        [ "military_explosive", 75, "LIST" ]
+      ],
       [ [ "delay_fuze", 1 ], [ "fuse", 1 ] ]
     ]
   },

--- a/data/json/recipes/other/traps.json
+++ b/data/json/recipes/other/traps.json
@@ -212,7 +212,7 @@
     "book_learn": [ [ "manual_traps_mil", 5 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [
-      [ [ "superglue", 1 ], [ "duct_tape", 75 ] ],
+      [ [ "superglue", 1 ], [ "bone_glue", 1 ], [ "duct_tape", 75 ] ],
       [
         [ "scrap", 3 ],
         [ "steel_chunk", 1 ],
@@ -220,20 +220,21 @@
         [ "clay_canister", 1 ],
         [ "can_food_unsealed", 1 ]
       ],
-      [ [ "bb", 200 ], [ "nail", 100 ] ],
       [
-        [ "gunpowder", 72 ],
-        [ "chem_black_powder", 72 ],
-        [ "shot_bird", 24 ],
-        [ "shot_00", 12 ],
-        [ "shot_slug", 12 ],
-        [ "shot_flechette", 12 ],
-        [ "shot_he", 3 ],
-        [ "gasoline", 600 ],
-        [ "diesel", 600 ],
-        [ "biodiesel", 600 ],
-        [ "grenade", 1 ]
-      ]
+        [ "scrap", 10 ],
+        [ "nail", 100 ],
+        [ "bb", 200 ],
+        [ "solder_wire", 100 ],
+        [ "platinum_small", 40 ],
+        [ "gold_small", 40 ],
+        [ "bearing", 50 ],
+        [ "lead", 70 ],
+        [ "silver_small", 70 ],
+        [ "bismuth", 70 ],
+        [ "shrapnel", 40 ]
+      ],
+      [ [ "volatile_explosive", 75, "LIST" ], [ "stable_explosive", 75, "LIST" ], [ "military_explosive", 75, "LIST" ] ],
+      [ [ "delay_fuze", 1 ], [ "fuse", 1 ] ]
     ]
   },
   {

--- a/data/json/uncraft/weapon/explosive.json
+++ b/data/json/uncraft/weapon/explosive.json
@@ -24,7 +24,7 @@
     "difficulty": 4,
     "time": "50 s",
     "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "components": [ [ [ "delay_fuze", 1 ] ], [ [ "canister_empty", 1 ] ], [ [ "chem_compositionb", 75 ] ] ]
+    "components": [ [ [ "delay_fuze", 1 ] ], [ [ "canister_empty", 1 ] ], [ [ "bearing", 50 ] ], [ [ "chem_compositionb", 600 ] ] ]
   },
   {
     "type": "uncraft",


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

fix #4381

To fix land mine component inconsistencies in regard to real life land mines and other explosives within the game. For more issue see #4381. To fully address the issue land mines still need to be divided into real world or fictional models, but this requires the land mine trap effect to be moved from an hardcoded effect to something that can be modified by JSON. 

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution

Introduces my changes to the crafting and uncrafting recipes for land mines mentioned in #4381. For crafting I added bone glue, changed the fragmentation element to be the same as the scrap loaded 00 shot recipe just 10x to be in line with what it was before, got rid of all that random nonsense that were useable as explosive and instead used the same lists as other explosives used equivalent in amount to 600 composition b and lastly I added the option to use fuses for landmines since for example the M16 mine uses a black powder fuse(there should be a mechanism to light it when stepped on so maybe a "makeshift fuze" item should be added that is made of fuse and some method to light it e.g. flint and steel). For disassembly I just increased the composition b amount to 600 and added bearings as frag.

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

## Describe alternatives you've considered

Rewrite how the game handles land mine traps, but this requires rewriting the hardcoded effect land mine traps currently have. Also, there is ambiguity about what kind of land mine the ingame landmines are supposed to be, I just assumed it's a classic explodes-in-the-ground type of land mine that has a charge about as strong as a claymore or M16 mine, but AFAIK the US military does not use such mines and none of them have composition b as main charges, but we do not have TNT or C4 in increments that would make it useable in crafting like we do for composition b or other explosives like RDX. We should probably also address this deficiency in the future, no reason why a player could take bits of C4 to make custom charges. It's basically a hard, chewy playdough style paste. TNT is harder, but probably still possible?

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing

Got no errors booting up, crafting or uncrafting in my playthrough using these changes.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
