### PR TITLE
fix: prevent segfault when loading invalid zone type

### DIFF
--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -1113,15 +1113,16 @@ void zone_manager::serialize( JsonOut &json ) const
 void zone_manager::deserialize( JsonIn &jsin )
 {
     jsin.read( zones );
-    for( auto it = zones.begin(); it != zones.end(); ++it ) {
-        const zone_type_id zone_type = it->get_type();
-        if( !has_type( zone_type ) ) {
-            it = zones.erase( it );
-            debugmsg( "Invalid zone type: %s", zone_type.c_str() );
-        } else {
-            it++;
-        }
-    }
+    zones.erase( std::remove_if( zones.begin(), zones.end(),
+    [this]( const zone_data & it ) -> bool {
+        const zone_type_id zone_type = it.get_type();
+        const bool is_valid = has_type( zone_type );
+
+        if( !is_valid ) debugmsg( "Invalid zone type: %s", zone_type.c_str() );
+
+        return is_valid;
+    } ),
+    zones.end() );
 }
 
 void zone_data::serialize( JsonOut &json ) const


### PR DESCRIPTION
## Purpose of change

- fixes #4397


## Describe the solution

use `std::remove_if` to remove unsafe pointer arithmatic

see: 
- https://en.cppreference.com/w/cpp/algorithm/remove
- https://www.codeproject.com/Articles/1227392/Erase-remove-Idiom-Revisited

## Describe alternatives you've considered

pointers pointers everywhere

## Testing

1. load save containing legacy zone type (CAMP_FOOD)
[Superior.zip](https://github.com/cataclysmbnteam/Cataclysm-BN/files/14772278/Superior.1.zip)
2. it does not segfault.

## Additional context

- introduced by #4369
- i _love_ C++ where a trivial operation of filtering elements causes segfault