### PR TITLE
perf: disable vsync by default

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2090,6 +2090,13 @@ void options_manager::add_options_graphics()
          false, COPT_CURSES_HIDE
        );
 
+#if defined(SDL_HINT_RENDER_VSYNC)
+    add( "VSYNC", graphics, translate_marker( "Use VSync" ),
+         translate_marker( "Enable vertical synchronization to prevent screen tearing.  Requires restart." ),
+         false, COPT_CURSES_HIDE
+       );
+#endif
+
 #if defined(__ANDROID__)
     get_option( "FRAMEBUFFER_ACCEL" ).setPrerequisite( "SOFTWARE_RENDERING" );
 #else

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2092,7 +2092,7 @@ void options_manager::add_options_graphics()
 
 #if defined(SDL_HINT_RENDER_VSYNC)
     add( "VSYNC", graphics, translate_marker( "Use VSync" ),
-         translate_marker( "Enable vertical synchronization to prevent screen tearing.  Requires restart." ),
+         translate_marker( "Enable vertical synchronization to prevent screen tearing.  VSync can slow the game down a lot.  Requires restart." ),
          false, COPT_CURSES_HIDE
        );
 #endif

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -350,8 +350,12 @@ static void WinCreate()
     if( !software_renderer ) {
         dbg( DL::Info ) << "Attempting to initialize accelerated SDL renderer.";
 
-        renderer.reset( SDL_CreateRenderer( ::window.get(), renderer_id, SDL_RENDERER_ACCELERATED |
-                                            SDL_RENDERER_PRESENTVSYNC | SDL_RENDERER_TARGETTEXTURE ) );
+        int init_flags = SDL_RENDERER_ACCELERATED | SDL_RENDERER_TARGETTEXTURE;
+        if( get_option<bool>( "VSYNC" ) ) {
+            init_flags |= SDL_RENDERER_PRESENTVSYNC;
+        }
+
+        renderer.reset( SDL_CreateRenderer( ::window.get(), renderer_id, init_flags ) );
         if( printErrorIf( !renderer,
                           "Failed to initialize accelerated renderer, falling back to software rendering" ) ) {
             software_renderer = true;


### PR DESCRIPTION
## Purpose of change

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/0531361c-90b4-40ad-bb0e-47a1c023bd3e)

(the section with red arrow indicates time taken to render spinner UI)

- kind of solves #251

[for more than 7 years](https://github.com/cataclysmbnteam/Cataclysm-BN/commit/46887880be4df657fb55681858fe50364568f6cf) SDL was initalized with [`SDL_RENDERER_PRESENTVSYNC`](https://wiki.libsdl.org/SDL2/SDL_RendererFlags). With vsync, the game must synchronize with monitor's refresh rate (60hz ~= 16.7ms), causing slowdown. Disabling VSync may improve performance.

## Describe the solution

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/2d2bb2e5-92e1-4694-98e3-642fa1c72815)

added disabled-by-default option `Use Vsync` (`VSYNC`) to control vsync behavior on GPU rendering.

## Describe alternatives you've considered

keep using vsync

## Testing

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/b6bd0e5c-3d80-40e1-8c25-4227e64f86de)

| with vsync | without vsync |
| :-: | :-: |
| ![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/421989c8-607b-4774-86dd-7db3224e30a0) | ![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/6e8bc0d2-2414-4955-8d1c-b5bf0728e748) |

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/82c80621-dc35-4eda-94da-95afa3b5edc8)

| with vsync | without vsync |
| :-: | :-: |
| ![03-31_03](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/a6b153a5-a2c7-4216-bb97-ced7f7cdfdc4) | ![03-31_02](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/afff632d-ed4d-4bba-9c77-6563ec6edd59) |

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/26f95696-267a-4c2b-b63e-1638154be390

## Additional context

_GPUs hate him! make your fps higher using this one weird trick_

- found while measuring render performance using tracy from #3253.
- [related discord thread](https://discord.com/channels/830879262763909202/1223085321399570492)
- tracy history file with both vsync off and on: [vsync-tracy.zip](https://github.com/cataclysmbnteam/Cataclysm-BN/files/14815298/vsync-tracy.zip)

