### PR TITLE
fix: add `UNSAFE_CONSUME` to all raw meat items

### DIFF
--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -9,7 +9,7 @@
     "color": "red",
     "parasites": 32,
     "vitamins": [  ],
-    "flags": [ "RAW" ]
+    "flags": [ "RAW", "UNSAFE_CONSUME" ]
   },
   {
     "id": "fish",
@@ -23,7 +23,7 @@
     "price": "5 USD",
     "price_postapoc": "50 cent",
     "spoils_in": "1 day",
-    "flags": [ "SMOKABLE", "RAW" ],
+    "extend": { "flags": [ "SMOKABLE" ] },
     "smoking_result": "fish_smoked",
     "vitamins": [ [ "vitA", 2 ], [ "vitC", 2 ], [ "calcium", 6 ], [ "iron", 14 ], [ "vitB", 154 ] ],
     "calories": 260
@@ -60,7 +60,7 @@
     "price": "5 USD",
     "price_postapoc": "50 cent",
     "spoils_in": "1 day",
-    "flags": [ "SMOKABLE", "RAW" ],
+    "extend": { "flags": [ "SMOKABLE" ] },
     "smoking_result": "lobster_smoked",
     "vitamins": [ [ "vitC", 2 ], [ "calcium", 6 ], [ "iron", 14 ] ],
     "calories": 250
@@ -269,7 +269,7 @@
     "cooks_like": "mutant_meat_cooked",
     "proportional": { "price": 0.2, "calories": 0.5 },
     "vitamins": [ [ "vitC", 6 ], [ "calcium", 1 ], [ "iron", 26 ], [ "vitB", 389 ], [ "mutant_toxin", 25 ] ],
-    "flags": [ "SMOKABLE", "BAD_TASTE", "RAW" ]
+    "extend": { "flags": [ "SMOKABLE", "BAD_TASTE" ] }
   },
   {
     "id": "mutant_meat_scrap",
@@ -348,7 +348,7 @@
     "parasites": 0,
     "fun": 0,
     "healthy": 0,
-    "flags": [ "NUTRIENT_OVERRIDE" ],
+    "flags": [ "EATEN_HOT", "NUTRIENT_OVERRIDE" ],
     "calories": 51
   },
   {
@@ -429,7 +429,7 @@
     "spoils_in": "2 days",
     "quench": -1,
     "fun": -1,
-    "delete": { "flags": [ "RAW" ] }
+    "delete": { "flags": [ "RAW", "UNSAFE_CONSUME" ] }
   },
   {
     "id": "offal_canned",
@@ -445,7 +445,7 @@
     "healthy": 1,
     "container": "can_food",
     "fun": -2,
-    "delete": { "flags": [ "RAW" ] }
+    "delete": { "flags": [ "RAW", "UNSAFE_CONSUME" ] }
   },
   {
     "id": "mutant_offal",
@@ -523,7 +523,7 @@
     "fun": 4,
     "calories": 348,
     "vitamins": [ [ "vitA", 0 ], [ "vitC", 0 ], [ "calcium", 2 ], [ "iron", 26 ], [ "vitB", 35 ] ],
-    "delete": { "flags": [ "RAW" ] }
+    "delete": { "flags": [ "RAW", "UNSAFE_CONSUME" ] }
   },
   {
     "id": "salted_fish",
@@ -540,7 +540,7 @@
     "quench": -5,
     "fun": 4,
     "proportional": { "price": 2, "volume": 0.345, "weight": 0.345 },
-    "delete": { "flags": [ "RAW" ] }
+    "delete": { "flags": [ "RAW", "UNSAFE_CONSUME" ] }
   },
   {
     "id": "meat_smoked",
@@ -715,7 +715,8 @@
     "volume": "250 ml",
     "parasites": 32,
     "stack_size": 1,
-    "fun": -20
+    "fun": -20,
+    "flags": [ "RAW", "UNSAFE_CONSUME" ]
   },
   {
     "type": "COMESTIBLE",

--- a/data/json/items/comestibles/offal_dishes.json
+++ b/data/json/items/comestibles/offal_dishes.json
@@ -159,7 +159,7 @@
     "parasites": 0,
     "healthy": -2,
     "fun": -8,
-    "delete": { "flags": [ "RAW" ] }
+    "delete": { "flags": [ "RAW", "UNSAFE_CONSUME" ] }
   },
   {
     "id": "fried_brain",
@@ -196,7 +196,7 @@
     "quench": -2,
     "fun": -3,
     "parasites": 0,
-    "delete": { "flags": [ "RAW" ] }
+    "delete": { "flags": [ "RAW", "UNSAFE_CONSUME" ] }
   },
   {
     "id": "deviled_kidney",
@@ -231,7 +231,7 @@
     "fun": -4,
     "description": "Normally a delicacy, it needs a little… something.",
     "parasites": 0,
-    "delete": { "flags": [ "RAW" ] }
+    "delete": { "flags": [ "RAW", "UNSAFE_CONSUME" ] }
   },
   {
     "id": "grilled_sweetbread",
@@ -253,7 +253,7 @@
     "price_postapoc": "50 cent",
     "fun": -2,
     "healthy": 0,
-    "delete": { "flags": [ "RAW" ] }
+    "delete": { "flags": [ "RAW", "UNSAFE_CONSUME" ] }
   },
   {
     "id": "canned_liver",
@@ -272,7 +272,7 @@
     "name": { "str": "cooked piece of lung", "str_pl": "cooked pieces of lung" },
     "description": " Prepared in this way, it's a chewy grayish lump of flavorless connective tissue.  It doesn't look any tastier than it did raw, but the parasites are all cooked out.",
     "parasites": 0,
-    "delete": { "flags": [ "RAW" ] }
+    "delete": { "flags": [ "RAW", "UNSAFE_CONSUME" ] }
   },
   {
     "id": "lung_provence",


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Fix getting parasites from having raw fish in your auto-eat zone:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/dcbe3c0d-3eae-4482-963a-857594c69ff6)

Along the way I decided to just also add the relevant flag to all raw items that can grant parasites. While the low fun value may stop auto-eat due to the code checking the fun level, it doesn't stop you from hitting the wrong key and instantly getting parasites from that.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Set the `flesh` abstract to have `UNSAFE_CONSUME` on it.
2. Converted raw fish, and  to add `SMOKABLE` to its flag list via `extend` instead of fully overriding the flags.
3. Set pickled and canned offal, jerky, salted fish, various cooked offal items to delete `UNSAFE_CONSUME` from flags.
4. Added `RAW` and `UNSAFE_CONSUME` to raw fat like tainted fat has.
5. Misc: Fixed cooked meat scraps lacking `EATEN_HOT`.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Checked affected files for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
