### PR TITLE
test: hide flaky tests

### DIFF
--- a/tests/effective_dps_test.cpp
+++ b/tests/effective_dps_test.cpp
@@ -165,7 +165,7 @@ TEST_CASE( "effective damage per second", "[effective][dps]" )
     }
 }
 
-TEST_CASE( "effective vs actual damage per second", "[actual][dps][!mayfail]" )
+TEST_CASE( "effective vs actual damage per second", "[.][actual][dps][!mayfail]" )
 {
     clear_all_state();
     avatar &dummy = g->u;

--- a/tests/filesystem_test.cpp
+++ b/tests/filesystem_test.cpp
@@ -169,7 +169,7 @@ TEST_CASE( "filesystem_utf8", "[filesystem]" )
 // (e.g. "è" vs "e\u0300"), but it also means that paths written with composed chars
 // will have them decomposed when read back from the filesystem.
 // Hence, the 'mayfail' flag.
-TEST_CASE( "filesystem_utf8_comp", "[filesystem][!mayfail]" )
+TEST_CASE( "filesystem_utf8_comp", "[.][filesystem][!mayfail]" )
 {
     // Hindi (should be unaffected)
     filesystem_test_group( 4, u8R"(नमस्ते)", u8R"(स्ते)", u8R"(मस्)" );

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -326,7 +326,7 @@ TEST_CASE( "monster_speed_square", "[speed]" )
 }
 
 // TODO: Figure out why this sometimes fails, seems to be RNG-dependent
-TEST_CASE( "monster_speed_trig", "[speed][!mayfail]" )
+TEST_CASE( "monster_speed_trig", "[.][speed][!mayfail]" )
 {
     clear_all_state();
     put_player_underground();

--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -225,7 +225,7 @@ static void assert_encumbrance( npc &shooter, int encumbrance )
 
 static constexpr tripoint shooter_pos( 60, 60, 0 );
 
-TEST_CASE( "unskilled_shooter_accuracy", "[ranged][balance][slow][!mayfail]" )
+TEST_CASE( "unskilled_shooter_accuracy", "[.][ranged][balance][slow][!mayfail]" )
 {
     clear_all_state();
     standard_npc shooter( "Shooter", shooter_pos, {}, 0, 8, 8, 8, 7 );

--- a/tests/stomach_contents_test.cpp
+++ b/tests/stomach_contents_test.cpp
@@ -147,7 +147,7 @@ TEST_CASE( "starve_test_hunger3", "[starve][slow]" )
 }
 
 // does eating enough food per day keep you alive
-TEST_CASE( "all_nutrition_starve_test", "[!mayfail][starve][slow]" )
+TEST_CASE( "all_nutrition_starve_test", "[.][!mayfail][starve][slow]" )
 {
     clear_all_state();
     // change this bool when editing the test


### PR DESCRIPTION
## Purpose of change

#4425 works so well it catches tests meant to fail and ~~fail the whole step~~ confuses reader as it isn't an actual fail

## Describe the solution
mark `[!mayfail]` as ~~hidden (`[.]`) so it's skipped by default~~ it doesn't work

## Describe alternatives you've considered

aaaahhh

## Testing

using CI

## Additional context

catch2 special tags: https://github.com/catchorg/Catch2/blob/devel/docs/test-cases-and-sections.md#special-tags
