### PR TITLE
fix: enable vsync by default

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2093,7 +2093,7 @@ void options_manager::add_options_graphics()
 #if defined(SDL_HINT_RENDER_VSYNC)
     add( "VSYNC", graphics, translate_marker( "Use VSync" ),
          translate_marker( "Enable vertical synchronization to prevent screen tearing.  VSync can slow the game down a lot.  Requires restart." ),
-         false, COPT_CURSES_HIDE
+         true, COPT_CURSES_HIDE
        );
 #endif
 


### PR DESCRIPTION

## Purpose of change

- may fix #4423
- resolves #4431 

## Describe the solution

turn vsync on by default.

## Describe alternatives you've considered

force enable vsync by default on windows?

## Testing

@Lamandus confirmed that with VSync on the issue is solved.
