### PR TITLE
feat(content): Adds Mechanical and Electrical engineering professions

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -1488,7 +1488,7 @@
     "type": "profession",
     "id": "mech_eng",
     "name": "Mechanical Engineer",
-    "description": "Fresh out of college, you've got little in the way of practical engineering experience.  The Cataclysm might prove to be a rather complicated problem to solve even from an engineering perspective, and you are not sure if you will pass this stress test.",
+    "description": "Fresh out of college, you've got little in the way of practical engineering experience.  The Cataclysm might prove to be a rather complicated problem to solve even from an engineering perspective, and you're not sure if you will pass this stress test.",
     "points": 2,
     "skills": [ 
      { "level": 4, "name": "mechanics" },

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -1463,23 +1463,9 @@
     "name": "Electrical Engineer",
     "description": "Fresh out of college, you've got little in the way of practical engineering experience.  The Cataclysm might prove to be a rather complicated problem to solve even from an engineering perspective, and you're not sure if you can solder your way out of this one.",
     "points": 2,
-    "skills": [ 
-     { "level": 4, "name": "electronics" },
-     { "level": 2, "name": "fabrication" },
-     { "level": 2, "name": "computer" } 
-    ],
+    "skills": [ { "level": 4, "name": "electronics" }, { "level": 2, "name": "fabrication" }, { "level": 2, "name": "computer" } ],
     "items": {
-      "both": {
-        "items": [
-          "pants",
-          "dress_shirt",
-          "socks",
-          "dress_shoes",
-          "wristwatch",
-          "water_clean",
-          "smart_phone",
-          "file" ]
-      },
+      "both": { "items": [ "pants", "dress_shirt", "socks", "dress_shoes", "wristwatch", "water_clean", "smart_phone", "file" ] },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]
     }
@@ -1490,23 +1476,9 @@
     "name": "Mechanical Engineer",
     "description": "Fresh out of college, you've got little in the way of practical engineering experience.  The Cataclysm might prove to be a rather complicated problem to solve even from an engineering perspective, and you're not sure if you will pass this stress test.",
     "points": 2,
-    "skills": [ 
-     { "level": 4, "name": "mechanics" },
-     { "level": 2, "name": "fabrication" },
-     { "level": 2, "name": "computer" } 
-    ],
+    "skills": [ { "level": 4, "name": "mechanics" }, { "level": 2, "name": "fabrication" }, { "level": 2, "name": "computer" } ],
     "items": {
-      "both": {
-        "items": [
-          "pants",
-          "dress_shirt",
-          "socks",
-          "dress_shoes",
-          "wristwatch",
-          "water_clean",
-          "smart_phone",
-          "file" ]
-      },
+      "both": { "items": [ "pants", "dress_shirt", "socks", "dress_shoes", "wristwatch", "water_clean", "smart_phone", "file" ] },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]
     }

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -1459,6 +1459,60 @@
   },
   {
     "type": "profession",
+    "id": "el_eng",
+    "name": "Electrical Engineer",
+    "description": "Fresh out of college, you've got little in the way of practical engineering experience.  The Cataclysm might prove to be a rather complicated problem to solve even from an engineering perspective, and you're not sure if you can solder your way out of this one.",
+    "points": 2,
+    "skills": [ 
+     { "level": 4, "name": "electronics" },
+     { "level": 2, "name": "fabrication" },
+     { "level": 2, "name": "computer" } 
+    ],
+    "items": {
+      "both": {
+        "items": [
+          "pants",
+          "dress_shirt",
+          "socks",
+          "dress_shoes",
+          "wristwatch",
+          "water_clean",
+          "smart_phone",
+          "file" ]
+      },
+      "male": [ "boxer_shorts" ],
+      "female": [ "bra", "panties" ]
+    }
+  },
+  {
+    "type": "profession",
+    "id": "mech_eng",
+    "name": "Mechanical Engineer",
+    "description": "Fresh out of college, you've got little in the way of practical engineering experience.  The Cataclysm might prove to be a rather complicated problem to solve even from an engineering perspective, and you are not sure if you will pass this stress test.",
+    "points": 2,
+    "skills": [ 
+     { "level": 4, "name": "mechanics" },
+     { "level": 2, "name": "fabrication" },
+     { "level": 2, "name": "computer" } 
+    ],
+    "items": {
+      "both": {
+        "items": [
+          "pants",
+          "dress_shirt",
+          "socks",
+          "dress_shoes",
+          "wristwatch",
+          "water_clean",
+          "smart_phone",
+          "file" ]
+      },
+      "male": [ "boxer_shorts" ],
+      "female": [ "bra", "panties" ]
+    }
+  },
+  {
+    "type": "profession",
     "id": "heli_pilot",
     "name": "Helicopter Pilot",
     "description": "You earned a living ferrying businessmen and tourists from helipad to helipad, the Cataclysm has grounded you, but the sky still calls you…",


### PR DESCRIPTION
Adds two professions, one for Electrical Engineering and one for Mechanical Engineering. They are mostly based on the Medical Resident profession and their own Mechanic/Electrician counterparts and are more focused on skill than gear.

This is my first Github PR ever, so perhaps expect a gigantic messup.
