### PR TITLE
fix: misaligned ladder in pump station

### DIFF
--- a/data/json/mapgen/pump_station.json
+++ b/data/json/mapgen/pump_station.json
@@ -354,7 +354,6 @@
         "RRRR~x2RRRRRRRRRRRRRRRRR",
         "RRRR~x2RRRRRRRRRRRRRRRRR",
         "RRRR~x2RRRRRRRRRRRRRRRRR",
-        "RRRR~x2RRRRRRRRRRRRRRRRR",
         "RRRR!*2RRRRRRRRRRRRRRRRR",
         "RRRR~x2RRRRRRRRRRRRRRRRR",
         "RRRR~x2RRRRRRRRRRRRRRRRR",
@@ -367,6 +366,7 @@
         "R~~~~~~Rc LRRRRRRRRRRRRR",
         "RRRRRRRRc LRRRRRRRRRRRRR",
         "RRRRRRRRR RRRRRRRRRRRRRR",
+        "RRRRRRRRRRRRRRRRRRRRRRRR",
         "RRRRRRRRRRRRRRRRRRRRRRRR",
         "RRRRRRRRRRRRRRRRRRRRRRRR",
         "RRRRRRRRRRRRRRRRRRRRRRRR",
@@ -388,7 +388,7 @@
         "~": "t_sewage"
       },
       "furniture": { "L": "f_locker", "c": "f_counter" },
-      "place_loot": [ { "group": "sewage_plant", "x": [ 10, 10 ], "y": [ 15, 16 ], "chance": 85, "repeat": [ 1, 3 ] } ],
+      "place_loot": [ { "group": "sewage_plant", "x": [ 10, 10 ], "y": [ 14, 15 ], "chance": 85, "repeat": [ 1, 3 ] } ],
       "place_monsters": [ { "monster": "GROUP_SEWER", "x": [ 1, 22 ], "y": [ 1, 22 ], "density": 0.1 } ]
     }
   }


### PR DESCRIPTION
## Purpose of change
Fix a misaligned ladder in the pump station.
## Describe the solution
Align the ladder with the manhole cover above in the mapgen `pump_station_5`.
## Describe alternatives you've considered
none
## Additional context
none