### PR TITLE
feat(UI): allow setting default gender

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -408,6 +408,7 @@ bool avatar::create( character_type type, const std::string &tempname )
 
     prof = profession::generic();
     g->scen = scenario::generic();
+    male = get_option<std::string>( "DEF_CHAR_GENDER" ) == "male";
 
     const bool interactive = type != character_type::NOW &&
                              type != character_type::FULL_RANDOM;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1233,6 +1233,12 @@ void options_manager::add_options_general()
          "", 30
        );
 
+    add( "DEF_CHAR_GENDER", general, translate_marker( "Default character gender" ),
+    translate_marker( "Set a default character gender that will be used on character creation." ), {
+        { "male", to_translation( "Male" )},
+        { "female", to_translation( "Female" )},
+    }, "male" );
+
     add_empty_line();
 
     add_option_group( general, Group( "comestible_merging",


### PR DESCRIPTION
## Purpose of change

Because I always create my avatar as female and it's tedious to change gender every time.

## Describe the solution

added `DEF_CHAR_GENDER` which sets gender on avatar creation.

## Describe alternatives you've considered

make character creation UI remember more options?

## Testing

![Cataclysm: Bright Nights - 0 C-57314-g5c1c8089e53d_02](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/8ae45730-62d1-4983-aa7f-2134d2a2d87a)

![Cataclysm: Bright Nights - 0 C-57314-g5c1c8089e53d_01](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/b075881e-54ba-4a2e-b16a-503bec6c96cd)

## Additional Context

Q: Who's maribel hearn and why do they always have to be a she?

<img width="40%" src="https://en.touhouwiki.net/images/thumb/f/fa/ZCDS-0014.jpg/911px-ZCDS-0014.jpg?20181014011829"/>

A: _touhou hijack lol_