### PR TITLE
feat(UI): show terrain flags

### DIFF
--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -575,6 +575,18 @@ std::optional<construction_id> construction_menu( const bool blueprint )
                 add_folded( current_con->requirements->get_folded_tools_list( available_window_width, color_stage,
                             total_inv ) );
 
+                const auto get_folded_flags_list = [&]( const auto & flags ) ->
+                std::vector<std::string> {
+                    return foldstring(
+                        colorize( _( "Terrain needs: " ), color_stage ) + enumerate_as_string( flags.begin(), flags.end(),
+                    []( const auto & flag ) -> std::string { return colorize( flag, color_data ); },
+                    enumeration_conjunction::and_ ), available_window_width );
+                };
+
+                if( !current_con->pre_flags.empty() ) {
+                    add_folded( get_folded_flags_list( current_con->pre_flags ) );
+                }
+
                 add_folded( current_con->requirements->get_folded_components_list( available_window_width,
                             color_stage, total_inv, is_crafting_component ) );
 

--- a/src/descriptions.cpp
+++ b/src/descriptions.cpp
@@ -254,5 +254,11 @@ std::string map_data_common_t::extended_description() const
         }
     }
 
+    if( !flags.empty() ) {
+        ss << _( "Flags: " ) << enumerate_as_string( flags.begin(), flags.end(), []( const auto & it ) {
+            return it;
+        } ) << '\n';
+    }
+
     return replace_colors( ss.str() );
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1805,6 +1805,7 @@ std::string map::features( const tripoint &p )
     add_if( has_flag( "UNSTABLE", p ), _( "Unstable." ) );
     add_if( has_flag( "SHARP", p ), _( "Sharp." ) );
     add_if( has_flag( "FLAT", p ), _( "Flat." ) );
+    add_if( has_flag( "ROOF", p ), _( "Roof." ) );
     add_if( has_flag( "EASY_DECONSTRUCT", p ), _( "Simple." ) );
     add_if( has_flag( "MOUNTABLE", p ), _( "Mountable." ) );
     return result;


### PR DESCRIPTION
## Purpose of change

https://github.com/cataclysmbnteam/Cataclysm-BN/blob/596091331acc4bb55a32fae53e8f1d479464995a/doc/src/content/docs/en/mod/json/reference/json_info.md#L863-L864

make it easier to check whether a terrain satisfies `pre_flags`.

## Describe the solution

added section to display terrain flags in construction and extended description

## Describe alternatives you've considered

also make more detailed error message on why a construction cannot be constructed

## Testing
![Cataclysm: Bright Nights - HEAD-HASH_01](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/67cb4d17-7be6-4284-8770-bb05fe265b9c)
![Cataclysm: Bright Nights - HEAD-HASH_02](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/8a9612fa-442e-4f6c-93c5-018166c25382)


## Additional context

idea from #4463