### PR TITLE
feat(content, balance): Add American Flag Recipe, balance Pride Flag mod recipes

### DIFF
--- a/data/json/recipes/armor/other.json
+++ b/data/json/recipes/armor/other.json
@@ -549,5 +549,16 @@
     "using": [ [ "blacksmithing_standard", 5 ], [ "steel_standard", 5 ] ],
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "shield_wooden_large", 1 ] ] ]
+  },
+  {
+    "result": "american_flag",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_OTHER",
+    "skill_used": "tailor",
+    "time": "80 m",
+    "autolearn": true,
+    "using": [ [ "sewing_standard", 20 ], [ "drawing_tool", 40 ] ],
+    "components": [ [ [ "rag", 40 ] ] ]
   }
 ]

--- a/data/mods/pride_flags/recipes.json
+++ b/data/mods/pride_flags/recipes.json
@@ -8,7 +8,7 @@
     "time": "80 m",
     "autolearn": true,
     "using": [ [ "sewing_standard", 20 ], [ "drawing_tool", 40 ] ],
-    "components": [ [ [ "rag", 35 ] ] ]
+    "components": [ [ [ "rag", 40 ] ] ]
   },
   {
     "result": "rainbow_flag",
@@ -19,7 +19,7 @@
     "time": "80 m",
     "autolearn": true,
     "using": [ [ "sewing_standard", 20 ], [ "drawing_tool", 40 ] ],
-    "components": [ [ [ "rag", 35 ] ] ]
+    "components": [ [ [ "rag", 40 ] ] ]
   },
   {
     "result": "aromantic_flag",
@@ -30,7 +30,7 @@
     "time": "80 m",
     "autolearn": true,
     "using": [ [ "sewing_standard", 20 ], [ "drawing_tool", 40 ] ],
-    "components": [ [ [ "rag", 35 ] ] ]
+    "components": [ [ [ "rag", 40 ] ] ]
   },
   {
     "result": "asexual_flag",
@@ -41,7 +41,7 @@
     "time": "80 m",
     "autolearn": true,
     "using": [ [ "sewing_standard", 20 ], [ "drawing_tool", 40 ] ],
-    "components": [ [ [ "rag", 35 ] ] ]
+    "components": [ [ [ "rag", 40 ] ] ]
   },
   {
     "result": "bisexual_flag",
@@ -52,7 +52,7 @@
     "time": "80 m",
     "autolearn": true,
     "using": [ [ "sewing_standard", 20 ], [ "drawing_tool", 40 ] ],
-    "components": [ [ [ "rag", 35 ] ] ]
+    "components": [ [ [ "rag", 40 ] ] ]
   },
   {
     "result": "intersex_flag",
@@ -63,7 +63,7 @@
     "time": "80 m",
     "autolearn": true,
     "using": [ [ "sewing_standard", 20 ], [ "drawing_tool", 40 ] ],
-    "components": [ [ [ "rag", 35 ] ] ]
+    "components": [ [ [ "rag", 40 ] ] ]
   },
   {
     "result": "lesbian_flag",
@@ -74,7 +74,7 @@
     "time": "80 m",
     "autolearn": true,
     "using": [ [ "sewing_standard", 20 ], [ "drawing_tool", 40 ] ],
-    "components": [ [ [ "rag", 35 ] ] ]
+    "components": [ [ [ "rag", 40 ] ] ]
   },
   {
     "result": "enby_flag",
@@ -85,7 +85,7 @@
     "time": "80 m",
     "autolearn": true,
     "using": [ [ "sewing_standard", 20 ], [ "drawing_tool", 40 ] ],
-    "components": [ [ [ "rag", 35 ] ] ]
+    "components": [ [ [ "rag", 40 ] ] ]
   },
   {
     "result": "pansexual_flag",
@@ -96,7 +96,7 @@
     "time": "80 m",
     "autolearn": true,
     "using": [ [ "sewing_standard", 20 ], [ "drawing_tool", 40 ] ],
-    "components": [ [ [ "rag", 35 ] ] ]
+    "components": [ [ [ "rag", 40 ] ] ]
   },
   {
     "result": "gay_flag",
@@ -107,7 +107,7 @@
     "time": "80 m",
     "autolearn": true,
     "using": [ [ "sewing_standard", 20 ], [ "drawing_tool", 40 ] ],
-    "components": [ [ [ "rag", 35 ] ] ]
+    "components": [ [ [ "rag", 40 ] ] ]
   },
   {
     "result": "genderfluid_flag",
@@ -118,6 +118,6 @@
     "time": "80 m",
     "autolearn": true,
     "using": [ [ "sewing_standard", 20 ], [ "drawing_tool", 40 ] ],
-    "components": [ [ [ "rag", 35 ] ] ]
+    "components": [ [ [ "rag", 40 ] ] ]
   }
 ]


### PR DESCRIPTION
## Purpose of change

I realized that there was no recipe for the American flag, and considering I already made a flag recipe for the pride flags mod I figured it would be a good fit here too. However, I also realized that cutting up a flag gives 40 rags, so a recipe only taking 35 would be a rag duplication.

## Describe the solution

- Adds a recipe to craft an American flag
- Also changes the recipes in the pride flags mod (alongside the new American flag recipe) to use 40 rags 

## Describe alternatives you've considered

Leave the flag uncraftable

## Testing

Recipe does indeed load correctly.

## Additional context

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/30732426/8f7699db-2878-45c6-90e5-64aa1f862634)
