### PR TITLE
chore(UI): Unbind suicide, provide defaults for others such as Spellcasting

### DIFF
--- a/data/raw/keybindings/keybindings.json
+++ b/data/raw/keybindings/keybindings.json
@@ -1956,8 +1956,7 @@
     "type": "keybinding",
     "name": "Commit Suicide",
     "category": "DEFAULTMODE",
-    "id": "SUICIDE",
-    "bindings": [ { "input_method": "keyboard", "key": "Q" } ]
+    "id": "SUICIDE"
   },
   {
     "type": "keybinding",
@@ -2050,7 +2049,8 @@
     "type": "keybinding",
     "name": "Debug Menu",
     "category": "DEFAULTMODE",
-    "id": "debug"
+    "id": "debug",
+    "bindings": [ { "input_method": "keyboard", "key": "`" } ]
   },
   {
     "type": "keybinding",
@@ -2333,13 +2333,15 @@
     "type": "keybinding",
     "id": "cast_spell",
     "name": "Spellcasting",
-    "category": "DEFAULTMODE"
+    "category": "DEFAULTMODE",
+    "bindings": [ { "input_method": "keyboard", "key": "]" } ]
   },
   {
     "type": "keybinding",
     "id": "diary",
     "name": "Open Diary",
-    "category": "DEFAULTMODE"
+    "category": "DEFAULTMODE",
+    "bindings": [ { "input_method": "keyboard", "key": "HOME" } ]
   },
   {
     "type": "keybinding",


### PR DESCRIPTION
## Purpose of change

Why we even had suicide bound by default, and to 'Q' of all keys, is a mystery to me. A mystery that can now be rectified.
Also, we were missing defaults for spellcasting, debug menu, and opening the diary, so I provided some for those upon receiving feedback.

## Describe the solution

- Unbinds Suicide by default
- Binds Spellcasting to ']' by default (it's right next to the mutations default on the keyboard)
- Binds Debug menu to '`' by default (also known as the grave key, or the default in a wide variety of other games)
- Binds Diary to the 'Home' key on the keyboard by default
  - I just kind of chose this key randomly. In truth, it could probably be bound to something else. However, it's not like people are going to be constantly using the diary anyway. 

## Describe alternatives you've considered

- Continuing to have to advise players against pressing 'Q', then Yes twice

- Leaving Spellcasting unbound by default
  - Yes, it's **technically** not really used in vanilla, but with how we have ~3 major magic mods now I'd say it deserves a default binding.

## Testing

It doesn't crash when I load in, and it looks like this should work.

## Additional context

"Watch how with just one simple trick, we reduced the number of player-suicides in Cata by 99.99%!"
