### PR TITLE
fix: Fix sauce sandwich containing dairy and meat

### DIFF
--- a/data/json/items/comestibles/sandwich.json
+++ b/data/json/items/comestibles/sandwich.json
@@ -98,6 +98,7 @@
     "copy-from": "sandwich_deluxe",
     "name": { "str": "sauce sandwich", "str_pl": "sauce sandwiches" },
     "description": "A simple sauce sandwich.  Not very filling but beats eating just the bread.",
+    "material": [ "veggy", "wheat" ],
     "price": "2 USD",
     "price_postapoc": "2 USD",
     "fun": 2


### PR DESCRIPTION
## Purpose of change

Fixes the fact that sauce sandwiches made out of entirely okay ingredients would suddenly trigger lactose intolerance (and presumably meat intolerance / allergy too) for no reason.

## Describe the solution

Explicitly defines materials to prevent it inheriting the deluxe sandwhich's materials

## Describe alternatives you've considered

- Leave the dairy matter because technically butter is a valid ingredient, and brioche and biscuits are made with milk
  - The vast majority of the ingredients are non-dairy. As such, ingredient democracy has dairy removal winning.

## Testing

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/30732426/57c6958d-34e5-4953-b6ea-6a4db7e67075)


## Additional context

Are there other oddities in the sandwiches file? Maybe, but it'd be good PR fodder for new contributors if they notice something. I just thought this one was particularly egregious, and I saw it being talked about firsthand.

