### PR TITLE
docs: Add BIOPROOF to JSON Flags Documentation

### DIFF
--- a/doc/src/content/docs/en/mod/json/reference/json_flags.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_flags.md
@@ -983,6 +983,7 @@ Multiple death functions can be used. Not all combinations make sense.
 - `BADVENOM` Attack may **severely** poison the player.
 - `BASHES` Bashes down doors.
 - `BILE_BLOOD` Makes monster bleed bile.
+- `BIOPROOF` Makes monster immune to Bio damage (A damage type mostly used by magic mods)
 - `BIRDFOOD` Becomes friendly / tamed with bird food.
 - `BLEED` Causes the player to bleed.
 - `BONES` May produce bones and sinews when butchered.


### PR DESCRIPTION
## Purpose of change

BIOPROOF doesn't appear to be listed in the JSON Flags documentation, so I thought I'd add it

## Describe the solution

Adds BIOPROOF to the JSON Flags documentation

## Describe alternatives you've considered

Just leave it out and let it be obscure

## Testing

My computer didn't explode upon saving the file, and that's really the most I can do.

## Additional context

Smol PR gang
