### PR TITLE
feat(content): add vehiclepart raincatcher

### DIFF
--- a/data/json/traps.json
+++ b/data/json/traps.json
@@ -737,6 +737,6 @@
     "action": "none",
     "drops": [ "tarp_raincatcher" ],
     "benign": true,
-    "funnel_radius": 342
+    "funnel_radius": 360
   }
 ]

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -2937,6 +2937,29 @@
   },
   {
     "type": "vehicle_part",
+    "id": "tarp_raincatcher_part",
+    "name": { "str": "tarp raincatcher" },
+    "symbol": "V",
+    "looks_like": "makeshift_funnel",
+    "color": "blue",
+    "broken_symbol": "*",
+    "broken_color": "light_gray",
+    "damage_modifier": 5,
+    "durability": 80,
+    "description": "An improvised raincatcher made using a tarpaulin, to collect rainwater into the tank beneath it.",
+    "size": "90 L",
+    "item": "tarp_raincatcher",
+    "location": "on_roof",
+    "requirements": {
+      "install": { "skills": [ [ "mechanics", 0 ] ], "time": "6 m", "using": [ [ "vehicle_nail_install", 1 ] ] },
+      "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "3 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },
+      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "6 m", "using": [ [ "adhesive", 2 ], [ "vehicle_repair_small_wood", 4 ] ] }
+    },
+    "flags": [ "FUNNEL" ],
+    "breaks_into": [ { "item": "splinter", "count": [ 5, 10 ] } ]
+  },
+  {
+    "type": "vehicle_part",
     "id": "vehicle_scoop",
     "name": { "str": "scoop" },
     "symbol": "R",


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This adds the option to use tarp raincatchers on vehicles, the only other vanilla funnel option besides gutters (which aren't exactly portable) to not have a vehiclepart option.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Added a vehiclepart version of tarp raincatcher. Since collection power is all in liters, used 90 instead of the jank-ass volume value the trap version used.
2. But for consistency, bumped the value the trap version can handle from 85.5 liters to 90 liters.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Mainlining leather tarp raincatchers from MST Extra too.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested and set up two raincatchers over 60-liter tanks, one in trap form and the other a vehiclepart over an installed tank.
3. Waited...motherfucking FOREVER to finally get weather that's fucking rainy.
4. Gave up and loaded back in after temporarily editing base humidity to be higher in regional map settings because blyaaat.
5. Loaded in, found it was raining now, waited it out. The tank under the trap version had 6 units of water in it, the vehicle version only had 5.
6. Re-loaded and waited out the rain a second time, different was now 14 vs 9 units.

Given this, I'm convinced there is some fuckery going on, either randomization that needs some good solid testing, or else vehicle funnels are busted.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Related issue: https://github.com/cataclysmbnteam/Cataclysm-BN/issues/4488

Until I do more testing I don't want to say this actually fixes that issue. Metal funnels are already still better than tarp raincatchers, so lacking tarp raincatchers doesn't seem like it'd be a magic bullet that'd fix things. Not unless the player in question just never bothered to test metal funnels on vehicles, presumably because they're a pain in the dick and have to be welded on to install, but I'd really want to test this more in case there's some hidden code fuckery going on too.

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
