### PR TITLE
fix: Construction Recipe check for components same as tool fixed.

### DIFF
--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -878,7 +878,14 @@ bool requirement_data::check_enough_materials( const item_comp &comp, const inve
     }
     const int cnt = std::abs( comp.count ) * batch;
     const tool_comp *tq = find_by_type( tools, comp.type );
-    if( tq != nullptr && tq->available == available_status::a_true ) {
+    // First check is that the use case is the same (soldering iron charges
+    // being used in tools but the item itself being used as a component)
+    // If it isn't count_by_charges() any loaded versions are not considered
+    // valid components
+    // Second check is just that the tool has been considered valid,
+    // so must be offset when you count how much is available.
+    if( tq != nullptr && comp.type->count_by_charges() == tq->by_charges() &&
+        tq->available == available_status::a_true ) {
         // The very same item type is also needed as tool!
         // Use charges of it, or use it by count?
         const int tc = tq->by_charges() ? 1 : std::abs( tq->count );


### PR DESCRIPTION
## Purpose of change

- Fixes #3004 and fixes #2002

Check was bugged, if an item requires charges for tool use but is not `count_by_charges()` only unloaded tools are considered valid components, but the game looks for the extra item that is used in the tools because it cannot discern that it doesn't need to.

## Describe the solution

An extra check was added so that if the tool uses charges but is not `count_by_charges()` it goes to standard checks. It would technically also work vice-versa but I don't think that use case can even happen under normal circumstances.

## Describe alternatives you've considered

- A healthy, happy life spent not staring at archaic code.

## Testing

- Spawn 2 soldering irons and all the other requirements for installing a soldering iron.
  - [x] Check that construction for soldering iron appliance doesn't allow it because both soldering irons are loaded so neither counts as a component.
  - [x] Unload both and check that it still doesn't allow it because now there's no tool.
  - [x] Unload only 1, check that the recipe is now green across the board and construction can occur.
- Give a plank hammering 2.
  - [x] Check that construction recipes requiring hammering 2 and planks don't work unless you have 1 more plank than the component requirement.
  - [x] Scream cause the display looks weird regardless.

## Additional context

I don't really think I can fix the display without a lot of code diving into parts I'd rather not.

## Checklist