### PR TITLE
feat(balance): lower humidity threshold for drizzle, slight increase to base humidity

### DIFF
--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -1017,7 +1017,7 @@
       "summer_temp": 16,
       "autumn_temp": 7,
       "winter_temp": -14,
-      "base_humidity": 70,
+      "base_humidity": 75,
       "base_pressure": 1015,
       "base_acid": 0,
       "base_wind": 3.4,

--- a/data/json/weather_type.json
+++ b/data/json/weather_type.json
@@ -107,7 +107,12 @@
     "animation": { "factor": 0.01, "color": "c_light_blue", "glyph": ".", "tile": "weather_rain_drop" },
     "sound_category": "drizzle",
     "sun_intensity": "light",
-    "requirements": { "pressure_max": 1000, "humidity_min": 90, "humidity_and_pressure": false, "required_weathers": [ "light_drizzle" ] }
+    "requirements": {
+      "pressure_max": 1000,
+      "humidity_min": 90,
+      "humidity_and_pressure": false,
+      "required_weathers": [ "cloudy", "light_drizzle" ]
+    }
   },
   {
     "id": "rain",
@@ -131,7 +136,7 @@
       "pressure_max": 993,
       "humidity_min": 95,
       "humidity_and_pressure": false,
-      "required_weathers": [ "light_drizzle", "drizzle" ]
+      "required_weathers": [ "cloudy", "light_drizzle", "drizzle" ]
     }
   },
   {

--- a/data/json/weather_type.json
+++ b/data/json/weather_type.json
@@ -87,7 +87,7 @@
     "animation": { "factor": 0.01, "color": "c_light_blue", "glyph": ",", "tile": "weather_rain_drop" },
     "sound_category": "drizzle",
     "sun_intensity": "light",
-    "requirements": { "pressure_max": 1003, "humidity_min": 96, "humidity_and_pressure": false, "required_weathers": [ "cloudy" ] }
+    "requirements": { "pressure_max": 1003, "humidity_min": 90, "humidity_and_pressure": false, "required_weathers": [ "cloudy" ] }
   },
   {
     "id": "drizzle",
@@ -107,7 +107,7 @@
     "animation": { "factor": 0.01, "color": "c_light_blue", "glyph": ".", "tile": "weather_rain_drop" },
     "sound_category": "drizzle",
     "sun_intensity": "light",
-    "requirements": { "pressure_max": 1000, "humidity_min": 97, "humidity_and_pressure": false, "required_weathers": [ "light_drizzle" ] }
+    "requirements": { "pressure_max": 1000, "humidity_min": 95, "humidity_and_pressure": false, "required_weathers": [ "light_drizzle" ] }
   },
   {
     "id": "rain",

--- a/data/json/weather_type.json
+++ b/data/json/weather_type.json
@@ -87,7 +87,7 @@
     "animation": { "factor": 0.01, "color": "c_light_blue", "glyph": ",", "tile": "weather_rain_drop" },
     "sound_category": "drizzle",
     "sun_intensity": "light",
-    "requirements": { "pressure_max": 1003, "humidity_min": 90, "humidity_and_pressure": false, "required_weathers": [ "cloudy" ] }
+    "requirements": { "pressure_max": 1003, "humidity_min": 85, "humidity_and_pressure": false, "required_weathers": [ "cloudy" ] }
   },
   {
     "id": "drizzle",
@@ -107,7 +107,7 @@
     "animation": { "factor": 0.01, "color": "c_light_blue", "glyph": ".", "tile": "weather_rain_drop" },
     "sound_category": "drizzle",
     "sun_intensity": "light",
-    "requirements": { "pressure_max": 1000, "humidity_min": 95, "humidity_and_pressure": false, "required_weathers": [ "light_drizzle" ] }
+    "requirements": { "pressure_max": 1000, "humidity_min": 90, "humidity_and_pressure": false, "required_weathers": [ "light_drizzle" ] }
   },
   {
     "id": "rain",
@@ -121,7 +121,7 @@
     "light_modifier": -30,
     "sound_attn": 4,
     "dangerous": false,
-    "precip": "heavy",
+    "precip": "medium",
     "rains": true,
     "acidic": false,
     "animation": { "factor": 0.02, "color": "c_light_blue", "glyph": ",", "tile": "weather_rain_drop" },
@@ -129,7 +129,7 @@
     "sun_intensity": "light",
     "requirements": {
       "pressure_max": 993,
-      "humidity_min": 98,
+      "humidity_min": 95,
       "humidity_and_pressure": false,
       "required_weathers": [ "light_drizzle", "drizzle" ]
     }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9420,6 +9420,9 @@ detached_ptr<item> item::process_extinguish( detached_ptr<item> &&self, player *
         case precip_class::light:
             precipitation = one_in( 50 );
             break;
+        case precip_class::medium:
+            precipitation = one_in( 25 );
+            break;
         case precip_class::heavy:
             precipitation = one_in( 10 );
             break;

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -123,6 +123,9 @@ inline void proc_weather_sum( const weather_type_id wtype, weather_sum &data,
             case precip_class::light:
                 amount = 4 * to_turns<int>( tick_size );
                 break;
+            case precip_class::medium:
+                amount = 6 * to_turns<int>( tick_size );
+                break;
             case precip_class::heavy:
                 amount = 8 * to_turns<int>( tick_size );
                 break;
@@ -520,8 +523,9 @@ double precip_mm_per_hour( precip_class const p )
 {
     return
         p == precip_class::very_light ? 0.5 :
-        p == precip_class::light ? 1.5 :
-        p == precip_class::heavy ? 3   :
+        p == precip_class::light ? 1 :
+        p == precip_class::medium ? 2 :
+        p == precip_class::heavy ? 4 :
         0;
 }
 
@@ -539,6 +543,9 @@ void handle_weather_effects( const weather_type_id &w )
         } else if( w->precip == precip_class::light ) {
             wetness = 30;
             decay_time = 15_turns;
+        } else if( w->precip == precip_class::medium ) {
+            wetness = 45;
+            decay_time = 30_turns;
         } else if( w->precip == precip_class::heavy ) {
             decay_time = 45_turns;
             wetness = 60;

--- a/src/weather_type.cpp
+++ b/src/weather_type.cpp
@@ -22,6 +22,8 @@ std::string enum_to_string<precip_class>( precip_class data )
             return "very_light";
         case precip_class::light:
             return "light";
+        case precip_class::medium:
+            return "medium";
         case precip_class::heavy:
             return "heavy";
         case precip_class::last:

--- a/src/weather_type.h
+++ b/src/weather_type.h
@@ -20,6 +20,7 @@ enum class precip_class : int {
     none,
     very_light,
     light,
+    medium,
     heavy,
     last
 };


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

So a recurring complaint has been that it seems like it rains far less often than desirable. After a while of eyeballing the code, the weather JSON, and some testing in a test save, I eventually figured out a potential solution that should be a bit more effective than simply cranking base humidity up by a ton.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

C++ changes:
1. In item.cpp, added an extinguish case for `precip_class::medium` to `item::process_extinguish`, defining a chance to affect fires in between the chance used by light and heavy.
2. In weather.cpp, updated `proc_weather_sum` to have a handling case for `precip_class::medium` with an `amount` value in between light and heavy.
3. Also in weather.cpp, changed `precip_mm_per_hour` so light rainfall has a value of 1 instead of 1.5, and added handling for medium rainfall at a value of 2. Finally, heavy rainfall elevated from 3 mm to 4. This makes the rainfall levels neatly scale up as multiples of 2.
4. And finally in weather.cpp, set `handle_weather_effects` so that medium rainfall has wetness effects in between light and heavy.
5. Finally, defined `precip_class::light` in weather_type.cpp and .h.

Idea here is, per initial musings in alternatives section, adding a bit more granularity to rainfall levels will help counterbalance the more aggressive humidity range that Viss proposed, and fit with rain now being a solid chunk of humidity below the heavier rain levels instead of being up top where all the heavy-tier weather patterns are crammed.

One additional minor thing this does is make the water collection of drizzle a bit lighter and defining an in-between value for medium rain that fits in this scale, in exchange for how rainfall should trigger much more frequently. But since heavy rainfall is now a whole other thing and still as rare as ever, when it does trigger it will provide more water than before, making them more valuable for that purpose when they do trigger.

JSON changes:
1. In regional settings, bumped `base_humidity` from 70 to 75.
2. Reduced the `humidity_min` of light drizzle from 96 down to 85.
3. Reduced the `humidity_min` of regular drizzles from 97 down to 90.
4. Changed regular rain to use the new `medium` value for `precip`, and reduced its `humidity_min` from 98 to 95.
5. Per one extra bit of feedback, made it so in theory drizzle and rain can also both show up directly from cloudy weather, instead of only ever triggering from their respective precursor weather.

Idea is, far as I can tell the humidity code is measuring mainly the humidity at ground level, given this seems to be the same stat the hygrometer reads (and a quick test confirmed that a save that wasn't rainy at a given report of the hygrometer would load in as a drizzle if I lowered the required amount to just below what it says it is, but not just above it). From what I could find you could get precipitation IRL with ground level humidity as low as 60%, but since it would likely require a much wider range of granularity for rain rates I went with a level that's low enough to hit more frequently but not likely to cause constant rain.

As for the humidity boost, I decided to do a very light change based on quick google-fu that said the average humidity for Massachusetts in 2023 was 74.67%. Bumping it up a lil bit should give more room for conditions meeting the required rain levels but I'd be leery of giving it a giant boost.

This implements Viss' proposal of expanding the valid range of humidity for different precipitation types even more than my initial implementation did, making it much easier for light drizzle to potentially trigger based on how after nearly a full month's worth of waiting the humidity level only reached the initial new threshold once. With these changes, the previous test would've hit the level of light drizzle once a lot earlier, and the rainfall I did see would likely have upgraded from light drizzle to medium drizzle.

But to balance this increase in frequency, regular old rain now fills a new niche in the scale of water collection levels in between light and heavy, with the aim of making those rains more frequent but lighter, while in return the still-rare heavy rains are now better for water collection.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Diving deeper into the humidity and pressure code because I feel like something is secretly deeply fucking wrong with it in ways I alone ain't gonna be able to fix.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON for syntax and lint errors.
2. Compiled and load-tested.
3. Decided for the current test to start all the way on spring day 1, with 30-day seasons, and just waited a bunch of times until weather changes to make note of precipitation during an in-game year.
4. Checked affected C++ files for astyle.

Precipitation periods and humidity observed across a 120-day year:
* spring 5 (light drizzle, 85% )
* spring 7 to spring 8 (light drizzle, 61% !!!)
* spring 23 to spring 24 (light drizzle, 86%)
* summer 7 (light drizzle, 89%)
* summer 7 (drizzle, 100% !!!) continuation of previous event
* winter 1 (light drizzle, 86%)
* winter 11 (light drizzle, 85%)
* winter 11 - winter 12 (flurries, 90%) continuation of previous event
* winter 12 (light drizzle, 89%) continuation of previous event
* winter 18 - winter 19 (light drizzle, 53% !!!)

> tfw literally no rain all fucking fall blyat

Interestingly, two cases were observed where rain triggered well below the expected humidity. My guess is that it's because `humidity_and_pressure` is set to false for most of these weather types, which I assume makes it trigger the weather if EITHER pressure or humidity requirement is meant, and pressure ranges are still restrictive enough that I hadn't observed this happen until just now?

I also encountered a case of drizzle at 100% humidity despite the fact that it should've progressed to rain or worse given rain also has `humidity_and_pressure` set to false and didn't I literally just have the above oddball case of low-humidity light drizzle indicate that it's not an AND requirement what the fuck aaaa.

Bonus for plain clear weather on a reading of 91% humidity afterward, so I guess I'm settling for "slightly less insane and at least does what I asked of it" even if actual sanity is too much to ask of the code.

<details>
<summary>Screenshots;</summary>

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/137a3716-ab81-4edb-8d89-c5f417547592)

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/893ee4af-a3bf-45ad-add4-c41876177cb4)

Forgot to screenshot the third precipitation until the check after when it stopped raining, so highlighted message is the humidity reading taken during that period:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/c3c53bc1-ba1e-46e1-9a40-77bf39035c20)

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/64cbf0ac-e3a0-42cc-8660-afe40b7bf9cf)

Uhhhh!?
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/98a640fc-7729-4576-a831-2ddd31aef589)

Reading for 1st of winter rain event, forgot to screenshot it right on taking the reading again:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/bc27c720-f254-4e49-88b9-fde7a67365eb)

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/102f7444-f18a-4828-a9e8-7b3ed8666673)

Full readings of winter 11/12 event:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/79c1af58-8801-4440-8b55-9090b47b9414)

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/0175832b-78ff-4ed3-856e-082bd88cda93)

</details>

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

![pokemon-rain-dance](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/e9c1dcd8-28eb-4057-a5a8-7ebdf710fd38)

Far as I can tell, our root cause for what so badly fucked up weather in both DDA and BN ever since was this PR by @Kodiologist: https://github.com/CleverRaven/Cataclysm-DDA/pull/34515 The JSON change itself was minor and actually increased humidity, and the weather types were basically unchanged by that PR (all hardcoded back then), so my only guess was some aspect of janky changes to pressure and/or humidity variation is the actual root cause of why the weather code has been so awful for the past 4-5 years.

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
