### PR TITLE
feat(content): grenade bandolier

### DIFF
--- a/data/json/items/armor/bandolier.json
+++ b/data/json/items/armor/bandolier.json
@@ -266,7 +266,7 @@
   {
     "id": "bandolier_grenade",
     "type": "ARMOR",
-    "name": { "str": "grenade bandolier" },
+    "name": { "str": "grenade ammo bandolier" },
     "description": "A leather bandolier for keeping cartridge grenades close to hand.",
     "weight": "140 g",
     "volume": "250 ml",

--- a/data/json/items/armor/bandolier.json
+++ b/data/json/items/armor/bandolier.json
@@ -262,5 +262,25 @@
     },
     "valid_mods": [ "resized_large" ],
     "flags": [ "WATER_FRIENDLY", "BELTED", "COMPACT" ]
+  },
+  {
+    "id": "bandolier_grenade",
+    "type": "ARMOR",
+    "name": { "str": "grenade bandolier" },
+    "description": "A leather bandolier for keeping cartridge grenades close to hand.",
+    "weight": "140 g",
+    "volume": "250 ml",
+    "price": "19 USD",
+    "price_postapoc": "15 USD",
+    "material": [ "leather" ],
+    "symbol": "[",
+    "looks_like": "bandolier_rifle",
+    "color": "dark_gray",
+    "covers": [ "torso" ],
+    "coverage": 10,
+    "encumbrance": 1,
+    "material_thickness": 1,
+    "use_action": { "type": "bandolier", "capacity": 12, "ammo": [ "40x46mm", "40x53mm" ], "draw_cost": 20 },
+    "flags": [ "WATER_FRIENDLY", "WAIST", "OVERSIZE" ]
   }
 ]

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -990,7 +990,7 @@
     "subcategory": "CSC_ARMOR_STORAGE",
     "skill_used": "tailor",
     "difficulty": 3,
-    "skills_required": [ [ "gun", 1 ], [ "launcher", 1 ] ],
+    
     "time": "1 h 20 m",
     "autolearn": true,
     "using": [ [ "sewing_standard", 10 ] ],

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -990,7 +990,6 @@
     "subcategory": "CSC_ARMOR_STORAGE",
     "skill_used": "tailor",
     "difficulty": 3,
-    
     "time": "1 h 20 m",
     "autolearn": true,
     "using": [ [ "sewing_standard", 10 ] ],

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -982,5 +982,18 @@
     "autolearn": true,
     "using": [ [ "sewing_standard", 5 ] ],
     "components": [ [ [ "fabric_standard", 3, "LIST" ], [ "fabric_hides_any", 3, "LIST" ] ] ]
+  },
+  {
+    "result": "bandolier_grenade",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_STORAGE",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "skills_required": [ [ "gun", 1 ], [ "launcher", 1 ] ],
+    "time": "1 h 20 m",
+    "autolearn": true,
+    "using": [ [ "sewing_standard", 10 ] ],
+    "components": [ [ [ "leather", 8 ] ] ]
   }
 ]


### PR DESCRIPTION
## Purpose of change

The following is a copy of @Tefnut PR #4539 on grenade bandoliers created due to issues with their branch. Co-authorship maintained, and description of PR maintained. For any inquiries in the PR and suggestions ask Tefnut.

Shotguns, pistols, and rifles have an over-the-shoulder bandolier. While the impact of adding an option for grenade launchers is minimal, it helps legitimize them as an option. They technically had a grenade pouch prior, but a bandolier option is something a post-cataclysm survivor would certainly think of.

## Describe the solution

I added them and a recipe, copy-pasted from rifle bandoliers with their name, description, and accepted ammo replaced. They have half the capacity due to using bulkier ammo, but I'd say that they'd be fairly balanced still.

## Describe alternatives you've considered

Not have grenade bandoliers
Buff grenade pouches slightly

## Testing

Loaded game.
Made sure they worked.
Made sure the recipe loaded.

## Additional context

While not something likely commercially sold, I feel like any post-cataclysm survivor who was lucky enough to find a grenade launcher or a stash of HEDP and the tools to make a pipe launcher would have considered a grenade bandolier.

Second PR, woo, it only took 2 tries.

Fox's Notes: Two tries you say? Also, whoever named grenade pouch in the JSON ID's to "grenadebandolier" is a criminal. Now we have "bandolier_grenade" and "grenadebandolier" and it's not worth fixing the item ID right now.
