### PR TITLE
feat(UI): trim some more iteminfo when not required, show range mod for gunmods

### DIFF
--- a/src/iteminfo_query.h
+++ b/src/iteminfo_query.h
@@ -117,6 +117,7 @@ enum class iteminfo_parts : size_t {
     GUNMOD_DAMAGE,
     GUNMOD_ARMORPIERCE,
     GUNMOD_HANDLING,
+    GUNMOD_RANGE,
     GUNMOD_AMMO,
     GUNMOD_RELOAD,
     GUNMOD_STRENGTH,

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -712,9 +712,8 @@ TEST_CASE( "ammunition", "[item][iteminfo][ammo]" )
             "test_rock", q,
             "--\n"
             "<color_c_white>Ammunition type</color>: rocks\n"
-            "Damage: <color_c_yellow>7</color>  Armor-pierce: <color_c_yellow>0</color>\n"
-            "Range: <color_c_yellow>10</color>  Dispersion: <color_c_yellow>14</color>\n"
-            "Recoil: <color_c_yellow>0</color>" );
+            "Damage: <color_c_yellow>7</color>\n"
+            "Range: <color_c_yellow>10</color>  Dispersion: <color_c_yellow>14</color>\n" );
     }
 }
 


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

I'd been meaning to rig it so that a bit more iteminfo stuff gets trimmed when it's not nessecary, and also found out in testing that there was a case of an iteminfo property not displaying at all when it probably should, so that finally gave me motivation to mess with this a bit more.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. In item.cpp, moved some values in `item::ammo_info` higher up since they get used a bit earlier than normal. Rigged it so that now, damage and armor values are not displayed for ammo unless they're actually defined. The reason for the values being moved up is to fix a newline issue, where if an ammo has damage and range but not arpen, it'd fail to move range+dispersion to the next line down since normally the needed newline is called for by armor-pierce info. Now damage info either calls for a newline or doesn't depending on whether armor info is present too.
2. Also in item.cpp, set `item::ammo_info` so that range, dispersion, and recoil info only shows if non-zero.
3. And in item.cpp, set `item::gun_info` so that damage multiplier and armor multiplier info is only showed if either the weapon or the ammo has a multiplier actually defined. If both are 1x then it's simply omitted.
4. And lastly in item.cpp, set `item::gunmod_info` so that range modifier is shown if present.
5. In iteminfo_query.h, defined `iteminfo_parts::GUNMOD_RANGE` for the above to use.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Spawned in a rifle round, observed that damage and arpen info showed as normal.
3. Spawned in an aluminum broadhead arrow, info is omitted except range and dispersion.
4. Spawned in an aluminum field point arrow, it correctly still shows damage multiplier and arpen+armor mult.
5. Spawned in an aluminum small game arrow, it correctly shows damage mult but not armor mult.
6. Spawned in some thread, it correctly shows nothing in that area but ammotype.
7. Spawned in an M1911, it doesn't show damage and armor multipliers anymore since those are at defaults.
8. Spawned in a longbow while only having 8 strength, it doesn't show armor mult but does show damage mult since it's penalized due to low strength.
9. Spawned in a beam scatterer, confirmed it shows range mod now.
10. Checked affected files for astyle.

<details>
<summary>Screenshots:</summary>

5.45 round:
![1](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/e57c2644-5998-4dfd-9822-e94e448421df)

Aluminum broadhead arrow:
![2](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/66ab1a7a-992b-4082-ac76-0fa2cd3d7ff4)

Aluminum field point arrow
![3](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/a93d6859-b40d-4e89-8bcc-00b1e6b7fd86)

Aluminum small game arrow
![4](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/8a479c05-0c32-43ae-873a-bd6fa47cd6fe)

Thread:
![5](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/ab4e89c2-7e95-446a-8f29-c88168553c43)

M1911:
![6](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/2c781a48-f288-4719-b699-6e97d3aa762a)

Longbow at 8 strength:
![7](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/cf45495d-f6b4-455a-8d94-1ddd32cd6d51)

Beam scatterer:
![8](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/b42e7bce-3e4b-4fdb-969b-a83231cdd633)

</details>

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
