### PR TITLE
feat: zombie soldier can grab and scratch

### DIFF
--- a/data/json/monsters/zed_soldiers.json
+++ b/data/json/monsters/zed_soldiers.json
@@ -28,7 +28,7 @@
     "vision_day": 30,
     "vision_night": 3,
     "harvest": "zombie_maybe_mil_bionics",
-    "special_attacks": [ { "type": "bite", "cooldown": 5, "min_mul": 0.8 } ],
+    "special_attacks": [ { "type": "bite", "cooldown": 5, "min_mul": 0.8 }, [ "GRAB", 7 ], [ "scratch", 20 ] ],
     "death_drops": "mon_zombie_soldier_death_drops",
     "death_function": [ "NORMAL" ],
     "upgrades": { "half_life": 28, "into_group": "GROUP_SOLDIER_UPGRADE" },


### PR DESCRIPTION
## Purpose of change
Give grab and scratch special attacks to the zombie soldier.
## Describe the solution
Add `GRAB` and `scratch` to `mon_zombie_soldier` special attacks.
## Describe alternatives you've considered
none
## Additional context
<img width="490" alt="image1" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/dae4451f-5113-476d-ac00-28b1d989e7d5">