### PR TITLE
fix: misaligned ladder, use `roof_palette` on `bank_roof`

### DIFF
--- a/data/json/mapgen/bank.json
+++ b/data/json/mapgen/bank.json
@@ -89,6 +89,7 @@
     "method": "json",
     "om_terrain": "bank_roof",
     "object": {
+      "palettes": [ "roof_palette" ],
       "fill_ter": "t_flat_roof",
       "rows": [
         "                        ",
@@ -111,23 +112,12 @@
         " |....................3 ",
         " |............=.......3 ",
         " |....................3 ",
-        " |........>.....&.....3 ",
-        " 5....................3 ",
+        " |..............&.....3 ",
+        " 5..........>.........3 ",
         " ---------------------- ",
         "                        "
       ],
-      "terrain": {
-        ".": "t_flat_roof",
-        " ": "t_open_air",
-        "2": "t_gutter_north",
-        "-": "t_gutter_south",
-        "3": "t_gutter_east",
-        "|": "t_gutter_west",
-        ">": "t_ladder_down",
-        "o": "t_glass_roof",
-        "5": "t_gutter_drop"
-      },
-      "furniture": { "&": "f_roof_turbine_vent", "=": "f_vent_pipe" },
+      "terrain": { ">": "t_ladder_down" },
       "place_nested": [
         {
           "chunks": [ [ "null", 20 ], [ "roof_2x2_utilities_b", 15 ], [ "roof_2x2_utilities_c", 5 ], [ "roof_2x2_utilities_d", 40 ] ],


### PR DESCRIPTION
## Purpose of change
Fix misaligned ladder on the roof and use `roof_palette`.
## Describe the solution
JSON change.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/dba3f621-f9bc-4bf5-85f8-8694b14e19f7">
After:
<img width="960" alt="image2" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/e2c642fe-2999-41e3-95de-ba2da7d0f6c0">