### PR TITLE
fix(balance): Fix Plated Leather Skirt's Weight Value

### DIFF
--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -382,7 +382,7 @@
     "type": "ARMOR",
     "name": { "str_sp": "plated leather skirt" },
     "description": "An armored skirt made of leather with metal plates expertly sewn into it.  It's not as protective as proper leg armor, but it's also far more tolerable to wear in the summer and far easier to move in.",
-    "weight": "640 g",
+    "weight": "1300 g",
     "material": [ "leather", "iron" ],
     "price_postapoc": "175 cent",
     "encumbrance": 6


### PR DESCRIPTION
## Purpose of change

Evidently, adding steel to a leather skirt actually makes the skirt lighter! Who knew, we must now inform scientists everywhere that steel has a negative mass when it is added to things.

In all seriousness, this seems like a silly little mistake regarding which weight value to adjust from.

## Describe the solution

Adds the weight value of the scrap metal used in the recipe to the weight of the precursor armored leather skirt to get the proper value for the plated leather skirt.

## Describe alternatives you've considered

- Leave in the harmless bug

## Testing

It loads.

## Additional context

Armored Leather Skirt:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/30732426/7e8416fe-dd55-4463-b5a7-98cea767354c)

Previous Plated Skirt:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/30732426/28cf4532-75bb-47bc-843c-ccdeca306e20)

New Plated Skirt:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/30732426/b385ac0d-5dc1-4176-9e55-8d40997eedad)
