### PR TITLE
fix: don't give holdout npc missions to starter npcs

### DIFF
--- a/data/json/npcs/cabin_chemist/chemist_missions.json
+++ b/data/json/npcs/cabin_chemist/chemist_missions.json
@@ -9,7 +9,7 @@
     "count": 1,
     "difficulty": 2,
     "value": 3000,
-    "origins": [ "ORIGIN_OPENER_NPC" ],
+    "origins": [ "ORIGIN_SECONDARY" ],
     "followup": "MISSION_CABIN_CHEMIST_GET_60_chem_muriatic_acid",
     "has_generic_rewards": true,
     "dialogue": {
@@ -35,7 +35,7 @@
     "count": 60,
     "difficulty": 7,
     "value": 10000,
-    "origins": [ "ORIGIN_OPENER_NPC" ],
+    "origins": [ "ORIGIN_SECONDARY" ],
     "end": { "effect": [ { "npc_add_var": "mass_chem_tradeable", "type": "dialogue", "context": "trade", "value": "yes" } ] },
     "followup": "MISSION_CABIN_CHEMIST_GET_500_GAS",
     "has_generic_rewards": true,
@@ -63,7 +63,7 @@
     "count": 100000,
     "difficulty": 10,
     "value": 1600000,
-    "origins": [ "ORIGIN_OPENER_NPC" ],
+    "origins": [ "ORIGIN_SECONDARY" ],
     "followup": "MISSION_CABIN_CHEMIST_SET_TRADE_ROUTE",
     "has_generic_rewards": true,
     "dialogue": {
@@ -88,7 +88,7 @@
     "count": 1,
     "difficulty": 30,
     "value": 20000,
-    "origins": [ "ORIGIN_OPENER_NPC" ],
+    "origins": [ "ORIGIN_SECONDARY" ],
     "start": { "assign_mission_target": { "om_terrain": "evac_center_18", "om_special": "evac_center", "reveal_radius": 0 } },
     "has_generic_rewards": true,
     "dialogue": {

--- a/data/json/npcs/homeless/group_camp_missions.json
+++ b/data/json/npcs/homeless/group_camp_missions.json
@@ -9,7 +9,7 @@
     "count": 6,
     "difficulty": 1,
     "value": 4000,
-    "origins": [ "ORIGIN_OPENER_NPC" ],
+    "origins": [ "ORIGIN_SECONDARY" ],
     "followup": "MISSION_HUNT_ANTS",
     "start": {
       "assign_mission_target": { "om_terrain": "field", "reveal_radius": 1, "random": true, "search_range": 15, "min_distance": 10 },
@@ -38,7 +38,7 @@
     "count": 10,
     "difficulty": 1,
     "value": 4000,
-    "origins": [ "ORIGIN_OPENER_NPC" ],
+    "origins": [ "ORIGIN_SECONDARY" ],
     "followup": "MISSION_BUILD_CAMP_1",
     "start": {
       "assign_mission_target": { "om_terrain": "field", "reveal_radius": 1, "random": true, "search_range": 15 },
@@ -68,7 +68,7 @@
     "count": 100,
     "difficulty": 1,
     "value": 10000,
-    "origins": [ "ORIGIN_OPENER_NPC" ],
+    "origins": [ "ORIGIN_SECONDARY" ],
     "followup": "MISSION_BUILD_CAMP_2",
     "end": {
       "update_mapgen": { "om_terrain": "homelesscamp", "place_nested": [ { "chunks": [ "homeless_camp_refurb_1" ], "x": 0, "y": 0 } ] }
@@ -96,7 +96,7 @@
     "count": 150,
     "difficulty": 1,
     "value": 15000,
-    "origins": [ "ORIGIN_OPENER_NPC" ],
+    "origins": [ "ORIGIN_SECONDARY" ],
     "followup": "MISSION_BUILD_CAMP_3",
     "end": {
       "update_mapgen": { "om_terrain": "homelesscamp", "place_nested": [ { "chunks": [ "homeless_camp_refurb_2" ], "x": 0, "y": 0 } ] }
@@ -131,7 +131,7 @@
     },
     "difficulty": 1,
     "value": 2500,
-    "origins": [ "ORIGIN_OPENER_NPC" ],
+    "origins": [ "ORIGIN_SECONDARY" ],
     "followup": "MISSION_BUILD_CAMP_4",
     "end": {
       "update_mapgen": { "om_terrain": "homelesscamp", "place_nested": [ { "chunks": [ "homeless_camp_refurb_3" ], "x": 0, "y": 0 } ] }
@@ -159,7 +159,7 @@
     "goal_condition": { "or": [ { "u_has_item": "saw" }, { "u_has_item": "bow_saw" }, { "u_has_item": "misc_repairkit" } ] },
     "difficulty": 1,
     "value": 2500,
-    "origins": [ "ORIGIN_OPENER_NPC" ],
+    "origins": [ "ORIGIN_SECONDARY" ],
     "followup": "MISSION_BUILD_CAMP_5",
     "has_generic_rewards": true,
     "dialogue": {
@@ -184,7 +184,7 @@
     "count": 1,
     "difficulty": 1,
     "value": 2500,
-    "origins": [ "ORIGIN_OPENER_NPC" ],
+    "origins": [ "ORIGIN_SECONDARY" ],
     "followup": "MISSION_BUILD_CAMP_6",
     "end": {
       "update_mapgen": { "om_terrain": "homelesscamp", "place_nested": [ { "chunks": [ "homeless_camp_refurb_4" ], "x": 0, "y": 0 } ] }
@@ -213,7 +213,7 @@
     "count": 1,
     "difficulty": 1,
     "value": 5000,
-    "origins": [ "ORIGIN_OPENER_NPC" ],
+    "origins": [ "ORIGIN_SECONDARY" ],
     "end": {
       "update_mapgen": { "om_terrain": "homelesscamp", "place_nested": [ { "chunks": [ "homeless_camp_refurb_5" ], "x": 0, "y": 0 } ] },
       "effect": [ { "npc_add_var": "smoked_meat_tradeable", "type": "dialogue", "context": "trade", "value": "yes" } ]

--- a/data/json/npcs/scrap_trader/scrap_trader_missions.json
+++ b/data/json/npcs/scrap_trader/scrap_trader_missions.json
@@ -9,7 +9,7 @@
     "count": 5,
     "difficulty": 2,
     "value": 10000,
-    "origins": [ "ORIGIN_OPENER_NPC" ],
+    "origins": [ "ORIGIN_SECONDARY" ],
     "followup": "MISSION_SCRAP_TRADER_GET_75_CHARCOAL",
     "end": { "effect": [ { "npc_add_var": "specific_metal_tradeable", "type": "dialogue", "context": "trade", "value": "yes" } ] },
     "has_generic_rewards": true,
@@ -35,7 +35,7 @@
     "count": 75,
     "difficulty": 4,
     "value": 7500,
-    "origins": [ "ORIGIN_OPENER_NPC" ],
+    "origins": [ "ORIGIN_SECONDARY" ],
     "followup": "MISSION_SCRAP_TRADER_GET_100_SOLDER",
     "has_generic_rewards": true,
     "dialogue": {
@@ -60,7 +60,7 @@
     "count": 100,
     "difficulty": 3,
     "value": 8000,
-    "origins": [ "ORIGIN_OPENER_NPC" ],
+    "origins": [ "ORIGIN_SECONDARY" ],
     "followup": "MISSION_SCRAPPER_SET_TRADE_ROUTE",
     "has_generic_rewards": true,
     "dialogue": {
@@ -85,7 +85,7 @@
     "count": 1,
     "difficulty": 35,
     "value": 10000,
-    "origins": [ "ORIGIN_OPENER_NPC" ],
+    "origins": [ "ORIGIN_SECONDARY" ],
     "start": { "assign_mission_target": { "om_terrain": "evac_center_18", "om_special": "evac_center", "reveal_radius": 0 } },
     "has_generic_rewards": true,
     "dialogue": {


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This fixes the new missions added by Zlor's NPC ports recently inexplicably showing up on starter NPCs.

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/4583

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Set the homeless camp NPC missions from `ORIGIN_OPENER_NPC` to `ORIGIN_SECONDARY`.
2. Set the chemist NPC missions from `ORIGIN_OPENER_NPC` to `ORIGIN_SECONDARY`.
3. Set the scrap trader NPC missions from `ORIGIN_OPENER_NPC` to `ORIGIN_SECONDARY`.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Used my eyes.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
