### PR TITLE
fix: replace radio tower stairs with ladders

### DIFF
--- a/data/json/mapgen/bugs/wasp_tower.json
+++ b/data/json/mapgen/bugs/wasp_tower.json
@@ -41,7 +41,7 @@
         "|": "t_chainfence_v",
         "6": "t_radio_controls",
         "_": "t_pavement",
-        "<": "t_stairs_up"
+        "<": "t_ladder_up"
       },
       "nested": {
         " ": { "chunks": [ [ "null", 50 ], [ "wasp_gibs", 10 ] ] },
@@ -93,7 +93,7 @@
         "_": "t_pavement",
         "+": [ "t_door_c", [ "t_door_b", 3 ], [ "t_door_frame", 3 ] ],
         "4": "t_gutter_downspout",
-        "<": "t_stairs_up",
+        "<": "t_ladder_up",
         "w": [ "t_window", [ "t_window_frame", 3 ], [ "t_window_empty", 3 ] ]
       },
       "furniture": { "C": "f_counter", "r": "f_rack", "h": "f_chair", "l": "f_locker" },
@@ -126,12 +126,12 @@
         "          Raaa,R        ",
         "                        ",
         "                        ",
-        "         ...........3   ",
-        "         ...........5   ",
-        "         ...........3   ",
-        "         .......&...3   ",
-        "          R   ......3   ",
-        "              ......3   ",
+        "         -----------    ",
+        "         -.........5    ",
+        "         -.........-    ",
+        "         ------.&..-    ",
+        "          R   -....-    ",
+        "              ------    ",
         "                        ",
         "                        ",
         "                        ",
@@ -141,7 +141,7 @@
         "                        "
       ],
       "palettes": [ "roof_palette" ],
-      "terrain": { "R": "t_radio_tower", "a": "t_railing", ",": "t_metal_floor_no_roof", "±": "t_ladder_up_down" }
+      "terrain": { "R": "t_radio_tower", "a": "t_railing", ",": "t_metal_floor_no_roof", "±": "t_ladder_up_down", "&": "t_flat_roof" }
     }
   },
   {

--- a/data/json/mapgen/radio_tower.json
+++ b/data/json/mapgen/radio_tower.json
@@ -41,7 +41,7 @@
         "|": "t_chainfence_v",
         "6": "t_radio_controls",
         "_": "t_pavement",
-        "<": "t_stairs_up"
+        "<": "t_ladder_up"
       }
     }
   },
@@ -89,7 +89,7 @@
         "_": "t_pavement",
         "+": "t_door_c",
         "4": "t_gutter_downspout",
-        "<": "t_stairs_up",
+        "<": "t_ladder_up",
         "w": "t_window"
       },
       "furniture": { "C": "f_counter", "r": "f_rack", "h": "f_chair", "l": "f_locker" },
@@ -118,12 +118,12 @@
         "          Raaa,R        ",
         "                        ",
         "                        ",
-        "         ..........-    ",
-        "         ..........5    ",
-        "         ..........-    ",
-        "         .......&..-    ",
-        "          R   .....-    ",
-        "              .....-    ",
+        "         -----------    ",
+        "         -.........5    ",
+        "         -.........-    ",
+        "         ------.&..-    ",
+        "          R   -....-    ",
+        "              ------    ",
         "                        ",
         "                        ",
         "                        ",
@@ -277,7 +277,7 @@
         "                        "
       ],
       "palettes": [ "roof_palette" ],
-      "terrain": { "R": "t_radio_tower", "a": "t_railing", ",": "t_metal_floor_no_roof", ">": "t_stairs_down" },
+      "terrain": { "R": "t_radio_tower", "a": "t_railing", ",": "t_metal_floor_no_roof", ">": "t_ladder_down" },
       "place_nested": [
         {
           "chunks": [

--- a/data/json/mapgen_palettes/wasp_palette.json
+++ b/data/json/mapgen_palettes/wasp_palette.json
@@ -13,8 +13,8 @@
       "a": "t_railing",
       ",": "t_metal_floor_no_roof",
       "±": "t_ladder_up_down",
-      "<": "t_stairs_up",
-      ">": "t_stairs_down",
+      "<": "t_ladder_up",
+      ">": "t_ladder_down",
       ":": "t_null",
       "#": "t_metal_floor_no_roof"
     },


### PR DESCRIPTION
## Purpose of change
Replace the stair at the base and top of the radio tower and wasp radio tower with ladder.
Also fix `radio_tower_roof_1`, `wasp_tower_roof_1`.
## Describe the solution
`t_ladder_up` instead of `t_stairs_up`
`t_ladder_down` instead of `t_stairs_down`
## Describe alternatives you've considered
none
## Additional context
`radio_tower_roof_1`:
<img width="960" alt="image1" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/170235b0-5170-48ea-ab52-ba5afeddd3e1">
`wasp_tower_roof_1`:
<img width="960" alt="image2" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/d81649f5-5145-4794-b3de-85ff1fd18b26">