### PR TITLE
fix: Specific guns now have correct `copy-from` to fix their weapon categories.

### DIFF
--- a/data/json/items/gun/22.json
+++ b/data/json/items/gun/22.json
@@ -44,7 +44,7 @@
   },
   {
     "id": "moss_brownie",
-    "copy-from": "pistol_base",
+    "copy-from": "pistol_1shot",
     "type": "GUN",
     "name": { "str_sp": "Mossberg Brownie" },
     "description": "The first gun produced by O.F. Mossberg & Sons.  A small pocket pistol, marketed to trappers during the early 20th century.  Its four barrels can accept .22 Short and .22 LR cartridges.",

--- a/data/json/items/gun/762.json
+++ b/data/json/items/gun/762.json
@@ -56,7 +56,7 @@
   },
   {
     "id": "sks",
-    "copy-from": "rifle_manual",
+    "copy-from": "rifle_semi",
     "type": "GUN",
     "name": { "str": "SKS" },
     "description": "Developed by the Soviets in 1945, this rifle was quickly replaced by the full-auto AK47.  However, due to its superb accuracy, low recoil and deployable integrated bayonet, this gun maintains immense popularity.",

--- a/data/json/items/gun/shot.json
+++ b/data/json/items/gun/shot.json
@@ -272,7 +272,7 @@
   },
   {
     "id": "pipe_shotgun",
-    "copy-from": "shotgun_base",
+    "copy-from": "shotgun_1shot",
     "type": "GUN",
     "name": { "str": "pipe shotgun" },
     "description": "A home-made shotgun.  It is simply a pipe attached to a stock, with a hammer to strike the single round it holds.",
@@ -670,7 +670,7 @@
   },
   {
     "id": "winchester_1897",
-    "copy-from": "shotgun_base",
+    "copy-from": "shotgun_pump",
     "type": "GUN",
     "name": { "str": "M1897 Trench Gun" },
     "description": "The Winchester 1897 was one of the first commercially successful pump action shotguns.  In its 'trench' configuration it has become a heavily romanticized American icon of World War 1.  With its barrel shroud, bayonet lug and 17 inch bayonet, this shotgun is undeniably fearsome in appearance.  There aren't any more trenches to clear, so the next zombie infested town will have to suffice.",


### PR DESCRIPTION
## Purpose of change

A long time ago someone on the discord noted that several guns have the wrong categories applied, I checked and agreed, and changed the copy-from so that they now point at the right category.

## Describe the solution

Change `copy-from` for the following guns.
- Mossberg Brownie: `pistol_base` -> `pistol_1shot` 
- SKS: `rifle_manual` -> `rifle_semi`
- Pipe Shotgun: `shotgun_base` -> `shotgun_1shot`
- M1897 Trench Gun: `shotgun_base` -> `shotgun_pump`

## Describe alternatives you've considered

Leaving it alone until someone points it out again.

## Testing

Load up the game, check that:
- Mossberg Brownie is now in One Shot category
- SKS is now in Autoloading category
- Pipe Shotgun is now in One Shot category.
- M1897 Trench Gun is now in Manual Action category
 
## Additional context

I made derringers count as 1 shot guns due to their barrel arrangement, we could probably make them into another abstract that uses manual action to separate them from true 1shot guns that lack any kind of rotating firing pin or similar mechanism.

## Checklist
