### PR TITLE
feat(balance): updates to firestarting tools

### DIFF
--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -185,7 +185,7 @@
     "ammo_type": "components",
     "stack_size": 200,
     "count": 30,
-    "flags": [ "UNRECOVERABLE" ]
+    "flags": [ "UNRECOVERABLE", "TINDER" ]
   },
   {
     "type": "AMMO",
@@ -397,7 +397,7 @@
     "color": "brown",
     "description": "Feathers from a bird.  Useful for fletching arrows.",
     "material": "cotton",
-    "flags": [ "NO_SALVAGE" ],
+    "flags": [ "NO_SALVAGE", "TINDER" ],
     "volume": "250 ml",
     "weight": "1 g",
     "ammo_type": "components",
@@ -415,7 +415,7 @@
     "color": "brown",
     "description": "Fluffy down feathers from a bird.  Useful for making cozy bedclothes.",
     "material": "cotton",
-    "flags": [ "NO_SALVAGE" ],
+    "flags": [ "NO_SALVAGE", "TINDER" ],
     "volume": "250 ml",
     "weight": "1 g",
     "ammo_type": "components",
@@ -696,7 +696,8 @@
     "ammo_type": "charcoal",
     "count": 50,
     "stack_size": 10,
-    "fuel": { "energy": 1.6 }
+    "fuel": { "energy": 1.6 },
+    "flags": [ "TINDER" ]
   },
   {
     "type": "AMMO",
@@ -734,7 +735,8 @@
     "ammo_type": "charcoal",
     "count": 250,
     "stack_size": 10,
-    "fuel": { "energy": 30 }
+    "fuel": { "energy": 30 },
+    "flags": [ "TINDER" ]
   },
   {
     "type": "AMMO",

--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -473,7 +473,7 @@
     "symbol": "*",
     "color": "white",
     "container": "bag_plastic",
-    "flags": [ "NO_INGEST" ],
+    "flags": [ "NO_INGEST", "TINDER" ],
     "use_action": { "type": "heal", "bandages_power": 2, "bleed": 0.9, "move_cost": 300 }
   },
   {

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -182,7 +182,7 @@
     "weight": "20 g",
     "volume": "250 ml",
     "to_hit": -2,
-    "flags": [ "TRADER_AVOID", "NO_SALVAGE" ]
+    "flags": [ "TRADER_AVOID", "NO_SALVAGE", "TINDER" ]
   },
   {
     "type": "GENERIC",
@@ -1891,7 +1891,7 @@
     "weight": "220 g",
     "volume": "500 ml",
     "to_hit": -2,
-    "flags": [ "TRADER_AVOID" ]
+    "flags": [ "TRADER_AVOID", "TINDER" ]
   },
   {
     "type": "GENERIC",
@@ -2293,7 +2293,7 @@
     "category": "spare_parts",
     "description": "A pile of dry grass.  Can be used to craft a straw bed if there is nothing else to sleep on.",
     "material": [ "dry_plant" ],
-    "flags": [ "TRADER_AVOID" ],
+    "flags": [ "TRADER_AVOID", "TINDER" ],
     "weight": "20 g",
     "volume": "250 ml",
     "to_hit": -2
@@ -2444,7 +2444,7 @@
     "weight": "1 g",
     "description": "A true gentleman always finishes his cigars.",
     "category": "other",
-    "flags": [ "TRADER_AVOID" ]
+    "flags": [ "TRADER_AVOID", "TINDER" ]
   },
   {
     "type": "GENERIC",
@@ -2476,7 +2476,7 @@
     "description": "What was once a wonderfully addictive tube of dried tobacco leaf is now just a smelly piece of trash.  What a tragedy!\nThe leftover tobacco in a few of these could probably be used to roll another cigarette.  If you're willing to go that far…",
     "category": "other",
     "weight": "1 g",
-    "flags": [ "TRADER_AVOID" ]
+    "flags": [ "TRADER_AVOID", "TINDER" ]
   },
   {
     "type": "GENERIC",
@@ -2508,7 +2508,7 @@
     "description": "The smoked-down butt of a joint, a reminder of some good times.  Pretty much trash now.  Bummer, man.\nA few of these could probably be used to roll another joint.",
     "category": "other",
     "weight": "1 g",
-    "flags": [ "TRADER_AVOID" ]
+    "flags": [ "TRADER_AVOID", "TINDER" ]
   },
   {
     "type": "GENERIC",

--- a/data/json/items/resources/wood.json
+++ b/data/json/items/resources/wood.json
@@ -173,7 +173,7 @@
     "description": "A hunk of dried plant matter condensed into a puck, then dried.  It burns well.",
     "material": "dry_plant",
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "TRADER_AVOID", "FIREWOOD" ],
+    "flags": [ "TRADER_AVOID", "FIREWOOD", "TINDER" ],
     "weight": "240 g",
     "volume": "3000 ml",
     "looks_like": "straw_pile",

--- a/data/json/items/tool/fire.json
+++ b/data/json/items/tool/fire.json
@@ -48,7 +48,7 @@
     "max_charges": 50,
     "charges_per_use": 1,
     "use_action": { "type": "firestarter", "moves": 500, "moves_slow": 25000 },
-    "flags": [ "FIRESTARTER" ]
+    "flags": [ "FIRESTARTER", "REQUIRES_TINDER" ]
   },
   {
     "id": "fire_drill_large",
@@ -67,7 +67,7 @@
     "max_charges": 500,
     "charges_per_use": 1,
     "use_action": { "type": "firestarter", "moves": 200, "moves_slow": 10000 },
-    "flags": [ "FIRESTARTER" ]
+    "flags": [ "FIRESTARTER", "REQUIRES_TINDER" ]
   },
   {
     "id": "flint_steel",
@@ -259,7 +259,7 @@
         "type": "transform"
       }
     ],
-    "flags": [ "FIRESTARTER" ]
+    "flags": [ "FIRESTARTER", "SLEEP_IGNORE" ]
   },
   {
     "id": "electric_lighter",


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Some adjustments to firestarting tools and related items. In particular making ember carriers a bit less bothersome to work with, while making the tinder mechanic used on a couple more tools in exchange for allowing more items to be used for that.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Added the `REQUIRES_TINDER` flag to fire drills and camp fire drills. These are even more work to light a fire with than a flint and steel, which was the only item to have this flag.
2. Added `SLEEP_IGNORE` to light ember carriers. As oddball of an item as they are, I've found them to be really useful for extreme innawoods runs where keeping a slow-burning fire on hand is a lot less trouble than fiddling with flint and steel and helps skip some potential issues when in the dark, but the main drawback with it is it expects you to keep it burning for long periods of them. Not pestering you about sleeping with it on will help make it more usable for that purpose.
3. Added the `TINDER` flag to several more items that might reasonable be useful fodder for starting a fire: rolling paper, feathers, down feathers, coal/charcoal, withered plants, pine boughs, straw piles, cigarette butts and related, cotton balls, and fuel briquette.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Adding `TINDER` flag to splintered wood to make things slightly easier, or any other items that others feel may be appropriate.
2. Alternatively, phasing out the `REQUIRES_TINDER` flag for now. In particular, I kinda would like for the fireplace examine action to automatically target an item with the `TINDER` flag as its first choice of fuel if the selected firestarter has the relevant flag, so that tinder gets used automatically from firewood sources. Not sure how to implement that though.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

1. Checked affected files for syntax and lint errors.
2. Checked in compiled test build that pine boughs and other non-ammo items are accepted as tinder.

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
