### PR TITLE
feat(balance): buff fingertip razor bionic, take 2

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -830,7 +830,7 @@
     "id": "bio_razors",
     "type": "bionic",
     "name": { "str": "Fingertip Razors" },
-    "description": "You possess razor-sharp claws underneath your fingernails that do a small amount of unarmed slashing damage whenever your fingertips are uncovered.",
+    "description": "You possess razor-sharp claws underneath your fingernails that do a fair amount of unarmed slashing damage whenever your fingertips are uncovered, and which you can use with some precision to cut and butcher..",
     "occupied_bodyparts": [ [ "hand_l", 2 ], [ "hand_r", 2 ] ],
     "fake_item": "fake_razor",
     "flags": [ "BIONIC_NPC_USABLE" ]

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -745,7 +745,7 @@
     "type": "BIONIC_ITEM",
     "name": { "str": "Fingertip Razors CBM" },
     "looks_like": "bio_int_enhancer",
-    "description": "A set of ten double-edged, four centimeter long razor-sharp claws that are implanted underneath the fingernails.  These will deal a small amount of unarmed slashing damage whenever the user's fingertips are uncovered.",
+    "description": "A set of ten double-edged, four centimeter long razor-sharp claws that are implanted underneath the fingernails.  These will deal a fair amount of unarmed slashing damage whenever the user's fingertips are uncovered, and allow the user to somewhat precisely slice things apart.",
     "price": "4500 USD",
     "weight": "5 g",
     "difficulty": 4

--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -71,7 +71,8 @@
     "copy-from": "fake_item",
     "type": "TOOL",
     "name": { "str": "bionic razor" },
-    "qualities": [ [ "BUTCHER", 8 ] ]
+    "//": "Bonus unarmed damage for having Fingertip Razors installed is applied in melee.cpp, see function Character::roll_cut_damage",
+    "qualities": [ [ "BUTCHER", 15 ], [ "CUT", 1 ], [ "CUT_FINE", 2 ] ]
   },
   {
     "id": "clairvoyance_plus_rod",

--- a/src/character_display.cpp
+++ b/src/character_display.cpp
@@ -660,7 +660,7 @@ int character_display::display_empty_handed_base_damage( const Character &you )
         // Mutation and bionic bonuses double if both hands are free
         int per_hand = 0;
         if( you.has_bionic( bionic_id( "bio_razors" ) ) ) {
-            per_hand += 4;
+            per_hand += 9;
         }
         for( const trait_id &mut : you.get_mutations() ) {
             if( mut->flags.count( trait_flag_NEED_ACTIVE_TO_MELEE ) > 0 &&

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1039,7 +1039,7 @@ void Character::roll_cut_damage( bool crit, damage_instance &di, bool average,
         if( left_empty || right_empty ) {
             float per_hand = 0.0f;
             if( has_bionic( bionic_id( "bio_razors" ) ) ) {
-                per_hand += 2;
+                per_hand += 9;
             }
 
             for( const trait_id &mut : get_mutations() ) {
@@ -1121,10 +1121,6 @@ void Character::roll_stab_damage( bool crit, damage_instance &di, bool /*average
                 }
 
                 per_hand += stab_bonus + unarmed_bonus;
-            }
-
-            if( has_bionic( bionic_id( "bio_razors" ) ) ) {
-                per_hand += 2;
             }
 
             stab_dam += per_hand; // First hand


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This grab the ideas yay/phoenix brought up in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4556 plus the required hardcode changes. Idea is adding more utility to a bionic described as install 4 cm each of high-tech razor blades into your fingers, which logically should be more on par with some claw mutations while being better for cutting.

Currently WIP because I also intend to update the bonus unarmed damage but that's C++ stuff, and currently out and about on wifi. Also part of intended functioning seems to need a hardcode touching up too, see testing below.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

C++ changes:
1. In character_display.cpp, updated the `per_hand` value in `character_display::display_empty_handed_base_damage` from 4 to 9, to match the total damage being added per yay's intended implementation.
2. In melee.cpp, updated `Character::roll_cut_damage` to give a `per_hand` bonus of 9, so that the total damage of fingertip razors with both hands available becomes 18, as per the initial PR.
3. And also in melee.cpp, removed the bonus stabbing damage for fingertip razors from `Character::roll_stab_damage`, making it the bonus all one damage type instead of a weird mix of both.

JSON changes:
1. Grabbed the changes that buff the finger razor fake item's tool qualities up to 15 butcher quality, 1 cutting quality, and 2 fine cutting quality. Also added a comment explaining where the bonus damage actually is.
2. Added the description changes to the bionic and its item form, hinting at the tool usage it gains.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Keeping the unarmed damage bonuses unchanged.
2. Hacking in a pure JSON method of specifying bonus unarmed damage by having the razors grant an enchantment the grants a mutation that grants unarmed damage like claws do, and removing the hardcode stuff entirely.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON files for syntax and lint errors.
2. Ported JSON changes to playthrough build and spawned in as a razor boy.
3. Dumped my starting tools and confirmed I was still able to butcher and dissect corpses.
4. Compiled and load-tested.

Problem: it recognizes I have access to cutting quality for the sake of butchering and even for crafting recipes that require cutting quality, but it won't let me salvage clothing items with them.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
