### PR TITLE
feat(balance): wood saw cuts trees better than a stone axe

### DIFF
--- a/data/json/items/tool/woodworking.json
+++ b/data/json/items/tool/woodworking.json
@@ -258,7 +258,7 @@
     "material": [ "steel", "wood" ],
     "symbol": ";",
     "color": "brown",
-    "qualities": [ [ "AXE", 1 ], [ "SAW_W", 2 ], [ "BUTCHER", -90 ] ],
+    "qualities": [ [ "AXE", 2 ], [ "SAW_W", 2 ], [ "BUTCHER", -90 ] ],
     "flags": [ "NONCONDUCTIVE", "BELT_CLIP" ]
   },
   {

--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -590,7 +590,7 @@
     "ammo": "tape",
     "max_charges": 200,
     "charges_per_use": 5,
-    "qualities": [ [ "CUT", 1 ], [ "CUT_FINE", 2 ], [ "AXE", 1 ], [ "SAW_W", 2 ], [ "BUTCHER", -90 ] ],
+    "qualities": [ [ "CUT", 1 ], [ "CUT_FINE", 2 ], [ "AXE", 2 ], [ "SAW_W", 2 ], [ "BUTCHER", -90 ] ],
     "use_action": [
       {
         "type": "repair_item",
@@ -964,7 +964,7 @@
       [ "HAMMER", 3 ],
       [ "SAW_M", 2 ],
       [ "SAW_W", 2 ],
-      [ "AXE", 1 ],
+      [ "AXE", 2 ],
       [ "WRENCH", 2 ],
       [ "SCREW", 1 ],
       [ "PRY", 1 ],
@@ -1031,7 +1031,7 @@
       [ "HAMMER", 3 ],
       [ "SAW_M", 2 ],
       [ "SAW_W", 2 ],
-      [ "AXE", 1 ],
+      [ "AXE", 2 ],
       [ "WRENCH", 2 ],
       [ "SCREW", 1 ],
       [ "PRY", 1 ],

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1698,7 +1698,7 @@
       [ "SAW_M", 2 ],
       [ "SAW_W", 2 ],
       [ "WRENCH", 2 ],
-      [ "AXE", 1 ],
+      [ "AXE", 2 ],
       [ "SCREW", 1 ],
       [ "HAMMER_FINE", 1 ],
       [ "SAW_M_FINE", 1 ],


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This aims to make wood saws more worth using as tree cutting tools than plain stone axes, while currently still keeping proper wood axes superior since they're bulkier and have less other tool utility.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Bumped `AXE` quality of wood saw from 1 to 2.
2. Accordingly bumped up the axe quality of all related items: toolbox, survivor utility belt, misc repair kit, and workshop toolbox.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Bumping wood saws up to 3 so they're equal to wood saws. Since the only makeshift axe to really match a wood saw is the copper one, which takes more effort to make than plaine stone, it's probably okay at its current level.
2. Baking in some hardcoded shenanigans to make the `chop_moves` function either pick best of wood-cutting vs sawing quality for the tool being used automatically.
3. At some point I kinda want to axe the survivor utility belt in favor of just making the survivor belt you craft it out of have multiple all-purpose tool storage like a tool belt does, so you can just fill it yourself with one's tools of choice.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected file for syntax and lint errors.
2. Spawned in a wood saw, confirmed its use action menu doesn't do anything weird like give the lumber action twice.
3. Chopped a trunk into logs with wood saw, it now takes about half an hour as expected.
4. Did the same with a stone axe, confirmed it still takes about an hour as expected.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

I'm also wondering if maybe we should give the copper and stone tomahawk axe quality since they're basically hatchets but old-school, but then the stone axe and stone tomahawk might feel about the same tool-wise? Copper tomahawk at least wouldn't have this problem since we could easily give it level 1 and thus have it still feel less heavy-duty than the copper axe's level 2 quality.

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
