### PR TITLE
fix: add a dot at the end of Multiple pools and Freeform sentences

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -724,13 +724,13 @@ tab_direction set_points( avatar &, points_left &points )
                                          _( "Multiple pools" ),
                                          _( "Stats, traits and skills have separate point pools.\n"
                                             "Putting stat points into traits and skills is allowed and putting trait points into skills is allowed.\n"
-                                            "Scenarios and professions affect skill point pool" ) );
+                                            "Scenarios and professions affect skill point pool." ) );
 
     const point_limit_tuple one_pool = std::make_tuple( points_left::ONE_POOL, _( "Single pool" ),
                                        _( "Stats, traits and skills share a single point pool." ) );
 
     const point_limit_tuple freeform = std::make_tuple( points_left::FREEFORM, _( "Freeform" ),
-                                       _( "No point limits are enforced" ) );
+                                       _( "No point limits are enforced." ) );
 
     if( point_pool == "multi_pool" ) {
         opts = {{ multi_pool }};


### PR DESCRIPTION
## Purpose of change
Add a dot at the end of certain sentences in the description of Multiple pools and Freeform
## Describe the solution
"Scenarios and professions affect skill point pool." instead of "Scenarios and professions affect skill point pool"
"No point limits are enforced." instead of "No point limits are enforced"
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/f95efe0c-26a0-48ec-8aa5-60e39b2b88ea">
<img width="489" alt="image2" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/48195c7c-0525-4b98-9de5-f866fa40aa9a">
After:
<img width="828" alt="image3" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/56cb6176-3ea5-4e50-b583-2e805fe0297e">
<img width="484" alt="image4" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/9a9eb1d8-4b3d-4862-9e41-67d13368b3bd">