### PR TITLE
fix: remove lumbermill sidewalk

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain_industrial.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_industrial.json
@@ -286,71 +286,19 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "lumbermill_0_0",
+    "id": [ "lumbermill_0_0", "lumbermill_0_1", "lumbermill_1_0", "lumbermill_1_1" ],
     "name": "lumbermill",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_no_sidewalk",
     "sym": "L",
     "color": "i_green",
-    "spawns": { "group": "GROUP_WASP_FORAGER", "population": [ 1, 3 ], "chance": 10 },
-    "extend": { "flags": [ "SOURCE_CONSTRUCTION", "SOURCE_FABRICATION" ] }
+    "extend": { "flags": [ "SOURCE_CONSTRUCTION", "SOURCE_FABRICATION" ] },
+    "spawns": { "group": "GROUP_WASP_FORAGER", "population": [ 1, 3 ], "chance": 10 }
   },
   {
     "type": "overmap_terrain",
-    "id": "lumbermill_0_1",
-    "name": "lumbermill",
-    "copy-from": "generic_city_building",
-    "sym": "L",
-    "color": "i_green",
-    "spawns": { "group": "GROUP_WASP_FORAGER", "population": [ 1, 3 ], "chance": 10 },
-    "extend": { "flags": [ "SOURCE_CONSTRUCTION", "SOURCE_FABRICATION" ] }
-  },
-  {
-    "type": "overmap_terrain",
-    "id": "lumbermill_1_0",
-    "name": "lumbermill",
-    "copy-from": "generic_city_building",
-    "sym": "L",
-    "color": "i_green",
-    "extend": { "flags": [ "SOURCE_CONSTRUCTION", "SOURCE_FABRICATION" ] }
-  },
-  {
-    "type": "overmap_terrain",
-    "id": "lumbermill_1_1",
-    "name": "lumbermill",
-    "copy-from": "generic_city_building",
-    "sym": "L",
-    "color": "i_green",
-    "extend": { "flags": [ "SOURCE_CONSTRUCTION", "SOURCE_FABRICATION" ] }
-  },
-  {
-    "type": "overmap_terrain",
-    "id": "lumbermill_0_0_roof",
+    "id": [ "lumbermill_0_0_roof", "lumbermill_0_1_roof", "lumbermill_1_0_roof", "lumbermill_1_1_roof" ],
     "name": "lumbermill roof",
-    "copy-from": "generic_city_building",
-    "sym": "L",
-    "color": "i_green"
-  },
-  {
-    "type": "overmap_terrain",
-    "id": "lumbermill_0_1_roof",
-    "name": "lumbermill roof",
-    "copy-from": "generic_city_building",
-    "sym": "L",
-    "color": "i_green"
-  },
-  {
-    "type": "overmap_terrain",
-    "id": "lumbermill_1_0_roof",
-    "name": "lumbermill roof",
-    "copy-from": "generic_city_building",
-    "sym": "L",
-    "color": "i_green"
-  },
-  {
-    "type": "overmap_terrain",
-    "id": "lumbermill_1_1_roof",
-    "name": "lumbermill roof",
-    "copy-from": "generic_city_building",
+    "copy-from": "generic_city_building_no_sidewalk",
     "sym": "L",
     "color": "i_green"
   },


### PR DESCRIPTION
## Purpose of change
Remove the sidewalk around the lumbermill.
## Describe the solution
Cut unnecessary lines in overmap_terrain_industrial.json for the lumbermill and use `generic_city_building_no_sidewalk`
## Describe alternatives you've considered
None.
## Additional context
No sidewalk.
<img width="960" alt="image1" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/908ce2d4-e88b-4a74-8c20-eb3f9a7c19b3">