### PR TITLE
feat: Remove lead from birdshot

### DIFF
--- a/data/json/recipes/ammo/shot.json
+++ b/data/json/recipes/ammo/shot.json
@@ -358,8 +358,8 @@
     "batch_time_factors": [ 60, 5 ],
     "book_learn": [ [ "recipe_bullets", 1 ], [ "manual_shotgun", 1 ] ],
     "charges": 1,
-    "using": [ [ "shot_forming", 1 ], [ "ammo_shot", 1 ] ],
-    "components": [ [ [ "gunpowder", 3 ] ], [ [ "scrap", 1 ], [ "bismuth", 30 ] ] ]
+    "using": [ [ "shot_forming", 1 ], [ "ammo_bullet_birdshot", 10 ], [ "ammo_shot", 1 ] ],
+    "components": [ [ [ "gunpowder", 3 ] ] ]
   },
   {
     "result": "shot_dragon",
@@ -437,8 +437,8 @@
     "book_learn": [ [ "recipe_bullets", 1 ], [ "manual_shotgun", 1 ] ],
     "charges": 1,
     "reversible": true,
-    "using": [ [ "shot_forming", 1 ], [ "ammo_shot", 1 ] ],
-    "components": [ [ [ "chem_black_powder", 3 ] ], [ [ "scrap", 1 ], [ "bismuth", 30 ] ] ]
+    "using": [ [ "shot_forming", 1 ], [ "ammo_bullet_birdshot", 10 ], [ "ammo_shot", 1 ] ],
+    "components": [ [ [ "chem_black_powder", 3 ] ] ]
   },
   {
     "result": "bp_shot_dragon",
@@ -640,12 +640,8 @@
     "charges": 1,
     "reversible": true,
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [
-      [ [ "chem_black_powder", 5 ] ],
-      [ [ "shotgun_primer", 1 ] ],
-      [ [ "paper", 1 ], [ "aluminum_foil", 1 ] ],
-      [ [ "scrap", 1 ], [ "bismuth", 24 ] ]
-    ]
+    "using": [ [ "ammo_bullet_birdshot", 8 ] ],
+    "components": [ [ [ "chem_black_powder", 5 ] ], [ [ "shotgun_primer", 1 ] ], [ [ "paper", 1 ], [ "aluminum_foil", 1 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/ammo/shot.json
+++ b/data/json/recipes/ammo/shot.json
@@ -358,8 +358,8 @@
     "batch_time_factors": [ 60, 5 ],
     "book_learn": [ [ "recipe_bullets", 1 ], [ "manual_shotgun", 1 ] ],
     "charges": 1,
-    "using": [ [ "shot_forming", 1 ], [ "ammo_bullet", 10 ], [ "ammo_shot", 1 ] ],
-    "components": [ [ [ "gunpowder", 3 ] ] ]
+    "using": [ [ "shot_forming", 1 ], [ "ammo_shot", 1 ] ],
+    "components": [ [ [ "gunpowder", 3 ] ], [ [ "scrap", 1 ], [ "bismuth", 30 ] ] ]
   },
   {
     "result": "shot_dragon",
@@ -437,8 +437,8 @@
     "book_learn": [ [ "recipe_bullets", 1 ], [ "manual_shotgun", 1 ] ],
     "charges": 1,
     "reversible": true,
-    "using": [ [ "shot_forming", 1 ], [ "ammo_bullet", 10 ], [ "ammo_shot", 1 ] ],
-    "components": [ [ [ "chem_black_powder", 3 ] ] ]
+    "using": [ [ "shot_forming", 1 ], [ "ammo_shot", 1 ] ],
+    "components": [ [ [ "chem_black_powder", 3 ] ], [ [ "scrap", 1 ], [ "bismuth", 30 ] ] ]
   },
   {
     "result": "bp_shot_dragon",
@@ -639,9 +639,13 @@
     "book_learn": [ [ "manual_shotgun", 3 ], [ "recipe_bullets", 2 ] ],
     "charges": 1,
     "reversible": true,
-    "using": [ [ "ammo_bullet", 8 ] ],
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "chem_black_powder", 5 ] ], [ [ "shotgun_primer", 1 ] ], [ [ "paper", 1 ], [ "aluminum_foil", 1 ] ] ]
+    "components": [
+      [ [ "chem_black_powder", 5 ] ],
+      [ [ "shotgun_primer", 1 ] ],
+      [ [ "paper", 1 ], [ "aluminum_foil", 1 ] ],
+      [ [ "scrap", 1 ], [ "bismuth", 24 ] ]
+    ]
   },
   {
     "type": "recipe",

--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -12,6 +12,12 @@
     "components": [ [ [ "lead", 1 ], [ "bismuth", 3 ] ] ]
   },
   {
+    "id": "ammo_bullet_birdshot",
+    "type": "requirement",
+    "//": "Materials used when forming bullets for birdshot",
+    "components": [ [ [ "lead", 1 ], [ "bismuth", 3 ], [ "bb", 2 ] ] ]
+  },
+  {
     "id": "chem_lye",
     "type": "requirement",
     "//": "Comparable ratios of liquid lye and lye powder.",

--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -15,7 +15,7 @@
     "id": "ammo_bullet_birdshot",
     "type": "requirement",
     "//": "Materials used when forming bullets for birdshot",
-    "components": [ [ [ "lead", 1 ], [ "bismuth", 3 ], [ "bb", 2 ] ] ]
+    "components": [ [ [ "bb", 2 ], [ "lead", 1 ], [ "bismuth", 3 ] ] ]
   },
   {
     "id": "chem_lye",

--- a/data/json/uncraft/ammo/shot.json
+++ b/data/json/uncraft/ammo/shot.json
@@ -26,7 +26,7 @@
     "difficulty": 5,
     "time": "1 s",
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "shot_hull", 1 ] ], [ [ "shotgun_primer", 1 ] ], [ [ "gunpowder", 3 ] ], [ [ "lead", 10 ] ] ],
+    "components": [ [ [ "shot_hull", 1 ] ], [ [ "shotgun_primer", 1 ] ], [ [ "gunpowder", 3 ] ], [ [ "scrap", 1 ] ] ],
     "charges": 1
   },
   {

--- a/data/json/uncraft/ammo/shot.json
+++ b/data/json/uncraft/ammo/shot.json
@@ -26,7 +26,7 @@
     "difficulty": 5,
     "time": "1 s",
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "shot_hull", 1 ] ], [ [ "shotgun_primer", 1 ] ], [ [ "gunpowder", 3 ] ], [ [ "scrap", 1 ] ] ],
+    "components": [ [ [ "shot_hull", 1 ] ], [ [ "shotgun_primer", 1 ] ], [ [ "gunpowder", 3 ] ], [ [ "bb", 20 ] ] ],
     "charges": 1
   },
   {


### PR DESCRIPTION
## Purpose of change

Lead is essentially illegal to actually use in birdshot irl in the USA. Plus, it helps to give birdshot a more unique identity, in a sense.

## Describe the solution

Changes uncraft to BBs for birdshot, allows for use of BBs in creating it yourself

## Describe alternatives you've considered
 - Use scrap
 
As pointed out by Chaos, undesirable

- Remove lead from crafting

Tempting, but unfortunately survivors care little about silly things like EPA regulations or safety other than keeping the zombies off their lawn.

## Testing

Loads, is able to be crafted

## Additional context

[Section on wikipedia explaining lead-free shot](https://en.wikipedia.org/wiki/Shotgun_shell#Lead_free)

