### PR TITLE
fix: don't spawn scrap metal in pairs, uncrafting consistency updates, add some more uncrafts

### DIFF
--- a/data/json/items/resources/metal.json
+++ b/data/json/items/resources/metal.json
@@ -28,7 +28,7 @@
     "volume": "250 ml",
     "price": "5 USD",
     "price_postapoc": "10 cent",
-    "count": 2,
+    "count": 1,
     "stack_size": 10,
     "//": "Density 7.60g/cm³ ~ 1.9kg/250ml @ 50g/unit ~ stack 40 but fragments stacks poorly so only 25% of this",
     "material": "steel",

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -256,7 +256,7 @@
     "autolearn": true,
     "using": [ [ "blacksmithing_intermediate", 2 ] ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "components": [ [ [ "scrap", 1 ] ] ]
+    "components": [ [ [ "scrap", 3 ] ] ]
   },
   {
     "type": "recipe",
@@ -276,13 +276,14 @@
     "result": "wire_mesh",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_MATERIALS",
+    "byproducts": [ [ "scrap", 3 ] ],
     "skill_used": "fabrication",
     "difficulty": 3,
     "time": "1 h",
     "autolearn": true,
     "qualities": [ { "id": "ANVIL", "level": 1 }, { "id": "HAMMER", "level": 2 } ],
     "tools": [ [ [ "swage", -1 ] ], [ [ "surface_heat", 2, "LIST" ], [ "forge", 2 ], [ "oxy_torch", 2 ] ] ],
-    "components": [ [ [ "wire", 6 ] ] ]
+    "components": [ [ [ "wire", 3 ] ] ]
   },
   {
     "type": "recipe",
@@ -1343,6 +1344,7 @@
     "type": "recipe",
     "category": "CC_OTHER",
     "id_suffix": "debarbing barbed wire",
+    "byproducts": [ [ "scrap", 3 ] ],
     "subcategory": "CSC_OTHER_MATERIALS",
     "skill_used": "fabrication",
     "autolearn": true,

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -3122,6 +3122,60 @@
     "type": "uncraft",
     "time": "1 m 30 s",
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
+    "components": [ [ [ "scrap", 3 ] ] ]
+  },
+  {
+    "result": "wire_barbed",
+    "type": "uncraft",
+    "time": "3 m",
+    "qualities": [ { "id": "HAMMER", "level": 1 } ],
+    "components": [ [ [ "scrap", 6 ] ] ]
+  },
+  {
+    "result": "wire_mesh",
+    "type": "uncraft",
+    "time": "3 m",
+    "qualities": [ { "id": "HAMMER", "level": 1 } ],
+    "components": [ [ [ "scrap", 6 ] ] ]
+  },
+  {
+    "result": "can_food_unsealed",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "time": "15 s",
+    "qualities": [ { "id": "HAMMER", "level": 1 } ],
+    "components": [ [ [ "scrap", 1 ] ] ]
+  },
+  {
+    "result": "can_medium_unsealed",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "time": "30 s",
+    "qualities": [ { "id": "HAMMER", "level": 1 } ],
+    "components": [ [ [ "scrap", 2 ] ] ]
+  },
+  {
+    "result": "can_food_big_unsealed",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "time": "1 m 45 s",
+    "qualities": [ { "id": "HAMMER", "level": 1 } ],
+    "components": [ [ [ "scrap", 7 ] ] ]
+  },
+  {
+    "result": "canister_empty",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "time": "45 s",
+    "qualities": [ { "id": "HAMMER", "level": 1 } ],
+    "components": [ [ [ "scrap", 3 ] ] ]
+  },
+  {
+    "result": "clockworks",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "time": "15 s",
+    "qualities": [ { "id": "HAMMER", "level": 1 } ],
     "components": [ [ [ "scrap", 1 ] ] ]
   },
   {


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This adds a few more ways to break down basic items into scrap, and along the way I found some weird inconsistencies to fix up.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Increased the amount of scrap used to make wire from 1 to 3. Scrap weighs 50 grams and wire weighs 151 grams, so now it's only magically gaining 1 gram of weight.
2. Likewise, increased the yield of uncrafting wires from 1 scrap to 3.
3. Set it so that the recipe for unbending barbed wire into wire yields 3 scrap as a byproduct. Barbed wire weighs 302 grams, so ideally this should be returning 3 scrap metal. This would incorrectly return 6 instead, if not for...
4. Lowered `count` of scrap metal from 2 to 1. **Why were they being paired up like that?** To my knowledge every single spawn of scrap metal in the game assumes that a single `count` of stack is gonna be 1, not 2. This was most likely doubling up every call to spawn scrap metal in itemgroups (unless it's set to use `charges` instead of `count`), recipe by-products, possibly vehiclepart destruction results too.
5. Added an uncraft for barbed wire, returning 6 scrap. Takes twice as long as taking apart regular wire, but much less bothersome than having to craft barbed wire into regular wire if you just want scrap.
6. Added an uncraft for wire mesh, also returning 6 scrap metal. Item weighs 318 grams and is made from...uh, 6 wires? Uhhh?
7. As predicted, lowered the amount of wire required for wire mesh item. Picked 3, with a by-product of 3 scrap metal.
8. Added an uncraft for tin cans, yielding 1 scrap metal. You technically gain a bit of mass here once more through the power of squashing metal flat with a rock, but it's only 10 grams.
9. Likewise added uncrafts for medium and large tin cans. Again some magical rock-induced weight gain for medium ones, but at long last large cans manage to yield a higher amount of scrap than small or medium ones without any weird conservation of mass bullshit going on.
10. Added an uncraft for empty canisters, yielding 3 scrap metal as the item weights 158 grams.
11. Added an uncraft to turn 50 grams of delicious clockworks into 50 grams of even more delicious scrap metal, finally giving a use to all those extra bits of steampunkery I'm always left with after scrapping all the gold and silver watches I find myself compulsively hoarding.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Having the recipe for unbending barbed wire give you 2 wires anyway for the hell of it, gluing the wire used to make the barbs back together through sci-fi plier sorcery or some such thing.
2. Obsoleting wire mesh in favor of screen mesh since it's not like wire basket type mesh, but instead is exclusively seen in coffee makers and washing machines. If so we may want to add a recipe for screen mesh. Which we maybe could be doing anyway since it does have construction uses too.
3. Bumping up the weight of small and medium cans a tiny lil bit to make them feel less weird when taken apart for scrap.
4. Lowering the weight of large tin cans a bit since it's a big jump from 80 grams to 350.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Ported JSON changes over to test build and load-tested.
3. Confirmed that unbending barbed wire correctly yields 3 scrap metal.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
