### PR TITLE
feat: reversible bullet recipes can have different uncraft requirements

### DIFF
--- a/data/json/recipes/ammo/shot.json
+++ b/data/json/recipes/ammo/shot.json
@@ -328,6 +328,7 @@
     "batch_time_factors": [ 60, 5 ],
     "book_learn": [ [ "recipe_bullets", 2 ], [ "manual_shotgun", 2 ] ],
     "charges": 1,
+    "reversible": true,
     "using": [ [ "shot_forming", 1 ], [ "ammo_bullet", 10 ], [ "ammo_shot", 1 ] ],
     "components": [ [ [ "gunpowder", 6 ] ] ]
   },

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -6,10 +6,16 @@
     "tools": [ [ [ "press", -1 ] ], [ [ "fire", -1 ], [ "hotplate", 2 ], [ "toolset", 2 ] ] ]
   },
   {
+    "id": "bullet_forming_rifle",
+    "type": "requirement",
+    "//": "Forming of rifle bullets from raw materials, this variant uses a flag that ensures that reversing the recipe will require a proper bullet pullet, and not just pliers.",
+    "tools": [ [ [ "press", -1, "UNCRAFT_CONVERT_TO_PULLING_2" ] ], [ [ "fire", -1 ], [ "hotplate", 2 ], [ "toolset", 2 ] ] ]
+  },
+  {
     "id": "shot_forming",
     "type": "requirement",
-    "//": "Forming of shot from raw materials, allows use of makeshift press",
-    "tools": [ [ [ "press", -1 ], [ "press_dowel", -1 ] ], [ [ "fire", -1 ], [ "hotplate", 2 ], [ "toolset", 2 ] ] ]
+    "//": "Forming of shot from raw materials, allows use of makeshift press, flag ensures reversing the recipe will replace pulling quality with cutting",
+    "tools": [ [ [ "press", -1, "UNCRAFT_CONVERT_TO_CUTTING" ], [ "press_dowel", -1 ] ], [ [ "fire", -1 ], [ "hotplate", 2 ], [ "toolset", 2 ] ] ]
   },
   {
     "id": "earthenware_firing",

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -15,7 +15,10 @@
     "id": "shot_forming",
     "type": "requirement",
     "//": "Forming of shot from raw materials, allows use of makeshift press, flag ensures reversing the recipe will replace pulling quality with cutting",
-    "tools": [ [ [ "press", -1, "UNCRAFT_CONVERT_TO_CUTTING" ], [ "press_dowel", -1 ] ], [ [ "fire", -1 ], [ "hotplate", 2 ], [ "toolset", 2 ] ] ]
+    "tools": [
+      [ [ "press", -1, "UNCRAFT_CONVERT_TO_CUTTING" ], [ "press_dowel", -1 ] ],
+      [ [ "fire", -1 ], [ "hotplate", 2 ], [ "toolset", 2 ] ]
+    ]
   },
   {
     "id": "earthenware_firing",

--- a/data/json/uncraft/ammo/shot.json
+++ b/data/json/uncraft/ammo/shot.json
@@ -1,15 +1,5 @@
 [
   {
-    "result": "shot_00",
-    "type": "uncraft",
-    "skill_used": "gun",
-    "difficulty": 5,
-    "time": "1 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "shot_hull", 1 ] ], [ [ "shotgun_primer", 1 ] ], [ [ "gunpowder", 6 ] ], [ [ "lead", 10 ] ] ],
-    "charges": 1
-  },
-  {
     "result": "shot_beanbag",
     "type": "uncraft",
     "skill_used": "gun",

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -319,6 +319,8 @@ const flag_id flag_TRADER_KEEP_EQUIPPED( "TRADER_KEEP_EQUIPPED" );
 const flag_id flag_TWO_WAY_RADIO( "TWO_WAY_RADIO" );
 const flag_id flag_UNARMED_WEAPON( "UNARMED_WEAPON" );
 const flag_id flag_UNBREAKABLE_MELEE( "UNBREAKABLE_MELEE" );
+const flag_id flag_UNCRAFT_CONVERT_TO_CUTTING( "UNCRAFT_CONVERT_TO_CUTTING" );
+const flag_id flag_UNCRAFT_CONVERT_TO_PULLING_2( "UNCRAFT_CONVERT_TO_PULLING_2" );
 const flag_id flag_UNDERSIZE( "UNDERSIZE" );
 const flag_id flag_UNDERWATER_GUN( "UNDERWATER_GUN" );
 const flag_id flag_UNRECOVERABLE( "UNRECOVERABLE" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -323,6 +323,8 @@ extern const flag_id flag_TRADER_KEEP_EQUIPPED;
 extern const flag_id flag_TWO_WAY_RADIO;
 extern const flag_id flag_UNARMED_WEAPON;
 extern const flag_id flag_UNBREAKABLE_MELEE;
+extern const flag_id flag_UNCRAFT_CONVERT_TO_CUTTING;
+extern const flag_id flag_UNCRAFT_CONVERT_TO_PULLING_2;
 extern const flag_id flag_UNDERSIZE;
 extern const flag_id flag_UNDERWATER_GUN;
 extern const flag_id flag_UNRECOVERABLE;

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -43,7 +43,6 @@ static const itype_id itype_forge( "forge" );
 static const itype_id itype_mold_plastic( "mold_plastic" );
 static const itype_id itype_oxy_torch( "oxy_torch" );
 static const itype_id itype_press( "press" );
-static const itype_id itype_press_dowel( "press_dowel" );
 static const itype_id itype_sewing_kit( "sewing_kit" );
 static const itype_id itype_UPS( "UPS" );
 static const itype_id itype_welder( "welder" );
@@ -1044,13 +1043,15 @@ requirement_data requirement_data::disassembly_requirements() const
                 replaced = true;
                 break;
             }
-            //This ensures that you don't need a hand press to break down reloaded ammo.
+            // This ensures that you don't need a hand press to break down reloaded ammo.
             if( type == itype_press ) {
                 replaced = true;
                 remove_fire = true;
-                if( type->has_flag( STATIC( flag_id( "UNCRAFT_CONVERT_TO_CUTTING" ) ) ) {
+                // Shotshells, can be pried open with just a knife
+                if( type->has_flag( STATIC( flag_id( "UNCRAFT_CONVERT_TO_CUTTING" ) ) ) ) {
                     new_qualities.emplace_back( quality_id( "CUT" ), 1, 1 );
-                } else if( type->has_flag( STATIC( flag_id( "UNCRAFT_CONVERT_TO_PULLING_2" ) ) ) {
+                // Proper rifle rounds, use a puller
+                } else if( type->has_flag( STATIC( flag_id( "UNCRAFT_CONVERT_TO_PULLING_2" ) ) ) ) {
                     new_qualities.emplace_back( quality_id( "PULL" ), 1, 2 );
                 } else {
                     new_qualities.emplace_back( quality_id( "PULL" ), 1, 1 );

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -43,6 +43,7 @@ static const itype_id itype_forge( "forge" );
 static const itype_id itype_mold_plastic( "mold_plastic" );
 static const itype_id itype_oxy_torch( "oxy_torch" );
 static const itype_id itype_press( "press" );
+static const itype_id itype_press_dowel( "press_dowel" );
 static const itype_id itype_sewing_kit( "sewing_kit" );
 static const itype_id itype_UPS( "UPS" );
 static const itype_id itype_welder( "welder" );
@@ -1047,7 +1048,13 @@ requirement_data requirement_data::disassembly_requirements() const
             if( type == itype_press ) {
                 replaced = true;
                 remove_fire = true;
-                new_qualities.emplace_back( quality_id( "PULL" ), 1, 1 );
+                if( type->has_flag( STATIC( flag_id( "UNCRAFT_CONVERT_TO_CUTTING" ) ) ) {
+                    new_qualities.emplace_back( quality_id( "CUT" ), 1, 1 );
+                } else if( type->has_flag( STATIC( flag_id( "UNCRAFT_CONVERT_TO_PULLING_2" ) ) ) {
+                    new_qualities.emplace_back( quality_id( "PULL" ), 1, 2 );
+                } else {
+                    new_qualities.emplace_back( quality_id( "PULL" ), 1, 1 );
+                }
                 break;
             }
             if( type == itype_fire && remove_fire ) {

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -1050,7 +1050,7 @@ requirement_data requirement_data::disassembly_requirements() const
                 // Shotshells, can be pried open with just a knife
                 if( type->has_flag( STATIC( flag_id( "UNCRAFT_CONVERT_TO_CUTTING" ) ) ) ) {
                     new_qualities.emplace_back( quality_id( "CUT" ), 1, 1 );
-                // Proper rifle rounds, use a puller
+                    // Proper rifle rounds, use a puller
                 } else if( type->has_flag( STATIC( flag_id( "UNCRAFT_CONVERT_TO_PULLING_2" ) ) ) ) {
                     new_qualities.emplace_back( quality_id( "PULL" ), 1, 2 );
                 } else {


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This at long last follows up on fixing all the jank in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/886 by properly implementing a way for reversible recipes to automatically decide whether it requires cutting 1, pulling 1, or pulling 2 to take the ammo apart. Without this you have to define explicit uncrafts for factory ammo, something we can now axe. Conversely, this fixes the issue of the few existing reversible ammo recipes all demanding pulling 1 no matter what their factory counterparts need to dismantle.

Currently WIP as it's gonna take a while to add to all the recipes, plus right now I'm having a problem actually finding how to get the code to correctly check for flags in the tool it finds. Was given the go-ahead to post it up here so others can look at it.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

C++ changes:
1. In flag.cpp and flag.h, defined two new flags: `UNCRAFT_CONVERT_TO_CUTTING` and `UNCRAFT_CONVERT_TO_PULLING_2`. These are intended to be used in tool entries, to affect what that recipe does when reversed, if marked as reversible.
2. In requirements.cpp, changed `requirement_data::disassembly_requirements` so that the handling of converting hand press recipes into bullet pulling when reversed is at long last sanity-checked: if it finds `UNCRAFT_CONVERT_TO_CUTTING` tacked onto the hand press, it adds cutting quality of 1 instead of bullet pulling. Meanwhile if it finds `UNCRAFT_CONVERT_TO_PULLING_2` it instead upgrades the required pulling requirement to level 2. At least, it's supposed to but currently I need to get it checking `tool_comp` for the flags, I think?

JSON changes:
1. Added `UNCRAFT_CONVERT_TO_CUTTING` to the hand press in the `shot_forming` crafting requirement. This makes it so that shotshells that use this crafting requirement can now be set to be reverisible while still converting them to use cutting instead of pulling quality, where previously this only worked right if you set aside an explicit uncraft for that.
2. Defined a new uncraft, `bullet_forming_rifle`. This is identical to `bullet_forming` except its hand press is flagged with `UNCRAFT_CONVERT_TO_PULLING_2`. Intended for rifle bullet recipes where we want them to require a bullet puller to take apart and not just mere pliers, this ensures they will get their pulling quality escalated from 1 to 2 during recipe reversal.

TODO:
1. Get it working blyat
2. Finish updating all ammo recipes to be reversible, and phase out the old uncrafts.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Unending fucking screaming at how janky the hardcoded uncraft generation is.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Testing to continue as implementation is completed. Right now I'm at an impasse: the actual check is a cursed-ass `for` loop buried in another `for` loop, which is why it's so hard to effectively vary up the conversions here. Far as I can tell, the check needs to be looking to see if the `tool_comp` that it found the tool in has the flag, and right now it's checking the `itype` of the tool it found for presumably item flags instead. Hence, it currently compiles without issue but completely fails to trigger either of the if statements, so 00 shot as of right now demands pliers to reverse its recipe instead of cutting quality.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Speaking of, the ability to axe explicit uncrafts for ammo and use purely reversible recipes will come in handy if developed further later on, to convert all those wacky conversions into a more JSONized form.

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
