### PR TITLE
feat(balance): increase variety of weapons dropped by feral humans

### DIFF
--- a/data/json/monsterdrops/feral_humans.json
+++ b/data/json/monsterdrops/feral_humans.json
@@ -4,9 +4,18 @@
     "subtype": "collection",
     "id": "feral_humans_death_drops_axe",
     "entries": [
-      { "item": "fire_ax", "prob": 100, "damage": [ 2, 4 ] },
-      { "group": "default_zombie_clothes", "prob": 100 },
-      { "group": "default_zombie_items_pockets", "prob": 50 }
+      {
+        "distribution": [ { "item": "fire_ax", "prob": 75, "damage": [ 2, 4 ] }, { "item": "ax", "prob": 25, "damage": [ 2, 4 ] } ]
+      },
+      {
+        "distribution": [
+          {
+            "collection": [ { "group": "default_zombie_clothes" }, { "group": "default_zombie_items_pockets", "prob": 50 } ],
+            "prob": 50
+          },
+          { "group": "mon_zombie_fireman_death_drops", "prob": 50 }
+        ]
+      }
     ]
   },
   {
@@ -24,10 +33,15 @@
     "subtype": "collection",
     "id": "feral_humans_death_drops_crowbar",
     "entries": [
-      { "item": "crowbar", "prob": 100, "damage": [ 1, 3 ] },
       {
-        "distribution": [ { "group": "default_zombie_clothes", "prob": 50 }, { "group": "mon_zombie_fireman_death_drops", "prob": 50 } ]
-      }
+        "distribution": [
+          { "item": "makeshift_crowbar", "prob": 50, "damage": [ 1, 3 ] },
+          { "item": "crowbar", "prob": 25, "damage": [ 1, 3 ] },
+          { "item": "claw_bar", "prob": 25, "damage": [ 1, 3 ] }
+        ]
+      },
+      { "group": "default_zombie_clothes", "prob": 100 },
+      { "group": "default_zombie_items_pockets", "prob": 50 }
     ]
   },
   {
@@ -67,14 +81,25 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "feral_humans_death_drops_tool",
-    "entries": [ { "item": "hammer", "prob": 100, "damage": [ 1, 3 ] }, { "group": "mon_zombie_technician_death_drops", "prob": 100 } ]
+    "entries": [
+      {
+        "distribution": [
+          { "item": "makeshift_hammer", "prob": 50, "damage": [ 1, 3 ] },
+          { "item": "hammer", "prob": 40, "damage": [ 1, 3 ] },
+          { "item": "hammer_bronze", "prob": 10, "damage": [ 1, 3 ] }
+        ]
+      },
+      { "group": "mon_zombie_technician_death_drops", "prob": 100 }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "feral_scientists_death_drops_scalpel",
     "entries": [
-      { "item": "scalpel", "prob": 100, "damage": [ 1, 3 ] },
+      {
+        "distribution": [ { "item": "xacto", "prob": 50, "damage": [ 1, 3 ] }, { "item": "scalpel", "prob": 50, "damage": [ 1, 3 ] } ]
+      },
       { "group": "lab_shoes", "damage": [ 1, 4 ] },
       { "group": "lab_torso", "damage": [ 1, 4 ] },
       { "group": "lab_pants", "damage": [ 1, 4 ] },
@@ -103,7 +128,14 @@
     "magazine": 100,
     "ammo": 20,
     "entries": [
-      { "item": "m9", "prob": 100, "damage": [ 2, 4 ] },
+      {
+        "distribution": [
+          { "item": "glock_19", "prob": 40, "damage": [ 2, 4 ] },
+          { "item": "m9", "prob": 35, "damage": [ 2, 4 ] },
+          { "item": "usp_9mm", "prob": 20, "damage": [ 2, 4 ] },
+          { "item": "kpf9", "prob": 5, "damage": [ 2, 4 ] }
+        ]
+      },
       { "group": "cop_gear", "prob": 50, "damage": [ 0, 2 ] },
       { "group": "cop_gloves", "prob": 30, "damage": [ 1, 4 ] },
       { "group": "security_pants", "damage": [ 1, 4 ] },
@@ -122,7 +154,9 @@
     "ammo": 20,
     "entries": [
       { "item": "heavy_flashlight", "prob": 100, "damage": [ 2, 4 ] },
-      { "item": "tazer", "prob": 100, "damage": [ 2, 4 ] },
+      {
+        "distribution": [ { "item": "tazer", "prob": 75, "damage": [ 2, 4 ] }, { "item": "shocktonfa_off", "prob": 25, "damage": [ 2, 4 ] } ]
+      },
       { "group": "cop_gloves", "prob": 30, "damage": [ 1, 4 ] },
       { "group": "security_pants", "damage": [ 1, 4 ] },
       { "group": "security_shoes", "prob": 70, "damage": [ 1, 4 ] },
@@ -157,7 +191,15 @@
     "subtype": "collection",
     "id": "feral_maids_death_drops_knife",
     "entries": [
-      { "item": "knife_chef", "prob": 100, "damage": [ 0, 3 ] },
+      {
+        "distribution": [
+          { "item": "knife_chef", "prob": 30, "damage": [ 0, 3 ] },
+          { "item": "knife_carving", "prob": 20, "damage": [ 0, 3 ] },
+          { "item": "knife_butcher", "prob": 20, "damage": [ 0, 3 ] },
+          { "item": "knife_meat_cleaver", "prob": 15, "damage": [ 0, 3 ] },
+          { "item": "knife_vegetable_cleaver", "prob": 15, "damage": [ 0, 3 ] }
+        ]
+      },
       { "group": "default_maid_clothes", "prob": 100 },
       { "group": "default_zombie_items_pockets", "prob": 50 }
     ]
@@ -197,7 +239,14 @@
     "subtype": "collection",
     "id": "feral_armored_death_drops_mace",
     "entries": [
-      { "item": "mace", "prob": 100, "damage": [ 2, 4 ] },
+      {
+        "distribution": [
+          { "item": "mace", "prob": 20, "damage": [ 2, 4 ] },
+          { "item": "mace_inferior", "prob": 30, "damage": [ 2, 4 ] },
+          { "item": "morningstar", "prob": 20, "damage": [ 2, 4 ] },
+          { "item": "morningstar_inferior", "prob": 30, "damage": [ 2, 4 ] }
+        ]
+      },
       { "group": "default_armored_clothes", "prob": 100 },
       { "group": "default_zombie_items_pockets", "prob": 50 }
     ]
@@ -207,7 +256,12 @@
     "subtype": "collection",
     "id": "feral_armored_death_drops_battleaxe",
     "entries": [
-      { "item": "battleaxe", "prob": 100, "damage": [ 2, 4 ] },
+      {
+        "distribution": [
+          { "item": "battleaxe", "prob": 40, "damage": [ 2, 4 ] },
+          { "item": "battleaxe_inferior", "prob": 60, "damage": [ 2, 4 ] }
+        ]
+      },
       { "group": "default_armored_clothes", "prob": 100 },
       { "group": "default_zombie_items_pockets", "prob": 50 }
     ]
@@ -541,7 +595,15 @@
     "magazine": 100,
     "ammo": 10,
     "id": "feral_autogun",
-    "items": [ [ "scar_l", 200 ], [ "m1a", 200 ], [ "ruger_mini", 200 ], [ "ar_pistol", 200 ], [ "ar15", 200 ] ]
+    "items": [
+      [ "scar_l", 200 ],
+      [ "m1a", 200 ],
+      [ "garand", 50 ],
+      [ "sks", 100 ],
+      [ "ruger_mini", 200 ],
+      [ "ar_pistol", 200 ],
+      [ "ar15", 200 ]
+    ]
   },
   {
     "id": "mon_feral_soldier_death_drops",
@@ -575,7 +637,10 @@
       { "item": "mossberg_590", "prob": 3, "charges": [ 0, 9 ] },
       { "item": "remington_870", "prob": 35, "charges": [ 0, 5 ] },
       { "item": "remington_870_express", "prob": 18, "charges": [ 0, 6 ] },
-      { "item": "mossberg_930", "prob": 15, "charges": [ 0, 6 ] }
+      { "item": "mossberg_930", "prob": 15, "charges": [ 0, 6 ] },
+      { "item": "browning_a5", "prob": 5, "charges": [ 0, 5 ] },
+      { "item": "winchester_1897", "prob": 5, "charges": [ 0, 6 ] },
+      { "item": "winchester_1887", "prob": 25, "charges": [ 0, 6 ] }
     ]
   },
   {
@@ -585,6 +650,7 @@
     "magazine": 100,
     "ammo": 20,
     "entries": [
+      { "group": "feral_jackboot_shotgun", "prob": 100, "damage": [ 1, 4 ] },
       {
         "distribution": [
           { "item": "jacket_leather", "prob": 65, "damage": [ 1, 4 ] },
@@ -601,7 +667,6 @@
           { "item": "tshirt_tour", "prob": 50, "damage": [ 1, 4 ] }
         ]
       },
-      { "group": "feral_jackboot_shotgun", "prob": 100, "damage": [ 1, 4 ] },
       { "group": "clothing_outdoor_shoes", "damage": [ 1, 4 ] },
       { "group": "clothing_outdoor_pants", "damage": [ 1, 4 ] },
       { "group": "socks_unisex", "damage": [ 1, 4 ] },

--- a/data/json/monsters/feral_humans.json
+++ b/data/json/monsters/feral_humans.json
@@ -190,7 +190,7 @@
         "fake_per": 10,
         "ranges": [ [ 0, 14, "DEFAULT" ] ],
         "require_targeting_player": false,
-        "description": "The feral security guard fires their Beretta M9A1!",
+        "description": "The feral security guard fires their pistol!",
         "no_crits": true
       }
     ],


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This makes the weapon selection dropped by feral humans vary a lil more, and a couple other tweaks.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Set it so that crowbar ferals can drop makeshift crowbars or claw bars instead of always full-on crowbars.
2. Set it so axe ferals pick between a fire axe and a wood axe at random, favoring a fire axe more often.
3. Speaking of, fixed it so that it's the axe feral that sometimes drops firefighter clothes, not crowbar ferals.
4. Gave hammer ferals a wider variety of handheld hammers they can drop instead of always proper hammers.
5. Gave feral scientists a chance to drop an x-acto knife instead of a scalpel.
6. Gave pistol-toting security ferals the full selection of 9mm pistols in `carried_guns_cop`, instead of just M9s.
7. Updated the fire message for feral-sec accordingly to not namedrop a specific model of pistol.
8. Switched up the tazer dropped by flashlight sec ferals to have a chance to be a shocktonfa instead.
9. Rigged knife-wielding maid ferals to drop a wider variety of kitchen knives.
10. Allowed mace ferals to potentially drop morningstars instead of just maces, with a chance of being the replica variant too.
11. Likewise gave battleaxe ferals a chance of their axe dropping as a replica instead.
12. Increased variety in `feral_autogun` a bit, adding the chance of an SKS and smaller chance of an M1 garand.
13. Added a few extra old-school shotguns to `feral_jackboot_shotgun`, in particular decent odds of the classic 1887.
14. Moved the shotgun spawn in `mon_feral_jackboot_death_drops` up top where weapon spawns are for all the others.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Rewording the descroption of pipe ferals to give them a chance to drop steel chains, planks, or other low-tier items of similar damage level.
2. Doing the same with broom ferals so they can potentially come at you with a mop instead.
3. Likewise, figuring out some way to reword the pun in the description of candlestick ferals so they can drop other potential improvised bludgeon.
4. Giving mace ferals a chance to drop war hammers too, even potentially making it an itemgroup so Arcana can inject hammers of the hunter into it. I'd have to reword the reference to maces though, whereas morningstars are at least close enough to maces for a general reference to a mace-toting enemy to not seem too weird.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Checked affected files for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
