### PR TITLE
feat(port): Mark overmap location if player drops favorited item

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -394,13 +394,12 @@ void drop_on_map( Character &c, item_drop_reason reason,
         }
 
 
-        if (get_option<bool>("AUTO_NOTES_DROPPED_FAVORITES") && it->is_favorite) {
+        if( get_option<bool>( "AUTO_NOTES_DROPPED_FAVORITES" ) && it->is_favorite ) {
             const tripoint_abs_omt your_pos = c.global_omt_location();
-            if (!overmap_buffer.has_note(your_pos)) {
-                overmap_buffer.add_note(your_pos, it->display_name());
-            }
-            else {
-                overmap_buffer.add_note(your_pos, overmap_buffer.note(your_pos) + "; " + it->display_name());
+            if( !overmap_buffer.has_note( your_pos ) ) {
+                overmap_buffer.add_note( your_pos, it->display_name() );
+            } else {
+                overmap_buffer.add_note( your_pos, overmap_buffer.note( your_pos ) + "; " + it->display_name() );
             }
         }
 

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -53,6 +53,8 @@
 #include "mtype.h"
 #include "npc.h"
 #include "output.h"
+#include "options.h"
+#include "overmapbuffer.h"
 #include "pickup.h"
 #include "pickup_token.h"
 #include "player.h"
@@ -390,6 +392,18 @@ void drop_on_map( Character &c, item_drop_reason reason,
                 );
                 break;
         }
+
+
+        if (get_option<bool>("AUTO_NOTES_DROPPED_FAVORITES") && it->is_favorite) {
+            const tripoint_abs_omt your_pos = c.global_omt_location();
+            if (!overmap_buffer.has_note(your_pos)) {
+                overmap_buffer.add_note(your_pos, it->display_name());
+            }
+            else {
+                overmap_buffer.add_note(your_pos, overmap_buffer.note(your_pos) + "; " + it->display_name());
+            }
+        }
+
     } else {
         switch( reason ) {
             case item_drop_reason::deliberate:

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1443,6 +1443,13 @@ void options_manager::add_options_general()
 
     get_option( "AUTO_NOTES_MAP_EXTRAS" ).setPrerequisite( "AUTO_NOTES" );
 
+    add ("AUTO_NOTES_DROPPED_FAVORITES", "general", translate_marker("Auto notes (dropped favorites)"),
+        translate_marker( "If true, automatically sets notes when player drops favorited items."),
+        true
+    );
+
+    get_option("AUTO_NOTES_DROPPED_FAVORITES").setPrerequisite("AUTO_NOTES");
+
     add_empty_line();
 
     add( "CIRCLEDIST", general, translate_marker( "Circular distances" ),

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1443,12 +1443,13 @@ void options_manager::add_options_general()
 
     get_option( "AUTO_NOTES_MAP_EXTRAS" ).setPrerequisite( "AUTO_NOTES" );
 
-    add ("AUTO_NOTES_DROPPED_FAVORITES", "general", translate_marker("Auto notes (dropped favorites)"),
-        translate_marker( "If true, automatically sets notes when player drops favorited items."),
-        true
-    );
+    add( "AUTO_NOTES_DROPPED_FAVORITES", "general",
+         translate_marker( "Auto notes (dropped favorites)" ),
+         translate_marker( "If true, automatically sets notes when player drops favorited items." ),
+         true
+       );
 
-    get_option("AUTO_NOTES_DROPPED_FAVORITES").setPrerequisite("AUTO_NOTES");
+    get_option( "AUTO_NOTES_DROPPED_FAVORITES" ).setPrerequisite( "AUTO_NOTES" );
 
     add_empty_line();
 


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

ports dda change
 - https://github.com/CleverRaven/Cataclysm-DDA/pull/62299
<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution

adds a new auto-note option that marks the location of a favorite item drop
<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

## Describe alternatives you've considered
forgetting the item that you forgot you need, again.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing
- spawn random NPC in default scenario, get Cowboy, Yeeee-Haw!
- mark whiskey as favorite item
- run out of evac center
- drop whiskey
- run some more
- check map and see new note

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/79779913/44bfc71d-8887-47b0-81ca-b0af4e392132)

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/79779913/4e16b4cf-cd8f-4dfb-b98d-08bc03ac66aa)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context
note that the note on the initial commit has the wrong dda port
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
