### PR TITLE
feat(mods/DinoMod): scenarios

### DIFF
--- a/data/mods/DinoMod/scenarios.json
+++ b/data/mods/DinoMod/scenarios.json
@@ -1,0 +1,175 @@
+[
+  {
+    "type": "scenario",
+    "id": "dm_wilderness",
+    "name": "Hunted by Dinosaurs",
+    "points": -2,
+    "description": "You find yourself among trees.  The screaming and moaning is fainter, but it sounds like something bigger and more dangerous is close by.",
+    "start_name": "Wilderness",
+    "allowed_locs": [ "sloc_field", "sloc_forest", "sloc_swamp", "sloc_campsite", "sloc_campground", "sloc_desert_island", "sloc_river" ],
+    "flags": [ "LONE_START" ],
+    "surround_groups": [ [ "GROUP_DINOSAUR_MEGA_CARNIVORE", 70.0 ] ]
+  },
+  {
+    "type": "scenario",
+    "id": "missed",
+    "copy-from": "missed",
+    "allowed_locs": [
+      "sloc_house",
+      "sloc_house_boarded",
+      "sloc_grocery_store",
+      "sloc_garage",
+      "sloc_furniture_store",
+      "sloc_library",
+      "sloc_bookstore",
+      "sloc_zoo_giftshop",
+      "sloc_zoo_cages",
+      "sloc_dinozoo_giftshop",
+      "sloc_dinozoo_cages",
+      "sloc_golfcourse_mid_course",
+      "sloc_golfcourse_clubhouse",
+      "sloc_church",
+      "sloc_cemetery",
+      "sloc_dinoexhibit"
+    ]
+  },
+  {
+    "type": "scenario",
+    "id": "surrounded",
+    "copy-from": "surrounded",
+    "allowed_locs": [
+      "sloc_house",
+      "sloc_house_boarded",
+      "sloc_school",
+      "sloc_grocery_store",
+      "sloc_garage",
+      "sloc_furniture_store",
+      "sloc_library",
+      "sloc_bookstore",
+      "sloc_zoo_giftshop",
+      "sloc_zoo_cages",
+      "sloc_dinozoo_giftshop",
+      "sloc_dinozoo_cages",
+      "sloc_golfcourse_mid_course",
+      "sloc_golfcourse_clubhouse",
+      "sloc_church",
+      "sloc_cemetery",
+      "sloc_fire_station",
+      "sloc_police",
+      "sloc_dinoexhibit"
+    ]
+  },
+  {
+    "type": "scenario",
+    "id": "infected",
+    "copy-from": "infected",
+    "allowed_locs": [
+      "sloc_house",
+      "sloc_house_boarded",
+      "sloc_school",
+      "sloc_grocery_store",
+      "sloc_garage",
+      "sloc_furniture_store",
+      "sloc_library",
+      "sloc_bookstore",
+      "sloc_zoo_giftshop",
+      "sloc_zoo_cages",
+      "sloc_dinozoo_giftshop",
+      "sloc_dinozoo_cages",
+      "sloc_golfcourse_mid_course",
+      "sloc_golfcourse_clubhouse",
+      "sloc_church",
+      "sloc_cemetery",
+      "sloc_dinoexhibit"
+    ]
+  },
+  {
+    "type": "scenario",
+    "id": "fungal_start",
+    "copy-from": "fungal_start",
+    "allowed_locs": [
+      "sloc_house",
+      "sloc_house_boarded",
+      "sloc_school",
+      "sloc_grocery_store",
+      "sloc_garage",
+      "sloc_furniture_store",
+      "sloc_library",
+      "sloc_bookstore",
+      "sloc_zoo_giftshop",
+      "sloc_zoo_cages",
+      "sloc_dinozoo_giftshop",
+      "sloc_dinozoo_cages",
+      "sloc_golfcourse_mid_course",
+      "sloc_golfcourse_clubhouse",
+      "sloc_church",
+      "sloc_cemetery",
+      "sloc_dinoexhibit"
+    ]
+  },
+  {
+    "type": "scenario",
+    "id": "bad_day",
+    "copy-from": "bad_day",
+    "allowed_locs": [
+      "sloc_house",
+      "sloc_house_boarded",
+      "sloc_school",
+      "sloc_grocery_store",
+      "sloc_gun_store",
+      "sloc_garage",
+      "sloc_pawn_shop",
+      "sloc_bank",
+      "sloc_military_surplus",
+      "sloc_furniture_store",
+      "sloc_library",
+      "sloc_bookstore",
+      "sloc_zoo_giftshop",
+      "sloc_zoo_cages",
+      "sloc_dinozoo_giftshop",
+      "sloc_dinozoo_cages",
+      "sloc_golfcourse_mid_course",
+      "sloc_golfcourse_clubhouse",
+      "sloc_church",
+      "sloc_cemetery",
+      "sloc_dinoexhibit"
+    ]
+  },
+  {
+    "type": "scenario",
+    "id": "lab_chal",
+    "copy-from": "lab_chal",
+    "allowed_locs": [
+      "sloc_lab_random",
+      "sloc_lab_escape_cells",
+      "sloc_lab_finale",
+      "sloc_ice_lab_stairs",
+      "sloc_ice_lab_finale",
+      "sloc_dinolab"
+    ]
+  },
+  {
+    "type": "scenario",
+    "id": "lab_staff",
+    "copy-from": "lab_staff",
+    "allowed_locs": [
+      "sloc_lab_random",
+      "sloc_lab_escape_cells",
+      "sloc_lab_finale",
+      "sloc_ice_lab_stairs",
+      "sloc_ice_lab_finale",
+      "sloc_dinolab"
+    ]
+  },
+  {
+    "type": "scenario",
+    "id": "dm_predator_nest",
+    "name": "Woke up in a Dinosaur Nest",
+    "points": 0,
+    "description": "When you wake up, you find yourself in the swamp next to some large eggs.",
+    "start_name": "Predator Dinosaur Nest",
+    "allowed_locs": [ "sloc_swamp" ],
+    "map_extra": "mx_nest_tyrannosaurus",
+    "flags": [ "LONE_START" ]
+  }
+]

--- a/data/mods/DinoMod/scenarios.json
+++ b/data/mods/DinoMod/scenarios.json
@@ -6,7 +6,7 @@
     "points": -2,
     "description": "You find yourself among trees.  The screaming and moaning is fainter, but it sounds like something bigger and more dangerous is close by.",
     "start_name": "Wilderness",
-    "allowed_locs": [ "sloc_field", "sloc_forest", "sloc_swamp", "sloc_campsite", "sloc_campground", "sloc_desert_island", "sloc_river" ],
+    "allowed_locs": [ "sloc_field", "sloc_forest", "sloc_swamp", "sloc_campsite", "sloc_campground" ],
     "flags": [ "LONE_START" ],
     "surround_groups": [ [ "GROUP_DINOSAUR_MEGA_CARNIVORE", 70.0 ] ]
   },

--- a/data/mods/DinoMod/scenarios.json
+++ b/data/mods/DinoMod/scenarios.json
@@ -14,151 +14,42 @@
     "type": "scenario",
     "id": "missed",
     "copy-from": "missed",
-    "allowed_locs": [
-      "sloc_house",
-      "sloc_house_boarded",
-      "sloc_grocery_store",
-      "sloc_garage",
-      "sloc_furniture_store",
-      "sloc_library",
-      "sloc_bookstore",
-      "sloc_zoo_giftshop",
-      "sloc_zoo_cages",
-      "sloc_dinozoo_giftshop",
-      "sloc_dinozoo_cages",
-      "sloc_golfcourse_mid_course",
-      "sloc_golfcourse_clubhouse",
-      "sloc_church",
-      "sloc_cemetery",
-      "sloc_dinoexhibit"
-    ]
+    "extend": { "allowed_locs": [ "sloc_dinozoo_giftshop", "sloc_dinozoo_cages", "sloc_dinoexhibit" ] }
   },
   {
     "type": "scenario",
     "id": "surrounded",
     "copy-from": "surrounded",
-    "allowed_locs": [
-      "sloc_house",
-      "sloc_house_boarded",
-      "sloc_school",
-      "sloc_grocery_store",
-      "sloc_garage",
-      "sloc_furniture_store",
-      "sloc_library",
-      "sloc_bookstore",
-      "sloc_zoo_giftshop",
-      "sloc_zoo_cages",
-      "sloc_dinozoo_giftshop",
-      "sloc_dinozoo_cages",
-      "sloc_golfcourse_mid_course",
-      "sloc_golfcourse_clubhouse",
-      "sloc_church",
-      "sloc_cemetery",
-      "sloc_fire_station",
-      "sloc_police",
-      "sloc_dinoexhibit"
-    ]
+    "extend": { "allowed_locs": [ "sloc_dinozoo_giftshop", "sloc_dinozoo_cages", "sloc_dinoexhibit" ] }
   },
   {
     "type": "scenario",
     "id": "infected",
     "copy-from": "infected",
-    "allowed_locs": [
-      "sloc_house",
-      "sloc_house_boarded",
-      "sloc_school",
-      "sloc_grocery_store",
-      "sloc_garage",
-      "sloc_furniture_store",
-      "sloc_library",
-      "sloc_bookstore",
-      "sloc_zoo_giftshop",
-      "sloc_zoo_cages",
-      "sloc_dinozoo_giftshop",
-      "sloc_dinozoo_cages",
-      "sloc_golfcourse_mid_course",
-      "sloc_golfcourse_clubhouse",
-      "sloc_church",
-      "sloc_cemetery",
-      "sloc_dinoexhibit"
-    ]
+    "extend": { "allowed_locs": [ "sloc_dinozoo_giftshop", "sloc_dinozoo_cages", "sloc_dinoexhibit" ] }
   },
   {
     "type": "scenario",
     "id": "fungal_start",
     "copy-from": "fungal_start",
-    "allowed_locs": [
-      "sloc_house",
-      "sloc_house_boarded",
-      "sloc_school",
-      "sloc_grocery_store",
-      "sloc_garage",
-      "sloc_furniture_store",
-      "sloc_library",
-      "sloc_bookstore",
-      "sloc_zoo_giftshop",
-      "sloc_zoo_cages",
-      "sloc_dinozoo_giftshop",
-      "sloc_dinozoo_cages",
-      "sloc_golfcourse_mid_course",
-      "sloc_golfcourse_clubhouse",
-      "sloc_church",
-      "sloc_cemetery",
-      "sloc_dinoexhibit"
-    ]
+    "extend": { "allowed_locs": [ "sloc_dinozoo_giftshop", "sloc_dinozoo_cages", "sloc_dinoexhibit" ] }
   },
   {
     "type": "scenario",
     "id": "bad_day",
     "copy-from": "bad_day",
-    "allowed_locs": [
-      "sloc_house",
-      "sloc_house_boarded",
-      "sloc_school",
-      "sloc_grocery_store",
-      "sloc_gun_store",
-      "sloc_garage",
-      "sloc_pawn_shop",
-      "sloc_bank",
-      "sloc_military_surplus",
-      "sloc_furniture_store",
-      "sloc_library",
-      "sloc_bookstore",
-      "sloc_zoo_giftshop",
-      "sloc_zoo_cages",
-      "sloc_dinozoo_giftshop",
-      "sloc_dinozoo_cages",
-      "sloc_golfcourse_mid_course",
-      "sloc_golfcourse_clubhouse",
-      "sloc_church",
-      "sloc_cemetery",
-      "sloc_dinoexhibit"
-    ]
+    "extend": { "allowed_locs": [ "sloc_dinozoo_giftshop", "sloc_dinozoo_cages", "sloc_dinoexhibit" ] }
   },
   {
     "type": "scenario",
     "id": "lab_chal",
     "copy-from": "lab_chal",
-    "allowed_locs": [
-      "sloc_lab_random",
-      "sloc_lab_escape_cells",
-      "sloc_lab_finale",
-      "sloc_ice_lab_stairs",
-      "sloc_ice_lab_finale",
-      "sloc_dinolab"
-    ]
+    "extend": { "allowed_locs": [ "sloc_dinolab" ] }
   },
   {
     "type": "scenario",
     "id": "lab_staff",
     "copy-from": "lab_staff",
-    "allowed_locs": [
-      "sloc_lab_random",
-      "sloc_lab_escape_cells",
-      "sloc_lab_finale",
-      "sloc_ice_lab_stairs",
-      "sloc_ice_lab_finale",
-      "sloc_dinolab"
-    ]
+    "extend": { "allowed_locs": [ "sloc_dinolab" ] }
   }
 ]

--- a/data/mods/DinoMod/scenarios.json
+++ b/data/mods/DinoMod/scenarios.json
@@ -160,16 +160,5 @@
       "sloc_ice_lab_finale",
       "sloc_dinolab"
     ]
-  },
-  {
-    "type": "scenario",
-    "id": "dm_predator_nest",
-    "name": "Woke up in a Dinosaur Nest",
-    "points": 0,
-    "description": "When you wake up, you find yourself in the swamp next to some large eggs.",
-    "start_name": "Predator Dinosaur Nest",
-    "allowed_locs": [ "sloc_swamp" ],
-    "map_extra": "mx_nest_tyrannosaurus",
-    "flags": [ "LONE_START" ]
   }
 ]

--- a/data/mods/DinoMod/startlocations.json
+++ b/data/mods/DinoMod/startlocations.json
@@ -4,5 +4,30 @@
     "id": "sloc_dinoexhibit",
     "name": "Dinosaur exhibit",
     "terrain": [ "dinoexhibit" ]
+  },
+  {
+    "type": "start_location",
+    "id": "sloc_dinolab",
+    "name": "DinoLab",
+    "terrain": [ "microlab_DinoLab_edge" ]
+  },
+  {
+    "type": "start_location",
+    "id": "sloc_dinozoo_giftshop",
+    "name": "DinoZoo (Giftshop)",
+    "terrain": [ "dinozoo_0_1" ]
+  },
+  {
+    "type": "start_location",
+    "id": "sloc_dinozoo_cages",
+    "name": "DinoZoo (Cages)",
+    "terrain": [ "dinozoo_1_1" ]
+  },
+  {
+    "type": "start_location",
+    "id": "sloc_swamp",
+    "name": "Middle of Swamp",
+    "terrain": [ "forest_water" ],
+    "flags": [ "ALLOW_OUTSIDE" ]
   }
 ]


### PR DESCRIPTION
## Purpose of change

Content parity with DDA

## Describe the solution

Ports most scenarios content from DDA. Includes material from https://github.com/CleverRaven/Cataclysm-DDA/pull/56451 and https://github.com/CleverRaven/Cataclysm-DDA/pull/50513 and https://github.com/CleverRaven/Cataclysm-DDA/pull/49968

## Describe alternatives you've considered

N/A

## Testing

Passes checks. I can't get the latest build to run on my Mac but that shouldn't be related.

## Additional context

Permitted by #4665

## Checklist

N/A, this adds JSON content
