### PR TITLE
fix: fix for the occupied lumbermill

### DIFF
--- a/data/json/mapgen/occupied_lumber_mill.json
+++ b/data/json/mapgen/occupied_lumber_mill.json
@@ -58,8 +58,9 @@
       "palettes": [ "lumberyard" ],
       "faction_owner": [
         { "id": "wasteland_scavengers", "x": [ 1, 23 ], "y": [ 1, 23 ] },
-        { "id": "wasteland_scavengers", "x": [ 24, 47 ], "y": [ 24, 47 ] },
-        { "id": "wasteland_scavengers", "x": [ 48, 71 ], "y": [ 48, 71 ] }
+        { "id": "wasteland_scavengers", "x": [ 1, 23 ], "y": [ 24, 47 ] },
+        { "id": "wasteland_scavengers", "x": [ 24, 47 ], "y": [ 1, 23 ] },
+        { "id": "wasteland_scavengers", "x": [ 24, 47 ], "y": [ 24, 47 ] }
       ],
       "terrain": { "o": "t_concrete" },
       "gaspumps": { "G": { "fuel": "gasoline", "amount": [ 50000, 268750 ] } },
@@ -253,6 +254,41 @@
       ],
       "terrain": { "v": "t_wall_wood", "!": "t_door_c", ".": "t_floor", "b": "t_floor", "0": "t_window" },
       "furniture": { "b": "f_makeshift_bed" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "occupied_lum_hotel_roof_1_1",
+    "object": {
+      "mapgensize": [ 24, 24 ],
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "             .........  ",
+        "             .........  ",
+        "             .........  ",
+        "             .........  ",
+        "             .........  ",
+        "             .........  ",
+        "             .........  ",
+        "                        ",
+        "                        "
+      ],
+      "terrain": { ".": "t_flat_roof" }
     }
   }
 ]

--- a/data/json/npcs/lumberyard/lumbermill_missions.json
+++ b/data/json/npcs/lumberyard/lumbermill_missions.json
@@ -117,7 +117,16 @@
     },
     "origins": [ "ORIGIN_OPENER_NPC" ],
     "end": {
-      "update_mapgen": { "om_terrain": "lumbermill_1_1_ocu", "place_nested": [ { "chunks": [ "occupied_lum_hotel_1_1" ], "x": 0, "y": 0 } ] }
+      "update_mapgen": [
+        {
+          "om_terrain": "lumbermill_1_1_ocu",
+          "place_nested": [ { "chunks": [ "occupied_lum_hotel_1_1" ], "x": 0, "y": 0 } ]
+        },
+        {
+          "om_terrain": "lumbermill_1_1_roof",
+          "place_nested": [ { "chunks": [ "occupied_lum_hotel_roof_1_1" ], "x": 0, "y": 0 } ]
+        }
+      ]
     },
     "followup": "MISSION_LUMBERMILL_SET_TRADE_ROUTE",
     "has_generic_rewards": true,

--- a/data/json/npcs/lumberyard/lumbermill_missions.json
+++ b/data/json/npcs/lumberyard/lumbermill_missions.json
@@ -118,10 +118,7 @@
     "origins": [ "ORIGIN_OPENER_NPC" ],
     "end": {
       "update_mapgen": [
-        {
-          "om_terrain": "lumbermill_1_1_ocu",
-          "place_nested": [ { "chunks": [ "occupied_lum_hotel_1_1" ], "x": 0, "y": 0 } ]
-        },
+        { "om_terrain": "lumbermill_1_1_ocu", "place_nested": [ { "chunks": [ "occupied_lum_hotel_1_1" ], "x": 0, "y": 0 } ] },
         {
           "om_terrain": "lumbermill_1_1_roof",
           "place_nested": [ { "chunks": [ "occupied_lum_hotel_roof_1_1" ], "x": 0, "y": 0 } ]

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -6623,7 +6623,7 @@
       { "point": [ 1, 3, 0 ], "overmap": "lumbermill_dforest_north" },
       { "point": [ 2, 3, 0 ], "overmap": "lumbermill_dforest_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 1, -1, 0 ] } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road" }, { "point": [ 1, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "forest" ],
     "city_distance": [ 5, 60 ],
     "city_sizes": [ 4, -1 ],


### PR DESCRIPTION
## Purpose of change
More fix for the occupied lumbermill.
## Describe the solution
Fix the ownership because a corner of the lumbermill doesn't belong to the loggers.
Use the same road connection as the unoccupied lumbermill.
Add a roof to the sleeping quarter placed by the mission `MISSION_LUMBERMILL_GET_6_BLANKETS` because it has no roof.
## Describe alternatives you've considered
none
## Additional context
Sleeping quarters roof.
<img width="960" alt="image1" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/2909b1f8-7ff7-4808-95e6-04ca050e845b">