### PR TITLE
fix: lab finales have science ID cards again

### DIFF
--- a/data/json/mapgen/lab/lab_floorplans_finale1level.json
+++ b/data/json/mapgen/lab/lab_floorplans_finale1level.json
@@ -38,7 +38,10 @@
       "terrain": { "?": "t_nanofab", "r": "t_metal_floor", "/": "t_nanofab_body" },
       "mapping": { "r": { "item": { "item": "standard_template_construct" } }, "R": { "item": { "item": "nanomaterial" } } },
       "place_nested": [ { "chunks": [ "lab_finale_loot" ], "x": 6, "y": 11 } ],
-      "place_loot": [ { "group": "mech_power_cell_spawn", "x": [ 4, 5 ], "y": [ 3, 5 ] } ],
+      "place_loot": [
+        { "group": "mech_power_cell_spawn", "x": [ 4, 5 ], "y": [ 3, 5 ] },
+        { "item": "id_science", "x": 17, "y": [ 11, 13 ] }
+      ],
       "place_monster": [
         { "monster": "mon_secubot", "x": [ 1, 4 ], "y": [ 20, 22 ], "chance": 90 },
         { "monster": "mon_secubot", "x": [ 19, 20 ], "y": [ 20, 22 ], "chance": 90 },
@@ -96,6 +99,7 @@
         }
       },
       "place_nested": [ { "chunks": [ "lab_finale_loot" ], "x": 4, "y": 1 } ],
+      "place_loot": [ { "item": "id_science", "x": [ 19, 20 ], "y": [ 2, 5 ] } ],
       "place_monster": [
         { "monster": "mon_hound_tindalos", "x": [ 7, 8 ], "y": [ 17, 18 ], "chance": 90 },
         { "monster": "mon_hound_tindalos", "x": [ 16, 17 ], "y": [ 17, 18 ], "chance": 90 },
@@ -152,7 +156,8 @@
           "failures": [ { "action": "damage" }, { "action": "secubots" } ]
         }
       },
-      "place_nested": [ { "chunks": [ "lab_finale_loot" ], "x": 4, "y": 13 } ]
+      "place_nested": [ { "chunks": [ "lab_finale_loot" ], "x": 4, "y": 13 } ],
+      "place_loot": [ { "item": "id_science", "x": [ 14, 16 ], "y": 12 } ]
     }
   },
   {
@@ -192,7 +197,8 @@
       "palettes": [ "lab_palette" ],
       "place_nested": [ { "chunks": [ "lab_finale_loot" ], "x": 5, "y": 8 } ],
       "monster": { "?": { "monster": "mon_turret_light" } },
-      "terrain": { "o": "t_cvdbody", "O": "t_cvdmachine" }
+      "terrain": { "o": "t_cvdbody", "O": "t_cvdmachine" },
+      "place_loot": [ { "item": "id_science", "x": [ 8, 10 ], "y": 10 } ]
     }
   },
   {

--- a/data/mods/DinoMod/mapgen/DinoLabFinale.json
+++ b/data/mods/DinoMod/mapgen/DinoLabFinale.json
@@ -144,7 +144,10 @@
           ]
         }
       },
-      "place_loot": [ { "group": "mech_power_cell_spawn", "x": 1, "y": [ 1, 4 ] } ],
+      "place_loot": [
+        { "group": "mech_power_cell_spawn", "x": 1, "y": [ 1, 4 ] },
+        { "item": "id_science", "x": [ 19, 20 ], "y": [ 2, 5 ] }
+      ],
       "place_monster": [
         { "monster": "mon_deinonychus", "x": [ 7, 8 ], "y": [ 17, 18 ], "chance": 90, "repeat": [ 1, 5 ] },
         { "monster": "mon_deinonychus", "x": [ 16, 17 ], "y": [ 17, 18 ], "chance": 90, "repeat": [ 1, 5 ] },
@@ -219,6 +222,7 @@
         },
         "D": { "item": [ { "item": "report_dino_exploration" } ] }
       },
+      "place_loot": [ { "item": "id_science", "x": [ 19, 20 ], "y": [ 2, 5 ] } ],
       "place_monster": [
         { "monster": "mon_fish_salmon", "x": [ 7, 8 ], "y": [ 17, 18 ], "chance": 90, "repeat": [ 1, 5 ] },
         { "monster": "mon_ceratosaurus", "x": [ 16, 17 ], "y": [ 17, 18 ], "chance": 90, "repeat": [ 1, 6 ] },


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

It turns out when lab finales were reworked a while back, the failsafe feature of them always spawning a science ID card somewhere was lost in the process. As I noted in the relevant issue, it's really more of a last resort if a player manages to completely master a lab they spawn in but somehow fail to find any reasonable escape method.

Ideally if the player can survive crawling their way down into the finale, grab the card, make it back to the entrance and get past the turret to swipe the card reader, then they're badass enough they should already have free rein to scour the rest of the lab for way easier escape methods, but it's a good bit of idiotproofing in case the RNG was feeling weird enough that day.

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/4598

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Placed a science ID card on the counters in the nanofab finale, in the room across from where the randomized secondary loot spawns.
2. Placed a science ID card on the big table in the portal finale, outside of the secondary loot spawn room.
3. Placed a science ID card on one of the tables in the center room in the resonance cascade finale.
4. Placed a science ID card on the table outside the secondary loot room in the CVD forge finale.
5. Fixed 2 of the 3 finale variants in Dinomod lacking an ID card spawn. Pinging @LyleSY so they'll be aware of the change.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

If we ever make microlabs a valid starting location for scenarios, we'll need to also give them a dedicated mini-finale room instead of being pure blobs of generic identically-constructed maze rooms. This would be important since there's not as wacky a variety of loot and less room to spawn stuff than in the average standard lab, so there's a better chance the player could get softlocked if they were allowed to spawn in one of those.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected file for syntax and lint errors.
2. Load-tested in compiled test build.
3. Debug map edited to generate one of each finale variant, confirmed they all had the expected ID card in the expected area.

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/e165ce34-4219-4c3e-a722-84da9567b8e3)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Also gave the lab finale variant added by Arcana mod over in its repo a quick check to confirm it never lost its ID card spawn.

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
