### PR TITLE
feat(content): use glue as nail alternative

### DIFF
--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -292,7 +292,8 @@
     "weight": "45 g",
     "volume": "250 ml",
     "to_hit": -2,
-    "flags": [ "UNRECOVERABLE", "NO_SALVAGE" ]
+    "flags": [ "UNRECOVERABLE", "NO_SALVAGE" ],
+    "stackable": true
   },
   {
     "type": "GENERIC",

--- a/data/json/recipes/armor/feet.json
+++ b/data/json/recipes/armor/feet.json
@@ -523,7 +523,7 @@
     "book_learn": [ [ "mag_swimming", 3 ], [ "manual_swimming", 2 ] ],
     "using": [ [ "sewing_standard", 20 ] ],
     "tools": [ [ [ "soldering_standard", 60, "LIST" ], [ "surface_heat", 60, "LIST" ] ] ],
-    "components": [ [ [ "plastic_chunk", 8 ] ], [ [ "duct_tape", 80 ], [ "medical_tape", 80 ] ], [ [ "superglue", 1 ] ] ]
+    "components": [ [ [ "plastic_chunk", 8 ] ], [ [ "adhesive", 5, "LIST" ] ] ]
   },
   {
     "result": "thermal_socks",

--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -262,7 +262,7 @@
     "components": [
       [ [ "goggles_ski", 1 ], [ "goggles_welding", 1 ], [ "glasses_safety", 1 ] ],
       [ [ "duct_tape", 120 ], [ "medical_tape", 120 ] ],
-      [ [ "superglue", 1 ] ]
+      [ [ "superglue", 3 ] ]
     ]
   },
   {

--- a/data/json/recipes/armor/other.json
+++ b/data/json/recipes/armor/other.json
@@ -248,7 +248,7 @@
     "components": [
       [ [ "oxy_powder", 50 ] ],
       [ [ "charcoal", 5 ], [ "coal_lump", 5 ] ],
-      [ [ "superglue", 1 ] ],
+      [ [ "superglue", 2 ] ],
       [ [ "scrap", 2 ], [ "can_food_unsealed", 1 ], [ "can_drink_unsealed", 1 ], [ "canister_empty", 1 ] ]
     ]
   },
@@ -302,7 +302,7 @@
     "components": [
       [ [ "oxy_powder", 50 ] ],
       [ [ "charcoal", 5 ], [ "coal_lump", 5 ] ],
-      [ [ "superglue", 1 ] ],
+      [ [ "superglue", 2 ] ],
       [ [ "scrap", 2 ], [ "can_food_unsealed", 1 ], [ "can_drink_unsealed", 1 ], [ "canister_empty", 1 ] ]
     ]
   },

--- a/data/json/recipes/armor/other.json
+++ b/data/json/recipes/armor/other.json
@@ -402,7 +402,7 @@
     "autolearn": true,
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 } ],
     "components": [
-      [ [ "nail", 8 ] ],
+      [ [ "nail_glue", 8, "LIST" ] ],
       [ [ "2x4", 4 ], [ "wood_panel", 1 ] ],
       [ [ "rag", 2 ], [ "felt_patch", 2 ], [ "fur", 2 ], [ "leather", 2 ] ]
     ]
@@ -418,7 +418,7 @@
     "autolearn": true,
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 } ],
     "components": [
-      [ [ "nail", 16 ] ],
+      [ [ "nail_glue", 16, "LIST" ] ],
       [ [ "2x4", 8 ], [ "wood_panel", 2 ] ],
       [ [ "rag", 2 ], [ "felt_patch", 2 ], [ "fur", 2 ], [ "leather", 2 ] ]
     ]

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -59,7 +59,7 @@
     "autolearn": true,
     "using": [ [ "adhesive", 1 ], [ "sewing_standard", 10 ] ],
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "components": [ [ [ "leather", 5 ] ], [ [ "scrap", 3 ], [ "sheet_metal_small", 1 ] ], [ [ "nail", 4 ] ] ]
+    "components": [ [ [ "leather", 5 ] ], [ [ "scrap", 3 ], [ "sheet_metal_small", 1 ] ], [ [ "nail_glue", 4, "LIST" ] ] ]
   },
   {
     "result": "back_holster",
@@ -110,7 +110,7 @@
     "autolearn": true,
     "using": [ [ "adhesive", 1 ] ],
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "fabric_hides_any", 12, "LIST" ] ], [ [ "wood_structural", 1, "LIST" ] ], [ [ "nail", 8 ] ] ]
+    "components": [ [ [ "fabric_hides_any", 12, "LIST" ] ], [ [ "wood_structural", 1, "LIST" ] ], [ [ "nail_glue", 8, "LIST" ] ] ]
   },
   {
     "result": "bandolier_pistol",
@@ -274,7 +274,7 @@
     "autolearn": true,
     "using": [ [ "adhesive", 1 ] ],
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "fabric_hides_any", 15, "LIST" ] ], [ [ "wood_structural", 1, "LIST" ] ], [ [ "nail", 10 ] ] ]
+    "components": [ [ [ "fabric_hides_any", 15, "LIST" ] ], [ [ "wood_structural", 1, "LIST" ] ], [ [ "nail_glue", 10, "LIST" ] ] ]
   },
   {
     "result": "chestpouch",
@@ -414,7 +414,7 @@
     "time": "60 m",
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 2 } ],
-    "components": [ [ [ "2x4", 3 ] ], [ [ "wood_panel", 1 ] ], [ [ "nail", 20 ] ], [ [ "rope_natural", 1, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 3 ] ], [ [ "wood_panel", 1 ] ], [ [ "nail_glue", 20, "LIST" ] ], [ [ "rope_natural", 1, "LIST" ] ] ]
   },
   {
     "result": "leather_belt",
@@ -622,7 +622,7 @@
     "autolearn": true,
     "using": [ [ "adhesive", 1 ] ],
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "fabric_hides_any", 10, "LIST" ] ], [ [ "wood_structural", 1, "LIST" ] ], [ [ "nail", 5 ] ] ]
+    "components": [ [ [ "fabric_hides_any", 10, "LIST" ] ], [ [ "wood_structural", 1, "LIST" ] ], [ [ "nail_glue", 5, "LIST" ] ] ]
   },
   {
     "result": "sheath",

--- a/data/json/recipes/armor/suit.json
+++ b/data/json/recipes/armor/suit.json
@@ -451,7 +451,7 @@
     "components": [
       [ [ "nomex", 40 ] ],
       [ [ "kevlar_plate", 8 ] ],
-      [ [ "duct_tape", 200 ], [ "superglue", 5 ] ],
+      [ [ "adhesive", 5, "LIST" ] ],
       [ [ "kevlar", 1 ], [ "modularvest", 1 ], [ "swat_armor", 1 ], [ "kevlar_plate", 24 ] ]
     ]
   },

--- a/data/json/recipes/chem/chemicals.json
+++ b/data/json/recipes/chem/chemicals.json
@@ -683,7 +683,7 @@
     "time": "5 m",
     "book_learn": [ [ "textbook_anarch", 5 ], [ "recipe_labchem", 4 ], [ "textbook_chemistry", 5 ] ],
     "qualities": [ { "id": "BOIL", "level": 2 } ],
-    "components": [ [ [ "zinc_metal", 500 ] ], [ [ "chem_sulphur", 750 ] ], [ [ "superglue", 2 ] ] ]
+    "components": [ [ [ "zinc_metal", 500 ] ], [ [ "chem_sulphur", 750 ] ], [ [ "superglue", 10 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/chem/other.json
+++ b/data/json/recipes/chem/other.json
@@ -108,6 +108,7 @@
     "time": "30 m",
     "batch_time_factors": [ 83, 5 ],
     "autolearn": true,
+	"charges": 10,
     "book_learn": [ [ "recipe_arrows", 1 ], [ "textbook_survival", 1 ], [ "survival_book", 1 ] ],
     "qualities": [ { "id": "COOK", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 3, "LIST" ] ] ],
@@ -124,6 +125,7 @@
     "autolearn": true,
     "qualities": [ { "id": "CHEM", "level": 1 } ],
     "batch_time_factors": [ 83, 5 ],
+	"charges": 10,
     "tools": [ [ [ "surface_heat", 5, "LIST" ] ] ],
     "components": [
       [ [ "water", 1 ], [ "water_clean", 1 ] ],

--- a/data/json/recipes/electronic/components.json
+++ b/data/json/recipes/electronic/components.json
@@ -58,7 +58,7 @@
     "decomp_learn": 3,
     "book_learn": [ [ "radio_book", 3 ], [ "textbook_anarch", 5 ] ],
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 1 } ],
-    "components": [ [ [ "amplifier", 1 ] ], [ [ "wire", 6 ] ], [ [ "2x4", 2 ] ], [ [ "nail", 12 ] ] ]
+    "components": [ [ [ "amplifier", 1 ] ], [ [ "wire", 6 ] ], [ [ "2x4", 2 ] ], [ [ "nail_glue", 12, "LIST" ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/electronic/lighting.json
+++ b/data/json/recipes/electronic/lighting.json
@@ -13,7 +13,7 @@
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [
       [ [ "plastic_chunk", 1 ] ],
-      [ [ "superglue", 1 ] ],
+      [ [ "superglue", 3 ] ],
       [ [ "power_supply", 1 ] ],
       [ [ "cable", 1 ] ],
       [ [ "light_bulb", 1 ], [ "e_scrap", 1 ] ]

--- a/data/json/recipes/electronic/other.json
+++ b/data/json/recipes/electronic/other.json
@@ -831,7 +831,7 @@
     "qualities": [ { "id": "SCREW_FINE", "level": 1 } ],
     "components": [
       [ [ "plastic_chunk", 4 ] ],
-      [ [ "superglue", 1 ] ],
+      [ [ "superglue", 3 ] ],
       [ [ "cable", 5 ] ],
       [ [ "small_lcd_screen", 1 ] ],
       [ [ "ai_module_basic", 1 ], [ "ai_module", 1 ], [ "ai_module_advanced", 1 ] ],

--- a/data/json/recipes/electronic/parts.json
+++ b/data/json/recipes/electronic/parts.json
@@ -80,7 +80,7 @@
       [ [ "motor_small", 1 ], [ "alternator_bicycle", 2 ], [ "alternator_car", 1 ], [ "alternator_motorbike", 1 ] ],
       [ [ "2x4", 5 ], [ "frame_wood", 1 ] ],
       [ [ "sheet_metal_small", 3 ] ],
-      [ [ "nail", 20 ] ],
+      [ [ "nail_glue", 20, "LIST" ] ],
       [ [ "pipe", 4 ] ]
     ]
   },
@@ -111,7 +111,7 @@
         [ "motor", 2 ],
         [ "motor_large", 1 ]
       ],
-      [ [ "nail", 120 ] ],
+      [ [ "nail_glue", 120, "LIST" ] ],
       [ [ "pipe", 20 ] ]
     ]
   },
@@ -139,7 +139,7 @@
       [ [ "motor_small", 1 ], [ "alternator_bicycle", 1 ], [ "alternator_motorbike", 1 ] ],
       [ [ "2x4", 20 ], [ "frame_wood", 3 ] ],
       [ [ "sheet_metal_small", 6 ] ],
-      [ [ "nail", 80 ] ],
+      [ [ "nail_glue", 80, "LIST" ] ],
       [ [ "pipe", 8 ] ],
       [ [ "wheel_wood_b", 2 ] ]
     ]
@@ -176,7 +176,7 @@
         [ "motor", 2 ],
         [ "motor_large", 1 ]
       ],
-      [ [ "nail", 240 ] ],
+      [ [ "nail_glue", 240, "LIST" ] ],
       [ [ "pipe", 24 ] ],
       [ [ "wheel_wood_b", 6 ] ]
     ]

--- a/data/json/recipes/electronic/tools.json
+++ b/data/json/recipes/electronic/tools.json
@@ -432,7 +432,7 @@
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [
       [ [ "plastic_chunk", 5 ] ],
-      [ [ "superglue", 1 ] ],
+      [ [ "superglue", 3 ] ],
       [ [ "power_supply", 1 ] ],
       [ [ "e_scrap", 3 ] ],
       [ [ "scrap", 3 ] ],
@@ -453,7 +453,7 @@
     "using": [ [ "soldering_standard", 5 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "tools": [ [ [ "mold_plastic", -1 ] ] ],
-    "components": [ [ [ "superglue", 1 ] ], [ [ "scrap", 1 ] ], [ [ "plastic_chunk", 3 ] ], [ [ "cable", 5 ] ], [ [ "motor_micro", 1 ] ] ]
+    "components": [ [ [ "superglue", 3 ] ], [ [ "scrap", 1 ] ], [ [ "plastic_chunk", 3 ] ], [ [ "cable", 5 ] ], [ [ "motor_micro", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -585,7 +585,7 @@
       [ [ "scrap", 4 ] ],
       [ [ "plastic_chunk", 2 ] ],
       [ [ "motor_micro", 1 ] ],
-      [ [ "superglue", 2 ] ],
+      [ [ "superglue", 6 ] ],
       [ [ "element", 2 ] ],
       [ [ "hose", 1 ] ],
       [ [ "power_supply", 1 ] ]

--- a/data/json/recipes/electronic/tools.json
+++ b/data/json/recipes/electronic/tools.json
@@ -110,7 +110,7 @@
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SCREW", "level": 1 } ],
     "components": [
       [ [ "e_scrap", 2 ], [ "glowplug", 1 ] ],
-      [ [ "copper", 1 ], [ "nail", 1 ], [ "wire", 1 ] ],
+      [ [ "copper", 1 ], [ "nail_glue", 1, "LIST" ], [ "wire", 1 ] ],
       [ [ "scrap", 1 ] ],
       [ [ "adhesive", 1, "LIST" ] ],
       [ [ "cable", 5 ] ]

--- a/data/json/recipes/other/containers.json
+++ b/data/json/recipes/other/containers.json
@@ -290,7 +290,7 @@
     "autolearn": true,
     "using": [ [ "soldering_standard", 40 ] ],
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "duct_tape", 200 ], [ "superglue", 4 ] ], [ [ "jerrycan", 12 ] ] ]
+    "components": [ [ [ "adhesive", 4, "LIST" ] ], [ [ "jerrycan", 12 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -625,7 +625,7 @@
     "using": [ [ "forging_standard", 10 ], [ "steel_standard", 5 ] ],
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 2 } ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "components": [ [ [ "2x4", 24 ] ], [ [ "nail", 40 ] ] ]
+    "components": [ [ [ "2x4", 24 ] ], [ [ "nail_glue", 40, "LIST" ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -79,7 +79,7 @@
     "book_learn": [ [ "textbook_fabrication", 3 ], [ "textbook_mechanics", 3 ], [ "welding_book", 5 ] ],
     "using": [ [ "welding_standard", 4 ] ],
     "qualities": [ { "id": "SAW_M", "level": 1 } ],
-    "components": [ [ [ "glass_sheet", 1 ] ], [ [ "wire", 8 ] ], [ [ "superglue", 1 ] ] ]
+    "components": [ [ [ "glass_sheet", 1 ] ], [ [ "wire", 8 ] ], [ [ "superglue", 8 ] ] ]
   },
   {
     "type": "recipe",
@@ -321,7 +321,7 @@
     "using": [ [ "filament", 50 ] ],
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "COOK", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 5, "LIST" ] ] ],
-    "components": [ [ [ "superglue", 1 ] ], [ [ "fabric_standard", 6, "LIST" ] ], [ [ "plastic_chunk", 1 ] ] ]
+    "components": [ [ [ "superglue", 5 ] ], [ [ "fabric_standard", 6, "LIST" ] ], [ [ "plastic_chunk", 1 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/other/other.json
+++ b/data/json/recipes/other/other.json
@@ -238,7 +238,7 @@
     "autolearn": true,
     "book_learn": [ [ "textbook_fabrication", 2 ], [ "textbook_mechanics", 2 ] ],
     "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "DRILL", "level": 1 }, { "id": "SCREW", "level": 1 } ],
-    "components": [ [ [ "scrap", 6 ] ], [ [ "pipe", 6 ] ], [ [ "nail", 12 ] ], [ [ "sheet_metal", 1 ] ] ]
+    "components": [ [ [ "scrap", 6 ] ], [ [ "pipe", 6 ] ], [ [ "nail_glue", 12, "LIST" ] ], [ [ "sheet_metal", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -276,7 +276,7 @@
     "reversible": true,
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 2 } ],
-    "components": [ [ [ "2x4", 4 ] ], [ [ "nail", 20 ] ], [ [ "hinge", 2 ] ] ]
+    "components": [ [ [ "2x4", 4 ] ], [ [ "nail_glue", 20, "LIST" ] ], [ [ "hinge", 2 ] ] ]
   },
   {
     "result": "fish_bait",

--- a/data/json/recipes/other/parts.json
+++ b/data/json/recipes/other/parts.json
@@ -195,7 +195,7 @@
     "time": "10 m",
     "autolearn": true,
     "qualities": [ { "id": "SAW_W", "level": 2 }, { "id": "HAMMER", "level": 2 } ],
-    "components": [ [ [ "2x4", 8 ] ], [ [ "nail", 36 ] ] ]
+    "components": [ [ [ "2x4", 8 ] ], [ [ "nail_glue", 36, "LIST" ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/other/tools.json
+++ b/data/json/recipes/other/tools.json
@@ -37,7 +37,7 @@
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SCREW", "level": 1 } ],
     "time": "32 m",
     "autolearn": true,
-    "components": [ [ [ "largebroketent", 2 ], [ "broketent", 4 ], [ "tent_kit", 3 ] ], [ [ "adhesive", 3 ] ] ]
+    "components": [ [ [ "largebroketent", 2 ], [ "broketent", 4 ], [ "tent_kit", 3 ] ], [ [ "adhesive", 3, "LIST" ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/other/tools.json
+++ b/data/json/recipes/other/tools.json
@@ -9,7 +9,7 @@
     "time": "8 m",
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 2 } ],
-    "components": [ [ [ "nail", 8 ] ], [ [ "2x4", 3 ] ] ]
+    "components": [ [ [ "nail_glue", 8, "LIST" ] ], [ [ "2x4", 3 ] ] ]
   },
   {
     "type": "recipe",
@@ -636,7 +636,7 @@
     "reversible": true,
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SAW_W", "level": 1 } ],
-    "components": [ [ [ "2x4", 12 ] ], [ [ "nail", 30 ] ] ]
+    "components": [ [ [ "2x4", 12 ] ], [ [ "nail_glue", 30, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -697,8 +697,7 @@
     "difficulty": 1,
     "time": "2 m",
     "autolearn": true,
-    "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "tools": [ [ [ "nail", -1 ], [ "spike", -1 ], [ "sharp_rock", -1 ], [ "rebar", -1 ], [ "spear_rebar", -1 ] ] ],
+    "qualities": [ { "id": "DRILL", "level": 1 } ],
     "components": [ [ [ "55gal_drum", 1 ] ] ]
   },
   {
@@ -710,8 +709,7 @@
     "difficulty": 1,
     "time": "2 m",
     "autolearn": true,
-    "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "tools": [ [ [ "nail", -1 ], [ "spike", -1 ], [ "sharp_rock", -1 ], [ "rebar", -1 ], [ "spear_rebar", -1 ] ] ],
+    "qualities": [ { "id": "DRILL", "level": 1 } ],
     "components": [ [ [ "30gal_drum", 1 ] ] ]
   },
   {
@@ -1797,7 +1795,7 @@
     "autolearn": true,
     "components": [
       [ [ "sheet_metal_small", 5 ] ],
-      [ [ "nail", 11 ] ],
+      [ [ "nail_glue", 11, "LIST" ] ],
       [ [ "wire", 1 ] ],
       [ [ "pockknife", 1 ], [ "primitive_knife", 1 ], [ "copper_knife", 1 ] ],
       [ [ "screwdriver_set", 1 ] ],
@@ -1819,7 +1817,7 @@
     "autolearn": true,
     "components": [
       [ [ "sheet_metal_small", 5 ] ],
-      [ [ "nail", 11 ] ],
+      [ [ "nail_glue", 11, "LIST" ] ],
       [ [ "wire", 1 ] ],
       [ [ "pockknife", 1 ], [ "primitive_knife", 1 ], [ "copper_knife", 1 ] ],
       [ [ "screwdriver_set", 1 ] ],
@@ -2120,7 +2118,7 @@
     "components": [
       [ [ "scrap", 6 ] ],
       [ [ "pipe", 12 ], [ "cu_pipe", 12 ], [ "frame", 2 ] ],
-      [ [ "nail", 12 ] ],
+      [ [ "nail_glue", 12, "LIST" ] ],
       [ [ "wire", 6 ], [ "rope_6", 6 ], [ "vine_6", 6 ], [ "rope_makeshift_6", 6 ] ],
       [ [ "chain", 1 ], [ "rope_natural", 1, "LIST" ] ],
       [ [ "spike", 2 ] ]
@@ -2146,7 +2144,7 @@
     "components": [
       [ [ "scrap", 6 ] ],
       [ [ "pipe", 15 ], [ "cu_pipe", 15 ], [ "frame", 2 ] ],
-      [ [ "nail", 12 ] ],
+      [ [ "nail_glue", 12, "LIST" ] ],
       [ [ "wire", 6 ], [ "rope_natural_short", 6, "LIST" ] ],
       [ [ "spike", 4 ] ]
     ]
@@ -2515,7 +2513,7 @@
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SCREW", "level": 1 } ],
     "components": [
       [ [ "2x4", 18 ] ],
-      [ [ "nail", 14 ] ],
+      [ [ "nail_glue", 14, "LIST" ] ],
       [ [ "sheet_metal", 1 ] ],
       [ [ "foot_crank", 1 ] ],
       [ [ "sheet_metal_small", 1 ] ]
@@ -2656,8 +2654,7 @@
     "time": "5 m",
     "autolearn": true,
     "book_learn": [ [ "mag_survival", 2 ], [ "textbook_survival", 1 ], [ "cookbook", 2 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "tools": [ [ [ "nail", -1 ], [ "spike", -1 ], [ "sharp_rock", -1 ], [ "rebar", -1 ], [ "spear_rebar", -1 ] ] ],
+    "qualities": [ { "id": "DRILL", "level": 1 } ],
     "components": [ [ [ "can_medium_unsealed", 1 ] ], [ [ "scrap", 3 ] ] ]
   },
   {

--- a/data/json/recipes/other/tools.json
+++ b/data/json/recipes/other/tools.json
@@ -23,7 +23,7 @@
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SCREW", "level": 1 } ],
     "time": "28 m",
     "autolearn": true,
-    "components": [ [ [ "largebroketent", 1 ], [ "broketent", 2 ] ], [ [ "superglue", 2 ], [ "duct_tape", 20 ] ] ]
+    "components": [ [ [ "largebroketent", 1 ], [ "broketent", 2 ] ], [ [ "adhesive", 2, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -37,7 +37,7 @@
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SCREW", "level": 1 } ],
     "time": "32 m",
     "autolearn": true,
-    "components": [ [ [ "largebroketent", 2 ], [ "broketent", 4 ], [ "tent_kit", 3 ] ], [ [ "superglue", 3 ], [ "duct_tape", 40 ] ] ]
+    "components": [ [ [ "largebroketent", 2 ], [ "broketent", 4 ], [ "tent_kit", 3 ] ], [ [ "adhesive", 3 ] ] ]
   },
   {
     "type": "recipe",
@@ -2824,7 +2824,7 @@
     "autolearn": true,
     "time": "1 h",
     "using": [ [ "sewing_standard", 30 ] ],
-    "components": [ [ [ "leather", 4 ] ], [ [ "superglue", 1 ] ] ]
+    "components": [ [ [ "leather", 4 ] ], [ [ "adhesive", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/other/tools.json
+++ b/data/json/recipes/other/tools.json
@@ -697,7 +697,8 @@
     "difficulty": 1,
     "time": "2 m",
     "autolearn": true,
-    "qualities": [ { "id": "DRILL", "level": 1 } ],
+    "qualities": [ { "id": "HAMMER", "level": 1 } ],
+    "tools": [ [ [ "nail", -1 ], [ "spike", -1 ], [ "sharp_rock", -1 ], [ "rebar", -1 ], [ "spear_rebar", -1 ] ] ],
     "components": [ [ [ "55gal_drum", 1 ] ] ]
   },
   {
@@ -709,7 +710,8 @@
     "difficulty": 1,
     "time": "2 m",
     "autolearn": true,
-    "qualities": [ { "id": "DRILL", "level": 1 } ],
+    "qualities": [ { "id": "HAMMER", "level": 1 } ],
+    "tools": [ [ [ "nail", -1 ], [ "spike", -1 ], [ "sharp_rock", -1 ], [ "rebar", -1 ], [ "spear_rebar", -1 ] ] ],
     "components": [ [ [ "30gal_drum", 1 ] ] ]
   },
   {
@@ -2654,7 +2656,8 @@
     "time": "5 m",
     "autolearn": true,
     "book_learn": [ [ "mag_survival", 2 ], [ "textbook_survival", 1 ], [ "cookbook", 2 ] ],
-    "qualities": [ { "id": "DRILL", "level": 1 } ],
+    "qualities": [ { "id": "HAMMER", "level": 1 } ],
+    "tools": [ [ [ "nail", -1 ], [ "spike", -1 ], [ "sharp_rock", -1 ], [ "rebar", -1 ], [ "spear_rebar", -1 ] ] ],
     "components": [ [ [ "can_medium_unsealed", 1 ] ], [ [ "scrap", 3 ] ] ]
   },
   {

--- a/data/json/recipes/other/traps.json
+++ b/data/json/recipes/other/traps.json
@@ -65,7 +65,7 @@
     "time": "30 s",
     "autolearn": true,
     "using": [ [ "cordage", 1 ] ],
-    "components": [ [ [ "adhesive", 1, "LIST" ], [ "nail", 2 ] ] ]
+    "components": [ [ [ "nail_glue", 2, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -93,7 +93,7 @@
     "reversible": true,
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "components": [ [ [ "2x4", 3 ], [ "stick", 3 ] ], [ [ "nail", 20 ] ] ]
+    "components": [ [ [ "2x4", 3 ], [ "stick", 3 ] ], [ [ "nail_glue", 20, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -106,7 +106,7 @@
     "reversible": true,
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "components": [ [ [ "nailboard", 3 ] ], [ [ "nail", 2 ] ] ]
+    "components": [ [ [ "nailboard", 3 ] ], [ [ "nail_glue", 2, "LIST" ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/other/traps.json
+++ b/data/json/recipes/other/traps.json
@@ -212,7 +212,7 @@
     "book_learn": [ [ "manual_traps_mil", 5 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [
-      [ [ "superglue", 1 ], [ "bone_glue", 1 ], [ "duct_tape", 75 ] ],
+      [ [ "adhesive", 1, "LIST" ] ],
       [
         [ "scrap", 3 ],
         [ "steel_chunk", 1 ],

--- a/data/json/recipes/other/traps.json
+++ b/data/json/recipes/other/traps.json
@@ -22,7 +22,7 @@
     "time": "25 m",
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "components": [ [ [ "glass_shard", 4 ] ], [ [ "superglue", 1 ], [ "bone_glue", 1 ] ] ]
+    "components": [ [ [ "glass_shard", 4 ] ], [ [ "superglue", 4 ], [ "bone_glue", 4 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/other/vehicles.json
+++ b/data/json/recipes/other/vehicles.json
@@ -15,7 +15,7 @@
     "components": [
       [ [ "2x4", 25 ], [ "frame_wood", 4 ] ],
       [ [ "sheet_metal_small", 3 ] ],
-      [ [ "nail", 100 ] ],
+      [ [ "nail_glue", 100, "LIST" ] ],
       [ [ "pipe", 4 ] ],
       [ [ "funnel", 1 ], [ "metal_funnel", 1 ], [ "makeshift_funnel", 1 ] ],
       [ [ "wire", 6 ], [ "rope_6", 6 ], [ "vine_6", 6 ], [ "rope_makeshift_6", 6 ] ],
@@ -46,7 +46,7 @@
       [ [ "2x4", 15 ], [ "frame_wood", 3 ] ],
       [ [ "wood_panel", 6 ], [ "wood_sheet", 3 ] ],
       [ [ "sheet_metal_small", 6 ] ],
-      [ [ "nail", 100 ] ],
+      [ [ "nail_glue", 100, "LIST" ] ],
       [ [ "pipe", 8 ] ],
       [ [ "wheel_wood_b", 2 ] ],
       [ [ "funnel", 1 ], [ "metal_funnel", 1 ], [ "makeshift_funnel", 1 ] ],
@@ -583,7 +583,7 @@
     "reversible": true,
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 1 } ],
-    "components": [ [ [ "2x4", 5 ] ], [ [ "nail", 30 ] ] ]
+    "components": [ [ [ "2x4", 5 ] ], [ [ "nail_glue", 15, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -608,7 +608,7 @@
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 1 } ],
     "using": [ [ "sewing_standard", 100 ] ],
-    "components": [ [ [ "sheet", 2 ] ], [ [ "2x4", 4 ], [ "stick", 4 ] ], [ [ "nail", 20 ] ] ]
+    "components": [ [ [ "sheet", 2 ] ], [ [ "2x4", 4 ], [ "stick", 4 ] ], [ [ "nail_glue", 20, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -620,7 +620,7 @@
     "time": "1 h",
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 1 } ],
-    "components": [ [ [ "2x4", 4 ] ], [ [ "nail", 10 ] ] ]
+    "components": [ [ [ "2x4", 4 ] ], [ [ "nail_glue", 10, "LIST" ] ] ]
   },
   {
     "result": "cargo_aisle",
@@ -646,7 +646,7 @@
     "time": "40 m",
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 1 } ],
-    "components": [ [ [ "nail", 4 ] ], [ [ "2x4", 2 ] ], [ [ "stick", 2 ], [ "2x4", 2 ] ], [ [ "towel", 3 ] ] ]
+    "components": [ [ [ "nail_glue", 4, "LIST" ] ], [ [ "2x4", 2 ] ], [ [ "stick", 2 ], [ "2x4", 2 ] ], [ [ "towel", 3 ] ] ]
   },
   {
     "type": "recipe",
@@ -780,7 +780,7 @@
     "reversible": true,
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "2x4", 5 ] ], [ [ "stick", 2 ] ], [ [ "nail", 20 ] ] ]
+    "components": [ [ [ "2x4", 5 ] ], [ [ "stick", 2 ] ], [ [ "nail_glue", 20, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -890,7 +890,7 @@
     "reversible": true,
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "components": [ [ [ "2x4", 5 ] ], [ [ "nail", 20 ] ] ]
+    "components": [ [ [ "2x4", 5 ] ], [ [ "nail_glue", 20, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -916,7 +916,7 @@
     "reversible": true,
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SAW_W", "level": 1 } ],
-    "components": [ [ [ "2x4", 5 ] ], [ [ "nail", 20 ] ] ]
+    "components": [ [ [ "2x4", 5 ] ], [ [ "nail_glue", 20, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -929,7 +929,7 @@
     "reversible": true,
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SAW_W", "level": 1 } ],
-    "components": [ [ [ "2x4", 5 ] ], [ [ "nail", 30 ] ], [ [ "scrap", 5 ] ] ]
+    "components": [ [ [ "2x4", 5 ] ], [ [ "nail_glue", 30, "LIST" ] ], [ [ "scrap", 5 ] ] ]
   },
   {
     "type": "recipe",
@@ -1237,7 +1237,7 @@
     "decomp_learn": 1,
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SAW_W", "level": 1 } ],
-    "components": [ [ [ "2x4", 4 ] ], [ [ "wood_panel", 1 ] ], [ [ "nail", 8 ] ] ]
+    "components": [ [ [ "2x4", 4 ] ], [ [ "wood_panel", 1 ] ], [ [ "nail_glue", 8, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -1454,7 +1454,7 @@
     "components": [
       [ [ "2x4", 20 ], [ "frame_wood", 4 ], [ "wood_panel", 4 ] ],
       [ [ "sheet_metal_small", 10 ] ],
-      [ [ "nail", 20 ] ],
+      [ [ "nail_glue", 20, "LIST" ] ],
       [ [ "pipe", 5 ] ],
       [ [ "chain", 1 ] ]
     ]
@@ -1485,6 +1485,6 @@
     "time": "20 m",
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 1 } ],
-    "components": [ [ [ "nail", 4 ] ], [ [ "stick", 2 ], [ "2x4", 2 ] ] ]
+    "components": [ [ [ "nail_glue", 4, "LIST" ] ], [ [ "stick", 2 ], [ "2x4", 2 ] ] ]
   }
 ]

--- a/data/json/recipes/other/vehicles.json
+++ b/data/json/recipes/other/vehicles.json
@@ -1181,7 +1181,7 @@
     "book_learn": [ [ "textbook_fabrication", 3 ], [ "textbook_mechanics", 3 ], [ "welding_book", 5 ] ],
     "using": [ [ "welding_standard", 2 ] ],
     "qualities": [ { "id": "SAW_M", "level": 1 } ],
-    "components": [ [ [ "car_headlight", 1 ] ], [ [ "wire", 2 ] ], [ [ "superglue", 1 ] ] ]
+    "components": [ [ [ "car_headlight", 1 ] ], [ [ "wire", 2 ] ], [ [ "adhesive", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -1194,7 +1194,7 @@
     "book_learn": [ [ "textbook_fabrication", 3 ], [ "textbook_mechanics", 3 ], [ "welding_book", 5 ] ],
     "using": [ [ "welding_standard", 2 ] ],
     "qualities": [ { "id": "SAW_M", "level": 1 } ],
-    "components": [ [ [ "car_wide_headlight", 1 ] ], [ [ "wire", 3 ] ], [ [ "superglue", 1 ] ] ]
+    "components": [ [ [ "car_wide_headlight", 1 ] ], [ [ "wire", 3 ] ], [ [ "adhesive", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -10,7 +10,7 @@
     "autolearn": true,
     "using": [ [ "adhesive", 1 ] ],
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "2x4", 1 ] ], [ [ "nail", 5 ] ] ]
+    "components": [ [ [ "2x4", 1 ] ], [ [ "nail_glue", 5, "LIST" ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/weapon/explosive.json
+++ b/data/json/recipes/weapon/explosive.json
@@ -76,7 +76,7 @@
     "using": [ [ "soldering_standard", 15 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [
-      [ [ "superglue", 1 ], [ "cordage", 1, "LIST" ] ],
+      [ [ "adhesive", 1, "LIST" ], [ "cordage", 1, "LIST" ] ],
       [
         [ "scrap", 3 ],
         [ "can_food_unsealed", 1 ],
@@ -145,7 +145,7 @@
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [
       [ [ "pilot_light", 1 ] ],
-      [ [ "superglue", 1 ], [ "duct_tape", 75 ], [ "cordage", 1, "LIST" ] ],
+      [ [ "adhesive", 1, "LIST" ], [ "cordage", 1, "LIST" ] ],
       [ [ "canister_empty", 1 ], [ "can_drink_unsealed", 1 ], [ "clay_canister", 1 ], [ "can_food_unsealed", 1 ] ],
       [ [ "oxy_powder", 75 ] ],
       [ [ "incendiary", 50 ] ]
@@ -168,7 +168,7 @@
       [ [ "bleach", 2 ], [ "oxy_powder", 200 ] ],
       [ [ "ammonia", 2 ], [ "lye_powder", 200 ] ],
       [ [ "canister_empty", 1 ], [ "can_food_unsealed", 1 ], [ "can_drink_unsealed", 1 ] ],
-      [ [ "superglue", 1 ] ]
+      [ [ "adhesive", 1, "LIST" ] ]
     ]
   },
   {
@@ -188,7 +188,7 @@
       [ [ "fungicide", 50 ] ],
       [ [ "chem_sulphur", 150 ] ],
       [ [ "canister_empty", 1 ], [ "can_food_unsealed", 1 ], [ "can_drink_unsealed", 1 ] ],
-      [ [ "superglue", 1 ] ]
+      [ [ "adhesive", 1, "LIST" ] ]
     ]
   },
   {
@@ -208,7 +208,7 @@
       [ [ "insecticide", 50 ] ],
       [ [ "water", 2 ], [ "water_clean", 2 ] ],
       [ [ "canister_empty", 1 ], [ "can_food_unsealed", 1 ], [ "can_drink_unsealed", 1 ] ],
-      [ [ "superglue", 1 ] ]
+      [ [ "adhesive", 1, "LIST" ] ]
     ]
   },
   {
@@ -225,7 +225,7 @@
     "components": [
       [ [ "volatile_explosive", 24, "LIST" ], [ "stable_explosive", 24, "LIST" ], [ "military_explosive", 24, "LIST" ] ],
       [ [ "delay_fuze", 1 ], [ "fuse", 1 ] ],
-      [ [ "superglue", 1 ], [ "duct_tape", 75 ], [ "cordage", 1, "LIST" ] ],
+      [ [ "adhesive", 1, "LIST" ], [ "cordage", 1, "LIST" ] ],
       [ [ "canister_empty", 1 ], [ "can_drink_unsealed", 1 ], [ "can_food_unsealed", 1 ] ],
       [ [ "nail", 30 ], [ "scrap", 2 ] ]
     ]
@@ -290,7 +290,7 @@
       [ [ "sugar", 40 ] ],
       [ [ "oxy_powder", 80 ], [ "chem_saltpetre", 20 ] ],
       [ [ "canister_empty", 1 ], [ "can_food_unsealed", 1 ], [ "clay_canister", 1 ], [ "can_drink_unsealed", 1 ] ],
-      [ [ "superglue", 1 ] ]
+      [ [ "adhesive", 1, "LIST" ] ]
     ]
   },
   {

--- a/data/json/recipes/weapon/mods.json
+++ b/data/json/recipes/weapon/mods.json
@@ -389,7 +389,7 @@
       [ [ "cordage_superior_short", 1, "LIST" ] ],
       [ [ "spring", 1 ] ],
       [ [ "scrap", 4 ] ],
-      [ [ "nail", 10 ] ],
+      [ [ "nail_glue", 10, "LIST" ] ],
       [ [ "plastic_chunk", 2 ] ]
     ]
   },

--- a/data/json/recipes/weapon/mods.json
+++ b/data/json/recipes/weapon/mods.json
@@ -819,7 +819,7 @@
     "time": "1 m 30 s",
     "book_learn": [ [ "mag_archery", 1 ], [ "manual_archery", 1 ] ],
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "plastic_chunk", 1 ], [ "fur", 1 ] ], [ [ "superglue", 1 ], [ "bone_glue", 1 ] ] ]
+    "components": [ [ [ "plastic_chunk", 1 ], [ "fur", 1 ] ], [ [ "superglue", 3 ], [ "bone_glue", 3 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/weapon/piercing.json
+++ b/data/json/recipes/weapon/piercing.json
@@ -477,7 +477,7 @@
     "components": [
       [ [ "fencing_foil_sharpened", 1 ] ],
       [ [ "fabric_hides_any", 1, "LIST" ] ],
-      [ [ "duct_tape", 100 ], [ "superglue", 1 ] ],
+      [ [ "adhesive", 1, "LIST" ] ],
       [ [ "tazer", 1 ] ],
       [ [ "cable", 10 ] ]
     ]
@@ -498,7 +498,7 @@
     "components": [
       [ [ "fencing_epee_sharpened", 1 ] ],
       [ [ "fabric_hides_any", 1, "LIST" ] ],
-      [ [ "duct_tape", 100 ], [ "superglue", 1 ] ],
+      [ [ "adhesive", 1, "LIST" ] ],
       [ [ "tazer", 1 ] ],
       [ [ "cable", 10 ] ]
     ]
@@ -519,7 +519,7 @@
     "components": [
       [ [ "fencing_sabre_sharpened", 1 ] ],
       [ [ "fabric_hides_any", 1, "LIST" ] ],
-      [ [ "duct_tape", 100 ], [ "superglue", 1 ] ],
+      [ [ "adhesive", 1, "LIST" ] ],
       [ [ "tazer", 1 ] ],
       [ [ "cable", 10 ] ]
     ]
@@ -540,7 +540,7 @@
     "components": [
       [ [ "rapier", 1 ] ],
       [ [ "fabric_hides_any", 1, "LIST" ] ],
-      [ [ "duct_tape", 100 ], [ "superglue", 1 ] ],
+      [ [ "adhesive", 1, "LIST" ] ],
       [ [ "tazer", 1 ] ],
       [ [ "cable", 10 ] ]
     ]

--- a/data/json/recipes/weapon/piercing.json
+++ b/data/json/recipes/weapon/piercing.json
@@ -312,7 +312,6 @@
         [ "tanto", 1 ],
         [ "kirpan", 1 ]
       ],
-      [ [ "nail", 2 ] ],
       [ [ "cordage", 2, "LIST" ], [ "duct_tape", 100 ] ]
     ]
   },
@@ -328,7 +327,7 @@
     "reversible": true,
     "autolearn": true,
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 }, { "id": "DRILL", "level": 1 } ],
-    "components": [ [ [ "spear_knife", 1 ] ], [ [ "nail", 2 ] ], [ [ "cordage", 1, "LIST" ], [ "duct_tape", 50 ] ] ]
+    "components": [ [ [ "spear_knife", 1 ] ], [ [ "cordage", 1, "LIST" ], [ "duct_tape", 50 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/weapon/ranged.json
+++ b/data/json/recipes/weapon/ranged.json
@@ -160,7 +160,7 @@
     "components": [
       [ [ "stick", 3 ], [ "2x4", 2 ] ],
       [ [ "bone_sturdy", 3, "LIST" ] ],
-      [ [ "adhesive", 5 ] ],
+      [ [ "adhesive", 5, "LIST" ] ],
       [ [ "cordage_superior", 2, "LIST" ] ]
     ]
   },

--- a/data/json/recipes/weapon/ranged.json
+++ b/data/json/recipes/weapon/ranged.json
@@ -648,7 +648,12 @@
     "decomp_learn": 4,
     "book_learn": [ [ "recipe_bows", 4 ], [ "textbook_weapeast", 6 ] ],
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SCREW", "level": 1 }, { "id": "HAMMER", "level": 1 } ],
-    "components": [ [ [ "2x4", 4 ], [ "stick", 8 ] ], [ [ "spring", 1 ] ], [ [ "cordage_superior", 1, "LIST" ] ], [ [ "nail_glue", 20, "LIST" ] ] ]
+    "components": [
+      [ [ "2x4", 4 ], [ "stick", 8 ] ],
+      [ [ "spring", 1 ] ],
+      [ [ "cordage_superior", 1, "LIST" ] ],
+      [ [ "nail_glue", 20, "LIST" ] ]
+    ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/weapon/ranged.json
+++ b/data/json/recipes/weapon/ranged.json
@@ -291,7 +291,7 @@
       [ [ "cordage_superior_short", 1, "LIST" ] ],
       [ [ "spring", 1 ] ],
       [ [ "scrap", 4 ] ],
-      [ [ "nail", 10 ] ]
+      [ [ "nail_glue", 10, "LIST" ] ]
     ]
   },
   {
@@ -633,7 +633,7 @@
       [ [ "foot_crank", 1 ] ],
       [ [ "spring", 4 ] ],
       [ [ "steel_chunk", 4 ], [ "scrap", 12 ] ],
-      [ [ "nail", 60 ] ]
+      [ [ "nail_glue", 60, "LIST" ] ]
     ]
   },
   {
@@ -648,7 +648,7 @@
     "decomp_learn": 4,
     "book_learn": [ [ "recipe_bows", 4 ], [ "textbook_weapeast", 6 ] ],
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SCREW", "level": 1 }, { "id": "HAMMER", "level": 1 } ],
-    "components": [ [ [ "2x4", 4 ], [ "stick", 8 ] ], [ [ "spring", 1 ] ], [ [ "cordage_superior", 1, "LIST" ] ], [ [ "nail", 20 ] ] ]
+    "components": [ [ [ "2x4", 4 ], [ "stick", 8 ] ], [ [ "spring", 1 ] ], [ [ "cordage_superior", 1, "LIST" ] ], [ [ "nail_glue", 20, "LIST" ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/weapon/ranged.json
+++ b/data/json/recipes/weapon/ranged.json
@@ -160,7 +160,7 @@
     "components": [
       [ [ "stick", 3 ], [ "2x4", 2 ] ],
       [ [ "bone_sturdy", 3, "LIST" ] ],
-      [ [ "superglue", 3 ], [ "bone_glue", 3 ] ],
+      [ [ "adhesive", 5 ] ],
       [ [ "cordage_superior", 2, "LIST" ] ]
     ]
   },
@@ -179,7 +179,7 @@
     "components": [
       [ [ "stick_long", 1 ], [ "2x4", 3 ] ],
       [ [ "bone_sturdy", 4, "LIST" ] ],
-      [ [ "superglue", 4 ], [ "bone_glue", 4 ] ],
+      [ [ "adhesive", 5, "LIST" ] ],
       [ [ "cordage_superior", 2, "LIST" ] ]
     ]
   },
@@ -983,7 +983,7 @@
     "components": [
       [ [ "hand_pump", 1 ] ],
       [ [ "pipe", 8 ] ],
-      [ [ "duct_tape", 100 ], [ "superglue", 1 ] ],
+      [ [ "adhesive", 1, "LIST" ] ],
       [ [ "2x4", 1 ], [ "stick", 1 ] ],
       [ [ "metal_tank_little", 1 ] ],
       [ [ "steel_chunk", 3 ], [ "scrap", 9 ] ]
@@ -1003,7 +1003,7 @@
     "components": [
       [ [ "hand_pump", 1 ] ],
       [ [ "pipe", 4 ] ],
-      [ [ "duct_tape", 100 ], [ "superglue", 1 ] ],
+      [ [ "adhesive", 1, "LIST" ] ],
       [ [ "2x4", 1 ], [ "stick", 1 ] ],
       [ [ "metal_tank_little", 1 ] ],
       [ [ "steel_chunk", 3 ], [ "scrap", 9 ] ]
@@ -1023,7 +1023,7 @@
     "qualities": [ { "id": "SAW_M_FINE", "level": 1 }, { "id": "SCREW_FINE", "level": 1 }, { "id": "WRENCH_FINE", "level": 1 } ],
     "components": [
       [ [ "pipe", 3 ] ],
-      [ [ "duct_tape", 100 ], [ "superglue", 1 ] ],
+      [ [ "adhesive", 1, "LIST" ] ],
       [ [ "2x4", 1 ], [ "stick", 1 ] ],
       [ [ "metal_tank_little", 1 ] ],
       [ [ "steel_chunk", 4 ], [ "scrap", 12 ] ]

--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -3,7 +3,7 @@
     "id": "adhesive",
     "type": "requirement",
     "//": "Materials used for joining (typically non-metallic) parts",
-    "components": [ [ [ "duct_tape", 25 ], [ "medical_tape", 25 ], [ "superglue", 1 ], [ "bone_glue", 1 ] ] ]
+    "components": [ [ [ "duct_tape", 25 ], [ "medical_tape", 25 ], [ "superglue", 5 ], [ "bone_glue", 5 ] ] ]
   },
   {
     "id": "nail_glue",

--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -6,6 +6,12 @@
     "components": [ [ [ "duct_tape", 25 ], [ "medical_tape", 25 ], [ "superglue", 1 ], [ "bone_glue", 1 ] ] ]
   },
   {
+    "id": "nail_glue",
+    "type": "requirement",
+    "//": "Materials that connect part together tightly, nails and glue.",
+    "components": [ [ [ "nail", 1 ], [ "superglue", 1 ], [ "bone_glue", 1 ] ] ]
+  },
+  {
     "id": "ammo_bullet",
     "type": "requirement",
     "//": "Materials used when forming bullets",


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change
Nails can be hard to come by innawoods. This let the player use glue as an alternative. While "not as effective" as nails would be, innawoods can now rely on making glue to get boats without the need of metallurgy. Sure, nails are still superior, but that would be a nail free alternative.
<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution
Using a new requirement list "nail_glue" to replace nails as an solo items where it makes sense.
<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

## Describe alternatives you've considered
Nailing...
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing
![grafik](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/33199510/eeecda8b-18a7-45be-a168-68417486fedb)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
