### PR TITLE
feat: Monster Adjustment additions, documentation and new mod to disable `zombify_into`

### DIFF
--- a/data/json/species.json
+++ b/data/json/species.json
@@ -1,6 +1,13 @@
 [
   {
     "type": "SPECIES",
+    "id": "ALL",
+    "name": { "str": "everything (debug)" },
+    "description": "an everything (debug)",
+    "//": "This only exists for special interactions where you want a filter to take all species"
+  },
+  {
+    "type": "SPECIES",
     "id": "MAMMAL",
     "name": { "str": "mammal" },
     "description": "a mammal",

--- a/data/mods/No_Reviving/modinfo.json
+++ b/data/mods/No_Reviving/modinfo.json
@@ -2,8 +2,8 @@
   {
     "type": "MOD_INFO",
     "id": "no_reviving_zombies",
-    "name": "Prevent Zombie Revivication",
-    "description": "Disables zombie revival.",
+    "name": "Prevent Revivication",
+    "description": "Disables zombie and feral revival.",
     "category": "rebalance",
     "dependencies": [ "bn" ]
   },

--- a/data/mods/No_Reviving/modinfo.json
+++ b/data/mods/No_Reviving/modinfo.json
@@ -2,19 +2,14 @@
   {
     "type": "MOD_INFO",
     "id": "no_reviving_zombies",
-    "name": "Prevent Revivication",
-    "description": "Disables zombie and feral revival.",
+    "name": "Prevent Zombie Revivication",
+    "description": "Disables zombie revival.",
     "category": "rebalance",
     "dependencies": [ "bn" ]
   },
   {
     "type": "monster_adjustment",
     "species": "ZOMBIE",
-    "flag": { "name": "REVIVES", "value": false }
-  },
-  {
-    "type": "monster_adjustment",
-    "species": "HUMAN",
     "flag": { "name": "REVIVES", "value": false }
   },
   {

--- a/data/mods/No_Reviving/modinfo.json
+++ b/data/mods/No_Reviving/modinfo.json
@@ -13,6 +13,11 @@
     "flag": { "name": "REVIVES", "value": false }
   },
   {
+    "type": "monster_adjustment",
+    "species": "HUMAN",
+    "flag": { "name": "REVIVES", "value": false }
+  },
+  {
     "type": "MONSTER_BLACKLIST",
     "monsters": [ "mon_zombie_necro" ]
   }

--- a/data/mods/No_Zombify/modinfo.json
+++ b/data/mods/No_Zombify/modinfo.json
@@ -1,0 +1,15 @@
+[
+  {
+    "type": "MOD_INFO",
+    "id": "no_zombify",
+    "name": "Prevent Zombification",
+    "description": "Disables zombification for monsters.",
+    "category": "rebalance",
+    "dependencies": [ "bn" ]
+  },
+  {
+    "type": "monster_adjustment",
+    "species": "ALL",
+    "special": "no_zombify"
+  }
+]

--- a/doc/src/content/docs/en/mod/json/tutorial/modding.md
+++ b/doc/src/content/docs/en/mod/json/tutorial/modding.md
@@ -290,6 +290,23 @@ specific mod. The format is as follows:
 Valid values for `subtype` are `whitelist` and `blacklist`. `scenarios` is an array of the scenario
 ids that you want to blacklist or whitelist.
 
+### Monster Adjustment
+
+```json
+[
+  {
+    "type": "monster_adjustment",
+    "species": "ZOMBIE",
+    "flag": { "name": "REVIVES", "value": false },
+    // Any flag will work here.
+    "stat": { "name": "speed", "modifier": 10 },
+    // stat only allows speed and HP as stat names.
+    "special": "nightvision",
+    // nightvision gives all monsters of this type night vision.
+    // no_zombify removes any "zombify_into" entries for the monster.
+  }
+```
+
 ## Important note on json files
 
 The following characters: `[ { , } ] : "` are _very_ important when adding or modifying JSON files.
@@ -320,29 +337,3 @@ game (just drag-and-drop the .json file on it).
 ## Addendum
 
 <!-- I really don't know if this should be here or not. Please let me know. -->
-
-### No Zombie Revival
-
-This mod is very simple, but it's worth a special section because it does things a little
-differently than other mods, and documentation on it is tricky to find.
-
-The entire mod can fit into fifteen lines of JSON, and it's presented below. Just copy/paste that
-into a modinfo.json file, and put it in a new folder in your mods directory.
-
-```json
-[
-  {
-    "type": "MOD_INFO",
-    "id": "no_reviving_zombies",
-    "name": "Prevent Zombie Revivication",
-    "description": "Disables zombie revival.",
-    "category": "rebalance",
-    "dependencies": ["bn"]
-  },
-  {
-    "type": "monster_adjustment",
-    "species": "ZOMBIE",
-    "flag": { "name": "REVIVES", "value": false }
-  }
-]
-```

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -307,6 +307,8 @@ void monster_adjustment::apply( mtype &mon )
     if( !special.empty() ) {
         if( special == "nightvision" ) {
             mon.vision_night = mon.vision_day;
+        } else if( special == "no_zombify" ) {
+            mon.zombify_into = mtype_id::NULL_ID();
         }
     }
 }

--- a/src/mtype.cpp
+++ b/src/mtype.cpp
@@ -121,6 +121,9 @@ bool mtype::in_category( const std::string &category ) const
 
 bool mtype::in_species( const species_id &spec ) const
 {
+    if( spec == species_id( "ALL" ) ) {
+        return true;
+    }
     return species.count( spec ) > 0;
 }
 


### PR DESCRIPTION
## Purpose of change

Some players have expressed concerns over `zombify_into` leading to revivication like behaviour. Added a mod to disable it without overwriting all the monsters. Also the modding docs for monster adjustment was unsatisfactory, as it only recorded the REVIVE flag removal instead of noting all possible options you have with it.

## Describe the solution

Adds a special to `monster_adjustment` that empties `zombify_into` for selected species. Add an ALL species for filters.

Add a mod that disables `zombify_into` called No Zombification.

## Describe alternatives you've considered

- Make a more robust `monster_adjustment` system that can work with more variables.
  - Would be nice but a pain in the ass to code.

## Testing

- [x] Kill a feral anything and confirm it doesn't show yellow and zombify.

## Additional context

## Checklist
