### PR TITLE
feat(content, port): UI, accessibility updates, tweaks, remade work 

### DIFF
--- a/data/raw/keybindings/keybindings.json
+++ b/data/raw/keybindings/keybindings.json
@@ -525,10 +525,17 @@
   },
   {
     "type": "keybinding",
-    "id": "CYCLE_MODE",
+    "id": "SCROLL_RECIPE_INFO_UP",
     "category": "CRAFTING",
-    "name": "Cycle display mode",
-    "bindings": [ { "input_method": "keyboard", "key": "m" } ]
+    "name": "Scroll recipe info up",
+    "bindings": [ { "input_method": "keyboard", "key": "[" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "SCROLL_RECIPE_INFO_DOWN",
+    "category": "CRAFTING",
+    "name": "Scroll recipe info down",
+    "bindings": [ { "input_method": "keyboard", "key": "]" } ]
   },
   {
     "type": "keybinding",
@@ -3351,5 +3358,139 @@
     "name": "Scroll to the bottom",
     "category": "LUA_CONSOLE",
     "bindings": [ { "input_method": "keyboard", "key": "END" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "TEXT.QUIT",
+    "name": "Cancel text input",
+    "bindings": [ { "input_method": "keyboard", "key": "ESC" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "TEXT.CONFIRM",
+    "name": "Confirm text input",
+    "bindings": [ { "input_method": "keyboard", "key": "RETURN" }, { "input_method": "keyboard", "key": "KEYPAD_ENTER" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "TEXT.UP",
+    "name": "Move cursor up",
+    "bindings": [ { "input_method": "keyboard", "key": "UP" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "TEXT.DOWN",
+    "name": "Move cursor down",
+    "bindings": [ { "input_method": "keyboard", "key": "DOWN" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "TEXT.LEFT",
+    "name": "Move cursor left",
+    "bindings": [ { "input_method": "keyboard", "key": "LEFT" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "TEXT.RIGHT",
+    "name": "Move cursor right",
+    "bindings": [ { "input_method": "keyboard", "key": "RIGHT" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "TEXT.PAGE_UP",
+    "name": "Move cursor to previous page",
+    "bindings": [ { "input_method": "keyboard", "key": "PPAGE" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "TEXT.PAGE_DOWN",
+    "name": "Move cursor to next page",
+    "bindings": [ { "input_method": "keyboard", "key": "NPAGE" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "TEXT.CLEAR",
+    "name": "Clear text",
+    "bindings": [
+      { "input_method": "keyboard", "key": "CTRL+U" }
+    ]
+  },
+  {
+    "type": "keybinding",
+    "id": "TEXT.BACKSPACE",
+    "name": "Remove previous character",
+    "bindings": [ { "input_method": "keyboard", "key": "BACKSPACE" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "TEXT.HOME",
+    "name": "Move cursor to start",
+    "bindings": [ { "input_method": "keyboard", "key": "HOME" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "TEXT.END",
+    "name": "Move cursor to end",
+    "bindings": [ { "input_method": "keyboard", "key": "END" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "TEXT.DELETE",
+    "name": "Remove current character",
+    "bindings": [ { "input_method": "keyboard", "key": "DELETE" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "TEXT.PASTE",
+    "name": "Paste from clipboard",
+    "bindings": [ { "input_method": "keyboard", "key": "CTRL+V" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "TEXT.INPUT_FROM_FILE",
+    "name": "Input text from file",
+    "bindings": [ { "input_method": "keyboard", "key": "F2" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "HISTORY_UP",
+    "name": "Show previous history",
+    "category": "STRING_INPUT",
+    "bindings": [ { "input_method": "keyboard", "key": "UP" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "HISTORY_DOWN",
+    "name": "Show next history",
+    "category": "STRING_INPUT",
+    "bindings": [ { "input_method": "keyboard", "key": "DOWN" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "HELP_KEYBINDINGS",
+    "name": "Display keybindings menu",
+    "category": "STRING_INPUT",
+    "//": "'?' is treated as text input, so a different key is used.",
+    "bindings": [ { "input_method": "keyboard", "key": "F1" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "TEXT.CONFIRM",
+    "name": "Confirm text input",
+    "category": "STRING_EDITOR",
+    "//": "RETURN is treated as text input, so use a different keybinding",
+    "//2": "CTRL+S is not available on curses, so add CTRL+Y as an alternative",
+    "bindings": [
+      { "input_method": "keyboard", "key": "CTRL+S" },
+      { "input_method": "keyboard", "key": "CTRL+Y" }
+    ]
+  },
+  {
+    "type": "keybinding",
+    "id": "HELP_KEYBINDINGS",
+    "name": "Display keybindings menu",
+    "category": "STRING_EDITOR",
+    "//": "'?' is treated as text input, so a different key is used.",
+    "bindings": [ { "input_method": "keyboard", "key": "F1" } ]
   }
 ]

--- a/data/raw/keybindings/keybindings.json
+++ b/data/raw/keybindings/keybindings.json
@@ -3411,9 +3411,7 @@
     "type": "keybinding",
     "id": "TEXT.CLEAR",
     "name": "Clear text",
-    "bindings": [
-      { "input_method": "keyboard", "key": "CTRL+U" }
-    ]
+    "bindings": [ { "input_method": "keyboard", "key": "CTRL+U" } ]
   },
   {
     "type": "keybinding",
@@ -3480,10 +3478,7 @@
     "category": "STRING_EDITOR",
     "//": "RETURN is treated as text input, so use a different keybinding",
     "//2": "CTRL+S is not available on curses, so add CTRL+Y as an alternative",
-    "bindings": [
-      { "input_method": "keyboard", "key": "CTRL+S" },
-      { "input_method": "keyboard", "key": "CTRL+Y" }
-    ]
+    "bindings": [ { "input_method": "keyboard", "key": "CTRL+S" }, { "input_method": "keyboard", "key": "CTRL+Y" } ]
   },
   {
     "type": "keybinding",

--- a/doc/accessibility.md
+++ b/doc/accessibility.md
@@ -1,0 +1,15 @@
+---
+title: Compatibility with screen readers
+---
+
+There are people who use screen readers to play Cataclysm Bright Nights. In order for screen readers
+to announce the most important information in a UI, the terminal cursor has to be placed at the
+correct location. This information may be text such as selected item names in a list, etc, and the
+cursor has to be placed exactly at the beginning of the text for screen readers to announce it.
+
+The recommended way to place the cursor is to use `ui_adaptor`. This ensures the desired cursor
+position is preserved when subsequent output code changes the cursor position. You can call
+`ui_adaptor::set_cursor` and similar methods at any position in a redrawing callback, and the last
+cursor position of the topmost UI set via the call will be used as the final cursor position. You
+can also call `ui_adaptor::disable_cursor` to prevent a UI's cursor from being used as the final
+cursor position.

--- a/doc/user_interface.md
+++ b/doc/user_interface.md
@@ -1,0 +1,13 @@
+---
+title: User Interface
+---
+
+Cataclysm: Bright Nights uses ncurses, or in the case of the tiles build, an ncurses port, for user
+interface. Window management is achieved by `ui_adaptor`, which requires a resizing callback and a
+redrawing callback for each UI to handle resizing and redrawing. Details on how to use `ui_adaptor`
+can be found within `ui_manager.h`.
+
+Some good examples of the usage of `ui_adaptor` can be found within the following files:
+
+- `query_popup` and `static_popup` in `popup.h/cpp`
+- `Messages::dialog` in `messages.cpp`

--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -559,7 +559,7 @@ void show_armor_layers_ui( Character &who )
     int leftListSize = 0;
     int rightListSize = 0;
 
-    ui.on_redraw( [&]( const ui_adaptor & ) {
+    ui.on_redraw( [&]( ui_adaptor & ui ) {
         draw_grid( w_sort_armor, left_w, middle_w );
 
         werase( w_sort_cat );
@@ -638,7 +638,7 @@ void show_armor_layers_ui( Character &who )
         }
 
         mvwprintz( w_encumb, point_east, c_white, _( "Encumbrance and Warmth" ) );
-        character_display::print_encumbrance( w_encumb, who, -1,
+        character_display::print_encumbrance( ui, w_encumb, who, -1,
                                               ( leftListSize > 0 ) ? *access_tmp_worn( leftListIndex ) : nullptr );
 
         // Right header

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -643,7 +643,7 @@ std::optional<construction_id> construction_menu( const bool blueprint )
     } );
     ui.mark_resize();
 
-    ui.on_redraw( [&]( const ui_adaptor & ) {
+    ui.on_redraw( [&]( ui_adaptor & ui ) {
         draw_grid( w_con, w_list_width + w_list_x0 );
 
         // Erase existing tab selection & list of constructions
@@ -655,7 +655,6 @@ std::optional<construction_id> construction_menu( const bool blueprint )
         // Determine where in the master list to start printing
         calcStartPos( offset, select, w_list_height, constructs.size() );
         // Print the constructions between offset and max (or how many will fit)
-        std::optional<point> cursor_pos;
         for( size_t i = 0; static_cast<int>( i ) < w_list_height &&
              ( i + offset ) < constructs.size(); i++ ) {
             int current = i + offset;
@@ -663,7 +662,7 @@ std::optional<construction_id> construction_menu( const bool blueprint )
             bool highlight = ( current == select );
             const point print_from( 0, i );
             if( highlight ) {
-                cursor_pos = print_from;
+                ui.set_cursor( w_list, print_from );
             }
             const std::string group_name = is_favorite( group ) ? "* " + group->name() : group->name();
             trim_and_print( w_list, print_from, w_list_width,
@@ -721,10 +720,6 @@ std::optional<construction_id> construction_menu( const bool blueprint )
         draw_scrollbar( w_con, select, w_list_height, constructs.size(), point( 0, 3 ) );
         wnoutrefresh( w_con );
 
-        // place the cursor at the selected construction name as expected by screen readers
-        if( cursor_pos ) {
-            wmove( w_list, cursor_pos.value() );
-        }
         wnoutrefresh( w_list );
     } );
 

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -29,6 +29,7 @@
 #include "json.h"
 #include "mod_manager.h"
 #include "output.h"
+#include "player.h"
 #include "point.h"
 #include "recipe.h"
 #include "recipe_dictionary.h"
@@ -133,35 +134,202 @@ void reset_recipe_categories()
     craft_subcat_list.clear();
 }
 
-static int print_items( const recipe &r, const catacurses::window &w, point pos,
-                        nc_color col, int batch )
+namespace
 {
-    if( !r.has_byproducts() ) {
-        return 0;
-    }
-
-    const int oldy = pos.y;
-
-    mvwprintz( w, point( pos.x, pos.y++ ), col, _( "Byproducts:" ) );
-    for( const auto &bp : r.byproducts ) {
-        const itype *t = &*bp.first;
-        int amount = bp.second * batch;
-        std::string desc;
-        if( t->count_by_charges() ) {
-            amount *= t->charges_default();
-            desc = string_format( "> %s (%d)", t->nname( 1 ), amount );
-        } else {
-            desc = string_format( "> %d %s", amount,
-                                  t->nname( static_cast<unsigned int>( amount ) ) );
+struct availability {
+    explicit availability( const recipe *r, int batch_size, bool known ) {
+        this->known = known;
+        const inventory &inv = get_avatar().crafting_inventory();
+        auto all_items_filter = r->get_component_filter( recipe_filter_flags::none );
+        auto no_rotten_filter = r->get_component_filter( recipe_filter_flags::no_rotten );
+        const deduped_requirement_data &req = r->deduped_requirements();
+        could_craft_if_knew = req.can_make_with_inventory(
+                                  inv, all_items_filter, batch_size, cost_adjustment::start_only );
+        can_craft = known && could_craft_if_knew;
+        can_craft_non_rotten = req.can_make_with_inventory(
+                                   inv, no_rotten_filter, batch_size, cost_adjustment::start_only );
+        const requirement_data &simple_req = r->simple_requirements();
+        apparently_craftable = simple_req.can_make_with_inventory(
+                                   inv, all_items_filter, batch_size, cost_adjustment::start_only );
+        has_all_skills = r->skill_used.is_null() ||
+                         get_player_character().get_skill_level( r->skill_used ) >= r->difficulty;
+        for( const std::pair<const skill_id, int> &e : r->required_skills ) {
+            if( get_player_character().get_skill_level( e.first ) < e.second ) {
+                has_all_skills = false;
+                break;
+            }
         }
-        mvwprintz( w, point( pos.x, pos.y++ ), col, desc );
+    }
+    bool can_craft;
+    bool can_craft_non_rotten;
+    bool could_craft_if_knew;
+    bool apparently_craftable;
+    bool has_all_skills;
+    bool known;
+
+    nc_color selected_color() const {
+        return can_craft
+               ? ( can_craft_non_rotten && has_all_skills ? h_white : h_brown )
+               : ( could_craft_if_knew && has_all_skills ? h_yellow : h_dark_gray );
     }
 
-    return pos.y - oldy;
+    nc_color color( bool ignore_missing_skills = false ) const {
+        return can_craft
+               ? ( ( can_craft_non_rotten && has_all_skills ) || ignore_missing_skills ? c_white : c_brown )
+               : ( ( could_craft_if_knew && has_all_skills ) || ignore_missing_skills ? c_yellow : c_dark_gray );
+    }
+
+};
+} // namespace
+
+static std::vector<std::string> recipe_info(
+    const recipe &recp,
+    const availability &avail,
+    player &u,
+    const std::string qry_comps,
+    const int batch_size,
+    const int fold_width,
+    const nc_color &color )
+{
+    std::ostringstream oss;
+
+    oss << string_format( _( "Primary skill: %s\n" ),
+                          recp.primary_skill_string( &u, false ) );
+
+    oss << string_format( _( "Other skills: %s\n" ),
+                          recp.required_skills_string( &u, false, false ) );
+
+
+    const int expected_turns = u.expected_time_to_craft( recp, batch_size )
+                               / to_moves<int>( 1_turns );
+    oss << string_format( _( "Time to complete: <color_cyan>%s</color>\n" ),
+                          to_string( time_duration::from_turns( expected_turns ) ) );
+
+    oss << string_format( _( "Batch time savings: <color_cyan>%s</color>\n" ),
+                          recp.batch_savings_string() );
+
+    const int makes = recp.makes_amount();
+    if( makes > 1 ) {
+        oss << string_format( _( "Recipe makes: <color_cyan>%d</color>\n" ), makes );
+    }
+
+    oss << string_format( _( "Craftable in the dark?  <color_cyan>%s</color>\n" ),
+                          recp.has_flag( flag_BLIND_EASY ) ? _( "Easy" ) :
+                          recp.has_flag( flag_BLIND_HARD ) ? _( "Hard" ) :
+                          _( "Impossible" ) );
+
+    std::string nearby_string;
+    const inventory &crafting_inv = u.crafting_inventory();
+    const int nearby_amount = crafting_inv.count_item( recp.result() );
+    if( nearby_amount == 0 ) {
+        nearby_string = "<color_light_gray>0</color>";
+    } else if( nearby_amount > 9000 ) {
+        // at some point you get too many to count at a glance and just know you have a lot
+        nearby_string = _( "<color_red>It's Over 9000!!!</color>" );
+    } else {
+        nearby_string = string_format( "<color_yellow>%d</color>", nearby_amount );
+    }
+    oss << string_format( _( "Nearby: %s\n" ), nearby_string );
+
+    const bool can_craft_this = avail.can_craft;
+    if( can_craft_this && !avail.can_craft_non_rotten ) {
+        oss << _( "<color_red>Will use rotten ingredients</color>\n" );
+    }
+    const bool too_complex = recp.deduped_requirements().is_too_complex();
+    if( can_craft_this && too_complex ) {
+        oss << _( "Due to the complex overlapping requirements, this "
+                  "recipe <color_yellow>may appear to be craftable "
+                  "when it is not</color>.\n" );
+    }
+    if( !can_craft_this && avail.apparently_craftable && avail.known ) {
+        oss << _( "<color_red>Cannot be crafted because the same item is needed "
+                  "for multiple components</color>\n" );
+    }
+    if( !avail.known ) {
+        oss << _( "<color_red>Not known</color>\n" );
+    }
+
+    if( recp.has_byproducts() ) {
+        oss << _( "Byproducts:\n" );
+        for( const std::pair<const itype_id, int> &bp : recp.byproducts ) {
+            const itype *t = &*bp.first;
+            int amount = bp.second * batch_size;
+            if( t->count_by_charges() ) {
+                amount *= t->charges_default();
+                oss << string_format( "> %s (%d)\n", t->nname( 1 ), amount );
+            } else {
+                oss << string_format( "> %d %s\n", amount,
+                                      t->nname( static_cast<unsigned int>( amount ) ) );
+            }
+        }
+    }
+
+    std::vector<std::string> result = foldstring( oss.str(), fold_width );
+
+    bool show_unavailable = false;
+    const requirement_data &req = recp.simple_requirements();
+    const std::vector<std::string> tools = req.get_folded_tools_list(
+            fold_width, color, crafting_inv, batch_size );
+    const std::vector<std::string> comps = req.get_folded_components_list(
+            fold_width, color, crafting_inv, recp.get_component_filter(), batch_size, qry_comps );
+    result.insert( result.end(), tools.begin(), tools.end() );
+    result.insert( result.end(), comps.begin(), comps.end() );
+
+    oss = std::ostringstream();
+    if( !u.knows_recipe( &recp ) ) {
+        oss << _( "Recipe not memorized yet\n" );
+        const std::set<itype_id> books_with_recipe = show_unavailable
+                ? crafting::get_books_for_recipe( &recp )
+                : crafting::get_books_for_recipe( u, crafting_inv, &recp );
+        const std::string enumerated_books =
+            enumerate_as_string( books_with_recipe.begin(), books_with_recipe.end(),
+        []( const itype_id & type_id ) {
+            return colorize( item::nname( type_id ), c_cyan );
+        } );
+        oss << string_format( _( "Written in: %s\n" ), enumerated_books );
+    }
+    std::vector<std::string> tmp = foldstring( oss.str(), fold_width );
+    result.insert( result.end(), tmp.begin(), tmp.end() );
+
+    return result;
 }
 
-const recipe *select_crafting_recipe( int &batch_size )
+const recipe *select_crafting_recipe( int &batch_size_out )
 {
+    struct {
+        const recipe *recp = nullptr;
+        std::string qry_comps;
+        int batch_size;
+        int fold_width;
+        std::vector<std::string> text;
+    } recipe_info_cache;
+    int recipe_info_scroll = 0;
+
+    const auto cached_recipe_info =
+        [&](
+            const recipe & recp,
+            const availability & avail,
+            player & u,
+            const std::string qry_comps,
+            const int batch_size,
+            const int fold_width,
+            const nc_color & color
+    ) -> const std::vector<std::string> & { // *NOPAD*
+        if( recipe_info_cache.recp != &recp
+            || recipe_info_cache.qry_comps != qry_comps
+            || recipe_info_cache.batch_size != batch_size
+            || recipe_info_cache.fold_width != fold_width )
+        {
+            recipe_info_cache.recp = &recp;
+            recipe_info_cache.qry_comps = qry_comps;
+            recipe_info_cache.batch_size = batch_size;
+            recipe_info_cache.fold_width = fold_width;
+            recipe_info_cache.text = recipe_info(
+                recp, avail, u, qry_comps, batch_size, fold_width, color );
+        }
+        return recipe_info_cache.text;
+    };
+
     struct {
         const recipe *last_recipe = nullptr;
         detached_ptr<item> dummy;
@@ -198,12 +366,36 @@ const recipe *select_crafting_recipe( int &batch_size )
     int dataLines = 0;
     int dataHalfLines = 0;
     int dataHeight = 0;
-    int componentPrintHeight = 0;
     int item_info_width = 0;
+
+    input_context ctxt( "CRAFTING" );
+    ctxt.register_cardinal();
+    ctxt.register_action( "QUIT" );
+    ctxt.register_action( "CONFIRM" );
+    ctxt.register_action( "SCROLL_RECIPE_INFO_UP" );
+    ctxt.register_action( "SCROLL_RECIPE_INFO_DOWN" );
+    ctxt.register_action( "PAGE_UP", to_translation( "Fast scroll up" ) );
+    ctxt.register_action( "PAGE_DOWN", to_translation( "Fast scroll down" ) );
+    ctxt.register_action( "SCROLL_ITEM_INFO_UP" );
+    ctxt.register_action( "SCROLL_ITEM_INFO_DOWN" );
+    ctxt.register_action( "PREV_TAB" );
+    ctxt.register_action( "NEXT_TAB" );
+    ctxt.register_action( "FILTER" );
+    ctxt.register_action( "RESET_FILTER" );
+    ctxt.register_action( "TOGGLE_FAVORITE" );
+    ctxt.register_action( "HELP_RECIPE" );
+    ctxt.register_action( "HELP_KEYBINDINGS" );
+    ctxt.register_action( "CYCLE_BATCH" );
+    ctxt.register_action( "RELATED_RECIPES" );
+    ctxt.register_action( "HIDE_SHOW_RECIPE" );
+    ctxt.register_action( "TOGGLE_UNAVAILABLE" );
+
     catacurses::window w_head;
     catacurses::window w_subhead;
     catacurses::window w_data;
     catacurses::window w_iteminfo;
+    std::vector<std::string> keybinding_tips;
+    int keybinding_x = 0;
     ui_adaptor ui;
     ui.on_screen_resize( [&]( ui_adaptor & ui ) {
         const int freeWidth = TERMX - FULL_SCREEN_WIDTH;
@@ -212,11 +404,39 @@ const recipe *select_crafting_recipe( int &batch_size )
         width = isWide ? ( freeWidth > FULL_SCREEN_WIDTH ? FULL_SCREEN_WIDTH * 2 : TERMX ) :
                 FULL_SCREEN_WIDTH;
         const int wStart = ( TERMX - width ) / 2;
-        const int tailHeight = isWide ? 3 : 4;
+
+        // Keybinding tips
+        static const translation inline_fmt = to_translation(
+                //~ %1$s: action description text before key,
+                //~ %2$s: key description,
+                //~ %3$s: action description text after key.
+                "keybinding", "%1$s[<color_yellow>%2$s</color>]%3$s" );
+        static const translation separate_fmt = to_translation(
+                //~ %1$s: key description,
+                //~ %2$s: action description.
+                "keybinding", "[<color_yellow>%1$s</color>]%2$s" );
+        std::vector<std::string> act_descs;
+        const auto add_action_desc = [&]( const std::string & act, const std::string & txt ) {
+            act_descs.emplace_back( ctxt.get_desc( act, txt, input_context::allow_all_keys,
+                                                   inline_fmt, separate_fmt ) );
+        };
+        add_action_desc( "CONFIRM", pgettext( "crafting gui", "Craft" ) );
+        add_action_desc( "HELP_RECIPE", pgettext( "crafting gui", "Describe" ) );
+        add_action_desc( "FILTER", pgettext( "crafting gui", "Filter" ) );
+        add_action_desc( "RESET_FILTER", pgettext( "crafting gui", "Reset filter" ) );
+        add_action_desc( "HIDE_SHOW_RECIPE", pgettext( "crafting gui", "Show/hide" ) );
+        add_action_desc( "RELATED_RECIPES", pgettext( "crafting gui", "Related" ) );
+        add_action_desc( "TOGGLE_FAVORITE", pgettext( "crafting gui", "Favorite" ) );
+        add_action_desc( "CYCLE_BATCH", pgettext( "crafting gui", "Batch" ) );
+        add_action_desc( "HELP_KEYBINDINGS", pgettext( "crafting gui", "Keybindings" ) );
+        keybinding_x = isWide ? 5 : 2;
+        keybinding_tips = foldstring( enumerate_as_string( act_descs, enumeration_conjunction::none ),
+                                      width - keybinding_x * 2 );
+
+        const int tailHeight = keybinding_tips.size() + 2;
         dataLines = TERMY - ( headHeight + subHeadHeight ) - tailHeight;
         dataHalfLines = dataLines / 2;
         dataHeight = TERMY - ( headHeight + subHeadHeight );
-        componentPrintHeight = dataHeight - tailHeight - 1;
 
         w_head = catacurses::newwin( headHeight, width, point( wStart, 0 ) );
         w_subhead = catacurses::newwin( subHeadHeight, width, point( wStart, 3 ) );
@@ -224,8 +444,8 @@ const recipe *select_crafting_recipe( int &batch_size )
                                      headHeight + subHeadHeight ) );
 
         if( isWide ) {
-            item_info_width = width - FULL_SCREEN_WIDTH - 2;
-            const int item_info_height = dataHeight - 3;
+            item_info_width = width - FULL_SCREEN_WIDTH - 1;
+            const int item_info_height = dataHeight - tailHeight;
             const point item_info( wStart + width - item_info_width, headHeight + subHeadHeight );
 
             w_iteminfo = catacurses::newwin( item_info_height, item_info_width,
@@ -242,48 +462,7 @@ const recipe *select_crafting_recipe( int &batch_size )
     list_circularizer<std::string> tab( craft_cat_list );
     list_circularizer<std::string> subtab( craft_subcat_list[tab.cur()] );
     std::vector<const recipe *> current;
-
-    struct availability {
-        availability( const recipe *r, int batch_size, bool known ) {
-            this->known = known;
-            const inventory &inv = get_avatar().crafting_inventory();
-            auto all_items_filter = r->get_component_filter( recipe_filter_flags::none );
-            auto no_rotten_filter = r->get_component_filter( recipe_filter_flags::no_rotten );
-            const deduped_requirement_data &req = r->deduped_requirements();
-            could_craft_if_knew = req.can_make_with_inventory(
-                                      inv, all_items_filter, batch_size, cost_adjustment::start_only );
-            can_craft = known && could_craft_if_knew;
-            can_craft_non_rotten = req.can_make_with_inventory(
-                                       inv, no_rotten_filter, batch_size, cost_adjustment::start_only );
-            const requirement_data &simple_req = r->simple_requirements();
-            apparently_craftable = simple_req.can_make_with_inventory(
-                                       inv, all_items_filter, batch_size, cost_adjustment::start_only );
-        }
-        bool can_craft;
-        bool can_craft_non_rotten;
-        bool could_craft_if_knew;
-        bool apparently_craftable;
-        bool known;
-
-        nc_color selected_color() const {
-            return can_craft
-                   ? ( can_craft_non_rotten ? h_white : h_brown )
-                   : ( could_craft_if_knew ? h_yellow : h_dark_gray );
-        }
-
-        nc_color color() const {
-            return can_craft
-                   ? ( can_craft_non_rotten ? c_white : c_brown )
-                   : ( could_craft_if_knew ? c_yellow : c_dark_gray );
-        }
-    };
-
     std::vector<availability> available;
-    //preserves component color printout between mode rotations
-    nc_color rotated_color = c_white;
-    int previous_item_line = -1;
-    std::string previous_tab;
-    std::string previous_subtab;
     int line = 0;
     bool recalc = true;
     bool keepline = false;
@@ -294,27 +473,7 @@ const recipe *select_crafting_recipe( int &batch_size )
     size_t num_hidden = 0;
     int num_recipe = 0;
     int batch_line = 0;
-    int display_mode = 0;
     const recipe *chosen = nullptr;
-
-    input_context ctxt( "CRAFTING" );
-    ctxt.register_cardinal();
-    ctxt.register_action( "QUIT" );
-    ctxt.register_action( "CONFIRM" );
-    ctxt.register_action( "CYCLE_MODE" );
-    ctxt.register_action( "SCROLL_UP" );
-    ctxt.register_action( "SCROLL_DOWN" );
-    ctxt.register_action( "PREV_TAB" );
-    ctxt.register_action( "NEXT_TAB" );
-    ctxt.register_action( "FILTER" );
-    ctxt.register_action( "RESET_FILTER" );
-    ctxt.register_action( "TOGGLE_FAVORITE" );
-    ctxt.register_action( "HELP_RECIPE" );
-    ctxt.register_action( "HELP_KEYBINDINGS" );
-    ctxt.register_action( "CYCLE_BATCH" );
-    ctxt.register_action( "RELATED_RECIPES" );
-    ctxt.register_action( "HIDE_SHOW_RECIPE" );
-    ctxt.register_action( "TOGGLE_UNAVAILABLE" );
 
     const inventory &crafting_inv = u.crafting_inventory();
     const std::vector<npc *> helpers = character_funcs::get_crafting_helpers( u );
@@ -330,7 +489,7 @@ const recipe *select_crafting_recipe( int &batch_size )
     const auto &all_recipes = recipe_subset( {}, all_recipes_flat );
 
     int recipe_scroll_window_min = 0;
-    ui.on_redraw( [&]( const ui_adaptor & ) {
+    ui.on_redraw( [&]( ui_adaptor & ui ) {
         const TAB_MODE m = ( batch ) ? BATCH : ( filterstring.empty() ) ? NORMAL : FILTERED;
         draw_recipe_tabs( w_head, tab.cur(), m );
         const auto &shown_recipes = show_unavailable ? all_recipes : available_recipes;
@@ -343,39 +502,12 @@ const recipe *select_crafting_recipe( int &batch_size )
         // Clear the screen of recipe data, and draw it anew
         werase( w_data );
 
-        if( isWide ) {
-            if( !filterstring.empty() ) {
-                fold_and_print( w_data, point( 5, dataLines + 1 ), 0, c_white,
-                                _( "Press [<color_yellow>ENTER</color>] to attempt to craft object.  "
-                                   "D[<color_yellow>e</color>]scribe, [<color_yellow>F</color>]ind, "
-                                   "[<color_red>R</color>]eset, [<color_yellow>m</color>]ode, "
-                                   "[<color_yellow>s</color>]how/hide, Re[<color_yellow>L</color>]ated, "
-                                   "[<color_yellow>*</color>]Favorite, %s, [<color_yellow>u</color>]navailable, "
-                                   "[<color_yellow>?</color>]keybindings" ),
-                                ( batch ) ? _( "<color_red>cancel</color> "
-                                               "[<color_yellow>b</color>]atch" ) : _( "[<color_yellow>b</color>]atch" ) );
-            } else {
-                fold_and_print( w_data, point( 5, dataLines + 1 ), 0, c_white,
-                                _( "Press [<color_yellow>ENTER</color>] to attempt to craft object.  "
-                                   "D[<color_yellow>e</color>]scribe, [<color_yellow>F</color>]ind, "
-                                   "[<color_yellow>m</color>]ode, [<color_yellow>s</color>]how/hide, "
-                                   "Re[<color_yellow>L</color>]ated, [<color_yellow>*</color>]Favorite, "
-                                   "%s, [<color_yellow>u</color>]navailable, "
-                                   "[<color_yellow>?</color>]keybindings" ),
-                                ( batch ) ? _( "<color_red>cancel</color> "
-                                               "[<color_yellow>b</color>]atch" ) : _( "[<color_yellow>b</color>]atch" ) );
-            }
-        } else {
-            if( !filterstring.empty() ) {
-                mvwprintz( w_data, point( 2, dataLines + 2 ), c_white,
-                           _( "[F]ind, [R]eset, [m]ode, [s]how/hide, Re[L]ated, [*]Fav, [b]atch." ) );
-            } else {
-                mvwprintz( w_data, point( 2, dataLines + 2 ), c_white,
-                           _( "[F]ind, [m]ode, [s]how/hide, Re[L]ated, [*]Fav, [b]atch." ) );
-            }
-            mvwprintz( w_data, point( 2, dataLines + 1 ), c_white,
-                       _( "Press [ENTER] to attempt to craft object.  D[e]scribe, [?]keybindings," ) );
+        for( size_t i = 0; i < keybinding_tips.size(); ++i ) {
+            nc_color dummy = c_white;
+            print_colored_text( w_data, point( keybinding_x, dataLines + 1 + i ),
+                                dummy, c_white, keybinding_tips[i] );
         }
+
         // Draw borders
         for( int i = 1; i < width - 1; ++i ) { // -
             mvwputch( w_data, point( i, dataHeight - 1 ), BORDER_COLOR, LINE_OXOX );
@@ -387,7 +519,7 @@ const recipe *select_crafting_recipe( int &batch_size )
         mvwputch( w_data, point( 0, dataHeight - 1 ), BORDER_COLOR, LINE_XXOO ); // |_
         mvwputch( w_data, point( width - 1, dataHeight - 1 ), BORDER_COLOR, LINE_XOOX ); // _|
 
-        std::optional<point> cursor_pos;
+        const int max_recipe_name_width = 27;
         int recmax = current.size();
 
         // Draw recipes with scroll list
@@ -404,187 +536,50 @@ const recipe *select_crafting_recipe( int &batch_size )
             const bool highlight = i == line;
             const nc_color col = highlight ? available[i].selected_color() : available[i].color();
             if( highlight ) {
-                cursor_pos = print_from;
+                ui.set_cursor( w_data, print_from );
             }
-            mvwprintz( w_data, print_from, col, trim_by_length( tmp_name, 27 ) );
+            mvwprintz( w_data, print_from, col, trim_by_length( tmp_name, max_recipe_name_width ) );
         }
 
-        const int count = batch ? line + 1 : 1; // batch size
+        const int batch_size = batch ? line + 1 : 1;
         if( !current.empty() ) {
-            int pane = FULL_SCREEN_WIDTH - 30 - 1;
-            nc_color col = available[line].color();
+            const recipe &recp = *current[line];
 
-            const auto &req = current[line]->simple_requirements();
-
-            draw_can_craft_indicator( w_head, *current[line] );
+            draw_can_craft_indicator( w_head, recp );
             wnoutrefresh( w_head );
 
-            int ypos = 0;
-
-            auto qry = trim( filterstring );
+            const availability &avail = available[line];
+            // border + padding + name + padding
+            const int xpos = 1 + 1 + max_recipe_name_width + 3;
+            const int fold_width = FULL_SCREEN_WIDTH - xpos - 2;
+            const nc_color color = avail.color( true );
+            const std::string qry = trim( filterstring );
             std::string qry_comps;
             if( qry.compare( 0, 2, "c:" ) == 0 ) {
                 qry_comps = qry.substr( 2 );
             }
 
-            std::vector<std::string> component_print_buffer;
-            auto tools = req.get_folded_tools_list( pane, col, crafting_inv, count );
-            auto comps = req.get_folded_components_list( pane, col, crafting_inv,
-                         current[line]->get_component_filter(), count, qry_comps );
-            component_print_buffer.insert( component_print_buffer.end(), tools.begin(), tools.end() );
-            component_print_buffer.insert( component_print_buffer.end(), comps.begin(), comps.end() );
+            const std::vector<std::string> &info = cached_recipe_info(
+                    recp, avail, u, qry_comps, batch_size, fold_width, color );
 
-            if( !u.knows_recipe( current[line] ) ) {
-                component_print_buffer.emplace_back( _( "Recipe not memorized yet" ) );
-                auto books_with_recipe = show_unavailable
-                                         ? crafting::get_books_for_recipe( current[line] )
-                                         : crafting::get_books_for_recipe( u, crafting_inv, current[line] );
-                std::string enumerated_books =
-                    enumerate_as_string( books_with_recipe.begin(), books_with_recipe.end(),
-                []( itype_id type_id ) {
-                    return colorize( item::nname( type_id ), c_cyan );
-                } );
-                const std::string text = string_format( _( "Written in: %s" ), enumerated_books );
-                std::vector<std::string> folded_lines = foldstring( text, pane );
-                component_print_buffer.insert(
-                    component_print_buffer.end(), folded_lines.begin(), folded_lines.end() );
+            const int total_lines = info.size();
+            if( recipe_info_scroll < 0 ) {
+                recipe_info_scroll = 0;
+            } else if( recipe_info_scroll + dataLines > total_lines ) {
+                recipe_info_scroll = std::max( 0, total_lines - dataLines );
+            }
+            for( int i = recipe_info_scroll;
+                 i < std::min( recipe_info_scroll + dataLines, total_lines );
+                 ++i ) {
+                nc_color dummy = color;
+                print_colored_text( w_data, point( xpos, i - recipe_info_scroll ),
+                                    dummy, color, info[i] );
             }
 
-            //handle positioning of component list if it needed to be scrolled
-            int componentPrintOffset = 0;
-            if( display_mode > 1 ) {
-                componentPrintOffset = ( display_mode - 1 ) * componentPrintHeight;
-            }
-            if( component_print_buffer.size() < static_cast<size_t>( componentPrintOffset ) ) {
-                componentPrintOffset = 0;
-                if( previous_tab != tab.cur() || previous_subtab != subtab.cur() || previous_item_line != line ) {
-                    display_mode = 1;
-                } else {
-                    display_mode = 0;
-                }
-            }
-
-            //only used to preserve mode position on components when
-            //moving to another item and the view is already scrolled
-            previous_tab = tab.cur();
-            previous_subtab = subtab.cur();
-            previous_item_line = line;
-            const int xpos = 30;
-
-            if( display_mode == 0 ) {
-                if( display_mod_source ) {
-                    const std::string source = enumerate_as_string( current[line]->src.begin(),
-                    current[line]->src.end(), []( const std::pair<recipe_id, mod_id> &content_source ) {
-                        return string_format( "'%s'", content_source.second->name() );
-                    }, enumeration_conjunction::arrow );
-
-                    const std::string text = string_format( _( "Origin: %s" ), colorize( source, c_light_blue ) );
-                    print_colored_text( w_data, point( xpos, ypos++ ), col, col, text );
-                }
-                if( display_object_ids ) {
-                    const std::string ident = string_format( "[%s]", current[line]->ident() );
-                    const std::string text = string_format( _( "ID: %s" ), colorize( ident, c_light_blue ) );
-                    print_colored_text( w_data, point( xpos, ypos++ ), col, col, text );
-                }
-
-                print_colored_text(
-                    w_data, point( xpos, ypos++ ), col, col,
-                    string_format( _( "Primary skill: %s" ),
-                                   current[line]->primary_skill_string( &u, false ) ) );
-
-                ypos += fold_and_print( w_data, point( xpos, ypos ), pane, col,
-                                        _( "Other skills: %s" ),
-                                        current[line]->required_skills_string( &u, false, false ) );
-
-                const int expected_turns = u.expected_time_to_craft( *current[line],
-                                           count ) / to_moves<int>( 1_turns );
-                ypos += fold_and_print( w_data, point( xpos, ypos ), pane, col,
-                                        _( "Time to complete: <color_cyan>%s</color>" ),
-                                        to_string( time_duration::from_turns( expected_turns ) ) );
-
-                ypos += fold_and_print( w_data, point( xpos, ypos ), pane, col,
-                                        _( "Batch time savings: <color_cyan>%s</color>" ),
-                                        current[line]->batch_savings_string() );
-
-                const int makes = current[line]->makes_amount();
-                if( makes > 1 ) {
-                    ypos += fold_and_print( w_data, point( xpos, ypos ), pane, col,
-                                            _( "One batch makes: <color_cyan>%d</color>" ),
-                                            makes );
-                }
-
-                print_colored_text(
-                    w_data, point( xpos, ypos++ ), col, col,
-                    string_format( _( "Dark craftable?  <color_cyan>%s</color>" ),
-                                   current[line]->has_flag( flag_BLIND_EASY ) ? _( "Easy" ) :
-                                   current[line]->has_flag( flag_BLIND_HARD ) ? _( "Hard" ) :
-                                   _( "Impossible" ) ) );
-
-                std::string nearby_string;
-                const int nearby_amount = crafting_inv.count_item( current[line]->result() );
-
-                if( nearby_amount == 0 ) {
-                    nearby_string = "<color_light_gray>0</color>";
-                } else if( nearby_amount > 9000 ) {
-                    // at some point you get too many to count at a glance and just know you have a lot
-                    nearby_string = _( "<color_red>It's Over 9000!!!</color>" );
-                } else {
-                    nearby_string = string_format( "<color_yellow>%d</color>", nearby_amount );
-                }
-                ypos += fold_and_print( w_data, point( xpos, ypos ), pane, col,
-                                        _( "Nearby: %s" ), nearby_string );
-
-                if( available[line].can_craft && !available[line].can_craft_non_rotten ) {
-                    ypos += fold_and_print( w_data, point( xpos, ypos ), pane, col,
-                                            _( "<color_red>Will use rotten ingredients</color>" ) );
-                }
-                const bool too_complex = current[line]->deduped_requirements().is_too_complex();
-                if( available[line].can_craft && too_complex ) {
-                    ypos += fold_and_print( w_data, point( xpos, ypos ), pane, col,
-                                            _( "Due to the complex overlapping requirements, this "
-                                               "recipe <color_yellow>may appear to be craftable "
-                                               "when it is not</color>." ) );
-                }
-                if( !available[line].can_craft &&
-                    available[line].apparently_craftable &&
-                    available[line].known ) {
-                    ypos += fold_and_print(
-                                w_data, point( xpos, ypos ), pane, col,
-                                _( "<color_red>Cannot be crafted because the same item is needed "
-                                   "for multiple components</color>" ) );
-                }
-                if( !available[line].known ) {
-                    ypos += fold_and_print(
-                                w_data, point( xpos, ypos ), pane, col,
-                                _( "<color_red>Not known</color>" ) );
-                }
-                ypos += print_items( *current[line], w_data, point( xpos, ypos ), col, batch ? line + 1 : 1 );
-            }
-
-            //color needs to be preserved in case part of the previous page was cut off
-            nc_color stored_color = col;
-            if( display_mode > 1 ) {
-                stored_color = rotated_color;
-            } else {
-                rotated_color = col;
-            }
-            int components_printed = 0;
-            for( size_t i = static_cast<size_t>( componentPrintOffset );
-                 i < component_print_buffer.size(); i++ ) {
-                if( ypos >= componentPrintHeight ) {
-                    break;
-                }
-
-                components_printed++;
-                print_colored_text( w_data, point( xpos, ypos++ ), stored_color, col, component_print_buffer[i] );
-            }
-
-            if( ypos >= componentPrintHeight &&
-                component_print_buffer.size() > static_cast<size_t>( components_printed ) ) {
-                mvwprintz( w_data, point( xpos, ypos++ ), col,
-                           _( "v (%s for more)" ),
-                           ctxt.press_x( "CYCLE_MODE" ) );
-                rotated_color = stored_color;
+            if( total_lines > dataLines ) {
+                scrollbar().offset_x( xpos + fold_width + 1 ).content_size( total_lines )
+                .viewport_pos( recipe_info_scroll ).viewport_size( dataLines )
+                .apply( w_data );
             }
         }
 
@@ -592,18 +587,12 @@ const recipe *select_crafting_recipe( int &batch_size )
         wnoutrefresh( w_data );
 
         if( isWide && !current.empty() ) {
-            item_info_data data = item_info_data_from_recipe( current[line], count, item_info_scroll );
+            item_info_data data = item_info_data_from_recipe( current[line], batch_size, item_info_scroll );
             data.without_getch = true;
             data.without_border = true;
             data.scrollbar_left = false;
             data.use_full_win = true;
             draw_item_info( w_iteminfo, data );
-        }
-
-        if( cursor_pos ) {
-            // place the cursor at the selected item name as expected by screen readers
-            wmove( w_data, cursor_pos.value() );
-            wnoutrefresh( w_data );
         }
     } );
 
@@ -616,10 +605,6 @@ const recipe *select_crafting_recipe( int &batch_size )
                 line = 0;
             } else {
                 keepline = false;
-            }
-
-            if( display_mode > 1 ) {
-                display_mode = 1;
             }
 
             show_hidden = false;
@@ -764,11 +749,10 @@ const recipe *select_crafting_recipe( int &batch_size )
 
         ui_manager::redraw();
         const std::string action = ctxt.handle_input();
-        if( action == "CYCLE_MODE" ) {
-            display_mode = display_mode + 1;
-            if( display_mode <= 0 ) {
-                display_mode = 0;
-            }
+        if( action == "SCROLL_RECIPE_INFO_UP" ) {
+            recipe_info_scroll -= dataLines;
+        } else if( action == "SCROLL_RECIPE_INFO_DOWN" ) {
+            recipe_info_scroll += dataLines;
         } else if( action == "LEFT" ) {
             std::string start = subtab.cur();
             do {
@@ -809,7 +793,7 @@ const recipe *select_crafting_recipe( int &batch_size )
                 // popup is already inside check
             } else {
                 chosen = current[line];
-                batch_size = ( batch ) ? line + 1 : 1;
+                batch_size_out = ( batch ) ? line + 1 : 1;
                 done = true;
             }
         } else if( action == "HELP_RECIPE" ) {
@@ -876,7 +860,6 @@ const recipe *select_crafting_recipe( int &batch_size )
 
             description +=
                 _( "\nUse <color_red>up/down arrow</color> to go through your search history." );
-            description += "\n\n\n";
 
             string_input_popup()
             .title( _( "Search:" ) )
@@ -947,6 +930,10 @@ const recipe *select_crafting_recipe( int &batch_size )
             }
 
             recalc = true;
+        } else if( action == "HELP_KEYBINDINGS" ) {
+            // Regenerate keybinding tips
+            ui.mark_resize();
+
         } else if( action == "TOGGLE_UNAVAILABLE" ) {
             show_unavailable = !show_unavailable;
 

--- a/src/crafting_gui.h
+++ b/src/crafting_gui.h
@@ -5,7 +5,7 @@
 class recipe;
 class JsonObject;
 
-const recipe *select_crafting_recipe( int &batch_size );
+const recipe *select_crafting_recipe( int &batch_size_out );
 
 void load_recipe_category( const JsonObject &jsobj );
 void reset_recipe_categories();

--- a/src/cursesdef.h
+++ b/src/cursesdef.h
@@ -89,6 +89,7 @@ enum base_color : short {
 using chtype = int;
 using attr_t = unsigned short;
 
+extern window newscr;
 extern window stdscr;
 
 window newwin( int nlines, int ncols, point begin );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -645,7 +645,7 @@ bool game::start_game()
     }
     //Load NPCs. Set nearby npcs to active.
     load_npcs();
-    
+
     // Spawn the monsters for `Surrounded` starting scenarios
     std::vector<std::pair<mongroup_id, float>> surround_groups = get_scenario()->surround_groups();
     const bool surrounded_start_scenario = !surround_groups.empty();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -645,7 +645,7 @@ bool game::start_game()
     }
     //Load NPCs. Set nearby npcs to active.
     load_npcs();
-
+    
     // Spawn the monsters for `Surrounded` starting scenarios
     std::vector<std::pair<mongroup_id, float>> surround_groups = get_scenario()->surround_groups();
     const bool surrounded_start_scenario = !surround_groups.empty();
@@ -2041,7 +2041,7 @@ std::pair<tripoint, tripoint> game::mouse_edge_scrolling( input_context &ctxt, c
         last_mouse_edge_scroll = now;
     }
     const input_event event = ctxt.get_raw_input();
-    if( event.type == CATA_INPUT_MOUSE ) {
+    if( event.type == input_event_t::mouse ) {
         const point threshold( projected_window_width() / 100, projected_window_height() / 100 );
         if( event.mouse_pos.x <= threshold.x ) {
             ret.first.x -= speed;
@@ -2066,7 +2066,7 @@ std::pair<tripoint, tripoint> game::mouse_edge_scrolling( input_context &ctxt, c
             }
         }
         ret.second = ret.first;
-    } else if( event.type == CATA_INPUT_TIMEOUT ) {
+    } else if( event.type == input_event_t::timeout ) {
         ret.first = ret.second;
     }
 #endif
@@ -2927,8 +2927,8 @@ shared_ptr_fast<ui_adaptor> game::create_or_get_main_ui_adaptor()
     shared_ptr_fast<ui_adaptor> ui = main_ui_adaptor.lock();
     if( !ui ) {
         main_ui_adaptor = ui = make_shared_fast<ui_adaptor>();
-        ui->on_redraw( []( const ui_adaptor & ) {
-            g->draw();
+        ui->on_redraw( []( ui_adaptor & ui ) {
+            g->draw( ui );
         } );
         ui->on_screen_resize( [this]( ui_adaptor & ui ) {
             // remove some space for the sidebar, this is the maximal space
@@ -3097,7 +3097,7 @@ static shared_ptr_fast<game::draw_callback_t> create_trail_callback(
     } );
 }
 
-void game::draw()
+void game::draw( ui_adaptor &ui )
 {
     if( test_mode ) {
         return;
@@ -3122,6 +3122,12 @@ void game::draw()
     wnoutrefresh( w_terrain );
 
     draw_panels( true );
+
+    // Ensure that the cursor lands on the character when everything is drawn.
+    // This allows screen readers to describe the area around the player, making it
+    // much easier to play with them
+    // (e.g. for blind players)
+    ui.set_cursor( w_terrain, -u.view_offset.xy() + point( POSX, POSY ) );
 }
 
 void game::draw_panels( bool force_draw )
@@ -3271,8 +3277,6 @@ void game::draw_ter( const tripoint &center, const bool looking, const bool draw
         draw_veh_dir_indicator( false );
         draw_veh_dir_indicator( true );
     }
-    // Place the cursor over the player as is expected by screen readers.
-    wmove( w_terrain, -center.xy() + g->u.pos().xy() + point( POSX, POSY ) );
 }
 
 std::optional<tripoint> game::get_veh_dir_indicator_location( bool next ) const
@@ -5070,13 +5074,13 @@ bool game::forced_door_closing( const tripoint &p, const ter_id &door_type, int 
         if( can_see ) {
             add_msg( _( "The %1$s hits the %2$s." ), door_name, critter.name() );
         }
-        if( critter.type->size <= MS_SMALL ) {
+        if( critter.type->size <= creature_size::small ) {
             critter.die_in_explosion( nullptr );
         } else {
             critter.apply_damage( nullptr, bodypart_id( "torso" ), bash_dmg );
             critter.check_dead_state();
         }
-        if( !critter.is_dead() && critter.type->size >= MS_HUGE ) {
+        if( !critter.is_dead() && critter.type->size >= creature_size::huge ) {
             // big critters simply prevent the gate from closing
             // TODO: perhaps damage/destroy the gate
             // if the critter was really big?
@@ -7404,14 +7408,14 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
 
     std::optional<item_filter_type> filter_type;
 
-    ui.on_redraw( [&]( const ui_adaptor & ) {
+    ui.on_redraw( [&]( ui_adaptor & ui ) {
         reset_item_list_state( w_items_border, iInfoHeight, sort_radius );
 
+        int iStartPos = 0;
         if( ground_items.empty() ) {
             wnoutrefresh( w_items_border );
             mvwprintz( w_items, point( 2, 10 ), c_white, _( "You don't see any items around you!" ) );
         } else {
-            int iStartPos = 0;
             werase( w_items );
             calcStartPos( iStartPos, iActive, iMaxRows, iItemNum );
             int iNum = 0;
@@ -7455,15 +7459,15 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
                             sText += string_format( "[%d]", iter->vIG[iThisPage].count );
                         }
 
-                        nc_color col = c_light_green;
-                        if( iNum != iActive ) {
-                            if( high ) {
-                                col = c_yellow;
-                            } else if( low ) {
-                                col = c_red;
-                            } else {
-                                col = iter->example->color_in_inventory();
-                            }
+                        nc_color col = c_light_gray;
+                        if( iNum == iActive ) {
+                            col = hilite( c_white );
+                        } else if( high ) {
+                            col = c_yellow;
+                        } else if( low ) {
+                            col = c_red;
+                        } else {
+                            col = iter->example->color_in_inventory();
                         }
                         trim_and_print( w_items, point( 1, iNum - iStartPos ), width - 9, col, sText );
                         const int numw = iItemNum > 9 ? 2 : 1;
@@ -7516,6 +7520,8 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
             trim_and_print( w_item_info, point( 4, 0 ), width - 8, activeItem->example->color_in_inventory(),
                             activeItem->example->display_name() );
             wprintw( w_item_info, " >" );
+            // move the cursor to the selected item (for screen readers)
+            ui.set_cursor( w_items, point( 1, iActive - iStartPos ) );
         }
 
         wnoutrefresh( w_items );
@@ -8749,13 +8755,13 @@ std::vector<std::string> game::get_dangerous_tile( const tripoint &dest_loc ) co
 bool game::walk_move( const tripoint &dest_loc, const bool via_ramp )
 {
     if( m.has_flag_ter( TFLAG_SMALL_PASSAGE, dest_loc ) ) {
-        if( u.get_size() > MS_MEDIUM ) {
+        if( u.get_size() > creature_size::medium ) {
             add_msg( m_warning, _( "You can't fit there." ) );
             return false; // character too large to fit through a tight passage
         }
         if( u.is_mounted() ) {
             monster *mount = u.mounted_creature.get();
-            if( mount->get_size() > MS_MEDIUM ) {
+            if( mount->get_size() > creature_size::medium ) {
                 add_msg( m_warning, _( "Your mount can't fit there." ) );
                 return false; // char's mount is too large for tight passages
             }
@@ -9003,18 +9009,18 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp )
             if( u.is_mounted() ) {
                 auto mons = u.mounted_creature.get();
                 switch( mons->get_size() ) {
-                    case MS_TINY:
+                    case creature_size::tiny:
                         volume = 0; // No sound for the tinies
                         break;
-                    case MS_SMALL:
+                    case creature_size::small:
                         volume /= 3;
                         break;
-                    case MS_MEDIUM:
+                    case creature_size::medium:
                         break;
-                    case MS_LARGE:
+                    case creature_size::large:
                         volume *= 1.5;
                         break;
-                    case MS_HUGE:
+                    case creature_size::huge:
                         volume *= 2;
                         break;
                     default:
@@ -10708,12 +10714,12 @@ void game::vertical_notes( int z_before, int z_after )
         }
         const oter_id &ter = overmap_buffer.ter( cursp_before );
         const oter_id &ter2 = overmap_buffer.ter( cursp_after );
-        if( z_after > z_before && ter->has_flag( known_up ) &&
-            !ter2->has_flag( known_down ) ) {
+        if( z_after > z_before && ter->has_flag( oter_flags::known_up ) &&
+            !ter2->has_flag( oter_flags::known_down ) ) {
             overmap_buffer.set_seen( cursp_after, true );
             overmap_buffer.add_note( cursp_after, string_format( ">:W;%s", _( "AUTO: goes down" ) ) );
-        } else if( z_after < z_before && ter->has_flag( known_down ) &&
-                   !ter2->has_flag( known_up ) ) {
+        } else if( z_after < z_before && ter->has_flag( oter_flags::known_down ) &&
+                   !ter2->has_flag( oter_flags::known_up ) ) {
             overmap_buffer.set_seen( cursp_after, true );
             overmap_buffer.add_note( cursp_after, string_format( "<:W;%s", _( "AUTO: goes up" ) ) );
         }

--- a/src/game.h
+++ b/src/game.h
@@ -196,7 +196,7 @@ class game
         shared_ptr_fast<ui_adaptor> create_or_get_main_ui_adaptor();
         void invalidate_main_ui_adaptor() const;
         void mark_main_ui_adaptor_resize() const;
-        void draw();
+        void draw( ui_adaptor &ui );
         void draw_ter( bool draw_sounds = true );
         void draw_ter( const tripoint &center, bool looking = false, bool draw_sounds = true );
 

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -157,7 +157,7 @@ void input_manager::init()
             action_contexts[action_id].clear();
             touched.insert( a->second );
         }
-        add_input_for_action( action_id, context, input_event( a->first, CATA_INPUT_KEYBOARD ) );
+        add_input_for_action( action_id, context, input_event( a->first, input_event_t::keyboard ) );
     }
     // Unmap actions that are explicitly not mapped
     for( const auto &elem : unbound_keymap ) {
@@ -223,11 +223,11 @@ void input_manager::load( const std::string &file_name, bool is_user_preferences
             std::string input_method = keybinding.get_string( "input_method" );
             input_event new_event;
             if( input_method == "keyboard" ) {
-                new_event.type = CATA_INPUT_KEYBOARD;
+                new_event.type = input_event_t::keyboard;
             } else if( input_method == "gamepad" ) {
-                new_event.type = CATA_INPUT_GAMEPAD;
+                new_event.type = input_event_t::gamepad;
             } else if( input_method == "mouse" ) {
-                new_event.type = CATA_INPUT_MOUSE;
+                new_event.type = input_event_t::mouse;
             }
 
             if( keybinding.has_array( "key" ) ) {
@@ -293,13 +293,13 @@ void input_manager::save()
                 for( const auto &event : events ) {
                     jsout.start_object();
                     switch( event.type ) {
-                        case CATA_INPUT_KEYBOARD:
+                        case input_event_t::keyboard:
                             jsout.member( "input_method", "keyboard" );
                             break;
-                        case CATA_INPUT_GAMEPAD:
+                        case input_event_t::gamepad:
                             jsout.member( "input_method", "gamepad" );
                             break;
-                        case CATA_INPUT_MOUSE:
+                        case input_event_t::mouse:
                             jsout.member( "input_method", "mouse" );
                             break;
                         default:
@@ -362,6 +362,15 @@ void input_manager::init_keycode_mapping()
     add_keycode_pair( KEY_END,       translate_marker_context( "key name", "END" ) );
     add_keycode_pair( '\n',          translate_marker_context( "key name", "RETURN" ) );
 
+    for( int c = 0; IS_CTRL_CHAR( c ); c++ ) {
+        // Some codes fall into this range but have more common names we'd prefer to use.
+        if( !IS_NAMED_CTRL_CHAR( c ) ) {
+            // These are directly translated in `get_keyname()`
+            // NOLINTNEXTLINE(cata-translate-string-literal)
+            add_keycode_pair( c, string_format( "CTRL+%c", c + 64 ) );
+        }
+    }
+
     // function keys, as defined by ncurses
     for( int i = F_KEY_NUM_BEG; i <= F_KEY_NUM_END; i++ ) {
         // not marked for translation here, but specially handled in get_keyname so
@@ -409,8 +418,9 @@ int input_manager::get_keycode( const std::string &name ) const
 
 std::string input_manager::get_keyname( int ch, input_event_t inp_type, bool portable ) const
 {
+
     std::optional<std::string> raw;
-    if( inp_type == CATA_INPUT_KEYBOARD ) {
+    if( inp_type == input_event_t::keyboard ) {
         const t_key_to_name_map::const_iterator a = keycode_to_keyname.find( ch );
         if( a != keycode_to_keyname.end() ) {
             if( IS_F_KEY( ch ) ) {
@@ -421,13 +431,19 @@ std::string input_manager::get_keyname( int ch, input_event_t inp_type, bool por
                 } else {
                     return string_format( pgettext( "function key name", "F%d" ), F_KEY_NUM( ch ) );
                 }
+            } else if( IS_CTRL_CHAR( ch ) && !IS_NAMED_CTRL_CHAR( ch ) ) {
+                if( portable ) {
+                    return a->second;
+                } else {
+                    return string_format( pgettext( "control key name", "CTRL+%c" ), ch + 64 );
+                }
             } else if( ch >= char_key_beg && ch <= char_key_end && ch != ' ' ) {
                 // character keys except space need no translation
                 return a->second;
             }
             raw = a->second;
         }
-    } else if( inp_type == CATA_INPUT_MOUSE ) {
+    } else if( inp_type == input_event_t::mouse ) {
         if( ch == MOUSE_BUTTON_LEFT ) {
             raw = translate_marker_context( "key name", "MOUSE_LEFT" );
         } else if( ch == MOUSE_BUTTON_RIGHT ) {
@@ -439,7 +455,7 @@ std::string input_manager::get_keyname( int ch, input_event_t inp_type, bool por
         } else if( ch == MOUSE_MOVE ) {
             raw = translate_marker_context( "key name", "MOUSE_MOVE" );
         }
-    } else if( inp_type == CATA_INPUT_GAMEPAD ) {
+    } else if( inp_type == input_event_t::gamepad ) {
         const t_key_to_name_map::const_iterator a = gamepad_keycode_to_keyname.find( ch );
         if( a != gamepad_keycode_to_keyname.end() ) {
             raw = a->second;
@@ -674,7 +690,8 @@ void input_context::register_action( const std::string &action_descriptor )
     register_action( action_descriptor, translation() );
 }
 
-void input_context::register_action( const std::string &action_descriptor, const translation &name )
+void input_context::register_action( const std::string &action_descriptor,
+                                     const translation &name )
 {
     if( action_descriptor == "ANY_INPUT" ) {
         registered_any_input = true;
@@ -697,7 +714,7 @@ std::vector<char> input_context::keys_bound_to( const std::string &action_descri
     for( const auto &events_event : events ) {
         // Ignore multi-key input and non-keyboard input
         // TODO: fix for Unicode.
-        if( events_event.type == CATA_INPUT_KEYBOARD && events_event.sequence.size() == 1 ) {
+        if( events_event.type == input_event_t::keyboard && events_event.sequence.size() == 1 ) {
             if( !restrict_to_printable || ( events_event.sequence.front() < 0xFF &&
                                             isprint( events_event.sequence.front() ) ) ) {
                 result.push_back( static_cast<char>( events_event.sequence.front() ) );
@@ -722,7 +739,7 @@ std::string input_context::get_available_single_char_hotkeys( std::string reques
 
         for( const auto &events_event : events ) {
             // Only consider keyboard events without modifiers
-            if( events_event.type == CATA_INPUT_KEYBOARD && events_event.modifiers.empty() ) {
+            if( events_event.type == input_event_t::keyboard && events_event.modifiers.empty() ) {
                 requested_keys.erase( std::remove_if( requested_keys.begin(), requested_keys.end(),
                                                       ContainsPredicate<std::vector<int>, char>(
                                                               events_event.sequence ) ),
@@ -736,7 +753,7 @@ std::string input_context::get_available_single_char_hotkeys( std::string reques
 
 const input_context::input_event_filter input_context::disallow_lower_case =
 []( const input_event &evt ) -> bool {
-    return evt.type != CATA_INPUT_KEYBOARD ||
+    return evt.type != input_event_t::keyboard ||
     // std::lower from <cctype> is undefined outside unsigned char range
     // and std::lower from <locale> may throw bad_cast for some locales
     evt.get_first_input() < 'a' || evt.get_first_input() > 'z';
@@ -769,7 +786,7 @@ std::string input_context::get_desc( const std::string &action_descriptor,
 
         if( evt_filter( event ) &&
             // Only display gamepad buttons if a gamepad is available.
-            ( gamepad_available() || event.type != CATA_INPUT_GAMEPAD ) ) {
+            ( gamepad_available() || event.type != input_event_t::gamepad ) ) {
 
             inputs_to_show.push_back( event );
         }
@@ -815,15 +832,17 @@ std::string input_context::get_desc( const std::string &action_descriptor,
     for( const auto &evt : events ) {
         if( evt_filter( evt ) &&
             // Only display gamepad buttons if a gamepad is available.
-            ( gamepad_available() || evt.type != CATA_INPUT_GAMEPAD ) ) {
+            ( gamepad_available() || evt.type != input_event_t::gamepad ) ) {
 
             na = false;
-            if( evt.type == CATA_INPUT_KEYBOARD && evt.sequence.size() == 1 ) {
+            if( evt.type == input_event_t::keyboard && evt.sequence.size() == 1 ) {
                 const int ch = evt.get_first_input();
-                const std::string key = utf32_to_utf8( ch );
-                const auto pos = ci_find_substr( text, key );
-                if( ch > ' ' && ch <= '~' && pos >= 0 ) {
-                    return text.substr( 0, pos ) + "(" + key + ")" + text.substr( pos + key.size() );
+                if( ch > ' ' && ch <= '~' ) {
+                    const std::string key = utf32_to_utf8( ch );
+                    const int pos = ci_find_substr( text, key );
+                    if( pos >= 0 ) {
+                        return text.substr( 0, pos ) + "(" + key + ")" + text.substr( pos + key.size() );
+                    }
                 }
             }
         }
@@ -856,11 +875,11 @@ const std::string &input_context::handle_input( const int timeout )
     if( timeout >= 0 ) {
         inp_mngr.set_timeout( timeout );
     }
-    next_action.type = CATA_INPUT_ERROR;
+    next_action.type = input_event_t::error;
     const std::string *result = &CATA_ERROR;
     while( true ) {
         next_action = inp_mngr.get_input_event();
-        if( next_action.type == CATA_INPUT_TIMEOUT ) {
+        if( next_action.type == input_event_t::timeout ) {
             result = &TIMEOUT;
             break;
         }
@@ -876,7 +895,7 @@ const std::string &input_context::handle_input( const int timeout )
             break;
         }
 
-        if( next_action.type == CATA_INPUT_MOUSE ) {
+        if( next_action.type == input_event_t::mouse ) {
             if( !handling_coordinate_input && action == CATA_ERROR ) {
                 continue; // Ignore this mouse input.
             }
@@ -990,6 +1009,22 @@ std::optional<tripoint> input_context::get_direction( const std::string &action 
 const std::string display_help_hotkeys =
     "abcdefghijkpqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789:;'\",/<>?!@#$%^&*()_[]\\{}|`~";
 
+namespace
+{
+enum class fallback_action {
+    add_local,
+    add_global,
+    remove,
+    execute,
+};
+} // namespace
+static const std::map<fallback_action, int> fallback_keys = {
+    { fallback_action::add_local, '+' },
+    { fallback_action::add_global, '=' },
+    { fallback_action::remove, '-' },
+    { fallback_action::execute, '.' },
+};
+
 action_id input_context::display_menu( const bool permit_execute_action )
 {
     action_id action_to_execute = ACTION_NULL;
@@ -1003,8 +1038,22 @@ action_id input_context::display_menu( const bool permit_execute_action )
     ctxt.register_action( "REMOVE" );
     ctxt.register_action( "ADD_LOCAL" );
     ctxt.register_action( "ADD_GLOBAL" );
-    ctxt.register_action( "EXECUTE" );
+    if( permit_execute_action ) {
+        ctxt.register_action( "EXECUTE" );
+    }
     ctxt.register_action( "QUIT" );
+    // String input actions
+    ctxt.register_action( "TEXT.LEFT" );
+    ctxt.register_action( "TEXT.RIGHT" );
+    ctxt.register_action( "TEXT.CLEAR" );
+    ctxt.register_action( "TEXT.BACKSPACE" );
+    ctxt.register_action( "TEXT.HOME" );
+    ctxt.register_action( "TEXT.END" );
+    ctxt.register_action( "TEXT.DELETE" );
+#if defined( TILES )
+    ctxt.register_action( "TEXT.PASTE" );
+#endif
+    ctxt.register_action( "TEXT.INPUT_FROM_FILE" );
     ctxt.register_action( "ANY_INPUT" );
 
     if( category != "HELP_KEYBINDINGS" ) {
@@ -1021,6 +1070,12 @@ action_id input_context::display_menu( const bool permit_execute_action )
     size_t display_height = 0;
     size_t legwidth = 0;
     string_input_popup spopup;
+    // ignore hardcoded keys in string input popup
+    for( const std::pair<const fallback_action, int> &v : fallback_keys ) {
+        spopup.callbacks[v.second] = []() {
+            return true;
+        };
+    }
     const auto recalc_size = [&]( ui_adaptor & ui ) {
         int maxwidth = std::max( FULL_SCREEN_WIDTH, TERMX );
         width = min( 80, maxwidth );
@@ -1031,9 +1086,11 @@ action_id input_context::display_menu( const bool permit_execute_action )
                                      point( maxwidth / 2 - width / 2, maxheight / 2 - height / 2 ) );
         // height of the area usable for display of keybindings, excludes headers & borders
         display_height = height - LEGEND_HEIGHT - BORDER_SPACE; // -2 for the border
+        const point filter_pos( 4, 8 );
         // width of the legend
-        legwidth = width - 4 - BORDER_SPACE;
-        spopup.window( w_help, point( 4, 8 ), legwidth )
+        legwidth = width - filter_pos.x * 2 - BORDER_SPACE;
+        // +1 for end-of-text cursor
+        spopup.window( w_help, filter_pos, filter_pos.x + legwidth + 1 )
         .max_length( legwidth )
         .context( ctxt );
         ui.position_from_window( w_help );
@@ -1066,9 +1123,15 @@ action_id input_context::display_menu( const bool permit_execute_action )
     legend += colorize( _( "Unbound keys" ), unbound_key ) + "\n";
     legend += colorize( _( "Keybinding active only on this screen" ), local_key ) + "\n";
     legend += colorize( _( "Keybinding active globally" ), global_key ) + "\n";
-    legend += _( "Press - to remove keybinding\nPress + to add local keybinding\nPress = to add global keybinding\n" );
+    legend += string_format(
+                  _( "Press %c to remove keybinding\nPress %c to add local keybinding\nPress %c to add global keybinding\n" ),
+                  fallback_keys.at( fallback_action::remove ),
+                  fallback_keys.at( fallback_action::add_local ),
+                  fallback_keys.at( fallback_action::add_global ) );
     if( permit_execute_action ) {
-        legend += _( "Press . to execute action\n" );
+        legend += string_format(
+                      _( "Press %c to execute action\n" ),
+                      fallback_keys.at( fallback_action::execute ) );
     }
 
     std::vector<std::string> filtered_registered_actions = org_registered_actions;
@@ -1076,7 +1139,7 @@ action_id input_context::display_menu( const bool permit_execute_action )
     std::string action;
     int raw_input_char = 0;
 
-    const auto redraw = [&]( const ui_adaptor & ) {
+    const auto redraw = [&]( ui_adaptor & ui ) {
         werase( w_help );
         draw_border( w_help, BORDER_COLOR, _( "Keybindings" ), c_light_red );
         draw_scrollbar( w_help, scroll_offset, display_height,
@@ -1123,9 +1186,12 @@ action_id input_context::display_menu( const bool permit_execute_action )
             mvwprintz( w_help, point( 52, i + 10 ), col, "%s", get_desc( action_id ) );
         }
 
-        // spopup.query_string() will call wnoutrefresh( w_help )
+        // spopup.query_string() will call wnoutrefresh( w_help ), and should
+        // be called last to position the cursor at the correct place in the curses build.
         spopup.text( filter_phrase );
         spopup.query_string( false, true );
+        // Record cursor immediately after spopup drawing
+        ui.record_term_cursor();
     };
     ui.on_redraw( redraw );
 
@@ -1141,28 +1207,81 @@ action_id input_context::display_menu( const bool permit_execute_action )
             action = ctxt.handle_input();
         }
         raw_input_char = ctxt.get_raw_input().get_first_input();
+        for( const std::pair<const fallback_action, int> &v : fallback_keys ) {
+            if( v.second == raw_input_char ) {
+                action.clear();
+            }
+        }
 
         filtered_registered_actions = filter_strings_by_phrase( org_registered_actions, filter_phrase );
         if( scroll_offset > filtered_registered_actions.size() ) {
             scroll_offset = 0;
         }
 
-        if( filtered_registered_actions.empty() && action != "QUIT" ) {
-            continue;
-        }
-
         // In addition to the modifiable hotkeys, we also check for hardcoded
         // keys, e.g. '+', '-', '=', '.' in order to prevent the user from
         // entering an unrecoverable state.
-        if( action == "ADD_LOCAL" || raw_input_char == '+' ) {
-            status = s_add;
-        } else if( action == "ADD_GLOBAL" || raw_input_char == '=' ) {
-            status = s_add_global;
-        } else if( action == "REMOVE" || raw_input_char == '-' ) {
-            status = s_remove;
-        } else if( ( action == "EXECUTE" || raw_input_char == '.' ) && permit_execute_action ) {
-            status = s_execute;
-        } else if( action == "ANY_INPUT" ) {
+        if( action == "ADD_LOCAL"
+            || raw_input_char == fallback_keys.at( fallback_action::add_local ) ) {
+            if( !filtered_registered_actions.empty() ) {
+                status = s_add;
+            }
+        } else if( action == "ADD_GLOBAL"
+                   || raw_input_char == fallback_keys.at( fallback_action::add_global ) ) {
+            if( !filtered_registered_actions.empty() ) {
+                status = s_add_global;
+            }
+        } else if( action == "REMOVE"
+                   || raw_input_char == fallback_keys.at( fallback_action::remove ) ) {
+            if( !filtered_registered_actions.empty() ) {
+                status = s_remove;
+            }
+        } else if( ( action == "EXECUTE"
+                     || raw_input_char == fallback_keys.at( fallback_action::execute ) )
+                   && permit_execute_action ) {
+            if( !filtered_registered_actions.empty() ) {
+                status = s_execute;
+            }
+        } else if( action == "DOWN" ) {
+            if( !filtered_registered_actions.empty()
+                && filtered_registered_actions.size() > display_height
+                && scroll_offset < filtered_registered_actions.size() - display_height ) {
+                scroll_offset++;
+            }
+        } else if( action == "UP" ) {
+            if( !filtered_registered_actions.empty()
+                && scroll_offset > 0 ) {
+                scroll_offset--;
+            }
+        } else if( action == "PAGE_DOWN" ) {
+            if( filtered_registered_actions.empty() ) {
+                // do nothing
+            } else if( scroll_offset + display_height < filtered_registered_actions.size() ) {
+                scroll_offset += std::min( display_height, filtered_registered_actions.size() -
+                                           display_height - scroll_offset );
+            } else if( filtered_registered_actions.size() > display_height ) {
+                scroll_offset = 0;
+            }
+        } else if( action == "PAGE_UP" ) {
+            if( filtered_registered_actions.empty() ) {
+                // do nothing
+            } else if( scroll_offset >= display_height ) {
+                scroll_offset -= display_height;
+            } else if( scroll_offset > 0 ) {
+                scroll_offset = 0;
+            } else if( filtered_registered_actions.size() > display_height ) {
+                scroll_offset = filtered_registered_actions.size() - display_height;
+            }
+        } else if( action == "QUIT" ) {
+            if( status != s_show ) {
+                status = s_show;
+            } else {
+                break;
+            }
+        } else if( action == "HELP_KEYBINDINGS" ) {
+            // update available hotkeys in case they've changed
+            hotkeys = ctxt.get_available_single_char_hotkeys( display_help_hotkeys );
+        } else if( !filtered_registered_actions.empty() && status != s_show ) {
             const size_t hotkey_index = hotkeys.find_first_of( raw_input_char );
             if( hotkey_index == std::string::npos ) {
                 continue;
@@ -1240,39 +1359,6 @@ action_id input_context::display_menu( const bool permit_execute_action )
                 break;
             }
             status = s_show;
-        } else if( action == "DOWN" ) {
-            if( filtered_registered_actions.size() > display_height &&
-                scroll_offset < filtered_registered_actions.size() - display_height ) {
-                scroll_offset++;
-            }
-        } else if( action == "UP" ) {
-            if( scroll_offset > 0 ) {
-                scroll_offset--;
-            }
-        } else if( action == "PAGE_DOWN" ) {
-            if( scroll_offset + display_height < filtered_registered_actions.size() ) {
-                scroll_offset += std::min( display_height, filtered_registered_actions.size() -
-                                           display_height - scroll_offset );
-            } else if( filtered_registered_actions.size() > display_height ) {
-                scroll_offset = 0;
-            }
-        } else if( action == "PAGE_UP" ) {
-            if( scroll_offset >= display_height ) {
-                scroll_offset -= display_height;
-            } else if( scroll_offset > 0 ) {
-                scroll_offset = 0;
-            } else if( filtered_registered_actions.size() > display_height ) {
-                scroll_offset = filtered_registered_actions.size() - display_height;
-            }
-        } else if( action == "QUIT" ) {
-            if( status != s_show ) {
-                status = s_show;
-            } else {
-                break;
-            }
-        } else if( action == "HELP_KEYBINDINGS" ) {
-            // update available hotkeys in case they've changed
-            hotkeys = ctxt.get_available_single_char_hotkeys( display_help_hotkeys );
         }
     }
 
@@ -1308,13 +1394,13 @@ void input_manager::wait_for_any_key()
     while( true ) {
         const input_event evt = inp_mngr.get_input_event();
         switch( evt.type ) {
-            case CATA_INPUT_KEYBOARD:
+            case input_event_t::keyboard:
                 if( !evt.sequence.empty() ) {
                     return;
                 }
                 break;
             // errors are accepted as well to avoid an infinite loop
-            case CATA_INPUT_ERROR:
+            case input_event_t::error:
                 return;
             default:
                 break;
@@ -1393,7 +1479,8 @@ std::string input_context::press_x( const std::string &action_id, const std::str
 }
 
 // TODO: merge this with input_context::get_desc
-std::string input_context::press_x( const std::string &action_id, const std::string &key_bound_pre,
+std::string input_context::press_x( const std::string &action_id,
+                                    const std::string &key_bound_pre,
                                     const std::string &key_bound_suf, const std::string &key_unbound ) const
 {
     if( action_id == "ANY_INPUT" ) {

--- a/src/input.h
+++ b/src/input.h
@@ -54,6 +54,17 @@ inline constexpr bool IS_F_KEY( const int key )
 {
     return key >= KEY_F( F_KEY_NUM_BEG ) && key <= KEY_F( F_KEY_NUM_END );
 }
+/** @return true if the given character is in the range of basic ASCII control characters */
+inline constexpr bool IS_CTRL_CHAR( const int key )
+{
+    // https://en.wikipedia.org/wiki/C0_and_C1_control_codes#Basic_ASCII_control_codes
+    return key >= 0 && key < ' ';
+}
+/** @return true if the given character is an ASCII control char but should not be rendered with "CTRL+" */
+inline constexpr bool IS_NAMED_CTRL_CHAR( const int key )
+{
+    return key == '\t' || key == '\n' || key == KEY_ESCAPE || key == KEY_BACKSPACE;
+}
 inline constexpr int KEY_NUM( const int n )
 {
     return 0x30 + n;     /* Numbers 0, 1, ..., 9 */
@@ -72,12 +83,12 @@ std::string get_input_string_from_file( const std::string &fname = "input.txt" )
 
 enum mouse_buttons { MOUSE_BUTTON_LEFT = 1, MOUSE_BUTTON_RIGHT, SCROLLWHEEL_UP, SCROLLWHEEL_DOWN, MOUSE_MOVE };
 
-enum input_event_t {
-    CATA_INPUT_ERROR,
-    CATA_INPUT_TIMEOUT,
-    CATA_INPUT_KEYBOARD,
-    CATA_INPUT_GAMEPAD,
-    CATA_INPUT_MOUSE
+enum class input_event_t : int  {
+    error,
+    timeout,
+    keyboard,
+    gamepad,
+    mouse
 };
 
 /**
@@ -112,7 +123,7 @@ struct input_event {
 #endif
 
     input_event() : edit_refresh( false ) {
-        type = CATA_INPUT_ERROR;
+        type = input_event_t::error;
 #if defined(__ANDROID__)
         shortcut_last_used_action_counter = 0;
 #endif
@@ -680,7 +691,7 @@ class input_context
          * Sets input polling timeout as appropriate for the current interface system.
          * Use this method to set timeouts when using input_context, rather than calling
          * the old timeout() method or using input_manager::(re)set_timeout, as using
-         * this method will cause CATA_INPUT_TIMEOUT events to be generated correctly,
+         * this method will cause input_event_t::timeout events to be generated correctly,
          * and will reset timeout correctly when a new input context is entered.
          */
         void set_timeout( int val );

--- a/src/loading_ui.cpp
+++ b/src/loading_ui.cpp
@@ -49,8 +49,8 @@ void loading_ui::init()
             menu->reposition( ui );
         } );
         menu->reposition( *ui );
-        ui->on_redraw( [this]( const ui_adaptor & ) {
-            menu->show();
+        ui->on_redraw( [this]( ui_adaptor & ui ) {
+            menu->show( ui );
         } );
     }
 }

--- a/src/ncurses_def.cpp
+++ b/src/ncurses_def.cpp
@@ -215,6 +215,7 @@ void catacurses::init_pair( const short pair, const base_color f, const base_col
                                 OK, "init_pair" );
 }
 
+catacurses::window catacurses::newscr;
 catacurses::window catacurses::stdscr;
 
 void catacurses::resizeterm()
@@ -236,6 +237,10 @@ void catacurses::init_interface()
     stdscr = std::shared_ptr<void>( ::initscr(), []( void *const ) { } );
     if( !stdscr ) {
         throw std::runtime_error( "initscr failed" );
+    }
+    newscr = window( std::shared_ptr<void>( ::newscr, []( void *const ) { } ) );
+    if( !newscr ) {
+        throw std::runtime_error( "null newscr" );
     }
 #if !defined(__CYGWIN__)
     // ncurses mouse registration
@@ -303,9 +308,9 @@ input_event input_manager::get_input_event()
         rval = input_event();
         if( key == ERR ) {
             if( input_timeout > 0 ) {
-                rval.type = CATA_INPUT_TIMEOUT;
+                rval.type = input_event_t::timeout;
             } else {
-                rval.type = CATA_INPUT_ERROR;
+                rval.type = input_event_t::error;
             }
             // ncurses mouse handling
         } else if( key == KEY_RESIZE ) {
@@ -313,7 +318,7 @@ input_event input_manager::get_input_event()
         } else if( key == KEY_MOUSE ) {
             MEVENT event;
             if( getmouse( &event ) == OK ) {
-                rval.type = CATA_INPUT_MOUSE;
+                rval.type = input_event_t::mouse;
                 rval.mouse_pos = point( event.x, event.y );
                 if( event.bstate & BUTTON1_CLICKED ) {
                     rval.add_input( MOUSE_BUTTON_LEFT );
@@ -326,17 +331,17 @@ input_event input_manager::get_input_event()
                         set_timeout( input_timeout );
                     }
                 } else {
-                    rval.type = CATA_INPUT_ERROR;
+                    rval.type = input_event_t::error;
                 }
             } else {
-                rval.type = CATA_INPUT_ERROR;
+                rval.type = input_event_t::error;
             }
         } else {
             if( key == 127 ) { // == Unicode DELETE
                 previously_pressed_key = KEY_BACKSPACE;
-                return input_event( KEY_BACKSPACE, CATA_INPUT_KEYBOARD );
+                return input_event( KEY_BACKSPACE, input_event_t::keyboard );
             }
-            rval.type = CATA_INPUT_KEYBOARD;
+            rval.type = input_event_t::keyboard;
             rval.text.append( 1, static_cast<char>( key ) );
             // Read the UTF-8 sequence (if any)
             if( key < 127 ) {
@@ -354,7 +359,7 @@ input_event input_manager::get_input_event()
                 // Other control character, etc. - no text at all, return an event
                 // without the text property
                 previously_pressed_key = key;
-                return input_event( key, CATA_INPUT_KEYBOARD );
+                return input_event( key, input_event_t::keyboard );
             }
             // Now we have loaded an UTF-8 sequence (possibly several bytes)
             // but we should only return *one* key, so return the code point of it.
@@ -363,7 +368,7 @@ input_event input_manager::get_input_event()
                 // Invalid UTF-8 sequence, this should never happen, what now?
                 // Maybe return any error instead?
                 previously_pressed_key = key;
-                return input_event( key, CATA_INPUT_KEYBOARD );
+                return input_event( key, input_event_t::keyboard );
             }
             previously_pressed_key = cp;
             // for compatibility only add the first byte, not the code point
@@ -378,7 +383,7 @@ input_event input_manager::get_input_event()
 void input_manager::set_timeout( const int delay )
 {
     timeout( delay );
-    // Use this to determine when curses should return a CATA_INPUT_TIMEOUT event.
+    // Use this to determine when curses should return a input_event_t::timeout event.
     input_timeout = delay;
 }
 

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -738,7 +738,8 @@ static tripoint_abs_omt show_notes_manager( const tripoint_abs_omt &origin )
     return result;
 }
 
-static void draw_ascii( const catacurses::window &w,
+static void draw_ascii( ui_adaptor &ui,
+                        const catacurses::window &w,
                         const tripoint_abs_omt &center,
                         const tripoint_abs_omt &/*orig*/,
                         bool blink,
@@ -1230,8 +1231,9 @@ static void draw_ascii( const catacurses::window &w,
         mvwputch( w, point( om_half_width + 1, om_half_height + 1 ), c_light_gray, LINE_XOOX );
     }
     // Done with all drawing!
-    wmove( w, point( om_half_width, om_half_height ) );
     wnoutrefresh( w );
+    // Set cursor for screen readers
+    ui.set_cursor( w, point( om_half_width, om_half_height ) );
 }
 
 static void draw_om_sidebar(
@@ -1428,6 +1430,7 @@ tiles_redraw_info redraw_info;
 #endif
 
 static void draw(
+    ui_adaptor &ui,
     const tripoint_abs_omt &center,
     const tripoint_abs_omt &orig,
     bool blink,
@@ -1439,7 +1442,7 @@ static void draw(
 {
     draw_om_sidebar( g->w_omlegend, center, orig, blink, fast_scroll, inp_ctxt, data );
     if( !use_tiles || !use_tiles_overmap ) {
-        draw_ascii( g->w_overmap, center, orig, blink, show_explored, fast_scroll, inp_ctxt, data,
+        draw_ascii( ui, g->w_overmap, center, orig, blink, show_explored, fast_scroll, inp_ctxt, data,
                     grids_data );
     } else {
 #ifdef TILES
@@ -1495,7 +1498,7 @@ static void create_note( const tripoint_abs_omt &curs )
     ui.on_redraw( [&]( const ui_adaptor & ) {
         update_note_preview( new_note, map_around, preview_windows );
     } );
-
+    
     // this implies enable_ime() and ensures that ime mode is always restored on return
     ime_sentry sentry;
 
@@ -1520,6 +1523,7 @@ static void create_note( const tripoint_abs_omt &curs )
         } else if( input_popup.confirmed() ) {
             break;
         }
+        ui.invalidate_ui();
     } while( true );
 
     disable_ime();
@@ -1994,8 +1998,8 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
     std::chrono::time_point<std::chrono::steady_clock> last_blink = std::chrono::steady_clock::now();
     grids_draw_data grids_data;
 
-    ui.on_redraw( [&]( const ui_adaptor & ) {
-        draw( curs, orig, uistate.overmap_show_overlays,
+    ui.on_redraw( [&]( ui_adaptor & ui ) {
+        draw( ui, curs, orig, uistate.overmap_show_overlays,
               show_explored, fast_scroll, &ictxt, data, grids_data );
     } );
 

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1498,7 +1498,7 @@ static void create_note( const tripoint_abs_omt &curs )
     ui.on_redraw( [&]( const ui_adaptor & ) {
         update_note_preview( new_note, map_around, preview_windows );
     } );
-    
+
     // this implies enable_ime() and ensures that ime mode is always restored on return
     ime_sentry sentry;
 

--- a/src/string_editor_window.cpp
+++ b/src/string_editor_window.cpp
@@ -11,6 +11,7 @@
 #endif
 
 #include "wcwidth.h"
+#include "ui_manager.h"
 
 static bool is_linebreak( const uint32_t uc )
 {
@@ -193,7 +194,7 @@ point string_editor_window::get_line_and_position( const int position, const boo
     return _folded->codepoint_coordinates( position, zero_x );
 }
 
-void string_editor_window::print_editor()
+void string_editor_window::print_editor( ui_adaptor &ui )
 {
     const point focus = _ime_preview_range ? _ime_preview_range->display_last : _cursor_display;
     const int ftsize = _folded->get_lines().size();
@@ -233,7 +234,9 @@ void string_editor_window::print_editor()
                 || is_linebreak( c_cursor ) || mk_wcwidth( c_cursor ) < 1 ) {
                 c_cursor = ' ';
             }
-            mvwprintz( _win, point( _cursor_display.x + 1, y ), h_white, "%s", utf32_to_utf8( c_cursor ) );
+            const point cursor_pos( _cursor_display.x + 1, y );
+            mvwprintz( _win, cursor_pos, h_white, "%s", utf32_to_utf8( c_cursor ) );
+            ui.set_cursor( _win, cursor_pos );
         }
         if( _ime_preview_range && i >= _ime_preview_range->display_first.y
             && i <= _ime_preview_range->display_last.y ) {
@@ -247,6 +250,11 @@ void string_editor_window::print_editor()
         }
     }
 
+    if( _ime_preview_range ) {
+        const point cursor_pos = _ime_preview_range->display_last + point( 1, -topoflist );
+        ui.set_cursor( _win, cursor_pos );
+    }
+
     if( ftsize > _max.y ) {
         scrollbar()
         .content_size( ftsize )
@@ -258,7 +266,25 @@ void string_editor_window::print_editor()
 
 void string_editor_window::create_context()
 {
-    ctxt = std::make_unique<input_context>();
+    ctxt = std::make_unique<input_context>( "STRING_EDITOR" );
+    ctxt->register_action( "TEXT.QUIT" );
+    ctxt->register_action( "TEXT.CONFIRM" );
+    ctxt->register_action( "TEXT.LEFT" );
+    ctxt->register_action( "TEXT.RIGHT" );
+    ctxt->register_action( "TEXT.UP" );
+    ctxt->register_action( "TEXT.DOWN" );
+    ctxt->register_action( "TEXT.CLEAR" );
+    ctxt->register_action( "TEXT.BACKSPACE" );
+    ctxt->register_action( "TEXT.HOME" );
+    ctxt->register_action( "TEXT.END" );
+    ctxt->register_action( "TEXT.PAGE_UP" );
+    ctxt->register_action( "TEXT.PAGE_DOWN" );
+    ctxt->register_action( "TEXT.DELETE" );
+#if defined(TILES)
+    ctxt->register_action( "TEXT.PASTE" );
+#endif
+    ctxt->register_action( "TEXT.INPUT_FROM_FILE" );
+    ctxt->register_action( "HELP_KEYBINDINGS" );
     ctxt->register_action( "ANY_INPUT" );
 }
 
@@ -330,7 +356,7 @@ std::pair<bool, std::string> string_editor_window::query_string()
         ui.position_from_window( _win );
     } );
     ui.mark_resize();
-    ui.on_redraw( [&]( const ui_adaptor & ) {
+    ui.on_redraw( [&]( ui_adaptor & ui ) {
         if( refold ) {
             utf8_wrapper text = _utext;
             if( !edit.empty() ) {
@@ -356,7 +382,7 @@ std::pair<bool, std::string> string_editor_window::query_string()
             reposition = false;
         }
         werase( _win );
-        print_editor();
+        print_editor( ui );
         wnoutrefresh( _win );
     } );
 
@@ -374,54 +400,50 @@ std::pair<bool, std::string> string_editor_window::query_string()
 
         const std::string action = ctxt->handle_input();
 
-        if( action != "ANY_INPUT" ) {
-            continue;
-        }
-
         const input_event ev = ctxt->get_raw_input();
-        ch = ev.type == input_event_t::CATA_INPUT_KEYBOARD ? ev.get_first_input() : 0;
+        ch = ev.get_first_input();
 
-        if( ch == KEY_ESCAPE ) {
+        if( action == "TEXT.QUIT" ) {
             return { false, _utext.str() };
-        } else if( ch == 0x13 ) {
+        } else if( action == "TEXT.CONFIRM" ) {
             // ctrl-s: confirm
             return { true, _utext.str() };
-        } else if( ch == KEY_UP ) {
+        } else if( action == "TEXT.UP" ) {
             if( edit.empty() ) {
                 cursor_updown( -1 );
                 reposition = true;
             }
-        } else if( ch == KEY_DOWN ) {
+        } else if( action == "TEXT.DOWN" ) {
             if( edit.empty() ) {
                 cursor_updown( 1 );
                 reposition = true;
             }
-        } else if( ch == KEY_RIGHT ) {
+        } else if( action == "TEXT.RIGHT" ) {
             if( edit.empty() ) {
                 cursor_leftright( 1 );
                 _cursor_desired_x = -1;
                 reposition = true;
             }
-        } else if( ch == KEY_LEFT ) {
+        } else if( action == "TEXT.LEFT" ) {
             if( edit.empty() ) {
                 cursor_leftright( -1 );
                 _cursor_desired_x = -1;
                 reposition = true;
             }
-        } else if( ch == 0x15 ) {
+        } else if( action == "TEXT.CLEAR" ) {
             // ctrl-u: delete all the things
             _position = 0;
             _cursor_desired_x = -1;
             _utext.erase( 0 );
             refold = true;
-        } else if( ch == KEY_BACKSPACE ) {
+        } else if( action == "TEXT.BACKSPACE" ) {
             if( _position > 0 && _position <= static_cast<int>( _utext.size() ) ) {
                 _position--;
                 _cursor_desired_x = -1;
                 _utext.erase( _position, 1 );
                 refold = true;
             }
-        } else if( ch == KEY_HOME ) {
+        } else if( action == "TEXT.HOME" ) {
             if( edit.empty()
                 && static_cast<size_t>( _cursor_display.y ) < _folded->get_lines().size() ) {
                 _position = _folded->get_lines()[_cursor_display.y].cpts_start;
@@ -429,7 +451,7 @@ std::pair<bool, std::string> string_editor_window::query_string()
                 _cursor_desired_x = 0;
                 reposition = true;
             }
-        } else if( ch == KEY_END ) {
+        } else if( action == "TEXT.END" ) {
             if( edit.empty()
                 && static_cast<size_t>( _cursor_display.y ) < _folded->get_lines().size() ) {
                 _position = _folded->get_lines()[_cursor_display.y].cpts_end;
@@ -440,26 +462,27 @@ std::pair<bool, std::string> string_editor_window::query_string()
                 _cursor_desired_x = -1;
                 reposition = true;
             }
-        } else if( ch == KEY_PPAGE ) {
+        } else if( action == "TEXT.PAGE_UP" ) {
             if( edit.empty() ) {
                 cursor_updown( -_max.y );
                 reposition = true;
             }
-        } else if( ch == KEY_NPAGE ) {
+        } else if( action == "TEXT.PAGE_DOWN" ) {
             if( edit.empty() ) {
                 cursor_updown( _max.y );
                 reposition = true;
             }
-        } else if( ch == KEY_DC ) {
+        } else if( action == "TEXT.DELETE" ) {
             if( _position < static_cast<int>( _utext.size() ) ) {
                 _cursor_desired_x = -1;
                 _utext.erase( _position, 1 );
                 refold = true;
             }
-        } else if( ch == 0x16 || ch == KEY_F( 2 ) || !ev.text.empty() || ch == KEY_ENTER || ch == '\n' ) {
-            // ctrl-v, f2, or _utext input
+        } else if( action == "TEXT.PASTE" || action == "TEXT.INPUT_FROM_FILE"
+                   || !ev.text.empty() || ch == '\n' ) {
+            // paste, input from file, or text input
             std::string entered;
-            if( ch == 0x16 ) {
+            if( action == "TEXT.PASTE" ) {
 #if defined(TILES)
                 if( edit.empty() ) {
                     char *const clip = SDL_GetClipboardText();
@@ -469,11 +492,11 @@ std::pair<bool, std::string> string_editor_window::query_string()
                     }
                 }
 #endif
-            } else if( ch == KEY_F( 2 ) ) {
+            } else if( action == "TEXT.INPUT_FROM_FILE" ) {
                 if( edit.empty() ) {
                     entered = get_input_string_from_file();
                 }
-            } else if( ch == KEY_ENTER || ch == '\n' ) {
+            } else if( ch == '\n' ) {
                 if( edit.empty() ) {
                     entered = "\n";
                 }

--- a/src/string_editor_window.h
+++ b/src/string_editor_window.h
@@ -9,11 +9,12 @@
 #include "input.h"
 #include "output.h"
 #include "ui.h"
-#include "ui_manager.h"
 
 class folded_text;
 
 struct ime_preview_range;
+
+class ui_adaptor;
 
 /// <summary>
 /// editor, to let the player edit text.
@@ -59,7 +60,7 @@ class string_editor_window
 
     private:
         /*print the editor*/
-        void print_editor();
+        void print_editor( ui_adaptor &ui );
 
         void create_context();
 

--- a/src/string_input_popup.cpp
+++ b/src/string_input_popup.cpp
@@ -12,6 +12,11 @@
 #include "ui.h"
 #include "ui_manager.h"
 #include "uistate.h"
+#include "wcwidth.h"
+
+#if defined(TILES)
+#include "sdl_wrappers.h"
+#endif
 
 #if defined(__ANDROID__)
 #include <SDL_keyboard.h>
@@ -58,17 +63,21 @@ void string_input_popup::create_window()
                 break;
             }
         }
-        w_height += static_cast<int>( title_split.size() ) - 1;
+        title_height = static_cast<int>( title_split.size() ) - 1;
+        w_height += title_height;
     }
 
-    descformatted.clear();
     if( !_description.empty() ) {
         const int twidth = std::min( utf8_width( remove_color_tags( _description ) ), w_width - 4 );
-        descformatted = foldstring( _description, twidth );
-        w_height += descformatted.size();
+        description_height = foldstring( _description, twidth ).size();
+        w_height += description_height;
+        if( w_height > TERMY ) {
+            description_height = TERMY - 2 - title_height - 1;
+            w_height = TERMY;
+        }
     }
     // length of title + border (left) + space
-    _startx = titlesize + 2;
+    _startx = titlesize + 1;
 
     if( _max_length <= 0 ) {
         _max_length = 1024;
@@ -77,9 +86,16 @@ void string_input_popup::create_window()
 
     const int w_y = ( TERMY - w_height ) / 2;
     const int w_x = std::max( ( TERMX - w_width ) / 2, 0 );
-    w = catacurses::newwin( w_height, w_width, point( w_x, w_y ) );
-
-    _starty = w_height - 2; // The ____ looks better at the bottom right when the title folds
+    _starty = title_height;
+    w_full = catacurses::newwin( w_height, w_width, point( w_x, w_y ) );
+    if( !_description.empty() ) {
+        w_description = catacurses::newwin( description_height, w_width - 1, point( w_x,
+                                            w_y + 1 ) );
+        desc_view_ptr = std::make_unique<scrolling_text_view>( w_description );
+        desc_view_ptr->set_text( _description );
+    }
+    w_title_and_entry = catacurses::newwin( w_height - description_height - 2, w_width - 2,
+                                            point( w_x + 1, w_y + 1 + description_height ) );
 
     custom_window = false;
 }
@@ -88,6 +104,28 @@ void string_input_popup::create_context()
 {
     ctxt_ptr = std::make_unique<input_context>( "STRING_INPUT" );
     ctxt = ctxt_ptr.get();
+    ctxt->register_action( "TEXT.QUIT" );
+    ctxt->register_action( "TEXT.CONFIRM" );
+    if( !_identifier.empty() ) {
+        ctxt->register_action( "HISTORY_UP" );
+        ctxt->register_action( "HISTORY_DOWN" );
+    }
+    ctxt->register_action( "TEXT.LEFT" );
+    ctxt->register_action( "TEXT.RIGHT" );
+    ctxt->register_action( "TEXT.CLEAR" );
+    ctxt->register_action( "TEXT.BACKSPACE" );
+    ctxt->register_action( "TEXT.HOME" );
+    ctxt->register_action( "TEXT.END" );
+    ctxt->register_action( "TEXT.DELETE" );
+#if defined(TILES)
+    ctxt->register_action( "TEXT.PASTE" );
+#endif
+    ctxt->register_action( "TEXT.INPUT_FROM_FILE" );
+    ctxt->register_action( "HELP_KEYBINDINGS" );
+    ctxt->register_action( "PAGE_UP" );
+    ctxt->register_action( "PAGE_DOWN" );
+    ctxt->register_action( "SCROLL_UP" );
+    ctxt->register_action( "SCROLL_DOWN" );
     ctxt->register_action( "ANY_INPUT" );
 }
 
@@ -114,17 +152,17 @@ void string_input_popup::show_history( utf8_wrapper &ret )
         hmenu.w_height_setup = [&]() -> int {
             // number of lines that make up the menu window: 2*border+entries
             int height = 2 + hmenu.entries.size();
-            if( getbegy( w ) < height )
+            if( getbegy( w_full ) < height )
             {
-                height = std::max( getbegy( w ), 4 );
+                height = std::max( getbegy( w_full ), 4 );
             }
             return height;
         };
         hmenu.w_x_setup = [&]( int ) -> int {
-            return getbegx( w );
+            return getbegx( w_full );
         };
         hmenu.w_y_setup = [&]( const int height ) -> int {
-            return std::max( getbegy( w ) - height, 0 );
+            return std::max( getbegy( w_full ) - height, 0 );
         };
 
         bool finished = false;
@@ -202,20 +240,19 @@ void string_input_popup::update_input_history( utf8_wrapper &ret, bool up )
     _position = ret.length();
 }
 
-void string_input_popup::draw( const utf8_wrapper &ret, const utf8_wrapper &edit,
-                               const int shift ) const
+void string_input_popup::draw( ui_adaptor *const ui, const utf8_wrapper &ret,
+                               const utf8_wrapper &edit ) const
 {
     if( !custom_window ) {
-        draw_border( w );
+        werase( w_full );
+        draw_border( w_full );
+        wnoutrefresh( w_full );
 
-        for( size_t i = 0; i < descformatted.size(); ++i ) {
-            trim_and_print( w, point( 1, 1 + i ), w_width - 2, _desc_color, descformatted[i] );
-        }
-        int pos_y = descformatted.size() + 1;
+        int pos_y = 0;
         for( int i = 0; i < static_cast<int>( title_split.size() ) - 1; i++ ) {
-            mvwprintz( w, point( i + 1, pos_y++ ), _title_color, title_split[i] );
+            mvwprintz( w_title_and_entry, point( i, pos_y++ ), _title_color, title_split[i] );
         }
-        right_print( w, pos_y, w_width - titlesize - 1, _title_color, title_split.back() );
+        trim_and_print( w_title_and_entry, point( 0, pos_y ), titlesize, _title_color, title_split.back() );
     }
 
     const int scrmax = _endx - _startx;
@@ -223,11 +260,13 @@ void string_input_popup::draw( const utf8_wrapper &ret, const utf8_wrapper &edit
     const utf8_wrapper ds( ret.substr_display( shift, scrmax ) );
     int start_x_edit = _startx;
     // Clear the line
-    mvwprintw( w, point( _startx, _starty ), std::string( std::max( 0, scrmax ), ' ' ) );
+    mvwprintw( w_title_and_entry, point( _startx, _starty ), std::string( std::max( 0, scrmax ),
+               ' ' ) );
     // Print the whole input string in default color
-    mvwprintz( w, point( _startx, _starty ), _string_color, "%s", ds.c_str() );
+    mvwprintz( w_title_and_entry, point( _startx, _starty ), _string_color, "%s", ds.c_str() );
     size_t sx = ds.display_width();
     // Print the cursor in its own color
+    point cursor_pos;
     if( _position >= 0 && static_cast<size_t>( _position ) < ret.length() ) {
         utf8_wrapper cursor = ret.substr( _position, 1 );
         size_t a = _position;
@@ -238,14 +277,18 @@ void string_input_popup::draw( const utf8_wrapper &ret, const utf8_wrapper &edit
             cursor = ret.substr( a, _position - a + 1 );
         }
         const size_t left_over = ret.substr( 0, a ).display_width() - shift;
-        mvwprintz( w, point( _startx + left_over, _starty ), _cursor_color, "%s", cursor.c_str() );
+        cursor_pos = point( _startx + left_over, _starty );
+        mvwprintz( w_title_and_entry, cursor_pos, _cursor_color, "%s", cursor.c_str() );
         start_x_edit += left_over;
-    } else if( _position == _max_length && _max_length > 0 ) {
-        mvwprintz( w, point( _startx + sx, _starty ), _cursor_color, " " );
+    } else if( _max_length > 0
+               && ret.display_width() >= static_cast<size_t>( _max_length ) ) {
+        cursor_pos = point( _startx + sx, _starty );
+        mvwprintz( w_title_and_entry, cursor_pos, _cursor_color, " " );
         start_x_edit += sx;
         sx++; // don't override trailing ' '
     } else {
-        mvwprintz( w, point( _startx + sx, _starty ), _cursor_color, "_" );
+        cursor_pos = point( _startx + sx, _starty );
+        mvwprintz( w_title_and_entry, cursor_pos, _cursor_color, "_" );
         start_x_edit += sx;
         sx++; // don't override trailing '_'
     }
@@ -253,24 +296,42 @@ void string_input_popup::draw( const utf8_wrapper &ret, const utf8_wrapper &edit
         // could be scrolled out of view when the cursor is at the start of the input
         size_t l = scrmax - sx;
         if( _max_length > 0 ) {
-            if( static_cast<int>( ret.length() ) >= _max_length ) {
+            if( ret.display_width() >= static_cast<size_t>( _max_length ) ) {
                 l = 0; // no more input possible!
             } else if( _position == static_cast<int>( ret.length() ) ) {
                 // one '_' is already printed, formatted as cursor
-                l = std::min<size_t>( l, _max_length - ret.length() - 1 );
+                l = std::min<size_t>( l, _max_length - ret.display_width() - 1 );
             } else {
-                l = std::min<size_t>( l, _max_length - ret.length() );
+                l = std::min<size_t>( l, _max_length - ret.display_width() );
             }
         }
         if( l > 0 ) {
-            mvwprintz( w, point( _startx + sx, _starty ), _underscore_color, std::string( l, '_' ) );
+            mvwprintz( w_title_and_entry, point( _startx + sx, _starty ), _underscore_color, std::string( l,
+                       '_' ) );
         }
     }
     if( !edit.empty() ) {
-        mvwprintz( w, point( start_x_edit, _starty ), _cursor_color, "%s", edit.c_str() );
+        mvwprintz( w_title_and_entry, point( start_x_edit, _starty ), _cursor_color, "%s", edit.c_str() );
+    }
+    wnoutrefresh( w_title_and_entry );
+
+    std::unique_ptr<on_out_of_scope> move_cursor_and_refresh;
+    if( ui ) {
+        ui->set_cursor( w_title_and_entry, cursor_pos );
+    } else {
+        // This ensures the cursor is set last for calling UIs to record and set
+        // for screen readers and IME preview
+        move_cursor_and_refresh = std::make_unique<on_out_of_scope>( [&]() {
+            wmove( w_title_and_entry, cursor_pos );
+            wnoutrefresh( w_title_and_entry );
+        } );
     }
 
-    wnoutrefresh( w );
+    //Draw scrolling description
+    if( !custom_window && desc_view_ptr ) {
+        desc_view_ptr->draw( _desc_color );
+        wnoutrefresh( w_description );
+    }
 }
 
 void string_input_popup::query( const bool loop, const bool draw_only )
@@ -290,7 +351,7 @@ int64_t string_input_popup::query_int64_t( const bool loop, const bool draw_only
 
 const std::string &string_input_popup::query_string( const bool loop, const bool draw_only )
 {
-    if( !custom_window && !w ) {
+    if( !custom_window && !w_full ) {
         create_window();
         _position = -1;
     }
@@ -307,20 +368,18 @@ const std::string &string_input_popup::query_string( const bool loop, const bool
     if( _position == -1 ) {
         _position = ret.length();
     }
-    const int scrmax = _endx - _startx;
-    // in output (console) cells, not characters of the string!
-    int shift = 0;
+    const int scrmax = std::max( 0, _endx - _startx );
 
     std::unique_ptr<ui_adaptor> ui;
     if( !draw_only && !custom_window ) {
         ui = std::make_unique<ui_adaptor>();
-        ui->position_from_window( w );
+        ui->position_from_window( w_full );
         ui->on_screen_resize( [this]( ui_adaptor & ui ) {
             create_window();
-            ui.position_from_window( w );
+            ui.position_from_window( w_full );
         } );
-        ui->on_redraw( [&]( const ui_adaptor & ) {
-            draw( ret, edit, shift );
+        ui->on_redraw( [&]( ui_adaptor & ui ) {
+            draw( &ui, ret, edit );
         } );
     }
 
@@ -329,39 +388,42 @@ const std::string &string_input_popup::query_string( const bool loop, const bool
     _canceled = false;
     _confirmed = false;
     do {
-
         if( _position < 0 ) {
             _position = 0;
         }
-
-        const size_t left_shift = ret.substr( 0, _position ).display_width();
-        if( static_cast<int>( left_shift ) < shift ) {
-            shift = 0;
-        } else if( _position < static_cast<int>( ret.length() ) &&
-                   static_cast<int>( left_shift ) + 1 >= shift + scrmax ) {
-            // if the cursor is inside the input string, keep one cell right of
-            // the cursor visible, because the cursor might be on a multi-cell
-            // character.
-            shift = left_shift - scrmax + 2;
-        } else if( _position == static_cast<int>( ret.length() ) &&
-                   static_cast<int>( left_shift ) >= shift + scrmax ) {
-            // cursor is behind the end of the input string, keep the
-            // trailing '_' visible (always a single cell character)
-            shift = left_shift - scrmax + 1;
-        } else if( shift < 0 ) {
+        if( shift < 0 ) {
             shift = 0;
         }
-        const size_t xleft_shift = ret.substr_display( 0, shift ).display_width();
-        if( static_cast<int>( xleft_shift ) != shift ) {
+
+        const size_t width_to_cursor_start = ret.substr( 0, _position ).display_width();
+        size_t width_to_cursor_end = width_to_cursor_start;
+        if( static_cast<size_t>( _position ) < ret.length() ) {
+            width_to_cursor_end += ret.substr( _position, 1 ).display_width();
+        } else {
+            width_to_cursor_end += 1;
+        }
+        // starts scrolling when the cursor is this far from the start or end
+        const size_t scroll_width = std::min( 10, scrmax / 5 );
+        if( ret.display_width() < static_cast<size_t>( scrmax ) ) {
+            shift = 0;
+        } else if( width_to_cursor_start < static_cast<size_t>( shift ) + scroll_width ) {
+            shift = std::max( width_to_cursor_start, scroll_width ) - scroll_width;
+        } else if( width_to_cursor_end > static_cast<size_t>( shift + scrmax ) - scroll_width ) {
+            shift = std::min( width_to_cursor_end + scroll_width, ret.display_width() ) - scrmax;
+        }
+        const utf8_wrapper text_before_start = ret.substr_display( 0, shift );
+        const size_t width_before_start = text_before_start.display_width();
+        if( width_before_start != static_cast<size_t>( shift ) ) {
             // This prevents a multi-cell character from been split, which is not possible
             // instead scroll a cell further to make that character disappear completely
-            shift++;
+            const size_t width_at_start = ret.substr( text_before_start.length(), 1 ).display_width();
+            shift = width_before_start + width_at_start;
         }
 
         if( ui ) {
             ui_manager::redraw();
         } else {
-            draw( ret, edit, shift );
+            draw( nullptr, ret, edit );
         }
 
         if( draw_only ) {
@@ -370,7 +432,7 @@ const std::string &string_input_popup::query_string( const bool loop, const bool
 
         const std::string action = ctxt->handle_input();
         const input_event ev = ctxt->get_raw_input();
-        ch = ev.type == CATA_INPUT_KEYBOARD ? ev.get_first_input() : 0;
+        ch = ev.type == input_event_t::keyboard ? ev.get_first_input() : 0;
         _handled = true;
 
         if( callbacks[ch] ) {
@@ -379,12 +441,7 @@ const std::string &string_input_popup::query_string( const bool loop, const bool
             }
         }
 
-        if( _ignore_custom_actions && action != "ANY_INPUT" ) {
-            _handled = false;
-            continue;
-        }
-
-        if( ch == KEY_ESCAPE ) {
+        if( action == "TEXT.QUIT" ) {
 #if defined(__ANDROID__)
             if( get_option<bool>( "ANDROID_AUTO_KEYBOARD" ) ) {
                 SDL_StopTextInput();
@@ -394,7 +451,7 @@ const std::string &string_input_popup::query_string( const bool loop, const bool
             _position = -1;
             _canceled = true;
             return _text;
-        } else if( ch == '\n' ) {
+        } else if( action == "TEXT.CONFIRM" ) {
             add_to_history( ret.str() );
             _confirmed = true;
             _text = ret.str();
@@ -403,58 +460,119 @@ const std::string &string_input_popup::query_string( const bool loop, const bool
                 _session_str_entered.erase( 0 );
             }
             return _text;
-        } else if( ch == KEY_UP ) {
+        } else if( action == "HISTORY_UP" ) {
             if( !_identifier.empty() ) {
-                if( _hist_use_uilist ) {
-                    show_history( ret );
-                } else {
-                    update_input_history( ret, true );
+                if( edit.empty() ) {
+                    if( _hist_use_uilist ) {
+                        show_history( ret );
+                    } else {
+                        update_input_history( ret, true );
+                    }
                 }
             } else {
                 _handled = false;
             }
-        } else if( ch == KEY_DOWN ) {
+        } else if( action == "HISTORY_DOWN" ) {
             if( !_identifier.empty() ) {
-                if( !_hist_use_uilist ) {
+                if( edit.empty() && !_hist_use_uilist ) {
                     update_input_history( ret, false );
                 }
             } else {
                 _handled = false;
             }
-        } else if( ch == KEY_DOWN || ch == KEY_NPAGE || ch == KEY_PPAGE || ch == KEY_BTAB || ch == 9 ) {
-            _handled = false;
-        } else if( ch == KEY_RIGHT ) {
-            if( _position + 1 <= static_cast<int>( ret.size() ) ) {
+
+        } else if( action == "TEXT.RIGHT" ) {
+            if( edit.empty() && _position + 1 <= static_cast<int>( ret.size() ) ) {
                 _position++;
             }
-        } else if( ch == KEY_LEFT ) {
-            if( _position > 0 ) {
+        } else if( action == "TEXT.LEFT" ) {
+            if( edit.empty() && _position > 0 ) {
                 _position--;
             }
-        } else if( ch == 0x15 ) {                      // ctrl-u: delete all the things
+        } else if( action == "TEXT.CLEAR" ) {
             _position = 0;
             ret.erase( 0 );
-            // Move the cursor back and re-draw it
-        } else if( ch == KEY_BACKSPACE ) {
-            // but silently drop input if we're at 0, instead of adding '^'
+        } else if( action == "TEXT.BACKSPACE" ) {
             if( _position > 0 && _position <= static_cast<int>( ret.size() ) ) {
-                // TODO: it is safe now since you only input ASCII chars
                 _position--;
                 ret.erase( _position, 1 );
             }
-        } else if( ch == KEY_HOME ) {
-            _position = 0;
-        } else if( ch == KEY_END ) {
-            _position = ret.size();
-        } else if( ch == KEY_DC ) {
+        } else if( action == "TEXT.HOME" ) {
+            if( edit.empty() ) {
+                _position = 0;
+            }
+        } else if( action == "TEXT.END" ) {
+            if( edit.empty() ) {
+                _position = ret.size();
+            }
+        } else if( action == "TEXT.DELETE" ) {
             if( _position < static_cast<int>( ret.size() ) ) {
                 ret.erase( _position, 1 );
             }
-        } else if( ch == KEY_F( 2 ) ) {
-            std::string tmp = get_input_string_from_file();
-            int tmplen = utf8_width( tmp );
-            if( tmplen > 0 && ( tmplen + utf8_width( ret ) <= _max_length || _max_length == 0 ) ) {
-                ret.append( tmp );
+            /*Note: SCROLL_UP/SCROLL_DOWN should by default only trigger on mousewheel,
+             * since up/down arrow were handled above */
+        } else if( action == "SCROLL_UP" ) {
+            if( desc_view_ptr ) {
+                desc_view_ptr->scroll_up();
+            }
+        } else if( action == "SCROLL_DOWN" ) {
+            if( desc_view_ptr ) {
+                desc_view_ptr->scroll_down();
+            }
+        } else if( action == "PAGE_UP" ) {
+            if( desc_view_ptr ) {
+                desc_view_ptr->page_up();
+            }
+        } else if( action == "PAGE_DOWN" ) {
+            if( desc_view_ptr ) {
+                desc_view_ptr->page_down();
+            }
+        } else if( action == "TEXT.PASTE" || action == "TEXT.INPUT_FROM_FILE"
+                   || ( action == "ANY_INPUT" && !ev.text.empty() ) ) {
+            // paste, input from file, or text input
+            // bail out early if already at length limit
+            if( _max_length <= 0 || ret.display_width() < static_cast<size_t>( _max_length ) ) {
+                std::string entered;
+                if( action == "TEXT.PASTE" ) {
+#if defined(TILES)
+                    if( edit.empty() ) {
+                        char *const clip = SDL_GetClipboardText();
+                        if( clip ) {
+                            entered = clip;
+                            SDL_free( clip );
+                        }
+                    }
+#endif
+                } else if( action == "TEXT.INPUT_FROM_FILE" ) {
+                    if( edit.empty() ) {
+                        entered = get_input_string_from_file();
+                    }
+                } else {
+                    entered = ev.text;
+                }
+                if( !entered.empty() ) {
+                    utf8_wrapper insertion;
+                    const char *str = entered.c_str();
+                    int len = entered.length();
+                    int width = ret.display_width();
+                    while( len > 0 ) {
+                        const uint32_t ch = UTF8_getch( &str, &len );
+                        // Use mk_wcwidth to filter out control characters
+                        if( _only_digits ? ch == '-' || isdigit( ch ) : mk_wcwidth( ch ) >= 0 ) {
+                            const int newwidth = mk_wcwidth( ch );
+                            if( _max_length <= 0 || width + newwidth <= _max_length ) {
+                                insertion.append( utf8_wrapper( utf32_to_utf8( ch ) ) );
+                                width += newwidth;
+                            } else {
+                                break;
+                            }
+                        }
+                    }
+                    ret.insert( _position, insertion );
+                    _position += insertion.length();
+                    edit = utf8_wrapper();
+                    ctxt->set_edittext( std::string() );
+                }
             }
         } else if( !ev.text.empty() && _only_digits && !( isdigit( ev.text[0] ) || ev.text[0] == '-' ) ) {
             // ignore non-digit (and '-' is a digit as well)
@@ -464,16 +582,14 @@ const std::string &string_input_popup::query_string( const bool loop, const bool
             const utf8_wrapper t( ev.text );
             ret.insert( _position, t );
             _position += t.length();
-            edit.erase( 0 );
-            ctxt->set_edittext( edit.c_str() );
+            edit = utf8_wrapper();
+            ctxt->set_edittext( std::string() );
         } else if( ev.edit_refresh ) {
-            const utf8_wrapper t( ev.edit );
-            edit.erase( 0 );
-            edit.insert( 0, t );
-            ctxt->set_edittext( edit.c_str() );
+            edit = utf8_wrapper( ev.edit );
+            ctxt->set_edittext( ev.edit );
         } else if( ev.edit.empty() ) {
-            edit.erase( 0 );
-            ctxt->set_edittext( edit.c_str() );
+            edit = utf8_wrapper();
+            ctxt->set_edittext( std::string() );
         } else {
             _handled = false;
         }
@@ -485,11 +601,11 @@ const std::string &string_input_popup::query_string( const bool loop, const bool
 string_input_popup &string_input_popup::window( const catacurses::window &w, point start,
         int endx )
 {
-    if( !custom_window && this->w ) {
+    if( !custom_window && this->w_full ) {
         // default window already created
         return *this;
     }
-    this->w = w;
+    this->w_title_and_entry = w;
     _startx = start.x;
     _starty = start.y;
     _endx = endx;

--- a/src/string_input_popup.h
+++ b/src/string_input_popup.h
@@ -15,6 +15,8 @@
 #include "cursesdef.h"
 
 class input_context;
+class scrolling_text_view;
+class ui_adaptor;
 class utf8_wrapper;
 struct point;
 
@@ -61,11 +63,12 @@ class string_input_popup // NOLINT(cata-xy)
         int _max_length = -1;
         bool _only_digits = false;
         bool _hist_use_uilist = true;
-        bool _ignore_custom_actions = true;
         int _startx = 0;
         int _starty = 0;
         int _endx = 0;
         int _position = -1;
+        // in output (console) cells, not characters of the string!
+        int shift = 0;
         int _hist_str_ind = 0;
         //Counts only when @_hist_use_uilist is false
         const size_t _hist_max_size = 100;
@@ -73,12 +76,16 @@ class string_input_popup // NOLINT(cata-xy)
         // Cache when using the default window
         int w_width = 0;
         int w_height = 0;
-        std::vector<std::string> descformatted;
+        int title_height = 0;
+        int description_height = 0;
         std::vector<std::string> title_split;
         int titlesize = 0;
 
         bool custom_window = false;
-        catacurses::window w;
+        catacurses::window w_full;
+        catacurses::window w_description;
+        catacurses::window w_title_and_entry;
+        std::unique_ptr<scrolling_text_view> desc_view_ptr;
 
         std::unique_ptr<input_context> ctxt_ptr;
         input_context *ctxt = nullptr;
@@ -93,7 +100,7 @@ class string_input_popup // NOLINT(cata-xy)
         void show_history( utf8_wrapper &ret );
         void add_to_history( const std::string &value ) const;
         void update_input_history( utf8_wrapper &ret, bool up );
-        void draw( const utf8_wrapper &ret, const utf8_wrapper &edit, int shift ) const;
+        void draw( ui_adaptor *ui, const utf8_wrapper &ret, const utf8_wrapper &edit ) const;
 
     public:
         string_input_popup();
@@ -166,16 +173,6 @@ class string_input_popup // NOLINT(cata-xy)
          */
         string_input_popup &hist_use_uilist( bool value ) {
             _hist_use_uilist = value;
-            return *this;
-        }
-        /**
-         * If true and the custom input context returns an input action, the
-         * action is not handled at all and left to be handled by the caller.
-         * Otherwise the action is always handled as an input event to the popup.
-         * The caller can use @ref handled to check whether the last input is handled.
-         */
-        string_input_popup &ignore_custom_actions( const bool value ) {
-            _ignore_custom_actions = value;
             return *this;
         }
         /**

--- a/src/ui.h
+++ b/src/ui.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "color.h"
+#include "cuboid_rectangle.h"
 #include "cursesdef.h"
 #include "memory_fast.h"
 #include "pimpl.h"
@@ -123,6 +124,8 @@ struct uilist_entry {
         text_color = c;
         return *this;
     }
+
+    std::optional<inclusive_rectangle<point>> drawn_rect;
 };
 
 /**
@@ -236,7 +239,7 @@ class uilist // NOLINT(cata-xy)
         void setup();
         // initialize the window or reposition it after screen size change.
         void reposition( ui_adaptor &ui );
-        void show();
+        void show( ui_adaptor &ui );
         bool scrollby( int scrollby );
         void query( bool loop = true, int timeout = -1 );
 
@@ -368,6 +371,8 @@ class uilist // NOLINT(cata-xy)
     private:
         std::string hotkeys;
         report_color_error _color_error = report_color_error::yes;
+        input_context create_main_input_context() const;
+        input_context create_filter_input_context() const;
 
     public:
         // Iternal states
@@ -411,7 +416,6 @@ class uilist // NOLINT(cata-xy)
         std::string ret_act;
         int ret;
         int keypress;
-
         int selected;
 };
 

--- a/src/ui_manager.cpp
+++ b/src/ui_manager.cpp
@@ -1,6 +1,7 @@
 #include "ui_manager.h"
 
 #include <algorithm>
+#include <cassert>
 #include <iterator>
 #include <memory>
 #include <optional>
@@ -134,6 +135,67 @@ void ui_adaptor::on_screen_resize( const screen_resize_callback_t &fun )
 {
     screen_resized_cb = fun;
 }
+
+void ui_adaptor::set_cursor( const catacurses::window &w, const point &pos )
+{
+#if !defined( TILES )
+    cursor_type = cursor::custom;
+    cursor_pos = point( getbegx( w ), getbegy( w ) ) + pos;
+#else
+    // Unimplemented
+    cursor_type = cursor::disabled;
+    static_cast<void>( w );
+    static_cast<void>( pos );
+#endif
+}
+
+void ui_adaptor::record_cursor( const catacurses::window &w )
+{
+#if !defined( TILES )
+    cursor_type = cursor::custom;
+    cursor_pos = point( getbegx( w ) + getcurx( w ), getbegy( w ) + getcury( w ) );
+#else
+    // Unimplemented
+    cursor_type = cursor::disabled;
+    static_cast<void>( w );
+#endif
+}
+
+void ui_adaptor::record_term_cursor()
+{
+#if !defined( TILES )
+    cursor_type = cursor::custom;
+    cursor_pos = point( getcurx( catacurses::newscr ), getcury( catacurses::newscr ) );
+#else
+    // Unimplemented
+    cursor_type = cursor::disabled;
+#endif
+}
+
+void ui_adaptor::default_cursor()
+{
+#if !defined( TILES )
+    cursor_type = cursor::last;
+#else
+    // Unimplemented
+    cursor_type = cursor::disabled;
+#endif
+}
+
+void ui_adaptor::disable_cursor()
+{
+    cursor_type = cursor::disabled;
+}
+
+static void restore_cursor( const point &p )
+{
+#if !defined( TILES )
+    wmove( catacurses::newscr, p );
+#else
+    static_cast<void>( p );
+#endif
+}
+
 
 void ui_adaptor::mark_resize() const
 {
@@ -343,16 +405,28 @@ void ui_adaptor::redraw_invalidated()
                 first_enabled = ui_stack_copy->begin() + ( first_enabled - ui_stack_orig->begin() );
                 ui_stack_orig = &*ui_stack_copy;
             }
+            std::optional<point> cursor_pos;
             for( auto it = first_enabled; !restart_redrawing && it != ui_stack_orig->end(); ++it ) {
-                const ui_adaptor &ui = *it;
+                ui_adaptor &ui = *it;
                 if( ui.invalidated ) {
                     if( ui.redraw_cb ) {
+                        ui.default_cursor();
                         ui.redraw_cb( ui );
+                        if( ui.cursor_type == cursor::last ) {
+                            ui.record_term_cursor();
+                            assert( ui.cursor_type != cursor::last );
+                        }
+                        if( ui.cursor_type == cursor::custom ) {
+                            cursor_pos = ui.cursor_pos;
+                        }
                     }
                     if( !restart_redrawing ) {
                         ui.invalidated = false;
                     }
                 }
+            }
+            if( !restart_redrawing && cursor_pos.has_value() ) {
+                restore_cursor( cursor_pos.value() );
             }
         }
     } while( restart_redrawing );

--- a/src/ui_manager.h
+++ b/src/ui_manager.h
@@ -35,11 +35,14 @@ class window;
  *     // Mark the resize callback to be called on the first redraw
  *     ui.mark_resize();
  *     // Things to do when redrawing the UI
- *     ui.on_redraw( [&]( const ui_adaptor & ) {
+ *     ui.on_redraw( [&]( ui_adaptor & ui ) {
  *         // Clear UI area
  *         werase( win );
  *         // Print things
  *         mvwprintw( win, point_zero, "Hello World!" );
+ *         // Record the cursor position for screen readers and IME preview to
+ *         // correctly function on curses
+ *         ui.record_cursor( win );
  *         // Write to frame buffer
  *         wnoutrefresh( win );
  *     } );
@@ -64,7 +67,7 @@ class window;
 class ui_adaptor
 {
     public:
-        using redraw_callback_t = std::function<void( const ui_adaptor & )>;
+        using redraw_callback_t = std::function<void( ui_adaptor & )>;
         using screen_resize_callback_t = std::function<void( ui_adaptor & )>;
 
         struct disable_uis_below {
@@ -133,7 +136,8 @@ class ui_adaptor
          * - Construct new `ui_adaptor` instances
          * - Deconstruct old `ui_adaptor` instances
          * - Call `redraw` or `screen_resized`
-         * - (Redraw callback) call `position_from_window`
+         * - (Redraw callback) call `position_from_window`, `position`, or
+         *   `invalidate_ui`
          * - Call any function that does these things, except for `debugmsg`
          *
          * Otherwise, display glitches or even crashes might happen.
@@ -141,6 +145,46 @@ class ui_adaptor
         void on_redraw( const redraw_callback_t &fun );
         /* See `on_redraw`. */
         void on_screen_resize( const screen_resize_callback_t &fun );
+
+        /**
+         * Automatically set the termianl cursor to a window position after
+         * drawing is done. The cursor position of the last drawn UI takes
+         * effect. This ensures the cursor is always set to the desired position
+         * even if some subsequent drawing code moves the cursor, so screen
+         * readers (and in the case of text input, the IME preview) can
+         * correctly function. This is only supposed to be called from the
+         * `on_redraw` callback on the `ui_adaptor` argument of the callback.
+         * Currently only supports curses (on tiles, the windows may have
+         * different cell sizes, so the current implementation of recording the
+         * on-screen position does not work, and screen readers do not work with
+         * the current tiles implementation anyway).
+         */
+        void set_cursor( const catacurses::window &win, const point &pos );
+        /**
+         * Record the current window cursor position and restore it when drawing
+         * is done. The most recent cursor position is recorded regardless of
+         * whether the terminal cursor is updated by refreshing the window. See
+         * also `set_cursor`.
+         */
+        void record_cursor( const catacurses::window &win );
+        /**
+         * Record the current terminal cursor position (where the cursor was
+         * placed when refreshing the last window) and restore it when drawing
+         * is done. See also `set_cursor`.
+         */
+        void record_term_cursor();
+        /**
+         * Use the terminal cursor position when the redraw callback returns.
+         * This is the default. See also `set_cursor`.
+         */
+        void default_cursor();
+        /**
+         * Do not set cursor for this `ui_adaptor`. If any higher or lower UI
+         * sets the cursor, that cursor position is used instead. If no UI sets
+         * the cursor, the final cursor position when drawing is done is used.
+         * See also `set_cursor`.
+         */
+        void disable_cursor();
 
         /**
          * Mark this `ui_adaptor` for resizing the next time it is redrawn.
@@ -177,6 +221,16 @@ class ui_adaptor
         rectangle<point> dimensions;
         redraw_callback_t redraw_cb;
         screen_resize_callback_t screen_resized_cb;
+
+        // For optimization purposes, these value may or may not be reset or
+        // modified before, during, or after drawing, so they do not necessarily
+        // indicate what the current cursor position would be, and therefore
+        // should not be made public or have a public getter.
+        enum class cursor {
+            last, custom, disabled
+        };
+        cursor cursor_type = cursor::last;
+        point cursor_pos;
 
         bool disabling_uis_below;
         bool is_debug_message_ui;

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -42,6 +42,12 @@ using namespace std::placeholders;
 // single instance of world generator
 std::unique_ptr<worldfactory> world_generator;
 
+/**
+  * Max utf-8 character worldname length.
+  * 0 index is inclusive.
+  */
+static const int max_worldname_len = 32;
+
 save_t::save_t( const std::string &name ): name( name ) {}
 
 std::string save_t::decoded_name() const
@@ -1359,6 +1365,32 @@ int worldfactory::show_worldgen_tab_confirm( const catacurses::window &win, WORL
 
     ui_adaptor ui;
 
+    string_input_popup spopup;
+    spopup.max_length( max_worldname_len );
+
+    const point namebar_pos( 3 + utf8_width( _( "World Name:" ) ), 1 );
+
+    input_context ctxt( "WORLDGEN_CONFIRM_DIALOG" );
+    // dialog actions
+    ctxt.register_action( "QUIT" );
+    ctxt.register_action( "NEXT_TAB" );
+    ctxt.register_action( "PREV_TAB" );
+    ctxt.register_action( "PICK_RANDOM_WORLDNAME" );
+    // string input popup actions
+    ctxt.register_action( "TEXT.LEFT" );
+    ctxt.register_action( "TEXT.RIGHT" );
+    ctxt.register_action( "TEXT.CLEAR" );
+    ctxt.register_action( "TEXT.BACKSPACE" );
+    ctxt.register_action( "TEXT.HOME" );
+    ctxt.register_action( "TEXT.END" );
+    ctxt.register_action( "TEXT.DELETE" );
+#if defined( TILES )
+    ctxt.register_action( "TEXT.PASTE" );
+#endif
+    ctxt.register_action( "TEXT.INPUT_FROM_FILE" );
+    ctxt.register_action( "HELP_KEYBINDINGS" );
+    ctxt.register_action( "ANY_INPUT" );
+
     const auto init_windows = [&]( ui_adaptor & ui ) {
         const int iTooltipHeight = 1;
         const int iContentHeight = TERMY - 3 - iTooltipHeight;
@@ -1368,22 +1400,16 @@ int worldfactory::show_worldgen_tab_confirm( const catacurses::window &win, WORL
         w_confirmation = catacurses::newwin( iContentHeight, iMinScreenWidth - 2,
                                              point( 1 + iOffsetX, iTooltipHeight + 2 ) );
 
+        // +1 for end-of-text cursor
+        spopup.window( w_confirmation, namebar_pos, namebar_pos.x + max_worldname_len + 1 )
+        .context( ctxt );
+
         ui.position_from_window( win );
     };
     init_windows( ui );
     ui.on_screen_resize( init_windows );
 
-    int namebar_y = 1;
-    int namebar_x = 3 + utf8_width( _( "World Name:" ) );
-
     bool noname = false;
-    input_context ctxt( "WORLDGEN_CONFIRM_DIALOG" );
-    ctxt.register_action( "HELP_KEYBINDINGS" );
-    ctxt.register_action( "QUIT" );
-    ctxt.register_action( "ANY_INPUT" );
-    ctxt.register_action( "NEXT_TAB" );
-    ctxt.register_action( "PREV_TAB" );
-    ctxt.register_action( "PICK_RANDOM_WORLDNAME" );
 
     std::string worldname = world->world_name;
 
@@ -1392,8 +1418,10 @@ int worldfactory::show_worldgen_tab_confirm( const catacurses::window &win, WORL
 
     ui.on_redraw( [&]( const ui_adaptor & ) {
         draw_worldgen_tabs( win, 2 );
+        wnoutrefresh( win );
 
-        mvwprintz( w_confirmation, point( 2, namebar_y ), c_white, _( "World Name:" ) );
+        werase( w_confirmation );
+        mvwprintz( w_confirmation, point( 2, namebar_pos.y ), c_white, _( "World Name:" ) );
         fold_and_print( w_confirmation, point( 2, 3 ), getmaxx( w_confirmation ) - 2, c_light_gray,
                         _( "Press [<color_yellow>%s</color>] to pick a random name for your world." ),
                         ctxt.get_desc( "PICK_RANDOM_WORLDNAME" ) );
@@ -1403,25 +1431,22 @@ int worldfactory::show_worldgen_tab_confirm( const catacurses::window &win, WORL
                            "to continue, or [<color_yellow>%s</color>] to go back and review your world." ),
                         ctxt.get_desc( "NEXT_TAB" ), ctxt.get_desc( "PREV_TAB" ) );
         if( noname ) {
-            mvwprintz( w_confirmation, point( namebar_x, namebar_y ), h_light_gray,
+            mvwprintz( w_confirmation, namebar_pos, h_light_gray,
                        _( "________NO NAME ENTERED!________" ) );
+            wnoutrefresh( w_confirmation );
         } else {
-            mvwprintz( w_confirmation, point( namebar_x, namebar_y ), c_light_gray, worldname );
-            wprintz( w_confirmation, h_light_gray, "_" );
-            for( int underscores = 31 - utf8_width( worldname );
-                 underscores > 0; --underscores ) {
-                wprintz( w_confirmation, c_light_gray, "_" );
-            }
+            // spopup.query_string() will call wnoutrefresh( w_confirmation ), and should
+            // be called last to position the cursor at the correct place in the curses build.
+            spopup.text( worldname );
+            spopup.query_string( false, true );
         }
-
-        wnoutrefresh( win );
-        wnoutrefresh( w_confirmation );
     } );
 
     do {
         ui_manager::redraw();
 
-        const std::string action = ctxt.handle_input();
+        worldname = spopup.query_string( false );
+        const std::string action = ctxt.input_to_action( ctxt.get_raw_input() );
         if( action == "NEXT_TAB" ) {
             if( worldname.empty() ) {
                 noname = true;
@@ -1437,13 +1462,9 @@ int worldfactory::show_worldgen_tab_confirm( const catacurses::window &win, WORL
                     }
                     return 1;
                 }
-            } else if( query_yn( _( "Are you SURE you're finished?" ) ) ) {
-                if( valid_worldname( worldname ) ) {
-                    world->world_name = worldname;
-                    return 1;
-                } else {
-                    continue;
-                }
+            } else if( valid_worldname( worldname ) && query_yn( _( "Are you SURE you're finished?" ) ) ) {
+                world->world_name = worldname;
+                return 1;
             } else {
                 continue;
             }
@@ -1455,27 +1476,6 @@ int worldfactory::show_worldgen_tab_confirm( const catacurses::window &win, WORL
         } else if( action == "QUIT" && ( !on_quit || on_quit() ) ) {
             world->world_name = worldname;
             return -999;
-        } else if( action == "ANY_INPUT" ) {
-            const input_event ev = ctxt.get_raw_input();
-            const int ch = ev.get_first_input();
-            utf8_wrapper wrap( worldname );
-            utf8_wrapper newtext( ev.text );
-            if( ch == KEY_BACKSPACE ) {
-                if( !wrap.empty() ) {
-                    wrap.erase( wrap.length() - 1, 1 );
-                    worldname = wrap.str();
-                }
-            } else if( ch == KEY_F( 2 ) ) {
-                std::string tmp = get_input_string_from_file();
-                int tmplen = utf8_width( tmp );
-                if( tmplen > 0 && tmplen + utf8_width( worldname ) < 30 ) {
-                    worldname.append( tmp );
-                }
-            } else if( !newtext.empty() && is_char_allowed( newtext.at( 0 ) ) ) {
-                // No empty string, no slash, no backslash, no control sequence
-                wrap.append( newtext );
-                worldname = wrap.str();
-            }
         }
     } while( true );
 
@@ -1583,12 +1583,29 @@ bool worldfactory::valid_worldname( const std::string &name, bool automated )
 {
     std::string msg;
 
-    if( name == "save" || name == "TUTORIAL" || name == "DEFENSE" ) {
+    if( name.empty() ) {
+        msg = _( "World name cannot be empty!" );
+    } else if( name == "save" || name == "TUTORIAL" || name == "DEFENSE" ) {
         msg = string_format( _( "%s is a reserved name!" ), name );
-    } else if( !has_world( name ) ) {
-        return true;
-    } else {
+    } else if( has_world( name ) ) {
         msg = string_format( _( "A world named %s already exists!" ), name );
+    } else {
+        // just check the raw bytes because unicode characters are always acceptable
+        bool allowed = true;
+        for( const char ch : name ) {
+            if( !is_char_allowed( ch ) ) {
+                if( std::isprint( ch ) ) {
+                    msg = string_format( _( "World name contains invalid character: '%c'" ), ch );
+                } else {
+                    msg = string_format( _( "World name contains invalid character: 0x%x" ), ch );
+                }
+                allowed = false;
+                break;
+            }
+        }
+        if( allowed ) {
+            return true;
+        }
     }
     if( !automated ) {
         popup( msg, PF_GET_KEY );


### PR DESCRIPTION
This should hopefully work correctly now

Ports these pull requests

CleverRaven/Cataclysm-DDA#47584,
CleverRaven/Cataclysm-DDA#47585,
CleverRaven/Cataclysm-DDA#58609,
CleverRaven/Cataclysm-DDA#51447,
CleverRaven/Cataclysm-DDA#59035,
CleverRaven/Cataclysm-DDA#50892,
CleverRaven/Cataclysm-DDA#41605,
CleverRaven/Cataclysm-DDA#57361,

So from pull request https://CleverRaven/Cataclysm-DDA#41605 tweaks from only a single file, `ui.h`, have been ported, whereas all other pull requests were essentially ported as fully as possible. This depends on #4634, #4635, so it cannot be merged until these are merged 

So, again, thanks to @Coolthulhu, @yay855, @AlecWhite, whereas @olanti-p helped to fix some initial errors, whereas @KheirFerrum has greatly helped with tidying, fixing keyboard format errors in #4635, but there are still some things to fix so it's a draft 

It's very important that these pull requests, #4634, #4635 along with this would be merged in exactly this order, to avoid conflicts, to avoid errors with files, I will ask for review when all of them are ready to be merged 

Coauthors have been linked properly via GitHub Desktop built-in function to do this work hopefully