### PR TITLE
fix: hydrogen sacs can stack, obsolete endochitin

### DIFF
--- a/data/json/harvest.json
+++ b/data/json/harvest.json
@@ -538,11 +538,10 @@
     "type": "harvest",
     "message": "<arachnid_harvest>",
     "entries": [
-      { "drop": "endochitin", "type": "bone", "mass_ratio": 0.1 },
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.33 },
       { "drop": "mutant_bug_lungs", "type": "flesh", "mass_ratio": 0.0035 },
       { "drop": "mutant_bug_organs", "type": "offal", "mass_ratio": 0.015 },
-      { "drop": "chitin_piece", "type": "bone", "mass_ratio": 0.1 }
+      { "drop": "chitin_piece", "type": "bone", "mass_ratio": 0.15 }
     ]
   },
   {
@@ -552,11 +551,10 @@
     "entries": [
       { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.1 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.01 },
-      { "drop": "endochitin", "type": "bone", "mass_ratio": 0.01 },
       { "drop": "mutant_bug_hydrogen_sacs", "type": "flesh", "mass_ratio": 0.2 },
       { "drop": "mutant_bug_lungs", "type": "flesh", "mass_ratio": 0.0035 },
       { "drop": "mutant_bug_organs", "type": "offal", "mass_ratio": 0.015 },
-      { "drop": "chitin_piece", "type": "bone", "mass_ratio": 0.01 }
+      { "drop": "chitin_piece", "type": "bone", "mass_ratio": 0.015 }
     ]
   },
   {
@@ -564,9 +562,8 @@
     "type": "harvest",
     "message": "<acidant_harvest>",
     "entries": [
-      { "drop": "endochitin", "type": "bone", "mass_ratio": 0.1 },
       { "drop": "mutant_meat", "base_num": [ 40, 55 ], "scale_num": [ 0.5, 0.7 ], "max": 80, "type": "flesh" },
-      { "drop": "acidchitin_piece", "base_num": [ 2, 6 ], "scale_num": [ 0.3, 0.6 ], "max": 10, "type": "skin" },
+      { "drop": "acidchitin_piece", "base_num": [ 2, 6 ], "scale_num": [ 0.45, 0.9 ], "max": 15, "type": "skin" },
       { "drop": "mutant_fat", "base_num": [ 5, 8 ], "scale_num": [ 0.6, 0.8 ], "max": 18, "type": "flesh" }
     ]
   },
@@ -575,13 +572,12 @@
     "type": "harvest",
     "message": "<arachnid_harvest>",
     "entries": [
-      { "drop": "endochitin", "type": "bone", "mass_ratio": 0.1 },
       { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.33 },
       { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.04 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.01 },
       { "drop": "mutant_bug_lungs", "type": "flesh", "mass_ratio": 0.0035 },
       { "drop": "mutant_bug_organs", "type": "offal", "mass_ratio": 0.015 },
-      { "drop": "chitin_piece", "type": "bone", "mass_ratio": 0.1 }
+      { "drop": "chitin_piece", "type": "bone", "mass_ratio": 0.15 }
     ]
   },
   {
@@ -592,8 +588,7 @@
       { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.33 },
       { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.04 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.01 },
-      { "drop": "endochitin", "type": "bone", "mass_ratio": 0.1 },
-      { "drop": "acidchitin_piece", "type": "bone", "mass_ratio": 0.1 }
+      { "drop": "acidchitin_piece", "type": "bone", "mass_ratio": 0.15 }
     ]
   },
   {
@@ -603,12 +598,11 @@
     "entries": [
       { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.23 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.01 },
-      { "drop": "endochitin", "type": "bone", "mass_ratio": 0.1 },
       { "drop": "mutant_bug_hydrogen_sacs", "type": "flesh", "mass_ratio": 0.1 },
       { "drop": "mutant_bug_lungs", "type": "flesh", "mass_ratio": 0.0035 },
       { "drop": "mutant_bug_organs", "type": "offal", "mass_ratio": 0.015 },
       { "drop": "bee_sting", "base_num": [ 0, 1 ], "type": "bone" },
-      { "drop": "chitin_piece", "type": "bone", "mass_ratio": 0.1 }
+      { "drop": "chitin_piece", "type": "bone", "mass_ratio": 0.15 }
     ]
   },
   {
@@ -618,12 +612,11 @@
     "entries": [
       { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.3 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.003 },
-      { "drop": "endochitin", "type": "bone", "mass_ratio": 0.01 },
       { "drop": "mutant_bug_hydrogen_sacs", "type": "flesh", "mass_ratio": 0.1 },
       { "drop": "mutant_bug_lungs", "type": "flesh", "mass_ratio": 0.01 },
       { "drop": "mutant_bug_organs", "type": "offal", "mass_ratio": 0.03 },
       { "drop": "wasp_sting", "base_num": [ 0, 1 ], "type": "bone" },
-      { "drop": "chitin_piece", "type": "bone", "mass_ratio": 0.1 }
+      { "drop": "chitin_piece", "type": "bone", "mass_ratio": 0.15 }
     ]
   },
   {
@@ -633,12 +626,11 @@
     "entries": [
       { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.2 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.003 },
-      { "drop": "endochitin", "type": "bone", "mass_ratio": 0.01 },
       { "drop": "mutant_bug_hydrogen_sacs", "type": "flesh", "mass_ratio": 0.1 },
       { "drop": "mutant_bug_lungs", "type": "flesh", "mass_ratio": 0.01 },
       { "drop": "mutant_bug_organs", "type": "offal", "mass_ratio": 0.03 },
       { "drop": "wasp_sting", "base_num": [ 0, 1 ], "type": "bone" },
-      { "drop": "chitin_piece", "type": "bone", "mass_ratio": 0.1 },
+      { "drop": "chitin_piece", "type": "bone", "mass_ratio": 0.15 },
       { "drop": "egg_wasp", "type": "offal", "base_num": [ 10, 30 ], "scale_num": [ 5, 5 ] }
     ]
   },
@@ -650,10 +642,9 @@
       { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.15 },
       { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.04 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.005 },
-      { "drop": "endochitin", "type": "bone", "mass_ratio": 0.05 },
       { "drop": "mutant_bug_lungs", "type": "flesh", "mass_ratio": 0.0045 },
       { "drop": "mutant_bug_organs", "type": "offal", "mass_ratio": 0.025 },
-      { "drop": "chitin_piece", "type": "bone", "mass_ratio": 0.01 },
+      { "drop": "chitin_piece", "type": "bone", "mass_ratio": 0.015 },
       { "drop": "egg_dragonfly", "type": "offal", "base_num": [ 5, 35 ], "scale_num": [ 0.3, 0.5 ] }
     ]
   },
@@ -665,11 +656,10 @@
     "entries": [
       { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.1 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.01 },
-      { "drop": "endochitin", "type": "bone", "mass_ratio": 0.01 },
       { "drop": "mutant_bug_hydrogen_sacs", "type": "flesh", "mass_ratio": 0.2 },
       { "drop": "mutant_bug_lungs", "type": "flesh", "mass_ratio": 0.0035 },
       { "drop": "mutant_bug_organs", "type": "offal", "mass_ratio": 0.015 },
-      { "drop": "chitin_piece", "type": "bone", "mass_ratio": 0.01 },
+      { "drop": "chitin_piece", "type": "bone", "mass_ratio": 0.015 },
       { "drop": "egg_firefly", "type": "offal", "base_num": [ 0, 3 ] }
     ]
   },
@@ -677,15 +667,14 @@
     "id": "arachnid_centipede",
     "type": "harvest",
     "message": "<centipede_harvest>",
-    "//": "More legs = more sinew, more endochitin, less rest",
+    "//": "More legs = more sinew, less rest",
     "entries": [
       { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.2 },
       { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.01 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.05 },
-      { "drop": "endochitin", "type": "bone", "mass_ratio": 0.2 },
       { "drop": "mutant_bug_lungs", "type": "flesh", "mass_ratio": 0.0035 },
       { "drop": "mutant_bug_organs", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "chitin_piece", "type": "bone", "mass_ratio": 0.08 }
+      { "drop": "chitin_piece", "type": "bone", "mass_ratio": 0.012 }
     ]
   },
   {
@@ -696,10 +685,9 @@
       { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.2 },
       { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.01 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.05 },
-      { "drop": "endochitin", "type": "bone", "mass_ratio": 0.2 },
       { "drop": "mutant_bug_lungs", "type": "flesh", "mass_ratio": 0.0035 },
       { "drop": "mutant_bug_organs", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "chitin_piece", "type": "bone", "mass_ratio": 0.08 },
+      { "drop": "chitin_piece", "type": "bone", "mass_ratio": 0.012 },
       { "drop": "egg_centipede", "type": "offal", "base_num": [ 3, 10 ], "scale_num": [ 0.5, 1 ], "max": 30 }
     ]
   },
@@ -712,10 +700,9 @@
       { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.4 },
       { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.015 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.05 },
-      { "drop": "endochitin", "type": "bone", "mass_ratio": 0.2 },
       { "drop": "mutant_bug_lungs", "type": "flesh", "mass_ratio": 0.0035 },
       { "drop": "mutant_bug_organs", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "chitin_piece", "type": "bone", "mass_ratio": 0.2 },
+      { "drop": "chitin_piece", "type": "bone", "mass_ratio": 0.3 },
       { "drop": "egg_centipede", "type": "offal", "base_num": [ 0, 3 ], "scale_num": [ 0.5, 1 ], "max": 10 }
     ]
   },

--- a/data/json/itemgroups/Monsters_Animals_Lairs/monster_drops_lairs.json
+++ b/data/json/itemgroups/Monsters_Animals_Lairs/monster_drops_lairs.json
@@ -403,7 +403,6 @@
     "entries": [
       { "item": "chitin_piece", "prob": 70 },
       { "item": "acidchitin_piece", "prob": 30 },
-      { "item": "endochitin", "prob": 70 },
       { "item": "mutant_bug_hydrogen_sacs", "prob": 30 },
       { "item": "mutant_bug_lungs", "prob": 10 },
       { "item": "mutant_bug_organs", "prob": 10 },

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -366,6 +366,7 @@
     "name": { "str": "cluster of gas sacs", "str_pl": "clusters of gas sacs" },
     "description": "This is a cluster of membranous bubbles, each about the size of a grape, retrieved from inside a mutant insect.  They float like tiny helium balloons, and are likely full of a lighter-than-air gas helping the bug to fly.",
     "price": 0,
+    "stackable": true,
     "material": "flesh",
     "flags": [ "NO_SALVAGE" ],
     "weight": "50 g",

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -342,23 +342,6 @@
   },
   {
     "type": "GENERIC",
-    "id": "endochitin",
-    "category": "spare_parts",
-    "symbol": ",",
-    "color": "light_gray",
-    "name": { "str": "strand of endochitin", "str_pl": "strands of endochitin" },
-    "snippet_category": "endochitin_desc",
-    "description": "A piece of an insect's endoskeleton.",
-    "price": 0,
-    "stackable": true,
-    "material": "chitin",
-    "flags": [ "NO_SALVAGE" ],
-    "weight": "89 g",
-    "volume": "300 ml",
-    "bashing": 1
-  },
-  {
-    "type": "GENERIC",
     "id": "mutant_bug_hydrogen_sacs",
     "category": "spare_parts",
     "symbol": "o",

--- a/data/json/obsoletion/migration.json
+++ b/data/json/obsoletion/migration.json
@@ -1908,5 +1908,10 @@
     "type": "MIGRATION",
     "replace": "welder",
     "flags": [ "resized_large" ]
+  },
+  {
+    "id": "endochitin",
+    "type": "MIGRATION",
+    "replace": "chitin_piece"
   }
 ]

--- a/data/json/snippets/mutant_anatomy.json
+++ b/data/json/snippets/mutant_anatomy.json
@@ -103,20 +103,6 @@
   },
   {
     "type": "snippet",
-    "category": "endochitin_desc",
-    "text": [
-      {
-        "id": "endochitin_1",
-        "text": "A piece of rigid, tube-shaped chitin from the inside of a giant bug.  It seemed to be performing some kind of support role.  You're quite sure normal insects don't have these."
-      },
-      {
-        "id": "endochitin_2",
-        "text": "A long, flexible rod of chitin from inside a giant mutant bug.  It is laced with blood vessels and chitinous nodules."
-      }
-    ]
-  },
-  {
-    "type": "snippet",
     "category": "<bug_harvest_general_chitin>",
     "text": [
       "As you peel away the outer shell, you find veins lining the chitin plates",


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

A while back I ran into an error with endochitin complaining about not being able to have charges, and haven't seen it trigger any since then, presumably due to https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4707 making them stackable.

Now there's still one more non-stacking tissue item obtained by harvesting, so I'm thinking this should fix the associated bug but can't 100% confirm since I can't find a reliable way to force the bug to trigger in the first place.

Relevant issue: https://github.com/cataclysmbnteam/Cataclysm-BN/issues/4730

Along the way, in the BN server I was encouraged to obsolete endochitin as it really does nothing for us except flavor.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Added `stackable` to hydrogen sacs.
2. Migrated out endochitin into regular chitin pieces, since it's basically just chitin pieces except they grow in the body too.
3. Removed endochitin from harvest entries. In return, chitin pieces all got their mass ratio bumped up a bit for any harvest entry that previously had endochitin.

I went ahead and kept hydrogen sacs for now since we might want to mainline hydrogen stuff from Cata++ anyway.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Obsoleting hydrogen sacs for being pointless flavor too. Hydrogen sacs have a use in Cata++ since hydrogen is craftable and used for stuff in it, but that's a third-party mod, and endochitin is still just outright useless.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected file for syntax and lint errors.
3. Load-tested in compiled test build.
4. Spawned in a giant wasp queen, debug killed it and dissected corpse.
5. Gas sacs show as stacking now.

I tried to mess around with hydrogen sacs before implementing this to see if there was a reliable way of triggering the error but couldn't find a way to force it to trigger the error message.

The old sacs from before I implemented it instead like to do this silliness once converted to stack:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/883e47f2-d1df-44b4-869b-9db0a0d6b8e0)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
