### PR TITLE
feat(balance): add ranged bash info to more terrain and furniture

### DIFF
--- a/data/json/furniture_and_terrain/furniture-migo.json
+++ b/data/json/furniture_and_terrain/furniture-migo.json
@@ -219,8 +219,8 @@
     "symbol": "i",
     "color": "magenta",
     "looks_like": "t_machinery_light",
-    "move_cost_mod": 4,
-    "coverage": 10,
+    "move_cost_mod": -1,
+    "coverage": 75,
     "light_emitted": 15,
     "required_str": -1,
     "emissions": [ "emit_shock_burst" ],
@@ -233,7 +233,8 @@
       "sound_fail": "whump!",
       "furn_set": "f_alien_scar",
       "items": [ { "item": "fetid_goop", "count": [ 3, 5 ], "prob": 100 } ],
-      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
+      "//": "destroy_threshold equal to str_min instead of str_max due to delicate wetware, and a pissed-off alien bug installed inside",
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 8, "block_unaimed_chance": "75%" }
     }
   }
 ]

--- a/data/json/furniture_and_terrain/terrain-fences-gates.json
+++ b/data/json/furniture_and_terrain/terrain-fences-gates.json
@@ -15,7 +15,8 @@
       "sound": "crunch!",
       "sound_fail": "whump!",
       "ter_set": "t_null",
-      "items": [ { "item": "splinter", "count": [ 10, 20 ] } ]
+      "items": [ { "item": "splinter", "count": [ 10, 20 ] } ],
+      "ranged": { "reduction": [ 12, 24 ], "destroy_threshold": 150 }
     }
   },
   {
@@ -166,7 +167,7 @@
     "symbol": "+",
     "color": "brown",
     "move_cost": 3,
-    "coverage": 60,
+    "coverage": 35,
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "DOOR", "MOUNTABLE", "BURROWABLE" ],
     "connects_to": "WOODFENCE",
     "open": "t_fencegate_o",
@@ -192,7 +193,8 @@
         { "item": "nail", "charges": [ 2, 8 ] },
         { "item": "splinter", "count": [ 1, 2 ] },
         { "item": "hinge", "count": [ 1, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 2, 4 ], "destroy_threshold": 20, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -370,6 +372,7 @@
     "symbol": "LINE_OXOX",
     "color": "brown",
     "move_cost": 3,
+    "coverage": 25,
     "flags": [
       "TRANSPARENT",
       "DIGGABLE",
@@ -390,7 +393,8 @@
       "sound": "crack.",
       "sound_fail": "wham.",
       "ter_set": "t_null",
-      "items": [ { "item": "2x4", "count": [ 1, 3 ] }, { "item": "nail", "charges": [ 2, 6 ] }, { "item": "splinter", "count": 1 } ]
+      "items": [ { "item": "2x4", "count": [ 1, 3 ] }, { "item": "nail", "charges": [ 2, 6 ] }, { "item": "splinter", "count": 1 } ],
+      "ranged": { "reduction": [ 2, 4 ], "destroy_threshold": 20, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -632,6 +636,7 @@
     "color": "brown",
     "looks_like": "t_fence",
     "move_cost": 0,
+    "coverage": 60,
     "examine_action": "chainfence",
     "flags": [
       "TRANSPARENT",
@@ -651,7 +656,8 @@
       "sound": "whump!",
       "sound_fail": "whack!",
       "ter_set": "t_fence_post",
-      "items": [ { "item": "2x4", "count": [ 1, 2 ] } ]
+      "items": [ { "item": "2x4", "count": [ 1, 2 ] } ],
+      "ranged": { "reduction": [ 3, 5 ], "destroy_threshold": 12, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -689,7 +695,8 @@
         { "item": "nail", "charges": [ 2, 8 ] },
         { "item": "splinter", "count": [ 1, 2 ] },
         { "item": "hinge", "count": [ 1, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 2, 4 ], "destroy_threshold": 20, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -746,7 +753,8 @@
         { "item": "pipe", "count": [ 4, 8 ] },
         { "item": "sheet_metal_small", "count": [ 8, 20 ] },
         { "item": "sheet_metal", "count": [ 0, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 18, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -785,7 +793,8 @@
         { "item": "sheet_metal_small", "count": [ 8, 20 ] },
         { "item": "sheet_metal", "count": [ 0, 2 ] },
         { "item": "hinge", "count": [ 1, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 20, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -847,7 +856,8 @@
       "sound": "whump!",
       "sound_fail": "whack!",
       "ter_set": "t_fence_post",
-      "items": [ { "item": "2x4", "count": [ 4, 10 ] } ]
+      "items": [ { "item": "2x4", "count": [ 4, 10 ] } ],
+      "ranged": { "reduction": [ 3, 5 ], "destroy_threshold": 12 }
     }
   },
   {
@@ -885,7 +895,8 @@
         { "item": "nail", "charges": [ 10, 20 ] },
         { "item": "splinter", "count": [ 4, 6 ] },
         { "item": "hinge", "count": [ 1, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 2, 4 ], "destroy_threshold": 20 }
     }
   },
   {
@@ -919,6 +930,7 @@
     "symbol": "LINE_OXOX",
     "color": "yellow",
     "move_cost": 3,
+    "coverage": 25,
     "flags": [ "TRANSPARENT", "NOITEM", "THIN_OBSTACLE", "MOUNTABLE", "SHORT", "AUTO_WALL_SYMBOL", "BURROWABLE" ],
     "connects_to": "RAILING",
     "bash": {
@@ -932,7 +944,8 @@
         { "item": "nail", "charges": [ 2, 6 ] },
         { "item": "scrap", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 1, 3 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 12, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -957,7 +970,9 @@
         { "item": "glass_shard", "count": [ 5, 15 ] },
         { "item": "pipe", "charges": [ 1, 2 ] },
         { "item": "scrap", "count": [ 1, 3 ] }
-      ]
+      ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 10 ], "destroy_threshold": 10, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -969,6 +984,7 @@
     "symbol": "LINE_OXOX",
     "color": "dark_gray",
     "move_cost": 3,
+    "coverage": 25,
     "flags": [ "TRANSPARENT", "NOITEM", "THIN_OBSTACLE", "MOUNTABLE", "SHORT", "AUTO_WALL_SYMBOL", "BURROWABLE" ],
     "connects_to": "RAILING",
     "deconstruct": { "ter_set": "t_rock_floor", "items": [ { "item": "sheet_metal", "count": 2 }, { "item": "pipe", "count": 4 } ] },
@@ -983,7 +999,8 @@
         { "item": "sheet_metal", "charges": 1 },
         { "item": "sheet_metal_small", "charges": [ 1, 4 ] },
         { "item": "scrap", "count": [ 1, 3 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 80, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -1008,7 +1025,9 @@
         { "item": "rock", "count": [ 5, 10 ] },
         { "item": "scrap", "count": [ 5, 8 ] },
         { "item": "rebar", "count": [ 0, 2 ] }
-      ]
+      ],
+      "//": "Stone obstacles have double the expected reduction but lower destroy_threshold in return",
+      "ranged": { "reduction": [ 100, 200 ], "destroy_threshold": 200, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -1020,6 +1039,7 @@
     "color": "light_gray",
     "looks_like": "t_guardrail_bg_dp",
     "move_cost": 3,
+    "coverage": 25,
     "flags": [ "TRANSPARENT", "NOITEM", "REDUCE_SCENT", "MOUNTABLE", "SHORT", "THIN_OBSTACLE", "ROAD", "BURROWABLE" ],
     "bash": {
       "str_min": 8,
@@ -1027,7 +1047,8 @@
       "sound": "crunch!",
       "sound_fail": "clang!",
       "ter_set": "t_pavement_hw_air",
-      "items": [ { "item": "pipe", "count": [ 1, 2 ] }, { "item": "scrap", "count": [ 3, 6 ] } ]
+      "items": [ { "item": "pipe", "count": [ 1, 2 ] }, { "item": "scrap", "count": [ 3, 6 ] } ],
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 150, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -1038,6 +1059,7 @@
     "symbol": "#",
     "color": "light_gray",
     "move_cost": 3,
+    "coverage": 25,
     "flags": [ "TRANSPARENT", "NOITEM", "REDUCE_SCENT", "MOUNTABLE", "SHORT", "THIN_OBSTACLE", "ROAD", "BURROWABLE" ],
     "bash": {
       "str_min": 8,
@@ -1045,7 +1067,8 @@
       "sound": "crunch!",
       "sound_fail": "clang!",
       "ter_set": "t_pavement_bg_dp",
-      "items": [ { "item": "pipe", "count": [ 1, 2 ] }, { "item": "scrap", "count": [ 3, 6 ] } ]
+      "items": [ { "item": "pipe", "count": [ 1, 2 ] }, { "item": "scrap", "count": [ 3, 6 ] } ],
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 150, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -1056,6 +1079,7 @@
     "symbol": "#",
     "color": "light_gray",
     "move_cost": 3,
+    "coverage": 25,
     "flags": [ "TRANSPARENT", "NOITEM", "REDUCE_SCENT", "MOUNTABLE", "SHORT", "THIN_OBSTACLE", "ROAD", "BURROWABLE" ],
     "looks_like": "t_guardrail_bg_dp",
     "bash": {
@@ -1064,7 +1088,8 @@
       "sound": "crunch!",
       "sound_fail": "clang!",
       "ter_set": "t_pavement",
-      "items": [ { "item": "pipe", "count": [ 1, 2 ] }, { "item": "scrap", "count": [ 3, 6 ] } ]
+      "items": [ { "item": "pipe", "count": [ 1, 2 ] }, { "item": "scrap", "count": [ 3, 6 ] } ],
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 150, "block_unaimed_chance": "25%" }
     }
   }
 ]

--- a/data/json/furniture_and_terrain/terrain-flora.json
+++ b/data/json/furniture_and_terrain/terrain-flora.json
@@ -19,7 +19,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -41,7 +42,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -66,7 +68,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -87,7 +90,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -110,7 +114,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -132,7 +137,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -155,7 +161,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -177,7 +184,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -200,7 +208,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -222,7 +231,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -245,7 +255,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -267,7 +278,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -288,7 +300,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -308,7 +321,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -328,7 +342,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 35, 70 ], "destroy_threshold": 140 }
     }
   },
   {
@@ -372,7 +387,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -395,7 +411,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -419,7 +436,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -442,7 +460,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -474,7 +493,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -497,7 +517,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -521,7 +542,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -544,7 +566,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -568,7 +591,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -591,7 +615,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -615,7 +640,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -638,7 +664,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -662,7 +689,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -685,7 +713,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -709,7 +738,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -732,7 +762,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -764,7 +795,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -787,7 +819,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -819,7 +852,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -842,7 +876,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -870,7 +905,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -903,7 +939,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 30, 60 ], "destroy_threshold": 120 }
     }
   },
   {
@@ -929,7 +966,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -949,7 +987,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -975,7 +1014,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -995,7 +1035,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -1016,7 +1057,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -1037,7 +1079,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -1063,7 +1106,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -1086,7 +1130,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -1110,7 +1155,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -1132,7 +1178,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -1156,7 +1203,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -1178,7 +1226,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -1202,7 +1251,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -1224,7 +1274,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -1245,7 +1296,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -1922,7 +1974,7 @@
     "symbol": "1",
     "color": "brown",
     "move_cost": 4,
-    "coverage": 45,
+    "coverage": 50,
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "DIGGABLE", "REDUCE_SCENT", "MOUNTABLE", "SHORT" ],
     "bash": {
       "str_min": 80,
@@ -1930,7 +1982,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "splinter", "count": [ 5, 15 ] } ]
+      "items": [ { "item": "splinter", "count": [ 5, 15 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -1950,7 +2003,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "splinter", "count": [ 5, 15 ] } ]
+      "items": [ { "item": "splinter", "count": [ 5, 15 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -2126,7 +2180,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -2148,7 +2203,8 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ]
+      "items": [ { "item": "stick_long", "count": [ 3, 10 ] }, { "item": "splinter", "count": [ 10, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 180 }
     }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-fungal.json
+++ b/data/json/furniture_and_terrain/terrain-fungal.json
@@ -77,7 +77,14 @@
     "move_cost": 0,
     "coverage": 100,
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "FUNGUS", "WALL", "REDUCE_SCENT", "MINEABLE" ],
-    "bash": { "str_min": 30, "str_max": 180, "sound": "crunch!", "sound_fail": "poof!", "ter_set": "t_fungus" }
+    "bash": {
+      "str_min": 30,
+      "str_max": 180,
+      "sound": "crunch!",
+      "sound_fail": "poof!",
+      "ter_set": "t_fungus",
+      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 180 }
+    }
   },
   {
     "type": "terrain",
@@ -89,7 +96,14 @@
     "move_cost": 0,
     "coverage": 100,
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "FUNGUS", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE" ],
-    "bash": { "str_min": 30, "str_max": 180, "sound": "crunch!", "sound_fail": "poof!", "ter_set": "t_fungus" }
+    "bash": {
+      "str_min": 30,
+      "str_max": 180,
+      "sound": "crunch!",
+      "sound_fail": "poof!",
+      "ter_set": "t_fungus",
+      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 180 }
+    }
   },
   {
     "type": "terrain",
@@ -124,7 +138,14 @@
     "move_cost": 0,
     "coverage": 80,
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "FUNGUS", "TREE", "REDUCE_SCENT" ],
-    "bash": { "str_min": 40, "str_max": 180, "sound": "crunch!", "sound_fail": "poof!", "ter_set": "t_fungus" }
+    "bash": {
+      "str_min": 40,
+      "str_max": 180,
+      "sound": "crunch!",
+      "sound_fail": "poof!",
+      "ter_set": "t_fungus",
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 180 }
+    }
   },
   {
     "type": "terrain",
@@ -148,6 +169,13 @@
     "coverage": 80,
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "FUNGUS", "TREE", "REDUCE_SCENT" ],
     "examine_action": "tree_marloss",
-    "bash": { "str_min": 40, "str_max": 180, "sound": "crunch!", "sound_fail": "poof!", "ter_set": "t_fungus" }
+    "bash": {
+      "str_min": 40,
+      "str_max": 180,
+      "sound": "crunch!",
+      "sound_fail": "poof!",
+      "ter_set": "t_fungus",
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 180 }
+    }
   }
 ]

--- a/data/json/furniture_and_terrain/terrain-migo.json
+++ b/data/json/furniture_and_terrain/terrain-migo.json
@@ -16,7 +16,8 @@
       "sound": "boom!",
       "sound_fail": "whack!",
       "ter_set": "t_resin_hole",
-      "items": [ { "item": "resin_chunk", "count": [ 10, 40 ] } ]
+      "items": [ { "item": "resin_chunk", "count": [ 10, 40 ] } ],
+      "ranged": { "reduction": [ 125, 250 ], "destroy_threshold": 700 }
     }
   },
   {
@@ -27,7 +28,7 @@
     "symbol": "#",
     "color": "dark_gray",
     "move_cost": 0,
-    "coverage": 100,
+    "coverage": 60,
     "roof": "t_resin_roof",
     "flags": [ "NOITEM", "WALL", "PERMEABLE", "TRANSPARENT", "INDOORS", "NONFLAMMABLE", "MINEABLE" ],
     "bash": {
@@ -36,7 +37,8 @@
       "sound": "boom!",
       "sound_fail": "whack!",
       "ter_set": "t_floor_resin",
-      "items": [ { "item": "resin_chunk", "count": [ 2, 5 ] } ]
+      "items": [ { "item": "resin_chunk", "count": [ 2, 5 ] } ],
+      "ranged": { "reduction": [ 35, 70 ], "destroy_threshold": 300, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -108,7 +110,8 @@
       "sound": "boom!",
       "sound_fail": "whack!",
       "ter_set": "t_resin_hole",
-      "items": [ { "item": "resin_chunk", "count": [ 2, 5 ] } ]
+      "items": [ { "item": "resin_chunk", "count": [ 2, 5 ] } ],
+      "ranged": { "reduction": [ 45, 90 ], "destroy_threshold": 120 }
     }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-triffid.json
+++ b/data/json/furniture_and_terrain/terrain-triffid.json
@@ -16,7 +16,8 @@
       "sound": "crunch!",
       "sound_fail": "whump!",
       "ter_set": "t_bark_wall_chipped",
-      "items": [ { "item": "splinter", "count": [ 5, 10 ] } ]
+      "items": [ { "item": "splinter", "count": [ 5, 10 ] } ],
+      "ranged": { "reduction": [ 30, 60 ], "destroy_threshold": 180 }
     }
   },
   {
@@ -36,7 +37,8 @@
       "sound": "crunch!",
       "sound_fail": "whump!",
       "ter_set": "t_bark_wall_broken",
-      "items": [ { "item": "splinter", "count": [ 5, 10 ] } ]
+      "items": [ { "item": "splinter", "count": [ 5, 10 ] } ],
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 160 }
     }
   },
   {
@@ -54,7 +56,8 @@
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_barkfloor",
-      "items": [ { "item": "splinter", "count": [ 10, 20 ] } ]
+      "items": [ { "item": "splinter", "count": [ 10, 20 ] } ],
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 150, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -74,7 +77,8 @@
       "sound": "crunch!",
       "sound_fail": "whump!",
       "ter_set": "t_barkfloor",
-      "items": [ { "item": "splinter", "count": [ 20, 25 ] } ]
+      "items": [ { "item": "splinter", "count": [ 20, 25 ] } ],
+      "ranged": { "reduction": [ 40, 80 ], "destroy_threshold": 160 }
     }
   },
   {
@@ -165,7 +169,8 @@
       "sound": "crunch!",
       "sound_fail": "whump!",
       "ter_set": "t_null",
-      "items": [ { "item": "splinter", "count": [ 2, 5 ] } ]
+      "items": [ { "item": "splinter", "count": [ 2, 5 ] } ],
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 150 }
     }
   },
   {


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This adds ranged bash info to a few more relevant terrain items I forgot.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Added the standard `ranged` info to all regular trees, at 100% hit rate since all of them block view.
2. Added to tree trunks and stumps, with intercept chances of 50% and 25% respectively.
3. Bumped coverage value of trunks from from 45 to 50 a bit for consistency.
4. Added ranged bash info to triffid terrain. which was missed since the PR for it was done while I was in the middle of adding these en masse last time so I forgot about the new terrain.
5. Added to relevant terrain in fence and gate file, evidently I forgot about those too.
6. Added a coverage values of 35 to picket fences, 60 to split rail fence, for consistency. The latter also fits with closed split rail gates having that value.
7. Lowered coverage value of picket fence gates to 35 to be more consistent with the fences they're paired with.
8. Added coverage values to railings for consistency.
9. Added ranged values to fungal terrain.
10. Added ranged values to mi-go terrain.
11. Lowered coverage of resin cages to 60 since transparent.
12. Increased coverage of mi-go nerve clusters to 75, set it to block movement, elevated coverage chance to 75%, and made it easier to destroy with bullets in the same manner as electronics and consoles. It's a floor to ceiling bundle of nerves with an oversized mi-go installed inside it, so it likely should be bigger, plus it'd be sensitive to disruption and logically shooting the hell out of it would injure the mi-go inside and disconnect it.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Checked affected files for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
