### PR TITLE
fix: prevent stairs leading to deep water

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10527,8 +10527,8 @@ std::optional<tripoint> game::find_or_make_stairs( map &mp, const int z_after, b
         for( const tripoint &dest : m.points_in_rectangle( omtile_align_start, omtile_align_end ) ) {
             if( rl_dist( u.pos(), dest ) <= best &&
                 ( ( going_down_1 && mp.has_flag( TFLAG_GOES_UP, dest ) ) ||
-                  ( going_up_1 && ( mp.has_flag( TFLAG_GOES_DOWN, dest ) && !mp.has_flag( TFLAG_DEEP_WATER, dest ) ||
-                                    mp.ter( dest ) == t_manhole_cover ) ) ||
+                  ( going_up_1 && ( mp.has_flag( TFLAG_GOES_DOWN, dest ) && !mp.has_flag( TFLAG_DEEP_WATER, dest ))) ||
+                                    mp.ter( dest ) == t_manhole_cover   ||
                   ( ( movez == 2 || movez == -2 ) && mp.ter( dest ) == t_elevator ) ) ) {
                 stairs.emplace( dest );
                 best = rl_dist( u.pos(), dest );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10528,8 +10528,9 @@ std::optional<tripoint> game::find_or_make_stairs( map &mp, const int z_after, b
         for( const tripoint &dest : m.points_in_rectangle( omtile_align_start, omtile_align_end ) ) {
             if( rl_dist( u.pos(), dest ) <= best &&
                 ( ( going_down_1 && mp.has_flag( TFLAG_GOES_UP, dest ) ) ||
-                  ( going_up_1 && ( mp.has_flag( TFLAG_GOES_DOWN, dest ) && !mp.has_flag( TFLAG_DEEP_WATER, dest ))) ||
-                                    mp.ter( dest ) == t_manhole_cover   ||
+                  ( going_up_1 && ( mp.has_flag( TFLAG_GOES_DOWN, dest ) &&
+                                    !mp.has_flag( TFLAG_DEEP_WATER, dest ) ) ) ||
+                  mp.ter( dest ) == t_manhole_cover   ||
                   ( ( movez == 2 || movez == -2 ) && mp.ter( dest ) == t_elevator ) ) ) {
                 stairs.emplace( dest );
                 best = rl_dist( u.pos(), dest );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10528,9 +10528,8 @@ std::optional<tripoint> game::find_or_make_stairs( map &mp, const int z_after, b
         for( const tripoint &dest : m.points_in_rectangle( omtile_align_start, omtile_align_end ) ) {
             if( rl_dist( u.pos(), dest ) <= best &&
                 ( ( going_down_1 && mp.has_flag( TFLAG_GOES_UP, dest ) ) ||
-                  ( going_up_1 && ( mp.has_flag( TFLAG_GOES_DOWN, dest ) &&
-                                    !mp.has_flag( TFLAG_DEEP_WATER, dest ) ) ) ||
-                  mp.ter( dest ) == t_manhole_cover   ||
+                  (( going_up_1 && ( mp.has_flag( TFLAG_GOES_DOWN, dest ) && !mp.has_flag( TFLAG_DEEP_WATER, dest ))) ||
+                                    mp.ter( dest ) == t_manhole_cover)   ||
                   ( ( movez == 2 || movez == -2 ) && mp.ter( dest ) == t_elevator ) ) ) {
                 stairs.emplace( dest );
                 best = rl_dist( u.pos(), dest );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10519,7 +10519,7 @@ std::optional<tripoint> game::find_or_make_stairs( map &mp, const int z_after, b
     if( going_down_1 && mp.has_flag( TFLAG_GOES_UP, u.pos() + tripoint_below ) ) {
         stairs.emplace( u.pos() + tripoint_below );
     }
-    if( going_up_1 && mp.has_flag( TFLAG_GOES_DOWN, u.pos() + tripoint_above ) ) {
+    if( going_up_1 && mp.has_flag( TFLAG_GOES_DOWN, u.pos() + tripoint_above ) && !mp.has_flag( TFLAG_DEEP_WATER, u.pos() + tripoint_below ) ) {
         stairs.emplace( u.pos() + tripoint_above );
     }
     // We did not find stairs directly above or below, so search the map for them
@@ -10527,7 +10527,7 @@ std::optional<tripoint> game::find_or_make_stairs( map &mp, const int z_after, b
         for( const tripoint &dest : m.points_in_rectangle( omtile_align_start, omtile_align_end ) ) {
             if( rl_dist( u.pos(), dest ) <= best &&
                 ( ( going_down_1 && mp.has_flag( TFLAG_GOES_UP, dest ) ) ||
-                  ( going_up_1 && ( mp.has_flag( TFLAG_GOES_DOWN, dest ) ||
+                  ( going_up_1 && ( mp.has_flag( TFLAG_GOES_DOWN, dest ) && !mp.has_flag( TFLAG_DEEP_WATER, dest ) ||
                                     mp.ter( dest ) == t_manhole_cover ) ) ||
                   ( ( movez == 2 || movez == -2 ) && mp.ter( dest ) == t_elevator ) ) ) {
                 stairs.emplace( dest );
@@ -10582,6 +10582,12 @@ std::optional<tripoint> game::find_or_make_stairs( map &mp, const int z_after, b
     }
 
     if( movez > 0 ) {
+        if( mp.has_flag( "DEEP_WATER", *stairs ) ) {
+            if( !query_yn( _( "There is a huge blob of water! You may be unable to return back down these stairs.  Continue up?" ) ) ) {
+                return std::nullopt;
+            }
+        }
+        else
         if( !mp.has_flag( "GOES_DOWN", *stairs ) ) {
             if( !query_yn( _( "You may be unable to return back down these stairs.  Continue up?" ) ) ) {
                 return std::nullopt;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10528,8 +10528,9 @@ std::optional<tripoint> game::find_or_make_stairs( map &mp, const int z_after, b
         for( const tripoint &dest : m.points_in_rectangle( omtile_align_start, omtile_align_end ) ) {
             if( rl_dist( u.pos(), dest ) <= best &&
                 ( ( going_down_1 && mp.has_flag( TFLAG_GOES_UP, dest ) ) ||
-                  (( going_up_1 && ( mp.has_flag( TFLAG_GOES_DOWN, dest ) && !mp.has_flag( TFLAG_DEEP_WATER, dest ))) ||
-                                    mp.ter( dest ) == t_manhole_cover)   ||
+                  ( ( going_up_1 && ( mp.has_flag( TFLAG_GOES_DOWN, dest ) &&
+                                      !mp.has_flag( TFLAG_DEEP_WATER, dest ) ) ) ||
+                    mp.ter( dest ) == t_manhole_cover )   ||
                   ( ( movez == 2 || movez == -2 ) && mp.ter( dest ) == t_elevator ) ) ) {
                 stairs.emplace( dest );
                 best = rl_dist( u.pos(), dest );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10586,7 +10586,7 @@ std::optional<tripoint> game::find_or_make_stairs( map &mp, const int z_after, b
     if( movez > 0 ) {
         if( mp.has_flag( "DEEP_WATER", *stairs ) ) {
             if( !query_yn(
-                    _( "There is a huge blob of water! You may be unable to return back down these stairs.  Continue up?" ) ) ) {
+                    _( "There is a huge blob of water!  You may be unable to return back down these stairs.  Continue up?" ) ) ) {
                 return std::nullopt;
             }
         } else if( !mp.has_flag( "GOES_DOWN", *stairs ) ) {


### PR DESCRIPTION
## Purpose of change
To fix the bug which leads to possibility to get into deep water instead of proper destination during going upstairs
- fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/4087
## Describe the solution
Added additional excluding checks for tiles with "DEEP_WATER" tag during search for stairs.
## Describe alternatives you've considered
None
## Testing
Solution has been successfully tested in previously affected place
## Additional context
## Checklist