### PR TITLE
feat(balance): increase variety of potential damage states for spawned vehicles

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -789,7 +789,8 @@ void vehicle::init_state( int init_veh_fuel, int init_veh_status )
     // destroy a random number of tires, vehicles with more wheels are more likely to survive
     if( destroyTires && !wheelcache.empty() ) {
         int tries = 0;
-        while( valid_wheel_config() && tries < wheelcache.size() ) {
+        int maxtries = wheelcache.size();
+        while( valid_wheel_config() && tries < maxtries ) {
             // keep going until either we've ruined all wheels or made one attempt for every wheel
             set_hp( parts[random_entry( wheelcache )], 0 );
             tries++;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -620,11 +620,15 @@ void vehicle::init_state( int init_veh_fuel, int init_veh_status )
         }
 
         for( const vpart_reference &vp : get_parts_including_carried( "FRIDGE" ) ) {
-            vp.part().enabled = true;
+            if( one_in( 2 ) ) {
+                vp.part().enabled = true;
+            }
         }
 
         for( const vpart_reference &vp : get_parts_including_carried( "FREEZER" ) ) {
-            vp.part().enabled = true;
+            if( one_in( 2 ) ) {
+                vp.part().enabled = true;
+            }
         }
 
         for( const vpart_reference &vp : get_parts_including_carried( "WATER_PURIFIER" ) ) {
@@ -637,8 +641,8 @@ void vehicle::init_state( int init_veh_fuel, int init_veh_status )
         const size_t p = vp.part_index();
         vehicle_part &pt = vp.part();
 
-        if( vp.has_feature( VPFLAG_REACTOR ) ) {
-            // De-hardcoded reactors. Should always start active
+        if( vp.has_feature( VPFLAG_REACTOR ) && one_in( 4 ) ) {
+            // De-hardcoded reactors, may or may not start active
             pt.enabled = true;
         }
 
@@ -733,6 +737,11 @@ void vehicle::init_state( int init_veh_fuel, int init_veh_status )
                 set_hp( pt, 0 );
             }
 
+            // An added 5% chance to bust each windshield
+            if( vp.has_feature( "WINDSHIELD" ) && one_in( 20 ) ) {
+                set_hp( pt, 0 );
+            }
+
             /* Bloodsplatter the front-end parts. Assume anything with x > 0 is
             * the "front" of the vehicle (since the driver's seat is at (0, 0).
             * We'll be generous with the blood, since some may disappear before
@@ -761,6 +770,11 @@ void vehicle::init_state( int init_veh_fuel, int init_veh_status )
                     blood_inside_pos.emplace( vp.mount() );
                 }
             }
+
+            // Potentially bust a single tire if not already wrecking them
+            if( !destroyTires && !wheelcache.empty() && one_in( 20 ) ) {
+                set_hp( parts[random_entry( wheelcache )], 0 );
+            }
         }
         //sets the vehicle to locked, if there is no key and an alarm part exists
         if( vp.has_feature( "SECURITY" ) && has_no_key && pt.is_available() ) {
@@ -772,11 +786,11 @@ void vehicle::init_state( int init_veh_fuel, int init_veh_status )
             }
         }
     }
-    // destroy tires until the vehicle is not drivable
+    // destroy a random number of tires, vehicles with more wheels are more likely to survive
     if( destroyTires && !wheelcache.empty() ) {
         int tries = 0;
-        while( valid_wheel_config() && tries < 100 ) {
-            // wheel config is still valid, destroy the tire.
+        while( valid_wheel_config() && tries < wheelcache.size() ) {
+            // keep going until either we've ruined all wheels or made one attempt for every wheel
             set_hp( parts[random_entry( wheelcache )], 0 );
             tries++;
         }

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -37,6 +37,7 @@ TEST_CASE( "vehicle power with reactor and solar panels", "[vehicle][power]" )
 
         REQUIRE( !veh_ptr->reactors.empty() );
         vehicle_part &reactor = veh_ptr->part( veh_ptr->reactors.front() );
+        reactor.enabled = true;
 
         GIVEN( "the reactor is empty" ) {
             reactor.ammo_unset();


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

It's a famous Cata meme, on Zero Day every tire in the world magically explodes. While all the other mechanisms for spawning a vehicle disabled in the game's code are more subtle and natural-looking, the "wreck the tires" code always looks jarring with how it vehicles only ever generate with intact wheels or with all wheels busted. It not only looks odd, but means the player rarely gets to contend with the "unbalanced" and "no steering" conditions.

Along the way, in looking at the code I found myself rapidly being tempted to tinker with the code a bit more to flesh out the variation in spawn conditions further.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

In vehicle.cpp, set the `destroyTires` behavior in `vehicle::init_state` to pick wheels to destroy a number of tries equal to the number of wheels it has, instead of intentionally trying to overkill the wheels with 100 attempts. Idea is, since it will target a random wheel each time and might try to hit the same wheel more than once, the odds of it wrecking every single wheel go down the more wheels the vehicle has, any the damage to wheels will fittingly appear more random and look less obviously faked.

In addition, as a bonus cars set to spawn damaged but not disabled can now also make a single bonus roll to spawn with a busted wheel and some added potential to spawn with a random amount of wrecked windshields. A single 5% chance to bust one wheel and a 5% chance per windshield, respectively.

Next, set it so that reactors, minifridges, and minifreezers only spawn active some of the time, adding more variation to whether a car with those features that spawns will drain its batteries and/or plutonium while left idle before you get to it.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Screaming.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Temporarily set the code to always pop tires on disabled vehicles for testing.
3. Spawned in multiple disabled cars, number and location of destroyed tires was random.
4. Spawned in a semi truck, the back wheels were a more pleasing mishmash of wrecked and intact wheels.
5. Went back to current setup and started spawning lightly-damaged cars, some have busted windshields now, a tire busted, etc.
6. Spawned in RVs, no longer always spawn with the fridge running.
7. Spawned in an atomic car, confirmed that the reactor doesn't always spawn running, and that this doesn't somehow break being able to turn it on.
8. Checked affected file for astyle.

Status of a car that spawned messed up in an uncommon way due to the new randomization:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/006343e1-ce73-4fc4-b077-26561c6ee5f5)

A semi showing how more wheels means better chance to still be drivable:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/6fc25650-5ecf-43d4-b159-996a37055a0e)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/57885995-86c3-444f-8574-35d64161dc8c)

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
