### PR TITLE
feat(balance): consistency updates to harvest entries

### DIFF
--- a/data/json/harvest.json
+++ b/data/json/harvest.json
@@ -84,7 +84,7 @@
       { "drop": "cyborg_harvest", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "cable", "base_num": [ 1, 3 ], "scale_num": [ 0.2, 0.6 ], "max": 8, "type": "flesh" },
-      { "drop": "bone_human", "base_num": [ 1, 2 ], "scale_num": [ 0.4, 0.7 ], "max": 10, "type": "bone" },
+      { "drop": "bone_human", "type": "bone", "mass_ratio": 0.15 },
       { "drop": "scrap", "base_num": [ 1, 5 ], "scale_num": [ 0.3, 0.7 ], "max": 12, "type": "bone" }
     ]
   },
@@ -111,7 +111,7 @@
       { "drop": "liver", "type": "offal", "mass_ratio": 0.01 },
       { "drop": "brain", "type": "flesh", "mass_ratio": 0.005 },
       { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.13 },
       { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
     ]
@@ -130,7 +130,7 @@
       { "drop": "kidney", "type": "offal", "mass_ratio": 0.002 },
       { "drop": "stomach", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
       { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.08 },
       { "drop": "fat", "type": "flesh", "mass_ratio": 0.075 }
     ]
@@ -149,7 +149,7 @@
       { "drop": "kidney", "type": "offal", "mass_ratio": 0.002 },
       { "drop": "stomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
       { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.04 },
       { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
     ]
@@ -161,8 +161,8 @@
     "entries": [
       { "drop": "mutant_human_flesh", "type": "flesh", "mass_ratio": 0.34 },
       { "drop": "hstomach", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "bone_human", "type": "bone", "mass_ratio": 0.15 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_hfur", "type": "skin", "mass_ratio": 0.02 },
       { "drop": "mutant_human_fat", "type": "flesh", "mass_ratio": 0.07 }
     ]
@@ -175,8 +175,8 @@
       { "drop": "cyborg_harvest_uncommon", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
       { "drop": "mutant_human_flesh", "type": "flesh", "mass_ratio": 0.34 },
       { "drop": "hstomach", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "bone_human", "type": "bone", "mass_ratio": 0.15 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_hfur", "type": "skin", "mass_ratio": 0.02 },
       { "drop": "mutant_human_fat", "type": "flesh", "mass_ratio": 0.07 }
     ]
@@ -188,8 +188,8 @@
     "entries": [
       { "drop": "mutant_human_flesh", "type": "flesh", "mass_ratio": 0.34 },
       { "drop": "hstomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "bone_human", "type": "bone", "mass_ratio": 0.15 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_hfur", "type": "skin", "mass_ratio": 0.02 },
       { "drop": "mutant_human_fat", "type": "flesh", "mass_ratio": 0.07 }
     ]
@@ -202,8 +202,8 @@
       { "drop": "cyborg_harvest_uncommon", "type": "bionic_group", "faults": [ "fault_bionic_nonsterile" ] },
       { "drop": "mutant_human_flesh", "type": "flesh", "mass_ratio": 0.34 },
       { "drop": "hstomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "bone_human", "type": "bone", "mass_ratio": 0.15 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_hfur", "type": "skin", "mass_ratio": 0.02 },
       { "drop": "mutant_human_fat", "type": "flesh", "mass_ratio": 0.07 }
     ]
@@ -219,7 +219,7 @@
       { "drop": "liver", "type": "offal", "mass_ratio": 0.01 },
       { "drop": "brain", "type": "flesh", "mass_ratio": 0.005 },
       { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_leather", "type": "skin", "mass_ratio": 0.13 },
       { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
     ]
@@ -234,7 +234,7 @@
       { "drop": "brain", "type": "flesh", "mass_ratio": 0.005 },
       { "drop": "mutant_offal", "type": "offal", "mass_ratio": 0.01 },
       { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.02 },
       { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.07 }
     ]
@@ -253,7 +253,7 @@
       { "drop": "kidney", "type": "offal", "mass_ratio": 0.002 },
       { "drop": "stomach", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
       { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_leather", "type": "skin", "mass_ratio": 0.08 },
       { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
     ]
@@ -269,7 +269,7 @@
       { "drop": "mutant_offal", "type": "offal", "mass_ratio": 0.01 },
       { "drop": "stomach", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
       { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_leather", "type": "skin", "mass_ratio": 0.02 },
       { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.07 }
     ]
@@ -288,7 +288,7 @@
       { "drop": "kidney", "type": "offal", "mass_ratio": 0.002 },
       { "drop": "stomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
       { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_leather", "type": "skin", "mass_ratio": 0.04 },
       { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
     ]
@@ -304,7 +304,7 @@
       { "drop": "mutant_offal", "type": "offal", "mass_ratio": 0.01 },
       { "drop": "stomach", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
       { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.02 },
       { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.07 }
     ]
@@ -323,7 +323,7 @@
       { "drop": "kidney", "type": "offal", "mass_ratio": 0.002 },
       { "drop": "stomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
       { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_leather", "type": "skin", "mass_ratio": 0.04 },
       { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.07 }
     ]
@@ -339,7 +339,7 @@
       { "drop": "liver", "type": "offal", "mass_ratio": 0.01 },
       { "drop": "brain", "type": "flesh", "mass_ratio": 0.005 },
       { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "wool_staple", "type": "skin", "mass_ratio": 0.04 },
       { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
     ]
@@ -358,7 +358,7 @@
       { "drop": "kidney", "type": "offal", "mass_ratio": 0.002 },
       { "drop": "stomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
       { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "wool_staple", "type": "skin", "mass_ratio": 0.04 },
       { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
     ]
@@ -374,9 +374,9 @@
       { "drop": "mutant_offal", "type": "offal", "mass_ratio": 0.01 },
       { "drop": "stomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
       { "drop": "bone", "type": "bone", "mass_ratio": 0.2 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.07 },
-      { "drop": "chitin_piece", "type": "skin", "mass_ratio": 0.01 }
+      { "drop": "chitin_piece", "type": "skin", "mass_ratio": 0.1 }
     ]
   },
   {
@@ -390,7 +390,7 @@
       { "drop": "mutant_offal", "type": "offal", "mass_ratio": 0.01 },
       { "drop": "stomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
       { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.02 },
       { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.07 }
     ]
@@ -409,7 +409,7 @@
       { "drop": "kidney", "type": "offal", "mass_ratio": 0.002 },
       { "drop": "stomach", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
       { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
     ]
   },
@@ -427,7 +427,7 @@
       { "drop": "kidney", "type": "offal", "mass_ratio": 0.002 },
       { "drop": "stomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
       { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
     ]
   },
@@ -445,7 +445,7 @@
       { "drop": "kidney", "type": "offal", "mass_ratio": 0.002 },
       { "drop": "stomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
       { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.07 }
     ]
   },
@@ -530,7 +530,7 @@
       { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.1 },
       { "drop": "stomach", "scale_num": [ 0, 1 ], "max": 1, "type": "offal" },
       { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 }
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 }
     ]
   },
   {
@@ -539,6 +539,7 @@
     "message": "<arachnid_harvest>",
     "entries": [
       { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.33 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "mutant_bug_lungs", "type": "flesh", "mass_ratio": 0.0035 },
       { "drop": "mutant_bug_organs", "type": "offal", "mass_ratio": 0.015 },
       { "drop": "chitin_piece", "type": "skin", "mass_ratio": 0.15 }
@@ -550,11 +551,11 @@
     "message": "<arachnid_flying_harvest>",
     "entries": [
       { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.1 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.01 },
-      { "drop": "mutant_bug_hydrogen_sacs", "type": "flesh", "mass_ratio": 0.2 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
+      { "drop": "mutant_bug_hydrogen_sacs", "type": "flesh", "mass_ratio": 0.02 },
       { "drop": "mutant_bug_lungs", "type": "flesh", "mass_ratio": 0.0035 },
       { "drop": "mutant_bug_organs", "type": "offal", "mass_ratio": 0.015 },
-      { "drop": "chitin_piece", "type": "skin", "mass_ratio": 0.015 }
+      { "drop": "chitin_piece", "type": "skin", "mass_ratio": 0.15 }
     ]
   },
   {
@@ -562,9 +563,10 @@
     "type": "harvest",
     "message": "<acidant_harvest>",
     "entries": [
-      { "drop": "mutant_meat", "base_num": [ 40, 55 ], "scale_num": [ 0.5, 0.7 ], "max": 80, "type": "flesh" },
-      { "drop": "acidchitin_piece", "base_num": [ 2, 6 ], "scale_num": [ 0.45, 0.9 ], "max": 15, "type": "skin" },
-      { "drop": "mutant_fat", "base_num": [ 5, 8 ], "scale_num": [ 0.6, 0.8 ], "max": 18, "type": "flesh" }
+      { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.33 },
+      { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.04 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
+      { "drop": "acidchitin_piece", "type": "skin", "mass_ratio": 0.15 }
     ]
   },
   {
@@ -574,7 +576,7 @@
     "entries": [
       { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.33 },
       { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.04 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.01 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "mutant_bug_lungs", "type": "flesh", "mass_ratio": 0.0035 },
       { "drop": "mutant_bug_organs", "type": "offal", "mass_ratio": 0.015 },
       { "drop": "chitin_piece", "type": "skin", "mass_ratio": 0.15 }
@@ -587,7 +589,7 @@
     "entries": [
       { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.33 },
       { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.04 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.01 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "acidchitin_piece", "type": "skin", "mass_ratio": 0.15 }
     ]
   },
@@ -597,8 +599,8 @@
     "message": "What appeared to be insect hairs on the chitin of this creature look more like tiny feathers as you pare them back.  Inside is a bundle of bubble-like tissue sacs that appear to be floating, which doesn't fit with what you know about real bees.",
     "entries": [
       { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.23 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.01 },
-      { "drop": "mutant_bug_hydrogen_sacs", "type": "flesh", "mass_ratio": 0.1 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
+      { "drop": "mutant_bug_hydrogen_sacs", "type": "flesh", "mass_ratio": 0.02 },
       { "drop": "mutant_bug_lungs", "type": "flesh", "mass_ratio": 0.0035 },
       { "drop": "mutant_bug_organs", "type": "offal", "mass_ratio": 0.015 },
       { "drop": "bee_sting", "base_num": [ 0, 1 ], "type": "bone" },
@@ -611,8 +613,8 @@
     "message": "<wasp_harvest>",
     "entries": [
       { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.3 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.003 },
-      { "drop": "mutant_bug_hydrogen_sacs", "type": "flesh", "mass_ratio": 0.1 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
+      { "drop": "mutant_bug_hydrogen_sacs", "type": "flesh", "mass_ratio": 0.02 },
       { "drop": "mutant_bug_lungs", "type": "flesh", "mass_ratio": 0.01 },
       { "drop": "mutant_bug_organs", "type": "offal", "mass_ratio": 0.03 },
       { "drop": "wasp_sting", "base_num": [ 0, 1 ], "type": "bone" },
@@ -625,8 +627,8 @@
     "message": "<wasp_queen_harvest>",
     "entries": [
       { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.2 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.003 },
-      { "drop": "mutant_bug_hydrogen_sacs", "type": "flesh", "mass_ratio": 0.1 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
+      { "drop": "mutant_bug_hydrogen_sacs", "type": "flesh", "mass_ratio": 0.02 },
       { "drop": "mutant_bug_lungs", "type": "flesh", "mass_ratio": 0.01 },
       { "drop": "mutant_bug_organs", "type": "offal", "mass_ratio": 0.03 },
       { "drop": "wasp_sting", "base_num": [ 0, 1 ], "type": "bone" },
@@ -641,10 +643,11 @@
     "entries": [
       { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.15 },
       { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.04 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.005 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
+      { "drop": "mutant_bug_hydrogen_sacs", "type": "flesh", "mass_ratio": 0.02 },
       { "drop": "mutant_bug_lungs", "type": "flesh", "mass_ratio": 0.0045 },
       { "drop": "mutant_bug_organs", "type": "offal", "mass_ratio": 0.025 },
-      { "drop": "chitin_piece", "type": "skin", "mass_ratio": 0.015 },
+      { "drop": "chitin_piece", "type": "skin", "mass_ratio": 0.15 },
       { "drop": "egg_dragonfly", "type": "offal", "base_num": [ 5, 35 ], "scale_num": [ 0.3, 0.5 ] }
     ]
   },
@@ -655,11 +658,11 @@
     "//": "copied from arachnid_flying+egg",
     "entries": [
       { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.1 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.01 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "mutant_bug_hydrogen_sacs", "type": "flesh", "mass_ratio": 0.2 },
       { "drop": "mutant_bug_lungs", "type": "flesh", "mass_ratio": 0.0035 },
       { "drop": "mutant_bug_organs", "type": "offal", "mass_ratio": 0.015 },
-      { "drop": "chitin_piece", "type": "skin", "mass_ratio": 0.015 },
+      { "drop": "chitin_piece", "type": "skin", "mass_ratio": 0.15 },
       { "drop": "egg_firefly", "type": "offal", "base_num": [ 0, 3 ] }
     ]
   },
@@ -674,7 +677,7 @@
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.05 },
       { "drop": "mutant_bug_lungs", "type": "flesh", "mass_ratio": 0.0035 },
       { "drop": "mutant_bug_organs", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "chitin_piece", "type": "skin", "mass_ratio": 0.012 }
+      { "drop": "chitin_piece", "type": "skin", "mass_ratio": 0.12 }
     ]
   },
   {
@@ -687,7 +690,7 @@
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.05 },
       { "drop": "mutant_bug_lungs", "type": "flesh", "mass_ratio": 0.0035 },
       { "drop": "mutant_bug_organs", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "chitin_piece", "type": "skin", "mass_ratio": 0.012 },
+      { "drop": "chitin_piece", "type": "skin", "mass_ratio": 0.12 },
       { "drop": "egg_centipede", "type": "offal", "base_num": [ 3, 10 ], "scale_num": [ 0.5, 1 ], "max": 30 }
     ]
   },
@@ -793,7 +796,7 @@
       { "drop": "human_flesh", "type": "flesh", "mass_ratio": 0.2 },
       { "drop": "hstomach", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
       { "drop": "human_fat", "type": "flesh", "mass_ratio": 0.1 },
-      { "drop": "bone_human", "type": "bone", "mass_ratio": 0.12 },
+      { "drop": "bone_human", "type": "bone", "mass_ratio": 0.15 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_hleather", "type": "skin", "mass_ratio": 0.03 }
     ]
@@ -805,7 +808,7 @@
       { "drop": "mutant_human_flesh", "type": "flesh", "mass_ratio": 0.2 },
       { "drop": "hstomach", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
       { "drop": "mutant_human_fat", "type": "flesh", "mass_ratio": 0.1 },
-      { "drop": "bone_human", "type": "bone", "mass_ratio": 0.12 },
+      { "drop": "bone_human", "type": "bone", "mass_ratio": 0.15 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_hleather", "type": "skin", "mass_ratio": 0.03 }
     ]
@@ -818,7 +821,7 @@
       { "drop": "meat", "type": "flesh", "mass_ratio": 0.4 },
       { "drop": "hstomach", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
       { "drop": "human_fat", "type": "flesh", "mass_ratio": 0.1 },
-      { "drop": "bone_human", "type": "bone", "mass_ratio": 0.12 },
+      { "drop": "bone_human", "type": "bone", "mass_ratio": 0.15 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_leather", "type": "skin", "mass_ratio": 0.03 },
       { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.001 }
@@ -838,10 +841,9 @@
     "type": "harvest",
     "message": "You laboriously hack and dig through the remains of the fungal mass.",
     "entries": [
-      { "drop": "veggy", "base_num": [ 6, 10 ], "scale_num": [ 0.6, 0.8 ], "max": 20, "type": "flesh" },
-      { "drop": "veggy_tainted", "base_num": [ 16, 25 ], "scale_num": [ 0.6, 0.8 ], "max": 50, "type": "flesh" },
-      { "drop": "plant_sac", "base_num": [ 3, 6 ], "scale_num": [ 0.7, 0.9 ], "max": 10, "type": "offal" },
-      { "drop": "stick_fiber", "base_num": [ 4, 8 ], "scale_num": [ 0.5, 0.7 ], "max": 10, "type": "bone" }
+      { "drop": "veggy_tainted", "type": "flesh", "mass_ratio": 0.5 },
+      { "drop": "plant_sac", "type": "offal", "mass_ratio": 0.2 },
+      { "drop": "stick_fiber", "type": "bone", "mass_ratio": 0.1 }
     ]
   },
   {
@@ -874,7 +876,7 @@
       { "drop": "human_flesh", "type": "flesh", "mass_ratio": 0.2 },
       { "drop": "hstomach", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
       { "drop": "human_fat", "type": "flesh", "mass_ratio": 0.1 },
-      { "drop": "bone_human", "type": "bone", "mass_ratio": 0.12 },
+      { "drop": "bone_human", "type": "bone", "mass_ratio": 0.15 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_hleather", "type": "skin", "mass_ratio": 0.03 }
     ]
@@ -909,7 +911,7 @@
       { "drop": "human_flesh", "type": "flesh", "mass_ratio": 0.2 },
       { "drop": "hstomach", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
       { "drop": "human_fat", "type": "flesh", "mass_ratio": 0.1 },
-      { "drop": "bone_human", "type": "bone", "mass_ratio": 0.12 },
+      { "drop": "bone_human", "type": "bone", "mass_ratio": 0.15 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_hleather", "type": "skin", "mass_ratio": 0.03 }
     ]
@@ -933,7 +935,7 @@
       { "drop": "human_flesh", "type": "flesh", "mass_ratio": 0.2 },
       { "drop": "hstomach", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
       { "drop": "human_fat", "type": "flesh", "mass_ratio": 0.1 },
-      { "drop": "bone_human", "type": "bone", "mass_ratio": 0.12 },
+      { "drop": "bone_human", "type": "bone", "mass_ratio": 0.15 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_hleather", "type": "skin", "mass_ratio": 0.03 }
     ]
@@ -979,7 +981,7 @@
       { "drop": "human_flesh", "type": "flesh", "mass_ratio": 0.2 },
       { "drop": "hstomach", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
       { "drop": "human_fat", "type": "flesh", "mass_ratio": 0.1 },
-      { "drop": "bone_human", "type": "bone", "mass_ratio": 0.12 },
+      { "drop": "bone_human", "type": "bone", "mass_ratio": 0.15 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_hleather", "type": "skin", "mass_ratio": 0.03 }
     ]
@@ -1072,7 +1074,7 @@
     "id": "triffid_small",
     "type": "harvest",
     "entries": [
-      { "drop": "stick_fiber", "type": "bone", "mass_ratio": 0.5 },
+      { "drop": "stick_fiber", "type": "bone", "mass_ratio": 0.1 },
       { "drop": "veggy", "type": "flesh", "mass_ratio": 0.2 },
       { "drop": "veggy", "type": "offal", "mass_ratio": 0.05 }
     ]
@@ -1081,7 +1083,7 @@
     "id": "triffid_large",
     "type": "harvest",
     "entries": [
-      { "drop": "stick_fiber", "type": "bone", "mass_ratio": 0.4 },
+      { "drop": "stick_fiber", "type": "bone", "mass_ratio": 0.1 },
       { "drop": "veggy", "type": "flesh", "mass_ratio": 0.2 },
       { "drop": "veggy", "type": "offal", "mass_ratio": 0.05 },
       { "drop": "stick", "type": "bone", "mass_ratio": 0.05 }
@@ -1092,7 +1094,7 @@
     "type": "harvest",
     "entries": [
       { "drop": "log", "type": "bone", "mass_ratio": 0.35 },
-      { "drop": "stick_fiber", "type": "bone", "mass_ratio": 0.15 },
+      { "drop": "stick_fiber", "type": "bone", "mass_ratio": 0.1 },
       { "drop": "veggy", "type": "flesh", "mass_ratio": 0.2 },
       { "drop": "veggy", "type": "offal", "mass_ratio": 0.05 }
     ]

--- a/doc/src/content/docs/en/mod/json/reference/creatures/monsters.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/monsters.md
@@ -318,6 +318,14 @@ see ITEM_SPAWN.md. The default subtype is "distribution".
 How the monster behaves on death. See JSON_FLAGS.md for a list of possible functions. One can add or
 remove entries in mods via "add:death_function" and "remove:death_function".
 
+## "harvest"
+
+(string, optional)
+
+If this monster's death function leaves a corpse behind, this defines what items will be produced
+when butchering or dissecting its corpse. If none is specified, it will default to `human`. Harvest
+entries, their yields, and mass ratios, are defined in harvest.json
+
 ## "emit_field"
 
 (array of objects of emit_id and time_duration, optional) "emit_fields": [ { "emit_id":


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This separates out the JSON and documentation changes that crept into https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4751, which I initially did because they were relevant to implementing and documenting the decay feature. Now that the intended implementation is able to use a monster's harvest entries directly, but also it's left in draft because the implementation has some flaws in it, I figured I'd yoink the now-unrelated updates as a separate PR so they won't be held up by technical issues.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

JSON changes: 
1. Fixed several cases of mutant human harvest entries having regular bones instead of human bones.
2. Set most arthopods to have more consistent use of sinew, and more consistent ratios of chitin. Left non-armored centipedes at a lower than standard (but no longer pathetically tiny) ratio since the comment notes they're meant to be more sinewy than anything else.
3. Toned down the mass ratios for hydrogen sacs in flying harvest entries, especially since while I have ideas for what to do with them they really don't need to be that high.
4. Fixed acid ant queens having weirdly-defined butcher yields that vastly limited their max butcher returns, instead using same ratios as regular acid ants for now. Later on should we add acid ant eggs they likely could drop some like other queen monsters do.
5. Made the mass ratios of sinew drops consistent across all creatures that drop them. Unlike initially, I went ahead and used the ratio human harvest entries were using as the standard instead of the much smaller amount most animals used.
6. Fixed up cyborg harvest also using a weird max for its bone yield instead of a standard ratio.
7. Updated bone mass ratios for human harvest to fit the ratio most other harvest entries use.
8. As with acidant queens, updated fungal boss creatures to use a consistent mass ratios as regular fungals use, and removed spawns of non-fungal plant marrow on them.
9. Toned down fibrous stalk yields in triffids, to be consistent with amounts in fungaloids.

Documentation changes:
1. Added missing documentation of harvest entry to monster documentation, along with explaining the fallback behavior of using human harvest that I found.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Leaving it in the other PR and just waiting to see if I can sort out how to make decay behavior work right with corpses rotting out of the reality bubble.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Checked affected file for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
