### PR TITLE
feat(UI): fix odd coloration of tools/components UI, recipes showing same color as ones using rotten components

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -175,8 +175,9 @@ struct availability {
 
     nc_color color( bool ignore_missing_skills = false ) const {
         return can_craft
-               ? ( ( can_craft_non_rotten && has_all_skills ) || ignore_missing_skills ? c_white : c_brown )
-               : ( ( could_craft_if_knew && has_all_skills ) || ignore_missing_skills ? c_yellow : c_dark_gray );
+               ? ( ( can_craft_non_rotten && has_all_skills ) || ignore_missing_skills ? c_white : c_yellow )
+               : ( ( could_craft_if_knew && has_all_skills ) ||
+                   ignore_missing_skills ? c_light_gray : c_dark_gray );
     }
 
 };


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

So recently, crafting GUI coloration changed to make recipes that you can attempt to craft despite lacking subskills to show with brown text. This is a Bad Idea, because "item will be rotten due to rotten ingredients" already uses brown texts, and we shouldn't have this ambiguity.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

In crafting_gui.cpp, set it so the text color for "could craft if known" is light grey instead of yellow, while using yellow for the "can craft but missing some skills" condition.

Reason is, I found in testing that the "could craft if known" condition also affects the UI of basically the entrire tools and components block. I was wondering why it changed to yellow for stuff you can't craft, and thought it looked utterly hiddeous. I was gonna go with red, but that made it look ugly too.

I decided it'd be less disruptive if it used shades of grey in general so that all recipes you can't attempt to craft show as grey, while yellow is reserved for recipes you can try to craft but will struggle with. Using light grey instead of dark grey will also make the UI fluff for recipes you can't currently attempt a shade of grey to designate them as not attemptable, while still being more readable than dark grey, not eye-searing yellow, and not red that blends in with missing tools/components too easily.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Viewed crafting menu, confirmed that recipes I can't attempt show as gray, and the UI fluff shows as light gray specifically.
3. Spawned in some materials, debugged all skills and hit `u`, saw bone shivs showing under a yellow name with white UI text, also saw a composite crossbow with light gray name and light gray text.
4. Can attempt to craft a bone shiv when at zero skills, can't attempt to craft a composite crossbow with all skills but without the recipe learned.
5. Checked affected file for astyle.

Bone shiv, showing as yellow name since can craft it despite missing skill:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/d99df9d1-3f56-4fb2-a82b-b40e7ebff975)

Bone shiv highlighted, showing UI text is white as normal since can craft:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/18ecbdd7-043c-49c4-a869-08c203bdbdf9)

Composite crossbow, showing not craftable because not learned but has skills to craft it were it learned:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/da557183-bb5f-4338-95a0-30a2f713d9ce)

Composite crossbow highlighted, showing UI text is light gray instead of yellow now:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/aec9dcab-834a-4139-abef-5a05e6648163)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
