### PR TITLE
feat(balance): Remove Nomex from fabric_standard

### DIFF
--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -87,7 +87,7 @@
     "id": "fabric_standard",
     "type": "requirement",
     "//": "Any valid fabric material, for when the material used shouldn't impact the material of the end product.  Excludes felt patches, since this may still be worn on skin.",
-    "components": [ [ [ "rag", 1 ], [ "nylon", 1 ], [ "nomex", 1 ], [ "neoprene", 1 ] ] ]
+    "components": [ [ [ "rag", 1 ], [ "nylon", 1 ], [ "neoprene", 1 ] ] ]
   },
   {
     "id": "fabric_hides_any",


### PR DESCRIPTION
## Purpose of change

As RoyalFox correctly pointed out in the Discord, having nomex as an option in so many recipes where it would get transmutated into cotton is a big noob trap due to how valuable nomex is. In the event that we had material inheritance, nomex being in fabric_standard would be fine (though still a little bit odd). However, since we don't, I feel it's a good idea to prevent anyone from falling into that trap and wasting their rare and valuable nomex.

## Describe the solution

Removes nomex from fabric_standard, thereby making it so that a majority of recipes will not have the potential to be a trap for wasting your nomex.

## Describe alternatives you've considered

- Continue to allow nomex to be wasted
- Bundle this with the cottonification of the ammo pouches, where it was discovered / talked about

I felt that this was a very different balance discussion, and that keeping the two separate was probably for the best.

## Testing

Lints just fine, and the good ol' eyeball method confirms that nomex isn't in fabric_standard anymore.

## Additional context

Thanks to RoyalFox for pointing out the noob trap that this is.
