### PR TITLE
fix: consistency problem with one of the roofs of the gothic church

### DIFF
--- a/data/json/mapgen/church.json
+++ b/data/json/mapgen/church.json
@@ -390,7 +390,7 @@
         "+": "t_door_locked",
         "D": "t_window_domestic",
         "B": "t_window_stained_blue",
-        "_": "t_flat_roof",
+        "_": "t_rock_floor_no_roof",
         ">": "t_stairs_down",
         "G": "t_window_stained_green"
       },


### PR DESCRIPTION
## Purpose of change
Consistency.
## Describe the solution
Replace `t_flat_roof` with `t_rock_floor_no_roof` in `church_3rdfloor_1`.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/fb23d236-2d62-44d0-ad0e-90d8e719dc85">
After:
<img width="960" alt="image2" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/711e8d8d-daca-4075-a2ae-a8376cd8aa97">