### PR TITLE
fix: Add keybind prompt for "Show unavailable"

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -432,6 +432,7 @@ const recipe *select_crafting_recipe( int &batch_size_out )
         add_action_desc( "RELATED_RECIPES", pgettext( "crafting gui", "Related" ) );
         add_action_desc( "TOGGLE_FAVORITE", pgettext( "crafting gui", "Favorite" ) );
         add_action_desc( "CYCLE_BATCH", pgettext( "crafting gui", "Batch" ) );
+        add_action_desc( "TOGGLE_UNAVAILABLE", pgettext( "crafting gui", "Show unavailable" ) );
         add_action_desc( "HELP_KEYBINDINGS", pgettext( "crafting gui", "Keybindings" ) );
         keybinding_x = isWide ? 5 : 2;
         keybinding_tips = foldstring( enumerate_as_string( act_descs, enumeration_conjunction::none ),


### PR DESCRIPTION
## Purpose of change

- fixes #4767 
  - #4713 had a contained PR that affected the crafting GUI keybind prompts, which removed the show unavailable prompt option.

## Describe the solution

Adds the prompt back to the keybind list.

## Describe alternatives you've considered

- Name the keybind "unavailable" rather than "show unavailable".
  - I don't actually know which one we had prior to the PR.

## Testing

- [x] Load into game
  - [x] Check that "Show unavailable" now shows in the keybind list of the crafting menu, and the key can be rebound and will appropriately change the highlighted key, or be otherwise outside of the text.

## Additional context

## Checklist