### PR TITLE
feat(content): ammo drops in different amounts

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
@@ -540,6 +540,118 @@
     ]
   },
   {
+    "type": "item_group",
+    "id": "ammo_pistol_common_full",
+    "//": "Pistol ammo commonly owned by citizens and found in many locations, for vending machines.",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "22_cphp", "prob": 50 },
+      { "item": "22_lr", "prob": 100 },
+      { "item": "22_ratshot", "prob": 30 },
+      { "item": "32_acp", "prob": 20 },
+      { "item": "380_FMJ", "prob": 25 },
+      { "item": "380_JHP", "prob": 20 },
+      { "item": "38_fmj", "prob": 25 },
+      { "item": "38_special", "prob": 25 },
+      { "item": "357mag_fmj", "prob": 15 },
+      { "item": "357mag_jhp", "prob": 15 },
+      { "item": "357sig_jhp", "prob": 25 },
+      { "item": "357sig_fmj", "prob": 25 },
+      { "item": "40sw", "prob": 40 },
+      { "item": "40fmj", "prob": 40 },
+      { "item": "45_acp", "prob": 40 },
+      { "item": "45_jhp", "prob": 40 },
+      { "item": "9mm", "prob": 100 },
+      { "item": "9mmfmj", "prob": 100 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "ammo_pistol_rare_full",
+    "//": "Less common pistol ammo including that only used by police/paramilitary forces, for vending machines.",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "10mm_fmj", "prob": 15 },
+      { "item": "38_super", "prob": 20 },
+      { "item": "38super_fmj", "prob": 20 },
+      { "item": "44fmj", "prob": 15 },
+      { "item": "44magnum", "prob": 35 },
+      { "item": "45_super", "prob": 30 },
+      { "item": "460_rowland", "prob": 15 },
+      { "item": "460_fmj", "prob": 10 },
+      { "item": "57mm", "prob": 50 },
+      { "item": "380_p", "prob": 10 },
+      { "item": "9mmP", "prob": 30 },
+      { "item": "9mmP2", "prob": 20 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "ammo_rifle_common_full",
+    "//": "Rifle ammo commonly owned by citizens and found in many locations, for vending machines.",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "223", "prob": 60 },
+      { "item": "22_cphp", "prob": 50 },
+      { "item": "22_lr", "prob": 100 },
+      { "item": "22_ratshot", "prob": 30 },
+      { "item": "270win_jsp", "prob": 25 },
+      { "item": "3006", "prob": 25 },
+      { "item": "308", "prob": 25 },
+      { "item": "762_54R", "prob": 10 },
+      { "item": "762_m43", "prob": 20 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "ammo_rifle_rare_full",
+    "//": "Less common rifle ammo including that only used by police/paramilitary forces, for vending machines.",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "300_winmag", "prob": 40 },
+      { "item": "3006fmj", "prob": 50 },
+      { "item": "556", "prob": 100 },
+      { "item": "762_51", "prob": 50 },
+      { "item": "4570_sp", "prob": 40 },
+      { "item": "4570_pen", "prob": 20 },
+      { "item": "4570_low", "prob": 40 },
+      { "item": "762_m87", "prob": 25 },
+      { "item": "8mm_civilian", "prob": 15 },
+      { "item": "300blk", "prob": 15 },
+      { "item": "300blk_ss", "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "ammo_shotgun_common_full",
+    "//": "Shotgun ammo commonly owned by citizens and found in many locations, for vending machines.",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "shot_00", "prob": 100 },
+      { "item": "shot_bird", "prob": 70 },
+      { "item": "shot_slug", "prob": 70 },
+      { "item": "410shot_000", "prob": 50 },
+      { "item": "shot_paper_00", "prob": 30 },
+      { "item": "shot_paper_bird", "prob": 30 },
+      { "item": "shot_paper_slug", "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "ammo_shotgun_rare_full",
+    "//": "Less common shotgun ammo including that only used by police/paramilitary forces, for vending machines.",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "20x66_beanbag", "prob": 10 },
+      { "item": "20x66_flare", "prob": 10 },
+      { "item": "20x66_shot", "prob": 40 },
+      { "item": "20x66_slug", "prob": 20 },
+      { "item": "shot_dragon", "prob": 10 },
+      { "item": "shot_beanbag", "prob": 20 },
+      { "item": "shot_paper_dragon", "prob": 5 }
+    ]
+  },
+  {
     "id": "ammo_casings",
     "type": "item_group",
     "subtype": "distribution",

--- a/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
@@ -81,7 +81,7 @@
     "subtype": "distribution",
     "entries": [
       { "group": "ammo_pistol_modern_handloads", "prob": 50 },
-      { "group": "ammo_pistol_blackpowder_handloads", "prob": 50] }
+      { "group": "ammo_pistol_blackpowder_handloads", "prob": 50 }
     ]
   },
   {

--- a/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
@@ -80,8 +80,8 @@
     "//": "Reloaded pistol ammo, black powder loads roughly half of the time.",
     "subtype": "distribution",
     "entries": [
-      { "group": "ammo_pistol_modern_handloads", "prob": 50, "charges": [ 1, 100 ] },
-      { "group": "ammo_pistol_blackpowder_handloads", "prob": 50, "charges": [ 1, 100 ] }
+      { "group": "ammo_pistol_modern_handloads", "prob": 50 },
+      { "group": "ammo_pistol_blackpowder_handloads", "prob": 50] }
     ]
   },
   {

--- a/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
@@ -5,24 +5,24 @@
     "//": "Pistol ammo commonly owned by citizens and found in many locations.",
     "subtype": "distribution",
     "entries": [
-      { "item": "22_cphp", "prob": 50 },
-      { "item": "22_lr", "prob": 100 },
-      { "item": "22_ratshot", "prob": 30 },
-      { "item": "32_acp", "prob": 20 },
-      { "item": "380_FMJ", "prob": 25 },
-      { "item": "380_JHP", "prob": 20 },
-      { "item": "38_fmj", "prob": 25 },
-      { "item": "38_special", "prob": 25 },
-      { "item": "357mag_fmj", "prob": 15 },
-      { "item": "357mag_jhp", "prob": 15 },
-      { "item": "357sig_jhp", "prob": 25 },
-      { "item": "357sig_fmj", "prob": 25 },
-      { "item": "40sw", "prob": 40 },
-      { "item": "40fmj", "prob": 40 },
-      { "item": "45_acp", "prob": 40 },
-      { "item": "45_jhp", "prob": 40 },
-      { "item": "9mm", "prob": 100 },
-      { "item": "9mmfmj", "prob": 100 }
+      { "item": "22_cphp", "prob": 50, "charges": [ 1, 100 ] },
+      { "item": "22_lr", "prob": 100, "charges": [ 1, 100 ] },
+      { "item": "22_ratshot", "prob": 30, "charges": [ 1, 100 ] },
+      { "item": "32_acp", "prob": 20, "charges": [ 1, 100 ] },
+      { "item": "380_FMJ", "prob": 25, "charges": [ 1, 100 ] },
+      { "item": "380_JHP", "prob": 20, "charges": [ 1, 100 ] },
+      { "item": "38_fmj", "prob": 25, "charges": [ 1, 100 ] },
+      { "item": "38_special", "prob": 25, "charges": [ 1, 100 ] },
+      { "item": "357mag_fmj", "prob": 15, "charges": [ 1, 100 ] },
+      { "item": "357mag_jhp", "prob": 15, "charges": [ 1, 100 ] },
+      { "item": "357sig_jhp", "prob": 25, "charges": [ 1, 100 ] },
+      { "item": "357sig_fmj", "prob": 25, "charges": [ 1, 100 ] },
+      { "item": "40sw", "prob": 40, "charges": [ 1, 100 ] },
+      { "item": "40fmj", "prob": 40, "charges": [ 1, 100 ] },
+      { "item": "45_acp", "prob": 40, "charges": [ 1, 100 ] },
+      { "item": "45_jhp", "prob": 40, "charges": [ 1, 100 ] },
+      { "item": "9mm", "prob": 100, "charges": [ 1, 100 ] },
+      { "item": "9mmfmj", "prob": 100, "charges": [ 1, 100 ] }
     ]
   },
   {
@@ -31,18 +31,18 @@
     "//": "Less common pistol ammo including that only used by police/paramilitary forces.",
     "subtype": "distribution",
     "entries": [
-      { "item": "10mm_fmj", "prob": 15 },
-      { "item": "38_super", "prob": 20 },
-      { "item": "38super_fmj", "prob": 20 },
-      { "item": "44fmj", "prob": 15 },
-      { "item": "44magnum", "prob": 35 },
-      { "item": "45_super", "prob": 30 },
-      { "item": "460_rowland", "prob": 15 },
-      { "item": "460_fmj", "prob": 10 },
-      { "item": "57mm", "prob": 50 },
-      { "item": "380_p", "prob": 10 },
-      { "item": "9mmP", "prob": 30 },
-      { "item": "9mmP2", "prob": 20 }
+      { "item": "10mm_fmj", "prob": 15, "charges": [ 1, 100 ] },
+      { "item": "38_super", "prob": 20, "charges": [ 1, 100 ] },
+      { "item": "38super_fmj", "prob": 20, "charges": [ 1, 100 ] },
+      { "item": "44fmj", "prob": 15, "charges": [ 1, 100 ] },
+      { "item": "44magnum", "prob": 35, "charges": [ 1, 100 ] },
+      { "item": "45_super", "prob": 30, "charges": [ 1, 100 ] },
+      { "item": "460_rowland", "prob": 15, "charges": [ 1, 100 ] },
+      { "item": "460_fmj", "prob": 10, "charges": [ 1, 100 ] },
+      { "item": "57mm", "prob": 50, "charges": [ 1, 100 ] },
+      { "item": "380_p", "prob": 10, "charges": [ 1, 100 ] },
+      { "item": "9mmP", "prob": 30, "charges": [ 1, 100 ] },
+      { "item": "9mmP2", "prob": 20, "charges": [ 1, 100 ] }
     ]
   },
   {
@@ -51,10 +51,10 @@
     "//": "Military specification pistol ammo found at military sites.",
     "subtype": "distribution",
     "entries": [
-      { "item": "46mm", "prob": 70 },
-      { "item": "5x50dart", "prob": 30 },
-      { "item": "5x50heavy", "prob": 20 },
-      { "item": "9mmfmj", "prob": 100 }
+      { "item": "46mm", "prob": 70, "charges": [ 1, 100 ] },
+      { "item": "5x50dart", "prob": 30, "charges": [ 1, 100 ] },
+      { "item": "5x50heavy", "prob": 20, "charges": [ 1, 100 ] },
+      { "item": "9mmfmj", "prob": 100, "charges": [ 1, 100 ] }
     ]
   },
   {
@@ -63,15 +63,15 @@
     "//": "Imported or otherwise very obscure pistol ammo.",
     "subtype": "distribution",
     "entries": [
-      { "item": "454_Casull", "prob": 100 },
-      { "item": "45colt_jhp", "prob": 50 },
-      { "item": "500_Magnum", "prob": 100 },
-      { "item": "762_25", "prob": 50 },
-      { "item": "762_25hot", "prob": 50 },
-      { "item": "762_25typeP", "prob": 50 },
-      { "item": "9x18mm", "prob": 50 },
-      { "item": "9x18mmfmj", "prob": 50 },
-      { "item": "9x18mmP2", "prob": 50 }
+      { "item": "454_Casull", "prob": 100, "charges": [ 1, 100 ] },
+      { "item": "45colt_jhp", "prob": 50, "charges": [ 1, 100 ] },
+      { "item": "500_Magnum", "prob": 100, "charges": [ 1, 100 ] },
+      { "item": "762_25", "prob": 50, "charges": [ 1, 100 ] },
+      { "item": "762_25hot", "prob": 50, "charges": [ 1, 100 ] },
+      { "item": "762_25typeP", "prob": 50, "charges": [ 1, 100 ] },
+      { "item": "9x18mm", "prob": 50, "charges": [ 1, 100 ] },
+      { "item": "9x18mmfmj", "prob": 50, "charges": [ 1, 100 ] },
+      { "item": "9x18mmP2", "prob": 50, "charges": [ 1, 100 ] }
     ]
   },
   {
@@ -80,8 +80,8 @@
     "//": "Reloaded pistol ammo, black powder loads roughly half of the time.",
     "subtype": "distribution",
     "entries": [
-      { "group": "ammo_pistol_modern_handloads", "prob": 50 },
-      { "group": "ammo_pistol_blackpowder_handloads", "prob": 50 }
+      { "group": "ammo_pistol_modern_handloads", "prob": 50, "charges": [ 1, 100 ] },
+      { "group": "ammo_pistol_blackpowder_handloads", "prob": 50, "charges": [ 1, 100 ] }
     ]
   },
   {
@@ -90,42 +90,42 @@
     "//": "Reloaded pistol ammo balanced according to rarity.",
     "subtype": "distribution",
     "entries": [
-      { "item": "10mm_fmj", "prob": 10 },
-      { "item": "22_cphp", "prob": 20 },
-      { "item": "22_lr", "prob": 70 },
-      { "item": "32_acp", "prob": 50 },
-      { "item": "38_fmj", "prob": 30 },
-      { "item": "38_special", "prob": 80 },
-      { "item": "38super_fmj", "prob": 40 },
-      { "item": "357mag_fmj", "prob": 30 },
-      { "item": "357mag_jhp", "prob": 30 },
-      { "item": "380_JHP", "prob": 10 },
-      { "item": "380_FMJ", "prob": 15 },
-      { "item": "380_p", "prob": 5 },
-      { "item": "357sig_fmj", "prob": 70 },
-      { "item": "357sig_jhp", "prob": 70 },
-      { "item": "40fmj", "prob": 20 },
-      { "item": "40sw", "prob": 50 },
-      { "item": "44magnum", "prob": 60 },
-      { "item": "44fmj", "prob": 30 },
-      { "item": "45_acp", "prob": 80 },
-      { "item": "45_jhp", "prob": 100 },
-      { "item": "45_super", "prob": 40 },
-      { "item": "46mm", "prob": 20 },
-      { "item": "454_Casull", "prob": 5 },
-      { "item": "45colt_jhp", "prob": 10 },
-      { "item": "460_fmj", "prob": 5 },
-      { "item": "460_rowland", "prob": 5 },
-      { "item": "500_Magnum", "prob": 5 },
-      { "item": "57mm", "prob": 50 },
-      { "item": "9mm", "prob": 160 },
-      { "item": "9mmfmj", "prob": 80 },
-      { "item": "9mmP", "prob": 80 },
-      { "item": "9mmP2", "prob": 40 },
-      { "item": "9x18mm", "prob": 20 },
-      { "item": "9x18mmfmj", "prob": 10 },
-      { "item": "9x18mmP2", "prob": 5 },
-      { "item": "762_25", "prob": 10 }
+      { "item": "10mm_fmj", "prob": 10, "charges": [ 1, 100 ] },
+      { "item": "22_cphp", "prob": 20, "charges": [ 1, 100 ] },
+      { "item": "22_lr", "prob": 70, "charges": [ 1, 100 ] },
+      { "item": "32_acp", "prob": 50, "charges": [ 1, 100 ] },
+      { "item": "38_fmj", "prob": 30, "charges": [ 1, 100 ] },
+      { "item": "38_special", "prob": 80, "charges": [ 1, 100 ] },
+      { "item": "38super_fmj", "prob": 40, "charges": [ 1, 100 ] },
+      { "item": "357mag_fmj", "prob": 30, "charges": [ 1, 100 ] },
+      { "item": "357mag_jhp", "prob": 30, "charges": [ 1, 100 ] },
+      { "item": "380_JHP", "prob": 10, "charges": [ 1, 100 ] },
+      { "item": "380_FMJ", "prob": 15, "charges": [ 1, 100 ] },
+      { "item": "380_p", "prob": 5, "charges": [ 1, 100 ] },
+      { "item": "357sig_fmj", "prob": 70, "charges": [ 1, 100 ] },
+      { "item": "357sig_jhp", "prob": 70, "charges": [ 1, 100 ] },
+      { "item": "40fmj", "prob": 20, "charges": [ 1, 100 ] },
+      { "item": "40sw", "prob": 50, "charges": [ 1, 100 ] },
+      { "item": "44magnum", "prob": 60, "charges": [ 1, 100 ] },
+      { "item": "44fmj", "prob": 30, "charges": [ 1, 100 ] },
+      { "item": "45_acp", "prob": 80, "charges": [ 1, 100 ] },
+      { "item": "45_jhp", "prob": 100, "charges": [ 1, 100 ] },
+      { "item": "45_super", "prob": 40, "charges": [ 1, 100 ] },
+      { "item": "46mm", "prob": 20, "charges": [ 1, 100 ] },
+      { "item": "454_Casull", "prob": 5, "charges": [ 1, 100 ] },
+      { "item": "45colt_jhp", "prob": 10, "charges": [ 1, 100 ] },
+      { "item": "460_fmj", "prob": 5, "charges": [ 1, 100 ] },
+      { "item": "460_rowland", "prob": 5, "charges": [ 1, 100 ] },
+      { "item": "500_Magnum", "prob": 5, "charges": [ 1, 100 ] },
+      { "item": "57mm", "prob": 50, "charges": [ 1, 100 ] },
+      { "item": "9mm", "prob": 160, "charges": [ 1, 100 ] },
+      { "item": "9mmfmj", "prob": 80, "charges": [ 1, 100 ] },
+      { "item": "9mmP", "prob": 80, "charges": [ 1, 100 ] },
+      { "item": "9mmP2", "prob": 40, "charges": [ 1, 100 ] },
+      { "item": "9x18mm", "prob": 20, "charges": [ 1, 100 ] },
+      { "item": "9x18mmfmj", "prob": 10, "charges": [ 1, 100 ] },
+      { "item": "9x18mmP2", "prob": 5, "charges": [ 1, 100 ] },
+      { "item": "762_25", "prob": 10, "charges": [ 1, 100 ] }
     ]
   },
   {
@@ -134,33 +134,33 @@
     "//": "Blackpowder pistol ammo balanced according to rarity, additional weight for calibers that have common, manual-action firearms available in that chambering.",
     "subtype": "distribution",
     "entries": [
-      { "item": "bp_10mm_fmj", "prob": 10 },
-      { "item": "bp_22_cphp", "prob": 45 },
-      { "item": "bp_22_lr", "prob": 95 },
-      { "item": "bp_32_acp", "prob": 50 },
-      { "item": "bp_38_fmj", "prob": 55 },
-      { "item": "bp_38_special", "prob": 105 },
-      { "item": "bp_357mag_fmj", "prob": 55 },
-      { "item": "bp_357mag_jhp", "prob": 55 },
-      { "item": "bp_380_JHP", "prob": 10 },
-      { "item": "bp_380_FMJ", "prob": 15 },
-      { "item": "bp_40fmj", "prob": 20 },
-      { "item": "bp_40sw", "prob": 50 },
-      { "item": "bp_44magnum", "prob": 85 },
-      { "item": "bp_44fmj", "prob": 55 },
-      { "item": "bp_45_acp", "prob": 80 },
-      { "item": "bp_45_jhp", "prob": 100 },
-      { "item": "bp_46mm", "prob": 20 },
-      { "item": "bp_454_Casull", "prob": 30 },
-      { "item": "bp_460_fmj", "prob": 5 },
-      { "item": "bp_460_rowland", "prob": 5 },
-      { "item": "bp_500_Magnum", "prob": 30 },
-      { "item": "bp_57mm", "prob": 50 },
-      { "item": "bp_9mm", "prob": 160 },
-      { "item": "bp_9mmfmj", "prob": 80 },
-      { "item": "bp_9x18mm", "prob": 20 },
-      { "item": "bp_9x18mmfmj", "prob": 10 },
-      { "item": "bp_762_25", "prob": 10 }
+      { "item": "bp_10mm_fmj", "prob": 10, "charges": [ 1, 100 ] },
+      { "item": "bp_22_cphp", "prob": 45, "charges": [ 1, 100 ] },
+      { "item": "bp_22_lr", "prob": 95, "charges": [ 1, 100 ] },
+      { "item": "bp_32_acp", "prob": 50, "charges": [ 1, 100 ] },
+      { "item": "bp_38_fmj", "prob": 55, "charges": [ 1, 100 ] },
+      { "item": "bp_38_special", "prob": 105, "charges": [ 1, 100 ] },
+      { "item": "bp_357mag_fmj", "prob": 55, "charges": [ 1, 100 ] },
+      { "item": "bp_357mag_jhp", "prob": 55, "charges": [ 1, 100 ] },
+      { "item": "bp_380_JHP", "prob": 10, "charges": [ 1, 100 ] },
+      { "item": "bp_380_FMJ", "prob": 15, "charges": [ 1, 100 ] },
+      { "item": "bp_40fmj", "prob": 20, "charges": [ 1, 100 ] },
+      { "item": "bp_40sw", "prob": 50, "charges": [ 1, 100 ] },
+      { "item": "bp_44magnum", "prob": 85, "charges": [ 1, 100 ] },
+      { "item": "bp_44fmj", "prob": 55, "charges": [ 1, 100 ] },
+      { "item": "bp_45_acp", "prob": 80, "charges": [ 1, 100 ] },
+      { "item": "bp_45_jhp", "prob": 100, "charges": [ 1, 100 ] },
+      { "item": "bp_46mm", "prob": 20, "charges": [ 1, 100 ] },
+      { "item": "bp_454_Casull", "prob": 30, "charges": [ 1, 100 ] },
+      { "item": "bp_460_fmj", "prob": 5, "charges": [ 1, 100 ] },
+      { "item": "bp_460_rowland", "prob": 5, "charges": [ 1, 100 ] },
+      { "item": "bp_500_Magnum", "prob": 30, "charges": [ 1, 100 ] },
+      { "item": "bp_57mm", "prob": 50, "charges": [ 1, 100 ] },
+      { "item": "bp_9mm", "prob": 160, "charges": [ 1, 100 ] },
+      { "item": "bp_9mmfmj", "prob": 80, "charges": [ 1, 100 ] },
+      { "item": "bp_9x18mm", "prob": 20, "charges": [ 1, 100 ] },
+      { "item": "bp_9x18mmfmj", "prob": 10, "charges": [ 1, 100 ] },
+      { "item": "bp_762_25", "prob": 10, "charges": [ 1, 100 ] }
     ]
   },
   {
@@ -204,15 +204,15 @@
     "//": "Rifle ammo commonly owned by citizens and found in many locations.",
     "subtype": "distribution",
     "entries": [
-      { "item": "223", "prob": 60 },
-      { "item": "22_cphp", "prob": 50 },
-      { "item": "22_lr", "prob": 100 },
-      { "item": "22_ratshot", "prob": 30 },
-      { "item": "270win_jsp", "prob": 25 },
-      { "item": "3006", "prob": 25 },
-      { "item": "308", "prob": 25 },
-      { "item": "762_54R", "prob": 10 },
-      { "item": "762_m43", "prob": 20 }
+      { "item": "223", "prob": 60, "charges": [ 1, 100 ] },
+      { "item": "22_cphp", "prob": 50, "charges": [ 1, 100 ] },
+      { "item": "22_lr", "prob": 100, "charges": [ 1, 100 ] },
+      { "item": "22_ratshot", "prob": 30, "charges": [ 1, 100 ] },
+      { "item": "270win_jsp", "prob": 25, "charges": [ 1, 100 ] },
+      { "item": "3006", "prob": 25, "charges": [ 1, 100 ] },
+      { "item": "308", "prob": 25, "charges": [ 1, 100 ] },
+      { "item": "762_54R", "prob": 10, "charges": [ 1, 100 ] },
+      { "item": "762_m43", "prob": 20, "charges": [ 1, 100 ] }
     ]
   },
   {
@@ -221,17 +221,17 @@
     "//": "Less common rifle ammo including that only used by police/paramilitary forces.",
     "subtype": "distribution",
     "entries": [
-      { "item": "300_winmag", "prob": 40 },
-      { "item": "3006fmj", "prob": 50 },
-      { "item": "556", "prob": 100 },
-      { "item": "762_51", "prob": 50 },
-      { "item": "4570_sp", "prob": 40 },
-      { "item": "4570_pen", "prob": 20 },
-      { "item": "4570_low", "prob": 40 },
-      { "item": "762_m87", "prob": 25 },
-      { "item": "8mm_civilian", "prob": 15 },
-      { "item": "300blk", "prob": 15 },
-      { "item": "300blk_ss", "prob": 10 }
+      { "item": "300_winmag", "prob": 40, "charges": [ 1, 100 ] },
+      { "item": "3006fmj", "prob": 50, "charges": [ 1, 100 ] },
+      { "item": "556", "prob": 100, "charges": [ 1, 100 ] },
+      { "item": "762_51", "prob": 50, "charges": [ 1, 100 ] },
+      { "item": "4570_sp", "prob": 40, "charges": [ 1, 100 ] },
+      { "item": "4570_pen", "prob": 20, "charges": [ 1, 100 ] },
+      { "item": "4570_low", "prob": 40, "charges": [ 1, 100 ] },
+      { "item": "762_m87", "prob": 25, "charges": [ 1, 100 ] },
+      { "item": "8mm_civilian", "prob": 15, "charges": [ 1, 100 ] },
+      { "item": "300blk", "prob": 15, "charges": [ 1, 100 ] },
+      { "item": "300blk_ss", "prob": 10, "charges": [ 1, 100 ] }
     ]
   },
   {
@@ -240,24 +240,24 @@
     "//": "Military specification rifle ammo found at military sites.",
     "subtype": "distribution",
     "entries": [
-      { "item": "12mm", "prob": 40 },
-      { "item": "3006_incendiary", "prob": 5 },
-      { "item": "3006", "prob": 20 },
-      { "item": "50_incendiary", "prob": 10 },
-      { "item": "50bmg", "prob": 30 },
-      { "item": "50match", "prob": 30 },
-      { "item": "50ss", "prob": 10 },
-      { "item": "50_mk211", "prob": 1 },
-      { "item": "556_incendiary", "prob": 15 },
-      { "item": "556", "prob": 85 },
-      { "item": "762_51_incendiary", "prob": 10 },
-      { "item": "762_51", "prob": 40 },
-      { "item": "8mm_caseless", "prob": 30 },
-      { "item": "8mm_hvp", "prob": 10 },
-      { "item": "8mm_inc", "prob": 20 },
-      { "item": "8mm_jhp", "prob": 10 },
-      { "item": "300blk", "prob": 15 },
-      { "item": "300blk_ss", "prob": 10 }
+      { "item": "12mm", "prob": 40, "charges": [ 1, 100 ] },
+      { "item": "3006_incendiary", "prob": 5, "charges": [ 1, 100 ] },
+      { "item": "3006", "prob": 20, "charges": [ 1, 100 ] },
+      { "item": "50_incendiary", "prob": 10, "charges": [ 1, 100 ] },
+      { "item": "50bmg", "prob": 30, "charges": [ 1, 100 ] },
+      { "item": "50match", "prob": 30, "charges": [ 1, 100 ] },
+      { "item": "50ss", "prob": 10, "charges": [ 1, 100 ] },
+      { "item": "50_mk211", "prob": 1, "charges": [ 1, 100 ] },
+      { "item": "556_incendiary", "prob": 15, "charges": [ 1, 100 ] },
+      { "item": "556", "prob": 85, "charges": [ 1, 100 ] },
+      { "item": "762_51_incendiary", "prob": 10, "charges": [ 1, 100 ] },
+      { "item": "762_51", "prob": 40, "charges": [ 1, 100 ] },
+      { "item": "8mm_caseless", "prob": 30, "charges": [ 1, 100 ] },
+      { "item": "8mm_hvp", "prob": 10, "charges": [ 1, 100 ] },
+      { "item": "8mm_inc", "prob": 20, "charges": [ 1, 100 ] },
+      { "item": "8mm_jhp", "prob": 10, "charges": [ 1, 100 ] },
+      { "item": "300blk", "prob": 15, "charges": [ 1, 100 ] },
+      { "item": "300blk_ss", "prob": 10, "charges": [ 1, 100 ] }
     ]
   },
   {
@@ -265,7 +265,11 @@
     "id": "ammo_rifle_obscure",
     "//": "Imported or otherwise very obscure rifle ammo.",
     "subtype": "distribution",
-    "entries": [ { "item": "545", "prob": 150 }, { "item": "545_ap", "prob": 100 }, { "item": "700nx", "prob": 70 } ]
+    "entries": [
+      { "item": "545", "prob": 150, "charges": [ 1, 100 ] },
+      { "item": "545_ap", "prob": 100, "charges": [ 1, 100 ] },
+      { "item": "700nx", "prob": 70, "charges": [ 1, 100 ] }
+    ]
   },
   {
     "type": "item_group",
@@ -280,25 +284,25 @@
     "//": "Reloaded rifle ammo balanced according to rarity.",
     "subtype": "distribution",
     "entries": [
-      { "item": "223", "prob": 60 },
-      { "item": "22_cphp", "prob": 20 },
-      { "item": "22_lr", "prob": 70 },
-      { "item": "270win_jsp", "prob": 15 },
-      { "item": "300_winmag", "prob": 15 },
-      { "item": "3006", "prob": 70 },
-      { "item": "3006fmj", "prob": 10 },
-      { "item": "3006_incendiary", "prob": 5 },
-      { "item": "308", "prob": 40 },
-      { "item": "556", "prob": 10 },
-      { "item": "556_incendiary", "prob": 5 },
-      { "item": "4570_sp", "prob": 15 },
-      { "item": "4570_pen", "prob": 5 },
-      { "item": "4570_low", "prob": 15 },
-      { "item": "762_51", "prob": 10 },
-      { "item": "762_51_incendiary", "prob": 5 },
-      { "item": "762_54R", "prob": 40 },
-      { "item": "762_m43", "prob": 20 },
-      { "item": "300blk", "prob": 10 }
+      { "item": "223", "prob": 60, "charges": [ 1, 100 ] },
+      { "item": "22_cphp", "prob": 20, "charges": [ 1, 100 ] },
+      { "item": "22_lr", "prob": 70, "charges": [ 1, 100 ] },
+      { "item": "270win_jsp", "prob": 15, "charges": [ 1, 100 ] },
+      { "item": "300_winmag", "prob": 15, "charges": [ 1, 100 ] },
+      { "item": "3006", "prob": 70, "charges": [ 1, 100 ] },
+      { "item": "3006fmj", "prob": 10, "charges": [ 1, 100 ] },
+      { "item": "3006_incendiary", "prob": 5, "charges": [ 1, 100 ] },
+      { "item": "308", "prob": 40, "charges": [ 1, 100 ] },
+      { "item": "556", "prob": 10, "charges": [ 1, 100 ] },
+      { "item": "556_incendiary", "prob": 5, "charges": [ 1, 100 ] },
+      { "item": "4570_sp", "prob": 15, "charges": [ 1, 100 ] },
+      { "item": "4570_pen", "prob": 5, "charges": [ 1, 100 ] },
+      { "item": "4570_low", "prob": 15, "charges": [ 1, 100 ] },
+      { "item": "762_51", "prob": 10, "charges": [ 1, 100 ] },
+      { "item": "762_51_incendiary", "prob": 5, "charges": [ 1, 100 ] },
+      { "item": "762_54R", "prob": 40, "charges": [ 1, 100 ] },
+      { "item": "762_m43", "prob": 20, "charges": [ 1, 100 ] },
+      { "item": "300blk", "prob": 10, "charges": [ 1, 100 ] }
     ]
   },
   {
@@ -307,21 +311,21 @@
     "//": "Blackpowder rifle ammo balanced according to rarity, additional weight for calibers that have common, manual-action firearms available in that chambering.",
     "subtype": "distribution",
     "entries": [
-      { "item": "bp_223", "prob": 60 },
-      { "item": "bp_22_cphp", "prob": 45 },
-      { "item": "bp_22_lr", "prob": 95 },
-      { "item": "bp_270win_jsp", "prob": 40 },
-      { "item": "bp_300_winmag", "prob": 40 },
-      { "item": "bp_3006", "prob": 95 },
-      { "item": "bp_3006fmj", "prob": 35 },
-      { "item": "bp_3006_incendiary", "prob": 30 },
-      { "item": "bp_308", "prob": 65 },
-      { "item": "bp_556", "prob": 10 },
-      { "item": "bp_556_incendiary", "prob": 5 },
-      { "item": "reloaded_4570_bp", "prob": 60 },
-      { "item": "bp_762_51", "prob": 35 },
-      { "item": "bp_762_51_incendiary", "prob": 30 },
-      { "item": "bp_300blk", "prob": 10 }
+      { "item": "bp_223", "prob": 60, "charges": [ 1, 100 ] },
+      { "item": "bp_22_cphp", "prob": 45, "charges": [ 1, 100 ] },
+      { "item": "bp_22_lr", "prob": 95, "charges": [ 1, 100 ] },
+      { "item": "bp_270win_jsp", "prob": 40, "charges": [ 1, 100 ] },
+      { "item": "bp_300_winmag", "prob": 40, "charges": [ 1, 100 ] },
+      { "item": "bp_3006", "prob": 95, "charges": [ 1, 100 ] },
+      { "item": "bp_3006fmj", "prob": 35, "charges": [ 1, 100 ] },
+      { "item": "bp_3006_incendiary", "prob": 30, "charges": [ 1, 100 ] },
+      { "item": "bp_308", "prob": 65, "charges": [ 1, 100 ] },
+      { "item": "bp_556", "prob": 10, "charges": [ 1, 100 ] },
+      { "item": "bp_556_incendiary", "prob": 5, "charges": [ 1, 100 ] },
+      { "item": "reloaded_4570_bp", "prob": 60, "charges": [ 1, 100 ] },
+      { "item": "bp_762_51", "prob": 35, "charges": [ 1, 100 ] },
+      { "item": "bp_762_51_incendiary", "prob": 30, "charges": [ 1, 100 ] },
+      { "item": "bp_300blk", "prob": 10, "charges": [ 1, 100 ] }
     ]
   },
   {
@@ -330,13 +334,13 @@
     "//": "Shotgun ammo commonly owned by citizens and found in many locations.",
     "subtype": "distribution",
     "entries": [
-      { "item": "shot_00", "prob": 100 },
-      { "item": "shot_bird", "prob": 70 },
-      { "item": "shot_slug", "prob": 70 },
-      { "item": "410shot_000", "prob": 50 },
-      { "item": "shot_paper_00", "prob": 30 },
-      { "item": "shot_paper_bird", "prob": 30 },
-      { "item": "shot_paper_slug", "prob": 10 }
+      { "item": "shot_00", "prob": 100, "charges": [ 1, 100 ] },
+      { "item": "shot_bird", "prob": 70, "charges": [ 1, 100 ] },
+      { "item": "shot_slug", "prob": 70, "charges": [ 1, 100 ] },
+      { "item": "410shot_000", "prob": 50, "charges": [ 1, 100 ] },
+      { "item": "shot_paper_00", "prob": 30, "charges": [ 1, 100 ] },
+      { "item": "shot_paper_bird", "prob": 30, "charges": [ 1, 100 ] },
+      { "item": "shot_paper_slug", "prob": 10, "charges": [ 1, 100 ] }
     ]
   },
   {
@@ -345,13 +349,13 @@
     "//": "Less common shotgun ammo including that only used by police/paramilitary forces.",
     "subtype": "distribution",
     "entries": [
-      { "item": "20x66_beanbag", "prob": 10 },
-      { "item": "20x66_flare", "prob": 10 },
-      { "item": "20x66_shot", "prob": 40 },
-      { "item": "20x66_slug", "prob": 20 },
-      { "item": "shot_dragon", "prob": 10 },
-      { "item": "shot_beanbag", "prob": 20 },
-      { "item": "shot_paper_dragon", "prob": 5 }
+      { "item": "20x66_beanbag", "prob": 10, "charges": [ 1, 100 ] },
+      { "item": "20x66_flare", "prob": 10, "charges": [ 1, 100 ] },
+      { "item": "20x66_shot", "prob": 40, "charges": [ 1, 100 ] },
+      { "item": "20x66_slug", "prob": 20, "charges": [ 1, 100 ] },
+      { "item": "shot_dragon", "prob": 10, "charges": [ 1, 100 ] },
+      { "item": "shot_beanbag", "prob": 20, "charges": [ 1, 100 ] },
+      { "item": "shot_paper_dragon", "prob": 5, "charges": [ 1, 100 ] }
     ]
   },
   {
@@ -360,11 +364,11 @@
     "//": "Military specification shotgun ammo found at military sites.",
     "subtype": "distribution",
     "entries": [
-      { "item": "20x66_exp", "prob": 10 },
-      { "item": "20x66_flechette", "prob": 60 },
-      { "item": "20x66_inc", "prob": 20 },
-      { "item": "shot_flechette", "prob": 100 },
-      { "item": "shot_he", "prob": 10 }
+      { "item": "20x66_exp", "prob": 10, "charges": [ 1, 100 ] },
+      { "item": "20x66_flechette", "prob": 60, "charges": [ 1, 100 ] },
+      { "item": "20x66_inc", "prob": 20, "charges": [ 1, 100 ] },
+      { "item": "shot_flechette", "prob": 100, "charges": [ 1, 100 ] },
+      { "item": "shot_he", "prob": 10, "charges": [ 1, 100 ] }
     ]
   },
   {
@@ -390,13 +394,13 @@
     "//": "Reloaded shotgun ammo balanced according to rarity.",
     "subtype": "distribution",
     "entries": [
-      { "item": "shot_00", "prob": 200 },
-      { "item": "shot_bird", "prob": 30 },
-      { "item": "shot_dragon", "prob": 20 },
-      { "item": "shot_flechette", "prob": 5 },
-      { "item": "shot_slug", "prob": 30 },
-      { "item": "shot_scrap", "prob": 80 },
-      { "item": "410shot_000", "prob": 25 }
+      { "item": "shot_00", "prob": 200, "charges": [ 1, 100 ] },
+      { "item": "shot_bird", "prob": 30, "charges": [ 1, 100 ] },
+      { "item": "shot_dragon", "prob": 20, "charges": [ 1, 100 ] },
+      { "item": "shot_flechette", "prob": 5, "charges": [ 1, 100 ] },
+      { "item": "shot_slug", "prob": 30, "charges": [ 1, 100 ] },
+      { "item": "shot_scrap", "prob": 80, "charges": [ 1, 100 ] },
+      { "item": "410shot_000", "prob": 25, "charges": [ 1, 100 ] }
     ]
   },
   {
@@ -405,14 +409,14 @@
     "//": "Blackpowder rifle ammo balanced according to rarity, additional weight for calibers that have common, manual-action firearms available in that chambering.",
     "subtype": "distribution",
     "entries": [
-      { "item": "bp_shot_00", "prob": 200 },
-      { "item": "bp_shot_bird", "prob": 30 },
-      { "item": "bp_shot_dragon", "prob": 20 },
-      { "item": "bp_shot_flechette", "prob": 5 },
-      { "item": "bp_shot_slug", "prob": 55 },
-      { "item": "shot_paper_00", "prob": 15 },
-      { "item": "shot_paper_bird", "prob": 10 },
-      { "item": "shot_paper_slug", "prob": 5 }
+      { "item": "bp_shot_00", "prob": 200, "charges": [ 1, 100 ] },
+      { "item": "bp_shot_bird", "prob": 30, "charges": [ 1, 100 ] },
+      { "item": "bp_shot_dragon", "prob": 20, "charges": [ 1, 100 ] },
+      { "item": "bp_shot_flechette", "prob": 5, "charges": [ 1, 100 ] },
+      { "item": "bp_shot_slug", "prob": 55, "charges": [ 1, 100 ] },
+      { "item": "shot_paper_00", "prob": 15, "charges": [ 1, 100 ] },
+      { "item": "shot_paper_bird", "prob": 10, "charges": [ 1, 100 ] },
+      { "item": "shot_paper_slug", "prob": 5, "charges": [ 1, 100 ] }
     ]
   },
   {
@@ -421,11 +425,11 @@
     "//": "Factory specification grenade launcher ammo intended for military use",
     "subtype": "distribution",
     "entries": [
-      { "item": "40x53mm_m1001", "prob": 10 },
-      { "item": "40x46mm_m433", "prob": 120 },
-      { "item": "40x53mm_m430a1", "prob": 75 },
-      { "item": "40x46mm_m576", "prob": 15 },
-      { "item": "40x46mm_m651", "prob": 20 }
+      { "item": "40x53mm_m1001", "prob": 10, "charges": [ 1, 100 ] },
+      { "item": "40x46mm_m433", "prob": 120, "charges": [ 1, 100 ] },
+      { "item": "40x53mm_m430a1", "prob": 75, "charges": [ 1, 100 ] },
+      { "item": "40x46mm_m576", "prob": 15, "charges": [ 1, 100 ] },
+      { "item": "40x46mm_m651", "prob": 20, "charges": [ 1, 100 ] }
     ]
   },
   {
@@ -511,14 +515,14 @@
     "//": "Ammo for police issue firearms.",
     "subtype": "distribution",
     "entries": [
-      { "item": "223", "prob": 30 },
-      { "item": "3006", "prob": 10 },
-      { "item": "40sw", "prob": 50 },
-      { "item": "45_acp", "prob": 20 },
-      { "item": "57mm", "prob": 80 },
-      { "item": "9mm", "prob": 100 },
-      { "item": "shot_00", "prob": 40 },
-      { "item": "shot_beanbag", "prob": 40 }
+      { "item": "223", "prob": 30, "charges": [ 1, 100 ] },
+      { "item": "3006", "prob": 10, "charges": [ 1, 100 ] },
+      { "item": "40sw", "prob": 50, "charges": [ 1, 100 ] },
+      { "item": "45_acp", "prob": 20, "charges": [ 1, 100 ] },
+      { "item": "57mm", "prob": 80, "charges": [ 1, 100 ] },
+      { "item": "9mm", "prob": 100, "charges": [ 1, 100 ] },
+      { "item": "shot_00", "prob": 40, "charges": [ 1, 100 ] },
+      { "item": "shot_beanbag", "prob": 40, "charges": [ 1, 100 ] }
     ]
   },
   {
@@ -528,11 +532,11 @@
     "subtype": "distribution",
     "entries": [
       { "group": "ammo_cop", "prob": 100 },
-      { "item": "300_winmag", "prob": 5 },
-      { "item": "40x46mm_m433", "prob": 5 },
-      { "item": "40x46mm_m651", "prob": 20 },
-      { "item": "556", "prob": 10 },
-      { "item": "shot_slug", "prob": 20 }
+      { "item": "300_winmag", "prob": 5, "charges": [ 1, 100 ] },
+      { "item": "40x46mm_m433", "prob": 5, "charges": [ 1, 100 ] },
+      { "item": "40x46mm_m651", "prob": 20, "charges": [ 1, 100 ] },
+      { "item": "556", "prob": 10, "charges": [ 1, 100 ] },
+      { "item": "shot_slug", "prob": 20, "charges": [ 1, 100 ] }
     ]
   },
   {
@@ -610,7 +614,7 @@
     "id": "ammo_casings_bulk",
     "type": "item_group",
     "subtype": "distribution",
-    "entries": [ { "group": "ammo_casings", "charges-min": 10, "charges-max": 20 } ]
+    "entries": [ { "group": "ammo_casings", "charges-min": 5, "charges-max": 30 } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/vending_machines.json
+++ b/data/json/itemgroups/vending_machines.json
@@ -30,12 +30,12 @@
     "subtype": "collection",
     "id": "vending_ammo",
     "entries": [
-      { "group": "ammo_pistol_common", "count-min": 3, "count-max": 8 },
-      { "group": "ammo_rifle_common", "prob": 50, "count-min": 2, "count-max": 6 },
-      { "group": "ammo_shotgun_common", "prob": 50, "count-min": 2, "count-max": 6 },
-      { "group": "ammo_pistol_rare", "prob": 20, "count-min": 1, "count-max": 2 },
-      { "group": "ammo_rifle_rare", "prob": 20, "count-min": 1, "count-max": 2 },
-      { "group": "ammo_shotgun_rare", "prob": 20, "count-min": 1, "count-max": 2 }
+      { "group": "ammo_pistol_common_full", "count-min": 3, "count-max": 8 },
+      { "group": "ammo_rifle_common_full", "prob": 50, "count-min": 2, "count-max": 6 },
+      { "group": "ammo_shotgun_common_full", "prob": 50, "count-min": 2, "count-max": 6 },
+      { "group": "ammo_pistol_rare_full", "prob": 20, "count-min": 1, "count-max": 2 },
+      { "group": "ammo_rifle_rare_full", "prob": 20, "count-min": 1, "count-max": 2 },
+      { "group": "ammo_shotgun_rare_full", "prob": 20, "count-min": 1, "count-max": 2 }
     ]
   },
   {


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change
ammo spawned always with their maximum charge, so you always got 80 .22 from a zombie.

now you get a randomized amount between 1-100. So it defaults to 50 (mathematically).
<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

## Describe alternatives you've considered
different counts for different ammo types. Shotguns getting 1-50, pistols 1-200. But maybe it gets a tweak in the future.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing
old
![grafik](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/33199510/60c807f3-642c-4cae-b1fb-830819f98080)

new
![grafik](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/33199510/87d6639d-130e-42c5-9b4d-5f45f7956105)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
