### PR TITLE
fix: fix mounting tied-up creatures, re-mounting recently-dismounted creatures

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1367,6 +1367,10 @@ void Character::mount_creature( monster &z )
             add_msg_if_player( m_good, _( "You hear your %s whir to life." ), z.get_name() );
         }
     }
+    // Unfreeze recently-dismounted horses
+    if( z.has_effect( effect_ai_waiting ) ) {
+        z.remove_effect( effect_ai_waiting );
+    }
     // some rideable mechs have night-vision
     recalc_sight_limits();
     mod_moves( -100 );

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -204,7 +204,11 @@ bool monexamine::pet_menu( monster &z )
 
     if( !z.has_flag( MF_RIDEABLE_MECH ) ) {
         if( z.has_flag( MF_PET_MOUNTABLE ) && you.can_mount( z ) ) {
-            amenu.addentry( mount, true, 'r', _( "Mount %s" ), pet_name );
+            if( z.has_effect( effect_tied ) ) {
+                amenu.addentry( mount, true, 'r', _( "Untie and mount %s" ), pet_name );
+            } else {
+                amenu.addentry( mount, true, 'r', _( "Mount %s" ), pet_name );
+            }
         } else if( !z.has_flag( MF_PET_MOUNTABLE ) ) {
             amenu.addentry( mount, false, 'r', _( "%s cannot be mounted" ), pet_name );
         } else if( z.get_size() <= you.get_size() ) {
@@ -604,7 +608,7 @@ bool Character::can_mount( const monster &critter ) const
         return false;
     }
     return ( critter.has_flag( MF_PET_MOUNTABLE ) && critter.friendly == -1 &&
-             !critter.has_effect( effect_ai_waiting ) && !critter.has_effect( effect_ridden ) ) &&
+             !critter.has_effect( effect_ridden ) ) &&
            ( ( critter.has_effect( effect_saddled ) && get_skill_level( skill_survival ) >= 1 ) ||
              get_skill_level( skill_survival ) >= 4 ) && ( critter.get_size() >= ( get_size() + 1 ) &&
                      get_weight() <= critter.get_weight() * critter.get_mountable_weight_ratio() );
@@ -612,6 +616,9 @@ bool Character::can_mount( const monster &critter ) const
 
 void monexamine::mount_pet( monster &z )
 {
+    if( z.has_effect( effect_tied ) ) {
+        untie_pet( z );
+    }
     get_avatar().mount_creature( z );
 }
 


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This fixes a few more oddities and oversights found with mount behavior.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Set it so that mounting a mountable creature that's been tied down is marked with the action "untie and mount", and have it commit the untie action when needed. This fixes a weird bug that happens when you mount a tied-down animal where it puts a duplicate rope in your inventory but then afterward still has the animal leashes when you dismount.
2. Additionally, set it so that the "AI is waiting" effect is no longer a prerequsite for mounting a horse, and set it so that mounting clears that effect. This fixes the issue where you can't re-mount a horse until you've waited a few turns after dismounting, which tends to be annoying if you ever need to dismount to go through a door, pick up an item, etc.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Not touching `Character::can_mount` because I can't tell if the "exclude mounts with the `ai_waiting` effect" was added to the check for a genuine good reason to avoid a bug I haven't found yet, or if the person who first added it didn't understand that removing the effect on dismount was maybe a good solution to whatever might've motivated them to add this check.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Got myself a horse with a leash.
3. Tied it down before mounting, the option correctly has me untie the horse before mounting and it no longer duplicates the rope.
4. Dismounted, it still shows as having the leash attached and I can opt to tie it down afterward, plus the mount option is now present immediately.
5. Re-mounted right after dismounting, no apparent problems and I can go on my merry way immediately without the horse being frozen in place or anything like that.
6. Tested just in case an NPC mounting a horse does anything weird. We sat around waiting on horseback for several minutes without issue, rode through a forest without them doing anything weird like rapidly dismounting and remounting or whatever else I was expecting, and they still happily join me in wailing on a menacing debug monster while on horseback right up until their horse finally got fed up with our bullshit, bucked the NPC off, and ran away due to being scared of the debug monster. Amusing but still normal behavior.
7. Checked affected files for astyle.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Far as I can tell, the origin of the remount problem was this PR by a deleted user (90% certain it was Dpwb), `Allow NPCs to ride horses`: https://github.com/CleverRaven/Cataclysm-DDA/pull/33550

Nothing in the PR OP gives any evidence as to why making the `controlled` effect (later replaced in BN with `ai_waitng` in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/638) a mandatory blocker for mounting a creature was needed. I do see file reviews by @BevapDin but none of them touch monexamine.cpp far as I can see, but asking them if they'd be able to recall whether the issue came up or not might be our best bet for figuring out if there ever was an important reason for that.

If an obscure bug crops up later then I guess reverting is an option, but worth trying to see what the rationale was just in case that warns us early.

Also tested DDA, as of build `2024-06-06-0252` they've still got both issues, we didn't miss any fixes there:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/7a7173bc-6457-41af-bb5d-485f5c51dbd3)
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/2cbfc9c0-0c00-4107-8a79-ec5a443889cd)
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/c1f30d00-a59c-407c-869d-10b7a64ff743)

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

For all Pull Requests:
- [ ] I wrote the PR title in conventional commit format, see above
- [ ] I ran the code formatter
- [ ] I linked any relevant issues using github keyword syntax

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
