### PR TITLE
fix: recipe scroll command scrolls both component and item info, fix support for page up/down

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -380,8 +380,6 @@ const recipe *select_crafting_recipe( int &batch_size_out )
     ctxt.register_action( "SCROLL_RECIPE_INFO_DOWN" );
     ctxt.register_action( "PAGE_UP", to_translation( "Fast scroll up" ) );
     ctxt.register_action( "PAGE_DOWN", to_translation( "Fast scroll down" ) );
-    ctxt.register_action( "SCROLL_ITEM_INFO_UP" );
-    ctxt.register_action( "SCROLL_ITEM_INFO_DOWN" );
     ctxt.register_action( "PREV_TAB" );
     ctxt.register_action( "NEXT_TAB" );
     ctxt.register_action( "FILTER" );
@@ -753,11 +751,20 @@ const recipe *select_crafting_recipe( int &batch_size_out )
         }
 
         ui_manager::redraw();
+        const int scroll_recipe_info_lines = catacurses::getmaxy( w_iteminfo ) - 4;
         const std::string action = ctxt.handle_input();
         if( action == "SCROLL_RECIPE_INFO_UP" ) {
             recipe_info_scroll -= dataLines;
+            item_info_scroll -= dataLines;
         } else if( action == "SCROLL_RECIPE_INFO_DOWN" ) {
             recipe_info_scroll += dataLines;
+            item_info_scroll += dataLines;
+        } else if( action == "PAGE_UP" ) {
+            recipe_info_scroll -= scroll_recipe_info_lines;
+            item_info_scroll -= scroll_recipe_info_lines;
+        } else if( action == "PAGE_DOWN" ) {
+            recipe_info_scroll += scroll_recipe_info_lines;
+            item_info_scroll += scroll_recipe_info_lines;
         } else if( action == "LEFT" ) {
             std::string start = subtab.cur();
             do {
@@ -765,10 +772,6 @@ const recipe *select_crafting_recipe( int &batch_size_out )
             } while( subtab.cur() != start && shown_recipes.empty_category( tab.cur(),
                      subtab.cur() != "CSC_ALL" ? subtab.cur() : "" ) );
             recalc = true;
-        } else if( action == "SCROLL_UP" ) {
-            item_info_scroll--;
-        } else if( action == "SCROLL_DOWN" ) {
-            item_info_scroll++;
         } else if( action == "PREV_TAB" ) {
             tab.prev();
             // Default ALL


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

I was asked to go ahead and fix the issue where you can't scroll item info in the recipe menu. I was initially going to port https://github.com/CleverRaven/Cataclysm-DDA/pull/44100 as Kenan linked me to that, but it turns out our problem is a lil bit different here. Only one tiny bit of that PR made it into the commit as a result.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. In crafting_gui.cpp, removed the unused, unbound bindings for `SCROLL_ITEM_INFO_UP` and `SCROLL_ITEM_INFO_DOWN`. Our root problem here is these keybinds were never ACTUALLY used later on in the `select_crafting_recipe` function, hence why they didn't do anything when bound. But, there's a less silly solution we can use here...
2. Set it so that the part of `select_crafting_recipe` that calls `recipe_info_scroll` when you hit the recipe info scrolling keys also scrolls item info. There is no reason I can think of why you'd need separate keybinds to scroll two separate parts of the UI when they're both right there on the same menu at the same time, and scrolling to the bottom of whichever is shorter doesn't affect your ability to continue scrolling the longer one.
3. Also removed calls to `SCROLL_UP` and `SCROLL_DOWN` that I assume where intended to be the item scrolling commands. They're now redundant anyway.
4. Fixed the "fast scroll" commands defined in this menu not working. This is where I opted to actually apply some of the above DDA PR, by defining `item_info_scroll_lines` as a separate value for fast scrolling, but naming it `scroll_recipe_info_lines`, and implementing it in new action registers for page up and page down instead of overriding our existing scrolling.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Going ahead and retaining a separate scrolling command for scrolling item info in the crafitng menu, and just fixing it to actually use the correct command IDs.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Found a recipe in the crafting menu (heavy rail rifle in my case) with both component and result info long enough to require scrolling.
3. Hit `[` and `]`, both info sections scroll as expected now. Page up and down also work. Seems to already scroll enough that you may need a fairly short window size for fast scrolling to have a noticeable effect? Either way, this does mean page up/down doubles as a scroll command too, more intuitive than `[` and `]`.
4. Checked affected file for astyle.

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/ac74b444-70cc-408c-80bd-041e14eebc45)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Related DDA PR: `Scroll several windows by page on pgup/pgdown keys` by @irwiss: https://github.com/CleverRaven/Cataclysm-DDA/pull/44100

That said, basically none of it except the idea of defining a value for faster scrolling was actually ported from that PR in the end, and even then it seems to not be needed as for some reason default scroll rate is fast too?

We could later on see if the vehicle menu needs scrolling support added since that PR touches it, but let's focus on fixing something that's broken for now.

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

For all Pull Requests:
- [ ] I wrote the PR title in conventional commit format, see above
- [ ] I ran the code formatter
- [ ] I linked any relevant issues using github keyword syntax

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
