### PR TITLE
feat(balance): nested gun spawns can come with speedloaders

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/everydaycarry_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/everydaycarry_guns.json
@@ -1253,7 +1253,21 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "ruger_lcr_38", "charges-min": 0, "charges-max": 5 }, { "group": "on_hand_38" } ]
+    "entries": [
+      { "item": "ruger_lcr_38", "charges-min": 0, "charges-max": 5 },
+      {
+        "distribution": [
+          {
+            "collection": [
+              { "item": "38_speedloader5", "ammo-item": "38_special", "charges": [ 0, 5 ] },
+              { "item": "38_speedloader5", "ammo-item": "38_special", "prob": 50, "charges": [ 0, 5 ] }
+            ],
+            "prob": 50
+          },
+          { "group": "on_hand_38", "prob": 50 }
+        ]
+      }
+    ]
   },
   {
     "id": "everyday_sw_610",
@@ -1261,7 +1275,19 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "sw_610", "charges-min": 0, "charges-max": 6 }, { "group": "on_hand_10mm" } ]
+    "entries": [
+      { "item": "sw_610", "charges-min": 0, "charges-max": 6 },
+      {
+        "distribution": [
+          {
+            "collection": [ { "item": "40_speedloader6", "charges": [ 0, 6 ] }, { "item": "40_speedloader6", "prob": 50, "charges": [ 0, 6 ] } ],
+            "prob": 50
+          },
+          { "group": "on_hand_40", "prob": 25 },
+          { "group": "on_hand_10mm", "prob": 25 }
+        ]
+      }
+    ]
   },
   {
     "id": "everyday_sw_619",
@@ -1269,7 +1295,18 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "sw_619", "charges-min": 0, "charges-max": 7 }, { "group": "on_hand_38" } ]
+    "entries": [
+      { "item": "sw_619", "charges-min": 0, "charges-max": 7 },
+      {
+        "distribution": [
+          {
+            "collection": [ { "item": "38_speedloader", "charges": [ 0, 7 ] }, { "item": "38_speedloader", "prob": 50, "charges": [ 0, 7 ] } ],
+            "prob": 50
+          },
+          { "group": "on_hand_357_38mixed", "prob": 50 }
+        ]
+      }
+    ]
   },
   {
     "id": "everyday_model_10_revolver",
@@ -1277,7 +1314,21 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "model_10_revolver", "charges-min": 0, "charges-max": 6 }, { "group": "on_hand_38" } ]
+    "entries": [
+      { "item": "model_10_revolver", "charges-min": 0, "charges-max": 6 },
+      {
+        "distribution": [
+          {
+            "collection": [
+              { "item": "38_speedloader6", "ammo-item": "38_special", "charges": [ 0, 6 ] },
+              { "item": "38_speedloader6", "ammo-item": "38_special", "prob": 50, "charges": [ 0, 6 ] }
+            ],
+            "prob": 50
+          },
+          { "group": "on_hand_38", "prob": 50 }
+        ]
+      }
+    ]
   },
   {
     "id": "everyday_bond_410",
@@ -1285,7 +1336,10 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "bond_410", "charges-min": 0, "charges-max": 2 }, { "group": "on_hand_45colt" } ]
+    "entries": [
+      { "item": "bond_410", "charges-min": 0, "charges-max": 2 },
+      { "distribution": [ { "group": "on_hand_45colt", "prob": 75 }, { "group": "on_hand_410shot", "prob": 25 } ] }
+    ]
   },
   {
     "id": "everyday_ruger_lcr_22",
@@ -1293,7 +1347,18 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "ruger_lcr_22", "charges-min": 0, "charges-max": 8 }, { "group": "on_hand_22" } ]
+    "entries": [
+      { "item": "ruger_lcr_22", "charges-min": 0, "charges-max": 8 },
+      {
+        "distribution": [
+          {
+            "collection": [ { "item": "22_speedloader8", "charges": [ 0, 8 ] }, { "item": "22_speedloader8", "prob": 50, "charges": [ 0, 8 ] } ],
+            "prob": 50
+          },
+          { "group": "on_hand_22", "prob": 50 }
+        ]
+      }
+    ]
   },
   {
     "id": "everyday_ruger_redhawk",
@@ -1301,7 +1366,18 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "ruger_redhawk", "charges-min": 0, "charges-max": 6 }, { "group": "on_hand_44" } ]
+    "entries": [
+      { "item": "ruger_redhawk", "charges-min": 0, "charges-max": 6 },
+      {
+        "distribution": [
+          {
+            "collection": [ { "item": "44_speedloader6", "charges": [ 0, 6 ] }, { "item": "44_speedloader6", "prob": 50, "charges": [ 0, 6 ] } ],
+            "prob": 50
+          },
+          { "group": "on_hand_44", "prob": 50 }
+        ]
+      }
+    ]
   },
   {
     "id": "everyday_sw_500",
@@ -1309,7 +1385,18 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "sw_500", "charges-min": 0, "charges-max": 5 }, { "group": "on_hand_500" } ]
+    "entries": [
+      { "item": "sw_500", "charges-min": 0, "charges-max": 5 },
+      {
+        "distribution": [
+          {
+            "collection": [ { "item": "500_speedloader5", "charges": [ 0, 5 ] }, { "item": "500_speedloader5", "prob": 50, "charges": [ 0, 5 ] } ],
+            "prob": 50
+          },
+          { "group": "on_hand_500", "prob": 50 }
+        ]
+      }
+    ]
   },
   {
     "id": "everyday_sw629",
@@ -1317,7 +1404,18 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "sw629", "charges-min": 0, "charges-max": 6 }, { "group": "on_hand_44" } ]
+    "entries": [
+      { "item": "sw629", "charges-min": 0, "charges-max": 6 },
+      {
+        "distribution": [
+          {
+            "collection": [ { "item": "44_speedloader6", "charges": [ 0, 6 ] }, { "item": "44_speedloader6", "prob": 50, "charges": [ 0, 6 ] } ],
+            "prob": 50
+          },
+          { "group": "on_hand_44", "prob": 50 }
+        ]
+      }
+    ]
   },
   {
     "id": "everyday_bfr",
@@ -1341,7 +1439,20 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "raging_bull" }, { "group": "on_hand_454" } ]
+    "entries": [
+      { "item": "raging_bull", "charges-min": 0, "charges-max": 5 },
+      {
+        "distribution": [
+          {
+            "collection": [ { "item": "454_speedloader5", "charges": [ 0, 5 ] }, { "item": "454_speedloader5", "prob": 50, "charges": [ 0, 5 ] } ],
+            "prob": 50
+          },
+          { "group": "on_hand_454", "prob": 25 },
+          { "group": "on_hand_410shot", "prob": 12 },
+          { "group": "on_hand_45colt", "prob": 13 }
+        ]
+      }
+    ]
   },
   {
     "id": "everyday_raging_judge",
@@ -1349,7 +1460,20 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "raging_judge" }, { "group": "on_hand_454" } ]
+    "entries": [
+      { "item": "raging_judge", "charges-min": 0, "charges-max": 6 },
+      {
+        "distribution": [
+          {
+            "collection": [ { "item": "454_speedloader6", "charges": [ 0, 6 ] }, { "item": "454_speedloader6", "prob": 50, "charges": [ 0, 6 ] } ],
+            "prob": 50
+          },
+          { "group": "on_hand_454", "prob": 25 },
+          { "group": "on_hand_410shot", "prob": 12 },
+          { "group": "on_hand_45colt", "prob": 13 }
+        ]
+      }
+    ]
   },
   {
     "id": "everyday_cop_38",
@@ -1357,7 +1481,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "cop_38", "charges-min": 0, "charges-max": 4 }, { "group": "on_hand_38" } ]
+    "entries": [ { "item": "cop_38", "charges-min": 0, "charges-max": 4 }, { "group": "on_hand_357_38mixed" } ]
   },
   {
     "id": "everyday_lemat_revolver",
@@ -1389,7 +1513,21 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "marlin_9a", "charges-min": 0, "charges-max": 19 }, { "group": "on_hand_22" } ]
+    "entries": [
+      { "item": "marlin_9a", "charges-min": 0, "charges-max": 19 },
+      {
+        "distribution": [
+          {
+            "collection": [
+              { "item": "marlin_tubeloader", "charges": [ 0, 19 ] },
+              { "item": "marlin_tubeloader", "prob": 50, "charges": [ 0, 19 ] }
+            ],
+            "prob": 50
+          },
+          { "group": "on_hand_22", "prob": 50 }
+        ]
+      }
+    ]
   },
   {
     "id": "everyday_mosin44",
@@ -1397,7 +1535,18 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "mosin44", "charges-min": 0, "charges-max": 5 }, { "group": "on_hand_762R" } ]
+    "entries": [
+      { "item": "mosin44", "charges-min": 0, "charges-max": 5 },
+      {
+        "distribution": [
+          {
+            "collection": [ { "item": "762R_clip", "charges": [ 0, 5 ] }, { "item": "762R_clip", "prob": 50, "charges": [ 0, 5 ] } ],
+            "prob": 50
+          },
+          { "group": "on_hand_762R", "prob": 50 }
+        ]
+      }
+    ]
   },
   {
     "id": "everyday_mosin91_30",
@@ -1405,7 +1554,18 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "mosin91_30", "charges-min": 0, "charges-max": 5 }, { "group": "on_hand_762R" } ]
+    "entries": [
+      { "item": "mosin91_30", "charges-min": 0, "charges-max": 5 },
+      {
+        "distribution": [
+          {
+            "collection": [ { "item": "762R_clip", "charges": [ 0, 5 ] }, { "item": "762R_clip", "prob": 50, "charges": [ 0, 5 ] } ],
+            "prob": 50
+          },
+          { "group": "on_hand_762R", "prob": 50 }
+        ]
+      }
+    ]
   },
   {
     "id": "everyday_remington700_270",
@@ -1429,7 +1589,18 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "sks", "charges-min": 0, "charges-max": 10 }, { "group": "on_hand_762" } ]
+    "entries": [
+      { "item": "sks", "charges-min": 0, "charges-max": 10 },
+      {
+        "distribution": [
+          {
+            "collection": [ { "item": "762x39_clip", "charges": [ 0, 10 ] }, { "item": "762x39_clip", "prob": 50, "charges": [ 0, 10 ] } ],
+            "prob": 50
+          },
+          { "group": "on_hand_762", "prob": 50 }
+        ]
+      }
+    ]
   },
   {
     "id": "everyday_win70",
@@ -1477,7 +1648,18 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "m1903", "charges-min": 0, "charges-max": 5 }, { "group": "on_hand_3006" } ]
+    "entries": [
+      { "item": "m1903", "charges-min": 0, "charges-max": 5 },
+      {
+        "distribution": [
+          {
+            "collection": [ { "item": "3006_clip", "charges": [ 0, 5 ] }, { "item": "3006_clip", "prob": 50, "charges": [ 0, 5 ] } ],
+            "prob": 50
+          },
+          { "group": "on_hand_3006", "prob": 50 }
+        ]
+      }
+    ]
   },
   {
     "id": "everyday_mosin44_ebr",
@@ -1485,7 +1667,18 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "mosin44_ebr", "prob": 1, "charges-min": 0, "charges-max": 5 }, { "group": "on_hand_762R" } ]
+    "entries": [
+      { "item": "mosin44_ebr", "prob": 1, "charges-min": 0, "charges-max": 5 },
+      {
+        "distribution": [
+          {
+            "collection": [ { "item": "762R_clip", "charges": [ 0, 5 ] }, { "item": "762R_clip", "prob": 50, "charges": [ 0, 5 ] } ],
+            "prob": 50
+          },
+          { "group": "on_hand_762R", "prob": 50 }
+        ]
+      }
+    ]
   },
   {
     "id": "everyday_mosin91_30_ebr",
@@ -1493,7 +1686,18 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "mosin91_30_ebr", "prob": 1, "charges-min": 0, "charges-max": 5 }, { "group": "on_hand_762R" } ]
+    "entries": [
+      { "item": "mosin91_30_ebr", "prob": 1, "charges-min": 0, "charges-max": 5 },
+      {
+        "distribution": [
+          {
+            "collection": [ { "item": "762R_clip", "charges": [ 0, 5 ] }, { "item": "762R_clip", "prob": 50, "charges": [ 0, 5 ] } ],
+            "prob": 50
+          },
+          { "group": "on_hand_762R", "prob": 50 }
+        ]
+      }
+    ]
   },
   {
     "id": "everyday_savage_111f",
@@ -1617,7 +1821,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "trex_gun", "charges-min": 0, "charges-max": 1 }, { "group": "on_hand_700nx" } ]
+    "entries": [ { "item": "trex_gun", "charges-min": 0, "charges-max": 2 }, { "group": "on_hand_700nx" } ]
   },
   {
     "id": "everyday_mossberg_500",

--- a/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
@@ -135,7 +135,12 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "ruger_lcr_38", "charges-min": 0, "charges-max": 5 }, { "group": "on_hand_38" } ]
+    "entries": [
+      { "item": "ruger_lcr_38", "charges-min": 0, "charges-max": 5 },
+      { "item": "38_speedloader5", "ammo-item": "38_special", "prob": 50, "charges": [ 0, 5 ] },
+      { "item": "38_speedloader5", "ammo-item": "38_special", "prob": 25, "charges": [ 0, 5 ] },
+      { "group": "on_hand_38" }
+    ]
   },
   {
     "id": "nested_sig_mosquito",
@@ -169,7 +174,12 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "sw_610", "charges-min": 0, "charges-max": 6 }, { "group": "on_hand_10mm" } ]
+    "entries": [
+      { "item": "sw_610", "charges-min": 0, "charges-max": 6 },
+      { "item": "40_speedloader6", "prob": 50, "charges": [ 0, 6 ] },
+      { "item": "40_speedloader6", "prob": 25, "charges": [ 0, 6 ] },
+      { "distribution": [ { "group": "on_hand_40", "prob": 50 }, { "group": "on_hand_10mm", "prob": 50 } ] }
+    ]
   },
   {
     "id": "nested_sw_619",
@@ -177,7 +187,12 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "sw_619", "charges-min": 0, "charges-max": 7 }, { "group": "on_hand_38" } ]
+    "entries": [
+      { "item": "sw_619", "charges-min": 0, "charges-max": 7 },
+      { "item": "38_speedloader", "prob": 50, "charges": [ 0, 7 ] },
+      { "item": "38_speedloader", "prob": 25, "charges": [ 0, 7 ] },
+      { "group": "on_hand_357_38mixed" }
+    ]
   },
   {
     "id": "nested_model_10_revolver",
@@ -185,7 +200,12 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "model_10_revolver", "charges-min": 0, "charges-max": 6 }, { "group": "on_hand_38" } ]
+    "entries": [
+      { "item": "model_10_revolver", "charges-min": 0, "charges-max": 6 },
+      { "item": "38_speedloader6", "ammo-item": "38_special", "prob": 50, "charges": [ 0, 6 ] },
+      { "item": "38_speedloader6", "ammo-item": "38_special", "prob": 25, "charges": [ 0, 6 ] },
+      { "group": "on_hand_38" }
+    ]
   },
   {
     "id": "nested_taurus_spectrum",
@@ -479,7 +499,10 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "bond_410", "charges-min": 0, "charges-max": 2 }, { "group": "on_hand_45colt" } ]
+    "entries": [
+      { "item": "bond_410", "charges-min": 0, "charges-max": 2 },
+      { "distribution": [ { "group": "on_hand_45colt", "prob": 75 }, { "group": "on_hand_410shot", "prob": 25 } ] }
+    ]
   },
   {
     "id": "nested_deagle_44",
@@ -526,7 +549,12 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "ruger_lcr_22", "charges-min": 0, "charges-max": 8 }, { "group": "on_hand_22" } ]
+    "entries": [
+      { "item": "ruger_lcr_22", "charges-min": 0, "charges-max": 8 },
+      { "item": "22_speedloader8", "prob": 50, "charges": [ 0, 8 ] },
+      { "item": "22_speedloader8", "prob": 25, "charges": [ 0, 8 ] },
+      { "group": "on_hand_22" }
+    ]
   },
   {
     "id": "nested_ruger_redhawk",
@@ -534,7 +562,12 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "ruger_redhawk", "charges-min": 0, "charges-max": 6 }, { "group": "on_hand_44" } ]
+    "entries": [
+      { "item": "ruger_redhawk", "charges-min": 0, "charges-max": 6 },
+      { "item": "44_speedloader6", "prob": 50, "charges": [ 0, 6 ] },
+      { "item": "44_speedloader6", "prob": 25, "charges": [ 0, 6 ] },
+      { "group": "on_hand_44" }
+    ]
   },
   {
     "id": "nested_sig_40",
@@ -568,7 +601,12 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "sw_500", "charges-min": 0, "charges-max": 5 }, { "group": "on_hand_500" } ]
+    "entries": [
+      { "item": "sw_500", "charges-min": 0, "charges-max": 5 },
+      { "item": "500_speedloader5", "prob": 50, "charges": [ 0, 5 ] },
+      { "item": "500_speedloader5", "prob": 25, "charges": [ 0, 5 ] },
+      { "group": "on_hand_500" }
+    ]
   },
   {
     "id": "nested_sw629",
@@ -576,7 +614,12 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "sw629", "charges-min": 0, "charges-max": 6 }, { "group": "on_hand_44" } ]
+    "entries": [
+      { "item": "sw629", "charges-min": 0, "charges-max": 6 },
+      { "item": "44_speedloader6", "prob": 50, "charges": [ 0, 6 ] },
+      { "item": "44_speedloader6", "prob": 25, "charges": [ 0, 6 ] },
+      { "group": "on_hand_44" }
+    ]
   },
   {
     "id": "nested_usp_45",
@@ -678,7 +721,18 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "raging_bull" }, { "group": "on_hand_454" } ]
+    "entries": [
+      { "item": "raging_bull", "charges-min": 0, "charges-max": 5 },
+      { "item": "454_speedloader5", "prob": 50, "charges": [ 0, 5 ] },
+      { "item": "454_speedloader5", "prob": 25, "charges": [ 0, 5 ] },
+      {
+        "distribution": [
+          { "group": "on_hand_454", "prob": 50 },
+          { "group": "on_hand_410shot", "prob": 25 },
+          { "group": "on_hand_45colt", "prob": 25 }
+        ]
+      }
+    ]
   },
   {
     "id": "nested_raging_judge",
@@ -686,7 +740,18 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "raging_judge" }, { "group": "on_hand_454" } ]
+    "entries": [
+      { "item": "raging_judge", "charges-min": 0, "charges-max": 6 },
+      { "item": "454_speedloader6", "prob": 50, "charges": [ 0, 6 ] },
+      { "item": "454_speedloader6", "prob": 25, "charges": [ 0, 6 ] },
+      {
+        "distribution": [
+          { "group": "on_hand_454", "prob": 50 },
+          { "group": "on_hand_410shot", "prob": 25 },
+          { "group": "on_hand_45colt", "prob": 25 }
+        ]
+      }
+    ]
   },
   {
     "id": "nested_tokarev",
@@ -736,7 +801,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "cop_38", "charges-min": 0, "charges-max": 4 }, { "group": "on_hand_38" } ]
+    "entries": [ { "item": "cop_38", "charges-min": 0, "charges-max": 4 }, { "group": "on_hand_357_38mixed" } ]
   },
   {
     "id": "nested_m1911-460",
@@ -1132,7 +1197,12 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "marlin_9a", "charges-min": 0, "charges-max": 19 }, { "group": "on_hand_22" } ]
+    "entries": [
+      { "item": "marlin_9a", "charges-min": 0, "charges-max": 19 },
+      { "item": "marlin_tubeloader", "prob": 50, "charges": [ 0, 19 ] },
+      { "item": "marlin_tubeloader", "prob": 25, "charges": [ 0, 19 ] },
+      { "group": "on_hand_22" }
+    ]
   },
   {
     "id": "nested_mosin44",
@@ -1140,7 +1210,12 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "mosin44", "charges-min": 0, "charges-max": 5 }, { "group": "on_hand_762R" } ]
+    "entries": [
+      { "item": "mosin44", "charges-min": 0, "charges-max": 5 },
+      { "item": "762R_clip", "prob": 50, "charges": [ 0, 5 ] },
+      { "item": "762R_clip", "prob": 25, "charges": [ 0, 5 ] },
+      { "group": "on_hand_762R" }
+    ]
   },
   {
     "id": "nested_mosin91_30",
@@ -1148,7 +1223,12 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "mosin91_30", "charges-min": 0, "charges-max": 5 }, { "group": "on_hand_762R" } ]
+    "entries": [
+      { "item": "mosin91_30", "charges-min": 0, "charges-max": 5 },
+      { "item": "762R_clip", "prob": 50, "charges": [ 0, 5 ] },
+      { "item": "762R_clip", "prob": 25, "charges": [ 0, 5 ] },
+      { "group": "on_hand_762R" }
+    ]
   },
   {
     "id": "nested_remington700_270",
@@ -1198,7 +1278,12 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "sks", "charges-min": 0, "charges-max": 10 }, { "group": "on_hand_762" } ]
+    "entries": [
+      { "item": "sks", "charges-min": 0, "charges-max": 10 },
+      { "item": "762x39_clip", "prob": 50, "charges": [ 0, 10 ] },
+      { "item": "762x39_clip", "prob": 25, "charges": [ 0, 10 ] },
+      { "group": "on_hand_762" }
+    ]
   },
   {
     "id": "nested_win70",
@@ -1324,7 +1409,12 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "m1903", "charges-min": 0, "charges-max": 5 }, { "group": "on_hand_3006" } ]
+    "entries": [
+      { "item": "m1903", "charges-min": 0, "charges-max": 5 },
+      { "item": "3006_clip", "prob": 50, "charges": [ 0, 5 ] },
+      { "item": "3006_clip", "prob": 25, "charges": [ 0, 5 ] },
+      { "group": "on_hand_3006" }
+    ]
   },
   {
     "id": "nested_m1918",
@@ -1345,7 +1435,12 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "mosin44_ebr", "prob": 1, "charges-min": 0, "charges-max": 5 }, { "group": "on_hand_762R" } ]
+    "entries": [
+      { "item": "mosin44_ebr", "charges-min": 0, "charges-max": 5 },
+      { "item": "762R_clip", "prob": 50, "charges": [ 0, 5 ] },
+      { "item": "762R_clip", "prob": 25, "charges": [ 0, 5 ] },
+      { "group": "on_hand_762R" }
+    ]
   },
   {
     "id": "nested_mosin91_30_ebr",
@@ -1353,7 +1448,12 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "mosin91_30_ebr", "prob": 1, "charges-min": 0, "charges-max": 5 }, { "group": "on_hand_762R" } ]
+    "entries": [
+      { "item": "mosin91_30_ebr", "charges-min": 0, "charges-max": 5 },
+      { "item": "762R_clip", "prob": 50, "charges": [ 0, 5 ] },
+      { "item": "762R_clip", "prob": 25, "charges": [ 0, 5 ] },
+      { "group": "on_hand_762R" }
+    ]
   },
   {
     "id": "nested_savage_111f",
@@ -1751,7 +1851,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "trex_gun", "charges-min": 0, "charges-max": 1 }, { "group": "on_hand_700nx" } ]
+    "entries": [ { "item": "trex_gun", "charges-min": 0, "charges-max": 2 }, { "group": "on_hand_700nx" } ]
   },
   {
     "id": "nested_arx160",


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content, mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This implements an idea that came up in the BN discord, allowing for nested gun spawns of revolvers and the like to potentially come with speedloaders.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Added speedloader spawns to nested guns in storage. As with spawns for guns that come with magazines they can spawn with both the loose ammo and speedloaders, just the odds of getting a speedloader aren't 100% in this case.
2. Implemented speedloader spawns for carried gun spawns. In this case, for guns that can potentially spawn with speedloaders, carried guns will randomly pick between spawning 1-2 speedloaders or just loose ammo, but not both. Net effect is this drives average ammo finds on random bodies down a bit for affected, but up a bit for stored guns when combined with the above.
3. Misc: The Bond Arms Derringer now picks between loose .45 Colt ammo or loose .410 ammo at random instead of always spawning with .45 Colt, the Raging Bull/Judge revolvers now pick between the above options or .454 Casull, while the S&W 619 and COP .357 Derringer now picks between .38 and .357 for their loose ammo since they accept either.
4. Misc: Fixed T-rex gun only ever spawning half-loaded since it was converted to a double-barrel, in the nested spawn version.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. For now I didn't mess around with adding shotgun speedloaders to the nested gun spawns, because right now all shotshell tubes require the gun to have the speedloader chute installed, and none come with it as a default or integral mod. Rigging it so a shotgun can sometimes have a speed chute installed, and only spawning speedloaders if so, is something a lil more complicated so I'll save that for a later PR.
2. Hacking it in via having spawns of speed tubes come with an uninstalled speed chute could work but ech, would be less than ideal I feel.
3. Lowering the odds of speedloaders spawning on carried guns from 50/50 odds to more like only a third of the time?

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Ported file changes over to playthrough release and load-tested.
3. Did an itemgroup test in debug to confirm that the .38 LCR and Model 10 were only spawning .38 Special in their speedloaders and not .357 Magnum, since those guns can't accept .357.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Additional plans for after this and related PR https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4805 are merged:
1. As mentioned, enabling for some way to potentially spawn some shotguns with a speed chute pre-installed, and only spawning shotshell tubes if the gun spawned with a chute installed.
2. Making more of the carried guns choose between either spawning with bonus mags or spawning with only loose ammo. Would cut down a lil on ammo cornucopias and stanag spam.
3. I also want to test `ammo-group`, something I spotted in documentation, so see if I can randomize the ammo loaded in guns and mags without any excess hassle.

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  

For all Pull Requests:
- [ ] I wrote the PR title in conventional commit format, see above
- [ ] I ran the code formatter
- [ ] I linked any relevant issues using github keyword syntax

If this is a C++ PR that modifies JSON loading or behavior:
- [ ] Document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
- [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
- [ ] If applicable, add checks on game load that would validate the loaded data.
- [ ] If it modifies format of save files, please add migration from the old format.

If this is a PR that modifies build process or code organization:
- [ ] Please document the changes in the appropriate location in the `doc/` folder.
- [ ] If documentation for this feature or process does not exist, please write it.
- [ ] If the change alters versions of software required to build or work with the game, please document it.

If this is a PR that removes JSON entities:
- [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
