### PR TITLE
fix: Correctly set yugg harvest to mutant_meatslug instead of meatslug.

### DIFF
--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -891,7 +891,7 @@
     "melee_cut": 8,
     "dodge": 1,
     "armor_bash": 6,
-    "harvest": "meatslug",
+    "harvest": "mutant_meatslug",
     "special_attacks": [ [ "GENE_STING", 20 ] ],
     "death_function": [ "NORMAL" ],
     "flags": [ "SEES", "SMELLS", "HEARS", "BASHES", "DESTROYS", "POISON", "VENOM", "NO_BREATHE", "CAN_DIG" ]


### PR DESCRIPTION
## Purpose of change

Yuggs were giving full animal meat, given that they have a 'gene sting' attack I think it's safe to consider them mutants. This fixes the harvest list to use the mutant_meatslug harvest group instead of the meatslug list. Fixes #4675.