### PR TITLE
feat(balance): nested gun/mag spawns vary in ammo loaded, several fixes

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/everydaycarry_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/everydaycarry_guns.json
@@ -6,7 +6,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "glock_17", "charges-min": 0, "charges-max": 15 },
+      { "item": "glock_17", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
       { "group": "nested_glock17_mag" },
       { "group": "nested_glock17_mag", "prob": 50 }
     ]
@@ -18,7 +18,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "glock_19", "charges-min": 0, "charges-max": 15 },
+      { "item": "glock_19", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
       { "group": "nested_glock19_mag" },
       { "group": "nested_glock19_mag", "prob": 50 }
     ]
@@ -30,7 +30,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "glock_21", "charges-min": 0, "charges-max": 15 },
+      { "item": "glock_21", "ammo-group": "on_hand_45", "charges": [ 0, 15 ] },
       { "group": "nested_glock21_mag" },
       { "group": "nested_glock21_mag", "prob": 50 }
     ]
@@ -42,7 +42,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "glock_22", "charges-min": 0, "ammo-item": "40sw", "charges-max": 15 },
+      { "item": "glock_22", "ammo-group": "on_hand_40", "charges": [ 0, 15 ] },
       { "group": "nested_glock22_mag" },
       { "group": "nested_glock22_mag", "prob": 50 }
     ]
@@ -54,7 +54,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "glock_31", "charges-min": 0, "charges-max": 15 },
+      { "item": "glock_31", "ammo-group": "on_hand_357sig", "charges": [ 0, 15 ] },
       { "group": "nested_glock22_mag" },
       { "group": "nested_glock22_mag", "prob": 50 }
     ]
@@ -66,7 +66,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m1911", "charges-min": 0, "charges-max": 7 },
+      { "item": "m1911", "ammo-group": "on_hand_45", "charges": [ 0, 7 ] },
       { "group": "nested_m1911_mag" },
       { "group": "nested_m1911_mag", "prob": 50 }
     ]
@@ -78,7 +78,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m1911_MEU", "charges-min": 0, "charges-max": 7 },
+      { "item": "m1911_MEU", "ammo-group": "on_hand_45", "charges": [ 0, 7 ] },
       { "group": "nested_m1911_mag" },
       { "group": "nested_m1911_mag", "prob": 50 }
     ]
@@ -90,7 +90,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m9", "charges-min": 0, "charges-max": 15 },
+      { "item": "m9", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
       { "group": "nested_m9_mag" },
       { "group": "nested_m9_mag", "prob": 50 }
     ]
@@ -101,7 +101,11 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "px4", "charges-min": 0, "charges-max": 15 }, { "item": "px4mag" }, { "item": "px4mag", "prob": 50 } ]
+    "entries": [
+      { "item": "px4", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
+      { "item": "px4mag", "ammo-group": "on_hand_9mm" },
+      { "item": "px4mag", "ammo-group": "on_hand_9mm", "prob": 50 }
+    ]
   },
   {
     "id": "everyday_px4_40",
@@ -110,9 +114,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "px4_40", "charges-min": 0, "charges-max": 15 },
-      { "item": "px4_40mag" },
-      { "item": "px4_40mag", "prob": 50 }
+      { "item": "px4_40", "ammo-group": "on_hand_40", "charges": [ 0, 15 ] },
+      { "item": "px4_40mag", "ammo-group": "on_hand_40" },
+      { "item": "px4_40mag", "ammo-group": "on_hand_40", "prob": 50 }
     ]
   },
   {
@@ -122,9 +126,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "sig_mosquito", "charges-min": 0, "charges-max": 10 },
-      { "item": "mosquitomag" },
-      { "item": "mosquitomag", "prob": 50 }
+      { "item": "sig_mosquito", "ammo-group": "on_hand_22", "charges": [ 0, 10 ] },
+      { "item": "mosquitomag", "ammo-group": "on_hand_22" },
+      { "item": "mosquitomag", "ammo-group": "on_hand_22", "prob": 50 }
     ]
   },
   {
@@ -133,7 +137,11 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "sw_22", "charges-min": 0, "charges-max": 10 }, { "item": "sw22mag" }, { "item": "sw22mag", "prob": 50 } ]
+    "entries": [
+      { "item": "sw_22", "ammo-group": "on_hand_22", "charges": [ 0, 10 ] },
+      { "item": "sw22mag", "ammo-group": "on_hand_22" },
+      { "item": "sw22mag", "ammo-group": "on_hand_22", "prob": 50 }
+    ]
   },
   {
     "id": "everyday_taurus_spectrum",
@@ -142,9 +150,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "taurus_spectrum", "charges-min": 0, "charges-max": 6 },
-      { "item": "taurus_spectrum_mag" },
-      { "item": "taurus_spectrum_mag", "prob": 50 }
+      { "item": "taurus_spectrum", "ammo-group": "on_hand_380", "charges": [ 0, 6 ] },
+      { "item": "taurus_spectrum_mag", "ammo-group": "on_hand_380" },
+      { "item": "taurus_spectrum_mag", "ammo-group": "on_hand_380", "prob": 50 }
     ]
   },
   {
@@ -154,9 +162,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "p226_357sig", "charges-min": 0, "charges-max": 12 },
-      { "item": "p226mag_12rd_357sig" },
-      { "item": "p226mag_12rd_357sig", "prob": 50 }
+      { "item": "p226_357sig", "ammo-group": "on_hand_357sig", "charges": [ 0, 12 ] },
+      { "item": "p226mag_12rd_357sig", "ammo-group": "on_hand_357sig" },
+      { "item": "p226mag_12rd_357sig", "ammo-group": "on_hand_357sig", "prob": 50 }
     ]
   },
   {
@@ -166,9 +174,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "p320_357sig", "charges-min": 0, "charges-max": 13 },
-      { "item": "p320mag_13rd_357sig" },
-      { "item": "p320mag_13rd_357sig", "prob": 50 }
+      { "item": "p320_357sig", "ammo-group": "on_hand_357sig", "charges": [ 0, 13 ] },
+      { "item": "p320mag_13rd_357sig", "ammo-group": "on_hand_357sig" },
+      { "item": "p320mag_13rd_357sig", "ammo-group": "on_hand_357sig", "prob": 50 }
     ]
   },
   {
@@ -177,7 +185,11 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "kp32", "charges-min": 0, "charges-max": 7 }, { "item": "kp32mag" }, { "item": "kp32mag", "prob": 50 } ]
+    "entries": [
+      { "item": "kp32", "ammo-group": "on_hand_32", "charges": [ 0, 7 ] },
+      { "item": "kp32mag", "ammo-group": "on_hand_32" },
+      { "item": "kp32mag", "ammo-group": "on_hand_32", "prob": 50 }
+    ]
   },
   {
     "id": "everyday_kp3at",
@@ -185,7 +197,11 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "kp3at", "charges-min": 0, "charges-max": 6 }, { "item": "kp3atmag" }, { "item": "kp3atmag", "prob": 50 } ]
+    "entries": [
+      { "item": "kp3at", "ammo-group": "on_hand_380", "charges": [ 0, 6 ] },
+      { "item": "kp3atmag", "ammo-group": "on_hand_380" },
+      { "item": "kp3atmag", "ammo-group": "on_hand_380", "prob": 50 }
+    ]
   },
   {
     "id": "everyday_rugerlcp",
@@ -194,9 +210,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "rugerlcp", "charges-min": 0, "charges-max": 6 },
-      { "item": "rugerlcpmag" },
-      { "item": "rugerlcpmag", "prob": 50 }
+      { "item": "rugerlcp", "ammo-group": "on_hand_380", "charges": [ 0, 6 ] },
+      { "item": "rugerlcpmag", "ammo-group": "on_hand_380" },
+      { "item": "rugerlcpmag", "ammo-group": "on_hand_380", "prob": 50 }
     ]
   },
   {
@@ -205,7 +221,11 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "kpf9", "charges-min": 0, "charges-max": 7 }, { "item": "kpf9mag" }, { "item": "kpf9mag", "prob": 50 } ]
+    "entries": [
+      { "item": "kpf9", "ammo-group": "on_hand_9mm", "charges": [ 0, 7 ] },
+      { "item": "kpf9mag", "ammo-group": "on_hand_9mm" },
+      { "item": "kpf9mag", "ammo-group": "on_hand_9mm", "prob": 50 }
+    ]
   },
   {
     "id": "everyday_hi_power_9mm",
@@ -214,7 +234,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hi_power_9mm", "charges-min": 0, "charges-max": 15 },
+      { "item": "hi_power_9mm", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
       { "group": "nested_hi_power_9mm_mag" },
       { "group": "nested_hi_power_9mm_mag", "prob": 50 }
     ]
@@ -226,9 +246,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hi_power_40", "charges-min": 0, "charges-max": 10 },
-      { "item": "bhp40mag" },
-      { "item": "bhp40mag", "prob": 50 }
+      { "item": "hi_power_40", "ammo-group": "on_hand_40", "charges": [ 0, 10 ] },
+      { "item": "bhp40mag", "ammo-group": "on_hand_40" },
+      { "item": "bhp40mag", "ammo-group": "on_hand_40", "prob": 50 }
     ]
   },
   {
@@ -238,9 +258,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "walther_p38", "charges-min": 0, "charges-max": 8 },
-      { "item": "p38mag" },
-      { "item": "p38mag", "prob": 50 }
+      { "item": "walther_p38", "ammo-group": "on_hand_9mm", "charges": [ 0, 8 ] },
+      { "item": "p38mag", "ammo-group": "on_hand_9mm" },
+      { "item": "p38mag", "ammo-group": "on_hand_9mm", "prob": 50 }
     ]
   },
   {
@@ -250,7 +270,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "walther_ppq_9mm", "charges-min": 0, "charges-max": 17 },
+      { "item": "walther_ppq_9mm", "ammo-group": "on_hand_9mm", "charges": [ 0, 17 ] },
       { "group": "nested_walther_ppq_9mm_mag" },
       { "group": "nested_walther_ppq_9mm_mag", "prob": 50 }
     ]
@@ -262,7 +282,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "walther_ppq_40", "charges-min": 0, "charges-max": 14 },
+      { "item": "walther_ppq_40", "ammo-group": "on_hand_40", "charges": [ 0, 14 ] },
       { "group": "nested_walther_ppq_40_mag" },
       { "group": "nested_walther_ppq_40_mag", "prob": 50 }
     ]
@@ -274,9 +294,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "walther_ppq_45", "charges-min": 0, "charges-max": 12 },
-      { "item": "ppq45mag" },
-      { "item": "ppq45mag", "prob": 50 }
+      { "item": "walther_ppq_45", "ammo-group": "on_hand_45", "charges": [ 0, 12 ] },
+      { "item": "ppq45mag", "ammo-group": "on_hand_45" },
+      { "item": "ppq45mag", "ammo-group": "on_hand_45", "prob": 50 }
     ]
   },
   {
@@ -286,7 +306,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hptc9", "charges-min": 0, "charges-max": 15 },
+      { "item": "hptc9", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
       { "group": "nested_hptc9_mag" },
       { "group": "nested_hptc9_mag", "prob": 50 }
     ]
@@ -298,7 +318,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hptcf380", "charges-min": 0, "charges-max": 10 },
+      { "item": "hptcf380", "ammo-group": "on_hand_380", "charges": [ 0, 10 ] },
       { "group": "nested_hptcf380_mag" },
       { "group": "nested_hptcf380_mag", "prob": 50 }
     ]
@@ -310,9 +330,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hptjcp", "charges-min": 0, "charges-max": 10 },
-      { "item": "hptjcpmag" },
-      { "item": "hptjcpmag", "prob": 50 }
+      { "item": "hptjcp", "ammo-group": "on_hand_40", "charges": [ 0, 10 ] },
+      { "item": "hptjcpmag", "ammo-group": "on_hand_40" },
+      { "item": "hptjcpmag", "ammo-group": "on_hand_40", "prob": 50 }
     ]
   },
   {
@@ -322,9 +342,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hptjhp", "charges-min": 0, "charges-max": 9 },
-      { "item": "hptjhpmag" },
-      { "item": "hptjhpmag", "prob": 50 }
+      { "item": "hptjhp", "ammo-group": "on_hand_45", "charges": [ 0, 9 ] },
+      { "item": "hptjhpmag", "ammo-group": "on_hand_45" },
+      { "item": "hptjhpmag", "ammo-group": "on_hand_45", "prob": 50 }
     ]
   },
   {
@@ -334,7 +354,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "cz75", "charges-min": 0, "charges-max": 26 },
+      { "item": "cz75", "ammo-group": "on_hand_9mm", "charges": [ 0, 26 ] },
       { "group": "nested_cz75_mag" },
       { "group": "nested_cz75_mag", "prob": 50 }
     ]
@@ -346,9 +366,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "walther_ccp", "charges-min": 0, "charges-max": 8 },
-      { "item": "ccpmag" },
-      { "item": "ccpmag", "prob": 50 }
+      { "item": "walther_ccp", "ammo-group": "on_hand_9mm", "charges": [ 0, 8 ] },
+      { "item": "ccpmag", "ammo-group": "on_hand_9mm" },
+      { "item": "ccpmag", "ammo-group": "on_hand_9mm", "prob": 50 }
     ]
   },
   {
@@ -358,9 +378,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "walther_p22", "charges-min": 0, "charges-max": 10 },
-      { "item": "wp22mag" },
-      { "item": "wp22mag", "prob": 50 }
+      { "item": "walther_p22", "ammo-group": "on_hand_22", "charges": [ 0, 10 ] },
+      { "item": "wp22mag", "ammo-group": "on_hand_22" },
+      { "item": "wp22mag", "ammo-group": "on_hand_22", "prob": 50 }
     ]
   },
   {
@@ -370,7 +390,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "90two", "charges-min": 0, "charges-max": 15 },
+      { "item": "90two", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
       { "group": "nested_m9_mag" },
       { "group": "nested_m9_mag", "prob": 50 }
     ]
@@ -382,9 +402,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "90two40", "charges-min": 0, "charges-max": 12 },
-      { "item": "90two40mag" },
-      { "item": "90two40mag", "prob": 50 }
+      { "item": "90two40", "ammo-group": "on_hand_40", "charges": [ 0, 12 ] },
+      { "item": "90two40mag", "ammo-group": "on_hand_40" },
+      { "item": "90two40mag", "ammo-group": "on_hand_40", "prob": 50 }
     ]
   },
   {
@@ -394,9 +414,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "deagle_44", "charges-min": 0, "charges-max": 2 },
-      { "item": "deaglemag" },
-      { "item": "deaglemag", "prob": 50 }
+      { "item": "deagle_44", "ammo-group": "on_hand_44", "charges": [ 0, 8 ] },
+      { "item": "deaglemag", "ammo-group": "on_hand_44" },
+      { "item": "deaglemag", "ammo-group": "on_hand_44", "prob": 50 }
     ]
   },
   {
@@ -406,9 +426,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m1911a1_38super", "charges-min": 0, "charges-max": 9 },
-      { "group": "nested_m1911_mag" },
-      { "group": "nested_m1911_mag", "prob": 50 }
+      { "item": "m1911a1_38super", "ammo-group": "on_hand_38super", "charges": [ 0, 9 ] },
+      { "item": "m1911mag_10rd_38super", "ammo-group": "on_hand_38super" },
+      { "item": "m1911mag_10rd_38super", "ammo-group": "on_hand_38super", "prob": 50 }
     ]
   },
   {
@@ -417,7 +437,11 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "fn57", "charges-min": 0, "charges-max": 20 }, { "item": "fn57mag" }, { "item": "fn57mag", "prob": 50 } ]
+    "entries": [
+      { "item": "fn57", "ammo-group": "on_hand_57", "charges": [ 0, 20 ] },
+      { "item": "fn57mag", "ammo-group": "on_hand_57" },
+      { "item": "fn57mag", "ammo-group": "on_hand_57", "prob": 50 }
+    ]
   },
   {
     "id": "everyday_sig_40",
@@ -426,9 +450,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "sig_40", "charges-min": 0, "charges-max": 12 },
-      { "item": "sig40mag" },
-      { "item": "sig40mag", "prob": 50 }
+      { "item": "sig_40", "ammo-group": "on_hand_40", "charges": [ 0, 12 ] },
+      { "item": "sig40mag", "ammo-group": "on_hand_40" },
+      { "item": "sig40mag", "ammo-group": "on_hand_40", "prob": 50 }
     ]
   },
   {
@@ -438,9 +462,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "sig_p230", "charges-min": 0, "charges-max": 8 },
-      { "item": "sigp230mag" },
-      { "item": "sigp230mag", "prob": 50 }
+      { "item": "sig_p230", "ammo-group": "on_hand_32", "charges": [ 0, 8 ] },
+      { "item": "sigp230mag", "ammo-group": "on_hand_32" },
+      { "item": "sigp230mag", "ammo-group": "on_hand_32", "prob": 50 }
     ]
   },
   {
@@ -449,11 +473,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [
-      { "item": "usp_45", "charges-min": 0, "charges-max": 12 },
-      { "item": "usp45mag" },
-      { "item": "usp45mag", "prob": 50 }
-    ]
+    "entries": [ { "item": "usp_45", "charges": [ 0, 12 ] }, { "item": "usp45mag" }, { "item": "usp45mag", "prob": 50 } ]
   },
   {
     "id": "everyday_usp_9mm",
@@ -461,7 +481,11 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "usp_9mm", "charges-min": 0, "charges-max": 15 }, { "item": "usp9mag" }, { "item": "usp9mag", "prob": 50 } ]
+    "entries": [
+      { "item": "usp_9mm", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
+      { "item": "usp9mag", "ammo-group": "on_hand_9mm" },
+      { "item": "usp9mag", "ammo-group": "on_hand_9mm", "prob": 50 }
+    ]
   },
   {
     "id": "everyday_draco",
@@ -470,7 +494,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "draco", "charges-min": 0, "charges-max": 30 },
+      { "item": "draco", "ammo-group": "on_hand_762", "charges": [ 0, 30 ] },
       { "group": "nested_ak47_mag" },
       { "group": "nested_ak47_mag", "prob": 50 }
     ]
@@ -482,9 +506,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m17", "charges-min": 0, "charges-max": 17 },
-      { "item": "p320mag_17rd_9x19mm" },
-      { "item": "p320mag_17rd_9x19mm", "prob": 50 }
+      { "item": "m17", "charges": [ 0, 17 ] },
+      { "item": "p320mag_17rd_9x19mm", "ammo-group": "on_hand_9mm" },
+      { "item": "p320mag_17rd_9x19mm", "ammo-group": "on_hand_9mm", "prob": 50 }
     ]
   },
   {
@@ -494,7 +518,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "glock_18c", "charges-min": 0, "charges-max": 17 },
+      { "item": "glock_18c", "ammo-group": "on_hand_9mm", "charges": [ 0, 17 ] },
       { "group": "nested_glock17_mag" },
       { "group": "nested_glock17_mag", "prob": 50 }
     ]
@@ -505,7 +529,11 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "mk23", "charges-min": 0, "charges-max": 12 }, { "item": "usp45mag" }, { "item": "usp45mag", "prob": 50 } ]
+    "entries": [
+      { "item": "mk23", "ammo-group": "on_hand_45", "charges": [ 0, 12 ] },
+      { "item": "usp45mag", "ammo-group": "on_hand_45" },
+      { "item": "usp45mag", "ammo-group": "on_hand_45", "prob": 50 }
+    ]
   },
   {
     "id": "everyday_tokarev",
@@ -513,7 +541,11 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "tokarev" }, { "item": "tokarevmag" }, { "item": "tokarevmag", "prob": 50 } ]
+    "entries": [
+      { "item": "tokarev", "ammo-group": "on_hand_762x25" },
+      { "item": "tokarevmag", "ammo-group": "on_hand_762x25" },
+      { "item": "tokarevmag", "ammo-group": "on_hand_762x25", "prob": 50 }
+    ]
   },
   {
     "id": "everyday_walther_ppk",
@@ -521,7 +553,11 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "walther_ppk" }, { "item": "ppkmag" }, { "item": "ppkmag", "prob": 50 } ]
+    "entries": [
+      { "item": "walther_ppk", "ammo-group": "on_hand_32" },
+      { "item": "ppkmag", "ammo-group": "on_hand_32" },
+      { "item": "ppkmag", "ammo-group": "on_hand_32", "prob": 50 }
+    ]
   },
   {
     "id": "everyday_rm103a_pistol",
@@ -529,7 +565,11 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "rm103a_pistol" }, { "group": "nested_rm103a_mag" }, { "group": "nested_rm103a_mag", "prob": 50 } ]
+    "entries": [
+      { "item": "rm103a_pistol", "ammo-group": "on_hand_8x40" },
+      { "group": "nested_rm103a_mag" },
+      { "group": "nested_rm103a_mag", "prob": 50 }
+    ]
   },
   {
     "id": "everyday_af2011a1_38super",
@@ -537,7 +577,11 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "af2011a1_38super" }, { "item": "af2011a1mag" }, { "item": "af2011a1mag", "prob": 50 } ]
+    "entries": [
+      { "item": "af2011a1_38super", "ammo-group": "on_hand_38super" },
+      { "item": "af2011a1mag", "ammo-group": "on_hand_38super" },
+      { "item": "af2011a1mag", "ammo-group": "on_hand_38super", "prob": 50 }
+    ]
   },
   {
     "id": "everyday_m1911-460",
@@ -546,9 +590,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m1911-460", "charges-min": 0, "charges-max": 7 },
-      { "group": "nested_m1911_mag" },
-      { "group": "nested_m1911_mag", "prob": 50 }
+      { "item": "m1911-460", "charges": [ 0, 7 ] },
+      { "group": "nested_m1911_mag_460" },
+      { "group": "nested_m1911_mag_460", "prob": 50 }
     ]
   },
   {
@@ -558,9 +602,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "makarov", "charges-min": 0, "charges-max": 8 },
-      { "item": "makarovmag" },
-      { "item": "makarovmag", "prob": 50 }
+      { "item": "makarov", "ammo-group": "on_hand_9x18", "charges": [ 0, 8 ] },
+      { "item": "makarovmag", "ammo-group": "on_hand_9x18" },
+      { "item": "makarovmag", "ammo-group": "on_hand_9x18", "prob": 50 }
     ]
   },
   {
@@ -570,7 +614,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hk_mp5_semi_pistol", "charges-min": 0, "charges-max": 30 },
+      { "item": "hk_mp5_semi_pistol", "ammo-group": "on_hand_9mm", "charges": [ 0, 30 ] },
       { "group": "nested_mp5_mag" },
       { "group": "nested_mp5_mag", "prob": 50 }
     ]
@@ -582,9 +626,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "calico", "charges-min": 0, "charges-max": 50 },
-      { "item": "calicomag" },
-      { "item": "calicomag", "prob": 50 }
+      { "item": "calico", "ammo-group": "on_hand_9mm", "charges": [ 0, 50 ] },
+      { "item": "calicomag", "ammo-group": "on_hand_9mm" },
+      { "item": "calicomag", "ammo-group": "on_hand_9mm", "prob": 50 }
     ]
   },
   {
@@ -594,9 +638,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "fn_p90", "charges-min": 0, "charges-max": 50 },
-      { "item": "fnp90mag" },
-      { "item": "fnp90mag", "prob": 50 }
+      { "item": "fn_p90", "ammo-group": "on_hand_57", "charges": [ 0, 50 ] },
+      { "item": "fnp90mag", "ammo-group": "on_hand_57" },
+      { "item": "fnp90mag", "ammo-group": "on_hand_57", "prob": 50 }
     ]
   },
   {
@@ -606,7 +650,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "tommygun", "charges-min": 0, "charges-max": 20 },
+      { "item": "tommygun", "ammo-group": "on_hand_45", "charges": [ 0, 20 ] },
       { "group": "nested_tommygun_mag" },
       { "group": "nested_tommygun_mag", "prob": 50 }
     ]
@@ -617,7 +661,11 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "sten", "charges-min": 0, "charges-max": 32 }, { "item": "stenmag" }, { "item": "stenmag", "prob": 50 } ]
+    "entries": [
+      { "item": "sten", "ammo-group": "on_hand_9mm", "charges": [ 0, 32 ] },
+      { "item": "stenmag", "ammo-group": "on_hand_9mm" },
+      { "item": "stenmag", "ammo-group": "on_hand_9mm", "prob": 50 }
+    ]
   },
   {
     "id": "everyday_uzi",
@@ -625,7 +673,11 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "uzi", "charges-min": 0, "charges-max": 32 }, { "item": "uzimag" }, { "item": "uzimag", "prob": 50 } ]
+    "entries": [
+      { "item": "uzi", "ammo-group": "on_hand_9mm", "charges": [ 0, 32 ] },
+      { "item": "uzimag", "ammo-group": "on_hand_9mm" },
+      { "item": "uzimag", "ammo-group": "on_hand_9mm", "prob": 50 }
+    ]
   },
   {
     "id": "everyday_hk_mp5",
@@ -634,7 +686,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hk_mp5", "charges-min": 0, "charges-max": 30 },
+      { "item": "hk_mp5", "ammo-group": "on_hand_9mm", "charges": [ 0, 30 ] },
       { "group": "nested_mp5_mag" },
       { "group": "nested_mp5_mag", "prob": 50 }
     ]
@@ -646,7 +698,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hk_mp5", "charges-min": 0, "charges-max": 30 },
+      { "item": "hk_mp5", "ammo-group": "on_hand_9mm", "charges": [ 0, 30 ] },
       { "group": "nested_mp5_mag" },
       { "group": "nested_mp5_mag", "prob": 50 }
     ]
@@ -658,9 +710,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hk_ump45", "charges-min": 0, "charges-max": 25 },
-      { "item": "ump45mag" },
-      { "item": "ump45mag", "prob": 50 }
+      { "item": "hk_ump45", "ammo-group": "on_hand_45", "charges": [ 0, 25 ] },
+      { "item": "ump45mag", "ammo-group": "on_hand_45" },
+      { "item": "ump45mag", "ammo-group": "on_hand_45", "prob": 50 }
     ]
   },
   {
@@ -670,9 +722,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "mac_10", "charges-min": 0, "charges-max": 30 },
-      { "item": "mac10mag" },
-      { "item": "mac10mag", "prob": 50 }
+      { "item": "mac_10", "ammo-group": "on_hand_45", "charges": [ 0, 30 ] },
+      { "item": "mac10mag", "ammo-group": "on_hand_45" },
+      { "item": "mac10mag", "ammo-group": "on_hand_45", "prob": 50 }
     ]
   },
   {
@@ -682,9 +734,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "mac_11", "charges-min": 0, "charges-max": 32 },
-      { "item": "mac11mag" },
-      { "item": "mac11mag", "prob": 50 }
+      { "item": "mac_11", "ammo-group": "on_hand_380", "charges": [ 0, 32 ] },
+      { "item": "mac11mag", "ammo-group": "on_hand_380" },
+      { "item": "mac11mag", "ammo-group": "on_hand_380", "prob": 50 }
     ]
   },
   {
@@ -694,7 +746,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "TDI", "charges-min": 0, "charges-max": 30 },
+      { "item": "TDI", "ammo-group": "on_hand_45", "charges": [ 0, 30 ] },
       { "group": "nested_TDI_mag" },
       { "group": "nested_TDI_mag", "prob": 50 }
     ]
@@ -706,9 +758,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "american_180", "charges-min": 0, "charges-max": 100 },
-      { "item": "a180mag" },
-      { "item": "a180mag", "prob": 50 }
+      { "item": "american_180", "ammo-group": "on_hand_22", "charges": [ 0, 100 ] },
+      { "item": "a180mag", "ammo-group": "on_hand_22" },
+      { "item": "a180mag", "ammo-group": "on_hand_22", "prob": 50 }
     ]
   },
   {
@@ -718,7 +770,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "briefcase_smg", "charges-min": 0, "charges-max": 30 },
+      { "item": "briefcase_smg", "ammo-group": "on_hand_9mm", "charges": [ 0, 30 ] },
       { "group": "nested_mp5_mag" },
       { "group": "nested_mp5_mag", "prob": 50 }
     ]
@@ -729,7 +781,11 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "tec9", "charges-min": 0, "charges-max": 30 }, { "item": "tec9mag" }, { "item": "tec9mag", "prob": 50 } ]
+    "entries": [
+      { "item": "tec9", "ammo-group": "on_hand_9mm", "charges": [ 0, 30 ] },
+      { "item": "tec9mag", "ammo-group": "on_hand_9mm" },
+      { "item": "tec9mag", "ammo-group": "on_hand_9mm", "prob": 50 }
+    ]
   },
   {
     "id": "everyday_hk_mp7",
@@ -738,7 +794,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hk_mp7", "charges-min": 0, "charges-max": 20 },
+      { "item": "hk_mp7", "ammo-group": "on_hand_46", "charges": [ 0, 20 ] },
       { "group": "nested_hk_mp7_mag" },
       { "group": "nested_hk_mp7_mag", "prob": 50 }
     ]
@@ -750,7 +806,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "rm2000_smg", "charges-min": 0, "charges-max": 10 },
+      { "item": "rm2000_smg", "ammo-group": "on_hand_8x40", "charges": [ 0, 10 ] },
       { "group": "nested_rm103a_mag" },
       { "group": "nested_rm103a_mag", "prob": 50 }
     ]
@@ -762,7 +818,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hk_mp5k", "charges-min": 0, "charges-max": 30 },
+      { "item": "hk_mp5k", "ammo-group": "on_hand_9mm", "charges": [ 0, 30 ] },
       { "group": "nested_mp5_mag" },
       { "group": "nested_mp5_mag", "prob": 50 }
     ]
@@ -774,9 +830,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "browning_blr", "charges-min": 0, "charges-max": 4 },
-      { "item": "blrmag" },
-      { "item": "blrmag", "prob": 50 }
+      { "item": "browning_blr", "ammo-group": "on_hand_3006", "charges": [ 0, 4 ] },
+      { "item": "blrmag", "ammo-group": "on_hand_3006" },
+      { "item": "blrmag", "ammo-group": "on_hand_3006", "prob": 50 }
     ]
   },
   {
@@ -786,7 +842,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "ar_pistol", "charges-min": 0, "charges-max": 30 },
+      { "item": "ar_pistol", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
       { "group": "nested_stanag_mag" },
       { "group": "nested_stanag_mag", "prob": 50 }
     ]
@@ -798,9 +854,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "garand", "charges-min": 0, "charges-max": 8 },
-      { "item": "garandclip" },
-      { "item": "garandclip", "prob": 50 }
+      { "item": "garand", "ammo-group": "on_hand_3006", "charges": [ 0, 8 ] },
+      { "item": "garandclip", "ammo-group": "on_hand_3006" },
+      { "item": "garandclip", "ammo-group": "on_hand_3006", "prob": 50 }
     ]
   },
   {
@@ -810,9 +866,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "ar10", "charges-min": 0, "charges-max": 20 },
-      { "item": "ar10mag_20rd" },
-      { "item": "ar10mag_20rd", "prob": 50 }
+      { "item": "ar10", "ammo-group": "on_hand_308", "charges": [ 0, 20 ] },
+      { "item": "ar10mag_20rd", "ammo-group": "on_hand_308" },
+      { "item": "ar10mag_20rd", "ammo-group": "on_hand_308", "prob": 50 }
     ]
   },
   {
@@ -822,7 +878,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "ar15", "charges-min": 0, "charges-max": 30 },
+      { "item": "ar15", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
       { "group": "nested_stanag_mag" },
       { "group": "nested_stanag_mag", "prob": 50 }
     ]
@@ -834,7 +890,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "cx4", "charges-min": 0, "charges-max": 15 },
+      { "item": "cx4", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
       { "group": "nested_m9_mag" },
       { "group": "nested_m9_mag", "prob": 50 }
     ]
@@ -846,7 +902,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "ksub2000", "charges-min": 0, "charges-max": 15 },
+      { "item": "ksub2000", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
       { "group": "nested_glock19_mag" },
       { "group": "nested_glock19_mag", "prob": 50 }
     ]
@@ -858,7 +914,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m1a", "charges-min": 0, "charges-max": 5 },
+      { "item": "m1a", "ammo-group": "on_hand_308", "charges": [ 0, 5 ] },
       { "group": "nested_m14_mag" },
       { "group": "nested_m14_mag", "prob": 50 }
     ]
@@ -870,7 +926,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "ruger_1022", "charges-min": 0, "charges-max": 10 },
+      { "item": "ruger_1022", "ammo-group": "on_hand_22", "charges": [ 0, 10 ] },
       { "group": "nested_ruger_1022_mag" },
       { "group": "nested_ruger_1022_mag", "prob": 50 }
     ]
@@ -882,7 +938,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "ruger_mini", "charges-min": 0, "charges-max": 5 },
+      { "item": "ruger_mini", "ammo-group": "on_hand_223", "charges": [ 0, 5 ] },
       { "group": "nested_ruger_mini_mag" },
       { "group": "nested_ruger_mini_mag", "prob": 50 }
     ]
@@ -894,7 +950,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "1895sbl", "charges-min": 0, "charges-max": 30 },
+      { "item": "aksemi", "ammo-group": "on_hand_762", "charges": [ 0, 30 ] },
       { "group": "nested_ak47_mag" },
       { "group": "nested_ak47_mag", "prob": 50 }
     ]
@@ -906,7 +962,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "fn_fal", "charges-min": 0, "charges-max": 20 },
+      { "item": "fn_fal", "ammo-group": "on_hand_308", "charges": [ 0, 20 ] },
       { "group": "nested_fn_fal_mag" },
       { "group": "nested_fn_fal_mag", "prob": 50 }
     ]
@@ -918,7 +974,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hk_g3", "charges-min": 0, "charges-max": 20 },
+      { "item": "hk_g3", "ammo-group": "on_hand_308", "charges": [ 0, 20 ] },
       { "group": "nested_hk_g3_mag" },
       { "group": "nested_hk_g3_mag", "prob": 50 }
     ]
@@ -930,7 +986,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hk_g36", "charges-min": 0, "charges-max": 30 },
+      { "item": "hk_g36", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
       { "group": "nested_hk_g36_mag" },
       { "group": "nested_hk_g36_mag", "prob": 50 }
     ]
@@ -942,7 +998,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m14ebr", "charges-min": 0, "charges-max": 20 },
+      { "item": "m14ebr", "ammo-group": "on_hand_308", "charges": [ 0, 20 ] },
       { "group": "nested_m14_mag" },
       { "group": "nested_m14_mag", "prob": 50 }
     ]
@@ -954,7 +1010,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m4a1", "charges-min": 0, "charges-max": 30 },
+      { "item": "m4a1", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
       { "group": "nested_stanag_mag" },
       { "group": "nested_stanag_mag", "prob": 50 }
     ]
@@ -966,7 +1022,12 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m4a1", "charges-min": 0, "charges-max": 30, "contents-group": "military_accessories_grenadier" },
+      {
+        "item": "m4a1",
+        "ammo-group": "on_hand_223",
+        "charges": [ 0, 30 ],
+        "contents-group": "military_accessories_grenadier"
+      },
       { "group": "nested_stanag_mag" },
       { "group": "nested_stanag_mag", "prob": 50 }
     ]
@@ -978,7 +1039,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m1918", "charges-min": 0, "charges-max": 20 },
+      { "item": "m1918", "ammo-group": "on_hand_3006", "charges": [ 0, 20 ] },
       { "group": "nested_m1918_mag" },
       { "group": "nested_m1918_mag", "prob": 50 }
     ]
@@ -990,7 +1051,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hk417_13", "charges-min": 0, "charges-max": 20 },
+      { "item": "hk417_13", "ammo-group": "on_hand_308", "charges": [ 0, 20 ] },
       { "group": "nested_hk417_13_mag" },
       { "group": "nested_hk417_13_mag", "prob": 50 }
     ]
@@ -1002,9 +1063,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "iwi_tavor_x95_300blk", "charges-min": 0, "charges-max": 30 },
-      { "group": "nested_stanag_mag" },
-      { "group": "nested_stanag_mag", "prob": 50 }
+      { "item": "iwi_tavor_x95_300blk", "ammo-group": "on_hand_300BLK", "charges": [ 0, 30 ] },
+      { "group": "nested_stanag_mag_300" },
+      { "group": "nested_stanag_mag_300", "prob": 50 }
     ]
   },
   {
@@ -1014,7 +1075,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "h&k416a5", "charges-min": 0, "charges-max": 30 },
+      { "item": "h&k416a5", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
       { "group": "nested_stanag_mag" },
       { "group": "nested_stanag_mag", "prob": 50 }
     ]
@@ -1026,7 +1087,12 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "h&k416a5", "charges-min": 0, "charges-max": 30, "contents-group": "military_accessories_grenadier" },
+      {
+        "item": "h&k416a5",
+        "ammo-group": "on_hand_223",
+        "charges": [ 0, 30 ],
+        "contents-group": "military_accessories_grenadier"
+      },
       { "group": "nested_stanag_mag" },
       { "group": "nested_stanag_mag", "prob": 50 }
     ]
@@ -1038,7 +1104,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m27iar", "charges-min": 0, "charges-max": 30 },
+      { "item": "m27iar", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
       { "group": "nested_stanag_mag" },
       { "group": "nested_stanag_mag", "prob": 50 }
     ]
@@ -1050,9 +1116,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "stanag100", "ammo-item": "556_incendiary", "container-item": "m27iar", "charges-min": 0, "charges-max": 100 },
-      { "item": "stanag100", "ammo-item": "556_incendiary" },
-      { "item": "stanag100", "prob": 50, "ammo-item": "556_incendiary" }
+      { "item": "stanag100", "ammo-group": "on_hand_223", "container-item": "m27iar", "charges": [ 0, 100 ] },
+      { "item": "stanag100", "ammo-group": "on_hand_223" },
+      { "item": "stanag100", "prob": 50, "ammo-group": "on_hand_223" }
     ]
   },
   {
@@ -1062,7 +1128,12 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m27iar", "charges-min": 0, "charges-max": 30, "contents-group": "military_accessories_grenadier" },
+      {
+        "item": "m27iar",
+        "ammo-group": "on_hand_223",
+        "charges": [ 0, 30 ],
+        "contents-group": "military_accessories_grenadier"
+      },
       { "group": "nested_stanag_mag" },
       { "group": "nested_stanag_mag", "prob": 50 }
     ]
@@ -1074,7 +1145,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "scar_l", "charges-min": 0, "charges-max": 30 },
+      { "item": "scar_l", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
       { "group": "nested_stanag_mag" },
       { "group": "nested_stanag_mag", "prob": 50 }
     ]
@@ -1086,9 +1157,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m107a1", "charges-min": 0, "charges-max": 10 },
-      { "item": "m107a1mag" },
-      { "item": "m107a1mag", "prob": 50 }
+      { "item": "m107a1", "ammo-group": "on_hand_50", "charges": [ 0, 10 ] },
+      { "item": "m107a1mag", "ammo-group": "on_hand_50" },
+      { "item": "m107a1mag", "ammo-group": "on_hand_50", "prob": 50 }
     ]
   },
   {
@@ -1097,7 +1168,11 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "tac50", "charges-min": 0, "charges-max": 5 }, { "item": "tac50mag" }, { "item": "tac50mag", "prob": 50 } ]
+    "entries": [
+      { "item": "tac50", "ammo-group": "on_hand_50", "charges": [ 0, 5 ] },
+      { "item": "tac50mag", "ammo-group": "on_hand_50" },
+      { "item": "tac50mag", "ammo-group": "on_hand_50", "prob": 50 }
+    ]
   },
   {
     "id": "everyday_m2010",
@@ -1105,7 +1180,11 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "m2010", "charges-min": 0, "charges-max": 5 }, { "item": "m2010mag" }, { "item": "m2010mag", "prob": 50 } ]
+    "entries": [
+      { "item": "m2010", "ammo-group": "on_hand_300", "charges": [ 0, 5 ] },
+      { "item": "m2010mag", "ammo-group": "on_hand_300" },
+      { "item": "m2010mag", "ammo-group": "on_hand_300", "prob": 50 }
+    ]
   },
   {
     "id": "everyday_rm11b_sniper_rifle",
@@ -1114,7 +1193,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "rm11b_sniper_rifle", "charges-min": 0, "charges-max": 10 },
+      { "item": "rm11b_sniper_rifle", "ammo-group": "on_hand_8x40", "charges": [ 0, 10 ] },
       { "group": "nested_rm103a_mag" },
       { "group": "nested_rm103a_mag", "prob": 50 }
     ]
@@ -1126,7 +1205,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "rm298", "charges-min": 0, "charges-max": 100 },
+      { "item": "rm298", "ammo-group": "on_hand_8x40", "charges": [ 0, 100 ] },
       { "group": "nested_rm298_mag" },
       { "group": "nested_rm298_mag", "prob": 50 }
     ]
@@ -1138,7 +1217,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "rm51_assault_rifle", "charges-min": 0, "charges-max": 50 },
+      { "item": "rm51_assault_rifle", "ammo-group": "on_hand_8x40", "charges": [ 0, 50 ] },
       { "group": "nested_rm51_mag" },
       { "group": "nested_rm51_mag", "prob": 50 }
     ]
@@ -1150,7 +1229,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "rm614_lmg", "charges-min": 0, "charges-max": 100 },
+      { "item": "rm614_lmg", "ammo-group": "on_hand_8x40", "charges": [ 0, 100 ] },
       { "group": "nested_rm298_mag" },
       { "group": "nested_rm298_mag", "prob": 50 }
     ]
@@ -1162,7 +1241,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "rm88_battle_rifle", "charges-min": 0, "charges-max": 50 },
+      { "item": "rm88_battle_rifle", "ammo-group": "on_hand_8x40", "charges": [ 0, 50 ] },
       { "group": "nested_rm51_mag" },
       { "group": "nested_rm51_mag", "prob": 50 }
     ]
@@ -1174,7 +1253,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "sig552", "charges-min": 0, "charges-max": 30 },
+      { "item": "sig552", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
       { "group": "nested_stanag_mag" },
       { "group": "nested_stanag_mag", "prob": 50 }
     ]
@@ -1186,7 +1265,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "scar_h", "charges-min": 0, "charges-max": 20 },
+      { "item": "scar_h", "ammo-group": "on_hand_308", "charges": [ 0, 20 ] },
       { "group": "nested_scar_h_mag" },
       { "group": "nested_scar_h_mag", "prob": 50 }
     ]
@@ -1198,7 +1277,12 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "scar_h", "charges-min": 0, "charges-max": 20, "contents-group": "military_accessories_grenadier" },
+      {
+        "item": "scar_h",
+        "ammo-group": "on_hand_308",
+        "charges": [ 0, 20 ],
+        "contents-group": "military_accessories_grenadier"
+      },
       { "group": "nested_scar_h_mag" },
       { "group": "nested_scar_h_mag", "prob": 50 }
     ]
@@ -1210,7 +1294,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m110a1", "charges-min": 0, "charges-max": 20 },
+      { "item": "m110a1", "ammo-group": "on_hand_308", "charges": [ 0, 20 ] },
       { "group": "nested_hk417_13_mag" },
       { "group": "nested_hk417_13_mag", "prob": 50 }
     ]
@@ -1222,9 +1306,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "acr_300blk", "charges-min": 0, "charges-max": 30 },
-      { "group": "nested_stanag_mag" },
-      { "group": "nested_stanag_mag", "prob": 50 }
+      { "item": "acr_300blk", "charges": [ 0, 30 ] },
+      { "group": "nested_stanag_mag_300" },
+      { "group": "nested_stanag_mag_300", "prob": 50 }
     ]
   },
   {
@@ -1234,7 +1318,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "ak47", "charges-min": 0, "charges-max": 30 },
+      { "item": "ak47", "ammo-group": "on_hand_762", "charges": [ 0, 30 ] },
       { "group": "nested_ak47_mag" },
       { "group": "nested_ak47_mag", "prob": 50 }
     ]
@@ -1246,7 +1330,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "ak74", "charges-min": 0, "charges-max": 30 },
+      { "item": "ak74", "ammo-group": "on_hand_545x39", "charges": [ 0, 30 ] },
       { "group": "nested_ak74_mag" },
       { "group": "nested_ak74_mag", "prob": 50 }
     ]
@@ -1257,7 +1341,11 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "famas", "charges-min": 0, "charges-max": 25 }, { "item": "famasmag" }, { "item": "famasmag", "prob": 50 } ]
+    "entries": [
+      { "item": "famas", "ammo-group": "on_hand_223", "charges": [ 0, 25 ] },
+      { "item": "famasmag", "ammo-group": "on_hand_223" },
+      { "item": "famasmag", "ammo-group": "on_hand_223", "prob": 50 }
+    ]
   },
   {
     "id": "everyday_oa93",
@@ -1266,7 +1354,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "oa93", "charges-min": 0, "charges-max": 30 },
+      { "item": "oa93", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
       { "group": "nested_stanag_mag" },
       { "group": "nested_stanag_mag", "prob": 50 }
     ]
@@ -1278,7 +1366,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "steyr_aug", "charges-min": 0, "charges-max": 30 },
+      { "item": "steyr_aug", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
       { "group": "nested_steyr_aug_mag" },
       { "group": "nested_steyr_aug_mag", "prob": 50 }
     ]
@@ -1290,7 +1378,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "arx160", "charges-min": 0, "charges-max": 30 },
+      { "item": "arx160", "ammo-group": "on_hand_762", "charges": [ 0, 30 ] },
       { "group": "nested_ak47_mag" },
       { "group": "nested_ak47_mag", "prob": 50 }
     ]
@@ -1302,7 +1390,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "rm20", "charges-min": 0, "charges-max": 20 },
+      { "item": "rm20", "ammo-group": "on_hand_20x66mm", "charges": [ 0, 20 ] },
       { "group": "nested_rm20_mag" },
       { "group": "nested_rm20_mag", "prob": 50 }
     ]
@@ -1314,7 +1402,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "saiga_12", "charges-min": 0, "charges-max": 10 },
+      { "item": "saiga_12", "ammo-group": "on_hand_shot", "charges": [ 0, 10 ] },
       { "group": "nested_saiga_12_mag" },
       { "group": "nested_saiga_12_mag", "prob": 50 }
     ]
@@ -1326,7 +1414,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "saiga_410", "charges-min": 0, "charges-max": 10 },
+      { "item": "saiga_410", "ammo-group": "on_hand_410shot", "charges": [ 0, 10 ] },
       { "group": "nested_saiga_410_mag" },
       { "group": "nested_saiga_410_mag", "prob": 50 }
     ]
@@ -1338,13 +1426,13 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "ruger_lcr_38", "charges-min": 0, "charges-max": 5 },
+      { "item": "ruger_lcr_38", "ammo-group": "on_hand_38", "charges": [ 0, 5 ] },
       {
         "distribution": [
           {
             "collection": [
-              { "item": "38_speedloader5", "ammo-item": "38_special", "charges": [ 0, 5 ] },
-              { "item": "38_speedloader5", "ammo-item": "38_special", "prob": 50, "charges": [ 0, 5 ] }
+              { "item": "38_speedloader5", "ammo-group": "on_hand_38" },
+              { "item": "38_speedloader5", "ammo-group": "on_hand_38", "prob": 50 }
             ],
             "prob": 50
           },
@@ -1360,15 +1448,17 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "sw_610", "charges-min": 0, "charges-max": 6 },
+      { "item": "sw_610", "ammo-group": "on_hand_40sw_or_10mm", "charges": [ 0, 6 ] },
       {
         "distribution": [
           {
-            "collection": [ { "item": "40_speedloader6", "charges": [ 0, 6 ] }, { "item": "40_speedloader6", "prob": 50, "charges": [ 0, 6 ] } ],
+            "collection": [
+              { "item": "40_speedloader6", "ammo-group": "on_hand_40sw_or_10mm" },
+              { "item": "40_speedloader6", "ammo-group": "on_hand_40sw_or_10mm", "prob": 50 }
+            ],
             "prob": 50
           },
-          { "group": "on_hand_40", "prob": 25 },
-          { "group": "on_hand_10mm", "prob": 25 }
+          { "group": "on_hand_40sw_or_10mm", "prob": 50 }
         ]
       }
     ]
@@ -1380,11 +1470,14 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "sw_619", "charges-min": 0, "charges-max": 7 },
+      { "item": "sw_619", "ammo-group": "on_hand_357_38mixed", "charges": [ 0, 7 ] },
       {
         "distribution": [
           {
-            "collection": [ { "item": "38_speedloader", "charges": [ 0, 7 ] }, { "item": "38_speedloader", "prob": 50, "charges": [ 0, 7 ] } ],
+            "collection": [
+              { "item": "38_speedloader", "ammo-group": "on_hand_357_38mixed" },
+              { "item": "38_speedloader", "ammo-group": "on_hand_357_38mixed", "prob": 50 }
+            ],
             "prob": 50
           },
           { "group": "on_hand_357_38mixed", "prob": 50 }
@@ -1399,13 +1492,13 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "model_10_revolver", "charges-min": 0, "charges-max": 6 },
+      { "item": "model_10_revolver", "ammo-group": "on_hand_38", "charges": [ 0, 6 ] },
       {
         "distribution": [
           {
             "collection": [
-              { "item": "38_speedloader6", "ammo-item": "38_special", "charges": [ 0, 6 ] },
-              { "item": "38_speedloader6", "ammo-item": "38_special", "prob": 50, "charges": [ 0, 6 ] }
+              { "item": "38_speedloader6", "ammo-group": "on_hand_38" },
+              { "item": "38_speedloader6", "ammo-group": "on_hand_38", "prob": 50 }
             ],
             "prob": 50
           },
@@ -1421,8 +1514,8 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "bond_410", "charges-min": 0, "charges-max": 2 },
-      { "distribution": [ { "group": "on_hand_45colt", "prob": 75 }, { "group": "on_hand_410shot", "prob": 25 } ] }
+      { "item": "bond_410", "ammo-group": "on_hand_410_or_45colt", "charges": [ 0, 2 ] },
+      { "group": "on_hand_410_or_45colt" }
     ]
   },
   {
@@ -1432,11 +1525,14 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "ruger_lcr_22", "charges-min": 0, "charges-max": 8 },
+      { "item": "ruger_lcr_22", "ammo-group": "on_hand_22", "charges": [ 0, 8 ] },
       {
         "distribution": [
           {
-            "collection": [ { "item": "22_speedloader8", "charges": [ 0, 8 ] }, { "item": "22_speedloader8", "prob": 50, "charges": [ 0, 8 ] } ],
+            "collection": [
+              { "item": "22_speedloader8", "ammo-group": "on_hand_22" },
+              { "item": "22_speedloader8", "ammo-group": "on_hand_22", "prob": 50 }
+            ],
             "prob": 50
           },
           { "group": "on_hand_22", "prob": 50 }
@@ -1451,11 +1547,14 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "ruger_redhawk", "charges-min": 0, "charges-max": 6 },
+      { "item": "ruger_redhawk", "ammo-group": "on_hand_44", "charges": [ 0, 6 ] },
       {
         "distribution": [
           {
-            "collection": [ { "item": "44_speedloader6", "charges": [ 0, 6 ] }, { "item": "44_speedloader6", "prob": 50, "charges": [ 0, 6 ] } ],
+            "collection": [
+              { "item": "44_speedloader6", "ammo-group": "on_hand_44" },
+              { "item": "44_speedloader6", "ammo-group": "on_hand_44", "prob": 50 }
+            ],
             "prob": 50
           },
           { "group": "on_hand_44", "prob": 50 }
@@ -1470,11 +1569,14 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "sw_500", "charges-min": 0, "charges-max": 5 },
+      { "item": "sw_500", "ammo-group": "on_hand_500", "charges": [ 0, 5 ] },
       {
         "distribution": [
           {
-            "collection": [ { "item": "500_speedloader5", "charges": [ 0, 5 ] }, { "item": "500_speedloader5", "prob": 50, "charges": [ 0, 5 ] } ],
+            "collection": [
+              { "item": "500_speedloader5", "ammo-group": "on_hand_500" },
+              { "item": "500_speedloader5", "ammo-group": "on_hand_500", "prob": 50 }
+            ],
             "prob": 50
           },
           { "group": "on_hand_500", "prob": 50 }
@@ -1489,11 +1591,14 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "sw629", "charges-min": 0, "charges-max": 6 },
+      { "item": "sw629", "ammo-group": "on_hand_44", "charges": [ 0, 6 ] },
       {
         "distribution": [
           {
-            "collection": [ { "item": "44_speedloader6", "charges": [ 0, 6 ] }, { "item": "44_speedloader6", "prob": 50, "charges": [ 0, 6 ] } ],
+            "collection": [
+              { "item": "44_speedloader6", "ammo-group": "on_hand_44" },
+              { "item": "44_speedloader6", "ammo-group": "on_hand_44", "prob": 50 }
+            ],
             "prob": 50
           },
           { "group": "on_hand_44", "prob": 50 }
@@ -1507,7 +1612,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "bfr" }, { "group": "on_hand_4570" } ]
+    "entries": [ { "item": "bfr", "ammo-group": "on_hand_4570", "charges": [ 0, 5 ] }, { "group": "on_hand_4570" } ]
   },
   {
     "id": "everyday_moss_brownie",
@@ -1515,7 +1620,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "moss_brownie" }, { "group": "on_hand_22" } ]
+    "entries": [ { "item": "moss_brownie", "ammo-group": "on_hand_22", "charges": [ 0, 6 ] }, { "group": "on_hand_22" } ]
   },
   {
     "id": "everyday_raging_bull",
@@ -1524,16 +1629,17 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "raging_bull", "charges-min": 0, "charges-max": 5 },
+      { "item": "raging_bull", "ammo-group": "on_hand_454_mixed", "charges": [ 0, 5 ] },
       {
         "distribution": [
           {
-            "collection": [ { "item": "454_speedloader5", "charges": [ 0, 5 ] }, { "item": "454_speedloader5", "prob": 50, "charges": [ 0, 5 ] } ],
+            "collection": [
+              { "item": "454_speedloader5", "ammo-group": "on_hand_454_mixed" },
+              { "item": "454_speedloader5", "ammo-group": "on_hand_454_mixed", "prob": 50 }
+            ],
             "prob": 50
           },
-          { "group": "on_hand_454", "prob": 25 },
-          { "group": "on_hand_410shot", "prob": 12 },
-          { "group": "on_hand_45colt", "prob": 13 }
+          { "group": "on_hand_454_mixed", "prob": 50 }
         ]
       }
     ]
@@ -1545,16 +1651,17 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "raging_judge", "charges-min": 0, "charges-max": 6 },
+      { "item": "raging_judge", "ammo-group": "on_hand_454_mixed", "charges": [ 0, 6 ] },
       {
         "distribution": [
           {
-            "collection": [ { "item": "454_speedloader6", "charges": [ 0, 6 ] }, { "item": "454_speedloader6", "prob": 50, "charges": [ 0, 6 ] } ],
+            "collection": [
+              { "item": "454_speedloader6", "ammo-group": "on_hand_454_mixed" },
+              { "item": "454_speedloader6", "ammo-group": "on_hand_454_mixed", "prob": 50 }
+            ],
             "prob": 50
           },
-          { "group": "on_hand_454", "prob": 25 },
-          { "group": "on_hand_410shot", "prob": 12 },
-          { "group": "on_hand_45colt", "prob": 13 }
+          { "group": "on_hand_454_mixed", "prob": 50 }
         ]
       }
     ]
@@ -1565,7 +1672,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "cop_38", "charges-min": 0, "charges-max": 4 }, { "group": "on_hand_357_38mixed" } ]
+    "entries": [ { "item": "cop_38", "ammo-group": "on_hand_357_38mixed", "charges": [ 0, 4 ] }, { "group": "on_hand_357_38mixed" } ]
   },
   {
     "id": "everyday_lemat_revolver",
@@ -1573,7 +1680,11 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "lemat_revolver", "charges-min": 0, "charges-max": 9 }, { "group": "on_hand_44paper" } ]
+    "entries": [
+      { "item": "lemat_revolver", "ammo-group": "on_hand_44paper", "charges": [ 0, 9 ] },
+      { "group": "on_hand_44paper" },
+      { "group": "on_hand_shotpaper", "prob": 25 }
+    ]
   },
   {
     "id": "everyday_pistol_flintlock",
@@ -1581,7 +1692,10 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "pistol_flintlock" }, { "group": "on_hand_flintlock" } ]
+    "entries": [
+      { "item": "pistol_flintlock", "ammo-group": "on_hand_flintlock", "charges": [ 0, 1 ] },
+      { "group": "on_hand_flintlock" }
+    ]
   },
   {
     "id": "everyday_colt_saa",
@@ -1589,7 +1703,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "colt_saa", "charges-min": 0, "charges-max": 6 }, { "group": "on_hand_45colt" } ]
+    "entries": [ { "item": "colt_saa", "ammo-group": "on_hand_45colt", "charges": [ 0, 6 ] }, { "group": "on_hand_45colt" } ]
   },
   {
     "id": "everyday_marlin_9a",
@@ -1598,13 +1712,13 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "marlin_9a", "charges-min": 0, "charges-max": 19 },
+      { "item": "marlin_9a", "ammo-group": "on_hand_22", "charges": [ 0, 19 ] },
       {
         "distribution": [
           {
             "collection": [
-              { "item": "marlin_tubeloader", "charges": [ 0, 19 ] },
-              { "item": "marlin_tubeloader", "prob": 50, "charges": [ 0, 19 ] }
+              { "item": "marlin_tubeloader", "ammo-group": "on_hand_22" },
+              { "item": "marlin_tubeloader", "ammo-group": "on_hand_22", "prob": 50 }
             ],
             "prob": 50
           },
@@ -1620,11 +1734,14 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "mosin44", "charges-min": 0, "charges-max": 5 },
+      { "item": "mosin44", "ammo-group": "on_hand_762R", "charges": [ 0, 5 ] },
       {
         "distribution": [
           {
-            "collection": [ { "item": "762R_clip", "charges": [ 0, 5 ] }, { "item": "762R_clip", "prob": 50, "charges": [ 0, 5 ] } ],
+            "collection": [
+              { "item": "762R_clip", "ammo-group": "on_hand_762R" },
+              { "item": "762R_clip", "ammo-group": "on_hand_762R", "prob": 50 }
+            ],
             "prob": 50
           },
           { "group": "on_hand_762R", "prob": 50 }
@@ -1639,11 +1756,14 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "mosin91_30", "charges-min": 0, "charges-max": 5 },
+      { "item": "mosin91_30", "ammo-group": "on_hand_762R", "charges": [ 0, 5 ] },
       {
         "distribution": [
           {
-            "collection": [ { "item": "762R_clip", "charges": [ 0, 5 ] }, { "item": "762R_clip", "prob": 50, "charges": [ 0, 5 ] } ],
+            "collection": [
+              { "item": "762R_clip", "ammo-group": "on_hand_762R" },
+              { "item": "762R_clip", "ammo-group": "on_hand_762R", "prob": 50 }
+            ],
             "prob": 50
           },
           { "group": "on_hand_762R", "prob": 50 }
@@ -1657,7 +1777,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "remington700_270", "charges-min": 0, "charges-max": 4 }, { "group": "on_hand_270win" } ]
+    "entries": [ { "item": "remington700_270", "ammo-group": "on_hand_270win", "charges": [ 0, 4 ] }, { "group": "on_hand_270win" } ]
   },
   {
     "id": "everyday_remington_700",
@@ -1665,7 +1785,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "remington_700", "charges-min": 0, "charges-max": 4 }, { "group": "on_hand_3006" } ]
+    "entries": [ { "item": "remington_700", "ammo-group": "on_hand_3006", "charges": [ 0, 4 ] }, { "group": "on_hand_3006" } ]
   },
   {
     "id": "everyday_sks",
@@ -1674,11 +1794,14 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "sks", "charges-min": 0, "charges-max": 10 },
+      { "item": "sks", "ammo-group": "on_hand_762", "charges": [ 0, 10 ] },
       {
         "distribution": [
           {
-            "collection": [ { "item": "762x39_clip", "charges": [ 0, 10 ] }, { "item": "762x39_clip", "prob": 50, "charges": [ 0, 10 ] } ],
+            "collection": [
+              { "item": "762x39_clip", "ammo-group": "on_hand_762" },
+              { "item": "762x39_clip", "ammo-group": "on_hand_762", "prob": 50 }
+            ],
             "prob": 50
           },
           { "group": "on_hand_762", "prob": 50 }
@@ -1692,7 +1815,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "win70", "charges-min": 0, "charges-max": 3 }, { "group": "on_hand_300" } ]
+    "entries": [ { "item": "win70", "ammo-group": "on_hand_300", "charges": [ 0, 3 ] }, { "group": "on_hand_300" } ]
   },
   {
     "id": "everyday_1895sbl",
@@ -1700,7 +1823,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "1895sbl", "charges-min": 0, "charges-max": 6 }, { "group": "on_hand_4570" } ]
+    "entries": [ { "item": "1895sbl", "ammo-group": "on_hand_4570", "charges": [ 0, 6 ] }, { "group": "on_hand_4570" } ]
   },
   {
     "id": "everyday_colt_lightning",
@@ -1708,7 +1831,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "colt_lightning", "charges-min": 0, "charges-max": 14 }, { "group": "on_hand_45colt" } ]
+    "entries": [ { "item": "colt_lightning", "ammo-group": "on_hand_45colt", "charges": [ 0, 14 ] }, { "group": "on_hand_45colt" } ]
   },
   {
     "id": "everyday_henry_big_boy",
@@ -1716,7 +1839,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "henry_big_boy", "charges-min": 0, "charges-max": 10 }, { "group": "on_hand_44" } ]
+    "entries": [ { "item": "henry_big_boy", "ammo-group": "on_hand_44", "charges": [ 0, 10 ] }, { "group": "on_hand_44" } ]
   },
   {
     "id": "everyday_M24",
@@ -1724,7 +1847,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "M24", "charges-min": 0, "charges-max": 5 }, { "group": "on_hand_308" } ]
+    "entries": [ { "item": "M24", "ammo-group": "on_hand_308", "charges": [ 0, 5 ] }, { "group": "on_hand_308" } ]
   },
   {
     "id": "everyday_m1903",
@@ -1733,11 +1856,14 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m1903", "charges-min": 0, "charges-max": 5 },
+      { "item": "m1903", "ammo-group": "on_hand_3006", "charges": [ 0, 5 ] },
       {
         "distribution": [
           {
-            "collection": [ { "item": "3006_clip", "charges": [ 0, 5 ] }, { "item": "3006_clip", "prob": 50, "charges": [ 0, 5 ] } ],
+            "collection": [
+              { "item": "3006_clip", "ammo-group": "on_hand_3006" },
+              { "item": "3006_clip", "ammo-group": "on_hand_3006", "prob": 50 }
+            ],
             "prob": 50
           },
           { "group": "on_hand_3006", "prob": 50 }
@@ -1752,11 +1878,14 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "mosin44_ebr", "prob": 1, "charges-min": 0, "charges-max": 5 },
+      { "item": "mosin44_ebr", "ammo-group": "on_hand_762R", "charges": [ 0, 5 ] },
       {
         "distribution": [
           {
-            "collection": [ { "item": "762R_clip", "charges": [ 0, 5 ] }, { "item": "762R_clip", "prob": 50, "charges": [ 0, 5 ] } ],
+            "collection": [
+              { "item": "762R_clip", "ammo-group": "on_hand_762R" },
+              { "item": "762R_clip", "ammo-group": "on_hand_762R", "prob": 50 }
+            ],
             "prob": 50
           },
           { "group": "on_hand_762R", "prob": 50 }
@@ -1771,11 +1900,14 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "mosin91_30_ebr", "prob": 1, "charges-min": 0, "charges-max": 5 },
+      { "item": "mosin91_30_ebr", "ammo-group": "on_hand_762R", "charges": [ 0, 5 ] },
       {
         "distribution": [
           {
-            "collection": [ { "item": "762R_clip", "charges": [ 0, 5 ] }, { "item": "762R_clip", "prob": 50, "charges": [ 0, 5 ] } ],
+            "collection": [
+              { "item": "762R_clip", "ammo-group": "on_hand_762R" },
+              { "item": "762R_clip", "ammo-group": "on_hand_762R", "prob": 50 }
+            ],
             "prob": 50
           },
           { "group": "on_hand_762R", "prob": 50 }
@@ -1789,7 +1921,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "savage_111f", "charges-min": 0, "charges-max": 3 }, { "group": "on_hand_308" } ]
+    "entries": [ { "item": "savage_111f", "ammo-group": "on_hand_308", "charges": [ 0, 3 ] }, { "group": "on_hand_308" } ]
   },
   {
     "id": "everyday_sharps",
@@ -1797,7 +1929,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "sharps", "charges-min": 0, "charges-max": 1 }, { "group": "on_hand_4570" } ]
+    "entries": [ { "item": "sharps", "ammo-group": "on_hand_4570", "charges": [ 0, 1 ] }, { "group": "on_hand_4570" } ]
   },
   {
     "id": "everyday_weatherby_5",
@@ -1805,7 +1937,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "weatherby_5", "charges-min": 0, "charges-max": 3 }, { "group": "on_hand_300" } ]
+    "entries": [ { "item": "weatherby_5", "ammo-group": "on_hand_300", "charges": [ 0, 3 ] }, { "group": "on_hand_300" } ]
   },
   {
     "id": "everyday_m134",
@@ -1814,8 +1946,13 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m134", "ammo-item": "762_51_incendiary", "charges-min": 0, "charges-max": 100 },
-      { "group": "on_hand_308" }
+      { "item": "m134", "ammo-group": "on_hand_308", "charges": [ 0, 100 ] },
+      {
+        "distribution": [
+          { "item": "belt308", "ammo-group": "on_hand_308", "charges": 100, "prob": 50 },
+          { "group": "on_hand_308", "prob": 50 }
+        ]
+      }
     ]
   },
   {
@@ -1825,8 +1962,13 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m240", "ammo-item": "762_51_incendiary", "charges-min": 0, "charges-max": 100 },
-      { "group": "on_hand_308" }
+      { "item": "m240", "ammo-group": "on_hand_308", "charges": [ 0, 100 ] },
+      {
+        "distribution": [
+          { "item": "belt308", "ammo-group": "on_hand_308", "charges": 100, "prob": 50 },
+          { "group": "on_hand_308", "prob": 50 }
+        ]
+      }
     ]
   },
   {
@@ -1835,7 +1977,15 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "m249", "ammo-item": "556_incendiary", "charges-min": 0, "charges-max": 100 }, { "group": "on_hand_223" } ]
+    "entries": [
+      { "item": "m249", "ammo-group": "on_hand_223", "charges": [ 0, 100 ] },
+      {
+        "distribution": [
+          { "item": "belt223", "ammo-group": "on_hand_223", "charges": 100, "prob": 50 },
+          { "group": "on_hand_223", "prob": 50 }
+        ]
+      }
+    ]
   },
   {
     "id": "everyday_m60",
@@ -1844,8 +1994,13 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m60", "ammo-item": "762_51_incendiary", "charges-min": 0, "charges-max": 100 },
-      { "group": "on_hand_308" }
+      { "item": "m60", "ammo-group": "on_hand_308", "charges": [ 0, 100 ] },
+      {
+        "distribution": [
+          { "item": "belt308", "ammo-group": "on_hand_308", "charges": 100, "prob": 50 },
+          { "group": "on_hand_308", "prob": 50 }
+        ]
+      }
     ]
   },
   {
@@ -1855,8 +2010,10 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m2browning", "ammo-item": "50_incendiary", "charges-min": 0, "charges-max": 100 },
-      { "group": "on_hand_50" }
+      { "item": "m2browning", "ammo-group": "on_hand_50", "charges": [ 0, 100 ] },
+      {
+        "distribution": [ { "item": "belt50", "ammo-group": "on_hand_50", "charges": 100, "prob": 50 }, { "group": "on_hand_50", "prob": 50 } ]
+      }
     ]
   },
   {
@@ -1865,7 +2022,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "bh_m89", "charges-min": 0, "charges-max": 7 }, { "group": "on_hand_500" } ]
+    "entries": [ { "item": "bh_m89", "ammo-group": "on_hand_500", "charges": [ 0, 7 ] }, { "group": "on_hand_500" } ]
   },
   {
     "id": "everyday_bfg50",
@@ -1873,7 +2030,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "bh_m89", "charges-min": 0, "charges-max": 1 }, { "group": "on_hand_50" } ]
+    "entries": [ { "item": "bfg50", "ammo-group": "on_hand_50", "charges": [ 0, 1 ] }, { "group": "on_hand_50" } ]
   },
   {
     "id": "everyday_carbine_flintlock",
@@ -1881,7 +2038,10 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "carbine_flintlock", "charges-min": 0, "charges-max": 1 }, { "group": "on_hand_flintlock" } ]
+    "entries": [
+      { "item": "carbine_flintlock", "ammo-group": "on_hand_flintlock", "charges": [ 0, 1 ] },
+      { "group": "on_hand_flintlock" }
+    ]
   },
   {
     "id": "everyday_rifle_flintlock",
@@ -1889,7 +2049,10 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "rifle_flintlock" }, { "group": "on_hand_flintlock" } ]
+    "entries": [
+      { "item": "rifle_flintlock", "ammo-group": "on_hand_flintlock", "charges": [ 0, 1 ] },
+      { "group": "on_hand_flintlock" }
+    ]
   },
   {
     "id": "everyday_longrifle_flintlock",
@@ -1897,7 +2060,10 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "longrifle_flintlock" }, { "group": "on_hand_flintlock" } ]
+    "entries": [
+      { "item": "longrifle_flintlock", "ammo-group": "on_hand_flintlock", "charges": [ 0, 1 ] },
+      { "group": "on_hand_flintlock" }
+    ]
   },
   {
     "id": "everyday_trex_gun",
@@ -1905,7 +2071,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "trex_gun", "charges-min": 0, "charges-max": 2 }, { "group": "on_hand_700nx" } ]
+    "entries": [ { "item": "trex_gun", "ammo-group": "on_hand_700nx", "charges": [ 0, 2 ] }, { "group": "on_hand_700nx" } ]
   },
   {
     "id": "everyday_mossberg_500",
@@ -1913,7 +2079,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "mossberg_500", "charges-min": 0, "charges-max": 6 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "mossberg_500", "ammo-group": "on_hand_shot", "charges": [ 0, 6 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "everyday_remington_870",
@@ -1921,7 +2087,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "remington_870", "charges-min": 0, "charges-max": 5 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "remington_870", "ammo-group": "on_hand_shot", "charges": [ 0, 5 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "everyday_mossberg_500_security",
@@ -1929,7 +2095,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "mossberg_500_security", "charges-min": 0, "charges-max": 6 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "mossberg_500_security", "ammo-group": "on_hand_shot", "charges": [ 0, 6 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "everyday_remington_870_express",
@@ -1937,7 +2103,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "remington_870_express", "charges-min": 0, "charges-max": 6 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "remington_870_express", "ammo-group": "on_hand_shot", "charges": [ 0, 6 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "everyday_browning_a5",
@@ -1945,7 +2111,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "browning_a5", "charges-min": 0, "charges-max": 5 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "browning_a5", "ammo-group": "on_hand_shot", "charges": [ 0, 5 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "everyday_remington_1100",
@@ -1953,7 +2119,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "remington_1100", "charges-min": 0, "charges-max": 5 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "remington_1100", "ammo-group": "on_hand_shot", "charges": [ 0, 5 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "everyday_mossberg_930",
@@ -1961,7 +2127,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "mossberg_930", "charges-min": 0, "charges-max": 6 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "mossberg_930", "ammo-group": "on_hand_shot", "charges": [ 0, 6 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "everyday_shotgun_410",
@@ -1969,7 +2135,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "shotgun_410", "charges-min": 0, "charges-max": 1 }, { "group": "on_hand_410shot" } ]
+    "entries": [ { "item": "shotgun_410", "ammo-group": "on_hand_shot", "charges": [ 0, 1 ] }, { "group": "on_hand_410shot" } ]
   },
   {
     "id": "everyday_shotgun_d",
@@ -1977,7 +2143,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "shotgun_d", "charges-min": 0, "charges-max": 2 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "shotgun_d", "ammo-group": "on_hand_shot", "charges": [ 0, 2 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "everyday_shotgun_s",
@@ -1985,7 +2151,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "shotgun_s", "charges-min": 0, "charges-max": 1 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "shotgun_s", "ammo-group": "on_hand_shot", "charges": [ 0, 1 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "everyday_shotgun_paper",
@@ -1993,7 +2159,10 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "shotgun_paper", "charges-min": 0, "charges-max": 1 }, { "group": "on_hand_shotpaper" } ]
+    "entries": [
+      { "item": "shotgun_paper", "ammo-group": "on_hand_shotpaper", "charges": [ 0, 1 ] },
+      { "group": "on_hand_shotpaper" }
+    ]
   },
   {
     "id": "everyday_ksg",
@@ -2001,7 +2170,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "ksg", "charges-min": 0, "charges-max": 7 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "ksg", "ammo-group": "on_hand_shot", "charges": [ 0, 7 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "everyday_ksg-25",
@@ -2009,7 +2178,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "ksg", "charges-min": 0, "charges-max": 12 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "ksg-25", "ammo-group": "on_hand_shot", "charges": [ 0, 12 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "everyday_tavor_12",
@@ -2017,7 +2186,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "tavor_12", "charges-min": 0, "charges-max": 5 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "tavor_12", "ammo-group": "on_hand_shot", "charges": [ 0, 5 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "everyday_m1014",
@@ -2025,7 +2194,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "m1014", "charges-min": 0, "charges-max": 8 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "m1014", "ammo-group": "on_hand_shot", "charges": [ 0, 8 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "everyday_SPAS_12",
@@ -2033,7 +2202,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "SPAS_12", "charges-min": 0, "charges-max": 9 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "SPAS_12", "ammo-group": "on_hand_shot", "charges": [ 0, 9 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "everyday_mossberg_590",
@@ -2041,7 +2210,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "mossberg_590", "charges-min": 0, "charges-max": 9 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "mossberg_590", "ammo-group": "on_hand_shot", "charges": [ 0, 9 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "everyday_remington_870_breacher",
@@ -2049,7 +2218,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "remington_870_breacher", "charges-min": 0, "charges-max": 4 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "remington_870_breacher", "ammo-group": "on_hand_shot", "charges": [ 0, 4 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "everyday_streetsweeper",
@@ -2057,7 +2226,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "streetsweeper", "charges-min": 0, "charges-max": 12 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "streetsweeper", "ammo-group": "on_hand_shot", "charges": [ 0, 12 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "everyday_rm228",
@@ -2066,9 +2235,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "rm228", "charges-min": 0, "charges-max": 10 },
-      { "item": "20x66_10_mag" },
-      { "item": "20x66_10_mag", "prob": 50 }
+      { "item": "rm228", "ammo-group": "on_hand_20x66mm", "charges": [ 0, 10 ] },
+      { "item": "20x66_10_mag", "ammo-group": "on_hand_20x66mm" },
+      { "item": "20x66_10_mag", "ammo-group": "on_hand_20x66mm", "prob": 50 }
     ]
   },
   {
@@ -2078,7 +2247,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "an94", "charges-min": 0, "charges-max": 30 },
+      { "item": "an94", "ammo-group": "on_hand_545x39", "charges": [ 0, 30 ] },
       { "group": "nested_ak74_mag" },
       { "group": "nested_ak74_mag", "prob": 50 }
     ]
@@ -2090,7 +2259,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "USAS_12", "charges-min": 0, "charges-max": 10 },
+      { "item": "USAS_12", "ammo-group": "on_hand_shot", "charges": [ 0, 10 ] },
       { "group": "nested_USAS_12_mag" },
       { "group": "nested_USAS_12_mag", "prob": 50 }
     ]
@@ -2101,7 +2270,11 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "as50", "charges-min": 0, "charges-max": 10 }, { "item": "as50mag" }, { "item": "as50mag", "prob": 50 } ]
+    "entries": [
+      { "item": "as50", "ammo-group": "on_hand_50", "charges": [ 0, 10 ] },
+      { "item": "as50mag", "ammo-group": "on_hand_50" },
+      { "item": "as50mag", "ammo-group": "on_hand_50", "prob": 50 }
+    ]
   },
   {
     "id": "everyday_needlepistol",
@@ -2110,7 +2283,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "needlepistol", "charges-min": 0, "charges-max": 50 },
+      { "item": "needlepistol", "ammo-group": "on_hand_5x50mm", "charges": [ 0, 50 ] },
       { "group": "nested_needlepistol_mag" },
       { "group": "nested_needlepistol_mag", "prob": 50 }
     ]
@@ -2122,9 +2295,19 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "rm99_pistol", "charges-min": 0, "charges-max": 50 },
-      { "group": "nested_rm51_mag" },
-      { "group": "nested_rm51_mag", "prob": 50 }
+      { "item": "rm99_pistol", "ammo-group": "on_hand_8x40", "charges": [ 0, 5 ] },
+      {
+        "distribution": [
+          {
+            "collection": [
+              { "item": "8x40_speedloader5", "ammo-group": "on_hand_8x40" },
+              { "item": "8x40_speedloader5", "ammo-group": "on_hand_8x40", "prob": 50 }
+            ],
+            "prob": 50
+          },
+          { "group": "on_hand_8x40", "prob": 50 }
+        ]
+      }
     ]
   },
   {
@@ -2134,9 +2317,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "ppsh", "charges-min": 0, "charges-max": 35 },
-      { "group": "nested_ppsh_mag" },
-      { "group": "nested_ppsh_mag", "prob": 50 }
+      { "item": "ppsh", "ammo-group": "on_hand_762x25", "charges": [ 0, 35 ] },
+      { "group": "nested_ppsh_mag", "ammo-group": "on_hand_762x25" },
+      { "group": "nested_ppsh_mag", "ammo-group": "on_hand_762x25", "prob": 50 }
     ]
   },
   {
@@ -2146,9 +2329,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "skorpion_61", "charges-min": 0, "charges-max": 20 },
-      { "item": "skorpion61mag" },
-      { "item": "skorpion61mag", "prob": 50 }
+      { "item": "skorpion_61", "ammo-group": "on_hand_32", "charges": [ 0, 20 ] },
+      { "item": "skorpion61mag", "ammo-group": "on_hand_32" },
+      { "item": "skorpion61mag", "ammo-group": "on_hand_32", "prob": 50 }
     ]
   },
   {
@@ -2158,9 +2341,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "skorpion_82", "charges-min": 0, "charges-max": 20 },
-      { "item": "skorpion82mag" },
-      { "item": "skorpion82mag", "prob": 50 }
+      { "item": "skorpion_82", "ammo-group": "on_hand_9x18", "charges": [ 0, 20 ] },
+      { "item": "skorpion82mag", "ammo-group": "on_hand_9x18" },
+      { "item": "skorpion82mag", "ammo-group": "on_hand_9x18", "prob": 50 }
     ]
   },
   {
@@ -2170,7 +2353,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "acr", "charges-min": 0, "charges-max": 30 },
+      { "item": "acr", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
       { "group": "nested_stanag_mag" },
       { "group": "nested_stanag_mag", "prob": 50 }
     ]
@@ -2182,9 +2365,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "ar15_retool_300blk", "charges-min": 0, "charges-max": 30 },
-      { "group": "nested_stanag_mag" },
-      { "group": "nested_stanag_mag", "prob": 50 }
+      { "item": "ar15_retool_300blk", "ammo-group": "on_hand_300BLK", "charges": [ 0, 30 ] },
+      { "group": "nested_stanag_mag_300", "ammo-group": "on_hand_300BLK" },
+      { "group": "nested_stanag_mag_300", "ammo-group": "on_hand_300BLK", "prob": 50 }
     ]
   },
   {
@@ -2194,7 +2377,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "needlegun", "charges-min": 0, "charges-max": 100 },
+      { "item": "needlegun", "ammo-group": "on_hand_5x50mm", "charges": [ 0, 100 ] },
       { "group": "nested_needlegun_mag" },
       { "group": "nested_needlegun_mag", "prob": 50 }
     ]
@@ -2205,7 +2388,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "rm120c", "charges-min": 0, "charges-max": 5 }, { "group": "on_hand_20x66mm" } ]
+    "entries": [ { "item": "rm120c", "ammo-group": "on_hand_20x66mm", "charges": [ 0, 5 ] }, { "group": "on_hand_20x66mm" } ]
   },
   {
     "id": "everyday_mgl",
@@ -2213,6 +2396,6 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "mgl", "charges-min": 0, "charges-max": 6 }, { "group": "on_hand_40x46mm" } ]
+    "entries": [ { "item": "mgl", "ammo-group": "on_hand_40x46mm", "charges": [ 0, 6 ] }, { "group": "on_hand_40x46mm" } ]
   }
 ]

--- a/data/json/itemgroups/Weapons_Mods_Ammo/nested_ammo.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/nested_ammo.json
@@ -30,7 +30,10 @@
     "type": "item_group",
     "//": "a collection of ammo that would be found with a loaded gun.",
     "subtype": "distribution",
-    "entries": [ { "item": "45colt_jhp", "prob": 100, "charges": [ 25, 50 ] } ]
+    "entries": [
+      { "item": "45colt_jhp", "prob": 100, "charges": [ 25, 50 ] },
+      { "item": "bp_45colt_jhp", "prob": 50, "charges": [ 25, 50 ] }
+    ]
   },
   {
     "id": "on_hand_38super",
@@ -65,7 +68,10 @@
     "type": "item_group",
     "//": "a collection of ammo that would be found with a loaded gun.",
     "subtype": "distribution",
-    "entries": [ { "item": "flintlock_ammo", "prob": 100, "charges": [ 15, 30 ] } ]
+    "entries": [
+      { "item": "flintlock_ammo", "prob": 100, "charges": [ 15, 30 ] },
+      { "item": "flintlock_shot", "prob": 50, "charges": [ 15, 30 ] }
+    ]
   },
   {
     "id": "on_hand_454",
@@ -193,19 +199,12 @@
   {
     "id": "on_hand_357_38mixed",
     "type": "item_group",
-    "//": "a mixed collection of 357mag and 38 ammo that would be found with a gun that is compatible with both calibers. favors spawning 357mag ammo but will rarely spawn more 38",
-    "subtype": "collection",
+    "//": "Selects between .357 or .38 ammo for guns that can use both.",
+    "subtype": "distribution",
     "entries": [
-      { "distribution": [ { "item": "357mag_fmj", "charges": [ 20, 40 ] }, { "item": "357mag_jhp", "charges": [ 20, 40 ] } ] },
-      {
-        "distribution": [
-          { "item": "357mag_fmj", "charges": [ 20, 40 ], "prob": 30 },
-          { "item": "357mag_jhp", "charges": [ 20, 40 ], "prob": 30 },
-          { "item": "38_fmj", "charges": [ 20, 40 ], "prob": 15 },
-          { "item": "38_special", "charges": [ 20, 40 ], "prob": 25 }
-        ],
-        "prob": 100
-      }
+      { "item": "357mag_fmj", "prob": 100, "charges": [ 20, 40 ] },
+      { "item": "357mag_jhp", "prob": 100, "charges": [ 20, 40 ] },
+      { "group": "on_hand_38", "prob": 100 }
     ]
   },
   {
@@ -228,7 +227,8 @@
     "entries": [
       { "item": "4570_sp", "prob": 100, "charges": [ 10, 20 ] },
       { "item": "4570_pen", "prob": 100, "charges": [ 10, 20 ] },
-      { "item": "4570_low", "prob": 100, "charges": [ 10, 20 ] }
+      { "item": "4570_low", "prob": 100, "charges": [ 10, 20 ] },
+      { "item": "reloaded_4570_bp", "prob": 100, "charges": [ 10, 20 ] }
     ]
   },
   {
@@ -260,7 +260,8 @@
     "subtype": "distribution",
     "entries": [
       { "item": "3006", "prob": 100, "charges": [ 10, 20 ] },
-      { "item": "3006_incendiary", "prob": 100, "charges": [ 10, 20 ] }
+      { "item": "3006_incendiary", "prob": 100, "charges": [ 10, 20 ] },
+      { "item": "3006fmj", "prob": 50, "charges": [ 10, 20 ] }
     ]
   },
   {
@@ -387,5 +388,26 @@
       { "item": "40x46mm_m576", "prob": 10, "charges": [ 5, 10 ] },
       { "item": "40x46mm_m651", "prob": 15, "charges": [ 5, 10 ] }
     ]
+  },
+  {
+    "id": "on_hand_40sw_or_10mm",
+    "type": "item_group",
+    "//": "Used for when a gun can freely use either .40 S&W or 10mm, for example sw_610.",
+    "subtype": "distribution",
+    "entries": [ { "group": "on_hand_40", "prob": 100 }, { "group": "on_hand_10mm", "prob": 50 } ]
+  },
+  {
+    "id": "on_hand_410_or_45colt",
+    "type": "item_group",
+    "//": "Used for when a gun can freely use either .410 shotshells or .45 Colt, for example bond_410.",
+    "subtype": "distribution",
+    "entries": [ { "group": "on_hand_45colt", "prob": 100 }, { "group": "on_hand_410shot", "prob": 50 } ]
+  },
+  {
+    "id": "on_hand_454_mixed",
+    "type": "item_group",
+    "//": "Used for when a gun can freely use either .410 shotshells or .45 Colt, for example bond_410.",
+    "subtype": "distribution",
+    "entries": [ { "group": "on_hand_454", "prob": 100 }, { "group": "on_hand_410_or_45colt", "prob": 50 } ]
   }
 ]

--- a/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
@@ -3,10 +3,11 @@
     "id": "nested_glock_17",
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "//2": "For guns with nested magazine groups like this, apply ammo-group to the items in said subgroups",
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "glock_17", "charges-min": 0, "charges-max": 15 },
+      { "item": "glock_17", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
       { "group": "nested_glock17_mag" },
       { "group": "nested_glock17_mag", "prob": 50 },
       { "group": "on_hand_9mm" }
@@ -19,7 +20,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "glock_19", "charges-min": 0, "charges-max": 15 },
+      { "item": "glock_19", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
       { "group": "nested_glock19_mag" },
       { "group": "nested_glock19_mag", "prob": 50 },
       { "group": "on_hand_9mm" }
@@ -32,7 +33,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "glock_21", "charges-min": 0, "charges-max": 15 },
+      { "item": "glock_21", "ammo-group": "on_hand_45", "charges": [ 0, 15 ] },
       { "group": "nested_glock21_mag" },
       { "group": "nested_glock21_mag", "prob": 50 },
       { "group": "on_hand_45" }
@@ -45,7 +46,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "glock_22", "charges-min": 0, "ammo-item": "40sw", "charges-max": 15 },
+      { "item": "glock_22", "ammo-group": "on_hand_40", "charges": [ 0, 15 ] },
       { "group": "nested_glock22_mag" },
       { "group": "nested_glock22_mag", "prob": 50 },
       { "group": "on_hand_40" }
@@ -58,7 +59,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "glock_31", "charges-min": 0, "charges-max": 15 },
+      { "item": "glock_31", "ammo-group": "on_hand_357sig", "charges": [ 0, 15 ] },
       { "group": "nested_glock22_mag" },
       { "group": "nested_glock22_mag", "prob": 50 },
       { "group": "on_hand_357sig" }
@@ -71,7 +72,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m1911", "charges-min": 0, "charges-max": 7 },
+      { "item": "m1911", "ammo-group": "on_hand_45", "charges": [ 0, 7 ] },
       { "group": "nested_m1911_mag" },
       { "group": "nested_m1911_mag", "prob": 50 },
       { "group": "on_hand_45" }
@@ -84,7 +85,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m1911_MEU", "charges-min": 0, "charges-max": 7 },
+      { "item": "m1911_MEU", "ammo-group": "on_hand_45", "charges": [ 0, 7 ] },
       { "group": "nested_m1911_mag" },
       { "group": "nested_m1911_mag", "prob": 50 },
       { "group": "on_hand_45" }
@@ -97,7 +98,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m9", "charges-min": 0, "charges-max": 15 },
+      { "item": "m9", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
       { "group": "nested_m9_mag" },
       { "group": "nested_m9_mag", "prob": 50 },
       { "group": "on_hand_9mm" }
@@ -107,12 +108,13 @@
     "id": "nested_px4",
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "//2": "With nested spawns like this where the mags are still single items and not groups, ammo-group can be called directly",
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "px4", "charges-min": 0, "charges-max": 15 },
-      { "item": "px4mag" },
-      { "item": "px4mag", "prob": 50 },
+      { "item": "px4", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
+      { "item": "px4mag", "ammo-group": "on_hand_9mm" },
+      { "item": "px4mag", "ammo-group": "on_hand_9mm", "prob": 50 },
       { "group": "on_hand_9mm" }
     ]
   },
@@ -123,9 +125,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "px4_40", "charges-min": 0, "charges-max": 15 },
-      { "item": "px4_40mag" },
-      { "item": "px4_40mag", "prob": 50 },
+      { "item": "px4_40", "ammo-group": "on_hand_40", "charges": [ 0, 15 ] },
+      { "item": "px4_40mag", "ammo-group": "on_hand_40" },
+      { "item": "px4_40mag", "ammo-group": "on_hand_40", "prob": 50 },
       { "group": "on_hand_40" }
     ]
   },
@@ -136,9 +138,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "ruger_lcr_38", "charges-min": 0, "charges-max": 5 },
-      { "item": "38_speedloader5", "ammo-item": "38_special", "prob": 50, "charges": [ 0, 5 ] },
-      { "item": "38_speedloader5", "ammo-item": "38_special", "prob": 25, "charges": [ 0, 5 ] },
+      { "item": "ruger_lcr_38", "ammo-group": "on_hand_38", "charges": [ 0, 5 ] },
+      { "item": "38_speedloader5", "ammo-group": "on_hand_38", "prob": 50 },
+      { "item": "38_speedloader5", "ammo-group": "on_hand_38", "prob": 25 },
       { "group": "on_hand_38" }
     ]
   },
@@ -149,9 +151,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "sig_mosquito", "charges-min": 0, "charges-max": 10 },
-      { "item": "mosquitomag" },
-      { "item": "mosquitomag", "prob": 50 },
+      { "item": "sig_mosquito", "ammo-group": "on_hand_22", "charges": [ 0, 10 ] },
+      { "item": "mosquitomag", "ammo-group": "on_hand_22" },
+      { "item": "mosquitomag", "ammo-group": "on_hand_22", "prob": 50 },
       { "group": "on_hand_22" }
     ]
   },
@@ -162,9 +164,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "sw_22", "charges-min": 0, "charges-max": 10 },
-      { "item": "sw22mag" },
-      { "item": "sw22mag", "prob": 50 },
+      { "item": "sw_22", "ammo-group": "on_hand_22", "charges": [ 0, 10 ] },
+      { "item": "sw22mag", "ammo-group": "on_hand_22" },
+      { "item": "sw22mag", "ammo-group": "on_hand_22", "prob": 50 },
       { "group": "on_hand_22" }
     ]
   },
@@ -175,10 +177,10 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "sw_610", "charges-min": 0, "charges-max": 6 },
-      { "item": "40_speedloader6", "prob": 50, "charges": [ 0, 6 ] },
-      { "item": "40_speedloader6", "prob": 25, "charges": [ 0, 6 ] },
-      { "distribution": [ { "group": "on_hand_40", "prob": 50 }, { "group": "on_hand_10mm", "prob": 50 } ] }
+      { "item": "sw_610", "ammo-group": "on_hand_40sw_or_10mm", "charges": [ 0, 6 ] },
+      { "item": "40_speedloader6", "ammo-group": "on_hand_40sw_or_10mm", "prob": 50 },
+      { "item": "40_speedloader6", "ammo-group": "on_hand_40sw_or_10mm", "prob": 25 },
+      { "group": "on_hand_40sw_or_10mm" }
     ]
   },
   {
@@ -188,9 +190,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "sw_619", "charges-min": 0, "charges-max": 7 },
-      { "item": "38_speedloader", "prob": 50, "charges": [ 0, 7 ] },
-      { "item": "38_speedloader", "prob": 25, "charges": [ 0, 7 ] },
+      { "item": "sw_619", "ammo-group": "on_hand_357_38mixed", "charges": [ 0, 7 ] },
+      { "item": "38_speedloader", "prob": 50, "ammo-group": "on_hand_357_38mixed" },
+      { "item": "38_speedloader", "prob": 25, "ammo-group": "on_hand_357_38mixed" },
       { "group": "on_hand_357_38mixed" }
     ]
   },
@@ -201,9 +203,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "model_10_revolver", "charges-min": 0, "charges-max": 6 },
-      { "item": "38_speedloader6", "ammo-item": "38_special", "prob": 50, "charges": [ 0, 6 ] },
-      { "item": "38_speedloader6", "ammo-item": "38_special", "prob": 25, "charges": [ 0, 6 ] },
+      { "item": "model_10_revolver", "ammo-group": "on_hand_38", "charges": [ 0, 6 ] },
+      { "item": "38_speedloader6", "ammo-group": "on_hand_38", "prob": 50 },
+      { "item": "38_speedloader6", "ammo-group": "on_hand_38", "prob": 25 },
       { "group": "on_hand_38" }
     ]
   },
@@ -214,9 +216,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "taurus_spectrum", "charges-min": 0, "charges-max": 6 },
-      { "item": "taurus_spectrum_mag" },
-      { "item": "taurus_spectrum_mag", "prob": 50 },
+      { "item": "taurus_spectrum", "ammo-group": "on_hand_380", "charges": [ 0, 6 ] },
+      { "item": "taurus_spectrum_mag", "ammo-group": "on_hand_380" },
+      { "item": "taurus_spectrum_mag", "ammo-group": "on_hand_380", "prob": 50 },
       { "group": "on_hand_380" }
     ]
   },
@@ -227,9 +229,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "p226_357sig", "charges-min": 0, "charges-max": 12 },
-      { "item": "p226mag_12rd_357sig" },
-      { "item": "p226mag_12rd_357sig", "prob": 50 },
+      { "item": "p226_357sig", "ammo-group": "on_hand_357sig", "charges": [ 0, 12 ] },
+      { "item": "p226mag_12rd_357sig", "ammo-group": "on_hand_357sig" },
+      { "item": "p226mag_12rd_357sig", "ammo-group": "on_hand_357sig", "prob": 50 },
       { "group": "on_hand_357sig" }
     ]
   },
@@ -240,9 +242,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "p320_357sig", "charges-min": 0, "charges-max": 13 },
-      { "item": "p320mag_13rd_357sig" },
-      { "item": "p320mag_13rd_357sig", "prob": 50 },
+      { "item": "p320_357sig", "ammo-group": "on_hand_357sig", "charges": [ 0, 13 ] },
+      { "item": "p320mag_13rd_357sig", "ammo-group": "on_hand_357sig" },
+      { "item": "p320mag_13rd_357sig", "ammo-group": "on_hand_357sig", "prob": 50 },
       { "group": "on_hand_357sig" }
     ]
   },
@@ -253,9 +255,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "kp32", "charges-min": 0, "charges-max": 7 },
-      { "item": "kp32mag" },
-      { "item": "kp32mag", "prob": 50 },
+      { "item": "kp32", "ammo-group": "on_hand_32", "charges": [ 0, 7 ] },
+      { "item": "kp32mag", "ammo-group": "on_hand_32" },
+      { "item": "kp32mag", "ammo-group": "on_hand_32", "prob": 50 },
       { "group": "on_hand_32" }
     ]
   },
@@ -266,9 +268,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "kp3at", "charges-min": 0, "charges-max": 6 },
-      { "item": "kp3atmag" },
-      { "item": "kp3atmag", "prob": 50 },
+      { "item": "kp3at", "ammo-group": "on_hand_380", "charges": [ 0, 6 ] },
+      { "item": "kp3atmag", "ammo-group": "on_hand_380" },
+      { "item": "kp3atmag", "ammo-group": "on_hand_380", "prob": 50 },
       { "group": "on_hand_380" }
     ]
   },
@@ -279,9 +281,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "rugerlcp", "charges-min": 0, "charges-max": 6 },
-      { "item": "rugerlcpmag" },
-      { "item": "rugerlcpmag", "prob": 50 },
+      { "item": "rugerlcp", "ammo-group": "on_hand_380", "charges": [ 0, 6 ] },
+      { "item": "rugerlcpmag", "ammo-group": "on_hand_380" },
+      { "item": "rugerlcpmag", "ammo-group": "on_hand_380", "prob": 50 },
       { "group": "on_hand_380" }
     ]
   },
@@ -292,9 +294,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "kpf9", "charges-min": 0, "charges-max": 7 },
-      { "item": "kpf9mag" },
-      { "item": "kpf9mag", "prob": 50 },
+      { "item": "kpf9", "ammo-group": "on_hand_9mm", "charges": [ 0, 7 ] },
+      { "item": "kpf9mag", "ammo-group": "on_hand_9mm" },
+      { "item": "kpf9mag", "ammo-group": "on_hand_9mm", "prob": 50 },
       { "group": "on_hand_9mm" }
     ]
   },
@@ -305,7 +307,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hi_power_9mm", "charges-min": 0, "charges-max": 15 },
+      { "item": "hi_power_9mm", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
       { "group": "nested_hi_power_9mm_mag" },
       { "group": "nested_hi_power_9mm_mag", "prob": 50 },
       { "group": "on_hand_9mm" }
@@ -318,9 +320,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hi_power_40", "charges-min": 0, "charges-max": 10 },
-      { "item": "bhp40mag" },
-      { "item": "bhp40mag", "prob": 50 },
+      { "item": "hi_power_40", "ammo-group": "on_hand_40", "charges": [ 0, 10 ] },
+      { "item": "bhp40mag", "ammo-group": "on_hand_40" },
+      { "item": "bhp40mag", "ammo-group": "on_hand_40", "prob": 50 },
       { "group": "on_hand_40" }
     ]
   },
@@ -331,9 +333,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "walther_p38", "charges-min": 0, "charges-max": 8 },
-      { "item": "p38mag" },
-      { "item": "p38mag", "prob": 50 },
+      { "item": "walther_p38", "ammo-group": "on_hand_9mm", "charges": [ 0, 8 ] },
+      { "item": "p38mag", "ammo-group": "on_hand_9mm" },
+      { "item": "p38mag", "ammo-group": "on_hand_9mm", "prob": 50 },
       { "group": "on_hand_9mm" }
     ]
   },
@@ -344,7 +346,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "walther_ppq_9mm", "charges-min": 0, "charges-max": 17 },
+      { "item": "walther_ppq_9mm", "ammo-group": "on_hand_9mm", "charges": [ 0, 17 ] },
       { "group": "nested_walther_ppq_9mm_mag" },
       { "group": "nested_walther_ppq_9mm_mag", "prob": 50 },
       { "group": "on_hand_9mm" }
@@ -357,7 +359,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "walther_ppq_40", "charges-min": 0, "charges-max": 14 },
+      { "item": "walther_ppq_40", "ammo-group": "on_hand_40", "charges": [ 0, 14 ] },
       { "group": "nested_walther_ppq_40_mag" },
       { "group": "nested_walther_ppq_40_mag", "prob": 50 },
       { "group": "on_hand_40" }
@@ -370,9 +372,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "walther_ppq_45", "charges-min": 0, "charges-max": 12 },
-      { "item": "ppq45mag" },
-      { "item": "ppq45mag", "prob": 50 },
+      { "item": "walther_ppq_45", "ammo-group": "on_hand_45", "charges": [ 0, 12 ] },
+      { "item": "ppq45mag", "ammo-group": "on_hand_45" },
+      { "item": "ppq45mag", "ammo-group": "on_hand_45", "prob": 50 },
       { "group": "on_hand_45" }
     ]
   },
@@ -383,7 +385,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hptc9", "charges-min": 0, "charges-max": 15 },
+      { "item": "hptc9", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
       { "group": "nested_hptc9_mag" },
       { "group": "nested_hptc9_mag", "prob": 50 },
       { "group": "on_hand_9mm" }
@@ -396,7 +398,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hptcf380", "charges-min": 0, "charges-max": 10 },
+      { "item": "hptcf380", "ammo-group": "on_hand_380", "charges": [ 0, 10 ] },
       { "group": "nested_hptcf380_mag" },
       { "group": "nested_hptcf380_mag", "prob": 50 },
       { "group": "on_hand_380" }
@@ -409,9 +411,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hptjcp", "charges-min": 0, "charges-max": 10 },
-      { "item": "hptjcpmag" },
-      { "item": "hptjcpmag", "prob": 50 },
+      { "item": "hptjcp", "ammo-group": "on_hand_40", "charges": [ 0, 10 ] },
+      { "item": "hptjcpmag", "ammo-group": "on_hand_40" },
+      { "item": "hptjcpmag", "ammo-group": "on_hand_40", "prob": 50 },
       { "group": "on_hand_40" }
     ]
   },
@@ -422,9 +424,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hptjhp", "charges-min": 0, "charges-max": 9 },
-      { "item": "hptjhpmag" },
-      { "item": "hptjhpmag", "prob": 50 },
+      { "item": "hptjhp", "ammo-group": "on_hand_45", "charges": [ 0, 9 ] },
+      { "item": "hptjhpmag", "ammo-group": "on_hand_45" },
+      { "item": "hptjhpmag", "ammo-group": "on_hand_45", "prob": 50 },
       { "group": "on_hand_45" }
     ]
   },
@@ -435,7 +437,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "cz75", "charges-min": 0, "charges-max": 26 },
+      { "item": "cz75", "ammo-group": "on_hand_9mm", "charges": [ 0, 26 ] },
       { "group": "nested_cz75_mag" },
       { "group": "nested_cz75_mag", "prob": 50 },
       { "group": "on_hand_9mm" }
@@ -448,9 +450,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "walther_ccp", "charges-min": 0, "charges-max": 8 },
-      { "item": "ccpmag" },
-      { "item": "ccpmag", "prob": 50 },
+      { "item": "walther_ccp", "ammo-group": "on_hand_9mm", "charges": [ 0, 8 ] },
+      { "item": "ccpmag", "ammo-group": "on_hand_9mm" },
+      { "item": "ccpmag", "ammo-group": "on_hand_9mm", "prob": 50 },
       { "group": "on_hand_9mm" }
     ]
   },
@@ -461,9 +463,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "walther_p22", "charges-min": 0, "charges-max": 10 },
-      { "item": "wp22mag" },
-      { "item": "wp22mag", "prob": 50 },
+      { "item": "walther_p22", "ammo-group": "on_hand_22", "charges": [ 0, 10 ] },
+      { "item": "wp22mag", "ammo-group": "on_hand_22" },
+      { "item": "wp22mag", "ammo-group": "on_hand_22", "prob": 50 },
       { "group": "on_hand_22" }
     ]
   },
@@ -474,7 +476,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "90two", "charges-min": 0, "charges-max": 15 },
+      { "item": "90two", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
       { "group": "nested_m9_mag" },
       { "group": "nested_m9_mag", "prob": 50 },
       { "group": "on_hand_9mm" }
@@ -487,9 +489,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "90two40", "charges-min": 0, "charges-max": 12 },
-      { "item": "90two40mag" },
-      { "item": "90two40mag", "prob": 50 },
+      { "item": "90two40", "ammo-group": "on_hand_40", "charges": [ 0, 12 ] },
+      { "item": "90two40mag", "ammo-group": "on_hand_40" },
+      { "item": "90two40mag", "ammo-group": "on_hand_40", "prob": 50 },
       { "group": "on_hand_40" }
     ]
   },
@@ -500,8 +502,8 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "bond_410", "charges-min": 0, "charges-max": 2 },
-      { "distribution": [ { "group": "on_hand_45colt", "prob": 75 }, { "group": "on_hand_410shot", "prob": 25 } ] }
+      { "item": "bond_410", "ammo-group": "on_hand_410_or_45colt", "charges": [ 0, 2 ] },
+      { "group": "on_hand_410_or_45colt" }
     ]
   },
   {
@@ -511,9 +513,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "deagle_44", "charges-min": 0, "charges-max": 2 },
-      { "item": "deaglemag" },
-      { "item": "deaglemag", "prob": 50 },
+      { "item": "deagle_44", "ammo-group": "on_hand_44", "charges": [ 0, 2 ] },
+      { "item": "deaglemag", "ammo-group": "on_hand_44" },
+      { "item": "deaglemag", "ammo-group": "on_hand_44", "prob": 50 },
       { "group": "on_hand_44" }
     ]
   },
@@ -524,9 +526,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m1911a1_38super", "charges-min": 0, "charges-max": 9 },
-      { "item": "m1911mag_10rd_38super" },
-      { "item": "m1911mag_10rd_38super", "prob": 50 },
+      { "item": "m1911a1_38super", "ammo-group": "on_hand_38super", "charges": [ 0, 9 ] },
+      { "item": "m1911mag_10rd_38super", "ammo-group": "on_hand_38super" },
+      { "item": "m1911mag_10rd_38super", "ammo-group": "on_hand_38super", "prob": 50 },
       { "group": "on_hand_38super" }
     ]
   },
@@ -537,9 +539,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "fn57", "charges-min": 0, "charges-max": 20 },
-      { "item": "fn57mag" },
-      { "item": "fn57mag", "prob": 50 },
+      { "item": "fn57", "ammo-group": "on_hand_57", "charges": [ 0, 20 ] },
+      { "item": "fn57mag", "ammo-group": "on_hand_57" },
+      { "item": "fn57mag", "ammo-group": "on_hand_57", "prob": 50 },
       { "group": "on_hand_57" }
     ]
   },
@@ -550,9 +552,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "ruger_lcr_22", "charges-min": 0, "charges-max": 8 },
-      { "item": "22_speedloader8", "prob": 50, "charges": [ 0, 8 ] },
-      { "item": "22_speedloader8", "prob": 25, "charges": [ 0, 8 ] },
+      { "item": "ruger_lcr_22", "ammo-group": "on_hand_22", "charges": [ 0, 8 ] },
+      { "item": "22_speedloader8", "ammo-group": "on_hand_22", "prob": 50 },
+      { "item": "22_speedloader8", "ammo-group": "on_hand_22", "prob": 25 },
       { "group": "on_hand_22" }
     ]
   },
@@ -563,9 +565,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "ruger_redhawk", "charges-min": 0, "charges-max": 6 },
-      { "item": "44_speedloader6", "prob": 50, "charges": [ 0, 6 ] },
-      { "item": "44_speedloader6", "prob": 25, "charges": [ 0, 6 ] },
+      { "item": "ruger_redhawk", "ammo-group": "on_hand_44", "charges": [ 0, 6 ] },
+      { "item": "44_speedloader6", "ammo-group": "on_hand_44", "prob": 50 },
+      { "item": "44_speedloader6", "ammo-group": "on_hand_44", "prob": 25 },
       { "group": "on_hand_44" }
     ]
   },
@@ -576,9 +578,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "sig_40", "charges-min": 0, "charges-max": 12 },
-      { "item": "sig40mag" },
-      { "item": "sig40mag", "prob": 50 },
+      { "item": "sig_40", "ammo-group": "on_hand_40", "charges": [ 0, 12 ] },
+      { "item": "sig40mag", "ammo-group": "on_hand_40" },
+      { "item": "sig40mag", "ammo-group": "on_hand_40", "prob": 50 },
       { "group": "on_hand_40" }
     ]
   },
@@ -589,9 +591,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "sig_p230", "charges-min": 0, "charges-max": 8 },
-      { "item": "sigp230mag" },
-      { "item": "sigp230mag", "prob": 50 },
+      { "item": "sig_p230", "ammo-group": "on_hand_32", "charges": [ 0, 8 ] },
+      { "item": "sigp230mag", "ammo-group": "on_hand_32" },
+      { "item": "sigp230mag", "ammo-group": "on_hand_32", "prob": 50 },
       { "group": "on_hand_32" }
     ]
   },
@@ -602,9 +604,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "sw_500", "charges-min": 0, "charges-max": 5 },
-      { "item": "500_speedloader5", "prob": 50, "charges": [ 0, 5 ] },
-      { "item": "500_speedloader5", "prob": 25, "charges": [ 0, 5 ] },
+      { "item": "sw_500", "ammo-group": "on_hand_500", "charges": [ 0, 5 ] },
+      { "item": "500_speedloader5", "ammo-group": "on_hand_500", "prob": 50 },
+      { "item": "500_speedloader5", "ammo-group": "on_hand_500", "prob": 25 },
       { "group": "on_hand_500" }
     ]
   },
@@ -615,9 +617,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "sw629", "charges-min": 0, "charges-max": 6 },
-      { "item": "44_speedloader6", "prob": 50, "charges": [ 0, 6 ] },
-      { "item": "44_speedloader6", "prob": 25, "charges": [ 0, 6 ] },
+      { "item": "sw629", "ammo-group": "on_hand_44", "charges": [ 0, 6 ] },
+      { "item": "44_speedloader6", "ammo-group": "on_hand_44", "prob": 50 },
+      { "item": "44_speedloader6", "ammo-group": "on_hand_44", "prob": 25 },
       { "group": "on_hand_44" }
     ]
   },
@@ -628,9 +630,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "usp_45", "charges-min": 0, "charges-max": 12 },
-      { "item": "usp45mag" },
-      { "item": "usp45mag", "prob": 50 },
+      { "item": "usp_45", "ammo-group": "on_hand_45", "charges": [ 0, 12 ] },
+      { "item": "usp45mag", "ammo-group": "on_hand_45" },
+      { "item": "usp45mag", "ammo-group": "on_hand_45", "prob": 50 },
       { "group": "on_hand_45" }
     ]
   },
@@ -641,9 +643,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "usp_9mm", "charges-min": 0, "charges-max": 15 },
-      { "item": "usp9mag" },
-      { "item": "usp9mag", "prob": 50 },
+      { "item": "usp_9mm", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
+      { "item": "usp9mag", "ammo-group": "on_hand_9mm" },
+      { "item": "usp9mag", "ammo-group": "on_hand_9mm", "prob": 50 },
       { "group": "on_hand_9mm" }
     ]
   },
@@ -654,7 +656,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "draco", "charges-min": 0, "charges-max": 30 },
+      { "item": "draco", "ammo-group": "on_hand_762", "charges": [ 0, 30 ] },
       { "group": "nested_ak47_mag" },
       { "group": "nested_ak47_mag", "prob": 50 },
       { "group": "on_hand_762" }
@@ -667,9 +669,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m17", "charges-min": 0, "charges-max": 17 },
-      { "item": "p320mag_17rd_9x19mm" },
-      { "item": "p320mag_17rd_9x19mm", "prob": 50 },
+      { "item": "m17", "ammo-group": "on_hand_9mm", "charges": [ 0, 17 ] },
+      { "item": "p320mag_17rd_9x19mm", "ammo-group": "on_hand_9mm" },
+      { "item": "p320mag_17rd_9x19mm", "ammo-group": "on_hand_9mm", "prob": 50 },
       { "group": "on_hand_9mm" }
     ]
   },
@@ -680,7 +682,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "glock_18c", "charges-min": 0, "charges-max": 17 },
+      { "item": "glock_18c", "ammo-group": "on_hand_9mm", "charges": [ 0, 17 ] },
       { "group": "nested_glock17_mag" },
       { "group": "nested_glock17_mag", "prob": 50 },
       { "group": "on_hand_9mm" }
@@ -693,9 +695,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "mk23", "charges-min": 0, "charges-max": 12 },
-      { "item": "usp45mag" },
-      { "item": "usp45mag", "prob": 50 },
+      { "item": "mk23", "ammo-group": "on_hand_45", "charges": [ 0, 12 ] },
+      { "item": "usp45mag", "ammo-group": "on_hand_45" },
+      { "item": "usp45mag", "ammo-group": "on_hand_45", "prob": 50 },
       { "group": "on_hand_45" }
     ]
   },
@@ -705,7 +707,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "bfr" }, { "group": "on_hand_4570" } ]
+    "entries": [ { "item": "bfr", "ammo-group": "on_hand_4570", "charges": [ 0, 5 ] }, { "group": "on_hand_4570" } ]
   },
   {
     "id": "nested_moss_brownie",
@@ -713,7 +715,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "moss_brownie" }, { "group": "on_hand_22" } ]
+    "entries": [ { "item": "moss_brownie", "ammo-group": "on_hand_22", "charges": [ 0, 4 ] }, { "group": "on_hand_22" } ]
   },
   {
     "id": "nested_raging_bull",
@@ -722,16 +724,10 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "raging_bull", "charges-min": 0, "charges-max": 5 },
-      { "item": "454_speedloader5", "prob": 50, "charges": [ 0, 5 ] },
-      { "item": "454_speedloader5", "prob": 25, "charges": [ 0, 5 ] },
-      {
-        "distribution": [
-          { "group": "on_hand_454", "prob": 50 },
-          { "group": "on_hand_410shot", "prob": 25 },
-          { "group": "on_hand_45colt", "prob": 25 }
-        ]
-      }
+      { "item": "raging_bull", "ammo-group": "on_hand_454_mixed", "charges": [ 0, 5 ] },
+      { "item": "454_speedloader5", "ammo-group": "on_hand_454_mixed", "prob": 50 },
+      { "item": "454_speedloader5", "ammo-group": "on_hand_454_mixed", "prob": 25 },
+      { "group": "on_hand_454_mixed" }
     ]
   },
   {
@@ -741,16 +737,10 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "raging_judge", "charges-min": 0, "charges-max": 6 },
-      { "item": "454_speedloader6", "prob": 50, "charges": [ 0, 6 ] },
-      { "item": "454_speedloader6", "prob": 25, "charges": [ 0, 6 ] },
-      {
-        "distribution": [
-          { "group": "on_hand_454", "prob": 50 },
-          { "group": "on_hand_410shot", "prob": 25 },
-          { "group": "on_hand_45colt", "prob": 25 }
-        ]
-      }
+      { "item": "raging_judge", "ammo-group": "on_hand_454_mixed", "charges": [ 0, 6 ] },
+      { "item": "454_speedloader6", "ammo-group": "on_hand_454_mixed", "prob": 50 },
+      { "item": "454_speedloader6", "ammo-group": "on_hand_454_mixed", "prob": 25 },
+      { "group": "on_hand_454_mixed" }
     ]
   },
   {
@@ -759,7 +749,12 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "tokarev" }, { "item": "tokarevmag" }, { "item": "tokarevmag", "prob": 50 }, { "group": "on_hand_762x25" } ]
+    "entries": [
+      { "item": "tokarev", "ammo-group": "on_hand_762x25", "charges": [ 0, 8 ] },
+      { "item": "tokarevmag", "ammo-group": "on_hand_762x25" },
+      { "item": "tokarevmag", "prob": 50, "ammo-group": "on_hand_762x25" },
+      { "group": "on_hand_762x25" }
+    ]
   },
   {
     "id": "nested_walther_ppk",
@@ -767,7 +762,12 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "walther_ppk" }, { "item": "ppkmag" }, { "item": "ppkmag", "prob": 50 }, { "group": "on_hand_32" } ]
+    "entries": [
+      { "item": "walther_ppk", "ammo-group": "on_hand_32", "charges": [ 0, 8 ] },
+      { "item": "ppkmag", "ammo-group": "on_hand_32" },
+      { "item": "ppkmag", "prob": 50, "ammo-group": "on_hand_32" },
+      { "group": "on_hand_32" }
+    ]
   },
   {
     "id": "nested_rm103a_pistol",
@@ -776,7 +776,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "rm103a_pistol" },
+      { "item": "rm103a_pistol", "ammo-group": "on_hand_8x40", "charges": [ 0, 10 ] },
       { "group": "nested_rm103a_mag" },
       { "group": "nested_rm103a_mag", "prob": 50 },
       { "group": "on_hand_8x40" }
@@ -789,9 +789,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "af2011a1_38super" },
-      { "item": "af2011a1mag" },
-      { "item": "af2011a1mag", "prob": 50 },
+      { "item": "af2011a1_38super", "ammo-group": "on_hand_38super", "charges": [ 0, 16 ] },
+      { "item": "af2011a1mag", "ammo-group": "on_hand_38super" },
+      { "item": "af2011a1mag", "ammo-group": "on_hand_38super", "prob": 50 },
       { "group": "on_hand_38super" }
     ]
   },
@@ -801,7 +801,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "cop_38", "charges-min": 0, "charges-max": 4 }, { "group": "on_hand_357_38mixed" } ]
+    "entries": [ { "item": "cop_38", "ammo-group": "on_hand_357_38mixed", "charges": [ 0, 4 ] }, { "group": "on_hand_357_38mixed" } ]
   },
   {
     "id": "nested_m1911-460",
@@ -810,9 +810,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m1911-460", "charges-min": 0, "charges-max": 7 },
-      { "group": "nested_m1911_mag" },
-      { "group": "nested_m1911_mag", "prob": 50 },
+      { "item": "m1911-460", "ammo-group": "on_hand_460", "charges": [ 0, 7 ] },
+      { "group": "nested_m1911_mag_460" },
+      { "group": "nested_m1911_mag_460", "prob": 50 },
       { "group": "on_hand_460" }
     ]
   },
@@ -822,7 +822,11 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "lemat_revolver", "charges-min": 0, "charges-max": 9 }, { "group": "on_hand_44paper" } ]
+    "entries": [
+      { "item": "lemat_revolver", "ammo-group": "on_hand_44paper", "charges": [ 0, 9 ] },
+      { "group": "on_hand_44paper" },
+      { "group": "on_hand_shotpaper", "prob": 50 }
+    ]
   },
   {
     "id": "nested_makarov",
@@ -831,9 +835,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "makarov", "charges-min": 0, "charges-max": 8 },
-      { "item": "makarovmag" },
-      { "item": "makarovmag", "prob": 50 },
+      { "item": "makarov", "ammo-group": "on_hand_9x18", "charges": [ 0, 8 ] },
+      { "item": "makarovmag", "ammo-group": "on_hand_9x18" },
+      { "item": "makarovmag", "ammo-group": "on_hand_9x18", "prob": 50 },
       { "group": "on_hand_9x18" }
     ]
   },
@@ -843,7 +847,10 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "pistol_flintlock" }, { "group": "on_hand_flintlock" } ]
+    "entries": [
+      { "item": "pistol_flintlock", "ammo-group": "on_hand_flintlock", "charges": [ 0, 1 ] },
+      { "group": "on_hand_flintlock" }
+    ]
   },
   {
     "id": "nested_colt_saa",
@@ -851,7 +858,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "colt_saa", "charges-min": 0, "charges-max": 6 }, { "group": "on_hand_45colt" } ]
+    "entries": [ { "item": "colt_saa", "ammo-group": "on_hand_45colt", "charges": [ 0, 6 ] }, { "group": "on_hand_45colt" } ]
   },
   {
     "id": "nested_hk_mp5_semi_pistol",
@@ -860,7 +867,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hk_mp5_semi_pistol", "charges-min": 0, "charges-max": 30 },
+      { "item": "hk_mp5_semi_pistol", "ammo-group": "on_hand_9mm", "charges": [ 0, 30 ] },
       { "group": "nested_mp5_mag" },
       { "group": "nested_mp5_mag", "prob": 50 },
       { "group": "on_hand_9mm" }
@@ -873,9 +880,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "calico", "charges-min": 0, "charges-max": 50 },
-      { "item": "calicomag" },
-      { "item": "calicomag", "prob": 50 },
+      { "item": "calico", "ammo-group": "on_hand_9mm", "charges": [ 0, 50 ] },
+      { "item": "calicomag", "ammo-group": "on_hand_9mm" },
+      { "item": "calicomag", "ammo-group": "on_hand_9mm", "prob": 50 },
       { "group": "on_hand_9mm" }
     ]
   },
@@ -886,9 +893,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "fn_p90", "charges-min": 0, "charges-max": 50 },
-      { "item": "fnp90mag" },
-      { "item": "fnp90mag", "prob": 50 },
+      { "item": "fn_p90", "ammo-group": "on_hand_57", "charges": [ 0, 50 ] },
+      { "item": "fnp90mag", "ammo-group": "on_hand_57" },
+      { "item": "fnp90mag", "ammo-group": "on_hand_57", "prob": 50 },
       { "group": "on_hand_57" }
     ]
   },
@@ -899,7 +906,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "tommygun", "charges-min": 0, "charges-max": 20 },
+      { "item": "tommygun", "ammo-group": "on_hand_45", "charges": [ 0, 20 ] },
       { "group": "nested_tommygun_mag" },
       { "group": "nested_tommygun_mag", "prob": 50 },
       { "group": "on_hand_45" }
@@ -912,9 +919,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "sten", "charges-min": 0, "charges-max": 32 },
-      { "item": "stenmag" },
-      { "item": "stenmag", "prob": 50 },
+      { "item": "sten", "ammo-group": "on_hand_9mm", "charges": [ 0, 32 ] },
+      { "item": "stenmag", "ammo-group": "on_hand_9mm" },
+      { "item": "stenmag", "ammo-group": "on_hand_9mm", "prob": 50 },
       { "group": "on_hand_9mm" }
     ]
   },
@@ -925,9 +932,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "uzi", "charges-min": 0, "charges-max": 32 },
-      { "item": "uzimag" },
-      { "item": "uzimag", "prob": 50 },
+      { "item": "uzi", "ammo-group": "on_hand_9mm", "charges": [ 0, 32 ] },
+      { "item": "uzimag", "ammo-group": "on_hand_9mm" },
+      { "item": "uzimag", "ammo-group": "on_hand_9mm", "prob": 50 },
       { "group": "on_hand_9mm" }
     ]
   },
@@ -938,7 +945,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hk_mp5", "charges-min": 0, "charges-max": 30 },
+      { "item": "hk_mp5", "ammo-group": "on_hand_9mm", "charges": [ 0, 30 ] },
       { "group": "nested_mp5_mag" },
       { "group": "nested_mp5_mag", "prob": 50 },
       { "group": "on_hand_9mm" }
@@ -951,7 +958,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hk_mp5", "charges-min": 0, "charges-max": 30 },
+      { "item": "hk_mp5", "ammo-group": "on_hand_9mm", "charges": [ 0, 30 ] },
       { "group": "nested_mp5_mag" },
       { "group": "nested_mp5_mag", "prob": 50 },
       { "group": "on_hand_9mm" }
@@ -964,9 +971,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hk_ump45", "charges-min": 0, "charges-max": 25 },
-      { "item": "ump45mag" },
-      { "item": "ump45mag", "prob": 50 },
+      { "item": "hk_ump45", "ammo-group": "on_hand_45", "charges": [ 0, 25 ] },
+      { "item": "ump45mag", "ammo-group": "on_hand_45" },
+      { "item": "ump45mag", "ammo-group": "on_hand_45", "prob": 50 },
       { "group": "on_hand_45" }
     ]
   },
@@ -977,9 +984,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "mac_10", "charges-min": 0, "charges-max": 30 },
-      { "item": "mac10mag" },
-      { "item": "mac10mag", "prob": 50 },
+      { "item": "mac_10", "ammo-group": "on_hand_45", "charges": [ 0, 30 ] },
+      { "item": "mac10mag", "ammo-group": "on_hand_45" },
+      { "item": "mac10mag", "ammo-group": "on_hand_45", "prob": 50 },
       { "group": "on_hand_45" }
     ]
   },
@@ -990,9 +997,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "mac_11", "charges-min": 0, "charges-max": 32 },
-      { "item": "mac11mag" },
-      { "item": "mac11mag", "prob": 50 },
+      { "item": "mac_11", "ammo-group": "on_hand_380", "charges": [ 0, 32 ] },
+      { "item": "mac11mag", "ammo-group": "on_hand_380" },
+      { "item": "mac11mag", "ammo-group": "on_hand_380", "prob": 50 },
       { "group": "on_hand_380" }
     ]
   },
@@ -1003,7 +1010,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "TDI", "charges-min": 0, "charges-max": 30 },
+      { "item": "TDI", "ammo-group": "on_hand_45", "charges": [ 0, 30 ] },
       { "group": "nested_TDI_mag" },
       { "group": "nested_TDI_mag", "prob": 50 },
       { "group": "on_hand_45" }
@@ -1016,9 +1023,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "american_180", "charges-min": 0, "charges-max": 100 },
-      { "item": "a180mag" },
-      { "item": "a180mag", "prob": 50 },
+      { "item": "american_180", "ammo-group": "on_hand_22", "charges": [ 0, 100 ] },
+      { "item": "a180mag", "ammo-group": "on_hand_22" },
+      { "item": "a180mag", "ammo-group": "on_hand_22", "prob": 50 },
       { "group": "on_hand_22" }
     ]
   },
@@ -1029,7 +1036,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "briefcase_smg", "charges-min": 0, "charges-max": 30 },
+      { "item": "briefcase_smg", "ammo-group": "on_hand_9mm", "charges": [ 0, 30 ] },
       { "group": "nested_mp5_mag" },
       { "group": "nested_mp5_mag", "prob": 50 },
       { "group": "on_hand_9mm" }
@@ -1042,9 +1049,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "tec9", "charges-min": 0, "charges-max": 30 },
-      { "item": "tec9mag" },
-      { "item": "tec9mag", "prob": 50 },
+      { "item": "tec9", "ammo-group": "on_hand_9mm", "charges": [ 0, 30 ] },
+      { "item": "tec9mag", "ammo-group": "on_hand_9mm" },
+      { "item": "tec9mag", "ammo-group": "on_hand_9mm", "prob": 50 },
       { "group": "on_hand_9mm" }
     ]
   },
@@ -1055,7 +1062,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hk_mp7", "charges-min": 0, "charges-max": 20 },
+      { "item": "hk_mp7", "ammo-group": "on_hand_46", "charges": [ 0, 20 ] },
       { "group": "nested_hk_mp7_mag" },
       { "group": "nested_hk_mp7_mag", "prob": 50 },
       { "group": "on_hand_46" }
@@ -1068,7 +1075,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "rm2000_smg", "charges-min": 0, "charges-max": 10 },
+      { "item": "rm2000_smg", "ammo-group": "on_hand_8x40", "charges": [ 0, 10 ] },
       { "group": "nested_rm103a_mag" },
       { "group": "nested_rm103a_mag", "prob": 50 },
       { "group": "on_hand_8x40" }
@@ -1081,7 +1088,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hk_mp5k", "charges-min": 0, "charges-max": 30 },
+      { "item": "hk_mp5k", "ammo-group": "on_hand_9mm", "charges": [ 0, 30 ] },
       { "group": "nested_mp5_mag" },
       { "group": "nested_mp5_mag", "prob": 50 },
       { "group": "on_hand_9mm" }
@@ -1094,9 +1101,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "browning_blr", "charges-min": 0, "charges-max": 4 },
-      { "item": "blrmag" },
-      { "item": "blrmag", "prob": 50 },
+      { "item": "browning_blr", "ammo-group": "on_hand_3006", "charges": [ 0, 4 ] },
+      { "item": "blrmag", "ammo-group": "on_hand_3006" },
+      { "item": "blrmag", "ammo-group": "on_hand_3006", "prob": 50 },
       { "group": "on_hand_3006" }
     ]
   },
@@ -1107,7 +1114,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "ar_pistol", "charges-min": 0, "charges-max": 30 },
+      { "item": "ar_pistol", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
       { "group": "nested_stanag_mag" },
       { "group": "nested_stanag_mag", "prob": 50 },
       { "group": "on_hand_223" }
@@ -1120,9 +1127,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "garand", "charges-min": 0, "charges-max": 8 },
-      { "item": "garandclip" },
-      { "item": "garandclip", "prob": 50 },
+      { "item": "garand", "ammo-group": "on_hand_3006", "charges": [ 0, 8 ] },
+      { "item": "garandclip", "ammo-group": "on_hand_3006" },
+      { "item": "garandclip", "ammo-group": "on_hand_3006", "prob": 50 },
       { "group": "on_hand_3006" }
     ]
   },
@@ -1133,9 +1140,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "ar10", "charges-min": 0, "charges-max": 20 },
-      { "item": "ar10mag_20rd" },
-      { "item": "ar10mag_20rd", "prob": 50 },
+      { "item": "ar10", "ammo-group": "on_hand_308", "charges": [ 0, 20 ] },
+      { "item": "ar10mag_20rd", "ammo-group": "on_hand_308" },
+      { "item": "ar10mag_20rd", "ammo-group": "on_hand_308", "prob": 50 },
       { "group": "on_hand_308" }
     ]
   },
@@ -1146,7 +1153,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "ar15", "charges-min": 0, "charges-max": 30 },
+      { "item": "ar15", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
       { "group": "nested_stanag_mag" },
       { "group": "nested_stanag_mag", "prob": 50 },
       { "group": "on_hand_223" }
@@ -1159,7 +1166,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "cx4", "charges-min": 0, "charges-max": 15 },
+      { "item": "cx4", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
       { "group": "nested_m9_mag" },
       { "group": "nested_m9_mag", "prob": 50 },
       { "group": "on_hand_9mm" }
@@ -1172,7 +1179,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "ksub2000", "charges-min": 0, "charges-max": 15 },
+      { "item": "ksub2000", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
       { "group": "nested_glock19_mag" },
       { "group": "nested_glock19_mag", "prob": 50 },
       { "group": "on_hand_9mm" }
@@ -1185,7 +1192,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m1a", "charges-min": 0, "charges-max": 5 },
+      { "item": "m1a", "ammo-group": "on_hand_308", "charges": [ 0, 5 ] },
       { "group": "nested_m14_mag" },
       { "group": "nested_m14_mag", "prob": 50 },
       { "group": "on_hand_308" }
@@ -1198,9 +1205,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "marlin_9a", "charges-min": 0, "charges-max": 19 },
-      { "item": "marlin_tubeloader", "prob": 50, "charges": [ 0, 19 ] },
-      { "item": "marlin_tubeloader", "prob": 25, "charges": [ 0, 19 ] },
+      { "item": "marlin_9a", "ammo-group": "on_hand_22", "charges": [ 0, 19 ] },
+      { "item": "marlin_tubeloader", "ammo-group": "on_hand_22", "prob": 50 },
+      { "item": "marlin_tubeloader", "ammo-group": "on_hand_22", "prob": 25 },
       { "group": "on_hand_22" }
     ]
   },
@@ -1211,9 +1218,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "mosin44", "charges-min": 0, "charges-max": 5 },
-      { "item": "762R_clip", "prob": 50, "charges": [ 0, 5 ] },
-      { "item": "762R_clip", "prob": 25, "charges": [ 0, 5 ] },
+      { "item": "mosin44", "ammo-group": "on_hand_762R", "charges": [ 0, 5 ] },
+      { "item": "762R_clip", "ammo-group": "on_hand_762R", "prob": 50 },
+      { "item": "762R_clip", "ammo-group": "on_hand_762R", "prob": 25 },
       { "group": "on_hand_762R" }
     ]
   },
@@ -1224,9 +1231,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "mosin91_30", "charges-min": 0, "charges-max": 5 },
-      { "item": "762R_clip", "prob": 50, "charges": [ 0, 5 ] },
-      { "item": "762R_clip", "prob": 25, "charges": [ 0, 5 ] },
+      { "item": "mosin91_30", "ammo-group": "on_hand_762R", "charges": [ 0, 5 ] },
+      { "item": "762R_clip", "ammo-group": "on_hand_762R", "prob": 50 },
+      { "item": "762R_clip", "ammo-group": "on_hand_762R", "prob": 25 },
       { "group": "on_hand_762R" }
     ]
   },
@@ -1236,7 +1243,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "remington700_270", "charges-min": 0, "charges-max": 4 }, { "group": "on_hand_270win" } ]
+    "entries": [ { "item": "remington700_270", "ammo-group": "on_hand_270win", "charges": [ 0, 4 ] }, { "group": "on_hand_270win" } ]
   },
   {
     "id": "nested_remington_700",
@@ -1244,7 +1251,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "remington_700", "charges-min": 0, "charges-max": 4 }, { "group": "on_hand_3006" } ]
+    "entries": [ { "item": "remington_700", "ammo-group": "on_hand_3006", "charges": [ 0, 4 ] }, { "group": "on_hand_3006" } ]
   },
   {
     "id": "nested_ruger_1022",
@@ -1253,7 +1260,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "ruger_1022", "charges-min": 0, "charges-max": 10 },
+      { "item": "ruger_1022", "ammo-group": "on_hand_22", "charges": [ 0, 10 ] },
       { "group": "nested_ruger_1022_mag" },
       { "group": "nested_ruger_1022_mag", "prob": 50 },
       { "group": "on_hand_22" }
@@ -1266,7 +1273,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "ruger_mini", "charges-min": 0, "charges-max": 5 },
+      { "item": "ruger_mini", "ammo-group": "on_hand_223", "charges": [ 0, 5 ] },
       { "group": "nested_ruger_mini_mag" },
       { "group": "nested_ruger_mini_mag", "prob": 50 },
       { "group": "on_hand_223" }
@@ -1279,9 +1286,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "sks", "charges-min": 0, "charges-max": 10 },
-      { "item": "762x39_clip", "prob": 50, "charges": [ 0, 10 ] },
-      { "item": "762x39_clip", "prob": 25, "charges": [ 0, 10 ] },
+      { "item": "sks", "ammo-group": "on_hand_762", "charges": [ 0, 10 ] },
+      { "item": "762x39_clip", "ammo-group": "on_hand_762", "prob": 50 },
+      { "item": "762x39_clip", "ammo-group": "on_hand_762", "prob": 25 },
       { "group": "on_hand_762" }
     ]
   },
@@ -1291,7 +1298,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "win70", "charges-min": 0, "charges-max": 3 }, { "group": "on_hand_300" } ]
+    "entries": [ { "item": "win70", "ammo-group": "on_hand_300", "charges": [ 0, 3 ] }, { "group": "on_hand_300" } ]
   },
   {
     "id": "nested_1895sbl",
@@ -1299,7 +1306,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "1895sbl", "charges-min": 0, "charges-max": 6 }, { "group": "on_hand_4570" } ]
+    "entries": [ { "item": "1895sbl", "ammo-group": "on_hand_4570", "charges": [ 0, 6 ] }, { "group": "on_hand_4570" } ]
   },
   {
     "id": "nested_aksemi",
@@ -1308,7 +1315,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "aksemi", "charges-min": 0, "charges-max": 30 },
+      { "item": "aksemi", "ammo-group": "on_hand_762", "charges": [ 0, 30 ] },
       { "group": "nested_ak47_mag" },
       { "group": "nested_ak47_mag", "prob": 50 },
       { "group": "on_hand_762" }
@@ -1320,7 +1327,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "colt_lightning", "charges-min": 0, "charges-max": 14 }, { "group": "on_hand_45colt" } ]
+    "entries": [ { "item": "colt_lightning", "ammo-group": "on_hand_45colt", "charges": [ 0, 14 ] }, { "group": "on_hand_45colt" } ]
   },
   {
     "id": "nested_fn_fal",
@@ -1329,7 +1336,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "fn_fal", "charges-min": 0, "charges-max": 20 },
+      { "item": "fn_fal", "ammo-group": "on_hand_308", "charges": [ 0, 20 ] },
       { "group": "nested_fn_fal_mag" },
       { "group": "nested_fn_fal_mag", "prob": 50 },
       { "group": "on_hand_308" }
@@ -1342,7 +1349,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hk_g3", "charges-min": 0, "charges-max": 20 },
+      { "item": "hk_g3", "ammo-group": "on_hand_308", "charges": [ 0, 20 ] },
       { "group": "nested_hk_g3_mag" },
       { "group": "nested_hk_g3_mag", "prob": 50 },
       { "group": "on_hand_308" }
@@ -1355,7 +1362,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hk_g36", "charges-min": 0, "charges-max": 30 },
+      { "item": "hk_g36", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
       { "group": "nested_hk_g36_mag" },
       { "group": "nested_hk_g36_mag", "prob": 50 },
       { "group": "on_hand_223" }
@@ -1367,7 +1374,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "henry_big_boy", "charges-min": 0, "charges-max": 10 }, { "group": "on_hand_44" } ]
+    "entries": [ { "item": "henry_big_boy", "ammo-group": "on_hand_44", "charges": [ 0, 10 ] }, { "group": "on_hand_44" } ]
   },
   {
     "id": "nested_m14ebr",
@@ -1376,7 +1383,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m14ebr", "charges-min": 0, "charges-max": 20 },
+      { "item": "m14ebr", "ammo-group": "on_hand_308", "charges": [ 0, 20 ] },
       { "group": "nested_m14_mag" },
       { "group": "nested_m14_mag", "prob": 50 },
       { "group": "on_hand_308" }
@@ -1388,7 +1395,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "M24", "charges-min": 0, "charges-max": 5 }, { "group": "on_hand_308" } ]
+    "entries": [ { "item": "M24", "ammo-group": "on_hand_308", "charges": [ 0, 5 ] }, { "group": "on_hand_308" } ]
   },
   {
     "id": "nested_m4a1",
@@ -1397,7 +1404,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m4a1", "charges-min": 0, "charges-max": 30 },
+      { "item": "m4a1", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
       { "group": "nested_stanag_mag" },
       { "group": "nested_stanag_mag", "prob": 50 },
       { "group": "on_hand_223" }
@@ -1410,9 +1417,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m1903", "charges-min": 0, "charges-max": 5 },
-      { "item": "3006_clip", "prob": 50, "charges": [ 0, 5 ] },
-      { "item": "3006_clip", "prob": 25, "charges": [ 0, 5 ] },
+      { "item": "m1903", "ammo-group": "on_hand_3006", "charges": [ 0, 5 ] },
+      { "item": "3006_clip", "ammo-group": "on_hand_3006", "prob": 50 },
+      { "item": "3006_clip", "ammo-group": "on_hand_3006", "prob": 25 },
       { "group": "on_hand_3006" }
     ]
   },
@@ -1423,7 +1430,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m1918", "charges-min": 0, "charges-max": 20 },
+      { "item": "m1918", "ammo-group": "on_hand_3006", "charges": [ 0, 20 ] },
       { "group": "nested_m1918_mag" },
       { "group": "nested_m1918_mag", "prob": 50 },
       { "group": "on_hand_3006" }
@@ -1436,9 +1443,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "mosin44_ebr", "charges-min": 0, "charges-max": 5 },
-      { "item": "762R_clip", "prob": 50, "charges": [ 0, 5 ] },
-      { "item": "762R_clip", "prob": 25, "charges": [ 0, 5 ] },
+      { "item": "mosin44_ebr", "ammo-group": "on_hand_762R", "charges": [ 0, 5 ] },
+      { "item": "762R_clip", "ammo-group": "on_hand_762R", "prob": 50 },
+      { "item": "762R_clip", "ammo-group": "on_hand_762R", "prob": 25 },
       { "group": "on_hand_762R" }
     ]
   },
@@ -1449,9 +1456,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "mosin91_30_ebr", "charges-min": 0, "charges-max": 5 },
-      { "item": "762R_clip", "prob": 50, "charges": [ 0, 5 ] },
-      { "item": "762R_clip", "prob": 25, "charges": [ 0, 5 ] },
+      { "item": "mosin91_30_ebr", "charges": [ 0, 5 ] },
+      { "item": "762R_clip", "ammo-group": "on_hand_762R", "prob": 50 },
+      { "item": "762R_clip", "ammo-group": "on_hand_762R", "prob": 25 },
       { "group": "on_hand_762R" }
     ]
   },
@@ -1461,7 +1468,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "savage_111f", "charges-min": 0, "charges-max": 3 }, { "group": "on_hand_308" } ]
+    "entries": [ { "item": "savage_111f", "ammo-group": "on_hand_308", "charges": [ 0, 3 ] }, { "group": "on_hand_308" } ]
   },
   {
     "id": "nested_sharps",
@@ -1469,7 +1476,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "sharps", "charges-min": 0, "charges-max": 1 }, { "group": "on_hand_4570" } ]
+    "entries": [ { "item": "sharps", "ammo-group": "on_hand_4570", "charges": [ 0, 1 ] }, { "group": "on_hand_4570" } ]
   },
   {
     "id": "nested_weatherby_5",
@@ -1477,7 +1484,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "weatherby_5", "charges-min": 0, "charges-max": 3 }, { "group": "on_hand_300" } ]
+    "entries": [ { "item": "weatherby_5", "ammo-group": "on_hand_300", "charges": [ 0, 3 ] }, { "group": "on_hand_300" } ]
   },
   {
     "id": "nested_hk417_13",
@@ -1486,7 +1493,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "hk417_13", "charges-min": 0, "charges-max": 20 },
+      { "item": "hk417_13", "ammo-group": "on_hand_308", "charges": [ 0, 20 ] },
       { "group": "nested_hk417_13_mag" },
       { "group": "nested_hk417_13_mag", "prob": 50 },
       { "group": "on_hand_308" }
@@ -1499,9 +1506,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "iwi_tavor_x95_300blk", "charges-min": 0, "charges-max": 30 },
-      { "group": "nested_stanag_mag" },
-      { "group": "nested_stanag_mag", "prob": 50 },
+      { "item": "iwi_tavor_x95_300blk", "ammo-group": "on_hand_300BLK", "charges": [ 0, 30 ] },
+      { "group": "nested_stanag_mag_300" },
+      { "group": "nested_stanag_mag_300", "prob": 50 },
       { "group": "on_hand_300BLK" }
     ]
   },
@@ -1512,7 +1519,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "h&k416a5", "charges-min": 0, "charges-max": 30 },
+      { "item": "h&k416a5", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
       { "group": "nested_stanag_mag" },
       { "group": "nested_stanag_mag", "prob": 50 },
       { "group": "on_hand_223" }
@@ -1525,7 +1532,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m27iar", "charges-min": 0, "charges-max": 30 },
+      { "item": "m27iar", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
       { "group": "nested_stanag_mag" },
       { "group": "nested_stanag_mag", "prob": 50 },
       { "group": "on_hand_223" }
@@ -1538,7 +1545,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "scar_l", "charges-min": 0, "charges-max": 30 },
+      { "item": "scar_l", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
       { "group": "nested_stanag_mag" },
       { "group": "nested_stanag_mag", "prob": 50 },
       { "group": "on_hand_223" }
@@ -1551,9 +1558,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m107a1", "charges-min": 0, "charges-max": 10 },
-      { "item": "m107a1mag" },
-      { "item": "m107a1mag", "prob": 50 },
+      { "item": "m107a1", "ammo-group": "on_hand_50", "charges": [ 0, 10 ] },
+      { "item": "m107a1mag", "ammo-group": "on_hand_50" },
+      { "item": "m107a1mag", "ammo-group": "on_hand_50", "prob": 50 },
       { "group": "on_hand_50" }
     ]
   },
@@ -1563,7 +1570,11 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "m134", "charges-min": 0, "charges-max": 100 }, { "group": "on_hand_308" } ]
+    "entries": [
+      { "item": "m134", "ammo-group": "on_hand_308", "charges": [ 0, 100 ] },
+      { "item": "belt308", "ammo-group": "on_hand_308", "charges": 100, "prob": 50 },
+      { "group": "on_hand_308" }
+    ]
   },
   {
     "id": "nested_tac50",
@@ -1572,9 +1583,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "tac50", "charges-min": 0, "charges-max": 5 },
-      { "item": "tac50mag" },
-      { "item": "tac50mag", "prob": 50 },
+      { "item": "tac50", "ammo-group": "on_hand_50", "charges": [ 0, 5 ] },
+      { "item": "tac50mag", "ammo-group": "on_hand_50" },
+      { "item": "tac50mag", "ammo-group": "on_hand_50", "prob": 50 },
       { "group": "on_hand_50" }
     ]
   },
@@ -1585,9 +1596,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m2010", "charges-min": 0, "charges-max": 5 },
-      { "item": "m2010mag" },
-      { "item": "m2010mag", "prob": 50 },
+      { "item": "m2010", "ammo-group": "on_hand_300", "charges": [ 0, 5 ] },
+      { "item": "m2010mag", "ammo-group": "on_hand_300" },
+      { "item": "m2010mag", "ammo-group": "on_hand_300", "prob": 50 },
       { "group": "on_hand_300" }
     ]
   },
@@ -1597,7 +1608,11 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "m240", "charges-min": 0, "charges-max": 100 }, { "group": "on_hand_308" } ]
+    "entries": [
+      { "item": "m240", "ammo-group": "on_hand_308", "charges": [ 0, 100 ] },
+      { "item": "belt308", "ammo-group": "on_hand_308", "charges": 100, "prob": 50 },
+      { "group": "on_hand_308" }
+    ]
   },
   {
     "id": "nested_m249",
@@ -1605,7 +1620,11 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "m249", "charges-min": 0, "charges-max": 100 }, { "group": "on_hand_223" } ]
+    "entries": [
+      { "item": "m249", "ammo-group": "on_hand_223", "charges": [ 0, 100 ] },
+      { "item": "belt223", "ammo-group": "on_hand_308", "charges": 100, "prob": 50 },
+      { "group": "on_hand_223" }
+    ]
   },
   {
     "id": "nested_m60",
@@ -1613,7 +1632,11 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "m60", "charges-min": 0, "charges-max": 100 }, { "group": "on_hand_308" } ]
+    "entries": [
+      { "item": "m60", "ammo-group": "on_hand_308", "charges": [ 0, 100 ] },
+      { "item": "belt308", "ammo-group": "on_hand_308", "charges": 100, "prob": 50 },
+      { "group": "on_hand_308" }
+    ]
   },
   {
     "id": "nested_m2browning",
@@ -1621,7 +1644,11 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "m2browning", "charges-min": 0, "charges-max": 100 }, { "group": "on_hand_50" } ]
+    "entries": [
+      { "item": "m2browning", "ammo-group": "on_hand_50", "charges": [ 0, 100 ] },
+      { "item": "belt50", "ammo-group": "on_hand_50", "charges": 100, "prob": 50 },
+      { "group": "on_hand_50" }
+    ]
   },
   {
     "id": "nested_rm11b_sniper_rifle",
@@ -1630,7 +1657,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "rm11b_sniper_rifle", "charges-min": 0, "charges-max": 10 },
+      { "item": "rm11b_sniper_rifle", "ammo-group": "on_hand_8x40", "charges": [ 0, 10 ] },
       { "group": "nested_rm103a_mag" },
       { "group": "nested_rm103a_mag", "prob": 50 },
       { "group": "on_hand_8x40" }
@@ -1643,7 +1670,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "rm298", "charges-min": 0, "charges-max": 100 },
+      { "item": "rm298", "ammo-group": "on_hand_8x40", "charges": [ 0, 100 ] },
       { "group": "nested_rm298_mag" },
       { "group": "nested_rm298_mag", "prob": 50 },
       { "group": "on_hand_8x40" }
@@ -1656,7 +1683,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "rm51_assault_rifle", "charges-min": 0, "charges-max": 50 },
+      { "item": "rm51_assault_rifle", "ammo-group": "on_hand_8x40", "charges": [ 0, 50 ] },
       { "group": "nested_rm51_mag" },
       { "group": "nested_rm51_mag", "prob": 50 },
       { "group": "on_hand_8x40" }
@@ -1669,7 +1696,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "rm614_lmg", "charges-min": 0, "charges-max": 100 },
+      { "item": "rm614_lmg", "ammo-group": "on_hand_8x40", "charges": [ 0, 100 ] },
       { "group": "nested_rm298_mag" },
       { "group": "nested_rm298_mag", "prob": 50 },
       { "group": "on_hand_8x40" }
@@ -1682,7 +1709,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "rm88_battle_rifle", "charges-min": 0, "charges-max": 50 },
+      { "item": "rm88_battle_rifle", "ammo-group": "on_hand_8x40", "charges": [ 0, 50 ] },
       { "group": "nested_rm51_mag" },
       { "group": "nested_rm51_mag", "prob": 50 },
       { "group": "on_hand_8x40" }
@@ -1695,7 +1722,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "sig552", "charges-min": 0, "charges-max": 30 },
+      { "item": "sig552", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
       { "group": "nested_stanag_mag" },
       { "group": "nested_stanag_mag", "prob": 50 },
       { "group": "on_hand_223" }
@@ -1708,7 +1735,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "scar_h", "charges-min": 0, "charges-max": 20 },
+      { "item": "scar_h", "ammo-group": "on_hand_308", "charges": [ 0, 20 ] },
       { "group": "nested_scar_h_mag" },
       { "group": "nested_scar_h_mag", "prob": 50 },
       { "group": "on_hand_308" }
@@ -1721,7 +1748,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m110a1", "charges-min": 0, "charges-max": 20 },
+      { "item": "m110a1", "ammo-group": "on_hand_308", "charges": [ 0, 20 ] },
       { "group": "nested_hk417_13_mag" },
       { "group": "nested_hk417_13_mag", "prob": 50 },
       { "group": "on_hand_308" }
@@ -1734,9 +1761,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "acr_300blk", "charges-min": 0, "charges-max": 30 },
-      { "group": "nested_stanag_mag" },
-      { "group": "nested_stanag_mag", "prob": 50 },
+      { "item": "acr_300blk", "ammo-group": "on_hand_300BLK", "charges": [ 0, 30 ] },
+      { "group": "nested_stanag_mag_300" },
+      { "group": "nested_stanag_mag_300", "prob": 50 },
       { "group": "on_hand_300BLK" }
     ]
   },
@@ -1747,7 +1774,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "ak47", "charges-min": 0, "charges-max": 30 },
+      { "item": "ak47", "ammo-group": "on_hand_762", "charges": [ 0, 30 ] },
       { "group": "nested_ak47_mag" },
       { "group": "nested_ak47_mag", "prob": 50 },
       { "group": "on_hand_762" }
@@ -1760,7 +1787,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "ak74", "charges-min": 0, "charges-max": 30 },
+      { "item": "ak74", "ammo-group": "on_hand_545x39", "charges": [ 0, 30 ] },
       { "group": "nested_ak74_mag" },
       { "group": "nested_ak74_mag", "prob": 50 },
       { "group": "on_hand_545x39" }
@@ -1772,7 +1799,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "bh_m89", "charges-min": 0, "charges-max": 7 }, { "group": "on_hand_500" } ]
+    "entries": [ { "item": "bh_m89", "ammo-group": "on_hand_500", "charges": [ 0, 7 ] }, { "group": "on_hand_500" } ]
   },
   {
     "id": "nested_bfg50",
@@ -1780,7 +1807,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "bh_m89", "charges-min": 0, "charges-max": 1 }, { "group": "on_hand_50" } ]
+    "entries": [ { "item": "bh_m89", "ammo-group": "on_hand_50", "charges": [ 0, 1 ] }, { "group": "on_hand_50" } ]
   },
   {
     "id": "nested_carbine_flintlock",
@@ -1788,7 +1815,10 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "carbine_flintlock", "charges-min": 0, "charges-max": 1 }, { "group": "on_hand_flintlock" } ]
+    "entries": [
+      { "item": "carbine_flintlock", "ammo-group": "on_hand_flintlock", "charges": [ 0, 1 ] },
+      { "group": "on_hand_flintlock" }
+    ]
   },
   {
     "id": "nested_famas",
@@ -1797,9 +1827,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "famas", "charges-min": 0, "charges-max": 25 },
-      { "item": "famasmag" },
-      { "item": "famasmag", "prob": 50 },
+      { "item": "famas", "ammo-group": "on_hand_223", "charges": [ 0, 25 ] },
+      { "item": "famasmag", "ammo-group": "on_hand_223" },
+      { "item": "famasmag", "ammo-group": "on_hand_223", "prob": 50 },
       { "group": "on_hand_223" }
     ]
   },
@@ -1809,7 +1839,10 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "rifle_flintlock" }, { "group": "on_hand_flintlock" } ]
+    "entries": [
+      { "item": "rifle_flintlock", "ammo-group": "on_hand_flintlock", "charges": [ 0, 1 ] },
+      { "group": "on_hand_flintlock" }
+    ]
   },
   {
     "id": "nested_longrifle_flintlock",
@@ -1817,7 +1850,10 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "longrifle_flintlock" }, { "group": "on_hand_flintlock" } ]
+    "entries": [
+      { "item": "longrifle_flintlock", "ammo-group": "on_hand_flintlock", "charges": [ 0, 1 ] },
+      { "group": "on_hand_flintlock" }
+    ]
   },
   {
     "id": "nested_oa93",
@@ -1826,7 +1862,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "oa93", "charges-min": 0, "charges-max": 30 },
+      { "item": "oa93", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
       { "group": "nested_stanag_mag" },
       { "group": "nested_stanag_mag", "prob": 50 },
       { "group": "on_hand_223" }
@@ -1839,7 +1875,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "steyr_aug", "charges-min": 0, "charges-max": 30 },
+      { "item": "steyr_aug", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
       { "group": "nested_steyr_aug_mag" },
       { "group": "nested_steyr_aug_mag", "prob": 50 },
       { "group": "on_hand_223" }
@@ -1851,7 +1887,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "trex_gun", "charges-min": 0, "charges-max": 2 }, { "group": "on_hand_700nx" } ]
+    "entries": [ { "item": "trex_gun", "ammo-group": "on_hand_700nx", "charges": [ 0, 2 ] }, { "group": "on_hand_700nx" } ]
   },
   {
     "id": "nested_arx160",
@@ -1860,7 +1896,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "arx160", "charges-min": 0, "charges-max": 30 },
+      { "item": "arx160", "ammo-group": "on_hand_762", "charges": [ 0, 30 ] },
       { "group": "nested_ak47_mag" },
       { "group": "nested_ak47_mag", "prob": 50 },
       { "group": "on_hand_762" }
@@ -1872,7 +1908,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "mossberg_500", "charges-min": 0, "charges-max": 6 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "mossberg_500", "ammo-group": "on_hand_shot", "charges": [ 0, 6 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "nested_remington_870",
@@ -1880,7 +1916,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "remington_870", "charges-min": 0, "charges-max": 5 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "remington_870", "ammo-group": "on_hand_shot", "charges": [ 0, 5 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "nested_mossberg_500_security",
@@ -1888,7 +1924,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "mossberg_500_security", "charges-min": 0, "charges-max": 6 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "mossberg_500_security", "ammo-group": "on_hand_shot", "charges": [ 0, 6 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "nested_remington_870_express",
@@ -1896,7 +1932,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "remington_870_express", "charges-min": 0, "charges-max": 6 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "remington_870_express", "ammo-group": "on_hand_shot", "charges": [ 0, 6 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "nested_browning_a5",
@@ -1904,7 +1940,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "browning_a5", "charges-min": 0, "charges-max": 5 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "browning_a5", "ammo-group": "on_hand_shot", "charges": [ 0, 5 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "nested_remington_1100",
@@ -1912,7 +1948,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "remington_1100", "charges-min": 0, "charges-max": 5 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "remington_1100", "ammo-group": "on_hand_shot", "charges": [ 0, 5 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "nested_mossberg_930",
@@ -1920,7 +1956,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "mossberg_930", "charges-min": 0, "charges-max": 6 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "mossberg_930", "ammo-group": "on_hand_shot", "charges": [ 0, 6 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "nested_shotgun_410",
@@ -1928,7 +1964,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "shotgun_410", "charges-min": 0, "charges-max": 1 }, { "group": "on_hand_410shot" } ]
+    "entries": [ { "item": "shotgun_410", "ammo-group": "on_hand_410shot", "charges": [ 0, 1 ] }, { "group": "on_hand_410shot" } ]
   },
   {
     "id": "nested_shotgun_d",
@@ -1936,7 +1972,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "shotgun_d", "charges-min": 0, "charges-max": 2 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "shotgun_d", "ammo-group": "on_hand_shot", "charges": [ 0, 2 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "nested_shotgun_s",
@@ -1944,7 +1980,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "shotgun_s", "charges-min": 0, "charges-max": 1 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "shotgun_s", "ammo-group": "on_hand_shot", "charges": [ 0, 1 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "nested_shotgun_paper",
@@ -1952,7 +1988,10 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "shotgun_paper", "charges-min": 0, "charges-max": 1 }, { "group": "on_hand_shotpaper" } ]
+    "entries": [
+      { "item": "shotgun_paper", "ammo-group": "on_hand_shotpaper", "charges": [ 0, 1 ] },
+      { "group": "on_hand_shotpaper" }
+    ]
   },
   {
     "id": "nested_ksg",
@@ -1960,7 +1999,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "ksg", "charges-min": 0, "charges-max": 7 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "ksg", "ammo-group": "on_hand_shot", "charges": [ 0, 7 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "nested_ksg-25",
@@ -1968,7 +2007,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "ksg", "charges-min": 0, "charges-max": 12 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "ksg-25", "charges": [ 0, 12 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "nested_tavor_12",
@@ -1976,7 +2015,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "tavor_12", "charges-min": 0, "charges-max": 5 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "tavor_12", "ammo-group": "on_hand_shot", "charges": [ 0, 5 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "nested_m1014",
@@ -1984,7 +2023,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "m1014", "charges-min": 0, "charges-max": 8 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "m1014", "ammo-group": "on_hand_shot", "charges": [ 0, 8 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "nested_SPAS_12",
@@ -1992,7 +2031,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "SPAS_12", "charges-min": 0, "charges-max": 9 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "SPAS_12", "ammo-group": "on_hand_shot", "charges": [ 0, 9 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "nested_rm20",
@@ -2001,7 +2040,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "rm20", "charges-min": 0, "charges-max": 20 },
+      { "item": "rm20", "ammo-group": "on_hand_20x66mm", "charges": [ 0, 20 ] },
       { "group": "nested_rm20_mag" },
       { "group": "nested_rm20_mag", "prob": 50 },
       { "group": "on_hand_20x66mm" }
@@ -2013,7 +2052,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "mossberg_590", "charges-min": 0, "charges-max": 9 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "mossberg_590", "ammo-group": "on_hand_shot", "charges": [ 0, 9 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "nested_remington_870_breacher",
@@ -2021,7 +2060,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "remington_870_breacher", "charges-min": 0, "charges-max": 4 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "remington_870_breacher", "ammo-group": "on_hand_shot", "charges": [ 0, 4 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "nested_saiga_12",
@@ -2030,7 +2069,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "saiga_12", "charges-min": 0, "charges-max": 10 },
+      { "item": "saiga_12", "ammo-group": "on_hand_shot", "charges": [ 0, 10 ] },
       { "group": "nested_saiga_12_mag" },
       { "group": "nested_saiga_12_mag", "prob": 50 },
       { "group": "on_hand_shot" }
@@ -2042,7 +2081,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "streetsweeper", "charges-min": 0, "charges-max": 12 }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "streetsweeper", "ammo-group": "on_hand_shot", "charges": [ 0, 12 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "nested_saiga_410",
@@ -2051,7 +2090,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "saiga_410", "charges-min": 0, "charges-max": 10 },
+      { "item": "saiga_410", "ammo-group": "on_hand_410shot", "charges": [ 0, 10 ] },
       { "group": "nested_saiga_410_mag" },
       { "group": "nested_saiga_410_mag", "prob": 50 },
       { "group": "on_hand_410shot" }
@@ -2064,7 +2103,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "needlepistol", "charges-min": 0, "charges-max": 50 },
+      { "item": "needlepistol", "ammo-group": "on_hand_5x50mm", "charges": [ 0, 50 ] },
       { "group": "nested_needlepistol_mag" },
       { "group": "nested_needlepistol_mag", "prob": 50 },
       { "group": "on_hand_5x50mm" }
@@ -2077,9 +2116,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "rm99_pistol", "charges-min": 0, "charges-max": 50 },
-      { "group": "nested_rm51_mag" },
-      { "group": "nested_rm51_mag", "prob": 50 },
+      { "item": "rm99_pistol", "ammo-group": "on_hand_8x40", "charges": [ 0, 5 ] },
+      { "item": "8x40_speedloader5", "ammo-group": "on_hand_8x40", "prob": 50 },
+      { "item": "8x40_speedloader5", "ammo-group": "on_hand_8x40", "prob": 25 },
       { "group": "on_hand_8x40" }
     ]
   },
@@ -2090,7 +2129,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "ppsh", "charges-min": 0, "charges-max": 35 },
+      { "item": "ppsh", "ammo-group": "on_hand_762x25", "charges": [ 0, 35 ] },
       { "group": "nested_ppsh_mag" },
       { "group": "nested_ppsh_mag", "prob": 50 },
       { "group": "on_hand_762x25" }
@@ -2103,9 +2142,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "skorpion_61", "charges-min": 0, "charges-max": 20 },
-      { "item": "skorpion61mag" },
-      { "item": "skorpion61mag", "prob": 50 },
+      { "item": "skorpion_61", "ammo-group": "on_hand_32", "charges": [ 0, 20 ] },
+      { "item": "skorpion61mag", "ammo-group": "on_hand_32" },
+      { "item": "skorpion61mag", "ammo-group": "on_hand_32", "prob": 50 },
       { "group": "on_hand_32" }
     ]
   },
@@ -2116,9 +2155,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "skorpion_82", "charges-min": 0, "charges-max": 20 },
-      { "item": "skorpion82mag" },
-      { "item": "skorpion82mag", "prob": 50 },
+      { "item": "skorpion_82", "ammo-group": "on_hand_9x18", "charges": [ 0, 20 ] },
+      { "item": "skorpion82mag", "ammo-group": "on_hand_9x18" },
+      { "item": "skorpion82mag", "ammo-group": "on_hand_9x18", "prob": 50 },
       { "group": "on_hand_9x18" }
     ]
   },
@@ -2129,7 +2168,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "acr", "charges-min": 0, "charges-max": 30 },
+      { "item": "acr", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
       { "group": "nested_stanag_mag" },
       { "group": "nested_stanag_mag", "prob": 50 },
       { "group": "on_hand_223" }
@@ -2142,9 +2181,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "ar15_retool_300blk", "charges-min": 0, "charges-max": 30 },
-      { "group": "nested_stanag_mag" },
-      { "group": "nested_stanag_mag", "prob": 50 },
+      { "item": "ar15_retool_300blk", "ammo-group": "on_hand_300BLK", "charges": [ 0, 30 ] },
+      { "group": "nested_stanag_mag_300" },
+      { "group": "nested_stanag_mag_300", "prob": 50 },
       { "group": "on_hand_300BLK" }
     ]
   },
@@ -2155,7 +2194,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "needlegun", "charges-min": 0, "charges-max": 100 },
+      { "item": "needlegun", "ammo-group": "on_hand_5x50mm", "charges": [ 0, 100 ] },
       { "group": "nested_needlegun_mag" },
       { "group": "nested_needlegun_mag", "prob": 50 },
       { "group": "on_hand_5x50mm" }
@@ -2167,7 +2206,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "rm120c", "charges-min": 0, "charges-max": 5 }, { "group": "on_hand_20x66mm" } ]
+    "entries": [ { "item": "rm120c", "ammo-group": "on_hand_20x66mm", "charges": [ 0, 5 ] }, { "group": "on_hand_20x66mm" } ]
   },
   {
     "id": "nested_rm228",
@@ -2176,9 +2215,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "rm228", "charges-min": 0, "charges-max": 10 },
-      { "item": "20x66_10_mag" },
-      { "item": "20x66_10_mag", "prob": 50 },
+      { "item": "rm228", "ammo-group": "on_hand_20x66mm", "charges": [ 0, 10 ] },
+      { "item": "20x66_10_mag", "ammo-group": "on_hand_20x66mm" },
+      { "item": "20x66_10_mag", "ammo-group": "on_hand_20x66mm", "prob": 50 },
       { "group": "on_hand_20x66mm" }
     ]
   },
@@ -2189,7 +2228,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "an94", "charges-min": 0, "charges-max": 30 },
+      { "item": "an94", "ammo-group": "on_hand_545x39", "charges": [ 0, 30 ] },
       { "group": "nested_ak74_mag" },
       { "group": "nested_ak74_mag", "prob": 50 },
       { "group": "on_hand_545x39" }
@@ -2202,7 +2241,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "USAS_12", "charges-min": 0, "charges-max": 10 },
+      { "item": "USAS_12", "ammo-group": "on_hand_shot", "charges": [ 0, 10 ] },
       { "group": "nested_USAS_12_mag" },
       { "group": "nested_USAS_12_mag", "prob": 50 },
       { "group": "on_hand_shot" }
@@ -2215,9 +2254,9 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "as50", "charges-min": 0, "charges-max": 10 },
-      { "item": "as50mag" },
-      { "item": "as50mag", "prob": 50 },
+      { "item": "as50", "ammo-group": "on_hand_50", "charges": [ 0, 10 ] },
+      { "item": "as50mag", "ammo-group": "on_hand_50" },
+      { "item": "as50mag", "ammo-group": "on_hand_50", "prob": 50 },
       { "group": "on_hand_50" }
     ]
   }

--- a/data/json/itemgroups/Weapons_Mods_Ammo/nested_magazines.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/nested_magazines.json
@@ -5,11 +5,11 @@
     "subtype": "distribution",
     "ammo": 100,
     "entries": [
-      { "item": "glock17_17", "prob": 100 },
-      { "item": "glock17_22", "prob": 5 },
-      { "item": "glock_drum_50rd", "prob": 5 },
-      { "item": "glock_drum_100rd", "prob": 5 },
-      { "item": "glockbigmag", "prob": 5 }
+      { "item": "glock17_17", "ammo-group": "on_hand_9mm", "prob": 100 },
+      { "item": "glock17_22", "ammo-group": "on_hand_9mm", "prob": 5 },
+      { "item": "glock_drum_50rd", "ammo-group": "on_hand_9mm", "prob": 5 },
+      { "item": "glock_drum_100rd", "ammo-group": "on_hand_9mm", "prob": 5 },
+      { "item": "glockbigmag", "ammo-group": "on_hand_9mm", "prob": 5 }
     ]
   },
   {
@@ -18,12 +18,12 @@
     "subtype": "distribution",
     "ammo": 100,
     "entries": [
-      { "item": "glockmag", "prob": 100 },
-      { "item": "glock17_17", "prob": 5 },
-      { "item": "glock17_22", "prob": 5 },
-      { "item": "glock_drum_50rd", "prob": 5 },
-      { "item": "glock_drum_100rd", "prob": 5 },
-      { "item": "glockbigmag", "prob": 5 }
+      { "item": "glockmag", "ammo-group": "on_hand_9mm", "prob": 100 },
+      { "item": "glock17_17", "ammo-group": "on_hand_9mm", "prob": 5 },
+      { "item": "glock17_22", "ammo-group": "on_hand_9mm", "prob": 5 },
+      { "item": "glock_drum_50rd", "ammo-group": "on_hand_9mm", "prob": 5 },
+      { "item": "glock_drum_100rd", "ammo-group": "on_hand_9mm", "prob": 5 },
+      { "item": "glockbigmag", "ammo-group": "on_hand_9mm", "prob": 5 }
     ]
   },
   {
@@ -31,35 +31,61 @@
     "type": "item_group",
     "subtype": "distribution",
     "ammo": 100,
-    "entries": [ { "item": "glock_21mag", "prob": 100 }, { "item": "glock_21mag26", "prob": 5 } ]
+    "entries": [
+      { "item": "glock_21mag", "ammo-group": "on_hand_45", "prob": 100 },
+      { "item": "glock_21mag26", "ammo-group": "on_hand_45", "prob": 5 }
+    ]
   },
   {
     "id": "nested_glock22_mag",
     "type": "item_group",
     "subtype": "distribution",
     "ammo": 100,
-    "entries": [ { "item": "glock40mag", "prob": 100 }, { "item": "glock40bigmag", "prob": 5 } ]
+    "entries": [
+      { "item": "glock40mag", "ammo-group": "on_hand_40", "prob": 100 },
+      { "item": "glock40bigmag", "ammo-group": "on_hand_40", "prob": 5 }
+    ]
   },
   {
     "id": "nested_m1911_mag",
     "type": "item_group",
     "subtype": "distribution",
     "ammo": 100,
-    "entries": [ { "item": "m1911mag", "prob": 100 }, { "item": "m1911bigmag", "prob": 5 } ]
+    "entries": [
+      { "item": "m1911mag", "ammo-group": "on_hand_45", "prob": 100 },
+      { "item": "m1911bigmag", "ammo-group": "on_hand_45", "prob": 5 }
+    ]
+  },
+  {
+    "id": "nested_m1911_mag_460",
+    "type": "item_group",
+    "subtype": "distribution",
+    "//": "Used so the .460 1911 spawns with correct ammo.",
+    "ammo": 100,
+    "entries": [
+      { "item": "m1911mag", "ammo-group": "on_hand_460", "prob": 100 },
+      { "item": "m1911bigmag", "ammo-group": "on_hand_460", "prob": 5 }
+    ]
   },
   {
     "id": "nested_m9_mag",
     "type": "item_group",
     "subtype": "distribution",
     "ammo": 100,
-    "entries": [ { "item": "m9mag", "prob": 100 }, { "item": "m9bigmag", "prob": 5 } ]
+    "entries": [
+      { "item": "m9mag", "ammo-group": "on_hand_9mm", "prob": 100 },
+      { "item": "m9bigmag", "ammo-group": "on_hand_9mm", "prob": 5 }
+    ]
   },
   {
     "id": "nested_hi_power_9mm_mag",
     "type": "item_group",
     "subtype": "distribution",
     "ammo": 100,
-    "entries": [ { "item": "bhp9mag_13rd", "prob": 100 }, { "item": "bhp9mag_15rd", "prob": 5 } ]
+    "entries": [
+      { "item": "bhp9mag_13rd", "ammo-group": "on_hand_9mm", "prob": 100 },
+      { "item": "bhp9mag_15rd", "ammo-group": "on_hand_9mm", "prob": 5 }
+    ]
   },
   {
     "id": "nested_walther_ppq_9mm_mag",
@@ -67,9 +93,9 @@
     "subtype": "distribution",
     "ammo": 100,
     "entries": [
-      { "item": "ppq9mag_10rd", "prob": 100 },
-      { "item": "ppq9mag_15rd", "prob": 5 },
-      { "item": "ppq9mag_17rd", "prob": 5 }
+      { "item": "ppq9mag_10rd", "ammo-group": "on_hand_9mm", "prob": 100 },
+      { "item": "ppq9mag_15rd", "ammo-group": "on_hand_9mm", "prob": 5 },
+      { "item": "ppq9mag_17rd", "ammo-group": "on_hand_9mm", "prob": 5 }
     ]
   },
   {
@@ -78,9 +104,9 @@
     "subtype": "distribution",
     "ammo": 100,
     "entries": [
-      { "item": "ppq40mag_10rd", "prob": 100 },
-      { "item": "ppq40mag_12rd", "prob": 5 },
-      { "item": "ppq40mag_14rd", "prob": 5 }
+      { "item": "ppq40mag_10rd", "ammo-group": "on_hand_40", "prob": 100 },
+      { "item": "ppq40mag_12rd", "ammo-group": "on_hand_40", "prob": 5 },
+      { "item": "ppq40mag_14rd", "ammo-group": "on_hand_40", "prob": 5 }
     ]
   },
   {
@@ -89,9 +115,9 @@
     "subtype": "distribution",
     "ammo": 100,
     "entries": [
-      { "item": "hptc9mag_8rd", "prob": 100 },
-      { "item": "hptc9mag_10rd", "prob": 5 },
-      { "item": "hptc9mag_15rd", "prob": 5 }
+      { "item": "hptc9mag_8rd", "ammo-group": "on_hand_9mm", "prob": 100 },
+      { "item": "hptc9mag_10rd", "ammo-group": "on_hand_9mm", "prob": 5 },
+      { "item": "hptc9mag_15rd", "ammo-group": "on_hand_9mm", "prob": 5 }
     ]
   },
   {
@@ -99,7 +125,10 @@
     "type": "item_group",
     "subtype": "distribution",
     "ammo": 100,
-    "entries": [ { "item": "hptcf380mag_8rd", "prob": 100 }, { "item": "hptcf380mag_10rd", "prob": 5 } ]
+    "entries": [
+      { "item": "hptcf380mag_8rd", "ammo-group": "on_hand_380", "prob": 100 },
+      { "item": "hptcf380mag_10rd", "ammo-group": "on_hand_380", "prob": 5 }
+    ]
   },
   {
     "id": "nested_cz75_mag",
@@ -107,9 +136,9 @@
     "subtype": "distribution",
     "ammo": 100,
     "entries": [
-      { "item": "cz75mag_12rd", "prob": 100 },
-      { "item": "cz75mag_20rd", "prob": 5 },
-      { "item": "cz75mag_26rd", "prob": 5 }
+      { "item": "cz75mag_12rd", "ammo-group": "on_hand_9mm", "prob": 100 },
+      { "item": "cz75mag_20rd", "ammo-group": "on_hand_9mm", "prob": 5 },
+      { "item": "cz75mag_26rd", "ammo-group": "on_hand_9mm", "prob": 5 }
     ]
   },
   {
@@ -118,11 +147,11 @@
     "subtype": "distribution",
     "ammo": 100,
     "entries": [
-      { "item": "akmag30", "prob": 100 },
-      { "item": "akmag10", "prob": 5 },
-      { "item": "akmag20", "prob": 5 },
-      { "item": "akmag40", "prob": 5 },
-      { "item": "akdrum75", "prob": 5 }
+      { "item": "akmag30", "ammo-group": "on_hand_762", "prob": 100 },
+      { "item": "akmag10", "ammo-group": "on_hand_762", "prob": 5 },
+      { "item": "akmag20", "ammo-group": "on_hand_762", "prob": 5 },
+      { "item": "akmag40", "ammo-group": "on_hand_762", "prob": 5 },
+      { "item": "akdrum75", "ammo-group": "on_hand_762", "prob": 5 }
     ]
   },
   {
@@ -130,14 +159,20 @@
     "type": "item_group",
     "subtype": "distribution",
     "ammo": 100,
-    "entries": [ { "item": "8x40_25_mag", "prob": 100 }, { "item": "8x40_10_mag", "prob": 5 } ]
+    "entries": [
+      { "item": "8x40_25_mag", "ammo-group": "on_hand_8x40", "prob": 100 },
+      { "item": "8x40_10_mag", "ammo-group": "on_hand_8x40", "prob": 5 }
+    ]
   },
   {
     "id": "nested_mp5_mag",
     "type": "item_group",
     "subtype": "distribution",
     "ammo": 100,
-    "entries": [ { "item": "mp5mag", "prob": 100 }, { "item": "mp5bigmag", "prob": 5 } ]
+    "entries": [
+      { "item": "mp5mag", "ammo-group": "on_hand_9mm", "prob": 100 },
+      { "item": "mp5bigmag", "ammo-group": "on_hand_9mm", "prob": 5 }
+    ]
   },
   {
     "id": "nested_tommygun_mag",
@@ -145,9 +180,9 @@
     "subtype": "distribution",
     "ammo": 100,
     "entries": [
-      { "item": "thompson_mag", "prob": 100 },
-      { "item": "thompson_bigmag", "prob": 5 },
-      { "item": "thompson_drum", "prob": 5 }
+      { "item": "thompson_mag", "ammo-group": "on_hand_45", "prob": 100 },
+      { "item": "thompson_bigmag", "ammo-group": "on_hand_45", "prob": 5 },
+      { "item": "thompson_drum", "ammo-group": "on_hand_45", "prob": 5 }
     ]
   },
   {
@@ -155,14 +190,21 @@
     "type": "item_group",
     "subtype": "distribution",
     "ammo": 100,
-    "entries": [ { "item": "tdi_mag", "prob": 100 }, { "item": "glock_21mag", "prob": 5 }, { "item": "glock_21mag26", "prob": 5 } ]
+    "entries": [
+      { "item": "tdi_mag", "ammo-group": "on_hand_45", "prob": 100 },
+      { "item": "glock_21mag", "ammo-group": "on_hand_45", "prob": 5 },
+      { "item": "glock_21mag26", "ammo-group": "on_hand_45", "prob": 5 }
+    ]
   },
   {
     "id": "nested_hk_mp7_mag",
     "type": "item_group",
     "subtype": "distribution",
     "ammo": 100,
-    "entries": [ { "item": "hk46mag", "prob": 100 }, { "item": "hk46bigmag", "prob": 5 } ]
+    "entries": [
+      { "item": "hk46mag", "ammo-group": "on_hand_46", "prob": 100 },
+      { "item": "hk46bigmag", "ammo-group": "on_hand_46", "prob": 5 }
+    ]
   },
   {
     "id": "nested_stanag_mag",
@@ -170,18 +212,39 @@
     "subtype": "distribution",
     "ammo": 100,
     "entries": [
-      { "item": "stanag30", "prob": 170 },
-      { "item": "stanag5", "prob": 5 },
-      { "item": "stanag10", "prob": 5 },
-      { "item": "stanag20", "prob": 5 },
-      { "item": "stanag40", "prob": 5 },
-      { "item": "stanag50", "prob": 5 },
-      { "item": "stanag60", "prob": 5 },
-      { "item": "stanag60drum", "prob": 5 },
-      { "item": "stanag90", "prob": 5 },
-      { "item": "stanag100", "prob": 5 },
-      { "item": "stanag100drum", "prob": 5 },
-      { "item": "stanag150", "prob": 5 }
+      { "item": "stanag30", "ammo-group": "on_hand_223", "prob": 170 },
+      { "item": "stanag5", "ammo-group": "on_hand_223", "prob": 5 },
+      { "item": "stanag10", "ammo-group": "on_hand_223", "prob": 5 },
+      { "item": "stanag20", "ammo-group": "on_hand_223", "prob": 5 },
+      { "item": "stanag40", "ammo-group": "on_hand_223", "prob": 5 },
+      { "item": "stanag50", "ammo-group": "on_hand_223", "prob": 5 },
+      { "item": "stanag60", "ammo-group": "on_hand_223", "prob": 5 },
+      { "item": "stanag60drum", "ammo-group": "on_hand_223", "prob": 5 },
+      { "item": "stanag90", "ammo-group": "on_hand_223", "prob": 5 },
+      { "item": "stanag100", "ammo-group": "on_hand_223", "prob": 5 },
+      { "item": "stanag100drum", "ammo-group": "on_hand_223", "prob": 5 },
+      { "item": "stanag150", "ammo-group": "on_hand_223", "prob": 5 }
+    ]
+  },
+  {
+    "id": "nested_stanag_mag_300",
+    "type": "item_group",
+    "subtype": "distribution",
+    "//": "Used so the retooled AR-15 spawns with correct ammo.",
+    "ammo": 100,
+    "entries": [
+      { "item": "stanag30", "ammo-group": "on_hand_300BLK", "prob": 170 },
+      { "item": "stanag5", "ammo-group": "on_hand_300BLK", "prob": 5 },
+      { "item": "stanag10", "ammo-group": "on_hand_300BLK", "prob": 5 },
+      { "item": "stanag20", "ammo-group": "on_hand_300BLK", "prob": 5 },
+      { "item": "stanag40", "ammo-group": "on_hand_300BLK", "prob": 5 },
+      { "item": "stanag50", "ammo-group": "on_hand_300BLK", "prob": 5 },
+      { "item": "stanag60", "ammo-group": "on_hand_300BLK", "prob": 5 },
+      { "item": "stanag60drum", "ammo-group": "on_hand_300BLK", "prob": 5 },
+      { "item": "stanag90", "ammo-group": "on_hand_300BLK", "prob": 5 },
+      { "item": "stanag100", "ammo-group": "on_hand_300BLK", "prob": 5 },
+      { "item": "stanag100drum", "ammo-group": "on_hand_300BLK", "prob": 5 },
+      { "item": "stanag150", "ammo-group": "on_hand_300BLK", "prob": 5 }
     ]
   },
   {
@@ -189,14 +252,20 @@
     "type": "item_group",
     "subtype": "distribution",
     "ammo": 100,
-    "entries": [ { "item": "m14mag", "prob": 100 }, { "item": "m14smallmag", "prob": 5 } ]
+    "entries": [
+      { "item": "m14mag", "ammo-group": "on_hand_308", "prob": 100 },
+      { "item": "m14smallmag", "ammo-group": "on_hand_308", "prob": 5 }
+    ]
   },
   {
     "id": "nested_ruger_1022_mag",
     "type": "item_group",
     "subtype": "distribution",
     "ammo": 100,
-    "entries": [ { "item": "ruger1022mag", "prob": 100 }, { "item": "ruger1022bigmag", "prob": 5 } ]
+    "entries": [
+      { "item": "ruger1022mag", "ammo-group": "on_hand_22", "prob": 100 },
+      { "item": "ruger1022bigmag", "ammo-group": "on_hand_22", "prob": 5 }
+    ]
   },
   {
     "id": "nested_ruger_mini_mag",
@@ -204,12 +273,12 @@
     "subtype": "distribution",
     "ammo": 100,
     "entries": [
-      { "item": "ruger20", "prob": 100 },
-      { "item": "ruger5", "prob": 5 },
-      { "item": "ruger10", "prob": 5 },
-      { "item": "ruger30", "prob": 5 },
-      { "item": "ruger90", "prob": 5 },
-      { "item": "ruger100", "prob": 5 }
+      { "item": "ruger20", "ammo-group": "on_hand_223", "prob": 100 },
+      { "item": "ruger5", "ammo-group": "on_hand_223", "prob": 5 },
+      { "item": "ruger10", "ammo-group": "on_hand_223", "prob": 5 },
+      { "item": "ruger30", "ammo-group": "on_hand_223", "prob": 5 },
+      { "item": "ruger90", "ammo-group": "on_hand_223", "prob": 5 },
+      { "item": "ruger100", "ammo-group": "on_hand_223", "prob": 5 }
     ]
   },
   {
@@ -217,42 +286,60 @@
     "type": "item_group",
     "subtype": "distribution",
     "ammo": 100,
-    "entries": [ { "item": "falmag", "prob": 100 }, { "item": "falbigmag", "prob": 5 } ]
+    "entries": [
+      { "item": "falmag", "ammo-group": "on_hand_308", "prob": 100 },
+      { "item": "falbigmag", "ammo-group": "on_hand_308", "prob": 5 }
+    ]
   },
   {
     "id": "nested_hk_g3_mag",
     "type": "item_group",
     "subtype": "distribution",
     "ammo": 100,
-    "entries": [ { "item": "g3mag", "prob": 100 }, { "item": "g3bigmag", "prob": 5 } ]
+    "entries": [
+      { "item": "g3mag", "ammo-group": "on_hand_308", "prob": 100 },
+      { "item": "g3bigmag", "ammo-group": "on_hand_308", "prob": 5 }
+    ]
   },
   {
     "id": "nested_hk_g36_mag",
     "type": "item_group",
     "subtype": "distribution",
     "ammo": 100,
-    "entries": [ { "item": "g36mag_30rd", "prob": 100 }, { "item": "g36mag_100rd", "prob": 5 } ]
+    "entries": [
+      { "item": "g36mag_30rd", "ammo-group": "on_hand_223", "prob": 100 },
+      { "item": "g36mag_100rd", "ammo-group": "on_hand_223", "prob": 5 }
+    ]
   },
   {
     "id": "nested_m1918_mag",
     "type": "item_group",
     "subtype": "distribution",
     "ammo": 100,
-    "entries": [ { "item": "m1918mag", "prob": 100 }, { "item": "m1918bigmag", "prob": 5 } ]
+    "entries": [
+      { "item": "m1918mag", "ammo-group": "on_hand_3006", "prob": 100 },
+      { "item": "m1918bigmag", "ammo-group": "on_hand_3006", "prob": 5 }
+    ]
   },
   {
     "id": "nested_hk417_13_mag",
     "type": "item_group",
     "subtype": "distribution",
     "ammo": 100,
-    "entries": [ { "item": "hk417mag_20rd", "prob": 100 }, { "item": "hk417mag_10rd", "prob": 5 } ]
+    "entries": [
+      { "item": "hk417mag_20rd", "ammo-group": "on_hand_308", "prob": 100 },
+      { "item": "hk417mag_10rd", "ammo-group": "on_hand_308", "prob": 5 }
+    ]
   },
   {
     "id": "nested_rm298_mag",
     "type": "item_group",
     "subtype": "distribution",
     "ammo": 100,
-    "entries": [ { "item": "8x40_500_mag", "prob": 100 }, { "item": "8x40_250_mag", "prob": 5 } ]
+    "entries": [
+      { "item": "8x40_500_mag", "ammo-group": "on_hand_8x40", "prob": 100 },
+      { "item": "8x40_250_mag", "ammo-group": "on_hand_8x40", "prob": 5 }
+    ]
   },
   {
     "id": "nested_rm51_mag",
@@ -266,14 +353,21 @@
     "type": "item_group",
     "subtype": "distribution",
     "ammo": 100,
-    "entries": [ { "item": "scarhmag", "prob": 100 }, { "item": "scarhbigmag", "prob": 5 }, { "item": "scarhmag_30rd", "prob": 5 } ]
+    "entries": [
+      { "item": "scarhmag", "ammo-group": "on_hand_308", "prob": 100 },
+      { "item": "scarhbigmag", "ammo-group": "on_hand_308", "prob": 5 },
+      { "item": "scarhmag_30rd", "ammo-group": "on_hand_308", "prob": 5 }
+    ]
   },
   {
     "id": "nested_ak74_mag",
     "type": "item_group",
     "subtype": "distribution",
     "ammo": 100,
-    "entries": [ { "item": "ak74mag", "prob": 100 }, { "item": "rpk74mag", "prob": 5 } ]
+    "entries": [
+      { "item": "ak74mag", "ammo-group": "on_hand_545x39", "prob": 100 },
+      { "item": "rpk74mag", "ammo-group": "on_hand_545x39", "prob": 5 }
+    ]
   },
   {
     "id": "nested_steyr_aug_mag",
@@ -281,10 +375,10 @@
     "subtype": "distribution",
     "ammo": 100,
     "entries": [
-      { "item": "augmag_30rd", "prob": 100 },
-      { "item": "augmag_10rd", "prob": 5 },
-      { "item": "augmag_42rd", "prob": 5 },
-      { "item": "augmag_100rd", "prob": 5 }
+      { "item": "augmag_30rd", "ammo-group": "on_hand_223", "prob": 100 },
+      { "item": "augmag_10rd", "ammo-group": "on_hand_223", "prob": 5 },
+      { "item": "augmag_42rd", "ammo-group": "on_hand_223", "prob": 5 },
+      { "item": "augmag_100rd", "ammo-group": "on_hand_223", "prob": 5 }
     ]
   },
   {
@@ -292,48 +386,69 @@
     "type": "item_group",
     "subtype": "distribution",
     "ammo": 100,
-    "entries": [ { "item": "20x66_20_mag", "prob": 100 }, { "item": "20x66_40_mag", "prob": 5 } ]
+    "entries": [
+      { "item": "20x66_20_mag", "ammo-group": "on_hand_20x66mm", "prob": 100 },
+      { "item": "20x66_40_mag", "ammo-group": "on_hand_20x66mm", "prob": 5 }
+    ]
   },
   {
     "id": "nested_saiga_12_mag",
     "type": "item_group",
     "subtype": "distribution",
     "ammo": 100,
-    "entries": [ { "item": "saiga10mag", "prob": 100 }, { "item": "saiga30mag", "prob": 5 } ]
+    "entries": [
+      { "item": "saiga10mag", "ammo-group": "on_hand_shot", "prob": 100 },
+      { "item": "saiga30mag", "ammo-group": "on_hand_shot", "prob": 5 }
+    ]
   },
   {
     "id": "nested_saiga_410_mag",
     "type": "item_group",
     "subtype": "distribution",
     "ammo": 100,
-    "entries": [ { "item": "saiga410mag_10rd", "prob": 100 }, { "item": "saiga410mag_30rd", "prob": 5 } ]
+    "entries": [
+      { "item": "saiga410mag_10rd", "ammo-group": "on_hand_410shot", "prob": 100 },
+      { "item": "saiga410mag_30rd", "ammo-group": "on_hand_410shot", "prob": 5 }
+    ]
   },
   {
     "id": "nested_needlepistol_mag",
     "type": "item_group",
     "subtype": "distribution",
     "ammo": 100,
-    "entries": [ { "item": "5x50_50_mag", "prob": 100 }, { "item": "5x50_100_mag", "prob": 5 } ]
+    "entries": [
+      { "item": "5x50_50_mag", "ammo-group": "on_hand_5x50mm", "prob": 100 },
+      { "item": "5x50_100_mag", "ammo-group": "on_hand_5x50mm", "prob": 5 }
+    ]
   },
   {
     "id": "nested_needlegun_mag",
     "type": "item_group",
     "subtype": "distribution",
     "ammo": 100,
-    "entries": [ { "item": "5x50_100_mag", "prob": 100 }, { "item": "5x50_50_mag", "prob": 5 } ]
+    "entries": [
+      { "item": "5x50_100_mag", "ammo-group": "on_hand_5x50mm", "prob": 100 },
+      { "item": "5x50_50_mag", "ammo-group": "on_hand_5x50mm", "prob": 5 }
+    ]
   },
   {
     "id": "nested_ppsh_mag",
     "type": "item_group",
     "subtype": "distribution",
     "ammo": 100,
-    "entries": [ { "item": "ppshmag", "prob": 100 }, { "item": "ppshdrum", "prob": 5 } ]
+    "entries": [
+      { "item": "ppshmag", "ammo-group": "on_hand_762x25", "prob": 100 },
+      { "item": "ppshdrum", "ammo-group": "on_hand_762x25", "prob": 5 }
+    ]
   },
   {
     "id": "nested_USAS_12_mag",
     "type": "item_group",
     "subtype": "distribution",
     "ammo": 100,
-    "entries": [ { "item": "USAS10mag", "prob": 100 }, { "item": "USAS20mag", "prob": 5 } ]
+    "entries": [
+      { "item": "USAS10mag", "ammo-group": "on_hand_shot", "prob": 100 },
+      { "item": "USAS20mag", "ammo-group": "on_hand_shot", "prob": 5 }
+    ]
   }
 ]


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

jfc why did we bring back the giant blocks of uncommented-out checklists that have zero impact on 90% of PRs again auuuugh, one of these in the required section isn't even relevant to many PRs since not all of them will have a linked issue.

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This follows up on https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4805 and https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4806, implementing a way for guns and magazines to pick at random what ammo is loaded in them, and modernizes how the gun charges are specified. Also comes with a consistency update to speedloader spawns per @Lamandus' request, and a fuckton of related fixes for weird issues found while implementing stuff.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Set nested gun spawns to make use of the previously-unused `ammo-group` feature. This, it turns out, has the convenient ability to not only define variation in what ammo is loaded in a gun or magazine, but allows me to use existing ammogroups for this without any weird behavior.
2. Likewise, added use of `ammo-group` to on-carry guns same as above.
3. Added injections of ammo-group to nested magazines too. I tested to see if I could inject ammogroups into nested magazines at the level of the nested guns themselves, but turns out a group won't correctly take ammo-group into account so it has to be slapped onto the item spawns themselves. Both methods seem about the same level of work, only real loss here is that magazine ammogroups end up being injected at different times depending on whether the gun in question has a nested magazine group or whether it spawns magazines directly as items (as mainly seen for speedloaders and for guns that only have one mag they can accept).
4. Defined a couple new nested ammo groups: `on_hand_40sw_or_10mm` picks between the contents of `on_hand_40` vs. `on_hand_10mm` for the S&W 610, `on_hand_410_or_45colt` for guns like the derringer, and `on_hand_454_mixed` for .454 Casull guns which pick between .454 or in turn a chance to pick the contents of `on_hand_410_or_45colt`.
5. Accordingly, reworked on_hand_357_38mixed` to behave like all other ammo groups, picking between either contents of `on_hand_38` or .357 Magnum ammo instead of being a collection.
6. In the process, I converted all the abuse of `charges-min` and `charges-max` to just use `charges` arrays. More work for me but less messy after implementing it.
7. Misc: Fixed `nested_ksg-25` spawning a regular KSG.
8. Misc: Defined a magazine group for the .300 blackout AR-15 to use that loads them with .300 instead of .223.
9. Misc: Defined a .460 version of `nested_m1911_mag` for the .460 M1911 conversion to use.
10. Misc: Fixed the .38 Super version of M1911 spawning normal .45 mags in the carried group.
11. Misc: Per Viss' feedback in the discord server, set it so that speedloaders no longer define variable ammo in them by default, on the basis that magazine spawns don't do this either. Monsterdrops already inject variation in how much ammo is left on hand by way of the top-level groups defining a lower ammo chance, anyway.
12. Misc: Gave MGs a chance to spawn with a spare belt (50% chance of a belt on top of loose ammo in the case of nested spawns, 50% chance of spawning in place of loose ammo in the case of carried spawns).
13. Misc: Fixed the desert eagle spawning with only up to 2 rounds, and a fewcases of guns always spawning with default ammo amounts.
14. Misc: Fixed mosin EBR spawns being set to only have a 1% chance to spawn the actual gun for some fucking reason.
15. Misc: Fixed `on_hand_flintlock` not having paper shot cartridges.
16. Misc: Added a chance of finding blackpowder loads in `on_hand_45colt` and `on_hand_4570`.
17. Misc: Allowed .30-06 AP rounds to spawn in `on_hand_3006` since other groups allow the full range of ammo for nested gun spawns, plus steel-core .30-06 is legal in some states (may also depend on licensing). Went with a lower weight however.
18. Misc: Gave `nested_lemat_revolver` and `everyday_lemat_revolver` an additional chance to spawn with 20ga ammo for the sake of its secondary barrel, at a lower rate for the carried variant.
19. Misc: Fixed incorrect gun in `everyday_aksemi`.
20. Misc: Fixed incorrect gun in `everyday_bfg50`.
21. Misc: Fixed RM99 having wrong capacity and mags instead of the speedloader it actually uses.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Never touching these files again because it's making my wrists hurt fixing all this.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Before actually working on implementation, I tested removing the extra ammo spawns from `nested_shotgun_d` and setting the gun itself to use `ammo-group`. This was used to confirm that the guns correctly spawned with a random selection of ammo without exceeding the max load of 2, but also that it wouldn't secretly try to spawn any excess shells on the side without me noticing (and it made the resulting test screenshot look nicer too). Confirmed that the guns spawned with no more than 2 shells loaded, in a nice variety of ammo loadouts, and without any excess ammo magically showing up.
2. Repeated the above test but with `nested_m1911`, to test that this feature also plays nicely with magazine-fed guns. It correctly varied in ammotype and amount, without displaying any weird behavior.
3. Before going all-in on implementing `ammo-group`, did the charges conversions and double-checked I didn't mess up the numbers for any of them.
4. Next implemented injection of `ammo-group` into both the gun spawns and magazine group spawns of `nested_glock_17` and tested, this was how I learned that the ammogroup injections need to go on only items, not groups, thus step three as outlined about.
5. Checked affected files for syntax and lint errors.
6. Load-tested in compiled test build.
7. Tested several itemgroups to confirm things worked.

<details>
<summary>Screenshots:</summary>

Initial proof of concept, where I tested removing loose ammo from double barrel spawn to confirm that the only ammo spawned in the guns at the right amounts (and because it looked neater):
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/39fca041-0fb4-4815-b819-707f26e81578)

Second proof of concept demonstrating this works with magazine-fed guns, again with loose ammo spawns removed temporarily:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/cb826772-39c7-4609-b249-f08860cf3fea)

Demonstrating that variation in speedloaders and rework of the .357 group was performing as planned:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/a369c159-e5e3-4fc3-b6fb-508fef5ef461)

Showing the loading a gun with a group that picks between two different groups (.40 and 10mm in this case) still works fine:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/aebcf4de-7513-41c6-b350-08c5426eccef)

More complex demonstration with even more nesting of ammo itemgroups under the hood:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/59a0285c-1c37-4375-bab4-7d05bc849283)

</details>

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
