### PR TITLE
fix: disallow loading mags with incompatible ammo

### DIFF
--- a/src/character_functions.cpp
+++ b/src/character_functions.cpp
@@ -1142,12 +1142,22 @@ void find_ammo_helper( T &src, const item &obj, bool empty, Output out, bool nes
     } else {
         // find compatible magazines excluding those already loaded in tools/guns
         const auto mags = obj.magazine_compatible();
+        const std::set<ammotype> &ammo = obj.ammo_types();
 
-        src.visit_items( [&nested, &out, mags, empty]( item * node ) {
+        src.visit_items( [&nested, &out, mags, empty, ammo]( item * node ) {
             if( node->is_gun() || node->is_tool() ) {
                 return VisitResponse::SKIP;
             }
             if( node->is_magazine() ) {
+
+                if( !node->contents.empty() ) {
+                    for( const ammotype &at : ammo ) {
+                        if( node->contents.front().ammo_type() != at ) {
+                            return VisitResponse::SKIP;
+                        }
+                    }
+                }
+
                 if( mags.count( node->typeId() ) && ( node->ammo_remaining() || empty ) ) {
                     out = node;
                 }

--- a/src/character_functions.cpp
+++ b/src/character_functions.cpp
@@ -1144,7 +1144,7 @@ void find_ammo_helper( T &src, const item &obj, bool empty, Output out, bool nes
         const auto mags = obj.magazine_compatible();
         const std::set<ammotype> &ammo = obj.ammo_types();
 
-        src.visit_items( [&nested, &out, mags, empty, ammo]( item * node ) {
+        src.visit_items( [&nested, &out, mags, empty, &ammo]( item * node ) {
             if( node->is_gun() || node->is_tool() ) {
                 return VisitResponse::SKIP;
             }


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This fixes the issue in which you can load a gun with a magazine containing ammo it can't use, such as a stanag full of .300 blackout into an unmodded AR-15, leaving players to get confused when the game lets you do it but then says you're not allowed to shoot afterward.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

In character_functions.cpp, updated `find_ammo_helper` so that the section concerning magazines tracks what ammotype the gun uses, as the preceding section for guns with internal mags does, then passes this info to the item visitor. In the statement specifically for magazines, it then asks if that magazine is already loaded, and if so skips over it if the ammotype of the ammo loaded in it doesn't match what the item about to be loaded can use.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Also stripping out the lil bit that tells you you're not allowed to fire the gun if it's misloaded. I think it's aight to leave in, as old saves will potentially still have misloaded guns, as will old nested gun spawns in current JSON until https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4814 is merged.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Spawned in an AR-15, and loaded up an empty mag with .300 blackout
3. Reloaded AR-15, no longer allowed to load the one with .300 in it.
4. Loaded and fired a stanag with normal .223 ammo in it, confirmed it still works.
5. Installed the conversion kit on it, confirmed it can correctly load and fire the mag with .300 blackout in it now, but can no longer load/fire the .223-filled mag.
6. Tested reloading a double-barrel shotgun and tested the mags themselves, no oddities observed.
7. Unloaded a mag and confirmed that it can still load empty mags just fine.
8. Checked affected file for astyle.

<details>
<summary>Screenshots:</summary>

Test inventory:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/024b6689-6fdc-4725-a55b-ad05c970a065)

Baseline AR no longer accepts blackout:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/76aa5777-732d-4473-b3d1-16640dbb6ea3)

After applying the conversion kit, it now accepts .300 but not the old ammo:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/8023be7a-6636-4d25-8ed6-0ec48a4308b5)

Empty mags are fine too:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/7dacf725-a0de-48ef-a6a5-84e4b349e26d)

</details>

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Tested DDA and looks like they figured this out at somne point along the way too, no idea when, in what PR, or how it'd differ from our fix.