### PR TITLE
fix: magazines dropped by zombies vary in ammocount, expand variety of guns

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/everydaycarry_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/everydaycarry_guns.json
@@ -4,11 +4,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "glock_17", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
-      { "group": "nested_glock17_mag" },
-      { "group": "nested_glock17_mag", "prob": 50 }
+      { "group": "nested_glock17_mag", "charges-min": 0 },
+      { "group": "nested_glock17_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -16,11 +15,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "glock_19", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
-      { "group": "nested_glock19_mag" },
-      { "group": "nested_glock19_mag", "prob": 50 }
+      { "group": "nested_glock19_mag", "charges-min": 0 },
+      { "group": "nested_glock19_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -28,11 +26,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "glock_21", "ammo-group": "on_hand_45", "charges": [ 0, 15 ] },
-      { "group": "nested_glock21_mag" },
-      { "group": "nested_glock21_mag", "prob": 50 }
+      { "group": "nested_glock21_mag", "charges-min": 0 },
+      { "group": "nested_glock21_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -40,11 +37,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "glock_22", "ammo-group": "on_hand_40", "charges": [ 0, 15 ] },
-      { "group": "nested_glock22_mag" },
-      { "group": "nested_glock22_mag", "prob": 50 }
+      { "group": "nested_glock22_mag", "charges-min": 0 },
+      { "group": "nested_glock22_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -52,11 +48,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "glock_31", "ammo-group": "on_hand_357sig", "charges": [ 0, 15 ] },
-      { "group": "nested_glock22_mag" },
-      { "group": "nested_glock22_mag", "prob": 50 }
+      { "group": "nested_glock22_mag", "charges-min": 0 },
+      { "group": "nested_glock22_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -64,11 +59,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "m1911", "ammo-group": "on_hand_45", "charges": [ 0, 7 ] },
-      { "group": "nested_m1911_mag" },
-      { "group": "nested_m1911_mag", "prob": 50 }
+      { "group": "nested_m1911_mag", "charges-min": 0 },
+      { "group": "nested_m1911_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -76,11 +70,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "m1911_MEU", "ammo-group": "on_hand_45", "charges": [ 0, 7 ] },
-      { "group": "nested_m1911_mag" },
-      { "group": "nested_m1911_mag", "prob": 50 }
+      { "group": "nested_m1911_mag", "charges-min": 0 },
+      { "group": "nested_m1911_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -88,11 +81,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "m9", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
-      { "group": "nested_m9_mag" },
-      { "group": "nested_m9_mag", "prob": 50 }
+      { "group": "nested_m9_mag", "charges-min": 0 },
+      { "group": "nested_m9_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -100,11 +92,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "px4", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
-      { "item": "px4mag", "ammo-group": "on_hand_9mm" },
-      { "item": "px4mag", "ammo-group": "on_hand_9mm", "prob": 50 }
+      { "item": "px4mag", "charges-min": 0, "ammo-group": "on_hand_9mm" },
+      { "item": "px4mag", "charges-min": 0, "ammo-group": "on_hand_9mm", "prob": 50 }
     ]
   },
   {
@@ -112,11 +103,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "px4_40", "ammo-group": "on_hand_40", "charges": [ 0, 15 ] },
-      { "item": "px4_40mag", "ammo-group": "on_hand_40" },
-      { "item": "px4_40mag", "ammo-group": "on_hand_40", "prob": 50 }
+      { "item": "px4_40mag", "charges-min": 0, "ammo-group": "on_hand_40" },
+      { "item": "px4_40mag", "charges-min": 0, "ammo-group": "on_hand_40", "prob": 50 }
     ]
   },
   {
@@ -124,11 +114,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "sig_mosquito", "ammo-group": "on_hand_22", "charges": [ 0, 10 ] },
-      { "item": "mosquitomag", "ammo-group": "on_hand_22" },
-      { "item": "mosquitomag", "ammo-group": "on_hand_22", "prob": 50 }
+      { "item": "mosquitomag", "charges-min": 0, "ammo-group": "on_hand_22" },
+      { "item": "mosquitomag", "charges-min": 0, "ammo-group": "on_hand_22", "prob": 50 }
     ]
   },
   {
@@ -136,11 +125,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "sw_22", "ammo-group": "on_hand_22", "charges": [ 0, 10 ] },
-      { "item": "sw22mag", "ammo-group": "on_hand_22" },
-      { "item": "sw22mag", "ammo-group": "on_hand_22", "prob": 50 }
+      { "item": "sw22mag", "charges-min": 0, "ammo-group": "on_hand_22" },
+      { "item": "sw22mag", "charges-min": 0, "ammo-group": "on_hand_22", "prob": 50 }
     ]
   },
   {
@@ -148,11 +136,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "taurus_spectrum", "ammo-group": "on_hand_380", "charges": [ 0, 6 ] },
-      { "item": "taurus_spectrum_mag", "ammo-group": "on_hand_380" },
-      { "item": "taurus_spectrum_mag", "ammo-group": "on_hand_380", "prob": 50 }
+      { "item": "taurus_spectrum_mag", "charges-min": 0, "ammo-group": "on_hand_380" },
+      { "item": "taurus_spectrum_mag", "charges-min": 0, "ammo-group": "on_hand_380", "prob": 50 }
     ]
   },
   {
@@ -160,7 +147,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "p226_357sig", "ammo-group": "on_hand_357sig", "charges": [ 0, 12 ] },
       { "item": "p226mag_12rd_357sig", "ammo-group": "on_hand_357sig" },
@@ -172,7 +158,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "p320_357sig", "ammo-group": "on_hand_357sig", "charges": [ 0, 13 ] },
       { "item": "p320mag_13rd_357sig", "ammo-group": "on_hand_357sig" },
@@ -184,11 +169,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "kp32", "ammo-group": "on_hand_32", "charges": [ 0, 7 ] },
-      { "item": "kp32mag", "ammo-group": "on_hand_32" },
-      { "item": "kp32mag", "ammo-group": "on_hand_32", "prob": 50 }
+      { "item": "kp32mag", "charges-min": 0, "ammo-group": "on_hand_32" },
+      { "item": "kp32mag", "charges-min": 0, "ammo-group": "on_hand_32", "prob": 50 }
     ]
   },
   {
@@ -196,11 +180,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "kp3at", "ammo-group": "on_hand_380", "charges": [ 0, 6 ] },
-      { "item": "kp3atmag", "ammo-group": "on_hand_380" },
-      { "item": "kp3atmag", "ammo-group": "on_hand_380", "prob": 50 }
+      { "item": "kp3atmag", "charges-min": 0, "ammo-group": "on_hand_380" },
+      { "item": "kp3atmag", "charges-min": 0, "ammo-group": "on_hand_380", "prob": 50 }
     ]
   },
   {
@@ -208,11 +191,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "rugerlcp", "ammo-group": "on_hand_380", "charges": [ 0, 6 ] },
-      { "item": "rugerlcpmag", "ammo-group": "on_hand_380" },
-      { "item": "rugerlcpmag", "ammo-group": "on_hand_380", "prob": 50 }
+      { "item": "rugerlcpmag", "charges-min": 0, "ammo-group": "on_hand_380" },
+      { "item": "rugerlcpmag", "charges-min": 0, "ammo-group": "on_hand_380", "prob": 50 }
     ]
   },
   {
@@ -220,11 +202,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "kpf9", "ammo-group": "on_hand_9mm", "charges": [ 0, 7 ] },
-      { "item": "kpf9mag", "ammo-group": "on_hand_9mm" },
-      { "item": "kpf9mag", "ammo-group": "on_hand_9mm", "prob": 50 }
+      { "item": "kpf9mag", "charges-min": 0, "ammo-group": "on_hand_9mm" },
+      { "item": "kpf9mag", "charges-min": 0, "ammo-group": "on_hand_9mm", "prob": 50 }
     ]
   },
   {
@@ -232,11 +213,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "hi_power_9mm", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
-      { "group": "nested_hi_power_9mm_mag" },
-      { "group": "nested_hi_power_9mm_mag", "prob": 50 }
+      { "group": "nested_hi_power_9mm_mag", "charges-min": 0 },
+      { "group": "nested_hi_power_9mm_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -244,11 +224,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "hi_power_40", "ammo-group": "on_hand_40", "charges": [ 0, 10 ] },
-      { "item": "bhp40mag", "ammo-group": "on_hand_40" },
-      { "item": "bhp40mag", "ammo-group": "on_hand_40", "prob": 50 }
+      { "item": "bhp40mag", "charges-min": 0, "ammo-group": "on_hand_40" },
+      { "item": "bhp40mag", "charges-min": 0, "ammo-group": "on_hand_40", "prob": 50 }
     ]
   },
   {
@@ -256,11 +235,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "walther_p38", "ammo-group": "on_hand_9mm", "charges": [ 0, 8 ] },
-      { "item": "p38mag", "ammo-group": "on_hand_9mm" },
-      { "item": "p38mag", "ammo-group": "on_hand_9mm", "prob": 50 }
+      { "item": "p38mag", "charges-min": 0, "ammo-group": "on_hand_9mm" },
+      { "item": "p38mag", "charges-min": 0, "ammo-group": "on_hand_9mm", "prob": 50 }
     ]
   },
   {
@@ -268,11 +246,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "walther_ppq_9mm", "ammo-group": "on_hand_9mm", "charges": [ 0, 17 ] },
-      { "group": "nested_walther_ppq_9mm_mag" },
-      { "group": "nested_walther_ppq_9mm_mag", "prob": 50 }
+      { "group": "nested_walther_ppq_9mm_mag", "charges-min": 0 },
+      { "group": "nested_walther_ppq_9mm_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -280,11 +257,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "walther_ppq_40", "ammo-group": "on_hand_40", "charges": [ 0, 14 ] },
-      { "group": "nested_walther_ppq_40_mag" },
-      { "group": "nested_walther_ppq_40_mag", "prob": 50 }
+      { "group": "nested_walther_ppq_40_mag", "charges-min": 0 },
+      { "group": "nested_walther_ppq_40_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -292,11 +268,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "walther_ppq_45", "ammo-group": "on_hand_45", "charges": [ 0, 12 ] },
-      { "item": "ppq45mag", "ammo-group": "on_hand_45" },
-      { "item": "ppq45mag", "ammo-group": "on_hand_45", "prob": 50 }
+      { "item": "ppq45mag", "charges-min": 0, "ammo-group": "on_hand_45" },
+      { "item": "ppq45mag", "charges-min": 0, "ammo-group": "on_hand_45", "prob": 50 }
     ]
   },
   {
@@ -304,11 +279,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "hptc9", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
-      { "group": "nested_hptc9_mag" },
-      { "group": "nested_hptc9_mag", "prob": 50 }
+      { "group": "nested_hptc9_mag", "charges-min": 0 },
+      { "group": "nested_hptc9_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -316,11 +290,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "hptcf380", "ammo-group": "on_hand_380", "charges": [ 0, 10 ] },
-      { "group": "nested_hptcf380_mag" },
-      { "group": "nested_hptcf380_mag", "prob": 50 }
+      { "group": "nested_hptcf380_mag", "charges-min": 0 },
+      { "group": "nested_hptcf380_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -328,11 +301,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "hptjcp", "ammo-group": "on_hand_40", "charges": [ 0, 10 ] },
-      { "item": "hptjcpmag", "ammo-group": "on_hand_40" },
-      { "item": "hptjcpmag", "ammo-group": "on_hand_40", "prob": 50 }
+      { "item": "hptjcpmag", "charges-min": 0, "ammo-group": "on_hand_40" },
+      { "item": "hptjcpmag", "charges-min": 0, "ammo-group": "on_hand_40", "prob": 50 }
     ]
   },
   {
@@ -340,11 +312,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "hptjhp", "ammo-group": "on_hand_45", "charges": [ 0, 9 ] },
-      { "item": "hptjhpmag", "ammo-group": "on_hand_45" },
-      { "item": "hptjhpmag", "ammo-group": "on_hand_45", "prob": 50 }
+      { "item": "hptjhpmag", "charges-min": 0, "ammo-group": "on_hand_45" },
+      { "item": "hptjhpmag", "charges-min": 0, "ammo-group": "on_hand_45", "prob": 50 }
     ]
   },
   {
@@ -352,11 +323,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "cz75", "ammo-group": "on_hand_9mm", "charges": [ 0, 26 ] },
-      { "group": "nested_cz75_mag" },
-      { "group": "nested_cz75_mag", "prob": 50 }
+      { "group": "nested_cz75_mag", "charges-min": 0 },
+      { "group": "nested_cz75_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -364,11 +334,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "walther_ccp", "ammo-group": "on_hand_9mm", "charges": [ 0, 8 ] },
-      { "item": "ccpmag", "ammo-group": "on_hand_9mm" },
-      { "item": "ccpmag", "ammo-group": "on_hand_9mm", "prob": 50 }
+      { "item": "ccpmag", "charges-min": 0, "ammo-group": "on_hand_9mm" },
+      { "item": "ccpmag", "charges-min": 0, "ammo-group": "on_hand_9mm", "prob": 50 }
     ]
   },
   {
@@ -376,11 +345,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "walther_p22", "ammo-group": "on_hand_22", "charges": [ 0, 10 ] },
-      { "item": "wp22mag", "ammo-group": "on_hand_22" },
-      { "item": "wp22mag", "ammo-group": "on_hand_22", "prob": 50 }
+      { "item": "wp22mag", "charges-min": 0, "ammo-group": "on_hand_22" },
+      { "item": "wp22mag", "charges-min": 0, "ammo-group": "on_hand_22", "prob": 50 }
     ]
   },
   {
@@ -388,11 +356,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "90two", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
-      { "group": "nested_m9_mag" },
-      { "group": "nested_m9_mag", "prob": 50 }
+      { "group": "nested_m9_mag", "charges-min": 0 },
+      { "group": "nested_m9_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -400,11 +367,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "90two40", "ammo-group": "on_hand_40", "charges": [ 0, 12 ] },
-      { "item": "90two40mag", "ammo-group": "on_hand_40" },
-      { "item": "90two40mag", "ammo-group": "on_hand_40", "prob": 50 }
+      { "item": "90two40mag", "charges-min": 0, "ammo-group": "on_hand_40" },
+      { "item": "90two40mag", "charges-min": 0, "ammo-group": "on_hand_40", "prob": 50 }
     ]
   },
   {
@@ -412,11 +378,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "deagle_44", "ammo-group": "on_hand_44", "charges": [ 0, 8 ] },
-      { "item": "deaglemag", "ammo-group": "on_hand_44" },
-      { "item": "deaglemag", "ammo-group": "on_hand_44", "prob": 50 }
+      { "item": "deaglemag", "charges-min": 0, "ammo-group": "on_hand_44" },
+      { "item": "deaglemag", "charges-min": 0, "ammo-group": "on_hand_44", "prob": 50 }
     ]
   },
   {
@@ -424,7 +389,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "m1911a1_38super", "ammo-group": "on_hand_38super", "charges": [ 0, 9 ] },
       { "item": "m1911mag_10rd_38super", "ammo-group": "on_hand_38super" },
@@ -436,11 +400,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "fn57", "ammo-group": "on_hand_57", "charges": [ 0, 20 ] },
-      { "item": "fn57mag", "ammo-group": "on_hand_57" },
-      { "item": "fn57mag", "ammo-group": "on_hand_57", "prob": 50 }
+      { "item": "fn57mag", "charges-min": 0, "ammo-group": "on_hand_57" },
+      { "item": "fn57mag", "charges-min": 0, "ammo-group": "on_hand_57", "prob": 50 }
     ]
   },
   {
@@ -448,11 +411,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "sig_40", "ammo-group": "on_hand_40", "charges": [ 0, 12 ] },
-      { "item": "sig40mag", "ammo-group": "on_hand_40" },
-      { "item": "sig40mag", "ammo-group": "on_hand_40", "prob": 50 }
+      { "item": "sig40mag", "charges-min": 0, "ammo-group": "on_hand_40" },
+      { "item": "sig40mag", "charges-min": 0, "ammo-group": "on_hand_40", "prob": 50 }
     ]
   },
   {
@@ -460,11 +422,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "sig_p230", "ammo-group": "on_hand_32", "charges": [ 0, 8 ] },
-      { "item": "sigp230mag", "ammo-group": "on_hand_32" },
-      { "item": "sigp230mag", "ammo-group": "on_hand_32", "prob": 50 }
+      { "item": "sigp230mag", "charges-min": 0, "ammo-group": "on_hand_32" },
+      { "item": "sigp230mag", "charges-min": 0, "ammo-group": "on_hand_32", "prob": 50 }
     ]
   },
   {
@@ -472,19 +433,21 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
-    "entries": [ { "item": "usp_45", "charges": [ 0, 12 ] }, { "item": "usp45mag" }, { "item": "usp45mag", "prob": 50 } ]
+    "entries": [
+      { "item": "usp_45", "charges": [ 0, 12 ] },
+      { "item": "usp45mag", "charges-min": 0 },
+      { "item": "usp45mag", "charges-min": 0, "prob": 50 }
+    ]
   },
   {
     "id": "everyday_usp_9mm",
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "usp_9mm", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
-      { "item": "usp9mag", "ammo-group": "on_hand_9mm" },
-      { "item": "usp9mag", "ammo-group": "on_hand_9mm", "prob": 50 }
+      { "item": "usp9mag", "charges-min": 0, "ammo-group": "on_hand_9mm" },
+      { "item": "usp9mag", "charges-min": 0, "ammo-group": "on_hand_9mm", "prob": 50 }
     ]
   },
   {
@@ -492,11 +455,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "draco", "ammo-group": "on_hand_762", "charges": [ 0, 30 ] },
-      { "group": "nested_ak47_mag" },
-      { "group": "nested_ak47_mag", "prob": 50 }
+      { "group": "nested_ak47_mag", "charges-min": 0 },
+      { "group": "nested_ak47_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -504,7 +466,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "m17", "charges": [ 0, 17 ] },
       { "item": "p320mag_17rd_9x19mm", "ammo-group": "on_hand_9mm" },
@@ -516,11 +477,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "glock_18c", "ammo-group": "on_hand_9mm", "charges": [ 0, 17 ] },
-      { "group": "nested_glock17_mag" },
-      { "group": "nested_glock17_mag", "prob": 50 }
+      { "group": "nested_glock17_mag", "charges-min": 0 },
+      { "group": "nested_glock17_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -528,11 +488,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "mk23", "ammo-group": "on_hand_45", "charges": [ 0, 12 ] },
-      { "item": "usp45mag", "ammo-group": "on_hand_45" },
-      { "item": "usp45mag", "ammo-group": "on_hand_45", "prob": 50 }
+      { "item": "usp45mag", "charges-min": 0, "ammo-group": "on_hand_45" },
+      { "item": "usp45mag", "charges-min": 0, "ammo-group": "on_hand_45", "prob": 50 }
     ]
   },
   {
@@ -540,11 +499,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "tokarev", "ammo-group": "on_hand_762x25" },
-      { "item": "tokarevmag", "ammo-group": "on_hand_762x25" },
-      { "item": "tokarevmag", "ammo-group": "on_hand_762x25", "prob": 50 }
+      { "item": "tokarevmag", "charges-min": 0, "ammo-group": "on_hand_762x25" },
+      { "item": "tokarevmag", "charges-min": 0, "ammo-group": "on_hand_762x25", "prob": 50 }
     ]
   },
   {
@@ -552,11 +510,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "walther_ppk", "ammo-group": "on_hand_32" },
-      { "item": "ppkmag", "ammo-group": "on_hand_32" },
-      { "item": "ppkmag", "ammo-group": "on_hand_32", "prob": 50 }
+      { "item": "ppkmag", "charges-min": 0, "ammo-group": "on_hand_32" },
+      { "item": "ppkmag", "charges-min": 0, "ammo-group": "on_hand_32", "prob": 50 }
     ]
   },
   {
@@ -564,11 +521,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "rm103a_pistol", "ammo-group": "on_hand_8x40" },
-      { "group": "nested_rm103a_mag" },
-      { "group": "nested_rm103a_mag", "prob": 50 }
+      { "group": "nested_rm103a_mag", "charges-min": 0 },
+      { "group": "nested_rm103a_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -576,11 +532,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "af2011a1_38super", "ammo-group": "on_hand_38super" },
-      { "item": "af2011a1mag", "ammo-group": "on_hand_38super" },
-      { "item": "af2011a1mag", "ammo-group": "on_hand_38super", "prob": 50 }
+      { "item": "af2011a1mag", "charges-min": 0, "ammo-group": "on_hand_38super" },
+      { "item": "af2011a1mag", "charges-min": 0, "ammo-group": "on_hand_38super", "prob": 50 }
     ]
   },
   {
@@ -588,7 +543,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "m1911-460", "charges": [ 0, 7 ] },
       { "group": "nested_m1911_mag_460" },
@@ -600,11 +554,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "makarov", "ammo-group": "on_hand_9x18", "charges": [ 0, 8 ] },
-      { "item": "makarovmag", "ammo-group": "on_hand_9x18" },
-      { "item": "makarovmag", "ammo-group": "on_hand_9x18", "prob": 50 }
+      { "item": "makarovmag", "charges-min": 0, "ammo-group": "on_hand_9x18" },
+      { "item": "makarovmag", "charges-min": 0, "ammo-group": "on_hand_9x18", "prob": 50 }
     ]
   },
   {
@@ -612,11 +565,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "hk_mp5_semi_pistol", "ammo-group": "on_hand_9mm", "charges": [ 0, 30 ] },
-      { "group": "nested_mp5_mag" },
-      { "group": "nested_mp5_mag", "prob": 50 }
+      { "group": "nested_mp5_mag", "charges-min": 0 },
+      { "group": "nested_mp5_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -624,11 +576,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "calico", "ammo-group": "on_hand_9mm", "charges": [ 0, 50 ] },
-      { "item": "calicomag", "ammo-group": "on_hand_9mm" },
-      { "item": "calicomag", "ammo-group": "on_hand_9mm", "prob": 50 }
+      { "item": "calicomag", "charges-min": 0, "ammo-group": "on_hand_9mm" },
+      { "item": "calicomag", "charges-min": 0, "ammo-group": "on_hand_9mm", "prob": 50 }
     ]
   },
   {
@@ -636,11 +587,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "fn_p90", "ammo-group": "on_hand_57", "charges": [ 0, 50 ] },
-      { "item": "fnp90mag", "ammo-group": "on_hand_57" },
-      { "item": "fnp90mag", "ammo-group": "on_hand_57", "prob": 50 }
+      { "item": "fnp90mag", "charges-min": 0, "ammo-group": "on_hand_57" },
+      { "item": "fnp90mag", "charges-min": 0, "ammo-group": "on_hand_57", "prob": 50 }
     ]
   },
   {
@@ -648,11 +598,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "tommygun", "ammo-group": "on_hand_45", "charges": [ 0, 20 ] },
-      { "group": "nested_tommygun_mag" },
-      { "group": "nested_tommygun_mag", "prob": 50 }
+      { "group": "nested_tommygun_mag", "charges-min": 0 },
+      { "group": "nested_tommygun_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -660,11 +609,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "sten", "ammo-group": "on_hand_9mm", "charges": [ 0, 32 ] },
-      { "item": "stenmag", "ammo-group": "on_hand_9mm" },
-      { "item": "stenmag", "ammo-group": "on_hand_9mm", "prob": 50 }
+      { "item": "stenmag", "charges-min": 0, "ammo-group": "on_hand_9mm" },
+      { "item": "stenmag", "charges-min": 0, "ammo-group": "on_hand_9mm", "prob": 50 }
     ]
   },
   {
@@ -672,11 +620,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "uzi", "ammo-group": "on_hand_9mm", "charges": [ 0, 32 ] },
-      { "item": "uzimag", "ammo-group": "on_hand_9mm" },
-      { "item": "uzimag", "ammo-group": "on_hand_9mm", "prob": 50 }
+      { "item": "uzimag", "charges-min": 0, "ammo-group": "on_hand_9mm" },
+      { "item": "uzimag", "charges-min": 0, "ammo-group": "on_hand_9mm", "prob": 50 }
     ]
   },
   {
@@ -684,11 +631,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "hk_mp5", "ammo-group": "on_hand_9mm", "charges": [ 0, 30 ] },
-      { "group": "nested_mp5_mag" },
-      { "group": "nested_mp5_mag", "prob": 50 }
+      { "group": "nested_mp5_mag", "charges-min": 0 },
+      { "group": "nested_mp5_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -696,11 +642,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "hk_mp5", "ammo-group": "on_hand_9mm", "charges": [ 0, 30 ] },
-      { "group": "nested_mp5_mag" },
-      { "group": "nested_mp5_mag", "prob": 50 }
+      { "group": "nested_mp5_mag", "charges-min": 0 },
+      { "group": "nested_mp5_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -708,11 +653,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "hk_ump45", "ammo-group": "on_hand_45", "charges": [ 0, 25 ] },
-      { "item": "ump45mag", "ammo-group": "on_hand_45" },
-      { "item": "ump45mag", "ammo-group": "on_hand_45", "prob": 50 }
+      { "item": "ump45mag", "charges-min": 0, "ammo-group": "on_hand_45" },
+      { "item": "ump45mag", "charges-min": 0, "ammo-group": "on_hand_45", "prob": 50 }
     ]
   },
   {
@@ -720,11 +664,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "mac_10", "ammo-group": "on_hand_45", "charges": [ 0, 30 ] },
-      { "item": "mac10mag", "ammo-group": "on_hand_45" },
-      { "item": "mac10mag", "ammo-group": "on_hand_45", "prob": 50 }
+      { "item": "mac10mag", "charges-min": 0, "ammo-group": "on_hand_45" },
+      { "item": "mac10mag", "charges-min": 0, "ammo-group": "on_hand_45", "prob": 50 }
     ]
   },
   {
@@ -732,11 +675,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "mac_11", "ammo-group": "on_hand_380", "charges": [ 0, 32 ] },
-      { "item": "mac11mag", "ammo-group": "on_hand_380" },
-      { "item": "mac11mag", "ammo-group": "on_hand_380", "prob": 50 }
+      { "item": "mac11mag", "charges-min": 0, "ammo-group": "on_hand_380" },
+      { "item": "mac11mag", "charges-min": 0, "ammo-group": "on_hand_380", "prob": 50 }
     ]
   },
   {
@@ -744,11 +686,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "TDI", "ammo-group": "on_hand_45", "charges": [ 0, 30 ] },
-      { "group": "nested_TDI_mag" },
-      { "group": "nested_TDI_mag", "prob": 50 }
+      { "group": "nested_TDI_mag", "charges-min": 0 },
+      { "group": "nested_TDI_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -756,11 +697,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "american_180", "ammo-group": "on_hand_22", "charges": [ 0, 100 ] },
-      { "item": "a180mag", "ammo-group": "on_hand_22" },
-      { "item": "a180mag", "ammo-group": "on_hand_22", "prob": 50 }
+      { "item": "a180mag", "charges-min": 0, "ammo-group": "on_hand_22" },
+      { "item": "a180mag", "charges-min": 0, "ammo-group": "on_hand_22", "prob": 50 }
     ]
   },
   {
@@ -768,11 +708,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "briefcase_smg", "ammo-group": "on_hand_9mm", "charges": [ 0, 30 ] },
-      { "group": "nested_mp5_mag" },
-      { "group": "nested_mp5_mag", "prob": 50 }
+      { "group": "nested_mp5_mag", "charges-min": 0 },
+      { "group": "nested_mp5_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -780,11 +719,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "tec9", "ammo-group": "on_hand_9mm", "charges": [ 0, 30 ] },
-      { "item": "tec9mag", "ammo-group": "on_hand_9mm" },
-      { "item": "tec9mag", "ammo-group": "on_hand_9mm", "prob": 50 }
+      { "item": "tec9mag", "charges-min": 0, "ammo-group": "on_hand_9mm" },
+      { "item": "tec9mag", "charges-min": 0, "ammo-group": "on_hand_9mm", "prob": 50 }
     ]
   },
   {
@@ -792,11 +730,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "hk_mp7", "ammo-group": "on_hand_46", "charges": [ 0, 20 ] },
-      { "group": "nested_hk_mp7_mag" },
-      { "group": "nested_hk_mp7_mag", "prob": 50 }
+      { "group": "nested_hk_mp7_mag", "charges-min": 0 },
+      { "group": "nested_hk_mp7_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -804,11 +741,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "rm2000_smg", "ammo-group": "on_hand_8x40", "charges": [ 0, 10 ] },
-      { "group": "nested_rm103a_mag" },
-      { "group": "nested_rm103a_mag", "prob": 50 }
+      { "group": "nested_rm103a_mag", "charges-min": 0 },
+      { "group": "nested_rm103a_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -816,11 +752,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "hk_mp5k", "ammo-group": "on_hand_9mm", "charges": [ 0, 30 ] },
-      { "group": "nested_mp5_mag" },
-      { "group": "nested_mp5_mag", "prob": 50 }
+      { "group": "nested_mp5_mag", "charges-min": 0 },
+      { "group": "nested_mp5_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -828,11 +763,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "browning_blr", "ammo-group": "on_hand_3006", "charges": [ 0, 4 ] },
-      { "item": "blrmag", "ammo-group": "on_hand_3006" },
-      { "item": "blrmag", "ammo-group": "on_hand_3006", "prob": 50 }
+      { "item": "blrmag", "charges-min": 0, "ammo-group": "on_hand_3006" },
+      { "item": "blrmag", "charges-min": 0, "ammo-group": "on_hand_3006", "prob": 50 }
     ]
   },
   {
@@ -840,11 +774,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "ar_pistol", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
-      { "group": "nested_stanag_mag" },
-      { "group": "nested_stanag_mag", "prob": 50 }
+      { "group": "nested_stanag_mag", "charges-min": 0 },
+      { "group": "nested_stanag_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -852,7 +785,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "garand", "ammo-group": "on_hand_3006", "charges": [ 0, 8 ] },
       { "item": "garandclip", "ammo-group": "on_hand_3006" },
@@ -864,7 +796,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "ar10", "ammo-group": "on_hand_308", "charges": [ 0, 20 ] },
       { "item": "ar10mag_20rd", "ammo-group": "on_hand_308" },
@@ -876,11 +807,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "ar15", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
-      { "group": "nested_stanag_mag" },
-      { "group": "nested_stanag_mag", "prob": 50 }
+      { "group": "nested_stanag_mag", "charges-min": 0 },
+      { "group": "nested_stanag_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -888,11 +818,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "cx4", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
-      { "group": "nested_m9_mag" },
-      { "group": "nested_m9_mag", "prob": 50 }
+      { "group": "nested_m9_mag", "charges-min": 0 },
+      { "group": "nested_m9_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -900,11 +829,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "ksub2000", "ammo-group": "on_hand_9mm", "charges": [ 0, 15 ] },
-      { "group": "nested_glock19_mag" },
-      { "group": "nested_glock19_mag", "prob": 50 }
+      { "group": "nested_glock19_mag", "charges-min": 0 },
+      { "group": "nested_glock19_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -912,11 +840,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "m1a", "ammo-group": "on_hand_308", "charges": [ 0, 5 ] },
-      { "group": "nested_m14_mag" },
-      { "group": "nested_m14_mag", "prob": 50 }
+      { "group": "nested_m14_mag", "charges-min": 0 },
+      { "group": "nested_m14_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -924,11 +851,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "ruger_1022", "ammo-group": "on_hand_22", "charges": [ 0, 10 ] },
-      { "group": "nested_ruger_1022_mag" },
-      { "group": "nested_ruger_1022_mag", "prob": 50 }
+      { "group": "nested_ruger_1022_mag", "charges-min": 0 },
+      { "group": "nested_ruger_1022_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -936,11 +862,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "ruger_mini", "ammo-group": "on_hand_223", "charges": [ 0, 5 ] },
-      { "group": "nested_ruger_mini_mag" },
-      { "group": "nested_ruger_mini_mag", "prob": 50 }
+      { "group": "nested_ruger_mini_mag", "charges-min": 0 },
+      { "group": "nested_ruger_mini_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -948,11 +873,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "aksemi", "ammo-group": "on_hand_762", "charges": [ 0, 30 ] },
-      { "group": "nested_ak47_mag" },
-      { "group": "nested_ak47_mag", "prob": 50 }
+      { "group": "nested_ak47_mag", "charges-min": 0 },
+      { "group": "nested_ak47_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -960,11 +884,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "fn_fal", "ammo-group": "on_hand_308", "charges": [ 0, 20 ] },
-      { "group": "nested_fn_fal_mag" },
-      { "group": "nested_fn_fal_mag", "prob": 50 }
+      { "group": "nested_fn_fal_mag", "charges-min": 0 },
+      { "group": "nested_fn_fal_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -972,11 +895,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "hk_g3", "ammo-group": "on_hand_308", "charges": [ 0, 20 ] },
-      { "group": "nested_hk_g3_mag" },
-      { "group": "nested_hk_g3_mag", "prob": 50 }
+      { "group": "nested_hk_g3_mag", "charges-min": 0 },
+      { "group": "nested_hk_g3_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -984,11 +906,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "hk_g36", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
-      { "group": "nested_hk_g36_mag" },
-      { "group": "nested_hk_g36_mag", "prob": 50 }
+      { "group": "nested_hk_g36_mag", "charges-min": 0 },
+      { "group": "nested_hk_g36_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -996,11 +917,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "m14ebr", "ammo-group": "on_hand_308", "charges": [ 0, 20 ] },
-      { "group": "nested_m14_mag" },
-      { "group": "nested_m14_mag", "prob": 50 }
+      { "group": "nested_m14_mag", "charges-min": 0 },
+      { "group": "nested_m14_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -1008,11 +928,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "m4a1", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
-      { "group": "nested_stanag_mag" },
-      { "group": "nested_stanag_mag", "prob": 50 }
+      { "group": "nested_stanag_mag", "charges-min": 0 },
+      { "group": "nested_stanag_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -1020,7 +939,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack.  Grenadier variant",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       {
         "item": "m4a1",
@@ -1028,8 +946,8 @@
         "charges": [ 0, 30 ],
         "contents-group": "military_accessories_grenadier"
       },
-      { "group": "nested_stanag_mag" },
-      { "group": "nested_stanag_mag", "prob": 50 }
+      { "group": "nested_stanag_mag", "charges-min": 0 },
+      { "group": "nested_stanag_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -1037,11 +955,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "m1918", "ammo-group": "on_hand_3006", "charges": [ 0, 20 ] },
-      { "group": "nested_m1918_mag" },
-      { "group": "nested_m1918_mag", "prob": 50 }
+      { "group": "nested_m1918_mag", "charges-min": 0 },
+      { "group": "nested_m1918_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -1049,11 +966,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "hk417_13", "ammo-group": "on_hand_308", "charges": [ 0, 20 ] },
-      { "group": "nested_hk417_13_mag" },
-      { "group": "nested_hk417_13_mag", "prob": 50 }
+      { "group": "nested_hk417_13_mag", "charges-min": 0 },
+      { "group": "nested_hk417_13_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -1061,7 +977,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "iwi_tavor_x95_300blk", "ammo-group": "on_hand_300BLK", "charges": [ 0, 30 ] },
       { "group": "nested_stanag_mag_300" },
@@ -1073,11 +988,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "h&k416a5", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
-      { "group": "nested_stanag_mag" },
-      { "group": "nested_stanag_mag", "prob": 50 }
+      { "group": "nested_stanag_mag", "charges-min": 0 },
+      { "group": "nested_stanag_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -1085,7 +999,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack.  Grenadier variant",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       {
         "item": "h&k416a5",
@@ -1093,8 +1006,8 @@
         "charges": [ 0, 30 ],
         "contents-group": "military_accessories_grenadier"
       },
-      { "group": "nested_stanag_mag" },
-      { "group": "nested_stanag_mag", "prob": 50 }
+      { "group": "nested_stanag_mag", "charges-min": 0 },
+      { "group": "nested_stanag_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -1102,11 +1015,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "m27iar", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
-      { "group": "nested_stanag_mag" },
-      { "group": "nested_stanag_mag", "prob": 50 }
+      { "group": "nested_stanag_mag", "charges-min": 0 },
+      { "group": "nested_stanag_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -1114,7 +1026,6 @@
     "type": "item_group",
     "//": "Currently speculative but has been floated as a potential idea for the fire support role",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "stanag100", "ammo-group": "on_hand_223", "container-item": "m27iar", "charges": [ 0, 100 ] },
       { "item": "stanag100", "ammo-group": "on_hand_223" },
@@ -1126,7 +1037,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack.  Grenadier variant",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       {
         "item": "m27iar",
@@ -1134,8 +1044,8 @@
         "charges": [ 0, 30 ],
         "contents-group": "military_accessories_grenadier"
       },
-      { "group": "nested_stanag_mag" },
-      { "group": "nested_stanag_mag", "prob": 50 }
+      { "group": "nested_stanag_mag", "charges-min": 0 },
+      { "group": "nested_stanag_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -1143,11 +1053,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "scar_l", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
-      { "group": "nested_stanag_mag" },
-      { "group": "nested_stanag_mag", "prob": 50 }
+      { "group": "nested_stanag_mag", "charges-min": 0 },
+      { "group": "nested_stanag_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -1155,11 +1064,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "m107a1", "ammo-group": "on_hand_50", "charges": [ 0, 10 ] },
-      { "item": "m107a1mag", "ammo-group": "on_hand_50" },
-      { "item": "m107a1mag", "ammo-group": "on_hand_50", "prob": 50 }
+      { "item": "m107a1mag", "charges-min": 0, "ammo-group": "on_hand_50" },
+      { "item": "m107a1mag", "charges-min": 0, "ammo-group": "on_hand_50", "prob": 50 }
     ]
   },
   {
@@ -1167,11 +1075,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "tac50", "ammo-group": "on_hand_50", "charges": [ 0, 5 ] },
-      { "item": "tac50mag", "ammo-group": "on_hand_50" },
-      { "item": "tac50mag", "ammo-group": "on_hand_50", "prob": 50 }
+      { "item": "tac50mag", "charges-min": 0, "ammo-group": "on_hand_50" },
+      { "item": "tac50mag", "charges-min": 0, "ammo-group": "on_hand_50", "prob": 50 }
     ]
   },
   {
@@ -1179,11 +1086,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "m2010", "ammo-group": "on_hand_300", "charges": [ 0, 5 ] },
-      { "item": "m2010mag", "ammo-group": "on_hand_300" },
-      { "item": "m2010mag", "ammo-group": "on_hand_300", "prob": 50 }
+      { "item": "m2010mag", "charges-min": 0, "ammo-group": "on_hand_300" },
+      { "item": "m2010mag", "charges-min": 0, "ammo-group": "on_hand_300", "prob": 50 }
     ]
   },
   {
@@ -1191,11 +1097,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "rm11b_sniper_rifle", "ammo-group": "on_hand_8x40", "charges": [ 0, 10 ] },
-      { "group": "nested_rm103a_mag" },
-      { "group": "nested_rm103a_mag", "prob": 50 }
+      { "group": "nested_rm103a_mag", "charges-min": 0 },
+      { "group": "nested_rm103a_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -1203,11 +1108,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "rm298", "ammo-group": "on_hand_8x40", "charges": [ 0, 100 ] },
-      { "group": "nested_rm298_mag" },
-      { "group": "nested_rm298_mag", "prob": 50 }
+      { "group": "nested_rm298_mag", "charges-min": 0 },
+      { "group": "nested_rm298_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -1215,11 +1119,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "rm51_assault_rifle", "ammo-group": "on_hand_8x40", "charges": [ 0, 50 ] },
-      { "group": "nested_rm51_mag" },
-      { "group": "nested_rm51_mag", "prob": 50 }
+      { "group": "nested_rm51_mag", "charges-min": 0 },
+      { "group": "nested_rm51_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -1227,11 +1130,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "rm614_lmg", "ammo-group": "on_hand_8x40", "charges": [ 0, 100 ] },
-      { "group": "nested_rm298_mag" },
-      { "group": "nested_rm298_mag", "prob": 50 }
+      { "group": "nested_rm298_mag", "charges-min": 0 },
+      { "group": "nested_rm298_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -1239,11 +1141,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "rm88_battle_rifle", "ammo-group": "on_hand_8x40", "charges": [ 0, 50 ] },
-      { "group": "nested_rm51_mag" },
-      { "group": "nested_rm51_mag", "prob": 50 }
+      { "group": "nested_rm51_mag", "charges-min": 0 },
+      { "group": "nested_rm51_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -1251,11 +1152,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "sig552", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
-      { "group": "nested_stanag_mag" },
-      { "group": "nested_stanag_mag", "prob": 50 }
+      { "group": "nested_stanag_mag", "charges-min": 0 },
+      { "group": "nested_stanag_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -1263,11 +1163,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "scar_h", "ammo-group": "on_hand_308", "charges": [ 0, 20 ] },
-      { "group": "nested_scar_h_mag" },
-      { "group": "nested_scar_h_mag", "prob": 50 }
+      { "group": "nested_scar_h_mag", "charges-min": 0 },
+      { "group": "nested_scar_h_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -1275,7 +1174,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack.  Grenadier variant",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       {
         "item": "scar_h",
@@ -1283,8 +1181,8 @@
         "charges": [ 0, 20 ],
         "contents-group": "military_accessories_grenadier"
       },
-      { "group": "nested_scar_h_mag" },
-      { "group": "nested_scar_h_mag", "prob": 50 }
+      { "group": "nested_scar_h_mag", "charges-min": 0 },
+      { "group": "nested_scar_h_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -1292,11 +1190,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "m110a1", "ammo-group": "on_hand_308", "charges": [ 0, 20 ] },
-      { "group": "nested_hk417_13_mag" },
-      { "group": "nested_hk417_13_mag", "prob": 50 }
+      { "group": "nested_hk417_13_mag", "charges-min": 0 },
+      { "group": "nested_hk417_13_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -1304,7 +1201,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "acr_300blk", "charges": [ 0, 30 ] },
       { "group": "nested_stanag_mag_300" },
@@ -1316,11 +1212,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "ak47", "ammo-group": "on_hand_762", "charges": [ 0, 30 ] },
-      { "group": "nested_ak47_mag" },
-      { "group": "nested_ak47_mag", "prob": 50 }
+      { "group": "nested_ak47_mag", "charges-min": 0 },
+      { "group": "nested_ak47_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -1328,11 +1223,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "ak74", "ammo-group": "on_hand_545x39", "charges": [ 0, 30 ] },
-      { "group": "nested_ak74_mag" },
-      { "group": "nested_ak74_mag", "prob": 50 }
+      { "group": "nested_ak74_mag", "charges-min": 0 },
+      { "group": "nested_ak74_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -1340,11 +1234,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "famas", "ammo-group": "on_hand_223", "charges": [ 0, 25 ] },
-      { "item": "famasmag", "ammo-group": "on_hand_223" },
-      { "item": "famasmag", "ammo-group": "on_hand_223", "prob": 50 }
+      { "item": "famasmag", "charges-min": 0, "ammo-group": "on_hand_223" },
+      { "item": "famasmag", "charges-min": 0, "ammo-group": "on_hand_223", "prob": 50 }
     ]
   },
   {
@@ -1352,11 +1245,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "oa93", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
-      { "group": "nested_stanag_mag" },
-      { "group": "nested_stanag_mag", "prob": 50 }
+      { "group": "nested_stanag_mag", "charges-min": 0 },
+      { "group": "nested_stanag_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -1364,11 +1256,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "steyr_aug", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
-      { "group": "nested_steyr_aug_mag" },
-      { "group": "nested_steyr_aug_mag", "prob": 50 }
+      { "group": "nested_steyr_aug_mag", "charges-min": 0 },
+      { "group": "nested_steyr_aug_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -1376,11 +1267,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "arx160", "ammo-group": "on_hand_762", "charges": [ 0, 30 ] },
-      { "group": "nested_ak47_mag" },
-      { "group": "nested_ak47_mag", "prob": 50 }
+      { "group": "nested_ak47_mag", "charges-min": 0 },
+      { "group": "nested_ak47_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -1388,11 +1278,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "rm20", "ammo-group": "on_hand_20x66mm", "charges": [ 0, 20 ] },
-      { "group": "nested_rm20_mag" },
-      { "group": "nested_rm20_mag", "prob": 50 }
+      { "group": "nested_rm20_mag", "charges-min": 0 },
+      { "group": "nested_rm20_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -1400,11 +1289,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "saiga_12", "ammo-group": "on_hand_shot", "charges": [ 0, 10 ] },
-      { "group": "nested_saiga_12_mag" },
-      { "group": "nested_saiga_12_mag", "prob": 50 }
+      { "group": "nested_saiga_12_mag", "charges-min": 0 },
+      { "group": "nested_saiga_12_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -1412,11 +1300,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "saiga_410", "ammo-group": "on_hand_410shot", "charges": [ 0, 10 ] },
-      { "group": "nested_saiga_410_mag" },
-      { "group": "nested_saiga_410_mag", "prob": 50 }
+      { "group": "nested_saiga_410_mag", "charges-min": 0 },
+      { "group": "nested_saiga_410_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -1424,7 +1311,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "ruger_lcr_38", "ammo-group": "on_hand_38", "charges": [ 0, 5 ] },
       {
@@ -1446,7 +1332,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "sw_610", "ammo-group": "on_hand_40sw_or_10mm", "charges": [ 0, 6 ] },
       {
@@ -1468,7 +1353,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "sw_619", "ammo-group": "on_hand_357_38mixed", "charges": [ 0, 7 ] },
       {
@@ -1490,7 +1374,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "model_10_revolver", "ammo-group": "on_hand_38", "charges": [ 0, 6 ] },
       {
@@ -1512,7 +1395,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "bond_410", "ammo-group": "on_hand_410_or_45colt", "charges": [ 0, 2 ] },
       { "group": "on_hand_410_or_45colt" }
@@ -1523,7 +1405,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "ruger_lcr_22", "ammo-group": "on_hand_22", "charges": [ 0, 8 ] },
       {
@@ -1545,7 +1426,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "ruger_redhawk", "ammo-group": "on_hand_44", "charges": [ 0, 6 ] },
       {
@@ -1567,7 +1447,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "sw_500", "ammo-group": "on_hand_500", "charges": [ 0, 5 ] },
       {
@@ -1589,7 +1468,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "sw629", "ammo-group": "on_hand_44", "charges": [ 0, 6 ] },
       {
@@ -1611,7 +1489,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "bfr", "ammo-group": "on_hand_4570", "charges": [ 0, 5 ] }, { "group": "on_hand_4570" } ]
   },
   {
@@ -1619,7 +1496,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "moss_brownie", "ammo-group": "on_hand_22", "charges": [ 0, 6 ] }, { "group": "on_hand_22" } ]
   },
   {
@@ -1627,7 +1503,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "raging_bull", "ammo-group": "on_hand_454_mixed", "charges": [ 0, 5 ] },
       {
@@ -1649,7 +1524,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "raging_judge", "ammo-group": "on_hand_454_mixed", "charges": [ 0, 6 ] },
       {
@@ -1671,7 +1545,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "cop_38", "ammo-group": "on_hand_357_38mixed", "charges": [ 0, 4 ] }, { "group": "on_hand_357_38mixed" } ]
   },
   {
@@ -1679,7 +1552,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "lemat_revolver", "ammo-group": "on_hand_44paper", "charges": [ 0, 9 ] },
       { "group": "on_hand_44paper" },
@@ -1691,7 +1563,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "pistol_flintlock", "ammo-group": "on_hand_flintlock", "charges": [ 0, 1 ] },
       { "group": "on_hand_flintlock" }
@@ -1702,7 +1573,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "colt_saa", "ammo-group": "on_hand_45colt", "charges": [ 0, 6 ] }, { "group": "on_hand_45colt" } ]
   },
   {
@@ -1710,7 +1580,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "marlin_9a", "ammo-group": "on_hand_22", "charges": [ 0, 19 ] },
       {
@@ -1732,7 +1601,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "mosin44", "ammo-group": "on_hand_762R", "charges": [ 0, 5 ] },
       {
@@ -1754,7 +1622,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "mosin91_30", "ammo-group": "on_hand_762R", "charges": [ 0, 5 ] },
       {
@@ -1776,7 +1643,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "remington700_270", "ammo-group": "on_hand_270win", "charges": [ 0, 4 ] }, { "group": "on_hand_270win" } ]
   },
   {
@@ -1784,7 +1650,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "remington_700", "ammo-group": "on_hand_3006", "charges": [ 0, 4 ] }, { "group": "on_hand_3006" } ]
   },
   {
@@ -1792,7 +1657,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "sks", "ammo-group": "on_hand_762", "charges": [ 0, 10 ] },
       {
@@ -1814,7 +1678,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "win70", "ammo-group": "on_hand_300", "charges": [ 0, 3 ] }, { "group": "on_hand_300" } ]
   },
   {
@@ -1822,7 +1685,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "1895sbl", "ammo-group": "on_hand_4570", "charges": [ 0, 6 ] }, { "group": "on_hand_4570" } ]
   },
   {
@@ -1830,7 +1692,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "colt_lightning", "ammo-group": "on_hand_45colt", "charges": [ 0, 14 ] }, { "group": "on_hand_45colt" } ]
   },
   {
@@ -1838,7 +1699,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "henry_big_boy", "ammo-group": "on_hand_44", "charges": [ 0, 10 ] }, { "group": "on_hand_44" } ]
   },
   {
@@ -1846,7 +1706,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "M24", "ammo-group": "on_hand_308", "charges": [ 0, 5 ] }, { "group": "on_hand_308" } ]
   },
   {
@@ -1854,7 +1713,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "m1903", "ammo-group": "on_hand_3006", "charges": [ 0, 5 ] },
       {
@@ -1876,7 +1734,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "mosin44_ebr", "ammo-group": "on_hand_762R", "charges": [ 0, 5 ] },
       {
@@ -1898,7 +1755,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "mosin91_30_ebr", "ammo-group": "on_hand_762R", "charges": [ 0, 5 ] },
       {
@@ -1920,7 +1776,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "savage_111f", "ammo-group": "on_hand_308", "charges": [ 0, 3 ] }, { "group": "on_hand_308" } ]
   },
   {
@@ -1928,7 +1783,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "sharps", "ammo-group": "on_hand_4570", "charges": [ 0, 1 ] }, { "group": "on_hand_4570" } ]
   },
   {
@@ -1936,7 +1790,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "weatherby_5", "ammo-group": "on_hand_300", "charges": [ 0, 3 ] }, { "group": "on_hand_300" } ]
   },
   {
@@ -1944,7 +1797,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "m134", "ammo-group": "on_hand_308", "charges": [ 0, 100 ] },
       {
@@ -1960,7 +1812,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "m240", "ammo-group": "on_hand_308", "charges": [ 0, 100 ] },
       {
@@ -1976,7 +1827,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "m249", "ammo-group": "on_hand_223", "charges": [ 0, 100 ] },
       {
@@ -1992,7 +1842,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "m60", "ammo-group": "on_hand_308", "charges": [ 0, 100 ] },
       {
@@ -2008,7 +1857,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "m2browning", "ammo-group": "on_hand_50", "charges": [ 0, 100 ] },
       {
@@ -2021,7 +1869,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "bh_m89", "ammo-group": "on_hand_500", "charges": [ 0, 7 ] }, { "group": "on_hand_500" } ]
   },
   {
@@ -2029,7 +1876,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "bfg50", "ammo-group": "on_hand_50", "charges": [ 0, 1 ] }, { "group": "on_hand_50" } ]
   },
   {
@@ -2037,7 +1883,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "carbine_flintlock", "ammo-group": "on_hand_flintlock", "charges": [ 0, 1 ] },
       { "group": "on_hand_flintlock" }
@@ -2048,7 +1893,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "rifle_flintlock", "ammo-group": "on_hand_flintlock", "charges": [ 0, 1 ] },
       { "group": "on_hand_flintlock" }
@@ -2059,7 +1903,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "longrifle_flintlock", "ammo-group": "on_hand_flintlock", "charges": [ 0, 1 ] },
       { "group": "on_hand_flintlock" }
@@ -2070,7 +1913,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "trex_gun", "ammo-group": "on_hand_700nx", "charges": [ 0, 2 ] }, { "group": "on_hand_700nx" } ]
   },
   {
@@ -2078,7 +1920,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "mossberg_500", "ammo-group": "on_hand_shot", "charges": [ 0, 6 ] }, { "group": "on_hand_shot" } ]
   },
   {
@@ -2086,7 +1927,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "remington_870", "ammo-group": "on_hand_shot", "charges": [ 0, 5 ] }, { "group": "on_hand_shot" } ]
   },
   {
@@ -2094,7 +1934,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "mossberg_500_security", "ammo-group": "on_hand_shot", "charges": [ 0, 6 ] }, { "group": "on_hand_shot" } ]
   },
   {
@@ -2102,7 +1941,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "remington_870_express", "ammo-group": "on_hand_shot", "charges": [ 0, 6 ] }, { "group": "on_hand_shot" } ]
   },
   {
@@ -2110,7 +1948,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "browning_a5", "ammo-group": "on_hand_shot", "charges": [ 0, 5 ] }, { "group": "on_hand_shot" } ]
   },
   {
@@ -2118,7 +1955,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "remington_1100", "ammo-group": "on_hand_shot", "charges": [ 0, 5 ] }, { "group": "on_hand_shot" } ]
   },
   {
@@ -2126,7 +1962,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "mossberg_930", "ammo-group": "on_hand_shot", "charges": [ 0, 6 ] }, { "group": "on_hand_shot" } ]
   },
   {
@@ -2134,15 +1969,13 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
-    "entries": [ { "item": "shotgun_410", "ammo-group": "on_hand_shot", "charges": [ 0, 1 ] }, { "group": "on_hand_410shot" } ]
+    "entries": [ { "item": "shotgun_410", "ammo-group": "on_hand_410shot", "charges": [ 0, 1 ] }, { "group": "on_hand_410shot" } ]
   },
   {
     "id": "everyday_shotgun_d",
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "shotgun_d", "ammo-group": "on_hand_shot", "charges": [ 0, 2 ] }, { "group": "on_hand_shot" } ]
   },
   {
@@ -2150,7 +1983,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "shotgun_s", "ammo-group": "on_hand_shot", "charges": [ 0, 1 ] }, { "group": "on_hand_shot" } ]
   },
   {
@@ -2158,7 +1990,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "shotgun_paper", "ammo-group": "on_hand_shotpaper", "charges": [ 0, 1 ] },
       { "group": "on_hand_shotpaper" }
@@ -2169,7 +2000,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "ksg", "ammo-group": "on_hand_shot", "charges": [ 0, 7 ] }, { "group": "on_hand_shot" } ]
   },
   {
@@ -2177,7 +2007,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "ksg-25", "ammo-group": "on_hand_shot", "charges": [ 0, 12 ] }, { "group": "on_hand_shot" } ]
   },
   {
@@ -2185,7 +2014,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "tavor_12", "ammo-group": "on_hand_shot", "charges": [ 0, 5 ] }, { "group": "on_hand_shot" } ]
   },
   {
@@ -2193,7 +2021,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "m1014", "ammo-group": "on_hand_shot", "charges": [ 0, 8 ] }, { "group": "on_hand_shot" } ]
   },
   {
@@ -2201,7 +2028,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "SPAS_12", "ammo-group": "on_hand_shot", "charges": [ 0, 9 ] }, { "group": "on_hand_shot" } ]
   },
   {
@@ -2209,7 +2035,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "mossberg_590", "ammo-group": "on_hand_shot", "charges": [ 0, 9 ] }, { "group": "on_hand_shot" } ]
   },
   {
@@ -2217,7 +2042,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "remington_870_breacher", "ammo-group": "on_hand_shot", "charges": [ 0, 4 ] }, { "group": "on_hand_shot" } ]
   },
   {
@@ -2225,7 +2049,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "streetsweeper", "ammo-group": "on_hand_shot", "charges": [ 0, 12 ] }, { "group": "on_hand_shot" } ]
   },
   {
@@ -2233,11 +2056,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "rm228", "ammo-group": "on_hand_20x66mm", "charges": [ 0, 10 ] },
-      { "item": "20x66_10_mag", "ammo-group": "on_hand_20x66mm" },
-      { "item": "20x66_10_mag", "ammo-group": "on_hand_20x66mm", "prob": 50 }
+      { "item": "20x66_10_mag", "charges-min": 0, "ammo-group": "on_hand_20x66mm" },
+      { "item": "20x66_10_mag", "charges-min": 0, "ammo-group": "on_hand_20x66mm", "prob": 50 }
     ]
   },
   {
@@ -2245,11 +2067,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "an94", "ammo-group": "on_hand_545x39", "charges": [ 0, 30 ] },
-      { "group": "nested_ak74_mag" },
-      { "group": "nested_ak74_mag", "prob": 50 }
+      { "group": "nested_ak74_mag", "charges-min": 0 },
+      { "group": "nested_ak74_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -2257,11 +2078,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "USAS_12", "ammo-group": "on_hand_shot", "charges": [ 0, 10 ] },
-      { "group": "nested_USAS_12_mag" },
-      { "group": "nested_USAS_12_mag", "prob": 50 }
+      { "group": "nested_USAS_12_mag", "charges-min": 0 },
+      { "group": "nested_USAS_12_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -2269,11 +2089,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "as50", "ammo-group": "on_hand_50", "charges": [ 0, 10 ] },
-      { "item": "as50mag", "ammo-group": "on_hand_50" },
-      { "item": "as50mag", "ammo-group": "on_hand_50", "prob": 50 }
+      { "item": "as50mag", "charges-min": 0, "ammo-group": "on_hand_50" },
+      { "item": "as50mag", "charges-min": 0, "ammo-group": "on_hand_50", "prob": 50 }
     ]
   },
   {
@@ -2281,11 +2100,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "needlepistol", "ammo-group": "on_hand_5x50mm", "charges": [ 0, 50 ] },
-      { "group": "nested_needlepistol_mag" },
-      { "group": "nested_needlepistol_mag", "prob": 50 }
+      { "group": "nested_needlepistol_mag", "charges-min": 0 },
+      { "group": "nested_needlepistol_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -2293,7 +2111,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "rm99_pistol", "ammo-group": "on_hand_8x40", "charges": [ 0, 5 ] },
       {
@@ -2315,11 +2132,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "ppsh", "ammo-group": "on_hand_762x25", "charges": [ 0, 35 ] },
-      { "group": "nested_ppsh_mag", "ammo-group": "on_hand_762x25" },
-      { "group": "nested_ppsh_mag", "ammo-group": "on_hand_762x25", "prob": 50 }
+      { "group": "nested_ppsh_mag", "charges-min": 0, "ammo-group": "on_hand_762x25" },
+      { "group": "nested_ppsh_mag", "charges-min": 0, "ammo-group": "on_hand_762x25", "prob": 50 }
     ]
   },
   {
@@ -2327,11 +2143,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "skorpion_61", "ammo-group": "on_hand_32", "charges": [ 0, 20 ] },
-      { "item": "skorpion61mag", "ammo-group": "on_hand_32" },
-      { "item": "skorpion61mag", "ammo-group": "on_hand_32", "prob": 50 }
+      { "item": "skorpion61mag", "charges-min": 0, "ammo-group": "on_hand_32" },
+      { "item": "skorpion61mag", "charges-min": 0, "ammo-group": "on_hand_32", "prob": 50 }
     ]
   },
   {
@@ -2339,11 +2154,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "skorpion_82", "ammo-group": "on_hand_9x18", "charges": [ 0, 20 ] },
-      { "item": "skorpion82mag", "ammo-group": "on_hand_9x18" },
-      { "item": "skorpion82mag", "ammo-group": "on_hand_9x18", "prob": 50 }
+      { "item": "skorpion82mag", "charges-min": 0, "ammo-group": "on_hand_9x18" },
+      { "item": "skorpion82mag", "charges-min": 0, "ammo-group": "on_hand_9x18", "prob": 50 }
     ]
   },
   {
@@ -2351,11 +2165,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "acr", "ammo-group": "on_hand_223", "charges": [ 0, 30 ] },
-      { "group": "nested_stanag_mag" },
-      { "group": "nested_stanag_mag", "prob": 50 }
+      { "group": "nested_stanag_mag", "charges-min": 0 },
+      { "group": "nested_stanag_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -2363,7 +2176,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "ar15_retool_300blk", "ammo-group": "on_hand_300BLK", "charges": [ 0, 30 ] },
       { "group": "nested_stanag_mag_300", "ammo-group": "on_hand_300BLK" },
@@ -2375,11 +2187,10 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [
       { "item": "needlegun", "ammo-group": "on_hand_5x50mm", "charges": [ 0, 100 ] },
-      { "group": "nested_needlegun_mag" },
-      { "group": "nested_needlegun_mag", "prob": 50 }
+      { "group": "nested_needlegun_mag", "charges-min": 0 },
+      { "group": "nested_needlegun_mag", "charges-min": 0, "prob": 50 }
     ]
   },
   {
@@ -2387,7 +2198,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "rm120c", "ammo-group": "on_hand_20x66mm", "charges": [ 0, 5 ] }, { "group": "on_hand_20x66mm" } ]
   },
   {
@@ -2395,7 +2205,6 @@
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
-    "ammo": 100,
     "entries": [ { "item": "mgl", "ammo-group": "on_hand_40x46mm", "charges": [ 0, 6 ] }, { "group": "on_hand_40x46mm" } ]
   }
 ]

--- a/data/json/monsterdrops/zombie_default.json
+++ b/data/json/monsterdrops/zombie_default.json
@@ -229,12 +229,28 @@
     "groups": [
       [ "default_zombie_items_bags", 16 ],
       [ "default_zombie_items_pockets", 20 ],
-      [ "ammo_pistol_common", 2 ],
-      [ "ammo_shotgun_common", 1 ],
-      [ "carried_guns_pistol_common", 2 ],
-      [ "carried_guns_shotgun_common", 1 ],
+      [ "default_zombie_carried_guns", 6 ],
       [ "postman_gear", 5 ],
       [ "hardware_plumbing", 5 ]
+    ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "distribution",
+    "id": "default_zombie_carried_guns",
+    "entries": [
+      { "group": "carried_guns_pistol_common", "prob": 45 },
+      { "group": "carried_guns_shotgun_common", "prob": 20 },
+      { "group": "carried_guns_rifle_common", "prob": 20 },
+      { "group": "guns_pistol_improvised", "prob": 5 },
+      { "group": "guns_shotgun_improvised", "prob": 5 },
+      { "group": "guns_rifle_improvised", "prob": 5 },
+      { "group": "ammo_pistol_common", "prob": 45 },
+      { "group": "ammo_shotgun_common", "prob": 20 },
+      { "group": "ammo_rifle_common", "prob": 20 },
+      { "group": "ammo_pistol_reloaded", "prob": 5 },
+      { "group": "ammo_shotgun_reloaded", "prob": 5 },
+      { "group": "ammo_rifle_reloaded", "prob": 5 }
     ]
   },
   {


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  
--->

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

CrystalNole over on the BN discord discovered that basic zombies were always dropping fully-loaded magazines when they drop ammo, when the guns an obviously-failed survivor spawned with logically should have some chance of being depleted. Along the way, I decided to also tweak it so the variety of guns that can spawn has a bit wider variety.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Removed the default 100 ammo rate for carried guns, needed to allow the following to work.
2. Added `charges-min` of zero to all mag spawns in carried itemgroups. Found this works fine to make magazine spawns, even for magazine groups, vary in ammo spawned even when the same group is used by a stored gun spawn to spawn a full mag.
3. As a bonus, reworked the guns that basic zeds can spawn with. Instead of only ever spawning with pistol or shotgun guns and ammo, I created a custom itemgroup that picks between pistols, shotguns, and rifles (with pistols being picked 50% of the time). The guns also have a small chance of using the improvised counterpart instead. Same vein as NPCs defaulting to sometimes picking improvised guns, with desperate rioters arming themselves with anything they could in the months prior to the cataclysm as well as potentially some post-cata survivors who eventually succumbed. Likewise for the ammo groups, it has a small chance of picking the reloaded itemgroup instead, meaning blackpowder loads can spawn on occasion when it picks those.
4. Misc: Fixed one of the carried gun groups spawning the gun with invalid ammo.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.
3. Spawned in a large number of basic zombies and debug-killed them.
4. Sorted their guns, ammo, and mag spawns off into sorting zones and examined contents, results look as expected.
5. Repeated with some soldier zombies to make sure their spawns didn't get fucked up.

<details>
<summary>Screenshots:</summary>

Ammo dropped by the group of zombies:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/ff224c8e-f4c6-4535-8e99-aeca520d61c6)
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/1c4a1a94-0d1d-44e9-97f9-8df74895d268)

Guns dropped by the group of zombies:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/6931db55-3e41-4534-93ac-106aca1b861d)
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/1178e961-f374-45c2-9501-f47a4cfa9635)

Mags dropped by the group of zombies:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/85c6443d-6738-4ca4-b28d-4b2fa8ad6df9)
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/52506557-bc29-4d9f-9adb-5ad98c414bb9)

</details>

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
