### PR TITLE
docs(content): correct spelling on fencer / primitive axe

### DIFF
--- a/data/json/items/tool/woodworking.json
+++ b/data/json/items/tool/woodworking.json
@@ -233,7 +233,7 @@
     "type": "GENERIC",
     "category": "tools",
     "weapon_category": [ "2H_AXES" ],
-    "name": { "str": "primtitive axe" },
+    "name": { "str": "primitive axe" },
     "conditional_names": [
       { "type": "COMPONENT_ID", "condition": "rock", "name": "stone axe" },
       { "type": "COMPONENT_ID", "condition": "ceramic", "name": "ceramic axe" }

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -4618,7 +4618,7 @@
   {
     "type": "profession",
     "id": "fencer",
-    "name": "Competetive Fencer",
+    "name": "Competitive Fencer",
     "description": "You were an avid sport fencer, always practicing at local clubs and competing in tournaments.  You were on your way to have a few bouts at the club when the world ended.  Now you're in your most important tournament, the refs are all dead, and none of your opponents follow the rules.",
     "points": 5,
     "skills": [ { "level": 2, "name": "melee" }, { "level": 2, "name": "dodge" } ],


### PR DESCRIPTION
Easy PR, fixes spelling for Competitive Fencer and Primitive Axe.