### PR TITLE
feat(balance): spawn updates to gunmods and gun safes

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -1480,6 +1480,7 @@
       { "item": "knife_trench", "prob": 14 },
       { "item": "switchblade", "prob": 15 },
       { "item": "bondage_mask", "prob": 1 },
+      { "group": "auto_sears", "prob": 20 },
       { "item": "survnote", "prob": 5 },
       { "item": "thermos", "prob": 25 }
     ]
@@ -1548,6 +1549,7 @@
       { "item": "soap", "prob": 5 },
       { "item": "detergent", "prob": 5 },
       { "item": "knitting_needles", "prob": 1 },
+      { "group": "auto_sears", "prob": 5 },
       { "item": "survnote", "prob": 2 }
     ]
   },

--- a/data/json/itemgroups/Locations_MapExtras/locations_mapextras.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_mapextras.json
@@ -129,7 +129,8 @@
       [ "katana", 1 ],
       [ "survnote", 3 ],
       [ "ear_spool", 30 ],
-      [ "bio_shotgun", 10 ]
+      [ "bio_shotgun", 10 ],
+      { "group": "auto_sears", "prob": 25 }
     ]
   },
   {

--- a/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
@@ -173,10 +173,6 @@
     "type": "item_group",
     "id": "auto_sears",
     "//": "Gunmods that enable full-auto fire, mainly in gunsmithing stores or rare registered examples, but could also spawn as contraband.",
-    "items": [
-      [ "dias", 25 ],
-      [ "llink", 25 ],
-      [ "glockswitch", 50 ]
-    ]
+    "items": [ [ "dias", 25 ], [ "llink", 25 ], [ "glockswitch", 50 ] ]
   }
 ]

--- a/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
@@ -41,7 +41,8 @@
       [ "shot_suppressor", 10 ],
       [ "u_shotgun", 60 ],
       [ "waterproof_gunmod", 40 ],
-      [ "retool_ar15_300blk", 40 ]
+      [ "retool_ar15_300blk", 40 ],
+      { "group": "auto_sears", "prob": 40 }
     ]
   },
   {
@@ -167,5 +168,15 @@
     "id": "gunmod_archery",
     "//": "Gunmods for bows and crossbows.",
     "items": [ [ "arrowrest", 100 ], [ "bow_sight", 100 ], [ "bow_stabilizer", 100 ], [ "crossbow_lever", 100 ] ]
+  },
+  {
+    "type": "item_group",
+    "id": "auto_sears",
+    "//": "Gunmods that enable full-auto fire, mainly in gunsmithing stores or rare registered examples, but could also spawn as contraband.",
+    "items": [
+      [ "dias", 25 ],
+      [ "llink", 25 ],
+      [ "glockswitch", 50 ]
+    ]
   }
 ]

--- a/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
@@ -1182,9 +1182,9 @@
     "subtype": "collection",
     "items": [
       { "group": "guns_safe_pistols", "prob": 75 },
-      { "group": "guns_safe_pistols", "prob": 25 },
+      { "group": "guns_safe_pistols", "prob": 50 },
       { "group": "gunmod_common", "prob": 25 },
-      { "group": "house_safe_misc", "count": [ 2, 5 ] }
+      { "group": "house_safe_misc", "prob": 100, "count": [ 2, 5 ] }
     ]
   },
   {
@@ -1211,7 +1211,7 @@
       { "group": "gunmod_rare", "prob": 15 },
       { "item": "small_repairkit", "prob": 10 },
       { "item": "large_repairkit", "prob": 3 },
-      { "group": "house_safe_misc", "count": [ 1, 2 ] }
+      { "group": "house_safe_misc", "prob": 100, "count": [ 1, 2 ] }
     ]
   }
 ]

--- a/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
@@ -1163,9 +1163,7 @@
     "//": "Guns found in a gun safe.",
     "subtype": "distribution",
     "items": [
-      { "group": "guns_pistol_common", "prob": 50 },
-      { "group": "guns_pistol_rare", "prob": 10 },
-      { "group": "guns_pistol_obscure", "prob": 5 },
+      { "group": "guns_safe_pistols", "prob": 65 },
       { "group": "guns_smg_common", "prob": 20 },
       { "group": "guns_smg_rare", "prob": 2 },
       { "group": "guns_smg_obscure", "prob": 1 },
@@ -1175,6 +1173,29 @@
       { "group": "guns_rifle_common", "prob": 75 },
       { "group": "guns_rifle_rare", "prob": 5 },
       { "group": "guns_rifle_obscure", "prob": 1 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "house_safe",
+    "//": "Potential contents of a small fire safe.",
+    "subtype": "collection",
+    "items": [
+      { "group": "guns_safe_pistols", "prob": 75 },
+      { "group": "guns_safe_pistols", "prob": 25 },
+      { "group": "gunmod_common", "prob": 25 },
+      { "group": "house_safe_misc", "count": [ 2, 5 ] }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "guns_safe_pistols",
+    "//": "Pistols that could be stored in either a small fire safe or a dedicated gun safe.",
+    "subtype": "distribution",
+    "items": [
+      { "group": "guns_pistol_common", "prob": 50 },
+      { "group": "guns_pistol_rare", "prob": 10 },
+      { "group": "guns_pistol_obscure", "prob": 5 }
     ]
   },
   {
@@ -1189,7 +1210,8 @@
       { "group": "gunmod_common", "prob": 50 },
       { "group": "gunmod_rare", "prob": 15 },
       { "item": "small_repairkit", "prob": 10 },
-      { "item": "large_repairkit", "prob": 3 }
+      { "item": "large_repairkit", "prob": 3 },
+      { "group": "house_safe_misc", "count": [ 1, 2 ] }
     ]
   }
 ]

--- a/data/json/itemgroups/collections_domestic.json
+++ b/data/json/itemgroups/collections_domestic.json
@@ -1094,15 +1094,15 @@
   {
     "type": "item_group",
     "id": "house_safe_misc",
-    "//": "A distribution of miscellaneous items that might be stashed in a household safe.",
+    "//": "A distribution of miscellaneous items that might be stashed in a household safe, not counting guns.",
     "subtype": "distribution",
     "entries": [
-        { "group": "everyday_gear", "prob": 30 },
-        { "group": "home_display_case", "prob": 20 },
-        { "group": "harddrugs", "prob": 25 },
-        { "group": "homebooks", "prob": 10 },
-        { "group": "art", "prob": 10 },
-        { "group": "gemstones", "prob": 5 }
+      { "group": "everyday_gear", "prob": 30 },
+      { "group": "home_display_case", "prob": 20 },
+      { "group": "harddrugs", "prob": 25 },
+      { "group": "homebooks", "prob": 10 },
+      { "group": "art", "prob": 10 },
+      { "group": "gemstones", "prob": 5 }
     ]
   }
 ]

--- a/data/json/itemgroups/collections_domestic.json
+++ b/data/json/itemgroups/collections_domestic.json
@@ -1090,5 +1090,19 @@
       { "item": "ref_lighter", "prob": 10 },
       { "item": "electric_lighter", "prob": 10 }
     ]
+  },
+  {
+    "type": "item_group",
+    "id": "house_safe_misc",
+    "//": "A distribution of miscellaneous items that might be stashed in a household safe.",
+    "subtype": "distribution",
+    "entries": [
+        { "group": "everyday_gear", "prob": 30 },
+        { "group": "home_display_case", "prob": 20 },
+        { "group": "harddrugs", "prob": 25 },
+        { "group": "homebooks", "prob": 10 },
+        { "group": "art", "prob": 10 },
+        { "group": "gemstones", "prob": 5 }
+    ]
   }
 ]

--- a/data/json/mapgen/farm_dairy.json
+++ b/data/json/mapgen/farm_dairy.json
@@ -151,7 +151,6 @@
         "b": "f_toilet",
         "c": "f_cupboard",
         "d": "f_desk",
-        "g": "f_gunsafe_ml",
         "o": "f_oven",
         "s": "f_shower",
         "t": "f_trashcan",
@@ -203,7 +202,8 @@
         { "vehicle": "cube_van_cheap", "x": 7, "y": 5, "chance": 50, "fuel": 300, "status": -1, "rotation": 0 },
         { "vehicle": "quad_bike", "x": 15, "y": 6, "chance": 30, "fuel": 200, "status": -1, "rotation": 0 },
         { "vehicle": "bicycle", "x": 13, "y": 8, "chance": 80, "fuel": 0, "status": 0, "rotation": 0 }
-      ]
+      ],
+      "nested": { "g": { "chunks": [ [ "house_chunk_spawn_firesafe", 50 ], [ "house_chunk_spawn_gunsafe", 50 ] ] } }
     }
   },
   {

--- a/data/json/mapgen/house/2Story01.json
+++ b/data/json/mapgen/house/2Story01.json
@@ -97,7 +97,7 @@
         ".o/,,,,,,#o*#y|QQ|B__t#.",
         ".#/,,NNNN#L  Ə|++||+||#.",
         ".##+######b         Əyo.",
-        ".#U W|}zz|R  Ə||||||||#.",
+        ".#U W|vzz|R  Ə||||||||#.",
         ".oq Z|z z|R  V|y h h y:.",
         ".oq U|z z|R  V| hffff :.",
         ".#|+|||+||R  V|  ffffh:.",
@@ -123,8 +123,8 @@
         "/": "t_thconc_floor",
         "N": "t_thconc_floor"
       },
-      "furniture": { "{": "f_counter", "c": "f_boulder_large", "}": "f_gunsafe_ml", "=": "f_clothing_rail", "/": "f_rack" },
-      "items": { "}": { "item": "guns_safe", "chance": 100 }, "=": { "item": "jackets", "chance": 50, "repeat": [ 2, 4 ] } },
+      "furniture": { "{": "f_counter", "c": "f_boulder_large", "=": "f_clothing_rail", "/": "f_rack" },
+      "items": { "=": { "item": "jackets", "chance": 50, "repeat": [ 2, 4 ] } },
       "place_loot": [
         { "group": "liquor_and_spirits", "x": [ 11, 14 ], "y": 16, "repeat": [ 2, 4 ] },
         { "item": "log", "x": 2, "y": [ 5, 8 ], "repeat": [ 2, 3 ] }

--- a/data/json/mapgen/house/bungalow16.json
+++ b/data/json/mapgen/house/bungalow16.json
@@ -16,7 +16,7 @@
         ".#R   l H#%--%#&&,,,}r#.",
         ".#R x l H#%--%#&&,,,,r#.",
         ".#    l H##o*##|,,,,,P#.",
-        ".o  |||||||L |c+,{$$,,o.",
+        ".o  |||||||L |v+,{$$,,o.",
         ".#  |BtS8Q|  |||||||+|#.",
         ".#  |B____+  ((      T#^",
         ".#  |||||||           #.",
@@ -65,7 +65,6 @@
         "0": "f_table",
         "{": "f_wardrobe",
         "}": "f_chair",
-        "c": "f_gunsafe_ml",
         "]": "f_table",
         "(": "f_table"
       },
@@ -79,7 +78,6 @@
           { "item": "SUS_wardrobe_womens", "chance": 50, "repeat": [ 1, 2 ] }
         ],
         "]": { "item": "nightstand", "chance": 40 },
-        "c": { "item": "guns_safe", "chance": 100 },
         "(": { "item": "table_foyer", "chance": 50, "repeat": [ 1, 2 ] }
       },
       "place_loot": [ { "item": "television", "x": 4, "y": 6, "chance": 100 } ]

--- a/data/json/mapgen/isherwood_farms/dairy_farm_isherwood.json
+++ b/data/json/mapgen/isherwood_farms/dairy_farm_isherwood.json
@@ -75,7 +75,6 @@
         "a": "f_dumpster",
         "c": "f_cupboard",
         "d": "f_desk",
-        "g": "f_gunsafe_ml",
         "o": "f_oven",
         "S": "f_shower",
         "t": "f_trashcan",
@@ -88,7 +87,6 @@
         "a": { "item": "trash_dumpster", "chance": 80 },
         "Y": { "item": "coat_rack", "chance": 35, "repeat": [ 1, 4 ] },
         "d": { "item": "office", "chance": 30 },
-        "g": { "item": "guns_safe", "chance": 100 },
         "{": [ { "item": "ranch_homebooks", "chance": 30 }, { "item": "book_survival", "chance": 30 } ],
         "^": { "item": "bed", "chance": 30 },
         "o": { "item": "oven", "chance": 30, "repeat": [ 1, 2 ] },
@@ -121,7 +119,8 @@
         { "vehicle": "quad_bike", "x": 17, "y": 2, "chance": 30, "fuel": 200, "status": -1, "rotation": 0 },
         { "vehicle": "bicycle", "x": 10, "y": 3, "chance": 80, "fuel": 0, "status": 0, "rotation": 0 }
       ],
-      "place_npcs": [ { "class": "isherwood_eddie", "x": 8, "y": 17 } ]
+      "place_npcs": [ { "class": "isherwood_eddie", "x": 8, "y": 17 } ],
+      "nested": { "g": { "chunks": [ [ "house_chunk_spawn_firesafe", 50 ], [ "house_chunk_spawn_gunsafe", 50 ] ] } }
     }
   },
   {

--- a/data/json/mapgen/nested/house_nested.json
+++ b/data/json/mapgen/nested/house_nested.json
@@ -1953,5 +1953,27 @@
       "terrain": { "_": [ [ "t_window_open", 9 ], "t_window_no_curtains_open" ] },
       "furniture": { "_": "f_grid_air_conditioner_off" }
     }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "house_chunk_spawn_firesafe",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "rows": [ "S" ],
+      "furniture": { "S": "f_safe_l" },
+      "items": { "S": { "item": "house_safe", "chance": 100 } }
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "house_chunk_spawn_gunsafe",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "rows": [ "S" ],
+      "furniture": { "S": [ "f_gun_safe_el", "f_gunsafe_ml" ] },
+      "items": { "S": { "item": "guns_safe", "chance": 100 } }
+    }
   }
 ]

--- a/data/json/mapgen_palettes/house_general_palette.json
+++ b/data/json/mapgen_palettes/house_general_palette.json
@@ -40,7 +40,6 @@
       "r": "f_desk",
       "s": "f_table",
       "u": "f_rotary_clothesline",
-      "v": [ "f_gun_safe_el", "f_gunsafe_ml" ],
       "w": "f_rack_wood",
       "x": "f_entertainment_center",
       "y": [ "f_indoor_plant", "f_indoor_plant_y" ],
@@ -149,14 +148,6 @@
       ],
       "r": [ { "item": "office_paper", "chance": 5 }, { "item": "office", "chance": 25 } ],
       "t": { "item": "SUS_toilet", "chance": 75 },
-      "v": [
-        { "item": "guns_safe", "chance": 100 },
-        { "item": "art", "chance": 5 },
-        { "item": "home_display_case", "chance": 30 },
-        { "item": "harddrugs", "chance": 10, "repeat": [ 1, 2 ] },
-        { "item": "maps", "chance": 2 },
-        { "item": "gemstones", "chance": 30, "repeat": [ 1, 2 ] }
-      ],
       "w": [
         { "item": "shower", "chance": 20 },
         { "item": "cleaning", "chance": 30, "repeat": [ 1, 2 ] },
@@ -223,7 +214,8 @@
     },
     "nested": {
       "ɸ": { "chunks": [ "NC_res_personal_items_1X1" ] },
-      "o": { "chunks": [ [ "null", 95 ], [ "house_place_air_conditioner", 5 ] ] }
+      "o": { "chunks": [ [ "null", 95 ], [ "house_place_air_conditioner", 5 ] ] },
+      "v": { "chunks": [ [ "house_chunk_spawn_firesafe", 50 ], [ "house_chunk_spawn_gunsafe", 50 ] ] }
     }
   },
   {

--- a/data/json/mapgen_palettes/house_w_palette.json
+++ b/data/json/mapgen_palettes/house_w_palette.json
@@ -79,9 +79,7 @@
     },
     "toilets": { "t": {  } },
     "liquids": { "g": { "liquid": "water", "amount": [ 0, 100 ] } },
-    "nested": {
-      "v": { "chunks": [ [ "house_chunk_spawn_firesafe", 50 ], [ "house_chunk_spawn_gunsafe", 50 ] ] }
-    }
+    "nested": { "v": { "chunks": [ [ "house_chunk_spawn_firesafe", 50 ], [ "house_chunk_spawn_gunsafe", 50 ] ] } }
   },
   {
     "type": "palette",

--- a/data/json/mapgen_palettes/house_w_palette.json
+++ b/data/json/mapgen_palettes/house_w_palette.json
@@ -55,7 +55,6 @@
       "r": "f_wood_keg",
       "s": "f_metal_butcher_rack",
       "u": "f_rotary_clothesline",
-      "v": [ "f_gun_safe_el", "f_gunsafe_ml" ],
       "w": "f_rack_wood",
       "x": "f_entertainment_center",
       "y": [ "f_indoor_plant", "f_indoor_plant_y" ],
@@ -78,9 +77,11 @@
       "6": { "param": "house_w_nest_carpet_type" },
       "?": "t_console_broken"
     },
-    "items": { "v": { "item": "guns_safe", "chance": 100 } },
     "toilets": { "t": {  } },
-    "liquids": { "g": { "liquid": "water", "amount": [ 0, 100 ] } }
+    "liquids": { "g": { "liquid": "water", "amount": [ 0, 100 ] } },
+    "nested": {
+      "v": { "chunks": [ [ "house_chunk_spawn_firesafe", 50 ], [ "house_chunk_spawn_gunsafe", 50 ] ] }
+    }
   },
   {
     "type": "palette",


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  
--->

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Promised followups to  and https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4831, this allows certain previously underused gunmods to finally spawn, and expands on gun safe spawns in houses to re-add mundane safes back in but with actually decent odds of spawning useful shit.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Defined itemgroup `house_safe_misc`, a distribution for the sort of random non-gun fluff one might see in a fire safe.
2. Defined itemgroup `guns_safe_pistols`, which bundles all the pistols previously in `guns_safe_guns` so that it can be spawned elsewhere.
3. Replaced separate pistol spawns in `guns_safe_guns` with an equal weight of `guns_safe_pistols`, and created an itemgroup called `house_safe` for smaller fire safes that has a chance to spawn up to two instances of `guns_safe_pistols` specifically, along with several calls to `house_safe_misc`.
4. Added a smaller number of calls to `house_safe_misc` to `guns_safe` since one might stash related small valuables in a gun safe if you already have one.
5. Created two mapgen nested chunks: `house_chunk_spawn_firesafe` and `house_chunk_spawn_gunsafe`, which respectively spawns either a regular safe filled with `house_safe` or a randomly-selected style of gun safe spawning `guns_safe`.
6. Replaced the gun safe spawns in `standard_domestic_palette`,  `house_w_nest_palette`, `dairy_farm_SW`, `2Story01_1`, `bungalow16`, `dairy_farm_isherwood_SW` with a nested chunk spawn that picks at random between `house_chunk_spawn_firesafe` or `house_chunk_spawn_gunsafe`
7. Defined itemgroup `auto_sear`, which spawns the new glock auto-sear as well as the two previously unused AR-15 gunmods.
8. Added `auto_sear` spawns to `gunmod_rare`, `cop_evidence`, `drugdealer`, and `contraband`.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Going ahead and letting fire safes have at least 1 100% certain gun spawn instead of fairly high but not guaranteed spawns.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.
3. Spawned in a few assorted houses and bungalows to confirm it randomizes correctly.
4. Cracked open safes to check contents and found them to seem okay.

Two example regular safes:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/28029e5a-ae02-4dab-a249-c26e4aefd1cd)
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/888e8fcc-2c38-4547-8505-0caf87994695)

Two example gun safes:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/12d66572-ce50-4265-a154-5d238218ef57)
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/e5ca8b09-641b-4a3b-afad-6edfcc73e272)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
