### PR TITLE
feat: map command for marking autodrive/fast-travel shortcuts

### DIFF
--- a/data/raw/keybindings/keybindings.json
+++ b/data/raw/keybindings/keybindings.json
@@ -880,6 +880,13 @@
   },
   {
     "type": "keybinding",
+    "id": "TOGGLE_MARK_PATH",
+    "category": "OVERMAP",
+    "name": "Mark/unmark Travel Path",
+    "bindings": [ { "input_method": "keyboard", "key": "P" } ]
+  },
+  {
+    "type": "keybinding",
     "id": "PLACE_TERRAIN",
     "category": "OVERMAP",
     "name": "Place Overmap Terrain",

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -2940,6 +2940,7 @@ void overmap::init_layers()
                 layer[k].terrain[i][j] = tid;
                 layer[k].visible[i][j] = false;
                 layer[k].explored[i][j] = false;
+                layer[k].path[i][j] = false;
             }
         }
     }
@@ -3015,6 +3016,23 @@ bool overmap::is_explored( const tripoint_om_omt &p ) const
         return false;
     }
     return layer[p.z() + OVERMAP_DEPTH].explored[p.x()][p.y()];
+}
+
+bool &overmap::path( const tripoint_om_omt &p )
+{
+    if( !inbounds( p ) ) {
+        nullbool = false;
+        return nullbool;
+    }
+    return layer[p.z() + OVERMAP_DEPTH].path[p.x()][p.y()];
+}
+
+bool overmap::is_path( const tripoint_om_omt &p ) const
+{
+    if( !inbounds( p ) ) {
+        return false;
+    }
+    return layer[p.z() + OVERMAP_DEPTH].path[p.x()][p.y()];
 }
 
 bool overmap::mongroup_check( const mongroup &candidate ) const

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -109,6 +109,7 @@ struct map_layer {
     oter_id terrain[OMAPX][OMAPY];
     bool visible[OMAPX][OMAPY];
     bool explored[OMAPX][OMAPY];
+    bool path[OMAPX][OMAPY];
     std::vector<om_note> notes;
     std::vector<om_map_extra> extras;
 };
@@ -236,6 +237,8 @@ class overmap
         bool seen( const tripoint_om_omt &p ) const;
         bool &explored( const tripoint_om_omt &p );
         bool is_explored( const tripoint_om_omt &p ) const;
+        bool &path( const tripoint_om_omt &p );
+        bool is_path( const tripoint_om_omt &p ) const;
 
         bool has_note( const tripoint_om_omt &p ) const;
         std::optional<int> has_note_with_danger_radius( const tripoint_om_omt &p ) const;

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1416,7 +1416,7 @@ static void draw_om_sidebar(
         print_hint( "TOGGLE_CITY_LABELS", uistate.overmap_show_city_labels ? c_pink : c_magenta );
         print_hint( "TOGGLE_HORDES", uistate.overmap_show_hordes ? c_pink : c_magenta );
         print_hint( "TOGGLE_EXPLORED", is_explored ? c_pink : c_magenta );
-        print_hint( "TOGGLE_MARK_PATH", is_explored ? c_pink : c_magenta );
+        print_hint( "TOGGLE_MARK_PATH", is_path ? c_pink : c_magenta );
         print_hint( "TOGGLE_FAST_SCROLL", fast_scroll ? c_pink : c_magenta );
         print_hint( "TOGGLE_FOREST_TRAILS", uistate.overmap_show_forest_trails ? c_pink : c_magenta );
         print_hint( "TOGGLE_OVERMAP_WEATHER", uistate.overmap_visible_weather ? c_pink : c_magenta );

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1000,6 +1000,9 @@ static void draw_ascii( ui_adaptor &ui,
             } else if( blink && is_npc_path ) {
                 ter_color = c_red;
                 ter_sym = "!";
+            } else if( blink && overmap_buffer.is_path( omp ) ) {
+                ter_color = c_light_blue;
+                ter_sym = "!";
             } else if( blink && showhordes && los &&
                        overmap_buffer.get_horde_size( omp ) >= HORDE_VISIBILITY_SIZE ) {
                 // Display Hordes only when within player line-of-sight
@@ -1396,6 +1399,7 @@ static void draw_om_sidebar(
 
         const bool show_overlays = uistate.overmap_show_overlays || uistate.overmap_blinking;
         const bool is_explored = overmap_buffer.is_explored( center );
+        const bool is_path = overmap_buffer.is_path( center );
 
         print_hint( "LEVEL_UP" );
         print_hint( "LEVEL_DOWN" );
@@ -1412,6 +1416,7 @@ static void draw_om_sidebar(
         print_hint( "TOGGLE_CITY_LABELS", uistate.overmap_show_city_labels ? c_pink : c_magenta );
         print_hint( "TOGGLE_HORDES", uistate.overmap_show_hordes ? c_pink : c_magenta );
         print_hint( "TOGGLE_EXPLORED", is_explored ? c_pink : c_magenta );
+        print_hint( "TOGGLE_MARK_PATH", is_explored ? c_pink : c_magenta );
         print_hint( "TOGGLE_FAST_SCROLL", fast_scroll ? c_pink : c_magenta );
         print_hint( "TOGGLE_FOREST_TRAILS", uistate.overmap_show_forest_trails ? c_pink : c_magenta );
         print_hint( "TOGGLE_OVERMAP_WEATHER", uistate.overmap_visible_weather ? c_pink : c_magenta );
@@ -1979,6 +1984,7 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
     ictxt.register_action( "TOGGLE_LAND_USE_CODES" );
     ictxt.register_action( "TOGGLE_CITY_LABELS" );
     ictxt.register_action( "TOGGLE_EXPLORED" );
+    ictxt.register_action( "TOGGLE_MARK_PATH" );
     ictxt.register_action( "TOGGLE_FAST_SCROLL" );
     ictxt.register_action( "TOGGLE_OVERMAP_WEATHER" );
     ictxt.register_action( "TOGGLE_FOREST_TRAILS" );
@@ -2117,6 +2123,8 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
             uistate.overmap_show_city_labels = !uistate.overmap_show_city_labels;
         } else if( action == "TOGGLE_EXPLORED" ) {
             overmap_buffer.toggle_explored( curs );
+        } else if( action == "TOGGLE_MARK_PATH" ) {
+            overmap_buffer.toggle_path( curs );
         } else if( action == "TOGGLE_OVERMAP_WEATHER" ) {
             uistate.overmap_visible_weather = !uistate.overmap_visible_weather;
         } else if( action == "TOGGLE_FAST_SCROLL" ) {

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -398,6 +398,20 @@ void overmapbuffer::toggle_explored( const tripoint_abs_omt &p )
     om_loc.om->explored( om_loc.local ) = !om_loc.om->explored( om_loc.local );
 }
 
+bool overmapbuffer::is_path( const tripoint_abs_omt &p )
+{
+    if( const overmap_with_local_coords om_loc = get_existing_om_global( p ) ) {
+        return om_loc.om->is_path( om_loc.local );
+    }
+    return false;
+}
+
+void overmapbuffer::toggle_path( const tripoint_abs_omt &p )
+{
+    const overmap_with_local_coords om_loc = get_om_global( p );
+    om_loc.om->path( om_loc.local ) = !om_loc.om->path( om_loc.local );
+}
+
 bool overmapbuffer::has_horde( const tripoint_abs_omt &p )
 {
     for( const auto &m : overmap_buffer.monsters_at( p ) ) {
@@ -769,7 +783,8 @@ static int get_terrain_cost( const tripoint_abs_omt &omt_pos, const overmap_path
         is_ot_match( "bridge_road", oter, ot_match_type::type ) ||
         is_ot_match( "bridgehead_ground", oter, ot_match_type::type ) ||
         is_ot_match( "bridgehead_ramp", oter, ot_match_type::type ) ||
-        is_ot_match( "road_nesw_manhole", oter, ot_match_type::type ) ) {
+        is_ot_match( "road_nesw_manhole", oter, ot_match_type::type ) ||
+        overmap_buffer.is_path( omt_pos ) ) {
         return params.road_cost;
     } else if( is_ot_match( "field", oter, ot_match_type::type ) ) {
         return params.field_cost;

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -196,6 +196,8 @@ class overmapbuffer
         void delete_extra( const tripoint_abs_omt &p );
         bool is_explored( const tripoint_abs_omt &p );
         void toggle_explored( const tripoint_abs_omt &p );
+        bool is_path( const tripoint_abs_omt &p );
+        void toggle_path( const tripoint_abs_omt &p );
         bool seen( const tripoint_abs_omt &p );
         void set_seen( const tripoint_abs_omt &p, bool seen = true );
         bool has_vehicle( const tripoint_abs_omt &p );

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -656,6 +656,14 @@ void overmap::unserialize_view( std::istream &fin, const std::string &file_path 
                 jsin.end_array();
             }
             jsin.end_array();
+        } else if( name == "path" ) {
+            jsin.start_array();
+            for( int z = 0; z < OVERMAP_LAYERS; ++z ) {
+                jsin.start_array();
+                unserialize_array_from_compacted_sequence( jsin, layer[z].path );
+                jsin.end_array();
+            }
+            jsin.end_array();
         } else if( name == "notes" ) {
             jsin.start_array();
             for( int z = 0; z < OVERMAP_LAYERS; ++z ) {
@@ -742,6 +750,16 @@ void overmap::serialize_view( std::ostream &fout ) const
     for( int z = 0; z < OVERMAP_LAYERS; ++z ) {
         json.start_array();
         serialize_array_to_compacted_sequence( json, layer[z].explored );
+        json.end_array();
+        fout << '\n';
+    }
+    json.end_array();
+
+    json.member( "path" );
+    json.start_array();
+    for( int z = 0; z < OVERMAP_LAYERS; ++z ) {
+        json.start_array();
+        serialize_array_to_compacted_sequence( json, layer[z].path );
         json.end_array();
         fout << '\n';
     }


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

I was getting pissed off in my desktop playthrough with fast travel always trying to slam me face-first into the back fence of the Isherwood's place instead of going around like a sane person, while also having debug-overmap'd a shortcut I cut through the forest to count as a dirt road so autodrive would go through it, when an idea finally struck for a way to just designate saner paths at will.

Ideal for cases where you really don't want autodrive or the like to go through town instead of taking the field around, too.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

C++ changes:
1. In overmap.cpp and overmap.h, defined functions `overmap::path` and `overmap::is_path`, both basically copies of `explored`-related functions.
2. In overmap_ui.cpp, set `draw_ascii` to mark an area that's been designated as a travel path the same way it designates an assigned fast travel/autodrive route. Currently uses a light blue `!` to contrast with the dark blue and red `!` used by player and NPC routes.
3. Also in overmap_ui.cpp, set `draw_om_sidebar` and `display` to add support for showing `TOGGLE_MARK_PATH` on the `m`ap menu, which of course calls `overmapbuffer::toggle_path` when used to toggle whether that particular area has a path assigned.
4. In overmapbuffer.cpp and overmapbuffer.h, defined functions `overmapbuffer::is_path` and `overmapbuffer::toggle_path`, copied from explored tile behavior.
5. Also in overmapbuffer.cpp, set `get_terrain_cost` to treat tiles marked as a path as equivalent to a road.
6. In savegame.cpp, updated `overmap::unserialize_view` and `overmap::serialize_view` to have sections for tracking assigned paths, so they'll be preserved when saved and loaded.

JSON changes:
1. Added default keybinding for `Mark/unmark Travel Path` command, set to `P`.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Picking a different symbol for marked paths instead of the same `!` that designated routes use, like `_` maybe?
2. Making it show on the minimap too? It might be more intrusive unless we changed it to do like a blue background or something instead of overriding the main tile content, however.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Found myself some road winding around some forest, marked a path on the other side with `W`.
3. Pathing prefers at first to set it to go around the forest via the road.
4. Marked forest tiles as paths, fast travel now wants to cut straight through the marked woods.
5. Saved and loaded, no errors and path is still there.
6. Went ahead with said travel, once I dealt with the fact that I did a stupid and make a spider nest part of my route I happily make a beeline through the woods to the other side.
7. Checked affected files for astyle.

Fast-travel wants me to take the road and go around these woods:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/96fd52c6-f4d8-4df2-a13b-6d3dc0816d62)

Designated a fast travel path straight through the woods:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/e0898ad0-0fa6-4fcc-b64e-0846aff3e8da)

Autotravel path now treats that area as a road:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/3ebfc025-1267-4f70-8135-7dbd3a2599b8)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
