### PR TITLE
fix: power armor actually benefits from advanced UPS efficiency, adjust efficiency ratio

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1475,7 +1475,7 @@ int Character::consume_remote_fuel( int amount )
             use_charges( itype_UPS_off, unconsumed_amount, used_ups );
             unconsumed_amount -= 1;
         } else if( has_charges( itype_adv_UPS_off, unconsumed_amount, used_ups ) ) {
-            use_charges( itype_adv_UPS_off, roll_remainder( unconsumed_amount * 0.6 ), used_ups );
+            use_charges( itype_adv_UPS_off, roll_remainder( unconsumed_amount * 0.5 ), used_ups );
             unconsumed_amount -= 1;
         }
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10238,10 +10238,10 @@ std::vector<detached_ptr<item>> Character::use_charges( const itype_id &what, in
             qty -= std::min( qty, bio );
         }
 
-        int adv = charges_of( itype_adv_UPS_off, static_cast<int>( qty * 0.5 ) );
-        adv += x_in_y( static_cast<int>( qty * 5 ) % 10, 10 ) ? 1 : 0;
+        int adv_odd = x_in_y( qty % 2, 2 );
+        int adv = charges_of( itype_adv_UPS_off, static_cast<int>( std::ceil( qty * 0.5 ) ) );
         if( adv > 0 ) {
-            std::vector<detached_ptr<item>> found = use_charges( itype_adv_UPS_off, adv );
+            std::vector<detached_ptr<item>> found = use_charges( itype_adv_UPS_off, adv - adv_odd );
             res.insert( res.end(), std::make_move_iterator( found.begin() ),
                         std::make_move_iterator( found.end() ) );
             qty -= std::min( qty, static_cast<int>( adv / 0.5 ) );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10238,12 +10238,12 @@ std::vector<detached_ptr<item>> Character::use_charges( const itype_id &what, in
             qty -= std::min( qty, bio );
         }
 
-        int adv = charges_of( itype_adv_UPS_off, static_cast<int>( std::ceil( qty * 0.6 ) ) );
+        int adv = charges_of( itype_adv_UPS_off, static_cast<int>( std::ceil( qty * 0.5 ) ) );
         if( adv > 0 ) {
             std::vector<detached_ptr<item>> found = use_charges( itype_adv_UPS_off, adv );
             res.insert( res.end(), std::make_move_iterator( found.begin() ),
                         std::make_move_iterator( found.end() ) );
-            qty -= std::min( qty, static_cast<int>( adv / 0.6 ) );
+            qty -= std::min( qty, static_cast<int>( adv / 0.5 ) );
         }
 
         int ups = charges_of( itype_UPS_off, qty );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10238,7 +10238,8 @@ std::vector<detached_ptr<item>> Character::use_charges( const itype_id &what, in
             qty -= std::min( qty, bio );
         }
 
-        int adv = charges_of( itype_adv_UPS_off, static_cast<int>( std::ceil( qty * 0.5 ) ) );
+        int adv = charges_of( itype_adv_UPS_off, static_cast<int>( qty * 0.5 ) );
+        adv += x_in_y( static_cast<int>( qty * 5 ) % 10, 10 ) ? 1 : 0;
         if( adv > 0 ) {
             std::vector<detached_ptr<item>> found = use_charges( itype_adv_UPS_off, adv );
             res.insert( res.end(), std::make_move_iterator( found.begin() ),

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10245,7 +10245,7 @@ std::vector<detached_ptr<item>> Character::use_charges( const itype_id &what, in
             // (eg: if 5, consumes either 2 or 3)
             std::vector<detached_ptr<item>> found = use_charges( itype_adv_UPS_off, adv - adv_odd );
             res.insert( res.end(), std::make_move_iterator( found.begin() ),
-                    std::make_move_iterator( found.end() ) );
+                        std::make_move_iterator( found.end() ) );
             qty -= std::min( qty, static_cast<int>( adv / 0.5 ) );
         }
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10238,12 +10238,14 @@ std::vector<detached_ptr<item>> Character::use_charges( const itype_id &what, in
             qty -= std::min( qty, bio );
         }
 
-        int adv_odd = x_in_y( qty % 2, 2 );
         int adv = charges_of( itype_adv_UPS_off, static_cast<int>( std::ceil( qty * 0.5 ) ) );
         if( adv > 0 ) {
+            int adv_odd = x_in_y( qty % 2, 2 );
+            // qty % 2 returns 1 if odd and 0 if even, giving a 50% chance of consuming one less charge if odd, 0 otherwise.
+            // (eg: if 5, consumes either 2 or 3)
             std::vector<detached_ptr<item>> found = use_charges( itype_adv_UPS_off, adv - adv_odd );
             res.insert( res.end(), std::make_move_iterator( found.begin() ),
-                        std::make_move_iterator( found.end() ) );
+                    std::make_move_iterator( found.end() ) );
             qty -= std::min( qty, static_cast<int>( adv / 0.5 ) );
         }
 

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -874,7 +874,7 @@ void Character::process_items()
         if( identifier == itype_UPS_off ) {
             ch_UPS += it.ammo_remaining();
         } else if( identifier == itype_adv_UPS_off ) {
-            ch_UPS += it.ammo_remaining() / 0.6;
+            ch_UPS += it.ammo_remaining() / 0.5;
         }
         if( it.has_flag( flag_USE_UPS ) && it.charges < it.type->maximum_charges() ) {
             active_held_items.push_back( index );
@@ -891,7 +891,7 @@ void Character::process_items()
         if( identifier == itype_UPS_off ) {
             ch_UPS += w->ammo_remaining();
         } else if( identifier == itype_adv_UPS_off ) {
-            ch_UPS += w->ammo_remaining() / 0.6;
+            ch_UPS += w->ammo_remaining() / 0.5;
         }
         if( !update_required && w->encumbrance_update_ ) {
             update_required = true;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -135,7 +135,6 @@ static const fault_id fault_bionic_nonsterile( "fault_bionic_nonsterile" );
 
 static const gun_mode_id gun_mode_REACH( "REACH" );
 
-static const itype_id itype_adv_UPS_off( "adv_UPS_off" );
 static const itype_id itype_barrel_small( "barrel_small" );
 static const itype_id itype_blood( "blood" );
 static const itype_id itype_brass_catcher( "brass_catcher" );
@@ -149,7 +148,6 @@ static const itype_id itype_rad_badge( "rad_badge" );
 static const itype_id itype_tuned_mechanism( "tuned_mechanism" );
 static const itype_id itype_stock_small( "stock_small" );
 static const itype_id itype_UPS( "UPS" );
-static const itype_id itype_UPS_off( "UPS" );
 static const itype_id itype_bio_armor( "bio_armor" );
 static const itype_id itype_waterproof_gunmod( "waterproof_gunmod" );
 static const itype_id itype_water( "water" );
@@ -9704,9 +9702,7 @@ detached_ptr<item> item::process_tool( detached_ptr<item> &&self, player *carrie
 
     // for items in player possession if insufficient charges within tool try UPS
     if( carrier && ( self->has_flag( flag_USE_UPS ) ) ) {
-        if( carrier->use_charges_if_avail( itype_adv_UPS_off, energy ) ) {
-            energy = 0;
-        } else if( carrier->use_charges_if_avail( itype_UPS_off, energy ) ) {
+        if( carrier->use_charges_if_avail( itype_UPS, energy ) ) {
             energy = 0;
         }
     }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9704,13 +9704,8 @@ detached_ptr<item> item::process_tool( detached_ptr<item> &&self, player *carrie
 
     // for items in player possession if insufficient charges within tool try UPS
     if( carrier && ( self->has_flag( flag_USE_UPS ) ) ) {
-        if( carrier->has_charges( itype_adv_UPS_off, energy ) ) {
-            // If we ever JSONize UPS items we need a better way to handle efficiency multipliers
-            if( one_in( 2 ) ) {
+        if( carrier->use_charges_if_avail( itype_UPS_off, energy ) ) {
                 energy = 0;
-            } else if( carrier->use_charges_if_avail( itype_adv_UPS_off, energy ) ) {
-                energy = 0;
-            }
         } else if( carrier->use_charges_if_avail( itype_UPS_off, energy ) ) {
             energy = 0;
         }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9705,7 +9705,7 @@ detached_ptr<item> item::process_tool( detached_ptr<item> &&self, player *carrie
     // for items in player possession if insufficient charges within tool try UPS
     if( carrier && ( self->has_flag( flag_USE_UPS ) ) ) {
         if( carrier->use_charges_if_avail( itype_adv_UPS_off, energy ) ) {
-                energy = 0;
+            energy = 0;
         } else if( carrier->use_charges_if_avail( itype_UPS_off, energy ) ) {
             energy = 0;
         }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9704,7 +9704,7 @@ detached_ptr<item> item::process_tool( detached_ptr<item> &&self, player *carrie
 
     // for items in player possession if insufficient charges within tool try UPS
     if( carrier && ( self->has_flag( flag_USE_UPS ) ) ) {
-        if( carrier->use_charges_if_avail( itype_UPS_off, energy ) ) {
+        if( carrier->use_charges_if_avail( itype_adv_UPS_off, energy ) ) {
                 energy = 0;
         } else if( carrier->use_charges_if_avail( itype_UPS_off, energy ) ) {
             energy = 0;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -135,6 +135,7 @@ static const fault_id fault_bionic_nonsterile( "fault_bionic_nonsterile" );
 
 static const gun_mode_id gun_mode_REACH( "REACH" );
 
+static const itype_id itype_adv_UPS_off( "adv_UPS_off" );
 static const itype_id itype_barrel_small( "barrel_small" );
 static const itype_id itype_blood( "blood" );
 static const itype_id itype_brass_catcher( "brass_catcher" );
@@ -148,6 +149,7 @@ static const itype_id itype_rad_badge( "rad_badge" );
 static const itype_id itype_tuned_mechanism( "tuned_mechanism" );
 static const itype_id itype_stock_small( "stock_small" );
 static const itype_id itype_UPS( "UPS" );
+static const itype_id itype_UPS_off( "UPS" );
 static const itype_id itype_bio_armor( "bio_armor" );
 static const itype_id itype_waterproof_gunmod( "waterproof_gunmod" );
 static const itype_id itype_water( "water" );
@@ -9702,7 +9704,14 @@ detached_ptr<item> item::process_tool( detached_ptr<item> &&self, player *carrie
 
     // for items in player possession if insufficient charges within tool try UPS
     if( carrier && ( self->has_flag( flag_USE_UPS ) ) ) {
-        if( carrier->use_charges_if_avail( itype_UPS, energy ) ) {
+        if( carrier->has_charges( itype_adv_UPS_off, energy ) ) {
+            // If we ever JSONize UPS items we need a better way to handle efficiency multipliers
+            if( one_in( 2 ) ) {
+                energy = 0;
+            } else if( carrier->use_charges_if_avail( itype_adv_UPS_off, energy ) ) {
+                energy = 0;
+            }
+        } else if( carrier->use_charges_if_avail( itype_UPS_off, energy ) ) {
             energy = 0;
         }
     }

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3781,7 +3781,7 @@ auto ranged::gunmode_checks_weapon( avatar &you, const map &m, std::vector<std::
 
     if( gmode->get_gun_ups_drain() > 0 ) {
         const int ups_drain = gmode->get_gun_ups_drain();
-        const int adv_ups_drain = std::max( 1, ups_drain * 3 / 5 );
+        const int adv_ups_drain = std::max( 1, ups_drain / 2 );
         bool is_mech_weapon = false;
         if( you.is_mounted() ) {
             monster *mons = get_player_character().mounted_creature.get();

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -1008,7 +1008,7 @@ int visitable<inventory>::charges_of( const itype_id &what, int limit,
     if( what == itype_UPS ) {
         int qty = 0;
         qty = sum_no_wrap( qty, charges_of( itype_UPS_off ) );
-        qty = sum_no_wrap( qty, static_cast<int>( charges_of( itype_adv_UPS_off ) / 0.6 ) );
+        qty = sum_no_wrap( qty, static_cast<int>( charges_of( itype_adv_UPS_off ) / 0.5 ) );
         return std::min( qty, limit );
     }
     const auto &binned = static_cast<const inventory *>( this )->get_binned_items();
@@ -1074,7 +1074,7 @@ int visitable<Character>::charges_of( const itype_id &what, int limit,
     if( what == itype_UPS ) {
         int qty = 0;
         qty = sum_no_wrap( qty, charges_of( itype_UPS_off ) );
-        qty = sum_no_wrap( qty, static_cast<int>( charges_of( itype_adv_UPS_off ) / 0.6 ) );
+        qty = sum_no_wrap( qty, static_cast<int>( charges_of( itype_adv_UPS_off ) / 0.5 ) );
         if( p && p->has_active_bionic( bio_ups ) ) {
             qty = sum_no_wrap( qty, units::to_kilojoule( p->get_power_level() ) );
         }


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This fixes a flaw I found with the advanced UPS not gaining any benefit when used with light power armor like it does for other items, and along the way I ended up deciding to make the efficiency multiplier used elsewhere by advanced UPS a little neater.

On further testing it was found that this mainly applies to power draw values that demand an odd number of charges, which is why light power armor was most strongly affected by this. @KheirFerrum provided a proper fix for that that compensates for odd-number charge consumption when using advanced UPS.

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/3765

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. In bionics.cpp. converted use of advanced UPS in `Character::consume_remote_fuel` to consume 0.5x charges when using advanced UPS, instead of a janky 0.6x.
2. In character.cpp, added a more graceful handling of advanced UPS handling in `Character::use_charges`, provided by Kheir. Basically, because it's being fed a raw `int` for how much power it needs to consume from the UPS, it can't gracefully handle cutting the power draw in half in those cases, and that's quite a big difference considering with UPS use each charge is a full kilojoule. Kheir's function checks if the power draw would be an odd number and applies a reduction 50% of the time so that net behavior over a long period of time will match expected results you'd get if power draw was an even number.
3. In character_turn.cpp, converted relevant multipliers in `Character::process_items` as well.
5. In ranged.cpp, set `ranged::gunmode_checks_weapon` to defined `adv_ups_drain` as half that of `ups_drain`
6. In visitable.cpp, set `visitable<inventory>::charges_of` and `visitable<Character>::charges_of` to use new multiplier for advanced UPS.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Banging the code against a rock until every single power-related function and all battery JSON has been converted to properly deal in joules instead of kJ. We'll probably have to suffer than someday anyway if we ever JSONize UPS items...

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Spawned in as a power armor soldier.
3. Tested a full set of light power armor (0.75+0.25 kW, total 1 kW). Power draw after 5 minutes was 297 (average 300) for standard UPS, 161 (average 150) for advanced UPS.
4. Tested medium power armor minus helmet (1.5 kW). Power draw after 5 minutes was 297 (average 300) for standard UPS, 161 (average 150) for advanced UPS.
5. Temporarily set heavy power armor's suit to draw 3 kW on its own (normally 2.25 kW) and tested. Power draw after 5 minutes was 900 (average 900) for standard UPS, 444 (average 450) for advanced UPS.
6. Spawned in a V29 laser pistol, tried firing it without any UPS and confirmed it asks for 10 UPS or 5 advanced UPS charges.
7. Fired it with advanced UPS in inventory, confirmed it uses 5 charges as expected.
8. Checked affected files for astyle.

Power draw is weird and random, so exact matches to expected average aren't as important as confirming the difference exists.

Comparison of UPS items after 5 minutes of light power armor+helm use each:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/5867eaba-980a-43d7-a95f-15ddcf64a465)

Modified 3-kW heavy power armor test results:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/d04f9de0-63a6-407a-b1d0-a1d1f20519c7)


Laser pistol message:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/31e08cf0-24f7-48d0-82dc-134f9de45086)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

At some point I want to unhardcode UPS items outright which will mean a JSONized efficiency rating for each item, which means the current hacks will likely need to be replaced with something that can handle it better. That might even require an outright overhaul of power draw code, `use_charges_if_avail`, or more to behave more sanely, I don't know.