### PR TITLE
fix: add uncraft recipe for new glock drums

### DIFF
--- a/data/json/uncraft/magazine/40.json
+++ b/data/json/uncraft/magazine/40.json
@@ -21,6 +21,13 @@
     "components": [ [ [ "scrap", 4 ] ] ]
   },
   {
+    "result": "glock40drum50rd",
+    "type": "uncraft",
+    "copy-from": "metal_magazine",
+    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
+    "components": [ [ [ "scrap", 4 ] ] ]
+  },
+  {
     "result": "glock40mag",
     "type": "uncraft",
     "copy-from": "metal_magazine",

--- a/data/json/uncraft/magazine/45.json
+++ b/data/json/uncraft/magazine/45.json
@@ -96,5 +96,12 @@
     "copy-from": "metal_magazine",
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
     "components": [ [ [ "scrap", 1 ] ] ]
+  },
+  {
+    "result": "glock21drum40rd",
+    "type": "uncraft",
+    "copy-from": "metal_magazine",
+    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
+    "components": [ [ [ "scrap", 2 ] ] ]
   }
 ]


### PR DESCRIPTION
## Purpose of change
I missed to add the 2 drums for the glock to uncraft lists. This fixes it.