### PR TITLE
fix: modernize recipes for Rivtech ammo

### DIFF
--- a/data/json/recipes/ammo/rifle.json
+++ b/data/json/recipes/ammo/rifle.json
@@ -403,28 +403,18 @@
     "skill_used": "fabrication",
     "skills_required": [ "cooking", 2 ],
     "difficulty": 8,
-    "time": 35000,
+    "time": "2 m",
     "batch_time_factors": [ 60, 5 ],
     "book_learn": [ [ "recipe_caseless", 5 ] ],
     "charges": 40,
     "qualities": [ { "id": "CHEM", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 50, "LIST" ] ], [ [ "press", -1 ] ] ],
+    "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 2 ] ],
     "components": [
-      [ [ "adhesive", 1, "LIST" ] ],
-      [ [ "plastic_chunk", 5 ] ],
-      [ [ "gunpowder", 280 ] ],
-      [ [ "oxy_powder", 80 ] ],
-      [ [ "lead", 80 ] ],
-      [
-        [ "gold_small", 4 ],
-        [ "silver_small", 4 ],
-        [ "tin", 4 ],
-        [ "bismuth", 4 ],
-        [ "solder_wire", 4 ],
-        [ "platinum_small", 4 ]
-      ],
-      [ [ "copper", 40 ] ],
-      [ [ "smrifle_primer", 40 ], [ "lgpistol_primer", 40 ] ]
+      [ [ "superglue", 1 ] ],
+      [ [ "gunpowder", 7 ] ],
+      [ [ "oxy_powder", 2 ] ],
+      [ [ "copper", 1 ] ],
+      [ [ "smrifle_primer", 1 ] ]
     ]
   },
   {
@@ -435,28 +425,18 @@
     "skill_used": "fabrication",
     "skills_required": [ "cooking", 2 ],
     "difficulty": 9,
-    "time": 45000,
+    "time": "2 m",
     "batch_time_factors": [ 60, 5 ],
     "book_learn": [ [ "recipe_caseless", 5 ] ],
-    "charges": 40,
+    "charges": 1,
     "qualities": [ { "id": "CHEM", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 50, "LIST" ] ], [ [ "press", -1 ] ] ],
+    "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 3 ] ],
     "components": [
-      [ [ "adhesive", 1, "LIST" ] ],
-      [ [ "plastic_chunk", 5 ] ],
-      [ [ "gunpowder", 320 ] ],
-      [ [ "oxy_powder", 80 ] ],
-      [ [ "lead", 120 ] ],
-      [
-        [ "gold_small", 4 ],
-        [ "silver_small", 4 ],
-        [ "tin", 4 ],
-        [ "bismuth", 4 ],
-        [ "solder_wire", 4 ],
-        [ "platinum_small", 4 ]
-      ],
-      [ [ "copper", 80 ] ],
-      [ [ "smrifle_primer", 40 ], [ "lgpistol_primer", 40 ] ]
+      [ [ "superglue", 1 ] ],
+      [ [ "gunpowder", 8 ] ],
+      [ [ "oxy_powder", 2 ] ],
+      [ [ "copper", 2 ] ],
+      [ [ "smrifle_primer", 1 ] ]
     ]
   },
   {
@@ -467,29 +447,19 @@
     "skill_used": "fabrication",
     "skills_required": [ "cooking", 2 ],
     "difficulty": 9,
-    "time": 55000,
+    "time": "2 m",
     "batch_time_factors": [ 60, 5 ],
     "book_learn": [ [ "recipe_caseless", 5 ] ],
-    "charges": 40,
+    "charges": 1,
     "qualities": [ { "id": "CHEM", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 50, "LIST" ] ], [ [ "press", -1 ] ] ],
+    "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 2 ] ],
     "components": [
-      [ [ "adhesive", 1, "LIST" ] ],
-      [ [ "plastic_chunk", 5 ] ],
-      [ [ "gunpowder", 400 ] ],
-      [ [ "oxy_powder", 120 ] ],
-      [ [ "lead", 80 ] ],
-      [ [ "combatnail", 40 ] ],
-      [
-        [ "gold_small", 4 ],
-        [ "silver_small", 4 ],
-        [ "tin", 4 ],
-        [ "bismuth", 4 ],
-        [ "solder_wire", 4 ],
-        [ "platinum_small", 4 ]
-      ],
-      [ [ "copper", 80 ] ],
-      [ [ "smrifle_primer", 40 ], [ "lgpistol_primer", 40 ] ]
+      [ [ "superglue", 1 ] ],
+      [ [ "gunpowder", 10 ] ],
+      [ [ "oxy_powder", 3 ] ],
+      [ [ "combatnail", 1 ] ],
+      [ [ "copper", 2 ] ],
+      [ [ "smrifle_primer", 1 ] ]
     ]
   },
   {
@@ -500,29 +470,19 @@
     "skill_used": "fabrication",
     "skills_required": [ "cooking", 2 ],
     "difficulty": 9,
-    "time": 55000,
+    "time": "2 m",
     "batch_time_factors": [ 60, 5 ],
     "book_learn": [ [ "recipe_caseless", 5 ] ],
     "charges": 40,
     "qualities": [ { "id": "CHEM", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 50, "LIST" ] ], [ [ "press", -1 ] ] ],
+    "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 2 ] ],
     "components": [
-      [ [ "adhesive", 1, "LIST" ] ],
-      [ [ "plastic_chunk", 5 ] ],
-      [ [ "gunpowder", 320 ] ],
-      [ [ "oxy_powder", 160 ] ],
-      [ [ "incendiary", 80 ] ],
-      [ [ "lead", 80 ] ],
-      [
-        [ "gold_small", 4 ],
-        [ "silver_small", 4 ],
-        [ "tin", 4 ],
-        [ "bismuth", 4 ],
-        [ "solder_wire", 4 ],
-        [ "platinum_small", 4 ]
-      ],
-      [ [ "copper", 40 ] ],
-      [ [ "smrifle_primer", 40 ], [ "lgpistol_primer", 40 ] ]
+      [ [ "superglue", 1 ] ],
+      [ [ "gunpowder", 8 ] ],
+      [ [ "oxy_powder", 4 ] ],
+      [ [ "incendiary", 2 ] ],
+      [ [ "copper", 1 ] ],
+      [ [ "smrifle_primer", 1 ] ]
     ]
   },
   {
@@ -533,19 +493,13 @@
     "skill_used": "fabrication",
     "difficulty": 6,
     "skills_required": [ "gun", 5 ],
-    "time": "2 m",
+    "time": "1 m",
     "batch_time_factors": [ 60, 5 ],
     "book_learn": [ [ "recipe_caseless", 4 ] ],
-    "charges": 8,
-    "using": [ [ "bullet_forming", 16 ], [ "ammo_bullet", 16 ] ],
+    "charges": 1,
+    "using": [ [ "bullet_forming", 3 ], [ "ammo_bullet", 3 ] ],
     "tools": [ [ [ "mold_plastic", -1 ] ] ],
-    "components": [
-      [ [ "5x50_hull", 8 ] ],
-      [ [ "plastic_chunk", 1 ] ],
-      [ [ "smrifle_primer", 8 ] ],
-      [ [ "gunpowder", 24 ] ],
-      [ [ "combatnail", 8 ] ]
-    ]
+    "components": [ [ [ "5x50_hull", 1 ] ], [ [ "smrifle_primer", 1 ] ], [ [ "gunpowder", 3 ] ], [ [ "combatnail", 1 ] ] ]
   },
   {
     "result": "5x50heavy",
@@ -555,19 +509,13 @@
     "skill_used": "fabrication",
     "difficulty": 6,
     "skills_required": [ "gun", 5 ],
-    "time": "2 m",
+    "time": "1 m",
     "batch_time_factors": [ 60, 5 ],
     "book_learn": [ [ "recipe_caseless", 4 ] ],
     "charges": 8,
-    "using": [ [ "bullet_forming", 16 ], [ "ammo_bullet", 24 ] ],
+    "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 2 ] ],
     "tools": [ [ [ "mold_plastic", -1 ] ] ],
-    "components": [
-      [ [ "5x50_hull", 8 ] ],
-      [ [ "plastic_chunk", 1 ] ],
-      [ [ "smrifle_primer", 8 ] ],
-      [ [ "gunpowder", 32 ] ],
-      [ [ "scrap", 8 ] ]
-    ]
+    "components": [ [ [ "5x50_hull", 1 ] ], [ [ "smrifle_primer", 1 ] ], [ [ "gunpowder", 4 ] ], [ [ "scrap", 1 ] ] ]
   },
   {
     "result": "50bmg",

--- a/data/json/recipes/ammo/shot.json
+++ b/data/json/recipes/ammo/shot.json
@@ -651,21 +651,13 @@
     "skill_used": "fabrication",
     "skills_required": [ "cooking", 2 ],
     "difficulty": 8,
-    "time": 45000,
+    "time": "2 m",
     "charges": 20,
     "batch_time_factors": [ 60, 5 ],
     "book_learn": [ [ "recipe_caseless", 5 ] ],
     "qualities": [ { "id": "CHEM", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 50, "LIST" ] ], [ [ "press", -1 ] ] ],
-    "components": [
-      [ [ "adhesive", 1, "LIST" ] ],
-      [ [ "plastic_chunk", 4 ] ],
-      [ [ "oxy_powder", 60 ] ],
-      [ [ "gunpowder", 120 ] ],
-      [ [ "lead", 160 ] ],
-      [ [ "gold_small", 5 ], [ "silver_small", 5 ], [ "tin", 5 ], [ "bismuth", 5 ], [ "solder_wire", 5 ] ],
-      [ [ "shotgun_primer", 20 ] ]
-    ]
+    "using": [ [ "bullet_forming", 3 ], [ "ammo_bullet", 8 ] ],
+    "components": [ [ [ "superglue", 1 ] ], [ [ "oxy_powder", 3 ] ], [ [ "gunpowder", 6 ] ], [ [ "shotgun_primer", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -675,27 +667,18 @@
     "skill_used": "fabrication",
     "skills_required": [ "cooking", 2 ],
     "difficulty": 8,
-    "time": 45000,
+    "time": "2 m",
     "charges": 20,
     "batch_time_factors": [ 60, 5 ],
     "book_learn": [ [ "recipe_caseless", 5 ] ],
     "qualities": [ { "id": "CHEM", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 50, "LIST" ] ], [ [ "boltcutters", -1 ], [ "toolset", -1 ] ], [ [ "press", -1 ] ] ],
+    "using": [ [ "bullet_forming", 3 ] ],
     "components": [
-      [ [ "adhesive", 1, "LIST" ] ],
-      [ [ "plastic_chunk", 4 ] ],
-      [ [ "oxy_powder", 60 ] ],
-      [ [ "gunpowder", 120 ] ],
-      [
-        [ "lead", 10 ],
-        [ "gold_small", 10 ],
-        [ "silver_small", 10 ],
-        [ "tin", 10 ],
-        [ "bismuth", 10 ],
-        [ "solder_wire", 10 ]
-      ],
-      [ [ "combatnail", 240 ] ],
-      [ [ "shotgun_primer", 20 ] ]
+      [ [ "superglue", 1 ] ],
+      [ [ "oxy_powder", 3 ] ],
+      [ [ "gunpowder", 6 ] ],
+      [ [ "combatnail", 12 ] ],
+      [ [ "shotgun_primer", 1 ] ]
     ]
   },
   {
@@ -706,21 +689,13 @@
     "skill_used": "fabrication",
     "skills_required": [ "cooking", 2 ],
     "difficulty": 8,
-    "time": 45000,
+    "time": "2 m",
     "charges": 20,
     "batch_time_factors": [ 60, 5 ],
     "book_learn": [ [ "recipe_caseless", 5 ] ],
     "qualities": [ { "id": "CHEM", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 50, "LIST" ] ], [ [ "press", -1 ] ] ],
-    "components": [
-      [ [ "adhesive", 1, "LIST" ] ],
-      [ [ "plastic_chunk", 4 ] ],
-      [ [ "oxy_powder", 80 ] ],
-      [ [ "gunpowder", 160 ] ],
-      [ [ "lead", 240 ] ],
-      [ [ "gold_small", 8 ], [ "silver_small", 8 ], [ "tin", 8 ], [ "bismuth", 8 ], [ "solder_wire", 8 ] ],
-      [ [ "shotgun_primer", 20 ] ]
-    ]
+    "using": [ [ "bullet_forming", 3 ], [ "ammo_bullet", 12 ] ],
+    "components": [ [ [ "superglue", 1 ] ], [ [ "oxy_powder", 4 ] ], [ [ "gunpowder", 8 ] ], [ [ "shotgun_primer", 1 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/uncraft/ammo/5x50.json
+++ b/data/json/uncraft/ammo/5x50.json
@@ -22,13 +22,7 @@
     "difficulty": 5,
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
-    "components": [
-      [ [ "lead", 3 ] ],
-      [ [ "5x50_hull", 1 ] ],
-      [ [ "smrifle_primer", 1 ] ],
-      [ [ "gunpowder", 4 ] ],
-      [ [ "scrap", 1 ] ]
-    ],
+    "components": [ [ [ "lead", 3 ] ], [ [ "5x50_hull", 1 ] ], [ [ "smrifle_primer", 1 ] ], [ [ "gunpowder", 4 ] ], [ [ "scrap", 1 ] ] ],
     "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/5x50.json
+++ b/data/json/uncraft/ammo/5x50.json
@@ -9,7 +9,6 @@
     "components": [
       [ [ "lead", 2 ] ],
       [ [ "5x50_hull", 1 ] ],
-      [ [ "plastic_chunk", 1 ] ],
       [ [ "smrifle_primer", 1 ] ],
       [ [ "gunpowder", 3 ] ],
       [ [ "combatnail", 1 ] ]
@@ -26,7 +25,6 @@
     "components": [
       [ [ "lead", 3 ] ],
       [ [ "5x50_hull", 1 ] ],
-      [ [ "plastic_chunk", 1 ] ],
       [ [ "smrifle_primer", 1 ] ],
       [ [ "gunpowder", 4 ] ],
       [ [ "scrap", 1 ] ]


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This fixes 5x50mm uncrafts generating a mountain of plastic chunks, presumably as a long-forgotten standin for the 5mm plastic casings they've had for a while. Along the way this led to sanity-checking the other Rivtech recipes a bit.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Set 5x50 recipes to be made 1 charge at a time and no longer require plastic chunks, as we don't require heaps of plastic to put plastic shotshells back together. Adjusted components accordingly, time was cut in half, kept the plastic mold requirement though. Also made the materials actually match the uncraft a bit better, with the heavy varient needing more lead.
2. Modernized the 8x40 caseless recipes to make 1 charge at a time and use proper crafting requirements, with material costs accordingly divided up. Phased out the use of plastic chunks, and switched it to use only superglue instead of duct tape and the like (which is more tolerable now that you get 10 per). Basic consistent recipe times added, converted over from what seems to be old integer time left unchanged from the 6-second-turn days.
3. Likewise modernized 20mm rounds in the same ways.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Making caseless rounds use plastic scrap would require we make plastic scrap craftable. My rough guess is realism-wise the oxy powder and superglue plus the chemistry equipment are what's meant to convert the propellant into a solid mixture, or else laquering it with a highly-flammable coating as a weird sci-fi counterpart to combustible paper cartridges.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
