### PR TITLE
ci: bump autofix to v1.3

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -43,7 +43,7 @@ jobs:
       - name: format JSON
         run: make style-all-json-parallel RELEASE=1
 
-      - uses: autofix-ci/action@bee19d72e71787c12ca0f29de72f2833e437e4c9
+      - uses: autofix-ci/action@v1.3
         if: ${{ always() }}
         with:
           commit-message: "style(autofix.ci): automated formatting"


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

prevents autofix inconsistencies issues found in PRs such as #3981.

## Describe the solution

see: https://github.com/autofix-ci/action/releases/tag/v1.3
