### PR TITLE
feat: allow stashing items in holsters/sheathes in `r`eload menu

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -1232,9 +1232,19 @@ void avatar_action::reload( item &loc, bool prompt, bool empty )
         use_loc = false;
     }
 
-    // for holsters and ammo pouches try to reload any contained item
-    if( it->type->can_use( "holster" ) && !it->contents.empty() ) {
-        it = &it->contents.front();
+    if( it->is_holster() ) {
+        auto ptr = dynamic_cast<const holster_actor *>
+                   ( it->type->get_use( "holster" )->get_actor_ptr() );
+        if( static_cast<int>( it->contents.num_item_stacks() ) < ptr->multi ) {
+            item *loc = game_menus::inv::holster( u, *it );
+
+            if( !loc ) {
+                u.add_msg_if_player( _( "Never mind." ) );
+                return;
+            }
+            ptr->store( u, *it, loc->detach() );
+            return;
+        }
     }
 
     // for bandoliers we currently defer to iuse_actor methods

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11651,10 +11651,7 @@ bool Character::can_reload( const item &it, const itype_id &ammo ) const
     if( it.is_holster() ) {
         const holster_actor *ptr = dynamic_cast<const holster_actor *>
                                    ( it.get_use( "holster" )->get_actor_ptr() );
-        if( static_cast<int>( it.contents.num_item_stacks() ) < ptr->multi ) {
-            return true;
-        }
-        return false;
+        return static_cast<int>( it.contents.num_item_stacks() ) < ptr->multi;
     }
     if( !it.is_reloadable_with( ammo ) ) {
         return false;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11648,6 +11648,14 @@ int Character::hp_percentage() const
 
 bool Character::can_reload( const item &it, const itype_id &ammo ) const
 {
+    if( it.is_holster() ) {
+        const holster_actor *ptr = dynamic_cast<const holster_actor *>
+                                   ( it.get_use( "holster" )->get_actor_ptr() );
+        if( static_cast<int>( it.contents.num_item_stacks() ) < ptr->multi ) {
+            return true;
+        }
+        return false;
+    }
     if( !it.is_reloadable_with( ammo ) ) {
         return false;
     }

--- a/src/character_functions.cpp
+++ b/src/character_functions.cpp
@@ -12,6 +12,7 @@
 #include "game.h"
 #include "handle_liquid.h"
 #include "itype.h"
+#include "iuse_actor.h"
 #include "make_static.h"
 #include "map_iterator.h"
 #include "map_selector.h"
@@ -1017,7 +1018,7 @@ item_reload_option select_ammo( const Character &who, item &base, bool prompt,
     const bool ammo_match_found = list_ammo( who, base, ammo_list, include_empty_mags,
                                   include_potential );
 
-    if( ammo_list.empty() ) {
+    if( ammo_list.empty() && !base.is_holster() ) {
         if( !who.is_npc() ) {
             if( !base.is_magazine() && !base.magazine_integral() && !base.magazine_current() ) {
                 who.add_msg_if_player( m_info, _( "You need a compatible magazine to reload the %s!" ),
@@ -1192,9 +1193,6 @@ std::vector<item *> find_reloadables( Character &who )
     std::vector<item *> reloadables;
 
     who.visit_items( [&]( item * node ) {
-        if( node->is_holster() ) {
-            return VisitResponse::NEXT;
-        }
         bool reloadable = false;
         if( node->is_gun() && !node->magazine_compatible().empty() ) {
             reloadable = node->magazine_current() == nullptr ||
@@ -1203,6 +1201,13 @@ std::vector<item *> find_reloadables( Character &who )
             reloadable = ( node->is_magazine() || node->is_bandolier() ||
                            ( node->is_gun() && node->magazine_integral() ) ) &&
                          node->ammo_remaining() < node->ammo_capacity();
+        }
+        if( node->is_holster() ) {
+            const holster_actor *ptr = dynamic_cast<const holster_actor *>
+                                       ( node->get_use( "holster" )->get_actor_ptr() );
+            if( static_cast<int>( node->contents.num_item_stacks() ) < ptr->multi ) {
+                reloadable = true;
+            }
         }
         if( reloadable ) {
             reloadables.push_back( node );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10052,7 +10052,7 @@ bool item::is_reloadable() const
     if( has_flag( flag_NO_RELOAD ) && !has_flag( flag_VEHICLE ) ) {
         return false; // turrets ignore NO_RELOAD flag
 
-    } else if( is_bandolier() ) {
+    } else if( is_bandolier() || is_holster() ) {
         return true;
 
     } else if( is_container() ) {


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This is essentially a followup to https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2881, allowing you to stash items in holsters, sheathes, mag pouches etc using the reload key.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. In avatar_action.cpp, removed an old "try to reload item in holster" if statement from `avatar_action::reload` that does not actually work anyway. Instead, holsters are now checked in this function for whether they have slots available. If so, prompt to holster an item as the use action does, but skip giving the player the option to draw any other items stashed in it since the entire point of this is a method that lets you skip an extra keypress (and potential extra faffing about with items if you mistype) if all you want is to stash an item immediately.
2. In character.cpp, `Character::can_reload` now checks if the item in question is a holster first, returning true or false based on if the item has slots to hold anything with. This is because holsters don't actually hold an ammotype like bandoliers do, so checking for `is_reloadable_with` first would be an immediate failure and exclude holsters from the reload UI.
3. In character_functions.cpp, set `select_ammo` to avoid trying to print a generic failure to reload message for holsters since ammo list will be empty.
4. Also in character_functions.cpp, `find_reloadables` no longer immediately skips holsters, instead lower down it checks if a holster has a slot available and if so sets it as such, in a separate check from the big and/or definition above since we may prefer to not define and check `holster_actor` stuff unless a holster is actually involved. This also mandated adding iuse_actor in the file includes.
5. In item.cpp, set `item::is_reloadable` to treat holsters as valid for reloading just as it does bandoliers, since the vital function `can_reload_item_or_mods` asks if both this function and `can_reload` (which we already handled earlier) return true.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Spawned myself a holster and an M1911, can holster it without issues by both using the holster or be reloading it.
3. Checked that I can no longer try to reload the holster once a gun is stashed in it.
4. Spawned myself a toolbelt and some relevant tools, can load multiple tools into it with reload command.
5. Tested navigating to both items and hitting reload from the inventory screen, doesn't let you try to reload them when full but does allow it if they can hold tools.
6. Checked affected files for astyle.

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/74b23578-1376-4372-92fb-646b182b2314)
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/c41cb612-7340-4de1-9a8c-6915f4160d76)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

![8utkj6](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/674e30eb-3ff5-4f68-a511-a8f138fb3213)