### PR TITLE
fix: put dirt floor under the planters in the nested mapgen `greenhouse_6x6_vegetable`

### DIFF
--- a/data/json/mapgen_palettes/house_w_palette.json
+++ b/data/json/mapgen_palettes/house_w_palette.json
@@ -240,7 +240,10 @@
       "3": "t_dirtfloor",
       "4": "t_dirtfloor",
       "5": "t_dirtfloor",
-      "6": "t_dirtfloor"
+      "6": "t_dirtfloor",
+      "7": "t_dirtfloor",
+      "8": "t_dirtfloor",
+      "9": "t_dirtfloor"
     },
     "furniture": {
       "a": "f_stool",


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Put dirt floor under the planters in the nested mapgen `greenhouse_6x6_vegetable`.
## Describe the solution
Modify `house_w_nest_garden_palette`.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/c2c771f7-4ca1-4d0a-8bd8-a1c06b0a687d">
After:
<img width="960" alt="image2" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/146018959/bf126bb7-de9d-46f9-951b-0feae9d262d3">