### PR TITLE
fix: don't try to bleed corpses that lack blood, remove rotten decay results, blood dumped on the ground becomes a field

### DIFF
--- a/data/json/emit.json
+++ b/data/json/emit.json
@@ -116,6 +116,12 @@
     "qty": 25
   },
   {
+    "id": "emit_drop_blood",
+    "type": "emit",
+    "field": "fd_blood",
+    "intensity": 1
+  },
+  {
     "id": "emit_acid_splash",
     "type": "emit",
     "//": "Small amount of strong acid - stacks, but weak on its own",

--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -570,7 +570,8 @@
     "material": "hflesh",
     "volume": "250 ml",
     "phase": "liquid",
-    "fun": -50
+    "fun": -50,
+    "drop_action": { "type": "emit_actor", "emits": [ "emit_drop_blood" ], "scale_qty": true }
   },
   {
     "type": "COMESTIBLE",

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8231,6 +8231,7 @@ static void butcher_submenu( const std::vector<item *> &corpses, int corpse = -1
     };
     const bool enough_light = character_funcs::can_see_fine_details( you );
 
+    bool has_blood = false;
     bool has_skin = false;
     bool has_organs = false;
 
@@ -8248,6 +8249,9 @@ static void butcher_submenu( const std::vector<item *> &corpses, int corpse = -1
         const mtype *dead_mon = it->get_mtype();
         if( dead_mon != nullptr ) {
             for( const harvest_entry &entry : dead_mon->harvest.obj() ) {
+                if( entry.type == "blood" ) {
+                    has_blood = true;
+                }
                 if( entry.type == "skin" ) {
                     has_skin = true;
                 }
@@ -8282,8 +8286,10 @@ static void butcher_submenu( const std::vector<item *> &corpses, int corpse = -1
                                           "(for ex. a table, a leather tarp, etc.).  "
                                           "Yields are plentiful and varied, but it is time consuming." ),
                                        msg_inv, info_on_action( BUTCHER_FULL ).c_str() ) );
-    smenu.addentry_col( BLEED, enough_light, 'l', _( "Bleed corpse" ),
-                        enough_light ? cut_time( BLEED ) : cannot_see,
+    smenu.addentry_col( BLEED, enough_light &&
+                        has_blood, 'l', _( "Bleed corpse" ),
+                        enough_light ? ( has_blood ? cut_time( BLEED ) : colorize( _( "has no blood" ),
+                                         c_red ) ) : cannot_see,
                         string_format( "%s  %s%s",
                                        _( "Bleeding involves severing the carotid arteries and jugular "
                                           "veins, or the blood vessels from which they arise.  "

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7319,8 +7319,9 @@ void map::handle_decayed_corpse( const item &it, const tripoint &pnt )
                 if( harvest->charges > 1 ) {
                     harvest->charges = 1;
                 }
-
-                add_item_or_charges( pnt, item::spawn( *harvest ) );
+                if( !harvest->rotten() ) {
+                    add_item_or_charges( pnt, item::spawn( *harvest ) );
+                }
             }
         }
     }


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Lil fixes that came about during discussion in the BN server, on discovering that you can still bleed corpses that lack blood, plus some other problems that came to mind during playtesting.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

C++ changes:
1. In game.cpp, `butcher_submenu` now properly checks for if a corpse has any blood to take before letting you bleed it, and if not disallowing it just as it does with skinning or field dressing.
2. In map.cpp, changed `map::handle_decayed_corpse` so that rotten harvest yields are excluded automatically. The corpse is already rotting away and hacks around it spawning weird unsightly piles of individual rotten fats.

JSON changes:
1. Went ahead and gave all blood items a `drop_action` coverting them into fields when dumped on the floor. In this case not for decay function hackery, but for when you manually dump blood from a bled corpse on the floor.
2. Defined an emit for blood to use.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Figuring how why chunks of fat were refusing to split up correctly and fixing the root cause instead of just not making them spawn from decay. My rough guess is the fix that prevents copper wire and such from spawning entire stacks for every wire it's supposed to drop is causing certain things like chunks of fat to split their stack? That shouldn't be the case however since both seem to say they default to spawning in stacks of 1.

It could alternatively be that the actual rot timers for decay results aren't as uniform as they should be and thus it's splitting them based off that, if so then not spawning items where the rot timer actually matters would be a reasonable fix for it instead of a bandaid.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON for syntax and lint errors.
2. Compiled and load-tested.
3. Tinkered with letting bodies decay, no longer encountered rotten fat spam.
4. Tested bleeding a triffid corpse, no longer permitted to try since it has no blood.
5. Bled a human corpse and chose to dump the blood on the ground, it splatters all over the place.
6. Checked affected files for astyle.

No longer allowed to bleed a triffid:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/463076b1-51cb-4c89-94b0-5803d41df919)

No sign of rotten fat on decayed body:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/8f6f591a-6435-4112-b2e5-6730e7c3da47)

Blood spilled after bleeding corpse creates fields instead:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/cecfcc22-14fd-4561-a31f-90a475164fb4)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
