### PR TITLE
feat(balance): swap damage bracket of ATGM and blackpowder cannon so civil war guns don't kill tanks better than a TOW

### DIFF
--- a/data/json/items/ammo/atgm.json
+++ b/data/json/items/ammo/atgm.json
@@ -15,7 +15,7 @@
     "bashing": 1,
     "ammo_type": "atgm",
     "casing": "atgm_spent",
-    "damage": { "damage_type": "bullet", "amount": 250, "armor_multiplier": 0.1 },
+    "damage": { "damage_type": "bullet", "amount": 450, "armor_multiplier": 0.1 },
     "range": 100,
     "recoil": 6000,
     "effects": [ "EXPLOSIVE_HUGE", "NEVER_MISFIRES" ]

--- a/data/json/items/ammo/cannon.json
+++ b/data/json/items/ammo/cannon.json
@@ -11,11 +11,11 @@
     "price": "200 USD",
     "price_postapoc": "20 USD",
     "looks_like": "cannon_round_ball",
-    "//2": "Base damage of 544, rounded down to 450 to be close to 25% that of round shot, balanced as FMJ.",
-    "damage": { "damage_type": "bullet", "amount": 450, "armor_penetration": 215 },
+    "//2": "balanced as +P with blackpowder levels of arpen.",
+    "damage": { "damage_type": "bullet", "amount": 250, "armor_penetration": 50 },
     "dispersion": 500,
     "recoil": 52500,
-    "extend": { "effects": [ "EXPLOSIVE", "FRAG" ] }
+    "extend": { "effects": [ "EXPLOSIVE_BIG" ] }
   },
   {
     "id": "cannon_round_ball",
@@ -35,8 +35,8 @@
     "stack_size": 1,
     "ammo_type": "cannon",
     "range": 50,
-    "//2": "Base damage of 352, rounded down to 350, balanced as FMJ.",
-    "damage": { "damage_type": "bullet", "amount": 350, "armor_penetration": 150 },
+    "//2": "Balanced as FMJ with blackpowder levels of arpen.",
+    "damage": { "damage_type": "bullet", "amount": 200, "armor_penetration": 50 },
     "dispersion": 620,
     "recoil": 26250,
     "loudness": 900,


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Yet more tinkering with damage balance of superheavy ammunition. In this case, I was once again off tinkering with Tankmod: Revived when I double-checked the ATGM and realized that, not only is its damage still barely a step above handheld rocket launchers despite being vastly more rare and vehicle-only, the blackpowder cannons deal much more damage and are craftable.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Swapped the base damage values of ATGM and explosive shells, those being 250 and 450.
2. Adjusted round shot accordingly, and toned arpen values down to be more in line with blackpowder ammo.
3. Exploding cannon shells also now get `EXPLOSIVE_BIG` instead of having both `EXPLOSIVE` plus `FRAG`.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Unending screaming at ammo balance.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Checked affected files for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

I crave the true ultimate weapon:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/8efd5402-f088-4721-b629-8ed7b1b48adb)
