### PR TITLE
fix(content): Make tinder made of dry plant instead of wood.

### DIFF
--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -995,7 +995,7 @@
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "bashing": 1,
-    "material": "wood",
+    "material": "dry_plant",
     "flags": [ "NO_SALVAGE", "TINDER" ],
     "symbol": "=",
     "color": "brown",


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Tinder appeared to be able to be burned for a LOT longer than a fuel briquette. This was because it was set to use the 'wood' material instead of the 'dry_plant' material, which burned a lot better.

## Describe the solution
Changed it to dry_plant. Fixes #4673.

## Describe alternatives you've considered
Buffing fuel briquettes to wood, but this should be better reflected in weight / volume changes instead. It appears to burn for around 10~ish minutes already, but this can be tweaked in a different PR if required.