### PR TITLE
fix: zombies and nether monsters are chill again

### DIFF
--- a/data/json/monster_factions.json
+++ b/data/json/monster_factions.json
@@ -18,13 +18,15 @@
     "type": "MONSTER_FACTION",
     "name": "zombie",
     "friendly": [ "blob", "cult", "zombie_aquatic" ],
-    "by_mood": [ "small_animal", "insect", "fish", "nether" ]
+    "neutral": [ "nether" ],
+    "by_mood": [ "small_animal", "insect", "fish" ]
   },
   {
     "type": "MONSTER_FACTION",
     "name": "zombie_aquatic",
     "friendly": [ "blob", "cult", "zombie" ],
-    "by_mood": [ "small_animal", "insect", "fish", "nether" ]
+    "neutral": [ "nether" ],
+    "by_mood": [ "small_animal", "insect", "fish" ]
   },
   {
     "type": "MONSTER_FACTION",


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This fixes a mistake made in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4898, nether monsters were already neutral towards zombies but that PR forced them to infight.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

Restored zombie factions viewing nether monsters as neutral.

Thing is, while it's perhaps reasonable that zombies chase after all other living things, nether monsters explicitly are not meant to be fighting with zombies right now. Main reason is gameplay-wise, I intend to make more use of nether monsters as a way to escalate things later in the game, making a threat that feral survivors in the affected scenario can't ignore, etc. Main thing delaying me there is I want to tie that escalation to the endgame so that completing it will cause those added spawns to start dying off.

Lore-wise, main thinking is nether monsters and the blob have a shared origin, so nether creatures can spot that critters animated by the blob are just side effects of the blob's presence (blob monsters likely are in the same boat), while zombies likely don't spot the nether monsters and register them as a threat in the same way they might creatures from their own plane. Why feral players are attacked by nether monsters but they don't attack feral human monsters is something I haven't figured out the lore reasons for (possibly related to the fact that something in them has caused them to start behaving abnormally, represented by player control over them), but it's mainly so Lost and Damned isn't even easier.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Reverting the PR fully as it did not seem properly tested for cases where one-sided fights weren't happening prior to the change.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Loaded in compiled test build.
3. Boxed in and summoned a zombie with a shoggoth, they don't fight each other.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

I feel like part of this is that `by_mood` is just kinda shitty in general, and it looks like it's not ever actually accounted for in the code that much. It seems to fall into the root problem of monster AI not having any real sense of who it's pissed off currently, so a monster that's been aggro'd will attack anything its factions don't tell it to ignore. Hence, famous newbie traps like a random stray dog attacking an ant and getting the player killed since they were enjoying worker ants they were walking past previously being neutral to them.