### PR TITLE
refactor: JSONize `mx_military` and `mx_science`

### DIFF
--- a/data/json/mapgen/map_extras/corpses.json
+++ b/data/json/mapgen/map_extras/corpses.json
@@ -40,5 +40,87 @@
       "mapgensize": [ 22, 22 ],
       "place_loot": [ { "group": "map_extra_college_lake", "chance": 100, "x": [ 0, 21 ], "y": [ 0, 21 ], "repeat": [ 2, 6 ] } ]
     }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "update_mapgen_id": "mx_military",
+    "object": {
+      "place_nested": [
+        {
+          "chunks": [ [ "lost_squad_chunk_1", 90 ], [ "lost_squad_chunk_2", 5 ], [ "lost_squad_chunk_3", 5 ] ],
+          "x": [ 1, 22 ],
+          "y": [ 1, 22 ],
+          "repeat": [ 2, 6 ]
+        }
+      ],
+      "place_loot": [ { "group": "rare", "chance": 50, "x": [ 1, 22 ], "y": [ 1, 22 ] } ],
+      "place_monster": [
+        { "group": "GROUP_NETHER_CAPTURED", "x": [ 1, 22 ], "y": [ 1, 22 ], "repeat": [ 1, 3 ] },
+        { "group": "GROUP_MAYBE_MIL", "x": [ 1, 22 ], "y": [ 1, 22 ], "repeat": [ 1, 5 ] }
+      ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "lost_squad_chunk_1",
+    "object": { "mapgensize": [ 1, 1 ], "place_loot": [ { "group": "map_extra_military", "chance": 100, "x": 0, "y": 0 } ] }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "lost_squad_chunk_2",
+    "object": { "mapgensize": [ 1, 1 ], "place_monster": [ { "group": "GROUP_MIL_STRONG", "chance": 100, "x": 0, "y": 0 } ] }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "lost_squad_chunk_3",
+    "object": { "mapgensize": [ 1, 1 ], "place_monster": [ { "group": "GROUP_ROBOTS_MIL", "chance": 100, "x": 0, "y": 0 } ] }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "update_mapgen_id": "mx_science",
+    "object": {
+      "place_nested": [
+        {
+          "chunks": [ [ "lost_science_chunk_1", 90 ], [ "lost_science_chunk_2", 10 ] ],
+          "x": [ 1, 22 ],
+          "y": [ 1, 22 ],
+          "repeat": [ 2, 6 ]
+        }
+      ],
+      "place_loot": [ { "group": "rare", "chance": 50, "x": [ 1, 22 ], "y": [ 1, 22 ] } ],
+      "place_monster": [ { "group": "GROUP_NETHER_CAPTURED", "x": [ 1, 22 ], "y": [ 1, 22 ], "repeat": [ 1, 3 ] } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "lost_science_chunk_1",
+    "object": { "mapgensize": [ 1, 1 ], "place_loot": [ { "group": "map_extra_science", "chance": 100, "x": 0, "y": 0 } ] }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "lost_science_chunk_2",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "place_monster": [
+        {
+          "monster": [
+            [ "mon_zombie_scientist", 14 ],
+            "mon_feral_scientist_scalpel",
+            [ "mon_zombie_labsecurity", 4 ],
+            "mon_feral_labsecurity_flashlight"
+          ],
+          "chance": 100,
+          "x": 0,
+          "y": 0
+        }
+      ]
+    }
   }
 ]

--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -102,7 +102,7 @@
     "type": "map_extra",
     "name": "Military",
     "description": "Several corpses of soldiers are here.",
-    "generator": { "generator_method": "map_extra_function", "generator_id": "mx_military" },
+    "generator": { "generator_method": "update_mapgen", "generator_id": "mx_military" },
     "sym": "m",
     "color": "light_red",
     "autonote": true
@@ -122,7 +122,7 @@
     "type": "map_extra",
     "name": "Scientists",
     "description": "Several corpses of scientists are here.",
-    "generator": { "generator_method": "map_extra_function", "generator_id": "mx_science" },
+    "generator": { "generator_method": "update_mapgen", "generator_id": "mx_science" },
     "sym": "s",
     "color": "light_red",
     "autonote": true


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.


## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This converts another couple of the old hardcorded map extras to use nested chunk spawns instead.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Set `mx_military` and `mx_science` to use `update_mapgen` as their generation method instead of `map_extra_function`
2. Defined nested chunks for the above to use. The science one was the simplest, spawning a scattered number of subchunks that randomly pick between picking a dead scientist or a monster spawn, then some bonus nether spawns and a chance to spawn an item from group `rare` at 50% chance (up slightly from 45%). Main changes are the max number of corpse checks were set to 2-6 instead of 2-5, 1-3 nether spawns instead of 0-3 as did with college spawns, and the "spawn a zombie instead of a corpse" function now varies the spawn results a bit to include occasional labsec zeds or ferals.

Meanwhile the military corpse spawn got a fair bit more tinkering with it. As with the hardcoded version it spawns 1-3 nether monsters (bumped up from 0-3), and 1-5 spawns of `GROUP_MAYBE_MIL` to replicate the weird group density that a code comment is meant to be equivalent to 1-5 spawns (note that the above group spawns nothing 50% of the time). Then it of course spawns scattered bodies as subchunks, picking at random between a dead soldier 90% of the time, and the other 10% of the time picking between `GROUP_MIL_STRONG` and `GROUP_ROBOTS_MIL` at random. Evokes but doesn't perfectly mimic the weird if/else chain the hardcoded version uses. The chance of a bonus `rare` item has now been bumped up to the same 50% the science version now uses, given it uses more potentially dangerous groups.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Also overhauling the drug deal map extra. That one's a lil more complicated given its use of spawning two opposing lines of dead bodies and grouped loot, so that one I figured deserves its own PR.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.
3. Spawned in a few examples to confirm it didn't look too weird.

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/c1f22975-365b-47c0-ad74-9ba4ad2bb7c5)
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/a45af367-c5ed-4b85-bcbd-76a77bf83616)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
