### PR TITLE
fix: Remove scent from player class

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -75,8 +75,6 @@ static const std::string flag_SECRET( "SECRET" );
 static const flag_id json_flag_no_auto_equip( "no_auto_equip" );
 static const flag_id json_flag_auto_wield( "auto_wield" );
 
-static const trait_id trait_SMELLY( "SMELLY" );
-static const trait_id trait_WEAKSCENT( "WEAKSCENT" );
 static const trait_id trait_XS( "XS" );
 static const trait_id trait_XXXL( "XXXL" );
 

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -529,13 +529,6 @@ bool avatar::create( character_type type, const std::string &tempname )
 
     recalc_hp();
 
-    if( has_trait( trait_SMELLY ) ) {
-        scent = 800;
-    }
-    if( has_trait( trait_WEAKSCENT ) ) {
-        scent = 300;
-    }
-
     remove_primary_weapon( );
 
     // Grab the skills from the profession, if there are any

--- a/src/player.h
+++ b/src/player.h
@@ -244,7 +244,6 @@ class player : public Character
         // Save favorite ammo location
         //TODO!: check this
         safe_reference<item> ammo_location;
-        int scent = 0;
         int cash = 0;
         int movecounter = 0;
 


### PR DESCRIPTION
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

- fixes #4625

Scent was a field in both the player and character class, leading to mishaps where the game updates the character scent field but uses the player scent field for calculations.

## Describe the solution

Remove player scent field so that when referenced it will always go to the character scent field.

## Describe alternatives you've considered

- Keep player scent field instead.
  - Rejected as player class is slated to be merged with character class eventually.

## Testing

- [x] Start new game with Weak Scent or Strong Scent, activate local scent display. (Check that character creation trait applies)
  - [x] Wait 30 minutes, see that centre tile scent is 300 (Weak Scent) or 800 (Strong Scent).
- [x] Remove mutations and check that waiting 30 minutes causes centre tile to become 500. (Check that later mutation applies)
  - [x] Add opposing mutation and check that values match up.

## Additional context

One of these days we need to continue the work olanti started merging player and character properly.
