### PR TITLE
fix: Move `last_target` and `last_target_pos` into `Character` class

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -210,9 +210,9 @@ void aim_activity_actor::finish( player_activity &act, Character &who )
     aim_actor->initial_view_offset = this->initial_view_offset;
 
     // if invalid target or it's dead - reset it so a new one is acquired
-    shared_ptr_fast<Creature> last_target = who.as_player()->last_target.lock();
+    shared_ptr_fast<Creature> last_target = who.last_target.lock();
     if( last_target && last_target->is_dead_state() ) {
-        who.as_player()->last_target.reset();
+        who.last_target.reset();
     }
     who.assign_activity( std::make_unique<player_activity>( std::move( aim_actor ) ), false );
 }

--- a/src/character.h
+++ b/src/character.h
@@ -1664,6 +1664,8 @@ class Character : public Creature, public location_visitable<Character>
         int focus_pool = 0;
         int cash = 0;
         std::set<character_id> follower_ids;
+        weak_ptr_fast<Creature> last_target;
+        std::optional<tripoint> last_target_pos;
         // Save favorite ammo location
         safe_reference<item> ammo_location;
         /* crafting inventory cached time */

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8044,7 +8044,6 @@ game::vmenu_ret game::list_monsters( const std::vector<Creature *> &monster_list
         } else if( action == "fire" ) {
             if( cCurMon != nullptr && rl_dist( u.pos(), cCurMon->pos() ) <= max_gun_range ) {
                 u.last_target = shared_from( *cCurMon );
-                add_msg( "Target_set" );
                 u.recoil = MAX_RECOIL;
                 u.view_offset = stored_view_offset;
                 return game::vmenu_ret::FIRE;

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -670,7 +670,7 @@ void Character::reach_attack( const tripoint &p )
     // Original target size, used when there are monsters in front of our target
     const int target_size = critter != nullptr ? static_cast<int>( critter->get_size() + 1 ) : 2;
     // Reset last target pos
-    as_player()->last_target_pos = std::nullopt;
+    last_target_pos = std::nullopt;
     // Max out recoil
     recoil = MAX_RECOIL;
 

--- a/src/player.h
+++ b/src/player.h
@@ -239,8 +239,6 @@ class player : public Character
         bool random_start_location = false;
         start_location_id start_location;
 
-        weak_ptr_fast<Creature> last_target;
-        std::optional<tripoint> last_target_pos;
         // Save favorite ammo location
         //TODO!: check this
         safe_reference<item> ammo_location;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1309,7 +1309,7 @@ dealt_projectile_attack throw_item( Character &who, const tripoint &target,
         who.as_player()->practice( skill_used, 5, 2 );
     }
     // Reset last target pos
-    who.as_player()->last_target_pos = std::nullopt;
+    who.last_target_pos = std::nullopt;
     who.recoil = MAX_RECOIL;
 
     return dealt_attack;


### PR DESCRIPTION
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

- Updates #2786, moving `last_target` and `last_target_pos` into Character class and removing unnecessary `as_player()` conversions.

## Describe the solution

Remove from Player class, move into Character class, reformat code to remove `as_player()` conversions for both.

## Describe alternatives you've considered

- Keep as is.
  - Rejected. Continuing work to merge Player class into Character class.

## Testing

- [x] Spawn 20 zombies. Save
  - [x] Shoot at zombies with M4A1 until all dead, check that last target switches appropriately.
  - [x] Reload and try again 6 times. Confirm still functions.

## Additional context
