### PR TITLE
feat(balance): define crafting quality for superglue and bone glue, adjustments to relevant recipes

### DIFF
--- a/data/json/recipes/ammo/components.json
+++ b/data/json/recipes/ammo/components.json
@@ -81,7 +81,7 @@
     "qualities": [ { "id": "SAW_M", "level": 1 } ],
     "components": [
       [ [ "can_food_unsealed", 1 ], [ "can_drink_unsealed", 1 ], [ "canister_empty", 1 ] ],
-      [ [ "superglue", 1 ], [ "cordage", 1, "LIST" ] ],
+      [ [ "adhesive_proper", 1, "LIST" ], [ "cordage", 1, "LIST" ] ],
       [
         [ "impact_fuze", 1 ],
         [ "smpistol_primer", 1 ],

--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -262,7 +262,7 @@
     "components": [
       [ [ "goggles_ski", 1 ], [ "goggles_welding", 1 ], [ "glasses_safety", 1 ] ],
       [ [ "duct_tape", 120 ], [ "medical_tape", 120 ] ],
-      [ [ "superglue", 3 ] ]
+      [ [ "adhesive_proper", 3, "LIST" ] ]
     ]
   },
   {

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -345,7 +345,7 @@
     "using": [ [ "filament", 50 ] ],
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "COOK", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 5, "LIST" ] ] ],
-    "components": [ [ [ "superglue", 5 ] ], [ [ "fabric_standard", 6, "LIST" ] ], [ [ "plastic_chunk", 1 ] ] ]
+    "components": [ [ [ "adhesive_proper", 5, "LIST" ] ], [ [ "fabric_standard", 6, "LIST" ] ], [ [ "plastic_chunk", 1 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/other/other.json
+++ b/data/json/recipes/other/other.json
@@ -224,7 +224,7 @@
       [ [ "large_stomach_sealed", 1 ], [ "leather", 10 ], [ "fur", 10 ] ],
       [ [ "stick", 1 ], [ "2x4", 1 ] ],
       [ [ "fabric_standard", 3, "LIST" ] ],
-      [ [ "adhesive", 1, "LIST" ], [ "medical_tape", 50 ] ]
+      [ [ "adhesive", 1, "LIST" ] ]
     ]
   },
   {

--- a/data/json/recipes/other/traps.json
+++ b/data/json/recipes/other/traps.json
@@ -22,7 +22,7 @@
     "time": "25 m",
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "components": [ [ [ "glass_shard", 4 ] ], [ [ "superglue", 4 ], [ "bone_glue", 4 ] ] ]
+    "components": [ [ [ "glass_shard", 4 ] ], [ [ "adhesive_proper", 4, "LIST" ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/weapon/cutting.json
+++ b/data/json/recipes/weapon/cutting.json
@@ -452,11 +452,10 @@
     "skill_used": "fabrication",
     "difficulty": 1,
     "time": "8 m",
-    "reversible": true,
     "autolearn": true,
-    "using": [ [ "adhesive", 1 ] ],
-    "tools": [  ],
-    "components": [ [ [ "rock", 5 ], [ "ceramic_shard", 5 ], [ "sharp_rock", 5 ] ], [ [ "stick", 1 ], [ "2x4", 1 ] ] ]
+    "using": [ [ "adhesive_proper", 1 ] ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 } ],
+    "components": [ [ [ "rock", 5 ], [ "ceramic_shard", 5 ], [ "sharp_rock", 5 ] ], [ [ "wood_structural_small", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/weapon/mods.json
+++ b/data/json/recipes/weapon/mods.json
@@ -844,7 +844,7 @@
     "time": "1 m 30 s",
     "book_learn": [ [ "mag_archery", 1 ], [ "manual_archery", 1 ] ],
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "plastic_chunk", 1 ], [ "fur", 1 ] ], [ [ "superglue", 3 ], [ "bone_glue", 3 ] ] ]
+    "components": [ [ [ "plastic_chunk", 1 ], [ "fur", 1 ] ], [ [ "adhesive_proper", 3, "LIST" ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/weapon/ranged.json
+++ b/data/json/recipes/weapon/ranged.json
@@ -160,7 +160,7 @@
     "components": [
       [ [ "stick", 3 ], [ "2x4", 2 ] ],
       [ [ "bone_sturdy", 3, "LIST" ] ],
-      [ [ "adhesive", 5, "LIST" ] ],
+      [ [ "adhesive_proper", 5, "LIST" ] ],
       [ [ "cordage_superior", 2, "LIST" ] ]
     ]
   },
@@ -179,7 +179,7 @@
     "components": [
       [ [ "stick_long", 1 ], [ "2x4", 3 ] ],
       [ [ "bone_sturdy", 4, "LIST" ] ],
-      [ [ "adhesive", 5, "LIST" ] ],
+      [ [ "adhesive_proper", 5, "LIST" ] ],
       [ [ "cordage_superior", 2, "LIST" ] ]
     ]
   },
@@ -217,7 +217,12 @@
       { "id": "ANVIL", "level": 1 },
       { "id": "SAW_W", "level": 1 }
     ],
-    "components": [ [ [ "log", 1 ] ], [ [ "steel_tiny", 5, "LIST" ] ], [ [ "rope_superior_short", 1, "LIST" ] ] ]
+    "components": [
+      [ [ "log", 1 ] ],
+      [ [ "steel_tiny", 5, "LIST" ] ],
+      [ [ "adhesive_proper", 10, "LIST" ] ],
+      [ [ "rope_superior_short", 1, "LIST" ] ]
+    ]
   },
   {
     "type": "recipe",
@@ -332,7 +337,12 @@
       [ "textbook_armschina", 6 ]
     ],
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SCREW", "level": 1 }, { "id": "SAW_W", "level": 1 } ],
-    "components": [ [ [ "stick", 5 ], [ "2x4", 3 ] ], [ [ "bone_sturdy", 3, "LIST" ] ], [ [ "cordage_superior", 1, "LIST" ] ] ]
+    "components": [
+      [ [ "stick", 5 ], [ "2x4", 3 ] ],
+      [ [ "bone_sturdy", 3, "LIST" ] ],
+      [ [ "adhesive_proper", 5, "LIST" ] ],
+      [ [ "cordage_superior", 1, "LIST" ] ]
+    ]
   },
   {
     "type": "recipe",

--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -3,13 +3,19 @@
     "id": "adhesive",
     "type": "requirement",
     "//": "Materials used for joining (typically non-metallic) parts",
-    "components": [ [ [ "duct_tape", 25 ], [ "medical_tape", 25 ], [ "superglue", 5 ], [ "bone_glue", 5 ] ] ]
+    "components": [ [ [ "duct_tape", 25 ], [ "medical_tape", 25 ], [ "adhesive_proper", 5, "LIST" ] ] ]
+  },
+  {
+    "id": "adhesive_proper",
+    "type": "requirement",
+    "//": "Materials used for joining (typically non-metallic) parts, excluding tape",
+    "components": [ [ [ "superglue", 1 ], [ "bone_glue", 2 ] ] ]
   },
   {
     "id": "nail_glue",
     "type": "requirement",
     "//": "Materials that connect part together tightly, nails and glue.",
-    "components": [ [ [ "nail", 1 ], [ "superglue", 1 ], [ "bone_glue", 1 ] ] ]
+    "components": [ [ [ "nail", 1 ], [ "adhesive_proper", 1, "LIST" ] ] ]
   },
   {
     "id": "ammo_bullet",

--- a/data/mods/Magiclysm/recipes/magic_tools.json
+++ b/data/mods/Magiclysm/recipes/magic_tools.json
@@ -76,7 +76,7 @@
     "time": "180 m",
     "book_learn": [ [ "cooking_poison", 3 ] ],
     "qualities": [ { "id": "CHISEL", "level": 1 }, { "id": "MANA_INFUSE", "level": 1 } ],
-    "components": [ [ [ "demon_chitin_piece", 16 ] ], [ [ "bone_glue", 10 ] ] ]
+    "components": [ [ [ "demon_chitin_piece", 16 ] ], [ [ "adhesive_proper", 10, "LIST" ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This rebalances the use of bone glue vs superglue, and tweaks a few recipes that use adhesives and superglue.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Defined `adhesive_proper` crafting quality, for recipes where superglue or bone glue are reasonable but tape shouldn't be allowed. In addition, it now uses 2 bone glue per 1 superglue, making superglue properly more efficient and fixing the oddity where making superglue from 20 bones offered no benefit when bone glue only needed 10 bones for the same number of charges.
2. Reworked `adhesive` and `nail_glue` to use `adhesive_proper` inside them in place of superglue or bone glue.
3. Updated makeshift macuahuitl recipe to require hammering and cutting quality since you're likely having to shape the rocks into blades and set them in the edges of the club, implemented use of `adhesive_proper` and `wood_structural_small` crafting qualities for the recipe, removed extraneous empty tool section, set to no longer be reversible since knapped blades.
4. Updated glue use of glass caltrops and bow dampener recipes to use `adhesive_proper` crafting qualities.
5. Allowed exploding arrow warheads, ski goggles, and duct tape recipes to use `adhesive_proper` instead of just superglue. I figured keep it using superglue only for caseless ammo, airtight uses like gas mask filters, and electronics but less fiddly uses seem reasonable to permit it.
6. Set composite bow recipes to all use `adhesive_proper` instead of `adhesive`, as the idea is the composite material is traditionally held together with horn glue, and also added them as components to composite greatbow and composite crossbow.
7. Misc: Fixed bagpipes recipe adding medical tape to components on top of adhesives requirement.
8. Updated demon cauldron recipe in Magiclysm to use `adhesive_proper` instead of just bone glue.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Mainlining tar oil and pitch from MST Extra so I have to remove my overrides to crafting qualities there instead of just updating them.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Ported changes to test build and load-tested.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
