### PR TITLE
fix: Sanity check worldname at input instead of confirmation

### DIFF
--- a/src/char_validity_check.cpp
+++ b/src/char_validity_check.cpp
@@ -30,17 +30,12 @@ bool is_char_allowed( int ch )
     }
 #endif
 
-    // Values outside 0-127 are unicode values (either part of a utf-8 sequence
-    // or a unicode codepoint), therefore OK. Negative values are allowed because
-    // `char` is usually signed. Also ensures that the argument to `std::isprint`
-    // is within 0-127 to avoid undefined behavior.
-    if( ch < 0 || ch >= 128 ) {
-        return true;
-    }
-    if( !std::isprint( ch ) ) {
+    if( !std::isprint( ch ) && ch <= 127 ) {
+        // above 127 are non-ASCII, therefore Unicode, therefore OK
         return false;
     }
-    if( ch == '\\' || ch == '/' ) {
+    if( ch == '<' || ch == '>' || ch == ':' || ch == '"' || ch == '\\' || ch == '/' || ch == '?' ||
+        ch == '|' || ch == '*' ) {
         // not valid in file names
         return false;
     }

--- a/src/char_validity_check.cpp
+++ b/src/char_validity_check.cpp
@@ -36,7 +36,7 @@ bool is_char_allowed( int ch )
     }
 
     if( ch == '/' ) {
-        // not valid in filenames for most operating systems
+        // not valid in filenames for most operating systems (Linux, MacOs, Windows, Android)
         return false;
     }
 
@@ -46,12 +46,11 @@ bool is_char_allowed( int ch )
         return false;
     }
 
-#if !defined(MACOSX)
+#if !defined(MACOSX) || !defined(__linux__)
     if( ch == '<' || ch == '>' || ch == '"' || ch == '\\' || ch == '?' || ch == '|' || ch == '*' ) {
         // not valid in Windows filenames
         return false;
     }
-    return true;
 
 #endif
 

--- a/src/char_validity_check.cpp
+++ b/src/char_validity_check.cpp
@@ -39,19 +39,19 @@ bool is_char_allowed( int ch )
         // not valid in filenames for most operating systems
         return false;
     }
-    
+
 #if !defined(__linux__)
     if( ch == ':' {
-        // not valid in macOS (Specific cases, best to be safe) and Windows filenames
-        return false;
-    }
+    // not valid in macOS (Specific cases, best to be safe) and Windows filenames
+    return false;
+}
 
 #if !defined(MACOSX)
-    if( ch == '<' || ch == '>' || ch == '"' || ch == '\\' || ch == '?' || ch == '|' || ch == '*' ) {
-        // not valid in Windows filenames
-        return false;
-    }
-    return true;
+if( ch == '<' || ch == '>' || ch == '"' || ch == '\\' || ch == '?' || ch == '|' || ch == '*' ) {
+    // not valid in Windows filenames
+    return false;
+}
+return true;
 
 #endif
 

--- a/src/char_validity_check.cpp
+++ b/src/char_validity_check.cpp
@@ -34,10 +34,27 @@ bool is_char_allowed( int ch )
         // above 127 are non-ASCII, therefore Unicode, therefore OK
         return false;
     }
-    if( ch == '<' || ch == '>' || ch == ':' || ch == '"' || ch == '\\' || ch == '/' || ch == '?' ||
-        ch == '|' || ch == '*' ) {
-        // not valid in file names
+
+    if( ch == '/' ) {
+        // not valid in filenames for most operating systems
+        return false;
+    }
+    
+#if !defined(__linux__)
+    if( ch == ':' {
+        // not valid in macOS (Specific cases, best to be safe) and Windows filenames
+        return false;
+    }
+
+#if !defined(MACOSX)
+    if( ch == '<' || ch == '>' || ch == '"' || ch == '\\' || ch == '?' || ch == '|' || ch == '*' ) {
+        // not valid in Windows filenames
         return false;
     }
     return true;
+
+#endif
+
+#endif
+
 }

--- a/src/char_validity_check.cpp
+++ b/src/char_validity_check.cpp
@@ -41,20 +41,20 @@ bool is_char_allowed( int ch )
     }
 
 #if !defined(__linux__)
-    if( ch == ':' {
-    // not valid in macOS (Specific cases, best to be safe) and Windows filenames
-    return false;
-}
+    if( ch == ':' ) {
+        // not valid in macOS (Specific cases, best to be safe) and Windows filenames
+        return false;
+    }
 
 #if !defined(MACOSX)
-if( ch == '<' || ch == '>' || ch == '"' || ch == '\\' || ch == '?' || ch == '|' || ch == '*' ) {
-    // not valid in Windows filenames
-    return false;
-}
-return true;
+    if( ch == '<' || ch == '>' || ch == '"' || ch == '\\' || ch == '?' || ch == '|' || ch == '*' ) {
+        // not valid in Windows filenames
+        return false;
+    }
+    return true;
 
 #endif
 
 #endif
-
+    return true;
 }

--- a/src/char_validity_check.cpp
+++ b/src/char_validity_check.cpp
@@ -41,19 +41,19 @@ bool is_char_allowed( int ch )
     }
 
 #if !defined(__linux__)
+#if defined(MACOSX)
     if( ch == ':' ) {
         // not valid in macOS (Specific cases, best to be safe) and Windows filenames
         return false;
     }
-
-#if !defined(MACOSX) || !defined(__linux__)
-    if( ch == '<' || ch == '>' || ch == '"' || ch == '\\' || ch == '?' || ch == '|' || ch == '*' ) {
+#else
+    if( ch == ':' || ch == '<' || ch == '>' || ch == '"' || ch == '\\' || ch == '?' || ch == '|' ||
+        ch == '*' ) {
         // not valid in Windows filenames
         return false;
     }
 
 #endif
-
 #endif
     return true;
 }

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -649,7 +649,6 @@ void input_context::clear_conflicting_keybindings( const input_event &event )
 
 const std::string CATA_ERROR = "ERROR";
 const std::string ANY_INPUT = "ANY_INPUT";
-const std::string ANY_PRINTABLE = "ANY_PRINTABLE";
 const std::string HELP_KEYBINDINGS = "HELP_KEYBINDINGS";
 const std::string COORDINATE = "COORDINATE";
 const std::string TIMEOUT = "TIMEOUT";
@@ -706,9 +705,6 @@ void input_context::register_action( const std::string &action_descriptor,
 {
     if( action_descriptor == "ANY_INPUT" ) {
         registered_any_input = true;
-    } else if( action_descriptor == "ANY_PRINTABLE" ) {
-        // ANY_PRINTABLE accepts any input, but will only print printable characters
-        registered_any_printable = true;
     } else if( action_descriptor == "COORDINATE" ) {
         handling_coordinate_input = true;
     }
@@ -946,12 +942,7 @@ const std::string &input_context::handle_input( const int timeout )
 
         // If we registered to receive any input, return ANY_INPUT
         // to signify that an unregistered key was pressed.
-        // ANY_PRINTABLE and ANY_INPUT are mutually exclusive,
-        // they both define how unregistered keys are handled.
-        if( registered_any_printable ) {
-            result = &ANY_PRINTABLE;
-            break;
-        } else if( registered_any_input ) {
+        if( registered_any_input ) {
             result = &ANY_INPUT;
             break;
         }
@@ -1142,12 +1133,12 @@ action_id input_context::display_menu( const bool permit_execute_action )
     input_manager::t_action_contexts old_action_contexts( inp_mngr.action_contexts );
     // current status: adding/removing/executing/showing keybindings
     enum { s_remove, s_add, s_add_global, s_execute, s_show } status = s_show;
-    // copy of registered_actions, but without the ANY_INPUT, COORDINATE and ANY_PRINTABLE, which should not be shown
+    // copy of registered_actions, but without the ANY_INPUT and COORDINATE, which should not be shown
     std::vector<std::string> org_registered_actions( registered_actions );
     org_registered_actions.erase( std::remove_if( org_registered_actions.begin(),
                                   org_registered_actions.end(),
     []( const std::string & a ) {
-        return a == ANY_INPUT || a == COORDINATE || a == ANY_PRINTABLE;
+        return a == ANY_INPUT || a == COORDINATE;
     } ), org_registered_actions.end() );
 
     // colors of the keybindings

--- a/src/input.h
+++ b/src/input.h
@@ -398,8 +398,8 @@ class input_context
         static std::list<input_context *> input_context_stack;
 #endif
 
-        input_context() : registered_any_input( false ), registered_any_printable( false ),
-            category( "default" ), coordinate_input_received( false ), handling_coordinate_input( false ) {
+        input_context() : registered_any_input( false ), category( "default" ),
+            coordinate_input_received( false ), handling_coordinate_input( false ) {
 #if defined(__ANDROID__)
             input_context_stack.push_back( this );
             allow_text_entry = false;
@@ -407,9 +407,8 @@ class input_context
         }
         // TODO: consider making the curses WINDOW an argument to the constructor, so that mouse input
         // outside that window can be ignored
-        input_context( const std::string &category ) : registered_any_input( false ),
-            registered_any_printable( false ), category( category ), coordinate_input_received( false ),
-            handling_coordinate_input( false ) {
+        input_context( const std::string &category ) : registered_any_input( false ), category( category ),
+            coordinate_input_received( false ), handling_coordinate_input( false ) {
 #if defined(__ANDROID__)
             input_context_stack.push_back( this );
             allow_text_entry = false;
@@ -714,8 +713,6 @@ class input_context
         const std::string &input_to_action( const input_event &inp ) const;
     private:
         bool registered_any_input;
-        // Only used in world factory to prevent unprintable names (that cannot be saved).
-        bool registered_any_printable;
         std::string category; // The input category this context uses.
         point coordinate;
         bool coordinate_input_received;

--- a/src/input.h
+++ b/src/input.h
@@ -398,8 +398,8 @@ class input_context
         static std::list<input_context *> input_context_stack;
 #endif
 
-        input_context() : registered_any_input( false ), category( "default" ),
-            coordinate_input_received( false ), handling_coordinate_input( false ) {
+        input_context() : registered_any_input( false ), registered_any_printable( false ),
+            category( "default" ), coordinate_input_received( false ), handling_coordinate_input( false ) {
 #if defined(__ANDROID__)
             input_context_stack.push_back( this );
             allow_text_entry = false;
@@ -408,7 +408,8 @@ class input_context
         // TODO: consider making the curses WINDOW an argument to the constructor, so that mouse input
         // outside that window can be ignored
         input_context( const std::string &category ) : registered_any_input( false ),
-            category( category ), coordinate_input_received( false ), handling_coordinate_input( false ) {
+            registered_any_printable( false ), category( category ), coordinate_input_received( false ),
+            handling_coordinate_input( false ) {
 #if defined(__ANDROID__)
             input_context_stack.push_back( this );
             allow_text_entry = false;
@@ -713,6 +714,8 @@ class input_context
         const std::string &input_to_action( const input_event &inp ) const;
     private:
         bool registered_any_input;
+        // Only used in world factory to prevent unprintable names (that cannot be saved).
+        bool registered_any_printable;
         std::string category; // The input category this context uses.
         point coordinate;
         bool coordinate_input_received;

--- a/src/string_editor_window.cpp
+++ b/src/string_editor_window.cpp
@@ -409,10 +409,6 @@ std::pair<bool, std::string> string_editor_window::query_string()
 
         const std::string action = ctxt->handle_input();
 
-        if( action != "ANY_INPUT" ) {
-            continue;
-        }
-
         const input_event ev = ctxt->get_raw_input();
         ch = ev.type == input_event_t::keyboard ? ev.get_first_input() : 0;
 

--- a/src/string_editor_window.cpp
+++ b/src/string_editor_window.cpp
@@ -409,8 +409,12 @@ std::pair<bool, std::string> string_editor_window::query_string()
 
         const std::string action = ctxt->handle_input();
 
+        if( action != "ANY_INPUT" ) {
+            continue;
+        }
+
         const input_event ev = ctxt->get_raw_input();
-        ch = ev.get_first_input();
+        ch = ev.type == input_event_t::keyboard ? ev.get_first_input() : 0;
 
         if( action == "TEXT.QUIT" ) {
             return { false, _utext.str() };

--- a/src/string_input_popup.cpp
+++ b/src/string_input_popup.cpp
@@ -350,7 +350,8 @@ int64_t string_input_popup::query_int64_t( const bool loop, const bool draw_only
     return std::atoll( query_string( loop, draw_only ).c_str() );
 }
 
-const std::string &string_input_popup::query_string( const bool loop, const bool draw_only )
+const std::string &string_input_popup::query_string( const bool loop, const bool draw_only,
+        const bool printable )
 {
     if( !custom_window && !w_full ) {
         create_window();
@@ -529,7 +530,7 @@ const std::string &string_input_popup::query_string( const bool loop, const bool
                 desc_view_ptr->page_down();
             }
         } else if( action == "TEXT.PASTE" || action == "TEXT.INPUT_FROM_FILE"
-                   || ( ( action == "ANY_INPUT" || action == "ANY_PRINTABLE" ) && !ev.text.empty() ) ) {
+                   || ( action == "ANY_INPUT" && !ev.text.empty() ) ) {
             // paste, input from file, or text input
             // bail out early if already at length limit
             if( _max_length <= 0 || ret.display_width() < static_cast<size_t>( _max_length ) ) {
@@ -562,7 +563,7 @@ const std::string &string_input_popup::query_string( const bool loop, const bool
                         if( _only_digits ? ch == '-' || isdigit( ch ) : mk_wcwidth( ch ) >= 0 ) {
                             const int newwidth = mk_wcwidth( ch );
                             // Filter out non-printable characters if necessary
-                            if( action == "ANY_PRINTABLE" && !is_char_allowed( ch ) ) {
+                            if( printable && !is_char_allowed( ch ) ) {
                                 break;
                             }
                             if( _max_length <= 0 || width + newwidth <= _max_length ) {

--- a/src/string_input_popup.h
+++ b/src/string_input_popup.h
@@ -244,7 +244,8 @@ class string_input_popup // NOLINT(cata-xy)
         void query( bool loop = true, bool draw_only = false );
         int query_int( bool loop = true, bool draw_only = false );
         int64_t query_int64_t( bool loop = true, bool draw_only = false );
-        const std::string &query_string( bool loop = true, bool draw_only = false );
+        const std::string &query_string( bool loop = true, bool draw_only = false,
+                                         bool printable = false );
         /**@}*/
         /**
          * Whether the input box was canceled via the ESCAPE key (or similar)

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -1388,9 +1388,7 @@ int worldfactory::show_worldgen_tab_confirm( const catacurses::window &win, WORL
 #endif
     ctxt.register_action( "TEXT.INPUT_FROM_FILE" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
-    // Literally the only place this is used right now
-    // Basically makes sure you can't have unprintable unicode chars in your world name.
-    ctxt.register_action( "ANY_PRINTABLE" );
+    ctxt.register_action( "ANY_INPUT" );
 
     const auto init_windows = [&]( ui_adaptor & ui ) {
         const int iTooltipHeight = 1;
@@ -1446,7 +1444,7 @@ int worldfactory::show_worldgen_tab_confirm( const catacurses::window &win, WORL
     do {
         ui_manager::redraw();
 
-        worldname = spopup.query_string( false );
+        worldname = spopup.query_string( false, false, true );
         const std::string action = ctxt.input_to_action( ctxt.get_raw_input() );
         if( action == "NEXT_TAB" ) {
             if( worldname.empty() ) {

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -1590,6 +1590,8 @@ bool worldfactory::valid_worldname( const std::string &name, bool automated )
         msg = string_format( _( "%s is a reserved name!" ), name );
     } else if( has_world( name ) ) {
         msg = string_format( _( "A world named %s already exists!" ), name );
+    } else if( name.front() == ' ' || name.back() == ' ' ) {
+        msg = string_format( _( "A world name cannot start or end with spaces!" ) );
     } else {
         return true;
     }

--- a/tests/char_validity_check_test.cpp
+++ b/tests/char_validity_check_test.cpp
@@ -4,21 +4,25 @@
 
 TEST_CASE( "char_validity_check" )
 {
+    CHECK( is_char_allowed( ' ' ) == true );
+    CHECK( is_char_allowed( '!' ) == true );
     CHECK( is_char_allowed( '\0' ) == false );
     CHECK( is_char_allowed( '\b' ) == false );
     CHECK( is_char_allowed( '\t' ) == false );
     CHECK( is_char_allowed( '\n' ) == false );
     CHECK( is_char_allowed( '\r' ) == false );
     CHECK( is_char_allowed( '\xa0' ) == false );
+    CHECK( is_char_allowed( '/' ) == false );
+#if !defined(__linux__)
+    CHECK( is_char_allowed( ':' ) == false );
+#if !defined(MACOSX)
     CHECK( is_char_allowed( '<' ) == false );
     CHECK( is_char_allowed( '>' ) == false );
-    CHECK( is_char_allowed( ':' ) == false );
     CHECK( is_char_allowed( '"' ) == false );
     CHECK( is_char_allowed( '\\' ) == false );
-    CHECK( is_char_allowed( '/' ) == false );
     CHECK( is_char_allowed( '?' ) == false );
     CHECK( is_char_allowed( '|' ) == false );
     CHECK( is_char_allowed( '*' ) == false );
-    CHECK( is_char_allowed( ' ' ) == true );
-    CHECK( is_char_allowed( '!' ) == true );
+#endif
+#endif
 }

--- a/tests/char_validity_check_test.cpp
+++ b/tests/char_validity_check_test.cpp
@@ -13,9 +13,28 @@ TEST_CASE( "char_validity_check" )
     CHECK( is_char_allowed( '\r' ) == false );
     CHECK( is_char_allowed( '\xa0' ) == false );
     CHECK( is_char_allowed( '/' ) == false );
-#if !defined(__linux__)
+#if defined(__linux__)
+    CHECK( is_char_allowed( ':' ) == true );
+    CHECK( is_char_allowed( '<' ) == true );
+    CHECK( is_char_allowed( '>' ) == true );
+    CHECK( is_char_allowed( '"' ) == true );
+    CHECK( is_char_allowed( '\\' ) == true );
+    CHECK( is_char_allowed( '?' ) == true );
+    CHECK( is_char_allowed( '|' ) == true );
+    CHECK( is_char_allowed( '*' ) == true );
+#endif
+#if defined(MACOSX)
     CHECK( is_char_allowed( ':' ) == false );
-#if !defined(MACOSX)
+    CHECK( is_char_allowed( '<' ) == true );
+    CHECK( is_char_allowed( '>' ) == true );
+    CHECK( is_char_allowed( '"' ) == true );
+    CHECK( is_char_allowed( '\\' ) == true );
+    CHECK( is_char_allowed( '?' ) == true );
+    CHECK( is_char_allowed( '|' ) == true );
+    CHECK( is_char_allowed( '*' ) == true );
+#endif
+#if !defined(__linux__) || !defined(MACOSX) // Catches Windows and Android(+unknown cases)
+    CHECK( is_char_allowed( ':' ) == false );
     CHECK( is_char_allowed( '<' ) == false );
     CHECK( is_char_allowed( '>' ) == false );
     CHECK( is_char_allowed( '"' ) == false );
@@ -23,6 +42,5 @@ TEST_CASE( "char_validity_check" )
     CHECK( is_char_allowed( '?' ) == false );
     CHECK( is_char_allowed( '|' ) == false );
     CHECK( is_char_allowed( '*' ) == false );
-#endif
 #endif
 }

--- a/tests/char_validity_check_test.cpp
+++ b/tests/char_validity_check_test.cpp
@@ -22,8 +22,7 @@ TEST_CASE( "char_validity_check" )
     CHECK( is_char_allowed( '?' ) == true );
     CHECK( is_char_allowed( '|' ) == true );
     CHECK( is_char_allowed( '*' ) == true );
-#endif
-#if defined(MACOSX)
+#elif defined(MACOSX)
     CHECK( is_char_allowed( ':' ) == false );
     CHECK( is_char_allowed( '<' ) == true );
     CHECK( is_char_allowed( '>' ) == true );
@@ -32,8 +31,7 @@ TEST_CASE( "char_validity_check" )
     CHECK( is_char_allowed( '?' ) == true );
     CHECK( is_char_allowed( '|' ) == true );
     CHECK( is_char_allowed( '*' ) == true );
-#endif
-#if !defined(__linux__) || !defined(MACOSX) // Catches Windows and Android(+unknown cases)
+#else
     CHECK( is_char_allowed( ':' ) == false );
     CHECK( is_char_allowed( '<' ) == false );
     CHECK( is_char_allowed( '>' ) == false );

--- a/tests/char_validity_check_test.cpp
+++ b/tests/char_validity_check_test.cpp
@@ -10,9 +10,15 @@ TEST_CASE( "char_validity_check" )
     CHECK( is_char_allowed( '\n' ) == false );
     CHECK( is_char_allowed( '\r' ) == false );
     CHECK( is_char_allowed( '\xa0' ) == false );
+    CHECK( is_char_allowed( '<' ) == false );
+    CHECK( is_char_allowed( '>' ) == false );
+    CHECK( is_char_allowed( ':' ) == false );
+    CHECK( is_char_allowed( '"' ) == false );
     CHECK( is_char_allowed( '\\' ) == false );
     CHECK( is_char_allowed( '/' ) == false );
+    CHECK( is_char_allowed( '?' ) == false );
+    CHECK( is_char_allowed( '|' ) == false );
+    CHECK( is_char_allowed( '*' ) == false );
     CHECK( is_char_allowed( ' ' ) == true );
-    CHECK( is_char_allowed( '?' ) == true );
     CHECK( is_char_allowed( '!' ) == true );
 }

--- a/tests/char_validity_check_test.cpp
+++ b/tests/char_validity_check_test.cpp
@@ -9,6 +9,7 @@ TEST_CASE( "char_validity_check" )
     CHECK( is_char_allowed( '\t' ) == false );
     CHECK( is_char_allowed( '\n' ) == false );
     CHECK( is_char_allowed( '\r' ) == false );
+    CHECK( is_char_allowed( '\xa0' ) == false );
     CHECK( is_char_allowed( '\\' ) == false );
     CHECK( is_char_allowed( '/' ) == false );
     CHECK( is_char_allowed( ' ' ) == true );


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

- Related to #4713.
- Revert #4918 (for the modifications to `is_char_allowed()` were better at silencing errors than catching true issues) update the game so that we now have a way to feed the string input popup printable, file/foldername safe characters only through `ANY_PRINTABLE` (name subject to change)
- Hopefully resolve #4816 (Hopefully because I don't know how to even produce the error, so maybe someone like scarf can test it) If it does, please link it back to this PR as fixed by, thank you.

## Describe the solution

~~Use new input context `ANY_PRINTABLE` that acts like `ANY_INPUT` except when it comes to text output. It prevents non-printable and non-file/folder name safe characters from being printed into textboxes to prevent world names from being impossible to save.~~

Give `query_string()` another variable to define if it should only allow printable characters. Should be much simpler than the old solution I was doing after being awake for about 14 hours.

Tear out the check at the confirmation end, it wasn't doing it's job and it shouldn't be doing it's job so late to begin with.

## Describe alternatives you've considered

- Kill myself.

## Testing

- [x] Type word salad Chinese into the world name box, as I cannot see what characters I am selecting, only the pinyin. Check that it allows me to save the world properly.
- [x] Check that [forbidden characters](https://stackoverflow.com/questions/1976007/what-characters-are-forbidden-in-windows-and-linux-directory-names) are not allowed in worldname (Linux has fewer but I don't really know how to make them differ by version)
- [x] Test that you also cannot paste forbidden characters.

<img width="152" alt="image" src="https://github.com/cataclysmbnteam/Cataclysm-BN/assets/102964889/4de18231-71f4-4ec5-9b64-d7da3ae8140a">
