### PR TITLE
feat(balance): sanity-check and rebalance mushroom farming, culture is easier to make, mushroom racks can be planted on via examine

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -3775,7 +3775,7 @@
     "required_skills": [ [ "fabrication", 3 ] ],
     "time": "5 m",
     "qualities": [ [ { "id": "HAMMER", "level": 1 } ], [ { "id": "SAW_W", "level": 1 } ] ],
-    "components": [ [ [ "2x4", 6 ] ], [ [ "bag_canvas", 1 ] ], [ [ "nail", 8 ] ] ],
+    "components": [ [ [ "2x4", 6 ], [ "log", 1 ] ], [ [ "nail_glue", 8, "LIST" ] ] ],
     "pre_special": "check_empty",
     "post_furniture": "f_rack_mushroom"
   },

--- a/data/json/furniture_and_terrain/furniture-domestic_plants.json
+++ b/data/json/furniture_and_terrain/furniture-domestic_plants.json
@@ -316,6 +316,7 @@
       "sound_fail": "whump.",
       "items": [ { "item": "2x4", "count": [ 0, 6 ] }, { "item": "nail", "charges": [ 0, 8 ] }, { "item": "rag", "count": [ 0, 12 ] } ]
     },
+    "examine_action": "dirtmound",
     "plant_data": { "transform": "f_rack_mushroom_seed" }
   },
   {

--- a/data/json/items/comestibles/mushroom.json
+++ b/data/json/items/comestibles/mushroom.json
@@ -9,6 +9,7 @@
     "price": "150 cent",
     "price_postapoc": "50 cent",
     "fun": 1,
+    "charges": 1,
     "vitamins": [ [ "vitC", 4 ], [ "iron", 7 ] ],
     "delete": { "flags": [ "RAW" ] }
   },
@@ -30,6 +31,7 @@
     "material": "mushroom",
     "volume": "250 ml",
     "fun": 1,
+    "charges": 6,
     "flags": [ "SMOKABLE", "UNSAFE_CONSUME" ],
     "smoking_result": "dry_mushroom",
     "vitamins": [ [ "calcium", 2 ], [ "iron", 52 ] ]
@@ -45,6 +47,7 @@
     "price": 1500,
     "price_postapoc": 50,
     "fun": 4,
+    "charges": 1,
     "vitamins": [ [ "calcium", 2 ], [ "iron", 52 ] ],
     "delete": { "flags": [ "UNSAFE_CONSUME" ] }
   },
@@ -98,6 +101,7 @@
     "material": "mushroom",
     "volume": "250 ml",
     "fun": -3,
+    "charges": 10,
     "flags": [ "SMOKABLE", "FORAGE_POISON", "FORAGE_HALLU", "RAW" ],
     "smoking_result": "dry_mushroom",
     "vitamins": [ [ "vitC", 2 ], [ "iron", 2 ] ]

--- a/data/json/items/comestibles/seed.json
+++ b/data/json/items/comestibles/seed.json
@@ -787,15 +787,8 @@
     "color": "light_gray",
     "id": "mushroom_culture",
     "copy-from": "seed",
-    "description": "A wet plant chunk, suitable for growing your own mushrooms.  You need to \"plant\" it on logs or racks to grow though.",
-    "seed_data": {
-      "plant_name": "mushroom",
-      "fruit": "mushroom",
-      "fruit_div": 2,
-      "seeds": false,
-      "required_terrain_flag": "MUSHROOM_PLANTABLE",
-      "grow": "28 days"
-    }
+    "description": "A chunk of compost laden with spores and mycelium, for growing your own mushrooms.  You'll need to \"plant\" these on tree trunks, or dedicated mushroom racks, for it to grow.",
+    "seed_data": { "plant_name": "mushroom", "fruit": "mushroom", "required_terrain_flag": "MUSHROOM_PLANTABLE", "grow": "14 days" }
   },
   {
     "type": "COMESTIBLE",
@@ -811,12 +804,12 @@
     "flags": [ "NUTRIENT_OVERRIDE", "PLANTABLE_SEED", "UNSAFE_CONSUME" ],
     "id": "mushroom_morel_culture",
     "copy-from": "seed",
-    "description": "A wet plant chunk, suitable for growing your own morel mushrooms.  You need to \"plant\" it on logs or racks to grow.",
+    "description": "A chunk of compost laden with spores and mycelium, for growing your own morel mushrooms.  You'll need to \"plant\" these on tree trunks, or dedicated mushroom racks, for it to grow.",
     "seed_data": {
       "plant_name": "morel mushroom",
       "required_terrain_flag": "MUSHROOM_PLANTABLE",
       "fruit": "mushroom_morel",
-      "grow": "42 days"
+      "grow": "14 days"
     }
   }
 ]

--- a/data/json/recipes/food/seeds.json
+++ b/data/json/recipes/food/seeds.json
@@ -522,26 +522,26 @@
     "skills_required": [ "cooking", 4 ],
     "difficulty": 4,
     "time": "15 m",
-    "autolearn": false,
-    "book_learn": [ [ "pocket_survival", 4 ], [ "textbook_survival", 4 ], [ "atomic_survival", 4 ], [ "survival_book", 4 ] ],
+    "autolearn": true,
+    "book_learn": [ [ "pocket_survival", 3 ], [ "textbook_survival", 3 ], [ "atomic_survival", 3 ], [ "survival_book", 3 ] ],
     "batch_time_factors": [ 50, 3 ],
     "qualities": [ { "id": "COOK", "level": 3 }, { "id": "BOIL", "level": 1 }, { "id": "CUT", "level": 1 } ],
-    "tools": [ [ [ "surface_heat", 100, "LIST" ] ] ],
+    "tools": [ [ [ "surface_heat", 10, "LIST" ] ] ],
     "components": [
       [
-        [ "stick", 2 ],
+        [ "stick", 1 ],
         [ "2x4", 1 ],
         [ "splinter", 8 ],
-        [ "paper", 1000 ],
-        [ "cardboard", 200 ],
-        [ "tinder", 200 ],
-        [ "withered", 100 ],
-        [ "fertilizer_liquid", 3 ],
+        [ "paper", 100 ],
+        [ "cardboard", 20 ],
+        [ "withered", 10 ],
+        [ "straw_pile", 10 ],
+        [ "fertilizer_liquid", 1 ],
         [ "fertilizer_commercial", 1 ],
         [ "cattlefodder", 1 ]
       ],
-      [ [ "mushroom", 5 ] ],
-      [ [ "water_clean", 30 ], [ "water", 30 ] ]
+      [ [ "mushroom", 1 ] ],
+      [ [ "water_clean", 3 ], [ "water", 3 ] ]
     ]
   },
   {
@@ -553,8 +553,8 @@
     "skills_required": [ "cooking", 5 ],
     "difficulty": 6,
     "time": "15 m",
-    "autolearn": false,
-    "book_learn": [ [ "pocket_survival", 6 ], [ "textbook_survival", 6 ], [ "atomic_survival", 6 ], [ "survival_book", 6 ] ],
+    "autolearn": true,
+    "book_learn": [ [ "pocket_survival", 5 ], [ "textbook_survival", 5 ], [ "atomic_survival", 5 ], [ "survival_book", 5 ] ],
     "batch_time_factors": [ 50, 3 ],
     "qualities": [ { "id": "COOK", "level": 3 }, { "id": "BOIL", "level": 1 }, { "id": "CUT", "level": 1 } ],
     "tools": [ [ [ "surface_heat", 100, "LIST" ] ] ],
@@ -571,8 +571,8 @@
         [ "fertilizer_commercial", 1 ],
         [ "cattlefodder", 1 ]
       ],
-      [ [ "mushroom_morel", 2 ] ],
-      [ [ "water_clean", 30 ], [ "water", 30 ] ]
+      [ [ "mushroom_morel", 1 ] ],
+      [ [ "water_clean", 3 ], [ "water", 3 ] ]
     ]
   }
 ]


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Some needed followups to https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4927 to sanity-check some things.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Added the `dirtmound` examine action to mushroom racks. Turns out it works fine here because it lacks the `PLANTABLE` flag, and thus it'll correctly only allow you to plant shrooms on it.
2. Bumped default `charges` of mushrooms up, 10 for regular shrooms and 6 for morels, as this it seems was the intent behind the accidental change to dried mushrooms in said PR. Now farming is actually worth it.
3. Made mushroom culture consistent, both now give culture as seeds and used the standard default growth rate instead of the much bigger values that were given (back to same values spores had). Also reworked description to give a clearer idea of what these items actually are and how to use them.
4. Sanity-checked recipes for mushroom cultures, no longer requiring gigantic amounts of components and devouring unreasonable numbers of shrooms to start your own farm, and also made them autolearn as is standard for seed recipes.
5. Updated construction to be a bit less hassle, mainly allowing other options for wood and including the `wood_glue` crafting quality, and axed the canvas bag requirement since regular planters don't need a liner either (and this is likely mainly growing on wood).

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build, confirmed that you can `e` on mushroom racks but only mushroom cultures are considered viable to plant on them.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

I still desire to allow planting shrooms underground, but this will be a bit more of a fiddly code change. Looking into it, changing how `warm_enough_to_plant` itself is defined would be the ideal solution, but it seems that there's both a tripoint and a `tripoint_abs_omt` version and I'm not sure how to make the latter check things like `has_flag_ter_or_furn`.