### PR TITLE
feat: can now plant mushrooms underground

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -162,6 +162,12 @@
     "context": [ "GENERIC" ]
   },
   {
+    "id": "CAN_PLANT_UNDERGROUND",
+    "type": "json_flag",
+    "context": [ "COMESTIBLE" ],
+    "info": "This seed can be <good>planted underground</good>."
+  },
+  {
     "id": "CANT_HEAL_EVERYONE",
     "type": "json_flag",
     "context": [ "COMESTIBLE" ],

--- a/data/json/items/comestibles/seed.json
+++ b/data/json/items/comestibles/seed.json
@@ -416,7 +416,7 @@
     "volume": "100 ml",
     "stack_size": 10,
     "fun": 30,
-    "flags": [ "UNSAFE_CONSUME" ],
+    "flags": [ "UNSAFE_CONSUME", "CAN_PLANT_UNDERGROUND" ],
     "seed_data": { "fruit": "null", "//": "dummy entry, results are hardcoded", "plant_name": "marloss berry", "grow": "14 days" }
   },
   {
@@ -788,7 +788,8 @@
     "id": "mushroom_culture",
     "copy-from": "seed",
     "description": "A chunk of compost laden with spores and mycelium, for growing your own mushrooms.  You'll need to \"plant\" these on tree trunks, or dedicated mushroom racks, for it to grow.",
-    "seed_data": { "plant_name": "mushroom", "fruit": "mushroom", "required_terrain_flag": "MUSHROOM_PLANTABLE", "grow": "14 days" }
+    "seed_data": { "plant_name": "mushroom", "fruit": "mushroom", "required_terrain_flag": "MUSHROOM_PLANTABLE", "grow": "14 days" },
+    "extend": { "flags": [ "CAN_PLANT_UNDERGROUND" ] }
   },
   {
     "type": "COMESTIBLE",
@@ -801,7 +802,6 @@
     "primary_material": "mushroom",
     "symbol": ".",
     "color": "light_gray",
-    "flags": [ "NUTRIENT_OVERRIDE", "PLANTABLE_SEED", "UNSAFE_CONSUME" ],
     "id": "mushroom_morel_culture",
     "copy-from": "seed",
     "description": "A chunk of compost laden with spores and mycelium, for growing your own morel mushrooms.  You'll need to \"plant\" these on tree trunks, or dedicated mushroom racks, for it to grow.",
@@ -810,6 +810,7 @@
       "required_terrain_flag": "MUSHROOM_PLANTABLE",
       "fruit": "mushroom_morel",
       "grow": "14 days"
-    }
+    },
+    "extend": { "flags": [ "CAN_PLANT_UNDERGROUND" ] }
   }
 ]

--- a/doc/src/content/docs/en/mod/json/reference/json_flags.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_flags.md
@@ -461,8 +461,8 @@ to find which flags work elsewhere.
 
 - `ACID` when consumed using the BLECH function, penalties are reduced if acidproof.
 - `CARNIVORE_OK` Can be eaten by characters with the Carnivore mutation.
-- `CAN_PLANT_UNDERGROUND` If this is a seed, it can be planted when below z-level zero,
-  regardless of the ambient temperature.
+- `CAN_PLANT_UNDERGROUND` If this is a seed, it can be planted when below z-level zero, regardless
+  of the ambient temperature.
 - `CANT_HEAL_EVERYONE` This med can't be used by everyone, it require a special mutation. See
   `can_heal_with` in mutation.
 - `EATEN_COLD` Morale bonus for eating cold.

--- a/doc/src/content/docs/en/mod/json/reference/json_flags.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_flags.md
@@ -461,6 +461,8 @@ to find which flags work elsewhere.
 
 - `ACID` when consumed using the BLECH function, penalties are reduced if acidproof.
 - `CARNIVORE_OK` Can be eaten by characters with the Carnivore mutation.
+- `CAN_PLANT_UNDERGROUND` If this is a seed, it can be planted when below z-level zero,
+  regardless of the ambient temperature.
 - `CANT_HEAL_EVERYONE` This med can't be used by everyone, it require a special mutation. See
   `can_heal_with` in mutation.
 - `EATEN_COLD` Morale bonus for eating cold.

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -62,6 +62,7 @@ enum class do_activity_reason : int {
     NEEDS_PLANTING,         // For farming - tile can be planted
     NEEDS_TILLING,          // For farming - tile can be tilled
     NEEDS_WARM_WEATHER,     // For farming - need warm weather to plant
+    NEEDS_ABOVE_GROUND,     // For farming - can't plant seeds lacking `CAN_PLANT_UNDERGROUND` flag below z-level 0
     BLOCKING_TILE,           // Something has made it's way onto the tile, so the activity cannot proceed
     NEEDS_CHOPPING,         // There is wood there to be chopped
     NEEDS_TREE_CHOPPING,    // There is a tree there that needs to be chopped

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1648,6 +1648,8 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
                     return activity_reason_info::fail( do_activity_reason::BLOCKING_TILE );
                 } else if( !warm_enough_to_plant( src_loc ) ) {
                     return activity_reason_info::fail( do_activity_reason::NEEDS_WARM_WEATHER );
+                } else if( !seed.obj().has_flag( flag_CAN_PLANT_UNDERGROUND ) && src_loc.z < 0 ) {
+                    return activity_reason_info::fail( do_activity_reason::NEEDS_ABOVE_GROUND );
                 } else {
                     // do we have the required seed on our person?
                     // If its a farm zone with no specified seed, and we've checked for tilling and harvesting.
@@ -2709,6 +2711,7 @@ static requirement_check_result generic_multi_activity_check_requirement( player
         reason == do_activity_reason::ALREADY_DONE ||
         reason == do_activity_reason::BLOCKING_TILE ||
         reason == do_activity_reason::NEEDS_WARM_WEATHER ||
+        reason == do_activity_reason::NEEDS_ABOVE_GROUND ||
         reason == do_activity_reason::UNKNOWN_ACTIVITY ) {
         // we can discount this tile, the work can't be done.
         if( reason == do_activity_reason::DONT_HAVE_SKILL ) {
@@ -2717,6 +2720,8 @@ static requirement_check_result generic_multi_activity_check_requirement( player
             p.add_msg_if_player( m_info, _( "There is something blocking the location for this task." ) );
         } else if( reason == do_activity_reason::NEEDS_WARM_WEATHER ) {
             p.add_msg_if_player( m_info, _( "It is too cold to plant anything now." ) );
+        } else if( reason == do_activity_reason::NEEDS_ABOVE_GROUND ) {
+            p.add_msg_if_player( m_info, _( "You can't plant this type of seed underground." ) );
         }
         return SKIP_LOCATION;
     } else if( reason == do_activity_reason::NO_COMPONENTS ||

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1649,7 +1649,8 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
                 } else if( !warm_enough_to_plant( src_loc ) ) {
                     return activity_reason_info::fail( do_activity_reason::NEEDS_WARM_WEATHER );
                     // Plants underground need to be either valid to plant underground, or given artificial heating
-                } else if( !seed.obj().has_flag( flag_CAN_PLANT_UNDERGROUND ) && src_loc.z < 0 && get_weather().get_temperature( src_loc ) < 10_c ) {
+                } else if( !seed.obj().has_flag( flag_CAN_PLANT_UNDERGROUND ) && src_loc.z < 0 &&
+                           get_weather().get_temperature( src_loc ) < 10_c ) {
                     return activity_reason_info::fail( do_activity_reason::NEEDS_ABOVE_GROUND );
                 } else {
                     // do we have the required seed on our person?
@@ -2722,7 +2723,8 @@ static requirement_check_result generic_multi_activity_check_requirement( player
         } else if( reason == do_activity_reason::NEEDS_WARM_WEATHER ) {
             p.add_msg_if_player( m_info, _( "It is too cold to plant anything now." ) );
         } else if( reason == do_activity_reason::NEEDS_ABOVE_GROUND ) {
-            p.add_msg_if_player( m_info, _( "It's too cold down here to plant this type of seed underground." ) );
+            p.add_msg_if_player( m_info,
+                                 _( "It's too cold down here to plant this type of seed underground." ) );
         }
         return SKIP_LOCATION;
     } else if( reason == do_activity_reason::NO_COMPONENTS ||

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1648,7 +1648,8 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
                     return activity_reason_info::fail( do_activity_reason::BLOCKING_TILE );
                 } else if( !warm_enough_to_plant( src_loc ) ) {
                     return activity_reason_info::fail( do_activity_reason::NEEDS_WARM_WEATHER );
-                } else if( !seed.obj().has_flag( flag_CAN_PLANT_UNDERGROUND ) && src_loc.z < 0 ) {
+                    // Plants underground need to be either valid to plant underground, or given artificial heating
+                } else if( !seed.obj().has_flag( flag_CAN_PLANT_UNDERGROUND ) && src_loc.z < 0 && get_weather().get_temperature( src_loc ) < 10_c ) {
                     return activity_reason_info::fail( do_activity_reason::NEEDS_ABOVE_GROUND );
                 } else {
                     // do we have the required seed on our person?
@@ -2721,7 +2722,7 @@ static requirement_check_result generic_multi_activity_check_requirement( player
         } else if( reason == do_activity_reason::NEEDS_WARM_WEATHER ) {
             p.add_msg_if_player( m_info, _( "It is too cold to plant anything now." ) );
         } else if( reason == do_activity_reason::NEEDS_ABOVE_GROUND ) {
-            p.add_msg_if_player( m_info, _( "You can't plant this type of seed underground." ) );
+            p.add_msg_if_player( m_info, _( "It's too cold down here to plant this type of seed underground." ) );
         }
         return SKIP_LOCATION;
     } else if( reason == do_activity_reason::NO_COMPONENTS ||

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -49,6 +49,7 @@ const flag_id flag_BUTCHER_RACK( "BUTCHER_RACK" );
 const flag_id flag_BYPRODUCT( "BYPRODUCT" );
 const flag_id flag_CABLE_SPOOL( "CABLE_SPOOL" );
 const flag_id flag_CAMERA_PRO( "CAMERA_PRO" );
+const flag_id flag_CAN_PLANT_UNDERGROUND( "CAN_PLANT_UNDERGROUND" );
 const flag_id flag_CANNIBAL( "CANNIBAL" );
 const flag_id flag_CANNIBALISM( "CANNIBALISM" );
 const flag_id flag_CANT_HEAL_EVERYONE( "CANT_HEAL_EVERYONE" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -52,6 +52,7 @@ extern const flag_id flag_BUTCHER_RACK;
 extern const flag_id flag_BYPRODUCT;
 extern const flag_id flag_CABLE_SPOOL;
 extern const flag_id flag_CAMERA_PRO;
+extern const flag_id flag_CAN_PLANT_UNDERGROUND;
 extern const flag_id flag_CANNIBAL;
 extern const flag_id flag_CANNIBALISM;
 extern const flag_id flag_CANT_HEAL_EVERYONE;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2218,6 +2218,11 @@ void iexamine::dirtmound( player &p, const tripoint &examp )
     }
     const auto &seed_id = std::get<0>( seed_entries[seed_index] );
 
+    if( !seed_id.obj().has_flag( flag_CAN_PLANT_UNDERGROUND ) && examp.z < 0 ) {
+        add_msg( _( "You can't plant this type of seed underground." ) );
+        return;
+    }
+
     if( !here.has_flag_ter_or_furn( seed_id->seed->required_terrain_flag, examp ) ) {
         add_msg( _( "This type of seed can not be planted in this location." ) );
         return;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2219,7 +2219,8 @@ void iexamine::dirtmound( player &p, const tripoint &examp )
     const auto &seed_id = std::get<0>( seed_entries[seed_index] );
 
     // Separate temp check because for now we permit growing regular plants underground with artificial heating
-    if( !seed_id.obj().has_flag( flag_CAN_PLANT_UNDERGROUND ) && examp.z < 0 && get_weather().get_temperature( examp ) < 10_c ) {
+    if( !seed_id.obj().has_flag( flag_CAN_PLANT_UNDERGROUND ) && examp.z < 0 &&
+        get_weather().get_temperature( examp ) < 10_c ) {
         add_msg( _( "It's too cold down here to plant this type of seed underground." ) );
         return;
     }

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2218,8 +2218,9 @@ void iexamine::dirtmound( player &p, const tripoint &examp )
     }
     const auto &seed_id = std::get<0>( seed_entries[seed_index] );
 
-    if( !seed_id.obj().has_flag( flag_CAN_PLANT_UNDERGROUND ) && examp.z < 0 ) {
-        add_msg( _( "You can't plant this type of seed underground." ) );
+    // Separate temp check because for now we permit growing regular plants underground with artificial heating
+    if( !seed_id.obj().has_flag( flag_CAN_PLANT_UNDERGROUND ) && examp.z < 0 && get_weather().get_temperature( examp ) < 10_c ) {
+        add_msg( _( "It's too cold down here to plant this type of seed underground." ) );
         return;
     }
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5413,7 +5413,8 @@ void vehicle::idle( bool on_map )
         engine_on = false;
     }
 
-    if( !warm_enough_to_plant( g->u.pos() ) ) {
+    // Disallow running a planter underground for now
+    if( !warm_enough_to_plant( g->u.pos() ) || global_pos3().z < 0 ) {
         for( const vpart_reference &vp : get_enabled_parts( "PLANTER" ) ) {
             if( g->u.sees( global_pos3() ) ) {
                 add_msg( _( "The %s's planter turns off due to low temperature." ), name );

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -644,7 +644,9 @@ bool vehicle::can_enable( const vehicle_part &pt, bool alert ) const
         return false;
     }
 
-    if( pt.info().has_flag( "PLANTER" ) && !warm_enough_to_plant( g->u.pos() ) ) {
+    // Disallow running a planter underground for now
+    if( pt.info().has_flag( "PLANTER" ) && ( !warm_enough_to_plant( g->u.pos() ) ||
+            global_pos3().z < 0 ) ) {
         if( alert ) {
             add_msg( m_bad, _( "It is too cold to plant anything now." ) );
         }

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -1031,12 +1031,13 @@ rl_vec2d convert_wind_to_coord( const int angle )
 bool warm_enough_to_plant( const tripoint &pos )
 {
     // semi-appropriate temperature for most plants
-    return get_weather().get_temperature( pos ) >= 10_c;
+    // exclude underground areas as we check that later
+    return ( get_weather().get_temperature( pos ) >= 10_c || pos.z < 0 );
 }
 
 bool warm_enough_to_plant( const tripoint_abs_omt &pos )
 {
-    return get_weather().get_temperature( pos ) >= 10_c;
+    return ( get_weather().get_temperature( pos ) >= 10_c || pos.z() < 0 );
 }
 
 weather_manager::weather_manager()


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This continues the follow-ups from the mushroom overhaul by adding support for planting stuff underground, and allowing you to grow shrooms underground. This WAS going to also close the exploit of being able to grow anything underground if you provide heating but I was talked into hacking my way around leaving the loophole in, so mushrooms mainly benefit from not having to set up a space heater or build near lava to work underground.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

C++ changes:
1. In activity_item_handling.cpp and activity_handlers.h, added separate handling of planting seeds while farming to `can_do_activity_there` and `generic_multi_activity_check_requirement`, where seeds no longer consider it too cold to plant if the target location is underground, and instead trigger `do_activity_reason::NEEDS_ABOVE_GROUND` as a failure reason if underground and trying to plant seeds without the `CAN_PLANT_UNDERGROUND` flag. Per feedback, it also checks temp again during this to enable planting other stuff underground if heating is provided.
2. Added definition of `CAN_PLANT_UNDERGROUND` to flag.cpp and flag.h.
3. In iexamine.cpp, changed up `iexamine::dirtmound` so that a separate failure condition now exists for mounds/planters being examined underground, failing if you pick a seed that can't be grown underground. Per feedback, it also checks temp again during this to enable planting other stuff underground if heating is provided.
4. In vehicle.cpp and vehicle_part.cpp, changed planter vehiclepart handling in `vehicle::idle` and `vehicle::can_enable` so that planters don't work underground. As for the reason for all of the above, well...
5. In weather.cpp, set `warm_enough_to_plant` to no longer consider underground locations as invalid, meaning all of the above conditions now automatically pass the "is it warm enough to plant" check if you're doing it underground. This is because handling of underground plants now depends on whether the seed you're trying to plant can be planted underground.

JSON changes:
1. Added JSON flag defintion for `CAN_PLANT_UNDERGROUND`
2. Added `CAN_PLANT_UNDERGROUND` to mushroom cultures, morel mushroom cultures, and as bonus lulz marloss seeds.

Doc changes:
1. Added documentation of `CAN_PLANT_UNDERGROUND` to json_flags.md.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Converting `required_terrain_flag` to an array so that marloss plants can be planted in either planters or mushroom racks.
2. Allowing you to run planter vehicles underground if you somehow get mounds of dirt down there. We'd need planters you can drive over though for this to actually be practical in practice...
3. Removing the light restriction from working on farm plots in the dark, as light level already doesn't restrict you from working on them via iexamine.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON files for syntax and lint errors.
2. Compiled and load-tested.
3. Tried examining planters and mushroom racks underground, I'm allowed to plant shrooms but not the corn.
4. Went back to the surface, can still plant either in summer but not spring.
5. Repeated above tests but with farm plot zones placed over planters and mushroom racks, both work as expected.
6. Spawned in a planter tractor both above and below ground, can still turn the planter on when above-ground and the weather's warm, while can't turn it on underground.
7. Spawned in some lava to heat things up, confirmed I could once again plant corn underground.
8. Checked affected C++ files for astyle.

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/94788d4d-0a4f-483b-bd39-33af25469235)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
