### PR TITLE
feat(balance): standardize current 3D printing recipes

### DIFF
--- a/data/json/recipes/ammo/arrows.json
+++ b/data/json/recipes/ammo/arrows.json
@@ -466,10 +466,11 @@
     "skill_used": "computer",
     "difficulty": 2,
     "skills_required": [ [ "fabrication", 2 ] ],
-    "time": "5 m",
+    "//": "Increased time since in this case you still have to forge arrowheads",
+    "time": "30 m",
     "book_learn": [ [ "textbook_robots", 2 ], [ "advanced_electronics", 2 ] ],
-    "tools": [ [ [ "3d_printer_basic", 100 ], [ "3d_printer_advanced", 100 ] ] ],
-    "components": [ [ [ "plastic_chunk", 15 ] ] ]
+    "using": [ [ "3d_printing_standard", 5 ], [ "blacksmithing_standard", 1 ] ],
+    "components": [ [ [ "steel_tiny", 1, "LIST" ], [ "scrap_bronze", 1 ] ] ]
   },
   {
     "result": "arrow_cf",
@@ -479,9 +480,10 @@
     "skill_used": "computer",
     "difficulty": 2,
     "skills_required": [ [ "fabrication", 2 ] ],
-    "time": "5 m",
+    "//": "Increased time since in this case you still have to forge arrowheads",
+    "time": "30 m",
     "book_learn": [ [ "textbook_computer", 2 ], [ "advanced_electronics", 2 ] ],
-    "tools": [ [ [ "3d_printer_basic", 100 ], [ "3d_printer_advanced", 100 ] ] ],
-    "components": [ [ [ "plastic_chunk", 15 ] ] ]
+    "using": [ [ "3d_printing_standard", 5 ], [ "blacksmithing_standard", 1 ] ],
+    "components": [ [ [ "steel_tiny", 1, "LIST" ], [ "scrap_bronze", 1 ] ] ]
   }
 ]

--- a/data/json/recipes/ammo/other.json
+++ b/data/json/recipes/ammo/other.json
@@ -374,5 +374,18 @@
       [ [ "pipe", 8 ] ],
       [ [ "chem_rocket_fuel", 33 ] ]
     ]
+  },
+  {
+    "result": "c_fishspear",
+    "type": "recipe",
+    "category": "CC_AMMO",
+    "subcategory": "CSC_AMMO_OTHER",
+    "skill_used": "computer",
+    "difficulty": 2,
+    "skills_required": [ [ "fabrication", 2 ] ],
+    "//": "Increased time since in this case you still have to forge spearheads",
+    "time": "30 m",
+    "book_learn": [ [ "textbook_computer", 2 ], [ "advanced_electronics", 2 ] ],
+    "using": [ [ "3d_printing_standard", 5 ], [ "blacksmithing_standard", 2 ], [ "steel_tiny", 2 ] ]
   }
 ]

--- a/data/json/recipes/armor/arms.json
+++ b/data/json/recipes/armor/arms.json
@@ -238,9 +238,8 @@
     "skill_used": "computer",
     "difficulty": 1,
     "skills_required": [ [ "fabrication", 2 ] ],
-    "time": "30 m",
+    "time": "35 m",
     "book_learn": [ [ "textbook_computer", 1 ], [ "advanced_electronics", 1 ] ],
-    "tools": [ [ [ "3d_printer_basic", 100 ], [ "3d_printer_advanced", 100 ] ] ],
-    "components": [ [ [ "plastic_chunk", 20 ] ] ]
+    "using": [ [ "3d_printing_standard", 35 ] ]
   }
 ]

--- a/data/json/recipes/armor/feet.json
+++ b/data/json/recipes/armor/feet.json
@@ -612,9 +612,8 @@
     "skill_used": "computer",
     "difficulty": 2,
     "skills_required": [ [ "fabrication", 2 ] ],
-    "time": "30 m",
+    "time": "20 m",
     "book_learn": [ [ "textbook_computer", 2 ], [ "advanced_electronics", 2 ] ],
-    "tools": [ [ [ "3d_printer_basic", 100 ], [ "3d_printer_advanced", 100 ] ] ],
-    "components": [ [ [ "plastic_chunk", 20 ] ] ]
+    "using": [ [ "3d_printing_standard", 20 ] ]
   }
 ]

--- a/data/json/recipes/armor/hands.json
+++ b/data/json/recipes/armor/hands.json
@@ -613,9 +613,8 @@
     "skill_used": "computer",
     "difficulty": 4,
     "skills_required": [ [ "fabrication", 2 ] ],
-    "time": "30 m",
+    "time": "15 m",
     "book_learn": [ [ "textbook_computer", 4 ], [ "advanced_electronics", 4 ] ],
-    "tools": [ [ [ "3d_printer_basic", 100 ], [ "3d_printer_advanced", 100 ] ] ],
-    "components": [ [ [ "plastic_chunk", 10 ] ] ]
+    "using": [ [ "3d_printing_standard", 15 ] ]
   }
 ]

--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -1537,10 +1537,9 @@
     "skill_used": "computer",
     "difficulty": 1,
     "skills_required": [ [ "fabrication", 2 ] ],
-    "time": "15 m",
+    "time": "20 m",
     "autolearn": true,
     "book_learn": [ [ "textbook_computer", 1 ], [ "advanced_electronics", 1 ] ],
-    "tools": [ [ [ "3d_printer_basic", 100 ], [ "3d_printer_advanced", 100 ] ] ],
-    "components": [ [ [ "plastic_chunk", 25 ] ] ]
+    "using": [ [ "3d_printing_standard", 20 ] ]
   }
 ]

--- a/data/json/recipes/armor/legs.json
+++ b/data/json/recipes/armor/legs.json
@@ -707,9 +707,8 @@
     "skill_used": "computer",
     "difficulty": 3,
     "skills_required": [ [ "fabrication", 2 ] ],
-    "time": "30 m",
+    "time": "50 m",
     "book_learn": [ [ "textbook_computer", 3 ], [ "advanced_electronics", 3 ] ],
-    "tools": [ [ [ "3d_printer_basic", 100 ], [ "3d_printer_advanced", 100 ] ] ],
-    "components": [ [ [ "plastic_chunk", 25 ] ] ]
+    "using": [ [ "3d_printing_standard", 50 ] ]
   }
 ]

--- a/data/json/recipes/armor/other.json
+++ b/data/json/recipes/armor/other.json
@@ -559,10 +559,9 @@
     "skill_used": "computer",
     "skills_required": [ [ "fabrication", 2 ] ],
     "autolearn": true,
-    "time": "15 m",
+    "time": "20 m",
     "book_learn": [ [ "textbook_robots", 0 ], [ "advanced_electronics", 0 ] ],
-    "tools": [ [ [ "3d_printer_basic", 100 ], [ "3d_printer_advanced", 100 ] ] ],
-    "components": [ [ [ "plastic_chunk", 25 ] ] ]
+    "using": [ [ "3d_printing_standard", 20 ] ]
   },
   {
     "result": "carbon_shield",
@@ -573,9 +572,8 @@
     "difficulty": 1,
     "skills_required": [ [ "fabrication", 2 ] ],
     "autolearn": true,
-    "time": "45 m",
+    "time": "30 m",
     "book_learn": [ [ "textbook_computer", 0 ], [ "advanced_electronics", 0 ] ],
-    "tools": [ [ [ "3d_printer_basic", 100 ], [ "3d_printer_advanced", 100 ] ] ],
-    "components": [ [ [ "plastic_chunk", 45 ] ] ]
+    "using": [ [ "3d_printing_standard", 30 ] ]
   }
 ]

--- a/data/json/recipes/armor/suit.json
+++ b/data/json/recipes/armor/suit.json
@@ -917,10 +917,9 @@
     "difficulty": 5,
     "skills_required": [ [ "fabrication", 2 ] ],
     "autolearn": true,
-    "time": "15 m",
+    "time": "2 h 15 m",
     "book_learn": [ [ "textbook_robots", 0 ], [ "advanced_electronics", 0 ] ],
-    "tools": [ [ [ "3d_printer_basic", 100 ], [ "3d_printer_advanced", 100 ] ] ],
-    "components": [ [ [ "plastic_chunk", 75 ] ] ]
+    "using": [ [ "3d_printing_standard", 135 ] ]
   },
   {
     "result": "armor_carbonplate",

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -1334,9 +1334,8 @@
     "skill_used": "computer",
     "difficulty": 4,
     "skills_required": [ [ "fabrication", 2 ] ],
-    "time": "30 m",
+    "time": "50 m",
     "book_learn": [ [ "textbook_computer", 3 ], [ "advanced_electronics", 3 ] ],
-    "tools": [ [ [ "3d_printer_basic", 100 ], [ "3d_printer_advanced", 100 ] ] ],
-    "components": [ [ [ "plastic_chunk", 40 ] ] ]
+    "using": [ [ "3d_printing_standard", 50 ] ]
   }
 ]

--- a/data/json/recipes/other/containers.json
+++ b/data/json/recipes/other/containers.json
@@ -610,9 +610,8 @@
     "skill_used": "computer",
     "skills_required": [ [ "fabrication", 2 ] ],
     "autolearn": true,
-    "time": "5 m",
-    "tools": [ [ [ "3d_printer_basic", 100 ], [ "3d_printer_advanced", 100 ] ] ],
-    "components": [ [ [ "plastic_chunk", 2 ] ] ]
+    "time": "2 m",
+    "using": [ [ "3d_printing_standard", 2 ] ]
   },
   {
     "result": "jug_plastic",
@@ -624,9 +623,8 @@
     "difficulty": 1,
     "skills_required": [ [ "fabrication", 2 ] ],
     "autolearn": true,
-    "time": "10 m",
-    "tools": [ [ [ "3d_printer_basic", 100 ], [ "3d_printer_advanced", 100 ] ] ],
-    "components": [ [ [ "plastic_chunk", 15 ] ] ]
+    "time": "15 m",
+    "using": [ [ "3d_printing_standard", 15 ] ]
   },
   {
     "result": "jerrycan",
@@ -638,8 +636,7 @@
     "difficulty": 2,
     "skills_required": [ [ "fabrication", 2 ] ],
     "autolearn": true,
-    "time": "10 m",
-    "tools": [ [ [ "3d_printer_basic", 100 ], [ "3d_printer_advanced", 100 ] ] ],
-    "components": [ [ [ "plastic_chunk", 40 ] ] ]
+    "time": "40 m",
+    "using": [ [ "3d_printing_standard", 40 ] ]
   }
 ]

--- a/data/json/recipes/other/vehicles.json
+++ b/data/json/recipes/other/vehicles.json
@@ -1475,5 +1475,17 @@
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 1 } ],
     "components": [ [ [ "nail_glue", 4, "LIST" ] ], [ [ "stick", 2 ], [ "2x4", 2 ] ] ]
+  },
+  {
+    "result": "carbonfiber_boat_hull",
+    "type": "recipe",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_VEHICLE",
+    "skill_used": "computer",
+    "difficulty": 2,
+    "skills_required": [ [ "fabrication", 2 ] ],
+    "time": "10 m",
+    "book_learn": [ [ "textbook_computer", 1 ], [ "advanced_electronics", 1 ] ],
+    "using": [ [ "3d_printing_standard", 10 ] ]
   }
 ]

--- a/data/json/recipes/weapon/cutting.json
+++ b/data/json/recipes/weapon/cutting.json
@@ -686,10 +686,10 @@
     "skill_used": "computer",
     "difficulty": 3,
     "skills_required": [ [ "fabrication", 2 ] ],
-    "time": "30 m",
+    "//": "Increased time since some forging incorporated into material for the edge",
+    "time": "60 m",
     "book_learn": [ [ "textbook_computer", 3 ], [ "advanced_electronics", 3 ] ],
-    "tools": [ [ [ "3d_printer_basic", 100 ], [ "3d_printer_advanced", 100 ] ] ],
-    "components": [ [ [ "plastic_chunk", 25 ] ] ]
+    "using": [ [ "3d_printing_standard", 10 ], [ "steel_standard", 1 ], [ "blacksmithing_standard", 4 ] ]
   },
   {
     "result": "katar_carbon",
@@ -699,9 +699,9 @@
     "skill_used": "computer",
     "difficulty": 4,
     "skills_required": [ [ "fabrication", 2 ] ],
-    "time": "30 m",
+    "//": "Increased time since some forging incorporated into material for the edge",
+    "time": "45 m",
     "book_learn": [ [ "textbook_computer", 4 ], [ "advanced_electronics", 4 ] ],
-    "tools": [ [ [ "3d_printer_basic", 100 ], [ "3d_printer_advanced", 100 ] ] ],
-    "components": [ [ [ "plastic_chunk", 20 ] ] ]
+    "using": [ [ "3d_printing_standard", 5 ], [ "steel_tiny", 6 ], [ "blacksmithing_standard", 6 ] ]
   }
 ]

--- a/data/json/recipes/weapon/magazines.json
+++ b/data/json/recipes/weapon/magazines.json
@@ -498,10 +498,9 @@
     "skill_used": "computer",
     "difficulty": 3,
     "skills_required": [ [ "fabrication", 2 ] ],
-    "time": "30 m",
+    "time": "3 m",
     "book_learn": [ [ "textbook_computer", 3 ], [ "advanced_electronics", 3 ], [ "textbook_anarch", 3 ] ],
-    "tools": [ [ [ "3d_printer_basic", 100 ], [ "3d_printer_advanced", 100 ] ] ],
-    "components": [ [ [ "plastic_chunk", 10 ] ] ]
+    "using": [ [ "3d_printing_standard", 3 ] ]
   },
   {
     "result": "glockbigmag",
@@ -511,10 +510,9 @@
     "skill_used": "computer",
     "difficulty": 3,
     "skills_required": [ [ "fabrication", 2 ] ],
-    "time": "30 m",
+    "time": "5 m",
     "book_learn": [ [ "textbook_computer", 3 ], [ "advanced_electronics", 3 ], [ "textbook_anarch", 3 ] ],
-    "tools": [ [ [ "3d_printer_basic", 100 ], [ "3d_printer_advanced", 100 ] ] ],
-    "components": [ [ [ "plastic_chunk", 10 ] ] ]
+    "using": [ [ "3d_printing_standard", 5 ] ]
   },
   {
     "result": "carbonmag_223",
@@ -524,9 +522,8 @@
     "skill_used": "computer",
     "difficulty": 3,
     "skills_required": [ [ "fabrication", 2 ] ],
-    "time": "30 m",
+    "time": "3 m",
     "book_learn": [ [ "textbook_computer", 3 ], [ "advanced_electronics", 3 ], [ "textbook_anarch", 3 ] ],
-    "tools": [ [ [ "3d_printer_basic", 100 ], [ "3d_printer_advanced", 100 ] ] ],
-    "components": [ [ [ "plastic_chunk", 10 ] ] ]
+    "using": [ [ "3d_printing_standard", 3 ] ]
   }
 ]

--- a/data/json/recipes/weapon/piercing.json
+++ b/data/json/recipes/weapon/piercing.json
@@ -882,10 +882,10 @@
     "subcategory": "CSC_WEAPON_PIERCING",
     "skill_used": "computer",
     "skills_required": [ [ "fabrication", 2 ] ],
-    "time": "15 m",
+    "//": "Increased time since some forging incorporated into material for the edge",
+    "time": "30 m",
     "autolearn": true,
-    "tools": [ [ [ "3d_printer_basic", 100 ], [ "3d_printer_advanced", 100 ] ] ],
-    "components": [ [ [ "plastic_chunk", 15 ] ] ]
+    "using": [ [ "3d_printing_standard", 5 ], [ "steel_tiny", 2 ], [ "blacksmithing_standard", 2 ] ]
   },
   {
     "result": "spear_carbon",
@@ -896,9 +896,9 @@
     "difficulty": 2,
     "skills_required": [ [ "fabrication", 2 ] ],
     "autolearn": true,
-    "time": "25 m",
-    "tools": [ [ [ "3d_printer_basic", 100 ], [ "3d_printer_advanced", 100 ] ] ],
-    "components": [ [ [ "plastic_chunk", 25 ] ] ]
+    "//": "Increased time since some forging incorporated into material for the edge",
+    "time": "45 m",
+    "using": [ [ "3d_printing_standard", 10 ], [ "steel_tiny", 2 ], [ "blacksmithing_standard", 2 ] ]
   },
   {
     "result": "jamadhar_carbon",
@@ -909,8 +909,8 @@
     "difficulty": 1,
     "skills_required": [ [ "fabrication", 2 ] ],
     "autolearn": true,
+    "//": "Increased time since some forging for the spearhead",
     "time": "15 m",
-    "tools": [ [ [ "3d_printer_basic", 100 ], [ "3d_printer_advanced", 100 ] ] ],
-    "components": [ [ [ "plastic_chunk", 15 ] ] ]
+    "using": [ [ "3d_printing_standard", 5 ], [ "steel_standard", 2 ], [ "blacksmithing_standard", 8 ] ]
   }
 ]

--- a/data/json/recipes/weapon/ranged.json
+++ b/data/json/recipes/weapon/ranged.json
@@ -1244,11 +1244,13 @@
     "subcategory": "CSC_WEAPON_RANGED",
     "skill_used": "computer",
     "difficulty": 5,
-    "skills_required": [ [ "fabrication", 2 ] ],
-    "time": "30 m",
+    "skills_required": [ [ "fabrication", 2 ], [ "mechanics", 2 ] ],
+    "//": "Increased time just to make and headspace the barrel",
+    "time": "60 m",
     "book_learn": [ [ "textbook_robots", 6 ], [ "advanced_electronics", 6 ], [ "textbook_anarch", 6 ] ],
-    "tools": [ [ [ "3d_printer_basic", 100 ], [ "3d_printer_advanced", 100 ] ] ],
-    "components": [ [ [ "plastic_chunk", 15 ] ] ]
+    "using": [ [ "3d_printing_standard", 5 ] ],
+    "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "SCREW", "level": 1 } ],
+    "components": [ [ [ "pipe", 1 ] ] ]
   },
   {
     "result": "crossbow_carbon",
@@ -1258,10 +1260,10 @@
     "skill_used": "computer",
     "difficulty": 5,
     "skills_required": [ [ "fabrication", 2 ] ],
-    "time": "30 m",
+    "time": "50 m",
     "book_learn": [ [ "textbook_computer", 6 ], [ "advanced_electronics", 6 ], [ "textbook_anarch", 6 ] ],
-    "tools": [ [ [ "3d_printer_basic", 100 ], [ "3d_printer_advanced", 100 ] ] ],
-    "components": [ [ [ "plastic_chunk", 25 ] ] ]
+    "using": [ [ "3d_printing_standard", 50 ] ],
+    "components": [ [ [ "cordage_superior", 3, "LIST" ] ] ]
   },
   {
     "result": "carbon_rifle",
@@ -1270,10 +1272,12 @@
     "subcategory": "CSC_WEAPON_RANGED",
     "skill_used": "computer",
     "difficulty": 6,
-    "skills_required": [ [ "fabrication", 2 ] ],
-    "time": "45 m",
+    "skills_required": [ [ "fabrication", 2 ], [ "mechanics", 2 ] ],
+    "//": "Increased time just to make and headspace the barrel",
+    "time": "1 h 30 m",
     "book_learn": [ [ "textbook_computer", 6 ], [ "advanced_electronics", 6 ], [ "textbook_anarch", 6 ] ],
-    "tools": [ [ [ "3d_printer_basic", 100 ], [ "3d_printer_advanced", 100 ] ] ],
-    "components": [ [ [ "plastic_chunk", 25 ] ] ]
+    "using": [ [ "3d_printing_standard", 20 ] ],
+    "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "SCREW", "level": 1 } ],
+    "components": [ [ [ "pipe", 1 ] ] ]
   }
 ]

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -1,5 +1,13 @@
 [
   {
+    "id": "3d_printing_standard",
+    "type": "requirement",
+    "//": "For working with an printing items made from plastic using a 3D printer.",
+    "//2": "Time is typically 1 minute per plastic chunk used.",
+    "tools": [ [ [ "3d_printer_basic", 4 ], [ "3d_printer_advanced", 2 ] ] ],
+    "components": [ [ [ "plastic_chunk", 1 ] ] ]
+  },
+  {
     "id": "bullet_forming",
     "type": "requirement",
     "//": "Forming of bullets from raw materials",


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.  
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

<!-- 
With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This implements some general rebalancing and fleshing out of 3D printing recipes.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Converted tool use of 3D printers, and plastic component use, into a standard tool quality for all relevant recipes to use. Printers should now be more efficient compared to using a hotplate to melt and shape plastic.
2. In the process, converted recipes to use amounts of plastic generally equal to the weight of the end item rounded up to the nearest multiple of five chunks, except for the recipes directly equivalent to a specific plastic mold recipe, and except for items that now include some extra materials in the recipe. Time requirements also now lean towards 1 minute per plastic chunk used, again except for recipes note das deliberate exceptions.
3. Speaking of, carbon fiber arrows now use the same arrowhead options as standard arrows since they're specifically noted to have broadheads, and likewise the melee weapons all take a bit of their weight out of plastic and add some steel for implied structural reasons, to provide an edge, etc. And likewise, added some additional requirements for making the carbon fiber guns, including a pipe to fashion a barrel, some added basic tools, and mechanics skill. Crossbow meanwhile just adds needing an actual bowstring.
4. Added printing recipes for the two remaining carbon fiber items in the game lacking recipes: carbon fiber fishing spears, and carbon fiber boat hulls.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Setting the carbon fiber items that have steel injected into their recipes have steel as a secondary material. My understanding is that the balance of these items is meant to be that they can't be repaired with normal tools, so didn't do that for now.
2. Also adding a lot more plastic printing recipes. Figured standardize for now then can add them later on.
3. When we finally actually spawn advanced printers anywhere, metal-printing alternative recipes could also be added, starting of course with the carbon fiber items that now need a bit of metalworking to finish up.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
