### PR TITLE
build: fix tracy builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,7 +288,6 @@ if (USE_TRACY)
         tracy
         GIT_REPOSITORY https://github.com/wolfpld/tracy.git
         GIT_TAG "${TRACY_VERSION}"
-        GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE)
 
     FetchContent_MakeAvailable(tracy)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,7 +277,7 @@ if (USE_TRACY)
 
     if (NOT TRACY_VERSION)
         if("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
-            set(TRACY_VERSION 30f1b901a9bab40a193c97c77ec82ac70805164d)
+            set(TRACY_VERSION 6d1deb5640ed11da01995fb1791115cfebe54dbf)
         else()
             set(TRACY_VERSION v0.10)
         endif()

--- a/doc/src/content/docs/en/dev/guides/tracy.md
+++ b/doc/src/content/docs/en/dev/guides/tracy.md
@@ -30,8 +30,11 @@ $ git checkout 6d1deb5640ed11da01995fb1791115cfebe54dbf # the commit used by BN 
 1. Clone <https://github.com/wolfpld/tracy>.
 
 ```sh
-# for ubuntu
+# for ubuntu (X11)
 $ sudo apt install cmake clang git libcapstone-dev xorg-dev dbus libgtk-3-dev
+
+# for ubuntu (wayland)
+$ sudo apt install libglfw-dev libgtk-3-dev libfreetype6-dev libtbb-dev debuginfod libwayland-dev dbus libxkbcommon-dev libglvnd-dev meson cmake git wayland-protocols
 
 # for arch, copied from https://github.com/wolfpld/tracy/blob/master/.github/workflows/linux.yml#L16C12-L16C163
 $ pacman -Syu --noconfirm && pacman -S --noconfirm --needed freetype2 tbb debuginfod wayland dbus libxkbcommon libglvnd meson cmake git wayland-protocols

--- a/doc/src/content/docs/en/dev/guides/tracy.md
+++ b/doc/src/content/docs/en/dev/guides/tracy.md
@@ -15,7 +15,7 @@ Both the game and profiler have to be built with same version of tracy to work p
 [numerous issues](https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3253#discussion_r1545267113),
 The windows version uses [`v0.10`](https://github.com/wolfpld/tracy/releases/tag/v0.10) wheras the
 linux version uses
-[`30f1b90`](https://github.com/wolfpld/tracy/commit/30f1b901a9bab40a193c97c77ec82ac70805164d).
+[`6d1deb5640ed11da01995fb1791115cfebe54dbf`](https://github.com/wolfpld/tracy/commit/6d1deb5640ed11da01995fb1791115cfebe54dbf).
 
 :::
 
@@ -24,7 +24,7 @@ linux version uses
 ```sh
 $ git clone https://github.com/wolfpld/tracy
 $ cd tracy
-$ git checkout 30f1b901a9bab40a193c97c77ec82ac70805164d # the commit used by BN tracy client
+$ git checkout 6d1deb5640ed11da01995fb1791115cfebe54dbf # the commit used by BN tracy client
 ```
 
 1. Clone <https://github.com/wolfpld/tracy>.


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This is a PR that modifies build process or code organization.
  - [x] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

## Purpose of change

It was not possible to build tracy because [while it used older commit `GIT_SHALLOW` was also set to true.](https://discord.com/channels/830879262763909202/830916451517857894/1257792450190245938)

## Describe the solution

please check individual commits.

## Testing

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/8492e792-daf4-424e-bddd-0e9bd620b195)