### PR TITLE
docs: Add Fedora package installation instructions for CMake builds

### DIFF
--- a/doc/src/content/docs/en/dev/guides/building/cmake.md
+++ b/doc/src/content/docs/en/dev/guides/building/cmake.md
@@ -46,7 +46,9 @@ You can obtain the source code tarball for the latest version from
 Obtain packages specified above with your system package manager.
 
 - For Fedora-based distros:
-  `sudo dnf install SDL2 SDL2_image SDL2_ttf SDL2_mixer freetype cmake glibc bzip2 gcc zlib-ng libvorbis ncurses gettext`
+```sh
+$ sudo dnf install SDL2 SDL2_image SDL2_ttf SDL2_mixer freetype cmake glibc bzip2 gcc zlib-ng libvorbis ncurses gettext
+```
 
 ### Windows Environment (MSYS2)
 

--- a/doc/src/content/docs/en/dev/guides/building/cmake.md
+++ b/doc/src/content/docs/en/dev/guides/building/cmake.md
@@ -46,6 +46,7 @@ You can obtain the source code tarball for the latest version from
 Obtain packages specified above with your system package manager.
 
 - For Fedora-based distros:
+
 ```sh
 $ sudo dnf install SDL2 SDL2_image SDL2_ttf SDL2_mixer freetype cmake glibc bzip2 gcc zlib-ng libvorbis ncurses gettext
 ```

--- a/doc/src/content/docs/en/dev/guides/building/cmake.md
+++ b/doc/src/content/docs/en/dev/guides/building/cmake.md
@@ -45,6 +45,8 @@ You can obtain the source code tarball for the latest version from
 
 Obtain packages specified above with your system package manager.
 
+- For Fedora-based distros: `sudo dnf install SDL2 SDL2_image SDL2_ttf SDL2_mixer freetype cmake glibc bzip2 gcc zlib-ng libvorbis ncurses gettext`
+
 ### Windows Environment (MSYS2)
 
 1. Follow steps from here: https://msys2.github.io/

--- a/doc/src/content/docs/en/dev/guides/building/cmake.md
+++ b/doc/src/content/docs/en/dev/guides/building/cmake.md
@@ -45,7 +45,8 @@ You can obtain the source code tarball for the latest version from
 
 Obtain packages specified above with your system package manager.
 
-- For Fedora-based distros: `sudo dnf install SDL2 SDL2_image SDL2_ttf SDL2_mixer freetype cmake glibc bzip2 gcc zlib-ng libvorbis ncurses gettext`
+- For Fedora-based distros:
+  `sudo dnf install SDL2 SDL2_image SDL2_ttf SDL2_mixer freetype cmake glibc bzip2 gcc zlib-ng libvorbis ncurses gettext`
 
 ### Windows Environment (MSYS2)
 


### PR DESCRIPTION
## Checklist


### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

While it can generally be expected that anyone doing c++ changes to the game presumably can also handle finding the relevant packages on their own, this will save future contributors time and annoyance tracking down a few of the ones with package names dissimilar to those found in the instructions.

## Describe the solution

Adds the relevant command to install all the packages listed as required in the 'Building with CMake' section on Fedora-based distributions of Linux.

## Describe alternatives you've considered

- Leave it for someone else to do

- Let it be an introductory ritual for anyone contributing on Linux to find the packages themselves

## Testing

The command does indeed install the packages without errors, as tested by me.

## Additional context

I was thinking about doing the command for Debian-based distros as well, but looking into the maw of the beast that is Debian's package list made me reconsider. I shall leave that one for someone braver than me.
