### PR TITLE
ci: bump `withastro/action` to v2

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout your repository using git
         uses: actions/checkout@v4
       - name: Install, build, and upload site
-        uses: withastro/action@v0
+        uses: withastro/action@v2
         with:
           path: doc
           node-version: 20


### PR DESCRIPTION

## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

[prevent documentation deployment from failing](https://github.com/cataclysmbnteam/Cataclysm-BN/actions/runs/9832860878) due to  [`ERR_INVALID_THIS` error](https://github.com/pnpm/action-setup/issues/135)

## Describe the solution

bump `withastro/action`  to v2 in which bumps [pnpm/action-setup](https://github.com/withastro/action/blob/v2.0.1/action.yml#L60) internally

## Describe alternatives you've considered

escape the node ecosystem (it can be done but needs some time)

## Testing

haven't. has to be tested on CI.

