### PR TITLE
refactor: Obsolete Combat Armor hardcoded iuse

### DIFF
--- a/data/json/item_actions.json
+++ b/data/json/item_actions.json
@@ -821,16 +821,6 @@
   },
   {
     "type": "item_action",
-    "id": "RM13ARMOR_OFF",
-    "name": { "str": "Turn on" }
-  },
-  {
-    "type": "item_action",
-    "id": "RM13ARMOR_ON",
-    "name": { "str": "Turn off" }
-  },
-  {
-    "type": "item_action",
     "id": "SEED",
     "name": { "str": "Consume" }
   },

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -817,9 +817,16 @@
     "volume": "9 L",
     "to_hit": -3,
     "max_charges": 5000,
-    "charges_per_use": 5,
+    "initial_charges": 5000,
     "ammo": "plutonium",
-    "use_action": "RM13ARMOR_OFF",
+    "use_action": {
+      "type": "transform",
+      "msg": "You activate your RM13 combat armor.",
+      "target": "rm13_armor_on",
+      "active": true,
+      "need_charges": 5,
+      "need_charges_msg": "It seems like this device needs power."
+    },
     "covers": [ "head", "mouth", "eyes", "torso", "arms", "hands", "legs", "feet" ],
     "storage": "8 L",
     "warmth": 30,
@@ -851,9 +858,13 @@
       "CLIMATE_CONTROL"
     ],
     "turns_per_charge": 18,
-    "charges_per_use": 0,
     "revert_to": "rm13_armor",
-    "use_action": "RM13ARMOR_ON",
+    "use_action": {
+      "type": "transform",
+      "menu_text": "Turn off",
+      "msg": "Your RM13 combat armor turns off.",
+      "target": "rm13_armor"
+    },
     "environmental_protection": 40,
     "encumbrance": 10,
     "qualities": [ [ "GLARE", 2 ] ],

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -859,12 +859,7 @@
     ],
     "turns_per_charge": 18,
     "revert_to": "rm13_armor",
-    "use_action": {
-      "type": "transform",
-      "menu_text": "Turn off",
-      "msg": "Your RM13 combat armor turns off.",
-      "target": "rm13_armor"
-    },
+    "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "Your RM13 combat armor turns off.", "target": "rm13_armor" },
     "environmental_protection": 40,
     "encumbrance": 10,
     "qualities": [ [ "GLARE", 2 ] ],

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -817,6 +817,7 @@
     "volume": "9 L",
     "to_hit": -3,
     "max_charges": 5000,
+    "charges_per_use": 5,
     "initial_charges": 5000,
     "ammo": "plutonium",
     "use_action": {

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1036,8 +1036,6 @@ void Item_factory::init()
     add_iuse( "REPORT_GRID_CHARGE", &iuse::report_grid_charge );
     add_iuse( "REPORT_GRID_CONNECTIONS", &iuse::report_grid_connections );
     add_iuse( "MODIFY_GRID_CONNECTIONS", &iuse::modify_grid_connections );
-    add_iuse( "RM13ARMOR_OFF", &iuse::rm13armor_off );
-    add_iuse( "RM13ARMOR_ON", &iuse::rm13armor_on );
     add_iuse( "ROBOTCONTROL", &iuse::robotcontrol );
     add_iuse( "SEED", &iuse::seed );
     add_iuse( "SEWAGE", &iuse::sewage );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1970,50 +1970,6 @@ int iuse::extinguisher( player *p, item *it, bool, const tripoint & )
     return it->type->charges_to_use();
 }
 
-int iuse::rm13armor_off( player *p, item *it, bool, const tripoint & )
-{
-    // This allows it to turn on for a turn, because ammo_sufficient assumes non-tool non-weapons need zero ammo, for some reason.
-    if( !it->ammo_sufficient() ) {
-        p->add_msg_if_player( m_info, _( "The RM13 combat armor's fuel cells are dead." ) );
-        return 0;
-    } else {
-        std::string oname = it->typeId().str() + "_on";
-        p->add_msg_if_player( _( "You activate your RM13 combat armor." ) );
-        p->add_msg_if_player( _( "Rivtech Model 13 RivOS v2.19:   ONLINE." ) );
-        p->add_msg_if_player( _( "CBRN defense system:            ONLINE." ) );
-        p->add_msg_if_player( _( "Acoustic dampening system:      ONLINE." ) );
-        p->add_msg_if_player( _( "Thermal regulation system:      ONLINE." ) );
-        p->add_msg_if_player( _( "Vision enhancement system:      ONLINE." ) );
-        p->add_msg_if_player( _( "Electro-reactive armor system:  ONLINE." ) );
-        p->add_msg_if_player( _( "All systems nominal." ) );
-        it->convert( itype_id( oname ) );
-        it->active = true;
-        p->reset_encumbrance();
-        return it->type->charges_to_use();
-    }
-}
-
-int iuse::rm13armor_on( player *p, item *it, bool t, const tripoint & )
-{
-    if( t ) { // Normal use
-    } else { // Turning it off
-        std::string oname = it->typeId().str();
-        if( string_ends_with( oname, "_on" ) ) {
-            oname.erase( oname.length() - 3, 3 );
-        } else {
-            debugmsg( "no item type to turn it into (%s)!", oname );
-            return 0;
-        }
-        p->add_msg_if_player( _( "RivOS v2.19 shutdown sequence initiated." ) );
-        p->add_msg_if_player( _( "Shutting down." ) );
-        p->add_msg_if_player( _( "Your RM13 combat armor turns off." ) );
-        it->convert( itype_id( oname ) );
-        it->active = false;
-        p->reset_encumbrance();
-    }
-    return it->type->charges_to_use();
-}
-
 int iuse::unpack_item( player *p, item *it, bool, const tripoint & )
 {
     if( p->is_underwater() ) {

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -166,8 +166,6 @@ int gun_clean( player *, item *, bool, const tripoint & );
 int gun_repair( player *, item *, bool, const tripoint & );
 int gunmod_attach( player *, item *, bool, const tripoint & );
 int toolmod_attach( player *, item *, bool, const tripoint & );
-int rm13armor_off( player *, item *, bool, const tripoint & );
-int rm13armor_on( player *, item *, bool, const tripoint & );
 int unpack_item( player *, item *, bool, const tripoint & );
 int pack_cbm( player *p, item *it, bool, const tripoint & );
 int pack_item( player *, item *, bool, const tripoint & );


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.


## Purpose of change

Combat armor was hardcoded with a unique use action. It was shown on the Discord to eat 5 charges when being disabled, but not when being enabled. This will convert it to a JSON use action, which will fix the combat armor. However, I don't know if the hardcoded use action is the culprit or if it's an issue with JSON inheritance (That's a lot of fancy code, too bad I can't read it), so this needs further investigation by someone actually competent with C++

## Describe the solution

Delete every reference to the now-orphaned C++, and converts the combat armor to JSON

## Describe alternatives you've considered

Making Kheir do it. Keeping this use action for flavor purposes but making Kheir fix it.

## Testing

This should work right out of the box given it's a fully functioning JSON use action we use in a lot of other items, and since code is only being removed. That said, since we've obsoleted MSYS 2 compiling I haven't re-learned how to compile in cmake and it could use a quick test beyond running the tests.

## Additional context

yeah they always get you with that.