### PR TITLE
fix: Add `transform_charges` so that transform `iuse_actors` can use charges on transform again.

### DIFF
--- a/data/json/items/items_holiday.json
+++ b/data/json/items/items_holiday.json
@@ -15,12 +15,12 @@
     "looks_like": "pumpkin",
     "initial_charges": 100,
     "max_charges": 100,
-    "charges_per_use": 1,
     "ammo": [ "battery" ],
     "use_action": {
       "target": "plastic_jack_o_lantern_lit",
       "msg": "You light the candle in the jack o'lantern.",
       "active": true,
+      "transform_charges": 1,
       "menu_text": "Light",
       "type": "transform"
     }

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -92,6 +92,7 @@
       "msg": "You light up the screen.",
       "active": true,
       "need_charges": 1,
+      "transform_charges": 1,
       "need_charges_msg": "The cellphone's batteries need more charge.",
       "type": "transform"
     },
@@ -328,6 +329,7 @@
         "msg": "You light up the screen.",
         "active": true,
         "need_charges": 1,
+        "transform_charges": 1,
         "need_charges_msg": "The laptop's batteries need more charge.",
         "type": "transform"
       },
@@ -465,6 +467,7 @@
         "msg": "You activate the flashlight app.",
         "active": true,
         "need_charges": 5,
+        "transform_charges": 1,
         "need_charges_msg": "The smartphone's charge is too low.",
         "type": "transform"
       },

--- a/data/json/items/tool/fire.json
+++ b/data/json/items/tool/fire.json
@@ -166,6 +166,7 @@
         "target": "ref_lighter_on",
         "msg": "You flick the lighter.",
         "active": true,
+        "transform_charges": 1,
         "need_charges": 1,
         "need_charges_msg": "Nothing happens.",
         "menu_text": "Light up",

--- a/data/json/items/tool/lighting.json
+++ b/data/json/items/tool/lighting.json
@@ -104,11 +104,11 @@
     "color": "white",
     "initial_charges": 100,
     "max_charges": 100,
-    "charges_per_use": 1,
     "use_action": {
       "target": "candle_lit",
       "msg": "You light the candle.",
       "active": true,
+      "transform_charges": 1,
       "need_fire": 1,
       "menu_text": "Light",
       "type": "transform"
@@ -153,12 +153,12 @@
     "material": [ "plastic" ],
     "symbol": ";",
     "color": "green",
-    "charges_per_use": 1,
     "ammo": "battery",
     "use_action": {
       "type": "transform",
       "target": "electric_lantern_on",
       "active": true,
+      "transform_charges": 1,
       "msg": "You turn the lamp on.",
       "need_charges": 1,
       "need_charges_msg": "The lantern has no batteries."
@@ -203,13 +203,13 @@
     "volume": "100 ml",
     "price": "5 USD",
     "price_postapoc": "1 USD",
-    "charges_per_use": 1,
     "ammo": "battery",
     "flags": [ "BELT_CLIP" ],
     "use_action": {
       "type": "transform",
       "msg": "You turn the flashlight on.",
       "target": "flashlight_on",
+      "transform_charges": 1,
       "active": true,
       "need_charges": 1,
       "need_charges_msg": "The flashlight's batteries are dead."
@@ -258,11 +258,11 @@
     "ammo": "gasoline",
     "initial_charges": 500,
     "max_charges": 500,
-    "charges_per_use": 1,
     "use_action": {
       "target": "gasoline_lantern_on",
       "msg": "You turn the lamp on.",
       "active": true,
+      "transform_charges": 1,
       "need_fire": 1,
       "need_charges": 1,
       "need_charges_msg": "The lamp is empty.",
@@ -393,7 +393,6 @@
     "material": [ "aluminum" ],
     "symbol": ";",
     "color": "blue",
-    "charges_per_use": 1,
     "ammo": "battery",
     "flags": [ "BELT_CLIP", "DURABLE_MELEE" ],
     "use_action": {
@@ -401,6 +400,7 @@
       "msg": "You turn the heavy duty flashlight on.",
       "target": "heavy_flashlight_on",
       "active": true,
+      "transform_charges": 1,
       "need_charges": 1,
       "need_charges_msg": "The heavy duty flashlight's batteries are dead."
     },
@@ -510,11 +510,11 @@
     "ammo": "lamp_oil",
     "initial_charges": 750,
     "max_charges": 750,
-    "charges_per_use": 1,
     "use_action": {
       "target": "oil_lamp_on",
       "msg": "You turn the lamp on.",
       "active": true,
+      "transform_charges": 1,
       "need_fire": 1,
       "need_charges": 1,
       "need_charges_msg": "The lamp is empty.",
@@ -546,13 +546,13 @@
     "symbol": ";",
     "color": "red",
     "material": [ "copper", "glass" ],
-    "charges_per_use": 1,
     "ammo": "weldgas",
     "use_action": {
       "type": "transform",
       "msg": "You light the %s.",
       "target": "oxylamp_on",
       "active": true,
+      "transform_charges": 1,
       "need_charges": 1,
       "need_charges_msg": "The %s must be attached to a gas cylinder to light."
     },
@@ -582,11 +582,11 @@
     "symbol": ";",
     "color": "white",
     "ammo": "battery",
-    "charges_per_use": 1,
     "use_action": {
       "target": "reading_light_on",
       "msg": "You switch on the reading light.",
       "active": true,
+      "transform_charges": 1,
       "need_charges": 1,
       "need_charges_msg": "The reading light winks out.",
       "type": "transform"
@@ -621,11 +621,11 @@
     "symbol": "&",
     "color": "blue",
     "ammo": "battery",
-    "charges_per_use": 1,
     "use_action": {
       "target": "smart_lamp_on",
       "msg": "You turn the smart lamp on.",
       "active": true,
+      "transform_charges": 1,
       "need_charges": 1,
       "need_charges_msg": "The smart lamp batteries are dead.",
       "type": "transform"
@@ -678,11 +678,11 @@
     "techniques": [ "WBLOCK_1" ],
     "initial_charges": 25,
     "max_charges": 25,
-    "charges_per_use": 1,
     "use_action": {
       "target": "torch_lit",
       "msg": "You light the torch.",
       "active": true,
+      "transform_charges": 1,
       "need_fire": 1,
       "menu_text": "Light torch",
       "type": "transform"

--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -166,13 +166,13 @@
     "color": "blue",
     "weight": "400 g",
     "volume": "500 ml",
-    "charges_per_use": 1,
     "ammo": "battery",
     "use_action": {
       "type": "transform",
       "msg": "You inject yourself into the Cube of Shame.",
       "target": "debug_active_relic_test_on",
       "active": true,
+      "transform_charges": 1,
       "need_charges": 1,
       "need_charges_msg": "Batteries not included."
     },

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -151,13 +151,13 @@
     "weight": "1196 g",
     "volume": "3 L",
     "bashing": 6,
-    "charges_per_use": 1,
     "ammo": "battery",
     "use_action": {
       "type": "transform",
       "msg": "You turn the helmet on.",
       "target": "miner_hat_on",
       "active": true,
+      "transform_charges": 1,
       "need_charges": 1,
       "need_charges_msg": "The helmet's batteries are dead."
     },
@@ -401,13 +401,13 @@
     "material": [ "cotton" ],
     "weight": "182 g",
     "volume": "750 ml",
-    "charges_per_use": 1,
     "ammo": "battery",
     "use_action": {
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "thermal_socks_on",
       "active": true,
+      "transform_charges": 1,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
@@ -459,13 +459,13 @@
     "material": [ "cotton" ],
     "weight": "864 g",
     "volume": "2 L",
-    "charges_per_use": 1,
     "ammo": "battery",
     "use_action": {
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "thermal_suit_on",
       "active": true,
+      "transform_charges": 1,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
@@ -517,13 +517,13 @@
     "material": [ "cotton" ],
     "weight": "210 g",
     "volume": "750 ml",
-    "charges_per_use": 1,
     "ammo": "battery",
     "use_action": {
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "thermal_gloves_on",
       "active": true,
+      "transform_charges": 1,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
@@ -575,13 +575,13 @@
     "material": [ "cotton" ],
     "weight": "196 g",
     "volume": "1 L",
-    "charges_per_use": 1,
     "ammo": "battery",
     "use_action": {
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "thermal_mask_on",
       "active": true,
+      "transform_charges": 1,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
@@ -656,13 +656,13 @@
     "weight": "520 g",
     "volume": "500 ml",
     "bashing": 1,
-    "charges_per_use": 1,
     "ammo": "battery",
     "use_action": {
       "type": "transform",
       "msg": "You turn the headlamp on.",
       "target": "wearable_light_on",
       "active": true,
+      "transform_charges": 1,
       "need_charges": 1,
       "need_charges_msg": "The headlamp batteries are dead."
     },
@@ -721,6 +721,7 @@
       "msg": "You turn the survivor headlamp on.",
       "target": "survivor_light_on",
       "active": true,
+      "transform_charges": 1,
       "need_charges": 1,
       "need_charges_msg": "The survivor headlamp batteries are dead."
     },
@@ -881,6 +882,7 @@
       "msg": "A LED light in the %s LED flickers on.",
       "target": "dimensional_anchor_on",
       "active": true,
+      "transform_charges": 1,
       "need_charges": 1,
       "need_charges_msg": "It seems like this device needs power."
     },
@@ -933,6 +935,7 @@
       "msg": "Initiating\nRunning suit integrity diagnostics…\nAll systems operational.",
       "target": "phase_immersion_suit_on",
       "active": true,
+      "transform_charges": 1,
       "need_charges": 1,
       "need_charges_msg": "Warning: Operating on minimal power.  Protection compromised."
     },
@@ -1007,13 +1010,13 @@
     "to_hit": -3,
     "max_charges": 60,
     "initial_charges": 60,
-    "charges_per_use": 1,
     "ammo": "rebreather_filter",
     "use_action": {
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "rebreather_on",
       "active": true,
+      "transform_charges": 1,
       "need_charges": 1,
       "need_charges_msg": "The %s's filter is used up."
     },
@@ -1055,13 +1058,13 @@
     "to_hit": -3,
     "max_charges": 60,
     "initial_charges": 60,
-    "charges_per_use": 1,
     "ammo": "rebreather_filter",
     "use_action": {
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "rebreather_xl_on",
       "active": true,
+      "transform_charges": 1,
       "need_charges": 1,
       "need_charges_msg": "The %s's filter is used up."
     },
@@ -1364,13 +1367,13 @@
     "weight": "1020 g",
     "volume": "1 L",
     "to_hit": -3,
-    "charges_per_use": 1,
     "ammo": "battery",
     "use_action": {
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "goggles_nv_on",
       "active": true,
+      "transform_charges": 1,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
@@ -1427,13 +1430,13 @@
     "weight": "1240 g",
     "volume": "1 L",
     "to_hit": -3,
-    "charges_per_use": 1,
     "ammo": "battery",
     "use_action": {
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "goggles_ir_on",
       "active": true,
+      "transform_charges": 1,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
@@ -1532,13 +1535,13 @@
     "volume": "1500 ml",
     "to_hit": -3,
     "max_charges": 120,
-    "charges_per_use": 1,
     "ammo": "rebreather_filter",
     "use_action": {
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "mask_h20survivor_on",
       "active": true,
+      "transform_charges": 1,
       "need_charges": 1,
       "need_charges_msg": "The %s's filter is used up."
     },
@@ -2181,13 +2184,13 @@
     "material": [ "cotton" ],
     "weight": "1452 g",
     "volume": "4500 ml",
-    "charges_per_use": 1,
     "ammo": "battery",
     "use_action": {
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "thermal_outfit_on",
       "active": true,
+      "transform_charges": 1,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
@@ -2542,13 +2545,13 @@
     "material": [ "plastic" ],
     "weight": "179 g",
     "volume": "1 L",
-    "charges_per_use": 1,
     "ammo": "battery",
     "use_action": {
       "type": "transform",
       "msg": "You turn the earmuffs on.",
       "target": "powered_earmuffs_on",
       "active": true,
+      "transform_charges": 1,
       "need_charges": 1,
       "need_charges_msg": "The earmuff's batteries are dead."
     },
@@ -2872,13 +2875,13 @@
     "warmth": 50,
     "material_thickness": 3,
     "environmental_protection": 1,
-    "charges_per_use": 1,
     "ammo": "battery",
     "use_action": {
       "type": "transform",
       "msg": "You turn the blanket's heating elements on.",
       "target": "electric_blanket_on",
       "active": true,
+      "transform_charges": 1,
       "need_charges": 1,
       "need_charges_msg": "The blanket's batteries are dead."
     },
@@ -2925,7 +2928,6 @@
     "warmth": 50,
     "material_thickness": 5,
     "environmental_protection": 2,
-    "charges_per_use": 1,
     "ammo": "battery",
     "use_action": {
       "type": "transform",
@@ -2933,6 +2935,7 @@
       "target": "foodperson_mask_on",
       "active": true,
       "need_worn": true,
+      "transform_charges": 1,
       "need_charges": 1,
       "need_charges_msg": "The mask's batteries are dead."
     },

--- a/data/mods/Aftershock/items/tool_armor.json
+++ b/data/mods/Aftershock/items/tool_armor.json
@@ -13,7 +13,6 @@
     "material": [ "graphene_weave" ],
     "weight": "1250 g",
     "volume": "4500 ml",
-    "charges_per_use": 5,
     "ammo": "battery",
     "magazines": [
       [
@@ -28,6 +27,7 @@
       "msg": "You activate your %s.",
       "target": "afs_cryopod_bodyglove_on",
       "active": true,
+      "transform_charges": 1,
       "need_charges": 5,
       "need_charges_msg": "The %s's batteries are dead."
     },

--- a/data/mods/Aftershock/items/weapons.json
+++ b/data/mods/Aftershock/items/weapons.json
@@ -13,12 +13,12 @@
     "looks_like": "flashlight",
     "color": "light_gray",
     "ammo": [ "battery" ],
-    "charges_per_use": 1,
     "use_action": {
       "menu_text": "Activate",
       "type": "transform",
       "target": "afs_energy_saber_on",
       "msg": "You activate the energy saber, and its blade blazes into existence!",
+      "transform_charges": 1,
       "need_charges": 1,
       "need_charges_msg": "The energy saber is out of charge.",
       "active": true

--- a/data/mods/CRT_EXPANSION/items/crt_toolarmor.json
+++ b/data/mods/CRT_EXPANSION/items/crt_toolarmor.json
@@ -132,13 +132,13 @@
     "covers": [ "torso" ],
     "max_charges": 300,
     "initial_charges": 300,
-    "charges_per_use": 1,
     "use_action": [
       {
         "type": "transform",
         "msg": "C.R.I.T. EM booting up…",
         "target": "crt_em_vest_on",
         "active": true,
+        "transform_charges": 1,
         "need_charges": 1,
         "need_charges_msg": "Power levels too low for safe bootup…"
       },

--- a/data/mods/CrazyCataclysm/crazy_items.json
+++ b/data/mods/CrazyCataclysm/crazy_items.json
@@ -237,12 +237,12 @@
     "color": "brown",
     "initial_charges": 25,
     "max_charges": 25,
-    "charges_per_use": 1,
     "techniques": [ "WBLOCK_1" ],
     "use_action": {
       "target": "battletorch_lit",
       "msg": "You light the Louisville Slaughterer.",
       "active": true,
+      "transform_charges": 1,
       "need_fire": 1,
       "menu_text": "Light",
       "type": "transform"

--- a/data/mods/Magiclysm/items/enchanted_misc.json
+++ b/data/mods/Magiclysm/items/enchanted_misc.json
@@ -17,7 +17,6 @@
     "flags": [ "ALLOWS_REMOTE_USE", "FIRE" ],
     "initial_charges": 60,
     "max_charges": 60,
-    "charges_per_use": 1,
     "sub": "hotplate",
     "artifact_data": { "charge_type": "ARTC_TIME" },
     "use_action": [
@@ -27,6 +26,7 @@
         "type": "transform",
         "target": "heat_cube_torch_on",
         "active": true,
+        "transform_charges": 1,
         "msg": "You push the torch button and the cube emits a large flame from the top, one that does radiate heat, but won't burn anything.",
         "menu_text": "Activate torch mode",
         "moves": 150

--- a/data/mods/No_Hope/Items/tools.json
+++ b/data/mods/No_Hope/Items/tools.json
@@ -138,12 +138,12 @@
     "color": "brown",
     "initial_charges": 25,
     "max_charges": 25,
-    "charges_per_use": 1,
     "techniques": [ "WBLOCK_1" ],
     "use_action": {
       "target": "battletorch_lit",
       "msg": "You light the Louisville Slaughterer.",
       "active": true,
+      "transform_charges": 1,
       "need_fire": 1,
       "menu_text": "Light",
       "type": "transform"

--- a/doc/src/content/docs/en/mod/json/reference/json_info.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_info.md
@@ -2203,7 +2203,8 @@ more structured function.
     "msg": "You turn the lamp on.", // Message to display when activated.
     "need_fire": 1,                 // Whether fire is needed to activate.
     "need_fire_msg": "You need a lighter!", // Message to display if there is no fire.
-    "need_charges": 1,                      // Number of charges the item needs to transform.
+    "transform_charges": 1,         // Number of charges used by item when it transforms.
+    "need_charges": 1,                      // Number of charges the item needs to transform. Just a check, nothing is consumed.
     "need_charges_msg": "The lamp is empty.", // Message to display if there aren't enough charges.
     "need_worn": true;                        // Whether the item needs to be worn to be transformed, is false by default.
     "target_charges" : 3, // Number of charges the transformed item has.

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -95,6 +95,9 @@ class iuse_transform : public iuse_actor
         /** displayed if item is in player possession with %s replaced by item name */
         translation need_charges_msg;
 
+        /** charges needed for process of transforming item */
+        int transform_charges = 0;
+
         /** Tool qualities needed, e.g. "fine bolt turning 1". **/
         std::map<quality_id, int> qualities_needed;
 


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `doc/` folder.
- [x] This is a PR that modifies build process or code organization.
  - [x] If documentation for this feature or process does not exist, please write it.

## Purpose of change

- fixes #4966 which was due to https://github.com/CleverRaven/Cataclysm-DDA/pull/16061 8 years ago.

## Describe the solution

`transform_charges` defines charges used when an item successfully transforms.

Shuffled code in character.cpp to fix issue where items that are called to consume charges without a `charges_per_use` field are consumed themselves. Now it also checks if the item has charges available at all as well.

## Describe alternatives you've considered

- Leaving it alone.
  - Honestly a thing I would have considered were it not for some of the panic in the Discord. Main use case for this is to prevent the ability to turn on an item, and benefit until charges are consumed later. Now many items with charge usage less than 1 charge per turn will use a charge when turning on, which was an edge case exploit at best in my opinion, but I'm already here so...

## Testing

- Spawn 2 flashlights and a UPS, unload one flashlight and install a UPS conversion mod into it.
  - [x] Check that both flashlights when turned on will consume the necessary charge, the non-UPS from it's battery and the UPS one from the carried UPS.

## Additional context
