### PR TITLE
docs: Add gcc-c++ to Fedora install script

### DIFF
--- a/doc/src/content/docs/en/dev/guides/building/cmake.md
+++ b/doc/src/content/docs/en/dev/guides/building/cmake.md
@@ -48,7 +48,7 @@ Obtain packages specified above with your system package manager.
 - For Fedora-based distros:
 
 ```sh
-$ sudo dnf install SDL2 SDL2_image SDL2_ttf SDL2_mixer freetype cmake glibc bzip2 gcc zlib-ng libvorbis ncurses gettext
+$ sudo dnf install SDL2 SDL2_image SDL2_ttf SDL2_mixer freetype cmake glibc bzip2 gcc gcc-c++ zlib-ng libvorbis ncurses gettext
 ```
 
 ### Windows Environment (MSYS2)


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

It generally helps to have a c++ compiler when compiling c++ code, and as demonstrated by my own use, it's not safe to assume that someone running the script would have one already.

## Describe the solution

Adds gcc-c++, the c++ compiler for gcc, to the install script for Fedora-based distros.

## Describe alternatives you've considered

- Provide Clang instead

Personal preference / taste really, but I figured I might as well use the gcc c++ compiler given I've already put gcc in the script.

- Add an instruction telling people to grab either gcc-c++ or clang instead

Open to the idea, but felt like just keeping it in one script was nicer.

## Testing

CMake does indeed recognize gcc-c++ after installing it as a valid CXX compiler.

## Additional context

Thanks to Scarf for their help with my CMake issue earlier
