### PR TITLE
feat(content): add chewing tobacco recipe, edit chewing tobacco description and make raw tobacco dryable by smoke rack

### DIFF
--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -261,7 +261,7 @@
     "type": "COMESTIBLE",
     "comestible_type": "MED",
     "name": "chewing tobacco",
-    "description": "Mint flavored chewing tobacco.  While still absolutely terrible for your health, it was once a favorite amongst baseball players, cowboys, and other macho types.",
+    "description": "Fruit flavored chewing tobacco.  While still absolutely terrible for your health, it was once a favorite amongst baseball players, cowboys, and other macho types.",
     "weight": "4 g",
     "volume": "250 ml",
     "price": "20 USD",

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -2513,7 +2513,8 @@
     "volume": "1 L"
   },
   {
-    "type": "GENERIC",
+    "type": "COMESTIBLE",
+	  "comestible_type": "MED",
     "id": "tobacco_raw",
     "symbol": "%",
     "color": "light_green",
@@ -2524,6 +2525,7 @@
     "price_postapoc": "50 cent",
     "material": "veggy",
     "weight": "100 g",
+	  "flags":["SMOKABLE"],
     "volume": "250 ml",
 	  "smoking_result": "tobacco"
   },

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -2514,7 +2514,7 @@
   },
   {
     "type": "COMESTIBLE",
-	  "comestible_type": "MED",
+    "comestible_type": "MED",
     "id": "tobacco_raw",
     "symbol": "%",
     "color": "light_green",
@@ -2525,9 +2525,9 @@
     "price_postapoc": "50 cent",
     "material": "veggy",
     "weight": "100 g",
-	  "flags":["SMOKABLE"],
+    "flags": [ "SMOKABLE" ],
     "volume": "250 ml",
-	  "smoking_result": "tobacco"
+    "smoking_result": "tobacco"
   },
   {
     "id": "cash_card",

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -2524,7 +2524,8 @@
     "price_postapoc": "50 cent",
     "material": "veggy",
     "weight": "100 g",
-    "volume": "250 ml"
+    "volume": "250 ml",
+	  "smoking_result": "tobacco"
   },
   {
     "id": "cash_card",

--- a/data/json/recipes/chem/drugs.json
+++ b/data/json/recipes/chem/drugs.json
@@ -26,6 +26,28 @@
   },
   {
     "type": "recipe",
+    "result": "chaw",
+    "category": "CC_CHEM",
+    "subcategory": "CSC_CHEM_DRUGS",
+    "skill_used": "cooking",
+    "difficulty": 4,
+	"charges":10,
+    "time": "30 m",
+    "autolearn": false,
+	"book_learn": [
+      [ "pocket_survival", 3 ],
+      [ "atomic_survival", 2 ],
+      [ "textbook_survival", 2 ],
+      [ "survival_book", 3 ],
+      [ "isherwood_herbal_remedies", 2 ]
+    ],
+    "batch_time_factors": [ 80, 5 ],
+    "tools": [ [ [ "surface_heat", 15, "LIST" ] ] ],
+	"qualities": [ { "id": "COOK", "level": 3 } ],
+    "components": [ [ [ "tobacco_raw", 10 ] ], [["sugar_standard",2,"LIST"] ],[["juice",3]],[["salt",5]]]
+  },
+  {
+    "type": "recipe",
     "result": "joint",
     "category": "CC_CHEM",
     "subcategory": "CSC_CHEM_DRUGS",

--- a/data/json/recipes/chem/drugs.json
+++ b/data/json/recipes/chem/drugs.json
@@ -31,10 +31,10 @@
     "subcategory": "CSC_CHEM_DRUGS",
     "skill_used": "cooking",
     "difficulty": 4,
-	"charges":10,
+    "charges": 10,
     "time": "30 m",
     "autolearn": false,
-	"book_learn": [
+    "book_learn": [
       [ "pocket_survival", 3 ],
       [ "atomic_survival", 2 ],
       [ "textbook_survival", 2 ],
@@ -43,8 +43,8 @@
     ],
     "batch_time_factors": [ 80, 5 ],
     "tools": [ [ [ "surface_heat", 15, "LIST" ] ] ],
-	"qualities": [ { "id": "COOK", "level": 3 } ],
-    "components": [ [ [ "tobacco_raw", 10 ] ], [["sugar_standard",2,"LIST"] ],[["juice",3]],[["salt",5]]]
+    "qualities": [ { "id": "COOK", "level": 3 } ],
+    "components": [ [ [ "tobacco_raw", 10 ] ], [ [ "sugar_standard", 2, "LIST" ] ], [ [ "juice", 3 ] ], [ [ "salt", 5 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
## Purpose of change

Raw tobaccos cant be dried without player crafting, that makes thing much slower. Chewing tobacco is also uncraftable, despite its recipe videos are all around and not much complex

## Describe the solution

Add SMOKABLE flag to raw tobacco, add recipe for chewing tobacco and replace "mint flavored" in description into "fruit flavored" because recipe uses fruit.

## Describe alternatives you've considered

Keep uncraftable chewing tobaccos

## Testing

Local JSON edits

## Additional context

Midst of writing json, i had to clean my bag from tobacco remains. A rechargable battery accidentaly dropped from balcony while i was trying to shake off tobacco dust. Does that mean i will do a PR about rechargable batteries in future?
