### PR TITLE
feat(balance): add more component options to soldering iron recipes, related tweaks

### DIFF
--- a/data/json/recipes/electronic/tools.json
+++ b/data/json/recipes/electronic/tools.json
@@ -109,8 +109,8 @@
     "book_learn": [ [ "manual_electronics", 1 ] ],
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SCREW", "level": 1 } ],
     "components": [
-      [ [ "e_scrap", 2 ], [ "glowplug", 1 ] ],
-      [ [ "copper", 1 ], [ "nail", 1 ], [ "wire", 1 ] ],
+      [ [ "element", 1 ], [ "glowplug", 1 ], [ "e_scrap", 2 ] ],
+      [ [ "copper", 1 ], [ "nail", 1 ], [ "wire", 1 ], [ "spike", 1 ] ],
       [ [ "scrap", 1 ] ],
       [ [ "adhesive", 1, "LIST" ] ],
       [ [ "cable", 5 ] ]

--- a/data/json/recipes/other/tools.json
+++ b/data/json/recipes/other/tools.json
@@ -866,7 +866,14 @@
     "book_learn": [ [ "fun_survival", 1 ], [ "manual_fabrication", 1 ] ],
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [
-      [ [ "can_medium_unsealed", 1 ], [ "bottle_plastic", 1 ], [ "jar_glass", 1 ] ],
+      [
+        [ "can_medium_unsealed", 1 ],
+        [ "bottle_plastic", 1 ],
+        [ "jar_glass", 1 ],
+        [ "can_drink_unsealed", 2 ],
+        [ "can_food_unsealed", 2 ],
+        [ "bottle_plastic_small", 2 ]
+      ],
       [ [ "scrap", 1 ], [ "steel_chunk", 1 ] ]
     ]
   },
@@ -882,8 +889,17 @@
     "book_learn": [ [ "fun_survival", 2 ], [ "manual_fabrication", 2 ], [ "reference_fabrication1", 2 ] ],
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [
-      [ [ "copper", 1 ], [ "nail", 1 ], [ "wire", 1 ] ],
-      [ [ "can_medium_unsealed", 1 ], [ "bottle_plastic", 1 ], [ "jar_glass", 1 ] ],
+      [ [ "copper", 1 ], [ "nail", 1 ], [ "wire", 1 ], [ "spike", 1 ] ],
+      [
+        [ "can_medium_unsealed", 1 ],
+        [ "bottle_plastic", 1 ],
+        [ "jar_glass", 1 ],
+        [ "can_drink_unsealed", 2 ],
+        [ "can_food_unsealed", 2 ],
+        [ "bottle_plastic_small", 2 ],
+        [ "canister_empty", 2 ],
+        [ "clay_canister", 2 ]
+      ],
       [ [ "scrap", 1 ], [ "steel_chunk", 1 ] ]
     ]
   },

--- a/data/json/requirements/electronics.json
+++ b/data/json/requirements/electronics.json
@@ -4,6 +4,6 @@
     "type": "requirement",
     "//": "Connect two grid tiles. Cost is multiplied by number of elements in resulting grid.",
     "components": [ [ [ "cable", 2 ] ] ],
-    "tools": [ [ [ "soldering_ethanol", 30 ], [ "soldering_iron", 3 ], [ "toolset", 1 ] ] ]
+    "tools": [ [ [ "soldering_iron", 3 ], [ "soldering_ethanol", 30 ], [ "toolset", 1 ] ] ]
   }
 ]

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -97,7 +97,7 @@
     "id": "soldering_standard",
     "type": "requirement",
     "//": "Soldering metal items",
-    "tools": [ [ [ "soldering_ethanol", 10 ], [ "soldering_iron", 1 ], [ "toolset", 1 ] ] ],
+    "tools": [ [ [ "soldering_iron", 1 ], [ "soldering_ethanol", 10 ], [ "toolset", 1 ] ] ],
     "components": [ [ [ "solder_wire", 1 ] ] ]
   },
   {


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This aims to give players a few more options to make crafting a soldering iron less restrictive, along with some related fixes and updates. In particular, this sets electric irons back to being the default tool mentioned when viewing what an item needs to uncraft it, something that had been bugging me a bit.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Reordered soldering irons in the `soldering_standard` crafting requirement so they show up as the most obvious tool to use for disassembling items, with `add_grid_connection` reordered for consistency too.
2. Added spikes as a potential alternative to nails or wire for both soldering recipes, opening up an additional potential material option for the soldering tip.
3. Added heating element as a potential alternative to electronic scrap and glow plugs as an alternative component in the recipe for electric soldering iron. Also ordered the components such that disassembling a prespawned soldering iron will default to yielding a heating element.
4. Allowed the alcohol soldering iron to use a pair small cans, canisters, or bottles as alternatives to the standard 500-ml containers, idea being split the carried fuel between them.
5. Misc: Updated the container options for soda can stove kits accordingly. Was kinda funny that it's called a soda can stove but did not allow actually using soda cans.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Adding a charcoal-fueled soldering item for innawoods use. Now that retorts exist, alcohol is less of a roadblock innawods so this is less of a priority I figure.
2. Also letting ethanol soldering irons and stoves use aluminum cans as an alternative to the scrap used to make the burner, since that's technically what the can in a can stove is actually being used for.
3. Letting ethanol soldering irons use a sharp rock as an extra innawoods-specific option.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Checked affected files for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
