### PR TITLE
docs: fix required fedora packages

### DIFF
--- a/doc/src/content/docs/en/dev/guides/building/cmake.md
+++ b/doc/src/content/docs/en/dev/guides/building/cmake.md
@@ -136,6 +136,37 @@ $ ccmake ..
 $ cmake-gui ..
 ```
 
+A CMake build with almost all options with build optimizations (ccache, ninja, mold) + tracy
+profiler may look like:
+
+```sh
+mkdir -p build
+cmake \
+  -B build-fedora \
+  -G Ninja \
+  -DCATA_CCACHE=ON \
+  -DCMAKE_C_COMPILER=clang-17 \
+  -DCMAKE_CXX_COMPILER=clang++-17 \
+  -DCMAKE_INSTALL_PREFIX=$HOME/.local/share \
+  -DJSON_FORMAT=ON \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DCURSES=OFF \
+  -DTILES=ON \
+  -DSOUND=ON \
+  -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+  -DCATA_CLANG_TIDY_PLUGIN=OFF \
+  -DLUA=ON \
+  -DBACKTRACE=ON \
+  -DLINKER=mold \
+  -DUSE_XDG_DIR=ON \
+  -DUSE_HOME_DIR=OFF \
+  -DUSE_PREFIX_DATA_DIR=OFF \
+  -DUSE_TRACY=ON \
+  -DTRACY_VERSION=master \
+  -DTRACY_ON_DEMAND=ON \
+  -DTRACY_ONLY_IPV4=ON
+```
+
 ## Build for MSYS2 (MinGW)
 
 **NOTE**: For development purposes it is preferred to use `MinGW Win64 Shell` or `MinGW Win32 Shell`

--- a/doc/src/content/docs/en/dev/guides/building/cmake.md
+++ b/doc/src/content/docs/en/dev/guides/building/cmake.md
@@ -48,7 +48,9 @@ Obtain packages specified above with your system package manager.
 - For Fedora-based distros:
 
 ```sh
-$ sudo dnf install SDL2 SDL2_image SDL2_ttf SDL2_mixer freetype cmake glibc bzip2 gcc gcc-c++ zlib-ng libvorbis ncurses gettext
+$ sudo dnf install git cmake ninja-build mold clang17 ccache \
+  SDL2-devel SDL2_image-devel SDL2_ttf-devel SDL2_mixer-devel \
+  freetype glibc bzip2 zlib-ng libvorbis ncurses gettext flac-devel
 ```
 
 ### Windows Environment (MSYS2)


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

continuation of #4957, #4971

## Describe the solution

list fedora packages required to build BN tiles.

## Describe alternatives you've considered



## Testing

was able to locally build on fedora 40 docker with following command:

```

sudo dnf install git cmake ninja-build mold clang17 ccache \
    SDL2-devel SDL2_image-devel SDL2_ttf-devel SDL2_mixer-devel \
    freetype glibc bzip2 zlib-ng libvorbis ncurses gettext flac-devel
mkdir -p build
cmake \
    -B build-fedora \
    -G Ninja \
    -DCATA_CCACHE=ON \
    -DCMAKE_C_COMPILER=clang-17 \
    -DCMAKE_CXX_COMPILER=clang++-17 \
    -DCMAKE_INSTALL_PREFIX=$HOME/.local/share \
    -DJSON_FORMAT=ON \
    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
    -DCURSES=OFF \
    -DTILES=ON \
    -DSOUND=ON \
    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
    -DCATA_CLANG_TIDY_PLUGIN=OFF \
    -DLUA=ON \
    -DBACKTRACE=ON \
    -DLINKER=mold \
    -DUSE_XDG_DIR=ON \
    -DUSE_HOME_DIR=OFF \
    -DUSE_PREFIX_DATA_DIR=OFF \
    -DUSE_TRACY=ON \
    -DTRACY_VERSION=master \
    -DTRACY_ON_DEMAND=ON \
    -DTRACY_ONLY_IPV4=ON
```

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
