### PR TITLE
ci: fix no release note on day after no commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,16 +74,8 @@ jobs:
           toTag: ${{ needs.metadata.outputs.tag_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Show Changelog
-        run: |
-          OUTPUT=$(cat << EOF
-            ${{ steps.build_changelog.outputs.changelog }} 
-            EOF
-            )
-          echo "$OUTPUT" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create release
-        if: ${{ steps.tag_check.outputs.exists == 'false' }}
         id: create_release
         uses: softprops/action-gh-release@v2.0.2
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,8 @@ jobs:
           toTag: ${{ needs.metadata.outputs.tag_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Show Changelog
+        run: echo ${{ steps.build_changelog.outputs.changelog }} >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create release
         if: ${{ steps.tag_check.outputs.exists == 'false' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
     name: Create Release
     runs-on: ubuntu-22.04
 
-    if: github.event_name == "workflow_dispatch" || fromJson(needs.metadata.outputs.count) > 0
+    if: github.event_name == 'workflow_dispatch' || fromJson(needs.metadata.outputs.count) > 0
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
       release_already_exists: ${{ steps.tag_check.outputs.exists }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       count: ${{ steps.env_vars.outputs.count }}
       tag_name: ${{ steps.env_vars.outputs.tag_name }}
       release_name: ${{ steps.env_vars.outputs.release_name }}
+      last_tag_name: ${{ steps.env_vars.outputs.last_tag_name }}
       yesterday_tag_name: ${{ steps.env_vars.outputs.yesterday_tag_name }}
     steps:
       - uses: actions/checkout@v4
@@ -22,6 +23,7 @@ jobs:
         run: |
           TAG_NAME=$(date -u --iso-8601 --date='1 day ago')
           YESTERDAY_TAG_NAME=$(date -u --iso-8601 --date='2 day ago')
+          LAST_TAG_NAME=$(git for-each-ref --sort=-creatordate --format '%(creatordate:short)' refs/tags | head -n 1)
           COMMITS=$(git log --oneline --since="$TAG_NAME" | wc -l)
           RELEASE_NAME="Experimental $TAG_NAME"
 
@@ -29,6 +31,7 @@ jobs:
 
           echo "count=$COMMITS" >> "$GITHUB_OUTPUT"
           echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
+          echo "last_tag_name=$LAST_TAG_NAME" >> "$GITHUB_OUTPUT"
           echo "yesterday_tag_name=$YESTERDAY_TAG_NAME" >> "$GITHUB_OUTPUT"
           echo "release_name=$RELEASE_NAME" >> "$GITHUB_OUTPUT"
 
@@ -67,7 +70,7 @@ jobs:
         uses: mikepenz/release-changelog-builder-action@v4.2.0
         with:
           configuration: "changelog.json"
-          fromTag: ${{ needs.metadata.outputs.yesterday_tag_name }}
+          fromTag: ${{ needs.metadata.outputs.last_tag_name }}
           toTag: ${{ needs.metadata.outputs.tag_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
     name: Create Release
     runs-on: ubuntu-22.04
 
-    if: fromJson(needs.metadata.outputs.count) > 0
+    if: github.event_name == "workflow_dispatch" || fromJson(needs.metadata.outputs.count) > 0
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
       release_already_exists: ${{ steps.tag_check.outputs.exists }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Show Changelog
-        run: echo ${{ steps.build_changelog.outputs.changelog }} >> "$GITHUB_STEP_SUMMARY"
+        run: |
+          OUTPUT=$(cat << EOF
+            ${{ steps.build_changelog.outputs.changelog }} 
+            EOF
+            )
+          echo "$OUTPUT" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create release
         if: ${{ steps.tag_check.outputs.exists == 'false' }}


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

fix generation of empty release note on daily release when yesterday had no release (this is because in that case nonexistant tag is passed to fromTag)

## Describe the solution

1. compare with tag of last release, not from the day before.
2. always create/update releases so release note can be updated when manually ran.

## Describe alternatives you've considered

remove usage of YESTERDAY_TAG_NAME completely? head foggy so not sure if it'd work

## Testing

- ran https://github.com/cataclysmbnteam/Cataclysm-BN/actions/runs/9950837172/job/27489346015 
- it correctly updated previously empty release note of https://github.com/cataclysmbnteam/Cataclysm-BN/releases/tag/2024-07-15
- existing release assets were kept intact.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
