### PR TITLE
fix: replace urban_7_house_garden outdoor terrain with regional terrain

### DIFF
--- a/data/json/mapgen/city_blocks/urban_7_house_garden.json
+++ b/data/json/mapgen/city_blocks/urban_7_house_garden.json
@@ -8,13 +8,13 @@
       "fill_ter": "t_floor",
       "rows": [
         "########################",
-        "#,,,,,qq|---|-----------",
-        "#,,,,,;;|W D|ffCoCSC2   ",
+        "#,,,,,,,|---|-----------",
+        "#,,,,#;;|W D|ffCoCSC2   ",
         "#,,,;;;;!   +22222222   ",
         "#,,,;#;;|rrr|22CCC222   ",
         "#,,,;,,,|---|22CCC222   ",
         "#,,,;,,,|AtA 22222222 |-",
-        "#,,,;,,,w             |,",
+        "#,,,;,,,w             |#",
         "#,##;,,,w     A       w#",
         "#,##;##,w    At       w#",
         "#,,,;##,|             w#",
@@ -33,6 +33,11 @@
         "########################"
       ],
       "palettes": [ "acidia_residential_commercial_palette" ],
+      "terrain": {
+        "#": [ "t_region_shrub", "t_region_shrub_fruit", "t_region_shrub_decorative" ],
+        ";": "t_concrete",
+        ",": "t_region_groundcover_urban"
+      },
       "toilets": { "T": {  } },
       "items": {
         " ": { "item": "livingroom", "chance": 2 },
@@ -78,12 +83,21 @@
         ",,,,,,##;;;;;;;##,,,,,,#",
         ",,,,,,,,,;;;;;,,,,,,,,,#",
         ",,,,,,,,,,;;;,,,,,,,,,,#",
-        ";;;;;;;;;;;;;,,,,,,,,,,#",
+        ";;;;;;;;;;;;;p̄,,,,,,,,,#",
         ",,,,,,,,,,;;;,,,,,,,,,,#",
         "##########;;;###########"
       ],
       "palettes": [ "acidia_residential_commercial_palette" ],
+      "terrain": {
+        "#": [ "t_region_shrub", "t_region_shrub_fruit", "t_region_shrub_decorative" ],
+        ";": "t_concrete",
+        ",": "t_region_groundcover_urban",
+        "p̄": "t_region_groundcover_urban",
+        "^": [ [ "t_region_tree_fruit", 2 ], [ "t_region_tree_nut", 2 ], "t_region_tree_shade" ]
+      },
+      "furniture": { "p̄": "f_mailbox" },
       "items": {
+        "p̄": { "item": "mail", "chance": 30, "repeat": [ 2, 5 ] },
         " ": { "item": "livingroom", "chance": 2 },
         "O": { "item": "homebooks", "chance": 60 },
         "r": { "item": "farming_seeds", "chance": 60 }


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Replace urban_7_house_garden outdoor terrain with regional terrain.
## Describe the solution
Override some of the terrain.
Add a mailbox somewhere, given that almost every house has one.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/8b680857-4337-4bbc-ba47-5f2e550829e6">
After:
<img width="960" alt="image2" src="https://github.com/user-attachments/assets/02df1c28-7f67-4b3d-bb28-0bd31510e648">