### PR TITLE
feat(balance): Swap mod locations for compound and normal crossbows

### DIFF
--- a/data/json/items/ranged/crossbows.json
+++ b/data/json/items/ranged/crossbows.json
@@ -338,7 +338,7 @@
     "dispersion": 375,
     "durability": 6,
     "reload": 800,
-    "valid_mod_locations": [ [ "sling", 1 ], [ "dampening", 1 ] ]
+    "valid_mod_locations": [ [ "sling", 1 ], [ "dampening", 1 ], [ "accessories", 1 ], [ "mechanism", 1 ] ]
   },
   {
     "id": "compositecrossbow",

--- a/data/json/items/ranged/crossbows.json
+++ b/data/json/items/ranged/crossbows.json
@@ -338,15 +338,7 @@
     "dispersion": 375,
     "durability": 6,
     "reload": 800,
-    "valid_mod_locations": [
-      [ "accessories", 4 ],
-      [ "dampening", 1 ],
-      [ "rail", 1 ],
-      [ "sights", 1 ],
-      [ "sling", 1 ],
-      [ "underbarrel", 1 ],
-      [ "mechanism", 1 ]
-    ]
+    "valid_mod_locations": [ [ "sling", 1 ], [ "dampening", 1 ] ]
   },
   {
     "id": "compositecrossbow",
@@ -389,7 +381,15 @@
     "dispersion": 325,
     "durability": 6,
     "reload": 1000,
-    "valid_mod_locations": [ [ "sling", 1 ], [ "dampening", 1 ] ]
+    "valid_mod_locations": [
+      [ "accessories", 4 ],
+      [ "dampening", 1 ],
+      [ "rail", 1 ],
+      [ "sights", 1 ],
+      [ "sling", 1 ],
+      [ "underbarrel", 1 ],
+      [ "mechanism", 1 ]
+    ]
   },
   {
     "id": "huge_crossbow",


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

As helpfully pointed out by Hegamonia on the Discord, the normal crossbow's mod slots and the compound crossbow's mod slots seemed completely the wrong way around. I agreed with this, because holy hell is how it was wacky.

## Describe the solution

Swaps the slots for gun mods that the crossbow and compound crossbow have.

## Describe alternatives you've considered

- Leave the normal crossbow alone and just give its superior mod slots to the compound crossbow

Also valid

## Testing

I swapped pretty much a single line of JSON around, if it breaks I will be very concerned.

## Additional context

https://tenor.com/view/threatening-sergei-kravinoff-aaron-taylor-johnson-kraven-the-hunter-holding-a-crossbow-gif-10776485014161891611
