### PR TITLE
fix: `extract clay` and related constructions can now target mounds and underground terrain

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -3160,7 +3160,7 @@
     "time": "30 m",
     "qualities": [ [ { "id": "DIG", "level": 1 } ] ],
     "byproducts": [ { "item": "material_sand", "charges": [ 300, 600 ] } ],
-    "pre_terrain": "t_sand",
+    "pre_flags": "SOURCE_SAND",
     "dark_craftable": true,
     "post_special": "done_extract_maybe_revert_to_dirt"
   },
@@ -3173,7 +3173,7 @@
     "time": "30 m",
     "qualities": [ [ { "id": "DIG", "level": 1 } ] ],
     "byproducts": [ { "item": "clay_lump", "count": [ 6, 12 ] } ],
-    "pre_terrain": "t_clay",
+    "pre_flags": "SOURCE_CLAY",
     "dark_craftable": true,
     "post_special": "done_extract_maybe_revert_to_dirt"
   },
@@ -3186,7 +3186,7 @@
     "time": "45 m",
     "qualities": [ [ { "id": "DIG", "level": 1 } ] ],
     "byproducts": [ { "item": "iron_ore", "count": [ 1, 4 ] } ],
-    "pre_terrain": "t_bog_iron",
+    "pre_flags": "SOURCE_IRON",
     "post_special": "done_extract_maybe_revert_to_dirt"
   },
   {

--- a/data/json/furniture_and_terrain/terrain-floors-indoor.json
+++ b/data/json/furniture_and_terrain/terrain-floors-indoor.json
@@ -708,7 +708,7 @@
     "looks_like": "t_sand",
     "move_cost": 3,
     "roof": "t_rock_roof",
-    "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "INDOORS", "FLAT", "DIGGABLE" ],
+    "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "INDOORS", "FLAT", "DIGGABLE", "SOURCE_SAND" ],
     "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
   },
   {
@@ -749,7 +749,7 @@
     "color": "light_red",
     "move_cost": 2,
     "roof": "t_rock_roof",
-    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "SUPPORTS_ROOF", "INDOORS" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "SUPPORTS_ROOF", "INDOORS", "SOURCE_CLAY" ],
     "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
   },
   {
@@ -762,13 +762,13 @@
     "color": "brown",
     "move_cost": 5,
     "roof": "t_rock_roof",
-    "flags": [ "TRANSPARENT", "BURROWABLE", "SUPPORTS_ROOF", "INDOORS" ],
+    "flags": [ "TRANSPARENT", "BURROWABLE", "SUPPORTS_ROOF", "INDOORS", "SOURCE_CLAY" ],
     "bash": {
-      "str_min": 2,
-      "str_max": 4,
-      "sound": "splosh!",
-      "sound_fail": "splosh!",
-      "ter_set": "t_water_dp",
+      "sound": "thump",
+      "sound_fail": "thump!",
+      "str_min": 20,
+      "str_max": 40,
+      "ter_set": "t_dirt_underground",
       "items": [ { "item": "clay_lump", "count": [ 6, 12 ] } ]
     }
   },

--- a/data/json/furniture_and_terrain/terrain-floors-outdoors.json
+++ b/data/json/furniture_and_terrain/terrain-floors-outdoors.json
@@ -18,7 +18,7 @@
     "symbol": ".",
     "color": "yellow",
     "move_cost": 3,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "VEH_TREAT_AS_BASH_BELOW" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "VEH_TREAT_AS_BASH_BELOW", "SOURCE_SAND" ],
     "bash": {
       "sound": "thump",
       "ter_set": "t_pit_shallow",
@@ -48,7 +48,7 @@
     "symbol": ".",
     "color": "light_red",
     "move_cost": 2,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "SOURCE_CLAY" ],
     "bash": {
       "sound": "thump",
       "ter_set": "t_pit_shallow",
@@ -67,13 +67,13 @@
     "symbol": "#",
     "color": "brown",
     "move_cost": 5,
-    "flags": [ "TRANSPARENT", "BURROWABLE" ],
+    "flags": [ "TRANSPARENT", "BURROWABLE", "SOURCE_CLAY" ],
     "bash": {
-      "str_min": 2,
-      "str_max": 4,
-      "sound": "splosh!",
-      "sound_fail": "splosh!",
-      "ter_set": "t_water_dp",
+      "sound": "thump",
+      "sound_fail": "thump!",
+      "str_min": 20,
+      "str_max": 40,
+      "ter_set": "t_dirt",
       "items": [ { "item": "clay_lump", "count": [ 6, 12 ] } ]
     }
   },
@@ -86,13 +86,13 @@
     "symbol": "#",
     "color": "brown",
     "move_cost": 5,
-    "flags": [ "TRANSPARENT", "BURROWABLE" ],
+    "flags": [ "TRANSPARENT", "BURROWABLE", "SOURCE_SAND" ],
     "bash": {
-      "str_min": 2,
-      "str_max": 4,
-      "sound": "splosh!",
-      "sound_fail": "splosh!",
-      "ter_set": "t_water_dp",
+      "sound": "thump!",
+      "sound_fail": "thump!",
+      "str_min": 20,
+      "str_max": 40,
+      "ter_set": "t_dirt",
       "items": [ { "item": "material_sand", "charges": [ 300, 600 ] } ]
     }
   },
@@ -105,7 +105,7 @@
     "looks_like": "t_claymound",
     "color": "brown",
     "move_cost": 5,
-    "flags": [ "TRANSPARENT", "BURROWABLE" ],
+    "flags": [ "TRANSPARENT", "BURROWABLE", "SOURCE_IRON" ],
     "bash": {
       "str_min": 20,
       "str_max": 40,

--- a/doc/src/content/docs/en/mod/json/reference/json_flags.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_flags.md
@@ -610,6 +610,9 @@ List of known flags, used in both `terrain.json` and `furniture.json`.
 - `SIGN` Show written message on examine.
 - `SMALL_PASSAGE` This terrain or furniture is too small for large or huge creatures to pass
   through.
+- `SOURCE_CLAY` Enables the `Extract Clay` Construction entry.
+- `SOURCE_IRON` Enables the `Extract Iron` Construction entry.
+- `SOURCE_SAND` Enables the `Extract Sand` Construction entry.
 - `SUN_ROOF_ABOVE` This furniture (terrain is not supported currently) has a "fake roof" above, that
   blocks sunlight. Special hack for #44421, to be removed later.
 - `SUPPORTS_ROOF` Used as a boundary for roof construction.


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

After some confusion in the BN server I eventually figured out that you can't use the "extract clay" construction on the mounds of clay found in landscaping stores, because the constructions in question were only checking for a specific terrain ID, and it was different from the one used in the store.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

JSON changes:
1. Converted the extract clay, extract sand, and extract bog iron constructions from using `pre_terrain` to `pre_flags`, defining an appropriate flag for each: `SOURCE_CLAY`, `SOURCE_SAND`, and `SOURCE_IRON`.
2. Added the `SOURCE_CLAY` flag to clay floors and clay mounds, both indoors and outdoors.
3. Added the `SOURCE_SAND` flag to indoor and outdoor sand terrain.
4. Added the `SOURCE_IRON` flag to bog iron.
5. Converted the clay and sand mounds to turn into dirt when bashed, as they no longer spawn in water. Left bog iron along however since it does.

Documentation changes:
1. Added the new flags to json_flags.md.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Screaming.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.
3. Examined clay mounds in a landscaping store, confirmed it shows the new flag on it.
4. Checked construction menu, I can now extract clay from it.

![image](https://github.com/user-attachments/assets/2966279e-b723-4191-b3f5-4f5405c7c726)

![image](https://github.com/user-attachments/assets/2297b885-1948-47e3-953e-86ab61398b6d)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

At some point later on we should convert the function that reverts extracted terrain to dirt to do something more flexible like checking if the terrain has a valid ter_set and if so setting it to that instead.

Converting mounds of sand/clay to furniture could also be done in the future too but we'd need the function to also support removing furniture instead of messing with terrain.