### PR TITLE
fix: replace urban_8_house_brick_garden outdoor terrain with regional terrain

### DIFF
--- a/data/json/mapgen/city_blocks/urban_8_house_brick_garden.json
+++ b/data/json/mapgen/city_blocks/urban_8_house_brick_garden.json
@@ -12,8 +12,8 @@
         ",N,,,,,,,,,,,,,,,,,,,`|r",
         ",N,,,,,,,,,,,,,,,##,,,wr",
         ",N,,,,,,,,,,,,,,,##,,,|r",
-        ",N,,,,,#|vv+vv|,,,,,,,|-",
-        ",N,,,,,#v:::::v,,,,^,,,,",
+        ",N,,##,,|vv+vv|,,,,,,,|-",
+        ",N,,##,,v:::::v,,,,^,,,,",
         ",N,,,,,,v:::::v,,,,,,,,,",
         ",N,,,,,,v:::::v,,,,,,,,,",
         ",N,,,,,`|:::::|,,,,,,,,,",
@@ -33,6 +33,12 @@
         ",,,,,,,,,,,,,,,,,,,,,,,,"
       ],
       "palettes": [ "acidia_residential_commercial_palette" ],
+      "terrain": {
+        "#": [ "t_region_shrub", "t_region_shrub_fruit", "t_region_shrub_decorative" ],
+        ";": "t_concrete",
+        ",": "t_region_groundcover_urban",
+        "^": [ [ "t_region_tree_fruit", 2 ], [ "t_region_tree_nut", 2 ], "t_region_tree_shade" ]
+      },
       "items": { ":": { "item": "farming_tools", "chance": 8 }, "r": { "item": "farming_tools", "chance": 60 } },
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 1, 22 ], "y": [ 1, 22 ], "density": 0.09 } ]
     }
@@ -54,8 +60,8 @@
         ",;,,,,,,mmmmm,,,,,,,,,N,",
         ",;,,,,,,,,,,,,,,,,,,,,N,",
         ",;,,`,,,,,,,,,,,,,,`,,N,",
-        ",;,qIiYiiiiiiYiiiiiI,,N,",
-        ",;,qICSCoC|u|  bbe I,,N,",
+        ",;,,IiYiiiiiiYiiiiiI,,N,",
+        ",;,,ICSCoC|u|  bbe I,,N,",
         ";;;;!22222|+|  bb  Y,,N,",
         ",,,,I22222  +     eY,,N,",
         ",,,,If2Wjj| |     eI,,N,",
@@ -67,12 +73,21 @@
         ",,,`IiiiYYii!iIiiiiI,,N,",
         ",,,,,,,,,,;;;;;,,,,,,,N,",
         ";;;;;;;;;;;;;;;,,,,,,,N,",
-        "nnnnnnnnnnnn;nnnnnnnnnN,",
-        ",,,,,,,,,,,,;,,,,,,,,,,,"
+        "nnnnnnnnnnnnṉnnnnnnnnnN,",
+        ",,,,,,,,,,,p̄;,,,,,,,,,,,"
       ],
       "palettes": [ "acidia_residential_commercial_palette" ],
+      "terrain": {
+        ";": "t_concrete",
+        ",": "t_region_groundcover_urban",
+        "p̄": "t_region_groundcover_urban",
+        "^": [ [ "t_region_tree_fruit", 2 ], [ "t_region_tree_nut", 2 ], "t_region_tree_shade" ],
+        "ṉ": "t_chaingate_c"
+      },
+      "furniture": { "p̄": "f_mailbox" },
       "toilets": { "T": {  } },
       "items": {
+        "p̄": { "item": "mail", "chance": 30, "repeat": [ 2, 5 ] },
         " ": { "item": "livingroom", "chance": 2 },
         "@": { "item": "magazines", "chance": 10 },
         "A": { "item": "livingroom", "chance": 15 },


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Replace urban_8_house_brick_garden outdoor terrain with regional terrain.
## Describe the solution
Override some of the terrain for now, standard_domestic_palette and the other house palette will be slapped here later.
Add a mailbox somewhere, given that almost every house has one.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/3e3df799-c988-48f6-9a0f-e6be97748ae4">
After:
<img width="960" alt="image2" src="https://github.com/user-attachments/assets/b61b6b1c-20a0-415c-b1cc-fbd92796de0d">