### PR TITLE
feat(balance): standardize time taken by mining tools, needs gain scales with time taken, remove pain penalties

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -255,7 +255,6 @@ static const std::string flag_AUTODOC( "AUTODOC" );
 static const std::string flag_AUTODOC_COUCH( "AUTODOC_COUCH" );
 static const std::string flag_BUTCHER_EQ( "BUTCHER_EQ" );
 static const std::string flag_PLANTABLE( "PLANTABLE" );
-static const std::string flag_SUPPORTS_ROOF( "SUPPORTS_ROOF" );
 static const std::string flag_TREE( "TREE" );
 
 using namespace activity_handlers;

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -414,22 +414,19 @@ void activity_handlers::burrow_finish( player_activity *act, player *p )
 {
     tripoint pos = act->placement; // make a copy to avoid use-after-free
     map &here = get_map();
-    act->set_to_null(); // kill activity before inflicting pain
-    if( here.is_bashable( pos ) && here.has_flag( flag_SUPPORTS_ROOF, pos ) &&
-        here.ter( pos ) != t_tree ) {
-        // Tunneling through solid rock is hungry, sweaty, tiring, backbreaking work
-        // Not quite as bad as the pickaxe, though
-        p->mod_stored_nutr( 10 );
-        p->mod_thirst( 10 );
-        p->mod_fatigue( 15 );
-        p->mod_pain( 3 * rng( 1, 3 ) );
-    } else if( here.move_cost( pos ) == 2 && g->get_levz() == 0 &&
-               here.ter( pos ) != t_dirt && here.ter( pos ) != t_grass ) {
-        //Breaking up concrete on the surface? not nearly as bad
-        p->mod_stored_nutr( 5 );
-        p->mod_thirst( 5 );
-        p->mod_fatigue( 10 );
+    if( p->is_avatar() ) {
+        int act_exertion = act->moves_total;
+        // Impossible in vanilla since competing thresholds, but allowed in case of mods
+        if( p->has_trait( trait_STOCKY_TROGLO ) ) {
+            act_exertion /= 2;
+        }
+        // Base cost of 1 fatigue per 3 minutes, or 20 fatigue at 8 strength since 60 minutes
+        // Strength, terrain, and helpers accounted for by time calculation
+        p->mod_stored_kcal( std::min( -1, -act_exertion / to_moves<int>( 45_seconds ) ) );
+        p->mod_thirst( std::max( 1, act_exertion / to_moves<int>( 6_minutes ) ) );
+        p->mod_fatigue( std::max( 1, act_exertion / to_moves<int>( 3_minutes ) ) );
     }
+    act->set_to_null();
     p->add_msg_if_player( m_good, _( "You finish burrowing." ) );
     here.destroy( pos, true );
 }
@@ -1914,31 +1911,19 @@ void activity_handlers::pickaxe_finish( player_activity *act, player *p )
 {
     map &here = get_map();
     const tripoint pos( here.getlocal( act->placement ) );
-    // Invalidate the activity early to prevent a query from mod_pain()
-    act->set_to_null();
     if( p->is_avatar() ) {
-        const int helpersize = character_funcs::get_crafting_helpers( *p, 3 ).size();
-        if( here.is_bashable( pos ) && here.has_flag( flag_SUPPORTS_ROOF, pos ) &&
-            here.ter( pos ) != t_tree ) {
-            // Tunneling through solid rock is hungry, sweaty, tiring, backbreaking work
-            // Betcha wish you'd opted for the J-Hammer ;P
-            p->mod_stored_nutr( 15 - ( helpersize * 3 ) );
-            p->mod_thirst( 15 - ( helpersize * 3 ) );
-            if( p->has_trait( trait_STOCKY_TROGLO ) ) {
-                // Yep, dwarves can dig longer before tiring
-                p->mod_fatigue( 20 - ( helpersize  * 3 ) );
-            } else {
-                p->mod_fatigue( 30 - ( helpersize  * 3 ) );
-            }
-            p->mod_pain( std::max( 0, ( 2 * static_cast<int>( rng( 1, 3 ) ) ) - helpersize ) );
-        } else if( here.move_cost( pos ) == 2 && g->get_levz() == 0 &&
-                   here.ter( pos ) != t_dirt && here.ter( pos ) != t_grass ) {
-            //Breaking up concrete on the surface? not nearly as bad
-            p->mod_stored_nutr( 5 - ( helpersize ) );
-            p->mod_thirst( 5 - ( helpersize ) );
-            p->mod_fatigue( 10 - ( helpersize  * 2 ) );
+        int act_exertion = act->moves_total;
+        // Troglodyte mutants can dig longer before tiring
+        if( p->has_trait( trait_STOCKY_TROGLO ) ) {
+            act_exertion /= 2;
         }
+        // Base cost of 1 fatigue per 3 minutes, or 30 fatigue at 8 strength since 90 minutes
+        // Strength, terrain, and helpers accounted for by time calculation
+        p->mod_stored_kcal( std::min( -1, -act_exertion / to_moves<int>( 45_seconds ) ) );
+        p->mod_thirst( std::max( 1, act_exertion / to_moves<int>( 6_minutes ) ) );
+        p->mod_fatigue( std::max( 1, act_exertion / to_moves<int>( 3_minutes ) ) );
     }
+    act->set_to_null();
     p->add_msg_player_or_npc( m_good,
                               _( "You finish digging." ),
                               _( "<npcname> finishes digging." ) );
@@ -4176,10 +4161,16 @@ void activity_handlers::jackhammer_finish( player_activity *act, player *p )
     }
 
     if( p->is_avatar() ) {
-        const int helpersize = character_funcs::get_crafting_helpers( *p, 3 ).size();
-        p->mod_stored_nutr( 5 - helpersize );
-        p->mod_thirst( 5 - helpersize );
-        p->mod_fatigue( 10 - ( helpersize * 2 ) );
+        int act_exertion = act->moves_total;
+        // Troglodyte mutants can dig longer before tiring
+        if( p->has_trait( trait_STOCKY_TROGLO ) ) {
+            act_exertion /= 2;
+        }
+        // Base cost of 1 fatigue per 3 minutes, or 10 fatigue at 8 strength since 30 minutes
+        // Strength, terrain, and helpers accounted for by time calculation
+        p->mod_stored_kcal( std::min( -1, -act_exertion / to_moves<int>( 45_seconds ) ) );
+        p->mod_thirst( std::max( 1, act_exertion / to_moves<int>( 6_minutes ) ) );
+        p->mod_fatigue( std::max( 1, act_exertion / to_moves<int>( 3_minutes ) ) );
     }
     p->add_msg_player_or_npc( m_good,
                               _( "You finish drilling." ),

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2464,9 +2464,11 @@ static bool mine_activity( player &p, const tripoint &src_loc )
     if( chosen_item == nullptr ) {
         return false;
     }
-    int moves = to_moves<int>( powered ? 30_minutes : 20_minutes );
-    if( !powered ) {
-        moves += ( ( MAX_STAT + 4 ) - std::min( p.str_cur, MAX_STAT ) ) * to_moves<int>( 5_minutes );
+    int moves = to_moves<int>( powered ? 10_minutes : 30_minutes );
+    if( powered ) {
+        moves += ( ( MAX_STAT + 4 ) - std::min( p.str_cur, MAX_STAT ) ) * to_moves<int>( 75_seconds );
+    } else {
+        moves += ( ( MAX_STAT + 4 ) - std::min( p.str_cur, MAX_STAT ) ) * to_moves<int>( 225_seconds );
     }
     if( here.move_cost( src_loc ) == 2 ) {
         // We're breaking up some flat surface like pavement, which is much easier

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3145,7 +3145,9 @@ int iuse::jackhammer( player *p, item *it, bool, const tripoint &pos )
         return 0;
     }
 
-    int moves = to_moves<int>( 30_minutes );
+    // Base time of 30 minutes at 8 strength
+    int moves = to_moves<int>( 10_minutes );
+    moves += ( 24 - std::min( p->str_cur, 24 ) ) * to_moves<int>( 75_seconds );
     if( g->m.move_cost( pnt ) == 2 ) {
         // We're breaking up some flat surface like pavement, which is much easier
         moves /= 2;
@@ -3235,8 +3237,9 @@ int iuse::pickaxe( player *p, item *it, bool, const tripoint &pos )
         return 0;
     }
 
-    int moves = to_moves<int>( 20_minutes );
-    moves += ( ( MAX_STAT + 4 ) - std::min( p->str_cur, MAX_STAT ) ) * to_moves<int>( 5_minutes );
+    // Base time of 90 minutes at 8 strength
+    int moves = to_moves<int>( 30_minutes );
+    moves += ( 24 - std::min( p->str_cur, 24 ) ) * to_moves<int>( 225_seconds );
     if( g->m.move_cost( pnt ) == 2 ) {
         // We're breaking up some flat surface like pavement, which is much easier
         moves /= 2;
@@ -3289,12 +3292,21 @@ int iuse::burrow( player *p, item *it, bool, const tripoint &pos )
         return 0;
     }
 
-    int moves = to_moves<int>( 5_minutes );
-    moves += ( ( MAX_STAT + 3 ) - std::min( p->str_cur, MAX_STAT ) ) * to_moves<int>( 2_minutes );
+    // Base time of 60 minutes at 8 strength
+    int moves = to_moves<int>( 20_minutes );
+    moves += ( 24 - std::min( p->str_cur, 24 ) ) * to_moves<int>( 150_seconds );
     if( g->m.move_cost( pnt ) == 2 ) {
         // We're breaking up some flat surface like pavement, which is much easier
         moves /= 2;
     }
+
+    // For consistency, makes as much sense as NPCs helping you mine faster when you're the only one with the tool
+    const std::vector<npc *> helpers = character_funcs::get_crafting_helpers( *p, 3 );
+    for( const npc *np : helpers ) {
+        add_msg( m_info, _( "%s helps with this task…" ), np->name );
+    }
+    moves = moves * ( 10 - helpers.size() ) / 10;
+
     p->assign_activity( ACT_BURROW, moves, -1, 0 );
     p->activity->placement = pnt;
     p->add_msg_if_player( _( "You start tearing into the %1$s with your %2$s." ),


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

I'd been meaning to finally update mining activities, so that their fake exertion penalties actually scale with time taken. This also tweaks it so the time requirements are a bit more consistent all around, and strength impacts all three types a bit more sanely.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. In activity_handlers.cpp, standardized the rate of needs gain for `activity_handlers::burrow_finish`, `activity_handlers::pickaxe_finish`, and `activity_handlers::jackhammer_finish`. They now all use the same rate derived from how long the action takes to compete, so crafting helpers and strength directly impact each the same rate. In addition, the pain infliction has been removed since no other activity forces this sort of thing on you.
2. In iuse.cpp, updated the logic for calculating moves for burrowing, pickaxe use, and jackhammering. Jackhammering set to a balance point of 30 minutes at 8 strength, burrowing 60 minutes at 8 strength (raised from 35 minutes, but now NPC followers can assist, as it makes sense that they can still help with moving overburden out of the way, or at least is consistent with them being able to help jackhammer even when you're the only one with a tool), and 90 minutes for pickaxes (lowered from 100 minutes). This also means that jackhammers actually benefit from strength now, given it's a tiresome enough activity to trigger fatigue and such.
3. In activity_item_handling.cpp, updated `mine_activity` to be consistent with the above calculations in iuse.cpp.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Keeping burrowing almost as fast as a jackhammer but disallowing friends from helping out.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Gave myself Debug Life Support and spawned in a pickaxe and jackhammer.
3. Confirmed at 8 strength that it takes 90 minutes to operate a pickaxe, and 30 for the jackhammer.
4. Confirmed that fatigue gain was 30 for the former, 10 for the latter.
6. Boosted strength to 24, time required for pickaxe and jackhammer is 30 minutes and 10 minutes respectively.
7. Set strength to 0, time for the former was 2 hours, time for the latter was 40 minutes. Note that this required skeletal bracing CBM plus Strong Back for accurate results, or else the speed penalty from being overburdened would throw the result off.

Time taken and needs penalties, pickaxe at 8 strength:
![image](https://github.com/user-attachments/assets/7154c58a-06df-4403-8063-74b3266fc61f)

Time taken and needs penalties, jackhammer at 8 strength:
![image](https://github.com/user-attachments/assets/efa78a6d-e9e6-48ba-8f38-9a7626fb7a84)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
