### PR TITLE
fix: turn all mapgen in urban_7_house_garden.json to the north

### DIFF
--- a/data/json/mapgen/city_blocks/urban_7_house_garden.json
+++ b/data/json/mapgen/city_blocks/urban_7_house_garden.json
@@ -2,10 +2,10 @@
   {
     "type": "mapgen",
     "method": "json",
-    "om_terrain": [ "urban_7_1" ],
-    "weight": 250,
+    "om_terrain": [ "urban_7_2" ],
     "object": {
       "fill_ter": "t_floor",
+      "rotation": 2,
       "rows": [
         "########################",
         "#,,,,,,,|---|-----------",
@@ -57,10 +57,10 @@
   {
     "type": "mapgen",
     "method": "json",
-    "om_terrain": [ "urban_7_2" ],
-    "weight": 250,
+    "om_terrain": [ "urban_7_1" ],
     "object": {
       "fill_ter": "t_floor",
+      "rotation": 2,
       "rows": [
         "########################",
         "--|-----|#,,,,,,,,,,,,,#",
@@ -108,10 +108,10 @@
   {
     "type": "mapgen",
     "method": "json",
-    "om_terrain": [ "urban_7_3" ],
-    "weight": 250,
+    "om_terrain": [ "urban_7_4" ],
     "object": {
       "fill_ter": "t_floor",
+      "rotation": 2,
       "rows": [
         "........................",
         "........|-w-w-|-|---|-|-",
@@ -156,10 +156,10 @@
   {
     "type": "mapgen",
     "method": "json",
-    "om_terrain": [ "urban_7_4" ],
-    "weight": 250,
+    "om_terrain": [ "urban_7_3" ],
     "object": {
       "fill_ter": "t_floor",
+      "rotation": 2,
       "rows": [
         "........................",
         "vvvvvvv-|...............",
@@ -198,10 +198,10 @@
   {
     "type": "mapgen",
     "method": "json",
-    "om_terrain": [ "urban_7_5" ],
-    "weight": 250,
+    "om_terrain": [ "urban_7_6" ],
     "object": {
       "fill_ter": "t_floor",
+      "rotation": 2,
       "rows": [
         "........................",
         "........1111111111111111",
@@ -234,10 +234,10 @@
   {
     "type": "mapgen",
     "method": "json",
-    "om_terrain": [ "urban_7_6" ],
-    "weight": 250,
+    "om_terrain": [ "urban_7_5" ],
     "object": {
       "fill_ter": "t_floor",
+      "rotation": 2,
       "rows": [
         "........................",
         "111111112...............",

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -5766,12 +5766,12 @@
     "type": "city_building",
     "id": "urban_7_house_garden",
     "overmaps": [
-      { "point": [ 1, 0, 0 ], "overmap": "urban_7_1_south" },
-      { "point": [ 0, 0, 0 ], "overmap": "urban_7_2_south" },
-      { "point": [ 1, 0, 1 ], "overmap": "urban_7_3_south" },
-      { "point": [ 0, 0, 1 ], "overmap": "urban_7_4_south" },
-      { "point": [ 1, 0, 2 ], "overmap": "urban_7_5_south" },
-      { "point": [ 0, 0, 2 ], "overmap": "urban_7_6_south" }
+      { "point": [ 0, 0, 0 ], "overmap": "urban_7_1_north" },
+      { "point": [ 1, 0, 0 ], "overmap": "urban_7_2_north" },
+      { "point": [ 0, 0, 1 ], "overmap": "urban_7_3_north" },
+      { "point": [ 1, 0, 1 ], "overmap": "urban_7_4_north" },
+      { "point": [ 0, 0, 2 ], "overmap": "urban_7_5_north" },
+      { "point": [ 1, 0, 2 ], "overmap": "urban_7_6_north" }
     ],
     "locations": [ "land" ],
     "flags": [ "CLASSIC" ]


### PR DESCRIPTION
### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Turn all mapgen in urban_7_house_garden.json to the north since all the house entrances face north.
## Describe the solution
Add `"rotation": 2,` in all mapgen of urban_7_house_garden.json
Modify things.
## Describe alternatives you've considered
none
## Additional context
none