### PR TITLE
feat: JSON byproducts generated by digging pits, digging in sand and clay produces reasonable amounts of expected product

### DIFF
--- a/data/json/furniture_and_terrain/terrain-floors-indoor.json
+++ b/data/json/furniture_and_terrain/terrain-floors-indoor.json
@@ -709,6 +709,7 @@
     "move_cost": 3,
     "roof": "t_rock_roof",
     "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "INDOORS", "FLAT", "DIGGABLE", "SOURCE_SAND" ],
+    "digging_result": "digging_sand_50L",
     "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
   },
   {
@@ -750,6 +751,7 @@
     "move_cost": 2,
     "roof": "t_rock_roof",
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "SUPPORTS_ROOF", "INDOORS", "SOURCE_CLAY" ],
+    "digging_result": "digging_clay_50L",
     "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-floors-outdoors.json
+++ b/data/json/furniture_and_terrain/terrain-floors-outdoors.json
@@ -19,6 +19,7 @@
     "color": "yellow",
     "move_cost": 3,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "VEH_TREAT_AS_BASH_BELOW", "SOURCE_SAND" ],
+    "digging_result": "digging_sand_50L",
     "bash": {
       "sound": "thump",
       "ter_set": "t_pit_shallow",
@@ -49,6 +50,7 @@
     "color": "light_red",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "SOURCE_CLAY" ],
+    "digging_result": "digging_clay_50L",
     "bash": {
       "sound": "thump",
       "ter_set": "t_pit_shallow",

--- a/data/json/itemgroups/misc.json
+++ b/data/json/itemgroups/misc.json
@@ -69,6 +69,32 @@
     ]
   },
   {
+    "id": "digging_clay_50L",
+    "type": "item_group",
+    "subtype": "collection",
+    "//": "~50L, 10% volume clay, for digging in clay terrain",
+    "items": [
+      { "item": "material_soil", "count": [ 7, 11 ] },
+      { "item": "clay_lump", "count": [ 10, 30 ] },
+      { "item": "material_sand", "charges": [ 1, 10 ], "prob": 5 },
+      { "item": "rock", "count": [ 1, 4 ], "prob": 15 },
+      { "item": "pebble", "count": [ 1, 4 ], "prob": 15 }
+    ]
+  },
+  {
+    "id": "digging_sand_50L",
+    "type": "item_group",
+    "subtype": "collection",
+    "//": "~50L, 10% volume sand, for digging in sand terrain",
+    "items": [
+      { "item": "material_soil", "count": [ 7, 11 ] },
+      { "item": "material_sand", "charges": [ 500, 1500 ] },
+      { "item": "clay_lump", "count": [ 1, 4 ], "prob": 5 },
+      { "item": "rock", "count": [ 1, 4 ], "prob": 15 },
+      { "item": "pebble", "count": [ 1, 4 ], "prob": 15 }
+    ]
+  },
+  {
     "id": "office_paper",
     "type": "item_group",
     "subtype": "collection",

--- a/doc/src/content/docs/en/mod/json/reference/json_info.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_info.md
@@ -2860,11 +2860,12 @@ source. For examples: An overhead light is 120, a utility light, 240, and a cons
 
 #### `digging_result`
 
-(Optional) String defining the ID of what itemgroup this terrain will produce when a pit is dug here.
+(Optional) String defining the ID of what itemgroup this terrain will produce when a pit is dug
+here.
 
 Only relevant for terrain with the `DIGGABLE` flag. If not specificed, default is itemgroup
-`digging_soil_loam_50L`. Note as well that this group will be called 4 times by default, 8 times
-if the terrain has the `DIGGABLE_CAN_DEEPEN` flag.
+`digging_soil_loam_50L`. Note as well that this group will be called 4 times by default, 8 times if
+the terrain has the `DIGGABLE_CAN_DEEPEN` flag.
 
 #### `lockpick_result`
 

--- a/doc/src/content/docs/en/mod/json/reference/json_info.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_info.md
@@ -2808,6 +2808,7 @@ it for the purpose of surgery.
   "trap": "spike_pit",
   "max_volume": "1000 L",
   "flags": ["TRANSPARENT", "DIGGABLE"],
+  "digging_result": "digging_sand_50L",
   "connects_to": "WALL",
   "close": "t_foo_closed",
   "open": "t_foo_open",
@@ -2856,6 +2857,14 @@ uses `2 * 50 = 100` move points when moving across the terrain.
 How much light the terrain emits. 10 will light the tile it's on brightly, 15 will light that tile
 and the tiles around it brightly, as well as slightly lighting the tiles two tiles away from the
 source. For examples: An overhead light is 120, a utility light, 240, and a console, 10.
+
+#### `digging_result`
+
+(Optional) String defining the ID of what itemgroup this terrain will produce when a pit is dug here.
+
+Only relevant for terrain with the `DIGGABLE` flag. If not specificed, default is itemgroup
+`digging_soil_loam_50L`. Note as well that this group will be called 4 times by default, 8 times
+if the terrain has the `DIGGABLE_CAN_DEEPEN` flag.
 
 #### `lockpick_result`
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2540,7 +2540,7 @@ struct digging_moves_and_byproducts {
 };
 
 static digging_moves_and_byproducts dig_pit_moves_and_byproducts( player *p, item *it, bool deep,
-        bool channel )
+        bool channel, const tripoint &pos )
 {
     // Vastly simplified version of DDA's version, which had a 77-line-long explanation.
     //
@@ -2579,7 +2579,7 @@ static digging_moves_and_byproducts dig_pit_moves_and_byproducts( player *p, ite
         result_terrain = deep ? ter_id( "t_pit" ) : ter_id( "t_pit_shallow" );
     }
 
-    return { moves, static_cast<int>( dig_minutes / 15 ), "digging_soil_loam_50L", result_terrain };
+    return { moves, static_cast<int>( dig_minutes / 15 ), g->m.ter( pos )->digging_result, result_terrain };
 }
 
 int iuse::dig( player *p, item *it, bool t, const tripoint & )
@@ -2658,7 +2658,7 @@ int iuse::dig( player *p, item *it, bool t, const tripoint & )
     }
 
     digging_moves_and_byproducts moves_and_byproducts = dig_pit_moves_and_byproducts( p, it,
-            can_deepen, false );
+            can_deepen, false, dig_point );
 
     const std::vector<npc *> helpers = character_funcs::get_crafting_helpers( *p, 3 );
     for( const npc *np : helpers ) {
@@ -2725,7 +2725,7 @@ int iuse::dig_channel( player *p, item *it, bool t, const tripoint & )
     }
 
     digging_moves_and_byproducts moves_and_byproducts = dig_pit_moves_and_byproducts( p, it, false,
-            true );
+            true, dig_point );
 
     const std::vector<npc *> helpers = character_funcs::get_crafting_helpers( *p, 3 );
     for( const npc *np : helpers ) {

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -1314,6 +1314,7 @@ void ter_t::load( const JsonObject &jo, const std::string &src )
     mandatory( jo, was_loaded, "name", name_ );
     mandatory( jo, was_loaded, "move_cost", movecost );
     assign( jo, "coverage", coverage, is_json_check_strict( src ) );
+    assign( jo, "digging_result", digging_result, is_json_check_strict( src ) );
     assign( jo, "max_volume", max_volume, is_json_check_strict( src ) );
     assign( jo, "trap", trap_id_str, is_json_check_strict( src ) );
 
@@ -1525,6 +1526,7 @@ void furn_t::load( const JsonObject &jo, const std::string &src )
     mandatory( jo, was_loaded, "name", name_ );
     mandatory( jo, was_loaded, "move_cost_mod", movecost );
     optional( jo, was_loaded, "coverage", coverage );
+    optional( jo, was_loaded, "digging_result", digging_result );
     optional( jo, was_loaded, "comfort", comfort, 0 );
     optional( jo, was_loaded, "floor_bedding_warmth", floor_bedding_warmth, 0 );
     optional( jo, was_loaded, "emissions", emissions );

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -459,6 +459,8 @@ struct map_data_common_t {
         int movecost = 0;
         // The coverage percentage of a furniture piece of terrain. <30 won't cover from sight.
         int coverage = 0;
+        // What itemgroup spawns when digging a shallow pit in this terrain, defaults to standard soil yield
+        std::string digging_result = "digging_soil_loam_50L";
         // Maximal volume of items that can be stored in/on this furniture
         units::volume max_volume = 1000_liter;
 


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This fixes up a thing @EkarusRyndren reminded me about, where "so lemme just dig in this clay by the river with a shovel aw fuck it just gave me soil" serves as a common newbie trap.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

C++ changes:
1. In iuse.cpp, converted `dig_pit_moves_and_byproducts` to also grab the position being dug in, and uses that to determine what itemgroup it spawns on digging via grabbing the terrain there and checking a newly-defined JSON property, `digging_result`.
2. In mapdata.cpp and .h, defined `digging_result` as a property of terrain JSON, which defaults to the original hardcoded `digging_soil_loam_50L`.

JSON changes:
2. Defined two new itemgroups, `digging_clay_50L` and `digging_sand_50L`. These resemble `digging_soil_loam_50L` except 10% of the soil volume is set aside for a guaranteed spawn of a comparable amount (i.e. average of 5 liters) of clay lumps or sand respectively, replacing the tiny randomized chance of getting said component.
1. Set `DIGGABLE` sand and clay terrain to use `digging_result` entries pointing to appropriate itemgroups.

Documentation changes:
1. Documented `digging_result` in json_info.md.

I left sand/clay mounds and bog iron intact for now because they use `BURROWABLE` instead of `MINEABLE`, meaning you can't accidentally dig a pit over them and are forced to either bash or use construction menu to extract from the.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Converting bog iron and sand/clay mounds from `BURROWABLE` to `DIGGABLE`, and defining a `digging_result` for it. Might need to go so far as to also define digging result terrain in JSON if so though, so ech.
2. Going further and completely phasing out the construction-based hax in favor of digging.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON for syntax and lint errors.
2. Compiled and load-tested.
3. Dug a pit into plain dirt, confirmed it's still giving me the expected default items.
4. Dug up some clay and sand terrain, confirmed each produces close to 200 liters of stuff, a good chunk of it being a guaranteed spawn of the expected material at a rate that seemed reasonable compared to gambling on the extraction construction multiple times in a row.
5. Checked affected C++ files for astyle.

Example of digging on clay (left) and sand (right):
![image](https://github.com/user-attachments/assets/a5b4a519-aa00-47da-841a-ee6afccea7a3)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->