### PR TITLE
build: Fix non-MSVC windows builds

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -217,7 +217,7 @@ jobs:
           sudo apt update
           sudo apt install astyle autoconf automake autopoint bash bison bzip2 cmake flex gettext git g++ gperf intltool \
             libffi-dev libgdk-pixbuf2.0-dev libtool libltdl-dev libssl-dev libxml-parser-perl lzip make mingw-w64 openssl \
-            p7zip-full patch perl pkg-config python ruby scons sed unzip wget xz-utils g++-multilib libc6-dev-i386 libtool-bin
+            p7zip-full patch perl pkg-config python2 ruby scons sed unzip wget xz-utils g++-multilib libc6-dev-i386 libtool-bin
       - name: Install MXE
         if: matrix.mxe != 'none'
         run: |

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -217,7 +217,7 @@ jobs:
           sudo apt update
           sudo apt install astyle autoconf automake autopoint bash bison bzip2 cmake flex gettext git g++ gperf intltool \
             libffi-dev libgdk-pixbuf2.0-dev libtool libltdl-dev libssl-dev libxml-parser-perl lzip make mingw-w64 openssl \
-            p7zip-full patch perl pkg-config python2 ruby scons sed unzip wget xz-utils g++-multilib libc6-dev-i386 libtool-bin
+            p7zip-full patch perl pkg-config python3 ruby scons sed unzip wget xz-utils g++-multilib libc6-dev-i386 libtool-bin
       - name: Install MXE
         if: matrix.mxe != 'none'
         run: |

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -89,14 +89,14 @@ jobs:
             mxe: x86_64
             mxe_apt: x86-64
             artifact: windows-tiles-x64
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             ext: zip
             content: application/zip
           - name: Windows Tiles x32
             mxe: i686
             mxe_apt: i686
             artifact: windows-tiles-x32
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             ext: zip
             content: application/zip
           - name: Linux Tiles x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,7 +242,7 @@ jobs:
           sudo apt update
           sudo apt install astyle autoconf automake autopoint bash bison bzip2 cmake flex gettext git g++ gperf intltool \
             libffi-dev libgdk-pixbuf2.0-dev libtool libltdl-dev libssl-dev libxml-parser-perl lzip make mingw-w64 openssl \
-            p7zip-full patch perl pkg-config python2 ruby scons sed unzip wget xz-utils g++-multilib libc6-dev-i386 libtool-bin
+            p7zip-full patch perl pkg-config python3 ruby scons sed unzip wget xz-utils g++-multilib libc6-dev-i386 libtool-bin
 
       - name: Install MXE
         if: matrix.mxe != 'none'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,14 +114,14 @@ jobs:
             mxe: x86_64
             mxe_apt: x86-64
             artifact: windows-tiles-x64
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             ext: zip
             content: application/zip
           - name: Windows Tiles x32
             mxe: i686
             mxe_apt: i686
             artifact: windows-tiles-x32
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             ext: zip
             content: application/zip
           - name: Linux Tiles x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,7 +242,7 @@ jobs:
           sudo apt update
           sudo apt install astyle autoconf automake autopoint bash bison bzip2 cmake flex gettext git g++ gperf intltool \
             libffi-dev libgdk-pixbuf2.0-dev libtool libltdl-dev libssl-dev libxml-parser-perl lzip make mingw-w64 openssl \
-            p7zip-full patch perl pkg-config python ruby scons sed unzip wget xz-utils g++-multilib libc6-dev-i386 libtool-bin
+            p7zip-full patch perl pkg-config python2 ruby scons sed unzip wget xz-utils g++-multilib libc6-dev-i386 libtool-bin
 
       - name: Install MXE
         if: matrix.mxe != 'none'


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Following a change made in the process of getting mac builds to work appropriately by RoyalFox, non-MSVC Windows builds were not building. Naturally, this fixes it so that they build again (even though MSVC is generally preferred, it's nice to have a backup in case MSVC ever goes wonky)

## Describe the solution

Bumps the version of Ubuntu used to build the non-MSVC Windows releases to 22.04 instead of 20.04.
Also changes package request to python3 instead of python (Technically grabbing python3 is redundant given it already ships with 22.04 in the first place, but a bit of extra redundancy won't hurt there)

## Describe alternatives you've considered

- Let these versions rot on the vine

- Upgrade to 24.04 instead

"Bleeding edge" is not always desirable, plus it could come with the dreaded too high of a gcc version.


## Testing

Manual release on personal fork, it builds!

## Additional context

![image](https://github.com/user-attachments/assets/41b9324b-766b-4c2d-b169-a76e0b794c9a)
