### PR TITLE
fix: use regional terrain for recycling centres

### DIFF
--- a/data/json/mapgen/recycle_center.json
+++ b/data/json/mapgen/recycle_center.json
@@ -1,34 +1,10 @@
 [
   {
+    "type": "mapgen",
     "method": "json",
+    "om_terrain": "recyclecenter",
     "object": {
       "fill_ter": "t_thconc_floor",
-      "furniture": {
-        "'": "f_street_light",
-        "#": "f_table",
-        "&": "f_trashcan",
-        "P": "f_sign",
-        "c": "f_chair",
-        "d": "f_desk",
-        "t": "f_table",
-        "{": "f_recycle_bin",
-        "S": "f_sink"
-      },
-      "toilets": { "T": {  } },
-      "place_items": [
-        { "chance": 50, "repeat": [ 120, 220 ], "item": "recycle_iron", "x": [ 10, 14 ], "y": [ 15, 16 ] },
-        { "chance": 50, "repeat": [ 50, 120 ], "item": "recycle_electronic", "x": [ 18, 19 ], "y": [ 12, 14 ] },
-        { "chance": 50, "repeat": [ 160, 400 ], "item": "recycle_paper", "x": [ 4, 5 ], "y": [ 11, 19 ] },
-        { "chance": 50, "repeat": [ 80, 180 ], "item": "recycle_copper", "x": [ 10, 14 ], "y": [ 12, 13 ] },
-        { "chance": 50, "repeat": [ 30, 100 ], "item": "recycle_battery", "x": [ 18, 19 ], "y": [ 17, 19 ] },
-        { "chance": 50, "repeat": [ 80, 180 ], "item": "recycle_glass", "x": [ 18, 19 ], "y": [ 7, 9 ] },
-        { "chance": 50, "repeat": [ 150, 250 ], "item": "recycle_steel", "x": [ 10, 14 ], "y": [ 18, 19 ] },
-        { "chance": 25, "item": "office_mess", "x": 6, "y": 7 },
-        { "chance": 25, "item": "office_mess", "x": 3, "y": 7 },
-        { "chance": 35, "repeat": 2, "item": "trash", "x": 3, "y": 5 },
-        { "chance": 50, "repeat": [ 80, 180 ], "item": "recycle_aluminum", "x": [ 10, 14 ], "y": [ 9, 10 ] },
-        { "chance": 50, "repeat": [ 180, 350 ], "item": "recycle_plastic", "x": [ 7, 8 ], "y": [ 11, 19 ] }
-      ],
       "rows": [
         ".........s.............'",
         ".........s..............",
@@ -58,8 +34,8 @@
       "terrain": {
         "&": "t_floor",
         "+": "t_door_metal_c",
-        ".": [ "t_grass", "t_grass", "t_grass", "t_grass", "t_dirt" ],
-        "'": "t_dirt",
+        ".": "t_region_groundcover_urban",
+        "'": "t_region_groundcover_urban",
         "D": "t_door_c",
         "_": "t_thconc_floor",
         "c": "t_floor",
@@ -72,6 +48,32 @@
         "|": "t_brick_wall",
         "4": "t_gutter_downspout"
       },
+      "furniture": {
+        "'": "f_street_light",
+        "#": "f_table",
+        "&": "f_trashcan",
+        "P": "f_sign",
+        "c": "f_chair",
+        "d": "f_desk",
+        "t": "f_table",
+        "{": "f_recycle_bin",
+        "S": "f_sink"
+      },
+      "toilets": { "T": {  } },
+      "place_items": [
+        { "chance": 50, "repeat": [ 120, 220 ], "item": "recycle_iron", "x": [ 10, 14 ], "y": [ 15, 16 ] },
+        { "chance": 50, "repeat": [ 50, 120 ], "item": "recycle_electronic", "x": [ 18, 19 ], "y": [ 12, 14 ] },
+        { "chance": 50, "repeat": [ 160, 400 ], "item": "recycle_paper", "x": [ 4, 5 ], "y": [ 11, 19 ] },
+        { "chance": 50, "repeat": [ 80, 180 ], "item": "recycle_copper", "x": [ 10, 14 ], "y": [ 12, 13 ] },
+        { "chance": 50, "repeat": [ 30, 100 ], "item": "recycle_battery", "x": [ 18, 19 ], "y": [ 17, 19 ] },
+        { "chance": 50, "repeat": [ 80, 180 ], "item": "recycle_glass", "x": [ 18, 19 ], "y": [ 7, 9 ] },
+        { "chance": 50, "repeat": [ 150, 250 ], "item": "recycle_steel", "x": [ 10, 14 ], "y": [ 18, 19 ] },
+        { "chance": 25, "item": "office_mess", "x": 6, "y": 7 },
+        { "chance": 25, "item": "office_mess", "x": 3, "y": 7 },
+        { "chance": 35, "repeat": 2, "item": "trash", "x": 3, "y": 5 },
+        { "chance": 50, "repeat": [ 80, 180 ], "item": "recycle_aluminum", "x": [ 10, 14 ], "y": [ 9, 10 ] },
+        { "chance": 50, "repeat": [ 180, 350 ], "item": "recycle_plastic", "x": [ 7, 8 ], "y": [ 11, 19 ] }
+      ],
       "place_signs": [
         { "signage": "GLASS", "x": 18, "y": 6 },
         { "signage": "ALUMINUM", "x": 15, "y": 9 },
@@ -83,10 +85,7 @@
         { "signage": "BATTERIES", "x": 18, "y": 16 },
         { "signage": "STEEL", "x": 15, "y": 18 }
       ]
-    },
-    "om_terrain": "recyclecenter",
-    "type": "mapgen",
-    "weight": 100
+    }
   },
   {
     "type": "mapgen",
@@ -138,9 +137,54 @@
     }
   },
   {
+    "type": "mapgen",
     "method": "json",
+    "om_terrain": "recyclecenter_1",
     "object": {
       "fill_ter": "t_thconc_floor",
+      "rows": [
+        ".....cccc..............'",
+        ".....cccc...............",
+        ".....cccc...............",
+        "..---S++S--|||ww||D|w|..",
+        "..-ccccccccwC_______b|..",
+        "..-ccPccPcc|a&##____b|||",
+        "..-c{{cc{{c|||||____b|T|",
+        "..-c{{cc{{c|&R#R_____=_|",
+        "..-c{{cc{{c|#_____s__|R|",
+        "..-c{{cc{{c|___s__dd_|||",
+        "..-c{{cc{{c|_ddd__dd_|4.",
+        "..-c{{cc{{c|_ddd__dd_|..",
+        "..-cccccccc|______dd_|..",
+        "..-ccPccPcc|___s__dd_|..",
+        "..-c{{cc{{c|_ddd__dd_|..",
+        "..-c{{cc{{c|_ddd__dd_|..",
+        "..-c{{ccccc_______dd_|..",
+        "..-c{{ccccc_______dd_|..",
+        "..-c{{ccPcc__ddds_dd_|..",
+        "..-c{{cc{{c__ddd__dd_|..",
+        "..-cccccccc|_________|..",
+        "..---------|||||||||||..",
+        "........................",
+        "........................"
+      ],
+      "terrain": {
+        "+": "t_chaingate_c",
+        "-": "t_chainfence",
+        ".": "t_region_groundcover_urban",
+        "'": "t_region_groundcover_urban",
+        "D": "t_door_metal_c",
+        "P": "t_concrete",
+        "S": "t_chainfence",
+        "_": "t_thconc_floor",
+        "R": "t_recycler",
+        "c": "t_concrete",
+        "w": "t_window",
+        "{": "t_concrete",
+        "|": "t_brick_wall",
+        "4": "t_gutter_downspout",
+        "=": "t_door_c"
+      },
       "furniture": {
         "'": "f_street_light",
         "#": "f_table",
@@ -171,49 +215,6 @@
         { "chance": 50, "repeat": [ 20, 150 ], "item": "recycle_glass", "x": [ 13, 15 ], "y": [ 10, 11 ] }
       ],
       "place_vehicles": [ { "chance": 75, "fuel": 0, "rotation": 270, "status": -1, "vehicle": "forklift", "x": 16, "y": [ 7, 16 ] } ],
-      "rows": [
-        ".....cccc..............'",
-        ".....cccc...............",
-        ".....cccc...............",
-        "..---S++S--|||ww||D|w|..",
-        "..-ccccccccwC_______b|..",
-        "..-ccPccPcc|a&##____b|||",
-        "..-c{{cc{{c|||||____b|T|",
-        "..-c{{cc{{c|&R#R_____=_|",
-        "..-c{{cc{{c|#_____s__|R|",
-        "..-c{{cc{{c|___s__dd_|||",
-        "..-c{{cc{{c|_ddd__dd_|4.",
-        "..-c{{cc{{c|_ddd__dd_|..",
-        "..-cccccccc|______dd_|..",
-        "..-ccPccPcc|___s__dd_|..",
-        "..-c{{cc{{c|_ddd__dd_|..",
-        "..-c{{cc{{c|_ddd__dd_|..",
-        "..-c{{ccccc_______dd_|..",
-        "..-c{{ccccc_______dd_|..",
-        "..-c{{ccPcc__ddds_dd_|..",
-        "..-c{{cc{{c__ddd__dd_|..",
-        "..-cccccccc|_________|..",
-        "..---------|||||||||||..",
-        "........................",
-        "........................"
-      ],
-      "terrain": {
-        "+": "t_chaingate_c",
-        "-": "t_chainfence",
-        ".": [ "t_grass", "t_grass", "t_grass", "t_grass", "t_dirt" ],
-        "'": "t_dirt",
-        "D": "t_door_metal_c",
-        "P": "t_concrete",
-        "S": "t_chainfence",
-        "_": "t_thconc_floor",
-        "R": "t_recycler",
-        "c": "t_concrete",
-        "w": "t_window",
-        "{": "t_concrete",
-        "|": "t_brick_wall",
-        "4": "t_gutter_downspout",
-        "=": "t_door_c"
-      },
       "toilets": { "T": {  } },
       "place_signs": [
         { "signage": "GLASS", "x": 15, "y": 9 },
@@ -228,10 +229,7 @@
         { "signage": "<given_name>'s Recycling", "x": 8, "y": 3 },
         { "signage": "Drop off 7am to 6pm Monday thru Friday", "x": 11, "y": 3 }
       ]
-    },
-    "om_terrain": "recyclecenter_1",
-    "type": "mapgen",
-    "weight": 100
+    }
   },
   {
     "type": "mapgen",
@@ -283,36 +281,11 @@
     }
   },
   {
+    "type": "mapgen",
     "method": "json",
+    "om_terrain": "recyclecenter_2",
     "object": {
       "fill_ter": "t_thconc_floor",
-      "furniture": {
-        "'": "f_street_light",
-        "#": "f_counter",
-        "&": "f_trashcan",
-        "P": "f_sign",
-        "c": "f_chair",
-        "d": "f_desk",
-        "s": "f_sign",
-        "{": "f_recycle_bin",
-        "S": "f_sink"
-      },
-      "toilets": { "T": {  } },
-      "place_items": [
-        { "chance": 15, "item": "office", "x": [ 4, 5 ], "y": 14 },
-        { "chance": 30, "item": "trash", "x": 3, "y": 14 },
-        { "chance": 20, "item": "tools_home", "x": 3, "y": [ 19, 20 ] },
-        { "chance": 50, "repeat": [ 80, 280 ], "item": "recycle_plastic", "x": [ 15, 16 ], "y": [ 7, 12 ] },
-        { "chance": 50, "repeat": [ 80, 280 ], "item": "recycle_glass", "x": [ 19, 20 ], "y": [ 7, 12 ] },
-        { "chance": 50, "repeat": [ 80, 350 ], "item": "recycle_paper", "x": [ 3, 9 ], "y": [ 7, 8 ] },
-        { "chance": 50, "repeat": [ 30, 150 ], "item": "recycle_electronic", "x": [ 3, 5 ], "y": [ 10, 11 ] },
-        { "chance": 50, "repeat": [ 20, 120 ], "item": "recycle_battery", "x": [ 8, 9 ], "y": [ 10, 11 ] },
-        { "chance": 50, "repeat": [ 80, 350 ], "item": "recycle_iron", "x": [ 9, 15 ], "y": [ 15, 16 ] },
-        { "chance": 50, "repeat": [ 80, 350 ], "item": "recycle_steel", "x": [ 9, 15 ], "y": [ 19, 20 ] },
-        { "chance": 50, "repeat": [ 50, 180 ], "item": "recycle_aluminum", "x": [ 18, 20 ], "y": [ 15, 16 ] },
-        { "chance": 50, "repeat": [ 50, 180 ], "item": "recycle_copper", "x": [ 18, 20 ], "y": [ 19, 20 ] }
-      ],
-      "place_loot": [ { "item": "television", "x": 4, "y": 14, "chance": 100 }, { "item": "stepladder", "x": 8, "y": 13, "chance": 100 } ],
       "rows": [
         "__________ppppp________'",
         "__________ppppp_________",
@@ -343,21 +316,48 @@
         "+": "t_chaingate_c",
         "-": "t_concrete_wall",
         ".": "t_concrete",
-        "4": "t_tree_pine",
-        "7": "t_tree",
+        "4": "t_region_tree_evergreen",
+        "7": "t_region_tree",
         "D": "t_door_c",
         "P": "t_concrete",
         "R": "t_recycler",
-        "_": [ "t_grass", "t_grass", "t_grass", "t_grass", "t_dirt" ],
-        "'": "t_dirt",
+        "_": "t_region_groundcover_urban",
+        "'": "t_region_groundcover_urban",
         "p": "t_pavement",
-        "s": "t_grass",
+        "s": "t_region_groundcover_urban",
         "t": "t_thconc_floor",
         "w": "t_window",
         "{": "t_concrete",
         "|": "t_chainfence",
         "5": "t_gutter_downspout"
       },
+      "furniture": {
+        "'": "f_street_light",
+        "#": "f_counter",
+        "&": "f_trashcan",
+        "P": "f_sign",
+        "c": "f_chair",
+        "d": "f_desk",
+        "s": "f_sign",
+        "{": "f_recycle_bin",
+        "S": "f_sink"
+      },
+      "toilets": { "T": {  } },
+      "place_items": [
+        { "chance": 15, "item": "office", "x": [ 4, 5 ], "y": 14 },
+        { "chance": 30, "item": "trash", "x": 3, "y": 14 },
+        { "chance": 20, "item": "tools_home", "x": 3, "y": [ 19, 20 ] },
+        { "chance": 50, "repeat": [ 80, 280 ], "item": "recycle_plastic", "x": [ 15, 16 ], "y": [ 7, 12 ] },
+        { "chance": 50, "repeat": [ 80, 280 ], "item": "recycle_glass", "x": [ 19, 20 ], "y": [ 7, 12 ] },
+        { "chance": 50, "repeat": [ 80, 350 ], "item": "recycle_paper", "x": [ 3, 9 ], "y": [ 7, 8 ] },
+        { "chance": 50, "repeat": [ 30, 150 ], "item": "recycle_electronic", "x": [ 3, 5 ], "y": [ 10, 11 ] },
+        { "chance": 50, "repeat": [ 20, 120 ], "item": "recycle_battery", "x": [ 8, 9 ], "y": [ 10, 11 ] },
+        { "chance": 50, "repeat": [ 80, 350 ], "item": "recycle_iron", "x": [ 9, 15 ], "y": [ 15, 16 ] },
+        { "chance": 50, "repeat": [ 80, 350 ], "item": "recycle_steel", "x": [ 9, 15 ], "y": [ 19, 20 ] },
+        { "chance": 50, "repeat": [ 50, 180 ], "item": "recycle_aluminum", "x": [ 18, 20 ], "y": [ 15, 16 ] },
+        { "chance": 50, "repeat": [ 50, 180 ], "item": "recycle_copper", "x": [ 18, 20 ], "y": [ 19, 20 ] }
+      ],
+      "place_loot": [ { "item": "television", "x": 4, "y": 14, "chance": 100 }, { "item": "stepladder", "x": 8, "y": 13, "chance": 100 } ],
       "place_signs": [
         { "signage": "GLASS", "x": 18, "y": 12 },
         { "signage": "ALUMINUM", "x": 18, "y": 14 },
@@ -371,10 +371,7 @@
         { "signage": "<city> Recycling", "x": 9, "y": 4 },
         { "signage": "Drop off 8am to 8pm, weekdays.", "x": 15, "y": 4 }
       ]
-    },
-    "om_terrain": "recyclecenter_2",
-    "type": "mapgen",
-    "weight": 100
+    }
   },
   {
     "type": "mapgen",


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Use regional terrain for recycling centres.
## Describe the solution
Replace non-regional terrain with regional terrain.
Also, fix the style.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/94934203-deae-4974-9a19-c7ac7bf83224">
<img width="960" alt="image2" src="https://github.com/user-attachments/assets/ffbe68d0-23d2-4b9d-a864-7fe69df551e8">
<img width="960" alt="image3" src="https://github.com/user-attachments/assets/c66b839d-de83-49cd-85e8-2146bb212486">
After:
<img width="960" alt="image4" src="https://github.com/user-attachments/assets/036618ac-ea88-49e6-be10-9017feb43db3">
<img width="960" alt="image5" src="https://github.com/user-attachments/assets/2939abdb-ad59-43c8-9ef9-231213ef2357">
<img width="960" alt="image6" src="https://github.com/user-attachments/assets/a68c7152-0cd5-4d28-9c52-19905940c307">
