### PR TITLE
fix: replace urban_40_house outdoor terrain with regional terrain

### DIFF
--- a/data/json/mapgen/city_blocks/urban_40_house.json
+++ b/data/json/mapgen/city_blocks/urban_40_house.json
@@ -3,12 +3,11 @@
     "type": "mapgen",
     "method": "json",
     "om_terrain": [ "urban_40_1" ],
-    "weight": 250,
     "object": {
       "fill_ter": "t_floor",
       "rows": [
         ",,,,,,,,,,,,,,;;;;;,,,,,",
-        ",,,,,,,,iwwwwi;;;;;qq,,,",
+        ",,,,,,,,iwwwwi;;;;;,,,,,",
         ",^,,,iiiiH44Hiii1iiiiwii",
         ",,,,,iCC2H44H22   c6c OO",
         ",,,,,wo22H44H22         ",
@@ -17,7 +16,7 @@
         ",,,,,iC22222222 @       ",
         ",,,,,if22CjjC22k@@@@@iiw",
         ",,^,,i-+iiiiiiiiiiiiii;;",
-        ",,,,,iS2i''''''''''''i;;",
+        ",,,,,iS2i'''''''''''/i;;",
         ",,,,,wD2+''''''''''''=__",
         ",,,,,iC2i''''''''''''=__",
         ",,,,,i--i''''''''''''=__",
@@ -33,6 +32,11 @@
         ",,,,,,,,,,,,,,,,,,,,,,,,"
       ],
       "palettes": [ "acidia_residential_commercial_palette" ],
+      "terrain": {
+        ";": "t_concrete",
+        ",": "t_region_groundcover_urban",
+        "^": [ [ "t_region_tree_fruit", 2 ], [ "t_region_tree_nut", 2 ], "t_region_tree_shade" ]
+      },
       "items": {
         " ": { "item": "livingroom", "chance": 1 },
         "'": { "item": "mechanics", "chance": 1 },
@@ -59,7 +63,6 @@
     "type": "mapgen",
     "method": "json",
     "om_terrain": [ "urban_40_2" ],
-    "weight": 250,
     "object": {
       "fill_ter": "t_floor",
       "rows": [
@@ -69,7 +72,7 @@
         "OA|ST|L|BTS| ebbbe i,,,,",
         "  +22|-|B22+  bbb  i,,,,",
         "  |--|>|---|  bbb  i,,,,",
-        "           _       w,,^,",
+        "           +       w,,^,",
         "           |       i,,,,",
         "wwii1iiwwwii   hd  i,,,,",
         ";;;;;;;;;;;ik d6dOOi`,,,",
@@ -81,16 +84,24 @@
         "____________________,,,,",
         "____________________,,,,",
         "____________________,,,,",
-        ",___________________,,,,",
+        ",,__________________,,,,",
+        ",,,_________________,,,,",
         ",,,,________________,,,,",
         ",,,,________________,,,,",
         ",,,,________________,,,,",
-        ",,,,________________,,,,",
-        ",,,,________________,,,,"
+        ",,p̄,________________,,,,"
       ],
       "palettes": [ "acidia_residential_commercial_palette" ],
+      "terrain": {
+        ";": "t_concrete",
+        ",": "t_region_groundcover_urban",
+        "p̄": "t_region_groundcover_urban",
+        "^": [ [ "t_region_tree_fruit", 2 ], [ "t_region_tree_nut", 2 ], "t_region_tree_shade" ]
+      },
+      "furniture": { "p̄": "f_mailbox" },
       "toilets": { "T": {  } },
       "items": {
+        "p̄": { "item": "mail", "chance": 30, "repeat": [ 2, 5 ] },
         " ": { "item": "livingroom", "chance": 1 },
         "2": { "item": "softdrugs", "chance": 10 },
         "4": { "item": "dining", "chance": 25 },


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Replace urban_40_house outdoor terrain with regional terrain.
## Describe the solution
Override some of the terrain.
Add a mailbox somewhere, given that almost every house has one.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/47da1df1-7148-42e9-8ef5-1d6617bfa58f">
After:
<img width="960" alt="image2" src="https://github.com/user-attachments/assets/a3e1c58b-c4de-419e-9931-67a5e39e18e3">