### PR TITLE
feat(balance): item updates to various professions, add a new profession, updates to scenario profession lists

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -13,7 +13,9 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "hitman_pistol",
-    "entries": [ { "item": "walther_ppq_45", "ammo-item": "45_super", "charges": 12, "contents-item": [ "suppressor", "pistol_grip" ] } ]
+    "entries": [
+      { "item": "walther_ppq_45", "ammo-item": "45_super", "charges": 12, "contents-item": [ "suppressor", "pistol_grip" ] }
+    ]
   },
   {
     "type": "item_group",

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -137,6 +137,12 @@
   {
     "type": "item_group",
     "subtype": "collection",
+    "id": "mags_m9_security",
+    "entries": [ { "item": "m9mag", "ammo-item": "9mm", "charges": 15 }, { "item": "m9mag", "ammo-item": "9mm", "charges": 15 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
     "id": "mags_waste_ranger",
     "entries": [ { "item": "blrmag", "ammo-item": "3006", "charges": 4 }, { "item": "blrmag", "ammo-item": "3006", "charges": 4 } ]
   },
@@ -147,6 +153,24 @@
     "entries": [
       { "item": "38_speedloader", "ammo-item": "357mag_jhp", "charges": 7 },
       { "item": "38_speedloader", "ammo-item": "357mag_jhp", "charges": 7 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "speedloaders_44_detective",
+    "entries": [
+      { "item": "44_speedloader6", "ammo-item": "44fmj", "charges": 6 },
+      { "item": "44_speedloader6", "ammo-item": "44fmj", "charges": 6 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "speedloaders_38_archaeologist",
+    "entries": [
+      { "item": "38_speedloader", "ammo-item": "38_special", "charges": 7 },
+      { "item": "38_speedloader", "ammo-item": "38_special", "charges": 7 }
     ]
   },
   {
@@ -1296,8 +1320,7 @@
         "entries": [
           { "group": "charged_flashlight" },
           { "item": "m9", "ammo-item": "9mm", "charges": 15, "container-item": "holster" },
-          { "item": "m9mag", "ammo-item": "9mm", "charges": 15 },
-          { "item": "m9mag", "ammo-item": "9mm", "charges": 15 }
+          { "item": "legpouch_large", "contents-group": "mags_m9_security" }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -1666,8 +1689,9 @@
         ],
         "entries": [
           { "group": "charged_two_way_radio" },
-          { "item": "sw_619", "ammo-item": "357mag_fmj", "charges": 6, "container-item": "holster" },
-          { "item": "357mag_fmj", "charges": 24 }
+          { "item": "sw629", "ammo-item": "44fmj", "charges": 6, "container-item": "shoulder_holster" },
+          { "item": "legpouch_large", "contents-group": "speedloaders_44_detective" },
+          { "item": "44fmj", "charges": 12 }
         ]
       },
       "male": [ "briefs" ],
@@ -2765,7 +2789,7 @@
     "description": "All you ever wanted was to make people laugh.  Dropping out of school and performing at kids' parties was a dream come true until the world ended.  There's precious few balloon animals in your future now.",
     "points": -1,
     "items": {
-      "both": { "items": [ "clown_wig", "clown_suit", "smart_phone", "clown_nose", "socks", "clownshoes", "airhorn" ] },
+      "both": { "items": [ "clown_wig", "clown_suit", "smart_phone", "clown_nose", "socks", "clownshoes", "airhorn", "balloon" ] },
       "male": [ "briefs" ],
       "female": [ "bra", "panties" ]
     }
@@ -2820,6 +2844,20 @@
       },
       "male": [ "briefs" ],
       "female": [ "bra", "panties" ]
+    }
+  },
+  {
+    "type": "profession",
+    "id": "prof_fursuiter",
+    "name": "Fursuiter",
+    "description": "You had plans to attend a local convention after your custom order finally arrived, only to find the world is ending.  You're starting to wish the company you bought this from made something armored and scaly instead.",
+    "points": 2,
+    "skills": [ { "level": 2, "name": "fabrication" }, { "level": 2, "name": "tailor" } ],
+    "items": {
+      "both": { "items": [ "socks", "tank_top", "wolfsuit", "mbag", "sewing_kit", "water_clean", "smart_phone" ] },
+      "//": "underarmor-style underwear is more common irl for comfort but warmth management would make that less ideal in-game",
+      "male": [ "briefs" ],
+      "female": [ "sports_bra", "boy_shorts" ]
     }
   },
   {
@@ -3438,7 +3476,8 @@
         ],
         "entries": [
           { "item": "sw_619", "ammo-item": "38_special", "charges": 7, "container-item": "holster" },
-          { "item": "38_special", "charges": 33 }
+          { "item": "legpouch_large", "contents-group": "speedloaders_38_archaeologist" },
+          { "item": "38_special", "charges": 19 }
         ]
       },
       "male": [ "briefs" ],

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -12,6 +12,21 @@
   {
     "type": "item_group",
     "subtype": "collection",
+    "id": "hitman_pistol",
+    "entries": [ { "item": "walther_ppq_45", "ammo-item": "45_super", "charges": 12, "contents-item": [ "suppressor", "pistol_grip" ] } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "hitman_mags_ppq",
+    "entries": [
+      { "item": "ppq45mag", "ammo-item": "45_super", "charges": 12 },
+      { "item": "ppq45mag", "ammo-item": "45_super", "charges": 12 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
     "id": "army_mags_m14",
     "entries": [
       { "item": "m14mag", "ammo-item": "762_51", "charges": 20 },
@@ -4918,11 +4933,10 @@
     ],
     "items": {
       "both": {
-        "items": [ "fancy_sunglasses", "platinum_watch", "suppressor", "tele_sight_pistol" ],
+        "items": [ "fancy_sunglasses", "platinum_watch" ],
         "entries": [
-          { "item": "glock_19", "ammo-item": "9mm", "container-item": "holster", "charges": 15 },
-          { "item": "glockmag", "ammo-item": "9mm", "charges": 15 },
-          { "item": "glockmag", "ammo-item": "9mm", "charges": 15 }
+          { "item": "shoulder_holster", "contents-group": "hitman_pistol" },
+          { "item": "legpouch_large", "contents-group": "hitman_mags_ppq" }
         ]
       },
       "male": [

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -164,7 +164,18 @@
       "sloc_church",
       "sloc_cemetery"
     ],
-    "professions": [ "svictim", "naked", "tweaker", "crackhead", "convict_ratman", "broken_cyborg" ],
+    "professions": [
+      "svictim",
+      "naked",
+      "tweaker",
+      "crackhead",
+      "homeless",
+      "convict_ratman",
+      "prof_fursuiter",
+      "clown",
+      "broken_cyborg",
+      "true_foodperson"
+    ],
     "flags": [ "FIRE_START", "INFECTED", "BAD_DAY", "CHALLENGE", "CITY_START" ]
   },
   {
@@ -239,7 +250,9 @@
       "broken_cyborg",
       "faulty_bionic",
       "cykotic",
-      "convict_political"
+      "convict_political",
+      "homeless",
+      "convict_ratman"
     ],
     "allowed_locs": [ "sloc_lab_random", "sloc_lab_escape_cells", "sloc_lab_finale", "sloc_ice_lab_stairs", "sloc_ice_lab_finale" ],
     "traits": [
@@ -303,7 +316,7 @@
     "points": -8,
     "description": "You were deemed non-essential and made to stay behind during the lab evacuation.  Find a way to escape or starve to death.",
     "start_name": "Locked Lab",
-    "professions": [ "labtech", "security", "medic", "bionic_installer", "bio_medic" ],
+    "professions": [ "labtech", "security", "medic", "bionic_installer", "bio_medic", "bionic_mentat", "bionic_spy" ],
     "allowed_locs": [ "sloc_lab_random", "sloc_lab_escape_cells", "sloc_lab_finale", "sloc_ice_lab_stairs", "sloc_ice_lab_finale" ],
     "flags": [ "CHALLENGE", "CITY_START", "LONE_START" ]
   },
@@ -474,16 +487,7 @@
     "description": "Since birth, your sole purpose in life has been the advancement of genetic science, willingly or not.  Once the Cataclysm struck, you left the lab, and wandered aimlessly, ending up in a forest.",
     "start_name": "Wilderness",
     "allowed_locs": [ "sloc_forest", "sloc_field" ],
-    "professions": [
-      "unemployed",
-      "mutant_patient",
-      "mutant_volunteer",
-      "labtech",
-      "broken_cyborg",
-      "faulty_bionic",
-      "cykotic",
-      "convict_political"
-    ],
+    "professions": [ "unemployed", "mutant_patient", "mutant_volunteer", "broken_cyborg", "faulty_bionic", "cykotic", "convict_political" ],
     "traits": [
       "ELFAEYES",
       "NIGHTVISION2",
@@ -608,7 +612,18 @@
     "description": "Your mission required you to eliminate a certain high-ranking individual in hiding. Your mark seems to have turned feral while escaping and the world appears to be ending, but not even that can stop you from finishing your mission.",
     "allowed_locs": [ "sloc_shelter", "sloc_shelter_vandalized" ],
     "start_name": "Evac Shelter",
-    "professions": [ "assassin", "hitman", "scoundrel", "gangster", "specops", "bionic_hitman", "bio_gangster", "razorgirl", "bio_sniper" ],
+    "professions": [
+      "assassin",
+      "hitman",
+      "scoundrel",
+      "gangster",
+      "specops",
+      "bionic_spy",
+      "bionic_hitman",
+      "bio_gangster",
+      "razorgirl",
+      "bio_sniper"
+    ],
     "flags": [ "CITY_START" ],
     "missions": [ "MISSION_ASSASSINATION" ]
   },


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

A few modernization updates to professions, changes for the sake of variety, and the like.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Stashed the loose magazines on security guard profession in a leg pouch.
2. For the sake of variety, swapped the police detective's basic .357 619 for a .44 629. Mixing the detective movie references a bit by having a film noir style outfit with the model made famous by Dirty Harry, but it seems fitting for a throwback profession not at all dressed like a modern police detective to mix their references a bit. Also gives them a pouch for speedloaders, and swapped the holster for a shoulder holster.
3. Set the archeologist profession up with a speedloader pouch with some of the .38 ammo shifted to it.
4. Gave hitman profession a Walther .45 PPQ with a supressor and ergonomic grip, basically mashing up the classic "secret against packing a Walther" trope with the Hitman series' use of the AMT Hardballer. Replaces the random gunmods (one being a makeshift one at that) they were just carrying stuffed in pockets. Also gets a mag pouch, ammo is upgraded to +p to help make up for carrying a bit less than the generic glock previously in use.
5. The clown may have a balloon, as a treat.
6. Added a new profession for flavor, fursuiter. Starts with a basic level of skills but little else beyond the suit and some basic starting items, 1 point higher cost than otaku.
7. Opted to add homeless, fursuiter, clown, and True Foodperson to Really Bad Day profession given those seem the most comical to have stuck in what's kinda de-facto a meme scenario.
8. Added rat prince and homeless professions to lab patient scenario. Aside from the former becoming an oblique Portal reference and the latter referencing Deus Ex ("I'm the captain here!"), it fits the flavor that political prisoners have of unwilling test subjects being shipped in from probably-illegal-in-normal-countries sources.
9. Removed lab tech from the patient scenario since it's already present on lab staff instead, added bionic boffin and agents to lab staff on the basic of potentially hypothetically being a corporate representatives and infiltrators respectively.
10. Added bionic agent to assassination mission.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Adding manga as a flavor variant of comic books for the otaku and urban samurai professions to have for funnies.
2. Adding a nice authentic Colt M1917 .45 ACP revolver for the archeologist profession to use, and thus having to wrangle the question of how best to handle moon clips in the JSON.
3. Adding all post-apoc professions that seem fitting to mi-go captive scenario and reflavoring it to better fit being more generic in setup.
4. Adding more professions to medieval peasant scenario and reflavoring it to allow for other out-of-place professions. Possibly requiring shifting illiterate to being a profession trait instead of scenario trait at minimum since some professions might be literate like monks or knights (we don't prevent them from talking to NPCs so it's not a language issue clearly), maybe also spiritual but that'd spark up a whole argument of when to draw the line at which medieval or antiquity professions would be mandatory to count as strongly religious.
5. Giving the bionic agent the 10mm glock since that's the closest to the pistol in Deus Ex we have. Wouldn't make as much sense since no trenchcoat and sunglasses to go with your augmented vision, however.
5. Any other obvious additions? Can't think of any at the moment.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.
3. Checked security guard profession to see its correctly says it has a mag pouch with 2 items.
4. Likewise confirmed the same with detective and archeologist professions.
5. Spawned in as a detective, confirmed I can draw and re-holster the pistol.
6. Restarted as a fursuiter to confirm nothing wacky happens with that profession.
7. Checked to confirm that hitman profession correctly has the expected gunmods on the gun, that all mags have the right ammo loaded, and that the gun can be drawn and re-holstered again.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

![image](https://github.com/user-attachments/assets/c9be9c9a-32a6-4e07-8532-e029c5399104)

Side note, looks like DDA had an attempt to do this sorta thing with adding a profession too at one point but their attempt was closed due to staleness: https://github.com/CleverRaven/Cataclysm-DDA/pull/66488

No starting skills and extra items besides some water, but extra clothes underneath to rack up the overheating even more, ich. Plus a touch of uwu in the profession description because PR OP just could not resist, lel.