### PR TITLE
refactor: use extends instead of overwrite on Ironshod Quarterstaff

### DIFF
--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -735,7 +735,7 @@
     "price": "60 USD",
     "price_postapoc": "15 USD",
     "material": [ "wood", "iron" ],
-    "flags": [ "DURABLE_MELEE", "NONCONDUCTIVE", "SHEATH_SPEAR", "ALWAYS_TWOHAND" ],
+    "extend": { "flags": [ "NONCONDUCTIVE" ] },
     "weight": "1275 g",
     "bashing": 30,
     "qualities": [ [ "HAMMER", 1 ] ]


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

As noted by Phoenix in the Discord, ironshod quarterstaff was not properly inheriting any flags extended onto the base quarterstaff. This fixes that by using json inheritance instead of overwriting the flags just to add nonconductive.

## Describe the solution

Uses `"extend":` to add the NONCONDUCTIVE flag to the ironshod quarterstaff instead of having it overwrite the flags inherited from the base quarterstaff

## Describe alternatives you've considered

Have people continue to need to specify that their changes are meant to apply to both the ironshod and the normal quarterstaff

## Testing

None

## Additional context

Shock staff correctly just lets inheritance do the work by inheriting from ironshod, so no need to worry about that one.

There are probably other examples of situations like this in the JSON just waiting to be discovered
