### PR TITLE
fix: use regional terrain for sporting goods store

### DIFF
--- a/data/json/mapgen/sports_store.json
+++ b/data/json/mapgen/sports_store.json
@@ -3,7 +3,6 @@
     "type": "mapgen",
     "method": "json",
     "om_terrain": [ "s_sports" ],
-    "weight": 300,
     "object": {
       "fill_ter": "t_floor",
       "rows": [
@@ -33,8 +32,8 @@
         "........4..............."
       ],
       "terrain": {
-        ".": [ "t_grass", "t_grass", "t_grass", "t_grass", "t_dirt" ],
-        "?": "t_dirt",
+        ".": "t_region_groundcover_urban",
+        "?": "t_region_groundcover_urban",
         " ": "t_floor",
         "'": "t_pavement",
         "`": "t_pavement_y",


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Use regional terrain for sporting goods store.
## Describe the solution
Replace non-regional terrain with regional terrain.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/91f5d8de-41f2-4e81-aecb-68ea27cd76e1">
After:
<img width="960" alt="image2" src="https://github.com/user-attachments/assets/e7b360e4-7ea1-461a-8693-65677b9afee6">