### PR TITLE
fix: change the `fill_ter` of the mapgen `office_doctor_2`

### DIFF
--- a/data/json/mapgen/office_doctor.json
+++ b/data/json/mapgen/office_doctor.json
@@ -267,7 +267,7 @@
     "om_terrain": [ "office_doctor_2" ],
     "weight": 200,
     "object": {
-      "fill_ter": "t_dirt",
+      "fill_ter": "t_floor",
       "rows": [
         "    ~~                 ]",
         "    ~~                  ",
@@ -295,7 +295,7 @@
         "                        "
       ],
       "palettes": [ "office_doctor" ],
-      "terrain": { "?": "t_floor", "/": "t_floor", "Y": "t_floor", "A": "t_floor", "R": "t_floor", "'": "t_door_glass_o" },
+      "terrain": { "'": "t_door_glass_o" },
       "furniture": { "?": "f_autodoc", "/": "f_autodoc_couch", "Y": "f_sofa", "T": "f_table", "A": "f_armchair", "R": "f_trashcan" },
       "computers": {
         "5": {


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Change the `fill_ter` of the mapgen `office_doctor_2` because it seems to be unused and also because it places dirt under the swivel chairs.
## Describe the solution
Use "t_floor" instead of "t_dirt" for the "fill_ter".
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/d68c7cea-a61e-43f8-9db0-870fc9acce1f">
After:
<img width="960" alt="image2" src="https://github.com/user-attachments/assets/91fc5313-ce20-43d7-8616-53553c1cbafc">