### PR TITLE
fix: make blood draw kit and harvesting blood more consistent, centrifuge now looks for tainted blood

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -1532,6 +1532,11 @@
     "context": [  ]
   },
   {
+    "id": "IS_BLOOD",
+    "type": "json_flag",
+    "context": [ "COMESTIBLE" ]
+  },
+  {
     "id": "IS_EXPLOSION_PROPELLED",
     "type": "json_flag",
     "context": [  ]

--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -571,6 +571,7 @@
     "volume": "250 ml",
     "phase": "liquid",
     "fun": -50,
+    "flags": [ "IS_BLOOD" ],
     "drop_action": { "type": "emit_actor", "emits": [ "emit_drop_blood" ], "scale_qty": true }
   },
   {
@@ -599,7 +600,9 @@
     "copy-from": "blood_concentrate",
     "name": { "str_sp": "concentrated animal blood" },
     "description": "Blood extracted from a living creature, concentrated by some means.",
-    "material": "flesh"
+    "material": "flesh",
+    "//": "Wouldn't be good to run it through a centrifuge",
+    "delete": { "flags": [ "IS_BLOOD" ] }
   },
   {
     "type": "COMESTIBLE",
@@ -620,7 +623,9 @@
     "volume": "250 ml",
     "phase": "liquid",
     "fun": -50,
-    "delete": { "flags": [ "SMOKABLE" ] }
+    "extend": { "flags": [ "IS_BLOOD" ] },
+    "delete": { "flags": [ "SMOKABLE" ] },
+    "drop_action": { "type": "emit_actor", "emits": [ "emit_drop_blood" ], "scale_qty": true }
   },
   {
     "type": "COMESTIBLE",
@@ -632,7 +637,8 @@
     "quench": 1,
     "price_postapoc": "20 cent",
     "description": "Blood from a mutated creature, concentrated by some means.  Despite it being a liquid, some parts are thicker than the other.",
-    "volume": "62 ml"
+    "volume": "62 ml",
+    "delete": { "flags": [ "IS_BLOOD" ] }
   },
   {
     "type": "COMESTIBLE",
@@ -772,7 +778,9 @@
     "volume": "250 ml",
     "phase": "liquid",
     "fun": -50,
-    "delete": { "flags": [ "SMOKABLE" ] }
+    "extend": { "flags": [ "IS_BLOOD" ] },
+    "delete": { "flags": [ "SMOKABLE" ] },
+    "drop_action": { "type": "emit_actor", "emits": [ "emit_drop_blood" ], "scale_qty": true }
   },
   {
     "type": "COMESTIBLE",
@@ -784,7 +792,8 @@
     "quench": 1,
     "price_postapoc": "20 cent",
     "description": "Poisonous and unhealthy blood, concentrated by some means.  You swear you could see it pulsing ever so slightly.",
-    "volume": "62 ml"
+    "volume": "62 ml",
+    "delete": { "flags": [ "IS_BLOOD" ] }
   },
   {
     "type": "COMESTIBLE",

--- a/data/json/npcs/missiondef.json
+++ b/data/json/npcs/missiondef.json
@@ -333,7 +333,7 @@
     "type": "mission_definition",
     "name": { "str": "Analyze Zombie Blood" },
     "goal": "MGOAL_FIND_ITEM",
-    "description": "Use a <color_light_blue>blood draw kit</color> to extract blood from a zombie, then bring the blood sample to a <color_red>hospital</color> and locate a centrifuge to analyze the blood with.",
+    "description": "Use a <color_light_blue>blood draw kit</color> to extract <color_red>tainted blood</color> from a zombie, then bring the blood sample to a <color_red>hospital</color> and locate a centrifuge to analyze the blood with.",
     "difficulty": 8,
     "value": 250000,
     "item": "software_blood_data",

--- a/data/json/npcs/refugee_center/surface_staff/NPC_old_guard_doctor.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_old_guard_doctor.json
@@ -65,6 +65,7 @@
     "type": "mission_definition",
     "name": { "str": "Analyze Zombie Blood" },
     "goal": "MGOAL_FIND_ITEM",
+    "description": "Use a <color_light_blue>blood draw kit</color> to extract <color_red>tainted blood</color> from a zombie, then bring the blood sample to a <color_red>hospital</color> and locate a centrifuge to analyze the blood with.",
     "difficulty": 5,
     "value": 50000,
     "item": "software_blood_data",

--- a/doc/src/content/docs/en/mod/json/reference/json_flags.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_flags.md
@@ -476,6 +476,7 @@ to find which flags work elsewhere.
 - `HIDDEN_POISON` ... Food displays as poisonous with a certain survival skill level. Note that this
   doesn't make items poisonous on its own, consider adding `"use_action": "POISON"` as well, or
   using `FORAGE_POISON` instead.
+- `IS_BLOOD` Will be scanned if placed in a centrifuge, in hospitals, labs, etc.
 - `MELTS` Provides half fun unless frozen. Edible when frozen.
 - `MILLABLE` Can be placed inside a mill, to turn into flour.
 - `MYCUS_OK` Can be eaten by post-threshold Mycus characters. Only applies to mycus fruits by

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -19,6 +19,7 @@
 #include "event_bus.h"
 #include "explosion.h"
 #include "field_type.h"
+#include "flag.h"
 #include "game.h"
 #include "game_constants.h"
 #include "game_inventory.h"
@@ -55,7 +56,6 @@
 static const efftype_id effect_amigara( "amigara" );
 
 static const itype_id itype_black_box( "black_box" );
-static const itype_id itype_blood( "blood" );
 static const itype_id itype_c4( "c4" );
 static const itype_id itype_cobalt_60( "cobalt_60" );
 static const itype_id itype_mininuke( "mininuke" );
@@ -758,20 +758,14 @@ void computer_session::action_blood_anal()
                 print_error( _( "ERROR: Please remove all but one sample from centrifuge." ) );
             } else if( items.only_item().contents.empty() ) {
                 print_error( _( "ERROR: Please only use container with blood sample." ) );
-            } else if( items.only_item().contents.front().typeId() != itype_blood ) {
+            } else if( !items.only_item().contents.front().has_flag( flag_IS_BLOOD ) ) {
                 print_error( _( "ERROR: Please only use blood samples." ) );
             } else { // Success!
                 const item &blood = items.only_item().contents.front();
-                const mtype *mt = blood.get_mtype();
-                if( mt == nullptr || mt->id == mtype_id::NULL_ID() ) {
-                    print_line( _( "Result: Human blood, no pathogens found." ) );
-                } else if( mt->in_species( ZOMBIE ) ) {
-                    if( mt->in_species( HUMAN ) ) {
-                        print_line( _( "Result: Human blood.  Unknown pathogen found." ) );
-                    } else {
-                        print_line( _( "Result: Unknown blood type.  Unknown pathogen found." ) );
-                    }
-                    print_line( _( "Pathogen bonded to erythrocytes and leukocytes." ) );
+                if( blood.get_use( "POISON" ) ) { // Tainted blood
+                    // Could separate human and non-human zombie blood?
+                    print_line(
+                        _( "Result: Unknown pathogen found.  Pathogen bonded to erythrocytes and leukocytes." ) );
                     if( query_bool( _( "Download data?" ) ) ) {
                         if( item *const usb = pick_usb() ) {
                             detached_ptr<item> software = item::spawn( "software_blood_data", calendar::start_of_cataclysm );
@@ -782,7 +776,9 @@ void computer_session::action_blood_anal()
                             print_error( _( "USB drive required!" ) );
                         }
                     }
-                } else {
+                } else if( blood.has_flag( flag_CANNIBALISM ) ) {  // Normal human blood
+                    print_line( _( "Result: Human blood, no pathogens found." ) );
+                } else { // Anything else
                     print_line( _( "Result: Unknown blood type.  Test non-conclusive." ) );
                 }
             }
@@ -1428,7 +1424,7 @@ void computer_session::failure_destroy_blood()
                 print_error( _( "ERROR: Please use blood-contained samples." ) );
             } else if( items.only_item().contents.empty() ) {
                 print_error( _( "ERROR: Blood draw kit, empty." ) );
-            } else if( items.only_item().contents.front().typeId() != itype_blood ) {
+            } else if( !items.only_item().contents.front().has_flag( flag_IS_BLOOD ) ) {
                 print_error( _( "ERROR: Please only use blood samples." ) );
             } else {
                 print_error( _( "ERROR: Blood sample destroyed." ) );

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -68,9 +68,6 @@ static const itype_id itype_vacutainer( "vacutainer" );
 
 static const skill_id skill_computer( "computer" );
 
-static const species_id HUMAN( "HUMAN" );
-static const species_id ZOMBIE( "ZOMBIE" );
-
 static const mtype_id mon_manhack( "mon_manhack" );
 static const mtype_id mon_secubot( "mon_secubot" );
 

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -161,6 +161,7 @@ const flag_id flag_IN_CBM( "IN_CBM" );
 const flag_id flag_IRREMOVABLE( "IRREMOVABLE" );
 const flag_id flag_IR_EFFECT( "IR_EFFECT" );
 const flag_id flag_IS_ARMOR( "IS_ARMOR" );
+const flag_id flag_IS_BLOOD( "IS_BLOOD" );
 const flag_id flag_IS_EXPLOSION_PROPELLED( "IS_EXPLOSION_PROPELLED" );
 const flag_id flag_IS_PET_ARMOR( "IS_PET_ARMOR" );
 const flag_id flag_IS_UPS( "IS_UPS" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -164,6 +164,7 @@ extern const flag_id flag_IN_CBM;
 extern const flag_id flag_IRREMOVABLE;
 extern const flag_id flag_IR_EFFECT;
 extern const flag_id flag_IS_ARMOR;
+extern const flag_id flag_IS_BLOOD;
 extern const flag_id flag_IS_EXPLOSION_PROPELLED;
 extern const flag_id flag_IS_PET_ARMOR;
 extern const flag_id flag_IS_UPS;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4660,7 +4660,7 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
     }
 
     std::string maintext;
-    if( is_corpse() || typeId() == itype_blood || item_vars.find( "name" ) != item_vars.end() ) {
+    if( is_corpse() || item_vars.find( "name" ) != item_vars.end() ) {
         maintext = type_name( quantity );
     } else if( is_craft() ) {
         maintext = string_format( _( "in progress %s" ), craft_data_->making->result_name() );
@@ -10076,15 +10076,7 @@ std::string item::type_name( unsigned int quantity ) const
 {
     const auto iter = item_vars.find( "name" );
     std::string ret_name;
-    if( typeId() == itype_blood ) {
-        if( corpse == nullptr || corpse->id.is_null() ) {
-            return vpgettext( "item name", "human blood", "human blood", quantity );
-        } else {
-            return string_format( vpgettext( "item name", "%s blood",
-                                             "%s blood",  quantity ),
-                                  corpse->nname() );
-        }
-    } else if( iter != item_vars.end() ) {
+    if( iter != item_vars.end() ) {
         return iter->second;
     } else {
         ret_name = type->nname( quantity );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -136,7 +136,6 @@ static const fault_id fault_bionic_nonsterile( "fault_bionic_nonsterile" );
 static const gun_mode_id gun_mode_REACH( "REACH" );
 
 static const itype_id itype_barrel_small( "barrel_small" );
-static const itype_id itype_blood( "blood" );
 static const itype_id itype_brass_catcher( "brass_catcher" );
 static const itype_id itype_cig_butt( "cig_butt" );
 static const itype_id itype_cig_lit( "cig_lit" );

--- a/tests/item_type_name_test.cpp
+++ b/tests/item_type_name_test.cpp
@@ -83,40 +83,6 @@ TEST_CASE( "custom named item", "[item][type_name][named]" )
     CHECK( shotgun.type_name() == "Boomstick" );
 }
 
-TEST_CASE( "blood item", "[item][type_name][blood]" )
-{
-    static const mtype_id mon_zombie( "mon_zombie" );
-    static const mtype_id mon_chicken( "mon_chicken" );
-
-    SECTION( "blood from a zombie corpse" ) {
-        item &corpse = *item::make_corpse( mon_zombie );
-        item &blood = *item::spawn_temporary( "blood" );
-        blood.set_mtype( corpse.get_mtype() );
-        REQUIRE( blood.typeId() == itype_id( "blood" ) );
-        REQUIRE_FALSE( blood.is_corpse() );
-
-        CHECK( blood.type_name() == "zombie blood" );
-    }
-
-    SECTION( "blood from a chicken corpse" ) {
-        item &corpse = *item::make_corpse( mon_chicken );
-        item &blood = *item::spawn_temporary( "blood" );
-        blood.set_mtype( corpse.get_mtype() );
-        REQUIRE( blood.typeId() == itype_id( "blood" ) );
-        REQUIRE_FALSE( blood.is_corpse() );
-
-        CHECK( blood.type_name() == "chicken blood" );
-    }
-
-    SECTION( "blood from an unknown corpse" ) {
-        item &blood = *item::spawn_temporary( "blood" );
-        REQUIRE( blood.typeId() == itype_id( "blood" ) );
-        REQUIRE_FALSE( blood.is_corpse() );
-
-        CHECK( blood.type_name() == "human blood" );
-    }
-}
-
 TEST_CASE( "corpse item", "[item][type_name][corpse]" )
 {
     static const mtype_id mon_zombie( "mon_zombie" );


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This aims to make it so that the same blood taken from a zombie will work for the "analyze zombie blood" whether it's taken via blood draw kit or from harvesting, instead of the same corpse yielding different types of blood.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

C++ changes:
1. In computer_session.cpp, reworked how `computer_session::action_blood_anal` works. Now instead of the weird old behavior of saving the monster type of the offending blood and only checking for a specific item ID of blood, it accepts any valid item with the `IS_BLOOD` item flag, and triggers the "uh oh, zombies!" alert the mission is looking for if the item it's fed has the `POISON` use action used by tainted blood. Afterwards it can still print the flavor messages for human blood and generic animal blood if it didn't find the poison action. Also updated `computer_session::failure_destroy_blood` accordingly with it looking for the `IS_BLOOD` flag for the relevant failure message.
2. In flag.cpp and .h, defined the `IS_BLOOD` item flag, to be used by the centrifuge.
3. In item.cpp, removed the "add monster name if possible" bits from `item::tname` and `item::type_name` since it's no longer needed, you'll be able to tell you've got the right kinda blood just from feeding it tainted blood.
4. In iuse.cpp, reworked `iuse::blood_draw` so that targeting a creature's corpse attempts to get any blood harvest entry available in it, and if one's found uses the item from that to provide the blood it obtains. Also sanity-checks for if a corpse lacks harvestable blood, and now drawing blood comes with a random chance to mark the corpse as drained dry so it's not an infinite source any more.

JSON changes:
1. Defined item flag `IS_BLOOD`.
2. Added new flag to all blood items, with it also being removed from concentrated blood since that likely would fail to centrifuge out properly.
3. Updated mission description for the "analyze zombie blood" to specify tainted blood as a hint, and fixed the Old Guard rep's version of the mission lacking a mission description.
4. Misc: Fixed tainted blood not converting to a field when spilled.

Test changes:
1. Removed the check for monster blood from item_type_name_test.cpp since that's no longer a thing.

Documentation changes:
1. Added documentation of `IS_BLOOD` to json_flags.md

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Making the centrifuge considerably more complicated to support clever flavor stuff like detecting effects in your blood that the blood analysis CBM would be able to detect, pointing out mutant toxins, etc.
2. Making tainted blood from human zombies and animal zombies different so that the old "oh hey this is not just zombie blood but human zombie blood" change in flavor message can be preserved.
3. @Lamandus noted that the message the code uses, "Pathogen bonded to erythrocytes and leukocytes" is pretty weird from a medical standpoint, but couldn't really think of a more fitting flavor message. My assumption is lore-wise the blob itself doesn't actually have any physical presence that can be detected, but what can be detected is side effects on the matter it's attached to and thus the machine is presumably seeing cellular or genetic damage from DNA being affected by blob interactions, and basically shrugging and going "something is doing this but [INSERT DEFAULT ANSWER HERE]"

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON for syntax and lint errors.
2. Compiled and load-tested.
3. Got myself the blood analysis mission from the Old Guard doc.
4. Warped over to a hospital and debug killed the zeds there.
5. Confirmed that the blood draw kit correctly takes tainted blood from a zombie if I stand over one, and that it yields tainted blood.
6. Confirmed that the centrifuge can spot both tainted blood drawn from a blood draw kit and blood from harvesting a corpse.
7. Tested that drawing blood from myself, a generic human corpse item, and a dead NPC all work as expected.
8. Spammed blood drawn on a body to confirm it declares it to be drained dry eventually.
9. Spawned in a pickeral, one of the few corpse-yielding critters to not have blood in its harvest entry due to being tiny, confirmed it's skipped over in the expected manner for not having any blood to take.

![image](https://github.com/user-attachments/assets/e0ce3dc1-eebe-46a7-b75f-9af6a4e9447e)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
