### PR TITLE
ci: fix broken matrix.yml indentation

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -8,7 +8,7 @@ on:
     branches: [main]
     paths-ignore: [doc/**, scripts/**]
     types: [opened, reopened, synchronize, ready_for_review]
-  workflow_dispatch:    
+  workflow_dispatch:
 
 # Cancel all previous instances in favor of latest revision of a PR.
 # Allow running main builds to complete to help with ccache refreshes.
@@ -175,14 +175,14 @@ jobs:
       #     sudo ln -s /usr/lib/gcc/x86_64-linux-gnu/11 /opt/mock-gcc-11/lib/gcc/x86_64-linux-gnu/11
 
       - name: install runtime dependencies (mac)
-      if: ${{ env.SKIP == 'false' && runner.os == 'macOS' }}
-      uses: BrettDong/setup-sdl2-frameworks@v1
-      with:
-        sdl2: latest
-        sdl2-ttf: latest
-        sdl2-image: latest
-        sdl2-mixer: latest
-    - name: install build dependencies (mac)
+        if: ${{ env.SKIP == 'false' && runner.os == 'macOS' }}
+        uses: BrettDong/setup-sdl2-frameworks@v1
+        with:
+          sdl2: latest
+          sdl2-ttf: latest
+          sdl2-image: latest
+          sdl2-mixer: latest
+      - name: install build dependencies (mac)
         if: ${{ env.SKIP == 'false' && runner.os == 'macOS' }}
         run: |
           ${{ matrix.compiler }} --version


### PR DESCRIPTION
## Checklist

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

![image](https://github.com/user-attachments/assets/1d0928cd-697d-4d9c-8090-2aff19a2d82c)

Been noticing that build matrix wasn't running. turns out [broken indentation borked the whole workflow from running](https://github.com/cataclysmbnteam/Cataclysm-BN/actions/runs/10086721419).

## Describe the solution

fix the indentation

## Testing

should run in CI.

## Additional context

![image](https://github.com/user-attachments/assets/f5060486-0430-44da-ba01-8b7b786f06a9)

https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4970/files#diff-ad27b48237ca3d400ad6724d82df1ba3293e68054182a87a0aa219df064d6f52R177-R183

hecc, it was broken for 2 weeks.