### PR TITLE
build: try fix curses build again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1191,10 +1191,10 @@ $(JSON_FORMATTER_BIN): $(JSON_FORMATTER_SOURCES)
 	$(CXX) $(CXXFLAGS) $(TOOL_CXXFLAGS) -Itools/format -Isrc \
 	  $(JSON_FORMATTER_SOURCES) -o $(JSON_FORMATTER_BIN)
 
-tests: version $(BUILD_PREFIX)cataclysm.a
+tests: version $(BUILD_PREFIX)$(TARGET_NAME).a
 	$(MAKE) -C tests
 
-check: version $(BUILD_PREFIX)cataclysm.a
+check: version $(BUILD_PREFIX)$(TARGET_NAME).a
 	$(MAKE) -C tests check
 
 clean-tests:

--- a/src/character_preview.cpp
+++ b/src/character_preview.cpp
@@ -1,3 +1,4 @@
+#if defined(TILES)
 #include "character_preview.h"
 #include "type_id.h"
 #include "character.h"
@@ -156,3 +157,5 @@ auto character_preview_window::clothes_showing() const -> bool
 {
     return !show_clothes;
 }
+
+#endif // TILES

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1385,22 +1385,23 @@ tab_direction set_traits( avatar &u, points_left &points )
             }
 
             recalc_display_cache();
-#if defined(TILES)
         } else if( action == "PREV_TAB" ) {
+#if defined(TILES)
             character_preview.clear();
+#endif
             return tab_direction::BACKWARD;
         } else if( action == "NEXT_TAB" ) {
+#if defined(TILES)
             character_preview.clear();
+#endif
             return tab_direction::FORWARD;
         } else if( action == "QUIT" && query_yn( _( "Return to main menu?" ) ) ) {
+#if defined(TILES)
             character_preview.clear();
+#endif
             return tab_direction::QUIT;
         }
-#else
-        }
-#endif
-    }
-    while( true );
+    } while( true );
 }
 
 struct {

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -7,7 +7,8 @@
 SOURCES = $(wildcard *.cpp)
 OBJS = $(sort $(SOURCES:%.cpp=$(ODIR)/%.o))
 
-CATA_LIB=../$(BUILD_PREFIX)cataclysm.a
+TARGET_NAME = cataclysm-benchmarks
+CATA_LIB=../$(BUILD_PREFIX)$(TARGET_NAME).a
 
 # If you invoke this makefile directly and the parent directory was
 # built with BUILD_PREFIX set, you must set it for this invocation as well.
@@ -23,7 +24,7 @@ DEFINES += -DCATCH_CONFIG_ENABLE_BENCHMARKING
 # Add no-sign-compare to fix MXE issue when compiling
 # Catch also uses "#pragma gcc diagnostic", which is not recognized on some supported compilers.
 # Clang and mingw are warning about Catch macros around perfectly normal boolean operations.
-CXXFLAGS += -I../src -I../src/lua -Wno-unused-variable -Wno-sign-compare -Wno-unknown-pragmas -Wno-parentheses -MMD -MP 
+CXXFLAGS += -I../src -I../src/lua -Wno-unused-variable -Wno-sign-compare -Wno-unknown-pragmas -Wno-parentheses -MMD -MP
 CXXFLAGS += -Wall -Wextra \
   -Wno-range-loop-analysis # TODO: Fix warnings instead of disabling
 


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

- fix matrix (again)
- turns out i've made an logic error in #5065 so without this fix curses selection will be borked

## Describe the solution

- rename stuff
- fix tiles macro

## Describe alternatives you've considered

purge makefile

## Testing

- it still fails but fails less

## Additional context

pls merge