### PR TITLE
feat: add construction for shallow graves not requiring a coffin

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -1692,8 +1692,22 @@
     "required_skills": [ [ "fabrication", 0 ] ],
     "time": "60 m",
     "qualities": [ [ { "id": "HAMMER", "level": 1 } ], [ { "id": "DIG", "level": 2 } ] ],
-    "components": [ [ [ "rock", 20 ], [ "2x4", 2 ] ] ],
+    "components": [ [ [ "rock", 20 ], [ "wood_structural_small", 2, "LIST" ] ] ],
     "pre_furniture": "f_coffin_c",
+    "post_flags": [ "keep_items" ],
+    "post_terrain": "t_grave_new",
+    "post_special": "done_grave"
+  },
+  {
+    "type": "construction",
+    "id": "constr_shallow_grave",
+    "group": "dig_shallow_grave",
+    "category": "DIG",
+    "required_skills": [ [ "fabrication", 0 ] ],
+    "time": "30 m",
+    "qualities": [ [ { "id": "HAMMER", "level": 1 } ], [ { "id": "DIG", "level": 2 } ] ],
+    "components": [ [ [ "rock", 20 ], [ "wood_structural_small", 2, "LIST" ] ] ],
+    "pre_terrain": "t_pit_shallow",
     "post_flags": [ "keep_items" ],
     "post_terrain": "t_grave_new",
     "post_special": "done_grave"

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -891,6 +891,11 @@
   },
   {
     "type": "construction_group",
+    "id": "dig_shallow_grave",
+    "name": "Fill Shallow Grave"
+  },
+  {
+    "type": "construction_group",
     "id": "extract_clay",
     "name": "Extract Clay"
   },

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1309,8 +1309,8 @@ void construct::done_grave( const tripoint &p )
     map &here = get_map();
     map_stack its = here.i_at( p );
     // Don't remove furniture when digging shallow graves, but also don't give full morale bonus
-    bool proper_burial = here.furn( p )->has_flag( flag_SEALED );
-    int burial_morale = proper_burial ? 50 : 25;
+    const bool proper_burial = here.furn( p )->has_flag( flag_SEALED );
+    const int burial_morale = proper_burial ? 50 : 25;
     for( item * const &it : its ) {
         if( it->is_corpse() ) {
             if( it->get_corpse_name().empty() ) {

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -91,6 +91,7 @@ static const trait_id trait_SPIRITUAL( "SPIRITUAL" );
 static const trait_id trait_STOCKY_TROGLO( "STOCKY_TROGLO" );
 
 static const std::string flag_FLAT( "FLAT" );
+static const std::string flag_SEALED( "SEALED" );
 static const std::string flag_INITIAL_PART( "INITIAL_PART" );
 static const std::string flag_SUPPORTS_ROOF( "SUPPORTS_ROOF" );
 
@@ -1307,12 +1308,15 @@ void construct::done_grave( const tripoint &p )
 {
     map &here = get_map();
     map_stack its = here.i_at( p );
+    // Don't remove furniture when digging shallow graves, but also don't give full morale bonus
+    bool proper_burial = here.furn( p )->has_flag( flag_SEALED );
+    int burial_morale = proper_burial ? 50 : 25;
     for( item * const &it : its ) {
         if( it->is_corpse() ) {
             if( it->get_corpse_name().empty() ) {
                 if( it->get_mtype()->has_flag( MF_HUMAN ) ) {
                     if( g->u.has_trait( trait_SPIRITUAL ) ) {
-                        g->u.add_morale( MORALE_FUNERAL, 50, 75, 1_days, 1_hours );
+                        g->u.add_morale( MORALE_FUNERAL, burial_morale, 75, 1_days, 1_hours );
                         add_msg( m_good,
                                  _( "You feel relieved after providing last rites for this human being, whose name is lost in the Cataclysm." ) );
                     } else {
@@ -1321,7 +1325,7 @@ void construct::done_grave( const tripoint &p )
                 }
             } else {
                 if( g->u.has_trait( trait_SPIRITUAL ) ) {
-                    g->u.add_morale( MORALE_FUNERAL, 50, 75, 1_days, 1_hours );
+                    g->u.add_morale( MORALE_FUNERAL, burial_morale, 75, 1_days, 1_hours );
                     add_msg( m_good,
                              _( "You feel sadness, but also relief after providing last rites for %s, whose name you will keep in your memory." ),
                              it->get_corpse_name() );
@@ -1342,7 +1346,9 @@ void construct::done_grave( const tripoint &p )
                  _( "Unfortunately you don't have anything sharp to place an inscription on the grave." ) );
     }
 
-    here.destroy_furn( p, true );
+    if( proper_burial ) {
+        here.destroy_furn( p, true );
+    }
 }
 
 static vpart_id vpart_from_item( const itype_id &item_id )


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This makes it a bit easier to wrangle bodies for burial, having noticed that coffins are pretty intensive in terms of wood required.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

C++ changes:
1. In construction.cpp, changed `construct::done_grave` so that the furniture destruction part of it only triggers if furniture on the targeted tile has the `SEALED` flag (used by sealed coffins but in theory will apply to any burial constructions players may mod in). In addition it halves the morale bonus from performing a burial without valid furniture to target, as a balance for the below JSON change.

JSON changes:
1. Defined a shallow grave construction option, which lets you build a grave directly over a shallow pit. Triggers the `done_grave` special as indicated above. So now it's possible to bury your NPC friends for flavor but putting on the ritz and providing a coffin for the burial is needed for the full flavor morale bonus.
2. Allowed using sticks as an alternative to planks for the construction.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Leaving the code unchanged and just not letting you have a funeral or inscribe anything on the grave if you're doing a quick-and-dirty shallow burial.
2. Just making coffins much less annoying to construct.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON for syntax and lint errors.
2. Compiled and load-tested.
3. Spawned in two human corpses, one on a shallow pit and the other with a sealed coffin debugged into it.
4. Performed the relevant constructions on each with Spiritual trait, confirmed the shallow burial only grants +25 morale, while the coffin grants the standard +50.
5. Spawned a fire ring on the shallow pit, confirming that filling the shallow pit didn't delete the fire rig.
6. Checked affected C++ changes for astyle.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
