### PR TITLE
fix: misplaced items in the shooting range

### DIFF
--- a/data/json/mapgen/shooting_range.json
+++ b/data/json/mapgen/shooting_range.json
@@ -101,7 +101,7 @@
         { "chance": 5, "item": "guns_smg_common", "x": 8, "y": 9 },
         { "chance": 10, "item": "guns_pistol_common", "x": 5, "y": 9 },
         { "chance": 5, "item": "guns_pistol_common", "x": 2, "y": 9 },
-        { "chance": 25, "item": "office", "x": 3, "y": 4 }
+        { "chance": 25, "item": "office", "x": 4, "y": 3 }
       ],
       "items": {
         "w": { "item": "casings", "chance": 60, "repeat": 4 },


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Fix misplaced items in the shooting range.
## Describe the solution
Change { "chance": 25, "item": "office", "x": 3, "y": 4 } to { "chance": 25, "item": "office", "x": 4, "y": 3 }
## Describe alternatives you've considered
none
## Additional context
Briefcase on the desk, so correct now.
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/738f9e97-101f-417e-b96d-8bde0439ab62">