### PR TITLE
docs: Update Special Attacks docs

### DIFF
--- a/doc/src/content/docs/en/mod/json/reference/creatures/monsters.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/monsters.md
@@ -393,13 +393,13 @@ listed below. Example:
 ]
 ```
 
-One can add entries (when doing inheritance) via the "extend" field.
+One can add entries (when doing inheritance) via the `"extend"` field.
 
 ```json
 "extend": { "special_attacks": [ [ "PARROT", 50 ] ] }
 ```
 
-Entries can be removed via the "delete" field. However, unlike adding a special attack (manually or
+Entries can be removed via the `"delete"` field. However, unlike adding a special attack (manually or
 via extends), the syntax is slightly different. There is no need for a second set of brackets, and
 you should not include the cooldown.
 

--- a/doc/src/content/docs/en/mod/json/reference/creatures/monsters.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/monsters.md
@@ -393,13 +393,14 @@ listed below. Example:
 ]
 ```
 
-One can add entries with "add:death_function", which takes the same content as the "special_attacks"
-member and remove entries with "remove:death_function", which requires an array of attack types.
-Example:
-
+One can add entries (when doing inheritance) via the "extend" field.
 ```json
-"remove:special_attacks": [ "GRAB" ],
-"add:special_attacks": [ [ "SHRIEK", 20 ] ]
+"extend": { "special_attacks": [ [ "PARROT", 50 ] ] }
+```
+
+Entries can be removed via the "delete" field. However, unlike adding a special attack (manually or via extends), the syntax is slightly different. There is no need for a second set of brackets, and you should not include the cooldown.
+```json
+"delete": { "special_attacks": [ "FUNGUS" ] },
 ```
 
 ## "flags"

--- a/doc/src/content/docs/en/mod/json/reference/creatures/monsters.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/monsters.md
@@ -399,9 +399,9 @@ One can add entries (when doing inheritance) via the `"extend"` field.
 "extend": { "special_attacks": [ [ "PARROT", 50 ] ] }
 ```
 
-Entries can be removed via the `"delete"` field. However, unlike adding a special attack (manually or
-via extends), the syntax is slightly different. There is no need for a second set of brackets, and
-you should not include the cooldown.
+Entries can be removed via the `"delete"` field. However, unlike adding a special attack (manually
+or via extends), the syntax is slightly different. There is no need for a second set of brackets,
+and you should not include the cooldown.
 
 ```json
 "delete": { "special_attacks": [ "FUNGUS" ] },

--- a/doc/src/content/docs/en/mod/json/reference/creatures/monsters.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/monsters.md
@@ -394,11 +394,15 @@ listed below. Example:
 ```
 
 One can add entries (when doing inheritance) via the "extend" field.
+
 ```json
 "extend": { "special_attacks": [ [ "PARROT", 50 ] ] }
 ```
 
-Entries can be removed via the "delete" field. However, unlike adding a special attack (manually or via extends), the syntax is slightly different. There is no need for a second set of brackets, and you should not include the cooldown.
+Entries can be removed via the "delete" field. However, unlike adding a special attack (manually or
+via extends), the syntax is slightly different. There is no need for a second set of brackets, and
+you should not include the cooldown.
+
 ```json
 "delete": { "special_attacks": [ "FUNGUS" ] },
 ```


### PR DESCRIPTION
## Checklist


### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

The previous docs were incorrect regarding how to add and remove entries. Additionally, "delete" works slightly differently with special attacks compared to how one might expect based on how "extend"s work.

## Describe the solution

Updates the docs, with examples of proper JSON code

## Describe alternatives you've considered

Just remove the outdated parts, and let people continue to suffer when trying to use "delete".

## Testing

I have confirmed that the game considers my examples for "extend" and "delete" valid.

## Additional context

In the process of doing this, I have discovered how misinformed the Limit Fungal Growth mod is and how it's not using "delete" correctly, but rather overwriting the inherited special attacks anyway. Expect a future PR to remedy its shortcomings.
