### PR TITLE
feat(mods/ruralbiome): Obsolete rural mapgen mod

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -83,7 +83,6 @@ scopes:
   - mods/no_zombify
   - mods/novitamins
   - mods/pride_flags
-  - mods/ruralbiome
   - mods/saveload_lua_test
   - mods/sees_player_hitbutton
   - mods/sees_player_retro

--- a/data/mods/rural_biome/modinfo.json
+++ b/data/mods/rural_biome/modinfo.json
@@ -8,6 +8,6 @@
     "category": "content",
     "dependencies": [ "bn" ],
     "version": "0.1",
-    "obsolete": false
+    "obsolete": true
   }
 ]

--- a/doc/src/assets/semantic.json
+++ b/doc/src/assets/semantic.json
@@ -76,7 +76,6 @@
     "mods/no_zombify",
     "mods/novitamins",
     "mods/pride_flags",
-    "mods/ruralbiome",
     "mods/saveload_lua_test",
     "mods/sees_player_hitbutton",
     "mods/sees_player_retro",


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Rural mapgen is a DDA-era mod by Erk that we've inherited, it contains a single regional map settings overwrite. It's been unmaintained for the time I've been in the project as I previously had to fix the mapgen settings due to things like burdock spawning and bog iron not spawning. It was also largely replaced by our version of innawoods mod by Zlor in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4224 I'm flagging it as obsolete but keeping it in the repo to ensure anyone can work on it and re-enable it if they want to still run it.

## Describe the solution

I replaced obsolete false with obsolete true. I also removed it from Semantics.

## Describe alternatives you've considered

Deleting it, as you're likely forced to re-create the regional map settings file from scratch just to save the mod due to all the changes we've been doing.

## Testing

It's gone.

## Additional context

I decided after a recent conversation that we should definitely cut back on mods that are unmaintained, unnecessary, and either problematic or directly broken, in this case it's arguably broken due to mapgen changes being missing. We're not removing it, we're just flagging it as obsolete so it won't clutter the menu and trick new players.
