### PR TITLE
ci: run typescript test before autofix

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -43,6 +43,12 @@ jobs:
       - name: format JSON
         run: make style-all-json-parallel RELEASE=1
 
+      - name: lint and test typescript files
+        run: |
+          deno lint
+          deno test
+          deno run --allow-read --allow-write scripts/semantic.ts
+
       - uses: autofix-ci/action@v1.3
         if: ${{ always() }}
         with:
@@ -68,9 +74,3 @@ jobs:
             If you don't do this, your following commits will be based on the old commit, and cause **MERGE CONFLICT**.
 
             [code-style]: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style
-
-      - name: lint and test typescript files
-        run: |
-          deno lint
-          deno test
-          deno run --allow-read --allow-write scripts/semantic.ts


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

diff of typescript lint and `semantic.yml` update script was ignored by `autofix.ci` because it ran after autofix ran in #5103. prevent this from happening

## Describe the solution

move autofix to the bottom.

## Describe alternatives you've considered

only move semantic update script before autofix since tests don't edit files, but that wouldn't save more than few seconds.

## Testing

will check on CI