### PR TITLE
fix: `drop` only drops one item

### DIFF
--- a/doc/src/content/docs/en/mod/json/reference/json_info.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_info.md
@@ -1487,19 +1487,21 @@ See also VEHICLE_JSON.md
 ### Ammo
 
 ```json
-"type" : "AMMO",      // Defines this as ammo
-...                   // same entries as above for the generic item.
-                      // additional some ammo specific entries:
-"ammo_type" : "shot", // Determines what it can be loaded in
-"damage" : 18,        // Ranged damage when fired
-"prop_damage": 2,     // Multiplies the damage of weapon by amount (overrides damage field)
-"pierce" : 0,         // Armor piercing ability when fired
-"range" : 5,          // Range when fired
-"dispersion" : 0,     // Inaccuracy of ammo, measured in quarter-degrees
-"recoil" : 18,        // Recoil caused when firing
-"count" : 25,         // Number of rounds that spawn together
-"stack_size" : 50,    // (Optional) How many rounds are in the above-defined volume. If omitted, is the same as 'count'
-"show_stats" : true,  // (Optional) Force stat display for combat ammo. (for projectiles lacking both damage and prop_damage)
+"type" : "AMMO",            // Defines this as ammo
+...                         // same entries as above for the generic item.
+                            // additional some ammo specific entries:
+"ammo_type" : "shot",       // Determines what it can be loaded in
+"damage" : 18,              // Ranged damage when fired
+"prop_damage": 2,           // Multiplies the damage of weapon by amount (overrides damage field)
+"pierce" : 0,               // Armor piercing ability when fired
+"range" : 5,                // Range when fired
+"dispersion" : 0,           // Inaccuracy of ammo, measured in quarter-degrees
+"recoil" : 18,              // Recoil caused when firing
+"count" : 25,               // Number of rounds that spawn together
+"stack_size" : 50,          // (Optional) How many rounds are in the above-defined volume. If omitted, is the same as 'count'
+"show_stats" : true,        // (Optional) Force stat display for combat ammo. (for projectiles lacking both damage and prop_damage)
+"dont_recover_one_in": 1    // (Optional) 1 in x chance of not recovering the ammo (100 means you have a 99% chance of getting it back)
+"drop": "nail"              // (Optional) Defines an object that drops at the projectile location at a 100% chance.
 "effects" : ["COOKOFF", "SHOT"]
 ```
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1737,7 +1737,7 @@ static projectile make_gun_projectile( const item &gun )
         }
 
         if( ammo.drop ) {
-            detached_ptr<item> drop = item::spawn( ammo.drop );
+            detached_ptr<item> drop = item::spawn( ammo.drop, calendar::turn, 1 );
             if( ammo.drop_active ) {
                 drop->activate();
             }


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

`drop` field for ammo drops the item as a full stack instead of a single item as is the norm for `dont_recover_one_in` which it is "complementary" to.

Neither of the two are documented either which is _great_.

## Describe the solution

Fixed the way `drop` spawns so that it will actually drop only a single item instead of a full stack for anything that is `count_by_charges`.

Adds documentation because why the hell isn't this documented?

## Describe alternatives you've considered

- Leaving it alone until I refactor it.
  - Great idea, if only I could pull time for it.

## Testing

- [x] Give nails `"drop": "nail"` entry and make it so that `dont_recover_one_in` is set to 1 so it never recovers from that.
  - [x] Check that using the nail rifle on semi and auto drops appropriate number of nails, ie: 1, and 3.
  - [x] Scream because `drop_active` is set to true by default so my nail rifle is dropping nail (active) 

## Additional context

This whole system is cursed as shit and needs refactoring when I have time.