### PR TITLE
fix: Update now unneeded comment

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -264,7 +264,6 @@ int iuse_transform::use( player &p, item &it, bool t, const tripoint &pos ) cons
 
     // All checks complete the damn thing can finally transform
     // Consume charges if necessary at this point.
-    // Cannot use consume_charges as that requires charge_per_use true.
     if( transform_charges ) {
         p.consume_charges( it, transform_charges );
     }


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

When I was doing #4968 there was a comment that remained from the time I was thinking of more convoluted solutions.

## Describe the solution

Removes the comment line.

## Describe alternatives you've considered

Leaving it alone and laughing maniacally when someone looks at it in confusion several months down the line

## Testing

If a comment removal ends up breaking the game I will exile myself from the project in shame and horror.

## Additional context
