### PR TITLE
fix: Prime stat weirdness #5123

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -3919,10 +3919,10 @@
     "points": 6,
     "description": "You're perfectly coordinated.",
     "valid": false,
-    "prereqs": [ "DEX_UP" ],
+    "prereqs": [ "DEX_UP_2" ],
     "threshreq": [ "THRESH_ALPHA" ],
     "category": [ "ALPHA" ],
-    "passive_mods": { "dex_mod": 1 }
+    "passive_mods": { "dex_mod": 2 }
   },
   {
     "type": "mutation",
@@ -3977,10 +3977,10 @@
     "points": 6,
     "description": "You understand almost everything about which you think, with minimal effort.",
     "valid": false,
-    "prereqs": [ "INT_UP" ],
+    "prereqs": [ "INT_UP_2" ],
     "threshreq": [ "THRESH_ALPHA" ],
     "category": [ "ALPHA" ],
-    "passive_mods": { "int_mod": 1 }
+    "passive_mods": { "int_mod": 2 }
   },
   {
     "type": "mutation",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -3875,8 +3875,8 @@
     "name": { "str": "Dextrous" },
     "points": 1,
     "description": "You are a little nimbler.  +1 Dexterity.",
-    "changes_to": [ "DEX_UP_2", "DEX_ALPHA" ],
-    "category": [ "INSECT", "SLIME", "ALPHA" ],
+    "changes_to": [ "DEX_UP_2" ],
+    "category": [ "INSECT", "SLIME" ],
     "passive_mods": { "dex_mod": 1 }
   },
   {
@@ -3886,8 +3886,8 @@
     "points": 2,
     "description": "You are nimbler.  +2 Dexterity.",
     "prereqs": [ "DEX_UP" ],
-    "changes_to": [ "DEX_UP_3" ],
-    "category": [ "LIZARD", "SPIDER", "CHIMERA", "RAPTOR", "MOUSE" ],
+    "changes_to": [ "DEX_UP_3", "DEX_ALPHA" ],
+    "category": [ "LIZARD", "SPIDER", "CHIMERA", "RAPTOR", "MOUSE", "ALPHA" ],
     "passive_mods": { "dex_mod": 2 }
   },
   {
@@ -3930,8 +3930,8 @@
     "name": { "str": "Smart" },
     "points": 1,
     "description": "You are a little smarter.  +1 Intelligence.",
-    "changes_to": [ "INT_UP_2", "INT_ALPHA", "INT_SLIME" ],
-    "category": [ "SLIME", "ALPHA" ],
+    "changes_to": [ "INT_UP_2", "INT_SLIME" ],
+    "category": [ "SLIME" ],
     "passive_mods": { "int_mod": 1 }
   },
   {
@@ -3941,7 +3941,8 @@
     "points": 2,
     "description": "You are smarter.  +2 Intelligence.",
     "prereqs": [ "INT_UP" ],
-    "changes_to": [ "INT_UP_3" ],
+    "changes_to": [ "INT_UP_3", "INT_ALPHA" ],
+    "category": [ "ALPHA" ],
     "passive_mods": { "int_mod": 2 }
   },
   {


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Fixes #5123

## Describe the solution

Make Prime Dex and Prime Int require and build-in Very Dexterous and Very Intelligent, so a character with 8 baseline stats ends up with 14 stats across the board.

## Describe alternatives you've considered

Making Prime Strength and Prime Perception require and build-in the +1 version of the stat mutations instead, making a 8 stat baseline character end up with 13 stats across the board instead of 14.

## Testing

Made the JSON changes on my install and checked to be sure it worked properly.