### PR TITLE
fix: turn the small power substation so that the entrance faces the road

### DIFF
--- a/data/json/mapgen/power_station_small.json
+++ b/data/json/mapgen/power_station_small.json
@@ -5,6 +5,7 @@
     "om_terrain": [ "pwr_sub_s" ],
     "object": {
       "fill_ter": "t_floor",
+      "rotation": 2,
       "rows": [
         "........................",
         "------------------------",
@@ -87,6 +88,7 @@
     "om_terrain": "pwr_sub_s_roof",
     "object": {
       "fill_ter": "t_tar_flat_roof",
+      "rotation": 2,
       "rows": [
         "                        ",
         "                        ",


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Turn the small power substation so that the entrance is on the road side.
## Describe the solution
Add "rotation": 2 for the mapgen `pwr_sub_s`, `pwr_sub_s_roof`
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="896" alt="image1" src="https://github.com/user-attachments/assets/8ab1f383-6667-46fe-9df7-124bde496a02">
After:
The entrance is on the road side.
<img width="960" alt="image2" src="https://github.com/user-attachments/assets/cbef6b97-b7d4-43b4-9ffd-9f94dd0aebfe">