### PR TITLE
fix: Wasp Tower uses the same road connection as Radio Tower

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -794,7 +794,7 @@
       { "point": [ 0, 0, 6 ], "overmap": "wasp_tower_top_north" },
       { "point": [ 0, 0, 7 ], "overmap": "wasp_tower_roof_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] } ],
+    "connections": [ { "point": [ 0, 1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "land" ],
     "city_distance": [ 0, 20 ],
     "occurrences": [ 80, 100 ],


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Change the road connection of the `Wasp Tower` so that it is identical to its non-wasp-infested counterpart.
## Describe the solution
Change a number in specials.json
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/ee1c55da-c69c-4e4c-9e38-d75a667c7124">
After:
<img width="960" alt="image2" src="https://github.com/user-attachments/assets/98704c07-3705-487a-b0ad-e70846aa30e7">