### PR TITLE
feat: balance fix for leg magazine satchel allowing 2 ammo belts or large magazines

### DIFF
--- a/data/json/items/armor/ammo_pouch.json
+++ b/data/json/items/armor/ammo_pouch.json
@@ -271,7 +271,6 @@
       "type": "holster",
       "holster_prompt": "Stash ammo",
       "holster_msg": "You stash your %s.",
-      "multi": 2,
       "min_volume": "50 ml",
       "max_volume": "1250 ml",
       "draw_cost": 40,


### PR DESCRIPTION

## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

There are two leg magazine storage items, the pouch and the satchel. The pouch allows 2 magazines up to 0.5L in size, the satchel is identical other than allowing 2 magazines or ammo belts up to 1.25L in size and is therefore strictly better. The description says the satchel only allows one magazine/ammo belt and this should actually be the case for balance reasons.

## Describe the solution

Delete the line of JSON that allows two magazines.

## Describe alternatives you've considered

Increasing the encumbrance of the leg magazine satchel, but this would probably allow for too much ammo to be easily carried.

## Testing

Tested the JSON changes on my end to be sure they worked properly.
