### PR TITLE
fix: put dirt floor under the gun safes on the farm

### DIFF
--- a/data/json/mapgen/farm.json
+++ b/data/json/mapgen/farm.json
@@ -80,7 +80,7 @@
         "F                                                                     F ",
         "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF "
       ],
-      "terrain": { "9": "t_gutter_downspout" },
+      "terrain": { "9": "t_gutter_downspout", "ü": "t_dirtfloor" },
       "place_item": [
         { "item": "straw_pile", "x": [ 3, 5 ], "y": [ 5, 7 ], "amount": [ 0, 8 ] },
         { "item": "cattlefodder", "x": [ 3, 5 ], "y": [ 5, 7 ], "amount": [ 0, 4 ] },
@@ -130,7 +130,7 @@
         "                        ",
         "FFFFFFFFFFFFFFFFFFFFFFFF"
       ],
-      "terrain": { "Q": "t_dirtfloor", "9": "t_gutter_downspout" },
+      "terrain": { "Q": "t_dirtfloor", "9": "t_gutter_downspout", "ü": "t_dirtfloor" },
       "items": {
         ".": { "item": "trash", "chance": 20 },
         "B": [


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Put dirt floor under the gun safes on the farm.
## Describe the solution
Put in terrain "ü": "t_dirtfloor" for the mapgen `farm_2` and all its variants.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/b453c8b2-aec6-4e69-a9c6-ef87b328a223">
After:
<img width="960" alt="image2" src="https://github.com/user-attachments/assets/c39972ff-7d56-4b26-b7c1-52aeca9f491d">
<img width="960" alt="image3" src="https://github.com/user-attachments/assets/83943924-c029-45dc-b73c-ae21364a7aaa">