### PR TITLE
fix: use regional terrain for `s_gun` (gun store)

### DIFF
--- a/data/json/mapgen/s_gun.json
+++ b/data/json/mapgen/s_gun.json
@@ -33,8 +33,8 @@
         "                  UUU   "
       ],
       "terrain": {
-        " ": [ "t_grass", "t_grass", "t_grass", "t_dirt" ],
-        "'": "t_dirt",
+        " ": "t_region_groundcover_urban",
+        "'": "t_region_groundcover_urban",
         "*": "t_pavement_y",
         "+": "t_door_metal_pickable",
         "-": "t_wall_w",
@@ -47,6 +47,8 @@
         "C": "t_thconc_floor",
         "s": "t_thconc_floor",
         "l": "t_thconc_floor",
+        "$": "t_thconc_floor",
+        "@": "t_thconc_floor",
         "|": "t_wall_w",
         "D": "t_door_c",
         "?": "t_console_broken",
@@ -54,7 +56,7 @@
         "4": "t_gutter_downspout",
         "A": "t_atm",
         "B": "t_sidewalk",
-        "U": [ "t_grass", "t_grass", "t_grass", "t_dirt" ]
+        "U": "t_region_groundcover_urban"
       },
       "toilets": { "&": {  } },
       "furniture": {


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Use regional terrain for `s_gun` (gun store).
## Describe the solution
Replace non-regional terrain with regional terrain.
Also, put concrete floor under the reinforced vending machine and the targets.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/7005668a-0875-457b-bb3a-e6efee636a0b">
After:
<img width="905" alt="image2" src="https://github.com/user-attachments/assets/e592d88d-7d8b-4d63-856c-3128792dede8">