### PR TITLE
refactor: Merges `deal_damage_handle_type` together.

### DIFF
--- a/doc/src/content/docs/en/mod/json/reference/json_flags.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_flags.md
@@ -1071,7 +1071,7 @@ Multiple death functions can be used. Not all combinations make sense.
 - `NULL` Source use only.
 - `PACIFIST` That monster will never do melee attacks.
 - `PARALYZE` Attack may paralyze the player with venom.
-- `PLASTIC` Absorbs physical damage to a great degree.
+- `PLASTIC` Reduces Bashing damage taken by 50%, 66% or 75%.
 - `POISON` Poisonous to eat.
 - `PUSH_MON` Can push creatures out of its way.
 - `QUEEN` When it dies, local populations start to die off too.

--- a/doc/src/content/docs/en/mod/json/reference/json_flags.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_flags.md
@@ -1071,7 +1071,7 @@ Multiple death functions can be used. Not all combinations make sense.
 - `NULL` Source use only.
 - `PACIFIST` That monster will never do melee attacks.
 - `PARALYZE` Attack may paralyze the player with venom.
-- `PLASTIC` Reduces Bashing damage taken by 50%, 66% or 75%.
+- `PLASTIC` Reduces Bashing damage taken by 50%, 66% or 75%.  Randomly selected with each hit.
 - `POISON` Poisonous to eat.
 - `PUSH_MON` Can push creatures out of its way.
 - `QUEEN` When it dies, local populations start to die off too.

--- a/doc/src/content/docs/en/mod/json/reference/json_flags.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_flags.md
@@ -1071,7 +1071,7 @@ Multiple death functions can be used. Not all combinations make sense.
 - `NULL` Source use only.
 - `PACIFIST` That monster will never do melee attacks.
 - `PARALYZE` Attack may paralyze the player with venom.
-- `PLASTIC` Reduces Bashing damage taken by 50%, 66% or 75%.  Randomly selected with each hit.
+- `PLASTIC` Reduces Bashing damage taken by 50%, 66% or 75%. Randomly selected with each hit.
 - `POISON` Poisonous to eat.
 - `PUSH_MON` Can push creatures out of its way.
 - `QUEEN` When it dies, local populations start to die off too.

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1010,7 +1010,7 @@ void Creature::deal_damage_handle_type( const damage_unit &du, bodypart_id bp, i
     }
 
     // Apply damage multiplier from skill, critical hits or grazes after all other modifications.
-    const int adjusted_damage = du.amount * du.damage_multiplier;
+    int adjusted_damage = du.amount * du.damage_multiplier;
     if( adjusted_damage <= 0 ) {
         return;
     }
@@ -1021,6 +1021,10 @@ void Creature::deal_damage_handle_type( const damage_unit &du, bodypart_id bp, i
         case DT_BASH:
             // Bashing damage is less painful
             div = 5.0f;
+            // Monster only. Having PLASTIC flag cuts damage from bashing by 50%, 66% or 75%
+            if( has_flag( MF_PLASTIC ) ) {
+                adjusted_damage /= rng( 2, 4 ); // lessened effect
+            }
             break;
 
         case DT_HEAT:

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1868,50 +1868,6 @@ void monster::deal_projectile_attack( Creature *source, dealt_projectile_attack 
     }
 }
 
-void monster::deal_damage_handle_type( const damage_unit &du, bodypart_id bp, int &damage,
-                                       int &pain )
-{
-    switch( du.type ) {
-        case DT_ELECTRIC:
-            if( has_flag( MF_ELECTRIC ) ) {
-                return; // immunity
-            }
-            break;
-        case DT_COLD:
-            if( has_flag( MF_COLDPROOF ) ) {
-                return; // immunity
-            }
-            break;
-        case DT_BASH:
-            if( has_flag( MF_PLASTIC ) ) {
-                damage += du.amount / rng( 2, 4 ); // lessened effect
-                pain += du.amount / 4;
-                return;
-            }
-            break;
-        case DT_NULL:
-            debugmsg( "monster::deal_damage_handle_type: illegal damage type DT_NULL" );
-            break;
-        case DT_ACID:
-            if( has_flag( MF_ACIDPROOF ) ) {
-                // immunity
-                return;
-            }
-        case DT_TRUE:
-        // typeless damage, should always go through
-        case DT_BIOLOGICAL:
-        // internal damage, like from smoke or poison
-        case DT_CUT:
-        case DT_STAB:
-        case DT_BULLET:
-        case DT_HEAT:
-        default:
-            break;
-    }
-
-    Creature::deal_damage_handle_type( du,  bp, damage, pain );
-}
-
 int monster::heal( const int delta_hp, bool overheal )
 {
     const int maxhp = type->hp;

--- a/src/monster.h
+++ b/src/monster.h
@@ -334,8 +334,6 @@ class monster : public Creature, public location_visitable<monster>
         void melee_attack( Creature &target, float accuracy );
         void melee_attack( Creature &p, bool ) = delete;
         void deal_projectile_attack( Creature *source, dealt_projectile_attack &attack ) override;
-        void deal_damage_handle_type( const damage_unit &du, bodypart_id bp, int &damage,
-                                      int &pain ) override;
         void apply_damage( Creature *source, bodypart_id bp, int dam,
                            bool bypass_med = false ) override;
         // create gibs/meat chunks/blood etc all over the place, does not kill, can be called on a dead monster.


### PR DESCRIPTION
## Checklist

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Monsters don't require a separate function specifically for them, as the standard `Creature::deal_damage_handle_type` already handles monster immunities within it. `monster::deal_damage_handle_type` also usually routes into the above function after it is done, making it redundant, skipping over it as the `PLASTIC` flag used to do means that damage is disproportionately reduced at higher skill levels or when using techniques, as both are never accounted for in the monster function.

The only unique bit is the `PLASTIC` flag, which has been merged into the Creature function. Documentation has also been updated to explain _what_ exactly the flag even does.

## Describe the solution

Deleted `monster::deal_damage_handle_type` entirely from the code. Added the only special consideration `PLASTIC` into the Creature variant. Effect on pain wasn't added as reduction of damage also reduces pain produced by attack, and because monsters and NPCs don't use pain at all to begin with.

## Describe alternatives you've considered

A far more robust method for handling this would be adding a % resistance value variable to the game, but that's out of scope for this fix.

## Testing

Spawn a debug monster, a shoggoth and an NPC. Attack all 3 with a mace and record values.
- [x] This didn't crash the game.
- [x] Damage between NPC and debug monster should be similar, as NPCs should have some bash armour over the debug monster's none.
- [x] Damage between debug monster and shoggoth should be reduced by 50~75%.

I should note here that I also tested using breakpoints to make sure NPCs weren't triggering the `PLASTIC` flag code, and that the damage was being reduced properly.

## Additional context

This increases bashing damage taken by Shoggoths indirectly as it allows skill and technique damage multipliers to come into play, but the huge % reduction _should_ in theory still make using bashing weapons against them not a great idea. You'd have to do more than 60 bashing damage on an attack to reach the same efficiency as using a cut weapon, which isn't something you'd be able to do without really high skill.