### PR TITLE
feat(balance): Allow belt clipping of unsheathable unarmed weapons

### DIFF
--- a/data/json/items/melee/unarmed_weapons.json
+++ b/data/json/items/melee/unarmed_weapons.json
@@ -12,7 +12,7 @@
     "material": [ "steel" ],
     "bashing": 2,
     "cutting": 15,
-    "flags": [ "UNARMED_WEAPON", "DURABLE_MELEE" ],
+    "flags": [ "UNARMED_WEAPON", "DURABLE_MELEE", "BELT_CLIP" ],
     "price": "200 USD",
     "price_postapoc": "250 cent",
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 14 ] ]
@@ -46,7 +46,7 @@
     "weight": "320 g",
     "bashing": 9,
     "price_postapoc": "250 cent",
-    "flags": [ "UNARMED_WEAPON", "DURABLE_MELEE" ]
+    "flags": [ "UNARMED_WEAPON", "DURABLE_MELEE", "BELT_CLIP" ]
   },
   {
     "id": "knuckle_katar",
@@ -64,7 +64,7 @@
     "cutting": 14,
     "price_postapoc": "5 USD",
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 8 ] ],
-    "flags": [ "UNARMED_WEAPON" ],
+    "flags": [ "UNARMED_WEAPON", "BELT_CLIP" ],
     "techniques": [ "WBLOCK_1" ]
   },
   {
@@ -82,7 +82,7 @@
     "bashing": 3,
     "cutting": 4,
     "price_postapoc": "50 cent",
-    "flags": [ "UNARMED_WEAPON" ]
+    "flags": [ "UNARMED_WEAPON", "BELT_CLIP" ]
   },
   {
     "id": "knuckle_steel",
@@ -162,7 +162,7 @@
     "bashing": 18,
     "price": "500 USD",
     "qualities": [ [ "HAMMER", 2 ] ],
-    "flags": [ "UNARMED_WEAPON", "DURABLE_MELEE" ]
+    "flags": [ "UNARMED_WEAPON", "DURABLE_MELEE", "BELT_CLIP" ]
   },
   {
     "type": "GENERIC",


### PR DESCRIPTION
Added BELT_CLIP tag to all unarmed weapons that aren't sheathable.

## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Allow unarmed weapons that don't have blades or edged parts to be as quickly wielded as those that do.

## Describe the solution

Add the BELT_CLIP tag to all the unarmed weapons that don't have SHEATHE_KNIFE.

## Describe alternatives you've considered

Continue to take 130 moves to wield my impact knuckles from the inventory.
Completely rework unarmed weapons to be worn on the hands and add damage to your base unarmed attacks so you can drop your gun and "wield" them in 0 moves.

## Testing

Made the JSON changes on my end and made sure they worked.
