### PR TITLE
feat(balance): Add Strong Back to Cattle and Ursine and Optimist to Mouse and Rat categories

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -141,6 +141,7 @@
     "description": "Nothing gets you down!  You savor the joys of life, ignore its hardships, and are generally happier than most people.",
     "starting_trait": true,
     "valid": false,
+    "category": [ "RAT", "MOUSE" ],
     "cancels": [ "BADTEMPER" ]
   },
   {
@@ -329,6 +330,7 @@
     "description": "You are capable of carrying far more than someone with similar strength could.  Your maximum weight carried is increased by 35%.",
     "starting_trait": true,
     "valid": false,
+    "category": [ "CATTLE", "URSINE" ],
     "cancels": [ "BADBACK" ],
     "weight_capacity_modifier": 1.35
   },

--- a/data/mods/Monster_Girls/vanilla_mutations.json
+++ b/data/mods/Monster_Girls/vanilla_mutations.json
@@ -2145,5 +2145,19 @@
     "copy-from": "FELINE_FLEXIBILITY",
     "delete": { "category": [ "FELINE" ] },
     "extend": { "category": [ "NEKO" ], "threshreq": [ "THRESH_NEKO" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "OPTIMISTIC",
+    "copy-from": "OPTIMISTIC",
+    "delete": { "category": [ "RAT", "MOUSE" ] },
+    "extend": { "category": [ "MOUSEGIRL" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "STRONGBACK",
+    "copy-from": "STRONGBACK",
+    "delete": { "category": [ "CATTLE", "URSINE" ] },
+    "extend": { "category": [ "COWGIRL", "BEARGIRL" ] }
   }
 ]


### PR DESCRIPTION
Added Strong Back to Cattle and Ursine categories and Optimist to Mouse and Rat categories.

## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional
## Purpose of change
Currently there's no way to mutate away Bad Back or Bad Temper. If you start with them then there's no way at all to get rid of them aside from getting lucky with completely random mutation, and if you get them from mutagen then getting rid of them requires using purifier. Bad Back in particular is very awkward to work around and with the amount of mutagen lines that give you strength, I'd think a few of them would also strengthen your back.

## Describe the solution
Add Strong Back to Cattle and Ursine categories and Optimist to Mouse and Rat. Cattle and Ursine want Strong Back the most because they cramp up in vehicles and it's thematically appropriate. Mouse and Rat seem the most appropriate for Optimist to me given that rodents would be pretty cheerful about the end of human civilization, but it could go somewhere else. If there was a Dog mutation line distinct from Wolf I'd put it in there, dogs are usually happy.

## Describe alternatives you've considered
Adding them to different categories.
Not doing this.

## Testing

Made the JSON changes on my end and mutated a lot to be sure that it all worked properly.
