### PR TITLE
chore: add `build.*` path to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,11 @@
 *.zip
 /WinDepend/
 /bindist/
-/build/
+build.*
+build
+!build-scripts
+!build-data
+test_user_dir*
 /build-start-time
 /cmake-build-debug/
 /config/


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

make it easier to test multiple cmake builds without polluting git
