### PR TITLE
ci: disable mac matrix test

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -107,18 +107,18 @@ jobs:
         #    ccache_limit: 2G
         #    ccache_key: linux-llvm-14-asan
 
-          - title: Clang 14, macOS 12, Tiles, Sound, Localize, Lua
-            compiler: clang++
-            os: macos-12
-            cmake: 0
-            tiles: 1
-            sound: 1
-            lua: 1
-            test-stage: 1
-            native: osx
-            grep_clang_version_rxp: "14\\.[0-9]+\\.[0-9]+"
-            ccache_limit: 1G # avg. 980MB~1100MB
-            ccache_key: macos-llvm-14
+          # - title: Clang 14, macOS 12, Tiles, Sound, Localize, Lua
+          #   compiler: clang++
+          #   os: macos-12
+          #   cmake: 0
+          #   tiles: 1
+          #   sound: 1
+          #   lua: 1
+          #   test-stage: 1
+          #   native: osx
+          #   grep_clang_version_rxp: "14\\.[0-9]+\\.[0-9]+"
+          #   ccache_limit: 1G # avg. 980MB~1100MB
+          #   ccache_key: macos-llvm-14
 
     name: ${{ matrix.title }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

fixes #5081

## Describe the solution

turn off macos matrix tests  (i know it's workaround)

## Describe alternatives you've considered

actually fix the mac builds but it may take longer than expected and until then the tests will constantly fail due to mac test which is confusing when reviewing
