### PR TITLE
fix: change the position of misplaced items in `room_10x10_junk_N` and `room_10x10_junk_S`

### DIFF
--- a/data/json/mapgen/nested/basement_nested.json
+++ b/data/json/mapgen/nested/basement_nested.json
@@ -3093,7 +3093,7 @@
       ],
       "palettes": [ "standard_domestic_palette" ],
       "place_vehicles": [ { "vehicle": "bikeshop", "x": 6, "y": 3, "rotation": 270, "chance": 100 } ],
-      "place_items": [ { "item": "bikeshop_tools", "x": 9, "y": 2, "chance": 80, "repeat": [ 1, 3 ] } ]
+      "place_items": [ { "item": "bikeshop_tools", "x": 8, "y": 2, "chance": 80, "repeat": [ 1, 3 ] } ]
     }
   },
   {
@@ -3117,8 +3117,8 @@
         "||||||+|||"
       ],
       "palettes": [ "standard_domestic_palette" ],
-      "place_vehicles": [ { "vehicle": "bikeshop", "x": 6, "y": 5, "rotation": 270, "chance": 100 } ],
-      "place_items": [ { "item": "bikeshop_tools", "x": 9, "y": 2, "chance": 80, "repeat": [ 1, 3 ] } ]
+      "place_vehicles": [ { "vehicle": "bikeshop", "x": 6, "y": 5, "rotation": 90, "chance": 100 } ],
+      "place_items": [ { "item": "bikeshop_tools", "x": 8, "y": 2, "chance": 80, "repeat": [ 1, 3 ] } ]
     }
   },
   {


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Fix misplaced items in `room_10x10_junk_N` and `room_10x10_junk_S`
## Describe the solution
Change the position where "bikeshop_tools" is placed in the two nested mapgen.
## Describe alternatives you've considered
none
## Additional context
Before:
Since the items are placed on a wall, they end up outside the room.
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/2780eabb-68eb-4e52-9c63-975ad2953a0a">
After:
<img width="960" alt="image2" src="https://github.com/user-attachments/assets/00eb1b9c-5296-4d1e-ab10-818a0b5fb831">