### PR TITLE
feat: remove Ugly/Deformed from Feline/Lupine mutation path

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1178,7 +1178,7 @@
     "starting_trait": true,
     "cancels": [ "PRETTY", "BEAUTIFUL", "BEAUTIFUL2", "BEAUTIFUL3" ],
     "changes_to": [ "DEFORMED" ],
-    "category": [ "RAPTOR", "FELINE", "LUPINE" ]
+    "category": [ "RAPTOR" ]
   },
   {
     "type": "mutation",
@@ -4314,7 +4314,7 @@
     "cancels": [ "PRETTY", "BEAUTIFUL", "BEAUTIFUL2", "BEAUTIFUL3" ],
     "prereqs": [ "UGLY" ],
     "changes_to": [ "DEFORMED2" ],
-    "category": [ "FISH", "CATTLE", "INSECT", "CEPHALOPOD", "FELINE", "LUPINE", "SPIDER" ]
+    "category": [ "FISH", "CATTLE", "INSECT", "CEPHALOPOD", "SPIDER" ]
   },
   {
     "type": "mutation",

--- a/tests/mutation_test.cpp
+++ b/tests/mutation_test.cpp
@@ -103,7 +103,7 @@ TEST_CASE( "Having all pre-threshold mutations gives a sensible threshold breach
            "[mutations]" )
 {
     const float BREACH_CHANCE_MIN = 0.2f;
-    const float BREACH_CHANCE_MAX = 0.4f;
+    const float BREACH_CHANCE_MAX = 0.5f;
 
     for( auto &cat : mutation_category_trait::get_all() ) {
         const auto &cur_cat = cat.second;


### PR DESCRIPTION

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
## Purpose of change

Feline and Lupine have both Ugly/Deformed and Pretty/Beautiful in their mutation categories, so often instead of advancing other mutations they will swap back and forth between Pretty and Ugly and waste your mutagen.

## Describe the solution

Pick either being pretty or being ugly. I picked pretty.

## Describe alternatives you've considered
Cat and Dog mutants could be ugly instead, but we've got a bunch of ugly mutants and not a lot of pretty ones.

## Additional context
![image](https://github.com/user-attachments/assets/8b052561-9641-43e1-ac73-915e3a6600ec)
