### PR TITLE
fix: sewage gators no longer have a near-guaranteed infection from bites

### DIFF
--- a/data/json/monsters/reptile_amphibian.json
+++ b/data/json/monsters/reptile_amphibian.json
@@ -69,7 +69,7 @@
           { "damage_type": "bash", "amount": 27, "armor_multiplier": 0.5 }
         ],
         "effects": [ { "id": "grabbed", "duration": 1000, "bp": "torso" } ],
-        "no_infection_chance": 2
+        "no_infection_chance": 12
       }
     ],
     "anger_triggers": [ "PLAYER_CLOSE", "PLAYER_WEAK" ],

--- a/data/json/monsters/reptile_amphibian.json
+++ b/data/json/monsters/reptile_amphibian.json
@@ -69,7 +69,7 @@
           { "damage_type": "bash", "amount": 27, "armor_multiplier": 0.5 }
         ],
         "effects": [ { "id": "grabbed", "duration": 1000, "bp": "torso" } ],
-        "no_infection_chance": 12
+        "no_infection_chance": 17
       }
     ],
     "anger_triggers": [ "PLAYER_CLOSE", "PLAYER_WEAK" ],


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Sewage Gators had a no infect chance of 2, which guaranteed they would infect you. In the future infection attacks should be redone but this is good enough. Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/4667 As I noted, 66% of sources of bite infection are animals and not zombies, it is not a zombie infection but we could always add a deadlier zombie infection later if it's desired.

## Describe the solution

Sets no infection chance to 17 for about 50% chance. It may not be a rotting corpse but it's swimming in sewage and has a stronger bite.

## Describe alternatives you've considered

buffing it, because it lives in the sewers. Adding sepsis or other illnesses.

## Testing

we do that?

## Additional context

That's how you get sepsis.
