### PR TITLE
fix: let burdock spawn again

### DIFF
--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -122,6 +122,7 @@
           "f_flower_spurge": 1,
           "f_chamomile": 1,
           "f_dandelion": 1,
+          "f_burdock": 1,
           "f_datura": 1,
           "f_dahlia": 1,
           "f_chicory": 1,
@@ -140,6 +141,7 @@
         },
         "f_region_weed": {
           "f_dandelion": 6,
+          "f_burdock": 4,
           "f_flower_spurge": 4,
           "f_chamomile": 4,
           "f_datura": 3,
@@ -217,6 +219,7 @@
         "f_dahlia": 3.5,
         "f_datura": 0.2,
         "f_dandelion": 5,
+        "f_burdock": 2,
         "f_sunflower": 3.5,
         "f_mustard": 0.2
       },


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Burdock is a fully implemented plant with a number of recipes and is farmable. It wasn't spawning ever. This just lets it spawn in the region data once again. I prefer not to obsolete stuff people might like, and it sits on similar terms with dandelions so if we're going to audit what crops should exist, they all need an audit.

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/4065

## Describe the solution

Changes region data to make it spawn similar to dandelions.

## Describe alternatives you've considered

obsolete it.

## Testing

should be fine

## Additional context

![image](https://github.com/user-attachments/assets/02ccc87e-b67d-4599-b949-f278f5946a21)

