### PR TITLE
docs: add missing martial art fields

### DIFF
--- a/doc/src/content/docs/en/mod/json/reference/creatures/martialart_json.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/martialart_json.md
@@ -133,10 +133,9 @@ Move cost is decreased by 100% of strength value
 
 Additional fields usable in static_bonuses
 
-"stealthy": true,           // All movement will make less noise 
-"quiet": true,              // Your attacks will be completely silent
-"wall_adjacent": true,      // You must be adjacent to a wall
-"throw_immune": true,       // You're immune to being thrown
+"stealthy": true, // All movement will make less noise "quiet": true, // Your attacks will be
+completely silent "wall_adjacent": true, // You must be adjacent to a wall "throw_immune": true, //
+You're immune to being thrown
 
 ### Place relevant items in the world and chargen
 

--- a/doc/src/content/docs/en/mod/json/reference/creatures/martialart_json.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/martialart_json.md
@@ -65,6 +65,7 @@ title: Martial arts & techniques
 "dodge_counter": true,      // This technique may automatically counterattack on a successful dodge
 "weighting": 2,             // Affects likelihood this technique will be seleted when many are available
 "defensive": true,          // Game won't try to select this technique when attacking
+"wall_adjacent": true,      // You must be adjacent to a wall
 "miss_recovery": true,      // Misses while attacking will use fewer moves
 "messages" : [              // What is printed when this technique is used by the player and by an npc
     "You phase-strike %s",
@@ -129,6 +130,13 @@ All cutting damage dealt is multiplied by `(10% of dexterity)*(damage)`:
 Move cost is decreased by 100% of strength value
 
 - `flat_bonuses : [ { "stat": "movecost", "scaling-stat": "str", "scale": -1.0 } ]`
+
+Additional fields usable in static_bonuses
+
+"stealthy": true,           // All movement will make less noise 
+"quiet": true,              // Your attacks will be completely silent
+"wall_adjacent": true,      // You must be adjacent to a wall
+"throw_immune": true,       // You're immune to being thrown
 
 ### Place relevant items in the world and chargen
 


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
## Purpose of change

I was working on martial arts and got annoyed that ninjutsu had fields that aren't listed in the docs. I fixed it.

## Describe the solution

I scoured the martial art code for declared JSON that wasn't listed in the docs and put it in

## Describe alternatives you've considered

Complain

## Testing

you can't make me test docs.

## Additional context

>:(
