### PR TITLE
refactor: Privatize active field. standardize functions for activating, deactivating and reverting items

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1886,7 +1886,7 @@ void activity_handlers::make_zlave_finish( player_activity *act, player *p )
 
         body->mod_damage( rng( 0, body->max_damage() - body->damage() ), DT_STAB );
         if( body->damage() == body->max_damage() ) {
-            body->active = false;
+            body->deactivate();
             p->add_msg_if_player( m_warning, _( "You cut up the corpse too much, it is thoroughly pulped." ) );
         } else {
             p->add_msg_if_player( m_warning,

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -988,21 +988,6 @@ void avatar_action::plthrow( avatar &you, item *loc,
                          ( *loc, blind_throw_from_pos ) ), false );
 }
 
-static void make_active( item &loc )
-{
-    map &here = get_map();
-    switch( loc.where() ) {
-        case item_location_type::map:
-            here.make_active( loc );
-            break;
-        case item_location_type::vehicle:
-            here.veh_at( loc.position() )->vehicle().make_active( loc );
-            break;
-        default:
-            break;
-    }
-}
-
 void avatar_action::use_item( avatar &you, item *loc )
 {
 

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -1003,21 +1003,8 @@ static void make_active( item &loc )
     }
 }
 
-static void update_lum( item &loc, bool add )
-{
-    switch( loc.where() ) {
-        case item_location_type::map:
-            get_map().update_lum( loc, add );
-            break;
-        default:
-            break;
-    }
-}
-
 void avatar_action::use_item( avatar &you, item *loc )
 {
-    // Some items may be used without being picked up first
-    bool use_in_place = false;
 
     if( !loc ) {
         loc = game_menus::inv::use( you );
@@ -1027,9 +1014,7 @@ void avatar_action::use_item( avatar &you, item *loc )
             return;
         }
 
-        if( loc->has_flag( flag_ALLOWS_REMOTE_USE ) ) {
-            use_in_place = true;
-        } else {
+        if( !loc->has_flag( flag_ALLOWS_REMOTE_USE ) ) {
             const int obtain_cost = loc->obtain_cost( you );
             loc->obtain( you );
 
@@ -1039,15 +1024,7 @@ void avatar_action::use_item( avatar &you, item *loc )
         }
     }
 
-    if( use_in_place ) {
-        update_lum( *loc, false );
-        avatar_funcs::use_item( you, *loc );
-        update_lum( *loc, true );
-
-        make_active( *loc );
-    } else {
-        avatar_funcs::use_item( you, *loc );
-    }
+    avatar_funcs::use_item( you, *loc );
 
     you.invalidate_crafting_inventory();
 }

--- a/src/avatar_functions.cpp
+++ b/src/avatar_functions.cpp
@@ -841,7 +841,7 @@ bool unload_item( avatar &you, item &loc )
     }
 
     // Turn off any active tools
-    if( target->is_tool() && target->_active() && target->ammo_remaining() == 0 ) {
+    if( target->is_tool() && target->is_active() && target->ammo_remaining() == 0 ) {
         target->type->invoke( you, *target, you.pos() );
     }
 

--- a/src/avatar_functions.cpp
+++ b/src/avatar_functions.cpp
@@ -841,7 +841,7 @@ bool unload_item( avatar &you, item &loc )
     }
 
     // Turn off any active tools
-    if( target->is_tool() && target->active && target->ammo_remaining() == 0 ) {
+    if( target->is_tool() && target->_active() && target->ammo_remaining() == 0 ) {
         target->type->invoke( you, *target, you.pos() );
     }
 

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1005,7 +1005,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
             ctr->charges = units::to_kilojoule( get_power_level() );
             int power_use = invoke_item( ctr );
             mod_power_level( units::from_kilojoule( -power_use ) );
-            bio.powered = ctr->_active();
+            bio.powered = ctr->is_active();
         } else {
             bio.powered = g->remoteveh() != nullptr || !get_value( "remote_controlling" ).empty();
         }
@@ -1400,7 +1400,7 @@ itype_id Character::find_remote_fuel( bool look_only )
     map &here = get_map();
 
     const std::vector<item *> cables = items_with( []( const item & it ) {
-        return it._active() && it.has_flag( flag_CABLE_SPOOL );
+        return it.is_active() && it.has_flag( flag_CABLE_SPOOL );
     } );
 
     for( const item *cable : cables ) {
@@ -1452,7 +1452,7 @@ int Character::consume_remote_fuel( int amount )
 {
     int unconsumed_amount = amount;
     const std::vector<item *> cables = items_with( []( const item & it ) {
-        return it._active() && it.has_flag( flag_CABLE_SPOOL );
+        return it.is_active() && it.has_flag( flag_CABLE_SPOOL );
     } );
 
     map &here = get_map();

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1005,7 +1005,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
             ctr->charges = units::to_kilojoule( get_power_level() );
             int power_use = invoke_item( ctr );
             mod_power_level( units::from_kilojoule( -power_use ) );
-            bio.powered = ctr->active;
+            bio.powered = ctr->_active();
         } else {
             bio.powered = g->remoteveh() != nullptr || !get_value( "remote_controlling" ).empty();
         }
@@ -1400,7 +1400,7 @@ itype_id Character::find_remote_fuel( bool look_only )
     map &here = get_map();
 
     const std::vector<item *> cables = items_with( []( const item & it ) {
-        return it.active && it.has_flag( flag_CABLE_SPOOL );
+        return it._active() && it.has_flag( flag_CABLE_SPOOL );
     } );
 
     for( const item *cable : cables ) {
@@ -1452,7 +1452,7 @@ int Character::consume_remote_fuel( int amount )
 {
     int unconsumed_amount = amount;
     const std::vector<item *> cables = items_with( []( const item & it ) {
-        return it.active && it.has_flag( flag_CABLE_SPOOL );
+        return it._active() && it.has_flag( flag_CABLE_SPOOL );
     } );
 
     map &here = get_map();

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2977,7 +2977,7 @@ invlets_bitset Character::allocated_invlets() const
 bool Character::has_active_item( const itype_id &id ) const
 {
     return has_item_with( [id]( const item & it ) {
-        return it.active && it.typeId() == id;
+        return it._active() && it.typeId() == id;
     } );
 }
 
@@ -4324,7 +4324,7 @@ bool Character::is_wearing_power_armor( bool *hasHelmet ) const
 bool Character::is_wearing_active_power_armor() const
 {
     for( const auto &w : worn ) {
-        if( w->has_flag( flag_POWERARMOR_EXO ) && w->active ) {
+        if( w->has_flag( flag_POWERARMOR_EXO ) && w->_active() ) {
             return true;
         }
     }
@@ -4334,7 +4334,7 @@ bool Character::is_wearing_active_power_armor() const
 bool Character::is_wearing_active_optcloak() const
 {
     for( const auto &w : worn ) {
-        if( w->active && w->has_flag( flag_ACTIVE_CLOAKING ) ) {
+        if( w->_active() && w->has_flag( flag_ACTIVE_CLOAKING ) ) {
             return true;
         }
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2977,7 +2977,7 @@ invlets_bitset Character::allocated_invlets() const
 bool Character::has_active_item( const itype_id &id ) const
 {
     return has_item_with( [id]( const item & it ) {
-        return it._active() && it.typeId() == id;
+        return it.is_active() && it.typeId() == id;
     } );
 }
 
@@ -4324,7 +4324,7 @@ bool Character::is_wearing_power_armor( bool *hasHelmet ) const
 bool Character::is_wearing_active_power_armor() const
 {
     for( const auto &w : worn ) {
-        if( w->has_flag( flag_POWERARMOR_EXO ) && w->_active() ) {
+        if( w->has_flag( flag_POWERARMOR_EXO ) && w->is_active() ) {
             return true;
         }
     }
@@ -4334,7 +4334,7 @@ bool Character::is_wearing_active_power_armor() const
 bool Character::is_wearing_active_optcloak() const
 {
     for( const auto &w : worn ) {
-        if( w->_active() && w->has_flag( flag_ACTIVE_CLOAKING ) ) {
+        if( w->is_active() && w->has_flag( flag_ACTIVE_CLOAKING ) ) {
             return true;
         }
     }

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -1752,7 +1752,7 @@ void emp_blast( const tripoint &p )
         if( cuffs.typeId() == itype_e_handcuffs && cuffs.charges > 0 ) {
             cuffs.unset_flag( flag_NO_UNWIELD );
             cuffs.charges = 0;
-            cuffs.active = false;
+            cuffs.deactivate();
             add_msg( m_good, _( "The %s on your wrists spark briefly, then release your hands!" ),
                      cuffs.tname() );
         }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1034,7 +1034,7 @@ static void sleep()
     std::vector<std::string> active;
     for( auto &it : u.inv_dump() ) {
         if( it->has_flag( flag_LITCIG ) ||
-            ( it->active && ( it->charges > 0 || it->units_remaining( u ) > 0 ) && it->is_tool() &&
+            ( it->_active() && ( it->charges > 0 || it->units_remaining( u ) > 0 ) && it->is_tool() &&
               !it->has_flag( flag_SLEEP_IGNORE ) ) ) {
             active.push_back( it->tname() );
         }
@@ -1065,10 +1065,10 @@ static void sleep()
 
     // check for deactivating any currently played music instrument.
     for( auto &item : u.inv_dump() ) {
-        if( item->active && item->get_use( "musical_instrument" ) != nullptr ) {
+        if( item->_active() && item->get_use( "musical_instrument" ) != nullptr ) {
             u.add_msg_if_player( _( "You stop playing your %s before trying to sleep." ), item->tname() );
             // deactivate instrument
-            item->active = false;
+            item->deactivate();
         }
     }
 
@@ -1308,7 +1308,7 @@ static void read()
     if( loc ) {
         if( loc->type->can_use( "learn_spell" ) ) {
             item &spell_book = *loc;
-            spell_book.get_use( "learn_spell" )->call( u, spell_book, spell_book.active, u.pos() );
+            spell_book.get_use( "learn_spell" )->call( u, spell_book, spell_book._active(), u.pos() );
         } else {
             u.read( loc );
         }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1034,7 +1034,7 @@ static void sleep()
     std::vector<std::string> active;
     for( auto &it : u.inv_dump() ) {
         if( it->has_flag( flag_LITCIG ) ||
-            ( it->_active() && ( it->charges > 0 || it->units_remaining( u ) > 0 ) && it->is_tool() &&
+            ( it->is_active() && ( it->charges > 0 || it->units_remaining( u ) > 0 ) && it->is_tool() &&
               !it->has_flag( flag_SLEEP_IGNORE ) ) ) {
             active.push_back( it->tname() );
         }
@@ -1065,7 +1065,7 @@ static void sleep()
 
     // check for deactivating any currently played music instrument.
     for( auto &item : u.inv_dump() ) {
-        if( item->_active() && item->get_use( "musical_instrument" ) != nullptr ) {
+        if( item->is_active() && item->get_use( "musical_instrument" ) != nullptr ) {
             u.add_msg_if_player( _( "You stop playing your %s before trying to sleep." ), item->tname() );
             // deactivate instrument
             item->deactivate();
@@ -1308,7 +1308,7 @@ static void read()
     if( loc ) {
         if( loc->type->can_use( "learn_spell" ) ) {
             item &spell_book = *loc;
-            spell_book.get_use( "learn_spell" )->call( u, spell_book, spell_book._active(), u.pos() );
+            spell_book.get_use( "learn_spell" )->call( u, spell_book, spell_book.is_active(), u.pos() );
         } else {
             u.read( loc );
         }

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -4872,7 +4872,7 @@ void iexamine::autodoc( player &p, const tripoint &examp )
     }
     if( &patient == &null_player ) {
         if( cyborg != nullptr ) {
-            if( cyborg->typeId() == itype_corpse && !cyborg->active ) {
+            if( cyborg->typeId() == itype_corpse && !cyborg->_active() ) {
                 popup( _( "Patient is dead.  Please remove corpse to proceed.  Exiting." ) );
                 return;
             } else if( cyborg->typeId() == itype_bot_broken_cyborg || cyborg->typeId() == itype_corpse ) {

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -4872,7 +4872,7 @@ void iexamine::autodoc( player &p, const tripoint &examp )
     }
     if( &patient == &null_player ) {
         if( cyborg != nullptr ) {
-            if( cyborg->typeId() == itype_corpse && !cyborg->_active() ) {
+            if( cyborg->typeId() == itype_corpse && !cyborg->is_active() ) {
                 popup( _( "Patient is dead.  Please remove corpse to proceed.  Exiting." ) );
                 return;
             } else if( cyborg->typeId() == itype_bot_broken_cyborg || cyborg->typeId() == itype_corpse ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -373,7 +373,7 @@ item::item( const recipe *rec, int qty, std::vector<detached_ptr<item>> &&items,
     craft_data_->comps_used = std::move( selections );
 
     if( is_food() ) {
-        active = true;
+        activate();
         last_rot_check = bday;
         if( goes_bad() ) {
             const item *most_rotten = get_most_rotten_component( *this );
@@ -542,26 +542,31 @@ void item::convert( const itype_id &new_type )
     relic_data = type->relic_data;
 }
 
-void item::deactivate( const Character *ch, bool alert )
+void item::deactivate()
 {
-    if( !( active && is_tool() ) ) {
+    if( !( _active() && is_tool() ) ) {
+        add_msg( "Already inactive" );
         return; // no-op
     }
 
-    const auto &revert_to = type->tool->revert_to;
-    if( revert_to ) {
-        if( ch && alert && !type->tool->revert_msg.empty() ) {
-            ch->add_msg_if_player( m_info, _( type->tool->revert_msg ), tname() );
-        }
-        convert( *revert_to );
-        active = false;
+    active = false;
 
+    switch( where() ) {
+        case item_location_type::map:
+            get_map().make_inactive( *this );
+            break;
+        case item_location_type::vehicle:
+            get_map().veh_at( position() )->vehicle().make_inactive( *this );
+            break;
+        default:
+            break;
     }
+
 }
 
 void item::activate()
 {
-    if( active ) {
+    if( _active() ) {
         return; // no-op
     }
 
@@ -571,6 +576,30 @@ void item::activate()
 
     active = true;
 
+    switch( where() ) {
+        case item_location_type::map:
+            get_map().make_active( *this );
+            break;
+        case item_location_type::vehicle:
+            get_map().veh_at( position() )->vehicle().make_active( *this );
+            break;
+        default:
+            break;
+    }
+}
+
+bool item::revert( const Character *ch, bool alert )
+{
+    const auto &tooldata = type->tool;
+    // Can't be reverted, prevents destruction of irrevertable items.
+    if( !tooldata->revert_to.has_value() ) {
+        return false;
+    }
+    if( ch && alert && !tooldata->revert_msg.empty() ) {
+        ch->add_msg_if_player( m_info, _( tooldata->revert_msg ), tname() );
+    }
+    convert( *tooldata->revert_to );
+    return true;
 }
 
 units::energy item::mod_energy( const units::energy &qty )
@@ -985,7 +1014,7 @@ bool item::stacks_with( const item &rhs, bool check_components, bool skip_type_c
     if( burnt != rhs.burnt ) {
         return false;
     }
-    if( active != rhs.active ) {
+    if( _active() != rhs._active() ) {
         return false;
     }
     if( item_tags != rhs.item_tags ) {
@@ -1750,7 +1779,7 @@ void item::basic_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
             info.emplace_back( "BASE", _( "damage: " ), "", iteminfo::lower_is_better,
                                damage_ );
             info.emplace_back( "BASE", _( "active: " ), "", iteminfo::lower_is_better,
-                               active );
+                               _active() );
             info.emplace_back( "BASE", _( "burn: " ), "", iteminfo::lower_is_better,
                                burnt );
 
@@ -4198,7 +4227,7 @@ nc_color item::color_in_inventory( const player &p ) const
         }
     } else if( has_flag( flag_LEAK_DAM ) && has_flag( flag_RADIOACTIVE ) && damage() > 0 ) {
         ret = c_light_green;
-    } else if( active && !is_food() && !is_food_container() && !is_corpse() ) {
+    } else if( _active() && !is_food() && !is_food_container() && !is_corpse() ) {
         // Active items show up as yellow
         ret = c_yellow;
     } else if( is_corpse() && ( can_revive() || corpse->zombify_into ) && !has_flag( flag_PULPED ) ) {
@@ -4407,7 +4436,7 @@ void item::on_wear( Character &p )
         }
         flag_id transform_flag( actor->dependencies );
         for( const auto &elem : p.worn ) {
-            if( elem->has_flag( transform_flag ) && elem->active != active ) {
+            if( elem->has_flag( transform_flag ) && elem->_active() != _active() ) {
                 transform = true;
             }
         }
@@ -4436,7 +4465,7 @@ void item::on_takeoff( Character &p )
     }
 
     // if power armor, no power_draw and active, shut down.
-    if( type->can_use( "set_transformed" ) && active ) {
+    if( type->can_use( "set_transformed" ) && _active() ) {
         const set_transformed_iuse *actor = dynamic_cast<const set_transformed_iuse *>
                                             ( this->get_use( "set_transformed" )->get_actor_ptr() );
         if( actor == nullptr ) {
@@ -4810,11 +4839,11 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
     if( already_used_by_player( you ) ) {
         tagtext += _( " (used)" );
     }
-    if( active && ( has_flag( flag_WATER_EXTINGUISH ) || has_flag( flag_LITCIG ) ) ) {
+    if( _active() && ( has_flag( flag_WATER_EXTINGUISH ) || has_flag( flag_LITCIG ) ) ) {
         tagtext += _( " (lit)" );
     } else if( has_flag( flag_IS_UPS ) && get_var( "cable" ) == "plugged_in" ) {
         tagtext += _( " (plugged in)" );
-    } else if( active && !is_food() && !is_corpse() &&
+    } else if( _active() && !is_food() && !is_corpse() &&
                !string_ends_with( typeId().str(), "_on" ) ) {
         // Usually the items whose ids end in "_on" have the "active" or "on" string already contained
         // in their name, also food is active while it rots.
@@ -8458,7 +8487,7 @@ bool item::burn( fire_data &frd )
 
     if( is_corpse() ) {
         const mtype *mt = get_mtype();
-        if( active && mt != nullptr && burnt + burn_added > mt->hp &&
+        if( _active() && mt != nullptr && burnt + burn_added > mt->hp &&
             !mt->burn_into.is_null() && mt->burn_into.is_valid() ) {
             corpse = &get_mtype()->burn_into.obj();
             // Delay rezing
@@ -9083,7 +9112,7 @@ uint64_t item::make_component_hash() const
 
 bool item::needs_processing() const
 {
-    return active || has_flag( flag_RADIO_ACTIVATION ) || has_flag( flag_ETHEREAL_ITEM ) ||
+    return _active() || has_flag( flag_RADIO_ACTIVATION ) || has_flag( flag_ETHEREAL_ITEM ) ||
            ( is_container() && !contents.empty() && contents.front().needs_processing() ) ||
            is_artifact() || is_food();
 }
@@ -9362,7 +9391,7 @@ detached_ptr<item> item::process_litcig( detached_ptr<item> &&self, player *carr
     }
     self = self->process_extinguish( std::move( self ), carrier, pos );
     // process_extinguish might have extinguished the item already
-    if( !self->active ) {
+    if( !self->_active() ) {
         return std::move( self );
     }
     item &it = *self;
@@ -9425,7 +9454,7 @@ detached_ptr<item> item::process_litcig( detached_ptr<item> &&self, player *carr
                 weed_msg( *carrier );
             }
         }
-        it.active = false;
+        it.deactivate();
     }
     // Item remains
     return std::move( self );
@@ -9501,15 +9530,12 @@ detached_ptr<item> item::process_extinguish( detached_ptr<item> &&self, player *
             self->convert( itype_joint_roach );
         }
     } else { // transform (lit) items
-        const auto &revert_to = self->type->tool->revert_to;
-        if( revert_to ) {
-            self->convert( *revert_to );
-        } else {
+        if( !self->revert( carrier ) ) {
             self->type->invoke( carrier != nullptr ? *carrier : get_avatar(), *self, pos, "transform" );
         }
 
     }
-    self->active = false;
+    self->deactivate();
     // Item remains
     return std::move( self );
 }
@@ -9603,7 +9629,7 @@ void item::reset_cable( player *p )
     erase_var( "source_x" );
     erase_var( "source_y" );
     erase_var( "source_z" );
-    active = false;
+    deactivate();
     charges = max_charges;
 
     if( p != nullptr ) {
@@ -9620,16 +9646,16 @@ detached_ptr<item> item::process_UPS( detached_ptr<item> &&self, player *carrier
     }
     if( carrier == nullptr ) {
         self->erase_var( "cable" );
-        self->active = false;
+        self->deactivate();
         return std::move( self );
     }
     bool has_connected_cable = carrier->has_item_with( []( const item & it ) {
-        return it.active && it.has_flag( flag_CABLE_SPOOL ) && ( it.get_var( "state" ) == "UPS_link" ||
+        return it._active() && it.has_flag( flag_CABLE_SPOOL ) && ( it.get_var( "state" ) == "UPS_link" ||
                 it.get_var( "state" ) == "UPS" );
     } );
     if( !has_connected_cable ) {
         self->erase_var( "cable" );
-        self->active = false;
+        self->deactivate();
     }
     return std::move( self );
 }
@@ -9641,7 +9667,7 @@ bool item::process_wet( player * /*carrier*/, const tripoint & /*pos*/ )
             convert( *type->tool->revert_to );
         }
         unset_flag( flag_WET );
-        active = false;
+        deactivate();
     }
     // Always return true so our caller will bail out instead of processing us as a tool.
     return true;
@@ -9670,7 +9696,7 @@ detached_ptr<item> item::process_tool( detached_ptr<item> &&self, player *carrie
                 bool active = false;
                 flag_id transform_flag( actor->dependencies );
                 for( const auto &elem : carrier->worn ) {
-                    if( elem->active && elem->has_flag( transform_flag ) ) {
+                    if( elem->_active() && elem->has_flag( transform_flag ) ) {
                         active = true;
                         break;
                     }
@@ -9734,7 +9760,7 @@ detached_ptr<item> item::process_tool( detached_ptr<item> &&self, player *carrie
             }
             flag_id transformed_flag( actor->flag );
             for( auto &elem : carrier->worn ) {
-                if( elem->active && elem->has_flag( transformed_flag ) ) {
+                if( elem->_active() && elem->has_flag( transformed_flag ) ) {
                     if( !elem->type->can_use( "set_transformed" ) ) {
                         debugmsg( "Expected set_transformed function" );
                         return std::move( self );
@@ -9750,13 +9776,12 @@ detached_ptr<item> item::process_tool( detached_ptr<item> &&self, player *carrie
             }
         }
 
-        // invoking the object can convert the item to another type
-        const bool had_revert_to = self->type->tool->revert_to.has_value();
-        self->type->invoke( carrier != nullptr ? *carrier : you, *self, pos );
-        if( had_revert_to ) {
-            self->deactivate( carrier );
+        // If no revert is defined, invoke the item (for use in grenades)
+        if( self->_active() && self->revert( carrier ) ) {
+            self->deactivate();
             return std::move( self );
         } else {
+            self->type->invoke( carrier != nullptr ? *carrier : you, *self, pos );
             return detached_ptr<item>();
         }
     }
@@ -9855,7 +9880,7 @@ detached_ptr<item> item::process_internal( detached_ptr<item> &&self, player *ca
     // food and as litcig and as ...
 
     // Remaining stuff is only done for active items.
-    if( !self->active ) {
+    if( !self->_active() ) {
         return std::move( self );
     }
 
@@ -10241,6 +10266,11 @@ void item::legacy_fast_forward_time()
 
     const time_duration tmp_rot = ( last_rot_check - calendar::turn_zero ) * 6;
     last_rot_check = calendar::turn_zero + tmp_rot;
+}
+
+bool item::_active() const
+{
+    return active;
 }
 
 time_point item::birthday() const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -551,6 +551,7 @@ void item::deactivate()
 
     active = false;
 
+    // Is not placed in the world, so either a template of some kind or a temporary item.
     if( !has_position() ) {
         return;
     }
@@ -579,6 +580,7 @@ void item::activate()
 
     active = true;
 
+    // Is not placed in the world, so either a template of some kind or a temporary item.
     if( !has_position() ) {
         return;
     }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -551,6 +551,9 @@ void item::deactivate()
 
     active = false;
 
+    if( !has_position() ) {
+        return;
+    }
     switch( where() ) {
         case item_location_type::map:
             get_map().make_inactive( *this );
@@ -576,6 +579,9 @@ void item::activate()
 
     active = true;
 
+    if( !has_position() ) {
+        return;
+    }
     switch( where() ) {
         case item_location_type::map:
             get_map().make_active( *this );

--- a/src/item.h
+++ b/src/item.h
@@ -2124,7 +2124,7 @@ class item : public location_visitable<item>, public game_object<item>
         time_duration age() const;
         void set_age( const time_duration &age );
         void legacy_fast_forward_time();
-        bool _active() const;
+        bool is_active() const;
         time_point birthday() const;
         void set_birthday( const time_point &bday );
         void handle_pickup_ownership( Character &c );

--- a/src/item.h
+++ b/src/item.h
@@ -320,10 +320,13 @@ class item : public location_visitable<item>, public game_object<item>
          * @param alert whether to display any messages
          * @return same instance to allow method chaining
          */
-        void deactivate( const Character *ch = nullptr, bool alert = true );
+        void deactivate();
 
         /** Converts instance to active state */
         void activate();
+
+        /** Reverts item if able*/
+        bool revert( const Character *ch, bool alert = true );
 
         /**
          * Add or remove energy from a battery.
@@ -2121,6 +2124,7 @@ class item : public location_visitable<item>, public game_object<item>
         time_duration age() const;
         void set_age( const time_duration &age );
         void legacy_fast_forward_time();
+        bool _active() const;
         time_point birthday() const;
         void set_birthday( const time_point &bday );
         void handle_pickup_ownership( Character &c );
@@ -2386,6 +2390,8 @@ class item : public location_visitable<item>, public game_object<item>
         time_point last_rot_check = calendar::turn_zero;
         /// The time the item was created.
         time_point bday;
+        // If true, it has active effects to be processed
+        bool active = false;
         // The faction that owns this item.
         mutable faction_id owner = faction_id::NULL_ID();
         // The faction that previously owned this item
@@ -2395,7 +2401,6 @@ class item : public location_visitable<item>, public game_object<item>
 
     public:
         char invlet = 0;      // Inventory letter
-        bool active = false; // If true, it has active effects to be processed
         //TODO! old safe reference type here
         player *activated_by = nullptr;
         bool is_favorite = false;

--- a/src/item.h
+++ b/src/item.h
@@ -316,16 +316,17 @@ class item : public location_visitable<item>, public game_object<item>
         /**
          * Converts this instance to the inactive type
          * If the item is either inactive or cannot be deactivated is a no-op
-         * @param ch character currently possessing or acting upon the item (if any)
-         * @param alert whether to display any messages
-         * @return same instance to allow method chaining
          */
         void deactivate();
 
         /** Converts instance to active state */
         void activate();
 
-        /** Reverts item if able*/
+        /** Reverts item if able
+         * @param ch character currently possessing or acting upon the item (if any)
+         * @param alert whether to display any messages
+         * @return true if item reverted or false if no revert available.
+         */
         bool revert( const Character *ch, bool alert = true );
 
         /**

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -438,7 +438,7 @@ void remove_radio_mod( item &it, player &p )
 static bool check_litcig( player &u )
 {
     auto cigs = u.items_with( []( const item & it ) {
-        return it._active() && it.has_flag( flag_LITCIG );
+        return it.is_active() && it.has_flag( flag_LITCIG );
     } );
     if( cigs.empty() ) {
         return true;
@@ -1782,7 +1782,7 @@ int iuse::fish_trap( player *p, item *it, bool t, const tripoint &pos )
 {
     if( !t ) {
         // Handle deploying fish trap.
-        if( it->_active() ) {
+        if( it->is_active() ) {
             it->deactivate();
             return 0;
         }
@@ -4173,7 +4173,7 @@ int iuse::dive_tank( player *p, item *it, bool t, const tripoint & )
     } else { // Turning it on/off
         if( it->charges == 0 ) {
             p->add_msg_if_player( _( "Your %s is empty." ), it->tname() );
-        } else if( it->_active() ) { //off
+        } else if( it->is_active() ) { //off
             p->add_msg_if_player( _( "You turn off the regulator and close the air valve." ) );
             it->set_var( "overwrite_env_resist", 0 );
             it->convert( itype_id( it->typeId().str().substr( 0,
@@ -6265,7 +6265,7 @@ int iuse::einktabletpc( player *p, item *it, bool t, const tripoint &pos )
 
         const int songs = it->get_var( "EIPC_MUSIC", 0 );
         if( songs > 0 ) {
-            if( it->_active() ) {
+            if( it->is_active() ) {
                 amenu.addentry( ei_music, true, 'm', _( "Turn music off" ) );
             } else {
                 amenu.addentry( ei_music, true, 'm', _( "Turn music on [%d]" ), songs );
@@ -6355,7 +6355,7 @@ int iuse::einktabletpc( player *p, item *it, bool t, const tripoint &pos )
 
             p->moves -= 30;
 
-            if( it->_active() ) {
+            if( it->is_active() ) {
                 it->deactivate();
                 it->erase_var( "EIPC_MUSIC_ON" );
 
@@ -7703,7 +7703,7 @@ int iuse::ehandcuffs( player *p, item *it, bool t, const tripoint &pos )
 
     }
 
-    if( it->_active() ) {
+    if( it->is_active() ) {
         add_msg( _( "The %s are clamped tightly on your wrists.  You can't take them off." ),
                  it->tname() );
     } else {
@@ -7919,7 +7919,7 @@ int iuse::radiocontrol( player *p, item *it, bool t, const tripoint & )
 
     const char *car_action = nullptr;
 
-    if( !it->_active() ) {
+    if( !it->is_active() ) {
         car_action = _( "Take control of RC car" );
     } else {
         car_action = _( "Stop controlling RC car" );
@@ -7933,7 +7933,7 @@ int iuse::radiocontrol( player *p, item *it, bool t, const tripoint & )
     if( choice < 0 ) {
         return 0;
     } else if( choice == 0 ) {
-        if( it->_active() ) {
+        if( it->is_active() ) {
             it->deactivate();
             p->remove_value( "remote_controlling" );
         } else {
@@ -8118,7 +8118,7 @@ int iuse::remoteveh( player *p, item *it, bool t, const tripoint &pos )
         return it->type->charges_to_use();
     }
 
-    bool controlling = it->_active() && remote != nullptr;
+    bool controlling = it->is_active() && remote != nullptr;
     int choice = uilist( _( "What to do with remote vehicle control:" ), {
         controlling ? _( "Stop controlling the vehicle." ) : _( "Take control of a vehicle." ),
         _( "Execute one vehicle action" )
@@ -8306,7 +8306,7 @@ int iuse::multicooker( player *p, item *it, bool t, const tripoint &pos )
             return !( it.is_toolmod() || it.is_magazine() );
         } );
 
-        if( it->_active() ) {
+        if( it->is_active() ) {
             menu.addentry( mc_stop, true, 's', _( "Stop cooking" ) );
         } else {
             if( dish_it == nullptr ) {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -438,7 +438,7 @@ void remove_radio_mod( item &it, player &p )
 static bool check_litcig( player &u )
 {
     auto cigs = u.items_with( []( const item & it ) {
-        return it.active && it.has_flag( flag_LITCIG );
+        return it._active() && it.has_flag( flag_LITCIG );
     } );
     if( cigs.empty() ) {
         return true;
@@ -579,7 +579,7 @@ int iuse::smoking( player *p, item *it, bool, const tripoint & )
     }
     // If we're here, we better have a cig to light.
     p->use_charges_if_avail( itype_fire, 1 );
-    cig->active = true;
+    cig->activate();
     p->add_msg_if_player( m_neutral, _( "You light a %s." ), cig->tname() );
 
     p->i_add( std::move( cig ) );
@@ -1782,8 +1782,8 @@ int iuse::fish_trap( player *p, item *it, bool t, const tripoint &pos )
 {
     if( !t ) {
         // Handle deploying fish trap.
-        if( it->active ) {
-            it->active = false;
+        if( it->_active() ) {
+            it->deactivate();
             return 0;
         }
 
@@ -1818,7 +1818,7 @@ int iuse::fish_trap( player *p, item *it, bool t, const tripoint &pos )
         if( !good_fishing_spot( pnt ) ) {
             return 0;
         }
-        it->active = true;
+        it->activate();
         it->set_age( 0_turns );
         g->m.add_item_or_charges( pnt, it->detach() );
         p->add_msg_if_player( m_info,
@@ -1829,11 +1829,11 @@ int iuse::fish_trap( player *p, item *it, bool t, const tripoint &pos )
     } else {
         // Handle processing fish trap over time.
         if( it->charges == 0 ) {
-            it->active = false;
+            it->deactivate();
             return 0;
         }
         if( it->age() > 3_hours ) {
-            it->active = false;
+            it->deactivate();
 
             if( !g->m.has_flag( "FISHABLE", pos ) ) {
                 return 0;
@@ -1981,7 +1981,7 @@ int iuse::unpack_item( player *p, item *it, bool, const tripoint & )
     p->moves -= to_moves<int>( 10_seconds );
     p->add_msg_if_player( _( "You unpack your %s for use." ), it->tname() );
     it->convert( itype_id( oname ) );
-    it->active = false;
+    it->deactivate();
     return 0;
 }
 
@@ -2039,7 +2039,7 @@ int iuse::pack_item( player *p, item *it, bool t, const tripoint & )
         p->moves -= to_moves<int>( 10_seconds );
         p->add_msg_if_player( _( "You pack your %s for storage." ), it->tname() );
         it->convert( itype_id( oname ) );
-        it->active = false;
+        it->deactivate();
     }
     return 0;
 }
@@ -2082,7 +2082,7 @@ int iuse::radio_off( player *p, item *it, bool, const tripoint & )
     } else {
         p->add_msg_if_player( _( "You turn the radio on." ) );
         it->convert( itype_radio_on );
-        it->active = true;
+        it->activate();
     }
     return it->type->charges_to_use();
 }
@@ -2199,7 +2199,7 @@ int iuse::radio_on( player *p, item *it, bool t, const tripoint &pos )
             case 1:
                 p->add_msg_if_player( _( "The radio dies." ) );
                 it->convert( itype_radio );
-                it->active = false;
+                it->deactivate();
                 sfx::fade_audio_channel( sfx::channel::radio, 300 );
                 break;
             default:
@@ -2216,7 +2216,7 @@ int iuse::noise_emitter_off( player *p, item *it, bool, const tripoint & )
     } else {
         p->add_msg_if_player( _( "You turn the noise emitter on." ) );
         it->convert( itype_noise_emitter_on );
-        it->active = true;
+        it->activate();
     }
     return it->type->charges_to_use();
 }
@@ -2230,7 +2230,7 @@ int iuse::noise_emitter_on( player *p, item *it, bool t, const tripoint &pos )
     } else { // Turning it off
         p->add_msg_if_player( _( "The infernal racket dies as the noise emitter turns off." ) );
         it->convert( itype_noise_emitter );
-        it->active = false;
+        it->deactivate();
     }
     return it->type->charges_to_use();
 }
@@ -2239,7 +2239,7 @@ int iuse::noise_emitter_on( player *p, item *it, bool t, const tripoint &pos )
 int iuse::note_bionics( player *p, item *it, bool t, const tripoint &pos )
 {
     if( !t ) {
-        it->deactivate( p, true );
+        it->deactivate();
         return 0;
     }
     if( !p->is_avatar() ) {
@@ -2249,7 +2249,7 @@ int iuse::note_bionics( player *p, item *it, bool t, const tripoint &pos )
     map &here = get_map();
 
     if( !p->has_enough_charges( *it, false ) ) {
-        it->deactivate( p, true );
+        it->deactivate();
         return 0;
     }
     for( const tripoint &pt : here.points_in_radius( pos, PICKUP_RANGE ) ) {
@@ -2926,7 +2926,7 @@ static int toolweapon_off( player &p, item &it, const bool fast_startup,
         p.add_msg_if_player( msg_success );
         // 4 is the length of "_off".
         it.convert( itype_id( it.typeId().str().substr( 0, it.typeId().str().size() - 4 ) + "_on" ) );
-        it.active = true;
+        it.activate();
         return it.type->charges_to_use();
     } else {
         if( it.typeId() == itype_chainsaw_off ) {
@@ -3025,7 +3025,7 @@ static int toolweapon_on( player &p, item &it, const bool t,
         if( !works_underwater && p.is_underwater() ) {
             p.add_msg_if_player( _( "Your %s gurgles in the water and stops." ), tname );
             it.convert( itype_id( off_type ) );
-            it.active = false;
+            it.deactivate();
         } else if( one_in( sound_chance ) ) {
             sounds::ambient_sound( p.pos(), volume, sounds::sound_t::activity, sound );
         }
@@ -3037,7 +3037,7 @@ static int toolweapon_on( player &p, item &it, const bool t,
         }
         p.add_msg_if_player( _( "Your %s goes quiet." ), tname );
         it.convert( itype_id( off_type ) );
-        it.active = false;
+        it.deactivate();
         return 0; // Don't consume charges when turning off.
     }
     return it.type->charges_to_use();
@@ -3353,7 +3353,7 @@ int iuse::geiger( player *p, item *it, bool t, const tripoint &pos )
     if( it->typeId() == itype_geiger_on ) {
         add_msg( _( "The geiger counter's SCANNING LED turns off." ) );
         it->convert( itype_geiger_off );
-        it->active = false;
+        it->deactivate();
         return 0;
     }
 
@@ -3392,7 +3392,7 @@ int iuse::geiger( player *p, item *it, bool t, const tripoint &pos )
         case 2:
             p->add_msg_if_player( _( "The geiger counter's scan LED turns on." ) );
             it->convert( itype_geiger_on );
-            it->active = true;
+            it->activate();
             break;
         default:
             return 0;
@@ -3494,7 +3494,7 @@ int iuse::throwable_extinguisher_act( player *, item *it, bool, const tripoint &
         it->charges = -1;
         return 1;
     }
-    it->active = false;
+    it->deactivate();
     return 0;
 }
 
@@ -3503,7 +3503,7 @@ int iuse::granade( player *p, item *it, bool, const tripoint & )
     p->add_msg_if_player( _( "You pull the pin on the Granade." ) );
     it->convert( itype_granade_act );
     it->charges = 5;
-    it->active = true;
+    it->activate();
     return it->type->charges_to_use();
 }
 
@@ -3663,7 +3663,7 @@ int iuse::c4( player *p, item *it, bool, const tripoint & )
     p->add_msg_if_player( _( "You set the timer to %d." ), time );
     it->convert( itype_c4armed );
     it->charges = time;
-    it->active = true;
+    it->activate();
     return it->type->charges_to_use();
 }
 
@@ -3761,7 +3761,7 @@ int iuse::molotov_lit( player *p, item *it, bool t, const tripoint &pos )
         if( one_in( 5 ) ) {
             p->add_msg_if_player( _( "Your lit Molotov goes out." ) );
             it->convert( itype_molotov );
-            it->active = false;
+            it->deactivate();
         }
         return 0;
     }
@@ -3782,7 +3782,7 @@ int iuse::firecracker_pack( player *p, item *it, bool, const tripoint & )
     it->convert( itype_firecracker_pack_act );
     it->charges = 26;
     it->set_age( 0_turns );
-    it->active = true;
+    it->activate();
     return 0; // don't use any charges at all. it has became a new item
 }
 
@@ -3822,7 +3822,7 @@ int iuse::firecracker( player *p, item *it, bool, const tripoint & )
     p->add_msg_if_player( _( "You light the firecracker." ) );
     it->convert( itype_firecracker_act );
     it->charges = 2;
-    it->active = true;
+    it->activate();
     return it->type->charges_to_use();
 }
 
@@ -3856,7 +3856,7 @@ int iuse::mininuke( player *p, item *it, bool, const tripoint & )
     g->events().send<event_type::activates_mininuke>( p->getID() );
     it->convert( itype_mininuke_act );
     it->charges = time;
-    it->active = true;
+    it->activate();
     return it->type->charges_to_use();
 }
 
@@ -4016,16 +4016,16 @@ int iuse::mp3( player *p, item *it, bool, const tripoint & )
         p->add_msg_if_player( m_info, _( "You put in the earbuds and start listening to music." ) );
         if( it->typeId() == itype_mp3 ) {
             it->convert( itype_mp3_on );
-            it->active = true;
+            it->activate();
         } else if( it->typeId() == itype_smart_phone ) {
             it->convert( itype_smartphone_music );
-            it->active = true;
+            it->activate();
         } else if( it->typeId() == itype_afs_atomic_smartphone ) {
             it->convert( itype_afs_atomic_smartphone_music );
-            it->active = true;
+            it->activate();
         } else if( it->typeId() == itype_afs_wraitheon_smartphone ) {
             it->convert( itype_afs_atomic_wraitheon_music );
-            it->active = true;
+            it->activate();
         }
         p->mod_moves( -200 );
     }
@@ -4104,19 +4104,19 @@ int iuse::mp3_on( player *p, item *it, bool t, const tripoint &pos )
         if( it->typeId() == itype_mp3_on ) {
             p->add_msg_if_player( _( "The mp3 player turns off." ) );
             it->convert( itype_mp3 );
-            it->active = false;
+            it->deactivate();
         } else if( it->typeId() == itype_smartphone_music ) {
             p->add_msg_if_player( _( "The phone turns off." ) );
             it->convert( itype_smart_phone );
-            it->active = false;
+            it->deactivate();
         } else if( it->typeId() == itype_afs_atomic_smartphone_music ) {
             p->add_msg_if_player( _( "The phone turns off." ) );
             it->convert( itype_afs_atomic_smartphone );
-            it->active = false;
+            it->deactivate();
         } else if( it->typeId() == itype_afs_atomic_wraitheon_music ) {
             p->add_msg_if_player( _( "The phone turns off." ) );
             it->convert( itype_afs_wraitheon_smartphone );
-            it->active = false;
+            it->deactivate();
         }
         p->mod_moves( -200 );
     }
@@ -4161,24 +4161,24 @@ int iuse::dive_tank( player *p, item *it, bool t, const tripoint & )
                 it->set_var( "overwrite_env_resist", 0 );
                 it->convert( itype_id( it->typeId().str().substr( 0,
                                        it->typeId().str().size() - 3 ) ) );
-                it->active = false; // 3 = "_on"
+                it->deactivate(); // 3 = "_on"
             }
         } else { // not worn = off thanks to on-demand regulator
             it->set_var( "overwrite_env_resist", 0 );
             it->convert( itype_id( it->typeId().str().substr( 0,
                                    it->typeId().str().size() - 3 ) ) );
-            it->active = false; // 3 = "_on"
+            it->deactivate(); // 3 = "_on"
         }
 
     } else { // Turning it on/off
         if( it->charges == 0 ) {
             p->add_msg_if_player( _( "Your %s is empty." ), it->tname() );
-        } else if( it->active ) { //off
+        } else if( it->_active() ) { //off
             p->add_msg_if_player( _( "You turn off the regulator and close the air valve." ) );
             it->set_var( "overwrite_env_resist", 0 );
             it->convert( itype_id( it->typeId().str().substr( 0,
                                    it->typeId().str().size() - 3 ) ) );
-            it->active = false; // 3 = "_on"
+            it->deactivate(); // 3 = "_on"
         } else { //on
             if( !p->is_worn( *it ) ) {
                 p->add_msg_if_player( _( "You should wear it first." ) );
@@ -4186,7 +4186,7 @@ int iuse::dive_tank( player *p, item *it, bool t, const tripoint & )
                 p->add_msg_if_player( _( "You turn on the regulator and open the air valve." ) );
                 it->set_var( "overwrite_env_resist", it->get_base_env_resist_w_filter() );
                 it->convert( itype_id( it->typeId().str() + "_on" ) );
-                it->active = true;
+                it->activate();
             }
         }
     }
@@ -4194,7 +4194,7 @@ int iuse::dive_tank( player *p, item *it, bool t, const tripoint & )
         it->set_var( "overwrite_env_resist", 0 );
         it->convert( itype_id( it->typeId().str().substr( 0,
                                it->typeId().str().size() - 3 ) ) );
-        it->active = false; // 3 = "_on"
+        it->deactivate(); // 3 = "_on"
     }
     return it->type->charges_to_use();
 }
@@ -4239,7 +4239,7 @@ int iuse::solarpack_off( player *p, item *it, bool, const tripoint & )
     // 3 = "_on"
     it->convert( itype_id( it->typeId().str().substr( 0,
                            it->typeId().str().size() - 3 ) ) );
-    it->active = false;
+    it->deactivate();
     return 0;
 }
 
@@ -4272,13 +4272,13 @@ int iuse::gasmask( player *p, item *it, bool t, const tripoint &pos )
             p->add_msg_if_player( _( "Your %s don't have a filter." ), it->tname() );
         } else {
             p->add_msg_if_player( _( "You prepared your %s." ), it->tname() );
-            it->active = true;
+            it->activate();
             it->set_var( "overwrite_env_resist", it->get_base_env_resist_w_filter() );
         }
     }
     if( it->charges == 0 ) {
         it->set_var( "overwrite_env_resist", 0 );
-        it->active = false;
+        it->deactivate();
     }
     return it->type->charges_to_use();
 }
@@ -5443,7 +5443,7 @@ int iuse::towel_common( player *p, item *it, bool t )
 
             // WET, active items have their timer decremented every turn
             it->set_flag( flag_WET );
-            it->active = true;
+            it->activate();
         }
     }
     return it ? it->type->charges_to_use() : 0;
@@ -6222,7 +6222,7 @@ int iuse::einktabletpc( player *p, item *it, bool t, const tripoint &pos )
             const int songs = it->get_var( "EIPC_MUSIC", 0 );
             play_music( *p, pos, 8, std::min( 25, songs ) );
         } else {
-            it->active = false;
+            it->deactivate();
             it->erase_var( "EIPC_MUSIC_ON" );
             p->add_msg_if_player( m_info, _( "Tablet's batteries are dead." ) );
         }
@@ -6265,7 +6265,7 @@ int iuse::einktabletpc( player *p, item *it, bool t, const tripoint &pos )
 
         const int songs = it->get_var( "EIPC_MUSIC", 0 );
         if( songs > 0 ) {
-            if( it->active ) {
+            if( it->_active() ) {
                 amenu.addentry( ei_music, true, 'm', _( "Turn music off" ) );
             } else {
                 amenu.addentry( ei_music, true, 'm', _( "Turn music on [%d]" ), songs );
@@ -6355,13 +6355,13 @@ int iuse::einktabletpc( player *p, item *it, bool t, const tripoint &pos )
 
             p->moves -= 30;
 
-            if( it->active ) {
-                it->active = false;
+            if( it->_active() ) {
+                it->deactivate();
                 it->erase_var( "EIPC_MUSIC_ON" );
 
                 p->add_msg_if_player( m_info, _( "You turned off music on your %s." ), it->tname() );
             } else {
-                it->active = true;
+                it->activate();
                 it->set_var( "EIPC_MUSIC_ON", "1" );
 
                 p->add_msg_if_player( m_info, _( "You turned on music on your %s." ), it->tname() );
@@ -7627,7 +7627,7 @@ int iuse::ehandcuffs( player *p, item *it, bool t, const tripoint &pos )
         if( g->m.has_flag( "SWIMMABLE", pos.xy() ) ) {
             it->unset_flag( flag_NO_UNWIELD );
             it->ammo_unset();
-            it->active = false;
+            it->deactivate();
             add_msg( m_good, _( "%s automatically turned off!" ), it->tname() );
             return it->type->charges_to_use();
         }
@@ -7636,7 +7636,7 @@ int iuse::ehandcuffs( player *p, item *it, bool t, const tripoint &pos )
 
             sounds::sound( pos, 2, sounds::sound_t::combat, "Click.", true, "tools", "handcuffs" );
             it->unset_flag( flag_NO_UNWIELD );
-            it->active = false;
+            it->deactivate();
 
             if( p->has_item( *it ) && p->primary_weapon().typeId() == itype_e_handcuffs ) {
                 add_msg( m_good, _( "%s on your hands opened!" ), it->tname() );
@@ -7652,7 +7652,7 @@ int iuse::ehandcuffs( player *p, item *it, bool t, const tripoint &pos )
 
                 it->unset_flag( flag_NO_UNWIELD );
                 it->ammo_unset();
-                it->active = false;
+                it->deactivate();
                 add_msg( m_good, _( "The %s crackle with electricity from your bionic, then come off your hands!" ),
                          it->tname() );
 
@@ -7703,7 +7703,7 @@ int iuse::ehandcuffs( player *p, item *it, bool t, const tripoint &pos )
 
     }
 
-    if( it->active ) {
+    if( it->_active() ) {
         add_msg( _( "The %s are clamped tightly on your wrists.  You can't take them off." ),
                  it->tname() );
     } else {
@@ -7758,7 +7758,7 @@ int iuse::radiocar( player *p, item *it, bool, const tripoint & )
         }
 
         it->convert( itype_radio_car_on );
-        it->active = true;
+        it->activate();
 
         p->add_msg_if_player(
             _( "You turned on your RC car, now place it on ground, and use radio control to play." ) );
@@ -7818,7 +7818,7 @@ int iuse::radiocaron( player *p, item *it, bool t, const tripoint &pos )
         return it->type->charges_to_use();
     } else if( !it->ammo_sufficient() ) {
         // Deactivate since other mode has an iuse too.
-        it->active = false;
+        it->deactivate();
         return 0;
     }
 
@@ -7832,7 +7832,7 @@ int iuse::radiocaron( player *p, item *it, bool t, const tripoint &pos )
 
     if( choice == 0 ) {
         it->convert( itype_radio_car );
-        it->active = false;
+        it->deactivate();
 
         p->add_msg_if_player( _( "You turned off your RC car." ) );
         return it->type->charges_to_use();
@@ -7908,10 +7908,10 @@ int iuse::radiocontrol( player *p, item *it, bool t, const tripoint & )
 {
     if( t ) {
         if( !it->units_sufficient( *p ) ) {
-            it->active = false;
+            it->deactivate();
             p->remove_value( "remote_controlling" );
         } else if( p->get_value( "remote_controlling" ).empty() ) {
-            it->active = false;
+            it->deactivate();
         }
 
         return it->type->charges_to_use();
@@ -7919,7 +7919,7 @@ int iuse::radiocontrol( player *p, item *it, bool t, const tripoint & )
 
     const char *car_action = nullptr;
 
-    if( !it->active ) {
+    if( !it->_active() ) {
         car_action = _( "Take control of RC car" );
     } else {
         car_action = _( "Stop controlling RC car" );
@@ -7933,8 +7933,8 @@ int iuse::radiocontrol( player *p, item *it, bool t, const tripoint & )
     if( choice < 0 ) {
         return 0;
     } else if( choice == 0 ) {
-        if( it->active ) {
-            it->active = false;
+        if( it->_active() ) {
+            it->deactivate();
             p->remove_value( "remote_controlling" );
         } else {
             std::vector<std::pair<tripoint, item *>> rc_pairs;
@@ -7974,7 +7974,7 @@ int iuse::radiocontrol( player *p, item *it, bool t, const tripoint & )
             p->set_value( "remote_controlling", serialize_wrapper( [&]( JsonOut & jo ) {
                 rc_loc.serialize( jo );
             } ) );
-            it->active = true;
+            it->activate();
         }
     } else if( choice > 0 ) {
         const flag_id signal( "RADIOSIGNAL_" + std::to_string( choice ) );
@@ -8111,14 +8111,14 @@ int iuse::remoteveh( player *p, item *it, bool t, const tripoint &pos )
             stop = true;
         }
         if( stop ) {
-            it->active = false;
+            it->deactivate();
             g->setremoteveh( nullptr );
         }
 
         return it->type->charges_to_use();
     }
 
-    bool controlling = it->active && remote != nullptr;
+    bool controlling = it->_active() && remote != nullptr;
     int choice = uilist( _( "What to do with remote vehicle control:" ), {
         controlling ? _( "Stop controlling the vehicle." ) : _( "Take control of a vehicle." ),
         _( "Execute one vehicle action" )
@@ -8129,7 +8129,7 @@ int iuse::remoteveh( player *p, item *it, bool t, const tripoint &pos )
     }
 
     if( choice == 0 && controlling ) {
-        it->active = false;
+        it->deactivate();
         g->setremoteveh( nullptr );
         return 0;
     }
@@ -8151,7 +8151,7 @@ int iuse::remoteveh( player *p, item *it, bool t, const tripoint &pos )
             add_msg( m_info,
                      _( "Despite using a controller, you still refuse to take control of this vehicle." ) );
         } else {
-            it->active = true;
+            it->activate();
             g->setremoteveh( veh );
             p->add_msg_if_player( m_good, _( "You take control of the vehicle." ) );
             if( !veh->engine_on ) {
@@ -8237,7 +8237,7 @@ int iuse::multicooker( player *p, item *it, bool t, const tripoint &pos )
     static const int charges_to_start = 50;
     if( t ) {
         if( !it->units_sufficient( *p ) ) {
-            it->active = false;
+            it->deactivate();
             return 0;
         }
 
@@ -8256,7 +8256,7 @@ int iuse::multicooker( player *p, item *it, bool t, const tripoint &pos )
 
         if( cooktime <= 0 ) {
 
-            it->active = false;
+            it->deactivate();
             it->erase_var( "COOKTIME" );
             it->put_in( item::spawn( it->get_var( "DISH" ) ) );
             it->erase_var( "DISH" );
@@ -8306,7 +8306,7 @@ int iuse::multicooker( player *p, item *it, bool t, const tripoint &pos )
             return !( it.is_toolmod() || it.is_magazine() );
         } );
 
-        if( it->active ) {
+        if( it->_active() ) {
             menu.addentry( mc_stop, true, 's', _( "Stop cooking" ) );
         } else {
             if( dish_it == nullptr ) {
@@ -8345,7 +8345,7 @@ int iuse::multicooker( player *p, item *it, bool t, const tripoint &pos )
 
         if( mc_stop == choice ) {
             if( query_yn( _( "Really stop cooking?" ) ) ) {
-                it->active = false;
+                it->deactivate();
                 it->erase_var( "DISH" );
                 it->erase_var( "COOKTIME" );
                 it->erase_var( "RECIPE" );
@@ -8451,7 +8451,7 @@ int iuse::multicooker( player *p, item *it, bool t, const tripoint &pos )
                                       _( "The screen flashes blue symbols and scales as the multi-cooker begins to shake." ) );
 
                 it->convert( itype_multi_cooker_filled );
-                it->active = true;
+                it->activate();
                 it->ammo_consume( charges_to_start, pos );
 
                 p->practice( skill_cooking, meal->difficulty * 3 ); //little bonus
@@ -8541,7 +8541,7 @@ int iuse::tow_attach( player *p, item *it, bool, const tripoint & )
     }
     const auto set_cable_active = []( player * p, item * it, const std::string & state ) {
         it->set_var( "state", state );
-        it->active = true;
+        it->activate();
         it->attempt_detach( [&p]( detached_ptr<item> &&e ) {
             return item::process( std::move( e ), p, p->pos(), false );
         } );
@@ -8684,7 +8684,7 @@ int iuse::cable_attach( player *p, item *it, bool, const tripoint & )
     const auto set_cable_active = []( player * p, item * it, const std::string & state ) {
         const std::string prev_state = it->get_var( "state" );
         it->set_var( "state", state );
-        it->active = true;
+        it->activate();
         it->attempt_detach( [&p]( detached_ptr<item> &&e ) {
             return item::process( std::move( e ), p, p->pos(), false );
         } );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -463,7 +463,7 @@ int countdown_actor::use( player &p, item &it, bool t, const tripoint &pos ) con
         return 0;
     }
 
-    if( it._active() ) {
+    if( it.is_active() ) {
         return 0;
     }
 
@@ -479,7 +479,7 @@ int countdown_actor::use( player &p, item &it, bool t, const tripoint &pos ) con
 ret_val<bool> countdown_actor::can_use( const Character &, const item &it, bool,
                                         const tripoint & ) const
 {
-    if( it._active() ) {
+    if( it.is_active() ) {
         return ret_val<bool>::make_failure( _( "It's already been triggered." ) );
     }
 
@@ -958,7 +958,7 @@ int set_transform_iuse::use( player &p, item &it, bool t, const tripoint &pos ) 
 
     const flag_id f( flag );
     for( auto &elem : p.worn ) {
-        if( elem->has_flag( f ) && elem->_active() == turn_off ) {
+        if( elem->has_flag( f ) && elem->is_active() == turn_off ) {
             if( elem->type->can_use( "set_transformed" ) ) {
                 const set_transformed_iuse *actor = dynamic_cast<const set_transformed_iuse *>
                                                     ( elem->get_use( "set_transformed" )->get_actor_ptr() );
@@ -1040,7 +1040,7 @@ int place_monster_iuse::use( player &p, item &it, bool, const tripoint &pos ) co
     shared_ptr_fast<monster> newmon_ptr = make_shared_fast<monster>( mtypeid );
     monster &newmon = *newmon_ptr;
     newmon.init_from_item( it );
-    tripoint pnt = it._active() ? pos : p.pos();
+    tripoint pnt = it.is_active() ? pos : p.pos();
     if( place_randomly ) {
         // place_critter_around returns the same pointer as its parameter (or null)
         // Allow position to be different from the player for tossed or launched items
@@ -1065,7 +1065,7 @@ int place_monster_iuse::use( player &p, item &it, bool, const tripoint &pos ) co
     }
     // If it's active then we know it was triggered by ACT_ON_RANGED_HIT and did not deactivate from lack of room earlier
     // If so, don't drain moves from remote deployment since it would trigger after the throw
-    if( !it._active() ) {
+    if( !it.is_active() ) {
         p.moves -= moves;
     }
     if( !newmon.has_flag( MF_INTERIOR_AMMO ) ) {
@@ -2042,7 +2042,8 @@ int enzlave_actor::use( player &p, item &it, bool t, const tripoint & ) const
         const mtype *mt = corpse_candidate->get_mtype();
         if( corpse_candidate->is_corpse() && mt->in_species( ZOMBIE ) &&
             mt->made_of( material_id( "flesh" ) ) &&
-            mt->in_species( HUMAN ) && corpse_candidate->_active() && !corpse_candidate->has_var( "zlave" ) ) {
+            mt->in_species( HUMAN ) && corpse_candidate->is_active() &&
+            !corpse_candidate->has_var( "zlave" ) ) {
             corpses.push_back( corpse_candidate );
         }
     }
@@ -2362,7 +2363,7 @@ int musical_instrument_actor::use( player &p, item &it, bool t, const tripoint &
         return 0;
     }
 
-    if( !t && it._active() ) {
+    if( !t && it.is_active() ) {
         p.add_msg_player_or_npc( _( "You stop playing your %s" ),
                                  _( "<npcname> stops playing their %s" ),
                                  it.display_name() );
@@ -2393,7 +2394,7 @@ int musical_instrument_actor::use( player &p, item &it, bool t, const tripoint &
     }
 
     // We can play the music now
-    if( !it._active() ) {
+    if( !it.is_active() ) {
         p.add_msg_player_or_npc( m_good,
                                  _( "You start playing your %s" ),
                                  _( "<npcname> starts playing their %s" ),
@@ -2667,7 +2668,7 @@ bool holster_actor::can_holster( const item &obj ) const
     if( max_weight > 0_gram && obj.weight() > max_weight ) {
         return false;
     }
-    if( obj._active() ) {
+    if( obj.is_active() ) {
         return false;
     }
     return std::any_of( flags.begin(), flags.end(), [&]( const std::string & f ) {
@@ -2702,7 +2703,7 @@ detached_ptr<item> holster_actor::store( player &p, item &holster, detached_ptr<
         return std::move( obj );
     }
 
-    if( obj->_active() ) {
+    if( obj->is_active() ) {
         p.add_msg_if_player( m_info, _( "You don't think putting your %1$s in your %2$s is a good idea" ),
                              obj->tname(), holster.tname() );
         return std::move( obj );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -276,6 +276,9 @@ int iuse_transform::use( player &p, item &it, bool t, const tripoint &pos ) cons
         p.moves -= moves;
     }
 
+    // Update Luminosity as object is "removed"
+    get_map().update_lum( it, false );
+
     if( p.is_worn( it ) ) {
         p.on_item_takeoff( it );
     }
@@ -308,8 +311,10 @@ int iuse_transform::use( player &p, item &it, bool t, const tripoint &pos ) cons
         p.on_item_wear( it );
     }
     p.inv_update_cache_with_item( it );
+    // Update luminosity as object is "added"
+    get_map().update_lum( it, true );
     it.item_counter = countdown > 0 ? countdown : it.type->countdown_interval;
-    it.active = active || it.item_counter;
+    ( active || it.item_counter ) ? it.activate() : it.deactivate();
     // Check for gaining or losing night vision, eye encumbrance effects, clairvoyance from transforming relics, etc.
     p.recalc_sight_limits();
 
@@ -458,7 +463,7 @@ int countdown_actor::use( player &p, item &it, bool t, const tripoint &pos ) con
         return 0;
     }
 
-    if( it.active ) {
+    if( it._active() ) {
         return 0;
     }
 
@@ -467,14 +472,14 @@ int countdown_actor::use( player &p, item &it, bool t, const tripoint &pos ) con
     }
 
     it.item_counter = interval > 0 ? interval : it.type->countdown_interval;
-    it.active = true;
+    it.activate();
     return 0;
 }
 
 ret_val<bool> countdown_actor::can_use( const Character &, const item &it, bool,
                                         const tripoint & ) const
 {
-    if( it.active ) {
+    if( it._active() ) {
         return ret_val<bool>::make_failure( _( "It's already been triggered." ) );
     }
 
@@ -953,7 +958,7 @@ int set_transform_iuse::use( player &p, item &it, bool t, const tripoint &pos ) 
 
     const flag_id f( flag );
     for( auto &elem : p.worn ) {
-        if( elem->has_flag( f ) && elem->active == turn_off ) {
+        if( elem->has_flag( f ) && elem->_active() == turn_off ) {
             if( elem->type->can_use( "set_transformed" ) ) {
                 const set_transformed_iuse *actor = dynamic_cast<const set_transformed_iuse *>
                                                     ( elem->get_use( "set_transformed" )->get_actor_ptr() );
@@ -1035,7 +1040,7 @@ int place_monster_iuse::use( player &p, item &it, bool, const tripoint &pos ) co
     shared_ptr_fast<monster> newmon_ptr = make_shared_fast<monster>( mtypeid );
     monster &newmon = *newmon_ptr;
     newmon.init_from_item( it );
-    tripoint pnt = it.active ? pos : p.pos();
+    tripoint pnt = it._active() ? pos : p.pos();
     if( place_randomly ) {
         // place_critter_around returns the same pointer as its parameter (or null)
         // Allow position to be different from the player for tossed or launched items
@@ -1043,7 +1048,7 @@ int place_monster_iuse::use( player &p, item &it, bool, const tripoint &pos ) co
             p.add_msg_if_player( m_info, _( "There is no adjacent square to release the %s in!" ),
                                  newmon.name() );
             // If remotely triggered due to ACT_ON_RANGED_HIT, set it back to being inactive so it won't spawn infinitely
-            it.active = false;
+            it.deactivate();
             return 0;
         }
     } else {
@@ -1060,7 +1065,7 @@ int place_monster_iuse::use( player &p, item &it, bool, const tripoint &pos ) co
     }
     // If it's active then we know it was triggered by ACT_ON_RANGED_HIT and did not deactivate from lack of room earlier
     // If so, don't drain moves from remote deployment since it would trigger after the throw
-    if( !it.active ) {
+    if( !it._active() ) {
         p.moves -= moves;
     }
     if( !newmon.has_flag( MF_INTERIOR_AMMO ) ) {
@@ -2037,7 +2042,7 @@ int enzlave_actor::use( player &p, item &it, bool t, const tripoint & ) const
         const mtype *mt = corpse_candidate->get_mtype();
         if( corpse_candidate->is_corpse() && mt->in_species( ZOMBIE ) &&
             mt->made_of( material_id( "flesh" ) ) &&
-            mt->in_species( HUMAN ) && corpse_candidate->active && !corpse_candidate->has_var( "zlave" ) ) {
+            mt->in_species( HUMAN ) && corpse_candidate->_active() && !corpse_candidate->has_var( "zlave" ) ) {
             corpses.push_back( corpse_candidate );
         }
     }
@@ -2197,7 +2202,7 @@ int fireweapon_off_actor::use( player &p, item &it, bool t, const tripoint & ) c
         p.add_msg_if_player( _( success_message ) );
 
         it.convert( target_id );
-        it.active = true;
+        it.activate();
     } else if( !failure_message.empty() ) {
         p.add_msg_if_player( m_bad, _( failure_message ) );
     }
@@ -2254,7 +2259,8 @@ int fireweapon_on_actor::use( player &p, item &it, bool t, const tripoint & ) co
     }
 
     if( extinguish ) {
-        it.deactivate( &p, false );
+        it.revert( &p, false );
+        it.deactivate();
 
     } else if( one_in( noise_chance ) ) {
         if( noise > 0 ) {
@@ -2335,14 +2341,14 @@ int musical_instrument_actor::use( player &p, item &it, bool t, const tripoint &
     if( p.is_mounted() ) {
         p.add_msg_player_or_npc( m_bad, _( "You can't play music while mounted." ),
                                  _( "<npcname> can't play music while mounted." ) );
-        it.active = false;
+        it.deactivate();
         return 0;
     }
     if( p.is_underwater() ) {
         p.add_msg_player_or_npc( m_bad,
                                  _( "You can't play music underwater" ),
                                  _( "<npcname> can't play music underwater" ) );
-        it.active = false;
+        it.deactivate();
         return 0;
     }
 
@@ -2352,15 +2358,15 @@ int musical_instrument_actor::use( player &p, item &it, bool t, const tripoint &
                                  _( "You stop playing your %s" ),
                                  _( "<npcname> stops playing their %s" ),
                                  it.display_name() );
-        it.active = false;
+        it.deactivate();
         return 0;
     }
 
-    if( !t && it.active ) {
+    if( !t && it._active() ) {
         p.add_msg_player_or_npc( _( "You stop playing your %s" ),
                                  _( "<npcname> stops playing their %s" ),
                                  it.display_name() );
-        it.active = false;
+        it.deactivate();
         return 0;
     }
 
@@ -2372,7 +2378,7 @@ int musical_instrument_actor::use( player &p, item &it, bool t, const tripoint &
                                  _( "You need to hold or wear %s to play it" ),
                                  _( "<npcname> needs to hold or wear %s to play it" ),
                                  it.display_name() );
-        it.active = false;
+        it.deactivate();
         return 0;
     }
 
@@ -2382,17 +2388,17 @@ int musical_instrument_actor::use( player &p, item &it, bool t, const tripoint &
                                  _( "You feel too weak to play your %s" ),
                                  _( "<npcname> feels too weak to play their %s" ),
                                  it.display_name() );
-        it.active = false;
+        it.deactivate();
         return 0;
     }
 
     // We can play the music now
-    if( !it.active ) {
+    if( !it._active() ) {
         p.add_msg_player_or_npc( m_good,
                                  _( "You start playing your %s" ),
                                  _( "<npcname> starts playing their %s" ),
                                  it.display_name() );
-        it.active = true;
+        it.activate();
     }
 
     if( p.get_effect_int( effect_playing_instrument ) <= speed_penalty ) {
@@ -2661,7 +2667,7 @@ bool holster_actor::can_holster( const item &obj ) const
     if( max_weight > 0_gram && obj.weight() > max_weight ) {
         return false;
     }
-    if( obj.active ) {
+    if( obj._active() ) {
         return false;
     }
     return std::any_of( flags.begin(), flags.end(), [&]( const std::string & f ) {
@@ -2696,7 +2702,7 @@ detached_ptr<item> holster_actor::store( player &p, item &holster, detached_ptr<
         return std::move( obj );
     }
 
-    if( obj->active ) {
+    if( obj->_active() ) {
         p.add_msg_if_player( m_info, _( "You don't think putting your %1$s in your %2$s is a good idea" ),
                              obj->tname(), holster.tname() );
         return std::move( obj );

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -175,7 +175,7 @@ bool enchantment::is_active( const Character &guy, const item &parent ) const
         return false;
     }
 
-    return is_active( guy, parent._active() );
+    return is_active( guy, parent.is_active() );
 }
 
 bool enchantment::is_active( const Character &guy, const bool active ) const

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -175,7 +175,7 @@ bool enchantment::is_active( const Character &guy, const item &parent ) const
         return false;
     }
 
-    return is_active( guy, parent.active );
+    return is_active( guy, parent._active() );
 }
 
 bool enchantment::is_active( const Character &guy, const bool active ) const

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3109,7 +3109,7 @@ void map::smash_items( const tripoint &p, const int power, const std::string &ca
                 return std::move( it );
             }
         }
-        bool is_active_explosive = it->_active() && it->type->get_use( "explosion" ) != nullptr;
+        bool is_active_explosive = it->is_active() && it->type->get_use( "explosion" ) != nullptr;
         if( is_active_explosive && it->charges == 0 ) {
             return std::move( it );
         }
@@ -3665,7 +3665,7 @@ bash_results map::bash_items( const tripoint &p, const bash_params &params )
     bool smashed_glass = false;
     for( auto bashed_item = bashed_items.begin(); bashed_item != bashed_items.end(); ) {
         // the check for active suppresses Molotovs smashing themselves with their own explosion
-        if( ( *bashed_item )->can_shatter() && !( *bashed_item )->_active() &&
+        if( ( *bashed_item )->can_shatter() && !( *bashed_item )->is_active() &&
             one_in( 2 ) ) {
             result.did_bash = true;
             smashed_glass = true;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3109,7 +3109,7 @@ void map::smash_items( const tripoint &p, const int power, const std::string &ca
                 return std::move( it );
             }
         }
-        bool is_active_explosive = it->active && it->type->get_use( "explosion" ) != nullptr;
+        bool is_active_explosive = it->_active() && it->type->get_use( "explosion" ) != nullptr;
         if( is_active_explosive && it->charges == 0 ) {
             return std::move( it );
         }
@@ -3665,7 +3665,7 @@ bash_results map::bash_items( const tripoint &p, const bash_params &params )
     bool smashed_glass = false;
     for( auto bashed_item = bashed_items.begin(); bashed_item != bashed_items.end(); ) {
         // the check for active suppresses Molotovs smashing themselves with their own explosion
-        if( ( *bashed_item )->can_shatter() && !( *bashed_item )->active &&
+        if( ( *bashed_item )->can_shatter() && !( *bashed_item )->_active() &&
             one_in( 2 ) ) {
             result.did_bash = true;
             smashed_glass = true;
@@ -4542,7 +4542,7 @@ void map::add_item( const tripoint &p, detached_ptr<item> &&new_item )
             new_item->convert( dynamic_cast<const iuse_transform *>
                                ( new_item->type->get_use( "transform" )->get_actor_ptr() )->target );
         }
-        new_item->active = true;
+        new_item->activate();
     }
 
     if( new_item->is_map() && !new_item->has_var( "reveal_map_center_omt" ) ) {
@@ -4614,6 +4614,19 @@ detached_ptr<item> map::water_from( const tripoint &p )
         return item::spawn( furn( p ).obj().provides_liquids, calendar::turn, item::INFINITE_CHARGES );
     }
     return detached_ptr<item>();
+}
+
+void map::make_inactive( item &loc )
+{
+    point l;
+    submap *const current_submap = get_submap_at( loc.position(), l );
+
+    // remove from the active items cache (if it isn't there does nothing)
+    current_submap->active_items.remove( &loc );
+    if( current_submap->active_items.empty() ) {
+        submaps_with_active_items.erase( tripoint( abs_sub.x + loc.position().x / SEEX,
+                                         abs_sub.y + loc.position().y / SEEY, loc.position().z ) );
+    }
 }
 
 void map::make_active( item &loc )

--- a/src/map.h
+++ b/src/map.h
@@ -1259,9 +1259,16 @@ class map
             return spawn_an_item( tripoint( p, abs_sub.z ), std::move( new_item ), charges, damlevel );
         }
 
+
+        /**
+         * Remove an item from active item processing queue as necessary
+         */
+        void make_inactive( item &loc );
+
         /**
          * Update an item's active status, for example when adding
          * hot or perishable liquid to a container.
+         * Should be called as part of activate()
          */
         void make_active( item &loc );
 

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -1000,7 +1000,7 @@ bool mattack::resurrect( monster *z )
 
         for( auto &i : g->m.i_at( p ) ) {
             const mtype *mt = i->get_mtype();
-            if( !( i->is_corpse() && i->can_revive() && i->_active() && mt->has_flag( MF_REVIVES ) &&
+            if( !( i->is_corpse() && i->can_revive() && i->is_active() && mt->has_flag( MF_REVIVES ) &&
                    mt->in_species( ZOMBIE ) && !mt->has_flag( MF_NO_NECRO ) ) ) {
                 continue;
             }

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -1000,7 +1000,7 @@ bool mattack::resurrect( monster *z )
 
         for( auto &i : g->m.i_at( p ) ) {
             const mtype *mt = i->get_mtype();
-            if( !( i->is_corpse() && i->can_revive() && i->active && mt->has_flag( MF_REVIVES ) &&
+            if( !( i->is_corpse() && i->can_revive() && i->_active() && mt->has_flag( MF_REVIVES ) &&
                    mt->in_species( ZOMBIE ) && !mt->has_flag( MF_NO_NECRO ) ) ) {
                 continue;
             }
@@ -4899,7 +4899,7 @@ bool mattack::riotbot( monster *z )
 
             detached_ptr<item> handcuffs = item::spawn( "e_handcuffs", calendar::start_of_cataclysm );
             handcuffs->charges = handcuffs->type->maximum_charges();
-            handcuffs->active = true;
+            handcuffs->activate();
             handcuffs->set_var( "HANDCUFFS_X", foe->posx() );
             handcuffs->set_var( "HANDCUFFS_Y", foe->posy() );
 
@@ -5595,7 +5595,7 @@ bool mattack::kamikaze( monster *z )
             z->die( nullptr );
             // Timer is out, detonate
             detached_ptr<item> i_explodes = item::spawn( act_bomb_type, calendar::turn, 0 );
-            i_explodes->active = true;
+            i_explodes->activate();
             item::process( std::move( i_explodes ), nullptr, z->pos(), false );
             return false;
         }

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -872,7 +872,7 @@ void mdeath::detonate( monster &z )
     for( const auto &bombs : dets ) {
         detached_ptr<item> bomb_item = item::spawn( bombs.first, calendar::start_of_cataclysm );
         bomb_item->charges = bombs.second;
-        bomb_item->active = true;
+        bomb_item->activate();
         g->m.add_item_or_charges( z.pos(), std::move( bomb_item ) );
     }
 }

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -574,7 +574,7 @@ bool avatar::create( character_type type, const std::string &tempname )
 
     for( detached_ptr<item> &it : prof_items ) {
         if( it->has_flag( STATIC( flag_id( "WET" ) ) ) ) {
-            it->active = true;
+            it->activate();
             it->item_counter = 450; // Give it some time to dry off
         }
         if( it->is_book() ) {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1818,7 +1818,7 @@ int npc::value( const item &it ) const
 
 int npc::value( const item &it, int market_price ) const
 {
-    if( it.is_dangerous() || ( it.has_flag( flag_BOMB ) && it._active() ) || it.made_of( LIQUID ) ) {
+    if( it.is_dangerous() || ( it.has_flag( flag_BOMB ) && it.is_active() ) || it.made_of( LIQUID ) ) {
         // NPCs won't be interested in buying active explosives or spilled liquids
         return -1000;
     }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1818,7 +1818,7 @@ int npc::value( const item &it ) const
 
 int npc::value( const item &it, int market_price ) const
 {
-    if( it.is_dangerous() || ( it.has_flag( flag_BOMB ) && it.active ) || it.made_of( LIQUID ) ) {
+    if( it.is_dangerous() || ( it.has_flag( flag_BOMB ) && it._active() ) || it.made_of( LIQUID ) ) {
         // NPCs won't be interested in buying active explosives or spilled liquids
         return -1000;
     }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3566,7 +3566,7 @@ bool npc::alt_attack()
     }
 
     // Are we going to throw this item?
-    if( !used->active && used->has_flag( flag_NPC_ACTIVATE ) ) {
+    if( !used->_active() && used->has_flag( flag_NPC_ACTIVATE ) ) {
         activate_item( weapon_index );
         // Note: intentional lack of return here
         // We want to ignore player-centric rules to avoid carrying live explosives

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3566,7 +3566,7 @@ bool npc::alt_attack()
     }
 
     // Are we going to throw this item?
-    if( !used->_active() && used->has_flag( flag_NPC_ACTIVATE ) ) {
+    if( !used->is_active() && used->has_flag( flag_NPC_ACTIVATE ) ) {
         activate_item( weapon_index );
         // Note: intentional lack of return here
         // We want to ignore player-centric rules to avoid carrying live explosives

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1211,12 +1211,12 @@ dealt_projectile_attack throw_item( Character &who, const tripoint &target,
 
     if( thrown.has_flag( flag_ACT_ON_RANGED_HIT ) ) {
         proj.add_effect( ammo_effect_ACT_ON_RANGED_HIT );
-        thrown.active = true;
+        thrown.activate();
     }
 
     // Item will shatter upon landing, destroying the item, dealing damage, and making noise
     /** @EFFECT_STR increases chance of shattering thrown glass items (NEGATIVE) */
-    const bool shatter = !thrown.active && thrown.can_shatter() &&
+    const bool shatter = !thrown._active() && thrown.can_shatter() &&
                          rng( 0, units::to_milliliter( 2_liter - volume ) ) < who.get_str() * 100;
 
     // Item will burst upon landing, destroying the item, and spilling its contents
@@ -1231,7 +1231,7 @@ dealt_projectile_attack throw_item( Character &who, const tripoint &target,
 
     proj.add_effect( ammo_effect_NO_ITEM_DAMAGE );
 
-    if( thrown.active ) {
+    if( thrown._active() ) {
         // Can't have Molotovs embed into monsters
         // Monsters don't have inventory processing
         proj.add_effect( ammo_effect_NO_EMBED );
@@ -1732,7 +1732,7 @@ static projectile make_gun_projectile( const item &gun )
 
         if( recover && !fx.has_effect( ammo_effect_IGNITE ) && !fx.has_effect( ammo_effect_EXPLOSIVE ) ) {
             detached_ptr<item> drop = item::spawn( gun.ammo_current(), calendar::turn, 1 );
-            drop->active = fx.has_effect( ammo_effect_ACT_ON_RANGED_HIT );
+            fx.has_effect( ammo_effect_ACT_ON_RANGED_HIT ) ? drop->activate() : 0;
             proj.set_drop( std::move( drop ) );
         }
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1732,7 +1732,9 @@ static projectile make_gun_projectile( const item &gun )
 
         if( recover && !fx.has_effect( ammo_effect_IGNITE ) && !fx.has_effect( ammo_effect_EXPLOSIVE ) ) {
             detached_ptr<item> drop = item::spawn( gun.ammo_current(), calendar::turn, 1 );
-            fx.has_effect( ammo_effect_ACT_ON_RANGED_HIT ) ? drop->activate() : 0;
+            if( fx.has_effect( ammo_effect_ACT_ON_RANGED_HIT ) ) {
+                drop->activate();
+            }
             proj.set_drop( std::move( drop ) );
         }
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1216,7 +1216,7 @@ dealt_projectile_attack throw_item( Character &who, const tripoint &target,
 
     // Item will shatter upon landing, destroying the item, dealing damage, and making noise
     /** @EFFECT_STR increases chance of shattering thrown glass items (NEGATIVE) */
-    const bool shatter = !thrown._active() && thrown.can_shatter() &&
+    const bool shatter = !thrown.is_active() && thrown.can_shatter() &&
                          rng( 0, units::to_milliliter( 2_liter - volume ) ) < who.get_str() * 100;
 
     // Item will burst upon landing, destroying the item, and spilling its contents
@@ -1231,7 +1231,7 @@ dealt_projectile_attack throw_item( Character &who, const tripoint &target,
 
     proj.add_effect( ammo_effect_NO_ITEM_DAMAGE );
 
-    if( thrown._active() ) {
+    if( thrown.is_active() ) {
         // Can't have Molotovs embed into monsters
         // Monsters don't have inventory processing
         proj.add_effect( ammo_effect_NO_EMBED );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2265,7 +2265,7 @@ void item::io( Archive &archive )
     if( is_food() ) {
         active = true;
     }
-    if( !active && has_flag( flag_WET ) ) {
+    if( !_active() && has_flag( flag_WET ) ) {
         // Some wet items from legacy saves may be inactive
         active = true;
     }
@@ -2292,7 +2292,7 @@ void item::io( Archive &archive )
     item_vars.erase( "item_note_type" );
 
     // Activate corpses from old saves
-    if( is_corpse() && !active ) {
+    if( is_corpse() && !_active() ) {
         active = true;
     }
 

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2265,7 +2265,7 @@ void item::io( Archive &archive )
     if( is_food() ) {
         active = true;
     }
-    if( !_active() && has_flag( flag_WET ) ) {
+    if( !is_active() && has_flag( flag_WET ) ) {
         // Some wet items from legacy saves may be inactive
         active = true;
     }
@@ -2292,7 +2292,7 @@ void item::io( Archive &archive )
     item_vars.erase( "item_note_type" );
 
     // Activate corpses from old saves
-    if( is_corpse() && !_active() ) {
+    if( is_corpse() && !is_active() ) {
         active = true;
     }
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5518,6 +5518,15 @@ units::volume vehicle::free_volume( const int part ) const
     return get_items( part ).free_volume();
 }
 
+void vehicle::make_inactive( item &target )
+{
+    auto cargo_parts = get_parts_at( target.position(), "CARGO", part_status_flag::any );
+    if( cargo_parts.empty() ) {
+        return;
+    }
+    active_items.remove( &target );
+}
+
 void vehicle::make_active( item &target )
 {
     if( !target.needs_processing() ) {

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1250,6 +1250,11 @@ class vehicle
         units::volume max_volume( int part ) const;
         units::volume free_volume( int part ) const;
         units::volume stored_volume( int part ) const;
+
+        /**
+         * Remove an item from active item processing queue as necessary
+         */
+        void make_inactive( item &loc );
         /**
          * Update an item's active status, for example when adding
          * hot or perishable liquid to a container.

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1254,7 +1254,7 @@ class vehicle
         /**
          * Remove an item from active item processing queue as necessary
          */
-        void make_inactive( item &loc );
+        void make_inactive( item &target );
         /**
          * Update an item's active status, for example when adding
          * hot or perishable liquid to a container.

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -159,7 +159,7 @@ detached_ptr<item> vehicle_part::properties_to_item() const
             tmp->erase_var( "source_y" );
             tmp->erase_var( "source_z" );
             tmp->erase_var( "state" );
-            tmp->active = false;
+            tmp->deactivate();
             tmp->charges = tmp->type->maximum_charges();
         } else {
             const tripoint local_pos = here.getlocal( target.first );
@@ -172,7 +172,7 @@ detached_ptr<item> vehicle_part::properties_to_item() const
             tmp->set_var( "source_y", target.first.y );
             tmp->set_var( "source_z", target.first.z );
             tmp->set_var( "state", "pay_out_cable" );
-            tmp->active = true;
+            tmp->activate();
         }
     }
 

--- a/tests/active_item_cache_test.cpp
+++ b/tests/active_item_cache_test.cpp
@@ -41,7 +41,7 @@ TEST_CASE( "place_active_item_at_various_coordinates", "[item]" )
             detached_ptr<item> n = item::spawn( active );
             item &item_ref = *n;
             g->m.add_item( { x, y, z }, std::move( n ) );
-            REQUIRE( item_ref.active );
+            REQUIRE( item_ref._active() );
             REQUIRE_FALSE( g->m.get_submaps_with_active_items().empty() );
             REQUIRE( g->m.get_submaps_with_active_items().find( abs_loc ) !=
                      g->m.get_submaps_with_active_items().end() );

--- a/tests/active_item_cache_test.cpp
+++ b/tests/active_item_cache_test.cpp
@@ -41,7 +41,7 @@ TEST_CASE( "place_active_item_at_various_coordinates", "[item]" )
             detached_ptr<item> n = item::spawn( active );
             item &item_ref = *n;
             g->m.add_item( { x, y, z }, std::move( n ) );
-            REQUIRE( item_ref._active() );
+            REQUIRE( item_ref.is_active() );
             REQUIRE_FALSE( g->m.get_submaps_with_active_items().empty() );
             REQUIRE( g->m.get_submaps_with_active_items().find( abs_loc ) !=
                      g->m.get_submaps_with_active_items().end() );


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Code handling `active` field for items is very haphazard. `active` by itself also doesn't guarantee processing, only processing for items in a character's inventory. Items on the submap, or in the cargo section of a vehicle, must be added to the active processing list for both in order for them to function.

This makes the code open to pitfalls in the future for any use actions that may want to activate an item, as much of the codebase uses `active = true` rather than proper standardized functions.

## Describe the solution

Makes the `active` field private, so that it will not be otherwise accessed and won't be seen as the appropriate method to set an item as active. `_active()` is now the function used to check if an item is set as active or not.

`activate()` now activates items and calls `make_active()`, it should be primary way to activate items.

`deactivate()` no longer reverts item, instead only sets item `active` false and calls `make_inactive()`.

`make_active()` and `make_inactive()` update submap active item list as necessary, adding or removing items from the active processing list.

`revert()` now reverts an item to whatever it is supposed to revert to, returns true if it succeeds and false otherwise.

Also reorganizes code, specifically, `avatar_action.cpp` where items activated remotely require the calling of `update_lum` and `make_active`. All of these have been moved out, with `update_lum` directly being used when items are transformed, which is their original use case, and `activate()` being called from `use_item()` properly updating the submap/vehicle active processing list as necessary.

The handling for running out of charges is also reshuffled in `item.cpp`, now when an item runs out of charges, it will first attempt to revert (for electronics and other items that become inert when charge empties), if it fails, then it invokes itself and then deletes itself (for use with grenades and other similar items)

## Describe alternatives you've considered

## Testing

- Spawn two electric lanterns
  - [x] Leave one in your inventory and one on the ground next to you.
    - [x] Save and load, confirm no issues raised.
  - [x] Check that you can activate it from the ground and in your inventory.
    - [x] Wait 30 minutes confirm charge usage.
    - [x] Save and load, confirm no issues raised.
    - [x] Wait 30 minutes confirm charge usage.
- Spawn two grenades
  - [x] Save and load, confirm no issues raised.
  - [x] activate a grenade, throw, confirm explosion behaviour and no grenade left behind.
  - [x] activate second grenade. Save and load, confirm no issues raised.
  - [x] Throw grenade, confirm explosion behaviour and no grenade left behind.

## Additional context
