### PR TITLE
feat: don't query the player about stealing from hostile factions, npcs trying to kill you won't stop mid-fight to complain about theft

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -924,7 +924,8 @@ void move_items_activity_actor::do_turn( player_activity &act, Character &who )
 
         // This is for hauling across zlevels, remove when going up and down stairs
         // is no longer teleportation
-        if( target->is_owned_by( who, true ) ) {
+        // Also ignores items owned by other NPCs, unless they'd already attack on sight
+        if( target->is_owned_by( who, true ) || target->get_owner()->likes_u < -10 ) {
             target->set_owner( who );
         } else {
             continue;

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2331,7 +2331,7 @@ void activity_on_turn_move_loot( player_activity &act, player &p )
             src_veh = &vp->vehicle();
             src_part = vp->part_index();
             for( auto &it : src_veh->get_items( src_part ) ) {
-                if( !it->is_owned_by( p, true ) ) {
+                if( !it->is_owned_by( p, true ) && it->get_owner()->likes_u >= -10 ) {
                     continue;
                 }
                 it->set_owner( p );
@@ -2342,7 +2342,7 @@ void activity_on_turn_move_loot( player_activity &act, player &p )
             src_part = -1;
         }
         for( auto &it : here.i_at( src_loc ) ) {
-            if( !it->is_owned_by( p, true ) ) {
+            if( !it->is_owned_by( p, true ) && it->get_owner()->likes_u >= -10 ) {
                 continue;
             }
             it->set_owner( p );
@@ -3230,8 +3230,8 @@ bool find_auto_consume( player &p, const consume_type type )
         {
             return false;
         }
-        /* not ours               */
-        if( !it.is_owned_by( p, true ) )
+        /* not ours, freely steal from hostiles however  */
+        if( !it.is_owned_by( p, true ) && it.get_owner()->likes_u >= -10 )
         {
             return false;
         }

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1479,7 +1479,8 @@ bool query_consume_ownership( item &target, avatar &you )
     if( you.get_value( "THIEF_MODE_KEEP" ) != "YES" ) {
         you.set_value( "THIEF_MODE", "THIEF_ASK" );
     }
-    if( !target.is_owned_by( you, true ) ) {
+    // We don't care about the opinions of NPCs that will already shoot us on sight, steal away!
+    if( !target.is_owned_by( you, true ) && target.get_owner()->likes_u >= -10 ) {
         bool choice = true;
         if( you.get_value( "THIEF_MODE" ) == "THIEF_ASK" ) {
             choice = pickup::query_thief();

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -2011,7 +2011,8 @@ static disass_prompt_result prompt_disassemble_in_seq( avatar &you, const item &
 
     const recipe &r = recipe_dictionary::get_uncraft( obj.typeId() );
     res.r = &r;
-    if( !obj.is_owned_by( you, true ) ) {
+    // Only worry about stealing from factions not already hostile
+    if( !obj.is_owned_by( you, true ) && obj.get_owner()->likes_u >= -10 ) {
         if( !query_yn( _( "Disassembling the %s may anger the people who own it, continue?" ),
                        obj.tname() ) ) {
             return res;

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -531,7 +531,7 @@ void inventory::form_from_map( map &m, std::vector<tripoint> pts, const Characte
             for( auto &i : m.i_at( p ) ) {
                 // if it's *the* player requesting this from from map inventory
                 // then don't allow items owned by another faction to be factored into recipe components etc.
-                if( pl && !i->is_owned_by( *pl, true ) ) {
+                if( pl && !i->is_owned_by( *pl, true ) && i->get_owner()->likes_u >= -10 ) {
                     continue;
                 }
                 if( allow_liquids || !i->made_of( LIQUID ) ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4521,8 +4521,9 @@ void item::handle_pickup_ownership( Character &c )
         if( !is_owned_by( c ) && &c == &you ) {
             std::vector<npc *> witnesses;
             for( npc &elem : g->all_npcs() ) {
+                // If they already want to murder you, no point in confronting you about theft
                 if( rl_dist( elem.pos(), you.pos() ) < MAX_VIEW_DISTANCE && elem.get_faction() &&
-                    is_owned_by( elem ) && elem.sees( you.pos() ) ) {
+                    is_owned_by( elem ) && elem.sees( you.pos() ) && !elem.guaranteed_hostile() ) {
                     elem.say( "<witnessed_thievery>", 7 );
                     npc *npc_to_add = &elem;
                     witnesses.push_back( npc_to_add );

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -24,6 +24,7 @@
 #include "debug.h"
 #include "drop_token.h"
 #include "enums.h"
+#include "faction.h"
 #include "game.h"
 #include "input.h"
 #include "int_id.h"
@@ -241,7 +242,8 @@ static bool pick_one_up( pickup::pick_drop_selection &selection, bool &got_water
     item *loc = &*selection.target;
 
     const std::optional<int> &quantity = selection.quantity;
-    if( !loc->is_owned_by( g->u, true ) ) {
+    // If the faction would murder you on sight, we no longer care about stealing from them since it can't make things worse
+    if( !loc->is_owned_by( g->u, true ) && loc->get_owner()->likes_u >= -10 ) {
         // Has the player given input on if stealing is ok?
         if( u.get_value( "THIEF_MODE" ) == "THIEF_ASK" ) {
             pickup::query_thief();


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

"What're ya gonna do if I nick yer stuff, shoot me again?"

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/5156

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. In activity_actor.cpp, updated `move_items_activity_actor::do_turn` so that moving items will also glom onto items not owned by you if they faction that owns them would attack you on sight, letting you haul drops from dead bandits or other hostiles.
2. In activity_item_handling.cpp, updated `activity_on_turn_move_loot` and `find_auto_consume` to disregard faction ownership of items if the faction in question hates your guts, for more item movement related purposes and for auto-eat zones.
3. In consumption.cpp, `query_consume_ownership` no longer checks thief mode if you're eating a hostile faction's lunch.
4. Likewise in crafting.cpp, `prompt_disassemble_in_seq` lets you uncraft faction-owned items at will if the faction in question is hostile.
5. In inventory.cpp, allow hostile-owned items to count as valid for crafting in `inventory::form_from_map`. Stuff in an bandit's inventory is safe from magpie players since contents of NPC inventories aren't considered accessible, but that just makes them a safe that requires a knife to crack the combination.
6. The most essential bit: in item.cpp, `item::handle_pickup_ownership` no longer flags NPCs who're in any way hostile as witnesses. While ownership interactions that would generate the theft prompt have to settle for merely checking the facton, with this one I can pull `guaranteed_hostile` which means that not only will hostile factions no longer scream at you for stealing their shit during a firefight, but fleeing NPCs won't be emboldened to turn around to yell at their tormentor for nicking any loot they left behind, NPCs somehow rigged to be pissed off will continue trying to murder you even if their faction says they're technically okay with your existence, and feral players from Lost and Damned scenario will continue to be treated with bullets instead of words.
7. Set pickup.cpp to be able to grasp the concept of factions, updated `pick_one_up` so that you skip worrying about thief mode settings if the faction it belongs to suffers from the angee.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Setting it so that items that belong to factions that're okay to steal from aren't marked with the read exclaimation mark of mild discontent.
2. Also messing with stealing of owned vehicles. Changes list was getting long enough with just items and hijacking has some more complicated interactions involving transferring ownership after a certain amount of time has passed so I figured leave it be for now, not as persistently annoying as handling of hostile-owned items.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. First, compiled and load-tested with only the change to NPCs not being flagged as witnesses if they're already hostile.
2. Spawned in a bandit camp, debug-killed one before warping into view to let others aggro.
3. Picked up an item dropped by the dead bandit, accepted the prompt to steal, no longer screamed at about thievery and they don't confront me, whether before or after they aggro.
4. Re-tested after implementing the rest of the code exceptions for hostile-by-default factions, can now pick up stuff dropped by dead bandits without the theft query, even when it's marked as owned by bandits.
5. Confirmed I can also eat from owned items and unload them without issues.
6. Confirmed that hauling their drops with `\` works as expected instead of only letting me haul around the corpse, and that autopickup no longer interrupts me with thief queries all the damn time when walking near dead bandits.
7. Warped off to a refugee center and debug killed one of the NPCs there, their stuff still queries me about theft, likewise I can't hijack stuff off the shelves because they aren't angry with me yet, hauling still won't automatically steal their drops, etc.
8. Tried to steal right in front of a guard, confirmed that being confronted about it doesn't yet give me freedom to steal stuff unhindered.
9. Threw a rock at one of the guards, now I can steal unhindered. You know, aside from all the NPCs trying to kill me now.
10. Retested a generic evac shelter start, confirmed that picking up, eating, unloading, and hauling stuff spawned on the ground don't act up any despite having no associated faction owner initially.
11. Repeated one last test warping to a bandit camp, this time while invisible confirmed that jeans worn by a bandit weren't usable for me to craft a makeshift knapsack from, but I go from having only the pair I'm wearing available to having 2 available if I murder the wearer. My pants now blyat.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Watch some obscure test complain because it was expecting bandits to always stop killing you to ask nicely if you'd stop nicking their shit (it's very rude and unprofessional behavior from a victim, you see), wouldn't be surprised.