### PR TITLE
fix: flesh walls are actually made of meat

### DIFF
--- a/data/json/monsters/zed_fusion.json
+++ b/data/json/monsters/zed_fusion.json
@@ -233,7 +233,7 @@
     "armor_bash": 50,
     "armor_cut": 25,
     "armor_bullet": 20,
-    "harvest": "exempt",
+    "harvest": "zombie",
     "death_function": [ "NORMAL" ],
     "flags": [ "SEES", "HEARS", "SMELLS", "IMMOBILE", "WARM", "POISON", "IMMOBILE", "NO_BREATHE", "FILTHY" ]
   }


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Welcome to Arby's, we've got the meat. Except right now we don't. Our flesh walls are made of air and customers aren't happy.

## Describe the solution

changes the harvest from exempt to zombie because its flagged as zombie and is a zed_fusion like a dissoluted devourer which is also a zombie harvest entry

## Describe alternatives you've considered

Going to Wendy's.

## Testing

github tests for my one json line change

## Additional context

Drain the blood, cure and slice the flesh, season and fry the potatoes, feed them the sugar water. Be born. Toil. Die. Arby's, we sell food.

![image](https://github.com/user-attachments/assets/af99934b-7c60-49b5-8f18-bad6c7ed3e32)
