### PR TITLE
feat: stop misgendering players in name_g dialogue snippets

### DIFF
--- a/data/json/npcs/talk_tags.json
+++ b/data/json/npcs/talk_tags.json
@@ -362,10 +362,8 @@
     "category": "<name_g>",
     "//": "Friendly name pro-nouns and references",
     "text": [
-      "amigo",
       "comrade",
       "my good fellow",
-      "lad",
       "mate",
       "my fellow nomad",
       "partner",
@@ -376,8 +374,7 @@
       "fella",
       "my dude",
       "buddy",
-      "chum",
-      "bruv"
+      "chum"
     ]
   },
   {

--- a/data/json/npcs/talk_tags.json
+++ b/data/json/npcs/talk_tags.json
@@ -374,7 +374,12 @@
       "fella",
       "my dude",
       "buddy",
-      "chum"
+      "chum",
+      "wanderer",
+      "homie",
+      "dawg",
+      "bud",
+      "pardner"
     ]
   },
   {


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Most/all NPC's have a chance of using male pronouns when you're playing a woman. This is not an ideal solution because we would ideally allow checking gender in the dialogue snippets, however that's a code refactor I can't do. These snippets can be added back later.

## Describe the solution

Removes amigo, lad, and bruv. Amigo is Spanish and a male gendered word, the female equivalent would be Amiga. Lad is also male gendered and the equivalent would be lass. Bruv is slang for brother.

Dude can stay, because that's just non-gendered stoner slang from my real life experiences.

## Describe alternatives you've considered

Gendered dialogue checks so we can have more. This can be closed/reverted if someone is going to work on those checks.

## Testing

yes

## Additional context

The lumberjack camp in-game is rude.