### PR TITLE
feat(balance): enable befriending certain non-mech bots using ID cards, friendly monsters more proactive about assisting against hostile NPCs, fix error message on retrieving items from pet inventory, assorted fixes to pet menu functions

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -498,7 +498,8 @@
     "id": "SPAWN_FRIENDLY",
     "type": "json_flag",
     "context": [ "GENERIC" ],
-    "//": "This item will spawn friendly. Used for pets and such."
+    "//": "This item will spawn friendly. Used for pets and such.",
+    "info": "Any creature spawned from this item will <info>always</info> emerge <good>friendly to you</good>."
   },
   {
     "id": "STAB",

--- a/data/json/items/corpses/inactive_bots.json
+++ b/data/json/items/corpses/inactive_bots.json
@@ -534,7 +534,6 @@
       "hostile_msg": "The miner bot spins out of control and lunges at you. Make way!",
       "//": "Digging parameters need special attention but no (intentional) lethal weapons",
       "difficulty": 3,
-      "is_pet": true,
       "moves": 100,
       "skills": [ "electronics", "computer" ]
     }

--- a/data/json/items/corpses/inactive_bots.json
+++ b/data/json/items/corpses/inactive_bots.json
@@ -482,6 +482,7 @@
       "//": "Currently has no higher functions",
       "difficulty": 1,
       "moves": 100,
+      "is_pet": true,
       "skills": [ "electronics", "computer" ]
     }
   },
@@ -533,6 +534,7 @@
       "hostile_msg": "The miner bot spins out of control and lunges at you. Make way!",
       "//": "Digging parameters need special attention but no (intentional) lethal weapons",
       "difficulty": 3,
+      "is_pet": true,
       "moves": 100,
       "skills": [ "electronics", "computer" ]
     }

--- a/data/json/monsters/utility_bot.json
+++ b/data/json/monsters/utility_bot.json
@@ -122,6 +122,7 @@
       "COLDPROOF",
       "NO_BREATHE",
       "PRIORITIZE_TARGETS",
+      "CARD_OVERRIDE",
       "PATH_AVOID_DANGER_1",
       "BIOPROOF"
     ]
@@ -159,6 +160,8 @@
       "PATH_AVOID_DANGER_2",
       "PACIFIST",
       "PET_HARNESSABLE",
+      "CARD_OVERRIDE",
+      "MILITARY_MECH",
       "BIOPROOF"
     ]
   },
@@ -189,7 +192,7 @@
     "revert_to_itype": "bot_molebot",
     "death_drops": { "groups": [ [ "robots", 4 ], [ "molebot", 1 ] ] },
     "death_function": [ "BROKEN" ],
-    "flags": [ "HEARS", "GOODHEARING", "CAN_DIG", "NO_BREATHE", "ELECTRONIC", "COLDPROOF", "PATH_AVOID_DANGER_1", "BIOPROOF" ]
+    "flags": [ "HEARS", "GOODHEARING", "CAN_DIG", "NO_BREATHE", "ELECTRONIC", "COLDPROOF", "PATH_AVOID_DANGER_1", "CARD_OVERRIDE", "MILITARY_MECH", "BIOPROOF" ]
   },
   {
     "//": "nurse_bot and nurse_bot_defective look very similar, part of the trick is figuring out which one is the good one.  So the sprites should probably look pretty similar to not give it away immediately",

--- a/data/json/monsters/utility_bot.json
+++ b/data/json/monsters/utility_bot.json
@@ -192,7 +192,7 @@
     "revert_to_itype": "bot_molebot",
     "death_drops": { "groups": [ [ "robots", 4 ], [ "molebot", 1 ] ] },
     "death_function": [ "BROKEN" ],
-    "flags": [ "HEARS", "GOODHEARING", "CAN_DIG", "NO_BREATHE", "ELECTRONIC", "COLDPROOF", "PATH_AVOID_DANGER_1", "CARD_OVERRIDE", "MILITARY_MECH", "BIOPROOF" ]
+    "flags": [ "HEARS", "GOODHEARING", "CAN_DIG", "NO_BREATHE", "ELECTRONIC", "COLDPROOF", "PATH_AVOID_DANGER_1", "BIOPROOF" ]
   },
   {
     "//": "nurse_bot and nurse_bot_defective look very similar, part of the trick is figuring out which one is the good one.  So the sprites should probably look pretty similar to not give it away immediately",

--- a/doc/src/content/docs/en/mod/json/reference/json_flags.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_flags.md
@@ -1042,6 +1042,7 @@ Multiple death functions can be used. Not all combinations make sense.
 - `HEARS` It can hear you.
 - `HIT_AND_RUN` Flee for several turns after a melee attack.
 - `HUMAN` It's a live human, as long as it's alive.
+- `MF_CARD_OVERRIDE` Not a mech, but can be converted to friendly using an ID card in the same way that mechs can.
 - `CONSOLE_DESPAWN` Despawns when a nearby console is properly hacked.
 - `IMMOBILE` Doesn't move (e.g. turrets)
 - `ID_CARD_DESPAWN` Despawns when a science ID card is used on a nearby console
@@ -1054,7 +1055,7 @@ Multiple death functions can be used. Not all combinations make sense.
 - `MECH_RECON_VISION` This mech grants you night-vision and enhanced overmap sight radius when
   piloted.
 - `MECH_DEFENSIVE` This mech can protect you thoroughly when piloted.
-- `MILITARY_MECH` Is a military-grade mech.
+- `MILITARY_MECH` Will demand a military ID card instead of an industrial one. Doesn't actually have to be a mech.
 - `MILKABLE` Produces milk when milked.
 - `NIGHT_INVISIBILITY` Monster becomes invisible if it's more than one tile away and the lighting on
   its tile is LL_LOW or less. Visibility is not affected by night vision.
@@ -1514,6 +1515,9 @@ Those flags are added by the game code to specific items (that specific welder, 
 - `NO_PARASITES` Invalidates parasites count set in food->type->comestible->parasites
 - `QUARTERED` Corpse was quartered into parts. Affects butcher results, weight, volume.
 - `REVIVE_SPECIAL` ... Corpses revives when the player is nearby.
+- `SPAWN_FRIENDLY` Applied to eggs laid by pets and to pet bots reverted to items. Any monster that
+  hatches from said egg will also spawn friendly, and deployable bots flagged with this will skip
+  checking for player skills since it's already been configured correctly once already.
 - `USE_UPS` The tool has the UPS mod and is charged from an UPS.
 - `WARM` A hidden flag used to track an item's journey to/from hot, buffers between HOT and cold.
 - `WET` Item is wet and will slowly dry off (e.g. towel).

--- a/doc/src/content/docs/en/mod/json/reference/json_flags.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_flags.md
@@ -1042,7 +1042,8 @@ Multiple death functions can be used. Not all combinations make sense.
 - `HEARS` It can hear you.
 - `HIT_AND_RUN` Flee for several turns after a melee attack.
 - `HUMAN` It's a live human, as long as it's alive.
-- `MF_CARD_OVERRIDE` Not a mech, but can be converted to friendly using an ID card in the same way that mechs can.
+- `MF_CARD_OVERRIDE` Not a mech, but can be converted to friendly using an ID card in the same way
+  that mechs can.
 - `CONSOLE_DESPAWN` Despawns when a nearby console is properly hacked.
 - `IMMOBILE` Doesn't move (e.g. turrets)
 - `ID_CARD_DESPAWN` Despawns when a science ID card is used on a nearby console
@@ -1055,7 +1056,8 @@ Multiple death functions can be used. Not all combinations make sense.
 - `MECH_RECON_VISION` This mech grants you night-vision and enhanced overmap sight radius when
   piloted.
 - `MECH_DEFENSIVE` This mech can protect you thoroughly when piloted.
-- `MILITARY_MECH` Will demand a military ID card instead of an industrial one. Doesn't actually have to be a mech.
+- `MILITARY_MECH` Will demand a military ID card instead of an industrial one. Doesn't actually have
+  to be a mech.
 - `MILKABLE` Produces milk when milked.
 - `NIGHT_INVISIBILITY` Monster becomes invisible if it's more than one tile away and the lighting on
   its tile is LL_LOW or less. Visibility is not affected by night vision.

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -833,7 +833,7 @@ void stash_activity_actor::do_turn( player_activity &, Character &who )
 
     monster *pet = g->critter_at<monster>( pos );
     if( pet != nullptr && pet->has_effect( effect_pet ) ) {
-        pet->add_effect( effect_ai_waiting, 1_turns );
+        pet->add_effect( effect_ai_waiting, 2_turns );
         std::vector<detached_ptr<item>> stashed = obtain_activity_items( who, items );
         stash_on_pet( stashed, *pet, who );
         if( items.empty() ) {

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -100,6 +100,7 @@ static const activity_id ACT_VEHICLE( "ACT_VEHICLE" );
 static const activity_id ACT_VEHICLE_DECONSTRUCTION( "ACT_VEHICLE_DECONSTRUCTION" );
 static const activity_id ACT_VEHICLE_REPAIR( "ACT_VEHICLE_REPAIR" );
 
+static const efftype_id effect_ai_waiting( "ai_waiting" );
 static const efftype_id effect_pet( "pet" );
 static const efftype_id effect_nausea( "nausea" );
 
@@ -832,10 +833,12 @@ void stash_activity_actor::do_turn( player_activity &, Character &who )
 
     monster *pet = g->critter_at<monster>( pos );
     if( pet != nullptr && pet->has_effect( effect_pet ) ) {
+        pet->add_effect( effect_ai_waiting, 1_turns );
         std::vector<detached_ptr<item>> stashed = obtain_activity_items( who, items );
         stash_on_pet( stashed, *pet, who );
         if( items.empty() ) {
             who.cancel_activity();
+            pet->remove_effect( effect_ai_waiting );
         }
     } else {
         who.add_msg_if_player( _( "The pet has moved somewhere else." ) );

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -435,7 +435,7 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
         }
         if( critter.is_npc() ) {
             // friendly to the player, not a target for us
-            return static_cast<const npc *>( &critter )->get_attitude() == NPCATT_KILL;
+            return static_cast<const npc *>( &critter )->guaranteed_hostile();
         }
         // TODO: what about g->u?
         return false;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5517,7 +5517,7 @@ void game::examine( const tripoint &examp )
                 if( monexamine::pet_menu( *mon ) ) {
                     return;
                 }
-            } else if( mon->has_flag( MF_RIDEABLE_MECH ) && !mon->has_effect( effect_pet ) ) {
+            } else if( ( mon->has_flag( MF_RIDEABLE_MECH ) || mon->has_flag( MF_CARD_OVERRIDE ) ) && !mon->has_effect( effect_pet ) && mon->attitude_to( u ) != Attitude::A_HOSTILE ) {
                 if( monexamine::mech_hack( *mon ) ) {
                     return;
                 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5517,7 +5517,8 @@ void game::examine( const tripoint &examp )
                 if( monexamine::pet_menu( *mon ) ) {
                     return;
                 }
-            } else if( ( mon->has_flag( MF_RIDEABLE_MECH ) || mon->has_flag( MF_CARD_OVERRIDE ) ) && !mon->has_effect( effect_pet ) && mon->attitude_to( u ) != Attitude::A_HOSTILE ) {
+            } else if( ( mon->has_flag( MF_RIDEABLE_MECH ) || mon->has_flag( MF_CARD_OVERRIDE ) ) &&
+                       !mon->has_effect( effect_pet ) && mon->attitude_to( u ) != Attitude::A_HOSTILE ) {
                 if( monexamine::mech_hack( *mon ) ) {
                     return;
                 }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4858,6 +4858,9 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
         // in their name, also food is active while it rots.
         tagtext += _( " (active)" );
     }
+    if( has_flag( flag_SPAWN_FRIENDLY ) ) {
+        tagtext += _( " (friendly)" );
+    }
 
     if( is_favorite ) {
         tagtext += _( " *" ); // Display asterisk for favorite items

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1095,7 +1095,8 @@ int place_monster_iuse::use( player &p, item &it, bool, const tripoint &pos ) co
         skill_offset += p.get_skill_level( sk );
     }
     /** @EFFECT_INT increases chance of a placed turret being friendly */
-    if( rng( 0, p.int_cur ) + skill_offset < rng( 0, 2 * difficulty ) ) {
+    /** Full-on pets also auto-succeed if we've already succeeded before deactivating it */
+    if( rng( 0, p.int_cur ) + skill_offset < rng( 0, 2 * difficulty ) && !it.has_flag( flag_SPAWN_FRIENDLY ) ) {
         if( hostile_msg.empty() ) {
             p.add_msg_if_player( m_bad, _( "The %s scans you and makes angry beeping noises!" ),
                                  newmon.name() );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1096,7 +1096,8 @@ int place_monster_iuse::use( player &p, item &it, bool, const tripoint &pos ) co
     }
     /** @EFFECT_INT increases chance of a placed turret being friendly */
     /** Full-on pets also auto-succeed if we've already succeeded before deactivating it */
-    if( rng( 0, p.int_cur ) + skill_offset < rng( 0, 2 * difficulty ) && !it.has_flag( flag_SPAWN_FRIENDLY ) ) {
+    if( rng( 0, p.int_cur ) + skill_offset < rng( 0, 2 * difficulty ) &&
+        !it.has_flag( flag_SPAWN_FRIENDLY ) ) {
         if( hostile_msg.empty() ) {
             p.add_msg_if_player( m_bad, _( "The %s scans you and makes angry beeping noises!" ),
                                  newmon.name() );

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -120,9 +120,9 @@ bool monexamine::pet_menu( monster &z )
     amenu.addentry( push_zlave, true, 'p', _( "Push %s" ), pet_name );
     if( z.has_effect( effect_leashed ) ) {
         if( z.has_effect( effect_led_by_leash ) ) {
-            amenu.addentry( stop_lead, true, 'p', _( "Stop leading %s" ), pet_name );
+            amenu.addentry( stop_lead, true, 'P', _( "Stop leading %s" ), pet_name );
         } else {
-            amenu.addentry( lead, true, 'p', _( "Lead %s by the leash" ), pet_name );
+            amenu.addentry( lead, true, 'P', _( "Lead %s by the leash" ), pet_name );
         }
     }
     amenu.addentry( rename, true, 'e', _( "Rename" ) );
@@ -451,17 +451,22 @@ bool monexamine::mech_hack( monster &z )
     itype_id card_type = ( z.has_flag( MF_MILITARY_MECH ) ? itype_id_military : itype_id_industrial );
     avatar &you = get_avatar();
     if( you.has_amount( card_type, 1 ) ) {
-        if( query_yn( _( "Swipe your %s into the mech's security port?" ), item::nname( card_type ) ) ) {
+        if( query_yn( _( "Swipe your %s into the %s's security port?" ), item::nname( card_type ), z.get_name() ) ) {
             you.mod_moves( -100 );
             z.add_effect( effect_pet, 1_turns, num_bp );
             z.friendly = -1;
-            add_msg( m_good, _( "The %s whirs into life and opens its restraints to accept a pilot." ),
-                     z.get_name() );
+            if( z.has_flag( MF_RIDEABLE_MECH ) ) {
+                add_msg( m_good, _( "The %s whirs into life and opens its restraints to accept a pilot." ),
+                         z.get_name() );
+            } else {
+                add_msg( m_good, _( "The %s begins to follow you." ),
+                         z.get_name() );
+            }
             you.use_amount( card_type, 1 );
             return true;
         }
     } else {
-        add_msg( m_info, _( "You do not have the required %s to activate this mech." ),
+        add_msg( m_info, _( "You do not have the required %s to activate this." ),
                  item::nname( card_type ) );
     }
     return false;
@@ -730,7 +735,7 @@ bool monexamine::give_items_to( monster &z )
             to_move.insert( to_move.end(), itq );
         }
     }
-    z.add_effect( effect_ai_waiting, 5_turns );
+    z.add_effect( effect_ai_waiting, 2_turns );
     you.drop( to_move, z.pos(), true );
 
     return false;

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -451,7 +451,8 @@ bool monexamine::mech_hack( monster &z )
     itype_id card_type = ( z.has_flag( MF_MILITARY_MECH ) ? itype_id_military : itype_id_industrial );
     avatar &you = get_avatar();
     if( you.has_amount( card_type, 1 ) ) {
-        if( query_yn( _( "Swipe your %s into the %s's security port?" ), item::nname( card_type ), z.get_name() ) ) {
+        if( query_yn( _( "Swipe your %s into the %s's security port?" ), item::nname( card_type ),
+                      z.get_name() ) ) {
             you.mod_moves( -100 );
             z.add_effect( effect_pet, 1_turns, num_bp );
             z.friendly = -1;

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1369,7 +1369,7 @@ int monster::calc_movecost( const tripoint &f, const tripoint &t ) const
     // If we're leading a pet around by a leash, make it a bit easier for them to catch up if they fall behind too much.
     if( has_effect( effect_led_by_leash ) && rl_dist( f, g->u.pos() ) > 4 ) {
         // Only give a bonus if the destination gets them closer to the player
-        if ( rl_dist( f, g->u.pos() ) > rl_dist( t, g->u.pos() ) ) {
+        if( rl_dist( f, g->u.pos() ) > rl_dist( t, g->u.pos() ) ) {
             movecost /= 2;
         }
     }

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1366,6 +1366,14 @@ int monster::calc_movecost( const tripoint &f, const tripoint &t ) const
         movecost = ( ( 50 * source_cost ) + ( 50 * dest_cost ) ) / 2.0;
     }
 
+    // If we're leading a pet around by a leash, make it a bit easier for them to catch up if they fall behind too much.
+    if( has_effect( effect_led_by_leash ) && rl_dist( f, g->u.pos() ) > 4 ) {
+        // Only give a bonus if the destination gets them closer to the player
+        if ( rl_dist( f, g->u.pos() ) > rl_dist( t, g->u.pos() ) ) {
+            movecost /= 2;
+        }
+    }
+
     return movecost;
 }
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1338,7 +1338,7 @@ monster_attitude monster::attitude( const Character *u ) const
         }
         // Zombies don't understand not attacking NPCs, but dogs and bots should.
         const npc *np = dynamic_cast< const npc * >( u );
-        if( np != nullptr && np->get_attitude() != NPCATT_KILL && !type->in_species( ZOMBIE ) ) {
+        if( np != nullptr && !np->guaranteed_hostile() && !type->in_species( ZOMBIE ) ) {
             return MATT_FRIEND;
         }
         if( np != nullptr && np->is_hallucination() ) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3068,6 +3068,10 @@ detached_ptr<item> monster::to_item() const
     if( !unique_name.empty() ) {
         result->set_var( "item_label", unique_name );
     }
+    // If it's configured as a pet and not merely friendly, make sure next time we skip re-rolling for a friendly deployment.
+    if( has_effect( effect_pet ) ) {
+        result->set_flag( flag_SPAWN_FRIENDLY );
+    }
     return result;
 }
 

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -121,6 +121,7 @@ std::string enum_to_string<m_flag>( m_flag data )
         case MF_IMMOBILE: return "IMMOBILE";
         case MF_ID_CARD_DESPAWN: return "ID_CARD_DESPAWN";
         case MF_RIDEABLE_MECH: return "RIDEABLE_MECH";
+        case MF_CARD_OVERRIDE: return "CARD_OVERRIDE";
         case MF_MILITARY_MECH: return "MILITARY_MECH";
         case MF_MECH_RECON_VISION: return "MECH_RECON_VISION";
         case MF_MECH_DEFENSIVE: return "MECH_DEFENSIVE";

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -116,7 +116,8 @@ enum m_flag : int {
     MF_IMMOBILE,            // Doesn't move (e.g. turrets)
     MF_ID_CARD_DESPAWN,     // Despawns when a science ID card is used on a nearby console
     MF_RIDEABLE_MECH,       // A rideable mech that is immobile until ridden.
-    MF_MILITARY_MECH,       // A rideable mech that was designed for military work.
+    MF_CARD_OVERRIDE        // Not a mech, but can be converted to friendly using an ID card in the same way that mechs can.
+    MF_MILITARY_MECH,       // Makes rideable mechs and card-scanner bots require a military ID instead of industrial to convert to friendly.
     MF_MECH_RECON_VISION,   // This mech gives you IR night-vision.
     MF_MECH_DEFENSIVE,      // This mech gives you thorough protection.
     MF_HIT_AND_RUN,         // Flee for several turns after a melee attack

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -116,7 +116,7 @@ enum m_flag : int {
     MF_IMMOBILE,            // Doesn't move (e.g. turrets)
     MF_ID_CARD_DESPAWN,     // Despawns when a science ID card is used on a nearby console
     MF_RIDEABLE_MECH,       // A rideable mech that is immobile until ridden.
-    MF_CARD_OVERRIDE        // Not a mech, but can be converted to friendly using an ID card in the same way that mechs can.
+    MF_CARD_OVERRIDE,        // Not a mech, but can be converted to friendly using an ID card in the same way that mechs can.
     MF_MILITARY_MECH,       // Makes rideable mechs and card-scanner bots require a military ID instead of industrial to convert to friendly.
     MF_MECH_RECON_VISION,   // This mech gives you IR night-vision.
     MF_MECH_DEFENSIVE,      // This mech gives you thorough protection.

--- a/src/rot.cpp
+++ b/src/rot.cpp
@@ -19,6 +19,8 @@ auto temperature_flag_for_location( const map &m, const item &loc ) -> temperatu
     switch( loc.where() ) {
         case item_location_type::character:
             return temperature_flag::TEMP_NORMAL;
+        case item_location_type::monster:
+            return temperature_flag::TEMP_NORMAL;
         case item_location_type::map: {
             tripoint pos = loc.position();
             if( m.has_flag_furn( TFLAG_FREEZER, pos ) ) {


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Time for another roundup of assorted attempts to improve pet monster behavior.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

C++ changes:
1. In activity_item_handling.cpp, set it so `stash_activity_actor::do_turn` automatically refreshes the `ai_waiting` effect each turn so the monster won't run off, instead of relying on the monexamine applying a fixed duration of the effect. Also automatically removes the effect when you're done stashing items.
2. In creature.cpp, changed `Creature::auto_find_hostile_target` so that friendly NPCs engage any NPC that'd be hostile to the player via `guaranteed_hostile`, not just ones currently aggro'd at you. This paired with a related change below makes it so monster allies are more proactive about fighting alongside you when encountering hostile NPCs.
3. In game.cpp, set `game::examine` so that monsters with the `CARD_OVERRIDE` flag can also check for an ID card, not just mechs. The check also excludes monsters currently hostile to the player, so you can't abuse this to hijack monsters currently trying to murder you (previously not a concern since mechs have no opinions on how murderable the player is).
4. In item.cpp, set `item::tname` so that items flagged with `SPAWN_FRIENDLY` tagtext `(friendly)` onto the item name.
5. In iuse_actor.cpp, set `place_monster_iuse::use` to auto-succeed if the item has the `SPAWN_FRIENDLY` flag. This can in theory be used asa drunken hack for custom items that never fail, even though you can just not bother assigning a difficulty, but the main use is assigning the flag to items that normally lack it in another context below.
6. In monexamine.cpp, reworded some messages in `monexamine::mech_hack` to account for some monsters potentially not being mechs when card-swiped.
7. Also in monexamine.cpp, changed `monexamine::give_items_to` to only give 2 turns of `ai_waiting` to the target monster, now that the associated activity automatically refreshes the effect each turn.
8. Also also in monexamine.cpp, updated the hotkey in `monexamine::pet_menu` for leading pets by a leash to not use the same hotkey as pushing.
9. In monmove.cpp, added a bit to `monster::calc_movecost` that gives monsters a bonus to movecost if they're being tugged around on a leash. This bonus only applies if they're getting closer to the limit of the leash's effect range, and if their destination tile would move them closer to the player.
10. In monster.cpp, set `monster::attitude` so that friendly monsters skip over any hostile NPC when choosing who to treat as fellow friends, not just those already aggro'd at the player.
11. Also in monster.cpp, set `monster::to_item` so that deactivating a monster that counts as a pet, and not merely friendly, flags the resulting item with the `SPAWN_FRIENDLY` flag so that the item will remember that you've already successfully programmed it once already. Since you can EMP, laptop, etc other monsters to render them deactivatable, I figured it reasonable to still allow non-pet deactivated monsters force a reroll to deploy, and for now only extend this benefit to valid pets like the hauler bot and such. This also enables for things like deactivating mechs in the future, maybe.
12. In monstergenerator.cpp and mytype.h, added a definition for monsterflag `CARD_OVERRIDE`, used to define non-mech monsters that can be rendered friendly via swiping an ID card. Also updates the comment for `MILITARY_MECH` to explain what it actually does.
13. In rot.cpp, updated `temperature_flag_for_location` to correctly handle items stored in monster inventory, fixing an error message I noticed while trying to take comestibles out of a pet's storage.

JSON changes:
1. Added `CARD_OVERRIDE` flag to cleaner bots and and hauler bots, also adding `MILITARY_MECH` to hauler bots. This makes them possible to convert from neutral to friendly with a card scan if not already friendly, and specifically makes hauler bots use military cards to do so (as that's the only actual code effect of `MILITARY_MECH`).
2. Set inactive cleaner bots to count as pets if successfully deployed.
3. Added info to `SPAWN_FRIENDLY` flag, worded generically enough to fit pet eggs as well as deactivated pet bots.

Documentation changes:
1. Added documentation for `CARD_OVERRIDE` monster flag.
2. Added documentation for `SPAWN_FRIENDLY` item flag to explain what it does.
3. Updated documentation for `MILITARY_MECH` monster flag to explain what it actually does, and specify the monster in question doesn't have to be a mech.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Not messing with NPC hostility on the off chance that it worsens performance.
2. Allowing all friendly monsters to flag their resulting item with `SPAWN_FRIENDLY` if deactivated. Would make control laptops pretty dang spicy, not sure if we want that?
3. I was initially also going to make miner bots cardable too, but changed my mind when I realized that slapping a backpack on a tunneling snakebot might seem kinda silly.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON changes for syntax and lint errors.
2. Compiled and load-tested.
3. Spawned in a hauler bot, confirmed I can swipe a military ID card to convert it to a pet.
4. Gave it a duffel bag and loaded a bunch of random items onto it, confirmed it never moves away and that it isn't frozen in place after I finish. Did so with a message temporarily added to confirm every turn it has the effect just to be sure.
5. Took items from the hauler bot's inventory, no longer prints an error message about being able to pick the contents type.
6. Put a leash on the hauler bot, confirmed the hotkey was now a captial `P` instead of lowercase `P`.
7. Gave myself Road-Runner and started sprinting away from it, it now actually keeps up due to being dragged along for the ride anytime it starts getting too far away from me.
8. Warped off to a bandit camp while invisible, spawned in a friendly turret, it correctly starts shooting at bandits despite them not yet being aggro'd at me.
9. Double-checked in build `2024-08-06` that friendly turrets already didn't attack unless the bandits are already aggro'd just to be 100% sure I didn't placebo-effect my own dumb ass.
10. Went back to my pet robot, deactivated and re-deployed it several times, every time it succeeded due to being spawned with the flag. Also confirmed the tagtext and flag appear as expected.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Some additional stuff I desire to do as possible followups to this:
1. Adding special attacks or abilities to cleaner bots that help justify having them as pets. Main thing I'm thinking about is how they're mentioned constantly trying to clean even when you fail the spawn roll, so a logical addition would be a special attack that automatically reduces the intensity of liquid fields around it, as well as automatically removing any spilled liquid on those tiles too. As a secondary bonus specifically to friendly ones, they could lean into the hazmat role as a bonus, and automatically chirp out a warning when they use this special attack if the tiles they're near have any ground radiation, possibly also reducing some of said ground rads too maybe? Idea being that any cleaner bot you encounter will do basic cleaning, while needin to be correctly configured to assist with hazmat cleanup and needing to regard the PC as an authorized user before they'll alert them about radiation (a feature I'm sure OSHA would absolutely LOVE).
2. Additionally, I want to eventually move the annoying hardcoded behavior of "load turrets with available ammo on activation" to instead become friend/pet menu commands to load/unload ammunition, and for good measure make it accept any valid ammo of their ammotype instead of only the default. That feels like it'd be complicated enough to warrant being a separate PR however. As a bonus though, might also move the dumbass hardcoded check for laser turrets warning you when deployed without enough sunlight to fire to automatically trigger when the placed monster has an attack that requires it, assuming we don't just move it to a monster flag or remove the restriction entirely.
3. I would LOVE to figure out how to make friendly and pet monsters not absolute dogshit at following the player up/down stairs and ramps but I got fuck-all idea how to fix that. :<