### PR TITLE
fix: define JSON flag for BIO_IMMUNE

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -203,6 +203,12 @@
     "info": "This item disappears as soon as its timer runs out whether it is food or not."
   },
   {
+    "id": "BIO_IMMUNE",
+    "context": [ "ARMOR", "TOOL_ARMOR" ],
+    "type": "json_flag",
+    "info": "This gear <good>completely protects</good> you from <info>biological damage</info>."
+  },
+  {
     "id": "BASH_IMMUNE",
     "context": [ "ARMOR", "TOOL_ARMOR" ],
     "type": "json_flag",


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

The flag already exists, it just wasn't defined. This causes errors with any mods that use it. Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/4261

## Describe the solution

Defines the flag.

## Describe alternatives you've considered

cry about it

## Testing

bot

## Additional context

aaaaaaa
