### PR TITLE
fix: label wooden walls and floors better

### DIFF
--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -187,7 +187,7 @@
   {
     "type": "construction_group",
     "id": "build_concrete_roof",
-    "name": "Build Concrete Roof"
+    "name": "Build Roof Over Concrete Floor"
   },
   {
     "type": "construction_group",
@@ -357,7 +357,7 @@
   {
     "type": "construction_group",
     "id": "build_log_sod_roof",
-    "name": "Build Log & Sod Roof"
+    "name": "Build Roof Over Primitive Floor"
   },
   {
     "type": "construction_group",
@@ -442,7 +442,7 @@
   {
     "type": "construction_group",
     "id": "build_metal_roof",
-    "name": "Build Metal Roof"
+    "name": "Build Roof Over Simple Metal Floor"
   },
   {
     "type": "construction_group",
@@ -522,7 +522,7 @@
   {
     "type": "construction_group",
     "id": "build_reinforced_concrete_roof",
-    "name": "Build Reinforced Concrete Roof"
+    "name": "Build Roof Over Reinforced Concrete Floor"
   },
   {
     "type": "construction_group",
@@ -582,7 +582,7 @@
   {
     "type": "construction_group",
     "id": "build_roof",
-    "name": "Build Roof"
+    "name": "Build Roof Over Wooden Floor"
   },
   {
     "type": "construction_group",
@@ -722,7 +722,7 @@
   {
     "type": "construction_group",
     "id": "build_thatched_roof",
-    "name": "Build Thatched Roof"
+    "name": "Build Thatched Roof Over Dirt Floor"
   },
   {
     "type": "construction_group",
@@ -1177,7 +1177,7 @@
   {
     "type": "construction_group",
     "id": "constr_wall_standard",
-    "name": "Build Standard Wall"
+    "name": "Build Plastered Wooden Wall"
   },
   {
     "type": "construction_group",
@@ -1352,7 +1352,7 @@
   {
     "type": "construction_group",
     "id": "remove_a_wall",
-    "name": "Remove a wall"
+    "name": "Remove a plastered wooden wall"
   },
   {
     "type": "construction_group",

--- a/data/json/furniture_and_terrain/terrain-floors-indoor.json
+++ b/data/json/furniture_and_terrain/terrain-floors-indoor.json
@@ -238,7 +238,7 @@
   {
     "type": "terrain",
     "id": "t_floor",
-    "name": "floor",
+    "name": "wooden floor",
     "description": "Interlocking wooden tiles that are more than likely treated against fire, with wooden posts and beams supporting a roof.",
     "symbol": ".",
     "color": "cyan",

--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -29,7 +29,7 @@
     "type": "terrain",
     "id": "t_wall",
     "alias": [ "t_wall_h", "t_wall_v" ],
-    "name": "wall",
+    "name": "plastered wooden wall",
     "description": "The stereotypical wall with wooden support structure filled with insulation and drywalled.  Paint job is the all too common and neutral off-white or cream color, it could use more vibrant paint.  The underlying material is still somewhat flammable.",
     "symbol": "LINE_OXOX",
     "color": "light_gray",


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Walls and floors confuse people in the construction menu. They're made of wood but aren't descriptive enough in their name. Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/5111

## Describe the solution

Actually label floors as wooden floors instead of "floor" and walls as plastered wooden walls.

## Describe alternatives you've considered

Make it worse (im kidding)

## Testing

bot

## Additional context

you have a sudden realization floors are made of floor.