### PR TITLE
perf: combat lag spikes from recipes with large component lists, calorie range now respects what ingredients you actually possess

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1875,9 +1875,9 @@ void item::food_info( const item *food_item, std::vector<iteminfo> &info,
 
     bool show_nutr = parts->test( iteminfo_parts::FOOD_NUTRITION ) ||
                      parts->test( iteminfo_parts::FOOD_VITAMINS );
-    if( min_nutr != max_nutr && show_nutr ) {
+    if( show_nutr && !food_item->has_flag( flag_NUTRIENT_OVERRIDE ) ) {
         info.emplace_back(
-            "FOOD", _( "Nutrition will <color_cyan>vary with chosen ingredients</color>." ) );
+            "FOOD", _( "Nutrition will <color_cyan>vary with available ingredients</color>." ) );
         if( recipe_dict.is_item_on_loop( food_item->typeId() ) ) {
             info.emplace_back(
                 "FOOD", _( "Nutrition range cannot be calculated accurately due to "

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -724,24 +724,14 @@ TEST_CASE( "nutrients in food", "[item][iteminfo][food]" )
                                 iteminfo_parts::FOOD_QUENCH
                               } );
 
-    SECTION( "fixed nutrient values in regular item" ) {
+    SECTION( "nutrient values of regular item" ) {
         test_info_equals(
             "icecream", q,
             "--\n"
+            "Nutrition will <color_cyan>vary with available ingredients</color>.\n"
             "<color_c_white>Calories (kcal)</color>: <color_c_yellow>325</color>  "
             "Quench: <color_c_yellow>0</color>\n"
             "Vitamins (RDA): Calcium (9%), Vitamin A (9%), and Vitamin B12 (11%)\n" );
-    }
-    SECTION( "nutrient ranges for recipe exemplars", "[item][iteminfo]" ) {
-        detached_ptr<item> i = item::spawn( "icecream" );
-        i->set_var( "recipe_exemplar", "icecream" );
-        test_info_equals(
-            *i, q,
-            "--\n"
-            "Nutrition will <color_cyan>vary with available ingredients</color>.\n"
-            "<color_c_white>Calories (kcal)</color>: <color_c_yellow>325</color>  Quench:"
-            "<color_c_yellow>0</color>Vitamins (RDA): Calcium (9%), Vitamin A (9%), and"
-            "Vitamin B12 (11%)\n");
     }
 }
 

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -740,8 +740,8 @@ TEST_CASE( "nutrients in food", "[item][iteminfo][food]" )
             "--\n"
             "Nutrition will <color_cyan>vary with available ingredients</color>.\n"
             "<color_c_white>Calories (kcal)</color>: <color_c_yellow>325</color>  Quench:"
-            "<color_c_yellow>0</color>"
-            "Vitamins (RDA): Calcium (9%), Vitamin A (9%), and Vitamin B12 (11%)\n");
+            "<color_c_yellow>0</color>Vitamins (RDA): Calcium (9%), Vitamin A (9%), and"
+            "Vitamin B12 (11%)\n");
     }
 }
 

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -738,9 +738,9 @@ TEST_CASE( "nutrients in food", "[item][iteminfo][food]" )
         test_info_equals(
             *i, q,
             "--\n"
-            "Nutrition will <color_cyan>vary with chosen ingredients</color>.\n"
-            "<color_c_white>Calories (kcal)</color>: <color_c_yellow>235</color>-"
-            "<color_c_yellow>716</color>  Quench: <color_c_yellow>0</color>\n"
+            "Nutrition will <color_cyan>vary with available ingredients</color>.\n"
+            "<color_c_white>Calories (kcal)</color>: <color_c_yellow>325</color>  Quench:"
+            "<color_c_yellow>0</color>"
             "Vitamins (RDA): Calcium (3-35%), Iron (0-98%), "
             "Vitamin A (0-11%), Vitamin B12 (0-6%), and Vitamin C (0-85%)\n");
     }

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -741,8 +741,7 @@ TEST_CASE( "nutrients in food", "[item][iteminfo][food]" )
             "Nutrition will <color_cyan>vary with available ingredients</color>.\n"
             "<color_c_white>Calories (kcal)</color>: <color_c_yellow>325</color>  Quench:"
             "<color_c_yellow>0</color>"
-            "Vitamins (RDA): Calcium (3-35%), Iron (0-98%), "
-            "Vitamin A (0-11%), Vitamin B12 (0-6%), and Vitamin C (0-85%)\n");
+            "Vitamins (RDA): Calcium (9%), Vitamin A (9%), and Vitamin B12 (11%)\n");
     }
 }
 


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This aims to fix the lag spike that hovering over food recipes with giant component lists generate.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. In consumption.cpp, `Character::compute_nutrient_range` has been set to only run calculations on components for a recipe if the player actually has said components available for crafting, so iterating over a gigantic list of potential components should lag the game less unless the player actually has everything the recipe allows. It also returns early with the item's average value if the player can't craft that item at all, to prevent the "only regard component we have" from telling the player an item they can't craft only has zero calories. If it did that, the player would have no way of knowing the calorie value might actually be above zero and they'd potentially assume the item isn't worth anything as food.
2. In item.cpp, set `item::food_info` the line mentioning variation in ingredients applies to all recipes that lack `NUTRIENT_OVERRIDE`, since recipes the player currently can't craft will display their default value now, we don't want the line to be omitted for those since the variation will kick in as soon as the player actually gets the components to craft it.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Spawned in some assorted meat and fish along with the needed cooking tools.
3. Scrolled back and forth over the recipe for cat food, no more lag spike.
4. Also observed that the calorie range cat food reports now shows the min and max of what the actual available components would provide, defaulting to an average if I warp away and can no longer craft it.
5. Spawned in buckwheat, wheat, and other components for flour as well as a quern, confirmed it shows either a fixed value or an expected range depending on variation of ingredients, with fixed values for stuff I can't craft.
6. Checked affected files for astyle.

![image](https://github.com/user-attachments/assets/2a289908-59d2-4e6e-93fa-027f7a94e5ca)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
