### PR TITLE
feat(balance): overhaul safecracking to allow more options, allow prying open pickable gun safes, pickable gun safes now jam on failed prying attempts instead of lockpicking

### DIFF
--- a/data/json/furniture_and_terrain/furniture-storage.json
+++ b/data/json/furniture_and_terrain/furniture-storage.json
@@ -371,8 +371,21 @@
     "flags": [ "TRANSPARENT", "CONTAINER", "SEALED", "PLACE_ITEM", "MOUNTABLE", "MINEABLE" ],
     "lockpick_result": "f_gunsafe_o",
     "lockpick_message": "With a satisfying click, the lock on the gun safe door opens.",
-    "examine_action": "locked_object_pickable",
-    "oxytorch": { "result": "f_safe_o", "duration": "14 seconds" },
+    "examine_action": "locked_object",
+    "oxytorch": { "result": "f_gunsafe_o", "duration": "14 seconds" },
+    "pry": {
+      "success_message": "You pry open the safe.",
+      "fail_message": "You pry, but cannot pry open the safe.",
+      "break_message": "Your clumsy attempt jams the safe!",
+      "pry_quality": 4,
+      "noise": 24,
+      "break_noise": 28,
+      "sound": "metal screeching!",
+      "difficulty": 12,
+      "breakable": true,
+      "new_furn_type": "f_gunsafe_o",
+      "break_furn_type": "f_gunsafe_mj"
+    },
     "bash": {
       "str_min": 40,
       "str_max": 200,
@@ -400,7 +413,7 @@
     "required_str": 14,
     "max_volume": "250 L",
     "flags": [ "TRANSPARENT", "CONTAINER", "SEALED", "PLACE_ITEM", "MOUNTABLE", "MINEABLE" ],
-    "oxytorch": { "result": "f_safe_o", "duration": "14 seconds" },
+    "oxytorch": { "result": "f_gunsafe_o", "duration": "14 seconds" },
     "bash": {
       "str_min": 40,
       "str_max": 200,
@@ -428,7 +441,8 @@
     "required_str": 14,
     "max_volume": "250 L",
     "flags": [ "TRANSPARENT", "CONTAINER", "SEALED", "PLACE_ITEM", "MOUNTABLE", "MINEABLE" ],
-    "oxytorch": { "result": "f_safe_o", "duration": "14 seconds" },
+    "oxytorch": { "result": "f_gunsafe_o", "duration": "14 seconds" },
+    "//": "Pry data to be added when this examine_action supports prying too.",
     "examine_action": "gunsafe_el",
     "bash": {
       "str_min": 40,
@@ -673,6 +687,7 @@
     "max_volume": "250 L",
     "oxytorch": { "result": "f_safe_o", "duration": "14 seconds" },
     "flags": [ "TRANSPARENT", "CONTAINER", "SEALED", "PLACE_ITEM", "MOUNTABLE", "MINEABLE" ],
+    "//": "Pry data to be added when this examine_action supports prying too.",
     "examine_action": "safe",
     "bash": {
       "str_min": 40,

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1461,9 +1461,6 @@ void lockpick_activity_actor::finish( player_activity &act, Character &who )
         g->m.furn_set( target, new_furn_type ) :
         static_cast<void>( g->m.ter_set( target, new_ter_type ) );
         who.add_msg_if_player( m_good, open_message );
-    } else if( furn_type == f_gunsafe_ml && lock_roll > ( 3 * pick_roll ) ) {
-        who.add_msg_if_player( m_bad, _( "Your clumsy attempt jams the lock!" ) );
-        g->m.furn_set( target, furn_str_id( "f_gunsafe_mj" ) );
     } else if( lock_roll > ( 1.5 * pick_roll ) ) {
         if( it->inc_damage() ) {
             who.add_msg_if_player( m_bad,

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -241,7 +241,6 @@ static const trait_flag_str_id trait_flag_CANNIBAL( "CANNIBAL" );
 static const trait_flag_str_id trait_flag_PSYCHOPATH( "PSYCHOPATH" );
 static const trait_flag_str_id trait_flag_SAPIOVORE( "SAPIOVORE" );
 
-static const bionic_id bio_ears( "bio_ears" );
 static const bionic_id bio_painkiller( "bio_painkiller" );
 
 static const itype_id itype_UPS( "UPS" );

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -228,6 +228,7 @@ static const skill_id skill_computer( "computer" );
 static const skill_id skill_electronics( "electronics" );
 static const skill_id skill_fabrication( "fabrication" );
 static const skill_id skill_firstaid( "firstaid" );
+static const skill_id skill_mechanics( "mechanics" );
 static const skill_id skill_survival( "survival" );
 
 static const quality_id qual_BUTCHER( "BUTCHER" );
@@ -3160,11 +3161,9 @@ void activity_handlers::fish_finish( player_activity *act, player *p )
 
 void activity_handlers::cracking_do_turn( player_activity *act, player *p )
 {
-    auto cracking_tool = p->crafting_inventory().items_with( []( const item & it ) -> bool {
-        return it.has_flag( flag_SAFECRACK );
-    } );
-    if( cracking_tool.empty() && !p->has_bionic( bio_ears ) ) {
-        // We lost our cracking tool somehow, bail out.
+    // We got deafened in the middle of it and can't decode by touch, so bail out
+    if( p->is_deaf() && p->get_skill_level( skill_mechanics ) < 5 ) {
+        add_msg( m_bad, _( "You can't hear the tumblers anymore, so you stop." ) );
         act->set_to_null();
         return;
     }

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -206,7 +206,6 @@ static const mtype_id mon_spider_cellar_giant_s( "mon_spider_cellar_giant_s" );
 static const mtype_id mon_spider_web_s( "mon_spider_web_s" );
 static const mtype_id mon_spider_widow_giant_s( "mon_spider_widow_giant_s" );
 
-static const bionic_id bio_ears( "bio_ears" );
 static const bionic_id bio_fingerhack( "bio_fingerhack" );
 static const bionic_id bio_lighter( "bio_lighter" );
 static const bionic_id bio_lockpick( "bio_lockpick" );


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

I was asked to sanity-check safecracking a bit, put together a few assorted ideas related to that in the process.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. In activity_actor.cpp, removed the risk of jamming locked gun safes from `lockpick_activity_actor::finish`. Plan is for this to instead be a potential outcome from alternative methods of opening instead.
2. In activity_handlers.cpp, set `activity_handlers::cracking_do_turn` to only cancel out of safecracking if the player has suddenly been deafened while mid-crack, and only if they wouldn't meet the requirements to crack safes without hearing assistance as outlined below.
3. In iexamine.cpp, overhauled how `examine::safe` works. For starters, hearing-enhancing mutations are now factored in together with the enhanced hearing CBM, meaning any level of hearing mutation stronger than Good Hearing will let you attempt to crack safes without a stethoscope. Moreover, it's now possible to skip this requirement entirely if you have mechanics skill of 5 or higher, with messages referencing these options accordingly. Lastly, the time calculation has been reworked to be more reasonable. Base time is now 2 hours instead of 2 and a half, mechanics skill has an immediate and direct effect at any level instead of penalizing you for anything below level 3, and it can scale as far down as a proper LockPickingLawyer level of safecracking at a minimum of 5 minutes. In exchange however, the time impact of skill and perception has been toned down some, and perception needs to be higher than 10 to actually help you any (in return for not penalizing you if below average).

JSON changes:
1. Changed locked gunsafes from `locked_object_pickable` to `locked_object`, and added prying data. Higher difficulty than pickable metal doors, with risk of being jammed by a damaging result.
2. Mixed oxy-torching gun safes converting them into regular safes.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

I plan to add support for checking for prying data to safecracking and electronic safes, with the same general behavior of needing a halligan bar and prioritizing the stealthier option if you crouch, in a follow-up PR.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON file for syntax and lint errors.
2. Compiled and load-tested.
3. Spawned in a locked save.
4. Examined at it, confirmed it now actually consumes 10 seconds while fiddling with the dial, also hints at what I'm missing to actually crack it.
5. Gave myself Lupine Ears, can now crack the safe. Takes ~2 hours as expected at zero skill and perception below 10.
6. Removed mutation and spawned in a stethoscope, can also crack the safe as normal.
7. Bumped mechanics skill up to 5, can now crack it way faster and no longer requires a stethoscope.
8. Checked affected file for syntax and lint errors.
9. Spawned in a pickable gunsafe, can attempt to pry it open with a halligan bar, or pick it if I either crouch or drop the bar.
10. Checked affected C++ files for astyle.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

I need to at some point rework the math for prying rolls to be less goofy uuugh.