### PR TITLE
fix: Add check to class-limitation warning on learning spells

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1373,16 +1373,16 @@ void known_magic::learn_spell( const spell_type *sp, Character &guy, bool force 
                     trait_cancel += ".";
                 }
             }
-            if(!sp->spell_class->cancels.empty()){
+            if( !sp->spell_class->cancels.empty() ) {
                 if( query_yn(
-                    _( "Learning this spell will make you a\n\n%s: %s\n\nand lock you out of\n\n%s\n\nContinue?" ),
-                    sp->spell_class->name(), sp->spell_class->desc(), trait_cancel ) ) {
-                guy.set_mutation( sp->spell_class );
-                guy.on_mutation_gain( sp->spell_class );
-                guy.add_msg_if_player( sp->spell_class.obj().desc() );
-            } else {
-                return;
-            }
+                        _( "Learning this spell will make you a\n\n%s: %s\n\nand lock you out of\n\n%s\n\nContinue?" ),
+                        sp->spell_class->name(), sp->spell_class->desc(), trait_cancel ) ) {
+                    guy.set_mutation( sp->spell_class );
+                    guy.on_mutation_gain( sp->spell_class );
+                    guy.add_msg_if_player( sp->spell_class.obj().desc() );
+                } else {
+                    return;
+                }
             }
         }
     }

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1373,7 +1373,8 @@ void known_magic::learn_spell( const spell_type *sp, Character &guy, bool force 
                     trait_cancel += ".";
                 }
             }
-            if( query_yn(
+            if(!sp->spell_class->cancels.empty()){
+                if( query_yn(
                     _( "Learning this spell will make you a\n\n%s: %s\n\nand lock you out of\n\n%s\n\nContinue?" ),
                     sp->spell_class->name(), sp->spell_class->desc(), trait_cancel ) ) {
                 guy.set_mutation( sp->spell_class );
@@ -1381,6 +1382,7 @@ void known_magic::learn_spell( const spell_type *sp, Character &guy, bool force 
                 guy.add_msg_if_player( sp->spell_class.obj().desc() );
             } else {
                 return;
+            }
             }
         }
     }


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

When attempting to learn a spell (from a spellbook) that has a class associated with it, the warning about closing off an opposing class would show up even when there was no closing off of another class (and the relevant spot would appear blank). This did not look good, and could be confusing for users.

## Describe the solution

This PR adds a check for if the spell class cancels mutations, and only shows the prompt if it does.

## Describe alternatives you've considered

- Leave it be
- Continue weh'ing eternally

## Testing

Built and tested locally on my machine. It still shows the prompt when it should, and doesn't show it when it shouldn't.

Using Magiclysm as an example, you can see that it still shows up as expected
![image](https://github.com/user-attachments/assets/f22c801c-929a-461d-8d86-8ec5b962c31f)

Meanwhile, you just learn the spell in Magical Nights (and thus indeed doesn't show up)
![image](https://github.com/user-attachments/assets/e53759c1-a889-41ff-889c-5885768e4724)


## Additional context

Woohoo, c++ PR! This was mostly an issue affecting Magical Nights players to my knowledge, hence it being enough of a thorn in my side to fix it.
