### PR TITLE
fix: rework `recalc_hp()`

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1964,12 +1964,13 @@ void Character::calc_all_parts_hp( float hp_mod, float hp_adjustment, int str_ma
             new_max *= 0.8;
         }
 
+        new_max = std::max( new_max, 1 );
         float max_hp_ratio = static_cast<float>( new_max ) /
                              static_cast<float>( bp.get_hp_max() );
 
         int new_cur = std::ceil( static_cast<float>( bp.get_hp_cur() ) * max_hp_ratio );
 
-        bp.set_hp_max( std::max( new_max, 1 ) );
+        bp.set_hp_max( new_max );
         bp.set_hp_cur( std::max( std::min( new_cur, new_max ), 0 ) );
     }
 }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1965,6 +1965,7 @@ void Character::calc_all_parts_hp( float hp_mod, float hp_adjustment, int str_ma
             new_max *= 0.8;
         }
 
+        new_max = std::max( new_max, 1 );
         int new_cur = std::ceil( static_cast<float>( new_max ) * hp_ratio );
 
         bp.set_hp_max( new_max );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1958,17 +1958,14 @@ void Character::calc_all_parts_hp( float hp_mod, float hp_adjustment, int str_ma
 {
     for( std::pair<const bodypart_str_id, bodypart> &part : get_body() ) {
         bodypart &bp = get_part( part.first );
+        float hp_ratio = static_cast<float>( bp.get_hp_cur() ) / bp.get_hp_max();
         int new_max = ( part.first->base_hp + str_max * 3 + hp_adjustment ) * hp_mod;
 
         if( has_trait( trait_GLASSJAW ) && part.first == bodypart_str_id( "head" ) ) {
             new_max *= 0.8;
         }
 
-        new_max = std::max( new_max, 1 );
-        float max_hp_ratio = static_cast<float>( new_max ) /
-                             static_cast<float>( bp.get_hp_max() );
-
-        int new_cur = std::ceil( static_cast<float>( bp.get_hp_cur() ) * max_hp_ratio );
+        int new_cur = std::ceil( static_cast<float>( new_max ) * hp_ratio );
 
         bp.set_hp_max( new_max );
         bp.set_hp_cur( std::max( std::min( new_cur, new_max ), 0 ) );


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

- fixes #5222 which is caused by a mutation setting your HP down to 0, `recalc_hp` actually has a caveat to make it minimum 1 for max hp, but does it too late so the max_hp_ratio ends up being 0, which multiplies your current max and makes it 0 too.

## Describe the solution

~~Uses the `std::max` function earlier in the code so that max HP will actually remain correct. This will drop you to a minimum of 1 HP due to new current being a ceiling function.~~

Reworks function to use the current ratio of health to max health to decide new current health values, this should in theory be more robust as it doesn't use any values that aren't set in stone.

## Describe alternatives you've considered

- Having it max out only in character creation
  - Would solve immediate problem but also cause HP to flatline if you gain a mutation of that nature in game. This solution elegantly prevents both, which is what I believe we'll all prefer.

## Testing

- [x] Spawn a character with a -100 `hp_adjustment` mutation, I just edited Fast Reader to give -100.
  - [x] Confirm you don't die on spawn.
- [x] Spawn a character without any mutations, debug drop HP to 50.
  - [x] Confirm that you don't die when mutation is added.
- [x] Spawn into the helicopter crash start
  - [x] Confirm HP still drops as a result of the scenario

## Additional context

Not surprised this has remained unnoticed so long.