### PR TITLE
fix: replace the wooden floor under the sandbags with dirt in `FEMA_te` (FEMA camp)

### DIFF
--- a/data/json/mapgen/fema/FEMA_te_03.json
+++ b/data/json/mapgen/fema/FEMA_te_03.json
@@ -42,7 +42,8 @@
         "]": "t_door_metal_locked",
         "=": "t_dirt",
         ",": "t_dirt",
-        "*": "t_dirt"
+        "*": "t_dirt",
+        "N": "t_region_soil"
       },
       "items": { "x": { "item": "mil_surplus", "chance": 30 }, "X": { "item": "ammo_rifle_milspec", "chance": 80 } },
       "monster": { "Z": { "monster": "mon_zombie_soldier" }, "z": { "monster": "mon_zombie_soldier" } }


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Replace the wooden floor under the sandbags outside `FEMA_te` armory variant with dirt.
## Describe the solution
Add "N": "t_region_soil" in the mapgen terrain.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/2421016f-71a3-458b-91bf-625ec3b5a8f8">
After:
<img width="960" alt="image2" src="https://github.com/user-attachments/assets/9588cd42-76b7-4ec2-bd72-b63efb4a9808">