### PR TITLE
docs: Add Ubuntu package installation script

### DIFF
--- a/doc/src/content/docs/en/dev/guides/building/cmake.md
+++ b/doc/src/content/docs/en/dev/guides/building/cmake.md
@@ -45,6 +45,14 @@ You can obtain the source code tarball for the latest version from
 
 Obtain packages specified above with your system package manager.
 
+- For Ubuntu-based distros (24.04 onwards):
+
+```sh
+$ sudo apt install git cmake ninja-build mold clang-17 ccache \ 
+  libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev \ 
+  freetype glibc bzip2 zlib libvorbis ncurses gettext libflac++-dev
+```
+
 - For Fedora-based distros:
 
 ```sh


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Ubuntu-based distros represent a fairly large chunk of Linux users, and smoother package installation is better.

## Describe the solution

Creates a script with package-parity to the currently existing Fedora example as best I can. **HOWEVER!** this means that, due to the use of clang-17 as a package, the script currently only works on the most recent release of Ubuntu (24.04). Hence the notice in the docs. Due to the nature of Ubuntu's releases being LTS, it's not as much of a guarantee that users will be on the latest one compared to Fedora's fairly cutting edge behavior.

## Describe alternatives you've considered

- Leave out clang and instead use g++ since 24.04 appears to still ship with g++ 13.

This would be a GREAT solution, but it'd break package parity with the Fedora script (unless I also updated that to use gcc-13 now that that package has a non-rawhide version) and wouldn't line up with the example  build command provided later. (also, we'd potentially end up adding clang-17 right back in thanks to next release shaping up to have gcc 14, my classic foe). Very much so not opposed if this alternative is decided upon instead though!

- Let someone else who has more experience do this

- Just tell Ubuntu users to figure it out themselves

## Testing

I at least know that all of the packages in the script exist, though I haven't worked up the bravery to make a virtual machine to test whether it actually works at installing them / they work for building.

## Additional context

Assumed we wanted the c++ version of flac because the game is in c++

zlib-ng doesn't appear to have a package of its own, and the only place it's mentioned is the rust-libz-sys packages, so I'm just assuming it's shipped as the standard zlib package and/or the standard zlib package is okay. Please correct me if you can figure out where it's hiding, though!
