### PR TITLE
fix: Fix `deactivate()`, add revert to `iuse::note_bionic()`

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -545,8 +545,7 @@ void item::convert( const itype_id &new_type )
 
 void item::deactivate()
 {
-    if( !( is_active() && is_tool() ) ) {
-        add_msg( "Already inactive" );
+    if( !is_active() ) {
         return; // no-op
     }
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2239,6 +2239,7 @@ int iuse::noise_emitter_on( player *p, item *it, bool t, const tripoint &pos )
 int iuse::note_bionics( player *p, item *it, bool t, const tripoint &pos )
 {
     if( !t ) {
+        it->revert( p, true );
         it->deactivate();
         return 0;
     }
@@ -2249,6 +2250,7 @@ int iuse::note_bionics( player *p, item *it, bool t, const tripoint &pos )
     map &here = get_map();
 
     if( !p->has_enough_charges( *it, false ) ) {
+        it->revert( p, true );
         it->deactivate();
         return 0;
     }


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

- fix #5225, fix #5221.
- Updates #5188 

## Describe the solution

- Deactivate required the item to have tooldata originally due to it's purpose in reverting items, removed that requirement.
- Bionic scanner relied on deactivate to revert the item to it's original off state, added revert to the code.

## Describe alternatives you've considered

## Testing

- [x] Activate a joint, wait 5 minutes. Confirm it converts appropriately.
- [x] Activate and deactivate bionic scanner, confirm it changes appropriately.
- [x] Activate the bionic scanner and wait 6 hours, confirm when it runs out of charges it reverts to off state.

## Additional context
