### PR TITLE
feat(balance): support use of prying on other types of safe

### DIFF
--- a/data/json/furniture_and_terrain/furniture-storage.json
+++ b/data/json/furniture_and_terrain/furniture-storage.json
@@ -442,8 +442,21 @@
     "max_volume": "250 L",
     "flags": [ "TRANSPARENT", "CONTAINER", "SEALED", "PLACE_ITEM", "MOUNTABLE", "MINEABLE" ],
     "oxytorch": { "result": "f_gunsafe_o", "duration": "14 seconds" },
-    "//": "Pry data to be added when this examine_action supports prying too.",
     "examine_action": "gunsafe_el",
+    "pry": {
+      "success_message": "You pry open the safe.",
+      "fail_message": "You pry, but cannot pry open the safe.",
+      "break_message": "Your clumsy attempt jams the safe!",
+      "pry_quality": 4,
+      "noise": 24,
+      "break_noise": 28,
+      "sound": "metal screeching!",
+      "difficulty": 12,
+      "alarm": true,
+      "breakable": true,
+      "new_furn_type": "f_gunsafe_o",
+      "break_furn_type": "f_gunsafe_mj"
+    },
     "bash": {
       "str_min": 40,
       "str_max": 200,
@@ -687,8 +700,17 @@
     "max_volume": "250 L",
     "oxytorch": { "result": "f_safe_o", "duration": "14 seconds" },
     "flags": [ "TRANSPARENT", "CONTAINER", "SEALED", "PLACE_ITEM", "MOUNTABLE", "MINEABLE" ],
-    "//": "Pry data to be added when this examine_action supports prying too.",
     "examine_action": "safe",
+    "pry": {
+      "success_message": "You pry open the safe.",
+      "fail_message": "You pry, but cannot pry open the safe.",
+      "pry_quality": 4,
+      "noise": 24,
+      "break_noise": 28,
+      "sound": "metal screeching!",
+      "difficulty": 12,
+      "new_furn_type": "f_safe_o"
+    },
     "bash": {
       "str_min": 40,
       "str_max": 200,

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -863,7 +863,7 @@ void hacking_activity_actor::finish( player_activity &act, Character &who )
                 }
             } else if( type == HACK_SAFE ) {
                 who.add_msg_if_player( m_good, _( "The door on the safe swings open." ) );
-                here.furn_set( examp, furn_str_id( "f_safe_o" ) );
+                here.furn_set( examp, furn_str_id( "f_gunsafe_o" ) );
             } else if( type == HACK_DOOR ) {
                 who.add_msg_if_player( _( "You activate the panel!" ) );
                 who.add_msg_if_player( m_good, _( "The nearby doors unlock." ) );


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Follows up on https://github.com/cataclysmbnteam/Cataclysm-BN/pull/5217 by coding in support for waving a halligan bar at all three types of safes, not just one of them.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

C++ changes:
1. In iexamine.cpp, changed `iexamine::safe` and `iexamine::gunsafe_el` and so that it's now able to check for prying data too. If the player has a good enough prying tool then, like with locked gun safes, it will prioritize prying if standing, hacking/safecracking if crouching, and skip over trying to pry in favor of the sneaky action if you examine it while standing when you lack a good enough prying tool to attempt it.
2. Moved `find_best_prying_tool` and `apply_prying_tool` up a bit as they're static functions now being called for a bit earlier in the file than they previously were.
3. Misc: in activity_actor.cpp, set `hacking_activity_actor::finish` so that it turns hacked gun safes into open gun safes, not open regular safes, derp.

JSON changes:
1. Added prying data to electronic gun safes and to regular locked-up safes. As with pickable safes, requires a full-on halligan bar with a decently high difficulty. Electronic safes differ in their prying entry mainly in being alarmed since hacking it can trigger an alarm, while regular safes differ in not having a failure state that breaks them into a jammed safe (since we currently have jammed gun safes but not jammed regular safes).

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Adding a variant furniture for jammed regular safes so prying can jam those too?

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON file for syntax and lint errors.
2. Compiled and load-tested.
3. Spawned in an electronic gunsafe and a normal locked safe.
4. Confirmed that with no prying tools, and with only a crowbar, both safes will skip even attempting to pry them in favor of asking me to try hacking and/or do the dial-fiddling interaction when examined.
5. Spawned in a halligan bar, confirmed both default to trying to pry when standing now, but go back to their normal action on crouch.
6. Spawned in an electrohack and debugged my skills up, confirmed hacking an electronic gun safe converts it to the right type of safe.
7. Checked affected C++ files for astyle.

![image](https://github.com/user-attachments/assets/ed8e3ba2-77c5-452e-a1fc-34560bdb9858)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
