### PR TITLE
fix: put dirt under the tent chairs in `fema_mess_hall`

### DIFF
--- a/data/json/mapgen/nested/fema_nested.json
+++ b/data/json/mapgen/nested/fema_nested.json
@@ -264,6 +264,7 @@
         "...................."
       ],
       "palettes": [ "FEMA_camp" ],
+      "terrain": { "c": "t_region_soil" },
       "monster": { ",": { "monster": "mon_zombie_fat", "chance": 2 } },
       "items": { "X": { "item": "stash_food", "chance": 50 }, "T": { "item": "dining", "chance": 50 } }
     }


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Put dirt under the tent chairs in the nested mapgen `fema_mess_hall`.
## Describe the solution
Dirt under the chairs.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/9c449909-ea64-4696-8304-f31a98592e89">
After:
<img width="960" alt="image2" src="https://github.com/user-attachments/assets/37663e39-a6e4-4572-8767-af3aced422d9">