### PR TITLE
fix: make reinforced glass description less confusing

### DIFF
--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -1199,7 +1199,7 @@
     "id": "t_reinforced_glass",
     "alias": [ "t_reinforced_glass_h", "t_reinforced_glass_v" ],
     "name": "reinforced glass",
-    "description": "A thicker pane of glass with thin metal wires embedded throughout, strengthening the structural properties.  Still weaker than other types of walls, and not made to support a roof either.",
+    "description": "A thicker pane of glass with thin metal wires embedded throughout, strengthening the structural properties.  It's a lot stronger than drywall, but it's not made to support a roof and is weaker than concrete.",
     "symbol": "LINE_OXOX",
     "color": "light_cyan",
     "move_cost": 0,


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Reinforced glass was described as weaker than other types of walls. Technically it's correct but that doesn't make it right. A lot of walls are stronger and weaker than it. Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/5239

## Describe the solution

New description. Won't confuse people as to where it stands.

## Describe alternatives you've considered

none

## Testing

aaaaaaaaaaaaaaaaaa

## Additional context

Some research on this topic.

https://www.youtube.com/watch?v=xLV2Nd77lmY
https://www.youtube.com/shorts/37q4VRSW458
