### PR TITLE
fix: stop ghee from spoiling as fast as butter

### DIFF
--- a/data/json/items/comestibles/dairy.json
+++ b/data/json/items/comestibles/dairy.json
@@ -92,6 +92,7 @@
     "name": { "str_sp": "ghee" },
     "copy-from": "butter",
     "weight": "13500 mg",
+    "spoils_in": "0 days",
     "container": "jar_glass_sealed",
     "calories": 112,
     "description": "Clarified butter, free from milk solids and water.  Will last a very long time.",


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

When https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4113 ported Nonperishable overhaul the spoil time for ghee was deleted, but it copies from butter. It was meant to not spoil in that PR, this overwrites it to not spoil.

## Describe the solution

Spoils in is set to 0 days

## Describe alternatives you've considered

None

## Testing

Tests.

## Additional context

Not a day goes by when I don't hate copy-from.
