### PR TITLE
feat(balance): remove sugar in canned fruit recipe

### DIFF
--- a/data/json/items/comestibles/fruit_dishes.json
+++ b/data/json/items/comestibles/fruit_dishes.json
@@ -374,7 +374,7 @@
     "symbol": "%",
     "quench": 3,
     "healthy": 1,
-    "calories": 275,
+    "calories": 100,
     "description": "This sodden mass of preserved fruit was boiled and canned in an earlier life.  Bland, mushy and losing color, likely due to the lack of added sugar.",
     "price": "220 cent",
     "price_postapoc": "50 cent",

--- a/data/json/items/comestibles/fruit_dishes.json
+++ b/data/json/items/comestibles/fruit_dishes.json
@@ -375,7 +375,7 @@
     "quench": 3,
     "healthy": 1,
     "calories": 275,
-    "description": "This sodden mass of preserved fruit was boiled and canned in an earlier life.  Bland, mushy and losing color.",
+    "description": "This sodden mass of preserved fruit was boiled and canned in an earlier life.  Bland, mushy and losing color, likely due to the lack of added sugar.",
     "price": "220 cent",
     "price_postapoc": "50 cent",
     "material": "fruit",

--- a/data/json/recipes/food/drinks.json
+++ b/data/json/recipes/food/drinks.json
@@ -49,7 +49,7 @@
     "components": [
       [ [ "protein_powder", 1 ] ],
       [ [ "water_clean", 1 ] ],
-      [ [ "lemonade_powder", 1 ], [ "sweet_fruit_like", 2, "LIST" ], [ "coconut", 1 ] ]
+      [ [ "lemonade_powder", 1 ], [ "sweet_fruit_like", 1, "LIST" ], [ "coconut", 1 ] ]
     ]
   },
   {

--- a/data/json/recipes/food/drinks.json
+++ b/data/json/recipes/food/drinks.json
@@ -49,7 +49,7 @@
     "components": [
       [ [ "protein_powder", 1 ] ],
       [ [ "water_clean", 1 ] ],
-      [ [ "lemonade_powder", 1 ], [ "sweet_fruit_like", 1, "LIST" ], [ "coconut", 1 ] ]
+      [ [ "lemonade_powder", 1 ], [ "sweet_fruit_like", 2, "LIST" ], [ "coconut", 1 ] ]
     ]
   },
   {

--- a/data/json/recipes/food/veggi.json
+++ b/data/json/recipes/food/veggi.json
@@ -1737,8 +1737,7 @@
     "components": [
       [ [ "water", 12 ], [ "water_clean", 12 ] ],
       [ [ "jar_glass", 1 ] ],
-      [ [ "sweet_fruit", 4, "LIST" ] ],
-      [ [ "sugar_standard", 2, "LIST" ] ]
+      [ [ "sweet_fruit", 4, "LIST" ] ]
     ]
   },
   {
@@ -1915,8 +1914,7 @@
       [ [ "canister_empty", 1 ], [ "can_food_unsealed", 1 ] ],
       [ [ "scrap", 1 ] ],
       [ [ "water", 1 ], [ "water_clean", 1 ] ],
-      [ [ "sweet_fruit", 2, "LIST" ] ],
-      [ [ "sugar_standard", 1, "LIST" ] ]
+      [ [ "sweet_fruit", 2, "LIST" ] ]
     ]
   },
   {
@@ -2034,8 +2032,7 @@
     "components": [
       [ [ "water", 22 ], [ "water_clean", 22 ] ],
       [ [ "jar_3l_glass", 1 ] ],
-      [ [ "sweet_fruit", 24, "LIST" ] ],
-      [ [ "sugar_standard", 12, "LIST" ] ]
+      [ [ "sweet_fruit", 24, "LIST" ] ]
     ]
   },
   {

--- a/data/json/recipes/food/veggi.json
+++ b/data/json/recipes/food/veggi.json
@@ -1734,11 +1734,7 @@
     "batch_time_factors": [ 80, 5 ],
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "COOK", "level": 3 } ],
     "tools": [ [ [ "surface_heat", 100, "LIST" ] ], [ [ "pot_canning", -1 ] ] ],
-    "components": [
-      [ [ "water", 12 ], [ "water_clean", 12 ] ],
-      [ [ "jar_glass", 1 ] ],
-      [ [ "sweet_fruit", 4, "LIST" ] ]
-    ]
+    "components": [ [ [ "water", 12 ], [ "water_clean", 12 ] ], [ [ "jar_glass", 1 ] ], [ [ "sweet_fruit", 4, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -2029,11 +2025,7 @@
     "batch_time_factors": [ 80, 5 ],
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "COOK", "level": 3 } ],
     "tools": [ [ [ "surface_heat", 200, "LIST" ] ], [ [ "pot_canning", -1 ] ] ],
-    "components": [
-      [ [ "water", 22 ], [ "water_clean", 22 ] ],
-      [ [ "jar_3l_glass", 1 ] ],
-      [ [ "sweet_fruit", 24, "LIST" ] ]
-    ]
+    "components": [ [ [ "water", 22 ], [ "water_clean", 22 ] ], [ [ "jar_3l_glass", 1 ] ], [ [ "sweet_fruit", 24, "LIST" ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/requirements/cooking_components.json
+++ b/data/json/requirements/cooking_components.json
@@ -767,7 +767,7 @@
         [ "sweet_fruit", 1, "LIST" ],
         [ "lemon", 1 ],
         [ "irradiated_lemon", 1 ],
-        [ "apple_canned", 1 ],
+        [ "apple_canned", 2 ],
         [ "apple_sugar", 1 ],
         [ "dry_fruit", 1 ],
         [ "can_peach", 1 ],


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Cooked fruit lets you avoid using sugar, but canning it doesn't. Jam allows you to use sugar to can your fruit, but IRL canned fruit can be preserved without extra sugar. This makes it easier for a player to can their fruits without relying on high level cooking recipes to create sustainable sugar. This does however lower calories from the canned fruit, because you will not be adding sugar.

Michigan State University confirms sugar isn't relevant for preservation of the food itself, but it will lose color and texture.

https://www.canr.msu.edu/news/home_canning_without_sugar

## Describe the solution

Changed the recipe and description a little bit. I'm also forced to change comestible value for canned fruit which will soft nerf food spawns, in the future I can see about converting those to canned jam spawns.

## Describe alternatives you've considered

Well I could do this in a new recipe, but Jam already exists. I really am not sure.

## Testing

Tests. Comestible calorie test might get mad but it shouldn't as the recipe should properly use inheritance of ingredients.

## Additional context

See the cooked fruit recipe?
![image](https://github.com/user-attachments/assets/bcb0b5d6-70e5-425c-9315-bbcf6a4def51)
