### PR TITLE
ci: rename `data` to `JSON`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,7 +4,7 @@ src:
 tests:
   - tests/**/*
 
-data:
+JSON:
   - data/**/*
 
 mods:


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

![image](https://github.com/user-attachments/assets/c014fdb1-4c05-4ccf-89af-df9e18037014) ![image](https://github.com/user-attachments/assets/b9183373-66ae-48ef-8756-dc20ab4392a9)

- there's no need to have separate `data` and `JSON` labels.
- the label `JSON` is widely used.
- it is argued by other dev members that `JSON` sounds less intimidating than `data`.

## Describe the solution

make [labeler](https://github.com/actions/labeler) label data paths as `JSON`
 
## Describe alternatives you've considered

rename back to `data` but let's see how it goes
