### PR TITLE
fix: Remove charge usage and item conversion from `heal_actor::finish_using`

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -3805,23 +3805,12 @@ int heal_actor::finish_using( player &healer, player &patient, item &it, hp_part
         }
     };
 
-    // TODO: make this less cursed
     if( !used_up_item_id.is_empty() ) {
-        // If the item is a tool, `make` it the new form
-        // Otherwise it probably was consumed, so create a new one
-        if( it.is_tool() || ( it.count_by_charges() && it.charges <= used_up_item_charges ) ) {
-            it.convert( used_up_item_id );
-            copy_flags( it );
-        } else {
-            if( it.count_by_charges() && it.charges > used_up_item_charges ) {
-                it.charges -= used_up_item_charges;
-            }
-            item *used_up = item::spawn_temporary( used_up_item_id, it.birthday() );
-            used_up->charges = used_up_item_charges;
-            copy_flags( *used_up );
-            for( int count = 0; count < used_up_item_quantity; count++ ) {
-                healer.i_add_or_drop( item::spawn( *used_up ) );
-            }
+        item *used_up = item::spawn_temporary( used_up_item_id, it.birthday() );
+        used_up->charges = used_up_item_charges;
+        copy_flags( *used_up );
+        for( int count = 0; count < used_up_item_quantity; count++ ) {
+            healer.i_add_or_drop( item::spawn( *used_up ) );
         }
     }
 


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

- fix #5260 
  - The issue is that `heal_actor::finish_using` uses up an extra charge or converts an item into the used up item when the charge consumption is already queued to be done at the end of `Character::consume_med()`

## Describe the solution

Complete the TODO listed in `heal_actor::finish_using` for `used_up_item` handling, making it so that that part of the code only spawns the used_up_item and doesn't touch the original item or use up their charges.

## Describe alternatives you've considered

## Testing

- [x] Spawn 5 antiseptic soaked cotton balls
  - [x] Use them and confirm that they last 5 uses.
- [x] Spawn 5 antiseptic soaked rags
  - [x] Confirm they last 5 uses.
- [x] Spawn 5 antiseptic powder
  - [x] Confirm they last 5 uses.

## Additional context

I love legacy spaghetti.