### PR TITLE
fix: antiseptic-soaked items yield correct byproducts when used, sanity-check stats, allow hydrogen peroxide too

### DIFF
--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -1765,7 +1765,7 @@
       "disinfectant_power": 2,
       "bite": 0.5,
       "move_cost": 200,
-      "used_up_item": { "id": "rag", "quantity": 2 }
+      "used_up_item": { "id": "rag", "charges": 1 }
     }
   },
   {
@@ -1786,10 +1786,10 @@
     "flags": [ "NO_INGEST" ],
     "use_action": {
       "type": "heal",
-      "disinfectant_power": 3,
-      "bite": 0.66,
-      "move_cost": 300,
-      "used_up_item": { "id": "cotton_ball", "quantity": 2 }
+      "disinfectant_power": 1,
+      "bite": 0.5,
+      "move_cost": 200,
+      "used_up_item": { "id": "cotton_ball", "charges": 1 }
     }
   },
   {

--- a/data/json/recipes/other/medical.json
+++ b/data/json/recipes/other/medical.json
@@ -313,7 +313,7 @@
     "autolearn": true,
     "charges": 4,
     "flags": [ "BLIND_EASY" ],
-    "components": [ [ [ "rag", 4 ] ], [ [ "disinfectant", 1 ] ] ]
+    "components": [ [ [ "rag", 4 ] ], [ [ "disinfectant", 1 ], [ "chem_hydrogen_peroxide", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -326,6 +326,6 @@
     "autolearn": true,
     "charges": 8,
     "flags": [ "BLIND_EASY" ],
-    "components": [ [ [ "cotton_ball", 8 ] ], [ [ "disinfectant", 1 ] ] ]
+    "components": [ [ [ "cotton_ball", 8 ] ], [ [ "disinfectant", 1 ], [ "chem_hydrogen_peroxide", 1 ] ] ]
   }
 ]


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Antiseptic-soaked cotton balls and rags duplicate the component items due to their `used_up_item` being set wrong. You use 8 cotton balls to get 8 soaked ones, and 4 rags to get 4 soaked rags, so it should not be creating 2 byproducts per use.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Set the heal actions of disinfectant-soaked rags and cotton balls to correctly produce 1 charge of byproduct instead of 2.
2. Misc: Set the disinfectant power of soaked cotton balls to be half that of disinfectant-soaked rags, because you're using twice as many balls per craft and still only 1 dose of antiseptic.
3. Misc: Allowed hydrogen peroxide as an alternative to antiseptic in the recipes, because they have the same stats.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Screaming.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.
3. Checked recipe menu, confirmed that soaking balls and rags in antiseptic indeed both uses and consumes 8 and 2 items respectively.
4. Used one of each, correctly get only 1 byproduct each.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
