### PR TITLE
fix: put dirt under the tent chairs in `FEMA_re`

### DIFF
--- a/data/json/mapgen/fema/FEMA_re_03.json
+++ b/data/json/mapgen/fema/FEMA_re_03.json
@@ -35,6 +35,7 @@
       ],
       "rotation": 1,
       "palettes": [ "FEMA_camp" ],
+      "terrain": { "c": "t_region_soil" },
       "monster": { "Z": { "monster": "mon_zombie_fat" } }
     }
   }


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Put dirt under the tent chairs in the mapgen `FEMA_re`
## Describe the solution
Dirt under the chairs.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/fd2bf341-0db0-4f30-8d34-ee465258a515">
After:
<img width="960" alt="image2" src="https://github.com/user-attachments/assets/488dba6f-bcad-4c75-8b38-c86c25378c15">