### PR TITLE
feat(balance): define itemgroups for bandit armor and weapons

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
@@ -896,8 +896,8 @@
     "//": "Imported or otherwise very obscure shotguns.",
     "items": [
       { "group": "nested_ksg-25", "prob": 15 },
-      { "group": "nested_saiga_12", "prob": 10 },
-      { "group": "nested_saiga_410", "prob": 20 },
+      { "group": "nested_saiga_12", "prob": 25 },
+      { "group": "nested_saiga_410", "prob": 10 },
       { "group": "nested_streetsweeper", "prob": 5 },
       { "group": "nested_USAS_12", "prob": 10 }
     ]
@@ -908,8 +908,8 @@
     "//": "Imported or otherwise very obscure shotguns. Actually has a decent chance of having mags instead of loose ammo.",
     "items": [
       { "group": "everyday_ksg-25", "prob": 15 },
-      { "group": "everyday_saiga_12", "prob": 10 },
-      { "group": "everyday_saiga_410", "prob": 20 },
+      { "group": "everyday_saiga_12", "prob": 25 },
+      { "group": "everyday_saiga_410", "prob": 10 },
       { "group": "everyday_streetsweeper", "prob": 5 },
       { "group": "everyday_USAS_12", "prob": 10 }
     ]
@@ -981,6 +981,7 @@
     "items": [
       { "item": "launcher_simple", "prob": 100 },
       { "item": "triple_launcher_simple", "prob": 15, "charges-min": 0, "charges-max": 3 },
+      { "item": "surv_rocket_launcher", "prob": 80 },
       { "item": "slingshot_cannon", "prob": 30 }
     ]
   },

--- a/data/json/npcs/NC_BANDIT.json
+++ b/data/json/npcs/NC_BANDIT.json
@@ -1,0 +1,404 @@
+[
+  {
+    "type": "item_group",
+    "id": "NC_BANDIT_pants_male",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "jeans", "prob": 25 },
+      { "item": "pants_leather", "prob": 25 },
+      { "item": "pants_cargo", "prob": 20 },
+      { "item": "motorbike_pants", "prob": 10 },
+      { "item": "shorts_cargo", "prob": 10 },
+      { "item": "pants_army", "prob": 5 },
+      { "item": "winter_pants_army", "prob": 5 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_BANDIT_pants_female",
+    "subtype": "distribution",
+    "entries": [
+      { "group": "NC_BANDIT_pants_male", "prob": 75 },
+      { "item": "shorts_denim", "prob": 5 },
+      { "item": "skirt_leather", "prob": 5 },
+      { "item": "skirt_armor", "prob": 5 },
+      { "item": "skirt_armor_leather", "prob": 5 },
+      { "item": "skirt_armor_plate", "prob": 5 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_BANDIT_shirt_male",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "motorbike_armor", "prob": 10 },
+      { "item": "tshirt", "prob": 25 },
+      { "item": "army_top", "prob": 20 },
+      { "item": "flag_shirt", "prob": 15 },
+      { "item": "tshirt_tour", "prob": 15 },
+      { "item": "striped_shirt", "prob": 10 },
+      { "item": "jersey", "prob": 5 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_BANDIT_shirt_female",
+    "subtype": "distribution",
+    "entries": [
+      { "group": "NC_BANDIT_shirt_male", "prob": 75 },
+      { "item": "tank_top", "prob": 5 },
+      { "item": "halter_top", "prob": 5 },
+      { "item": "corset", "prob": 15 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_BANDIT_gloves",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "null", "prob": 25 },
+      { "item": "gloves_fingerless", "prob": 15 },
+      { "item": "gloves_fingerless_mod", "prob": 10 },
+      { "item": "gloves_leather", "prob": 15 },
+      { "item": "gloves_work", "prob": 10 },
+      { "item": "gloves_tactical", "prob": 10 },
+      { "item": "winter_gloves_army", "prob": 5 },
+      { "item": "gauntlets_larmor", "prob": 5 },
+      { "item": "gauntlets_plarmor", "prob": 5 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_BANDIT_coat",
+    "subtype": "distribution",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "jacket_leather_mod", "prob": 25 },
+          { "item": "vest_leather_mod", "prob": 25 },
+          { "item": "jacket_leather", "prob": 20 },
+          { "item": "vest_leather", "prob": 20 },
+          { "item": "jacket_jean", "prob": 10 }
+        ],
+        "prob": 75
+      },
+      { "item": "hoodie", "prob": 5 },
+      { "item": "jacket_army", "prob": 5 },
+      { "item": "winter_jacket_army", "prob": 5 },
+      { "item": "duster", "prob": 5 },
+      { "item": "sleeveless_duster", "prob": 5 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_BANDIT_vest",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "null", "prob": 50 },
+      { "item": "football_armor", "prob": 10 },
+      { "item": "cuirass_scrap", "prob": 10 },
+      { "item": "armor_scrapsuit", "prob": 5 },
+      { "item": "armor_larmor", "prob": 5 },
+      { "item": "armor_plarmor", "prob": 5 },
+      { "item": "kevlar", "prob": 5 },
+      { "item": "modularvest", "prob": 5 },
+      { "item": "flotation_vest_sandbag", "prob": 5 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_BANDIT_shoes_male",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "motorbike_boots", "prob": 25 },
+      { "item": "boots_combat", "prob": 15 },
+      { "item": "boots_steel", "prob": 15 },
+      { "item": "boots", "prob": 5 },
+      { "item": "boots_hiking", "prob": 5 },
+      { "item": "boots_western", "prob": 10 },
+      { "item": "boots_scrap", "prob": 10 },
+      { "item": "boots_larmor", "prob": 5 },
+      { "item": "boots_plarmor", "prob": 5 },
+      { "item": "sandal_armor", "prob": 5 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_BANDIT_shoes_female",
+    "subtype": "distribution",
+    "entries": [
+      { "group": "NC_BANDIT_shoes_male", "prob": 75 },
+      { "item": "knee_high_boots", "prob": 15 },
+      { "item": "thigh_high_boots", "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_BANDIT_masks",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "null", "prob": 50 },
+      { "item": "bandana", "prob": 15 },
+      { "item": "mask_hockey", "prob": 15 },
+      { "item": "mask_rioter", "prob": 10 },
+      { "item": "mask_bal", "prob": 5 },
+      { "item": "mask_gas", "prob": 5 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_BANDIT_hat",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "null", "prob": 10 },
+      { "item": "hat_ball", "prob": 5 },
+      { "item": "hat_boonie", "prob": 5 },
+      { "item": "cowboy_hat", "prob": 5 },
+      { "item": "pickelhaube", "prob": 5 },
+      { "item": "helmet_skid", "prob": 10 },
+      { "item": "helmet_motor", "prob": 10 },
+      { "item": "helmet_bike", "prob": 5 },
+      { "item": "helmet_football", "prob": 5 },
+      { "item": "hat_hard", "prob": 5 },
+      { "item": "hat_hard_hooded", "prob": 5 },
+      { "item": "helmet_ball", "prob": 5 },
+      { "item": "helmet_larmor", "prob": 5 },
+      { "item": "helmet_plarmor", "prob": 5 },
+      { "item": "helmet_skull", "prob": 5 },
+      { "item": "helmet_army", "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_BANDIT_extra",
+    "subtype": "distribution",
+    "entries": [
+      {
+        "distribution": [
+          { "group": "accessory_bracelet", "prob": 15 },
+          { "group": "accessory_earring", "prob": 20 },
+          { "group": "accessory_necklace", "prob": 15 },
+          { "group": "accessory_ring", "prob": 20 },
+          { "group": "accessory_teeth", "prob": 25 },
+          { "item": "ear_spool", "prob": 5 }
+        ],
+        "prob": 40
+      },
+      {
+        "distribution": [
+          { "item": "elbow_pads", "prob": 25 },
+          { "item": "knee_pads", "prob": 25 },
+          { "item": "armguard_hard", "prob": 20 },
+          { "item": "legguard_hard", "prob": 20 },
+          { "item": "vambrace_larmor", "prob": 10 }
+        ],
+        "prob": 50
+      },
+      {
+        "distribution": [
+          { "item": "shield_wooden", "prob": 10 },
+          { "item": "shield_spiked", "prob": 5 },
+          { "item": "shield_welded", "prob": 5 },
+          { "item": "shield_ballistic", "prob": 5 }
+        ],
+        "prob": 10
+      }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_BANDIT_bashing",
+    "subtype": "distribution",
+    "//": "Ranged bandits only sometimes get a weapon if they rolled higher melee skills.",
+    "entries": [ { "group": "NC_THUG_bashing", "prob": 75 }, { "item": "null", "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "distribution",
+    "id": "NC_BANDIT_cutting",
+    "entries": [ { "group": "NC_THUG_cutting", "prob": 75 }, { "item": "null", "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "distribution",
+    "id": "NC_BANDIT_stabbing",
+    "entries": [ { "group": "NC_THUG_stabbing", "prob": 75 }, { "item": "null", "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "distribution",
+    "id": "NC_BANDIT_unarmed",
+    "entries": [ { "group": "NC_THUG_unarmed", "prob": 75 }, { "item": "null", "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_BANDIT_pistol",
+    "subtype": "distribution",
+    "//": "Chance of rare guns, some specific individual obscure guns, and bonus weight to make specific common guns show up more often.",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "hand_crossbow", "prob": 10 },
+          { "item": "glock_17", "prob": 55 },
+          { "item": "glock_19", "prob": 40 },
+          { "item": "glock_20", "prob": 20 },
+          { "item": "glock_21", "prob": 15 },
+          { "item": "glock_22", "prob": 30 },
+          { "item": "glock_31", "prob": 15 },
+          { "item": "hptc9", "prob": 15 },
+          { "item": "hptcf380", "prob": 10 },
+          { "item": "hptjcp", "prob": 10 },
+          { "item": "hptjhp", "prob": 10 }
+        ],
+        "prob": 50
+      },
+      { "group": "guns_pistol_common", "prob": 25 },
+      {
+        "distribution": [
+          { "item": "colt_army", "prob": 50 },
+          { "item": "colt_navy", "prob": 50 },
+          { "item": "colt_saa", "prob": 60 },
+          { "item": "draco", "prob": 30 },
+          { "item": "lemat_revolver", "prob": 50 },
+          { "item": "makarov", "prob": 50 }
+        ],
+        "prob": 10
+      },
+      { "group": "guns_pistol_rare", "prob": 5 },
+      { "group": "guns_pistol_improvised", "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_BANDIT_shotgun",
+    "subtype": "distribution",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "browning_a5", "prob": 15 },
+          { "item": "shotgun_410", "prob": 30 },
+          { "item": "shotgun_d", "prob": 40 },
+          { "item": "shotgun_s", "prob": 30 },
+          { "item": "winchester_1887", "prob": 5 },
+          { "item": "winchester_1897", "prob": 10 }
+        ],
+        "prob": 50
+      },
+      { "group": "guns_shotgun_common", "prob": 25 },
+      { "distribution": [ { "item": "saiga_12", "prob": 25 }, { "item": "saiga_410", "prob": 10 } ], "prob": 10 },
+      { "group": "guns_shotgun_rare", "prob": 5 },
+      { "group": "guns_shotgun_improvised", "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_BANDIT_rifle",
+    "subtype": "distribution",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "crossbow", "prob": 25 },
+          { "item": "rep_crossbow", "prob": 10 },
+          { "item": "bullet_crossbow", "prob": 10 },
+          { "item": "compcrossbow", "prob": 20 },
+          { "item": "compositecrossbow", "prob": 10 },
+          { "item": "aksemi", "prob": 15 },
+          { "item": "ar15", "prob": 30 },
+          { "item": "m1a", "prob": 40 },
+          { "item": "mosin44", "prob": 10 },
+          { "item": "mosin91_30", "prob": 20 },
+          { "item": "sks", "prob": 40 }
+        ],
+        "prob": 50
+      },
+      { "group": "guns_rifle_common", "prob": 25 },
+      {
+        "distribution": [
+          { "item": "crossbow_carbon", "prob": 10 },
+          { "item": "huge_crossbow", "prob": 5 },
+          { "item": "ak47", "prob": 50 },
+          { "item": "ak74", "prob": 50 }
+        ],
+        "prob": 10
+      },
+      { "group": "guns_rifle_rare", "prob": 5 },
+      { "group": "guns_rifle_improvised", "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_BANDIT_smg",
+    "subtype": "distribution",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "mac_10", "prob": 40 },
+          { "item": "mac_11", "prob": 20 },
+          { "item": "sten", "prob": 100 },
+          { "item": "tec9", "prob": 20 }
+        ],
+        "prob": 50
+      },
+      { "group": "guns_smg_common", "prob": 25 },
+      {
+        "distribution": [ { "item": "ppsh", "prob": 150 }, { "item": "skorpion_61", "prob": 100 }, { "item": "skorpion_82", "prob": 100 } ],
+        "prob": 10
+      },
+      { "group": "guns_smg_rare", "prob": 5 },
+      { "group": "guns_smg_improvised", "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_BANDIT_launcher",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "null", "prob": 25 },
+      { "item": "flamethrower", "prob": 25 },
+      { "item": "m79", "prob": 15 },
+      { "item": "RPG", "prob": 10 },
+      { "group": "guns_launcher_improvised", "prob": 25 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_BANDIT_throw",
+    "subtype": "distribution",
+    "entries": [ { "group": "npc_throw", "prob": 75 }, { "group": "survivor_grenades", "prob": 75 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_BANDIT_archery",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "selfbow", "prob": 20 },
+      { "item": "shortbow", "prob": 20 },
+      { "item": "compbow", "prob": 20 },
+      { "item": "compositebow_short", "prob": 20 },
+      { "item": "longbow", "prob": 20 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_BANDIT_misc",
+    "subtype": "distribution",
+    "entries": [
+      { "group": "stash_food", "prob": 15 },
+      { "group": "salty_snacks", "prob": 10 },
+      { "group": "drugs_heal_simple", "prob": 10 },
+      {
+        "distribution": [
+          { "group": "baddrugs", "prob": 50 },
+          { "group": "smokedrugs", "prob": 25 },
+          { "group": "liquor_and_spirits", "prob": 25 }
+        ],
+        "prob": 15
+      },
+      { "group": "survivor_grenades", "prob": 10, "count": [ 1, 3 ] },
+      { "group": "meth_ingredients", "prob": 10 },
+      { "group": "contraband", "prob": 10 },
+      { "group": "gear_survival", "prob": 10 },
+      { "group": "book_survival", "prob": 10 }
+    ]
+  }
+]

--- a/data/json/npcs/NC_THUG.json
+++ b/data/json/npcs/NC_THUG.json
@@ -1,18 +1,205 @@
 [
   {
     "type": "item_group",
+    "id": "NC_THUG_pants_male",
+    "subtype": "distribution",
+    "//": "Thugs use the exact same Mad Max getup as ranged bandits.",
+    "entries": [ { "group": "NC_BANDIT_pants_male", "prob": 100 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_THUG_pants_female",
+    "subtype": "distribution",
+    "entries": [ { "group": "NC_BANDIT_pants_female", "prob": 100 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_THUG_shirt_male",
+    "subtype": "distribution",
+    "entries": [ { "group": "NC_BANDIT_shirt_male", "prob": 100 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_THUG_shirt_female",
+    "subtype": "distribution",
+    "entries": [ { "group": "NC_BANDIT_shirt_female", "prob": 100 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_THUG_gloves",
+    "subtype": "distribution",
+    "entries": [ { "group": "NC_BANDIT_gloves", "prob": 100 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_THUG_coat",
+    "subtype": "distribution",
+    "entries": [ { "group": "NC_BANDIT_coat", "prob": 100 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_THUG_vest",
+    "subtype": "distribution",
+    "entries": [ { "group": "NC_BANDIT_vest", "prob": 100 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_THUG_shoes_male",
+    "subtype": "distribution",
+    "entries": [ { "group": "NC_BANDIT_shoes_male", "prob": 100 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_THUG_shoes_female",
+    "subtype": "distribution",
+    "entries": [ { "group": "NC_BANDIT_shoes_female", "prob": 100 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_THUG_masks",
+    "subtype": "distribution",
+    "entries": [ { "group": "NC_BANDIT_masks", "prob": 100 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_THUG_hat",
+    "subtype": "distribution",
+    "entries": [ { "group": "NC_BANDIT_hat", "prob": 100 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_THUG_extra",
+    "subtype": "distribution",
+    "entries": [ { "group": "NC_BANDIT_extra", "prob": 100 } ]
+  },
+  {
+    "type": "item_group",
     "id": "NC_THUG_bashing",
     "subtype": "distribution",
     "entries": [
       { "item": "hammer_sledge", "prob": 10 },
-      { "item": "hammer_sledge_short", "prob": 10 },
-      { "item": "spear_rebar", "prob": 20 },
-      { "item": "bat", "prob": 20 },
-      { "item": "crowbar", "prob": 20 },
-      { "item": "q_staff", "prob": 20 },
-      { "item": "bwirebat", "prob": 20 },
-      { "item": "bat_metal", "prob": 20 },
+      { "item": "hammer_sledge_short", "prob": 5 },
+      { "item": "shovel_short", "prob": 5 },
+      { "item": "crowbar", "prob": 5 },
+      { "item": "bat", "prob": 10 },
+      { "item": "bat_metal", "prob": 5 },
+      { "item": "bwirebat", "prob": 5 },
+      { "item": "nailbat", "prob": 5 },
+      { "item": "pool_cue", "prob": 5 },
+      { "item": "pipe", "prob": 5 },
+      { "item": "makeshift_sap", "prob": 5 },
+      { "item": "q_staff", "prob": 5 },
+      { "item": "qstaff_extended", "prob": 5 },
+      { "item": "nailboard", "prob": 10 },
+      { "item": "club_spiked", "prob": 10 },
       { "item": "homewrecker", "prob": 5 }
     ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_THUG_cutting",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "machete", "prob": 10 },
+      { "item": "machete_gimmick", "prob": 5 },
+      { "item": "kukri", "prob": 5 },
+      { "item": "ax", "prob": 10 },
+      { "item": "fire_ax", "prob": 10 },
+      { "item": "hatchet", "prob": 5 },
+      { "item": "crash_axe", "prob": 5 },
+      { "item": "sword_wood", "prob": 5 },
+      { "item": "sword_nail", "prob": 5 },
+      { "item": "sword_crude", "prob": 5 },
+      { "item": "razor_macuahuitl", "prob": 10 },
+      { "item": "makeshift_machete", "prob": 10 },
+      { "item": "makeshift_scythe_war", "prob": 5 },
+      { "item": "makeshift_halberd", "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_THUG_stabbing",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "switchblade", "prob": 5 },
+      { "item": "knife_hunting", "prob": 5 },
+      { "item": "knife_rambo", "prob": 5 },
+      { "item": "knife_combat", "prob": 10 },
+      { "item": "knife_trench", "prob": 15 },
+      { "item": "iceaxe", "prob": 5 },
+      { "item": "grip_hook", "prob": 5 },
+      { "item": "makeshift_knife", "prob": 5 },
+      { "item": "bowling_axe", "prob": 5 },
+      { "item": "spear_pipe", "prob": 10 },
+      { "item": "spear_knife", "prob": 15 },
+      { "item": "spear_rebar", "prob": 5 },
+      { "item": "spear_homemade_halfpike", "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_THUG_unarmed",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "knuckle_brass", "prob": 40 },
+      { "item": "punch_dagger", "prob": 40 },
+      { "item": "impact_knuckle", "prob": 10 },
+      { "item": "cestus", "prob": 10 },
+      { "item": "spiked_boxing", "prob": 10 },
+      { "item": "knuckle_nail", "prob": 10 },
+      { "item": "knuckle_steel", "prob": 10 },
+      { "item": "knuckle_katar", "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_THUG_pistol",
+    "subtype": "distribution",
+    "//": "Melee bandits only sometimes get a weapon if they rolled higher ranged skills.",
+    "entries": [ { "group": "NC_BANDIT_pistol", "prob": 75 }, { "item": "null", "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_THUG_shotgun",
+    "subtype": "distribution",
+    "entries": [ { "group": "NC_BANDIT_shotgun", "prob": 75 }, { "item": "null", "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_THUG_rifle",
+    "subtype": "distribution",
+    "entries": [ { "group": "NC_BANDIT_rifle", "prob": 75 }, { "item": "null", "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_THUG_smg",
+    "subtype": "distribution",
+    "entries": [ { "group": "NC_BANDIT_smg", "prob": 75 }, { "item": "null", "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_THUG_launcher",
+    "subtype": "distribution",
+    "//": "Reduce odds even further if we're trying to give a melee bandit a big bada-boom.",
+    "entries": [ { "group": "NC_BANDIT_launcher", "prob": 50 }, { "item": "null", "prob": 50 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_THUG_throw",
+    "subtype": "distribution",
+    "entries": [ { "group": "NC_BANDIT_throw", "prob": 75 }, { "item": "null", "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_THUG_archery",
+    "subtype": "distribution",
+    "entries": [ { "group": "NC_BANDIT_archery", "prob": 75 }, { "item": "null", "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_THUG_misc",
+    "subtype": "distribution",
+    "//": "As with armor, directly use same group that bandits use.",
+    "entries": [ { "group": "NC_BANDIT_misc", "prob": 100 } ]
   }
 ]

--- a/data/json/npcs/classes.json
+++ b/data/json/npcs/classes.json
@@ -203,6 +203,29 @@
   },
   {
     "type": "npc_class",
+    "id": "NC_BANDIT",
+    "name": { "str": "Bandit" },
+    "job_description": "I'm in it for the loot and fresh meat.",
+    "traits": [
+      { "group": "BG_survival_story_CRIMINAL" },
+      { "group": "NPC_starting_traits" },
+      { "group": "Appearance_demographics" }
+    ],
+    "common": false,
+    "bonus_dex": { "rng": [ 1, 3 ] },
+    "bonus_per": { "rng": [ 1, 3 ] },
+    "skills": [
+      { "skill": "ALL", "level": { "sum": [ { "dice": [ 3, 2 ] }, { "constant": -4 } ] } },
+      { "skill": "gun", "bonus": { "rng": [ 2, 4 ] } },
+      { "skill": "launcher", "bonus": { "rng": [ 0, 2 ] } },
+      { "skill": "smg", "bonus": { "rng": [ 0, 2 ] } },
+      { "skill": "pistol", "bonus": { "rng": [ 1, 5 ] } },
+      { "skill": "rifle", "bonus": { "rng": [ 1, 5 ] } },
+      { "skill": "shotgun", "bonus": { "rng": [ 1, 5 ] } }
+    ]
+  },
+  {
+    "type": "npc_class",
     "id": "NC_SCAVENGER",
     "name": { "str": "Scavenger" },
     "job_description": "I'm just trying to survive.",

--- a/data/json/npcs/npc.json
+++ b/data/json/npcs/npc.json
@@ -15,7 +15,7 @@
     "id": "bandit",
     "//": "Generic pistol/rifle focused guard for the Hell's Raiders faction.",
     "name_suffix": "Bandit",
-    "class": "NC_SCAVENGER",
+    "class": "NC_BANDIT",
     "attitude": 0,
     "mission": 8,
     "chat": "TALK_DONE",

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_carpenter2.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_carpenter2.json
@@ -4,7 +4,7 @@
     "id": "ranch_construction_2",
     "//": "Construction skill trainer",
     "name_suffix": "Carpenter",
-    "class": "NC_THUG",
+    "class": "NC_COWBOY",
     "attitude": 0,
     "mission": 7,
     "chat": "TALK_RANCH_CONSTRUCTION_2",

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_farmer1.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_farmer1.json
@@ -4,7 +4,7 @@
     "id": "ranch_farmer_1",
     "//": "Flavor",
     "name_suffix": "Farmer",
-    "class": "NC_THUG",
+    "class": "NC_FARMER",
     "attitude": 0,
     "mission": 7,
     "chat": "TALK_RANCH_FARMER_1",


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This finally actually defines itemgroups for bandit and thug NPC items, so they favor more biker and Mad Max style gear instead of mostly using the same itemgroups as generic NPCs.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Defined a new NPC class `NC_BANDIT`, which is similar to `NC_THUG` except getting a broad focus on ranged skills instead of melee.
2. Set generic ranged bandits to use `NC_BANDIT` instead of `NC_SCAVENGER`.
3. Defined a bunch of accompanying itemgroups for bandit armor. Generally leans a lot more towards the expected biker and Mad Max asthetic as you'd expect with less normal clothes. Their "extra" items also include less jewelry but a better variety of such when they do spawn it, allowing for a few other alternatives like elbow+knee pads or even shields.
4. Rigged it so that `NC_THUG` automatically gets the same armor choices as `NC_BANDIT` where relevant.
5. Defined a proper, full set of relevant weapon itemgroups for `NC_BANDIT` and `NC_THUG`. They're also rigged such that thugs that choose to spawn with a ranged weapon will randomly pick either bandit weapons or nothing, and vice-versa with melee bandits only sometimes rolling the thug's weapon list.
6. Misc: Adjust the weights of saigas in `guns_shotgun_obscure` and `carried_guns_shotgun_obscure` because it was odd that the .410 variant was more common than the 12 gauge one, and I wanted it to stay consistent with the rate of appearance in bandit inventory.
7. Misc: Fixed crude rocket launcher not being present in `guns_launcher_improvised`.
8. Misc; Set two tacoma ranch NPCs to use different NPC classes that were set to count as thugs, a random farmer and a construction worker.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Defining these via overrides instead to use a giant collection for their armor items.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.
3. Debugged in a bandit camp and warped there.
4. No errors, looked at their items and they seem to more or less fit expectations.
5. Debug-killed them all to examine inventory contents, also more or less as expected.

<details><summary>Screenshots:</summary>

![1](https://github.com/user-attachments/assets/cc903c25-08f3-446d-83ea-c2a96a0c0efc)
![2](https://github.com/user-attachments/assets/22ac9d01-32e3-41ed-9a1c-de04e2f7c3f6)
![3](https://github.com/user-attachments/assets/6efd8e39-e09d-4720-b9ee-b1bc5db46215)
![4](https://github.com/user-attachments/assets/d3bf2c80-75d7-42a5-85df-c59570b463aa)
![5](https://github.com/user-attachments/assets/b87230ed-988b-4935-89f6-9f47e1ecfb75)
![body1](https://github.com/user-attachments/assets/e0a5046c-7934-4338-9b4e-0353abc56b8d)
![body2](https://github.com/user-attachments/assets/869eece0-5a63-47ce-88c1-0b33a8aabeb4)
![body3](https://github.com/user-attachments/assets/ac91cd0c-baa2-4518-8bbf-89c4bc296501)
![body4](https://github.com/user-attachments/assets/b6d14b51-a5ed-4676-8e69-8e0a3b802e1b)
![body5](https://github.com/user-attachments/assets/2a5cffbc-6a24-4b30-84c8-c38d90393441)

</details>

One thing I noticed however is I still sometimes see masks and vests only present in the default NPC itemgroups, which I assume happens when it tries to spawn a null result for that slot?

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
