### PR TITLE
fix: put dirt under the tent chairs in `FEMA_trc`

### DIFF
--- a/data/json/mapgen/fema/FEMA_trc_03.json
+++ b/data/json/mapgen/fema/FEMA_trc_03.json
@@ -12,14 +12,14 @@
         ".Fffffffffffffffffffffff",
         ".f......................",
         ".f..tt.t................",
-        ".f..--------**========..",
+        ".f..||||||||**========..",
         ".f..|sCooCC|,,,XX,,XX=..",
         ".f..|~~~~~~|,,,XX,,XX=..",
         ".f..|~~CC~~C,,,,,,,,,=..",
         ".f..+~~CC~~C,,,,,,,XX=..",
         ".f..|~~~~~~|,,,,,,,XX=..",
         ".f..|sUUUUR|,,,,,,,,,=..",
-        ".f..---+----,,,,,,,,,=..",
+        ".f..|||+||||,,,,,,,,,=..",
         ".f..*,,,,,,,,,,,,,,,,*..",
         ".f..*,,,,,,,,,,,,,,,,*..",
         ".f..=,,,TT,,,,,,TT,,,=..",
@@ -35,7 +35,7 @@
       ],
       "rotation": 1,
       "palettes": [ "FEMA_camp" ],
-      "terrain": { "C": "t_floor", "o": "t_floor", "R": "t_floor", "s": "t_floor", "U": "t_floor" },
+      "terrain": { "C": "t_floor", "o": "t_floor", "R": "t_floor", "s": "t_floor", "U": "t_floor", "c": "t_region_soil" },
       "items": { "C": { "item": "kitchen", "chance": 30 }, "X": { "item": "mil_food", "chance": 70 } }
     }
   }


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Put dirt under the tent chairs in the mapgen `FEMA_trc`
## Describe the solution
Dirt under the chairs.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/2137acae-68a6-4d8d-8248-474aa8099143">
After:
<img width="960" alt="image2" src="https://github.com/user-attachments/assets/2fa7e967-1b44-49dc-bd4d-8bfdd81c685d">