### PR TITLE
fix: Correctly add class mutations when class is non-exclusive

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1384,6 +1384,11 @@ void known_magic::learn_spell( const spell_type *sp, Character &guy, bool force 
                     return;
                 }
             }
+            else {
+                guy.set_mutation( sp->spell_class );
+                guy.on_mutation_gain( sp->spell_class );
+                guy.add_msg_if_player( sp->spell_class.obj().desc() );
+            }
         }
     }
     if( force || can_learn_spell( guy, sp->id ) ) {

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1383,8 +1383,7 @@ void known_magic::learn_spell( const spell_type *sp, Character &guy, bool force 
                 } else {
                     return;
                 }
-            }
-            else {
+            } else {
                 guy.set_mutation( sp->spell_class );
                 guy.on_mutation_gain( sp->spell_class );
                 guy.add_msg_if_player( sp->spell_class.obj().desc() );


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

As noted by Phoenix in the Discord, the mutations were not being properly applied in Magical Nights. I then realized "Oh wait, that's a self-own because *I'm the one who added the check to get rid of the prompt when it was unnecessary*". This fixes it so that the mutations do get properly added

## Describe the solution

Just adds the mutation-adding code to an `else` block

## Describe alternatives you've considered

- Explode

- Re-arrange the code somehow

## Testing

Compiled locally, and it works
![image](https://github.com/user-attachments/assets/0bbc23a9-e332-479b-a73b-ff0b691adaf2)


## Additional context

The rare self-own
