### PR TITLE
feat(content): 3D print plastic bags

### DIFF
--- a/data/json/recipes/other/containers.json
+++ b/data/json/recipes/other/containers.json
@@ -710,5 +710,18 @@
     "qualities": [ { "id": "HAMMER_FINE", "level": 1 }, { "id": "SCREW_FINE", "level": 1 }, { "id": "SAW_M_FINE", "level": 1 } ],
     "using": [ [ "welding_standard", 10 ], [ "steel_standard", 1 ] ],
     "components": [ [ [ "2lcanteen", 1 ] ] ]
+  },
+  {
+    "result": "bag_plastic",
+    "type": "recipe",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_CONTAINERS",
+    "id_suffix": "printed",
+    "skill_used": "computer",
+    "skills_required": [ [ "fabrication", 2 ] ],
+    "autolearn": true,
+    "time": "1 m",
+    "using": [ [ "3d_printing_standard", 1 ] ],
+    "components": [ [ [ "plastic_chunk", 1 ] ] ]
   }
 ]

--- a/data/json/recipes/other/containers.json
+++ b/data/json/recipes/other/containers.json
@@ -714,6 +714,7 @@
   {
     "result": "bag_plastic",
     "type": "recipe",
+    "result_mult": 10,
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_CONTAINERS",
     "id_suffix": "printed",


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

We lacked this recipe, most other plastic items were 3D printable. Plastic bags are for vacuum sealing food.

## Describe the solution

Adds plastic bag recipe, same cost as not using a 3D printer, same recipe as the small plastic bottle.

## Describe alternatives you've considered

None

## Testing

Tests

## Additional context

![image](https://github.com/user-attachments/assets/28426859-e513-4ca2-864d-71a557a7830c)

