### PR TITLE
fix: missing roofs in the trailer park outside the cities

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -2674,8 +2674,11 @@
     "id": "Trailer Park",
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "trailerparksmall0_north" },
+      { "point": [ 0, 0, 1 ], "overmap": "trailerparksmall0_roof_north" },
       { "point": [ 1, 0, 0 ], "overmap": "trailerparksmall1_north" },
-      { "point": [ 2, 0, 0 ], "overmap": "trailerparksmall2_north" }
+      { "point": [ 1, 0, 1 ], "overmap": "trailerparksmall1_roof_north" },
+      { "point": [ 2, 0, 0 ], "overmap": "trailerparksmall2_north" },
+      { "point": [ 2, 0, 1 ], "overmap": "trailerparksmall2_roof_north" }
     ],
     "connections": [ { "point": [ 1, -1, 0 ], "connection": "local_road", "from": [ 1, 0, 0 ] } ],
     "locations": [ "wilderness" ],


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Fix because the trailer park `overmap_special`, the one placed outside the cities doesn't use roofs.
## Describe the solution
Modify `Trailer Park` in json/overmap/overmap_special/specials.json to make it place `trailerparksmall0_roof`, `trailerparksmall1_roof` and `trailerparksmall2_roof`.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/1030c8bb-a185-4937-9a7d-996e15f57d03">
After:
<img width="960" alt="image2" src="https://github.com/user-attachments/assets/2644cd04-42b2-4434-9488-2402f5482f07">