### PR TITLE
docs: Atomic builds documentation

### DIFF
--- a/doc/src/content/docs/en/dev/guides/building/atomic_cmake.md
+++ b/doc/src/content/docs/en/dev/guides/building/atomic_cmake.md
@@ -1,0 +1,69 @@
+---
+title: CMake builds on Atomic Distros
+---
+
+This article goes over building BN on distros that are immutable, and thus where containerization is the desired solution rather than layering the dependencies onto your base install.
+
+# Example: Fedora Atomic-based (Bazzite)
+
+:::note
+
+This section is based off of the process taken to help another contributor build on Bazzite
+
+:::
+
+:::caution
+
+As of writing this, Bazzite's default container image is fedora-toolbox:38, which results in having to edit the dependencies installation script. On distros that grab a more modern version of Fedora as their image (or by manually grabbing one yourself), you can instead just use the standard Fedora script
+
+:::
+
+## Setting up the container
+
+Bazzite, being based on the Atomic versions of Fedora Linux, has the containerization tool known as Toolbx pre-installed. As such, it is the method we will be using for this example.
+
+To start, create a toolbox with:
+
+```sh
+$ toolbox create
+```
+
+This will likely prompt you to download an image to base the container on. If this asks about downloading "fedora-toolbox:38" (or any other number) or asks about downloading Fedora Workstation, then you're on the right track!
+Answer 'y'es, and wait for the container to be built. This can take some time, depending on your hardware, but is fortunately a step you should only need to take once.
+
+After creating your toolbox, navigate to your Cataclysm-BN folder **with a `src` folder.** (I.e. your local copy of the github repo or your downloaded source code). There, you can enter into your toolbox with a simple command:
+
+```sh
+$ toolbox enter
+```
+
+You'll need to run this command every time you intend on building in order to enter into your container.
+
+Once you're in your toolbox, you can install your dependencies with a Fedora-based distro installation script.
+For Bazzite, that script looks like:
+
+```sh
+$ sudo dnf install git cmake clang ninja-build mold ccache \
+  SDL2-devel SDL2_image-devel SDL2_ttf-devel SDL2_mixer-devel \
+  freetype glibc bzip2 zlib-ng libvorbis ncurses gettext flac-devel
+```
+
+After this, your container is set up for all your building needs in the future! Now, onto the steps of actually building.
+
+## Building
+
+If you aren't already in your container, in the Cataclysm-BN folder, then navigate to the folder and enter into the container.
+From there, you may run the cmake script to generate its files (don't worry about creating the build folder yourself, cmake will automatically generate it if it's not present already)
+For Bazzite, this looks like:
+
+```sh
+cmake     -B build     -G Ninja     -DCATA_CCACHE=ON     -DCMAKE_C_COMPILER=clang     -DCMAKE_CXX_COMPILER=clang++     -DCMAKE_INSTALL_PREFIX=$HOME/.local/share     -DJSON_FORMAT=ON     -DCMAKE_BUILD_TYPE=RelWithDebInfo     -DCURSES=OFF     -DTILES=ON     -DSOUND=ON     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON     -DCATA_CLANG_TIDY_PLUGIN=OFF     -DLUA=ON     -DBACKTRACE=ON     -DLINKER=mold     -DUSE_XDG_DIR=ON     -DUSE_HOME_DIR=OFF     -DUSE_PREFIX_DATA_DIR=OFF     -DUSE_TRACY=ON     -DTRACY_VERSION=master     -DTRACY_ON_DEMAND=ON     -DTRACY_ONLY_IPV4=ON
+```
+
+Assuming all goes well, you should now have your CMake files generated! Now, all you need to do is run the Ninja command to actually build.
+
+```sh
+$ ninja -C build -j $(nproc) -k 0 cataclysm-bn-tiles
+```
+
+`$(nproc)` just grabs the number of "threads" your CPU has, but you can specify a lower number if you'd prefer to use less threads for compiling (albeit at the cost of performance).

--- a/doc/src/content/docs/en/dev/guides/building/atomic_cmake.md
+++ b/doc/src/content/docs/en/dev/guides/building/atomic_cmake.md
@@ -2,7 +2,8 @@
 title: CMake builds on Atomic Distros
 ---
 
-This article goes over building BN on distros that are immutable, and thus where containerization is the desired solution rather than layering the dependencies onto your base install.
+This article goes over building BN on distros that are immutable, and thus where containerization is
+the desired solution rather than layering the dependencies onto your base install.
 
 # Example: Fedora Atomic-based (Bazzite)
 
@@ -10,13 +11,17 @@ Note: This section is based off of the process taken to help another contributor
 
 :::caution
 
-As of writing this, Bazzite's default container image is fedora-toolbox:38, which results in having to edit the dependencies installation script. On distros that grab a more modern version of Fedora as their image (or by manually grabbing one yourself), you can instead just use the standard Fedora script
+As of writing this, Bazzite's default container image is fedora-toolbox:38, which results in having
+to edit the dependencies installation script. On distros that grab a more modern version of Fedora
+as their image (or by manually grabbing one yourself), you can instead just use the standard Fedora
+script
 
 :::
 
 ## Setting up the container
 
-Bazzite, being based on the Atomic versions of Fedora Linux, has the containerization tool known as Toolbx pre-installed. As such, it is the method we will be using for this example.
+Bazzite, being based on the Atomic versions of Fedora Linux, has the containerization tool known as
+Toolbx pre-installed. As such, it is the method we will be using for this example.
 
 To start, create a toolbox with:
 
@@ -24,19 +29,24 @@ To start, create a toolbox with:
 $ toolbox create
 ```
 
-This will likely prompt you to download an image to base the container on. If this asks about downloading "fedora-toolbox:38" (or any other number) or asks about downloading Fedora Workstation, then you're on the right track!
-Answer 'y'es, and wait for the container to be built. This can take some time, depending on your hardware, but is fortunately a step you should only need to take once.
+This will likely prompt you to download an image to base the container on. If this asks about
+downloading "fedora-toolbox:38" (or any other number) or asks about downloading Fedora Workstation,
+then you're on the right track! Answer 'y'es, and wait for the container to be built. This can take
+some time, depending on your hardware, but is fortunately a step you should only need to take once.
 
-After creating your toolbox, navigate to your Cataclysm-BN folder **with a `src` folder.** (I.e. your local copy of the github repo or your downloaded source code). There, you can enter into your toolbox with a simple command:
+After creating your toolbox, navigate to your Cataclysm-BN folder **with a `src` folder.** (I.e.
+your local copy of the github repo or your downloaded source code). There, you can enter into your
+toolbox with a simple command:
 
 ```sh
 $ toolbox enter
 ```
 
-You'll need to run this command every time you intend on building in order to enter into your container.
+You'll need to run this command every time you intend on building in order to enter into your
+container.
 
-Once you're in your toolbox, you can install your dependencies with a Fedora-based distro installation script.
-For Bazzite, that script looks like:
+Once you're in your toolbox, you can install your dependencies with a Fedora-based distro
+installation script. For Bazzite, that script looks like:
 
 ```sh
 $ sudo dnf install git cmake clang ninja-build mold ccache \
@@ -44,22 +54,26 @@ $ sudo dnf install git cmake clang ninja-build mold ccache \
   freetype glibc bzip2 zlib-ng libvorbis ncurses gettext flac-devel
 ```
 
-After this, your container is set up for all your building needs in the future! Now, onto the steps of actually building.
+After this, your container is set up for all your building needs in the future! Now, onto the steps
+of actually building.
 
 ## Building
 
-If you aren't already in your container, in the Cataclysm-BN folder, then navigate to the folder and enter into the container.
-From there, you may run the cmake script to generate its files (don't worry about creating the build folder yourself, cmake will automatically generate it if it's not present already)
-For Bazzite, this looks like:
+If you aren't already in your container, in the Cataclysm-BN folder, then navigate to the folder and
+enter into the container. From there, you may run the cmake script to generate its files (don't
+worry about creating the build folder yourself, cmake will automatically generate it if it's not
+present already) For Bazzite, this looks like:
 
 ```sh
 cmake     -B build     -G Ninja     -DCATA_CCACHE=ON     -DCMAKE_C_COMPILER=clang     -DCMAKE_CXX_COMPILER=clang++     -DCMAKE_INSTALL_PREFIX=$HOME/.local/share     -DJSON_FORMAT=ON     -DCMAKE_BUILD_TYPE=RelWithDebInfo     -DCURSES=OFF     -DTILES=ON     -DSOUND=ON     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON     -DCATA_CLANG_TIDY_PLUGIN=OFF     -DLUA=ON     -DBACKTRACE=ON     -DLINKER=mold     -DUSE_XDG_DIR=ON     -DUSE_HOME_DIR=OFF     -DUSE_PREFIX_DATA_DIR=OFF     -DUSE_TRACY=ON     -DTRACY_VERSION=master     -DTRACY_ON_DEMAND=ON     -DTRACY_ONLY_IPV4=ON
 ```
 
-Assuming all goes well, you should now have your CMake files generated! Now, all you need to do is run the Ninja command to actually build.
+Assuming all goes well, you should now have your CMake files generated! Now, all you need to do is
+run the Ninja command to actually build.
 
 ```sh
 $ ninja -C build -j $(nproc) -k 0 cataclysm-bn-tiles
 ```
 
-`$(nproc)` just grabs the number of "threads" your CPU has, but you can specify a lower number if you'd prefer to use less threads for compiling (albeit at the cost of performance).
+`$(nproc)` just grabs the number of "threads" your CPU has, but you can specify a lower number if
+you'd prefer to use less threads for compiling (albeit at the cost of performance).

--- a/doc/src/content/docs/en/dev/guides/building/atomic_cmake.md
+++ b/doc/src/content/docs/en/dev/guides/building/atomic_cmake.md
@@ -6,11 +6,7 @@ This article goes over building BN on distros that are immutable, and thus where
 
 # Example: Fedora Atomic-based (Bazzite)
 
-:::note
-
-This section is based off of the process taken to help another contributor build on Bazzite
-
-:::
+Note: This section is based off of the process taken to help another contributor build on Bazzite
 
 :::caution
 

--- a/doc/src/content/docs/en/dev/guides/building/cmake.md
+++ b/doc/src/content/docs/en/dev/guides/building/cmake.md
@@ -150,7 +150,7 @@ profiler may look like:
 ```sh
 mkdir -p build
 cmake \
-  -B build-fedora \
+  -B build \
   -G Ninja \
   -DCATA_CCACHE=ON \
   -DCMAKE_C_COMPILER=clang-17 \


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

With atomic linux distros gaining popularity, having instructions for them seemed worthy of a docs page. Plus, as I helped Royal Fox out with compiling on Bazzite anyway, I already had the information all ready to go.

Additionally, I noticed a small inconsistency with the CMake command on the normal CMake page, and thus I edited it to better reflect the command right before it.

## Describe the solution

- Adds a page for cmake builds on atomic distros
- Fixes a small inconsistency in the cmake command on the main cmake build page

## Describe alternatives you've considered

- Put the atomic guide on the same page as the rest of the instructions for cmake

Fair, but I felt that it would have bloated it a bit and in general that it was better for a separation between atomic and non-atomic (Funnily enough, embodying the exact ideals of the containerization used within)

## Testing

Royal Fox can compile (after some bumps from Bazzite choosing to download a Fedora 38 image for its container for some silly reason, but we worked through it), so I consider the process verified enough.

## Additional context

Hopefully my style/writing of the atomic docs article is adequate
