### PR TITLE
fix: Other tools zone is named correctly

### DIFF
--- a/data/mods/Item_Category_Overhaul/zones.json
+++ b/data/mods/Item_Category_Overhaul/zones.json
@@ -2,8 +2,8 @@
   {
     "id": "LOOT_TOOLS",
     "type": "LOOT_ZONE",
-    "name": "Loot: Unsorted Tools",
-    "description": "Destination for unsorted tools."
+    "name": "Loot: Other Tools",
+    "description": "Destination for other tools."
   },
   {
     "id": "LOOT_ENTRY_TOOLS",


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [ ] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

When I was directed to rename unsorted tools to Other tools via review comment, We managed to all miss that the zone was never renamed. That was mostly on me as author. This fixes it.

## Describe the solution

Rename it.

## Describe alternatives you've considered

Nah

## Testing

Tests

## Additional context

aaaaaaaaa
