### PR TITLE
feat(balance): reduce `armor_multiplier` for larger and military-issue explosives

### DIFF
--- a/data/json/ammo_effects.json
+++ b/data/json/ammo_effects.json
@@ -140,17 +140,17 @@
   {
     "id": "FRAG_BIG",
     "type": "ammo_effect",
-    "explosion": { "fragment": { "impact": { "damage_type": "bullet", "amount": 100, "armor_multiplier": 3 }, "range": 7 } }
+    "explosion": { "fragment": { "impact": { "damage_type": "bullet", "amount": 100, "armor_multiplier": 2 }, "range": 7 } }
   },
   {
     "id": "FRAG",
     "type": "ammo_effect",
-    "explosion": { "fragment": { "impact": { "damage_type": "bullet", "amount": 50, "armor_multiplier": 3 }, "range": 5 } }
+    "explosion": { "fragment": { "impact": { "damage_type": "bullet", "amount": 50, "armor_multiplier": 2 }, "range": 5 } }
   },
   {
     "id": "FRAG_SMALL",
     "type": "ammo_effect",
-    "explosion": { "fragment": { "impact": { "damage_type": "bullet", "amount": 30, "armor_multiplier": 3 }, "range": 3 } }
+    "explosion": { "fragment": { "impact": { "damage_type": "bullet", "amount": 30, "armor_multiplier": 2.5 }, "range": 3 } }
   },
   {
     "id": "MININUKE_MOD",

--- a/data/json/items/resources/misc.json
+++ b/data/json/items/resources/misc.json
@@ -197,11 +197,7 @@
     "to_hit": -6,
     "flags": [ "TRADER_AVOID" ],
     "bashing": 18,
-    "explosion": {
-      "damage": 50,
-      "radius": 3,
-      "fragment": { "impact": { "damage_type": "bullet", "amount": 50, "armor_multiplier": 3 }, "range": 5 }
-    },
+    "explosion": { "damage": 70, "radius": 5 },
     "explode_in_fire": true
   },
   {

--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -198,7 +198,7 @@
     "explosion": {
       "damage": 70,
       "radius": 6,
-      "fragment": { "impact": { "damage_type": "bullet", "amount": 100, "armor_multiplier": 3 }, "range": 10 }
+      "fragment": { "impact": { "damage_type": "bullet", "amount": 100, "armor_multiplier": 2.5 }, "range": 10 }
     },
     "use_action": {
       "target": "dynamite_bomb_act",
@@ -232,7 +232,7 @@
     "explosion": {
       "damage": 70,
       "radius": 6,
-      "fragment": { "impact": { "damage_type": "bullet", "amount": 100, "armor_multiplier": 3 }, "range": 10 }
+      "fragment": { "impact": { "damage_type": "bullet", "amount": 100, "armor_multiplier": 2.5 }, "range": 10 }
     },
     "use_action": {
       "type": "explosion",
@@ -242,7 +242,7 @@
       "explosion": {
         "damage": 70,
         "radius": 6,
-        "fragment": { "impact": { "damage_type": "bullet", "amount": 100, "armor_multiplier": 3 }, "range": 10 }
+        "fragment": { "impact": { "damage_type": "bullet", "amount": 100, "armor_multiplier": 2.5 }, "range": 10 }
       }
     },
     "flags": [ "TRADER_AVOID", "BOMB", "ALLOWS_REMOTE_USE" ]
@@ -641,7 +641,7 @@
       "explosion": {
         "damage": 40,
         "radius": 3,
-        "fragment": { "impact": { "damage_type": "bullet", "amount": 80, "armor_multiplier": 3 }, "range": 6 }
+        "fragment": { "impact": { "damage_type": "bullet", "amount": 80, "armor_multiplier": 2 }, "range": 6 }
       }
     },
     "flags": [ "BOMB", "TRADER_AVOID" ]
@@ -1187,9 +1187,9 @@
     "color": "red",
     "explode_in_fire": true,
     "explosion": {
-      "power": 25000,
-      "//": "Fire would burn away/degrade some of the ANFO before the detonator would trigger.",
-      "shrapnel": 12600
+      "damage": 250,
+      "radius": 12,
+      "fragment": { "impact": { "damage_type": "bullet", "amount": 100, "armor_multiplier": 2.5 }, "range": 20 }
     },
     "use_action": {
       "target": "tool_anfo_charge_act",
@@ -1224,7 +1224,7 @@
     "explosion": {
       "damage": 250,
       "radius": 12,
-      "fragment": { "impact": { "damage_type": "bullet", "amount": 100, "armor_multiplier": 3 }, "range": 20 }
+      "fragment": { "impact": { "damage_type": "bullet", "amount": 100, "armor_multiplier": 2.5 }, "range": 20 }
     },
     "use_action": {
       "type": "explosion",
@@ -1232,9 +1232,10 @@
       "sound_msg": "Tick.",
       "no_deactivate_msg": "You've already lit the fuse - run!",
       "explosion": {
-        "power": 48900,
         "//": "Fire exposure would burn away/degrade some of the ANFO before the detonator would trigger.",
-        "shrapnel": 12600
+        "damage": 250,
+        "radius": 12,
+        "fragment": { "impact": { "damage_type": "bullet", "amount": 100, "armor_multiplier": 2.5 }, "range": 20 }
       }
     },
     "flags": [ "BOMB", "TRADER_AVOID", "ALLOWS_REMOTE_USE" ]
@@ -1257,7 +1258,7 @@
     "explosion": {
       "damage": 50,
       "radius": 6,
-      "fragment": { "impact": { "damage_type": "bullet", "amount": 150, "armor_multiplier": 3 }, "range": 20 }
+      "fragment": { "impact": { "damage_type": "bullet", "amount": 150, "armor_multiplier": 2.5 }, "range": 20 }
     },
     "use_action": {
       "target": "tool_small_improvised_fragmentation_device_act",
@@ -1290,7 +1291,7 @@
     "explosion": {
       "damage": 50,
       "radius": 6,
-      "fragment": { "impact": { "damage_type": "bullet", "amount": 150, "armor_multiplier": 3 }, "range": 20 }
+      "fragment": { "impact": { "damage_type": "bullet", "amount": 150, "armor_multiplier": 2.5 }, "range": 20 }
     },
     "use_action": {
       "type": "explosion",
@@ -1300,7 +1301,7 @@
       "explosion": {
         "damage": 50,
         "radius": 6,
-        "fragment": { "impact": { "damage_type": "bullet", "amount": 150, "armor_multiplier": 3 }, "range": 20 }
+        "fragment": { "impact": { "damage_type": "bullet", "amount": 150, "armor_multiplier": 2.5 }, "range": 20 }
       }
     },
     "flags": [ "BOMB", "TRADER_AVOID", "ALLOWS_REMOTE_USE" ]
@@ -1325,7 +1326,7 @@
     "explosion": {
       "damage": 200,
       "radius": 15,
-      "fragment": { "impact": { "damage_type": "bullet", "amount": 80, "armor_multiplier": 3 }, "range": 20 }
+      "fragment": { "impact": { "damage_type": "bullet", "amount": 80, "armor_multiplier": 2.5 }, "range": 20 }
     },
     "use_action": {
       "target": "tool_improvised_barrel_bomb_act",
@@ -1361,7 +1362,7 @@
     "explosion": {
       "damage": 200,
       "radius": 15,
-      "fragment": { "impact": { "damage_type": "bullet", "amount": 80, "armor_multiplier": 3 }, "range": 20 }
+      "fragment": { "impact": { "damage_type": "bullet", "amount": 80, "armor_multiplier": 2.5 }, "range": 20 }
     },
     "use_action": {
       "type": "explosion",
@@ -1371,7 +1372,7 @@
       "explosion": {
         "damage": 200,
         "radius": 15,
-        "fragment": { "impact": { "damage_type": "bullet", "amount": 80, "armor_multiplier": 3 }, "range": 20 }
+        "fragment": { "impact": { "damage_type": "bullet", "amount": 80, "armor_multiplier": 2.5 }, "range": 20 }
       }
     },
     "flags": [ "BOMB", "TRADER_AVOID", "ALLOWS_REMOTE_USE" ]


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This adjusts the impact against armor of fragmentation explosives, which is planned to make them a bit less wonky against some armored enemies.

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/5082 technically, though it will need a companion PR I have planned to get a bit better at actually tackling this problem, and even then I'm not yet 100% happy with the results.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Lowered the `armor_multiplier` for fragmentation of dynamite bombs, ANFO charges, improvised frag devices, and barrel bombs from 3 to 2.5, matching that of 12 gauge scrap shot.
2. Lowered the `armor_multiplier` of proper frag grenade's fragmentation from 3 to 2, matching that of 12 gauge standard buckshot.
3. Lowered the armor multiplier of the `FRAG_SMALL` ammo effect from 3 to 2.5.
4. Lowered the armor multiplier of the `FRAG` and `FRAG_BIG` ammo effects from 3 to 2.
5. Misc: Fixed ANFO charges still using old-style explosion power and shrapnel info in some parts.
6. Misc: Removed fragmentation from disassembled explosive cannon shells when dumped into fire, instead giving them the same explosive info as the `EXPLOSIVE_BIG` ammo effect their ammo version has when fired.

In short, all regular cheapo homemade explosives use the worse multiplier for armor so will bounce off any amount of decent armor, big-ass makeshift explosives throw bigger chunks that'll hurt some armored enemies they otherwise can't touch, while proper military explosives will do more to actually harm basic armored enemies like zombie soldiers.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Screaming about implementing armor coverage percentages for zombies and making it affect AoE damage.
2. Adding some level of `armor_penetration` to explosives to make things a bit easier and to allow it to tear through mundane clothes a bit better. If I picked an amount like 20 arpen for frag grenades, then at 2x armor multiplier and with planned adjustments to monster armor a point-blank grenade explosion would still just barely not be enough to one-shot a zombie soldier.
3. Lowering the armor multiplier of frag grenades down even further to 1.5 to be equivalent to flechette shells. I looked at the math for this and it would still only deal an expected total of 65 damage to a zombier soldier standing directly on top of a grenade (and that's when paired with the planned adjustments to armor), so at best it'd make two-shotting soldier zombies with close grenades more reliable, and make them easily three-shot with frag-only hits. Even going as far down as 1x falls just shy of even a potential one-shot at an expected total of 90 damage (zombie soldiers having 100 HP), while also making it no longer possible for players to fully negate the frag damage with a ceramic MBR vest.
4. Buffing the damage of explosives in general, and frag grenades in particular. I would've been inclined to suggest 50 blast damage and 100 fragmentation damage, but I ran the math and that STILL would not be enough to one-shot a soldier zombie standing directly on top of one, even with my planned nerfs to their armor and with a 2x armor mult. It would still meet the goal of letting a player wearing an MBR vest take zero damage when standing just outside the direct blast radius, but their head would take a bit of damage through an army helmet.

Some combination of the above alternatives might add up to being reliable about one-shotting zombie soldiers at point-blank range without being too deadly to a suitably-armored player who manages to get out of the main blast range, but I'd have to dick around with it to figure out the exact combo, and it will likely need to wait until after the armor audit anyway, so I'll settle for taking a step in the right direction and letting zombie soldiers actually take any damage at all from fragmentation.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.
3. Did some math along with testing point-blank grenade explosions on zombie soldiers.

Without this change, having 35 ballistic armor multiplied by 3 due to armor_multiplier means they take zero damage from a standard military grenade's fragmentation, only taking blast damage if close enough to it. With this change, expected fragmentation damage is 10.

I have a companion PR planned that will audit armor levels for various zeds to make them match some current armor items as used by the player, when paired with this change expect 20 fragmentation damage and for blast damage to more reliably deal 30 damage, meaning two close-proximity frag grenades should kill a zombie soldier.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
