### PR TITLE
fix: use regional terrain for `music_venue`

### DIFF
--- a/data/json/mapgen/music_venue.json
+++ b/data/json/mapgen/music_venue.json
@@ -1,12 +1,57 @@
 [
   {
+    "type": "mapgen",
     "method": "json",
+    "om_terrain": "music_venue",
     "object": {
       "fill_ter": "t_floor",
+      "rows": [
+        "        ss             '",
+        "       -ss-----|||W||   ",
+        "       -sssssssW...#|   ",
+        "       -sssssss+....|   ",
+        " ||||||||||||||||..|||| ",
+        " |ccccc7.............^| ",
+        " |cecccc...#...#......| ",
+        " |cccccc..#t#.#t#....#| ",
+        " |cccccc...#...#.....t| ",
+        " |cccccc.....#.......#| ",
+        " |c7cccc..#.#t#.......| ",
+        " |cccccc..t..#..#t#..H| ",
+        " |ccecc7..#..........H| ",
+        " |||||||.............H| ",
+        " |&|&|&|...#####......| ",
+        " |+|+|+|..aaaaaaa.....| ",
+        " |.....+..a.....a.....| ",
+        " |SaSah|.....{{{a....^| ",
+        " ||||||||www|www||+|||| ",
+        "      <-bCCCTCCCCCCCbb- ",
+        "       -TCCCCCCCCCCCCC- ",
+        "       -bCCCCCCCCCCCCC- ",
+        "       ---------------- ",
+        "                        "
+      ],
+      "terrain": {
+        "+": "t_door_c",
+        "-": "t_railing",
+        ".": "t_floor",
+        "C": "t_concrete",
+        "T": "t_concrete",
+        "W": "t_window_no_curtains",
+        " ": "t_region_groundcover_urban",
+        "'": "t_region_groundcover_urban",
+        "b": "t_concrete",
+        "c": "t_carpet_red",
+        "e": "t_carpet_red",
+        "s": "t_sidewalk",
+        "w": "t_wall_glass",
+        "|": "t_wall_w",
+        "<": "t_gutter_downspout",
+        "7": "t_carpet_red"
+      },
       "furniture": {
         "'": "f_street_light",
         "#": "f_chair",
-        "&": "f_toilet",
         "H": "f_sofa",
         "S": "f_sink",
         "T": "f_table",
@@ -56,64 +101,13 @@
         { "furn": "f_speaker_cabinet", "x": 2, "y": [ 5, 12 ], "repeat": [ 1, 2 ] },
         { "furn": "f_speaker_cabinet", "x": [ 3, 4 ], "y": [ 5, 12 ], "repeat": [ 1, 4 ] }
       ],
-      "place_toilets": [ { "x": 2, "y": 14 }, { "x": 4, "y": 14 }, { "x": 6, "y": 14 } ],
-      "rows": [
-        "________ss_____________'",
-        "_______rss-----|||W||___",
-        "______ursssssssW...#|___",
-        "____dufrsssssss+....|___",
-        "_||||||||||||||||..||||_",
-        "_|ccccc7.............^|_",
-        "_|cecccc...#...#......|_",
-        "_|cccccc..#t#.#t#....#|_",
-        "_|cccccc...#...#.....t|_",
-        "_|cccccc.....#.......#|_",
-        "_|c7cccc..#.#t#.......|_",
-        "_|cccccc..t..#..#t#..H|_",
-        "_|ccecc7..#..........H|_",
-        "_|||||||.............H|_",
-        "_|&|&|&|...#####......|_",
-        "_|g|D|D|..aaaaaaa.....|_",
-        "_|.....+..a.....a.....|_",
-        "_|SaSah|.....{{{a....^|_",
-        "_||||||||www|www||+||||_",
-        "_____u<|bCCCTCCCCCCCbb|_",
-        "______urTCCCCCCCCCCCCCr_",
-        "_______rbCCCCCCCCCCCCCr_",
-        "_______----------------_",
-        "________________________"
-      ],
-      "terrain": {
-        "+": "t_door_c",
-        "-": "t_railing_h",
-        ".": "t_floor",
-        "C": "t_concrete",
-        "D": "t_door_metal_c",
-        "T": "t_concrete",
-        "W": "t_window_no_curtains",
-        "_": [ [ "t_grass", 6 ], [ "t_dirt", 2 ], [ "t_grass_long", 4 ], [ "t_underbrush", 2 ] ],
-        "'": "t_dirt",
-        "b": "t_concrete",
-        "c": "t_carpet_red",
-        "d": "t_dirt",
-        "e": "t_carpet_red",
-        "f": "t_shrub",
-        "g": "t_door_metal_o",
-        "r": "t_railing_v",
-        "s": "t_sidewalk",
-        "u": "t_underbrush",
-        "w": "t_wall_glass",
-        "|": "t_wall_w",
-        "<": "t_gutter_downspout",
-        "7": "t_carpet_red"
-      }
-    },
-    "om_terrain": "music_venue",
-    "type": "mapgen",
-    "weight": 100
+      "toilets": { "&": {  } }
+    }
   },
   {
+    "type": "mapgen",
     "method": "json",
+    "om_terrain": "music_venue_roof",
     "object": {
       "fill_ter": "t_flat_roof",
       "rows": [
@@ -160,10 +154,7 @@
           "y": [ 7, 15 ]
         }
       ]
-    },
-    "om_terrain": "music_venue_roof",
-    "type": "mapgen",
-    "weight": 100
+    }
   },
   {
     "method": "json",


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Use regional terrain for the mapgen `music_venue`
## Describe the solution
Replace non-regional terrain with regional terrain.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/3f1a93ce-af54-42f2-bfef-7072e5b2b3ce">
After:
<img width="960" alt="image2" src="https://github.com/user-attachments/assets/1ac3707b-c346-4741-b9b4-1898f1f5d450">