### PR TITLE
fix: replace the gate in the corners of several mapgen in the FEMA camp into chain link fence

### DIFF
--- a/data/json/mapgen/fema/FEMA_tlc_01.json
+++ b/data/json/mapgen/fema/FEMA_tlc_01.json
@@ -9,7 +9,7 @@
       "fill_ter": "t_dirt",
       "rows": [
         "........................",
-        ".Fffffffffffffffffffffff",
+        ".fffffffffffffffffffffff",
         ".f......................",
         ".f......................",
         ".f..========**========..",

--- a/data/json/mapgen/fema/FEMA_trc_01.json
+++ b/data/json/mapgen/fema/FEMA_trc_01.json
@@ -9,7 +9,7 @@
       "fill_ter": "t_dirt",
       "rows": [
         "........................",
-        ".Fffffffffffffffffffffff",
+        ".fffffffffffffffffffffff",
         ".f......................",
         ".f......................",
         ".f..========**========..",

--- a/data/json/mapgen/fema/FEMA_trc_03.json
+++ b/data/json/mapgen/fema/FEMA_trc_03.json
@@ -9,7 +9,7 @@
       "fill_ter": "t_dirt",
       "rows": [
         "........................",
-        ".Fffffffffffffffffffffff",
+        ".fffffffffffffffffffffff",
         ".f......................",
         ".f..tt.t................",
         ".f..||||||||**========..",


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Replace the gates in the corners of several mapgen in the FEMA camp with chain link fence.
## Describe the solution
Replace the gates in the corners of the fence in `FEMA_tlc`, `FEMA_trc` with a chain link fence.
## Describe alternatives you've considered
none
## Additional context
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/5f6f5db5-55dc-4038-a813-0176a1d06a5e">