### PR TITLE
fix: shift power generation of wind turbine location to the rotor itself, add `ELECTRIC_GRID` flag

### DIFF
--- a/data/json/furniture_and_terrain/furniture-industrial.json
+++ b/data/json/furniture_and_terrain/furniture-industrial.json
@@ -234,8 +234,7 @@
         { "item": "pipe", "count": [ 1, 2 ] }
       ]
     },
-    "deconstruct": { "items": [ { "item": "cable", "charges": [ 200, 800 ] }, { "item": "pipe", "count": [ 2, 4 ] } ] },
-    "active": [ "steady_consumer", { "power": -1, "consume_every": "300 s" } ]
+    "deconstruct": { "items": [ { "item": "cable", "charges": [ 200, 800 ] }, { "item": "pipe", "count": [ 2, 4 ] } ] }
   },
   {
     "type": "furniture",
@@ -265,7 +264,50 @@
         { "item": "power_supply", "count": [ 0, 2 ] },
         { "item": "metal_tank_little", "count": [ 0, 6 ] }
       ]
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "f_wind_turbine_rotor",
+    "name": "wind turbine rotor assembly",
+    "description": "A large, bladed turbine meant for generating power from wind.  Spinning idly in the breeze, it could be connected to and provide power to a base built nearby.  The turbine could be salvaged for local power generation elsewhere instead, but it would provide far less power than a fully-operational dedicated turbine.",
+    "symbol": "$",
+    "color": "yellow",
+    "looks_like": "vp_heavy_duty_military_rotor",
+    "move_cost_mod": 4,
+    "coverage": 55,
+    "required_str": -1,
+    "flags": [ "TRANSPARENT", "MOUNTABLE" ],
+    "deconstruct": {
+      "items": [
+        { "item": "frame", "prob": 80 },
+        { "item": "chain", "count": [ 1, 2 ] },
+        { "item": "pipe", "count": [ 1, 2 ] },
+        { "item": "sheet_metal", "count": [ 1, 3 ] },
+        { "item": "steel_lump", "count": [ 1, 3 ] },
+        { "item": "steel_chunk", "count": [ 3, 6 ] },
+        { "item": "xl_wind_turbine", "count": 1 }
+      ]
     },
-    "active": [ "steady_consumer", { "power": -1, "consume_every": "15 s" } ]
+    "bash": {
+      "str_min": 32,
+      "str_max": 80,
+      "sound": "crash!",
+      "sound_fail": "clang!",
+      "items": [
+        { "item": "sheet_metal", "prob": 75 },
+        { "item": "sheet_metal_small", "count": [ 10, 20 ] },
+        { "item": "steel_lump", "count": [ 4, 8 ] },
+        { "item": "steel_chunk", "count": [ 5, 10 ] },
+        { "item": "scrap", "count": [ 6, 12 ] },
+        { "item": "solder_wire", "charges": [ 10, 20 ] },
+        { "item": "cable", "charges": [ 10, 15 ] },
+        { "item": "pipe", "count": [ 0, 3 ] }
+      ],
+      "//": "destroy_threshold equal to str_min instead of str_max due to delicate electronics",
+      "ranged": { "reduction": [ 16, 32 ], "destroy_threshold": 32, "block_unaimed_chance": "50%" }
+    },
+    "//": "Matches the power output across 5 minutes that the capacitors and conduits provided on first implementation",
+    "active": [ "steady_consumer", { "power": -49, "consume_every": "300 s" } ]
   }
 ]

--- a/data/json/furniture_and_terrain/terrain-manufactured.json
+++ b/data/json/furniture_and_terrain/terrain-manufactured.json
@@ -1495,48 +1495,5 @@
       "items": [ { "item": "pointy_stick", "count": 4 }, { "item": "string_6", "count": 4 }, { "item": "tarp", "count": 1 } ]
     },
     "flags": [ "TRANSPARENT", "FLAMMABLE", "THIN_OBSTACLE", "INDOORS", "MOUNTABLE", "EASY_DECONSTRUCT" ]
-  },
-  {
-    "type": "terrain",
-    "id": "t_wind_turbine_rotor",
-    "name": "wind turbine rotor assembly",
-    "description": "A large, bladed turbine meant for generating power from wind.  Spinning idly in the breeze trying to power a grid that's since gone dark, the turbine could be salvaged for local power generation instead.",
-    "symbol": "$",
-    "color": "yellow",
-    "looks_like": "vp_heavy_duty_military_rotor",
-    "move_cost": 8,
-    "coverage": 55,
-    "flags": [ "TRANSPARENT", "BASHABLE" ],
-    "deconstruct": {
-      "ter_set": "t_metal_floor_no_roof",
-      "items": [
-        { "item": "frame", "prob": 80 },
-        { "item": "chain", "count": [ 1, 2 ] },
-        { "item": "pipe", "count": [ 1, 2 ] },
-        { "item": "sheet_metal", "count": [ 1, 3 ] },
-        { "item": "steel_lump", "count": [ 1, 3 ] },
-        { "item": "steel_chunk", "count": [ 3, 6 ] },
-        { "item": "xl_wind_turbine", "count": 1 }
-      ]
-    },
-    "bash": {
-      "str_min": 32,
-      "str_max": 80,
-      "sound": "crash!",
-      "sound_fail": "clang!",
-      "ter_set": "t_metal_floor_no_roof",
-      "items": [
-        { "item": "sheet_metal", "prob": 75 },
-        { "item": "sheet_metal_small", "count": [ 10, 20 ] },
-        { "item": "steel_lump", "count": [ 4, 8 ] },
-        { "item": "steel_chunk", "count": [ 5, 10 ] },
-        { "item": "scrap", "count": [ 6, 12 ] },
-        { "item": "solder_wire", "charges": [ 10, 20 ] },
-        { "item": "cable", "charges": [ 10, 15 ] },
-        { "item": "pipe", "count": [ 0, 3 ] }
-      ],
-      "//": "destroy_threshold equal to str_min instead of str_max due to delicate electronics",
-      "ranged": { "reduction": [ 16, 32 ], "destroy_threshold": 32, "block_unaimed_chance": "50%" }
-    }
   }
 ]

--- a/data/json/mapgen/wind_turbine.json
+++ b/data/json/mapgen/wind_turbine.json
@@ -160,7 +160,7 @@
         "                        ",
         "                        "
       ],
-      "furniture": { "I": "f_electrical_conduit", "C": "f_capacitor" },
+      "furniture": { "I": "f_electrical_conduit", "C": "f_capacitor", "W": "f_wind_turbine_rotor" },
       "terrain": {
         " ": "t_open_air",
         "H": "t_ladder_up_down",
@@ -172,7 +172,7 @@
         "|": "t_machinery_heavy",
         "I": "t_metal_floor_no_roof",
         "#": "t_wall_metal",
-        "W": "t_wind_turbine_rotor"
+        "W": "t_metal_floor_no_roof"
       }
     }
   },

--- a/data/json/obsoletion/uncategorized.json
+++ b/data/json/obsoletion/uncategorized.json
@@ -407,5 +407,48 @@
       "remove_trap": true,
       "spawn_items": [ "shotgun_d", "string_6" ]
     }
+  },
+  {
+    "type": "terrain",
+    "id": "t_wind_turbine_rotor",
+    "name": "wind turbine rotor assembly",
+    "description": "A large, bladed turbine meant for generating power from wind.  Spinning idly in the breeze trying to power a grid that's since gone dark, the turbine could be salvaged for local power generation instead.",
+    "symbol": "$",
+    "color": "yellow",
+    "looks_like": "vp_heavy_duty_military_rotor",
+    "move_cost": 8,
+    "coverage": 55,
+    "flags": [ "TRANSPARENT", "BASHABLE" ],
+    "deconstruct": {
+      "ter_set": "t_metal_floor_no_roof",
+      "items": [
+        { "item": "frame", "prob": 80 },
+        { "item": "chain", "count": [ 1, 2 ] },
+        { "item": "pipe", "count": [ 1, 2 ] },
+        { "item": "sheet_metal", "count": [ 1, 3 ] },
+        { "item": "steel_lump", "count": [ 1, 3 ] },
+        { "item": "steel_chunk", "count": [ 3, 6 ] },
+        { "item": "xl_wind_turbine", "count": 1 }
+      ]
+    },
+    "bash": {
+      "str_min": 32,
+      "str_max": 80,
+      "sound": "crash!",
+      "sound_fail": "clang!",
+      "ter_set": "t_metal_floor_no_roof",
+      "items": [
+        { "item": "sheet_metal", "prob": 75 },
+        { "item": "sheet_metal_small", "count": [ 10, 20 ] },
+        { "item": "steel_lump", "count": [ 4, 8 ] },
+        { "item": "steel_chunk", "count": [ 5, 10 ] },
+        { "item": "scrap", "count": [ 6, 12 ] },
+        { "item": "solder_wire", "charges": [ 10, 20 ] },
+        { "item": "cable", "charges": [ 10, 15 ] },
+        { "item": "pipe", "count": [ 0, 3 ] }
+      ],
+      "//": "destroy_threshold equal to str_min instead of str_max due to delicate electronics",
+      "ranged": { "reduction": [ 16, 32 ], "destroy_threshold": 32, "block_unaimed_chance": "50%" }
+    }
   }
 ]

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -6761,6 +6761,6 @@
     "locations": [ "field" ],
     "city_distance": [ 8, 40 ],
     "occurrences": [ 0, 20 ],
-    "flags": [ "CLASSIC", "WILDERNESS" ]
+    "flags": [ "CLASSIC", "WILDERNESS", "ELECTRIC_GRID" ]
   }
 ]


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

We are once again screaming at wind turbines. Makes it so the free powergen that snuck into https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4447 is instead tied to the spinny thing so taking it off makes it stop, but also had to migrate it to a furniture because `active` doesn't work on terrain.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Added the `ELECTRIC_GRID` flag to the overmap special for wind turbines, since the apparent idea is you can use them for free power if you connect your base to one since it has free powergen furniture in it. However...
2. Removed the `active` data from electrical conduits and capacitor banks. Their power supply rate was noted to be fast enough to risk creating lag for some players, we might end up using that furniture elsewhere that have no business generating free power from nothing, and moreover it would look extremely weird to get free power from a wind turbine after you've climbed up there and stripped the actual physical turbine off of it. Speaking of...
3. Migrated the rotor assembly from terrain to furniture, gave it active data, at a rate of power generation equal to what all the capacitors and conduits provided previously, but over 5 minutes to reduce lag.
4. Updated description of the rotor assembly accordingly.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Coding in terrain having support for `active` data just for this.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.
3. Warped over to a turbine and installed a grid battery at the base, it starts charging after a while.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

https://www.youtube.com/watch?v=ahVsa0jAdy0