### PR TITLE
feat(balance): allow sheathing throwing knives and throwing axes, add a storage item for throwing knives

### DIFF
--- a/data/json/itemgroups/Clothing_Gear/clothing.json
+++ b/data/json/itemgroups/Clothing_Gear/clothing.json
@@ -3588,9 +3588,10 @@
           { "item": "bandolier_rifle", "prob": 20 },
           { "item": "bandolier_shotgun", "prob": 10 },
           { "item": "bandolier_wrist", "prob": 5 },
-          { "item": "quiver", "prob": 30 },
+          { "item": "quiver", "prob": 25 },
           { "item": "quiver_large", "prob": 20 },
-          { "item": "torso_bandolier_shotgun", "prob": 5 }
+          { "item": "torso_bandolier_shotgun", "prob": 5 },
+          { "item": "bandolier_knife", "prob": 5 }
         ],
         "prob": 25
       },

--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -341,6 +341,7 @@
       [ "hat_sombrero", 5 ],
       [ "bandolier_shotgun", 8 ],
       [ "torso_bandolier_shotgun", 3 ],
+      [ "bandolier_knife", 3 ],
       [ "holster", 8 ],
       [ "shoulder_holster", 4 ],
       [ "bootstrap", 2 ],

--- a/data/json/itemgroups/Locations_MapExtras/mall_item_groups.json
+++ b/data/json/itemgroups/Locations_MapExtras/mall_item_groups.json
@@ -336,7 +336,8 @@
       [ "cowboy_hat", 20 ],
       [ "tophat", 25 ],
       [ "hat_sombrero", 25 ],
-      [ "apron_leather", 20 ]
+      [ "apron_leather", 20 ],
+      [ "bandolier_knife", 15 ]
     ]
   },
   {

--- a/data/json/items/armor/bandolier.json
+++ b/data/json/items/armor/bandolier.json
@@ -282,5 +282,35 @@
     "material_thickness": 1,
     "use_action": { "type": "bandolier", "capacity": 12, "ammo": [ "40x46mm", "40x53mm" ], "draw_cost": 20 },
     "flags": [ "WATER_FRIENDLY", "WAIST", "OVERSIZE" ]
+  },
+  {
+    "id": "bandolier_knife",
+    "type": "ARMOR",
+    "name": { "str": "throwing knife bandolier" },
+    "description": "A bandolier worn across the chest with small leather sheathes sewn on.  Able to hold up to ten small knives, whether throwing knives or other small blades.  Activate to sheath or draw a knife.",
+    "weight": "140 g",
+    "volume": "250 ml",
+    "price": "19 USD",
+    "price_postapoc": "15 USD",
+    "material": [ "leather" ],
+    "symbol": "[",
+    "looks_like": "bandolier_rifle",
+    "color": "brown",
+    "covers": [ "torso" ],
+    "coverage": 10,
+    "encumbrance": 1,
+    "max_encumbrance": 3,
+    "material_thickness": 1,
+    "use_action": {
+      "type": "holster",
+      "holster_prompt": "Sheath knife",
+      "holster_msg": "You sheath your %s",
+      "multi": 10,
+      "min_volume": "15 ml",
+      "max_volume": "250 ml",
+      "draw_cost": 50,
+      "flags": [ "SHEATH_KNIFE" ]
+    },
+    "flags": [ "WATER_FRIENDLY", "WAIST", "OVERSIZE" ]
   }
 ]

--- a/data/json/items/ranged/throwing.json
+++ b/data/json/items/ranged/throwing.json
@@ -99,7 +99,7 @@
     "bashing": 10,
     "cutting": 17,
     "thrown_damage": [ { "damage_type": "bash", "amount": 6 }, { "damage_type": "cut", "amount": 16 } ],
-    "flags": [ "SHEATH_AXE" ]
+    "flags": [ "SHEATH_AXE", "BELT_CLIP" ]
   },
   {
     "type": "GENERIC",

--- a/data/json/items/ranged/throwing.json
+++ b/data/json/items/ranged/throwing.json
@@ -98,7 +98,8 @@
     "to_hit": -1,
     "bashing": 10,
     "cutting": 17,
-    "thrown_damage": [ { "damage_type": "bash", "amount": 6 }, { "damage_type": "cut", "amount": 16 } ]
+    "thrown_damage": [ { "damage_type": "bash", "amount": 6 }, { "damage_type": "cut", "amount": 16 } ],
+    "flags": [ "SHEATH_AXE" ]
   },
   {
     "type": "GENERIC",
@@ -115,7 +116,8 @@
     "weight": "268 g",
     "bashing": 1,
     "cutting": 10,
-    "thrown_damage": [ { "damage_type": "stab", "amount": 14 } ]
+    "thrown_damage": [ { "damage_type": "stab", "amount": 14 } ],
+    "flags": [ "SHEATH_KNIFE" ]
   },
   {
     "id": "throwing_stick",

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -4981,16 +4981,14 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "fancy_sunglasses",
-          "throwing_knife",
-          "throwing_knife",
-          "throwing_knife",
-          "throwing_knife",
-          "throwing_knife",
-          "throwing_knife"
-        ],
-        "entries": [ { "item": "knife_combat", "container-item": "bootsheath" } ]
+        "items": [ "fancy_sunglasses" ],
+        "entries": [
+          {
+            "item": "bandolier_knife",
+            "contents-item": [ "throwing_knife", "throwing_knife", "throwing_knife", "throwing_knife", "throwing_knife", "throwing_knife" ]
+          },
+          { "item": "knife_combat", "container-item": "bootsheath" }
+        ]
       },
       "male": [
         "boxer_briefs",

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -149,6 +149,18 @@
     "components": [ [ [ "leather", 8 ] ] ]
   },
   {
+    "result": "bandolier_knife",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_STORAGE",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "time": "1 h 20 m",
+    "autolearn": true,
+    "using": [ [ "sewing_standard", 10 ] ],
+    "components": [ [ [ "leather", 8 ] ] ]
+  },
+  {
     "result": "torso_bandolier_shotgun",
     "type": "recipe",
     "category": "CC_ARMOR",


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This makes it possible to actually store throwing knives and axes somewhere other than loose in your inventory, and adds an item that caters to one of said throwing weapons.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Added the `SHEATH_KNIFE` flag to throwing knives.
2. Added the `SHEATH_AXE` and `BELT_CLIP` flags to throwing axes. Right now the former flag is irrelevant for this item as axe ring holsters are too big (also too big for hatchets I should add), but the latter works.
3. Added a new item, throwing knife bandolier. Serves the role of a torso-waist slot item capable of holding up to 10 knives, with the same 250-ml size limit as wrist sheathes.
4. Moved the assassin profession's throwing knives to a throwing knife bandolier.
5. Added recipe for throwing knife bandolier, generally comparable to most of the standard bandoliers.
6. Added knife bandolier to itemgroups `pawn`, `costume_accessories`, and the quiver/bandolier within `wardrobe_sporting_misc`.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Adding some kinda multi-storage bandolier for throwing axes. Would need a size limit of 750 ml, those being the size of throwing axes.
2. Bumping the size limit of throwing knife bandoliers up to 750 ml and letting them hold `SHEATH_AXE` items, reflavoring it as a general holder for throwing weapons.
3. Porting DDA's leg sheath for throwing knives. I figured taking up the more valuable torso-waist slot was a far trade for being able to hold a lot more knives than you normally can.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Ported JSON changes to laptop build and load-tested.
3. Started a game as an assassin, confirmed I start with 6 knives in my bandolier.
4. Also confirmed I can draw and sheath them without issue, and that item info correctly says they fit in relevant sheathes.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Mood music of the day: https://www.youtube.com/watch?v=8Ksksu9JDkg

DDA did something similar, though far as I could tell from looking through the files they only have the leg version mentioned above.