### PR TITLE
fix: lower wind turbine overmap occurrence rate

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -6760,7 +6760,7 @@
     "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "field" ],
     "city_distance": [ 8, 40 ],
-    "occurrences": [ 0, 20 ],
+    "occurrences": [ 0, 10 ],
     "flags": [ "CLASSIC", "WILDERNESS", "ELECTRIC_GRID" ]
   }
 ]


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
These are very powerful locations and up to 8 were spawning on my overmaps. This drowns out other locations and also causes issues with the supply of materials it brings. The materials is another issue as `advanced_object_deconstruction` appears to be broken in the code, I'll ask around on that. Basically it seems to ignore the advanced recipe and allow a deconstruct furniture on electrical conduits which erroneously grants up to 800 copper wire.

## Describe the solution

Change occurrence to 0, 10. This should to my understanding halve it.

## Describe alternatives you've considered

Overhaul overmap generation.

## Testing

Tests.

## Additional context

It is what it is. @chaosvolt GUESS WHAT, WE'RE ABOUT TO SUFFER WHEN YOU GET BACK HOME! :D
