### PR TITLE
fix: assign loudness to rail crossbow

### DIFF
--- a/data/json/items/gunmod/rail.json
+++ b/data/json/items/gunmod/rail.json
@@ -20,6 +20,7 @@
       "ranged_damage": { "damage_type": "stab", "amount": 28 },
       "dispersion": 387,
       "durability": 10,
+      "loudness": 10,
       "clip_size": 1
     },
     "dispersion_modifier": 60,


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Rail crossbows made no noise, this is because bolts don't have loudness, instead the crossbow does.

## Describe the solution

Give it loudness 10 like the crossbow. This is attached to the gun data of the rail crossbow gunmod, so the other items which inherit it will correctly inherit loudness.

## Describe alternatives you've considered

Make the problem worse

## Testing

Tests

## Additional context

Scream for me, crossbow-chan.
