### PR TITLE
fix: wire conduits give sane copper wire quantities

### DIFF
--- a/data/json/deconstruction.json
+++ b/data/json/deconstruction.json
@@ -796,7 +796,7 @@
     "id": "constr_remove_electrical_conduit",
     "//": "Breaks an electrical conduit.",
     "category": "CONSTRUCT",
-    "required_skills": [ [ "fabrication", 2 ] ],
+    "required_skills": [ [ "fabrication", 2 ], [ "electronics", 1 ] ],
     "time": "90 m",
     "using": [ [ "object_deconstruction_advanced", 1 ] ],
     "byproducts": [

--- a/data/json/furniture_and_terrain/furniture-industrial.json
+++ b/data/json/furniture_and_terrain/furniture-industrial.json
@@ -233,8 +233,7 @@
         { "item": "cable", "charges": [ 20, 100 ] },
         { "item": "pipe", "count": [ 1, 2 ] }
       ]
-    },
-    "deconstruct": { "items": [ { "item": "cable", "charges": [ 200, 800 ] }, { "item": "pipe", "count": [ 2, 4 ] } ] }
+    }
   },
   {
     "type": "furniture",


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Electrical conduits gave between 200 and 800 copper wire, and 9 spawned per wind turbine. This removes the deconstruct and sets it to require the advanced object deconstruction. I also put an electrical skill of 1 so it can train electronics and so it requires some skill to take apart.

## Describe the solution

Remove the deconstruct entry, add electronics 1

## Describe alternatives you've considered

Redoing all electrical furniture to add skill value and convert some to advanced object.

## Testing

Tests

## Additional context

Pain
