### PR TITLE
fix: make `scent_modifier` affect your scent equilibrium.

### DIFF
--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -239,8 +239,13 @@ void Character::process_turn()
             }
         }
 
-        //mask from scent altering items;
+        // Mask from scent altering items;
         norm_scent += mask_intensity;
+
+        // Now that all the additions are done, multiply norm_scent by any scent modifiers.
+        for( const trait_id &mut : get_mutations() ) {
+            norm_scent *= mut.obj().scent_modifier;
+        }
 
         // Scent increases fast at first, and slows down as it approaches normal levels.
         // Estimate it will take about norm_scent * 2 turns to go from 0 - norm_scent / 2
@@ -252,10 +257,6 @@ void Character::process_turn()
         // Unusually high scent decreases steadily until it reaches normal levels.
         if( scent > norm_scent ) {
             scent--;
-        }
-
-        for( const trait_id &mut : get_mutations() ) {
-            scent *= mut.obj().scent_modifier;
         }
     }
 


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

`scent_modifier` was multiplying the scent value after addition/subtraction. Meaning that if you had a value less than 1 and just created the character/loaded it, the scent map would be 0 and increased to 1, then multiplied by 0.x which is then truncated to 0 by the game to fit it into the int value.

This also means that the only way it does work is by multiplying any existing scent by the value, meaning that any value greater than 1 will cause runaway compounding until scent hits the max value. (example courtesy of @RoyalFox2140)

![image](https://github.com/user-attachments/assets/c0449ddf-1ae7-47be-a149-06577d860aee)
![image](https://github.com/user-attachments/assets/510ddfcd-9a96-4db6-bdc3-7c7045260482)

## Describe the solution

Make `scent_modifier` multiply your scent equilibrium instead, and multiply it _after_ all scent affecting addition/subtraction to make the expected values more intuitive.

## Describe alternatives you've considered

- Multiply before scent mask effects
  - Rejected on basis that it makes them produce stronger relative values for masking scents but weaker relative values for intensifying them.

## Testing

- Edit weak scent to use `scent_modifier` of 0.6 and strong scent to use 1.5. Remove the `scent_intensity` values of both
  - [x] Confirm that over time the game normalizes to the appropriate values. (300 for weak scent and 750 for strong scent)

## Additional context

https://www.youtube.com/watch?v=eJiUfnIzbVM
