### PR TITLE
feat(balance): allow oxytorching reinforced vending machines, lockpicking and prying display cases

### DIFF
--- a/data/json/furniture_and_terrain/furniture-storage.json
+++ b/data/json/furniture_and_terrain/furniture-storage.json
@@ -951,7 +951,25 @@
     "move_cost_mod": 2,
     "coverage": 80,
     "required_str": 9,
-    "flags": [ "TRANSPARENT", "SEALED", "PLACE_ITEM" ],
+    "flags": [ "TRANSPARENT", "SEALED", "PLACE_ITEM", "LOCKED", "PICKABLE" ],
+    "lockpick_result": "f_displaycase_o",
+    "lockpick_message": "With a satisfying click, the display case slides open.",
+    "examine_action": "locked_object",
+    "pry": {
+      "success_message": "You pry open the display case.",
+      "fail_message": "You pry, but cannot pry open the display.",
+      "break_message": "You break the glass.",
+      "pry_quality": 1,
+      "pry_bonus_mult": 3,
+      "noise": 12,
+      "break_noise": 24,
+      "breakable": true,
+      "break_sound": "glass breaking!",
+      "difficulty": 11,
+      "new_furn_type": "f_displaycase_o",
+      "break_furn_type": "f_displaycase_b",
+      "break_items": [ { "item": "glass_shard", "count": [ 1, 5 ] } ]
+    },
     "bash": {
       "str_min": 6,
       "str_max": 20,
@@ -977,13 +995,41 @@
     "coverage": 80,
     "required_str": 9,
     "flags": [ "TRANSPARENT", "PLACE_ITEM" ],
+    "deconstruct": { "items": [ { "item": "2x4", "count": 8 }, { "item": "nail", "charges": 12 } ] },
     "bash": {
       "str_min": 8,
       "str_max": 30,
       "sound": "crunch!",
       "sound_fail": "whump.",
-      "items": [ { "item": "2x4", "count": [ 3, 6 ] }, { "item": "splinter", "count": [ 2, 4 ] } ],
+      "items": [
+        { "item": "2x4", "count": [ 3, 6 ] },
+        { "item": "splinter", "count": [ 2, 4 ] },
+        { "item": "nail", "charges": [ 0, 8 ] }
+      ],
       "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 30, "block_unaimed_chance": "25%" }
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "f_displaycase_o",
+    "copy-from": "f_displaycase_b",
+    "name": "unlocked display case",
+    "looks_like": "f_displaycase",
+    "description": "Display your stuff.  Not very secure anymore, but still looks nice.",
+    "symbol": "#",
+    "color": "light_cyan",
+    "deconstruct": { "items": [ { "item": "2x4", "count": 8 }, { "item": "nail", "charges": 12 }, { "item": "glass_sheet", "count": 1 } ] },
+    "bash": {
+      "str_min": 6,
+      "str_max": 20,
+      "sound": "glass breaking",
+      "sound_fail": "whack!",
+      "sound_vol": 16,
+      "sound_fail_vol": 12,
+      "furn_set": "f_displaycase_b",
+      "items": [ { "item": "glass_shard", "count": [ 1, 5 ] } ],
+      "//": "reduction matches that of the underlying broken case, destroy_threshold matches str_min since glass might shatter",
+      "ranged": { "reduction": [ 4, 8 ], "destroy_threshold": 6, "block_unaimed_chance": "75%" }
     }
   },
   {

--- a/data/json/furniture_and_terrain/furniture-tools.json
+++ b/data/json/furniture_and_terrain/furniture-tools.json
@@ -1243,6 +1243,15 @@
     "required_str": 30,
     "flags": [ "SEALED", "PLACE_ITEM", "ALARMED", "CONTAINER", "BLOCKSDOOR", "FLAMMABLE_HARD", "MINEABLE" ],
     "examine_action": "vending",
+    "oxytorch": {
+      "result": "f_vending_o",
+      "duration": "14 seconds",
+      "byproducts": [
+        { "item": "glass_sheet", "count": 1 },
+        { "item": "sheet_metal", "count": [ 1, 2 ] },
+        { "item": "steel_lump", "count": [ 1, 2 ] }
+      ]
+    },
     "bash": {
       "str_min": 150,
       "str_max": 520,


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Some assorted ideas that came up to allow more options for breaking into certain locked objects.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Gave display cases lockpick and prying data. Idea being that getting around to the employee side to get at the sliding door to access it with a bit less smash and grab. Prying data uses same general difficulty as prying windows. A successful pry or lockpick turns it into...
2. Added an unlocked state for display cases, resembling locked ones but accessible like broken ones.
3. Also allowed you to deconstruct broken and unlocked display cases, now with some nails in bash results of busted cases.
4. Added `oxytorch` data to reinforced vending machines, allowing you to cut them open as an alternative to using a jackhammer.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Adding a reinforced or laminated version of display cases and using them in gun stores, maybe a few other places.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.
3. Spawned in a reinforced vending machine, confirmed I can oxytorch it open.
4. Spawned in some display cases, confirmed I can lockpick and pry them, and that items become accessible when opened successfully.

![image](https://github.com/user-attachments/assets/b58b8a9a-ed9b-42ab-8a35-d345e5bb7bb4)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

It would seem DDA presumably added something in this vein at some point, as UDP already has a sprite for unlocked cases.