### PR TITLE
fix: fix large storage battery plural

### DIFF
--- a/data/json/items/vehicle/battery.json
+++ b/data/json/items/vehicle/battery.json
@@ -104,7 +104,7 @@
     "id": "storage_battery",
     "type": "MAGAZINE",
     "category": "battery",
-    "name": { "str": "large storage battery", "str_pl": "storage batteries" },
+    "name": { "str": "large storage battery", "str_pl": "large storage batteries" },
     "description": "A large storage battery containing many lithium-ion cells.  Could be installed into a storage battery case for easy removal from a vehicle, or just welded straight in.",
     "weight": "75 kg",
     "volume": "50 L",


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Large storage battery has a plural of storage batteries. This confused me when looting. It's because I used the menu to find nearby items but when I went into loot the tile it showed up as "storage batteries".
![image](https://github.com/user-attachments/assets/e6bf3cf2-5430-4a77-8c01-23962c73baa8)


## Describe the solution

Add large to the plural. I also checked all batteries in the file, they're all good. Normal tool batteries should all be all good as I never noticed a problem.


## Describe alternatives you've considered

None.

## Testing

Tests.

## Additional context

![image](https://github.com/user-attachments/assets/74ae0d5d-8c8d-4b59-ba4e-a55ab3dfa3cc)

