### PR TITLE
perf: Update steady_consumer to longer intervals to avoid lag

### DIFF
--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -322,7 +322,7 @@
     "message": "You switch off the floodlight.",
     "//": "Increased brightness and power draw over utility lights which don't draw grid power, but far less than vehicle ones",
     "light_emitted": 400,
-    "//": "Please keep steady_consumer to 300 s or more to avoid lag.",
+    "//2": "Please keep steady_consumer to 300 s or more to avoid lag.",
     "active": [
       "steady_consumer",
       {
@@ -2426,7 +2426,7 @@
         { "item": "power_supply", "count": 3 }
       ]
     },
-    "//": "Please keep steady_consumer to 300 s or more to avoid lag.",
+    "//2": "Please keep steady_consumer to 300 s or more to avoid lag.",
     "active": [ "steady_consumer", { "power": -100, "consume_every": "300 s" } ]
   },
   {

--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -238,11 +238,12 @@
     "prompt": "Switch off the floor lamp.",
     "message": "You switch off the floor lamp.",
     "light_emitted": 160,
+    "//": "Please keep steady_consumer to 300 s or more to avoid lag.",
     "active": [
       "steady_consumer",
       {
-        "power": 1,
-        "consume_every": "100 s",
+        "power": 3,
+        "consume_every": "300 s",
         "transform": { "id": "f_floor_lamp", "msg": "The lamp flickers and dies." }
       }
     ]
@@ -321,11 +322,12 @@
     "message": "You switch off the floodlight.",
     "//": "Increased brightness and power draw over utility lights which don't draw grid power, but far less than vehicle ones",
     "light_emitted": 400,
+    "//": "Please keep steady_consumer to 300 s or more to avoid lag.",
     "active": [
       "steady_consumer",
       {
-        "power": 1,
-        "consume_every": "40 s",
+        "power": 7,
+        "consume_every": "300 s",
         "transform": { "id": "f_grid_floodlight", "msg": "The utility light flickers and dies." }
       }
     ]
@@ -405,11 +407,12 @@
     "prompt": "Switch off the street light.",
     "message": "You switch off the street light.",
     "light_emitted": 320,
+    "//": "Please keep steady_consumer to 300 s or more to avoid lag.",
     "active": [
       "steady_consumer",
       {
-        "power": 1,
-        "consume_every": "50 s",
+        "power": 6,
+        "consume_every": "300 s",
         "transform": { "id": "f_street_light_rewired", "msg": "The street light flickers and dies." }
       }
     ]
@@ -909,6 +912,7 @@
     "move_cost_mod": -1,
     "required_str": -1,
     "//": "10 watts, all of these below are staggered across 5 minutes to avoid lag.  Todo: convert to not rely on steady_consumer hacks",
+    "//2": "Please keep steady_consumer to 300 s or more to avoid lag.",
     "active": [ "steady_consumer", { "power": -3, "consume_every": "300 s" } ],
     "flags": [ "TRANSPARENT" ],
     "deconstruct": {
@@ -946,6 +950,7 @@
     "coverage": 30,
     "required_str": -1,
     "//": "30 watts",
+    "//2": "Please keep steady_consumer to 300 s or more to avoid lag.",
     "active": [ "steady_consumer", { "power": -9, "consume_every": "300 s" } ],
     "flags": [ "TRANSPARENT" ],
     "deconstruct": {
@@ -985,6 +990,7 @@
     "coverage": 30,
     "required_str": -1,
     "//": "80 watts",
+    "//2": "Please keep steady_consumer to 300 s or more to avoid lag.",
     "active": [ "steady_consumer", { "power": -24, "consume_every": "300 s" } ],
     "flags": [ "TRANSPARENT" ],
     "deconstruct": {
@@ -1022,6 +1028,7 @@
     "color": "yellow",
     "coverage": 60,
     "//": "30 watts",
+    "//2": "Please keep steady_consumer to 300 s or more to avoid lag.",
     "active": [ "steady_consumer", { "power": -54, "consume_every": "300 s" } ],
     "deconstruct": {
       "items": [
@@ -1954,6 +1961,7 @@
     "message": "You switch off the fridge.",
     "color": "light_cyan",
     "extend": { "flags": [ "FRIDGE" ] },
+    "//": "Please keep steady_consumer to 300 s or more to avoid lag.",
     "active": [
       "steady_consumer",
       { "power": 20, "consume_every": "600 s", "transform": { "id": "f_fridge", "msg": "The fridge shuts down." } }
@@ -2002,6 +2010,7 @@
     "color": "blue",
     "extend": { "flags": [ "FREEZER" ] },
     "deconstruct": { "items": [ { "item": "freezer", "count": 1 } ] },
+    "//": "Please keep steady_consumer to 300 s or more to avoid lag.",
     "active": [
       "steady_consumer",
       { "power": 25, "consume_every": "600 s", "transform": { "id": "f_freezer", "msg": "The freezer shuts down." } }
@@ -2079,6 +2088,7 @@
     "message": "You switch off the minifreezer.",
     "color": "blue",
     "extend": { "flags": [ "FREEZER" ] },
+    "//": "Please keep steady_consumer to 300 s or more to avoid lag.",
     "active": [
       "steady_consumer",
       {
@@ -2207,11 +2217,12 @@
     "transforms_into": "f_grid_air_conditioner_off",
     "prompt": "Switch off AC unit",
     "message": "You turn the AC off.",
+    "//": "Exception on steady_consumer for some furniture.",
     "active": [
       "steady_consumer",
       {
-        "power": 1,
-        "consume_every": "2 s",
+        "power": 30,
+        "consume_every": "60 s",
         "transform": { "id": "f_grid_air_conditioner", "msg": "The AC runs out of power and cools off." }
       }
     ],
@@ -2292,11 +2303,12 @@
     "transforms_into": "f_space_heater_off",
     "message": "You turn the heater off.",
     "light_emitted": 2,
+    "//": "Exception on steady_consumer for some furniture.",
     "active": [
       "steady_consumer",
       {
-        "power": 1,
-        "consume_every": "2 s",
+        "power": 30,
+        "consume_every": "60 s",
         "transform": { "id": "f_space_heater", "msg": "The heater runs out of power and cools off." }
       }
     ],
@@ -2360,11 +2372,12 @@
     "transforms_into": "f_space_heater_large_off",
     "message": "You turn the heater off.",
     "light_emitted": 2,
+    "//": "Exception on steady_consumer for some furniture.",
     "active": [
       "steady_consumer",
       {
-        "power": 1,
-        "consume_every": "1 s",
+        "power": 60,
+        "consume_every": "60 s",
         "transform": { "id": "f_space_heater_large", "msg": "The heater runs out of power and cools off." }
       }
     ],
@@ -2413,7 +2426,8 @@
         { "item": "power_supply", "count": 3 }
       ]
     },
-    "active": [ "steady_consumer", { "power": -1, "consume_every": "3 s" } ]
+    "//": "Please keep steady_consumer to 300 s or more to avoid lag.",
+    "active": [ "steady_consumer", { "power": -100, "consume_every": "300 s" } ]
   },
   {
     "type": "furniture",

--- a/data/json/furniture_and_terrain/furniture-industrial.json
+++ b/data/json/furniture_and_terrain/furniture-industrial.json
@@ -307,6 +307,7 @@
       "ranged": { "reduction": [ 16, 32 ], "destroy_threshold": 32, "block_unaimed_chance": "50%" }
     },
     "//": "Matches the power output across 5 minutes that the capacitors and conduits provided on first implementation",
+    "//2": "Please keep steady_consumer to 300 s or more to avoid lag.",
     "active": [ "steady_consumer", { "power": -49, "consume_every": "300 s" } ]
   }
 ]

--- a/tests/electric_grid_test.cpp
+++ b/tests/electric_grid_test.cpp
@@ -271,9 +271,9 @@ static void test_steady_consumer( grid_setup_consumer &setup )
     }
 
     WHEN( "the battery has power for 1 consumer tick" ) {
-        int excess = battery.mod_resource( 1 );
+        int excess = battery.mod_resource( 3 );
         REQUIRE( excess == 0 );
-        REQUIRE( battery.get_resource() == 1 );
+        REQUIRE( battery.get_resource() == 3 );
         REQUIRE( grid.get_resource() == battery.get_resource() );
 
         AND_WHEN( "1 consumer tick passes" ) {
@@ -289,7 +289,7 @@ static void test_steady_consumer( grid_setup_consumer &setup )
             time_point to = calendar::turn + consumer.consume_every - 1_seconds;
             grid.update( to );
             THEN( "no changes" ) {
-                REQUIRE( grid.get_resource() == 1 );
+                REQUIRE( grid.get_resource() == 3 );
                 require_empty_queue( tf_queue );
             }
 


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

A lot of steady consumers were set to fast intervals. This sets them to slow ones to avoid lag. Also adds a note to avoid setting it to fast.

## Describe the solution

Steady consumer is generally set to 300 seconds, with a few exceptions for 1 minute. Note added to avoid under 300 seconds.  Also, heaters and AC's have insane power draw so this is bad, I don't know how to solve that, but it doesn't matter if its 1 in 1 second or 300 in 300 seconds its still the same insane draw.

## Describe alternatives you've considered

Pain

## Testing

Tests

## Additional context

aaaaa
