### PR TITLE
fix: create the mapgen `mil_base_3g2` and place it above `mil_base_3g1`

### DIFF
--- a/data/json/mapgen/military/mil_base/mil_base_z2.json
+++ b/data/json/mapgen/military/mil_base/mil_base_z2.json
@@ -2,6 +2,41 @@
   {
     "type": "mapgen",
     "method": "json",
+    "om_terrain": [ [ "mil_base_3g2" ] ],
+    "object": {
+      "fill_ter": "t_open_air",
+      "rows": [
+        "         ::::           ",
+        "         ::::           ",
+        "         ::::           ",
+        "         ::::           ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "palettes": [ "mil_base_roof_palette" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
     "om_terrain": [ [ "mil_base_3i2" ] ],
     "weight": 250,
     "object": {

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -5613,6 +5613,7 @@
       { "point": [ 5, 10, 1 ], "overmap": "mil_base_6k1_north" },
       { "point": [ 6, 10, 1 ], "overmap": "mil_base_7k1_north" },
       { "point": [ 7, 10, 1 ], "overmap": "mil_base_8k1_north" },
+      { "point": [ 2, 6, 2 ], "overmap": "mil_base_3g2_north" },
       { "point": [ 2, 8, 2 ], "overmap": "mil_base_3i2_north" },
       { "point": [ 2, 8, 3 ], "overmap": "mil_base_3i3_north" },
       { "point": [ 2, 8, 4 ], "overmap": "mil_base_3i4_north" }

--- a/data/json/overmap/overmap_terrain/overmap_terrain_military.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_military.json
@@ -369,7 +369,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": [ "mil_base_2g1", "mil_base_2g", "mil_base_3g1", "mil_base_3g" ],
+    "id": [ "mil_base_2g1", "mil_base_2g", "mil_base_3g1", "mil_base_3g", "mil_base_3g2" ],
     "copy-from": "generic_military_base",
     "name": "military base - warehouse"
   },


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
In the military base:
Create a proper roof above `mil_base_3g1` because `mil_base_3g1` has no roof.
## Describe the solution
Create the mapgen `mil_base_3g2` and place it above `mil_base_3g1`
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/0d20c811-6d95-411c-8fa5-41b8d31cd846">
After:
<img width="960" alt="image2" src="https://github.com/user-attachments/assets/659f7c54-73d3-481f-9366-ca02987841c0">