### PR TITLE
feat(balance,mods/innawoods): reduce wasp nest spawn weight

### DIFF
--- a/data/mods/innawoods/regional_settings.json
+++ b/data/mods/innawoods/regional_settings.json
@@ -411,6 +411,7 @@
           "mx_portal_in": 3,
           "mx_grass": 10,
           "mx_spider": 200,
+          "mx_nest_wasp": 100,
           "mx_jabberwock": 1,
           "mx_grove": 500,
           "mx_shrubbery": 500,
@@ -451,7 +452,7 @@
           "mx_fallen_shed": 0,
           "mx_pond": 0,
           "mx_point_burned_ground": 0,
-          "mx_nest_wasp": 200,
+          "mx_nest_wasp": 5,
           "mx_mass_grave": 0
         }
       },


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

<img width="50%" src="https://github.com/user-attachments/assets/a2fa4609-b728-4349-b512-a2b9f0aead6d"/>

wasp nests are too frequent in innawoods mod, which doesn't seem to be done on purpose.

## Describe the solution

matches wasp spawn weight to that of regular map extra rate.

https://github.com/cataclysmbnteam/Cataclysm-BN/blob/629979e4fbefa1ee9bdbe144acd8d23d64729a7d/data/json/regional_map_settings.json#L489

- reduced `field` wasp nest spawn weight from 200 -> 5, same as vanilla `field` wasp nest spawn weight.

https://github.com/cataclysmbnteam/Cataclysm-BN/blob/629979e4fbefa1ee9bdbe144acd8d23d64729a7d/data/json/regional_map_settings.json#L399

- added `forest_thick` wasp nest spawn weight as 100, same as vanilla `forest_thick` wasp nest spawn weight.

## Describe alternatives you've considered

asking @Zlorthishen whether the numbers are correct

## Testing

haven't, but should work since it's just a number change.

## Additional context

opened PR since it sounded like a easy fix.

original discussion: https://discord.com/channels/830879262763909202/830916329053487124/1282322762815377491