### PR TITLE
fix: ally-only spells no longer autotarget enemies, fix crash when casting `SWAP_POS` on a tile with no creature to swap with

### DIFF
--- a/doc/src/content/docs/en/mod/json/reference/creatures/magic.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/magic.md
@@ -92,7 +92,8 @@ experience you need to get to a level is below:
 
 - `IGNORE_WALLS` - spell's aoe goes through walls
 
-- `SWAP_POS` - a projectile spell swaps the positions of the caster and target
+- `SWAP_POS` - teleports the caster to the target location when used by a ranged spell, switching
+ places with any creature that might be in the way
 
 - `HOSTILE_SUMMON` - summon spell always spawns a hostile monster
 

--- a/doc/src/content/docs/en/mod/json/reference/creatures/magic.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/magic.md
@@ -93,7 +93,7 @@ experience you need to get to a level is below:
 - `IGNORE_WALLS` - spell's aoe goes through walls
 
 - `SWAP_POS` - teleports the caster to the target location when used by a ranged spell, switching
- places with any creature that might be in the way
+  places with any creature that might be in the way
 
 - `HOSTILE_SUMMON` - summon spell always spawns a hostile monster
 

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -131,7 +131,9 @@ void spell_effect::teleport_random( const spell &sp, Creature &caster, const tri
 static void swap_pos( Creature &caster, const tripoint &target )
 {
     Creature *const critter = g->critter_at<Creature>( target );
-    critter->setpos( caster.pos() );
+    if( critter != nullptr ) {
+        critter->setpos( caster.pos() );
+    }
     caster.setpos( target );
     //update map in case a monster swapped positions with the player
     g->update_map( get_avatar() );

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2757,6 +2757,11 @@ void target_ui::update_target_list()
 
 tripoint target_ui::choose_initial_target()
 {
+    // If we're casting a spell, don't lock onto enemies if the spell is meant for using on friendlies.
+    if( mode == TargetMode::Spell && !casting->is_valid_target( valid_target::target_hostile ) ) {
+        return src;
+    }
+
     // Try previously targeted creature
     shared_ptr_fast<Creature> cr = you->last_target.lock();
     if( cr && pl_sees( *cr ) && dist_fn( cr->pos() ) <= range ) {


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This fixes a couple long-running annoyances in spellcasting code I figured out solutions for. Also technically opens up unrestricted controlled teleportation as something spells can do without even needing a new spell function.

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/4216

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

C++ changes:
1. In magic_spell_effect.cpp, changed `swap_pos` so that it only tries to move any creatures found in the epicenter if there actually is one. If the tile targeted is empty, now instead of the game just imploding like before, it simply warps you over there without any complaints, meaning you can freely use `SWAP_POS` spells on any tile you want if you write the spell's JSON to permit targeting the ground to just use it for teleportation if you so choose.
2. In ranged.cpp, set `target_ui::choose_initial_target` so that spells don't try to autotarget any enemy in range unless they can ACTUALLY be used on hostiles, so you won't be prompted to try and waste your time casting a spell only usable on allies, and likewise making it less annoying trying to heal or buff yourself in the middle of a fight via whatever's kicking your ass trying to run off with your cursor.

Documentation changes:
1. Updated the explaination of what `SWAP_POS` does in magic.md.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Adding a spell in Magiclysm that uses `SWAP_POS` as a full-on blink spell. Robbie and Fox said they have plans already so will leave it to them.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Started up a world with Magiclysm in it as a novice stormshaper.
3. Tested against both the starter NPC and a zombie, Lightning Bolt will highlight these targets automatically if in range but Windrunning no longer tries to target them.
4. Tested giving myself Holographic Transposition after temporarily removing the monster restriction and letting me cast it at the ground.
5. Cast this modified spell and I warp over to the selected tile without any crashes this time, even if the tile is empty.
6. Zapped starter NPC with it to confirm it also still works fine to just swap with the target.
7. Also tested temporarily giving Holographic Transposition damage while it was rigged to let me tag an NPC with it, doing so still lets me swap places with them, and simply teleports me on top of their corpse if the damage was lethal.
8. Checked affected files for syntax and lint errors.

Casual bullying of an NPC with a version of Holographic Transposition temporarily given damage, and it working without issue when the victim dies from it:
![image](https://github.com/user-attachments/assets/917af842-0218-435f-8c48-cd64a4ff6131)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


Checked in DDA, as of build `2024-08-30-1256` targeting an invalid tile with a `SWAP_POS` spell still crashes the game:
![image](https://github.com/user-attachments/assets/97462bf1-3fc7-4d4a-b11c-6dd303c0888f)

Even better, a basic attempt to test and confirm if you still auto-target non-allies with Windrunning revealed that the spell I selected on the spellcasting menu ends up not being the spell it tries to cast:
![image](https://github.com/user-attachments/assets/b6892b79-a1e0-4096-bc35-80fed130df8e)
![image](https://github.com/user-attachments/assets/e15bfa62-aa41-42ed-aedc-96c05059e6c3)

So I have to try and cast Shocking Lash instead, which ACTUALLY casts Windrunning, and only then can I confirm DDA auto-targets non-allies with ally-only spells.