### PR TITLE
feat: firing message instead of printing all player-made combat sounds, allow fragmentation explosions to create sounds

### DIFF
--- a/data/json/ammo_effects.json
+++ b/data/json/ammo_effects.json
@@ -153,6 +153,24 @@
     "explosion": { "fragment": { "impact": { "damage_type": "bullet", "amount": 30, "armor_multiplier": 2.5 }, "range": 3 } }
   },
   {
+    "id": "EXPLOSIVE_PLUS_FRAG",
+    "type": "ammo_effect",
+    "explosion": {
+      "damage": 50,
+      "radius": 3,
+      "fragment": { "impact": { "damage_type": "bullet", "amount": 50, "armor_multiplier": 2 }, "range": 5 }
+    }
+  },
+  {
+    "id": "EXPLOSIVE_BIG_PLUS_FRAG",
+    "type": "ammo_effect",
+    "explosion": {
+      "damage": 70,
+      "radius": 5,
+      "fragment": { "impact": { "damage_type": "bullet", "amount": 50, "armor_multiplier": 2 }, "range": 5 }
+    }
+  },
+  {
     "id": "MININUKE_MOD",
     "type": "ammo_effect",
     "aoe": {

--- a/data/json/items/ammo/84x246mm.json
+++ b/data/json/items/ammo/84x246mm.json
@@ -20,7 +20,7 @@
     "recoil": 45,
     "count": 4,
     "stack_size": 1,
-    "effects": [ "COOKOFF", "EXPLOSIVE_BIG", "FRAG", "NEVER_MISFIRES" ]
+    "effects": [ "COOKOFF", "EXPLOSIVE_BIG_PLUS_FRAG", "NEVER_MISFIRES" ]
   },
   {
     "type": "AMMO",
@@ -52,6 +52,6 @@
     "range": 140,
     "dispersion": 30,
     "extend": { "effects": [ "SMOKE_BIG" ] },
-    "delete": { "effects": [ "EXPLOSIVE_BIG", "FRAG" ] }
+    "delete": { "effects": [ "EXPLOSIVE_BIG_PLUS_FRAG" ] }
   }
 ]

--- a/data/json/items/ammo/rpg.json
+++ b/data/json/items/ammo/rpg.json
@@ -38,7 +38,7 @@
     "range": 60,
     "dispersion": 75,
     "recoil": 450,
-    "effects": [ "COOKOFF", "EXPLOSIVE", "FRAG", "TRAIL", "NEVER_MISFIRES" ]
+    "effects": [ "COOKOFF", "EXPLOSIVE_PLUS_FRAG", "TRAIL", "NEVER_MISFIRES" ]
   },
   {
     "type": "AMMO",

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -1436,9 +1436,14 @@ void explosion_funcs::regular( const queued_explosion &qe )
 {
     const tripoint &p = qe.pos;
     const explosion_data &ex = qe.exp_data;
-
     auto &shr = ex.fragment;
-    const int noise = ( std::max( ex.damage, shr.value().impact.total_damage() ) ) / explosion_handler::power_to_dmg_mult * ( ex.fire ? 2 : 10 );
+
+    int base_noise = ex.damage;
+    if( shr ) {
+        base_noise = shr.value().impact.total_damage();
+    }
+
+    const int noise = base_noise / explosion_handler::power_to_dmg_mult * ( ex.fire ? 2 : 10 );
     if( noise >= 30 ) {
         sounds::sound( p, noise, sounds::sound_t::combat, _( "a huge explosion!" ), false, "explosion",
                        "huge" );

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -1437,7 +1437,8 @@ void explosion_funcs::regular( const queued_explosion &qe )
     const tripoint &p = qe.pos;
     const explosion_data &ex = qe.exp_data;
 
-    const int noise = ex.damage / explosion_handler::power_to_dmg_mult * ( ex.fire ? 2 : 10 );
+    auto &shr = ex.fragment;
+    const int noise = ( std::max( ex.damage, shr.value().impact.total_damage() ) ) / explosion_handler::power_to_dmg_mult * ( ex.fire ? 2 : 10 );
     if( noise >= 30 ) {
         sounds::sound( p, noise, sounds::sound_t::combat, _( "a huge explosion!" ), false, "explosion",
                        "huge" );
@@ -1450,7 +1451,6 @@ void explosion_funcs::regular( const queued_explosion &qe )
 
     std::map<const Creature *, int> damaged_by_blast;
     std::map<const Creature *, int> damaged_by_shrapnel;
-    auto &shr = ex.fragment;
 
     if( get_option<bool>( "OLD_EXPLOSIONS" ) ) {
         if( shr ) {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -933,6 +933,13 @@ int ranged::fire_gun( Character &who, const tripoint &target, int max_shots, ite
         }
         curshot++;
 
+        if( !who.is_deaf() ) {
+            who.add_msg_if_player( m_info, _( "You fire your %s, %s" ),
+                                   gun.tname(), gun.gun_noise( shots > 1 ) );
+        } else {
+            who.add_msg_if_player( m_info, _( "You fire your %s!" ),
+                                   gun.tname() );
+        }
         ranged::make_gun_sound_effect( who, shots > 1, gun );
 
         cycle_action( gun, who.pos() );

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -948,7 +948,7 @@ int ranged::fire_gun( Character &who, const tripoint &target, int max_shots, ite
         curshot++;
 
         int noise = calc_gun_volume( gun );
-        if( !who.is_deaf() && noise > 1 ) {
+        if( !who.is_deaf() && noise > 0 ) {
             who.add_msg_if_player( m_warning, _( "You fire your %s, %s" ),
                                    gun.tname(), gun.gun_noise( shots > 1 ).sound );
         } else {

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -390,13 +390,13 @@ static bool describe_sound( sounds::sound_t category, bool from_player_position 
             case sounds::sound_t::movement:
             case sounds::sound_t::activity:
             case sounds::sound_t::destructive_activity:
+            case sounds::sound_t::combat:
             case sounds::sound_t::alert:
             case sounds::sound_t::order:
             case sounds::sound_t::speech:
                 return false;
             case sounds::sound_t::electronic_speech:
             case sounds::sound_t::alarm:
-            case sounds::sound_t::combat:
                 return true;
         }
     } else {


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Much as I liked https://github.com/cataclysmbnteam/Cataclysm-BN/pull/5309, turns out it also prints the sound your melee attacks in the message log, which is a bit less desirable. So time for the alternative idea I mused upon in said PR discussion, and as a bonus fixing the issue with fragmentation ammo effects Soad spotted.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->


C++ changes:
1. In explosion.cpp, `explosion_funcs::regular` is now able to look for fragmentation in the explosion definition it's handed. If the explosion has fragmentation defined, it'll use the damage value for that instead of the raw explosive damage as the starting point for noise calculation. This fixes ammo effects and explosives that have fragmentation but no regular explosion being dead silent when they go off.
2. In ranged.cpp, defined static function `calc_gun_volume` and moved the noise info from `item::gun_noise` into it, because there's now gonna be two different functions that need to know the gun's raw loudness. Which leads us to...
3. Also in ranged.cpp, `ranged::fire_gun` now prints a message when you fire, which includes the firing sound baked in automatically if the gun's volume is above zero and the player can currently hear it. `calc_gun_volume` was needed specifically so we can skip over trying to print what will be an empty string if the gun is considered completely silent. This supersedes the need to print combat sounds at the player's position, avoiding issues with other sound sources that may feel weird to have show up like whacking sounds every time you make a melee attack.
4. In sounds.cpp, accordingly updated `describe_sound` to move combat sounds back where it was, to not print when originating from the player's position.

JSON changes:
1. Defined ammo effect `EXPLOSIVE_BIG_PLUS_FRAG` that combines the effects of `EXPLOSIVE_BIG` and `FRAG` ammo effects, so 84x246mm HE rockets won't make two explosion sounds now.
2. Defined `EXPLOSIVE_PLUS_FRAG` ammo effect for PG-7VR RPG-7 rockets to use.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Figuring out some `std::min` fuckery to make explosions pick between base explosive damage or fragmentation damage for sound calculation based on whichever is higher.
2. Not doing the ranged.cpp and sounds.cpp stuff and instead figuring out a way for sound code to distinguish between big angry boom combat noises and slappy combat noises to choose arbitrarily if we want the player to hear their meatsack sloshing around trying to perforate other meatsacks.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON files for syntax and lint errors.
2. Compiled and load-tested.
3. Fired off a gun, expected message prints, changes to not tell me about the kaboom if I deafen myself beforehand.
4. Temporarily added a test message to report explosion volume directly before changing explosion.cpp further, got a volume value of 5250 for an AT4's main explosion.
5. Used this test message after explosion.cpp changes, explosion values for the AT4 prior to changing ammo effects was 5250 and 3749, meaning explosion volume was correctly unchanged and frag volume was correctly lower than explosion volume. This is 1 below `5250 * 5 / 7` (compare `FRAG` ammo effect having an impact damage of 50, and `EXPLOSIVE_BIG` having 70 base damage), so the math just about checks out with expectations.
6. Fired off an M79, I get both the kerblam (because the fix to make it go thump is in a different PR) but I also get to hear an explosion from the HEDP that used to be completely silent.
7. Fired an M203 mounted on an M4, the firing message correctly prints the name of the gunmod instead of the gun it's on.
8. Fired a slingshot cannon, it likewise doesn't mention firing sound in the fire message since it's completely silent (as noted in the other PR, even though it has `loudness` defined yet is perfectly quiet for reasons I don't understand).
9. Fired off an AT4 after giving it a combined ammo effect, I now correctly only hear one kaboom, not two.
10. Slapped around a debug monster in melee, I can no longer hear myself smacking it.
11. Checked affected C++ files for astyle.

![image](https://github.com/user-attachments/assets/5d2eb464-0622-4c72-86e8-0b5fa0147331)
![image](https://github.com/user-attachments/assets/0ea008fa-95d7-4893-a0bf-090f1fea1330)
![image](https://github.com/user-attachments/assets/63bf5410-857e-4f4d-9a1b-d304df6610ab)
![image](https://github.com/user-attachments/assets/fd891487-2d78-46fd-adca-9d9d62e2e23d)
![image](https://github.com/user-attachments/assets/60d74f1a-3a72-4599-8a6c-d9b3c812c52e)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

DDA it seems does something similar with adding specific firing messages, but a test confirms that frag-only explosives are still silent. Didn't look into it beyond a basic test.