### PR TITLE
feat(balance): sanity-check power curve of sails with angle, allow minimum power even when sailing into the wind

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1306,20 +1306,26 @@ int vehicle::part_vpower_w( const int index, const bool at_full_hp ) const
         if( vp.info().fuel_type == fuel_type_wind ) {
             const weather_manager &weather = get_weather();
             int windpower = weather.windspeed;
-            rl_vec2d windvec;
-            double raddir = ( ( weather.winddirection + 180 ) % 360 ) * ( M_PI / 180 );
-            windvec = windvec.normalized();
-            windvec.y = -std::cos( raddir );
-            windvec.x = std::sin( raddir );
-            rl_vec2d fv = face_vec();
-            double dot = windvec.dot_product( fv );
-            if( dot <= 0 ) {
-                dot = std::min( -0.1, dot );
+            // We're dead in the water.
+            if( windpower < 1 ) {
+                pwr = 0;
             } else {
-                dot = std::max( 0.1, dot );
+                rl_vec2d windvec;
+                double raddir = ( ( weather.winddirection + 180 ) % 360 ) * ( M_PI / 180 );
+                windvec = windvec.normalized();
+                windvec.y = -std::cos( raddir );
+                windvec.x = std::sin( raddir );
+                rl_vec2d fv = face_vec();
+                double dot = windvec.dot_product( fv );
+                if( dot <= 0 ) {
+                    dot = std::min( -0.1, dot );
+                } else {
+                    dot = std::max( 0.1, dot );
+                }
+                int windeffectint = static_cast<int>( ( windpower * dot ) * 200 );
+                // For gameplay purposes, permit adjusting sails enough to sail upwind so long as it's blowing at all.
+                pwr = std::max( pwr, pwr + windeffectint );
             }
-            int windeffectint = static_cast<int>( ( windpower * dot ) * 200 );
-            pwr = std::max( 1, pwr + windeffectint );
         }
     }
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1310,21 +1310,19 @@ int vehicle::part_vpower_w( const int index, const bool at_full_hp ) const
             if( windpower < 1 ) {
                 pwr = 0;
             } else {
+                // For gameplay purposes, permit adjusting sails enough to sail upwind so long as it's blowing at all.
                 rl_vec2d windvec;
                 double raddir = ( ( weather.winddirection + 180 ) % 360 ) * ( M_PI / 180 );
                 windvec = windvec.normalized();
                 windvec.y = -std::cos( raddir );
                 windvec.x = std::sin( raddir );
                 rl_vec2d fv = face_vec();
-                double dot = windvec.dot_product( fv );
-                if( dot <= 0 ) {
-                    dot = std::min( -0.1, dot );
-                } else {
-                    dot = std::max( 0.1, dot );
-                }
+                // We want 0.5 multiplier at 90 degrees instead of 0.0, so add 0.5.
+                double dot = windvec.dot_product( fv ) + 0.5;
+                // We don't want negatives or over 100% power, however.
+                dot = std::min( 1.0, std::max( 0.0, dot ) );
                 int windeffectint = static_cast<int>( ( windpower * dot ) * 200 );
-                // For gameplay purposes, permit adjusting sails enough to sail upwind so long as it's blowing at all.
-                pwr = std::max( pwr, pwr + windeffectint );
+                pwr = pwr + windeffectint;
             }
         }
     }


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

So, I looked into how sail code works. Face the wind and no sailing for you, sail with the wind at your back and you go fast. One problem though: you don't merely lose power sailing directly against the wind, but instead as soon as you're 90 degrees to the wind your power drops to a near useless amount.

Considering that sails can be adjusted to differing angles, this is a tad silly, at bare minimum you shouldn't have power drop down to the point of stopping the vehicle until you're actually close to sailing into the wind. But arguably for game purposes it'd be reasonable to just permit some level of movement regardless of facing.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

In vehicle.cpp, reworked the handling of wind power in `vehicle::part_vpower_w` a bit. Thanks to Soad explaining out the multiplier works, it's been adjusted to no longer return 0x power at 90 degrees and -1 when facing directly into the wind. Instead it produces 50% of the potential benefit from the wind at 90 degrees, and 0 when facing into the wind, with values being capped at a range of 0.0-1.0.

No longer being negative, this value is then added directly to the vehiclepart's base power output instead of allowing it to `std::max` itself into becoming basically null, on the assumption that realistically the only sails we have are small and adjustable enough that we can afford to abstract away the process of tacking your way upwind, since autodrive can't be trusted to do it for us.

However, just to prevent explot-y-ness, it skips out on complicated wind calculation and grants zero power output if the wind is below 1 MPH, so you can't exploit the changed `std::max` to sail in no wind at all.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

We could always just say "fuck it" and convert wind power to not give a shit about wind direction at all, and just get raw power from current wind speed.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Created an unholy abomination by putting a sail on a shopping cart.
3. Started sailing about, confirmed I can sail against the wind but still get way better speed going into the wind.
4. Temporarily added a message print that reported the multiplier being spat out. Confirmed I get 1.0 when driving with the wind properly, 0.5 when 90 degrees to the wind, and 0.0 when facing into the wind.
5. Checked affected file for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

![image](https://github.com/user-attachments/assets/d3c115b1-d391-498e-9a4b-f3ace8c08a2a)