### PR TITLE
fix: use regional terrain for `bank` and `bank_1`

### DIFF
--- a/data/json/mapgen/bank.json
+++ b/data/json/mapgen/bank.json
@@ -33,8 +33,8 @@
         "                        "
       ],
       "terrain": {
-        " ": [ "t_grass", "t_grass", "t_grass", "t_dirt", "t_shrub" ],
-        "'": "t_dirt",
+        " ": "t_region_groundcover_urban",
+        "'": "t_region_groundcover_urban",
         "#": "t_wall_w",
         "$": "t_metal_floor",
         "%": [ "t_door_c", "t_door_c", "t_door_locked_interior" ],
@@ -161,7 +161,7 @@
         "########4               "
       ],
       "terrain": {
-        " ": [ "t_grass", "t_grass", "t_grass", "t_dirt" ],
+        " ": "t_region_groundcover_urban",
         "'": "t_sidewalk",
         "_": "t_metal_floor",
         "|": [ "t_door_c", "t_wall_w", "t_wall_w", "t_wall_w", "t_wall_w", "t_wall_w", "t_wall_w", "t_wall_w", "t_wall_w" ],


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Use regional terrain for the mapgen `bank` and `bank_1`
## Describe the solution
Replace non-regional terrain with regional terrain.
## Describe alternatives you've considered
none
## Additional context
Before:
`bank`:
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/d6e74e61-2b8e-4bff-81f6-f756efdca122">
`bank_1`:
<img width="960" alt="image2" src="https://github.com/user-attachments/assets/a9f02275-4509-4ad5-a1b1-645df4faa638">
After:
<img width="960" alt="image3" src="https://github.com/user-attachments/assets/619c513e-d92f-4d39-a882-9d2f4d36192b">
<img width="960" alt="image4" src="https://github.com/user-attachments/assets/bd9c3eb0-3b59-4091-bee0-3d9d5791dea8">