### PR TITLE
fix: change the `fill_ter` of the mapgen `microlab_generic_surface` and use the regional terrain

### DIFF
--- a/data/json/mapgen/microlab/microlab_connector.json
+++ b/data/json/mapgen/microlab/microlab_connector.json
@@ -236,7 +236,7 @@
     "om_terrain": [ [ "microlab_generic_surface" ] ],
     "method": "json",
     "object": {
-      "fill_ter": "t_concrete",
+      "fill_ter": "t_thconc_floor",
       "rows": [
         " yyyyyyyyyyyyyyyyyyyyyy ",
         " yyyyyyyyyyyyyyyyyyyyyy ",
@@ -249,14 +249,14 @@
         " |         SS|________y ",
         " |         SS|________y ",
         " |   |((((|22||555555|y ",
-        " |   |........|yyyyyy|. ",
-        " |   |..dddd..|......|. ",
-        " |   |^.d.hd..5yyyyyy|  ",
+        " |   |........|ZZZZZZ|  ",
+        " |   |..dddd..|......|  ",
+        " |   |^.d.hd..5ZZZZZZ|  ",
         " |   |||||||..5......|  ",
-        " |   (V.??....Gyyyyyy|  ",
+        " |   (V.??....GZZZZZZ|  ",
         " |   (t.......|......|  ",
-        " |   (^???....|yyyyyy|  ",
-        " |   ||||||..^|yyyyyy|  ",
+        " |   (^???....|ZZZZZZ|  ",
+        " |   ||||||..^|ZZZZZZ|  ",
         " |   |.hd^=..^|eeeeee|  ",
         " |   |.dd.=..^|eeeeee|  ",
         " |   |B...=..^|EeeeeE|  ",
@@ -267,10 +267,11 @@
       "terrain": {
         "e": "t_elevator",
         "E": "t_elevator_control",
-        " ": "t_grass",
+        " ": "t_region_groundcover",
         "_": "t_pavement",
         "S": "t_sidewalk",
         ".": "t_thconc_floor",
+        "Z": "t_thconc_y",
         "G": "t_card_science"
       }
     }


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Change the `fill_ter` of the mapgen `microlab_generic_surface` because placing an outdoor terrain (`t_concrete`) indoors underneath the furniture is not good.
## Describe the solution
Use `t_thconc_floor` instead of `t_concrete` for the `fill_ter`
Replaced "t_grass" of the terrain " " by "t_region_groundcover"
Replaced `t_pavement_y` (yellow pavement) inside the building with `t_thconc_y`
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/c17c7556-312c-4b06-83ce-598263ffd208">
After:
<img width="960" alt="image2" src="https://github.com/user-attachments/assets/96567ec6-b3f8-4db8-a1c1-fda780b6f84a">