### PR TITLE
feat(balance): fix opaque furniture absorbing bullets, add ranged bash info to a few more furniture entries

### DIFF
--- a/data/json/furniture_and_terrain/furniture-decorative.json
+++ b/data/json/furniture_and_terrain/furniture-decorative.json
@@ -191,9 +191,9 @@
     "description": "A decorative wreath for the winter holidays.",
     "symbol": "o",
     "color": "light_green",
-    "move_cost_mod": -1,
+    "move_cost_mod": 0,
     "required_str": 10,
-    "flags": [ "PLACE_ITEM" ]
+    "flags": [ "PLACE_ITEM", "TRANSPARENT" ]
   },
   {
     "type": "furniture",
@@ -218,7 +218,8 @@
         { "item": "pine_bough", "count": [ 4, 6 ] },
         { "item": "nail", "charges": [ 5, 14 ] },
         { "item": "stick", "count": [ 1, 3 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 10, 20 ], "destroy_threshold": 40, "block_unaimed_chance": "25%" }
     }
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-domestic_plants.json
+++ b/data/json/furniture_and_terrain/furniture-domestic_plants.json
@@ -148,7 +148,7 @@
     },
     "bash": {
       "str_min": 6,
-      "str_max": 14,
+      "str_max": 20,
       "sound": "crunch.",
       "sound_fail": "whish.",
       "items": [
@@ -156,7 +156,9 @@
         { "item": "nail", "charges": [ 15, 30 ] },
         { "item": "pebble", "charges": [ 150, 200 ] },
         { "item": "material_soil", "count": [ 60, 75 ] }
-      ]
+      ],
+      "//": "reduction equal to str_max, since filled with soil.",
+      "ranged": { "reduction": [ 20, 20 ], "destroy_threshold": 20, "block_unaimed_chance": "25%" }
     },
     "plant_data": { "transform": "f_planter_seed" },
     "examine_action": "dirtmound"
@@ -183,7 +185,7 @@
     },
     "bash": {
       "str_min": 6,
-      "str_max": 14,
+      "str_max": 20,
       "sound": "crunch.",
       "sound_fail": "whish.",
       "items": [
@@ -191,7 +193,9 @@
         { "item": "nail", "charges": [ 15, 30 ] },
         { "item": "pebble", "charges": [ 150, 200 ] },
         { "item": "material_soil", "count": [ 60, 75 ] }
-      ]
+      ],
+      "//": "reduction equal to str_max, since filled with soil.",
+      "ranged": { "reduction": [ 20, 20 ], "destroy_threshold": 20, "block_unaimed_chance": "25%" }
     },
     "plant_data": { "transform": "f_planter", "base": "f_planter" }
   },
@@ -217,7 +221,7 @@
     },
     "bash": {
       "str_min": 6,
-      "str_max": 14,
+      "str_max": 20,
       "sound": "crunch.",
       "sound_fail": "whish.",
       "items": [
@@ -225,7 +229,9 @@
         { "item": "nail", "charges": [ 15, 30 ] },
         { "item": "pebble", "charges": [ 150, 200 ] },
         { "item": "material_soil", "count": [ 60, 75 ] }
-      ]
+      ],
+      "//": "reduction equal to str_max, since filled with soil.",
+      "ranged": { "reduction": [ 20, 20 ], "destroy_threshold": 20, "block_unaimed_chance": "25%" }
     },
     "plant_data": { "transform": "f_planter_harvest", "base": "f_planter" }
   },
@@ -251,7 +257,7 @@
     },
     "bash": {
       "str_min": 6,
-      "str_max": 14,
+      "str_max": 20,
       "sound": "crunch.",
       "sound_fail": "whish.",
       "items": [
@@ -259,7 +265,9 @@
         { "item": "nail", "charges": [ 15, 30 ] },
         { "item": "pebble", "charges": [ 150, 200 ] },
         { "item": "material_soil", "count": [ 60, 75 ] }
-      ]
+      ],
+      "//": "reduction equal to str_max, since filled with soil.",
+      "ranged": { "reduction": [ 20, 20 ], "destroy_threshold": 20, "block_unaimed_chance": "25%" }
     },
     "plant_data": { "transform": "f_planter_seedling", "base": "f_planter" }
   },
@@ -285,7 +293,7 @@
     },
     "bash": {
       "str_min": 6,
-      "str_max": 14,
+      "str_max": 20,
       "sound": "crunch.",
       "sound_fail": "whish.",
       "items": [
@@ -293,7 +301,9 @@
         { "item": "nail", "charges": [ 15, 30 ] },
         { "item": "pebble", "charges": [ 150, 200 ] },
         { "item": "material_soil", "count": [ 60, 75 ] }
-      ]
+      ],
+      "//": "reduction equal to str_max, since filled with soil.",
+      "ranged": { "reduction": [ 20, 20 ], "destroy_threshold": 20, "block_unaimed_chance": "25%" }
     },
     "plant_data": { "transform": "f_planter_mature", "base": "f_planter" }
   },
@@ -314,7 +324,8 @@
       "str_max": 15,
       "sound": "crack.",
       "sound_fail": "whump.",
-      "items": [ { "item": "2x4", "count": [ 0, 6 ] }, { "item": "nail", "charges": [ 0, 8 ] }, { "item": "rag", "count": [ 0, 12 ] } ]
+      "items": [ { "item": "2x4", "count": [ 0, 6 ] }, { "item": "nail", "charges": [ 0, 8 ] }, { "item": "rag", "count": [ 0, 12 ] } ],
+      "ranged": { "reduction": [ 3, 5 ], "destroy_threshold": 15, "block_unaimed_chance": "25%" }
     },
     "examine_action": "dirtmound",
     "plant_data": { "transform": "f_rack_mushroom_seed" }

--- a/data/json/furniture_and_terrain/furniture-fungal.json
+++ b/data/json/furniture_and_terrain/furniture-fungal.json
@@ -35,7 +35,13 @@
     "move_cost_mod": -10,
     "required_str": -1,
     "flags": [ "CONTAINER", "SEALED", "ALLOW_FIELD_EFFECT", "FLAMMABLE_ASH", "FUNGUS", "MOUNTABLE", "SHORT" ],
-    "bash": { "str_min": 6, "str_max": 30, "sound": "poof.", "sound_fail": "poof." }
+    "bash": {
+      "str_min": 6,
+      "str_max": 30,
+      "sound": "poof.",
+      "sound_fail": "poof.",
+      "ranged": { "reduction": [ 3, 6 ], "destroy_threshold": 30, "block_unaimed_chance": "50%" }
+    }
   },
   {
     "type": "furniture",
@@ -60,6 +66,12 @@
     "move_cost_mod": -1,
     "required_str": -1,
     "flags": [ "FLAMMABLE_ASH", "FUNGUS" ],
-    "bash": { "str_min": 26, "str_max": 50, "sound": "poof.", "sound_fail": "squelch." }
+    "bash": {
+      "str_min": 26,
+      "str_max": 50,
+      "sound": "poof.",
+      "sound_fail": "squelch.",
+      "ranged": { "reduction": [ 13, 26 ], "destroy_threshold": 50, "block_unaimed_chance": "75%" }
+    }
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-industrial.json
+++ b/data/json/furniture_and_terrain/furniture-industrial.json
@@ -220,6 +220,7 @@
     "symbol": "|",
     "color": "light_gray",
     "move_cost_mod": 1,
+    "coverage": 30,
     "required_str": -1,
     "flags": [ "TRANSPARENT", "NOCOLLIDE" ],
     "bash": {
@@ -232,7 +233,8 @@
         { "item": "scrap_copper", "count": [ 10, 20 ] },
         { "item": "cable", "charges": [ 20, 100 ] },
         { "item": "pipe", "count": [ 1, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 5, 10 ], "destroy_threshold": 100, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -262,7 +264,8 @@
         { "item": "amplifier", "count": [ 0, 4 ] },
         { "item": "power_supply", "count": [ 0, 2 ] },
         { "item": "metal_tank_little", "count": [ 0, 6 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 13, 25 ], "destroy_threshold": 200, "block_unaimed_chance": "25%" }
     }
   },
   {

--- a/data/json/furniture_and_terrain/furniture-terrains.json
+++ b/data/json/furniture_and_terrain/furniture-terrains.json
@@ -134,7 +134,7 @@
         { "item": "paper", "count": [ 20, 40 ] },
         { "item": "plastic_chunk", "count": [ 5, 20 ] },
         { "item": "plastic_sheet", "count": [ 0, 2 ] }
-      ]
+      ],      "ranged": { "reduction": [ 3, 6 ], "destroy_threshold": 20 }
     }
   },
   {
@@ -274,7 +274,7 @@
         { "item": "paper", "count": [ 50, 150 ] },
         { "item": "plastic_chunk", "count": [ 5, 20 ] },
         { "item": "plastic_sheet", "count": [ 0, 2 ] }
-      ]
+      ],      "ranged": { "reduction": [ 2, 4 ], "destroy_threshold": 13 }
     }
   },
   {
@@ -303,7 +303,9 @@
         { "item": "string_36", "count": [ 3, 15 ] },
         { "item": "stick_long", "count": 1 },
         { "item": "wooden_bead", "count": [ 200, 500 ] }
-      ]
+      ],
+      "//": "Go straight through without taking any damage.",
+      "ranged": { "block_unaimed_chance": "0%" }
     }
   },
   {
@@ -362,7 +364,9 @@
       "sound": "rrrrip!",
       "sound_fail": "slap!",
       "sound_vol": 8,
-      "tent_centers": [ "f_groundsheet", "f_fema_groundsheet", "f_skin_groundsheet" ]
+      "tent_centers": [ "f_groundsheet", "f_fema_groundsheet", "f_skin_groundsheet" ],
+      "//": "Go straight through without taking any damage.",
+      "ranged": { "block_unaimed_chance": "0%" }
     }
   },
   {
@@ -383,7 +387,9 @@
       "sound_fail": "slap!",
       "sound_vol": 8,
       "collapse_radius": 2,
-      "tent_centers": [ "f_center_groundsheet" ]
+      "tent_centers": [ "f_center_groundsheet" ],
+      "//": "Go straight through without taking any damage.",
+      "ranged": { "block_unaimed_chance": "0%" }
     }
   },
   {
@@ -404,7 +410,9 @@
       "sound": "rrrrip!",
       "sound_fail": "slap!",
       "sound_vol": 8,
-      "tent_centers": [ "f_groundsheet", "f_fema_groundsheet", "f_skin_groundsheet" ]
+      "tent_centers": [ "f_groundsheet", "f_fema_groundsheet", "f_skin_groundsheet" ],
+      "//": "Go straight through without taking any damage.",
+      "ranged": { "block_unaimed_chance": "0%" }
     }
   },
   {
@@ -446,7 +454,9 @@
       "sound_fail": "slap!",
       "sound_vol": 8,
       "collapse_radius": 2,
-      "tent_centers": [ "f_center_groundsheet" ]
+      "tent_centers": [ "f_center_groundsheet" ],
+      "//": "Go straight through without taking any damage.",
+      "ranged": { "block_unaimed_chance": "0%" }
     }
   },
   {
@@ -571,7 +581,9 @@
       "sound": "rrrrip!",
       "sound_fail": "slap!",
       "sound_vol": 8,
-      "tent_centers": [ "f_groundsheet", "f_fema_groundsheet", "f_skin_groundsheet" ]
+      "tent_centers": [ "f_groundsheet", "f_fema_groundsheet", "f_skin_groundsheet" ],
+      "//": "Go straight through without taking any damage.",
+      "ranged": { "block_unaimed_chance": "0%" }
     }
   },
   {
@@ -592,7 +604,9 @@
       "sound": "rrrrip!",
       "sound_fail": "slap!",
       "sound_vol": 8,
-      "tent_centers": [ "f_groundsheet", "f_fema_groundsheet", "f_skin_groundsheet" ]
+      "tent_centers": [ "f_groundsheet", "f_fema_groundsheet", "f_skin_groundsheet" ],
+      "//": "Go straight through without taking any damage.",
+      "ranged": { "block_unaimed_chance": "0%" }
     }
   },
   {

--- a/data/json/furniture_and_terrain/furniture-terrains.json
+++ b/data/json/furniture_and_terrain/furniture-terrains.json
@@ -134,7 +134,8 @@
         { "item": "paper", "count": [ 20, 40 ] },
         { "item": "plastic_chunk", "count": [ 5, 20 ] },
         { "item": "plastic_sheet", "count": [ 0, 2 ] }
-      ],      "ranged": { "reduction": [ 3, 6 ], "destroy_threshold": 20 }
+      ],
+      "ranged": { "reduction": [ 3, 6 ], "destroy_threshold": 20 }
     }
   },
   {
@@ -274,7 +275,8 @@
         { "item": "paper", "count": [ 50, 150 ] },
         { "item": "plastic_chunk", "count": [ 5, 20 ] },
         { "item": "plastic_sheet", "count": [ 0, 2 ] }
-      ],      "ranged": { "reduction": [ 2, 4 ], "destroy_threshold": 13 }
+      ],
+      "ranged": { "reduction": [ 2, 4 ], "destroy_threshold": 13 }
     }
   },
   {

--- a/data/json/furniture_and_terrain/furniture-tools.json
+++ b/data/json/furniture_and_terrain/furniture-tools.json
@@ -954,6 +954,7 @@
     "symbol": "O",
     "color": "brown",
     "move_cost_mod": -1,
+    "coverage": 60,
     "required_str": -1,
     "flags": [ "NOITEM", "SEALED", "TRANSPARENT", "FLAMMABLE", "CONTAINER", "DONT_REMOVE_ROTTEN" ],
     "examine_action": "fvat_empty",
@@ -977,7 +978,8 @@
         { "item": "sheet_metal_small", "count": [ 2, 6 ] },
         { "item": "scrap", "count": [ 5, 10 ] },
         { "item": "splinter", "count": 1 }
-      ]
+      ],
+      "ranged": { "reduction": [ 2, 3 ], "destroy_threshold": 45, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -988,6 +990,7 @@
     "symbol": "O",
     "color": "brown_cyan",
     "move_cost_mod": -1,
+    "coverage": 60,
     "required_str": -1,
     "flags": [ "NOITEM", "SEALED", "TRANSPARENT", "FLAMMABLE", "CONTAINER", "DONT_REMOVE_ROTTEN" ],
     "examine_action": "fvat_full",
@@ -1012,7 +1015,8 @@
         { "item": "sheet_metal_small", "count": [ 2, 6 ] },
         { "item": "scrap", "count": [ 5, 10 ] },
         { "item": "splinter", "count": 1 }
-      ]
+      ],
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -1084,6 +1088,7 @@
     "symbol": "T",
     "bgcolor": "red",
     "move_cost_mod": 2,
+    "coverage": 30,
     "required_str": -1,
     "examine_action": "quern_examine",
     "flags": [ "SEALED", "ALLOW_FIELD_EFFECT", "CONTAINER", "NOITEM", "BLOCKSDOOR" ],
@@ -1098,7 +1103,8 @@
         { "item": "pipe", "count": [ 1, 3 ] },
         { "item": "sheet_metal_small", "count": [ 4, 8 ] },
         { "item": "rock", "count": [ 8, 15 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 8, 16 ], "destroy_threshold": 50, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -1109,6 +1115,7 @@
     "symbol": "T",
     "bgcolor": "red",
     "move_cost_mod": 2,
+    "coverage": 30,
     "required_str": -1,
     "examine_action": "quern_examine",
     "flags": [ "SEALED", "ALLOW_FIELD_EFFECT", "CONTAINER", "NOITEM", "BLOCKSDOOR" ],
@@ -1123,7 +1130,8 @@
         { "item": "pipe", "count": [ 1, 3 ] },
         { "item": "sheet_metal_small", "count": [ 4, 8 ] },
         { "item": "rock", "count": [ 8, 15 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 8, 16 ], "destroy_threshold": 50, "block_unaimed_chance": "25%" }
     }
   },
   {
@@ -1134,6 +1142,7 @@
     "symbol": "*",
     "bgcolor": "red",
     "move_cost_mod": 2,
+    "coverage": 60,
     "required_str": -1,
     "examine_action": "quern_examine",
     "flags": [ "SEALED", "ALLOW_FIELD_EFFECT", "CONTAINER", "NOITEM", "BLOCKSDOOR" ],
@@ -1150,7 +1159,8 @@
         { "item": "sheet_metal_small", "count": [ 2, 3 ] },
         { "item": "scrap", "count": [ 3, 5 ] },
         { "item": "rock", "count": [ 8, 15 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -1161,6 +1171,7 @@
     "symbol": "*",
     "bgcolor": "red",
     "move_cost_mod": 2,
+    "coverage": 60,
     "required_str": -1,
     "examine_action": "quern_examine",
     "flags": [ "SEALED", "ALLOW_FIELD_EFFECT", "CONTAINER", "NOITEM", "BLOCKSDOOR" ],
@@ -1177,7 +1188,8 @@
         { "item": "sheet_metal_small", "count": [ 2, 3 ] },
         { "item": "scrap", "count": [ 3, 5 ] },
         { "item": "rock", "count": [ 8, 15 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 6, 12 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
     }
   },
   {


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

I noticed that opaque furniture can stop bullets if they lack ranged bash info, destroying the furniture but perfectly preventing any overpenetration. Decided to fix it so relevant affected furniture will be shot through as expected, and applied ranged bash info to a few more furniture items I spotted along the way.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Added ranged bash info to decorative trees, being a weirdo opaque furniture capable of always absorbing bullets, and set wreathes to be transparent and permit walking under them to stop being an obstacle.
2. Added ranged bash info to planters and mushroom racks, with planters getting `str_max` raised a bit and ballistic resistance fitting for an item stuffed with soil.
3. Added ranged bash info to the two fungal furniture entries that're opaque.
4. Updated coverage and ranged bash info of electrical conduits and capacitor banks.
5. Added ranged bash info to privacy curtains to make them no longer intercept bullets.
6. Added ranged bash info to cardboard walls, beaded curtains, and canvas walls to stop them from perfectly absorbing a single bullet and then crumbling. Adding ranged data to these furniture walls means the shots will correctly punch through instead of stopping.
7. Added coverage value and ranged bash info to fermenting vats, wind mills, and water mills.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

screm

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Ported file changes to playthrough release and load-tested.
3. Placed a tent, confirmed shooting through it no longer intercepts the bullet.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Also on the list for flavor: tempted to make the steel target transform into a knocked-down version instead of being destroyed when bashed, then adding a transform iexamine to swap it back and forth between those states. I'd likely need to add an external tileset sprite for the knocked-down version since I'm not sure what'd be a good looks-like entry for a knocked-over target...