### PR TITLE
feat(content): add a larger size of sail, adjust recipes, show sails on top of vehicles

### DIFF
--- a/data/json/items/vehicle/boat.json
+++ b/data/json/items/vehicle/boat.json
@@ -66,7 +66,7 @@
     "type": "GENERIC",
     "id": "sail",
     "name": { "str": "sail" },
-    "description": "Sails for a boat.",
+    "description": "A small sail and makeshift rigging for a raft.",
     "weight": "7904 g",
     "to_hit": -1,
     "color": "light_gray",
@@ -77,6 +77,20 @@
     "category": "veh_parts",
     "price": "90 USD",
     "price_postapoc": "1250 cent"
+  },
+  {
+    "type": "GENERIC",
+    "id": "sail_large_item",
+    "copy-from": "sail",
+    "name": { "str": "large sail" },
+    "description": "A wooden mast with sails fit for a yacht or sloop, and about as much rigging as a single sailor can handle.",
+    "//": "About half the weight and volume of the wooden beam, assumes a good amount is lost in the recipe",
+    "weight": "18 kg",
+    "to_hit": -4,
+    "volume": "30 L",
+    "bashing": 12,
+    "price": "300 USD",
+    "price_postapoc": "20 USD"
   },
   {
     "type": "GENERIC",

--- a/data/json/recipes/other/vehicles.json
+++ b/data/json/recipes/other/vehicles.json
@@ -608,7 +608,21 @@
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 1 } ],
     "using": [ [ "sewing_standard", 100 ] ],
-    "components": [ [ [ "sheet", 2 ] ], [ [ "2x4", 4 ], [ "stick", 4 ] ], [ [ "nail_glue", 20, "LIST" ] ] ]
+    "components": [ [ [ "sheet", 2 ] ], [ [ "wood_structural", 2, "LIST" ] ], [ [ "rope_natural_short", 1, "LIST" ] ], [ [ "nail_glue", 20, "LIST" ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "sail_large_item",
+    "byproducts": [ [ "splinter", 15 ] ],
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_VEHICLE",
+    "skill_used": "fabrication",
+    "difficulty": 4,
+    "time": "50 m",
+    "autolearn": true,
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 1 } ],
+    "using": [ [ "sewing_standard", 250 ] ],
+    "components": [ [ [ "sheet", 8 ] ], [ [ "wood_beam", 1 ] ], [ [ "wood_structural", 2, "LIST" ] ], [ [ "rope_natural", 1, "LIST" ] ], [ [ "nail_glue", 50, "LIST" ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -1311,7 +1311,8 @@
   {
     "type": "vehicle_part",
     "id": "sail",
-    "name": { "str": "sail" },
+    "name": { "str": "small sail" },
+    "description": "A sail for a raft, small enough to be foldable.",
     "symbol": "M",
     "color": "light_gray",
     "broken_symbol": "#",
@@ -1324,12 +1325,12 @@
     "m2c": 90,
     "exclusions": [ "wind" ],
     "item": "sail",
-    "location": "engine_block",
+    "location": "on_roof",
     "folded_volume": "500 ml",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "60 m", "using": [ [ "vehicle_nail_install", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "60 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "60 m", "using": [ [ "adhesive", 2 ], [ "wood_structural_small", 1 ] ] }
+      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_nail_install", 1 ] ] },
+      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },
+      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "30 m", "using": [ [ "adhesive", 2 ], [ "wood_structural_small", 1 ] ] }
     },
     "flags": [
       "ENGINE",
@@ -1343,6 +1344,23 @@
       "UNMOUNT_ON_DAMAGE"
     ],
     "breaks_into": [ { "item": "splinter", "count": [ 2, 4 ] }, { "item": "rag", "count": [ 5, 10 ] } ]
+  },
+  {
+    "type": "vehicle_part",
+    "id": "sail_large",
+    "copy-from": "sail",
+    "name": { "str": "large sail" },
+    "description": "Sails and rigging fit for a yacht or sloop, about as large as a single person can reasonably crew.",
+    "durability": 150,
+    "power": 4000,
+    "item": "sail_large_item",
+    "requirements": {
+      "install": { "skills": [ [ "mechanics", 4 ] ], "time": "60 m", "using": [ [ "vehicle_nail_install", 2 ] ] },
+      "removal": { "skills": [ [ "mechanics", 4 ] ], "time": "60 m", "using": [ [ "vehicle_nail_removal", 2 ] ] },
+      "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "60 m", "using": [ [ "adhesive", 2 ], [ "wood_structural_small", 1 ] ] }
+    },
+    "breaks_into": [ { "item": "log", "count": [ 1, 2 ] }, { "item": "splinter", "count": [ 10, 20 ] }, { "item": "sheet", "count": [ 0, 1 ] }, { "item": "rag", "count": [ 25, 50 ] } ],
+    "delete": { "flags": [ "UNMOUNT_ON_DAMAGE" ] }
   },
   {
     "type": "vehicle_part",


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Fer plunderin'

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Moved sails to the `on_roof` slot, as there is a sprite for them that now becomes visible when viewing the part from outside, and added a description to clarify these are smaller sails, and reduced time to install/repair. Speaking of...
2. Defined a part for a larger set of sails with a higher baseline power.
3. Defined the item form for large sails.
4. Defined recipe, uses a wooden beam, rope, and in general more materials than normal sails.
5. Misc: Added a single short rope to the requirements for small sails.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Adding a better sprite for sails, especially big ones. I'd have to test whether multi-tile sprites for vehicleparts works or not, a long time ago I tried testing that for tankmod and it had some weird layering issues.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.
3. Temporarily added in a test vehicle uploaded below, a small sloop loaded with cannon.
4. Confirmed it has enough power to sail around reliably, when installing small sails on it makes it spam "too heavy for engines" messages if you aren't catching enough with.
5. Stepped off and confirmed I can see the sail. It's kinda smol though...

![image](https://github.com/user-attachments/assets/2d211aec-8a62-4894-b334-1eaa4b36b99e)

Test vehicle:
[The Silly.json](https://github.com/user-attachments/files/17032706/The.Silly.json)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
