### PR TITLE
fix: prevent sewer from passing under `4x4_microlab_surface` entrance

### DIFF
--- a/data/json/mapgen/microlab/microlab_connector.json
+++ b/data/json/mapgen/microlab/microlab_connector.json
@@ -2,6 +2,12 @@
   {
     "type": "mapgen",
     "method": "json",
+    "om_terrain": [ "microlab_under_connector" ],
+    "object": { "fill_ter": "t_rock" }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
     "om_terrain": [ "microlab_sub_connector" ],
     "weight": 1000,
     "object": {

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -2922,6 +2922,7 @@
     "overmaps": [
       { "point": [ 2, 1, 1 ], "overmap": "microlab_generic_surface_roof_north" },
       { "point": [ 2, 1, 0 ], "overmap": "microlab_generic_surface_north" },
+      { "point": [ 2, 1, -1 ], "overmap": "microlab_under_connector" },
       { "point": [ 2, -1, -2 ], "overmap": "microlab_sub_station_north" },
       { "point": [ 0, -1, -2 ], "overmap": "microlab_rock_border" },
       { "point": [ 1, -1, -2 ], "overmap": "microlab_rock_border" },

--- a/data/json/overmap/overmap_terrain/overmap_terrain_microlab.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_microlab.json
@@ -85,5 +85,10 @@
     "type": "overmap_terrain",
     "id": "microlab_generic_surface_roof",
     "copy-from": "microlab_generic_surface"
+  },
+  {
+    "type": "overmap_terrain",
+    "id": "microlab_under_connector",
+    "copy-from": "empty_rock"
   }
 ]


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Prevent sewer from passing under the surface entrance of `4x4_microlab_surface` because there is an elevator on the mapgen `microlab_generic_surface` and `microlab_generic_surface_connector`
## Describe the solution
Create the mapgen `microlab_under_connector` and place it under the surface entrance of `4x4_microlab_surface` to prevent sewer from passing between `microlab_generic_surface` and `microlab_generic_surface_connector`
## Describe alternatives you've considered
none
## Testing
none
## Additional context
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/c951a96a-b38d-49f2-b9a6-ca236adc39d8">