### PR TITLE
feat(balance): cave entrances can spawn niter and other minerals, sanity-check gunpowder recipe

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -275,9 +275,10 @@
     "id": "cave_minerals",
     "subtype": "distribution",
     "entries": [
-      { "item": "material_niter", "prob": 20 },
-      { "item": "iron_ore", "prob": 10 },
-      { "item": "material_limestone", "prob": 5 }
+      { "item": "material_niter", "prob": 75 },
+      { "item": "material_rocksalt", "prob": 10 },
+      { "item": "chunk_sulfur", "prob": 10 },
+      { "item": "iron_ore", "prob": 5 }
     ]
   },
   {

--- a/data/json/mapgen/cave.json
+++ b/data/json/mapgen/cave.json
@@ -40,14 +40,7 @@
         ";": "t_dirt",
         "<": "t_slope_down"
       },
-      "furniture": {  },
-      "items": {
-        "O": { "item": "gym", "chance": 30 },
-        "c": { "item": "gym", "chance": 10 },
-        "f": { "item": "vending_drink_items", "chance": 30, "repeat": [ 2, 4 ] },
-        "r": { "item": "snacks", "chance": 20, "repeat": [ 2, 4 ] }
-      },
-      "nested": { "U": { "chunks": [ [ "roof_6x6_garden_1", 50 ], [ "roof_6x6_garden_2", 50 ] ] } }
+      "items": { ",": [ { "item": "cave_minerals", "chance": 5 } ] }
     }
   },
   {
@@ -91,7 +84,8 @@
         ",": "t_rock_roof",
         "<": "t_slope_down"
       },
-      "furniture": {  }
+      "furniture": {  },
+      "items": { ",": [ { "item": "cave_minerals", "chance": 5 } ] }
     }
   },
   {
@@ -138,7 +132,8 @@
       },
       "furniture": {  },
       "fields": { "W": { "field": "fd_web", "intensity": 2, "age": 10 } },
-      "monsters": { "W": { "monster": "GROUP_SPIDER", "chance": 2, "density": 0.01 } }
+      "monsters": { "W": { "monster": "GROUP_SPIDER", "chance": 2, "density": 0.01 } },
+      "items": { ",": [ { "item": "cave_minerals", "chance": 5 } ] }
     }
   },
   {
@@ -184,7 +179,8 @@
         "<": "t_slope_down"
       },
       "fields": { "W": { "field": "fd_web", "intensity": 1, "age": 10 } },
-      "furniture": {  }
+      "furniture": {  },
+      "items": { ",": [ { "item": "cave_minerals", "chance": 5 } ] }
     }
   },
   {
@@ -230,7 +226,8 @@
         "<": "t_slope_down"
       },
       "furniture": {  },
-      "monster": { "B": { "monster": "mon_bat" } }
+      "monster": { "B": { "monster": "mon_bat" } },
+      "items": { ",": [ { "item": "cave_minerals", "chance": 5 } ] }
     }
   },
   {
@@ -278,7 +275,8 @@
       },
       "furniture": {  },
       "fields": { "W": { "field": "fd_web", "intensity": 1, "age": 10 } },
-      "monster": { "B": { "monster": "mon_bear" } }
+      "monster": { "B": { "monster": "mon_bear" } },
+      "items": { ",": [ { "item": "cave_minerals", "chance": 5 } ] }
     }
   },
   {
@@ -325,7 +323,8 @@
         "<": "t_slope_down"
       },
       "fields": { "W": { "field": "fd_web", "intensity": 1, "age": 10 } },
-      "furniture": {  }
+      "furniture": {  },
+      "items": { ",": [ { "item": "cave_minerals", "chance": 5 } ] }
     }
   },
   {
@@ -373,7 +372,8 @@
       },
       "furniture": {  },
       "fields": { "W": { "field": "fd_web", "intensity": 1, "age": 10 } },
-      "monster": { "B": { "monster": "mon_cougar" } }
+      "monster": { "B": { "monster": "mon_cougar" } },
+      "items": { ",": [ { "item": "cave_minerals", "chance": 5 } ] }
     }
   },
   {

--- a/data/json/recipes/ammo/components.json
+++ b/data/json/recipes/ammo/components.json
@@ -16,11 +16,10 @@
       [ "book_icef", 5 ],
       [ "reference_cooking", 5 ]
     ],
-    "charges": 10,
+    "//": "Roughly consistent by weight, about 70 grams of material.",
+    "charges": 35,
     "qualities": [ { "id": "CONTAIN", "level": 1 } ],
-    "//": "Roughly consistent by weight, saltpeter is in smaller stack sizes than most chems, so much less is used.",
-    "//2": "Charcoal is in excess of the amount required however, due to even smaller stack size.",
-    "components": [ [ [ "chem_saltpetre", 2 ] ], [ [ "chem_sulphur", 5 ] ], [ [ "charcoal", 1 ], [ "coal_lump", 1 ] ] ]
+    "components": [ [ [ "chem_saltpetre", 10 ] ], [ [ "chem_sulphur", 20 ] ], [ [ "charcoal", 1 ], [ "coal_lump", 1 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Had an idea to make saltpeter less hassle to deal with, but along the way I started sanity-checking my math in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/1268 and realized I completely bungled it such that the recipe was only like 50% saltpeter, when it wasn't that hard to calculate a ratio that's more accurate but not absurdly wasteful.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Gave cave entrances a chance to spawn items of group `cave_mineral`, mainly representing bat activity in conjuction with the below change but still potentially spawning some other loose minerals.
2. Adjusted weights of contents in `cave_minerals` to favor niter 75% of the time, with some chances of spawning sulfur, rock salt, or iron ore. Limestone no longer present since it's already widely available from mining rocks or smashing boulders, and iron ore also kept more rare since it's easy to find in swamps.
3. Fixed the ratio in gunpowder recipe. So it turns out at some point I seriously screwed up the math, for it to be consistent by weight you'd want about 55 grams of saltpeter per 11-gram unit of charcoal, and 1 unit of saltpeter is 5.275 grams so it makes sense for it to be about 10:1. Sulfur meanwhile is .32 grams per unit, so you'd want ~22.92 units of it to match 1 charcoal. I opted to make it a simple even 20 sulfur instead, meanwhile in exchange bumped charges produced per batch to 35 since it now uses 70 grams of material (not counting how coal affects this) and each unit of powder is 2 grams.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Putting mineral spawns in the underground sections instead, which tend to spawn their own things.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.
3. Warped over to a cave and took a look.
4. Also actually did the math properly this time for blackpowder.

![image](https://github.com/user-attachments/assets/a8f5ecf0-f1c0-4807-853d-6e1212ecfbbe)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Also on my radar for a later PR: https://github.com/CleverRaven/Cataclysm-DDA/pull/55486