### PR TITLE
feat(balance): use mattresses for vehicle beds and clocks for vehicle clocks, balance updates to associated items and recipes

### DIFF
--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -1757,7 +1757,7 @@
     "symbol": ";",
     "color": "light_gray",
     "name": { "str": "clock" },
-    "description": "A cheap digital clock.  Tells the time and has an alarm clock feature.",
+    "description": "A small mechanical clock.  Tells the time and has an alarm clock feature.",
     "price": "10 USD",
     "price_postapoc": "10 cent",
     "material": [ "plastic", "steel" ],

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -1757,14 +1757,15 @@
     "symbol": ";",
     "color": "light_gray",
     "name": { "str": "clock" },
-    "description": "A small mechanical clock, it's stopped at 10:10.",
+    "description": "A cheap digital clock.  Tells the time and has an alarm clock feature.",
     "price": "10 USD",
     "price_postapoc": "10 cent",
     "material": [ "plastic", "steel" ],
     "weight": "725 g",
     "volume": "250 ml",
     "bashing": 4,
-    "to_hit": -3
+    "to_hit": -3,
+    "flags": [ "WATCH", "ALARMCLOCK" ]
   },
   {
     "type": "GENERIC",

--- a/data/json/recipes/other/other.json
+++ b/data/json/recipes/other/other.json
@@ -25,13 +25,24 @@
   },
   {
     "type": "recipe",
+    "result": "mattress",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_OTHER",
+    "skill_used": "tailor",
+    "difficulty": 6,
+    "time": "240 m",
+    "autolearn": true,
+    "using": [ [ "sewing_standard", 12 ] ],
+    "components": [ [ [ "rag", 60 ] ], [ [ "cotton_ball", 100 ] ], [ [ "spring", 5 ] ] ]
+  },
+  {
+    "type": "recipe",
     "result": "down_mattress",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_OTHER",
     "skill_used": "tailor",
     "difficulty": 6,
     "time": "240 m",
-    "reversible": true,
     "autolearn": true,
     "using": [ [ "sewing_standard", 12 ] ],
     "components": [ [ [ "rag", 60 ] ], [ [ "down_feather", 1160 ] ] ]
@@ -576,7 +587,6 @@
     "skill_used": "tailor",
     "difficulty": 6,
     "time": "240 m",
-    "reversible": true,
     "autolearn": true,
     "using": [ [ "sewing_standard", 12 ] ],
     "components": [ [ [ "felt_patch", 60 ] ], [ [ "yarn", 650 ] ] ]

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -76,9 +76,27 @@
     "type": "uncraft",
     "skill_used": "tailor",
     "difficulty": 1,
-    "time": "22 s",
+    "time": "15 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "rag", 60 ] ], [ [ "sheet", 4 ] ], [ [ "scrap", 20 ] ], [ [ "wire", 20 ] ] ]
+    "components": [ [ [ "rag", 60 ] ], [ [ "cotton_ball", 100 ] ], [ [ "spring", 5 ] ] ]
+  },
+  {
+    "result": "down_mattress",
+    "type": "uncraft",
+    "skill_used": "tailor",
+    "difficulty": 1,
+    "time": "15 m",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "rag", 60 ] ], [ [ "down_feather", 1160 ] ] ]
+  },
+  {
+    "result": "wool_mattress",
+    "type": "uncraft",
+    "skill_used": "tailor",
+    "difficulty": 1,
+    "time": "15 m",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "felt_patch", 60 ] ], [ [ "yarn", 650 ] ] ]
   },
   {
     "result": "character_sheet",
@@ -1609,7 +1627,7 @@
     "type": "uncraft",
     "time": "1 m",
     "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "components": [ [ [ "scrap", 3 ] ], [ [ "clockworks", 2 ] ] ]
+    "components": [ [ [ "plastic_chunk", 2 ] ], [ [ "processor", 1 ] ], [ [ "power_supply", 1 ] ] ]
   },
   {
     "result": "collarpin",

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -1627,7 +1627,7 @@
     "type": "uncraft",
     "time": "1 m",
     "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "components": [ [ [ "plastic_chunk", 2 ] ], [ [ "processor", 1 ] ], [ [ "power_supply", 1 ] ] ]
+    "components": [ [ [ "plastic_chunk", 2 ] ], [ [ "processor", 1 ] ], [ [ "light_battery_cell", 1 ] ] ]
   },
   {
     "result": "collarpin",

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -1627,7 +1627,7 @@
     "type": "uncraft",
     "time": "1 m",
     "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "components": [ [ [ "plastic_chunk", 2 ] ], [ [ "processor", 1 ] ], [ [ "light_battery_cell", 1 ] ] ]
+    "components": [ [ [ "scrap", 3 ] ], [ [ "clockworks", 2 ] ] ]
   },
   {
     "result": "collarpin",

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -266,17 +266,22 @@
     "durability": 95,
     "description": "A small but comfortable bed.",
     "size": "50 L",
-    "item": "seat",
+    "item": "mattress",
     "comfort": 4,
-    "floor_bedding_warmth": 300,
+    "floor_bedding_warmth": 800,
     "location": "center",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] },
-      "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "30 m", "using": [ [ "vehicle_weld_removal", 1 ] ] },
+      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "60 m", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
+      "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "30 m", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ], [ "steel_tiny", 1 ] ] }
     },
     "flags": [ "BED", "BOARDABLE", "CARGO", "MOUNTABLE" ],
-    "breaks_into": "ig_vp_seat",
+    "breaks_into": [
+      { "item": "rag", "count": [ 1, 20 ] },
+      { "item": "cotton_ball", "count": [ 5, 25 ] },
+      { "item": "spring", "count": [ 0, 3 ] },
+      { "item": "scrap", "count": [ 4, 6 ] }
+    ],
     "damage_reduction": { "all": 3 }
   },
   {
@@ -2871,7 +2876,7 @@
     "description": "A clock, so you know what time it is.",
     "epower": 0,
     "folded_volume": "250 ml",
-    "item": "wristwatch",
+    "item": "clock",
     "requirements": {
       "install": { "skills": [ [ "mechanics", 0 ] ], "time": "150 s", "using": [ [ "vehicle_screw", 1 ] ] },
       "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "150 s", "using": [ [ "vehicle_screw", 1 ] ] },

--- a/tests/vehicle_drag_test.cpp
+++ b/tests/vehicle_drag_test.cpp
@@ -288,7 +288,7 @@ TEST_CASE( "vehicle_drag", "[vehicle] [engine]" )
     test_vehicle_drag( "cube_van_cheap", 0.512775, 3.556550, 2563.049085, 9853, 11885 );
     test_vehicle_drag( "hippie_van", 0.386033, 2.886681, 1167.694643, 10881, 13109 );
     test_vehicle_drag( "icecream_truck", 0.681673, 3.686107, 1974.662162, 10726, 12873 );
-    test_vehicle_drag( "lux_rv", 1.609183, 3.431263, 1936.754934, 8453, 9826 );
+    test_vehicle_drag( "lux_rv", 1.609183, 3.662015, 2066.995614, 8453, 9826 );
     test_vehicle_drag( "meth_lab", 0.518580, 2.948098, 2018.085106, 11800, 14147 );
     test_vehicle_drag( "rv", 0.541800, 2.926340, 2003.191489, 11648, 13961 );
     test_vehicle_drag( "schoolbus", 0.411188, 3.331642, 1491.510227, 12930, 15101 );

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -436,35 +436,35 @@ TEST_CASE( "vehicle_efficiency", "[vehicle] [engine]" )
 {
     clear_all_state();
     test_vehicle( "beetle", 818837, 431300, 338700, 95610, 68060 );
-    test_vehicle( "car", 1124954, 617500, 386100, 52730, 25170 );
+    test_vehicle( "car", 1125629, 617500, 386100, 52730, 25170 );
     test_vehicle( "car_sports", 1157382, 352600, 267600, 36790, 22350 );
-    test_vehicle( "electric_car", 878423, 183880, 127125, 13410, 8705 );
-    test_vehicle( "suv", 1324622, 1163000, 614130, 85540, 32000 );
+    test_vehicle( "electric_car", 879098, 183880, 127125, 13410, 8705 );
+    test_vehicle( "suv", 1325297, 1163000, 614130, 85540, 32000 );
     test_vehicle( "motorcycle", 163085, 120300, 99930, 63320, 50810 );
     test_vehicle( "quad_bike", 265345, 116100, 116100, 46770, 46770 );
     test_vehicle( "scooter", 57587, 233500, 233500, 167900, 167900 );
     test_vehicle( "superbike", 244085, 109800, 65300, 41780, 24070 );
-    test_vehicle( "ambulance", 1842467, 613400, 504700, 77700, 58290 );
+    test_vehicle( "ambulance", 1854071, 613400, 504700, 77700, 57139 );
     test_vehicle( "fire_engine", 2257115, 1938615, 1819475, 394660, 363895 );
     test_vehicle( "fire_truck", 6319523, 410700, 83850, 19080, 4063 );
     test_vehicle( "truck_swat", 5966006, 682900, 131700, 29610, 7604 );
     test_vehicle( "tractor_plow", 725658, 681200, 681200, 132400, 132400 );
-    test_vehicle( "apc", 5805459, 2103310, 2124343, 110600, 110657 );
-    test_vehicle( "humvee", 5506381, 767900, 564679, 25620, 18343 );
+    test_vehicle( "apc", 5806134, 2103310, 2124343, 110600, 110657 );
+    test_vehicle( "humvee", 5507056, 767900, 564679, 25620, 18343 );
     test_vehicle( "road_roller", 8831804, 602500, 147100, 22760, 6925 );
     test_vehicle( "golf_cart", 319630, 49585, 47185, 22700, 12745 );
 
     // in reverse
     test_vehicle( "beetle", 818837, 58970, 58870, 44560, 43060, 0, 0, true );
-    test_vehicle( "car", 1124954, 76060, 76060, 44230, 24870, 0, 0, true );
+    test_vehicle( "car", 1125629, 76060, 76060, 44230, 24870, 0, 0, true );
     test_vehicle( "car_sports", 1157382, 353200, 268000, 35200, 19540, 0, 0, true );
-    test_vehicle( "electric_car", 878423, 133100, 72520, 8140, 3390, 0, 0, true );
-    test_vehicle( "suv", 1324622, 112000, 111800, 66880, 31670, 0, 0, true );
+    test_vehicle( "electric_car", 879098, 133100, 72520, 8140, 3390, 0, 0, true );
+    test_vehicle( "suv", 1325297, 112000, 111800, 66880, 31670, 0, 0, true );
     test_vehicle( "motorcycle", 163085, 19980, 19030, 15490, 14890, 0, 0, true );
     test_vehicle( "quad_bike", 265345, 19650, 19650, 15440, 15440, 0, 0, true );
     test_vehicle( "scooter", 57587, 62440, 62440, 47990, 47990, 0, 0, true );
     test_vehicle( "superbike", 244085, 18320, 10570, 13070, 8497, 0, 0, true );
-    test_vehicle( "ambulance", 1842467, 58460, 57780, 42480, 39130, 0, 0, true );
+    test_vehicle( "ambulance", 1854071, 58460, 57780, 42480, 39130, 0, 0, true );
     test_vehicle( "fire_engine", 2257115, 258000, 257800, 179800, 173300, 0, 0, true );
     test_vehicle( "fire_truck", 6319523, 58480, 58640, 18600, 4471, 0, 0, true );
     test_vehicle( "truck_swat", 5966006, 129300, 130100, 29350, 7668, 0, 0, true );


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This started at first as just "swap in different items for two specific vehicleparts" but since one of them happened to be mattresses, that turned into a minor rabbithole of sanity-checking some associated recipes and uncrafts.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

JSON updates:
1. Set it so that vehiclepart beds use a mattress to construct instead of a seat, and uses bolt turning quality of 1 instead of welding to install. Also updated its `breaks_into` entry to be consistent with uncraft results. Lastly, bumped its `floor_bedding_warmth` up to 800 to match that of a floor mattress.
2. Added a recipe for mattresses, like how you can craft down-filled and wool mattresses. Made it however use springs instead of wire and scrap, along with enough cotton balls so the total materials (minus the thread in `sewing_standard`, admittedly) add up to the same 20 kg the mattress itself weighs. Accordingly...
3. Updated components in the uncraft for mattresses, and switched from reversible recipes for wool and down-filled mattresses to instead having uncrafts of their own, so they don't take 2 hours to cut back up and don't require level 6 fabrication to get components back. Did bump time up from 22 seconds to 15 minutes though, since sheets and blankets take 10 and 20 minutes respectively to uncraft, so it's way faster than crafting but not nigh-instant like mattresses used to be.
4. And the other much more minor thing in comparison, set it so vehicle clocks use the clock item to install instead of a wristwatch.
5. Accordingly, since we allow wristwatches to infinitely tell time without needing power and pocket watches don't need to be rewound, gave item clocks the `WATCH` and `ALARMCLOCK` flags, and updated description accordingly.

Test updates:
1. Fixed up numbers in vehicle_drag_test.cpp.
2. Fixed up numbers in vehicle_efficiency_test.cpp.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Adding support for making time-telling items work within crafting radius so you can set a clock on a table by the bed or the like instead of having to carry it in your inventory. I dunno how performance-heavy that'd be tho.
2. Adding wool and down-filled beds for vehicles. Also weird that slapping a wool or down-filled mattress on a bed frame transmutates it into a normal mattress, bleh.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.
4. Confirmed mattresses uncraft into exactly 20 kg worth of stuff.
5. Confirmed uncrafting a clock doesn't give me more than its weight of components.
6. Built and ran tests locally, all tests pass.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
