### PR TITLE
build: bump SDL version

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   release:
     name: Create Release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
       release_already_exists: ${{ steps.tag_check.outputs.exists }}
@@ -100,7 +100,7 @@ jobs:
             ext: zip
             content: application/zip
           - name: Linux Tiles x64
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             mxe: none
             android: none
             tiles: 1
@@ -108,7 +108,7 @@ jobs:
             ext: tar.gz
             content: application/gzip
           - name: linux-curses-x64
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             mxe: none
             android: none
             tiles: 0

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   skip-duplicates:
     continue-on-error: true
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       should_skip_code: ${{ steps.skip_code_check.outputs.should_skip }}
       should_skip_data: ${{ steps.skip_data_check.outputs.should_skip }}
@@ -42,7 +42,7 @@ jobs:
         include:
           - title: GCC 12, Ubuntu, Curses
             compiler: g++-12
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             cmake: 0
             tiles: 0
             sound: 0
@@ -56,7 +56,7 @@ jobs:
 
           - title: GCC 12, Ubuntu, Tiles, Sound, Lua, CMake, Languages
             compiler: g++-12
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             cmake: 1
             tiles: 1
             sound: 1
@@ -69,7 +69,7 @@ jobs:
 
           - title: GCC 12, Ubuntu, Tiles, Sound, Lua
             compiler: g++-12
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             cmake: 1
             tiles: 1
             sound: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
             ext: zip
             content: application/zip
           - name: Linux Tiles x64
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             mxe: none
             android: none
             tiles: 1
@@ -133,7 +133,7 @@ jobs:
             ext: tar.gz
             content: application/gzip
           - name: linux-curses-x64
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             mxe: none
             android: none
             tiles: 0


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Older versions of SDL have potential issues, this brings it in line 2.30.3 according to my debug.log

This does not fix any of my specific outstanding issues with the renderer. I tested.

18:23:52.918 INFO : SDL version used during compile is 2.30.0
18:23:52.918 INFO : SDL version used during linking and in runtime is 2.30.3

## Describe the solution

Bump Ubuntu to 24.04 which will fetch the proper dependencies. Thanks Robbie.

You can find a working manual release of this here, but without linux you can't test the PR.
https://github.com/RoyalFox2140/Cataclysm-BN/releases

## Describe alternatives you've considered

None. We don't need to support older Ubuntu as we can assist users in self compiling and they should get around to upgrading anyway.

## Testing

https://github.com/RoyalFox2140/Cataclysm-BN/releases Load tested on Linux x64 Tiles and my existing saves still work. I can't find any new problems.

## Additional context

@OrenAudeles @scarf005 Pings due to relevancy.
