### PR TITLE
fix: Stop preview from modifying character directly

### DIFF
--- a/src/character_preview.h
+++ b/src/character_preview.h
@@ -7,7 +7,7 @@
 #include "type_id.h"
 
 class item;
-class Character;
+class avatar;
 
 /** Gets size of single width terminal unit size value in pixels **/
 auto termx_to_pixel_value() -> int;
@@ -34,7 +34,7 @@ struct character_preview_window {
 
         catacurses::window w_preview;
 
-        void init( Character *character );
+        void init( const avatar &u );
         /** Window preparations before displaying. Sets desirable position. Could also be usefull for ui-rescale **/
         void prepare( int nlines, int ncols, const Orientation *orientation, int hide_below_ncols );
         void zoom_in();
@@ -42,7 +42,7 @@ struct character_preview_window {
         void toggle_clothes();
         void display() const;
         /** Use it as you done with preview **/
-        void clear() const;
+        void clear();
         auto clothes_showing() const -> bool;
 
     private:
@@ -56,7 +56,7 @@ struct character_preview_window {
         int hide_below_ncols = 0;
         int ncols_width = 0;
         int nlines_width = 0;
-        Character *character = nullptr;
+        std::unique_ptr<avatar> preview;
         std::vector<detached_ptr<item>> clothes;
         std::vector<trait_id> spells;
         bool show_clothes = true;

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1108,7 +1108,7 @@ tab_direction set_traits( avatar &u, points_left &points )
 
 #if defined(TILES)
     character_preview_window character_preview;
-    character_preview.init( &u );
+    character_preview.init( u );
     const bool use_character_preview = get_option<bool>( "USE_CHARACTER_PREVIEW" ) &&
                                        get_option<bool>( "USE_TILES" );
 #endif
@@ -1369,13 +1369,6 @@ tab_direction set_traits( avatar &u, points_left &points )
             //inc_type is either -1 or 1, so we can just multiply by it to invert
             if( inc_type != 0 ) {
                 u.toggle_trait( cur_trait );
-#if defined(TILES)
-                // If character had trait - it's now removed. Trait could blocked some clothes, need to retoggle
-                if( has_trait && character_preview.clothes_showing() ) {
-                    character_preview.toggle_clothes();
-                    character_preview.toggle_clothes();
-                }
-#endif
                 points.trait_points -= mdata.points * inc_type;
                 if( iCurWorkingPage == 0 ) {
                     num_good += mdata.points * inc_type;


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Modifies #5031 to stop altering the actual character at game start, this was causing a lot of unintentional behaviour and is _incredibly_ problematic.

## Describe the solution

Init now takes avatar as a const value so that the preview only creates a preview rather than modifies the existing character.

Attempting to make the copy a `unique_ptr` that would otherwise not be allocated to memory, but having trouble with the constructor. If anyone can help that would be great. @scarf005 or @OrenAudeles.

## Describe alternatives you've considered

- Make the copy of an avatar a direct copy of the object.
  - Could be done but I wanted to get familiar with `unique_ptr` as it seems useful for things that might not ever be used again in the code throughout a playthrough.

## Testing

- [ ] Load character preview and check that it actually displays correctly.

## Additional context


