### PR TITLE
ci: rename from Experimental to Nightly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: "Experimental Release"
+name: "Nightly Release"
 concurrency: release
 on:
   schedule:
@@ -25,7 +25,7 @@ jobs:
           YESTERDAY_TAG_NAME=$(date -u --iso-8601 --date='2 day ago')
           LAST_TAG_NAME=$(git for-each-ref --sort=-creatordate --format '%(creatordate:short)' refs/tags | head -n 1)
           COMMITS=$(git log --oneline --since="$TAG_NAME" | wc -l)
-          RELEASE_NAME="Experimental $TAG_NAME"
+          RELEASE_NAME="Nightly $TAG_NAME"
 
           echo "commits yesterday ($TAG_NAME): $COMMITS" >> "$GITHUB_STEP_SUMMARY"
 
@@ -85,7 +85,7 @@ jobs:
           name: ${{ needs.metadata.outputs.release_name }}
           body: |
             ${{ steps.build_changelog.outputs.changelog }}
-            These are the outputs for the experimental build of commit [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})
+            These are the outputs for the build of commit [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})
           draft: false
           prerelease: true
 


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

People have continued to be scared of using the so-called "Experimental" builds, and thus running stables, often to their own detriment. 

## Describe the solution

- Renames the builds currently called "Experimental" to "Nightly" instead.

In my opinion, as well as the opinion of several others who provided their input as to the idea, Nightly is a far less intimidating name that fits our current build type perfectly. It still (to those familiar with the term, at least) comes with the connotation of a few bugs not being *unusual* to see, but without the heavy-handed "There WILL be bugs, and lots of them" that Experimental generally implies. 
Additionally, it (generally) fits literally, as for many the builds are in fact done every *night*. 

## Describe alternatives you've considered

- Leave it be out of tradition
- Change "Stable" as well

I see less of a problem with Stable, as that one simply carries the connotation of being a version that's unchanging, as opposed to the ever-flowing regular builds. Sort of like Debian vs Fedora, to use a Linux analogy. 

## Testing
Test-ran the release on my fork, it seems to work fine (Android failing as usual, but that happens on literally every fork lol)
https://github.com/RobbieNeko/Cataclysm-BN/actions/runs/10977512821
## Additional context

I didn't bother touching the solely-android commands / file paths because that looks a bit above my paygrade and is not something I could properly test myself anyway. For someone more familiar with the build process on Android, feel free to take the opportunity for a follow-up PR.

Also, feel free to change the type in the title. I had no clue which one exactly to select for such a change, and so I just went with CI on gut instinct.
