### PR TITLE
feat(balance): glass items only shatter if made solely of glass

### DIFF
--- a/data/json/items/containers.json
+++ b/data/json/items/containers.json
@@ -732,7 +732,8 @@
     "contains": "250 ml",
     "seals": true,
     "watertight": true,
-    "qualities": [ [ "BOIL", 1 ] ]
+    "qualities": [ [ "BOIL", 1 ] ],
+    "flags": [ "SHATTERS" ]
   },
   {
     "id": "test_tube",
@@ -752,7 +753,8 @@
     "contains": "10ml",
     "seals": true,
     "watertight": true,
-    "qualities": [ [ "BOIL", 1 ], [ "CONTAIN", 1 ] ]
+    "qualities": [ [ "BOIL", 1 ], [ "CONTAIN", 1 ] ],
+    "flags": [ "SHATTERS" ]
   },
   {
     "id": "beaker",

--- a/data/json/items/tool/cooking.json
+++ b/data/json/items/tool/cooking.json
@@ -296,7 +296,8 @@
       "type": "delayed_transform",
       "transform_age": 33600,
       "not_ready_msg": "The eggs are not done yet."
-    }
+    },
+    "flags": [ "SHATTERS" ]
   },
   {
     "id": "esbit_stove",
@@ -345,7 +346,7 @@
       "not_ready_msg": "The yeast isn't done culturing yet.",
       "//": "12 hours"
     },
-    "flags": [ "TRADER_AVOID" ]
+    "flags": [ "TRADER_AVOID", "SHATTERS" ]
   },
   {
     "id": "jar_yeast",
@@ -560,7 +561,8 @@
       "target_charges": 6,
       "menu_text": "Open jar",
       "type": "transform"
-    }
+    },
+    "flags": [ "SHATTERS" ]
   },
   {
     "id": "jar_pickles_pickled",
@@ -583,7 +585,8 @@
       "target_charges": 2,
       "menu_text": "Open jar",
       "type": "transform"
-    }
+    },
+    "flags": [ "SHATTERS" ]
   },
   {
     "id": "jar_sauerkraut_pickled",
@@ -606,7 +609,8 @@
       "target_charges": 2,
       "menu_text": "Open jar",
       "type": "transform"
-    }
+    },
+    "flags": [ "SHATTERS" ]
   },
   {
     "id": "makeshift_sealer",
@@ -817,7 +821,8 @@
       "transform_age": 33600,
       "not_ready_msg": "The pickles are not done fermenting yet.",
       "//": "2 1/3 days, from the suggested recipie of 1 rl week"
-    }
+    },
+    "flags": [ "SHATTERS" ]
   },
   {
     "id": "popcan_stove",
@@ -900,7 +905,8 @@
       "transform_age": 33600,
       "not_ready_msg": "The sauerkraut isn't done fermenting yet.",
       "//": "2 1/3 days, from the suggested recipie of 1 rl week"
-    }
+    },
+    "flags": [ "SHATTERS" ]
   },
   {
     "id": "still",

--- a/data/json/items/tool/science.json
+++ b/data/json/items/tool/science.json
@@ -593,7 +593,8 @@
     "looks_like": "flask_glass",
     "symbol": "V",
     "color": "light_blue",
-    "qualities": [ [ "SEPARATE", 1 ] ]
+    "qualities": [ [ "SEPARATE", 1 ] ],
+    "flags": [ "SHATTERS" ]
   },
   {
     "id": "rotovap",

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -630,7 +630,7 @@
     "price": "300 USD",
     "price_postapoc": "5 USD",
     "material": [ "plastic", "glass" ],
-    "flags": [ "ZOOM", "OVERSIZE", "BELTED", "COMPACT", "ALLOWS_NATURAL_ATTACKS", "FIRESTARTER" ],
+    "flags": [ "ZOOM", "OVERSIZE", "BELTED", "COMPACT", "ALLOWS_NATURAL_ATTACKS", "FIRESTARTER", "FRAGILE" ],
     "weight": "708 g",
     "volume": "500 ml",
     "bashing": 4,

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5572,7 +5572,8 @@ int item::reach_range( const Character &guy ) const
 
 bool item::can_shatter() const
 {
-    return made_of( material_id( "glass" ) ) || has_flag( flag_SHATTERS );
+    static const std::set<material_id> is_glass{ material_id( "glass" ) };
+    return only_made_of( is_glass ) || has_flag( flag_SHATTERS );
 }
 
 void item::unset_flags()


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This tweaks it so that items which aren't made purely of glass, like glass fridges famously, won't instantly melt when hit by stuff.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

C++ changes:
1. In item.cpp, `item::can_shatter` changed so that it asks if the item is made exclusively of glass via `only_made_of`, instead of if it's made of glass period. This excludes multi-material items from being in danger of shattering unless they're given the `SHATTERS` flag.

JSON changes:
1. Glass flasks and test tubes given the `SHATTERS` flag so they'll still break like expected when tossed.
2. Fermenting jars of eggs, yeast, and the like given the `SHATTERS` flag.
3. Added `SHATTERS` flag to separation funnel.
4. `FRAGILE` flag given to binoculars, to make it vulnerable to being wrecked but not as much as it was beforehand.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Going to bed, it's like 3 AM currently.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON files for syntax and lint errors.
2. Compiled and load-tested.
3. Spawned in a glass shiv, saw it no longer mentions being liable to shatter in its flag list, and bashing stuff with the just has it take damage normally instead of instantly being destroyed.
4. Spawned in a glass flask, confirmed it now gets its shatter risk from the item flag.
5. Checked a glass bottle, confirmed it has the expected shatter vulnerability.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
