### PR TITLE
docs: troubleshoot guide for distrobox exports

### DIFF
--- a/doc/src/content/docs/en/dev/guides/building/atomic_cmake.md
+++ b/doc/src/content/docs/en/dev/guides/building/atomic_cmake.md
@@ -18,6 +18,16 @@ script
 
 :::
 
+:::caution
+
+when using [distrobox](https://distrobox.it), using
+[exported](https://github.com/89luca89/distrobox/blob/main/docs/usage/distrobox-export.md) compiler
+(e.g `~/.local/bin/clang`)
+[won't work as it cannot access `/usr`.](https://github.com/89luca89/distrobox/issues/1548) instead,
+use absolute path for compilers like `/usr/bin/clang`.
+
+:::
+
 ## Setting up the container
 
 Bazzite, being based on the Atomic versions of Fedora Linux, has the containerization tool known as


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

followup of #5287, attempt to address the situation when you exported clang and suddenly build doesn't work inside distrobox

## Describe the solution

add an troubleshooting guide

## Additional context

https://github.com/89luca89/distrobox/issues/1548