### PR TITLE
ci: fix deno cache

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 
 env:
-  DENO_DIR: '~/.cache/deno'
+  DENO_DIR: /home/runner/.cache/deno
 
 jobs:
   autofix:
@@ -26,7 +26,7 @@ jobs:
           deno-version: v1.x
 
       - name: cache deno dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.DENO_DIR }}
           key: deno-${{ hashFiles('deno.lock') }}


### PR DESCRIPTION
## Purpose of change

deno packages weren't being properly cached due to `~` not getting expanded.