### PR TITLE
fix: re-allow players to smash windows with metal bars

### DIFF
--- a/data/json/furniture_and_terrain/terrain-windows.json
+++ b/data/json/furniture_and_terrain/terrain-windows.json
@@ -535,7 +535,18 @@
       "byproducts": [ { "item": "rebar", "count": [ 1, 8 ] } ]
     },
     "oxytorch": { "result": "t_window_alarm", "duration": "9 seconds", "byproducts": [ { "item": "rebar", "count": [ 1, 2 ] } ] },
-    "bash": { "ter_set": "t_window_bars" }
+    "bash": {
+      "str_min": 3,
+      "str_max": 6,
+      "sound": "glass breaking!",
+      "sound_fail": "whack!",
+      "sound_vol": 16,
+      "sound_fail_vol": 10,
+      "ter_set": "t_window_bars",
+      "items": [ { "item": "glass_shard", "count": [ 1, 5 ] } ],
+      "//": "reduction and destroy_threshold are lower for plain glass",
+      "ranged": { "reduction": [ 1, 3 ], "reduction_laser": [ 0, 5 ], "destroy_threshold": 3 }
+    }
   },
   {
     "type": "terrain",


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Because I didn't catch that the window with metal bars didn't have bash data assigned other than the resulting furniture, it was un-bashable after I merged https://github.com/cataclysmbnteam/Cataclysm-BN/pull/5326

Yet another day where copy-from makes clowns of us all.

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/5432

## Describe the solution

Adds back the bash data from t_window.

## Describe alternatives you've considered

Make Chaos do it, for making the original PR. Leave it as is, nuclear weapons to breach windows is funny.

## Testing

The tests.

## Additional context

This is why I refuse to have copy-froms in 2200, unless it's to overwrite a field on a base-game ID.
