### PR TITLE
fix: makeshift gas canisters have correct max charges

### DIFF
--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -574,8 +574,8 @@
     "material": "steel",
     "symbol": "*",
     "color": "dark_gray",
-    "initial_charges": 3,
-    "max_charges": 3,
+    "initial_charges": 10,
+    "max_charges": 10,
     "turns_per_charge": 1,
     "revert_to": "canister_empty",
     "use_action": {


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
## Purpose of change

Makeshift gas canisters get 10/3 charges on activation. This fixes that.
![image](https://github.com/user-attachments/assets/e54aefdb-d025-46eb-9adf-56228bf95f1f)


## Describe the solution

Initial and max charges on the activated version is set to 10. This coincides with 10 charges on the target_charges

## Describe alternatives you've considered

None

## Testing

Tests

## Additional context
