### PR TITLE
docs: Replace `clang-17` with just `clang` in the docs

### DIFF
--- a/doc/src/content/docs/en/dev/guides/building/atomic_cmake.md
+++ b/doc/src/content/docs/en/dev/guides/building/atomic_cmake.md
@@ -9,9 +9,9 @@ the desired solution rather than layering the dependencies onto your base instal
 
 :::caution
 
-As of writing this, Bazzite's default container image is fedora-toolbox:38, which results in having
+As of writing this, Bazzite's default container image is fedora-toolbox:38, which *may* result in having
 to edit the dependencies installation script. On distros that grab a more modern version of Fedora
-as their image (or by manually grabbing one yourself), you can instead just use the standard Fedora
+as their image (or by manually grabbing one yourself), you can be more certain in just using the standard Fedora
 script
 
 :::

--- a/doc/src/content/docs/en/dev/guides/building/atomic_cmake.md
+++ b/doc/src/content/docs/en/dev/guides/building/atomic_cmake.md
@@ -9,10 +9,10 @@ the desired solution rather than layering the dependencies onto your base instal
 
 :::caution
 
-As of writing this, Bazzite's default container image is fedora-toolbox:38, which *may* result in having
-to edit the dependencies installation script. On distros that grab a more modern version of Fedora
-as their image (or by manually grabbing one yourself), you can be more certain in just using the standard Fedora
-script
+As of writing this, Bazzite's default container image is fedora-toolbox:38, which _may_ result in
+having to edit the dependencies installation script. On distros that grab a more modern version of
+Fedora as their image (or by manually grabbing one yourself), you can be more certain in just using
+the standard Fedora script
 
 :::
 

--- a/doc/src/content/docs/en/dev/guides/building/cmake.md
+++ b/doc/src/content/docs/en/dev/guides/building/cmake.md
@@ -48,7 +48,7 @@ Obtain packages specified above with your system package manager.
 - For Ubuntu-based distros (24.04 onwards):
 
 ```sh
-$ sudo apt install git cmake ninja-build mold clang-17 ccache \ 
+$ sudo apt install git cmake ninja-build mold clang ccache \ 
   libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev \ 
   freetype glibc bzip2 zlib libvorbis ncurses gettext libflac++-dev
 ```
@@ -56,7 +56,7 @@ $ sudo apt install git cmake ninja-build mold clang-17 ccache \
 - For Fedora-based distros:
 
 ```sh
-$ sudo dnf install git cmake ninja-build mold clang17 ccache \
+$ sudo dnf install git cmake ninja-build mold clang ccache \
   SDL2-devel SDL2_image-devel SDL2_ttf-devel SDL2_mixer-devel \
   freetype glibc bzip2 zlib-ng libvorbis ncurses gettext flac-devel
 ```
@@ -153,8 +153,8 @@ cmake \
   -B build \
   -G Ninja \
   -DCATA_CCACHE=ON \
-  -DCMAKE_C_COMPILER=clang-17 \
-  -DCMAKE_CXX_COMPILER=clang++-17 \
+  -DCMAKE_C_COMPILER=clang \
+  -DCMAKE_CXX_COMPILER=clang++ \
   -DCMAKE_INSTALL_PREFIX=$HOME/.local/share \
   -DJSON_FORMAT=ON \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

With Scarf fixing Clang-18 builds, there is no reason to specify an older version of clang and thus the build scripts can now just use `clang` instead of `clang-17` for greater compatibility with a variety of systems.

## Describe the solution

- Replaces `clang-17` with `clang` in build docs
- Lightens the warning in the atomic docs regarding bazzite's outdated fedora image.

## Describe alternatives you've considered

- Do nothing
- Completely remove Bazzite warnings due to no longer being needed

Fair, but I feel like noting that Bazzite has an outdated Fedora image by default can still be helpful on the off chance something borks itself in the future related to it.

## Testing

I can confirm it is indeed legible

## Additional context

Woohoo, we support an up-to-date compiler now ^-^

~~Now to go test AOCC and see how that works for us~~
