### PR TITLE
feat(mods/Monster_Girls): Add elves to Monster Girl Mutations

### DIFF
--- a/data/mods/Monster_Girls/categories.json
+++ b/data/mods/Monster_Girls/categories.json
@@ -82,5 +82,14 @@
     "iv_message": "This stuff takes you back.  Downright primordial!",
     "memorial_message": "Gave up on rigid human norms.",
     "junkie_message": "Maybe if you drank enough, you'd become mutagen..."
+  },
+  {
+    "type": "mutation_category",
+    "id": "ELF",
+    "name": "Fey",
+    "threshold_mut": "THRESH_ELF",
+    "mutagen_message": "You feel the woods calling to you.",
+    "iv_message": "You feel like you could live forever, just like the trees!",
+    "memorial_message": "Spoke with the trees."
   }
 ]

--- a/data/mods/Monster_Girls/migration.json
+++ b/data/mods/Monster_Girls/migration.json
@@ -32,12 +32,12 @@
   {
     "id": "mutagen_elfa",
     "type": "MIGRATION",
-    "replace": "mutagen"
+    "replace": "mutagen_elf"
   },
   {
     "id": "iv_mutagen_elfa",
     "type": "MIGRATION",
-    "replace": "iv_mutagen"
+    "replace": "iv_mutagen_elf"
   },
   {
     "id": "mutagen_medical",

--- a/data/mods/Monster_Girls/mutagens.json
+++ b/data/mods/Monster_Girls/mutagens.json
@@ -124,5 +124,19 @@
     "copy-from": "mutagen_slime",
     "name": "Slime mutagen",
     "use_action": { "type": "mutagen", "mutation_category": "SLIMEGIRL" }
+  },
+  {
+    "id": "mutagen_elf",
+    "type": "COMESTIBLE",
+    "copy-from": "mutagen_elfa",
+    "name": "Fey mutagen",
+    "use_action": { "type": "mutagen", "mutation_category": "ELF" }
+  },
+  {
+    "id": "iv_mutagen_elf",
+    "type": "COMESTIBLE",
+    "copy-from": "iv_mutagen_elfa",
+    "name": "Fey serum",
+    "use_action": { "type": "mutagen_iv", "mutation_category": "ELF" }
   }
 ]

--- a/data/mods/Monster_Girls/recipes.json
+++ b/data/mods/Monster_Girls/recipes.json
@@ -110,5 +110,17 @@
     "result": "mutagen_slimegirl",
     "copy-from": "mutagen_slime",
     "components": [ [ [ "mutagen", 1 ] ], [ [ "sewage", 3 ], [ "slime_scrap", 3 ] ], [ [ "ammonia", 1 ], [ "lye_powder", 100 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "iv_mutagen_elf",
+    "copy-from": "iv_mutagen_elfa",
+    "components": [ [ [ "mutagen_elf", 2 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "mutagen_elf",
+    "copy-from": "mutagen_elfa",
+    "components": [ [ [ "mutagen_slime", 2 ], [ "iv_mutagen_slime", 1 ] ], [ [ "mutagen_plant", 1 ] ], [ [ "mutagen_bird", 1 ] ] ]
   }
 ]

--- a/data/mods/Monster_Girls/thresh_mutation.json
+++ b/data/mods/Monster_Girls/thresh_mutation.json
@@ -97,5 +97,16 @@
     "purifiable": false,
     "threshold": true,
     "mutagen_target_modifier": 10
+  },
+  {
+    "type": "mutation",
+    "id": "THRESH_ELF",
+    "name": { "str": "Fey" },
+    "points": 1,
+    "description": "You've found yourself with an incredible craving for lembas, as well as a strong desire to knock an arrow to a bow.  The trees speak to you, and you speak back.  In the darkest hour of mankind, the fae shall bring the light!",
+    "valid": false,
+    "purifiable": false,
+    "threshold": true,
+    "mutagen_target_modifier": 10
   }
 ]

--- a/data/mods/Monster_Girls/vanilla_mutations.json
+++ b/data/mods/Monster_Girls/vanilla_mutations.json
@@ -23,13 +23,14 @@
     "id": "GOODHEARING",
     "copy-from": "GOODHEARING",
     "delete": { "category": [ "ALPHA", "MOUSE", "ELFA" ] },
-    "extend": { "category": [ "MOUSEGIRL" ] }
+    "extend": { "category": [ "MOUSEGIRL", "ELF" ] }
   },
   {
     "type": "mutation",
     "id": "FEYHEARING",
     "copy-from": "FEYHEARING",
-    "delete": { "category": [ "ELFA" ] }
+    "delete": { "category": [ "ELFA" ] },
+    "extend": { "category": [ "ELF" ], "threshreq": [ "THRESH_ELF" ] }
   },
   {
     "type": "mutation",
@@ -137,13 +138,15 @@
     "type": "mutation",
     "id": "ANIMALEMPATH",
     "copy-from": "ANIMALEMPATH",
-    "delete": { "category": [ "BEAST", "ELFA" ] }
+    "delete": { "category": [ "BEAST", "ELFA" ] },
+    "extend": { "category": [ "ELF" ] }
   },
   {
     "type": "mutation",
     "id": "ANIMALEMPATH2",
     "copy-from": "ANIMALEMPATH2",
-    "delete": { "category": [ "ELFA" ] }
+    "delete": { "category": [ "ELFA" ] },
+    "extend": { "category": [ "ELF" ] }
   },
   {
     "type": "mutation",
@@ -161,7 +164,8 @@
     "type": "mutation",
     "id": "WAKEFUL",
     "copy-from": "WAKEFUL",
-    "delete": { "category": [ "ALPHA", "ELFA" ] }
+    "delete": { "category": [ "ALPHA", "ELFA" ] },
+    "extend": { "category": [ "ELF" ] }
   },
   {
     "type": "mutation",
@@ -174,7 +178,7 @@
     "id": "LIGHTSTEP",
     "copy-from": "LIGHTSTEP",
     "delete": { "category": [ "BIRD", "ELFA", "FELINE" ] },
-    "extend": { "category": [ "NEKO", "HARPY" ] }
+    "extend": { "category": [ "NEKO", "HARPY", "ELF" ] }
   },
   {
     "type": "mutation",
@@ -228,7 +232,7 @@
     "id": "BADBACK",
     "copy-from": "BADBACK",
     "delete": { "category": [ "BIRD", "ELFA" ] },
-    "extend": { "category": [ "HARPY" ] }
+    "extend": { "category": [ "HARPY", "ELF" ] }
   },
   {
     "type": "mutation",
@@ -254,7 +258,8 @@
     "type": "mutation",
     "id": "ANTIJUNK",
     "copy-from": "ANTIJUNK",
-    "delete": { "category": [ "BEAST", "RAPTOR", "ALPHA", "ELFA" ] }
+    "delete": { "category": [ "BEAST", "RAPTOR", "ALPHA", "ELFA" ] },
+    "extend": { "category": [ "ELF" ] }
   },
   {
     "type": "mutation",
@@ -360,7 +365,7 @@
     "id": "FLIMSY",
     "copy-from": "FLIMSY",
     "delete": { "category": [ "MOUSE", "ELFA" ] },
-    "extend": { "category": [ "MOUSEGIRL" ] }
+    "extend": { "category": [ "MOUSEGIRL", "ELF" ] }
   },
   {
     "type": "mutation",
@@ -387,7 +392,7 @@
     "id": "NIGHTVISION3",
     "copy-from": "NIGHTVISION3",
     "delete": { "category": [ "FISH", "TROGLOBITE", "SPIDER", "INSECT", "ELFA", "CEPHALOPOD" ] },
-    "extend": { "category": [ "SPIDERGIRL" ], "threshreq": [ "THRESH_SPIDERGIRL" ] }
+    "extend": { "category": [ "SPIDERGIRL", "ELF" ], "threshreq": [ "THRESH_SPIDERGIRL", "THRESH_ELF" ] }
   },
   {
     "type": "mutation",
@@ -399,7 +404,8 @@
     "type": "mutation",
     "id": "ELFAEYES",
     "copy-from": "ELFAEYES",
-    "delete": { "category": [ "ELFA" ] }
+    "delete": { "category": [ "ELFA" ] },
+    "extend": { "category": [ "ELF" ] }
   },
   {
     "type": "mutation",
@@ -458,13 +464,15 @@
     "type": "mutation",
     "id": "WAKEFUL2",
     "copy-from": "WAKEFUL2",
-    "delete": { "category": [ "ALPHA", "ELFA" ] }
+    "delete": { "category": [ "ALPHA", "ELFA" ] },
+    "extend": { "category": [ "ELF" ], "threshreq": [ "THRESH_ELF" ] }
   },
   {
     "type": "mutation",
     "id": "WAKEFUL3",
     "copy-from": "WAKEFUL3",
-    "delete": { "category": [ "ELFA" ] }
+    "delete": { "category": [ "ELFA" ] },
+    "extend": { "category": [ "ELF" ], "threshreq": [ "THRESH_ELF" ] }
   },
   {
     "type": "mutation",
@@ -648,7 +656,7 @@
     "id": "PLANTSKIN",
     "copy-from": "PLANTSKIN",
     "delete": { "category": [ "PLANT", "ELFA" ] },
-    "extend": { "category": [ "DRYAD" ] }
+    "extend": { "category": [ "DRYAD", "ELF" ] }
   },
   {
     "type": "mutation",
@@ -669,7 +677,7 @@
     "id": "LEAVES",
     "copy-from": "LEAVES",
     "delete": { "category": [ "PLANT", "ELFA" ] },
-    "extend": { "category": [ "DRYAD" ] }
+    "extend": { "category": [ "DRYAD", "ELF" ] }
   },
   {
     "type": "mutation",
@@ -697,14 +705,14 @@
     "id": "FLOWERS",
     "copy-from": "FLOWERS",
     "delete": { "category": [ "PLANT", "ELFA" ] },
-    "extend": { "category": [ "DRYAD" ], "threshreq": [ "THRESH_DRYAD" ] }
+    "extend": { "category": [ "DRYAD", "ELF" ], "threshreq": [ "THRESH_DRYAD", "THRESH_ELF" ] }
   },
   {
     "type": "mutation",
     "id": "ROSEBUDS",
     "copy-from": "ROSEBUDS",
     "delete": { "category": [ "PLANT", "ELFA" ] },
-    "extend": { "category": [ "DRYAD" ], "threshreq": [ "THRESH_DRYAD" ] }
+    "extend": { "category": [ "DRYAD", "ELF" ], "threshreq": [ "THRESH_DRYAD", "THRESH_ELF" ] }
   },
   {
     "type": "mutation",
@@ -848,7 +856,7 @@
     "id": "PARAIMMUNE",
     "copy-from": "PARAIMMUNE",
     "delete": { "category": [ "ELFA", "CHIMERA", "MEDICAL", "SLIME" ] },
-    "extend": { "category": [ "SLIMEGIRL" ] }
+    "extend": { "category": [ "SLIMEGIRL", "ELF" ] }
   },
   {
     "type": "mutation",
@@ -876,7 +884,7 @@
     "id": "BENDY1",
     "copy-from": "BENDY1",
     "delete": { "category": [ "SLIME", "ELFA" ] },
-    "extend": { "category": [ "SLIMEGIRL" ], "threshreq": [ "THRESH_SLIMEGIRL" ] }
+    "extend": { "category": [ "SLIMEGIRL", "ELF" ], "threshreq": [ "THRESH_SLIMEGIRL", "THRESH_ELF" ] }
   },
   {
     "type": "mutation",
@@ -1232,7 +1240,8 @@
     "type": "mutation",
     "id": "ELFA_EARS",
     "copy-from": "ELFA_EARS",
-    "delete": { "category": [ "ELFA" ] }
+    "delete": { "category": [ "ELFA" ] },
+    "extend": { "category": [ "ELF" ] }
   },
   {
     "type": "mutation",
@@ -1332,7 +1341,8 @@
     "type": "mutation",
     "id": "STR_UP",
     "copy-from": "STR_UP",
-    "delete": { "category": [ "INSECT", "ELFA", "RAPTOR" ] }
+    "delete": { "category": [ "INSECT", "ELFA", "RAPTOR" ] },
+    "extend": { "category": [ "ELF" ] }
   },
   {
     "type": "mutation",
@@ -1380,7 +1390,7 @@
     "id": "DEX_UP_3",
     "copy-from": "DEX_UP_3",
     "delete": { "category": [ "BIRD", "ELFA", "FELINE" ] },
-    "extend": { "category": [ "NEKO", "HARPY" ] }
+    "extend": { "category": [ "NEKO", "HARPY", "ELF" ] }
   },
   {
     "type": "mutation",
@@ -1405,7 +1415,8 @@
     "type": "mutation",
     "id": "INT_UP_3",
     "copy-from": "INT_UP_3",
-    "delete": { "category": [ "ELFA" ] }
+    "delete": { "category": [ "ELFA" ] },
+    "extend": { "category": [ "ELF" ] }
   },
   {
     "type": "mutation",
@@ -1436,7 +1447,8 @@
     "type": "mutation",
     "id": "PER_UP_3",
     "copy-from": "PER_UP_3",
-    "delete": { "category": [ "ELFA", "RAPTOR" ] }
+    "delete": { "category": [ "ELFA", "RAPTOR" ] },
+    "extend": { "category": [ "ELF" ] }
   },
   {
     "type": "mutation",
@@ -1565,7 +1577,8 @@
     "type": "mutation",
     "id": "BEAUTIFUL3",
     "copy-from": "BEAUTIFUL3",
-    "delete": { "category": [ "ELFA" ] }
+    "delete": { "category": [ "ELFA" ] },
+    "extend": { "category": [ "ELF" ] }
   },
   {
     "type": "mutation",
@@ -1614,7 +1627,7 @@
     "id": "HOLLOW_BONES",
     "copy-from": "HOLLOW_BONES",
     "delete": { "category": [ "BIRD", "SLIME", "ELFA" ] },
-    "extend": { "category": [ "SLIMEGIRL", "HARPY" ] }
+    "extend": { "category": [ "SLIMEGIRL", "HARPY", "ELF" ] }
   },
   {
     "type": "mutation",
@@ -1647,7 +1660,7 @@
     "id": "HUNGER",
     "copy-from": "HUNGER",
     "delete": { "category": [ "RAT", "ALPHA", "MEDICAL", "ELFA", "BEAST", "SLIME", "RAPTOR", "CHIMERA", "MOUSE" ] },
-    "extend": { "category": [ "MOUSEGIRL", "SLIMEGIRL" ] }
+    "extend": { "category": [ "MOUSEGIRL", "SLIMEGIRL", "ELF" ] }
   },
   {
     "type": "mutation",
@@ -1674,7 +1687,7 @@
     "id": "THIRST",
     "copy-from": "THIRST",
     "delete": { "category": [ "SLIME", "CEPHALOPOD", "CHIMERA", "ELFA" ] },
-    "extend": { "category": [ "SLIMEGIRL" ] }
+    "extend": { "category": [ "SLIMEGIRL", "ELF" ] }
   },
   {
     "type": "mutation",
@@ -1908,7 +1921,7 @@
     "id": "HAIRROOTS",
     "copy-from": "HAIRROOTS",
     "delete": { "category": [ "PLANT", "ELFA" ] },
-    "extend": { "category": [ "DRYAD" ] }
+    "extend": { "category": [ "DRYAD", "ELF" ] }
   },
   {
     "type": "mutation",
@@ -1943,7 +1956,7 @@
     "id": "TREE_COMMUNION",
     "copy-from": "TREE_COMMUNION",
     "delete": { "category": [ "PLANT", "ELFA" ] },
-    "extend": { "category": [ "DRYAD" ], "threshreq": [ "THRESH_DRYAD" ] }
+    "extend": { "category": [ "DRYAD", "ELF" ], "threshreq": [ "THRESH_DRYAD", "THRESH_ELF" ] }
   },
   {
     "type": "mutation",


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Standpipe maintenance log served no purpose in the mod previously, and elves are historically lumped in with monster girls anyway. Besides, more direct mutation path equivalents between the mod and base BN is always good!

## Describe the solution

Adds an Elf mutation path based on, you guessed it, ~~Medical~~ Elf-A!

## Describe alternatives you've considered

- Leave the standpipe maintenance log useless

## Testing

Load tested, it works.
![image](https://github.com/user-attachments/assets/299b200b-8069-4511-ba76-b8171472b97e)

## Additional context

Now to debate whether to fix the issue of regular mutagen in theory still allowing you to get the undesirable mutations from base game, or to treat it as sort-of chimera. If I do fix it, it'll mean more work on the scripts to help others maintain it tho...
