### PR TITLE
chore(mods/Monster_Girls): Use 'nock' instead of 'knock' for archery

### DIFF
--- a/data/mods/Monster_Girls/thresh_mutation.json
+++ b/data/mods/Monster_Girls/thresh_mutation.json
@@ -103,7 +103,7 @@
     "id": "THRESH_ELF",
     "name": { "str": "Fey" },
     "points": 1,
-    "description": "You've found yourself with an incredible craving for lembas, as well as a strong desire to knock an arrow to a bow.  The trees speak to you, and you speak back.  In the darkest hour of mankind, the fae shall bring the light!",
+    "description": "You've found yourself with an incredible craving for lembas, as well as a strong desire to nock an arrow to a bow.  The trees speak to you, and you speak back.  In the darkest hour of mankind, the fae shall bring the light!",
     "valid": false,
     "purifiable": false,
     "threshold": true,


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Spelling / grammar mistake thanks to homophones and a word pretty much exclusive to archery.

## Describe the solution

'knock' -> 'nock'

## Describe alternatives you've considered

- leave it be

## Testing

Funnily enough, both Discord and Github / Firefox are unaware of 'nock' being a valid word
![image](https://github.com/user-attachments/assets/33bd07e4-b18f-4172-9f63-c20a33874c64)
![image](https://github.com/user-attachments/assets/82eaa057-6d49-4807-818c-130c27aea89c)


## Additional context

Thanks jetscooters for promptly noticing my error ^-^
