### PR TITLE
feat(balance): Make chickens fatter

### DIFF
--- a/data/json/monsters/bird.json
+++ b/data/json/monsters/bird.json
@@ -9,7 +9,7 @@
     "categories": [ "WILDLIFE" ],
     "species": [ "BIRD" ],
     "volume": "750 ml",
-    "weight": "1 kg",
+    "weight": "2 kg",
     "hp": 8,
     "speed": 80,
     "material": [ "flesh" ],


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Chickens in real life are usually a bit bigger, and also are bred for meat.

## Describe the solution
Set weight from 1kg to 2kg

https://farmhouseguide.com/how-much-chickens-weigh/

## Describe alternatives you've considered
None

## Testing
Tests

## Additional context

