### PR TITLE
fix: Corrects charges draining from forges

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5109,7 +5109,7 @@ static void use_charges_from_furn( const furn_t &f, const itype_id &type, int &q
             } );
             if( iter != stack.end() ) {
 
-                ( *iter )->attempt_detach( [&filter, &type, &quantity, &ret, &p, &ammo]( detached_ptr<item> &&it ) {
+                ( *iter )->attempt_detach( [&filter, &ammo, &quantity, &ret, &p]( detached_ptr<item> &&it ) {
                     if( filter( *it ) ) {
                         return item::use_charges( std::move( it ), ammo, quantity, ret, p );
                     }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5109,9 +5109,9 @@ static void use_charges_from_furn( const furn_t &f, const itype_id &type, int &q
             } );
             if( iter != stack.end() ) {
 
-                ( *iter )->attempt_detach( [&filter, &type, &quantity, &ret, &p]( detached_ptr<item> &&it ) {
+                ( *iter )->attempt_detach( [&filter, &type, &quantity, &ret, &p, &ammo]( detached_ptr<item> &&it ) {
                     if( filter( *it ) ) {
-                        return item::use_charges( std::move( it ), type, quantity, ret, p );
+                        return item::use_charges( std::move( it ), ammo, quantity, ret, p );
                     }
                     return std::move( it );
                 } );


### PR DESCRIPTION
## Checklist

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Fixes #3754 

## Describe the solution

Forges were trying to consume charges of the fake forge item itself (e.g. char_forge) instead of its ammo (e.g. charcoal).

## Additional context

I'm not sure if this does relate to #5439. If someone could check if it's still present that would be great but I'm guessing it will be.

Also notice there's a very similar thing just above this (line 5099) for the power grid charge consumption. Again it's using the fake item as what it's depleting but I'm not sure if that's correct for power? Could you take a quick look @chaosvolt and make sure it's ok?
