### PR TITLE
style: Less hyperbolic MOTD regarding nightly builds

### DIFF
--- a/data/motd/en.motd
+++ b/data/motd/en.motd
@@ -27,24 +27,24 @@
 
 <color_white>Q: </color><color_yellow>What is a nightly build?</color>
 
-<color_white>A: </color><color_light_gray>The goal of the nightly builds is to be a second tier of quality control.  It's the frontline where new content is released to be tested and balanced after initial quality control.  Be aware that by choosing to play the latest nightly builds you are participating in the development process by literally playtesting the new content, and it is prone to bugs and underdeveloped features.</color>
+<color_white>A: </color><color_light_gray>Nightly builds are released every day, and have the latest features.  Compared to the unchanging stone of stable builds, nightly builds can be said to be ever-changing.  As such, they're often preferred by most players.</color>
 
 <color_white>Q: </color><color_yellow>Why are nightly builds even a thing?</color>
 
-<color_white>A: </color><color_light_gray>Consider it like playing an alpha/beta version - bugs and underdeveloped features are part of it.  Due to continuous integration rigors, nightly builds are always in a state of a constant work in progress.  Nightly is a sandbox where the bug detecting and feature polishing takes place.  Big and small features are constantly released to those builds to be checked for overall stability and balance.  Because of that, nightlies are not under the rigor of guaranteeing balance and stability.  In fact, nothing is guaranteed in the nightly builds.</color>
+<color_white>A: </color><color_light_gray>Players want to play with the latest features, and if we had to wait for the infrequent stable builds before anyone could play with new content, we'd likely have a much smaller community.  Additionally, whenever a big change is made, bugs are not uncommon.  By having frequent releases, we are better able to fix up bugs that somehow slipped through our current testing process.</color>
 
 <color_white>Q: </color><color_yellow>Are nightly builds playable then?</color>
 
-<color_white>A: </color><color_light_gray>Yes.  But while nightly builds overall are stable, it is also not guaranteed as features may be introduced in an underdeveloped state, in parts; and may introduce bugs, including severe ones that may crash the game or corrupt savegames.  It's rare, but due to the complexity of the game, the initial quality control before merging with nightly build may be inadequate, and there is always room for human error.  This is why nightly builds exist in the first place.</color>
+<color_white>A: </color><color_light_gray>Yes!  In fact, the majority of players prefer Nightly builds to the stables thanks to all the fresh content.  Additionally, the testing that we do before PRs get merged means that you're very unlikely to encounter seriously game-breaking bugs, even in Nightly.</color>
 
 <color_white>Q: </color><color_yellow>Should I play nightly builds then, or stick to stable build?</color>
 
-<color_white>A: </color><color_light_gray>The reward is instant access to the newest content, the risk is losing your game progress if a nasty bug emerges.  It is always your choice to play nightly builds, with a stable build available, so play at your own discretion.  You take all of the burden if something goes wrong, so be warned.  Take precautions, make backups.  Sometimes it's even best to postpone updating for few days until a big feature has been stabilized or a significant bug has been removed.</color>
+<color_white>A: </color><color_light_gray>Your choice to play nightly builds as opposed to stables is entirely up to you, but we would note that a majority of "Stable Releases" are really moreso just bookmarks in our history.  In truth, many in the community would highly recommend playing on a recent Nightly build for the sake of experiencing the new content.</color>
 
 <color_white>Q: </color><color_yellow>Should I be aware of anything else?</color>
 
-<color_white>A: </color><color_light_gray>Yes.  Remember that everything you see and are about to see is potentially subject to change.  All features, including newly implemented, are a work in progress and may change in the course of game development.  And, as said previously, nothing is guaranteed, including balance and stability.</color>
+<color_white>A: </color><color_light_gray>Many mods that are not in-repo, unless having created a release specifically labeled for a given stable, are based on the latest Nightly as opposed to latest Stable.  As such, if you wish to use certain mods, it may likely be in your best interest to be using the latest (or at least fairly recent) Nightly builds.</color>
 
 <color_white>Q: </color><color_yellow>What if I find the risk of playing nightly build unacceptable?</color>
 
-<color_white>A: </color><color_light_gray>If the risk is unacceptable - play the stable version.  If you are willing to take the risk - enjoy the newly added content of the nightly builds and partake in development - report bugs, submit suggestions, or even contribute your own content to the game.  Good luck.</color>
+<color_white>A: </color><color_light_gray>While we would note that, unlike in DDA's Experimentals, the Nightly builds are generally still fairly well-balanced and tested, it is ultimately up to you if you feel that Nightly releases are too risky for you.  However, if you ever report a bug or request a feature, we kindly ask you to make sure it hasn't already been fixed or implemented in a Nightly build if you do choose to stick to Stable releases.</color>


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

As I discovered looking at #5463 , the messages in the MoTD regarding Experimental / Nightly builds were still the same-old fearmongering DDA ones regarding unbalanced, half-baked features and rampant bugs. Considering the testing we're doing on PRs, and our general philosophy regarding Nightly releases, this felt out of place and thus I aim to correct it.

## Describe the solution

Rewrites each of the "answer" portions regarding nightly builds to better reflect our current philosophy and ideas behind Nightly builds.

## Describe alternatives you've considered

- Completely rewrite that section of the MoTD rather than leaving the questions in-tact

Fair, the questions are still a *bit* off for our current idea of Nightly builds, but that's a bit more work. Could easily be an alternative solution though.

## Testing

My spell checker seems happy with it, and if anything the lines are shorter than before.

## Additional context

Would have suggested it as an additional change to the original PR that scarf made that edited the MoTD, but it got merged before I could actually do so.

Tried to avoid referencing DDA's Experimentals too much for sake of not trying to throw shade on their policies regarding said builds.