### PR TITLE
fix: don't modify character while drawing character preview

### DIFF
--- a/src/character_preview.cpp
+++ b/src/character_preview.cpp
@@ -11,6 +11,9 @@
 #include "cata_tiles.h"
 #include "cursesport.h"
 #include "game.h"
+#include "avatar.h"
+#include "overlay_ordering.h"
+#include "effect.h"
 
 auto termx_to_pixel_value() -> int
 {
@@ -22,30 +25,102 @@ auto termy_to_pixel_value() -> int
     return projected_window_height() / TERMY;
 }
 
+// @brief adapter to get access to protected functions of cata_tiles
+// exclusively for use by character_preview ui
+class char_preview_adapter : public cata_tiles
+{
+    public:
+        static char_preview_adapter *convert( cata_tiles *ct ) {
+            return static_cast<char_preview_adapter *>( ct );
+        }
+
+        // This will need to stay in sync with cata_tiles::draw_entity_with_overlays
+        void display_avatar_preview_with_overlays( const avatar &ch, const point &p, bool with_clothing ) {
+            // ch is never an npc so we can set ent_name directly
+            std::string ent_name = ch.male ? "player_male" : "player_female";
+
+            int height_3d = 0;
+            int prev_height_3d = 0;
+            // depending on the toggle flip sprite left or right
+            if( ch.facing == FD_RIGHT ) {
+                draw_from_id_string( ent_name, C_NONE, "", tripoint( p, 0 ), corner, 0, lit_level::BRIGHT, false,
+                                     height_3d, 0, true );
+            } else if( ch.facing == FD_LEFT ) {
+                draw_from_id_string( ent_name, C_NONE, "", tripoint( p, 0 ), corner, 4, lit_level::BRIGHT, false,
+                                     height_3d, 0, true );
+            }
+
+            // next up, draw all the overlays, need to construct them locally
+            std::vector<std::string> overlays = get_overlay_ids( ch, with_clothing );
+            for( const std::string &overlay : overlays ) {
+                std::string draw_id = overlay;
+                if( find_overlay_looks_like( ch.male, overlay, draw_id ) ) {
+                    int overlay_height_3d = prev_height_3d;
+                    if( ch.facing == FD_RIGHT ) {
+                        draw_from_id_string( draw_id, C_NONE, "", tripoint( p, 0 ), corner, /*rota*/ 0, lit_level::BRIGHT,
+                                             false, overlay_height_3d, 0,
+                                             true );
+                    } else if( ch.facing == FD_LEFT ) {
+                        draw_from_id_string( draw_id, C_NONE, "", tripoint( p, 0 ), corner, /*rota*/ 4, lit_level::BRIGHT,
+                                             false, overlay_height_3d, 0,
+                                             true );
+                    }
+                    // the tallest height-having overlay is the one that counts
+                    height_3d = std::max( height_3d, overlay_height_3d );
+                }
+            }
+        }
+    private:
+        // @brief This is basically a copy of Character::get_overlay_ids but builds up ids we care about
+        std::vector<std::string> get_overlay_ids( const avatar &av, bool with_clothing ) {
+            std::vector<std::string> rval;
+            std::multimap<int, std::string> mutation_sorting;
+
+            // first get effects
+            for( const auto &eff : av.get_all_effects() ) { // only returns non-removed effects
+                rval.emplace_back( "effect_" + eff.first.str() );
+            }
+            // then get mutations
+            for( const auto &mut : av.my_mutations ) {
+                std::string overlay_id = ( mut.second.powered ? "active_" : "" ) + mut.first.str();
+                int order = get_overlay_order_of_mutation( overlay_id );
+                mutation_sorting.insert( std::pair<int, std::string>( order, overlay_id ) );
+            }
+
+            // add any profession bionics
+            // we'll use a temporary character for this and clothing so we aren't modifying the base character
+            avatar t_av;
+            for( const bionic_id &bio : av.prof->CBMs() ) {
+                t_av.add_bionic( bio );
+            }
+            for( const bionic &bio : *t_av.my_bionics ) {
+                std::string overlay_id = ( bio.powered ? "active_" : "" ) + bio.id.str();
+                int order = get_overlay_order_of_mutation( overlay_id );
+                mutation_sorting.insert( std::pair<int, std::string>( order, overlay_id ) );
+            }
+
+            for( auto &mutorder : mutation_sorting ) {
+                rval.push_back( "mutation_" + mutorder.second );
+            }
+
+            // now that we have bionics applied we can see what clothing we can wear
+            if( with_clothing ) {
+                for( const auto &it : av.prof->items( av.male, av.get_mutations() ) ) {
+                    if( it->is_armor() && av.can_wear( *it ).success() ) {
+                        t_av.wear_item( item::spawn( *std::move( it ) ), false );
+                    }
+                }
+                for( const item * const &worn_item : t_av.worn ) {
+                    rval.push_back( "worn_" + worn_item->typeId().str() );
+                }
+            }
+            return rval;
+        }
+};
+
 void character_preview_window::init( Character *character )
 {
     this->character = character;
-
-    // Setting bionics
-    for( const bionic_id &bio : character->prof->CBMs() ) {
-        character->add_bionic( bio );
-        // Saving possible spells to cancell them later
-        for( const std::pair<const spell_id, int> &spell_pair : bio->learned_spells ) {
-            const spell_id learned_spell = spell_pair.first;
-            if( learned_spell->spell_class != trait_id( "NONE" ) ) {
-                spells.push_back( learned_spell->spell_class );
-            }
-        }
-    }
-
-    // Collecting profession clothes
-    std::vector<detached_ptr<item>> prof_items = character->prof->items( character->male,
-                                 character->get_mutations() );
-    for( detached_ptr<item> &it : prof_items ) {
-        if( it->is_armor() ) {
-            clothes.push_back( std::move( it ) );
-        }
-    }
     toggle_clothes();
 }
 
@@ -129,13 +204,6 @@ void character_preview_window::zoom_out()
 
 void character_preview_window::toggle_clothes()
 {
-    if( !show_clothes ) {
-        character->worn.clear();
-    } else {
-        for( detached_ptr<item> &it : clothes ) {
-            character->wear_item( item::spawn( *std::move( it ) ), false );
-        }
-    }
     show_clothes = !show_clothes;
 }
 
@@ -153,22 +221,13 @@ void character_preview_window::display() const
 
     // Drawing character itself
     const point pos = calc_character_pos();
-    tilecontext->display_character( *character, pos );
+    // tilecontext->display_character( *character, pos );
+    char_preview_adapter::convert( &*tilecontext )->display_avatar_preview_with_overlays( *
+            ( character->as_avatar() ), pos, show_clothes );
 }
 
 void character_preview_window::clear() const
 {
-    character->worn.clear();
-    character->clear_bionics();
-    character->set_max_power_level( 0_kJ );
-    character->set_power_level( character->get_max_power_level() );
-    character->magic = pimpl<known_magic>();
-    for( const trait_id &spell : spells ) {
-        if( character->has_trait( spell ) ) {
-            character->remove_mutation( spell );
-        }
-    }
-    character->clear_morale();
     Messages::clear_messages();
     tilecontext->set_draw_scale( DEFAULT_TILESET_ZOOM );
 }


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Alternate PR to #5393 
Copying its Purpose of change:

> Modifies #5031 to stop altering the actual character at game start, this was causing a lot of unintentional behaviour and is _incredibly problematic_.

Fixes #5120
Fixes #5317

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution
Instead of modifying the input character directly we use an adapter of `cata_tiles` to customize character drawing and a temporary `avatar` where appropriate to contain changes necessary to keep character preview working properly.
While this works I don't particularly like this solution. It feels a bit hacky, and will require maintenance whenever `cata_tiles::draw_entity_with_overlays` or `Character::get_overlay_ids` are modified.
<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

## Describe alternatives you've considered
Make `avatar`'s copy constructor usable. Doing this may have undesirable side effects and I don't have the time to put into making sure the action won't mess something up.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing
Looks the same as pre-PR character preview but does not modify the character.

~~May be related to #5120 and #5317, need to test more to confirm.~~
Is related and fixes both

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
