### PR TITLE
fix: Stop using forge charges for all crafts

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5102,6 +5102,9 @@ static void use_charges_from_furn( const furn_t &f, const itype_id &type, int &q
             }
         } else if( itt.tool && !itt.tool->ammo_id.empty() ) {
             const itype_id ammo = ammotype( *itt.tool->ammo_id.begin() )->default_ammotype();
+            if( itt.tool->subtype!=type && type!=ammo && itt.get_id()!=type ){
+                continue;
+            }
             auto stack = m->i_at( p );
             auto iter = std::find_if( stack.begin(), stack.end(),
             [ammo]( const item * const & i ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5102,7 +5102,7 @@ static void use_charges_from_furn( const furn_t &f, const itype_id &type, int &q
             }
         } else if( itt.tool && !itt.tool->ammo_id.empty() ) {
             const itype_id ammo = ammotype( *itt.tool->ammo_id.begin() )->default_ammotype();
-            if( itt.tool->subtype!=type && type!=ammo && itt.get_id()!=type ){
+            if( itt.tool->subtype != type && type != ammo && itt.get_id() != type ) {
                 continue;
             }
             auto stack = m->i_at( p );


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Fix my lack of testing. 

## Describe the solution

It seems forge charges not being consumed was masking the problem that they're always considered consumable. Now it will only accept them if the tool or ammo type is correct.

## Testing

Both draining charges from forges and crafting normally now seem to work.