### PR TITLE
ci(i18n): commit translation files directly to `main`

### DIFF
--- a/.github/workflows/pull-translations.yml
+++ b/.github/workflows/pull-translations.yml
@@ -1,6 +1,7 @@
 name: "Pull translations from Transifex"
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "42 1 * * 6"
 

--- a/.github/workflows/pull-translations.yml
+++ b/.github/workflows/pull-translations.yml
@@ -33,8 +33,8 @@ jobs:
         uses: peter-evans/create-pull-request@v3.10.0
         with:
           commit-message: "feat(i18n): routine i18n updates on ${{ steps.get-timestamp.outputs.time }}"
-          committer: Coolthulhu (BOT) <Coolthulhu@gmail.com>
-          author: Coolthulhu (BOT) <Coolthulhu@gmail.com>
+          committer: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+          author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
           token: ${{ secrets.TX_PR_CREATOR }}
           branch: i18n
           delete-branch: true

--- a/.github/workflows/pull-translations.yml
+++ b/.github/workflows/pull-translations.yml
@@ -8,10 +8,12 @@ jobs:
   pull-translations:
     if: github.repository == 'cataclysmbnteam/Cataclysm-BN'
     runs-on: ubuntu-20.04
+
     steps:
       - name: "Install Transifex CLI"
         run: |
           curl -sL https://github.com/transifex/cli/releases/download/v1.6.7/tx-linux-amd64.tar.gz | sudo tar zxvf - -C /usr/bin tx
+
       - name: "Checkout"
         uses: actions/checkout@v4
         with:
@@ -19,16 +21,19 @@ jobs:
           sparse-checkout: |
             .tx
             lang
+
       - name: "Get current date"
         uses: nanzm/get-time-action@v1.1
         id: get-timestamp
         with:
           timeZone: 0
           format: "YYYY-MM-DD"
+
       - name: "Pull translations"
+        run: tx pull --force
         env:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
-        run: tx pull --force
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3.10.0
         with:

--- a/.github/workflows/pull-translations.yml
+++ b/.github/workflows/pull-translations.yml
@@ -8,7 +8,10 @@ on:
 jobs:
   pull-translations:
     if: github.repository == 'cataclysmbnteam/Cataclysm-BN'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
 
     steps:
       - name: "Install Transifex CLI"
@@ -35,16 +38,16 @@ jobs:
         env:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
 
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3.10.0
+      - name: Show Changes
+        run: |
+          git status
+          git diff --numstat
+
+      - name: Create Commit
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit-message: "feat(i18n): routine i18n updates on ${{ steps.get-timestamp.outputs.time }}"
-          committer: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
-          author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
-          token: ${{ secrets.TX_PR_CREATOR }}
-          branch: i18n
-          delete-branch: true
-          base: main
-          title: "feat(i18n): routine i18n updates on ${{ steps.get-timestamp.outputs.time }}"
-          body: ""
-          labels: Translation
+          branch: main
+          commit_message: "feat(i18n): routine i18n updates on ${{ steps.get-timestamp.outputs.time }}"
+          commit_user_name: "github-actions[bot]"
+          commit_user_email: "github-actions[bot]@users.noreply.github.com"
+          commit_author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"

--- a/.github/workflows/pull-translations.yml
+++ b/.github/workflows/pull-translations.yml
@@ -14,6 +14,11 @@ jobs:
           curl -sL https://github.com/transifex/cli/releases/download/v1.6.7/tx-linux-amd64.tar.gz | sudo tar zxvf - -C /usr/bin tx
       - name: "Checkout"
         uses: actions/checkout@v4
+        with:
+          filter: blob:none
+          sparse-checkout: |
+            .tx
+            lang
       - name: "Get current date"
         uses: nanzm/get-time-action@v1.1
         id: get-timestamp


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

![image](https://github.com/user-attachments/assets/e155fb00-1f39-4fa9-a817-6df97802a5c1)

automate weekly i18n PR review process

## Describe the solution

- uses https://github.com/marketplace/actions/git-auto-commit to directly commit to `main`.
- uses https://git-scm.com/docs/git-sparse-checkout to only checkout relevant directories and speed up cloning.

## Describe alternatives you've considered

keep opening PRs but it's rather cluttered and requires human intervention.

## Testing

should probably work... probably...
can be also ran manually to debug it