### PR TITLE
ci(i18n): fix pull translations action freezing

### DIFF
--- a/.github/workflows/pull-translations.yml
+++ b/.github/workflows/pull-translations.yml
@@ -20,11 +20,6 @@ jobs:
 
       - name: "Checkout"
         uses: actions/checkout@v4
-        with:
-          filter: blob:none
-          sparse-checkout: |
-            .tx
-            lang
 
       - name: "Get current date"
         uses: nanzm/get-time-action@v1.1

--- a/.github/workflows/pull-translations.yml
+++ b/.github/workflows/pull-translations.yml
@@ -22,11 +22,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: "Get current date"
-        uses: nanzm/get-time-action@v1.1
         id: get-timestamp
-        with:
-          timeZone: 0
-          format: "YYYY-MM-DD"
+        run: echo "time=$(date -u "+%F")" >> $GITHUB_OUTPUT
 
       - name: "Pull translations"
         run: tx pull --force


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

fix bug in #5492 where the workflow would freeze on pushing

## Describe the solution

remove `sparse-checkout` option

## Testing

![image](https://github.com/user-attachments/assets/e8fac961-194f-4f46-95d3-61af57cf3298)

[actually tested it works on fork this time.](https://github.com/scarf005/Cataclysm-BN/actions/runs/11157508424)