### PR TITLE
feat: Show item kill count in the examine item menu, make the menu option red

### DIFF
--- a/src/examine_item_menu.cpp
+++ b/src/examine_item_menu.cpp
@@ -110,6 +110,9 @@ bool run(
             case hint_rating::good:
                 list_entry.text_color = c_light_green;
                 break;
+            case hint_rating::blood:
+                list_entry.text_color = c_red;
+                break;
         }
     };
 
@@ -191,7 +194,7 @@ bool run(
     } );
 
     if( itm.kill_count() > 0 ) {
-        add_entry( "SHOW_KILL_LIST", hint_rating::good, [&]() {
+        add_entry( "SHOW_KILL_LIST", hint_rating::blood, [&]() {
             itm.show_kill_list();
             return true;
         } );

--- a/src/examine_item_menu.cpp
+++ b/src/examine_item_menu.cpp
@@ -416,6 +416,10 @@ hint_rating rate_action_reload( const avatar &you, const item &it )
             case hint_rating::good:
                 return hint_rating::good;
 
+            case hint_rating::blood:
+                // This doesn't happen, but if it did, just pass the color hint along
+                return hint_rating::blood;
+
             case hint_rating::cant:
                 continue;
 

--- a/src/examine_item_menu.cpp
+++ b/src/examine_item_menu.cpp
@@ -86,7 +86,16 @@ bool run(
     std::vector<action_entry> actions;
     uilist action_list;
 
-    const auto add_entry = [&]( const char *act, hint_rating hint, std::function<bool()> &&on_select ) {
+    /**
+    Add a menu entry
+    @param act the action name, corresponding to an action in data/raw/keybindings.json
+    @param hint determines what color the text will be
+    @param on_select lambda function for what the menu entry actually does
+    @param number will be printed after the menu entry in parentheses, optional
+                  INT_MIN is treated as a null value
+    */
+    const auto add_entry = [&]( const char *act, hint_rating hint, std::function<bool()> &&on_select,
+    int number = INT_MIN ) {
         action_entry ae;
         ae.action = act;
         ae.on_select = std::move( on_select );
@@ -97,7 +106,12 @@ bool run(
         std::string bound_key = ctxt.key_bound_to( act );
         int bound_key_i = bound_key.size() == 1 ? bound_key[0] : '?';
         std::string act_name = ctxt.get_action_name( act );
-        action_list.addentry( actions.size(), true, bound_key_i, act_name );
+        if( number == INT_MIN ) {
+            action_list.addentry( actions.size(), true, bound_key_i, act_name );
+        } else {
+            action_list.addentry( actions.size(), true, bound_key_i,
+                                  act_name + " (" + std::to_string( number ) + ")" );
+        }
 
         auto &list_entry = action_list.entries.back();
         switch( hint ) {
@@ -197,7 +211,7 @@ bool run(
         add_entry( "SHOW_KILL_LIST", hint_rating::blood, [&]() {
             itm.show_kill_list();
             return true;
-        } );
+        }, itm.kill_count() );
     }
 
     if( !itm.is_favorite ) {

--- a/src/examine_item_menu.h
+++ b/src/examine_item_menu.h
@@ -29,7 +29,9 @@ enum class hint_rating : int {
     /** Item should display as red (action impossible at the moment) */
     iffy,
     /** Item should display as green (action possible at the moment) */
-    good
+    good,
+    /** Item should display as bright red (kill list) */
+    blood
 };
 
 hint_rating rate_action_use( const avatar &you, const item &it );


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change
UI improvement for the kill counter added in #5394. @RoyalFox2140 asked me to recolor the Kills button in the examine item menu to make it a bit more visible. While looking through the menu code, I also figured out a way to add a kill counter in the menu, which I'd wanted to have since the beginning.
<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution
The Kills menu option was given its own hint color (red). The `add_entry()` function in `examine_item_menu.cpp` was modified to optionally print a number in addition to menu text.
<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

## Describe alternatives you've considered
I think dark red has the appropriate connotations of violence, but changing the color is easy if someone has a better idea. Light red is already used in the menu in a different context, but yellow for example might work. 

Thought about adding a new `add_entry_with_number` function instead of overloading the existing one, but that would have meant copypasting the whole thing.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing
Loaded save with items with recorded kills. Menu option appears correctly. Menu option does not appear for items with no kills. Counted list entries to double check number is correct.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context
Before:
![cata-2024-10-05-09-59-53](https://github.com/user-attachments/assets/886e2c87-f045-4e31-876f-5b7b1a533a4b)

After:
![cata-2024-10-05-11-10-57](https://github.com/user-attachments/assets/b787697d-e7a6-4991-a5b7-54be860e33c9)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
