### PR TITLE
fix: Fix itemgroup code and fix recharge scheme code

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8028,7 +8028,7 @@ bool item::magazine_integral() const
         // We have an integral magazine if we're a gun with an ammo capacity (clip)
         return type->gun->clip;
     } else if( is_tool() ) {
-        // Or we are a tool with max_charges defined
+        // Or we are a tool with max_charges
         return type->tool->max_charges;
     }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8028,7 +8028,7 @@ bool item::magazine_integral() const
         // We have an integral magazine if we're a gun with an ammo capacity (clip)
         return type->gun->clip;
     } else if( is_tool() ) {
-        // Or we are a tool with max_charges
+        // Or we are a tool with max_charges defined
         return type->tool->max_charges;
     }
 

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -342,8 +342,8 @@ detached_ptr<item> Item_modifier::modify( detached_ptr<item> &&new_item ) const
     if( new_item->is_tool() || new_item->is_gun() || new_item->is_magazine() ) {
         bool spawn_ammo = rng( 0, 99 ) < with_ammo && new_item->ammo_remaining() == 0 && ch == -1 &&
                           ( !new_item->is_tool() || new_item->type->tool->rand_charges.empty() );
-        bool spawn_mag  = rng( 0, 99 ) < with_magazine && !new_item->magazine_integral() &&
-                          !new_item->magazine_current();
+        bool spawn_mag  = rng( 0, 99 ) < with_magazine && !new_item->magazine_current()
+                          && new_item->magazine_default() != itype_id::NULL_ID();
 
         if( spawn_mag ) {
             new_item->put_in( item::spawn( new_item->magazine_default(), new_item->birthday() ) );

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -82,7 +82,8 @@ void relic_recharge::load( const JsonObject &jo )
 {
     try {
         src_loc = jo.get_source_location();
-    } catch( const std::exception & ) { // NOLINT: Savefiles don't specify source, so ignore error
+        // NOLINTNEXTLINE(bugprone-empty-catch): Savefiles don't specify source, so ignore error
+    } catch( const std::exception & ) {
     }
 
     jo.read( "type", type );

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -82,8 +82,7 @@ void relic_recharge::load( const JsonObject &jo )
 {
     try {
         src_loc = jo.get_source_location();
-    } catch( const std::exception & ) {
-        // Savefiles don't specify source, so ignore error
+    } catch( const std::exception & ) { // NOLINT: Savefiles don't specify source, so ignore error
     }
 
     jo.read( "type", type );

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -444,7 +444,7 @@ bool process_recharge_entry( item &itm, const relic_recharge &rech, Character &c
             itm.ammo_set( itm.ammo_default(), clamp( itm.ammo_remaining() + rech.rate, 0,
                           itm.ammo_capacity() ) );
         } else {
-            itm.charges = clamp( itm.charges + rech.rate, 0, itm.charges );
+            itm.charges = clamp( itm.charges + rech.rate, 0, itm.ammo_capacity() );
         }
     }
     if( rech.message ) {


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

- fix #5508, due to #5283 which revealed the issue that our item group code will attempt to insert magazines into items that aren't explicitly labelled as having integral magazines, leading to null items being shoved into them and causing issues. Also fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/5396
- fix #5283 where I noticed that my code will attempt to infinitely increment tool charges instead of respecting the maximum charges of a tool.

## Describe the solution

- item group item spawn code will now only load magazines into an item if it both doesn't already have one, and has a non-null item for a default magazine.

## Describe alternatives you've considered

## Testing

- [x] Spawned a set of 9 zombie soldiers via debug menu, killed them all and prayed they spawned a grenade
  - [x] Picking up a grenade doesn't error the game, and it doesn't display it's contents as having "none"

## Additional context

Another shining testament to the spaghetti in our code. If I could eat all of our code spaghetti I'd never have to buy food again.
