### PR TITLE
test: disable clang-tidy warnings-as-error

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -111,4 +111,6 @@ CheckOptions:
     value: "L;UL;LL;ULL"
   - key: cata-text-style.EscapeUnicode
     value: 0
+  - key: readability-simplify-boolean-expr.SimplifyDeMorgan
+    value: false
 # vim:tw=0

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -102,7 +102,8 @@ Checks: >
 # https://github.com/llvm/llvm-project/issues/59572
 # https://github.com/llvm/llvm-project/issues/111003
 
-WarningsAsErrors: '*'
+# Turn back on when all the fixes are applied
+# WarningsAsErrors: '*'
 HeaderFilterRegex: "(src|(test(?!.*catch.*catch.h))|tools).*"
 FormatStyle: none
 CheckOptions:


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

just too many clang-tidy violations atm which makes current clang-tidy rule of warnings-as-errors not desirable.

## Describe the solution

- disable warnings-as-errors.
- also disable [`SimplifyDeMorgan`](https://clang.llvm.org/extra/clang-tidy/checks/readability/simplify-boolean-expr.html#cmdoption-arg-SimplifyDeMorgan), check commit for details

## Testing

should work since it loosens clang-tidy tests.