### PR TITLE
feat: capitalize all skill names

### DIFF
--- a/data/json/skills.json
+++ b/data/json/skills.json
@@ -2,14 +2,14 @@
   {
     "type": "skill",
     "id": "barter",
-    "name": { "str": "bartering" },
+    "name": { "str": "Bartering" },
     "description": "Your skill in bargaining, haggling, and trading with others.  Higher levels increase the odds of getting the better end of a deal, and might even see you convincing others to give you free stuff.",
     "display_category": "display_social"
   },
   {
     "type": "skill",
     "id": "speech",
-    "name": { "str": "speaking" },
+    "name": { "str": "Speaking" },
     "description": "Your skill in speaking to other people.  Covers ability in boasting, flattery, threats, persuasion, lies, and other facets of interpersonal communication.  Works best in conjunction with a high level of intelligence.",
     "companion_survival_rank_factor": 1,
     "display_category": "display_social",
@@ -18,14 +18,14 @@
   {
     "type": "skill",
     "id": "computer",
-    "name": { "str": "computers" },
+    "name": { "str": "Computers" },
     "description": "Your skill in accessing and manipulating computers.  Higher levels can allow a user to navigate complex software systems and even bypass their security.",
     "display_category": "display_interaction"
   },
   {
     "type": "skill",
     "id": "firstaid",
-    "name": { "str": "first aid" },
+    "name": { "str": "First Aid" },
     "description": "Your skill in effecting emergency medical treatment.  Higher levels allow better use of medicines and items like bandages and first aid kits, and reduce the failure and complication rates of medical procedures.",
     "companion_survival_rank_factor": 1,
     "companion_industry_rank_factor": 1,
@@ -35,7 +35,7 @@
   {
     "type": "skill",
     "id": "mechanics",
-    "name": { "str": "mechanics" },
+    "name": { "str": "Mechanics" },
     "description": "Your skill in engineering, maintaining and repairing vehicles and other mechanical systems.  This skill covers the craft of items with complex parts, and plays a role in the installation of bionic equipment.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_interaction",
@@ -44,7 +44,7 @@
   {
     "type": "skill",
     "id": "traps",
-    "name": { "str": "trapping" },
+    "name": { "str": "Trapping" },
     "description": "Your skill in creating, setting, finding and disarming traps safely and effectively.  This skill does not affect the evasion of traps that are triggered.",
     "companion_survival_rank_factor": 1,
     "display_category": "display_interaction",
@@ -53,14 +53,14 @@
   {
     "type": "skill",
     "id": "driving",
-    "name": { "str": "driving" },
+    "name": { "str": "Driving" },
     "description": "Your skill in operating and steering a vehicle in motion.  A higher level allows greater control over vehicles at higher speeds, and reduces the penalty of shooting while driving.",
     "display_category": "display_interaction"
   },
   {
     "type": "skill",
     "id": "swimming",
-    "name": { "str": "swimming" },
+    "name": { "str": "Swimming" },
     "description": "Your ability to stay afloat and move around in bodies of water.  This skill keeps you from drowning, affects your combat effectiveness and speed in deep water, and determines the detriment of swimming with heavier gear.",
     "display_category": "display_interaction",
     "companion_skill_practice": [ { "skill": "", "weight": 5 }, { "skill": "gathering", "weight": 5 }, { "skill": "trapping", "weight": 5 } ]
@@ -68,7 +68,7 @@
   {
     "type": "skill",
     "id": "fabrication",
-    "name": { "str": "fabrication" },
+    "name": { "str": "Fabrication" },
     "description": "Your skill in working with raw materials and shaping them into useful objects.  This skill plays an important role in the crafting of many objects.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_crafting",
@@ -83,7 +83,7 @@
   {
     "type": "skill",
     "id": "cooking",
-    "name": { "str": "cooking" },
+    "name": { "str": "Cooking" },
     "description": "Your skill in combining food ingredients to make other, tastier food items.  It may also be used in certain chemical mixtures and other, more esoteric tasks.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_crafting",
@@ -92,7 +92,7 @@
   {
     "type": "skill",
     "id": "tailor",
-    "name": { "str": "tailoring" },
+    "name": { "str": "Tailoring" },
     "description": "Your skill in the craft and repair of clothing, bags, blankets and other textiles.  Affects knitting, sewing, stitching, weaving, and nearly anything else involving a needle and thread.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_crafting",
@@ -101,7 +101,7 @@
   {
     "type": "skill",
     "id": "survival",
-    "name": { "str": "survival" },
+    "name": { "str": "Survival" },
     "description": "Your skill in surviving the wilderness, and in crafting various basic survival items.  This also covers your ability to skin and butcher animals for meat and hides.",
     "companion_survival_rank_factor": 1,
     "display_category": "display_crafting",
@@ -119,7 +119,7 @@
   {
     "type": "skill",
     "id": "electronics",
-    "name": { "str": "electronics" },
+    "name": { "str": "Electronics" },
     "description": "Your skill in dealing with electrical systems, used in the craft and repair of objects with electrical components.  This skill is an important part of installing and managing bionic implants.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_crafting"
@@ -127,7 +127,7 @@
   {
     "type": "skill",
     "id": "archery",
-    "name": { "str": "archery" },
+    "name": { "str": "Archery" },
     "description": "Your skill in using bow weapons, from hand-carved self bows to complex compound bows.  Quiet and effective, they require strength of body and sight to wield, and are not terribly accurate over a long distance.",
     "tags": [ "combat_skill", "weapon_skill" ],
     "time_to_attack": { "min_time": 20, "base_time": 80, "time_reduction_per_level": 6 },
@@ -145,7 +145,7 @@
   {
     "type": "skill",
     "id": "gun",
-    "name": { "str": "marksmanship" },
+    "name": { "str": "Marksmanship" },
     "description": "Your overall skill in using bows and firearms.  With higher levels, this general experience increases accuracy with any bows or firearms, but is secondary to practice with the type of ranged weapon in question.",
     "tags": [ "combat_skill" ],
     "display_category": "display_ranged",
@@ -154,7 +154,7 @@
   {
     "type": "skill",
     "id": "launcher",
-    "name": { "str": "launchers" },
+    "name": { "str": "Launchers" },
     "description": "Your skill in using heavy weapons like rocket, grenade or missile launchers.  These weapons have a variety of applications and may carry immense destructive power, but they are cumbersome and hard to manage.",
     "tags": [ "combat_skill", "weapon_skill" ],
     "time_to_attack": { "min_time": 30, "base_time": 100, "time_reduction_per_level": 7 },
@@ -163,7 +163,7 @@
   {
     "type": "skill",
     "id": "pistol",
-    "name": { "str": "handguns" },
+    "name": { "str": "Handguns" },
     "description": "Handguns have poor accuracy compared to rifles, but are usually quick to fire and reload faster than other guns.  They are very effective at close quarters, though unsuited for long range engagement.",
     "tags": [ "combat_skill", "weapon_skill" ],
     "time_to_attack": { "min_time": 10, "base_time": 80, "time_reduction_per_level": 7 },
@@ -173,7 +173,7 @@
   {
     "type": "skill",
     "id": "rifle",
-    "name": { "str": "rifles" },
+    "name": { "str": "Rifles" },
     "description": "Rifles have terrific range and accuracy compared to other firearms, but may be slow to fire and reload, and can prove difficult to use in close quarters.  Fully automatic rifles can fire rapidly, but are harder to handle properly.",
     "tags": [ "combat_skill", "weapon_skill" ],
     "time_to_attack": { "min_time": 15, "base_time": 75, "time_reduction_per_level": 6 },
@@ -183,7 +183,7 @@
   {
     "type": "skill",
     "id": "shotgun",
-    "name": { "str": "shotguns" },
+    "name": { "str": "Shotguns" },
     "description": "Shotguns are easy to shoot and can inflict massive damage, but their effectiveness and accuracy decline rapidly with range.  Slugs can be loaded into shotguns to provide greater range, though they are somewhat inaccurate.",
     "tags": [ "combat_skill", "weapon_skill" ],
     "time_to_attack": { "min_time": 15, "base_time": 75, "time_reduction_per_level": 6 },
@@ -193,7 +193,7 @@
   {
     "type": "skill",
     "id": "smg",
-    "name": { "str": "submachine guns" },
+    "name": { "str": "Submachine Guns" },
     "description": "Comprised of an automatic rifle carbine designed to fire a pistol cartridge, submachine guns can reload and fire quickly, sometimes in bursts, but they are relatively inaccurate and may be prone to mechanical failures.",
     "tags": [ "combat_skill", "weapon_skill" ],
     "time_to_attack": { "min_time": 20, "base_time": 80, "time_reduction_per_level": 6 },
@@ -203,7 +203,7 @@
   {
     "type": "skill",
     "id": "throw",
-    "name": { "str": "throwing" },
+    "name": { "str": "Throwing" },
     "description": "Your skill in throwing objects over a distance.  Skill increases accuracy, and at higher levels, the range of a throw.",
     "tags": [ "combat_skill", "weapon_skill" ],
     "time_to_attack": { "min_time": 50, "base_time": 220, "time_reduction_per_level": 25 },
@@ -212,7 +212,7 @@
   {
     "type": "skill",
     "id": "melee",
-    "name": { "str": "melee" },
+    "name": { "str": "Melee" },
     "description": "Your skill and finesse in personal combat, both with and without a weapon.  Higher levels can significantly increase the accuracy and effectiveness of your physical attacks.",
     "tags": [ "combat_skill" ],
     "time_to_attack": { "min_time": 50, "base_time": 200, "time_reduction_per_level": 20 },
@@ -230,7 +230,7 @@
   {
     "type": "skill",
     "id": "bashing",
-    "name": { "str": "bashing weapons" },
+    "name": { "str": "Bashing Weapons" },
     "description": "Your skill in fighting with blunt weaponry, from rocks and sticks to baseball bats and the butts of rifles.  Skill increases damage, and higher levels will improve the accuracy of an attack.",
     "tags": [ "combat_skill", "weapon_skill" ],
     "companion_combat_rank_factor": 1,
@@ -240,7 +240,7 @@
   {
     "type": "skill",
     "id": "cutting",
-    "name": { "str": "cutting weapons" },
+    "name": { "str": "Cutting Weapons" },
     "description": "Your skill in fighting with weaponry designed to cut, hack and slash an opponent.  Lower levels of skill increase accuracy and damage, while higher levels will help to bypass heavy armor and thick hides.",
     "tags": [ "combat_skill", "weapon_skill" ],
     "companion_combat_rank_factor": 1,
@@ -250,7 +250,7 @@
   {
     "type": "skill",
     "id": "dodge",
-    "name": { "str": "dodging" },
+    "name": { "str": "Dodging" },
     "description": "Your ability to dodge an oncoming threat, be it an enemy's attack, a triggered trap, or a falling rock.  This skill is also used in attempts to fall gracefully, and for other acrobatic feats.  The first number shown includes modifiers, and the second does not.",
     "display_category": "display_melee",
     "companion_skill_practice": [ { "skill": "hunting", "weight": 15 }, { "skill": "combat", "weight": 20 } ]
@@ -258,7 +258,7 @@
   {
     "type": "skill",
     "id": "stabbing",
-    "name": { "str": "piercing weapons" },
+    "name": { "str": "Piercing Weapons" },
     "description": "Your skill in fighting with knives, spears and other such stabbing implements.  Skill increases attack accuracy as well as the chance of inflicting a deadly and critical blow.",
     "tags": [ "combat_skill", "weapon_skill" ],
     "companion_combat_rank_factor": 1,
@@ -268,7 +268,7 @@
   {
     "type": "skill",
     "id": "unarmed",
-    "name": { "str": "unarmed combat" },
+    "name": { "str": "Unarmed Combat" },
     "description": "Your skill in hand-to-hand fighting, with unarmed weapons or empty-handed.  Skill increases attack accuracy and unlocks techniques in many martial arts, while also providing a bonus to bare-handed damage.",
     "tags": [ "combat_skill", "weapon_skill" ],
     "companion_combat_rank_factor": 1,
@@ -279,7 +279,7 @@
   {
     "type": "skill",
     "id": "weapon",
-    "name": { "str": "weapon" },
+    "name": { "str": "Weapon" },
     "description": "seeing this is a bug",
     "tags": [ "contextual_skill" ],
     "display_category": "none"

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -627,7 +627,7 @@ TEST_CASE( "ranged weapon attributes", "[item][iteminfo][weapon][ranged][gun]" )
         test_info_equals(
             "test_compbow", q,
             "--\n"
-            "Skill used: <color_c_cyan>archery</color>\n" );
+            "Skill used: <color_c_cyan>Archery</color>\n" );
     }
 
     SECTION( "ammo capacity of weapon" ) {

--- a/tests/memorial_test.cpp
+++ b/tests/memorial_test.cpp
@@ -181,7 +181,7 @@ TEST_CASE( "memorials" )
         m, b, "Gained the mutation 'Carnivore'.", ch, mut );
 
     check_memorial<event_type::gains_skill_level>(
-        m, b, "Reached skill level 8 in driving.", ch, skill_id( "driving" ), 8 );
+        m, b, "Reached skill level 8 in Driving.", ch, skill_id( "driving" ), 8 );
 
     check_memorial<event_type::game_over>(
         m, b, u_name + " was killed.\nLast words: last_words", false, "last_words" );

--- a/tests/reading_test.cpp
+++ b/tests/reading_test.cpp
@@ -326,7 +326,7 @@ TEST_CASE( "reasons for not being able to read", "[reading][reasons]" )
             dummy.set_skill_level( skill_id( "cooking" ), 7 );
 
             CHECK( dummy.get_book_reader( alpha, reasons ) == nullptr );
-            expect_reasons = { "cooking 8 needed to understand.  You have 7" };
+            expect_reasons = { "Cooking 8 needed to understand.  You have 7" };
             CHECK( reasons == expect_reasons );
         }
 


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
able fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.

## Purpose of change

I think capitalizing skill names looks nicer and is slightly more readable. I'm willing to poll it to the community if there's any opposition.

## Describe the solution

Capitalizes all skill names

## Describe alternatives you've considered

Only capitalize proper nouns instead of each word.

## Testing

Tests.

## Additional context

People said it looks better so I figured it was worth a shot.
