### PR TITLE
fix: Rework spell studying and notify

### DIFF
--- a/doc/src/content/docs/en/mod/json/reference/creatures/magic.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/magic.md
@@ -267,10 +267,10 @@ that use a negative 'recover' effect to cause pain or stamina damage. For exampl
 ### Learning Spells
 
 There are three ways of granting spells that are implemented: Mutating can grant a spell with the
-"spells_learned" field which also lets you specify the level granted. Certain spells can also
-teach you spells once they reach an appropriate level via the "learn_spells" variable. Finally,
-You can learn a spell from an item through a use_action, which is also the only way to train a
-spell other than using it. Examples of all three are shown below:
+"spells_learned" field which also lets you specify the level granted. Certain spells can also teach
+you spells once they reach an appropriate level via the "learn_spells" variable. Finally, You can
+learn a spell from an item through a use_action, which is also the only way to train a spell other
+than using it. Examples of all three are shown below:
 
 ```json
 {
@@ -289,7 +289,8 @@ spell other than using it. Examples of all three are shown below:
 },
 ```
 
-For the below example you will learn the spell Greater Acid Resistance once Acid Resistance reaches level 15
+For the below example you will learn the spell Greater Acid Resistance once Acid Resistance reaches
+level 15
 
 ```json
 {

--- a/doc/src/content/docs/en/mod/json/reference/creatures/magic.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/magic.md
@@ -66,6 +66,7 @@ In `data/mods/Magiclysm` there is a template spell, copied here for your perusal
   "sound_ambient": true, // whether or not this is treated as an ambient sound or not
   "sound_id": "misc", // the sound id
   "sound_variant": "shockwave" // the sound variant
+  "learn_spells": { "acid_resistance_greater": 15 } // You learn the specified spell once your level in this spell is greater than or equal to the number shown.
 }
 ```
 
@@ -265,10 +266,11 @@ that use a negative 'recover' effect to cause pain or stamina damage. For exampl
 
 ### Learning Spells
 
-There are two ways of granting spells that is implemented: Mutating can grant a spell with the
-"spells_learned" field which also lets you specify the level granted. Otherwise you can learn a
-spell from an item through a use_action, which is also the only way to train a spell other than
-using it. Examples of both are shown below:
+There are three ways of granting spells that are implemented: Mutating can grant a spell with the
+"spells_learned" field which also lets you specify the level granted. Certain spells can also
+teach you spells once they reach an appropriate level via the "learn_spells" variable. Finally,
+You can learn a spell from an item through a use_action, which is also the only way to train a
+spell other than using it. Examples of all three are shown below:
 
 ```json
 {
@@ -285,6 +287,19 @@ using it. Examples of both are shown below:
     "spells": [ "debug_hp", "debug_stamina", "example_template", "debug_bionic", "pain_split", "fireball" ] // this is a list of spells you can learn from the item
   }
 },
+```
+
+For the below example you will learn the spell Greater Acid Resistance once Acid Resistance reaches level 15
+
+```json
+{
+    "id": "acid_resistance",
+    "type": "SPELL",
+    "name": { "str": "Acid Resistance" },
+    "description": "Protects the user from acid.",
+    ...
+    "learn_spells": { "acid_resistance_greater": 15 }
+}
 ```
 
 You can study this spellbook for a rate of ~1 experience per turn depending on intelligence,

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2576,7 +2576,7 @@ int learn_spell_actor::use( player &p, item &, bool, const tripoint & ) const
     if( study_spell->moves_total == 10100 ) {
         study_spell->str_values[0] = "gain_level";
         study_spell->values[0] = 0; // reserved for xp
-        study_spell->values[1] = p.magic->get_spell( spell_id( spells[action] ) ).get_level() + 1;
+        study_spell->values[1] = 0; // reserved for levels
     }
     study_spell->name = spells[action];
     p.assign_activity( std::move( study_spell ), false );

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2159,13 +2159,12 @@ void spell_events::notify( const cata::event &e )
                  it != spell_cast.learn_spells.end(); ++it ) {
                 std::string learn_spell_id = it->first;
                 int learn_at_level = it->second;
-                if( learn_at_level == slvl ) {
+                if( slvl >= learn_at_level && !g->u.magic->knows_spell( learn_spell_id ) ) {
                     g->u.magic->learn_spell( learn_spell_id, g->u );
                     spell_type spell_learned = spell_factory.obj( spell_id( learn_spell_id ) );
                     add_msg(
                         _( "Your experience and knowledge in creating and manipulating magical energies to cast %s have opened your eyes to new possibilities, you can now cast %s." ),
-                        spell_cast.name,
-                        spell_learned.name );
+                        spell_cast.name, spell_learned.name );
                 }
             }
             break;


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Was noted on the Discord that we had weird behaviour with spell studying where levelling up would not teach you the spell written in `learn_spell`, as it does not send an event for it. Also due to how the notify event works if you miss it in any way you will not learn the spell on later level ups.

## Describe the solution

Studying a spell now tracks level gained and sends appropriate level up event on level up. (It also shows if you gained a level when the activity finishes, with consideration if you leveled more than once per session)

Updates notify event such that it will grant new spell if the spell level is equal to or greater than target level.

## Describe alternatives you've considered

## Testing

- [x] Spawn a character with the acid resistance spell scroll. Debug his skills to 10 and Int to 500. Save
  - [x] Check that casting the spell still produces expected behaviour with level up and learning spells.
  - [x] Check that studying from a book until next level produces correct text (ie: and 1 level), and that multiple levels show appropriate message. Check that you learn the spell when you cross the threshold.
  - [x] Check that the game doesn't produce unexpected behaviour when you level up again past the `learn_spell` threshold.
  - [x] Check that if you level a spell via debug menu past level 15, you'll still gain the spell through study/spellcasting 

## Additional context

Some of the activity is still weird like storing a whole ass string to remember that this is to gain a level, and spell code could probably be reworked, but that day is not today and that person is not me.
