### PR TITLE
fix: Print messages with monster names properly

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9100,12 +9100,12 @@ dealt_damage_instance Character::deal_damage( Creature *source, bodypart_id bp,
 
             if( has_grab_break_tec() && ( rng( 0, get_dex() )  > rng( 0, 10 ) ) ) {
                 if( has_effect( effect_grabbed ) ) {
-                    add_msg_if_player( m_warning, _( "The %s tries to grab you as well, but you bat it away!" ),
-                                       source->disp_name() );
+                    add_msg_if_player( m_warning, _( "%s tries to grab you as well, but you bat it away!" ),
+                                       source->disp_name( false, true ) );
                 } else {
-                    add_msg_player_or_npc( m_info, _( "The %s tries to grab you, but you break its grab!" ),
-                                           _( "The %s tries to grab <npcname>, but they break its grab!" ),
-                                           source->disp_name() );
+                    add_msg_player_or_npc( m_info, _( "%s tries to grab you, but you break its grab!" ),
+                                           _( "%s tries to grab <npcname>, but they break its grab!" ),
+                                           source->disp_name( false, true ) );
                 }
             } else {
                 int prev_effect = get_effect_int( effect_grabbed );

--- a/src/gates.cpp
+++ b/src/gates.cpp
@@ -264,7 +264,7 @@ void doors::close_door( map &m, Character &who, const tripoint &closep )
             who.add_msg_if_player( m_info, _( "There's some buffoon in the way!" ) );
         } else if( mon->is_monster() ) {
             // TODO: Houseflies, mosquitoes, etc shouldn't count
-            who.add_msg_if_player( m_info, _( "The %s is in the way!" ), mon->get_name() );
+            who.add_msg_if_player( m_info, _( "%s is in the way!" ), mon->disp_name( false, true ) );
         } else {
             who.add_msg_if_player( m_info, _( "%s is in the way!" ), mon->disp_name() );
         }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -4667,7 +4667,7 @@ int deploy_tent_actor::use( player &p, item &it, bool, const tripoint & ) const
             return 0;
         }
         if( const Creature *const c = g->critter_at( dest ) ) {
-            add_msg( m_info, _( "The %s is in the way." ), c->disp_name() );
+            add_msg( m_info, _( "%s is in the way." ), c->disp_name( false, true ) );
             return 0;
         }
         if( here.impassable( dest ) || !here.has_flag( "FLAT", dest ) ) {

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -511,7 +511,7 @@ static void damage_targets( const spell &sp, Creature &caster,
         } else if( sp.damage() < 0 ) {
             sp.heal( target );
             if( get_avatar().sees( cr->pos() ) ) {
-                add_msg( m_good, _( "%s wounds are closing up!" ), cr->disp_name( true ) );
+                add_msg( m_good, _( "%s wounds are closing up!" ), cr->disp_name( true, true ) );
             }
         }
     }

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -1146,9 +1146,9 @@ bool mattack::smash( monster *z )
         return true;
     }
 
-    target->add_msg_player_or_npc( _( "A blow from the %1$s sends %2$s flying!" ),
-                                   _( "A blow from the %s sends <npcname> flying!" ),
-                                   z->name(), target->disp_name() );
+    target->add_msg_player_or_npc( _( "A blow from %1$s sends %2$s flying!" ),
+                                   _( "A blow from %s sends <npcname> flying!" ),
+                                   z->disp_name(), target->disp_name() );
     // TODO: Make this parabolic
     g->fling_creature( target, coord_to_angle( z->pos(), target->pos() ),
                        z->type->melee_sides * z->type->melee_dice * 3 );
@@ -1327,8 +1327,8 @@ bool mattack::science( monster *const z ) // I said SCIENCE again!
             // if the player can see it
             if( g->u.sees( *z ) ) {
                 // TODO: mutate() doesn't like non-players right now
-                add_msg( m_bad, _( "The %1$s fires a shimmering beam towards %2$s!" ),
-                         z->name(), target->disp_name() );
+                add_msg( m_bad, _( "%1$s fires a shimmering beam towards %2$s!" ),
+                         z->disp_name( false, true ), target->disp_name() );
             }
 
             // (1) Give the target a chance at an uncanny_dodge.
@@ -1930,8 +1930,8 @@ bool mattack::fungus_bristle( monster *z )
 
     auto msg_type = target == &g->u ? m_warning : m_neutral;
 
-    add_msg( msg_type, _( "The %1$s swipes at %2$s with a barbed tendril!" ), z->name(),
-             target->disp_name() );
+    add_msg( msg_type, _( "%1$s swipes at %2$s with a barbed tendril!" ),
+             z->disp_name( false, true ), target->disp_name() );
     z->moves -= 150;
 
     if( target->uncanny_dodge() ) {
@@ -2354,7 +2354,7 @@ static bool blobify( monster &blob, monster &target )
 {
     if( g->u.sees( target ) ) {
         add_msg( m_warning, _( "%s is engulfed by %s!" ),
-                 target.disp_name(), blob.disp_name() );
+                 target.disp_name( false, true ), blob.disp_name() );
     }
 
     switch( target.get_size() ) {
@@ -2751,8 +2751,8 @@ bool mattack::ranged_pull( monster *z )
     here.creature_on_trap( *target );
     if( seen ) {
         if( z->type->bodytype == "human" || z->type->bodytype == "angel" ) {
-            add_msg( _( "The %1$s's arms fly out and pull and grab %2$s!" ), z->name(),
-                     target->disp_name() );
+            add_msg( _( "%1$s's arms fly out and pull and grab %2$s!" ),
+                     z->disp_name( false, true ), target->disp_name() );
 
             // Stop player from hauling when grabbed and pulled
             if( z->is_player() && z->as_character()->is_hauling() ) {
@@ -2760,8 +2760,8 @@ bool mattack::ranged_pull( monster *z )
             }
 
         } else {
-            add_msg( _( "The %1$s reaches out and pulls %2$s!" ), z->name(),
-                     target->disp_name() );
+            add_msg( _( "%1$s reaches out and pulls %2$s!" ),
+                     z->disp_name( false, true ), target->disp_name() );
         }
     }
 
@@ -4386,8 +4386,8 @@ bool mattack::flesh_golem( monster *z )
         return false;
     }
     if( g->u.sees( *z ) ) {
-        add_msg( _( "The %1$s swings a massive claw at %2$s!" ), z->name(),
-                 target->disp_name() );
+        add_msg( _( "%1$s swings a massive claw at %2$s!" ),
+                 z->disp_name( false, true ), target->disp_name() );
     }
     z->moves -= 100;
 
@@ -4496,7 +4496,7 @@ bool mattack::lunge( monster *z )
             }
             z->moves += 200;
             if( seen ) {
-                add_msg( _( "The %1$s lunges for %2$s!" ), z->name(), target->disp_name() );
+                add_msg( _( "%1$s lunges for %2$s!" ), z->disp_name( false, true ), target->disp_name() );
             }
             return true;
         }
@@ -5354,8 +5354,8 @@ bool mattack::bio_op_takedown( monster *z )
     bool seen = g->u.sees( *z );
     player *foe = dynamic_cast< player * >( target );
     if( seen ) {
-        add_msg( _( "The %1$s mechanically grabs at %2$s!" ), z->name(),
-                 target->disp_name() );
+        add_msg( _( "%1$s mechanically grabs at %2$s!" ),
+                 z->disp_name( false, true ), target->disp_name() );
     }
     z->moves -= 100;
 
@@ -5380,7 +5380,7 @@ bool mattack::bio_op_takedown( monster *z )
         target->deal_damage( z, bodypart_id( "torso" ), damage_instance( DT_BASH, dam ) );
         target->add_effect( effect_downed, 3_turns );
         if( seen ) {
-            add_msg( _( "%1$s slams %2$s to the ground!" ), z->name(), target->disp_name() );
+            add_msg( _( "%1$s slams %2$s to the ground!" ), z->disp_name( false, true ), target->disp_name() );
         }
         target->check_dead_state();
         return true;
@@ -5448,8 +5448,8 @@ bool mattack::bio_op_impale( monster *z )
     const bool seen = g->u.sees( *z );
     player *foe = dynamic_cast< player * >( target );
     if( seen ) {
-        add_msg( _( "The %1$s mechanically lunges at %2$s!" ), z->name(),
-                 target->disp_name() );
+        add_msg( _( "%1$s mechanically lunges at %2$s!" ),
+                 z->disp_name( false, true ), target->disp_name() );
     }
     z->moves -= 100;
 
@@ -5482,7 +5482,7 @@ bool mattack::bio_op_impale( monster *z )
             target->add_effect( effect_bleed, rng( 75_turns, 125_turns ), body_part_torso );
         }
         if( seen ) {
-            add_msg( _( "The %1$s impales %2$s!" ), z->name(), target->disp_name() );
+            add_msg( _( "%1$s impales %2$s!" ), z->disp_name( false, true ), target->disp_name() );
         }
         target->check_dead_state();
         return true;
@@ -5535,8 +5535,8 @@ bool mattack::bio_op_disarm( monster *z )
     }
 
     if( seen ) {
-        add_msg( _( "The %1$s mechanically reaches for %2$s!" ), z->name(),
-                 target->disp_name() );
+        add_msg( _( "%1$s mechanically reaches for %2$s!" ),
+                 z->disp_name( false, true ), target->disp_name() );
     }
     z->moves -= 100;
 

--- a/src/mondefense.cpp
+++ b/src/mondefense.cpp
@@ -85,8 +85,8 @@ void mdefense::zapback( monster &m, Creature *const source,
 
     if( get_avatar().sees( source->pos() ) ) {
         const auto msg_type = source == &get_avatar() ? m_bad : m_info;
-        add_msg( msg_type, _( "Striking the %1$s shocks %2$s!" ),
-                 m.name(), source->disp_name() );
+        add_msg( msg_type, _( "Striking %1$s shocks %2$s!" ),
+                 m.disp_name(), source->disp_name() );
     }
 
     const damage_instance shock {

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1918,8 +1918,8 @@ bool monster::push_to( const tripoint &p, const int boost, const size_t depth )
     critter->add_effect( effect_stunned, rng( 0_turns, 2_turns ) );
     // Only print the message when near player or it can get spammy
     if( rl_dist( g->u.pos(), pos() ) < 4 && g->u.sees( *critter ) ) {
-        add_msg( m_warning, _( "The %1$s tramples %2$s" ),
-                 name(), critter->disp_name() );
+        add_msg( m_warning, _( "%1$s tramples %2$s" ),
+                 disp_name( false, true ), critter->disp_name() );
     }
 
     moves -= movecost_attacker;
@@ -2176,8 +2176,8 @@ void monster::shove_vehicle( const tripoint &remote_destination,
             if( shove_velocity > 0 ) {
                 if( g->u.sees( this->pos() ) ) {
                     //~ %1$s - monster name, %2$s - vehicle name
-                    g->u.add_msg_if_player( m_bad, _( "%1$s shoves %2$s out of their way!" ), this->disp_name(),
-                                            veh.disp_name() );
+                    g->u.add_msg_if_player( m_bad, _( "%1$s shoves %2$s out of their way!" ),
+                                            this->disp_name( false, true ), veh.disp_name() );
                 }
                 int shove_moves = shove_veh_mass_moves_factor * veh_mass / 10_kilogram;
                 shove_moves = std::max( shove_moves, shove_moves_minimal );

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1734,10 +1734,10 @@ void monster::melee_attack( Creature &target, float accuracy )
                 add_msg( _( "You dodge %s." ), disp_name() );
             } else if( target.is_npc() ) {
                 add_msg( _( "%1$s dodges %2$s attack." ),
-                         target.disp_name(), name() );
+                         target.disp_name(), disp_name( true ) );
             } else {
-                add_msg( _( "The %1$s misses %2$s!" ),
-                         name(), target.disp_name() );
+                add_msg( _( "%1$s misses %2$s!" ),
+                         disp_name( false, true ), target.disp_name() );
             }
         } else if( target.is_player() ) {
             add_msg( _( "You dodge an attack from an unseen source." ) );
@@ -1750,7 +1750,7 @@ void monster::melee_attack( Creature &target, float accuracy )
                                          sfx::get_heard_volume( target.pos() ) );
                 sfx::do_player_death_hurt( dynamic_cast<player &>( target ), false );
                 //~ 1$s is attacker name, 2$s is bodypart name in accusative.
-                add_msg( m_bad, _( "The %1$s hits your %2$s." ), name(),
+                add_msg( m_bad, _( "%1$s hits your %2$s." ), disp_name( false, true ),
                          body_part_name_accusative( bp_hit ) );
             } else if( target.is_npc() ) {
                 if( has_effect( effect_ridden ) && has_flag( MF_RIDEABLE_MECH ) && pos() == g->u.pos() ) {
@@ -1759,7 +1759,7 @@ void monster::melee_attack( Creature &target, float accuracy )
                              total_dealt );
                 } else {
                     //~ %1$s: attacker name, %2$s: target NPC name, %3$s: bodypart name in accusative
-                    add_msg( _( "The %1$s hits %2$s %3$s." ), name(),
+                    add_msg( _( "%1$s hits %2$s %3$s." ), disp_name( false, true ),
                              target.disp_name( true ),
                              body_part_name_accusative( bp_hit ) );
                 }
@@ -1770,7 +1770,7 @@ void monster::melee_attack( Creature &target, float accuracy )
                              total_dealt );
                 } else {
                     //~ %1$s: attacker name, %2$s: target creature name
-                    add_msg( _( "The %1$s hits %2$s!" ), name(), target.disp_name() );
+                    add_msg( _( "%1$s hits %2$s!" ), disp_name( false, true ), target.disp_name() );
                 }
             }
         } else if( target.is_player() ) {
@@ -1783,13 +1783,13 @@ void monster::melee_attack( Creature &target, float accuracy )
         if( u_see_me ) {
             if( target.is_player() ) {
                 //~ 1$s is attacker name, 2$s is bodypart name in accusative, 3$s is armor name
-                add_msg( _( "The %1$s hits your %2$s, but your %3$s protects you." ), name(),
+                add_msg( _( "%1$s hits your %2$s, but your %3$s protects you." ), disp_name( false, true ),
                          body_part_name_accusative( bp_hit ), target.skin_name() );
             } else if( target.is_npc() ) {
                 //~ $1s is monster name, %2$s is that monster target name,
                 //~ $3s is target bodypart name in accusative, $4s is the monster target name,
                 //~ 5$s is target armor name.
-                add_msg( _( "The %1$s hits %2$s %3$s but is stopped by %4$s %5$s." ), name(),
+                add_msg( _( "%1$s hits %2$s %3$s but is stopped by %4$s %5$s." ), disp_name( false, true ),
                          target.disp_name( true ),
                          body_part_name_accusative( bp_hit ),
                          target.disp_name( true ),
@@ -1797,8 +1797,8 @@ void monster::melee_attack( Creature &target, float accuracy )
             } else {
                 //~ $1s is monster name, %2$s is that monster target name,
                 //~ $3s is target armor name.
-                add_msg( _( "The %1$s hits %2$s but is stopped by its %3$s." ),
-                         name(),
+                add_msg( _( "%1$s hits %2$s but is stopped by its %3$s." ),
+                         disp_name( false, true ),
                          target.disp_name(),
                          target.skin_name() );
             }
@@ -2358,7 +2358,7 @@ void monster::set_special( const std::string &special_name, int time )
     if( iter != special_attacks.end() ) {
         iter->second.cooldown = time;
     } else {
-        debugmsg( "%s has no special attack %s", disp_name().c_str(), special_name.c_str() );
+        debugmsg( "%s has no special attack %s", disp_name(), special_name );
     }
 }
 
@@ -2368,7 +2368,7 @@ void monster::disable_special( const std::string &special_name )
     if( iter != special_attacks.end() ) {
         iter->second.enabled = false;
     } else {
-        debugmsg( "%s has no special attack %s", disp_name().c_str(), special_name.c_str() );
+        debugmsg( "%s has no special attack %s", disp_name(), special_name );
     }
 }
 
@@ -3182,9 +3182,9 @@ void monster::on_damage_of_type( int amt, damage_type dt, const bodypart_id &bp 
         x_in_y( amt * 10, full_hp ) ) {
         remove_effect( effect_grabbing );
         for( player *p : find_targets_to_ungrab( pos() ) ) {
-            p->add_msg_player_or_npc( m_good, _( "The %s flinches, letting you go!" ),
-                                      _( "The %s flinches, letting <npcname> go!" ),
-                                      disp_name().c_str() );
+            p->add_msg_player_or_npc( m_good, _( "%s flinches, letting you go!" ),
+                                      _( "%s flinches, letting <npcname> go!" ),
+                                      disp_name( false, true ) );
             p->remove_effect( effect_grabbed );
         }
     }

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1740,8 +1740,8 @@ units::angle map::shake_vehicle( vehicle &veh, const int velocity_before,
                                                "the power of the impact!" ), veh.name );
                 unboard_vehicle( part_pos );
             } else if( get_player_character().sees( part_pos ) ) {
-                add_msg( m_bad, _( "The %s is hurled from %s's by the power of the impact!" ),
-                         pet->disp_name(), veh.name );
+                add_msg( m_bad, _( "%s is hurled from %s's by the power of the impact!" ),
+                         pet->disp_name( false, true ), veh.name );
             }
             ///\EFFECT_STR reduces distance thrown from seat in a vehicle impact
             g->fling_creature( rider, direction + rng_float( -30_degrees, 30_degrees ),

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1593,9 +1593,9 @@ bool vehicle::can_close( int part_index, Character &who )
                     who.add_msg_if_player( m_info, _( "There's some buffoon in the way!" ) );
                 } else if( mon->is_monster() ) {
                     // TODO: Houseflies, mosquitoes, etc shouldn't count
-                    who.add_msg_if_player( m_info, _( "The %s is in the way!" ), mon->get_name() );
+                    who.add_msg_if_player( m_info, _( "%s is in the way!" ), mon->disp_name( false, true ) );
                 } else {
-                    who.add_msg_if_player( m_info, _( "%s is in the way!" ), mon->disp_name() );
+                    who.add_msg_if_player( m_info, _( "%s is in the way!" ), mon->disp_name( false, true ) );
                 }
                 return false;
             }


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Some issues were noted in our messages printing the word the multiple times.

Checking further also revealed that some weren't being properly capitalized. In fact, I'm almost 90% sure that I'm the first person to actually _use_ the capitalize first function for `disp_name`

## Describe the solution

Audits all code that uses `disp_name` in an attempt to standardize our message display.

## Describe alternatives you've considered

- Stop using `disp_name` entirely and just use `name`.
  - Tempting, probably doable for monster names but breaks down when you use NPCs as you usually don't call people's names with The in front. "The John dodges the zombie's attack" probably means something different from "John dodges the zombie's attack"

## Testing

If someone wants to test they're welcome, I'll test this shit later this week or something. Main ones are the one's that appear when grabbed and breaking grabs.
- [ ] Confirm that most text actually displays correctly.

## Additional context
