### PR TITLE
fix: bone shiv doesnt take survival twice

### DIFF
--- a/data/json/recipes/weapon/piercing.json
+++ b/data/json/recipes/weapon/piercing.json
@@ -425,7 +425,6 @@
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_PIERCING",
     "skill_used": "survival",
-    "skills_required": [ "survival", 1 ],
     "time": "2 m",
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 1 } ],


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
## Purpose of change

![image](https://github.com/user-attachments/assets/6ec6d8f4-8c8c-48ea-9d5c-696d70747a97)


## Describe the solution

![image](https://github.com/user-attachments/assets/1e8f74c7-d716-4263-8440-aa2880d9be3f)


## Describe alternatives you've considered

## Testing

## Additional context

