### PR TITLE
feat: Permanent flagged spells are always permanent, even at min. level

### DIFF
--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -753,7 +753,7 @@ void spell_effect::spawn_ethereal_item( const spell &sp, Creature &caster, const
 {
     detached_ptr<item> granted = item::spawn( sp.effect_data(), calendar::turn );
     item &as_item = *granted;
-    if( !granted->is_comestible() && !( sp.has_flag( spell_flag::PERMANENT ) && sp.is_max_level() ) ) {
+    if( !granted->is_comestible() && !( sp.has_flag( spell_flag::PERMANENT ) ) ) {
         granted->set_var( "ethereal", to_turns<int>( sp.duration_turns() ) );
         granted->set_flag( flag_id( "ETHEREAL_ITEM" ) );
     }


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
## Purpose of change

Previously spells that give items only give them temporarily at a level less than max, even if a spell is flagged as permanent. This changes that, because permanent flag is permanent. We could eventually add this check back as a new Semi-Permanent flag.

## Describe the solution

Isolates and removes the level check

## Describe alternatives you've considered

Have someone else overhaul it to add a new semi-permanent flag or TRUE permanent flag

## Testing

Compile tested. Loaded. Used a spell that was partially leveled but with a permanent flag.
![image](https://github.com/user-attachments/assets/89f90453-0cc1-49f2-ab8f-afdb07db4672)
![image](https://github.com/user-attachments/assets/07d3f4c0-3212-4a10-b5b9-b23c196849b0)

## Additional context

:(
