### PR TITLE
refactor: use C++20 `string::{starts,ends}_with`

### DIFF
--- a/src/cata_libintl.cpp
+++ b/src/cata_libintl.cpp
@@ -124,7 +124,7 @@ struct PlfTStream {
             }
             std::string ss = s->substr( pos, end - pos );
             for( const auto &t : simple_tokens ) {
-                if( string_starts_with( ss, t.first ) ) {
+                if( ss.starts_with( t.first ) ) {
                     return PlfToken{ t.second, 0, pos, t.first.size() };
                 }
             }
@@ -546,7 +546,7 @@ void trans_catalogue::check_encoding( const meta_headers &headers )
     {
         bool found = false;
         for( const std::string &entry : headers ) {
-            if( !string_starts_with( entry, "Content-Type:" ) ) {
+            if( !entry.starts_with( "Content-Type:" ) ) {
                 continue;
             }
             found = true;
@@ -566,7 +566,7 @@ void trans_catalogue::check_encoding( const meta_headers &headers )
     {
         bool found = false;
         for( const std::string &entry : headers ) {
-            if( !string_starts_with( entry, "Content-Transfer-Encoding:" ) ) {
+            if( !entry.starts_with( "Content-Transfer-Encoding:" ) ) {
                 continue;
             }
             found = true;
@@ -602,7 +602,7 @@ trans_catalogue::catalogue_plurals_info trans_catalogue::parse_plf_header(
     {
         bool found = false;
         for( const std::string &entry : headers ) {
-            if( !string_starts_with( entry, "Plural-Forms:" ) ) {
+            if( !entry.starts_with( "Plural-Forms:" ) ) {
                 continue;
             }
             found = true;
@@ -624,7 +624,7 @@ trans_catalogue::catalogue_plurals_info trans_catalogue::parse_plf_header(
     // Parse & validate nplurals
     {
         std::string plf_n_raw = parts[0];
-        if( !string_starts_with( plf_n_raw, " nplurals=" ) ) {
+        if( !plf_n_raw.starts_with( " nplurals=" ) ) {
             throw std::runtime_error( "failed to parse Plural-Forms header" );
         }
         plf_n_raw = plf_n_raw.substr( 10 ); // 10 is length of " nplurals=" string
@@ -645,7 +645,7 @@ trans_catalogue::catalogue_plurals_info trans_catalogue::parse_plf_header(
     // Parse & validate plural formula
     {
         std::string plf_rules_raw = parts[1];
-        if( !string_starts_with( plf_rules_raw, " plural=" ) ) {
+        if( !plf_rules_raw.starts_with( " plural=" ) ) {
             throw std::runtime_error( "failed to parse Plural-Forms header" );
         }
         plf_rules_raw = plf_rules_raw.substr( 8 ); // 8 is length of " plural=" string

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -715,7 +715,7 @@ std::optional<tile_search_result> cata_tiles::tile_type_search(
         } else if( category == C_ITEM ) {
             //TODO!: push this up, it's a bad one
             item *tmp;
-            if( string_starts_with( found_id, "corpse_" ) ) {
+            if( found_id.starts_with( "corpse_" ) ) {
                 tmp = item::spawn_temporary( itype_corpse, calendar::start_of_cataclysm );
             } else {
                 tmp = item::spawn_temporary( found_id, calendar::start_of_cataclysm );
@@ -2090,7 +2090,7 @@ cata_tiles::find_tile_looks_like( const std::string &id, TILE_CATEGORY category,
         case C_ITEM: {
             itype_id iid = itype_id( id );
             if( !iid.is_valid() ) {
-                if( string_starts_with( id, "corpse_" ) ) {
+                if( id.starts_with( "corpse_" ) ) {
                     return find_tile_looks_like(
                                itype_corpse.str(), category, looks_like_jumps_limit - 1
                            );
@@ -2113,10 +2113,10 @@ bool cata_tiles::find_overlay_looks_like( const bool male, const std::string &ov
     std::string looks_like;
     std::string over_type;
 
-    if( string_starts_with( overlay, "worn_" ) ) {
+    if( overlay.starts_with( "worn_" ) ) {
         looks_like = overlay.substr( 5 );
         over_type = "worn_";
-    } else if( string_starts_with( overlay, "wielded_" ) ) {
+    } else if( overlay.starts_with( "wielded_" ) ) {
         looks_like = overlay.substr( 8 );
         over_type = "wielded_";
     } else {
@@ -2134,7 +2134,7 @@ bool cata_tiles::find_overlay_looks_like( const bool male, const std::string &ov
             exists = true;
             break;
         }
-        if( string_starts_with( looks_like, "mutation_active_" ) ) {
+        if( looks_like.starts_with( "mutation_active_" ) ) {
             looks_like = "mutation_" + looks_like.substr( 16 );
             continue;
         }
@@ -2280,12 +2280,12 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
             break;
         default:
             // player
-            if( string_starts_with( found_id, "player_" ) ) {
+            if( found_id.starts_with( "player_" ) ) {
                 seed = g->u.name[0];
                 break;
             }
             // NPC
-            if( string_starts_with( found_id, "npc_" ) ) {
+            if( found_id.starts_with( "npc_" ) ) {
                 if( npc *const guy = g->critter_at<npc>( pos ) ) {
                     seed = guy->getID().get_value();
                     break;
@@ -2673,7 +2673,7 @@ bool cata_tiles::has_terrain_memory_at( const tripoint &p ) const
 {
     if( g->u.should_show_map_memory() ) {
         const memorized_terrain_tile t = g->u.get_memorized_tile( get_map().getabs( p ) );
-        if( string_starts_with( t.tile, "t_" ) ) {
+        if( t.tile.starts_with( "t_" ) ) {
             return true;
         }
     }
@@ -2684,7 +2684,7 @@ bool cata_tiles::has_furniture_memory_at( const tripoint &p ) const
 {
     if( g->u.should_show_map_memory() ) {
         const memorized_terrain_tile t = g->u.get_memorized_tile( get_map().getabs( p ) );
-        if( string_starts_with( t.tile, "f_" ) ) {
+        if( t.tile.starts_with( "f_" ) ) {
             return true;
         }
     }
@@ -2695,7 +2695,7 @@ bool cata_tiles::has_trap_memory_at( const tripoint &p ) const
 {
     if( g->u.should_show_map_memory() ) {
         const memorized_terrain_tile t = g->u.get_memorized_tile( get_map().getabs( p ) );
-        if( string_starts_with( t.tile, "tr_" ) ) {
+        if( t.tile.starts_with( "tr_" ) ) {
             return true;
         }
     }
@@ -2706,7 +2706,7 @@ bool cata_tiles::has_vpart_memory_at( const tripoint &p ) const
 {
     if( g->u.should_show_map_memory() ) {
         const memorized_terrain_tile t = g->u.get_memorized_tile( get_map().getabs( p ) );
-        if( string_starts_with( t.tile, "vp_" ) ) {
+        if( t.tile.starts_with( "vp_" ) ) {
             return true;
         }
     }
@@ -2717,7 +2717,7 @@ memorized_terrain_tile cata_tiles::get_terrain_memory_at( const tripoint &p ) co
 {
     if( g->u.should_show_map_memory() ) {
         const memorized_terrain_tile t = g->u.get_memorized_tile( get_map().getabs( p ) );
-        if( string_starts_with( t.tile, "t_" ) ) {
+        if( t.tile.starts_with( "t_" ) ) {
             return t;
         }
     }
@@ -2728,7 +2728,7 @@ memorized_terrain_tile cata_tiles::get_furniture_memory_at( const tripoint &p ) 
 {
     if( g->u.should_show_map_memory() ) {
         const memorized_terrain_tile t = g->u.get_memorized_tile( get_map().getabs( p ) );
-        if( string_starts_with( t.tile, "f_" ) ) {
+        if( t.tile.starts_with( "f_" ) ) {
             return t;
         }
     }
@@ -2739,7 +2739,7 @@ memorized_terrain_tile cata_tiles::get_trap_memory_at( const tripoint &p ) const
 {
     if( g->u.should_show_map_memory() ) {
         const memorized_terrain_tile t = g->u.get_memorized_tile( get_map().getabs( p ) );
-        if( string_starts_with( t.tile, "tr_" ) ) {
+        if( t.tile.starts_with( "tr_" ) ) {
             return t;
         }
     }
@@ -2750,7 +2750,7 @@ memorized_terrain_tile cata_tiles::get_vpart_memory_at( const tripoint &p ) cons
 {
     if( g->u.should_show_map_memory() ) {
         const memorized_terrain_tile t = g->u.get_memorized_tile( get_map().getabs( p ) );
-        if( string_starts_with( t.tile, "vp_" ) ) {
+        if( t.tile.starts_with( "vp_" ) ) {
             return t;
         }
     }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -315,7 +315,7 @@ tile_type &tileset::create_tile_type( const std::string &id, tile_type &&new_til
     };
     bool has_season_suffix = false;
     for( int i = 0; i < 4; i++ ) {
-        if( string_ends_with( id, season_suffix[i] ) ) {
+        if( id.ends_with( season_suffix[i] ) ) {
             has_season_suffix = true;
             // key is id without _season suffix
             season_tile_value &value = tile_ids_by_season[i][id.substr( 0,

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -204,12 +204,12 @@ void check_consistency()
     for( const construction &c_it : all_constructions.get_all() ) {
         construction &c = const_cast<construction &>( c_it );
         bool did_migrate = false;
-        if( string_starts_with( c.pre_terrain.str(), "f_" ) ) {
+        if( c.pre_terrain.str().starts_with( "f_" ) ) {
             c.pre_furniture = furn_str_id( c.pre_terrain.str() );
             c.pre_terrain = ter_str_id();
             did_migrate = true;
         }
-        if( string_starts_with( c.post_terrain.str(), "f_" ) ) {
+        if( c.post_terrain.str().starts_with( "f_" ) ) {
             c.post_furniture = furn_str_id( c.post_terrain.str() );
             c.post_terrain = ter_str_id();
             did_migrate = true;

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -853,7 +853,7 @@ static std::optional<uintptr_t> debug_compute_load_offset(
             while( !line.empty() && isspace( line.end()[-1] ) ) {
                 line.erase( line.end() - 1 );
             }
-            if( string_ends_with( line, string_sought ) ) {
+            if( line.ends_with( string_sought ) ) {
                 std::istringstream line_is( line );
                 uintptr_t symbol_address;
                 line_is >> std::hex >> symbol_address;

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -331,7 +331,7 @@ std::vector<std::string> find_file_if_bfs( const std::string &root_path,
     std::deque<std::string>  directories;
     if( root_path.empty() ) {
         directories.emplace_back( "./" );
-    } else if( string_ends_with( root_path, "/" ) ) {
+    } else if( root_path.ends_with( "/" ) ) {
         directories.emplace_back( root_path );
     } else {
         directories.emplace_back( root_path + "/" );
@@ -496,7 +496,7 @@ const char *CBN = "Q2F0YWNseXNtQnJpZ2h0TmlnaHRz";
 bool can_write_to_dir( const std::string &dir_path )
 {
     std::string dummy_file;
-    if( string_ends_with( dir_path, "/" ) ) {
+    if( dir_path.ends_with( "/" ) ) {
         dummy_file = dir_path + CBN;
     } else {
         dummy_file = dir_path + "/" + CBN;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4937,7 +4937,7 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
     } else if( has_flag( flag_IS_UPS ) && get_var( "cable" ) == "plugged_in" ) {
         tagtext += _( " (plugged in)" );
     } else if( is_active() && !is_food() && !is_corpse() &&
-               !string_ends_with( typeId().str(), "_on" ) ) {
+               ! typeId().str().ends_with( "_on" ) ) {
         // Usually the items whose ids end in "_on" have the "active" or "on" string already contained
         // in their name, also food is active while it rots.
         tagtext += _( " (active)" );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -276,7 +276,7 @@ void Item_factory::finalize_pre( itype &obj )
     }
     // remove LIGHT_[X] flags
     erase_if( obj.item_tags, []( const flag_id & f ) {
-        return string_starts_with( f.str(), "LIGHT_" );
+        return f.str().starts_with( "LIGHT_" );
     } );
 
     // Set max volume for containers to prevent integer overflow
@@ -589,7 +589,7 @@ void Item_factory::finalize_pre( itype &obj )
     }
 
     if( obj.can_use( "MA_MANUAL" ) && obj.book && obj.book->martial_art.is_null() &&
-        string_starts_with( obj.get_id().str(), "manual_" ) ) {
+        obj.get_id().str().starts_with( "manual_" ) ) {
         // HACK: Legacy martial arts books rely on a hack whereby the name of the
         // martial art is derived from the item id
         obj.book->martial_art = matype_id( "style_" + obj.get_id().str().substr( 7 ) );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2049,7 +2049,7 @@ int iuse::pack_item( player *p, item *it, bool t, const tripoint & )
         return 0;
     } else { // Turning it off
         std::string oname = it->typeId().str();
-        if( string_ends_with( oname, "_on" ) ) {
+        if( oname.ends_with( "_on" ) ) {
             oname.erase( oname.length() - 3, 3 );
         } else {
             debugmsg( "no item type to turn it into (%s)!", oname );

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -118,7 +118,7 @@ void JsonObject::report_unvisited() const
         reported_unvisited_members = true;
         for( const std::pair<const std::string, int> &p : positions ) {
             const std::string &name = p.first;
-            if( !visited_members.count( name ) && !string_starts_with( name, "//" ) ) {
+            if( !visited_members.count( name ) && !name.starts_with( "//" ) ) {
                 try {
                     throw_error( string_format( "Invalid or misplaced field name \"%s\" in JSON data", name ), name );
                 } catch( const JsonError &e ) {

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -106,7 +106,7 @@ static std::string getSystemUILang()
     std::replace( lang_code.begin(), lang_code.end(), '-', '_' );
 
     for( const language_info &info : lang_options ) {
-        if( !info.osx.empty() && string_starts_with( lang_code, info.osx ) ) {
+        if( !info.osx.empty() && lang_code.starts_with( info.osx ) ) {
             return info.id;
         }
     }
@@ -121,7 +121,7 @@ std::string to_valid_language( const std::string &lang )
         return lang;
     }
     for( const language_info &info : lang_options ) {
-        if( string_starts_with( lang, info.id ) ) {
+        if( lang.starts_with( info.id ) ) {
             return info.id;
         }
     }
@@ -129,7 +129,7 @@ std::string to_valid_language( const std::string &lang )
     if( p != std::string::npos ) {
         std::string lang2 = lang.substr( 0, p );
         for( const language_info &info : lang_options ) {
-            if( string_starts_with( lang2, info.id ) ) {
+            if( lang2.starts_with( info.id ) ) {
                 return info.id;
             }
         }
@@ -170,7 +170,7 @@ static std::string getSystemUILang()
         }
     }
 
-    if( ret == "C" || string_starts_with( ret, "C." ) ) {
+    if( ret == "C" || ret.starts_with( "C." ) ) {
         ret = "en";
     }
 

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6306,7 +6306,7 @@ om_direction::type oter_get_rotation_dir( const oter_id &oter )
 {
     for( const om_direction::type &rot : om_direction::all ) {
         const std::string &rot_s = om_direction::get_suffix( rot );
-        if( string_ends_with( oter.id().str(), rot_s ) ) {
+        if( oter.id().str().ends_with( rot_s ) ) {
             return rot;
         }
     }

--- a/src/sdl_font.cpp
+++ b/src/sdl_font.cpp
@@ -40,7 +40,7 @@ std::unique_ptr<Font> Font::load_font( SDL_Renderer_Ptr &renderer, SDL_PixelForm
                                        const palette_array &palette,
                                        const bool fontblending )
 {
-    if( string_ends_with( typeface, ".bmp" ) || string_ends_with( typeface, ".png" ) ) {
+    if( typeface.ends_with( ".bmp" ) || typeface.ends_with( ".png" ) ) {
         // Seems to be an image file, not a font.
         // Try to load as bitmap font from user font dir, then from font dir.
         try {
@@ -185,7 +185,7 @@ CachedTTFFont::CachedTTFFont(
     std::vector<std::string> known_suffixes = { ".ttf", ".otf", ".ttc", ".fon" };
     bool add_suffix = true;
     for( const std::string &ks : known_suffixes ) {
-        if( string_ends_with( typeface, ks ) ) {
+        if( typeface.ends_with( ks ) ) {
             add_suffix = false;
             break;
         }

--- a/src/sdl_font.cpp
+++ b/src/sdl_font.cpp
@@ -228,7 +228,7 @@ CachedTTFFont::CachedTTFFont(
 #endif
 
     for( const std::string &kp : known_prefixes ) {
-        if( string_starts_with( typeface, kp ) ) {
+        if( typeface.starts_with( kp ) ) {
             add_prefix = false;
             break;
         }

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -77,11 +77,6 @@ bool match_include_exclude( const std::string &text, std::string filter )
     return found;
 }
 
-bool string_starts_with( const std::string &s1, const std::string &s2 )
-{
-    return s1.compare( 0, s2.size(), s2 ) == 0;
-}
-
 bool string_ends_with( const std::string &s1, const std::string &s2 )
 {
     return s1.size() >= s2.size() &&

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -77,12 +77,6 @@ bool match_include_exclude( const std::string &text, std::string filter )
     return found;
 }
 
-bool string_ends_with( const std::string &s1, const std::string &s2 )
-{
-    return s1.size() >= s2.size() &&
-           s1.compare( s1.size() - s2.size(), s2.size(), s2 ) == 0;
-}
-
 std::string join( const std::vector<std::string> &strings, const std::string &joiner )
 {
     std::ostringstream buffer;

--- a/src/string_utils.h
+++ b/src/string_utils.h
@@ -40,26 +40,6 @@ bool lcequal( const std::string &str1, const std::string &str2 );
 bool match_include_exclude( const std::string &text, std::string filter );
 
 /**
- * \brief Returns true if s1 ends with s2
- *
- * TODO: Switch to ends_with method of std::string when we move to C++20
- */
-bool string_ends_with( const std::string &s1, const std::string &s2 );
-
-/**
- *  Returns true iff s1 ends with s2.
- *  This version accepts constant string literals and is ≈1.5 times faster than std::string version.
- *  Note: N is (size+1) for null-terminated strings.
- *
- * TODO: Maybe switch to std::string::ends_with + std::string_view when we move to C++20
- */
-template <std::size_t N>
-inline bool string_ends_with( const std::string &s1, const char( &s2 )[N] )
-{
-    return s1.size() >= N - 1 && s1.compare( s1.size() - ( N - 1 ), std::string::npos, s2, N - 1 ) == 0;
-}
-
-/**
  * Joins a vector of `std::string`s into a single string with a delimiter/joiner
  */
 std::string join( const std::vector<std::string> &strings, const std::string &joiner );

--- a/src/string_utils.h
+++ b/src/string_utils.h
@@ -40,26 +40,6 @@ bool lcequal( const std::string &str1, const std::string &str2 );
 bool match_include_exclude( const std::string &text, std::string filter );
 
 /**
- * \brief Returns true if s1 starts with s2
- *
- * TODO: Switch to starts_with method of std::string when we move to C++20
- */
-bool string_starts_with( const std::string &s1, const std::string &s2 );
-
-/**
- * Returns true if s1 starts with s2.
- * This version accepts constant string literals and is ≈1.5 times faster than std::string version.
- * Note: N is (size+1) for null-terminated strings.
- *
- * TODO: Maybe switch to std::string::starts_with + std::string_view when we move to C++20
- */
-template <std::size_t N>
-inline bool string_starts_with( const std::string &s1, const char( &s2 )[N] )
-{
-    return s1.compare( 0, N - 1, s2, N - 1 ) == 0;
-}
-
-/**
  * \brief Returns true if s1 ends with s2
  *
  * TODO: Switch to ends_with method of std::string when we move to C++20

--- a/tests/cata_utility_test.cpp
+++ b/tests/cata_utility_test.cpp
@@ -6,17 +6,6 @@
 #include "units_utility.h"
 #include "units.h"
 
-// tests both variants of string_starts_with
-template <std::size_t N>
-bool test_string_starts_with( const std::string &s1, const char( &s2 )[N] )
-{
-    CAPTURE( s1, s2, N );
-    bool r1 =  string_starts_with( s1, s2 );
-    bool r2 =  string_starts_with( s1, std::string( s2 ) );
-    CHECK( r1 == r2 );
-    return r1;
-}
-
 // tests both variants of string_ends_with
 template <std::size_t N>
 bool test_string_ends_with( const std::string &s1, const char( &s2 )[N] )
@@ -26,16 +15,6 @@ bool test_string_ends_with( const std::string &s1, const char( &s2 )[N] )
     bool r2 =  string_ends_with( s1, std::string( s2 ) );
     CHECK( r1 == r2 );
     return r1;
-}
-
-TEST_CASE( "string_starts_with", "[utility]" )
-{
-    CHECK( test_string_starts_with( "", "" ) );
-    CHECK( test_string_starts_with( "a", "" ) );
-    CHECK_FALSE( test_string_starts_with( "", "a" ) );
-    CHECK( test_string_starts_with( "ab", "a" ) );
-    CHECK_FALSE( test_string_starts_with( "ab", "b" ) );
-    CHECK_FALSE( test_string_starts_with( "a", "ab" ) );
 }
 
 TEST_CASE( "string_ends_with", "[utility]" )

--- a/tests/cata_utility_test.cpp
+++ b/tests/cata_utility_test.cpp
@@ -6,52 +6,6 @@
 #include "units_utility.h"
 #include "units.h"
 
-// tests both variants of string_ends_with
-template <std::size_t N>
-bool test_string_ends_with( const std::string &s1, const char( &s2 )[N] )
-{
-    CAPTURE( s1, s2, N );
-    bool r1 =  string_ends_with( s1, s2 );
-    bool r2 =  string_ends_with( s1, std::string( s2 ) );
-    CHECK( r1 == r2 );
-    return r1;
-}
-
-TEST_CASE( "string_ends_with", "[utility]" )
-{
-    CHECK( test_string_ends_with( "", "" ) );
-    CHECK( test_string_ends_with( "a", "" ) );
-    CHECK_FALSE( test_string_ends_with( "", "a" ) );
-    CHECK( test_string_ends_with( "ba", "a" ) );
-    CHECK_FALSE( test_string_ends_with( "ba", "b" ) );
-    CHECK_FALSE( test_string_ends_with( "a", "ba" ) );
-}
-
-TEST_CASE( "string_ends_with_benchmark", "[.][utility][benchmark]" )
-{
-    const std::string s1 = "long_string_with_suffix";
-
-    BENCHMARK( "old version" ) {
-        return string_ends_with( s1, std::string( "_suffix" ) );
-    };
-    BENCHMARK( "new version" ) {
-        return string_ends_with( s1, "_suffix" );
-    };
-}
-
-TEST_CASE( "string_ends_with_season_suffix", "[utility]" )
-{
-    constexpr size_t suffix_len = 15;
-    constexpr char season_suffix[4][suffix_len] = {
-        "_season_spring", "_season_summer", "_season_autumn", "_season_winter"
-    };
-
-    CHECK( test_string_ends_with( "t_tile_season_spring", season_suffix[0] ) );
-    CHECK_FALSE( test_string_ends_with( "t_tile", season_suffix[0] ) );
-    CHECK_FALSE( test_string_ends_with( "t_tile_season_summer", season_suffix[0] ) );
-    CHECK_FALSE( test_string_ends_with( "t_tile_season_spring1", season_suffix[0] ) );
-}
-
 TEST_CASE( "divide_round_up", "[utility]" )
 {
     CHECK( divide_round_up( 0, 5 ) == 0 );

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -233,7 +233,7 @@ static std::string extract_user_dir( std::vector<const char *> &arg_vec )
     if( option_user_dir.empty() ) {
         return "./test_user_dir/";
     }
-    if( !string_ends_with( option_user_dir, "/" ) ) {
+    if( !option_user_dir.ends_with( "/" ) ) {
         option_user_dir += "/";
     }
     return option_user_dir;


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

code is liability; replace them with functions available in C++20 stdlib since we have #5514 

## Describe the solution

- use C++20 features like https://en.cppreference.com/w/cpp/string/basic_string/starts_with
- remove obsolete benchmarks

## Describe alternatives you've considered


## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
