### PR TITLE
refactor: use concepts more

### DIFF
--- a/src/assign.h
+++ b/src/assign.h
@@ -18,6 +18,7 @@
 #include "json.h"
 #include "units.h"
 #include "units_serde.h"
+#include "concepts_utility.h"
 
 namespace detail
 {
@@ -43,7 +44,7 @@ bool is_strict_enabled( const std::string &src );
 void report_strict_violation( const JsonObject &jo, const std::string &message,
                               const std::string &name );
 
-template <typename T, typename std::enable_if<std::is_arithmetic<T>::value, int>::type = 0>
+template <Arithmetic T>
 bool assign( const JsonObject &jo, const std::string &name, T &val, bool strict = false,
              T lo = std::numeric_limits<T>::lowest(), T hi = std::numeric_limits<T>::max() )
 {
@@ -95,7 +96,7 @@ bool assign( const JsonObject &jo, const std::string &name, T &val, bool strict 
 // and also to avoid potentially nonsensical interactions between relative and proportional.
 bool assign( const JsonObject &jo, const std::string &name, bool &val, bool strict = false );
 
-template <typename T, typename std::enable_if<std::is_arithmetic<T>::value, int>::type = 0>
+template <Arithmetic T>
 bool assign( const JsonObject &jo, const std::string &name, std::pair<T, T> &val,
              bool strict = false, T lo = std::numeric_limits<T>::lowest(), T hi = std::numeric_limits<T>::max() )
 {

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -804,8 +804,8 @@ words: `MemberType foo( ReaderType(...) );` does not work. This is what `is_cons
 If the 5. parameter can be used to construct a `MemberType`, it is assumed to be the default value,
 otherwise it is assumed to be the reader.
 */
-template<typename MemberType, typename DefaultType = MemberType,
-         typename = typename std::enable_if<std::is_constructible<MemberType, const DefaultType &>::value>::type>
+template<typename MemberType, typename DefaultType = MemberType>
+requires( std::is_constructible_v<MemberType, const DefaultType &> )
 inline void optional( const JsonObject &jo, const bool was_loaded, const std::string &name,
                       MemberType &member, const DefaultType &default_value )
 {
@@ -816,9 +816,9 @@ inline void optional( const JsonObject &jo, const bool was_loaded, const std::st
         }
     }
 }
-template < typename MemberType, typename ReaderType, typename DefaultType = MemberType,
-           typename = typename std::enable_if <
-               !std::is_constructible<MemberType, const ReaderType &>::value >::type >
+
+template<typename MemberType, typename ReaderType, typename DefaultType = MemberType>
+requires( !std::is_constructible_v<MemberType, const ReaderType &> )
 inline void optional( const JsonObject &jo, const bool was_loaded, const std::string &name,
                       MemberType &member, const ReaderType &reader )
 {
@@ -828,6 +828,7 @@ inline void optional( const JsonObject &jo, const bool was_loaded, const std::st
         }
     }
 }
+
 template<typename MemberType, typename ReaderType, typename DefaultType = MemberType>
 inline void optional( const JsonObject &jo, const bool was_loaded, const std::string &name,
                       MemberType &member, const ReaderType &reader, const DefaultType &default_value )

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -657,48 +657,45 @@ std::true_type {};
 template<>
 struct supports_proportional<bool> : std::false_type {};
 
+template<typename T>
+concept SupportsProportional = supports_proportional<T>::value;
+
 // This checks that all units:: types will support relative and proportional
-static_assert( supports_relative<units::energy>::value, "units should support relative" );
-static_assert( supports_proportional<units::energy>::value, "units should support proportional" );
+static_assert( SupportsRelative<units::energy>, "units should support relative" );
+static_assert( SupportsProportional<units::energy>, "units should support proportional" );
 
-static_assert( supports_relative<int>::value, "ints should support relative" );
-static_assert( supports_proportional<int>::value, "ints should support proportional" );
+static_assert( SupportsRelative<int>, "ints should support relative" );
+static_assert( SupportsProportional<int>, "ints should support proportional" );
 
-static_assert( !supports_relative<bool>::value, "bools should not support relative" );
-static_assert( !supports_proportional<bool>::value, "bools should not support proportional" );
+static_assert( !SupportsRelative<bool>, "bools should not support relative" );
+static_assert( !SupportsProportional<bool>, "bools should not support proportional" );
 
 // Using string ids with ints doesn't make sense in practice, but it doesn't matter here
 // The type that it is templated with does not change it's behavior
-static_assert( !supports_relative<string_id<int>>::value,
-               "string ids should not support relative" );
-static_assert( !supports_proportional<string_id<int>>::value,
+static_assert( !SupportsRelative<string_id<int>>, "string ids should not support relative" );
+static_assert( !SupportsProportional<string_id<int>>,
                "string ids should not support proportional" );
 
 // Using int ids with ints doesn't make sense in practice, but it doesn't matter here
 // The type that it is templated with does not change it's behavior
-static_assert( !supports_relative<int_id<int>>::value,
-               "int ids should not support relative" );
-static_assert( !supports_proportional<int_id<int>>::value,
-               "int ids should not support proportional" );
+static_assert( !SupportsRelative<int_id<int>>, "int ids should not support relative" );
+static_assert( !SupportsProportional<int_id<int>>, "int ids should not support proportional" );
 
-static_assert( !supports_relative<std::string>::value, "strings should not support relative" );
-static_assert( !supports_proportional<std::string>::value,
-               "strings should not support proportional" );
+static_assert( !SupportsRelative<std::string>, "strings should not support relative" );
+static_assert( !SupportsProportional<std::string>, "strings should not support proportional" );
 
 // Grab an enum class from debug.h
-static_assert( !supports_relative<DebugOutput>::value, "enum classes should not support relative" );
-static_assert( !supports_proportional<DebugOutput>::value,
-               "enum classes should not support proportional" );
+static_assert( !SupportsRelative<DebugOutput>, "enum classes should not support relative" );
+static_assert( !SupportsProportional<DebugOutput>, "enum classes should not support proportional" );
 
 // Grab a normal enum from there too
-static_assert( !supports_relative<DL>::value, "enums should not support relative" );
-static_assert( !supports_proportional<DL>::value, "enums should not support relative" );
+static_assert( !SupportsRelative<DL>, "enums should not support relative" );
+static_assert( !SupportsProportional<DL>, "enums should not support relative" );
 
 // Dummy template:
 // Warn if it's trying to use proportional where it cannot, but otherwise just
 // return.
-template < typename MemberType, std::enable_if_t < !supports_proportional<MemberType>::value > * =
-           nullptr >
+template<typename MemberType> requires( !SupportsProportional<MemberType> )
 inline bool handle_proportional( const JsonObject &jo, const std::string &name, MemberType & )
 {
     if( jo.has_object( "proportional" ) ) {
@@ -717,7 +714,7 @@ inline bool handle_proportional( const JsonObject &jo, const std::string &name, 
 // this, so member will contain the value of the thing we inherit from
 // So, check if there is a proportional entry, check if it's got a valid value
 // and if it does, multiply the member by it.
-template<typename MemberType, std::enable_if_t<supports_proportional<MemberType>::value>* = nullptr>
+template<SupportsProportional MemberType>
 inline bool handle_proportional( const JsonObject &jo, const std::string &name, MemberType &member )
 {
     if( jo.has_object( "proportional" ) ) {
@@ -745,9 +742,7 @@ inline bool handle_proportional( const JsonObject &jo, const std::string &name, 
 // Dummy template:
 // Warn when trying to use relative when it's not supported, but otherwise,
 // return
-template < typename MemberType,
-           std::enable_if_t < !supports_relative<MemberType>::value > * = nullptr
-           >
+template<typename MemberType> requires( !SupportsRelative<MemberType> )
 inline bool handle_relative( const JsonObject &jo, const std::string &name, MemberType & )
 {
     if( jo.has_object( "relative" ) ) {
@@ -766,7 +761,7 @@ inline bool handle_relative( const JsonObject &jo, const std::string &name, Memb
 // Copy-from makes it so the thing we're inheriting from is used to construct
 // this, so member will contain the value of the thing we inherit from
 // So, check if there is a relative entry, then add it to our member
-template<typename MemberType, std::enable_if_t<supports_relative<MemberType>::value>* = nullptr>
+template<SupportsRelative MemberType>
 inline bool handle_relative( const JsonObject &jo, const std::string &name, MemberType &member )
 {
     if( jo.has_object( "relative" ) ) {

--- a/src/numeric_interval.h
+++ b/src/numeric_interval.h
@@ -5,11 +5,13 @@
 #include <limits>
 #include <type_traits>
 
+#include "concepts_utility.h"
+
 /**
  * An interval of numeric values between @ref min and @ref max (including both).
  * By default it's [0, 0].
  */
-template<typename T, typename = typename std::enable_if<std::is_arithmetic<T>::value, T>::type>
+template<Arithmetic T>
 struct numeric_interval {
     T min = static_cast<T>( 0 );
     T max = static_cast<T>( 0 );


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.


## Purpose of change

followup to #5514; [concept](https://en.cppreference.com/w/cpp/language/constraints) is easier to understand than [SNIFAE](https://en.cppreference.com/w/cpp/language/sfinae), let's use them more!

## Describe the solution

check individual commits for details.

## Describe alternatives you've considered

use less overloading trickery and just use different name for `optional`?

## Testing

compiled in my machine (tm) but need to check if the concepts translation is correct because they're done 100% manually

## Additional context

i'm dumdum and found this after i've done it manually: https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-constraints.html