### PR TITLE
refactor: use concepts even more

### DIFF
--- a/src/all_enum_values.h
+++ b/src/all_enum_values.h
@@ -2,6 +2,9 @@
 #ifndef CATA_SRC_ALL_ENUM_VALUES_H
 #define CATA_SRC_ALL_ENUM_VALUES_H
 
+#include <cstddef>
+#include <utility>
+
 #include "enum_traits.h"
 
 template<typename E>

--- a/src/assign.h
+++ b/src/assign.h
@@ -32,7 +32,7 @@ class is_optional_helper<std::optional<T>> : public std::true_type
 };
 } // namespace detail
 template<typename T>
-class is_optional : public detail::is_optional_helper<typename std::decay<T>::type>
+class is_optional : public detail::is_optional_helper<std::decay_t<T>>
 {
 };
 
@@ -134,9 +134,9 @@ bool assign( const JsonObject &jo, const std::string &name, std::pair<T, T> &val
 
 // Note: is_optional excludes any types based on std::optional, which is
 // handled below in a separate function.
-template < typename T, typename std::enable_if < std::is_class<T>::value &&!is_optional<T>::value,
-           int >::type = 0 >
+template < typename T>
 bool assign( const JsonObject &jo, const std::string &name, T &val, bool strict = false )
+requires( std::is_class_v<T> && !is_optional<T>::value ) //*NOPAD*
 {
     T out;
     if( !jo.read( name, out ) ) {
@@ -363,18 +363,17 @@ bool assign( const JsonObject &jo,
 
 // Kinda hacky way to avoid allowing multiplying temperature
 // For example, in 10 * 0 Fahrenheit, 10 * 0 Celsius - what's the expected result of those?
-template < typename lvt, typename ut, typename s,
-           typename std::enable_if_t<units::quantity_details<ut>::common_zero_point::value>* = nullptr>
+template < typename lvt, typename ut, typename s>
 inline units::quantity<lvt, ut> mult_unit( const JsonObject &, const std::string &,
         const units::quantity<lvt, ut> &val, const s scalar )
-{
+requires units::quantity_details<ut>::common_zero_point::value {
     return val * scalar;
 }
 
-template < typename lvt, typename ut, typename s,
-           typename std::enable_if_t < !units::quantity_details<ut>::common_zero_point::value > * = nullptr >
+template < typename lvt, typename ut, typename s>
 inline units::quantity<lvt, ut> mult_unit( const JsonObject &err, const std::string &name,
         const units::quantity<lvt, ut> &, const s )
+requires( !units::quantity_details<ut>::common_zero_point::value )
 {
     err.throw_error( "Multiplying units with multiple scales with different zero points is not well defined",
                      name );
@@ -454,16 +453,17 @@ bool assign( const JsonObject &jo,
 class time_duration;
 
 template<typename T>
-inline typename
-std::enable_if<std::is_same<typename std::decay<T>::type, time_duration>::value, bool>::type
+inline bool
 read_with_factor( const JsonObject &jo, const std::string &name, T &val, const T &factor )
-{
+requires std::is_same_v<std::decay_t<T>, time_duration> {
     int tmp;
-    if( jo.read( name, tmp, false ) ) {
+    if( jo.read( name, tmp, false ) )
+    {
         // JSON contained a raw number -> apply factor
         val = tmp * factor;
         return true;
-    } else if( jo.has_string( name ) ) {
+    } else if( jo.has_string( name ) )
+    {
         // JSON contained a time duration string -> no factor
         val = read_from_json_string<time_duration>( *jo.get_raw( name ), time_duration::units );
         return true;

--- a/src/cata_utility.h
+++ b/src/cata_utility.h
@@ -57,9 +57,9 @@ double round_up( double val, unsigned int dp );
 *
 * @p num must be non-negative, @p den must be positive, and @c num+den must not overflow.
 */
-template<typename T, typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+template<typename T>
 T divide_round_up( T num, T den )
-{
+requires std::is_integral_v<T> {
     return ( num + den - 1 ) / den;
 }
 

--- a/src/cata_variant.h
+++ b/src/cata_variant.h
@@ -95,7 +95,7 @@ constexpr cata_variant_type type_for_impl( std::index_sequence<I...> )
 {
     constexpr size_t num_types = static_cast<size_t>( cata_variant_type::num_types );
     constexpr std::array<bool, num_types> matches = {{
-            std::is_same<T, typename convert<static_cast<cata_variant_type>( I )>::type>::value...
+            std::is_same_v<T, typename convert<static_cast<cata_variant_type>( I )>::type>...
         }
     };
     for( size_t i = 0; i < num_types; ++i ) {
@@ -112,7 +112,7 @@ constexpr cata_variant_type type_for_impl( std::index_sequence<I...> )
 template<typename T>
 struct convert_string {
     using type = T;
-    static_assert( std::is_same<T, std::string>::value,
+    static_assert( std::is_same_v<T, std::string>,
                    "Intended for use only with string typedefs" );
     static std::string to_string( const T &v ) {
         return v;
@@ -355,10 +355,9 @@ class cata_variant
 
         // Constructor that attempts to infer the type from the type of the
         // value passed.
-        template < typename Value,
-                   typename = std::enable_if_t <(
-                           cata_variant_type_for<Value>() < cata_variant_type::num_types )>>
-        explicit cata_variant( Value && value ) {
+        template < typename Value>
+        explicit cata_variant( Value &&value ) requires(
+            cata_variant_type_for<Value>() < cata_variant_type::num_types ) {
             constexpr cata_variant_type Type = cata_variant_type_for<Value>();
             type_ = Type;
             value_ =
@@ -372,8 +371,8 @@ class cata_variant
         template<cata_variant_type Type, typename Value>
         static cata_variant make( Value &&value ) {
             return cata_variant(
-                Type, cata_variant_detail::convert<Type>::to_string(
-                    std::forward<Value>( value ) ) );
+                       Type, cata_variant_detail::convert<Type>::to_string(
+                           std::forward<Value>( value ) ) );
         }
 
         // Call this to construct from a type + string.  This should rarely be

--- a/src/catalua_luna.h
+++ b/src/catalua_luna.h
@@ -87,7 +87,7 @@ struct luna_traits {
 extern std::string_view current_comment;
 
 template<typename T>
-using remove_cv_ref_t = typename std::remove_cv<typename std::remove_reference<T>::type>::type;
+using remove_cv_ref_t = std::remove_cv_t<std::remove_reference_t<T>>;
 
 template<typename Signature>
 using fx_traits = sol::meta::meta_detail::fx_traits<Signature>;
@@ -107,7 +107,7 @@ std::string doc_value_impl()
     if constexpr( luna_traits<Val>::impl ) {
         return std::string( luna_traits<Val>::name );
     } else {
-        using ValNoPtr = typename std::remove_pointer<Val>::type;
+        using ValNoPtr = std::remove_pointer_t<Val>;
         using ValBare = remove_cv_ref_t<ValNoPtr>;
         if constexpr( luna_traits<ValBare>::impl ) {
             return std::string( luna_traits<ValBare>::name );

--- a/src/coordinates.h
+++ b/src/coordinates.h
@@ -227,13 +227,11 @@ constexpr inline auto operator+(
     return coord_point<PointResult, OriginL, Scale>( l.raw() + r.raw() );
 }
 
-template < typename PointL, typename PointR, origin OriginR, scale Scale,
-           // enable_if to prevent ambiguity with above when both args are
-           // relative
-           typename = std::enable_if_t < OriginR != origin::relative >>
+template < typename PointL, typename PointR, origin OriginR, scale Scale>
 constexpr inline auto operator+(
     const coord_point<PointL, origin::relative, Scale> &l,
     const coord_point<PointR, OriginR, Scale> &r )
+requires( OriginR != origin::relative )
 {
     using PointResult = decltype( PointL() + PointR() );
     return coord_point<PointResult, OriginR, Scale>( l.raw() + r.raw() );
@@ -248,13 +246,11 @@ constexpr inline auto operator-(
     return coord_point<PointResult, OriginL, Scale>( l.raw() - r.raw() );
 }
 
-template < typename PointL, typename PointR, origin Origin, scale Scale,
-           // enable_if to prevent ambiguity with above when both args are
-           // relative
-           typename = std::enable_if_t < Origin != origin::relative >>
+template < typename PointL, typename PointR, origin Origin, scale Scale>
 constexpr inline auto operator-(
     const coord_point<PointL, Origin, Scale> &l,
     const coord_point<PointR, Origin, Scale> &r )
+requires( Origin != origin::relative )
 {
     using PointResult = decltype( PointL() + PointR() );
     return coord_point<PointResult, origin::relative, Scale>( l.raw() - r.raw() );

--- a/src/dialogue.h
+++ b/src/dialogue.h
@@ -36,8 +36,8 @@ enum dialogue_consequence : unsigned char {
     action
 };
 
-using talkfunction_ptr = std::add_pointer<void ( npc & )>::type;
-using dialogue_fun_ptr = std::add_pointer<void( npc & )>::type;
+using talkfunction_ptr = std::add_pointer_t<void ( npc & )>;
+using dialogue_fun_ptr = std::add_pointer_t<void( npc & )>;
 
 using trial_mod = std::pair<std::string, int>;
 

--- a/src/enum_bitset.h
+++ b/src/enum_bitset.h
@@ -10,7 +10,7 @@
 template<typename E>
 class enum_bitset
 {
-        static_assert( std::is_enum<E>::value, "the template argument is not an enum." );
+        static_assert( std::is_enum_v<E>, "the template argument is not an enum." );
         static_assert( has_enum_traits<E>::value,
                        "a specialization of 'enum_traits<E>' template containing 'last' element of the enum must be defined somewhere.  "
                        "The `last` constant must be of the same type as the enum iteslf."
@@ -89,7 +89,7 @@ class enum_bitset
 
     private:
         static constexpr size_t get_pos( E e ) noexcept {
-            return static_cast<size_t>( static_cast<typename std::underlying_type<E>::type>( e ) );
+            return static_cast<size_t>( static_cast<std::underlying_type_t<E>>( e ) );
         }
 
         std::bitset<enum_bitset<E>::size()> bits;

--- a/src/enum_conversions.h
+++ b/src/enum_conversions.h
@@ -41,7 +41,7 @@ std::string enum_to_string( E );
 template<typename E>
 std::unordered_map<std::string, E> build_enum_lookup_map()
 {
-    static_assert( std::is_enum<E>::value, "E should be an enum type" );
+    static_assert( std::is_enum_v<E>, "E should be an enum type" );
     static_assert( has_enum_traits<E>::value, "enum E needs a specialization of enum_traits" );
     std::unordered_map<std::string, E> result;
 

--- a/src/enum_traits.h
+++ b/src/enum_traits.h
@@ -11,7 +11,7 @@ namespace enum_traits_detail
 {
 
 template<typename E>
-using last_type = typename std::decay<decltype( enum_traits<E>::last )>::type;
+using last_type = std::decay_t<decltype( enum_traits<E>::last )>;
 
 } // namespace enum_traits_detail
 

--- a/src/event.h
+++ b/src/event.h
@@ -560,7 +560,7 @@ class event
             using Spec = event_detail::event_spec<Type>;
             // Using is_empty mostly just to verify that the type is defined at
             // all, but it so happens that it ought to be empty too.
-            static_assert( std::is_empty<Spec>::value,
+            static_assert( std::is_empty_v<Spec>,
                            "spec for this event type must be defined and empty" );
             static_assert( sizeof...( Args ) == Spec::fields.size(),
                            "wrong number of arguments for event type" );

--- a/src/fmtlib_core.h
+++ b/src/fmtlib_core.h
@@ -2185,7 +2185,7 @@ struct wformat_args : basic_format_args<wformat_context> {
 namespace detail
 {
 
-template < typename Char, FMT_ENABLE_IF( !std::is_same<Char, char>::value ) >
+template < typename Char, FMT_ENABLE_IF( !std::is_same_v<Char, char> ) >
 std::basic_string<Char> vformat(
     basic_string_view<Char> format_str,
     basic_format_args<buffer_context<type_identity_t<Char>>> args );
@@ -2199,7 +2199,7 @@ void vformat_to(
     detail::locale_ref loc = {} );
 
 template < typename Char, typename Args,
-           FMT_ENABLE_IF( !std::is_same<Char, char>::value ) >
+           FMT_ENABLE_IF( !std::is_same_v<Char, char> ) >
 inline void vprint_mojibake( std::FILE *, basic_string_view<Char>, const Args & ) {}
 
 FMT_API void vprint_mojibake( std::FILE *, string_view, format_args );

--- a/src/fmtlib_core.h
+++ b/src/fmtlib_core.h
@@ -257,16 +257,16 @@ FMT_BEGIN_NAMESPACE
 
 // Implementations of enable_if_t and other metafunctions for older systems.
 template <bool B, class T = void>
-using enable_if_t = typename std::enable_if<B, T>::type;
+using enable_if_t = std::enable_if_t<B, T>;
 template <bool B, class T, class F>
-using conditional_t = typename std::conditional<B, T, F>::type;
+using conditional_t = std::conditional_t<B, T, F>;
 template <bool B> using bool_constant = std::integral_constant<bool, B>;
 template <typename T>
-using remove_reference_t = typename std::remove_reference<T>::type;
+using remove_reference_t = std::remove_reference_t<T>;
 template <typename T>
-using remove_const_t = typename std::remove_const<T>::type;
+using remove_const_t = std::remove_const_t<T>;
 template <typename T>
-using remove_cvref_t = typename std::remove_cv<remove_reference_t<T>>::type;
+using remove_cvref_t = std::remove_cv_t<remove_reference_t<T>>;
 template <typename T> struct type_identity {
     using type = T;
 };
@@ -329,10 +329,10 @@ struct uint128_t {};
 
 // Casts a nonnegative integer to unsigned.
 template <typename Int>
-FMT_CONSTEXPR typename std::make_unsigned<Int>::type to_unsigned( Int value )
+FMT_CONSTEXPR std::make_unsigned_t<Int>to_unsigned( Int value )
 {
     FMT_ASSERT( value >= 0, "negative value" );
-    return static_cast<typename std::make_unsigned<Int>::type>( value );
+    return static_cast<std::make_unsigned_t<Int>>( value );
 }
 
 FMT_SUPPRESS_MSC_WARNING( 4566 ) constexpr unsigned char micro[] = "\u00B5";
@@ -1376,8 +1376,8 @@ template <typename Context> struct arg_mapper {
                               !has_fallback_formatter<T, Context>::value ) >
     FMT_CONSTEXPR auto map( const T &val )
     -> decltype( std::declval<arg_mapper>().map(
-                     static_cast<typename std::underlying_type<T>::type>( val ) ) ) {
-        return map( static_cast<typename std::underlying_type<T>::type>( val ) );
+                     static_cast<std::underlying_type_t<T>>( val ) ) ) {
+        return map( static_cast<std::underlying_type_t<T>>( val ) );
     }
     template < typename T,
                FMT_ENABLE_IF( !is_string<T>::value
@@ -1839,8 +1839,8 @@ inline auto make_args_checked( const S &format_str,
 {
     static_assert(
         detail::count < (
-            std::is_base_of<detail::view, remove_reference_t<Args>>::value &&
-            std::is_reference<Args>::value )... > () == 0,
+            std::is_base_of_v<detail::view, remove_reference_t<Args>> &&
+            std::is_reference_v<Args> )... > () == 0,
         "passing views as lvalues is disallowed" );
     detail::check_format_string<Args...>( format_str );
     return {args...};
@@ -1889,8 +1889,8 @@ class dynamic_format_arg_store
 
             enum {
                 value = !( detail::is_reference_wrapper<T>::value ||
-                           std::is_same<T, basic_string_view<char_type>>::value ||
-                           std::is_same<T, detail::std_string_view<char_type>>::value ||
+                           std::is_same_v<T, basic_string_view<char_type>> ||
+                           std::is_same_v<T, detail::std_string_view<char_type>> ||
                            ( mapped_type != detail::type::cstring_type &&
                              mapped_type != detail::type::string_type &&
                              mapped_type != detail::type::custom_type ) )
@@ -1993,7 +1993,7 @@ class dynamic_format_arg_store
         */
         template <typename T> void push_back( std::reference_wrapper<T> arg ) {
             static_assert(
-                detail::is_named_arg<typename std::remove_cv<T>::type>::value ||
+                detail::is_named_arg<std::remove_cv_t<T>>::value ||
                 need_copy<T>::value,
                 "objects of built-in types and string views are always copied" );
             emplace_arg( arg.get() );
@@ -2215,7 +2215,8 @@ template <typename OutputIt, typename S, typename Char = char_t<S>,
           bool enable = detail::is_output_iterator<OutputIt, Char>::value>
 auto vformat_to( OutputIt out, const S &format_str,
                  basic_format_args<buffer_context<type_identity_t<Char>>> args )
--> typename std::enable_if<enable, OutputIt>::type
+-> OutputIt
+    requires( enable )
 {
     decltype( detail::get_buffer<Char>( out ) ) buf( detail::get_buffer_init( out ) );
     detail::vformat_to( buf, to_string_view( format_str ), args );
@@ -2237,7 +2238,8 @@ auto vformat_to( OutputIt out, const S &format_str,
 template <typename OutputIt, typename S, typename... Args,
           bool enable = detail::is_output_iterator<OutputIt, char_t<S>>::value>
 inline auto format_to( OutputIt out, const S &format_str, Args && ... args ) ->
-typename std::enable_if<enable, OutputIt>::type
+OutputIt
+requires( enable )
 {
     const auto &vargs = fmt::make_args_checked<Args...>( format_str, args... );
     return vformat_to( out, to_string_view( format_str ), vargs );
@@ -2273,7 +2275,8 @@ template <typename OutputIt, typename S, typename... Args,
           bool enable = detail::is_output_iterator<OutputIt, char_t<S>>::value>
 inline auto format_to_n( OutputIt out, size_t n, const S &format_str,
                          const Args &... args ) ->
-typename std::enable_if<enable, format_to_n_result<OutputIt>>::type
+format_to_n_result<OutputIt>
+requires( enable )
 {
     const auto &vargs = fmt::make_args_checked<Args...>( format_str, args... );
     return vformat_to_n( out, n, to_string_view( format_str ), vargs );

--- a/src/fmtlib_format-inl.h
+++ b/src/fmtlib_format-inl.h
@@ -2647,7 +2647,7 @@ void fallback_format( Double d, int num_digits, bool binary32, buffer<char> &buf
 template <typename T>
 int format_float( T value, int precision, float_specs specs, buffer<char> &buf )
 {
-    static_assert( !std::is_same<T, float>::value, "" );
+    static_assert( !std::is_same_v<T, float>, "" );
     FMT_ASSERT( value >= 0, "value is negative" );
 
     const bool fixed = specs.format == float_format::fixed;
@@ -2718,7 +2718,7 @@ int snprintf_float( T value, int precision, float_specs specs,
 {
     // Buffer capacity must be non-zero, otherwise MSVC's vsnprintf_s will fail.
     FMT_ASSERT( buf.capacity() > buf.size(), "empty buffer" );
-    static_assert( !std::is_same<T, float>::value, "" );
+    static_assert( !std::is_same_v<T, float>, "" );
 
     // Subtract 1 to account for the difference in precision since we use %e for
     // both general and exponent format.

--- a/src/fmtlib_format.h
+++ b/src/fmtlib_format.h
@@ -1,5 +1,4 @@
 #pragma once
-//NOLINT(modernize-type-traits)
 /*
  Formatting library for C++
 

--- a/src/fmtlib_format.h
+++ b/src/fmtlib_format.h
@@ -1,4 +1,5 @@
 #pragma once
+//NOLINT(modernize-type-traits)
 /*
  Formatting library for C++
 
@@ -641,9 +642,9 @@ inline size_t code_point_index( basic_string_view<char8_type> s, size_t n )
 
 template <typename InputIt, typename OutChar>
 using needs_conversion = bool_constant <
-                         std::is_same<typename std::iterator_traits<InputIt>::value_type,
-                         char>::value &&
-                         std::is_same<OutChar, char8_type>::value >;
+                         std::is_same_v<typename std::iterator_traits<InputIt>::value_type,
+                         char> &&
+                         std::is_same_v<OutChar, char8_type> >;
 
 template < typename OutChar, typename InputIt, typename OutputIt,
            FMT_ENABLE_IF( !needs_conversion<InputIt, OutChar>::value ) >
@@ -891,7 +892,7 @@ namespace detail
 template <typename T>
 using is_signed =
     std::integral_constant < bool, std::numeric_limits<T>::is_signed ||
-    std::is_same<T, int128_t>::value >;
+    std::is_same_v<T, int128_t> >;
 
 // Returns true if value is negative, false otherwise.
 // Same as `value < 0` but doesn't produce warnings if T is an unsigned type.
@@ -909,9 +910,9 @@ FMT_CONSTEXPR bool is_negative( T )
 template <typename T, FMT_ENABLE_IF( std::is_floating_point<T>::value )>
 FMT_CONSTEXPR bool is_supported_floating_point( T )
 {
-    return ( std::is_same<T, float>::value && FMT_USE_FLOAT ) ||
-           ( std::is_same<T, double>::value && FMT_USE_DOUBLE ) ||
-           ( std::is_same<T, long double>::value && FMT_USE_LONG_DOUBLE );
+    return ( std::is_same_v<T, float> &&FMT_USE_FLOAT ) ||
+           ( std::is_same_v<T, double> &&FMT_USE_DOUBLE ) ||
+           ( std::is_same_v<T, long double> &&FMT_USE_LONG_DOUBLE );
 }
 
 // Smallest of uint32_t, uint64_t, uint128_t that is large enough to
@@ -2242,7 +2243,7 @@ OutputIt write( OutputIt out, T value )
         return out;
     }
 
-    using floaty = conditional_t<std::is_same<T, long double>::value, double, T>;
+    using floaty = conditional_t<std::is_same_v<T, long double>, double, T>;
     using uint = typename dragonbox::float_info<floaty>::carrier_uint;
     auto bits = bit_cast<uint>( value );
 
@@ -2397,10 +2398,9 @@ OutputIt write( OutputIt out, const void *value )
 }
 
 template <typename Char, typename OutputIt, typename T>
-auto write( OutputIt out, const T &value ) -> typename std::enable_if <
-mapped_type_constant<T, basic_format_context<OutputIt, Char>>::value ==
-        type::custom_type,
-             OutputIt >::type
+auto write( OutputIt out, const T &value ) -> OutputIt
+requires( mapped_type_constant<T, basic_format_context<OutputIt, Char>>::value ==
+          type::custom_type )
 {
     using context_type = basic_format_context<OutputIt, Char>;
     using formatter_type =
@@ -2731,9 +2731,9 @@ template <typename Context> class custom_formatter
 
 template <typename T>
 using is_integer =
-    bool_constant < is_integral<T>::value && !std::is_same<T, bool>::value &&
-    !std::is_same<T, char>::value &&
-    !std::is_same<T, wchar_t>::value >;
+    bool_constant < is_integral<T>::value && !std::is_same_v<T, bool> &&
+    !std::is_same_v<T, char> &&
+    !std::is_same_v<T, wchar_t> >;
 
 template <typename ErrorHandler> class width_checker
 {
@@ -3186,7 +3186,7 @@ constexpr Char to_ascii( Char value )
     return value;
 }
 template <typename Char, FMT_ENABLE_IF( std::is_enum<Char>::value )>
-constexpr typename std::underlying_type<Char>::type to_ascii( Char value )
+constexpr std::underlying_type_t<Char>to_ascii( Char value )
 {
     return value;
 }
@@ -4359,7 +4359,7 @@ make_format_to_n_args( const Args &... args )
     return format_arg_store<buffer_context<Char>, Args...>( args... );
 }
 
-template < typename Char, enable_if_t < ( !std::is_same<Char, char>::value ), int >>
+template < typename Char, enable_if_t < ( !std::is_same_v<Char, char> ), int >>
 std::basic_string<Char> detail::vformat(
     basic_string_view<Char> format_str,
     basic_format_args<buffer_context<type_identity_t<Char>>> args )

--- a/src/fmtlib_ostream.h
+++ b/src/fmtlib_ostream.h
@@ -80,9 +80,9 @@ template <typename T, typename Char> class is_streamable
 {
     private:
         template <typename U>
-        static bool_constant < !std::is_same < decltype( std::declval<test_stream<Char>&>()
+        static bool_constant < !std::is_same_v < decltype( std::declval<test_stream<Char>&>()
                 << std::declval<U>() ),
-                void_t< >>::value >
+                void_t< >> >
                 test( int );
 
         template <typename> static std::false_type test( ... );
@@ -98,7 +98,7 @@ template <typename Char>
 void write_buffer( std::basic_ostream<Char> &os, buffer<Char> &buf )
 {
     const Char *buf_data = buf.data();
-    using unsigned_streamsize = std::make_unsigned<std::streamsize>::type;
+    using unsigned_streamsize = std::make_unsigned_t<std::streamsize>;
     unsigned_streamsize size = buf.size();
     unsigned_streamsize max_size = to_unsigned( max_value<std::streamsize>() );
     do {

--- a/src/generic_readers.h
+++ b/src/generic_readers.h
@@ -208,9 +208,9 @@ class generic_typed_reader
          * The `enable_if` is here to prevent the compiler from considering it
          * when called on a simple data member, the other `operator()` will be used.
          */
-        template<typename C, typename std::enable_if<reader_detail::handler<C>::is_container, int>::type = 0>
+        template<typename C>
         bool operator()( const JsonObject &jo, const std::string &member_name,
-                         C &container, bool was_loaded ) const {
+                         C &container, bool was_loaded ) const requires reader_detail::handler<C>::is_container {
             const Derived &derived = static_cast<const Derived &>( *this );
             // If you get an error about "incomplete type 'struct reader_detail::handler...",
             // you have to implement a specialization of your container type, so above for

--- a/src/hash_utils.h
+++ b/src/hash_utils.h
@@ -91,7 +91,8 @@ namespace hash64_detail
 {
 
 template<typename T>
-std::enable_if_t < sizeof( T ) < 8, T > maybe_mix_bits( std::uint64_t val )
+T maybe_mix_bits( std::uint64_t val )
+requires( sizeof( T ) < 8 )
 {
     std::uint32_t hi = val >> 32;
     std::uint32_t lo = val;
@@ -101,7 +102,8 @@ std::enable_if_t < sizeof( T ) < 8, T > maybe_mix_bits( std::uint64_t val )
 }
 
 template<typename T>
-std::enable_if_t < sizeof( T ) >= 8, T > maybe_mix_bits( std::uint64_t val )
+T maybe_mix_bits( std::uint64_t val )
+requires( sizeof( T ) >= 8 )
 {
     return val;
 }

--- a/src/int_id.h
+++ b/src/int_id.h
@@ -32,8 +32,8 @@ class int_id
         /**
          * Prevent accidental construction from other int ids.
          */
-        template < typename S, typename std::enable_if_t < !std::is_same<S, T>::value, int > = 0 >
-        int_id( const int_id<S> &id ) = delete;
+        template < typename S>
+        int_id( const int_id<S> &id ) requires( !std::is_same_v<S, T> ) = delete;
 
         /**
          * Default constructor constructs a 0-id. No id value is special to this class, 0 as id
@@ -53,9 +53,8 @@ class int_id
          * constructor to create the int id. This allows plain C-strings,
          * and std::strings to be used.
          */
-        template<typename S, class =
-                 typename std::enable_if< std::is_convertible<S, std::string >::value>::type >
-        explicit int_id( S && id ) : int_id( string_id<T>( std::forward<S>( id ) ) ) {}
+        template<typename S> requires std::is_convertible_v<S, std::string >
+        explicit int_id( S &&id ) : int_id( string_id<T>( std::forward<S>( id ) ) ) {}
 
         /**
          * Comparison, only useful when the id is used in std::map or std::set as key.

--- a/src/item.h
+++ b/src/item.h
@@ -170,7 +170,7 @@ struct iteminfo {
 
 inline iteminfo::flags operator|( iteminfo::flags l, iteminfo::flags r )
 {
-    using I = std::underlying_type<iteminfo::flags>::type;
+    using I = std::underlying_type_t<iteminfo::flags>;
     return static_cast<iteminfo::flags>( static_cast<I>( l ) | r );
 }
 

--- a/src/mod_tracker.h
+++ b/src/mod_tracker.h
@@ -30,18 +30,20 @@ struct has_src_member<T, std::void_t<decltype( std::declval<T &>().src.emplace_b
 std::true_type {};
 
 /** Dummy function, for if those conditions are not satisfied */
-template < typename T, typename std::enable_if_t < !has_src_member<T>::value > * = nullptr >
+template < typename T>
 void assign_src( T &, const std::string & )
+requires( !has_src_member<T>::value )
 {
 }
 
 /** If those conditions are satisfied, keep track of where this item has been modified */
-template<typename T, typename std::enable_if_t<has_src_member<T>::value > * = nullptr>
+template<typename T>
 void assign_src( T &def, const std::string &src )
-{
+requires has_src_member<T>::value {
     // We need to make sure we're keeping where this entity has been loaded
     // If the id this was last loaded with is not this one, discard the history and start again
-    if( !def.src.empty() && def.src.back().first != def.id ) {
+    if( !def.src.empty() && def.src.back().first != def.id )
+    {
         def.src.clear();
     }
     def.src.emplace_back( def.id, mod_id( src ) );

--- a/src/output.h
+++ b/src/output.h
@@ -747,19 +747,20 @@ void draw_tabs( const catacurses::window &, const std::vector<std::string> &tab_
 //      { tab_mode::second_tab, _( "SECOND_TAB" ) },
 // };
 // draw_tabs( w, tabs, current_tab );
-template<typename TabList, typename CurrentTab, typename = std::enable_if_t<
-             std::is_same<CurrentTab,
-                          std::remove_const_t<typename TabList::value_type::first_type>>::value>>
+template<typename TabList, typename CurrentTab>
 void draw_tabs( const catacurses::window &w, const TabList &tab_list,
                 const CurrentTab &current_tab )
-{
+requires std::is_same_v<CurrentTab,
+std::remove_const_t<typename TabList::value_type::first_type>> {
     std::vector<std::string> tab_text;
     std::transform( tab_list.begin(), tab_list.end(), std::back_inserter( tab_text ),
-    []( const typename TabList::value_type & pair ) {
+                    []( const typename TabList::value_type & pair )
+    {
         return pair.second;
     } );
     auto current_tab_it = std::find_if( tab_list.begin(), tab_list.end(),
-    [&current_tab]( const typename TabList::value_type & pair ) {
+                                        [&current_tab]( const typename TabList::value_type & pair )
+    {
         return pair.first == current_tab;
     } );
     assert( current_tab_it != tab_list.end() );
@@ -768,14 +769,14 @@ void draw_tabs( const catacurses::window &w, const TabList &tab_list,
 
 // Similar to the above, but where the order of tabs is specified separately
 // TabList is expected to be a map type.
-template<typename TabList, typename TabKeys, typename CurrentTab, typename = std::enable_if_t<
-             std::is_same<CurrentTab,
-                          std::remove_const_t<typename TabList::value_type::first_type>>::value>>
+template<typename TabList, typename TabKeys, typename CurrentTab>
 void draw_tabs( const catacurses::window &w, const TabList &tab_list, const TabKeys &keys,
                 const CurrentTab &current_tab )
-{
+requires std::is_same_v<CurrentTab,
+std::remove_const_t<typename TabList::value_type::first_type>> {
     std::vector<typename TabList::value_type> ordered_tab_list;
-    for( const auto &key : keys ) {
+    for( const auto &key : keys )
+    {
         auto it = tab_list.find( key );
         assert( it != tab_list.end() );
         ordered_tab_list.push_back( *it );

--- a/src/pimpl.h
+++ b/src/pimpl.h
@@ -16,7 +16,7 @@ class is_pimpl_helper<pimpl<T>> : public std::true_type
 {
 };
 template<typename T>
-class is_pimpl : public is_pimpl_helper<typename std::decay<T>::type>
+class is_pimpl : public is_pimpl_helper<std::decay_t<T>>
 {
 };
 /**
@@ -39,10 +39,10 @@ class pimpl : private std::unique_ptr<T>
         // The new argument serves the same purpose: this constructor should *not* be available when the
         // argument is a `pimpl` itself (the other copy constructors should be used instead).
         explicit pimpl() : std::unique_ptr<T>( new T() ) { }
-        template < typename P, typename ...Args,
-                   typename = typename std::enable_if < !is_pimpl<P>::value >::type >
-        explicit pimpl( P && head, Args &&
-                        ... args ) : std::unique_ptr<T>( new T( std::forward<P>( head ), std::forward<Args>( args )... ) ) { }
+        template < typename P, typename ...Args>
+        explicit pimpl( P &&head, Args &&
+                        ... args ) requires( !is_pimpl<P>::value ) : std::unique_ptr<T>( new T( std::forward<P>( head ),
+                                    std::forward<Args>( args )... ) ) { }
 
         explicit pimpl( const pimpl<T> &rhs ) : std::unique_ptr<T>( new T( *rhs ) ) { }
         explicit pimpl( pimpl<T> &&rhs )  noexcept : std::unique_ptr<T>( new T( std::move( *rhs ) ) ) { }

--- a/src/point_traits.h
+++ b/src/point_traits.h
@@ -33,7 +33,7 @@ struct point_traits {
 template<typename Point>
 struct point_traits <
     Point,
-    std::enable_if_t < std::is_same<Point, point>::value || std::is_same<Point, tripoint>::value >
+    std::enable_if_t < std::is_same_v<Point, point> || std::is_same_v<Point, tripoint> >
     >  {
     static int &x( Point &p ) {
         return p.x;
@@ -58,7 +58,7 @@ struct point_traits <
 template<typename Point>
 struct point_traits <
     Point,
-    std::enable_if_t < std::is_same<Point, rl_vec2d>::value || std::is_same<Point, rl_vec3d>::value >
+    std::enable_if_t < std::is_same_v<Point, rl_vec2d> || std::is_same_v<Point, rl_vec3d> >
     >  {
     static float &x( Point &p ) {
         return p.x;

--- a/src/ret_val.h
+++ b/src/ret_val.h
@@ -19,11 +19,11 @@
 template<typename T>
 class ret_val
 {
-        static_assert( !std::is_convertible<T, std::string>::value, "string values aren't allowed" );
+        static_assert( !std::is_convertible_v<T, std::string>, "string values aren't allowed" );
 
         template<typename S>
-        using is_convertible_to_string = typename
-                                         std::enable_if< std::is_convertible<S, std::string>::value>::type;
+        using is_convertible_to_string =
+            std::enable_if_t< std::is_convertible_v<S, std::string>>;
 
     public:
         /**

--- a/src/rng.h
+++ b/src/rng.h
@@ -135,7 +135,7 @@ class is_std_array_helper<std::array<T, N>> : public std::true_type
 {
 };
 template<typename T>
-class is_std_array : public is_std_array_helper<typename std::decay<T>::type>
+class is_std_array : public is_std_array_helper<std::decay_t<T>>
 {
 };
 

--- a/src/simple_pathfinding.h
+++ b/src/simple_pathfinding.h
@@ -79,9 +79,10 @@ directed_path<point> greedy_path( point source, point dest, point max,
  * @param max Max permissible coordinates for a point on the path
  * @param scorer function of (node &current, node *previous) that returns node_score.
  */
-template<typename Point, typename = std::enable_if_t<Point::dimension == 2>>
+template<typename Point>
 directed_path<Point> greedy_path( const Point &source, const Point &dest, const Point &max,
                                   two_node_scoring_fn<Point> scorer )
+requires( Point::dimension == 2 )
 {
     directed_path<Point> res;
     const two_node_scoring_fn<point> point_scorer

--- a/src/stats_tracker.h
+++ b/src/stats_tracker.h
@@ -109,7 +109,7 @@ class event_multiset_watcher : public base_watcher
 template<typename Watcher>
 class watcher_set
 {
-        static_assert( std::is_base_of<base_watcher, Watcher>::value,
+        static_assert( std::is_base_of_v<base_watcher, Watcher>,
                        "Watcher must be derived from base_watcher" );
     public:
         void insert( Watcher *watcher ) {

--- a/src/string_formatter.h
+++ b/src/string_formatter.h
@@ -54,44 +54,44 @@ std::string handle_string_format_error();
 /**@{*/
 // Test for arithmetic type, *excluding* bool. printf can not handle bool, so can't we.
 template<typename T>
-using is_numeric = typename std::conditional <
-                   std::is_arithmetic<typename std::decay<T>::type>::value &&
-                   !std::is_same<typename std::decay<T>::type, bool>::value, std::true_type, std::false_type >::type;
+using is_numeric = std::conditional_t <
+                   std::is_arithmetic_v<std::decay_t<T>> &&
+                   !std::is_same_v<std::decay_t<T>, bool>, std::true_type, std::false_type >;
 // Test for integer type (not floating point, not bool).
 template<typename T>
-using is_integer = typename std::conditional < is_numeric<T>::value &&
-                   !std::is_floating_point<typename std::decay<T>::type>::value, std::true_type,
-                   std::false_type >::type;
+using is_integer = std::conditional_t < is_numeric<T>::value &&
+                   !std::is_floating_point_v<std::decay_t<T>>, std::true_type,
+                   std::false_type >;
 template<typename T>
-using is_char = typename
-                std::conditional<std::is_same<typename std::decay<T>::type, char>::value, std::true_type, std::false_type>::type;
+using is_char =
+    std::conditional_t<std::is_same_v<std::decay_t<T>, char>, std::true_type, std::false_type>;
 // Test for std::string type.
 template<typename T>
-using is_string = typename
-                  std::conditional<std::is_same<typename std::decay<T>::type, std::string>::value, std::true_type, std::false_type>::type;
+using is_string =
+    std::conditional_t<std::is_same_v<std::decay_t<T>, std::string>, std::true_type, std::false_type>;
 // Test for std::string_view type.
 template<typename T>
-using is_string_view = typename
-                       std::conditional<std::is_same<typename std::decay<T>::type, std::string_view>::value, std::true_type, std::false_type>::type;
+using is_string_view =
+    std::conditional_t<std::is_same_v<std::decay_t<T>, std::string_view>, std::true_type, std::false_type>;
 // Test for c-string type.
 template<typename T>
-using is_cstring = typename std::conditional <
-                   std::is_same<typename std::decay<T>::type, const char *>::value ||
-                   std::is_same<typename std::decay<T>::type, char *>::value, std::true_type, std::false_type >::type;
+using is_cstring = std::conditional_t <
+                   std::is_same_v<std::decay_t<T>, const char *> ||
+                   std::is_same_v<std::decay_t<T>, char *>, std::true_type, std::false_type >;
 // Test for class translation
 template<typename T>
-using is_translation = typename std::conditional <
-                       std::is_same<typename std::decay<T>::type, translation>::value, std::true_type,
-                       std::false_type >::type;
+using is_translation = std::conditional_t <
+                       std::is_same_v<std::decay_t<T>, translation>, std::true_type,
+                       std::false_type >;
 // Test for string_id<T>
 template <typename, template <typename> class>
 struct is_instance_of : std::false_type {};
 template <typename T, template <typename> class TMPL>
 struct is_instance_of<TMPL<T>, TMPL> : std::true_type {};
 template<typename T>
-using is_string_id = typename std::conditional <
-                     is_instance_of<typename std::decay<T>::type, string_id>::value, std::true_type,
-                     std::false_type >::type;
+using is_string_id = std::conditional_t <
+                     is_instance_of<std::decay_t<T>, string_id>::value, std::true_type,
+                     std::false_type >;
 
 template<typename RT, typename T>
 inline typename std::enable_if < is_integer<RT>::value &&is_integer<T>::value,
@@ -117,7 +117,7 @@ inline typename std::enable_if < std::is_same<RT, void *>::value
 &&std::is_pointer<typename std::decay<T>::type>::value, void * >::type convert( RT *,
         const string_formatter &, T &&value, int )
 {
-    return const_cast<typename std::remove_const<typename std::remove_pointer<typename std::decay<T>::type>::type>::type *>
+    return const_cast<std::remove_const_t<std::remove_pointer_t<std::decay_t<T>>> *>
            ( value );
 }
 template<typename RT, typename T>
@@ -127,9 +127,10 @@ inline typename std::enable_if < std::is_same<RT, std::string_view>::value &&is_
     return value;
 }
 template<typename RT, typename T>
-inline typename std::enable_if < std::is_same<RT, std::string_view >::value
-&&is_string_view<T>::value, std::string_view >::type
+inline std::string_view
 convert( RT *, const string_formatter &, T &&value, int )
+requires( std::is_same_v<RT, std::string_view >
+          &&is_string_view<T>::value )
 {
     return value;
 }
@@ -174,12 +175,12 @@ template<typename RT, typename T>
 // NOLINTNEXTLINE(cert-dcl50-cpp)
 inline RT convert( RT *, const string_formatter &sf, T &&, ... )
 {
-    static_assert( std::is_pointer<typename std::decay<T>::type>::value ||
+    static_assert( std::is_pointer_v<std::decay_t<T>> ||
                    is_numeric<T>::value ||
                    is_string<T>::value ||
                    is_string_view<T>::value ||
                    is_char<T>::value ||
-                   std::is_enum<typename std::decay<T>::type>::value ||
+                   std::is_enum_v<std::decay_t<T>> ||
                    is_cstring<T>::value ||
                    is_translation<T>::value ||
                    is_string_id<T>::value,
@@ -439,9 +440,9 @@ inline std::string string_format( std::string_view format, Args &&...args )
     }
 }
 template<typename T, typename ...Args>
-inline typename std::enable_if<cata::is_translation<T>::value, std::string>::type
+inline std::string
 string_format( T &&format, Args &&...args )
-{
+requires cata::is_translation<T>::value {
     return string_format( format.translated(), std::forward<Args>( args )... );
 }
 /**@}*/

--- a/src/string_id.h
+++ b/src/string_id.h
@@ -129,8 +129,8 @@ class string_identity_static
 #endif
         {}
 
-        template<typename S, class = std::enable_if_t<std::is_convertible<S, std::string>::value>>
-        explicit string_identity_static( S && id )
+        template<typename S> requires std::is_convertible_v<S, std::string>
+        explicit string_identity_static( S &&id )
             : _id( string_id_intern( std::forward<S>( id ) ) )
 #ifdef CATA_STRING_ID_DEBUGGING
             , _string_id( str().c_str() )
@@ -176,8 +176,8 @@ class string_identity_dynamic
 
         string_identity_dynamic() = default;
 
-        template<typename S, class = std::enable_if_t<std::is_convertible<S, std::string>::value>>
-        explicit string_identity_dynamic( S && id ) : _id( std::forward<S>( id ) )  {}
+        template<typename S> requires std::is_convertible_v<S, std::string>
+        explicit string_identity_dynamic( S &&id ) : _id( std::forward<S>( id ) )  {}
 
         inline const std::string &str() const {
             return _id;
@@ -213,8 +213,8 @@ class string_id
          */
         // Beautiful C++11: enable_if makes sure that S is always something that can be used to constructor
         // a std::string, otherwise a "no matching function to call..." error is generated.
-        template<typename S, class = std::enable_if_t<std::is_convertible<S, std::string>::value>>
-        explicit string_id( S && id ) : _id( std::forward<S>( id ) ) {}
+        template<typename S> requires std::is_convertible_v<S, std::string>
+        explicit string_id( S &&id ) : _id( std::forward<S>( id ) ) {}
         /**
          * Default constructor constructs an empty id string.
          * Note that this id class does not enforce empty id strings (or any specific string at all)

--- a/src/string_id_utils.h
+++ b/src/string_id_utils.h
@@ -17,13 +17,13 @@
 template<typename Col,
          typename El = std::decay_t<decltype( *std::declval<const Col &>().begin() )>,
          typename K =  std::decay_t<typename El::first_type>,
-         typename V = std::decay_t<typename El::second_type>,
-         std::enable_if_t<std::is_same<K, string_id<typename K::value_type>>::value, int> = 0>
+         typename V = std::decay_t<typename El::second_type>>
 std::vector<std::pair<K, V>> sorted_lex( Col col )
-{
+requires std::is_same_v<K, string_id<typename K::value_type>> {
     std::vector<std::pair<K, V>> ret;
     ret.insert( ret.begin(), col.begin(), col.end() );
-    std::sort( ret.begin(), ret.end(), []( const auto & a, const auto & b ) {
+    std::sort( ret.begin(), ret.end(), []( const auto & a, const auto & b )
+    {
         return typename K::LexCmp()( a.first, b.first );
     } );
     return ret;
@@ -35,10 +35,9 @@ std::vector<std::pair<K, V>> sorted_lex( Col col )
  * @return sorted (using string_id::LexCmp) `std::vector<string_id<T>>`
  */
 template<typename Col,
-         typename El = std::decay_t<decltype( *std::declval<const Col &>().begin() )>,
-         std::enable_if_t<std::is_same<El, string_id<typename El::value_type>>::value, int> = 0>
+         typename El = std::decay_t<decltype( *std::declval<const Col &>().begin() )>>
 std::vector<El> sorted_lex( Col col )
-{
+requires std::is_same_v<El, string_id<typename El::value_type>> {
     std::vector<El> ret;
     ret.insert( ret.begin(), col.begin(), col.end() );
     std::sort( ret.begin(), ret.end(), typename El::LexCmp() );

--- a/src/units_utility.h
+++ b/src/units_utility.h
@@ -34,9 +34,9 @@ T divide_round_up( units::quantity<T, U> num, units::quantity<T, U> den )
  */
 units::angle normalize( units::angle, units::angle mod = 360_degrees );
 
-template<typename T, typename U, std::enable_if_t<std::is_floating_point<T>::value>* = nullptr>
+template<typename T, typename U>
 units::quantity<T, U> round_to_multiple_of( units::quantity<T, U> val, units::quantity<T, U> of )
-{
+requires std::is_floating_point_v<T> {
     int multiple = std::lround( val / of );
     return multiple * of;
 }


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

followup to #5537: apply https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-constraints.html

## Describe the solution

ran:

```
$ parallel ./build-scripts/clang-tidy-wrapper.sh {} -fix '--checks=-\*,modernize-use-constraints,modernize-type-traits' ::: src/*.{cpp,h}
```

btw it took 370s lol

## Testing

should (probably) build