### PR TITLE
refactor: apply all clang-tidy fixes

### DIFF
--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -26,7 +26,7 @@ class aim_activity_actor : public activity_actor
         std::vector<tripoint> fin_trajectory;
 
     public:
-        std::string action = "";
+        std::string action;
         int aif_duration = 0; // Counts aim-and-fire duration
         bool aiming_at_critter = false; // Whether aiming at critter or a tile
         bool snap_to_target = false;

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1772,11 +1772,11 @@ void activity_handlers::hotwire_finish( player_activity *act, player *p )
                                            p->posz() ) ) ) ) {
         vehicle *const veh = &vp->vehicle();
         const int mech_skill = act->values[2];
-        if( mech_skill > static_cast<int>( rng( 1, 6 ) ) ) {
+        if( mech_skill > rng( 1, 6 ) ) {
             //success
             veh->is_locked = false;
             add_msg( _( "This wire will start the engine." ) );
-        } else if( mech_skill > static_cast<int>( rng( 0, 4 ) ) ) {
+        } else if( mech_skill > rng( 0, 4 ) ) {
             //soft fail
             veh->is_locked = false;
             veh->is_alarm_on = veh->has_security_working();

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -579,7 +579,7 @@ std::list<act_item> reorder_for_dropping( Character &p, const drop_locations &dr
         const_invslice old_inv = p.inv_const_slice();
         for( size_t i = 0; i < old_inv.size() && excessive_volume > 0_ml; i++ ) {
             // TODO: Reimplement random dropping?
-            if( inv_indices.count( i ) != 0 ) {
+            if( inv_indices.contains( i ) ) {
                 continue;
             }
             const std::vector<item *> &inv_stack = *old_inv[i];
@@ -1149,7 +1149,7 @@ static activity_reason_info find_base_construction(
         pq.pop();
 
         auto con = cur.id;
-        if( used.count( con ) != 0 ) {
+        if( used.contains( con ) ) {
             continue;    // already evaluated this one
         }
         if( strict && con->group != id->group ) {
@@ -1157,7 +1157,7 @@ static activity_reason_info find_base_construction(
         }
         used.insert( con );
 
-        auto con_build = con.obj();
+        const auto &con_build = con.obj();
         if(
             ( !con_build.post_terrain.is_empty() && con_build.post_terrain.id() == ter ) ||
             ( !con_build.post_furniture.is_empty() && con_build.post_furniture.id() == furn )

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1369,7 +1369,7 @@ void advanced_inventory::display()
 
             w_height = TERMY < min_w_height + head_height ? min_w_height : TERMY - head_height;
             w_width = TERMX < min_w_width ? min_w_width : TERMX > max_w_width ? max_w_width :
-                      static_cast<int>( TERMX );
+                      TERMX;
 
             //(TERMY>w_height)?(TERMY-w_height)/2:0;
             headstart = 0;

--- a/src/ammo.cpp
+++ b/src/ammo.cpp
@@ -33,7 +33,7 @@ void ammunition_type::load_ammunition_type( const JsonObject &jsobj )
 template<>
 bool string_id<ammunition_type>::is_valid() const
 {
-    return all_ammunition_types().count( *this ) > 0;
+    return all_ammunition_types().contains( *this );
 }
 
 /** @relates string_id */

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -852,7 +852,7 @@ void draw_sct_curses( const game &g )
             continue;
         }
 
-        const bool is_old = text.getStep() >= SCT.iMaxSteps / 2;
+        const bool is_old = text.getStep() >= scrollingcombattext::iMaxSteps / 2;
 
         nc_color const col1 = msgtype_to_color( text.getMsgType( "first" ),  is_old );
         nc_color const col2 = msgtype_to_color( text.getMsgType( "second" ), is_old );

--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -312,17 +312,17 @@ std::vector<std::string> clothing_protection( const item &worn_item, const int w
     const std::string space = "  ";
     prot.push_back( string_format( "<color_c_green>[%s]</color>", _( "Protection" ) ) );
     prot.push_back( name_and_value( space + _( "Bash:" ),
-                                    string_format( "%3d", static_cast<int>( worn_item.bash_resist() ) ), width ) );
+                                    string_format( "%3d", worn_item.bash_resist() ), width ) );
     prot.push_back( name_and_value( space + _( "Cut:" ),
-                                    string_format( "%3d", static_cast<int>( worn_item.cut_resist() ) ), width ) );
+                                    string_format( "%3d", worn_item.cut_resist() ), width ) );
     prot.push_back( name_and_value( space + _( "Ballistic:" ),
-                                    string_format( "%3d", static_cast<int>( worn_item.bullet_resist() ) ), width ) );
+                                    string_format( "%3d", worn_item.bullet_resist() ), width ) );
     prot.push_back( name_and_value( space + _( "Acid:" ),
-                                    string_format( "%3d", static_cast<int>( worn_item.acid_resist() ) ), width ) );
+                                    string_format( "%3d", worn_item.acid_resist() ), width ) );
     prot.push_back( name_and_value( space + _( "Fire:" ),
-                                    string_format( "%3d", static_cast<int>( worn_item.fire_resist() ) ), width ) );
+                                    string_format( "%3d", worn_item.fire_resist() ), width ) );
     prot.push_back( name_and_value( space + _( "Environmental:" ),
-                                    string_format( "%3d", static_cast<int>( worn_item.get_env_resist() ) ), width ) );
+                                    string_format( "%3d", worn_item.get_env_resist() ), width ) );
     return prot;
 }
 

--- a/src/auto_note.cpp
+++ b/src/auto_note.cpp
@@ -116,7 +116,7 @@ void auto_note_settings::set_discovered( const string_id<map_extra> &mapExtId )
 
 bool auto_note_settings::was_discovered( const string_id<map_extra> &mapExtId ) const
 {
-    return discovered.count( mapExtId ) != 0;
+    return discovered.contains( mapExtId );
 }
 
 void auto_note_settings::show_gui()
@@ -131,7 +131,7 @@ void auto_note_settings::show_gui()
 
 bool auto_note_settings::has_auto_note_enabled( const string_id<map_extra> &mapExtId ) const
 {
-    return autoNoteEnabled.count( mapExtId ) != 0;
+    return autoNoteEnabled.contains( mapExtId );
 }
 
 void auto_note_settings::set_auto_note_status( const string_id<map_extra> &mapExtId,

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -546,7 +546,7 @@ bool avatar::read( item *loc, const bool continuous )
             }
             act.index = menu.ret;
         }
-        if( it.type->use_methods.count( "MA_MANUAL" ) ) {
+        if( it.type->use_methods.contains( "MA_MANUAL" ) ) {
 
             if( martial_arts_data->has_martialart( martial_art_learned_from( *it.type ) ) ) {
                 add_msg_if_player( m_info, _( "You already know all this book has to teach." ) );
@@ -636,7 +636,7 @@ bool avatar::read( item *loc, const bool continuous )
     }
 
     // push an indentifier of martial art book to the action handling
-    if( it.type->use_methods.count( "MA_MANUAL" ) ) {
+    if( it.type->use_methods.contains( "MA_MANUAL" ) ) {
 
         if( get_stamina() < get_stamina_max() / 10 ) {
             add_msg( m_info, _( "You are too exhausted to train martial arts." ) );
@@ -706,7 +706,7 @@ static void skim_book_msg( const item &book, avatar &u )
                  character_funcs::get_book_fun_for( u, book ) );
     }
 
-    if( book.type->use_methods.count( "MA_MANUAL" ) ) {
+    if( book.type->use_methods.contains( "MA_MANUAL" ) ) {
         const matype_id style_to_learn = martial_art_learned_from( *book.type );
         add_msg( m_info, _( "You can learn %s style from it." ), style_to_learn->name );
         add_msg( m_info, _( "This fighting style is %s to learn." ),
@@ -958,7 +958,7 @@ void avatar::do_read( item *loc )
 
 bool avatar::has_identified( const itype_id &item_id ) const
 {
-    return items_identified.count( item_id ) > 0;
+    return items_identified.contains( item_id );
 }
 
 void avatar::wake_up()

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -270,7 +270,7 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
         monster &critter = *mon_ptr;
         // Additional checking to make sure we won't take a swing at friendly monsters.
         Character &u = get_player_character();
-        monster_attitude att = critter.attitude( const_cast<Character *>( &u ) );
+        monster_attitude att = critter.attitude( ( &u ) );
         if( critter.friendly == 0 &&
             !critter.has_effect( effect_pet ) && att != MATT_FRIEND ) {
             if( you.is_auto_moving() ) {
@@ -768,7 +768,7 @@ void avatar_action::fire_wielded_weapon( avatar &you )
     } else if( !weapon.is_gun() ) {
         return;
     } else if( weapon.ammo_data() && weapon.type->gun &&
-               !weapon.ammo_types().count( weapon.ammo_data()->ammo->type ) ) {
+               !weapon.ammo_types().contains( weapon.ammo_data()->ammo->type ) ) {
         std::string ammoname = weapon.ammo_current()->nname( 1 );
         add_msg( m_info, _( "The %s can't be fired while loaded with incompatible ammunition %s" ),
                  weapon.tname(), ammoname );
@@ -1294,8 +1294,8 @@ void avatar_action::reload_weapon( bool try_everything )
             return true;
         }
         // Second sort by affiliation with wielded gun
-        const bool mag_ap = compatible_magazines.count( ap->typeId() ) > 0;
-        const bool mag_bp = compatible_magazines.count( bp->typeId() ) > 0;
+        const bool mag_ap = compatible_magazines.contains( ap->typeId() );
+        const bool mag_bp = compatible_magazines.contains( bp->typeId() );
         if( mag_ap != mag_bp ) {
             return mag_ap;
         }

--- a/src/avatar_functions.cpp
+++ b/src/avatar_functions.cpp
@@ -179,7 +179,7 @@ void mend_item( avatar &you, item &obj, bool interactive )
         menu.text = _( "Toggle which fault?" );
         std::vector<std::pair<fault_id, bool>> opts;
         for( const auto &f : obj.faults_potential() ) {
-            opts.emplace_back( f, !!obj.faults.count( f ) );
+            opts.emplace_back( f, !!obj.faults.contains( f ) );
             menu.addentry( -1, true, -1, string_format(
                                opts.back().second ? pgettext( "fault", "Mend: %s" ) : pgettext( "fault", "Set: %s" ),
                                f.obj().name() ) );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -237,7 +237,7 @@ std::vector<bodypart_id> get_occupied_bodyparts( const bionic_id &bid )
 
 bool bionic_data::has_flag( const flag_id &flag ) const
 {
-    return flags.count( flag ) > 0;
+    return flags.contains( flag );
 }
 
 itype_id bionic_data::itype() const
@@ -873,7 +873,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
                         if( water && water->charges < avail ) {
                             add_msg_activate();
                             extracted = true;
-                            it->set_var( "remaining_water", static_cast<int>( water->charges ) );
+                            it->set_var( "remaining_water", water->charges );
                         }
                         break;
                     }
@@ -2100,7 +2100,7 @@ bool Character::can_uninstall_bionic( const bionic_id &b_id, player &installer, 
     } else {
         if( !g->u.query_yn(
                 _( "WARNING: %i percent chance of SEVERE damage to all body parts!  Continue anyway?" ),
-                ( 100 - static_cast<int>( chance_of_success ) ) ) ) {
+                ( 100 - chance_of_success ) ) ) {
             return false;
         }
     }
@@ -2508,7 +2508,7 @@ void Character::do_damage_for_bionic_failure( int min_damage, int max_damage )
     std::set<bodypart_id> bp_hurt;
     for( const bodypart_id &bp : get_all_body_parts() ) {
         if( has_effect( effect_under_op, bp.id() ) ) {
-            if( bp_hurt.count( bp->main_part ) > 0 ) {
+            if( bp_hurt.contains( bp->main_part ) ) {
                 continue;
             }
             bp_hurt.emplace( bp->main_part );
@@ -2753,7 +2753,7 @@ void Character::remove_bionic( const bionic_id &b )
 
     // any spells you learn from installing a bionic you forget.
     for( const std::pair<const spell_id, int> &spell_pair : b->learned_spells ) {
-        if( cbm_spells.count( spell_pair.first ) == 0 ) {
+        if( !cbm_spells.contains( spell_pair.first ) ) {
             magic->forget_spell( spell_pair.first );
         }
     }

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -453,41 +453,41 @@ class time_point
             return point.turn_;
         }
 
-        friend constexpr inline bool operator<( const time_point &lhs, const time_point &rhs ) {
+        friend constexpr bool operator<( const time_point &lhs, const time_point &rhs ) {
             return to_turn<int>( lhs ) < to_turn<int>( rhs );
         }
-        friend constexpr inline bool operator<=( const time_point &lhs, const time_point &rhs ) {
+        friend constexpr bool operator<=( const time_point &lhs, const time_point &rhs ) {
             return to_turn<int>( lhs ) <= to_turn<int>( rhs );
         }
-        friend constexpr inline bool operator>( const time_point &lhs, const time_point &rhs ) {
+        friend constexpr bool operator>( const time_point &lhs, const time_point &rhs ) {
             return to_turn<int>( lhs ) > to_turn<int>( rhs );
         }
-        friend constexpr inline bool operator>=( const time_point &lhs, const time_point &rhs ) {
+        friend constexpr bool operator>=( const time_point &lhs, const time_point &rhs ) {
             return to_turn<int>( lhs ) >= to_turn<int>( rhs );
         }
-        friend constexpr inline bool operator==( const time_point &lhs, const time_point &rhs ) {
+        friend constexpr bool operator==( const time_point &lhs, const time_point &rhs ) {
             return to_turn<int>( lhs ) == to_turn<int>( rhs );
         }
-        friend constexpr inline bool operator!=( const time_point &lhs, const time_point &rhs ) {
+        friend constexpr bool operator!=( const time_point &lhs, const time_point &rhs ) {
             return to_turn<int>( lhs ) != to_turn<int>( rhs );
         }
 
-        friend constexpr inline time_duration operator-(
+        friend constexpr time_duration operator-(
             const time_point &lhs, const time_point &rhs ) {
             return time_duration::from_turns( to_turn<int>( lhs ) - to_turn<int>( rhs ) );
         }
-        friend constexpr inline time_point operator+(
+        friend constexpr time_point operator+(
             const time_point &lhs, const time_duration &rhs ) {
             return time_point::from_turn( to_turn<int>( lhs ) + to_turns<int>( rhs ) );
         }
-        friend time_point inline &operator+=( time_point &lhs, const time_duration &rhs ) {
+        friend time_point &operator+=( time_point &lhs, const time_duration &rhs ) {
             return lhs = time_point::from_turn( to_turn<int>( lhs ) + to_turns<int>( rhs ) );
         }
-        friend constexpr inline time_point operator-(
+        friend constexpr time_point operator-(
             const time_point &lhs, const time_duration &rhs ) {
             return time_point::from_turn( to_turn<int>( lhs ) - to_turns<int>( rhs ) );
         }
-        friend time_point inline &operator-=( time_point &lhs, const time_duration &rhs ) {
+        friend time_point &operator-=( time_point &lhs, const time_duration &rhs ) {
             return lhs = time_point::from_turn( to_turn<int>( lhs ) - to_turns<int>( rhs ) );
         }
 

--- a/src/cata_arena.h
+++ b/src/cata_arena.h
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef CATA_SRC_ARENA_H
-#define CATA_SRC_ARENA_H
+#ifndef CATA_SRC_CATA_ARENA_H
+#define CATA_SRC_CATA_ARENA_H
 
 #include <unordered_map>
 #include <set>
@@ -61,4 +61,4 @@ class cata_arena
 
 void cleanup_arenas();
 
-#endif
+#endif // CATA_SRC_CATA_ARENA_H

--- a/src/cata_libintl.h
+++ b/src/cata_libintl.h
@@ -105,20 +105,20 @@ class trans_catalogue
 
         explicit trans_catalogue( std::string buffer );
 
-        inline void set_buffer( std::string buffer ) {
+        void set_buffer( std::string buffer ) {
             this->buffer = std::move( buffer );
         }
-        inline u32 buf_size() const {
+        u32 buf_size() const {
             return static_cast<u32>( buffer.size() );
         }
 
         u8 get_u8( u32 offs ) const;
-        inline u8 get_u8_unsafe( u32 offs ) const {
+        u8 get_u8_unsafe( u32 offs ) const {
             return static_cast<u8>( buffer[offs] );
         }
 
         u32 get_u32( u32 offs ) const;
-        inline u32 get_u32_unsafe( u32 offs ) const {
+        u32 get_u32_unsafe( u32 offs ) const {
             if( is_little_endian ) {
                 return get_u8_unsafe( offs ) |
                        get_u8_unsafe( offs + 1 ) << 8 |
@@ -135,7 +135,7 @@ class trans_catalogue
         string_descr get_string_descr( u32 offs ) const;
         string_descr get_string_descr_unsafe( u32 offs ) const;
 
-        inline const char *offs_to_cstr( u32 offs ) const {
+        const char *offs_to_cstr( u32 offs ) const {
             return &buffer[offs];
         }
 
@@ -159,7 +159,7 @@ class trans_catalogue
         static trans_catalogue load_from_memory( std::string mo_file );
 
         /** Number of entries in the catalogue. */
-        inline u32 get_num_strings() const {
+        u32 get_num_strings() const {
             return number_of_strings;
         }
         /** Get singular translated string of given entry. */

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -213,7 +213,7 @@ void idle_animation_manager::prepare_for_redraw()
 }
 
 struct tile_render_info {
-    tripoint pos{};
+    tripoint pos;
     // accumulator for 3d tallness of sprites rendered here so far;
     int height_3d = 0;
     lit_level ll;
@@ -946,7 +946,7 @@ void tileset_loader::load( const std::string &tileset_id, const bool precheck,
             dbg( DL::Warn ) << "tile " << it->first << " has no (valid) foreground nor background";
             // remove the id from seasonal variations!
             for( auto &container : ts.tile_ids_by_season ) {
-                if( container.count( it->first ) != 0 ) {
+                if( container.contains( it->first ) ) {
                     container.erase( it->first );
                 }
             }
@@ -3710,7 +3710,7 @@ void cata_tiles::draw_sct_frame( std::multimap<point, formatted_text> &overlay_s
         for( int j = 0; j < 2; ++j ) {
             std::string sText = iter->getText( ( j == 0 ) ? "first" : "second" );
             int FG = msgtype_to_tilecolor( iter->getMsgType( ( j == 0 ) ? "first" : "second" ),
-                                           iter->getStep() >= SCT.iMaxSteps / 2 );
+                                           iter->getStep() >= scrollingcombattext::iMaxSteps / 2 );
 
             if( use_font ) {
                 const auto direction = iter->getDirecton();

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -69,10 +69,10 @@ class tile_lookup_res
         tile_type *_tile;
     public:
         tile_lookup_res( const std::string &id, tile_type &tile ): _id( &id ), _tile( &tile ) {}
-        inline const std::string &id() {
+        const std::string &id() {
             return *_id;
         }
-        inline tile_type &tile() {
+        tile_type &tile() {
             return *_tile;
         }
 };
@@ -308,7 +308,7 @@ class idle_animation_manager
 
     public:
         /** Set whether idle animations are enabled. */
-        inline void set_enabled( bool enabled ) {
+        void set_enabled( bool enabled ) {
             enabled_ = enabled;
         }
 
@@ -316,22 +316,22 @@ class idle_animation_manager
         void prepare_for_redraw();
 
         /** Whether idle animations are enabled */
-        inline bool enabled() const {
+        bool enabled() const {
             return enabled_;
         }
 
         /** Current animation frame (increments by approx. 60 per second) */
-        inline int current_frame() const {
+        int current_frame() const {
             return frame;
         }
 
         /** Mark presence of an idle animation on screen */
-        inline void mark_present() {
+        void mark_present() {
             present_ = true;
         }
 
         /** Whether there are idle animations on screen */
-        inline bool present() const {
+        bool present() const {
             return present_;
         }
 };

--- a/src/catacharset.cpp
+++ b/src/catacharset.cpp
@@ -391,7 +391,7 @@ std::wstring utf8_to_wstr( const std::string &str )
 #else
     std::size_t sz = std::mbstowcs( nullptr, str.c_str(), 0 ) + 1;
     std::wstring wstr( sz, '\0' );
-    std::mbstowcs( &wstr[0], str.c_str(), sz );
+    std::mbstowcs( wstr.data(), str.c_str(), sz );
     strip_trailing_nulls( wstr );
     return wstr;
 #endif
@@ -408,7 +408,7 @@ std::string wstr_to_utf8( const std::wstring &wstr )
 #else
     std::size_t sz = std::wcstombs( nullptr, wstr.c_str(), 0 ) + 1;
     std::string str( sz, '\0' );
-    std::wcstombs( &str[0], wstr.c_str(), sz );
+    std::wcstombs( str.data(), wstr.c_str(), sz );
     strip_trailing_nulls( str );
     return str;
 #endif

--- a/src/catalua_console.cpp
+++ b/src/catalua_console.cpp
@@ -112,7 +112,7 @@ void show_lua_console_impl()
 
     const auto create_string_editor = [&]() {
         // Offset by one for the scrollbar
-        return catacurses::newwin( prompt_size.y, prompt_size.x + 1, prompt_pos - point( 1, 0 ) );
+        return catacurses::newwin( prompt_size.y, prompt_size.x + 1, prompt_pos - point_east );
     };
 
     catacurses::window w_console;
@@ -129,8 +129,8 @@ void show_lua_console_impl()
         win_pos = point( ( TERMX - win_size.x ) / 2, ( TERMY - win_size.y ) / 2 );
         prompt_size = point( win_size.x - 3, input_area_size );
         prompt_pos = win_pos + point( 2, win_size.y - input_area_size - 1 );
-        log_pos = win_pos + point( 1, 1 );
-        log_size = point( win_size.x - 2, win_size.y - input_area_size - 7 );
+        log_pos = win_pos + point_south_east;
+        log_size = win_size + point( -2, -7 - input_area_size );
         w_console = catacurses::newwin( win_size.y, win_size.x, win_pos );
         w_log = catacurses::newwin( log_size.y, log_size.x, log_pos );
         w_prompt = catacurses::newwin( prompt_size.y, prompt_size.x, prompt_pos );

--- a/src/catalua_log.h
+++ b/src/catalua_log.h
@@ -35,7 +35,7 @@ class lua_log_handler
 
         void clear();
 
-        inline const std::deque<lua_log_msg> &get_entries() const {
+        const std::deque<lua_log_msg> &get_entries() const {
             return entries;
         }
 

--- a/src/catalua_luna.h
+++ b/src/catalua_luna.h
@@ -491,7 +491,7 @@ struct userenum {
     sol::table t;
     bool finalized = false;
 
-    inline ~userenum() {
+    ~userenum() {
         if( !finalized ) {
             debugmsg( "Userenum<%s> has not been finalized!", detail::luna_traits<E>::name );
             std::abort();
@@ -553,7 +553,7 @@ struct userlib {
     sol::table dt;
     bool finalized = false;
 
-    inline ~userlib() {
+    ~userlib() {
         if( !finalized ) {
             debugmsg( "Userlib has not been finalized!" );
             std::abort();

--- a/src/catalua_serde.cpp
+++ b/src/catalua_serde.cpp
@@ -11,7 +11,6 @@
 #include <utility>
 #include <vector>
 #include <stdexcept>
-#include <utility>
 
 namespace cata
 {

--- a/src/catalua_type_operators.h
+++ b/src/catalua_type_operators.h
@@ -24,10 +24,10 @@
  */
 #define LUA_TYPE_OPS( T, id_getter )                    \
     inline bool operator==( const T &rhs ) const {      \
-        return id_getter == rhs.id_getter;              \
+        return (id_getter) == rhs.id_getter;              \
     };                                                  \
     inline bool operator<( const T &rhs ) const {       \
-        return id_getter < rhs.id_getter;               \
+        return (id_getter) < rhs.id_getter;               \
     }
 
 #endif // CATA_SRC_CATALUA_TYPE_OPERATORS_H

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1004,7 +1004,7 @@ int Character::overmap_sight_range( int light_level ) const
 
     sight = 6;
     // The higher your perception, the farther you can see.
-    sight += static_cast<int>( get_per() / 2 );
+    sight += ( get_per() / 2 );
     // The higher up you are, the farther you can see.
     sight += std::max( 0, posz() ) * 2;
     // Mutations like Scout and Topographagnosia affect how far you can see.
@@ -2102,7 +2102,7 @@ float Character::get_vision_threshold( float light_level ) const
 
     // As light_level goes from LIGHT_AMBIENT_MINIMAL to LIGHT_AMBIENT_LIT,
     // dimming goes from 1.0 to 2.0.
-    const float dimming_from_light = 1.0 + ( ( static_cast<float>( light_level ) -
+    const float dimming_from_light = 1.0 + ( ( light_level -
                                      LIGHT_AMBIENT_MINIMAL ) /
                                      ( LIGHT_AMBIENT_LIT - LIGHT_AMBIENT_MINIMAL ) );
 
@@ -3036,7 +3036,7 @@ units::mass Character::weight_carried_reduced_by( const excluded_stacks &without
     // Worn items
     units::mass ret = 0_gram;
     for( auto &i : worn ) {
-        if( !without.count( i ) ) {
+        if( !without.contains( i ) ) {
             ret += i->weight();
         }
     }
@@ -3152,7 +3152,7 @@ units::volume Character::volume_capacity_reduced_by(
 
     units::volume ret = -mod;
     for( const auto &i : worn ) {
-        if( !without.count( i ) ) {
+        if( !without.contains( i ) ) {
             ret += i->get_storage();
         }
     }
@@ -8315,7 +8315,7 @@ void Character::set_highest_cat_level()
         // Then use the map to set the category levels
         for( const std::pair<const trait_id, int> &i : dependency_map ) {
             const mutation_branch &mdata = i.first.obj();
-            if( !mdata.flags.count( flag_NON_THRESH ) ) {
+            if( !mdata.flags.contains( flag_NON_THRESH ) ) {
                 for( const mutation_category_id &cat : mdata.category ) {
                     // Decay category strength based on how far it is from the current mutation
                     mutation_category_level[cat] += 8 / static_cast<int>( std::pow( 2, i.second ) );
@@ -10850,7 +10850,7 @@ std::vector<Creature *> Character::get_hostile_creatures( int range ) const
 bool Character::knows_trap( const tripoint &pos ) const
 {
     const tripoint p = get_map().getabs( pos );
-    return known_traps.count( p ) > 0;
+    return known_traps.contains( p );
 }
 
 void Character::add_known_trap( const tripoint &pos, const trap &t )

--- a/src/character.h
+++ b/src/character.h
@@ -810,25 +810,25 @@ class Character : public Creature, public location_visitable<Character>
             WT_GOOD,
             NUM_WATER_TOLERANCE
         };
-        inline int posx() const override {
+        int posx() const override {
             return position.x;
         }
-        inline int posy() const override {
+        int posy() const override {
             return position.y;
         }
-        inline int posz() const override {
+        int posz() const override {
             return position.z;
         }
-        inline void setx( int x ) {
+        void setx( int x ) {
             setpos( tripoint( x, position.y, position.z ) );
         }
-        inline void sety( int y ) {
+        void sety( int y ) {
             setpos( tripoint( position.x, y, position.z ) );
         }
-        inline void setz( int z ) {
+        void setz( int z ) {
             setpos( tripoint( position.xy(), z ) );
         }
-        inline void setpos( const tripoint &p ) override {
+        void setpos( const tripoint &p ) override {
             position = p;
         }
 

--- a/src/character_display.cpp
+++ b/src/character_display.cpp
@@ -699,7 +699,7 @@ int character_display::display_empty_handed_base_damage( const Character &you )
             per_hand += 9;
         }
         for( const trait_id &mut : you.get_mutations() ) {
-            if( mut->flags.count( trait_flag_NEED_ACTIVE_TO_MELEE ) > 0 &&
+            if( mut->flags.contains( trait_flag_NEED_ACTIVE_TO_MELEE ) &&
                 !you.has_active_mutation( mut ) ) {
                 continue;
             }
@@ -712,7 +712,7 @@ int character_display::display_empty_handed_base_damage( const Character &you )
             per_hand += rand_bash.first + rand_cut.first;
 
             // Extra skill bonus is also fairly simple, but each type of fixed bonus can trigger it separately
-            if( mut->flags.count( trait_flag_UNARMED_BONUS ) > 0 ) {
+            if( mut->flags.contains( trait_flag_UNARMED_BONUS ) ) {
                 if( mut->bash_dmg_bonus > 0 ) {
                     per_hand += std::min( you.get_skill_level( skill_unarmed ) / 2, 4 );
                 }

--- a/src/character_functions.cpp
+++ b/src/character_functions.cpp
@@ -369,9 +369,9 @@ int rate_sleep_spot( const Character &who, const tripoint &p )
     }
 
     if( who.get_fatigue() < fatigue_levels::tired + 1 ) {
-        sleepy -= static_cast<int>( ( fatigue_levels::tired + 1 - who.get_fatigue() ) / 4 );
+        sleepy -= ( ( fatigue_levels::tired + 1 - who.get_fatigue() ) / 4 );
     } else {
-        sleepy += static_cast<int>( ( who.get_fatigue() - fatigue_levels::tired + 1 ) / 16 );
+        sleepy += ( ( who.get_fatigue() - fatigue_levels::tired + 1 ) / 16 );
     }
 
     if( current_stim > 0 || !who.has_trait( trait_INSOMNIA ) ) {
@@ -805,7 +805,7 @@ item_reload_option select_ammo( const Character &who, item &base,
     std::back_inserter( names ), [&]( const item_reload_option & e ) {
         const auto ammo_color = [&]( const std::string & name ) {
             return base.is_gun() && e.ammo->ammo_data() &&
-                   !base.ammo_types().count( e.ammo->ammo_data()->ammo->type ) ?
+                   !base.ammo_types().contains( e.ammo->ammo_data()->ammo->type ) ?
                    colorize( name, c_dark_gray ) : name;
         };
         if( e.ammo->is_magazine() && e.ammo->ammo_data() ) {
@@ -1148,7 +1148,7 @@ void find_ammo_helper( T &src, const item &obj, bool empty, Output out, bool nes
                 }
             }
             if( node->is_magazine() && node->has_flag( flag_SPEEDLOADER ) ) {
-                if( mags.count( node->typeId() ) && node->ammo_remaining() ) {
+                if( mags.contains( node->typeId() ) && node->ammo_remaining() ) {
                     out = node;
                 }
             }
@@ -1173,7 +1173,7 @@ void find_ammo_helper( T &src, const item &obj, bool empty, Output out, bool nes
                     }
                 }
 
-                if( mags.count( node->typeId() ) && ( node->ammo_remaining() || empty ) ) {
+                if( mags.contains( node->typeId() ) && ( node->ammo_remaining() || empty ) ) {
                     out = node;
                 }
                 return VisitResponse::SKIP;

--- a/src/character_id.h
+++ b/src/character_id.h
@@ -32,19 +32,19 @@ class character_id
         void serialize( JsonOut & ) const;
         void deserialize( JsonIn & );
 
-        friend inline bool operator==( character_id l, character_id r ) {
+        friend bool operator==( character_id l, character_id r ) {
             return l.get_value() == r.get_value();
         }
 
-        friend inline bool operator!=( character_id l, character_id r ) {
+        friend bool operator!=( character_id l, character_id r ) {
             return l.get_value() != r.get_value();
         }
 
-        friend inline bool operator<( character_id l, character_id r ) {
+        friend bool operator<( character_id l, character_id r ) {
             return l.get_value() < r.get_value();
         }
 
-        friend inline std::ostream &operator<<( std::ostream &o, character_id id ) {
+        friend std::ostream &operator<<( std::ostream &o, character_id id ) {
             return o << id.get_value();
         }
     private:

--- a/src/character_preview.h
+++ b/src/character_preview.h
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef CHARACTER_PREVIEW_H
-#define CHARACTER_PREVIEW_H
+#ifndef CATA_SRC_CHARACTER_PREVIEW_H
+#define CATA_SRC_CHARACTER_PREVIEW_H
 
 #include "cursesdef.h"
 #include "detached_ptr.h"
@@ -64,4 +64,4 @@ struct character_preview_window {
         auto calc_character_pos() const -> point ;
 };
 
-#endif // CHARACTER_PREVIEW_H
+#endif // CATA_SRC_CHARACTER_PREVIEW_H

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -568,7 +568,7 @@ std::string zone_manager::get_name_from_type( const zone_type_id &type ) const
 
 bool zone_manager::has_type( const zone_type_id &type ) const
 {
-    return types.count( type ) > 0;
+    return types.contains( type );
 }
 
 bool zone_manager::has_defined( const zone_type_id &type, const faction_id &fac ) const

--- a/src/concepts_utility.h
+++ b/src/concepts_utility.h
@@ -1,9 +1,9 @@
 #pragma once
-#ifndef CATA_SRC_CONCEPTS_UTILITY_DEF_H
-#define CATA_SRC_CONCEPTS_UTILITY_DEF_H
+#ifndef CATA_SRC_CONCEPTS_UTILITY_H
+#define CATA_SRC_CONCEPTS_UTILITY_H
 #include <cmath>
 
 template<typename T>
 concept Arithmetic = std::is_arithmetic_v<T>;
 
-#endif // CATA_SRC_CONCEPTS_UTILITY_DEF_H
+#endif // CATA_SRC_CONCEPTS_UTILITY_H

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -377,7 +377,7 @@ static nc_color construction_color( const construction_group_str_id &group, bool
 
 static bool is_favorite( const construction_group_str_id &c )
 {
-    return uistate.favorite_construct_recipes.count( c ) > 0;
+    return uistate.favorite_construct_recipes.contains( c );
 }
 
 static void favorite_add( const construction_group_str_id &c )
@@ -1136,7 +1136,7 @@ void complete_construction( Character &ch )
     }
     here.partial_con_remove( terp );
     // Some constructions are allowed to have items left on the tile.
-    if( built.post_flags.count( "keep_items" ) == 0 ) {
+    if( !built.post_flags.contains( "keep_items" ) ) {
         // Move any items that have found their way onto the construction site.
         std::vector<tripoint> dump_spots;
         for( const tripoint &pt : here.points_in_radius( terp, 1 ) ) {
@@ -1547,7 +1547,7 @@ void construct::done_mine_upstair( const tripoint &p )
         }
     };
 
-    if( liquids.count( tmpmap.ter( local_tmp ) ) > 0 ) {
+    if( liquids.contains( tmpmap.ter( local_tmp ) ) ) {
         here.ter_set( p.xy(), t_rock_floor ); // You dug a bit before discovering the problem
         add_msg( m_warning, _( "The rock above is rather damp.  You decide *not* to mine water." ) );
         unroll_digging( 12 );

--- a/src/coordinates.h
+++ b/src/coordinates.h
@@ -178,19 +178,19 @@ class coord_point
             return *this;
         }
 
-        friend inline coord_point operator+( const coord_point &l, point r ) {
+        friend coord_point operator+( const coord_point &l, point r ) {
             return coord_point( l.raw() + r );
         }
 
-        friend inline coord_point operator+( const coord_point &l, const tripoint &r ) {
+        friend coord_point operator+( const coord_point &l, const tripoint &r ) {
             return coord_point( l.raw() + r );
         }
 
-        friend inline coord_point operator-( const coord_point &l, point r ) {
+        friend coord_point operator-( const coord_point &l, point r ) {
             return coord_point( l.raw() - r );
         }
 
-        friend inline coord_point operator-( const coord_point &l, const tripoint &r ) {
+        friend coord_point operator-( const coord_point &l, const tripoint &r ) {
             return coord_point( l.raw() - r );
         }
     private:
@@ -198,28 +198,28 @@ class coord_point
 };
 
 template<typename Point, origin Origin, scale Scale>
-constexpr inline bool operator==( const coord_point<Point, Origin, Scale> &l,
-                                  const coord_point<Point, Origin, Scale> &r )
+constexpr bool operator==( const coord_point<Point, Origin, Scale> &l,
+                           const coord_point<Point, Origin, Scale> &r )
 {
     return l.raw() == r.raw();
 }
 
 template<typename Point, origin Origin, scale Scale>
-constexpr inline bool operator!=( const coord_point<Point, Origin, Scale> &l,
-                                  const coord_point<Point, Origin, Scale> &r )
+constexpr bool operator!=( const coord_point<Point, Origin, Scale> &l,
+                           const coord_point<Point, Origin, Scale> &r )
 {
     return l.raw() != r.raw();
 }
 
 template<typename Point, origin Origin, scale Scale>
-constexpr inline bool operator<( const coord_point<Point, Origin, Scale> &l,
-                                 const coord_point<Point, Origin, Scale> &r )
+constexpr bool operator<( const coord_point<Point, Origin, Scale> &l,
+                          const coord_point<Point, Origin, Scale> &r )
 {
     return l.raw() < r.raw();
 }
 
 template<typename PointL, typename PointR, origin OriginL, scale Scale>
-constexpr inline auto operator+(
+constexpr auto operator+(
     const coord_point<PointL, OriginL, Scale> &l,
     const coord_point<PointR, origin::relative, Scale> &r )
 {
@@ -228,7 +228,7 @@ constexpr inline auto operator+(
 }
 
 template < typename PointL, typename PointR, origin OriginR, scale Scale>
-constexpr inline auto operator+(
+constexpr auto operator+(
     const coord_point<PointL, origin::relative, Scale> &l,
     const coord_point<PointR, OriginR, Scale> &r )
 requires( OriginR != origin::relative )
@@ -238,7 +238,7 @@ requires( OriginR != origin::relative )
 }
 
 template<typename PointL, typename PointR, origin OriginL, scale Scale>
-constexpr inline auto operator-(
+constexpr auto operator-(
     const coord_point<PointL, OriginL, Scale> &l,
     const coord_point<PointR, origin::relative, Scale> &r )
 {
@@ -247,7 +247,7 @@ constexpr inline auto operator-(
 }
 
 template < typename PointL, typename PointR, origin Origin, scale Scale>
-constexpr inline auto operator-(
+constexpr auto operator-(
     const coord_point<PointL, Origin, Scale> &l,
     const coord_point<PointR, Origin, Scale> &r )
 requires( Origin != origin::relative )
@@ -258,14 +258,14 @@ requires( Origin != origin::relative )
 
 // Only relative points can be multiplied by a constant
 template<typename Point, scale Scale>
-constexpr inline coord_point<Point, origin::relative, Scale> operator*(
+constexpr coord_point<Point, origin::relative, Scale> operator*(
     int l, const coord_point<Point, origin::relative, Scale> &r )
 {
     return coord_point<Point, origin::relative, Scale>( l * r.raw() );
 }
 
 template<typename Point, scale Scale>
-constexpr inline coord_point<Point, origin::relative, Scale> operator*(
+constexpr coord_point<Point, origin::relative, Scale> operator*(
     const coord_point<Point, origin::relative, Scale> &r, int l )
 {
     return coord_point<Point, origin::relative, Scale>( r.raw() * l );

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -83,7 +83,7 @@ void load_recipe_category( const JsonObject &jsobj )
     const std::string category = jsobj.get_string( "id" );
     const bool is_hidden = jsobj.get_bool( "is_hidden", false );
 
-    if( category.find( "CC_" ) != 0 ) {
+    if( !category.starts_with( "CC_" ) ) {
         jsobj.throw_error( "Crafting category id has to be prefixed with 'CC_'" );
     }
 
@@ -94,7 +94,7 @@ void load_recipe_category( const JsonObject &jsobj )
         const std::string cat_name = get_cat_unprefixed( category );
 
         for( const std::string subcat_id : jsobj.get_array( "recipe_subcategories" ) ) {
-            if( subcat_id.find( "CSC_" + cat_name + "_" ) != 0 && subcat_id != "CSC_ALL" ) {
+            if( !subcat_id.starts_with( "CSC_" + cat_name + "_" ) && subcat_id != "CSC_ALL" ) {
                 jsobj.throw_error( "Crafting sub-category id has to be prefixed with CSC_<category_name>_" );
             }
             if( std::find( craft_subcat_list[category].begin(), craft_subcat_list[category].end(),
@@ -109,7 +109,7 @@ static std::string get_subcat_unprefixed( const std::string &cat, const std::str
 {
     std::string prefix = "CSC_" + get_cat_unprefixed( cat ) + "_";
 
-    if( prefixed_name.find( prefix ) == 0 ) {
+    if( prefixed_name.starts_with( prefix ) ) {
         return prefixed_name.substr( prefix.size(), prefixed_name.size() - prefix.size() );
     }
 
@@ -717,7 +717,7 @@ const recipe *select_crafting_recipe( int &batch_size_out )
                 available.reserve( current.size() );
                 // cache recipe availability on first display
                 for( const recipe *e : current ) {
-                    if( availability_cache.count( e ) == 0 ) {
+                    if( !availability_cache.contains( e ) ) {
                         availability_cache.emplace( e, availability( e, 1,
                                                     !show_unavailable || available_recipes.contains( *e ) ) );
                     }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -384,7 +384,7 @@ static bool overlaps_vehicle( const std::set<tripoint> &veh_area, const tripoint
 {
     for( const tripoint &tmp : tripoint_range<tripoint>( pos - tripoint( area, area, 0 ),
             pos + tripoint( area - 1, area - 1, 0 ) ) ) {
-        if( veh_area.count( tmp ) > 0 ) {
+        if( veh_area.contains( tmp ) ) {
             return true;
         }
     }
@@ -841,7 +841,7 @@ void Creature::deal_projectile_attack( Creature *source, item *source_weapon,
     impact.mult_damage( damage_mult );
 
     if( proj.has_effect( ammo_effect_NOGIB ) ) {
-        float dmg_ratio = static_cast<float>( impact.total_damage() ) / get_hp_max( bp_hit );
+        float dmg_ratio = impact.total_damage() / get_hp_max( bp_hit );
         if( dmg_ratio > 1.25f ) {
             impact.mult_damage( 1.0f / dmg_ratio );
         }

--- a/src/damage.cpp
+++ b/src/damage.cpp
@@ -15,7 +15,6 @@
 #include "monster.h"
 #include "mtype.h"
 #include "translations.h"
-#include "cata_utility.h"
 
 bool damage_unit::operator==( const damage_unit &other ) const
 {

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -251,7 +251,7 @@ static void debug_error_prompt(
     std::string msg_key( filename );
     msg_key += line;
 
-    if( !force && ignored_messages.count( msg_key ) > 0 ) {
+    if( !force && ignored_messages.contains( msg_key ) ) {
         return;
     }
 

--- a/src/detached_ptr.h
+++ b/src/detached_ptr.h
@@ -50,4 +50,4 @@ class detached_ptr
         explicit detached_ptr( T *obj );
         T *release();
 };
-#endif
+#endif // CATA_SRC_DETACHED_PTR_H

--- a/src/dialogue.h
+++ b/src/dialogue.h
@@ -208,7 +208,7 @@ struct talk_response {
     mission *mission_selected = nullptr;
     skill_id skill = skill_id::NULL_ID();
     matype_id style = matype_id::NULL_ID();
-    spell_id dialogue_spell = spell_id();
+    spell_id dialogue_spell;
 
     talk_effect_t success;
     talk_effect_t failure;

--- a/src/diary.cpp
+++ b/src/diary.cpp
@@ -328,7 +328,7 @@ void diary::kill_changes()
                 std::string symbol = m.sym;
                 std::string nname = m.nname( elem.second );
                 int kills = elem.second;
-                if( prev_page->kills.count( elem.first ) > 0 ) {
+                if( prev_page->kills.contains( elem.first ) ) {
                     const int prev_kills = prev_page->kills[elem.first];
                     if( kills > prev_kills ) {
                         if( flag ) {

--- a/src/distribution_grid.cpp
+++ b/src/distribution_grid.cpp
@@ -249,7 +249,7 @@ void distribution_grid_tracker::on_changed( const tripoint_abs_ms &p )
 {
     tripoint_abs_sm sm_pos = project_to<coords::sm>( p );
     // TODO: If not in bounds, just drop the grid, rebuild lazily
-    if( parent_distribution_grids.count( sm_pos ) > 0 ||
+    if( parent_distribution_grids.contains( sm_pos ) ||
         bounds.contains( sm_pos.xy() ) ) {
         // TODO: Don't rebuild, update
         make_distribution_grid_at( sm_pos );

--- a/src/distribution_grid.h
+++ b/src/distribution_grid.h
@@ -203,13 +203,13 @@ void traverse( StartPoint &start,
                VehFunc veh_action, GridFunc grid_action );
 
 /* Useful if we want to act only in one type. */
-inline constexpr traverse_visitor_result noop_visitor_grid( const distribution_grid & )
+constexpr traverse_visitor_result noop_visitor_grid( const distribution_grid & )
 {
     return traverse_visitor_result::continue_further;
 }
 
 /* Useful if we want to act only in one type. */
-inline constexpr traverse_visitor_result noop_visitor_veh( const vehicle & )
+constexpr traverse_visitor_result noop_visitor_veh( const vehicle & )
 {
     return traverse_visitor_result::continue_further;
 }

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -1309,7 +1309,7 @@ void editmap::edit_fld()
                     fsel_intensity = femenu.ret;
                 }
             } else if( fmenu.ret_act == "RIGHT" &&
-                       field_intensity < static_cast<int>( ftype.get_max_intensity() ) ) {
+                       field_intensity < ftype.get_max_intensity() ) {
                 fsel_intensity++;
             } else if( fmenu.ret_act == "LEFT" && field_intensity > 0 ) {
                 fsel_intensity--;
@@ -1443,7 +1443,7 @@ void editmap::edit_itm()
             imenu.addentry( imenu_damage, true, -1, pgettext( "item manipulation debug menu entry",
                             "damage: %d" ), it.damage() );
             imenu.addentry( imenu_burnt, true, -1, pgettext( "item manipulation debug menu entry",
-                            "burnt: %d" ), static_cast<int>( it.burnt ) );
+                            "burnt: %d" ), it.burnt );
             imenu.addentry( imenu_sep, false, 0, pgettext( "item manipulation debug menu entry",
                             "-[ light emission ]-" ) );
             imenu.addentry( imenu_savetest, true, -1, pgettext( "item manipulation debug menu entry",
@@ -1468,7 +1468,7 @@ void editmap::edit_itm()
                             intval = it.damage();
                             break;
                         case imenu_burnt:
-                            intval = static_cast<int>( it.burnt );
+                            intval = it.burnt;
                             break;
                     }
                     string_input_popup popup;

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -61,7 +61,7 @@ const effect_type &string_id<effect_type>::obj() const
 template<>
 bool string_id<effect_type>::is_valid() const
 {
-    return effect_types.count( *this ) > 0;
+    return effect_types.contains( *this );
 }
 
 std::vector<efftype_id> find_all_effect_types()
@@ -419,7 +419,7 @@ bool effect_type::load_mod_data( const JsonObject &jo, const std::string &member
 
 bool effect_type::has_flag( const flag_id &flag ) const
 {
-    return flags.count( flag );
+    return flags.contains( flag );
 }
 
 effect_rating effect_type::get_rating() const
@@ -948,7 +948,7 @@ int effect::get_mod( const std::string &arg, bool reduced ) const
     }
     if( static_cast<int>( max ) != 0 ) {
         // Return a random value between [min, max]
-        return static_cast<int>( rng( min, max ) );
+        return rng( min, max );
     } else {
         // Else return the minimum value
         return min;
@@ -1381,7 +1381,7 @@ void load_effect_type( const JsonObject &jo )
     new_etype.load_mod_data( jo, "base_mods" );
     new_etype.load_mod_data( jo, "scaling_mods" );
 
-    new_etype.impairs_movement = hardcoded_movement_impairing.count( new_etype.id ) > 0;
+    new_etype.impairs_movement = hardcoded_movement_impairing.contains( new_etype.id );
 
     new_etype.flags = jo.get_tags<flag_id>( "flags" );
 

--- a/src/enums.h
+++ b/src/enums.h
@@ -7,7 +7,7 @@
 template<typename T> struct enum_traits;
 
 template<typename T>
-constexpr inline int sgn( const T x )
+constexpr int sgn( const T x )
 {
     return x < 0 ? -1 : ( x > 0 ? 1 : 0 );
 }

--- a/src/event_statistics.cpp
+++ b/src/event_statistics.cpp
@@ -487,7 +487,7 @@ struct event_transformation_impl : public event_transformation::impl {
         const cata::event::fields_type input_fields = source_->fields();
 
         for( const std::pair<std::string, new_field> &p : new_fields_ ) {
-            if( input_fields.count( p.first ) ) {
+            if( input_fields.contains( p.first ) ) {
                 debugmsg( "event_transformation %s tries to add field with name %s but a field "
                           "with that name already exists", name, p.first );
             }

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -379,7 +379,7 @@ class ExplosionProcess
             return a.first < b.first;
         };
 
-        inline void update_timings() {
+        void update_timings() {
             if( !is_animated() ) {
                 // Arbitrary large number since for null delays
                 //   we just want to scroll thru events as fast as possible
@@ -401,11 +401,11 @@ class ExplosionProcess
         void init_event_queue();
         inline float generate_fling_angle( const tripoint from, const tripoint to );
         inline bool is_occluded( const tripoint from, const tripoint to );
-        inline void add_event( const float delay, const ExplosionEvent &event ) {
+        void add_event( const float delay, const ExplosionEvent &event ) {
             assert( delay >= 0 );
             event_queue.emplace( cur_relative_time + delay + std::numeric_limits<float>::epsilon(), event );
         }
-        inline bool is_animated() {
+        bool is_animated() {
             return !test_mode && get_option<int>( "ANIMATION_DELAY" ) > 0;
         }
 
@@ -419,7 +419,7 @@ class ExplosionProcess
                           bool is_mob );
 
         // How long should it take for an entity to travel 1 unit of distance at `velocity`?
-        inline float one_tile_at_vel( float velocity ) {
+        float one_tile_at_vel( float velocity ) {
             assert( velocity > 0 );
             return ExplosionConstants::FLING_SLOWDOWN / velocity;
         };
@@ -681,7 +681,7 @@ void ExplosionProcess::blast_tile( const tripoint position, const int rl_distanc
         {
             Creature *critter = g->critter_at( position );
 
-            if( critter != nullptr && !mobs_blasted.count( critter ) ) {
+            if( critter != nullptr && !mobs_blasted.contains( critter ) ) {
                 const int blast_damage = blast_power * critter_blast_percentage( critter, blast_radius,
                                          rl_distance );
                 const auto shockwave_dmg = damage_instance::physical( blast_damage, 0, 0, 0.4f );
@@ -731,7 +731,7 @@ void ExplosionProcess::blast_tile( const tripoint position, const int rl_distanc
         {
             Creature *critter = g->critter_at( position );
 
-            if( critter != nullptr && !flung_set.count( critter ) ) {
+            if( critter != nullptr && !flung_set.contains( critter ) ) {
                 const int push_strength = ( blast_radius - rl_distance ) * blast_power;
                 const float move_power = ExplosionConstants::MOB_FLING_FACTOR * push_strength;
 
@@ -1279,7 +1279,7 @@ static std::map<const Creature *, int> legacy_blast( const tripoint &p, const fl
         const tripoint pt = open.top().second;
         open.pop();
 
-        if( closed.count( pt ) != 0 ) {
+        if( closed.contains( pt ) ) {
             continue;
         }
 
@@ -1298,7 +1298,7 @@ static std::map<const Creature *, int> legacy_blast( const tripoint &p, const fl
         // Iterate over all neighbors. Bash all of them, propagate to some
         for( size_t i = 0; i < max_index; i++ ) {
             tripoint dest( pt + tripoint( x_offset[i], y_offset[i], z_offset[i] ) );
-            if( closed.count( dest ) != 0 || !here.inbounds( dest ) ||
+            if( closed.contains( dest ) || !here.inbounds( dest ) ||
                 here.obstructed_by_vehicle_rotation( pt, dest ) ) {
                 continue;
             }
@@ -1325,7 +1325,7 @@ static std::map<const Creature *, int> legacy_blast( const tripoint &p, const fl
                 next_dist += zlev_dist;
             }
 
-            if( dist_map.count( dest ) == 0 || dist_map[dest] > next_dist ) {
+            if( !dist_map.contains( dest ) || dist_map[dest] > next_dist ) {
                 open.emplace( next_dist, dest );
                 dist_map[dest] = next_dist;
             }

--- a/src/explosion_queue.h
+++ b/src/explosion_queue.h
@@ -55,13 +55,13 @@ class explosion_queue
         std::deque<queued_explosion> elems;
 
     public:
-        inline void add( queued_explosion &&exp ) {
+        void add( queued_explosion &&exp ) {
             elems.push_back( std::move( exp ) );
         }
 
         void execute();
 
-        inline void clear() {
+        void clear() {
             elems.clear();
         }
 };

--- a/src/fault.cpp
+++ b/src/fault.cpp
@@ -15,7 +15,7 @@ static std::map<fault_id, fault> faults_all;
 template<>
 bool string_id<fault>::is_valid() const
 {
-    return faults_all.count( *this );
+    return faults_all.contains( *this );
 }
 
 /** @relates string_id */

--- a/src/fault.h
+++ b/src/fault.h
@@ -59,7 +59,7 @@ class fault
         }
 
         bool has_flag( const std::string &flag ) const {
-            return flags.count( flag );
+            return flags.contains( flag );
         }
 
         /** Load fault from JSON definition */

--- a/src/flat_set.h
+++ b/src/flat_set.h
@@ -189,7 +189,7 @@ class flat_set : private Compare, Data
             return 0;
         }
 
-        friend void swap( flat_set &l, flat_set &r ) {
+        friend void swap( flat_set &l, flat_set &r )  noexcept {
             using std::swap;
             swap( static_cast<Compare &>( l ), static_cast<Compare &>( r ) );
             swap( static_cast<Data &>( l ), static_cast<Data &>( r ) );

--- a/src/fmtlib_format-inl.h
+++ b/src/fmtlib_format-inl.h
@@ -2961,7 +2961,7 @@ FMT_FUNC void format_system_error( detail::buffer<char> &out, int error_code,
         buf.resize( inline_buffer_size );
         for( ;; )
         {
-            char *system_message = &buf[0];
+            char *system_message = buf.data();
             int result =
             detail::safe_strerror( error_code, system_message, buf.size() );
             if( result == 0 ) {

--- a/src/fmtlib_format.h
+++ b/src/fmtlib_format.h
@@ -380,7 +380,7 @@ template <typename T> using sentinel_t = decltype( std::end( std::declval<T &>()
 // A workaround for std::string not having mutable data() until C++17.
 template <typename Char> inline Char *get_data( std::basic_string<Char> &s )
 {
-    return &s[0];
+    return s.data();
 }
 template <typename Container>
 inline typename Container::value_type *get_data( Container &c )
@@ -1297,16 +1297,16 @@ class utf8_to_utf16
     public:
         FMT_API explicit utf8_to_utf16( string_view s );
         operator wstring_view() const {
-            return {&buffer_[0], size()};
+            return {buffer_.data(), size()};
         }
         size_t size() const {
             return buffer_.size() - 1;
         }
         const wchar_t *c_str() const {
-            return &buffer_[0];
+            return buffer_.data();
         }
         std::wstring str() const {
-            return {&buffer_[0], size()};
+            return {buffer_.data(), size()};
         }
 };
 
@@ -2582,7 +2582,7 @@ class arg_formatter_base
 
         iterator operator()( Char value ) {
             handle_char_specs( specs_,
-                               char_spec_handler( *this, static_cast<Char>( value ) ) );
+                               char_spec_handler( *this, value ) );
             return out_;
         }
 

--- a/src/fstream_utils.h
+++ b/src/fstream_utils.h
@@ -38,7 +38,7 @@ struct cata_ofstream {
         cata_ofstream &operator=( const cata_ofstream & ) = delete;
         cata_ofstream &operator=( cata_ofstream && ) noexcept;
 
-        inline cata_ofstream &mode( cata_ios_mode m ) {
+        cata_ofstream &mode( cata_ios_mode m ) {
             _mode = m;
             return *this;
         }
@@ -76,7 +76,7 @@ struct cata_ifstream {
         cata_ifstream &operator=( const cata_ifstream & ) = delete;
         cata_ifstream &operator=( cata_ifstream && ) noexcept;
 
-        inline cata_ifstream &mode( cata_ios_mode m ) {
+        cata_ifstream &mode( cata_ios_mode m ) {
             _mode = m;
             return *this;
         }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2848,7 +2848,7 @@ void game::display_faction_epilogues()
 }
 
 struct npc_dist_to_player {
-    const tripoint_abs_omt ppos{};
+    const tripoint_abs_omt ppos;
     npc_dist_to_player() : ppos( get_player_character().global_omt_location() ) { }
     // Operator overload required to leverage sort API.
     bool operator()( const shared_ptr_fast<npc> &a,
@@ -4961,7 +4961,7 @@ void game::save_cyborg( item *cyborg, const tripoint &couch_pos, player &install
 
     if( !g->u.query_yn(
             _( "WARNING: %i percent chance of SEVERE damage to all body parts!  Continue anyway?" ),
-            100 - static_cast<int>( chance_of_success ) ) ) {
+            100 - chance_of_success ) ) {
         return;
     }
 
@@ -10151,7 +10151,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
         tmp_map_ptr = std::make_unique<map>();
     }
 
-    map &maybetmp = m.has_zlevels() ? m : *( tmp_map_ptr.get() );
+    map &maybetmp = m.has_zlevels() ? m : *( tmp_map_ptr );
     if( m.has_zlevels() ) {
         // We no longer need to shift the map here! What joy
     } else {

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1740,7 +1740,7 @@ void game_menus::inv::swap_letters( player &p )
     while( true ) {
         const std::string invlets = colorize_symbols( inv_chars.get_allowed_chars(),
         [ &p ]( const std::string::value_type & elem ) {
-            if( p.inv_assigned_invlet().count( elem ) ) {
+            if( p.inv_assigned_invlet().contains( elem ) ) {
                 return c_yellow;
             } else if( p.invlet_to_item( elem ) != nullptr ) {
                 return c_white;

--- a/src/game_object.h
+++ b/src/game_object.h
@@ -28,7 +28,7 @@ class game_object
         friend location_vector<T>;
         friend location_visitable<location_inventory>;
         template<typename U>
-        friend void ::std::swap( location_vector<U> &, location_vector<U> & );
+        friend void ::std::swap( location_vector<U> &, location_vector<U> & ) noexcept ;
     protected:
         location<T> *saved_loc = nullptr;
         location<T> *loc = nullptr;

--- a/src/gamemode_defense.cpp
+++ b/src/gamemode_defense.cpp
@@ -206,7 +206,7 @@ void defense_game::init_mtypes()
     for( auto &type : MonsterGenerator::generator().get_all_mtypes() ) {
         mtype *const t = const_cast<mtype *>( &type );
         t->difficulty *= 1.5;
-        t->difficulty += static_cast<int>( t->difficulty / 5 );
+        t->difficulty += ( t->difficulty / 5 );
         t->set_flag( MF_BASHES );
         t->set_flag( MF_SMELLS );
         t->set_flag( MF_HEARS );
@@ -1045,7 +1045,7 @@ void defense_game::caravan()
                                              "Buy %d items, leaving you with %s?",
                                              items[0].size() ),
                                    items[0].size(),
-                                   format_money( static_cast<int>( g->u.cash ) - static_cast<int>( total_price ) ) ) ) ) {
+                                   format_money( g->u.cash - total_price ) ) ) ) {
                 done = true;
             }
         } // "switch" on (action)
@@ -1224,7 +1224,7 @@ void draw_caravan_categories( const catacurses::window &w, int category_selected
     mvwprintz( w, point( 1, 1 ), c_white, _( "Your Cash: %s" ), format_money( cash ) );
     wprintz( w, c_light_gray, " -> " );
     wprintz( w, ( total_price > cash ? c_red : c_green ), "%s",
-             format_money( static_cast<int>( cash ) - static_cast<int>( total_price ) ) );
+             format_money( cash - total_price ) );
 
     for( int i = 0; i < NUM_CARAVAN_CATEGORIES; i++ ) {
         mvwprintz( w, point( 1, i + 3 ), ( i == category_selected ? h_white : c_white ),

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -87,7 +87,7 @@ auto get_vehicle_str_requirement( vehicle *veh ) -> int
     // off-road coefficient (always 1.0 on a road, as low as 0.1 off road.)
     const float traction = veh->k_traction(
                                get_map().vehicle_wheel_traction( *veh ) );
-    return int { 1 + all_movecost / get_effective_wheels( veh ) } / traction;
+    return ( 1 + all_movecost / get_effective_wheels( veh ) ) / traction;
 }
 
 } // namespace

--- a/src/gun_mode.h
+++ b/src/gun_mode.h
@@ -31,7 +31,7 @@ class gun_mode
 
         /** if true perform a melee attach as opposed to shooting */
         bool melee() const {
-            return flags.count( "MELEE" );
+            return flags.contains( "MELEE" );
         }
 
         operator bool() const {

--- a/src/harvest.cpp
+++ b/src/harvest.cpp
@@ -35,7 +35,7 @@ const harvest_list &string_id<harvest_list>::obj() const
 template<>
 bool string_id<harvest_list>::is_valid() const
 {
-    return harvest_all.count( *this ) > 0;
+    return harvest_all.contains( *this );
 }
 
 harvest_list::harvest_list() : id_( harvest_id::NULL_ID() ) {}

--- a/src/help.cpp
+++ b/src/help.cpp
@@ -151,8 +151,8 @@ void help::display_help()
                                             point( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0,
                                                     TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 ) );
         w_help = catacurses::newwin( FULL_SCREEN_HEIGHT - 2, FULL_SCREEN_WIDTH - 2,
-                                     point( 1 + static_cast<int>( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0 ),
-                                            1 + static_cast<int>( TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 ) ) );
+                                     point( 1 + ( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0 ),
+                                            1 + ( TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 ) ) );
         ui.position_from_window( w_help_border );
     };
     init_windows( ui );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -45,7 +45,6 @@
 #include "enums.h"
 #include "event.h"
 #include "event_bus.h"
-#include "flag.h"
 #include "field_type.h"
 #include "flat_set.h"
 #include "fungal_effects.h"

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -951,7 +951,7 @@ void init::load_world_modfiles( loading_ui &ui, const std::string &artifacts_fil
     // remove any duplicates whilst preserving order (fixes #19385)
     std::set<mod_id> found;
     mods.erase( std::remove_if( mods.begin(), mods.end(), [&found]( const mod_id & e ) {
-        if( found.count( e ) ) {
+        if( found.contains( e ) ) {
             return true;
         } else {
             found.insert( e );

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -145,9 +145,9 @@ void input_manager::init()
         // (if an action with that ident already exists there - think movement keys)
         // or otherwise to the DEFAULTMODE context.
         std::string context = "DEFAULTMODE";
-        if( action_contexts[default_context_id].count( action_id ) > 0 ) {
+        if( action_contexts[default_context_id].contains( action_id ) ) {
             context = default_context_id;
-        } else if( touched.count( a->second ) == 0 ) {
+        } else if( !touched.contains( a->second ) ) {
             // Note: movement keys are somehow special as the default in keymap
             // does not contain the arrow keys, so we don't clear existing keybindings
             // for them.
@@ -265,7 +265,7 @@ void input_manager::load( const std::string &file_name, bool is_user_preferences
         if( !is_user_preferences ||
             !events.empty() ||
             context == default_context_id ||
-            actions.count( action_id ) > 0 ) {
+            actions.contains( action_id ) ) {
             // In case this is the second file containing user preferences,
             // this replaces the default bindings with the user's preferences.
             action_attributes &attributes = actions[action_id];

--- a/src/input.h
+++ b/src/input.h
@@ -40,32 +40,32 @@ static constexpr int KEY_BACKSPACE  =
     0x107;    /* Backspace */                  //<---------not used
 static constexpr int KEY_DC         = 0x151;    /* Delete Character */
 static constexpr int KEY_F0         = 0x108;
-inline constexpr int KEY_F( const int n )
+constexpr int KEY_F( const int n )
 {
     return KEY_F0 + n;    /* F1, F2, etc*/
 }
 static constexpr int F_KEY_NUM_BEG  = 0;
 static constexpr int F_KEY_NUM_END  = 63;
-inline constexpr int F_KEY_NUM( const int key )
+constexpr int F_KEY_NUM( const int key )
 {
     return key - KEY_F0;
 }
-inline constexpr bool IS_F_KEY( const int key )
+constexpr bool IS_F_KEY( const int key )
 {
     return key >= KEY_F( F_KEY_NUM_BEG ) && key <= KEY_F( F_KEY_NUM_END );
 }
 /** @return true if the given character is in the range of basic ASCII control characters */
-inline constexpr bool IS_CTRL_CHAR( const int key )
+constexpr bool IS_CTRL_CHAR( const int key )
 {
     // https://en.wikipedia.org/wiki/C0_and_C1_control_codes#Basic_ASCII_control_codes
     return key >= 0 && key < ' ';
 }
 /** @return true if the given character is an ASCII control char but should not be rendered with "CTRL+" */
-inline constexpr bool IS_NAMED_CTRL_CHAR( const int key )
+constexpr bool IS_NAMED_CTRL_CHAR( const int key )
 {
     return key == '\t' || key == '\n' || key == KEY_ESCAPE || key == KEY_BACKSPACE;
 }
-inline constexpr int KEY_NUM( const int n )
+constexpr int KEY_NUM( const int n )
 {
     return 0x30 + n;     /* Numbers 0, 1, ..., 9 */
 }

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -266,7 +266,7 @@ char inventory::find_usable_cached_invlet( const itype_id &item_type )
     // Some of our preferred letters might already be used.
     for( auto invlet : invlet_cache.invlets_for( item_type ) ) {
         // Don't overwrite user assignments.
-        if( assigned_invlet.count( invlet ) ) {
+        if( assigned_invlet.contains( invlet ) ) {
             continue;
         }
         // Check if anything is using this invlet.
@@ -1196,7 +1196,7 @@ void inventory::assign_empty_invlet( item &it, const Character &p, const bool fo
         std::vector<char> binds = selector.all_bound_keys();
 
         for( const auto &inv_char : inv_chars ) {
-            if( assigned_invlet.count( inv_char ) ) {
+            if( assigned_invlet.contains( inv_char ) ) {
                 // don't overwrite assigned keys
                 continue;
             }

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -176,7 +176,7 @@ nc_color inventory_entry::get_invlet_color() const
 {
     if( !is_selectable() ) {
         return c_dark_gray;
-    } else if( g->u.inv_assigned_invlet().count( get_invlet() ) ) {
+    } else if( g->u.inv_assigned_invlet().contains( get_invlet() ) ) {
         return c_yellow;
     } else {
         return c_white;
@@ -238,8 +238,8 @@ bool inventory_selector_preset::sort_compare( const inventory_entry &lhs,
         const inventory_entry &rhs ) const
 {
     // Place items with an assigned inventory letter first, since the player cared enough to assign them
-    const bool left_fav  = g->u.inv_assigned_invlet().count( lhs.any_item()->invlet );
-    const bool right_fav = g->u.inv_assigned_invlet().count( rhs.any_item()->invlet );
+    const bool left_fav  = g->u.inv_assigned_invlet().contains( lhs.any_item()->invlet );
+    const bool right_fav = g->u.inv_assigned_invlet().contains( rhs.any_item()->invlet );
     if( left_fav == right_fav ) {
         return lhs.cached_name.compare( rhs.cached_name ) < 0; // Simple alphabetic order
     } else if( left_fav ) {
@@ -779,7 +779,7 @@ void inventory_column::prepare_paging( const std::string &filter )
             to->update_cache();
             std::advance( to, 1 );
         }
-        if( ordered_categories.count( from->get_category_ptr()->get_id().c_str() ) == 0 ) {
+        if( !ordered_categories.contains( from->get_category_ptr()->get_id().c_str() ) ) {
             std::sort( from, to, [ this ]( const inventory_entry & lhs, const inventory_entry & rhs ) {
                 if( lhs.is_selectable() != rhs.is_selectable() ) {
                     return lhs.is_selectable(); // Disabled items always go last

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -666,7 +666,7 @@ void item::ammo_set( const itype_id &ammo, int qty )
 
     // check ammo is valid for the item
     const itype *atype = &*ammo;
-    if( !atype->ammo || !ammo_types().count( atype->ammo->type ) ) {
+    if( !atype->ammo || !ammo_types().contains( atype->ammo->type ) ) {
         debugmsg( "Tried to set invalid ammo %s[%d] for %s", atype->get_id(), qty, typeId() );
         return;
     }
@@ -1238,7 +1238,7 @@ std::string item::get_var( const std::string &name ) const
 
 bool item::has_var( const std::string &name ) const
 {
-    return item_vars.count( name ) > 0;
+    return item_vars.contains( name );
 }
 
 void item::erase_var( const std::string &name )
@@ -2195,21 +2195,21 @@ void item::ammo_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
                              _( "This ammo will produce effects with the following shape:\n<bold>%s</bold>" ),
                              ammo.shape->get_description() ) );
     }
-    if( ammo.ammo_effects.count( ammo_effect_RECYCLED ) &&
+    if( ammo.ammo_effects.contains( ammo_effect_RECYCLED ) &&
         parts->test( iteminfo_parts::AMMO_FX_RECYCLED ) ) {
         fx.emplace_back( _( "This ammo has been <bad>hand-loaded</bad>." ) );
     }
-    if( ammo.ammo_effects.count( ammo_effect_BLACKPOWDER ) &&
+    if( ammo.ammo_effects.contains( ammo_effect_BLACKPOWDER ) &&
         parts->test( iteminfo_parts::AMMO_FX_BLACKPOWDER ) ) {
         fx.emplace_back(
             _( "This ammo has been loaded with <bad>blackpowder</bad>, and will quickly "
                "clog up most guns, and cause rust if the gun is not cleaned." ) );
     }
-    if( ammo.ammo_effects.count( ammo_effect_NEVER_MISFIRES ) &&
+    if( ammo.ammo_effects.contains( ammo_effect_NEVER_MISFIRES ) &&
         parts->test( iteminfo_parts::AMMO_FX_CANTMISSFIRE ) ) {
         fx.emplace_back( _( "This ammo <good>never misfires</good>." ) );
     }
-    if( ammo.ammo_effects.count( ammo_effect_INCENDIARY ) &&
+    if( ammo.ammo_effects.contains( ammo_effect_INCENDIARY ) &&
         parts->test( iteminfo_parts::AMMO_FX_INCENDIARY ) ) {
         fx.emplace_back( _( "This ammo <neutral>starts fires</neutral>." ) );
     }
@@ -3048,7 +3048,7 @@ void item::book_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
                               "read</info>.",
                               "A chapter of this book takes <num> <info>minutes to "
                               "read</info>.", book.time );
-        if( type->use_methods.count( "MA_MANUAL" ) ) {
+        if( type->use_methods.contains( "MA_MANUAL" ) ) {
             fmt = vgettext(
                       "<info>A training session</info> with this book takes "
                       "<num> <info>minute</info>.",
@@ -4395,11 +4395,11 @@ nc_color item::color_in_inventory( const player &p ) const
         // ltred if you have the gun but no mags
         // Gun with integrated mag counts as both
         bool has_gun = p.has_item_with( [this]( const item & i ) {
-            return i.is_gun() && i.ammo_types().count( ammo_type() );
+            return i.is_gun() && i.ammo_types().contains( ammo_type() );
         } );
         bool has_mag = p.has_item_with( [this]( const item & i ) {
-            return ( i.is_gun() && i.magazine_integral() && i.ammo_types().count( ammo_type() ) ) ||
-                   ( i.is_magazine() && i.ammo_types().count( ammo_type() ) );
+            return ( i.is_gun() && i.magazine_integral() && i.ammo_types().contains( ammo_type() ) ) ||
+                   ( i.is_magazine() && i.ammo_types().contains( ammo_type() ) );
         } );
         if( has_gun && has_mag ) {
             ret = c_green;
@@ -4410,7 +4410,7 @@ nc_color item::color_in_inventory( const player &p ) const
         // Magazines are green if you have guns and ammo for them
         // ltred if you have one but not the other
         bool has_gun = p.has_item_with( [this]( const item & it ) {
-            return it.is_gun() && it.magazine_compatible().count( typeId() ) > 0;
+            return it.is_gun() && it.magazine_compatible().contains( typeId() );
         } );
         bool has_ammo = !character_funcs::find_ammo_items_or_mags( p, *this, false, -1 ).empty();
         if( has_gun && has_ammo ) {
@@ -4799,7 +4799,7 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
         }
         if( is_gun() ) {
             for( const item *mod : gunmods() ) {
-                if( !type->gun->built_in_mods.count( mod->typeId() ) ) {
+                if( !type->gun->built_in_mods.contains( mod->typeId() ) ) {
                     modamt++;
                 }
             }
@@ -5571,7 +5571,7 @@ int item::reach_range( const Character &guy ) const
     // for guns consider any attached gunmods
     if( is_gun() && !is_gunmod() ) {
         for( const std::pair<const gun_mode_id, gun_mode> &m : gun_all_modes() ) {
-            if( guy.is_npc() && m.second.flags.count( "NPC_AVOID" ) ) {
+            if( guy.is_npc() && m.second.flags.contains( "NPC_AVOID" ) ) {
                 continue;
             }
             if( m.second.melee() ) {
@@ -5596,7 +5596,7 @@ void item::unset_flags()
 
 bool item::has_fault( const fault_id &fault ) const
 {
-    return faults.count( fault );
+    return faults.contains( fault );
 }
 
 bool item::has_own_flag( const flag_id &f ) const
@@ -5697,7 +5697,7 @@ int item::get_quality( const quality_id &id ) const
             // Do not block if checking itself - we are checking only item contents not item itself.
             return false;
         } else if( itm.is_ammo() ) {
-            return ammo_types().count( itm.ammo_type() ) == 0;
+            return !ammo_types().contains( itm.ammo_type() );
         } else if( itm.is_magazine() ) {
             // we want to return "fine for boiling" if any of the ammo types match and "blocks boiling" if none match.
             for( const ammotype &at : ammo_types() ) {
@@ -5741,7 +5741,7 @@ std::map<quality_id, int> item::get_qualities() const
 
 bool item::has_technique( const matec_id &tech ) const
 {
-    return type->techniques.count( tech ) > 0 || techniques.count( tech ) > 0;
+    return type->techniques.contains( tech ) || techniques.contains( tech );
 }
 
 void item::add_technique( const matec_id &tech )
@@ -6366,7 +6366,7 @@ bool item::ready_to_revive( const tripoint &pos ) const
 
 bool item::is_money() const
 {
-    return ammo_types().count( ammotype( "money" ) );
+    return ammo_types().contains( ammotype( "money" ) );
 }
 
 bool item::count_by_charges() const
@@ -6483,7 +6483,7 @@ int item::acid_resist( bool to_self, int base_env_resist ) const
     float mod = get_clothing_mod_val( clothing_mod_type_acid );
 
     std::optional<resistances> overriden_resistance = damage_resistance_override();
-    if( overriden_resistance && overriden_resistance->flat.count( DT_ACID ) ) {
+    if( overriden_resistance && overriden_resistance->flat.contains( DT_ACID ) ) {
         return std::lround( overriden_resistance->flat[DT_ACID] + mod );
     }
 
@@ -6522,7 +6522,7 @@ int item::fire_resist( bool to_self, int base_env_resist ) const
     float mod = get_clothing_mod_val( clothing_mod_type_fire );
 
     std::optional<resistances> overriden_resistance = damage_resistance_override();
-    if( overriden_resistance && overriden_resistance->flat.count( DT_HEAT ) ) {
+    if( overriden_resistance && overriden_resistance->flat.contains( DT_HEAT ) ) {
         return std::lround( overriden_resistance->flat[DT_HEAT] + mod );
     }
 
@@ -6900,7 +6900,7 @@ int item::get_reload_time() const
 
     int reload_time = is_gun() ? type->gun->reload_time : type->magazine->reload_time;
     for( const item *mod : gunmods() ) {
-        reload_time = static_cast<int>( reload_time * ( 100 + mod->type->gunmod->reload_modifier ) / 100 );
+        reload_time = ( reload_time * ( 100 + mod->type->gunmod->reload_modifier ) / 100 );
     }
 
     return reload_time;
@@ -7262,8 +7262,8 @@ bool item::is_reloadable_helper( const itype_id &ammo, bool now ) const
                 }
             } else {
                 const itype *at = &*ammo;
-                if( ( !at->ammo || !ammo_types().count( at->ammo->type ) ) &&
-                    !magazine_compatible().count( ammo ) ) {
+                if( ( !at->ammo || !ammo_types().contains( at->ammo->type ) ) &&
+                    !magazine_compatible().contains( ammo ) ) {
                     return false;
                 }
             }
@@ -7974,7 +7974,7 @@ itype_id item::common_ammo_default( bool conversion ) const
     if( !ammo_types( conversion ).empty() ) {
         for( const ammotype &at : ammo_types( conversion ) ) {
             const item *mag = magazine_current();
-            if( mag && mag->type->magazine->type.count( at ) ) {
+            if( mag && mag->type->magazine->type.contains( at ) ) {
                 itype_id res = at->default_ammotype();
                 if( !res.is_empty() ) {
                     return res;
@@ -8065,7 +8065,7 @@ std::set<itype_id> item::magazine_compatible( bool conversion ) const
     for( const item *m : mods ) {
         if( !m->type->mod->magazine_adaptor.empty() ) {
             for( const ammotype &atype : ammo_types( conversion ) ) {
-                if( m->type->mod->magazine_adaptor.count( atype ) ) {
+                if( m->type->mod->magazine_adaptor.contains( atype ) ) {
                     std::set<itype_id> magazines_for_atype = m->type->mod->magazine_adaptor.find( atype )->second;
                     mags.insert( magazines_for_atype.begin(), magazines_for_atype.end() );
                 }
@@ -8075,7 +8075,7 @@ std::set<itype_id> item::magazine_compatible( bool conversion ) const
     }
 
     for( const ammotype &atype : ammo_types( conversion ) ) {
-        if( type->magazines.count( atype ) ) {
+        if( type->magazines.contains( atype ) ) {
             std::set<itype_id> magazines_for_atype = type->magazines.find( atype )->second;
             mags.insert( magazines_for_atype.begin(), magazines_for_atype.end() );
         }
@@ -8137,7 +8137,7 @@ ret_val<bool> item::is_gunmod_compatible( const item &mod ) const
     } else if( gunmod_find( mod.typeId() ) ) {
         return ret_val<bool>::make_failure( _( "already has a %s" ), mod.tname( 1 ) );
 
-    } else if( !get_mod_locations().count( g_mod.location ) ) {
+    } else if( !get_mod_locations().contains( g_mod.location ) ) {
         return ret_val<bool>::make_failure( _( "doesn't have a slot for this mod" ) );
 
     } else if( get_free_mod_locations( g_mod.location ) <= 0 ) {
@@ -8147,7 +8147,7 @@ ret_val<bool> item::is_gunmod_compatible( const item &mod ) const
     } else if( !g_mod.usable.empty() || !g_mod.usable_category.empty() || !g_mod.exclusion.empty() ||
                !g_mod.exclusion_category.empty() ) {
         // First check that it's not explicitly excluded by id.
-        bool excluded = g_mod.exclusion.count( this->typeId() );
+        bool excluded = g_mod.exclusion.contains( this->typeId() );
         // Then check if it's excluded by category.
         for( const std::unordered_set<weapon_category_id> &mod_cat : g_mod.exclusion_category ) {
             if( excluded ) {
@@ -8162,7 +8162,7 @@ ret_val<bool> item::is_gunmod_compatible( const item &mod ) const
 
         // Check that it's included by id, if so, override banned so it's allowed.
         // A check is already in item_factory so that explicit inclusion and exclusion of the same id throws errors.
-        bool usable = g_mod.usable.count( this->typeId() );
+        bool usable = g_mod.usable.contains( this->typeId() );
         if( usable ) {
             excluded = false;
         }
@@ -8188,7 +8188,7 @@ ret_val<bool> item::is_gunmod_compatible( const item &mod ) const
     } else if( !mod.type->mod->acceptable_ammo.empty() ) {
         bool compat_ammo = false;
         for( const ammotype &at : mod.type->mod->acceptable_ammo ) {
-            if( ammo_types( false ).count( at ) ) {
+            if( ammo_types( false ).contains( at ) ) {
                 compat_ammo = true;
             }
         }
@@ -8211,7 +8211,7 @@ ret_val<bool> item::is_gunmod_compatible( const item &mod ) const
     }
 
     for( const gunmod_location &slot : mod.type->gunmod->blacklist_mod ) {
-        if( get_mod_locations().count( slot ) ) {
+        if( get_mod_locations().contains( slot ) ) {
             return ret_val<bool>::make_failure( _( "cannot be installed on a weapon with \"%s\"" ),
                                                 slot.name() );
         }
@@ -8294,7 +8294,7 @@ gun_mode_id item::gun_get_mode_id() const
 
 bool item::gun_set_mode( const gun_mode_id &mode )
 {
-    if( !is_gun() || is_gunmod() || !gun_all_modes().count( mode ) ) {
+    if( !is_gun() || is_gunmod() || !gun_all_modes().contains( mode ) ) {
         return false;
     }
     set_var( GUN_MODE_VAR_NAME, mode.str() );
@@ -8398,7 +8398,7 @@ int item::units_remaining( const Character &ch, int limit ) const
         res += ch.charges_of( itype_UPS, limit - res );
     }
 
-    return std::min( static_cast<int>( res ), limit );
+    return std::min( res, limit );
 }
 
 bool item::units_sufficient( const Character &ch, int qty ) const
@@ -8921,7 +8921,7 @@ bool item::allow_crafting_component() const
     }
 
     // vehicle batteries are implemented as magazines of charge
-    if( is_magazine() && ammo_types().count( ammo_battery ) ) {
+    if( is_magazine() && ammo_types().contains( ammo_battery ) ) {
         return true;
     }
 
@@ -10084,7 +10084,7 @@ detached_ptr<item> item::process_internal( detached_ptr<item> &&self, player *ca
         }
     }
 
-    if( self->faults.count( fault_gun_blackpowder ) ) {
+    if( self->faults.contains( fault_gun_blackpowder ) ) {
         return process_blackpowder_fouling( std::move( self ), carrier );
     }
 

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -102,7 +102,7 @@ static void hflesh_to_flesh( itype &item_template );
 
 bool item_is_blacklisted( const itype_id &id )
 {
-    return item_blacklist.count( id );
+    return item_blacklist.contains( id );
 }
 
 static void assign( const JsonObject &jo, const std::string &name,
@@ -198,7 +198,7 @@ void Item_factory::finalize_pre( itype &obj )
 
     // We want to recalculate DEFAULT attack, because it defaults to 0
     // But if it doesn't exist, we want to keep it that way
-    if( obj.attacks.empty() || obj.attacks.count( "DEFAULT" ) ) {
+    if( obj.attacks.empty() || obj.attacks.contains( "DEFAULT" ) ) {
         attack_statblock att;
         att.to_hit = obj.m_to_hit;
         for( size_t i = 0; i < NUM_DT; i++ ) {
@@ -298,15 +298,15 @@ void Item_factory::finalize_pre( itype &obj )
         if( std::find( mats.begin(), mats.end(), material_id( "hydrocarbons" ) ) == mats.end() &&
             std::find( mats.begin(), mats.end(), material_id( "oil" ) ) == mats.end() ) {
             const auto &ammo_effects = obj.ammo->ammo_effects;
-            obj.ammo->cookoff = ammo_effects.count( ammo_effect_INCENDIARY ) > 0 ||
-                                ammo_effects.count( ammo_effect_COOKOFF ) > 0;
+            obj.ammo->cookoff = ammo_effects.contains( ammo_effect_INCENDIARY ) ||
+                                ammo_effects.contains( ammo_effect_COOKOFF );
             static const std::set<ammo_effect_str_id> special_cookoff_tags = {{
                     ammo_effect_EXPLOSIVE, ammo_effect_EXPLOSIVE_BIG, ammo_effect_EXPLOSIVE_HUGE, ammo_effect_EXPLOSIVE_SMALL, ammo_effect_FLASHBANG, ammo_effect_FRAG, ammo_effect_NAPALM, ammo_effect_NAPALM_BIG, ammo_effect_SMOKE, ammo_effect_SMOKE_BIG, ammo_effect_TOXICGAS,
                 }
             };
             obj.ammo->special_cookoff = std::any_of( ammo_effects.begin(), ammo_effects.end(),
             []( const ammo_effect_str_id & ae_id ) {
-                return special_cookoff_tags.count( ae_id ) > 0;
+                return special_cookoff_tags.contains( ae_id );
             } );
         } else {
             obj.ammo->cookoff = false;
@@ -482,7 +482,7 @@ void Item_factory::finalize_pre( itype &obj )
         if( obj.gun->handling < 0 ) {
             bool burst_only = std::all_of( obj.gun->modes.begin(), obj.gun->modes.end(),
             []( const std::pair<gun_mode_id, gun_modifier_data> &pr ) {
-                return pr.second.qty() > 1 || pr.second.flags().count( "MELEE" ) > 0;
+                return pr.second.qty() > 1 || pr.second.flags().contains( "MELEE" );
             } );
             // TODO: specify in JSON via classes
             if( obj.gun->skill_used == skill_id( "shotgun" ) ) {
@@ -522,7 +522,7 @@ void Item_factory::finalize_pre( itype &obj )
 
             // For comestibles composed of multiple edible materials we calculate the average.
             for( const auto &v : vitamin::all() ) {
-                if( !vitamins.count( v.first ) ) {
+                if( !vitamins.contains( v.first ) ) {
                     for( const auto &m : mat ) {
                         double amount = m->vitamin( v.first ) * healthy / mat.size();
                         vitamins[v.first] += std::ceil( amount );
@@ -541,7 +541,7 @@ void Item_factory::finalize_pre( itype &obj )
     // Legacy food heating stuff
     {
         // Needs to be split into 2 functions + flag
-        if( obj.use_methods.count( "HOTPLATE" ) != 0 ) {
+        if( obj.use_methods.contains( "HOTPLATE" ) ) {
             obj.use_methods.erase( "HOTPLATE" );
             obj.use_methods["TOGGLE_HEATS_FOOD"] =
                 use_function( "TOGGLE_HEATS_FOOD", &iuse::toggle_heats_food );
@@ -551,12 +551,12 @@ void Item_factory::finalize_pre( itype &obj )
             obj.item_tags.insert( flag_HEATS_FOOD_USING_CHARGES );
         }
 
-        if( obj.use_methods.count( "HEAT_FOOD" ) != 0 ) {
+        if( obj.use_methods.contains( "HEAT_FOOD" ) ) {
             obj.use_methods.erase( "HEAT_FOOD" );
             obj.item_tags.insert( flag_HEATS_FOOD_USING_FIRE );
         }
 
-        if( obj.use_methods.count( "HEATPACK" ) != 0 ) {
+        if( obj.use_methods.contains( "HEATPACK" ) ) {
             obj.use_methods.erase( "HEATPACK" );
             obj.use_methods["TOGGLE_HEATS_FOOD"] =
                 use_function( "TOGGLE_HEATS_FOOD", &iuse::toggle_heats_food );
@@ -625,7 +625,7 @@ void Item_factory::register_cached_uses( const itype &obj )
 {
     for( auto &e : obj.use_methods ) {
         // can this item function as a repair tool?
-        if( repair_actions.count( e.first ) ) {
+        if( repair_actions.contains( e.first ) ) {
             repair_tools.insert( obj.id );
         }
 
@@ -666,7 +666,7 @@ void Item_factory::finalize_post( itype &obj )
             // tool has a possible repair action, check if the materials are compatible
             const auto &opts = dynamic_cast<const repair_item_actor *>( func->get_actor_ptr() )->materials;
             if( std::any_of( obj.materials.begin(), obj.materials.end(), [&opts]( const material_id & m ) {
-            return opts.count( m ) > 0;
+            return opts.contains( m );
             } ) ) {
                 obj.repair.insert( tool );
             }
@@ -889,7 +889,7 @@ void Item_factory::add_actor( std::unique_ptr<iuse_actor> ptr )
 
 void Item_factory::add_item_type( const itype &def )
 {
-    if( m_runtimes.count( def.id ) > 0 ) {
+    if( m_runtimes.contains( def.id ) ) {
         // Do NOT allow overwriting it, it's undefined behavior
         debugmsg( "Tried to add runtime type %s, but it exists already", def.id.c_str() );
         return;
@@ -1352,7 +1352,7 @@ void Item_factory::check_definitions() const
                     msg += "RELOAD_AND_SHOOT cannot be used with magazines\n";
                 }
                 for( const ammotype &at : type->gun->ammo ) {
-                    if( !type->gun->clip && !type->magazines.empty() && !type->magazine_default.count( at ) ) {
+                    if( !type->gun->clip && !type->magazines.empty() && !type->magazine_default.contains( at ) ) {
                         msg += string_format( "specified magazine but none provided for ammo type %s\n", at.str() );
                     }
                 }
@@ -1391,7 +1391,7 @@ void Item_factory::check_definitions() const
                 }
 
                 const itype *target = &*t;
-                if( target->gun->valid_mod_locations.count( type->gunmod->location ) == 0 ) {
+                if( !target->gun->valid_mod_locations.contains( type->gunmod->location ) ) {
                     msg += string_format( "gunmod is usable for gun %s which doesn't have a slot of type %s\n",
                                           t.c_str(), type->gunmod->location.str() );
                 }
@@ -1416,7 +1416,7 @@ void Item_factory::check_definitions() const
                 if( !t.is_valid() ) {
                     msg += string_format( "gunmod excludes for invalid item %s\n", t.c_str() );
                 }
-                if( type->gunmod->usable.count( t ) ) {
+                if( type->gunmod->usable.contains( t ) ) {
                     msg += string_format( "gunmod includes and excludes same item %s\n", t.c_str() );
                 }
             }
@@ -1460,7 +1460,7 @@ void Item_factory::check_definitions() const
                 }
                 for( const itype_id &opt : e.second ) {
                     const itype *mag = find_template( opt );
-                    if( !mag->magazine || !mag->magazine->type.count( e.first ) ) {
+                    if( !mag->magazine || !mag->magazine->type.contains( e.first ) ) {
                         msg += string_format( "invalid magazine %s in magazine adapter\n", opt.str() );
                     }
                 }
@@ -1480,7 +1480,7 @@ void Item_factory::check_definitions() const
                 msg += string_format( "invalid count %i\n", type->magazine->count );
             }
             const itype *da = find_template( type->magazine->default_ammo );
-            if( !( da->ammo && type->magazine->type.count( da->ammo->type ) ) ) {
+            if( !( da->ammo && type->magazine->type.contains( da->ammo->type ) ) ) {
                 msg += string_format( "invalid default_ammo %s\n", type->magazine->default_ammo.str() );
             }
             if( type->magazine->reliability < 0 || type->magazine->reliability > 100 ) {
@@ -1509,7 +1509,7 @@ void Item_factory::check_definitions() const
                     msg += string_format(
                                "magazine \"%s\" specified for \"%s\" is not a magazine\n", magazine.str(),
                                ammo_variety.first.str() );
-                } else if( !mag_ptr->magazine->type.count( ammo_variety.first ) ) {
+                } else if( !mag_ptr->magazine->type.contains( ammo_variety.first ) ) {
                     msg += string_format( "magazine \"%s\" does not take compatible ammo\n", magazine );
                 } else if( mag_ptr->has_flag( flag_SPEEDLOADER ) &&
                            mag_ptr->magazine->capacity > type->gun->clip ) {
@@ -1581,11 +1581,11 @@ void Item_factory::check_definitions() const
         debugmsg( "warnings for type %s:\n%s", type->id.c_str(), msg );
     }
     for( const auto &e : migrations ) {
-        if( !m_templates.count( e.second.replace ) ) {
+        if( !m_templates.contains( e.second.replace ) ) {
             debugmsg( "Invalid migration target: %s", e.second.replace.c_str() );
         }
         for( const auto &c : e.second.contents ) {
-            if( !m_templates.count( c ) ) {
+            if( !m_templates.contains( c ) ) {
                 debugmsg( "Invalid migration contents: %s", c.c_str() );
             }
         }
@@ -2556,7 +2556,7 @@ void hflesh_to_flesh( itype &item_template )
 
 void Item_factory::npc_implied_flags( itype &item_template )
 {
-    if( item_template.use_methods.count( "explosion" ) ) {
+    if( item_template.use_methods.contains( "explosion" ) ) {
         item_template.item_tags.insert( flag_DANGEROUS );
     }
 
@@ -2719,7 +2719,7 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
                     ammotype ammo( arr.get_string( 0 ) );
                     JsonArray compat = arr.get_array( 1 );
 
-                    if( def.magazine_default.count( ammo ) == 0 ) {
+                    if( !def.magazine_default.contains( ammo ) ) {
                         def.magazine_default[ ammo ] = itype_id( compat.get_string( 0 ) );
                     }
                 }
@@ -2929,7 +2929,7 @@ void Item_factory::set_qualities_from_json( const JsonObject &jo, const std::str
         for( JsonArray curr : jo.get_array( member ) ) {
             const auto quali = std::pair<quality_id, int>( quality_id( curr.get_string( 0 ) ),
                                curr.get_int( 1 ) );
-            if( def.qualities.count( quali.first ) > 0 ) {
+            if( def.qualities.contains( quali.first ) ) {
                 curr.throw_error( "Duplicated quality", 0 );
             }
             def.qualities.insert( quali );
@@ -2964,7 +2964,7 @@ void Item_factory::set_properties_from_json( const JsonObject &jo, const std::st
     if( jo.has_array( member ) ) {
         for( JsonArray curr : jo.get_array( member ) ) {
             const auto prop = std::pair<std::string, std::string>( curr.get_string( 0 ), curr.get_string( 1 ) );
-            if( def.properties.count( prop.first ) > 0 ) {
+            if( def.properties.contains( prop.first ) ) {
                 curr.throw_error( "Duplicated property", 0 );
             }
             def.properties.insert( prop );
@@ -3496,7 +3496,7 @@ void item_group::debug_spawn()
 
 bool Item_factory::has_template( const itype_id &id ) const
 {
-    return m_templates.count( id ) || m_runtimes.count( id );
+    return m_templates.contains( id ) || m_runtimes.contains( id );
 }
 
 std::vector<const itype *> Item_factory::all() const

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -112,7 +112,7 @@ int itype::charges_default() const
 int itype::charges_to_use() const
 {
     if( tool ) {
-        return static_cast<int>( tool->charges_per_use );
+        return tool->charges_per_use;
     }
     return 1;
 }
@@ -147,7 +147,7 @@ bool itype::has_use() const
 
 bool itype::has_flag( const flag_id &flag ) const
 {
-    return item_tags.count( flag );
+    return item_tags.contains( flag );
 }
 
 const itype::FlagsSetType &itype::get_flags() const

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -854,7 +854,7 @@ int iuse::meth( player *p, item *it, bool, const tripoint & )
         }
         // breathe out some smoke
         for( int i = 0; i < 3; i++ ) {
-            g->m.add_field( {p->posx() + static_cast<int>( rng( -2, 2 ) ), p->posy() + static_cast<int>( rng( -2, 2 ) ), p->posz()},
+            g->m.add_field( {p->posx() + rng( -2, 2 ), p->posy() + rng( -2, 2 ), p->posz()},
                             fd_methsmoke, 2 );
         }
     } else {
@@ -2601,7 +2601,7 @@ static digging_moves_and_byproducts dig_pit_moves_and_byproducts( player *p, ite
         result_terrain = deep ? ter_id( "t_pit" ) : ter_id( "t_pit_shallow" );
     }
 
-    return { moves, static_cast<int>( dig_minutes / 60 ), g->m.ter( pos )->digging_result, result_terrain };
+    return { moves, ( dig_minutes / 60 ), g->m.ter( pos )->digging_result, result_terrain };
 }
 
 int iuse::dig( player *p, item *it, bool t, const tripoint & )
@@ -5985,7 +5985,7 @@ static bool einkpc_download_memory_card( player &p, item &eink, item &mc )
 
                 const std::string mtype = s;
                 getline( f, s, ',' );
-                char *chq = &s[0];
+                char *chq = s.data();
                 const int quality = atoi( chq );
 
                 const size_t eink_strpos = photos.find( "," + mtype + "," );
@@ -5999,7 +5999,7 @@ static bool einkpc_download_memory_card( player &p, item &eink, item &mc )
                     const int old_quality = atoi( chq );
 
                     if( quality > old_quality ) {
-                        chq = &string_format( "%d", quality )[0];
+                        chq = string_format( "%d", quality ).data();
                         photos[strqpos] = *chq;
                     }
                 }
@@ -6129,7 +6129,7 @@ int iuse::einktabletpc( player *p, item *it, bool t, const tripoint &pos )
         if( ei_photo == choice ) {
 
             const int photos = it->get_var( "EIPC_PHOTOS", 0 );
-            const int viewed = std::min( photos, static_cast<int>( rng( 10, 30 ) ) );
+            const int viewed = std::min( photos, rng( 10, 30 ) );
             const int count = photos - viewed;
             if( count == 0 ) {
                 it->erase_var( "EIPC_PHOTOS" );
@@ -6251,7 +6251,7 @@ int iuse::einktabletpc( player *p, item *it, bool t, const tripoint &pos )
                 const monster dummy( monster_photos.back() );
                 menu_str = dummy.name();
                 getline( f, s, ',' );
-                char *chq = &s[0];
+                char *chq = s.data();
                 const int quality = atoi( chq );
                 menu_str += " [" + photo_quality_name( quality ) + "]";
                 pmenu.addentry( k++, true, -1, menu_str.c_str() );
@@ -7343,7 +7343,7 @@ int iuse::camera( player *p, item *it, bool, const tripoint & )
             descriptions.push_back( dummy.type->get_description() );
 
             getline( f_mon, s, ',' );
-            char *chq = &s[0];
+            char *chq = s.data();
             const int quality = atoi( chq );
 
             menu_str += " [" + photo_quality_name( quality ) + "]";
@@ -8201,7 +8201,7 @@ int iuse::multicooker( player *p, item *it, bool t, const tripoint &pos )
             int counter = 0;
 
             for( const auto &r : g->u.get_learned_recipes().in_category( "CC_FOOD" ) ) {
-                if( multicooked_subcats.count( r->subcategory ) > 0 ) {
+                if( multicooked_subcats.contains( r->subcategory ) ) {
                     dishes.push_back( r );
                     const bool can_make = r->deduped_requirements().can_make_with_inventory(
                                               crafting_inv, r->get_component_filter() );
@@ -8958,7 +8958,7 @@ int iuse::capture_monster_act( player *p, item *it, bool, const tripoint &pos )
             return 0;
         }
         const std::string capacity = it->get_property_string( "creature_size_capacity" );
-        if( Creature::size_map.count( capacity ) == 0 ) {
+        if( !Creature::size_map.contains( capacity ) ) {
             debugmsg( "%s has invalid creature_size_capacity %s.",
                       it->tname(), capacity.c_str() );
             return 0;

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -811,7 +811,7 @@ void consume_drug_iuse::info( const item &, std::vector<iteminfo> &dump ) const
         dump.emplace_back( "TOOL", _( "Vitamins (RDA): " ), vits );
     }
 
-    if( tools_needed.count( itype_syringe ) ) {
+    if( tools_needed.contains( itype_syringe ) ) {
         dump.emplace_back( "TOOL", _( "You need a <info>syringe</info> to inject this drug." ) );
     }
 }
@@ -819,7 +819,7 @@ void consume_drug_iuse::info( const item &, std::vector<iteminfo> &dump ) const
 int consume_drug_iuse::use( player &p, item &it, bool, const tripoint & ) const
 {
     auto need_these = tools_needed;
-    if( need_these.count( itype_syringe ) && p.has_bionic( bio_syringe ) ) {
+    if( need_these.contains( itype_syringe ) && p.has_bionic( bio_syringe ) ) {
         need_these.erase( itype_syringe ); // no need for a syringe with bionics like these!
     }
     // Check prerequisites first.
@@ -864,7 +864,7 @@ int consume_drug_iuse::use( player &p, item &it, bool, const tripoint & ) const
     for( const auto &field : fields_produced ) {
         const field_type_id fid = field_type_id( field.first );
         for( int i = 0; i < 3; i++ ) {
-            here.add_field( {p.posx() + static_cast<int>( rng( -2, 2 ) ), p.posy() + static_cast<int>( rng( -2, 2 ) ), p.posz()},
+            here.add_field( {p.posx() + rng( -2, 2 ), p.posy() + rng( -2, 2 ), p.posz()},
                             fid,
                             field.second );
         }
@@ -1211,7 +1211,7 @@ void deploy_furn_actor::info( const item &, std::vector<iteminfo> &dump ) const
     if( the_furn.has_flag( "FIRE_CONTAINER" ) ) {
         can_function_as.emplace_back( _( "a safe place to <info>contain a fire</info>" ) );
     }
-    if( pseudo_list.count( itype_char_smoker ) > 0 ) {
+    if( pseudo_list.contains( itype_char_smoker ) ) {
         can_function_as.emplace_back( _( "a place to <info>smoke or dry food</info> for preservation" ) );
     }
 
@@ -2873,7 +2873,7 @@ bool bandolier_actor::is_valid_ammo_type( const itype &t ) const
     if( !t.ammo ) {
         return false;
     }
-    return ammo.count( t.ammo->type );
+    return ammo.contains( t.ammo->type );
 }
 
 bool bandolier_actor::can_store( const item &bandolier, const item &obj ) const

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -87,7 +87,7 @@ JsonObject::JsonObject( JsonIn &j )
     while( !jsin->end_object() ) {
         std::string n = jsin->get_member_name();
         int p = jsin->tell();
-        if( positions.count( n ) > 0 ) {
+        if( positions.contains( n ) ) {
             j.error( "duplicate entry in json object" );
         }
         positions[n] = p;
@@ -118,7 +118,7 @@ void JsonObject::report_unvisited() const
         reported_unvisited_members = true;
         for( const std::pair<const std::string, int> &p : positions ) {
             const std::string &name = p.first;
-            if( !visited_members.count( name ) && !name.starts_with( "//" ) ) {
+            if( !visited_members.contains( name ) && !name.starts_with( "//" ) ) {
                 try {
                     throw_error( string_format( "Invalid or misplaced field name \"%s\" in JSON data", name ), name );
                 } catch( const JsonError &e ) {
@@ -181,7 +181,7 @@ int JsonObject::verify_position( const std::string &name,
 
 bool JsonObject::has_member( const std::string &name ) const
 {
-    return positions.count( name ) > 0;
+    return positions.contains( name );
 }
 
 std::string JsonObject::line_number() const
@@ -2065,7 +2065,7 @@ std::string JsonIn::substr( size_t pos, size_t len )
     }
     ret.resize( len );
     stream->seekg( pos );
-    stream->read( &ret[0], len );
+    stream->read( ret.data(), len );
     return ret;
 }
 

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -26,7 +26,6 @@
 #include "name.h"
 #include "options.h"
 #include "path_info.h"
-#include "path_info.h"
 #include "string_utils.h"
 #include "translations.h"
 #include "ui.h"

--- a/src/lightmap.h
+++ b/src/lightmap.h
@@ -51,19 +51,19 @@ enum class lit_level : int {
 };
 
 template<typename T>
-constexpr inline bool operator>( const T &lhs, const lit_level &rhs )
+constexpr bool operator>( const T &lhs, const lit_level &rhs )
 {
     return lhs > static_cast<T>( rhs );
 }
 
 template<typename T>
-constexpr inline bool operator<=( const T &lhs, const lit_level &rhs )
+constexpr bool operator<=( const T &lhs, const lit_level &rhs )
 {
     return !operator>( lhs, rhs );
 }
 
 template<typename T>
-constexpr inline bool operator!=( const lit_level &lhs, const T &rhs )
+constexpr bool operator!=( const lit_level &lhs, const T &rhs )
 {
     return static_cast<T>( lhs ) != rhs;
 }

--- a/src/line.h
+++ b/src/line.h
@@ -28,7 +28,7 @@ double iso_tangent( double distance, units::angle vertex );
 //! Specifically, (0, -, +) => (0, 1, 2); a base-3 number.
 //! This only works correctly for inputs between -1,-1,-1 and 1,1,1.
 //! For numbers outside that range, use make_xyz().
-inline constexpr unsigned make_xyz_unit( const tripoint &p ) noexcept
+constexpr unsigned make_xyz_unit( const tripoint &p ) noexcept
 {
     return ( ( p.x > 0 ) ? 2u : ( p.x < 0 ) ? 1u : 0u ) * 1u +
            ( ( p.y > 0 ) ? 2u : ( p.y < 0 ) ? 1u : 0u ) * 3u +
@@ -87,37 +87,37 @@ template <> struct hash<direction> {
 } // namespace std
 
 template< class T >
-constexpr inline direction operator%( const direction &lhs, const T &rhs )
+constexpr direction operator%( const direction &lhs, const T &rhs )
 {
     return static_cast<direction>( static_cast<T>( lhs ) % rhs );
 }
 
 template< class T >
-constexpr inline T operator+( const direction &lhs, const T &rhs )
+constexpr T operator+( const direction &lhs, const T &rhs )
 {
     return static_cast<T>( lhs ) + rhs;
 }
 
 template< class T >
-constexpr inline bool operator==( const direction &lhs, const T &rhs )
+constexpr bool operator==( const direction &lhs, const T &rhs )
 {
     return static_cast<T>( lhs ) == rhs;
 }
 
 template< class T >
-constexpr inline bool operator==( const T &lhs, const direction &rhs )
+constexpr bool operator==( const T &lhs, const direction &rhs )
 {
     return operator==( rhs, lhs );
 }
 
 template< class T >
-constexpr inline bool operator!=( const T &lhs, const direction &rhs )
+constexpr bool operator!=( const T &lhs, const direction &rhs )
 {
     return !operator==( rhs, lhs );
 }
 
 template< class T >
-constexpr inline bool operator!=( const direction &lhs, const T &rhs )
+constexpr bool operator!=( const direction &lhs, const T &rhs )
 {
     return !operator==( lhs, rhs );
 }
@@ -201,22 +201,22 @@ struct FastDistanceApproximation {
     private:
         int value;
     public:
-        inline FastDistanceApproximation( int value ) : value( value ) { }
+        FastDistanceApproximation( int value ) : value( value ) { }
         template<typename T>
-        inline bool operator<=( const T &rhs ) const {
+        bool operator<=( const T &rhs ) const {
             if( trigdist ) {
                 return value <= rhs * rhs;
             }
             return value <= rhs;
         }
         template<typename T>
-        inline bool operator>=( const T &rhs ) const {
+        bool operator>=( const T &rhs ) const {
             if( trigdist ) {
                 return value >= rhs * rhs;
             }
             return value >= rhs;
         }
-        inline operator int() const {
+        operator int() const {
             if( trigdist ) {
                 return std::sqrt( value );
             }

--- a/src/location_ptr.h
+++ b/src/location_ptr.h
@@ -61,4 +61,4 @@ class location_ptr
         location<T> *get_loc_hack() const;
 };
 
-#endif
+#endif // CATA_SRC_LOCATION_PTR_H

--- a/src/location_vector.cpp
+++ b/src/location_vector.cpp
@@ -462,6 +462,7 @@ void location_vector<T>::on_destroy()
 
 template<>
 void std::swap<item>( location_vector<item> &lhs, location_vector<item> &rhs )
+noexcept
 {
     for( item *&it : lhs.contents ) {
         it->remove_location();

--- a/src/location_vector.h
+++ b/src/location_vector.h
@@ -22,8 +22,8 @@ class location_vector;
 namespace std
 {
 template<typename T>
-void swap( location_vector<T> &lhs, location_vector<T> &rhs );
-}
+void swap( location_vector<T> &lhs, location_vector<T> &rhs ) noexcept ;
+} // namespace std
 
 template<typename T>
 class location_vector
@@ -34,7 +34,7 @@ class location_vector
         bool destroyed = false;
 
         template<typename U>
-        friend void std::swap( location_vector<U> &lhs, location_vector<U> &rhs );
+        friend void std::swap( location_vector<U> &lhs, location_vector<U> &rhs ) noexcept ;
 
     public:
         struct const_iterator;
@@ -273,4 +273,4 @@ class location_vector
         void on_destroy();
 };
 
-#endif
+#endif // CATA_SRC_LOCATION_VECTOR_H

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -331,7 +331,7 @@ void spell_type::load( const JsonObject &jo, const std::string & )
 
 static bool spell_infinite_loop_check( std::set<spell_id> spell_effects, const spell_id &sp )
 {
-    if( spell_effects.count( sp ) ) {
+    if( spell_effects.contains( sp ) ) {
         return true;
     }
     spell_effects.emplace( sp );
@@ -916,7 +916,7 @@ bool spell::is_valid() const
 
 bool spell::bp_is_affected( body_part bp ) const
 {
-    return type->affected_bps.count( convert_bp( bp ) );
+    return type->affected_bps.contains( convert_bp( bp ) );
 }
 
 void spell::create_field( const tripoint &at ) const
@@ -1824,7 +1824,7 @@ void spellcasting_callback::draw_spell_info( const spell &sp, const uilist *menu
 
 bool known_magic::set_invlet( const spell_id &sp, int invlet, const std::set<int> &used_invlets )
 {
-    if( used_invlets.count( invlet ) > 0 ) {
+    if( used_invlets.contains( invlet ) ) {
         return false;
     }
     invlets[sp] = invlet;
@@ -1846,19 +1846,19 @@ int known_magic::get_invlet( const spell_id &sp, std::set<int> &used_invlets )
         used_invlets.emplace( invlet_pair.second );
     }
     for( int i = 'a'; i <= 'z'; i++ ) {
-        if( used_invlets.count( i ) == 0 ) {
+        if( !used_invlets.contains( i ) ) {
             used_invlets.emplace( i );
             return i;
         }
     }
     for( int i = 'A'; i <= 'Z'; i++ ) {
-        if( used_invlets.count( i ) == 0 ) {
+        if( !used_invlets.contains( i ) ) {
             used_invlets.emplace( i );
             return i;
         }
     }
     for( int i = '!'; i <= '-'; i++ ) {
-        if( used_invlets.count( i ) == 0 ) {
+        if( !used_invlets.contains( i ) ) {
             used_invlets.emplace( i );
             return i;
         }

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -117,7 +117,7 @@ class enchantment
          * Whether this enchantment will be active if parent item is wielded.
          * Assumes condition is satisfied.
          */
-        inline bool is_active_when_wielded() const {
+        bool is_active_when_wielded() const {
             return has::WIELD == active_conditions.first || has::HELD == active_conditions.first;
         }
 

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -439,7 +439,7 @@ static std::set<tripoint> spell_effect_area(
         explosion_colors[pt] = sp.damage_type_color();
     }
 
-    if( sp.id()->sprite.length() > 0 ) {
+    if( !sp.id()->sprite.empty() ) {
         explosion_handler::draw_custom_explosion( get_player_character().pos(), explosion_colors,
                 sp.id()->sprite );
     } else {
@@ -569,7 +569,7 @@ area_expander::area_expander() : frontier( area_node_comparator( area ) )
 // Check whether we have already visited this node.
 int area_expander::contains( const tripoint &pt ) const
 {
-    return area_search.count( pt ) > 0;
+    return area_search.contains( pt );
 }
 
 // Adds node to a search tree. Returns true if new node is allocated.
@@ -976,7 +976,7 @@ void spell_effect::explosion( const spell &sp, Creature &caster, const tripoint 
 
 void spell_effect::flashbang( const spell &sp, Creature &caster, const tripoint &target )
 {
-    if( sp.id()->sprite.length() > 0 ) {
+    if( !sp.id()->sprite.empty() ) {
         explosion_handler::flashbang( target, caster.is_avatar() &&
                                       !sp.is_valid_target( valid_target::target_self ), sp.id()->sprite );
     } else {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3332,7 +3332,7 @@ bash_results map::bash_ter_success( const tripoint &p, const bash_params &params
             int down_bash_tries = 10;
             do {
                 const ter_id &ter_now = ter( p );
-                if( encountered_types.count( ter_now ) != 0 ) {
+                if( encountered_types.contains( ter_now ) ) {
                     // We have encountered this type before and destroyed it (didn't block us)
                     ter_set( p, t_open_air );
                     bash_params params_below = params;
@@ -3421,13 +3421,13 @@ bash_results map::bash_furn_success( const tripoint &p, const bash_params &param
 
         // Find the center of the tent
         // First check if we're not currently bashing the center
-        if( centers.count( furn( p ) ) > 0 ) {
+        if( centers.contains( furn( p ) ) ) {
             tentp.emplace( p, furn( p ) );
         } else {
             for( const tripoint &pt : points_in_radius( p, bash.collapse_radius ) ) {
                 const furn_id &f_at = furn( pt );
                 // Check if we found the center of the current tent
-                if( centers.count( f_at ) > 0 ) {
+                if( centers.contains( f_at ) ) {
                     tentp.emplace( pt, f_at );
                     break;
                 }
@@ -3449,7 +3449,7 @@ bash_results map::bash_furn_success( const tripoint &p, const bash_params &param
                 const map_bash_info &recur_bash = frn.obj().bash;
                 // Check if we share a center type and thus a "tent type"
                 for( const auto &cur_id : recur_bash.tent_centers ) {
-                    if( centers.count( cur_id.id() ) > 0 ) {
+                    if( centers.contains( cur_id.id() ) ) {
                         // Found same center, wreck current tile
                         spawn_items( p, item_group::items_from( recur_bash.drop_group, calendar::turn ) );
                         furn_set( pt, recur_bash.furn_set );
@@ -4755,7 +4755,7 @@ std::vector<tripoint> map::check_submap_active_item_consistency()
                 tripoint p( x, y, z );
                 submap *s = get_submap_at_grid( p );
                 bool has_active_items = !s->active_items.get().empty();
-                bool map_has_active_items = submaps_with_active_items.count( p + abs_sub.xy() );
+                bool map_has_active_items = submaps_with_active_items.contains( p + abs_sub.xy() );
                 if( has_active_items != map_has_active_items ) {
                     result.push_back( p + abs_sub.xy() );
                 }
@@ -9268,11 +9268,11 @@ bool map::is_cornerfloor( const tripoint &p ) const
         //to check if a floor is a corner we first search if any of its diagonal adjacent points is impassable
         std::set< tripoint> diagonals = { p + tripoint_north_east, p + tripoint_north_west, p + tripoint_south_east, p + tripoint_south_west };
         for( const tripoint &impassable_diagonal : diagonals ) {
-            if( impassable_adjacent.count( impassable_diagonal ) != 0 ) {
+            if( impassable_adjacent.contains( impassable_diagonal ) ) {
                 //for every impassable diagonal found, we check if that diagonal terrain has at least two impassable neighbors that also neighbor point p
                 int f = 0;
                 for( const tripoint &l : points_in_radius( impassable_diagonal, 1 ) ) {
-                    if( impassable_adjacent.count( l ) != 0 ) {
+                    if( impassable_adjacent.contains( l ) ) {
                         f++;
                     }
                     if( f > 2 ) {

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -421,7 +421,7 @@ void map::process_fields_in_submap( submap *const current_submap,
         for( locy = 0; locy < SEEY; locy++ ) {
             // Get a reference to the field variable from the submap;
             // contains all the pointers to the real field effects.
-            field &curfield = current_submap->get_field( { static_cast<int>( locx ), static_cast<int>( locy ) } );
+            field &curfield = current_submap->get_field( { locx, locy } );
 
             // when displayed_field_type == fd_null it means that `curfield` has no fields inside
             // avoids instantiating (relatively) expensive map iterator
@@ -1952,7 +1952,7 @@ void map::propagate_field( const tripoint &center, const field_type_id &type, in
     const bool not_gas = type.obj().phase != GAS;
 
     while( amount > 0 && !open.empty() ) {
-        if( closed.count( open.top().second ) ) {
+        if( closed.contains( open.top().second ) ) {
             open.pop();
             continue;
         }
@@ -1963,7 +1963,7 @@ void map::propagate_field( const tripoint &center, const field_type_id &type, in
         const int cur_intensity = get_field_intensity( open.top().second, type );
         open.pop();
         while( !open.empty() && get_field_intensity( open.top().second, type ) == cur_intensity ) {
-            if( closed.count( open.top().second ) == 0 ) {
+            if( !closed.contains( open.top().second ) ) {
                 gas_front.push_back( open.top() );
             }
 
@@ -1992,7 +1992,7 @@ void map::propagate_field( const tripoint &center, const field_type_id &type, in
             static const std::array<int, 8> y_offset = {{  0, 0, -1, 1, -1,  1, -1, 1  }};
             for( size_t i = 0; i < 8; i++ ) {
                 tripoint pt = gp.second + point( x_offset[ i ], y_offset[ i ] );
-                if( closed.count( pt ) > 0 ) {
+                if( closed.contains( pt ) ) {
                     continue;
                 }
 

--- a/src/map_iterator.h
+++ b/src/map_iterator.h
@@ -37,7 +37,7 @@ class tripoint_range
 
                 // Increment x, then if it goes outside range, "wrap around" and increment y
                 // Same for y and z
-                inline point_generator &operator++() {
+                point_generator &operator++() {
                     traits::x( p )++;
                     if( traits::x( p ) <= traits::x( range.maxp ) ) {
                         return *this;
@@ -54,11 +54,11 @@ class tripoint_range
                     return *this;
                 }
 
-                inline const Tripoint &operator*() const {
+                const Tripoint &operator*() const {
                     return p;
                 }
 
-                inline bool operator!=( const point_generator &other ) const {
+                bool operator!=( const point_generator &other ) const {
                     // Reverse coordinates order, because it will usually only be compared with endpoint
                     // which will always differ in Z, except for the very last comparison
                     // TODO: In C++17 this range should use a sentinel to
@@ -67,7 +67,7 @@ class tripoint_range
                     return traits::z( p ) != traits::z( pt ) || p.xy() != pt.xy();
                 }
 
-                inline bool operator==( const point_generator &other ) const {
+                bool operator==( const point_generator &other ) const {
                     return !( *this != other );
                 }
         };

--- a/src/map_memory.h
+++ b/src/map_memory.h
@@ -17,11 +17,11 @@ struct memorized_terrain_tile {
     int subtile;
     int rotation;
 
-    inline bool operator==( const memorized_terrain_tile &rhs ) const {
+    bool operator==( const memorized_terrain_tile &rhs ) const {
         return ( rotation == rhs.rotation ) && ( subtile == rhs.subtile ) && ( tile == rhs.tile );
     }
 
-    inline bool operator!=( const memorized_terrain_tile &rhs ) const {
+    bool operator!=( const memorized_terrain_tile &rhs ) const {
         return !( *this == rhs );
     }
 };
@@ -40,7 +40,7 @@ struct mm_submap {
             return tiles.empty() && symbols.empty();
         }
 
-        inline const memorized_terrain_tile &tile( point p ) const {
+        const memorized_terrain_tile &tile( point p ) const {
             if( tiles.empty() ) {
                 return default_tile;
             } else {
@@ -48,7 +48,7 @@ struct mm_submap {
             }
         }
 
-        inline void set_tile( point p, const memorized_terrain_tile &value ) {
+        void set_tile( point p, const memorized_terrain_tile &value ) {
             if( tiles.empty() ) {
                 // call 'reserve' first to force allocation of exact size
                 tiles.reserve( SEEX * SEEY );
@@ -57,7 +57,7 @@ struct mm_submap {
             tiles[p.y * SEEX + p.x] = value;
         }
 
-        inline int symbol( point p ) const {
+        int symbol( point p ) const {
             if( symbols.empty() ) {
                 return default_symbol;
             } else {
@@ -65,7 +65,7 @@ struct mm_submap {
             }
         }
 
-        inline void set_symbol( point p, int value ) {
+        void set_symbol( point p, int value ) {
             if( symbols.empty() ) {
                 // call 'reserve' first to force allocation of exact size
                 symbols.reserve( SEEX * SEEY );

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -49,7 +49,7 @@ void mapbuffer::clear()
 
 bool mapbuffer::add_submap( const tripoint &p, std::unique_ptr<submap> &sm )
 {
-    if( submaps.count( p ) ) {
+    if( submaps.contains( p ) ) {
         return false;
     }
 
@@ -129,7 +129,7 @@ void mapbuffer::save( bool delete_after_save )
         // Submaps are generated in quads, so we know if we have one member of a quad,
         // we have the rest of it, if that assumption is broken we have REAL problems.
         const tripoint om_addr = sm_to_omt_copy( elem.first );
-        if( saved_submaps.count( om_addr ) != 0 ) {
+        if( saved_submaps.contains( om_addr ) ) {
             // Already handled this one.
             continue;
         }
@@ -185,7 +185,7 @@ void mapbuffer::save_quad( const std::string &dirname, const std::string &filena
         // Nothing to save - this quad will be regenerated faster than it would be re-read
         if( delete_after_save ) {
             for( auto &submap_addr : submap_addrs ) {
-                if( submaps.count( submap_addr ) > 0 && submaps[submap_addr] != nullptr ) {
+                if( submaps.contains( submap_addr ) && submaps[submap_addr] != nullptr ) {
                     submaps_to_delete.push_back( submap_addr );
                 }
             }
@@ -204,7 +204,7 @@ void mapbuffer::save_quad( const std::string &dirname, const std::string &filena
         JsonOut jsout( fout );
         jsout.start_array();
         for( auto &submap_addr : submap_addrs ) {
-            if( submaps.count( submap_addr ) == 0 ) {
+            if( !submaps.contains( submap_addr ) ) {
                 continue;
             }
 
@@ -264,7 +264,7 @@ submap *mapbuffer::unserialize_submaps( const tripoint &p )
         // If it doesn't exist, trigger generating it.
         return nullptr;
     }
-    if( submaps.count( p ) == 0 ) {
+    if( !submaps.contains( p ) ) {
         debugmsg( "file %s did not contain the expected submap %d,%d,%d",
                   quad_path, p.x, p.y, p.z );
         return nullptr;

--- a/src/mapbuffer.h
+++ b/src/mapbuffer.h
@@ -62,15 +62,15 @@ class mapbuffer
         using submap_map_t = std::map<tripoint, std::unique_ptr<submap>>;
 
     public:
-        inline submap_map_t::iterator begin() {
+        submap_map_t::iterator begin() {
             return submaps.begin();
         }
-        inline submap_map_t::iterator end() {
+        submap_map_t::iterator end() {
             return submaps.end();
         }
 
         bool is_submap_loaded( const tripoint &p ) const {
-            return submaps.count( p ) > 0;
+            return submaps.contains( p );
         }
 
     private:

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -85,7 +85,7 @@ struct map_bash_info {
     // sound  made on fail
     translation sound_fail = to_translation( "thump!" );
     // message upon successfully bashing a field
-    translation field_bash_msg_success = translation();
+    translation field_bash_msg_success;
     // terrain to set (REQUIRED for terrain))
     ter_str_id ter_set = ter_str_id::NULL_ID();
     // terrain to set if bashed from above (defaults to ter_set)
@@ -488,7 +488,7 @@ struct map_data_common_t {
         }
 
         bool has_flag( const std::string &flag ) const {
-            return flags.count( flag ) > 0;
+            return flags.contains( flag );
         }
 
         bool has_flag( const ter_bitflags flag ) const {

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -355,7 +355,7 @@ class mapgen_factory
             const std::set<std::string> usages = get_usages();
             for( std::pair<const std::string, mapgen_basic_container> &omw : mapgens_ ) {
                 omw.second.check_consistency( omw.first );
-                if( usages.count( omw.first ) == 0 ) {
+                if( !usages.contains( omw.first ) ) {
                     debugmsg( "Mapgen %s is not used by anything!", omw.first );
                 }
             }
@@ -366,7 +366,7 @@ class mapgen_factory
          * (could all have been removed via @ref erase).
          */
         bool has( const std::string &key ) const {
-            return mapgens_.count( key ) != 0;
+            return mapgens_.contains( key );
         }
         /// @see mapgen_basic_container::add
         int add( const std::string &key, const std::shared_ptr<mapgen_function> &ptr ) {
@@ -1199,7 +1199,7 @@ class mapgen_value
                 }
                 std::vector<std::string> possible_values = on->all_possible_results( params );
                 for( const std::string &value : possible_values ) {
-                    if( !cases.count( value ) ) {
+                    if( !cases.contains( value ) ) {
                         debugmsg( "mapgen '%s' has switch whcih does not account for potential "
                                   "case '%s' of the switched-on value", context, value );
                     }
@@ -1833,7 +1833,7 @@ class jmapgen_gaspump : public jmapgen_piece
             };
             for( const itype_id &possible_fuel : fuel.all_possible_results( parameters ) ) {
                 // may want to not force this, if we want to support other fuels for some reason
-                if( !valid_fuels.count( possible_fuel ) ) {
+                if( !valid_fuels.contains( possible_fuel ) ) {
                     debugmsg( "invalid fuel %s in %s", possible_fuel.str(), oter_name );
                 }
             }
@@ -3743,7 +3743,7 @@ bool jmapgen_setmap::apply( const mapgendata &dat, const point &offset ) const
                 const std::vector<point> line = line_to( point( x_get(), y_get() ), point( x2_get(), y2_get() ),
                                                 0 );
                 for( auto &i : line ) {
-                    m.set_radiation( i, static_cast<int>( val.get() ) );
+                    m.set_radiation( i, val.get() );
                 }
             }
             break;
@@ -3775,7 +3775,7 @@ bool jmapgen_setmap::apply( const mapgendata &dat, const point &offset ) const
                 const int cy2 = y2_get();
                 for( int tx = cx; tx <= cx2; tx++ ) {
                     for( int ty = cy; ty <= cy2; ty++ ) {
-                        m.set_radiation( point( tx, ty ), static_cast<int>( val.get() ) );
+                        m.set_radiation( point( tx, ty ), val.get() );
                     }
                 }
             }
@@ -6638,44 +6638,32 @@ bool connects_to( const oter_id &there, int dir )
     switch( dir ) {
         // South
         case 2:
-            if( there == "sewer_ns"   || there == "sewer_es" || there == "sewer_sw" ||
-                there == "sewer_nes"  || there == "sewer_nsw" || there == "sewer_esw" ||
-                there == "sewer_nesw" || there == "ants_ns" || there == "ants_es" ||
-                there == "ants_sw"    || there == "ants_nes" ||  there == "ants_nsw" ||
-                there == "ants_esw"   || there == "ants_nesw" ) {
-                return true;
-            }
-            return false;
+            return there == "sewer_ns"   || there == "sewer_es" || there == "sewer_sw" ||
+                   there == "sewer_nes"  || there == "sewer_nsw" || there == "sewer_esw" ||
+                   there == "sewer_nesw" || there == "ants_ns" || there == "ants_es" ||
+                   there == "ants_sw"    || there == "ants_nes" ||  there == "ants_nsw" ||
+                   there == "ants_esw"   || there == "ants_nesw";
         // West
         case 3:
-            if( there == "sewer_ew"   || there == "sewer_sw" || there == "sewer_wn" ||
-                there == "sewer_new"  || there == "sewer_nsw" || there == "sewer_esw" ||
-                there == "sewer_nesw" || there == "ants_ew" || there == "ants_sw" ||
-                there == "ants_wn"    || there == "ants_new" || there == "ants_nsw" ||
-                there == "ants_esw"   || there == "ants_nesw" ) {
-                return true;
-            }
-            return false;
+            return there == "sewer_ew"   || there == "sewer_sw" || there == "sewer_wn" ||
+                   there == "sewer_new"  || there == "sewer_nsw" || there == "sewer_esw" ||
+                   there == "sewer_nesw" || there == "ants_ew" || there == "ants_sw" ||
+                   there == "ants_wn"    || there == "ants_new" || there == "ants_nsw" ||
+                   there == "ants_esw"   || there == "ants_nesw";
         // North
         case 0:
-            if( there == "sewer_ns"   || there == "sewer_ne" ||  there == "sewer_wn" ||
-                there == "sewer_nes"  || there == "sewer_new" || there == "sewer_nsw" ||
-                there == "sewer_nesw" || there == "ants_ns" || there == "ants_ne" ||
-                there == "ants_wn"    || there == "ants_nes" || there == "ants_new" ||
-                there == "ants_nsw"   || there == "ants_nesw" ) {
-                return true;
-            }
-            return false;
+            return there == "sewer_ns"   || there == "sewer_ne" ||  there == "sewer_wn" ||
+                   there == "sewer_nes"  || there == "sewer_new" || there == "sewer_nsw" ||
+                   there == "sewer_nesw" || there == "ants_ns" || there == "ants_ne" ||
+                   there == "ants_wn"    || there == "ants_nes" || there == "ants_new" ||
+                   there == "ants_nsw"   || there == "ants_nesw";
         // East
         case 1:
-            if( there == "sewer_ew"   || there == "sewer_ne" || there == "sewer_es" ||
-                there == "sewer_nes"  || there == "sewer_new" || there == "sewer_esw" ||
-                there == "sewer_nesw" || there == "ants_ew" || there == "ants_ne" ||
-                there == "ants_es"    || there == "ants_nes" || there == "ants_new" ||
-                there == "ants_esw"   || there == "ants_nesw" ) {
-                return true;
-            }
-            return false;
+            return there == "sewer_ew"   || there == "sewer_ne" || there == "sewer_es" ||
+                   there == "sewer_nes"  || there == "sewer_new" || there == "sewer_esw" ||
+                   there == "sewer_nesw" || there == "ants_ew" || there == "ants_ne" ||
+                   there == "ants_es"    || there == "ants_nes" || there == "ants_new" ||
+                   there == "ants_esw"   || there == "ants_nesw";
         default:
             debugmsg( "Connects_to with dir of %d", dir );
             return false;
@@ -6735,12 +6723,12 @@ void science_room( map *m, const point &p1, const point &p2, int z, int rotate )
             break;
         case room_lobby:
             if( rotate % 2 == 0 ) { // Vertical
-                int desk = p1.y + rng( static_cast<int>( height / 2 ) - static_cast<int>( height / 4 ),
-                                       static_cast<int>( height / 2 ) + 1 );
-                for( int x = p1.x + static_cast<int>( width / 4 ); x < p2.x - static_cast<int>( width / 4 ); x++ ) {
+                int desk = p1.y + rng( ( height / 2 ) - ( height / 4 ),
+                                       ( height / 2 ) + 1 );
+                for( int x = p1.x + ( width / 4 ); x < p2.x - ( width / 4 ); x++ ) {
                     m->furn_set( point( x, desk ), f_counter );
                 }
-                computer *tmpcomp = m->add_computer( tripoint( p2.x - static_cast<int>( width / 4 ), desk, z ),
+                computer *tmpcomp = m->add_computer( tripoint( p2.x - ( width / 4 ), desk, z ),
                                                      _( "Log Console" ), 3 );
                 tmpcomp->add_option( _( "View Research Logs" ), COMPACT_RESEARCH, 0 );
                 tmpcomp->add_option( _( "Download Map Data" ), COMPACT_MAPS, 0 );
@@ -6748,15 +6736,15 @@ void science_room( map *m, const point &p1, const point &p2, int z, int rotate )
                 tmpcomp->add_failure( COMPFAIL_ALARM );
                 tmpcomp->add_failure( COMPFAIL_DAMAGE );
                 m->place_spawns( GROUP_TURRET, 1,
-                                 point( static_cast<int>( ( p1.x + p2.x ) / 2 ), desk ),
-                                 point( static_cast<int>( ( p1.x + p2.x ) / 2 ), desk ), 1, true );
+                                 point( ( ( p1.x + p2.x ) / 2 ), desk ),
+                                 point( ( ( p1.x + p2.x ) / 2 ), desk ), 1, true );
             } else {
-                int desk = p1.x + rng( static_cast<int>( height / 2 ) - static_cast<int>( height / 4 ),
-                                       static_cast<int>( height / 2 ) + 1 );
-                for( int y = p1.y + static_cast<int>( width / 4 ); y < p2.y - static_cast<int>( width / 4 ); y++ ) {
+                int desk = p1.x + rng( ( height / 2 ) - ( height / 4 ),
+                                       ( height / 2 ) + 1 );
+                for( int y = p1.y + ( width / 4 ); y < p2.y - ( width / 4 ); y++ ) {
                     m->furn_set( point( desk, y ), f_counter );
                 }
-                computer *tmpcomp = m->add_computer( tripoint( desk, p2.y - static_cast<int>( width / 4 ), z ),
+                computer *tmpcomp = m->add_computer( tripoint( desk, p2.y - ( width / 4 ), z ),
                                                      _( "Log Console" ), 3 );
                 tmpcomp->add_option( _( "View Research Logs" ), COMPACT_RESEARCH, 0 );
                 tmpcomp->add_option( _( "Download Map Data" ), COMPACT_MAPS, 0 );
@@ -6764,8 +6752,8 @@ void science_room( map *m, const point &p1, const point &p2, int z, int rotate )
                 tmpcomp->add_failure( COMPFAIL_ALARM );
                 tmpcomp->add_failure( COMPFAIL_DAMAGE );
                 m->place_spawns( GROUP_TURRET, 1,
-                                 point( desk, static_cast<int>( ( p1.y + p2.y ) / 2 ) ),
-                                 point( desk, static_cast<int>( ( p1.y + p2.y ) / 2 ) ), 1, true );
+                                 point( desk, ( ( p1.y + p2.y ) / 2 ) ),
+                                 point( desk, ( ( p1.y + p2.y ) / 2 ) ), 1, true );
             }
             break;
         case room_chemistry:
@@ -6802,19 +6790,19 @@ void science_room( map *m, const point &p1, const point &p2, int z, int rotate )
             }
             break;
         case room_teleport:
-            m->furn_set( point( ( p1.x + p2.x ) / 2, static_cast<int>( ( p1.y + p2.y ) / 2 ) ), f_counter );
-            m->furn_set( point( static_cast<int>( ( p1.x + p2.x ) / 2 ) + 1,
-                                static_cast<int>( ( p1.y + p2.y ) / 2 ) ),
+            m->furn_set( point( ( p1.x + p2.x ) / 2, ( ( p1.y + p2.y ) / 2 ) ), f_counter );
+            m->furn_set( point( ( ( p1.x + p2.x ) / 2 ) + 1,
+                                ( ( p1.y + p2.y ) / 2 ) ),
                          f_counter );
-            m->furn_set( point( ( p1.x + p2.x ) / 2, static_cast<int>( ( p1.y + p2.y ) / 2 ) + 1 ),
+            m->furn_set( point( ( p1.x + p2.x ) / 2, ( ( p1.y + p2.y ) / 2 ) + 1 ),
                          f_counter );
-            m->furn_set( point( static_cast<int>( ( p1.x + p2.x ) / 2 ) + 1,
-                                static_cast<int>( ( p1.y + p2.y ) / 2 ) + 1 ),
+            m->furn_set( point( ( ( p1.x + p2.x ) / 2 ) + 1,
+                                ( ( p1.y + p2.y ) / 2 ) + 1 ),
                          f_counter );
             mtrap_set( m, trap, tr_telepad );
             m->place_items( item_group_id( "teleport" ), 70, point( ( p1.x + p2.x ) / 2,
-                            static_cast<int>( ( p1.y + p2.y ) / 2 ) ),
-                            point( static_cast<int>( ( p1.x + p2.x ) / 2 ) + 1, static_cast<int>( ( p1.y + p2.y ) / 2 ) + 1 ),
+                            ( ( p1.y + p2.y ) / 2 ) ),
+                            point( ( ( p1.x + p2.x ) / 2 ) + 1, ( ( p1.y + p2.y ) / 2 ) + 1 ),
                             false,
                             calendar::start_of_cataclysm );
             break;
@@ -6883,19 +6871,19 @@ void science_room( map *m, const point &p1, const point &p2, int z, int rotate )
                 m->place_items( item_group_id( "dissection" ), 80, point( p2.x - 1, p1.y ), p2 + point_west, false,
                                 calendar::start_of_cataclysm );
             }
-            mtrap_set( m, point( ( p1.x + p2.x ) / 2, static_cast<int>( ( p1.y + p2.y ) / 2 ) ),
+            mtrap_set( m, point( ( p1.x + p2.x ) / 2, ( ( p1.y + p2.y ) / 2 ) ),
                        tr_dissector );
             m->place_spawns( GROUP_LAB_CYBORG, 10,
-                             point( static_cast<int>( ( ( p1.x + p2.x ) / 2 ) + 1 ),
-                                    static_cast<int>( ( ( p1.y + p2.y ) / 2 ) + 1 ) ),
-                             point( static_cast<int>( ( ( p1.x + p2.x ) / 2 ) + 1 ),
-                                    static_cast<int>( ( ( p1.y + p2.y ) / 2 ) + 1 ) ), 1, true );
+                             point( ( ( ( p1.x + p2.x ) / 2 ) + 1 ),
+                                    ( ( ( p1.y + p2.y ) / 2 ) + 1 ) ),
+                             point( ( ( ( p1.x + p2.x ) / 2 ) + 1 ),
+                                    ( ( ( p1.y + p2.y ) / 2 ) + 1 ) ), 1, true );
             break;
 
         case room_bionics:
             if( rotate % 2 == 0 ) {
                 int biox = p1.x + 2;
-                int bioy = static_cast<int>( ( p1.y + p2.y ) / 2 );
+                int bioy = ( ( p1.y + p2.y ) / 2 );
                 mapf::formatted_set_simple( m, point( biox - 1, bioy - 1 ),
                                             "---\n"
                                             "|c|\n"
@@ -6936,7 +6924,7 @@ void science_room( map *m, const point &p1, const point &p2, int z, int rotate )
                     _( "ERROR!  Access denied!  Unauthorized access will be met with lethal force!" ) );
             } else {
                 int bioy = p1.y + 2;
-                int biox = static_cast<int>( ( p1.x + p2.x ) / 2 );
+                int biox = ( ( p1.x + p2.x ) / 2 );
                 mapf::formatted_set_simple( m, point( biox - 1, bioy - 1 ),
                                             "|-|\n"
                                             "|c=\n"
@@ -7025,19 +7013,19 @@ void science_room( map *m, const point &p1, const point &p2, int z, int rotate )
             break;
         case room_split:
             if( rotate % 2 == 0 ) {
-                int w1 = static_cast<int>( ( p1.x + p2.x ) / 2 ) - 2;
-                int w2 = static_cast<int>( ( p1.x + p2.x ) / 2 ) + 2;
+                int w1 = ( ( p1.x + p2.x ) / 2 ) - 2;
+                int w2 = ( ( p1.x + p2.x ) / 2 ) + 2;
                 for( int y = p1.y; y <= p2.y; y++ ) {
                     m->ter_set( point( w1, y ), t_concrete_wall );
                     m->ter_set( point( w2, y ), t_concrete_wall );
                 }
-                m->ter_set( point( w1, static_cast<int>( ( p1.y + p2.y ) / 2 ) ), t_door_glass_frosted_c );
-                m->ter_set( point( w2, static_cast<int>( ( p1.y + p2.y ) / 2 ) ), t_door_glass_frosted_c );
+                m->ter_set( point( w1, ( ( p1.y + p2.y ) / 2 ) ), t_door_glass_frosted_c );
+                m->ter_set( point( w2, ( ( p1.y + p2.y ) / 2 ) ), t_door_glass_frosted_c );
                 science_room( m, p1, point( w1 - 1, p2.y ), z, 1 );
                 science_room( m, point( w2 + 1, p1.y ), p2, z, 3 );
             } else {
-                int w1 = static_cast<int>( ( p1.y + p2.y ) / 2 ) - 2;
-                int w2 = static_cast<int>( ( p1.y + p2.y ) / 2 ) + 2;
+                int w1 = ( ( p1.y + p2.y ) / 2 ) - 2;
+                int w2 = ( ( p1.y + p2.y ) / 2 ) + 2;
                 for( int x = p1.x; x <= p2.x; x++ ) {
                     m->ter_set( point( x, w1 ), t_concrete_wall );
                     m->ter_set( point( x, w2 ), t_concrete_wall );

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -1784,7 +1784,7 @@ void mapgen_parking_lot( mapgendata &dat )
                     dat.when() );
     for( int i = 1; i < 4; i++ ) {
         const std::string &id = dat.t_nesw[i].id().str();
-        if( id.size() > 5 && id.find( "road_" ) == 0 ) {
+        if( id.size() > 5 && id.starts_with( "road_" ) ) {
             m->rotate( i );
         }
     }
@@ -2782,7 +2782,7 @@ void mapgen_lake_shore( mapgendata &dat )
 
     bool open[8] = { false };
     for( int i = 0; i < 8; i++ ) {
-        open[i] = slots.count( i );
+        open[i] = slots.contains( i );
         // Shores with two connections per side have overlapping offsets, we need to swap them
         if( i % 2 && open[i] && open[i - 1] ) {
             point p = slots[i];
@@ -2798,7 +2798,7 @@ void mapgen_lake_shore( mapgendata &dat )
 
         // Check the next slot, and inverse direction if any
         int next = i % 2 == 0 ? 1 : -1;
-        int dir = slots.count( i + next ) ? -next : next;
+        int dir = slots.contains( i + next ) ? -next : next;
 
         // Now make a full round loop from our current point
         int pair = i;

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -874,10 +874,10 @@ bool martialart::has_technique( const Character &u, const matec_id &tec_id ) con
 
 bool martialart::has_weapon( const itype_id &itt ) const
 {
-    return weapons.count( itt ) > 0 ||
+    return weapons.contains( itt ) ||
            std::any_of( itt->weapon_category.begin(), itt->weapon_category.end(),
     [&]( const weapon_category_id & weap ) {
-        return weapon_category.count( weap ) > 0;
+        return weapon_category.contains( weap );
     } );
 }
 

--- a/src/matrix_math.h
+++ b/src/matrix_math.h
@@ -21,7 +21,7 @@ struct matrix {
         {}
 
         template<typename Vec, typename Traits = point_traits<Vec>>
-        friend inline constexpr Vec operator*( const matrix &m, const Vec &v ) {
+        friend constexpr Vec operator*( const matrix &m, const Vec &v ) {
             // TODO: std::get equivalent for point_traits?
             static_assert( Vec::dimension == 3, "Currently only vectors of dimension 3 are supported" );
             static_assert( Vec::dimension == w, "Vector dimension must match matrix width" );
@@ -35,7 +35,7 @@ struct matrix {
         }
 
         // NOLINTNEXTLINE(cata-xy): We don't want point dependence in this .h
-        inline constexpr const T &at( size_t x, size_t y ) const {
+        constexpr const T &at( size_t x, size_t y ) const {
             return data.at( y * w + x );
         }
 };

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -237,7 +237,7 @@ bool Character::handle_melee_wear( item &shield, float wear_multiplier )
         const std::set<itype_id> blacklist = { itype_rag, itype_leather, itype_fur };
 
         for( auto &comp : shield.get_components() ) {
-            if( blacklist.count( comp->typeId() ) <= 0 ) {
+            if( !blacklist.contains( comp->typeId() ) ) {
                 if( weak_chip > comp->chip_resistance() ) {
                     weak_chip = comp->chip_resistance();
                     weak_comp = comp->typeId();
@@ -640,7 +640,7 @@ void Character::melee_attack( Creature &t, bool allow_special, const matec_id *f
                                  2.0f );
     const int deft_bonus = hit_spread < 0 && has_trait( trait_DEFT ) ? 50 : 0;
     const float strbonus = 1 / ( 2 + ( str_cur * 0.25f ) );
-    const float skill_cost = std::max( 0.667f, static_cast<float>( ( 30.0f - melee ) / 30.0f ) );
+    const float skill_cost = std::max( 0.667f, ( ( 30.0f - melee ) / 30.0f ) );
     /** @EFFECT_MELEE and @EFFECT_STR reduce stamina cost of melee attacks */
     const int mod_sta = -( weight_cost + encumbrance_cost - deft_bonus + 50 ) * skill_cost *
                         ( 0.75f + strbonus );
@@ -953,13 +953,13 @@ void melee::roll_bash_damage( const Character &c, bool crit, damage_instance &di
         if( left_empty || right_empty ) {
             float per_hand = 0.0f;
             for( const trait_id &mut : c.get_mutations() ) {
-                if( mut->flags.count( trait_flag_NEED_ACTIVE_TO_MELEE ) > 0 &&
+                if( mut->flags.contains( trait_flag_NEED_ACTIVE_TO_MELEE ) &&
                     !c.has_active_mutation( mut ) ) {
                     continue;
                 }
                 float unarmed_bonus = 0.0f;
                 const int bash_bonus = mut->bash_dmg_bonus;
-                if( mut->flags.count( trait_flag_UNARMED_BONUS ) > 0 && bash_bonus > 0 ) {
+                if( mut->flags.contains( trait_flag_UNARMED_BONUS ) && bash_bonus > 0 ) {
                     unarmed_bonus += std::min( c.get_skill_level( skill_unarmed ) / 2, 4 );
                 }
                 per_hand += bash_bonus + unarmed_bonus;
@@ -1047,13 +1047,13 @@ void melee::roll_cut_damage( const Character &c, bool crit, damage_instance &di,
             }
 
             for( const trait_id &mut : c.get_mutations() ) {
-                if( mut->flags.count( trait_flag_NEED_ACTIVE_TO_MELEE ) > 0 &&
+                if( mut->flags.contains( trait_flag_NEED_ACTIVE_TO_MELEE ) &&
                     !c.has_active_mutation( mut ) ) {
                     continue;
                 }
                 float unarmed_bonus = 0.0f;
                 const int cut_bonus = mut->cut_dmg_bonus;
-                if( mut->flags.count( trait_flag_UNARMED_BONUS ) > 0 && cut_bonus > 0 ) {
+                if( mut->flags.contains( trait_flag_UNARMED_BONUS ) && cut_bonus > 0 ) {
                     unarmed_bonus += std::min( c.get_skill_level( skill_unarmed ) / 2, 4 );
                 }
                 per_hand += cut_bonus + unarmed_bonus;
@@ -1120,7 +1120,7 @@ void melee::roll_stab_damage( const Character &c, bool crit, damage_instance &di
             for( const trait_id &mut : c.get_mutations() ) {
                 int stab_bonus = mut->pierce_dmg_bonus;
                 int unarmed_bonus = 0;
-                if( mut->flags.count( trait_flag_UNARMED_BONUS ) > 0 && stab_bonus > 0 ) {
+                if( mut->flags.contains( trait_flag_UNARMED_BONUS ) && stab_bonus > 0 ) {
                     unarmed_bonus = std::min( unarmed_skill / 2, 4 );
                 }
 
@@ -2300,7 +2300,7 @@ int Character::attack_cost( const item &weap ) const
     const int melee_skill = has_active_bionic( bionic_id( bio_cqb ) ) ? BIO_CQB_LEVEL : get_skill_level(
                                 skill_melee );
     /** @EFFECT_MELEE increases melee attack speed */
-    const int skill_cost = static_cast<int>( ( base_move_cost * ( 15 - melee_skill ) / 15 ) );
+    const int skill_cost = ( base_move_cost * ( 15 - melee_skill ) / 15 );
     /** @EFFECT_DEX increases attack speed */
     const int dexbonus = dex_cur;
     const int encumbrance_penalty = encumb( body_part_torso ) +

--- a/src/mod_manager.cpp
+++ b/src/mod_manager.cpp
@@ -38,7 +38,7 @@ const MOD_INFORMATION &string_id<MOD_INFORMATION>::obj() const
 template<>
 bool string_id<MOD_INFORMATION>::is_valid() const
 {
-    return world_generator->get_mod_manager().mod_map.count( *this ) > 0;
+    return world_generator->get_mod_manager().mod_map.contains( *this );
 }
 
 std::string MOD_INFORMATION::name() const
@@ -183,7 +183,7 @@ void mod_manager::remove_mod( const mod_id &ident )
 void mod_manager::remove_invalid_mods( t_mod_list &mods ) const
 {
     mods.erase( std::remove_if( mods.begin(), mods.end(), [this]( const mod_id & mod ) {
-        return mod_map.count( mod ) == 0;
+        return !mod_map.contains( mod );
     } ), mods.end() );
 }
 
@@ -202,7 +202,7 @@ std::vector<MOD_INFORMATION> load_mods_from( const std::string &path )
     std::set<mod_id> has_dupes;
 
     for( const MOD_INFORMATION &it : out ) {
-        if( idents.count( it.ident ) > 0 ) {
+        if( idents.contains( it.ident ) ) {
             has_dupes.emplace( it.ident );
         } else {
             idents.emplace( it.ident );

--- a/src/mod_manager.h
+++ b/src/mod_manager.h
@@ -49,7 +49,7 @@ struct MOD_INFORMATION {
         std::string name() const;
         std::string description() const;
 
-        inline void set_translatable_info( translatable_mod_info &&tmi ) {
+        void set_translatable_info( translatable_mod_info &&tmi ) {
             translatable_info = std::move( tmi );
         }
 

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -2836,7 +2836,7 @@ bool mattack::grab( monster *z )
     // A hit to use up our moves
     z->melee_attack( *target );
     // Set up a bite on the next turn
-    if( z->type->special_attacks.count( "BITE" ) != 0 ) {
+    if( z->type->special_attacks.contains( "BITE" ) ) {
         z->set_special( "BITE", 1 );
     }
 
@@ -5669,7 +5669,7 @@ bool mattack::kamikaze( monster *z )
     }
     // Extra check here to avoid sqrt if not needed
     if( exp_actor->explosion ) {
-        int tmp = static_cast<int>( exp_actor->explosion.safe_range() / 2 );
+        int tmp = ( exp_actor->explosion.safe_range() / 2 );
         if( tmp > radius ) {
             radius = tmp;
         }

--- a/src/monfaction.cpp
+++ b/src/monfaction.cpp
@@ -64,14 +64,14 @@ const monfaction &string_id<monfaction>::obj() const
 template<>
 bool int_id<monfaction>::is_valid() const
 {
-    return faction_map.count( this->id() ) > 0;
+    return faction_map.contains( this->id() );
 }
 
 /** @relates string_id */
 template<>
 bool string_id<monfaction>::is_valid() const
 {
-    return faction_map.count( *this ) > 0;
+    return faction_map.contains( *this );
 }
 
 /** @relates int_id */
@@ -105,7 +105,7 @@ static void apply_base_faction( mfaction_id base, mfaction_id faction_id )
     for( const auto &pair : base.obj().attitude_map ) {
         // Fill in values set in base faction, but not in derived one
         auto &faction = faction_list[faction_id.to_i()];
-        if( faction.attitude_map.count( pair.first ) == 0 ) {
+        if( !faction.attitude_map.contains( pair.first ) ) {
             faction.attitude_map.insert( pair );
         }
     }
@@ -160,7 +160,7 @@ void monfactions::finalize()
         }
 
         // Set faction as friendly to itself if not explicitly set to anything
-        if( faction.attitude_map.count( faction.loadid ) == 0 ) {
+        if( !faction.attitude_map.contains( faction.loadid ) ) {
             faction.attitude_map[faction.loadid] = MFA_FRIENDLY;
         }
     }
@@ -188,7 +188,7 @@ void monfactions::finalize()
     while( !queue.empty() ) {
         mfaction_id cur = queue.front();
         queue.pop();
-        if( unloaded.count( cur ) != 0 ) {
+        if( unloaded.contains( cur ) ) {
             unloaded.erase( cur );
         } else {
             debugmsg( "Tried to load monster faction %s more than once", cur.obj().id.c_str() );

--- a/src/mongroup.cpp
+++ b/src/mongroup.cpp
@@ -243,7 +243,7 @@ std::vector<mtype_id> MonsterGroupManager::GetMonstersFromGroup( const mongroup_
 
 bool MonsterGroupManager::isValidMonsterGroup( const mongroup_id &group )
 {
-    return monsterGroupMap.count( group ) > 0;
+    return monsterGroupMap.contains( group );
 }
 
 const MonsterGroup &MonsterGroupManager::GetMonsterGroup( const mongroup_id &group )
@@ -279,21 +279,21 @@ void MonsterGroupManager::LoadMonsterWhitelist( const JsonObject &jo )
 
 bool MonsterGroupManager::monster_is_blacklisted( const mtype_id &m )
 {
-    if( monster_whitelist.count( m.str() ) > 0 ) {
+    if( monster_whitelist.contains( m.str() ) ) {
         return false;
     }
     const mtype &mt = m.obj();
     for( const auto &elem : monster_categories_whitelist ) {
-        if( mt.categories.count( elem ) > 0 ) {
+        if( mt.categories.contains( elem ) ) {
             return false;
         }
     }
     for( const auto &elem : monster_categories_blacklist ) {
-        if( mt.categories.count( elem ) > 0 ) {
+        if( mt.categories.contains( elem ) ) {
             return true;
         }
     }
-    if( monster_blacklist.count( m.str() ) > 0 ) {
+    if( monster_blacklist.contains( m.str() ) ) {
         return true;
     }
     // Return true if the whitelist mode is exclusive and either whitelist is populated.
@@ -338,7 +338,7 @@ void MonsterGroupManager::LoadMonsterGroup( const JsonObject &jo )
     g.name = mongroup_id( jo.get_string( "name" ) );
     bool extending = false;  //If already a group with that name, add to it instead of overwriting it
     bool allow_override = jo.get_bool( "override", false );
-    if( monsterGroupMap.count( g.name ) != 0 && !allow_override ) {
+    if( monsterGroupMap.contains( g.name ) && !allow_override ) {
         g = monsterGroupMap[g.name];
         extending = true;
     }

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -77,7 +77,9 @@ static const species_id ZOMBIE( "ZOMBIE" );
 static const std::string flag_AUTODOC_COUCH( "AUTODOC_COUCH" );
 static const std::string flag_LIQUID( "LIQUID" );
 
-#define MONSTER_FOLLOW_DIST 8
+enum {
+    MONSTER_FOLLOW_DIST = 8
+};
 
 bool monster::wander()
 {
@@ -108,7 +110,7 @@ bool monster::is_immune_field( const field_type_id &fid ) const
     if( ft.has_elec ) {
         return has_flag( MF_ELECTRIC );
     }
-    if( ft.immune_mtypes.count( type->id ) > 0 ) {
+    if( ft.immune_mtypes.contains( type->id ) ) {
         return true;
     }
     // No specific immunity was found, so fall upwards
@@ -583,7 +585,7 @@ void monster::plan()
         if( angers_hostile_weak && att_to_target != Attitude::A_FRIENDLY ) {
             int hp_per = target->hp_percentage();
             if( hp_per <= 70 ) {
-                anger += 10 - static_cast<int>( hp_per / 10 );
+                anger += 10 - ( hp_per / 10 );
             }
         }
     } else if( friendly > 0 && one_in( 3 ) ) {
@@ -767,7 +769,7 @@ void monster::move()
 
             // `special_attacks` might have changed at this point. Sadly `reset_special`
             // doesn't check the attack name, so we need to do it here.
-            if( special_attacks.count( special_name ) == 0 ) {
+            if( !special_attacks.contains( special_name ) ) {
                 continue;
             }
             reset_special( special_name );

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -136,7 +136,9 @@ struct pathfinding_settings;
 // Limit the number of iterations for next upgrade_time calculations.
 // This also sets the percentage of monsters that will never upgrade.
 // The rough formula is 2^(-x), e.g. for x = 5 it's 0.03125 (~ 3%).
-#define UPGRADE_MAX_ITERS 5
+enum {
+    UPGRADE_MAX_ITERS = 5
+};
 
 static const std::map<creature_size, translation> size_names {
     { creature_size::tiny, to_translation( "size adj", "tiny" ) },
@@ -1923,7 +1925,7 @@ void monster::apply_damage( Creature *source, item *source_weapon, item *source_
             source_projectile->add_monster_kill( type->id );
         }
     } else if( dam > 0 ) {
-        process_trigger( mon_trigger::HURT, 1 + static_cast<int>( dam / 3 ) );
+        process_trigger( mon_trigger::HURT, 1 + ( dam / 3 ) );
     }
 }
 void monster::apply_damage( Creature *source, item *source_weapon, bodypart_id bp, int dam,

--- a/src/monster.h
+++ b/src/monster.h
@@ -519,13 +519,13 @@ class monster : public Creature, public location_visitable<monster>
 
         void setpos( const tripoint &p ) override;
         const tripoint &pos() const override;
-        inline int posx() const override {
+        int posx() const override {
             return position.x;
         }
-        inline int posy() const override {
+        int posy() const override {
             return position.y;
         }
-        inline int posz() const override {
+        int posz() const override {
             return position.z;
         }
 

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -1053,7 +1053,7 @@ void MonsterGenerator::add_attack( std::unique_ptr<mattack_actor> ptr )
 
 void MonsterGenerator::add_attack( const mtype_special_attack &wrapper )
 {
-    if( attack_map.count( wrapper->id ) > 0 ) {
+    if( attack_map.contains( wrapper->id ) ) {
         if( test_mode ) {
             debugmsg( "Overwriting monster attack with id %s", wrapper->id.c_str() );
         }
@@ -1132,7 +1132,7 @@ void mtype::add_special_attack( const JsonObject &obj, const std::string &src )
 {
     mtype_special_attack new_attack = MonsterGenerator::generator().create_actor( obj, src );
 
-    if( special_attacks.count( new_attack->id ) > 0 ) {
+    if( special_attacks.contains( new_attack->id ) ) {
         special_attacks.erase( new_attack->id );
         const auto iter = std::find( special_attacks_names.begin(), special_attacks_names.end(),
                                      new_attack->id );
@@ -1158,7 +1158,7 @@ void mtype::add_special_attack( JsonArray inner, const std::string & )
         inner.throw_error( "Invalid special_attacks" );
     }
 
-    if( special_attacks.count( name ) > 0 ) {
+    if( special_attacks.contains( name ) ) {
         special_attacks.erase( name );
         const auto iter = std::find( special_attacks_names.begin(), special_attacks_names.end(), name );
         if( iter != special_attacks_names.end() ) {
@@ -1213,7 +1213,7 @@ void mtype::add_regeneration_modifier( const JsonObject &inner, const std::strin
     //TODO: if invalid effect, throw error
     //  inner.throw_error( "Invalid regeneration_modifiers" );
 
-    if( regeneration_modifiers.count( effect ) > 0 ) {
+    if( regeneration_modifiers.contains( effect ) ) {
         regeneration_modifiers.erase( effect );
         debugmsg( "%s specifies more than one regeneration modifer for effect %s, ignoring all but the last",
                   id.c_str(), effect_name );

--- a/src/mtype.cpp
+++ b/src/mtype.cpp
@@ -124,12 +124,12 @@ bool mtype::in_species( const species_id &spec ) const
     if( spec == species_id( "ALL" ) ) {
         return true;
     }
-    return species.count( spec ) > 0;
+    return species.contains( spec );
 }
 
 bool mtype::in_species( const species_type &spec ) const
 {
-    return species_ptrs.count( &spec ) > 0;
+    return species_ptrs.contains( &spec );
 }
 std::vector<std::string> mtype::species_descriptions() const
 {

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -100,14 +100,14 @@ std::string enum_to_string<mutagen_technique>( mutagen_technique data )
 
 bool Character::has_trait( const trait_id &b ) const
 {
-    return my_mutations.count( b ) || enchantment_cache->get_mutations().count( b );
+    return my_mutations.count( b ) || enchantment_cache->get_mutations().contains( b );
 }
 
 bool Character::has_trait_flag( const trait_flag_str_id &b ) const
 {
     return std::any_of( cached_mutations.cbegin(), cached_mutations.cend(),
     [&b]( const mutation_branch * mut ) -> bool {
-        return mut->flags.count( b );
+        return mut->flags.contains( b );
     } );
 }
 
@@ -376,7 +376,7 @@ bool Character::is_category_allowed( const std::vector<mutation_category_id> &ca
             restricted = true;
         }
         for( const mutation_category_id &Mu_cat : category ) {
-            if( mut.obj().allowed_category.count( Mu_cat ) ) {
+            if( mut.obj().allowed_category.contains( Mu_cat ) ) {
                 allowed = true;
                 break;
             }
@@ -429,7 +429,7 @@ bool Character::can_use_heal_item( const item &med ) const
         if( !mut.obj().can_only_heal_with.empty() ) {
             got_restriction = true;
         }
-        if( mut.obj().can_only_heal_with.count( heal_id ) ) {
+        if( mut.obj().can_only_heal_with.contains( heal_id ) ) {
             can_use = true;
             break;
         }
@@ -440,7 +440,7 @@ bool Character::can_use_heal_item( const item &med ) const
 
     if( !can_use ) {
         for( const trait_id &mut : get_mutations() ) {
-            if( mut.obj().can_heal_with.count( heal_id ) ) {
+            if( mut.obj().can_heal_with.contains( heal_id ) ) {
                 can_use = true;
                 break;
             }
@@ -455,7 +455,7 @@ bool Character::can_install_cbm_on_bp( const std::vector<bodypart_id> &bps ) con
     bool can_install = true;
     for( const trait_id &mut : get_mutations() ) {
         for( const bodypart_id &bp : bps ) {
-            if( mut.obj().no_cbm_on_bp.count( bp.id() ) ) {
+            if( mut.obj().no_cbm_on_bp.contains( bp.id() ) ) {
                 can_install = false;
                 break;
             }

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -54,7 +54,7 @@ bool string_id<mutation_branch>::is_valid() const
 template<>
 bool string_id<Trait_group>::is_valid() const
 {
-    return trait_groups.count( *this );
+    return trait_groups.contains( *this );
 }
 
 static void extract_mod(
@@ -694,7 +694,7 @@ void mutation_branch::load_trait_blacklist( const JsonObject &jsobj )
 
 bool mutation_branch::trait_is_blacklisted( const trait_id &tid )
 {
-    return trait_blacklist.count( tid );
+    return trait_blacklist.contains( tid );
 }
 
 void mutation_branch::finalize()
@@ -881,11 +881,11 @@ const mutation_category_trait &string_id<mutation_category_trait>::obj() const
 
 bool mutation_category_is_valid( const mutation_category_id &cat )
 {
-    return mutation_category_traits.count( cat );
+    return mutation_category_traits.contains( cat );
 }
 
 template<>
 bool string_id<mutation_category_trait>::is_valid() const
 {
-    return mutation_category_traits.count( *this );
+    return mutation_category_traits.contains( *this );
 }

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -274,7 +274,7 @@ detail::mutations_ui_result detail::show_mutations_ui_internal( Character &who )
             for( int i = scroll_position; static_cast<size_t>( i ) < passive.size(); i++ ) {
                 const mutation_branch &md = passive[i].obj();
                 const char_trait_data &td = who.my_mutations[passive[i]];
-                const bool is_highlighted = cursor == static_cast<int>( i );
+                const bool is_highlighted = cursor == i;
                 if( i - scroll_position == list_height ) {
                     break;
                 }
@@ -294,7 +294,7 @@ detail::mutations_ui_result detail::show_mutations_ui_internal( Character &who )
             for( int i = scroll_position; static_cast<size_t>( i ) < active.size(); i++ ) {
                 const mutation_branch &md = active[i].obj();
                 const char_trait_data &td = who.my_mutations[active[i]];
-                const bool is_highlighted = cursor == static_cast<int>( i );
+                const bool is_highlighted = cursor == i;
                 if( i - scroll_position == list_height ) {
                     break;
                 }

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -108,9 +108,13 @@ static const trait_id trait_XXXL( "XXXL" );
 #define COL_HEADER          c_white   // Captions, like "Profession items"
 #define COL_NOTE_MINOR      c_light_gray  // Just regular note
 
-#define HIGH_STAT 14 // The point after which stats cost double
+enum {
+    HIGH_STAT = 14 // The point after which stats cost double
+};
 
-#define NEWCHAR_TAB_MAX 6 // The ID of the rightmost tab
+enum {
+    NEWCHAR_TAB_MAX = 6 // The ID of the rightmost tab
+};
 
 static int skill_increment_cost( const Character &u, const skill_id &skill );
 
@@ -1744,7 +1748,7 @@ tab_direction set_profession( avatar &u, points_left &points,
         const std::string action = ctxt.handle_input();
         if( action == "DOWN" ) {
             cur_id++;
-            if( cur_id > static_cast<int>( profs_length ) - 1 ) {
+            if( cur_id > profs_length - 1 ) {
                 cur_id = 0;
             }
             desc_offset = 0;
@@ -1911,7 +1915,7 @@ tab_direction set_skills( avatar &u, points_left &points )
             auto req_skill = r.required_skills.find( currentSkill->ident() );
             int skill = req_skill != r.required_skills.end() ? req_skill->second : 0;
             bool would_autolearn_recipe =
-                recipe_dict.all_autolearn().count( &r ) &&
+                recipe_dict.all_autolearn().contains( &r ) &&
                 with_prof_skills.meets_skill_requirements( r.autolearn_requirements );
 
             if( !would_autolearn_recipe && !r.never_learn &&
@@ -2629,7 +2633,7 @@ tab_direction set_description( avatar &you, const bool allow_reroll,
                 mvwprintz( w_skills, point( 2, line ), c_light_gray,
                            elem->name() + ":" );
                 mvwprintz( w_skills, point( 25, line ), c_light_gray, "%-2d",
-                           static_cast<int>( level ) );
+                           level );
                 line++;
                 has_skills = true;
             }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -278,7 +278,7 @@ void npc_template::check_consistency()
 template<>
 bool string_id<npc_template>::is_valid() const
 {
-    return npc_templates.count( *this ) > 0;
+    return npc_templates.contains( *this );
 }
 
 template<>
@@ -1046,7 +1046,7 @@ void npc::start_read( item &it, player *pl )
     act->targets.emplace_back( it );
     act->str_values.push_back( std::to_string( penalty ) );
     // push an identifier of martial art book to the action handling
-    if( chosen.type->use_methods.count( "MA_MANUAL" ) ) {
+    if( chosen.type->use_methods.contains( "MA_MANUAL" ) ) {
         act->str_values.clear();
         act->str_values.emplace_back( "martial_art" );
     }
@@ -1854,14 +1854,14 @@ int npc::value( const item &it, int market_price ) const
 
     if( it.is_ammo() ) {
         const ammotype &at = it.ammo_type();
-        if( primary_weapon().is_gun() && primary_weapon().ammo_types().count( at ) ) {
+        if( primary_weapon().is_gun() && primary_weapon().ammo_types().contains( at ) ) {
             // TODO: magazines - don't count ammo as usable if the weapon isn't.
             ret += 14;
         }
 
         bool has_gun_for_ammo = has_item_with( [at]( const item & itm ) {
             // item::ammo_type considers the active gunmod.
-            return itm.is_gun() && itm.ammo_types().count( at );
+            return itm.is_gun() && itm.ammo_types().contains( at );
         } );
 
         if( has_gun_for_ammo ) {

--- a/src/npc_class.cpp
+++ b/src/npc_class.cpp
@@ -118,7 +118,7 @@ void npc_class::finalize_all()
         apply_all_to_unassigned( cl.bonus_skills );
 
         for( const auto &pr : cl.bonus_skills ) {
-            if( cl.skills.count( pr.first ) == 0 ) {
+            if( !cl.skills.contains( pr.first ) ) {
                 cl.skills[ pr.first ] = pr.second;
             } else {
                 cl.skills[ pr.first ] = cl.skills[ pr.first ] + pr.second;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4533,7 +4533,7 @@ void npc::do_reload( item &it )
 
     // Note: we may be reloading the magazine inside, not the gun itself
     // Maybe TODO: allow reload functions to understand such reloads instead of const casts
-    item &target = const_cast<item &>( *reload_opt.target );
+    item &target = ( *reload_opt.target );
     item *usable_ammo = reload_opt.ammo;
 
     // If in danger, don't spend multiple turns reloading a weapon to full one by one.

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -115,7 +115,9 @@ static const trait_id trait_PROF_FOODP( "PROF_FOODP" );
 static std::map<std::string, json_talk_topic> json_talk_topics;
 
 // Every OWED_VAL that the NPC owes you counts as +1 towards convincing
-#define OWED_VAL 1000
+enum {
+    OWED_VAL = 1000
+};
 
 int topic_category( const talk_topic &the_topic );
 
@@ -978,7 +980,7 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic ) const
             "TALK_MISSION_SUCCESS", "TALK_MISSION_SUCCESS_LIE", "TALK_MISSION_FAILURE"
         }
     };
-    if( mission_topics.count( topic ) > 0 ) {
+    if( mission_topics.contains( topic ) ) {
         if( p->chatbin.mission_selected == nullptr ) {
             return "mission_selected == nullptr; BUG!  (npctalk.cpp:dynamic_line)";
         }
@@ -1088,25 +1090,25 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic ) const
         }
 
         std::string info = "&";
-        int str_range = static_cast<int>( 100 / ability );
-        int str_min = static_cast<int>( p->str_max / str_range ) * str_range;
+        int str_range = ( 100 / ability );
+        int str_min = ( p->str_max / str_range ) * str_range;
         info += string_format( _( "Str %d - %d" ), str_min, str_min + str_range );
 
         if( ability >= 40 ) {
-            int dex_range = static_cast<int>( 160 / ability );
-            int dex_min = static_cast<int>( p->dex_max / dex_range ) * dex_range;
+            int dex_range = ( 160 / ability );
+            int dex_min = ( p->dex_max / dex_range ) * dex_range;
             info += string_format( _( "  Dex %d - %d" ), dex_min, dex_min + dex_range );
         }
 
         if( ability >= 50 ) {
-            int int_range = static_cast<int>( 200 / ability );
-            int int_min = static_cast<int>( p->int_max / int_range ) * int_range;
+            int int_range = ( 200 / ability );
+            int int_min = ( p->int_max / int_range ) * int_range;
             info += string_format( _( "  Int %d - %d" ), int_min, int_min + int_range );
         }
 
         if( ability >= 60 ) {
-            int per_range = static_cast<int>( 240 / ability );
-            int per_min = static_cast<int>( p->per_max / per_range ) * per_range;
+            int per_range = ( 240 / ability );
+            int per_min = ( p->per_max / per_range ) * per_range;
             info += string_format( _( "  Per %d - %d" ), per_min, per_min + per_range );
         }
 
@@ -1155,7 +1157,7 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic ) const
     } else if( topic == "TALK_OPINION" ) {
         return "&" + p->opinion_text();
     } else if( topic == "TALK_MIND_CONTROL" ) {
-        bool not_following = g->get_follower_list().count( p->getID() ) == 0;
+        bool not_following = !g->get_follower_list().contains( p->getID() );
         talk_function::follow( *p );
         if( not_following ) {
             return _( "YES, MASTER!" );
@@ -1544,70 +1546,70 @@ int topic_category( const talk_topic &the_topic )
             "TALK_MISSION_DESCRIBE_URGENT"
         }
     };
-    if( topic_1.count( topic ) > 0 ) {
+    if( topic_1.contains( topic ) ) {
         return 1;
     }
     static const std::unordered_set<std::string> topic_2 = { {
             "TALK_SHARE_EQUIPMENT", "TALK_GIVE_EQUIPMENT", "TALK_DENY_EQUIPMENT"
         }
     };
-    if( topic_2.count( topic ) > 0 ) {
+    if( topic_2.contains( topic ) ) {
         return 2;
     }
     static const std::unordered_set<std::string> topic_3 = { {
             "TALK_SUGGEST_FOLLOW", "TALK_AGREE_FOLLOW", "TALK_DENY_FOLLOW",
         }
     };
-    if( topic_3.count( topic ) > 0 ) {
+    if( topic_3.contains( topic ) ) {
         return 3;
     }
     static const std::unordered_set<std::string> topic_4 = { {
             "TALK_COMBAT_ENGAGEMENT",
         }
     };
-    if( topic_4.count( topic ) > 0 ) {
+    if( topic_4.contains( topic ) ) {
         return 4;
     }
     static const std::unordered_set<std::string> topic_5 = { {
             "TALK_COMBAT_COMMANDS",
         }
     };
-    if( topic_5.count( topic ) > 0 ) {
+    if( topic_5.contains( topic ) ) {
         return 5;
     }
     static const std::unordered_set<std::string> topic_6 = { {
             "TALK_TRAIN", "TALK_TRAIN_START", "TALK_TRAIN_FORCE"
         }
     };
-    if( topic_6.count( topic ) > 0 ) {
+    if( topic_6.contains( topic ) ) {
         return 6;
     }
     static const std::unordered_set<std::string> topic_7 = { {
             "TALK_MISC_RULES",
         }
     };
-    if( topic_7.count( topic ) > 0 ) {
+    if( topic_7.contains( topic ) ) {
         return 7;
     }
     static const std::unordered_set<std::string> topic_8 = { {
             "TALK_AIM_RULES",
         }
     };
-    if( topic_8.count( topic ) > 0 ) {
+    if( topic_8.contains( topic ) ) {
         return 8;
     }
     static const std::unordered_set<std::string> topic_9 = { {
             "TALK_FRIEND", "TALK_GIVE_ITEM", "TALK_USE_ITEM",
         }
     };
-    if( topic_9.count( topic ) > 0 ) {
+    if( topic_9.contains( topic ) ) {
         return 9;
     }
     static const std::unordered_set<std::string> topic_99 = { {
             "TALK_SIZE_UP", "TALK_LOOK_AT", "TALK_OPINION", "TALK_SHOUT"
         }
     };
-    if( topic_99.count( topic ) > 0 ) {
+    if( topic_99.contains( topic ) ) {
         return 99;
     }
     return -1; // Not grouped with other topics
@@ -1719,11 +1721,11 @@ talk_data talk_response::create_option_line( const dialogue &d, const char lette
 
     nc_color color;
     std::set<dialogue_consequence> consequences = get_consequences( d );
-    if( consequences.count( dialogue_consequence::hostile ) > 0 ) {
+    if( consequences.contains( dialogue_consequence::hostile ) ) {
         color = c_red;
-    } else if( text[0] == '*' || consequences.count( dialogue_consequence::helpless ) > 0 ) {
+    } else if( text[0] == '*' || consequences.contains( dialogue_consequence::helpless ) ) {
         color = c_light_red;
-    } else if( text[0] == '&' || consequences.count( dialogue_consequence::action ) > 0 ) {
+    } else if( text[0] == '&' || consequences.contains( dialogue_consequence::action ) ) {
         color = c_green;
     } else {
         color = c_white;
@@ -1853,9 +1855,9 @@ talk_topic dialogue::opt( dialogue_window &d_win, const std::string &npc_name,
         } while( ( ch < 0 || ch >= static_cast<int>( responses.size() ) ) );
         okay = true;
         std::set<dialogue_consequence> consequences = responses[ch].get_consequences( *this );
-        if( consequences.count( dialogue_consequence::hostile ) > 0 ) {
+        if( consequences.contains( dialogue_consequence::hostile ) ) {
             okay = query_yn( _( "You may be attacked!  Proceed?" ) );
-        } else if( consequences.count( dialogue_consequence::helpless ) > 0 ) {
+        } else if( consequences.contains( dialogue_consequence::helpless ) ) {
             okay = query_yn( _( "You'll be helpless!  Proceed?" ) );
         }
     } while( !okay );

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -304,11 +304,11 @@ void talk_function::goto_location( npc &p )
     selection_menu.selected = 0;
     selection_menu.query();
     auto index = selection_menu.ret;
-    if( index < 0 || index > static_cast<int>( 2 ) ||
-        index == static_cast<int>( 1 ) ) {
+    if( index < 0 || index > 2 ||
+        index == 1 ) {
         return;
     }
-    if( index == static_cast<int>( 1 ) ) {
+    if( index == 1 ) {
         destination = g->u.global_omt_location();
     }
     p.goal = destination;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -859,7 +859,7 @@ int options_manager::cOpt::getIntPos( const int iSearch ) const
 std::optional< std::tuple<int, std::string> > options_manager::cOpt::findInt(
     const int iSearch ) const
 {
-    int i = static_cast<int>( getIntPos( iSearch ) );
+    int i = getIntPos( iSearch );
     if( i == -1 ) {
         return std::nullopt;
     }
@@ -922,7 +922,7 @@ void options_manager::cOpt::setNext()
 void options_manager::cOpt::setPrev()
 {
     if( sType == "string_select" ) {
-        int iPrev = static_cast<int>( getItemPos( sSet ) ) - 1;
+        int iPrev = getItemPos( sSet ) - 1;
         if( iPrev < 0 ) {
             iPrev = vItems.size() - 1;
         }
@@ -942,7 +942,7 @@ void options_manager::cOpt::setPrev()
         }
 
     } else if( sType == "int_map" ) {
-        int iPrev = static_cast<int>( getIntPos( iSet ) ) - 1;
+        int iPrev = getIntPos( iSet ) - 1;
         if( iPrev < 0 ) {
             iPrev = mIntValues.size() - 1;
         }
@@ -1067,7 +1067,7 @@ static std::vector<options_manager::id_and_option> build_resource_list(
             }
             resource_names.emplace_back( resource_name,
                                          view_name.empty() ? no_translation( resource_name ) : to_translation( view_name ) );
-            if( resource_option.count( resource_name ) != 0 ) {
+            if( resource_option.contains( resource_name ) ) {
                 debugmsg( "Found \"%s\" duplicate with name \"%s\" (new definition will be ignored)",
                           operation_name, resource_name );
             } else {
@@ -2793,7 +2793,7 @@ static void draw_borders_external(
 static void draw_borders_internal( const catacurses::window &w, std::set<int> &vert_lines )
 {
     for( int i = 0; i < getmaxx( w ); ++i ) {
-        if( vert_lines.count( i ) != 0 ) {
+        if( vert_lines.contains( i ) ) {
             // intersection
             mvwputch( w, point( i, 0 ), BORDER_COLOR, LINE_OXXX );
         } else {
@@ -3502,12 +3502,12 @@ void options_manager::cache_balance_options()
 
 bool options_manager::has_option( const std::string &name ) const
 {
-    return options.count( name );
+    return options.contains( name );
 }
 
 options_manager::cOpt &options_manager::get_option( const std::string &name )
 {
-    if( options.count( name ) == 0 ) {
+    if( !options.contains( name ) ) {
         debugmsg( "requested non-existing option %s", name );
     }
     if( !world_options.has_value() ) {
@@ -3515,7 +3515,7 @@ options_manager::cOpt &options_manager::get_option( const std::string &name )
         return options[name];
     }
     auto &wopts = *world_options.value();
-    if( wopts.count( name ) == 0 ) {
+    if( !wopts.contains( name ) ) {
         auto &opt = options[name];
         if( opt.getPage() != world_default ) {
             // Requested a non-world option, deliver it.

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1926,7 +1926,7 @@ void scrollingcombattext::advanceAllSteps()
     std::vector<cSCT>::iterator iter = vSCT.begin();
 
     while( iter != vSCT.end() ) {
-        if( iter->advanceStep() > this->iMaxSteps ) {
+        if( iter->advanceStep() > scrollingcombattext::iMaxSteps ) {
             iter = vSCT.erase( iter );
         } else {
             ++iter;

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -79,7 +79,9 @@ class map_extra;
 
 #define dbg(x) DebugLogFL((x),DC::MapGen)
 
-#define BUILDINGCHANCE 4
+enum {
+    BUILDINGCHANCE = 4
+};
 
 ////////////////
 oter_id  ot_null,
@@ -289,7 +291,7 @@ city::city( const point_om_omt &P, int const S )
 
 int city::get_distance_from( const tripoint_om_omt &p ) const
 {
-    return std::max( static_cast<int>( trig_dist( p, tripoint_om_omt{ pos, 0 } ) ) - size, 0 );
+    return std::max( trig_dist( p, tripoint_om_omt{ pos, 0 } ) - size, 0 );
 }
 
 std::map<enum radio_type, std::string> radio_type_names =
@@ -1170,7 +1172,7 @@ struct fixed_overmap_special_data : overmap_special_data {
             const oter_str_id &oter = elem.terrain;
 
             if( !oter.is_valid() ) {
-                if( !invalid_terrains.count( oter ) ) {
+                if( !invalid_terrains.contains( oter ) ) {
                     // Not a huge fan of the the direct id manipulation here, but I don't know
                     // how else to do this
                     oter_str_id invalid( oter.str() + "_north" );
@@ -1186,7 +1188,7 @@ struct fixed_overmap_special_data : overmap_special_data {
 
             const auto &pos = elem.p;
 
-            if( points.count( pos ) > 0 ) {
+            if( points.contains( pos ) ) {
                 debugmsg( "In %s, point %s is duplicated.", context, pos.to_string() );
             } else {
                 points.insert( pos );
@@ -1856,7 +1858,7 @@ class joins_tracker
 
                 if( const join *other_side_join = resolved.find( other_side ) ) {
                     erase_unresolved( this_side );
-                    if( !avoid.count( this_side ) ) {
+                    if( !avoid.contains( this_side ) ) {
                         used.emplace_back( other_side, other_side_join->join->id );
                         // Because of the existence of alternative joins, we don't
                         // simply add this_side_join here, we add the opposite of
@@ -1947,7 +1949,7 @@ class joins_tracker
             }
 
             bool count( const om_pos_dir &p ) const {
-                return position_index.count( p );
+                return position_index.contains( p );
             }
 
             const join *find( const om_pos_dir &p ) const {
@@ -2392,7 +2394,7 @@ struct mutable_overmap_special_data : overmap_special_data {
             const mutable_overmap_terrain &ter = p.second;
             ter.check( string_format( "overmap %s in %s", p.first, context ) );
         }
-        if( !overmaps.count( root ) ) {
+        if( !overmaps.contains( root ) ) {
             debugmsg( "root %s is not amongst the defined overmaps for %s", root, context );
         }
         for( const mutable_overmap_phase &phase : phases ) {
@@ -2831,7 +2833,7 @@ void overmap_special::check() const
     std::unordered_set<overmap_special_id> parents ) -> std::optional<overmap_special_id> {
         for( const auto &nested : special->get_nested_specials() )
         {
-            if( parents.count( nested.second ) > 0 ) {
+            if( parents.contains( nested.second ) ) {
                 return nested.second;
             } else {
                 std::unordered_set<overmap_special_id> copy = parents;
@@ -3448,7 +3450,7 @@ static void elevate_bridges(
     }
     // Put bridge points
     for( const point_om_omt &bp : bridge_points ) {
-        if( flatten_points.count( bp ) != 0 ) {
+        if( flatten_points.contains( bp ) ) {
             continue;
         }
         tripoint_om_omt p( bp, 0 );
@@ -3615,7 +3617,7 @@ void overmap::reset_oter_id_migrations()
 
 bool overmap::is_oter_id_obsolete( const std::string &oterid )
 {
-    return oter_id_migrations.count( oterid ) > 0;
+    return oter_id_migrations.contains( oterid );
 }
 
 void overmap::migrate_oter_ids( const std::unordered_map<tripoint_om_omt, std::string> &points )
@@ -3759,7 +3761,7 @@ void overmap::move_hordes()
             // Check if the monster is a zombie.
             auto &type = *( this_monster.type );
             if(
-                !type.species.count( ZOMBIE ) || // Only add zombies to hordes.
+                !type.species.contains( ZOMBIE ) || // Only add zombies to hordes.
                 type.id == mtype_id( "mon_jabberwock" ) || // Jabberwockies are an exception.
                 this_monster.get_speed() <= 30 || // So are very slow zombies, like crawling zombies.
                 this_monster.has_flag( MF_IMMOBILE ) || // Also exempt anything stationary.
@@ -5737,7 +5739,7 @@ int overmap::place_special_attempt( const overmap_special &special, const int ma
 
         // City check is the fastest => it goes first.
         if( need_city ) {
-            if( valid_city.count( &nearest_city ) < 1 ||
+            if( !valid_city.contains( &nearest_city ) ||
                 valid_city[&nearest_city] >= max_per_city ||
                 !special.can_belong_to_city( *p, nearest_city ) ) {
                 p++;

--- a/src/overmap_connection.h
+++ b/src/overmap_connection.h
@@ -46,7 +46,7 @@ class overmap_connection
                 }
 
                 bool is_orthogonal() const {
-                    return flags.count( flag::orthogonal );
+                    return flags.contains( flag::orthogonal );
                 }
 
                 void load( const JsonObject &jo );

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -984,7 +984,7 @@ static void draw_ascii( ui_adaptor &ui,
                 ter_color = c_dark_gray;
                 ter_sym = "#";
                 // All cases below assume that see is true.
-            } else if( blink && npc_color.count( omp ) != 0 ) {
+            } else if( blink && npc_color.contains( omp ) ) {
                 // Visible NPCs are cached already
                 ter_color = npc_color[omp].color;
                 ter_sym = "@";
@@ -1639,7 +1639,7 @@ static bool search( const ui_adaptor &om_ui, tripoint_abs_omt &curs, const tripo
 
         mvwprintz( w_search, point( 1, 3 ), c_light_blue, _( "Direction:" ) );
         mvwprintz( w_search, point( align_width, 3 ), c_light_red, "%d %s",
-                   static_cast<int>( trig_dist( orig, tripoint_abs_omt( locations[i], orig.z() ) ) ),
+                   trig_dist( orig, tripoint_abs_omt( locations[i], orig.z() ) ),
                    direction_name_short( direction_from( orig, tripoint_abs_omt( locations[i], orig.z() ) ) ) );
 
         if( locations.size() > 1 ) {

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -262,7 +262,7 @@ overmap *overmapbuffer::get_existing( const point_abs_om &p )
     if( it != overmaps.end() ) {
         return last_requested_overmap = it->second.get();
     }
-    if( known_non_existing.count( p ) > 0 ) {
+    if( known_non_existing.contains( p ) ) {
         // This overmap does not exist on disk (this has already been
         // checked in a previous call of this function).
         return nullptr;
@@ -618,7 +618,7 @@ void overmapbuffer::add_vehicle( vehicle *veh )
     }
     int id = om_loc.om->vehicles.size() + 1;
     // this *should* be unique but just in case
-    while( om_loc.om->vehicles.count( id ) > 0 ) {
+    while( om_loc.om->vehicles.contains( id ) ) {
         id++;
     }
     om_vehicle &tracked_veh = om_loc.om->vehicles[id];
@@ -1621,7 +1621,7 @@ std::set<tripoint_abs_omt> overmapbuffer::electric_grid_at( const tripoint_abs_o
         for( size_t i = 0; i < six_cardinal_directions.size(); i++ ) {
             if( connections_bitset.test( i ) ) {
                 tripoint_abs_omt other = elem + six_cardinal_directions[i];
-                if( result.count( other ) == 0 ) {
+                if( !result.contains( other ) ) {
                     open.emplace( other );
                 }
             }

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -39,7 +39,7 @@ struct regional_settings;
 namespace om_direction
 {
 enum class type;
-}
+} // namespace om_direction
 
 struct overmap_path_params {
     int road_cost = -1;

--- a/src/panels_utility.h
+++ b/src/panels_utility.h
@@ -13,4 +13,4 @@ std::string value_trimmed( int value, int maximum = 100 );
 
 nc_color focus_color( int focus );
 
-#endif
+#endif // CATA_SRC_PANELS_UTILITY_H

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -1063,7 +1063,7 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
                                           !selected_stack.pick ) );
                 if( action != "RIGHT" && action != "LEFT" ) {
                     selected = idx;
-                    start = static_cast<int>( idx / maxitems ) * maxitems;
+                    start = ( idx / maxitems ) * maxitems;
                 }
 
                 if( !selected_stack.pick ) {

--- a/src/point.h
+++ b/src/point.h
@@ -75,7 +75,7 @@ struct point {
     }
 
 #ifndef CATA_NO_STL
-    inline point abs() const {
+    point abs() const {
         return point( std::abs( x ), std::abs( y ) );
     }
 #endif
@@ -93,13 +93,13 @@ struct point {
     void serialize( JsonOut &jsout ) const;
     void deserialize( JsonIn &jsin );
 
-    friend inline constexpr bool operator<( point a, point b ) {
+    friend constexpr bool operator<( point a, point b ) {
         return a.x < b.x || ( a.x == b.x && a.y < b.y );
     }
-    friend inline constexpr bool operator==( point a, point b ) {
+    friend constexpr bool operator==( point a, point b ) {
         return a.x == b.x && a.y == b.y;
     }
-    friend inline constexpr bool operator!=( point a, point b ) {
+    friend constexpr bool operator!=( point a, point b ) {
         return !( a == b );
     }
 
@@ -198,7 +198,7 @@ struct tripoint {
     }
 
 #ifndef CATA_NO_STL
-    inline tripoint abs() const {
+    tripoint abs() const {
         return tripoint( std::abs( x ), std::abs( y ), std::abs( z ) );
     }
 #endif
@@ -222,7 +222,7 @@ struct tripoint {
      * the dimensions specified by @param dim.
      * By default rotates around the origin (0, 0).
      * NOLINTNEXTLINE(cata-use-named-point-constants) */
-    inline tripoint rotate_2d( int turns, point dim = { 1, 1 } ) const {
+    tripoint rotate_2d( int turns, point dim = { 1, 1 } ) const {
         return tripoint( xy().rotate( turns, dim ), z );
     }
 
@@ -231,13 +231,13 @@ struct tripoint {
 
     friend std::ostream &operator<<( std::ostream &, const tripoint & );
 
-    friend inline constexpr bool operator==( const tripoint &a, const tripoint &b ) {
+    friend constexpr bool operator==( const tripoint &a, const tripoint &b ) {
         return a.x == b.x && a.y == b.y && a.z == b.z;
     }
-    friend inline constexpr bool operator!=( const tripoint &a, const tripoint &b ) {
+    friend constexpr bool operator!=( const tripoint &a, const tripoint &b ) {
         return !( a == b );
     }
-    friend inline bool operator<( const tripoint &a, const tripoint &b ) {
+    friend bool operator<( const tripoint &a, const tripoint &b ) {
         if( a.x != b.x ) {
             return a.x < b.x;
         }

--- a/src/point_float.h
+++ b/src/point_float.h
@@ -92,13 +92,13 @@ struct rl_vec3d {
         ret.z = z + rhs.z;
         return ret;
     }
-    friend inline constexpr bool operator==( const rl_vec3d &a, const rl_vec3d &b ) {
+    friend constexpr bool operator==( const rl_vec3d &a, const rl_vec3d &b ) {
         return a.x == b.x && a.y == b.y && a.z == b.z;
     }
-    friend inline constexpr bool operator!=( const rl_vec3d &a, const rl_vec3d &b ) {
+    friend constexpr bool operator!=( const rl_vec3d &a, const rl_vec3d &b ) {
         return !( a == b );
     }
-    friend inline constexpr bool operator<( const rl_vec3d &a, const rl_vec3d &b ) {
+    friend constexpr bool operator<( const rl_vec3d &a, const rl_vec3d &b ) {
         if( a.x != b.x ) {
             return a.x < b.x;
         }

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -508,7 +508,7 @@ profession::StartingSkillList profession::skills() const
 
 bool profession::has_flag( const std::string &flag ) const
 {
-    return flags.count( flag ) != 0;
+    return flags.contains( flag );
 }
 
 bool profession::is_locked_trait( const trait_id &trait ) const
@@ -519,7 +519,7 @@ bool profession::is_locked_trait( const trait_id &trait ) const
 
 bool profession::is_forbidden_trait( const trait_id &trait ) const
 {
-    return _forbidden_traits.count( trait ) != 0;
+    return _forbidden_traits.contains( trait );
 }
 
 std::map<spell_id, int> profession::spells() const

--- a/src/projectile.h
+++ b/src/projectile.h
@@ -53,7 +53,7 @@ struct projectile {
         void load( JsonObject &jo );
 
         bool has_effect( const ammo_effect_str_id &id ) const {
-            return proj_effects.count( id ) > 0;
+            return proj_effects.contains( id );
         }
         void add_effect( const ammo_effect_str_id &id ) {
             proj_effects.insert( id );

--- a/src/ranged_aoe.cpp
+++ b/src/ranged_aoe.cpp
@@ -74,7 +74,7 @@ void execute_shaped_attack( const shape &sh, const projectile &proj, Creature &a
     while( !queue.empty() ) {
         tripoint p = queue.top().p;
         queue.pop();
-        if( closed.count( p ) != 0 || !here.inbounds( p ) ) {
+        if( closed.contains( p ) || !here.inbounds( p ) ) {
             continue;
         }
         closed.insert( p );
@@ -114,8 +114,8 @@ void execute_shaped_attack( const shape &sh, const projectile &proj, Creature &a
             for( const tripoint &child : here.points_in_radius( p, 1 ) ) {
                 double coverage = sigdist_to_coverage( sh.distance_at( child ) );
                 if( coverage > 0.0 && !get_map().obstructed_by_vehicle_rotation( p, child ) &&
-                    closed.count( child ) == 0 &&
-                    ( open.count( child ) == 0 || open.at( child ).parent_coverage < current_coverage ) ) {
+                    !closed.contains( child ) &&
+                    ( !open.contains( child ) || open.at( child ).parent_coverage < current_coverage ) ) {
                     open[child] = aoe_flood_node( p, current_coverage );
                     queue.emplace( child, trig_dist_squared( origin, child ) );
                 }
@@ -167,7 +167,7 @@ std::map<tripoint, double> expected_coverage( const shape &sh, const map &here, 
     while( !queue.empty() ) {
         tripoint p = queue.top().p;
         queue.pop();
-        if( closed.count( p ) != 0 ) {
+        if( closed.contains( p ) ) {
             continue;
         }
         closed.insert( p );
@@ -202,8 +202,8 @@ std::map<tripoint, double> expected_coverage( const shape &sh, const map &here, 
             for( const tripoint &child : here.points_in_radius( p, 1 ) ) {
                 double coverage = sigdist_to_coverage( sh.distance_at( child ) );
                 if( coverage > 0.0 && !get_map().obstructed_by_vehicle_rotation( p, child ) &&
-                    closed.count( child ) == 0 &&
-                    ( open.count( child ) == 0 || open.at( child ).parent_coverage < current_coverage ) ) {
+                    !closed.contains( child ) &&
+                    ( !open.contains( child ) || open.at( child ).parent_coverage < current_coverage ) ) {
                     open[child] = aoe_flood_node( p, current_coverage );
                     queue.emplace( child, trig_dist_squared( origin, child ) );
                 }

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -93,7 +93,7 @@ int recipe::batch_time( int batch, float multiplier, size_t assistants ) const
 
 bool recipe::has_flag( const std::string &flag_name ) const
 {
-    return flags.count( flag_name );
+    return flags.contains( flag_name );
 }
 
 void recipe::load( const JsonObject &jo, const std::string &src )

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -27,7 +27,7 @@ enum class recipe_filter_flags : int {
     no_rotten = 1,
 };
 
-inline constexpr recipe_filter_flags operator&( recipe_filter_flags l, recipe_filter_flags r )
+constexpr recipe_filter_flags operator&( recipe_filter_flags l, recipe_filter_flags r )
 {
     return static_cast<recipe_filter_flags>(
                static_cast<unsigned>( l ) & static_cast<unsigned>( r ) );

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -321,7 +321,7 @@ recipe &recipe_dictionary::load( const JsonObject &jo, const std::string &src,
     // defer entries dependent upon as-yet unparsed definitions
     if( jo.has_string( "copy-from" ) ) {
         auto base = recipe_id( jo.get_string( "copy-from" ) );
-        if( !out.count( base ) ) {
+        if( !out.contains( base ) ) {
             deferred.emplace_back( jo.get_source_location(), src );
             jo.allow_omitted_members();
             return null_recipe;
@@ -356,7 +356,7 @@ std::map<recipe_id, recipe>::const_iterator recipe_dictionary::end() const
 
 bool recipe_dictionary::is_item_on_loop( const itype_id &i ) const
 {
-    return items_on_loops.count( i );
+    return items_on_loops.contains( i );
 }
 
 void recipe_dictionary::finalize_internal( std::map<recipe_id, recipe> &obj )
@@ -455,7 +455,7 @@ void recipe_dictionary::finalize()
         }
 
         // if reversible and no specific uncraft recipe exists use this recipe
-        if( r.is_reversible() && !recipe_dict.uncraft.count( recipe_id( r.result().str() ) ) ) {
+        if( r.is_reversible() && !recipe_dict.uncraft.contains( recipe_id( r.result().str() ) ) ) {
             recipe_dict.uncraft[ recipe_id( r.result().str() ) ] = r;
         }
     }
@@ -466,7 +466,7 @@ void recipe_dictionary::finalize()
         const recipe_id rid = recipe_id( id.str() );
 
         // books that don't already have an uncrafting recipe
-        if( e->book && !recipe_dict.uncraft.count( rid ) && e->volume > 0_ml ) {
+        if( e->book && !recipe_dict.uncraft.contains( rid ) && e->volume > 0_ml ) {
             int pages = std::max( 1, static_cast<int>( e->volume / 12.5_ml ) );
             auto &bk = recipe_dict.uncraft[rid];
             bk.ident_ = rid;
@@ -513,7 +513,7 @@ void recipe_subset::include( const recipe *r, int custom_difficulty )
         custom_difficulty = r->difficulty;
     }
     // We always prefer lower difficulty for the subset, but we save it only if it's not default
-    if( recipes.count( r ) > 0 ) {
+    if( recipes.contains( r ) ) {
         const auto iter = difficulties.find( r );
         // See if we need to lower the difficulty of the existing recipe
         if( iter != difficulties.end() && custom_difficulty < iter->second ) {

--- a/src/recipe_dictionary.h
+++ b/src/recipe_dictionary.h
@@ -104,7 +104,7 @@ class recipe_subset
 
         /** Check if the subset contains a recipe with the specified id. */
         bool contains( const recipe &r ) const {
-            return ids.count( r.ident() ) != 0;
+            return ids.contains( r.ident() );
         }
 
         /**

--- a/src/relic.h
+++ b/src/relic.h
@@ -128,10 +128,10 @@ class relic
         void add_active_effect( const fake_spell &sp );
         void add_recharge_scheme( const relic_recharge &r );
 
-        inline const std::vector<enchantment> &get_enchantments() const {
+        const std::vector<enchantment> &get_enchantments() const {
             return passive_effects;
         }
-        inline const std::vector<relic_recharge> &get_recharge_scheme() const {
+        const std::vector<relic_recharge> &get_recharge_scheme() const {
             return recharge_scheme;
         }
 

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -58,7 +58,7 @@ static std::map<requirement_id, requirement_data> requirements_all;
 template<>
 bool string_id<requirement_data>::is_valid() const
 {
-    return requirements_all.count( *this );
+    return requirements_all.contains( *this );
 }
 
 /** @relates string_id */
@@ -519,7 +519,7 @@ void inline_requirements( std::vector<std::vector<T>> &list,
             }
             // stack just holds the current path of inlining for debug purposes
             stack.push_back( r );
-            if( already_nested.count( r ) ) {
+            if( already_nested.contains( r ) ) {
                 // print debug msg and skip just this one requirement
                 debugmsg( "Tried to inline requirement %s which forms a cycle", r.c_str() );
                 stack.pop_back();
@@ -1480,7 +1480,7 @@ deduped_requirement_data::deduped_requirement_data( const requirement_data &in,
         auto first_duplicated = std::stable_partition(
                                     this_requirement.begin(), this_requirement.end(),
         [&]( const item_comp & c ) {
-            return !later_itypes.count( c.type );
+            return !later_itypes.contains( c.type );
         }
                                 );
 

--- a/src/requirements.h
+++ b/src/requirements.h
@@ -176,7 +176,7 @@ enum class requirement_display_flags {
     no_unavailable = 1,
 };
 
-inline constexpr requirement_display_flags operator&( requirement_display_flags l,
+constexpr requirement_display_flags operator&( requirement_display_flags l,
         requirement_display_flags r )
 {
     return static_cast<requirement_display_flags>(

--- a/src/safe_reference.h
+++ b/src/safe_reference.h
@@ -114,7 +114,7 @@ class safe_reference
         inline static rbi_type records_by_id;
         inline static uint32_t next_id = 1;
 
-        inline void fill( T *obj ) {
+        void fill( T *obj ) {
             rbp_it search = records_by_pointer.find( obj );
             if( search != records_by_pointer.end() ) {
                 rec = search->second;
@@ -123,7 +123,7 @@ class safe_reference
                 records_by_pointer.insert( {obj, rec} );
             }
         }
-        inline void fill( id_type id ) {
+        void fill( id_type id ) {
             rbi_it search = records_by_id.find( id );
             if( search != records_by_id.end() ) {
                 rec = search->second;
@@ -134,19 +134,19 @@ class safe_reference
             }
         }
 
-        inline static bool id_is_destroyed( id_type id ) {
+        static bool id_is_destroyed( id_type id ) {
             return ( id & DESTROYED_MASK ) != 0;
         }
 
-        inline static bool id_is_redirected( id_type id ) {
+        static bool id_is_redirected( id_type id ) {
             return ( id & REDIRECTED_MASK ) != 0;
         }
 
-        inline static id_type base_id( id_type id ) {
+        static id_type base_id( id_type id ) {
             return ( id & ~( DESTROYED_MASK | REDIRECTED_MASK ) );
         }
 
-        inline void resolve_redirects() const {
+        void resolve_redirects() const {
             while( rec != nullptr && id_is_redirected( rec->id ) ) {
                 if( rec->mem_count == 1 && rec->json_count == 0 ) {
                     record *old_rec = rec;
@@ -160,7 +160,7 @@ class safe_reference
             }
         }
 
-        inline void remove() {
+        void remove() {
             resolve_redirects();
             if( rec == nullptr ) {
                 return;
@@ -219,15 +219,15 @@ class safe_reference
         ~safe_reference();
         static void cleanup();
 
-        inline bool is_unassigned() const {
+        bool is_unassigned() const {
             return rec == nullptr;
         }
 
-        inline bool is_accessible() const {
+        bool is_accessible() const {
             return rec != nullptr && rec->target.p != nullptr;
         }
 
-        inline bool is_unloaded() const {
+        bool is_unloaded() const {
             resolve_redirects();
             if( is_unassigned() ) {
                 return false;
@@ -239,7 +239,7 @@ class safe_reference
                                                    !rec->target.p->is_detached() ) );
         }
 
-        inline bool is_destroyed() const {
+        bool is_destroyed() const {
             resolve_redirects();
             if( is_unassigned() ) {
                 return false;
@@ -281,7 +281,7 @@ class safe_reference
             return rec->target.p;
         }
 
-        inline T *get() const {
+        T *get() const {
             resolve_redirects();
             if( !*this ) {
                 debugmsg( "Attempted to resolve invalid safe reference" );
@@ -290,29 +290,29 @@ class safe_reference
             return rec->target.p;
         }
 
-        explicit inline operator bool() const {
+        explicit operator bool() const {
             return !!*this;
         }
 
-        inline bool operator!() const {
+        bool operator!() const {
             return is_unassigned() || is_unloaded() || is_destroyed();
         }
 
-        inline T &operator*() const {
+        T &operator*() const {
             return *get();
         }
 
-        inline T *operator->() const {
+        T *operator->() const {
             return get();
         }
 
-        inline bool operator==( const safe_reference<T> &against ) const {
+        bool operator==( const safe_reference<T> &against ) const {
             resolve_redirects();
             against.resolve_redirects();
             return rec == against.rec;
         }
 
-        inline bool operator==( const T &against ) const {
+        bool operator==( const T &against ) const {
             if( !rec ) {
                 return false;
             }
@@ -320,7 +320,7 @@ class safe_reference
             return rec->target.p == &against;
         }
 
-        inline bool operator==( const T *against ) const {
+        bool operator==( const T *against ) const {
             if( !rec ) {
                 return against == nullptr;
             }
@@ -329,7 +329,7 @@ class safe_reference
         }
 
         template <typename U>
-        inline bool operator!=( const U against ) const {
+        bool operator!=( const U against ) const {
             return !( *this == against );
         }
 
@@ -394,11 +394,11 @@ class cache_reference
 
         inline static ref_map reference_map;
 
-        inline void invalidate() {
+        void invalidate() {
             p = nullptr;
         }
 
-        inline void add_to_map() {
+        void add_to_map() {
             if( !p ) {
                 return;
             }
@@ -410,7 +410,7 @@ class cache_reference
             }
         }
 
-        inline void remove_from_map() {
+        void remove_from_map() {
             if( !p ) {
                 return;
             }
@@ -428,7 +428,7 @@ class cache_reference
 
     public:
 
-        inline static void mark_destroyed( T *obj ) {
+        static void mark_destroyed( T *obj ) {
             ref_map_it search = reference_map.find( obj );
             if( search == reference_map.end() ) {
                 return;
@@ -509,7 +509,7 @@ class cache_reference
             remove_from_map();
         }
 
-        inline T *get() const {
+        T *get() const {
             if( !*this ) {
                 debugmsg( "Tried to access invalid safe_reference" );
                 return nullptr;
@@ -517,36 +517,36 @@ class cache_reference
             return p;
         }
 
-        explicit inline operator bool() const {
+        explicit operator bool() const {
             return !!*this;
         }
 
-        inline bool operator!() const {
+        bool operator!() const {
             return p == nullptr;
         }
 
-        inline T &operator*() const {
+        T &operator*() const {
             return *get();
         }
 
-        inline T *operator->() const {
+        T *operator->() const {
             return get();
         }
 
-        inline bool operator==( const cache_reference<T> &against ) const {
+        bool operator==( const cache_reference<T> &against ) const {
             return against.p == p;
         }
 
-        inline bool operator==( const T &against ) const {
+        bool operator==( const T &against ) const {
             return p == &against;
         }
 
-        inline bool operator==( const T *against ) const {
+        bool operator==( const T *against ) const {
             return p == against;
         }
 
         template <typename U>
-        inline bool operator!=( const U against ) const {
+        bool operator!=( const U against ) const {
             return !( *this == against );
         }
 };

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -112,7 +112,6 @@
 #include "vitamin.h"
 #include "vpart_position.h"
 #include "vpart_range.h"
-#include "flag.h"
 
 struct mutation_branch;
 
@@ -1483,7 +1482,7 @@ void npc::load( const JsonObject &data )
                 NPC_MISSION_LEGACY_3
             }
         };
-        if( legacy_missions.count( mission ) > 0 ) {
+        if( legacy_missions.contains( mission ) ) {
             mission = NPC_MISSION_NULL;
         }
     }
@@ -1494,7 +1493,7 @@ void npc::load( const JsonObject &data )
                 NPC_MISSION_LEGACY_3
             }
         };
-        if( legacy_missions.count( mission ) > 0 ) {
+        if( legacy_missions.contains( mission ) ) {
             previous_mission = NPC_MISSION_NULL;
         }
     }
@@ -1516,7 +1515,7 @@ void npc::load( const JsonObject &data )
                 NPCATT_LEGACY_4, NPCATT_LEGACY_5, NPCATT_LEGACY_6
             }
         };
-        if( legacy_attitudes.count( attitude ) > 0 ) {
+        if( legacy_attitudes.contains( attitude ) ) {
             attitude = NPCATT_NULL;
         }
     }
@@ -1527,7 +1526,7 @@ void npc::load( const JsonObject &data )
                 NPCATT_LEGACY_4, NPCATT_LEGACY_5, NPCATT_LEGACY_6
             }
         };
-        if( legacy_attitudes.count( attitude ) > 0 ) {
+        if( legacy_attitudes.contains( attitude ) ) {
             previous_attitude = NPCATT_NULL;
         }
     }
@@ -2104,7 +2103,7 @@ static bool migration_required( const item &i )
     if( !i.count_by_charges() ) {
         return false;
     }
-    return the_list.count( i.typeId() ) > 0;
+    return the_list.contains( i.typeId() );
 }
 
 /**
@@ -2178,8 +2177,8 @@ void item::io( Archive &archive )
     archive.io( "item_vars", item_vars, io::empty_default_tag() );
     // TODO: change default to empty string
     archive.io( "name", corpse_name, std::string() );
-    archive.io( "owner", owner, owner.NULL_ID() );
-    archive.io( "old_owner", old_owner, old_owner.NULL_ID() );
+    archive.io( "owner", owner, faction_id::NULL_ID() );
+    archive.io( "old_owner", old_owner, faction_id::NULL_ID() );
     archive.io( "invlet", invlet, '\0' );
     archive.io( "damaged", damage_, 0 );
     archive.io( "active", active, false );
@@ -2302,7 +2301,7 @@ void item::io( Archive &archive )
     if( charges != 0 && !type->can_have_charges() ) {
         // Types that are known to have charges, but should not have them.
         // We fix it here, but it's expected from bugged saves and does not require a message.
-        if( charge_removal_blacklist::get().count( type->get_id() ) == 0 ) {
+        if( !charge_removal_blacklist::get().contains( type->get_id() ) ) {
             debugmsg( "Item %s was loaded with charges, but can not have any!", type->get_id() );
         }
         charges = 0;

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -240,7 +240,7 @@ start_location_id scenario::random_start_location() const
 
 bool scenario::scen_is_blacklisted() const
 {
-    return sc_blacklist.allowed_scenarios.count( id ) == 0;
+    return !sc_blacklist.allowed_scenarios.contains( id );
 }
 
 void scen_blacklist::load_scen_blacklist( const JsonObject &jo, const std::string &src )
@@ -271,12 +271,12 @@ void scen_blacklist::finalize()
         all_scen.insert( scen.ident() );
     }
     for( const string_id<scenario> &sc : blacklist_scenarios ) {
-        if( all_scen.count( sc ) == 0 ) {
+        if( !all_scen.contains( sc ) ) {
             debugmsg( "Scenario blacklist contains invalid scenario" );
         }
     }
     for( const string_id<scenario> &sc : whitelist_scenarios ) {
-        if( all_scen.count( sc ) == 0 ) {
+        if( !all_scen.contains( sc ) ) {
             debugmsg( "Scenario whitelist contains invalid scenario" );
         }
     }
@@ -288,7 +288,7 @@ void scen_blacklist::finalize()
     }
 
     for( auto i = allowed_scenarios.begin(); i != allowed_scenarios.end(); ) {
-        if( blacklist_scenarios.count( *i ) != 0 ) {
+        if( blacklist_scenarios.contains( *i ) ) {
             i = allowed_scenarios.erase( i );
         } else {
             i++;
@@ -420,7 +420,7 @@ vproto_id scenario::vehicle() const
 
 bool scenario::traitquery( const trait_id &trait ) const
 {
-    return _allowed_traits.count( trait ) != 0 || is_locked_trait( trait ) ||
+    return _allowed_traits.contains( trait ) || is_locked_trait( trait ) ||
            ( !is_forbidden_trait( trait ) && trait->startingtrait );
 }
 
@@ -431,17 +431,17 @@ std::set<trait_id> scenario::get_locked_traits() const
 
 bool scenario::is_locked_trait( const trait_id &trait ) const
 {
-    return _forced_traits.count( trait ) != 0;
+    return _forced_traits.contains( trait );
 }
 
 bool scenario::is_forbidden_trait( const trait_id &trait ) const
 {
-    return _forbidden_traits.count( trait ) != 0;
+    return _forbidden_traits.contains( trait );
 }
 
 bool scenario::has_flag( const std::string &flag ) const
 {
-    return flags.count( flag ) != 0;
+    return flags.contains( flag );
 }
 
 bool scenario::allowed_start( const start_location_id &loc ) const

--- a/src/simplexnoise.cpp
+++ b/src/simplexnoise.cpp
@@ -18,6 +18,7 @@
 #include "simplexnoise.h"
 
 #include <cmath>
+#include <numbers>
 
 /* 2D, 3D and 4D Simplex Noise functions return 'random' values in (-1, 1).
 
@@ -187,13 +188,13 @@ float raw_noise_2d( const float x, const float y )
     float n2 = 0;
 
     // Skew the input space to determine which simplex cell we're in
-    static const float F2 = 0.5f * ( std::sqrt( 3.0f ) - 1.0f );
+    static const float F2 = 0.5f * ( std::numbers::sqrt3_v<float> - 1.0f );
     // Hairy factor for 2D
     float s = ( x + y ) * F2;
     int i = fastfloor( x + s );
     int j = fastfloor( y + s );
 
-    static const float G2 = ( 3.0f - std::sqrt( 3.0f ) ) / 6.0f;
+    static const float G2 = ( 3.0f - std::numbers::sqrt3_v<float> ) / 6.0f;
     float t = ( i + j ) * G2;
     // Unskew the cell origin back to (x,y) space
     float X0 = i - t;

--- a/src/skill.cpp
+++ b/src/skill.cpp
@@ -212,20 +212,20 @@ skill_id Skill::random_skill()
 bool Skill::is_combat_skill() const
 {
     static const std::string combat_skill( "combat_skill" );
-    return _tags.count( combat_skill ) > 0;
+    return _tags.contains( combat_skill );
 }
 
 bool Skill::is_contextual_skill() const
 {
     static const std::string contextual_skill( "contextual_skill" );
-    return _tags.count( contextual_skill ) > 0;
+    return _tags.contains( contextual_skill );
 }
 
 // used to check NPC weapon skills for determining starting weapon
 bool Skill::is_weapon_skill() const
 {
     static const std::string weapon_skill( "weapon_skill" );
-    return _tags.count( weapon_skill ) > 0;
+    return _tags.contains( weapon_skill );
 }
 
 void SkillLevel::train( int amount, bool skip_scaling )

--- a/src/skill.h
+++ b/src/skill.h
@@ -104,7 +104,7 @@ class Skill
         bool is_weapon_skill() const;
 
         // Required for LUA
-        inline bool operator<( const Skill &rhs ) const {
+        bool operator<( const Skill &rhs ) const {
             return _ident < rhs._ident;
         }
 };

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1533,7 +1533,7 @@ void sfx::do_footstep()
 
         auto veh_displayed_part = g->m.veh_at( g->u.pos() ).part_displayed();
 
-        if( !veh_displayed_part && ( water.count( terrain ) > 0 ) ) {
+        if( !veh_displayed_part && ( water.contains( terrain ) ) ) {
             play_plmove_sound_variant( "walk_water" );
             return;
         }
@@ -1556,19 +1556,19 @@ void sfx::do_footstep()
             play_plmove_sound_variant( terrain.str() );
             return;
         }
-        if( grass.count( terrain ) > 0 ) {
+        if( grass.contains( terrain ) ) {
             play_plmove_sound_variant( "walk_grass" );
             return;
         }
-        if( dirt.count( terrain ) > 0 ) {
+        if( dirt.contains( terrain ) ) {
             play_plmove_sound_variant( "walk_dirt" );
             return;
         }
-        if( metal.count( terrain ) > 0 ) {
+        if( metal.contains( terrain ) ) {
             play_plmove_sound_variant( "walk_metal" );
             return;
         }
-        if( chain_fence.count( terrain ) > 0 ) {
+        if( chain_fence.contains( terrain ) ) {
             play_plmove_sound_variant( "clear_obstacle" );
             return;
         }
@@ -1597,7 +1597,7 @@ void sfx::do_obstacle( const std::string &obst )
     };
     if( sfx::has_variant_sound( "plmove", obst ) ) {
         play_variant_sound( "plmove", obst, heard_volume, 0_degrees, 0.8, 1.2 );
-    } else if( water.count( obst ) > 0 ) {
+    } else if( water.contains( obst ) ) {
         play_variant_sound( "plmove", "walk_water", heard_volume, 0_degrees, 0.8, 1.2 );
     } else {
         play_variant_sound( "plmove", "clear_obstacle", heard_volume, 0_degrees, 0.8, 1.2 );

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -198,7 +198,7 @@ static void board_up( map &m, const tripoint_range<tripoint> &range )
 void start_location::prepare_map( tinymap &m ) const
 {
     const int z = m.get_abs_sub().z;
-    if( flags().count( "BOARDED" ) > 0 ) {
+    if( flags().contains( "BOARDED" ) ) {
         m.build_outside_cache( z );
         board_up( m, m.points_on_zlevel( z ) );
     } else {
@@ -346,7 +346,7 @@ void start_location::place_player( player &u ) const
     u.setz( g->get_levz() );
     m.invalidate_map_cache( m.get_abs_sub().z );
     m.build_map_cache( m.get_abs_sub().z );
-    const bool must_be_inside = flags().count( "ALLOW_OUTSIDE" ) == 0;
+    const bool must_be_inside = !flags().contains( "ALLOW_OUTSIDE" );
     ///\EFFECT_STR allows player to start behind less-bashable furniture and terrain
     // TODO: Allow using items here
     const int bash = u.get_str();
@@ -445,7 +445,7 @@ void start_location::handle_heli_crash( player &u ) const
         if( bp == bodypart_id( "head" ) || bp == bodypart_id( "torso" ) ) {
             continue;// Skip head + torso for balance reasons.
         }
-        const int roll = static_cast<int>( rng( 1, 8 ) );
+        const int roll = rng( 1, 8 );
         switch( roll ) {
             // Damage + Bleed
             case 1:
@@ -458,7 +458,7 @@ void start_location::handle_heli_crash( player &u ) const
             case 5: {
                 const int maxHp = u.get_hp_max( bp );
                 // Body part health will range from 33% to 66% with occasional bleed
-                const int dmg = static_cast<int>( rng( maxHp / 3, maxHp * 2 / 3 ) );
+                const int dmg = rng( maxHp / 3, maxHp * 2 / 3 );
                 u.apply_damage( nullptr, bp, dmg );
                 break;
             }

--- a/src/stats_tracker.cpp
+++ b/src/stats_tracker.cpp
@@ -237,7 +237,7 @@ std::vector<const score *> stats_tracker::valid_scores() const
 {
     std::vector<const score *> result;
     for( const score &scr : score::get_all() ) {
-        if( initial_scores.count( scr.id ) ) {
+        if( initial_scores.contains( scr.id ) ) {
             result.push_back( &scr );
         }
     }

--- a/src/string_formatter.h
+++ b/src/string_formatter.h
@@ -432,7 +432,7 @@ template<typename ...Args>
 inline std::string string_format( std::string_view format, Args &&...args )
 {
     try {
-        cata::string_formatter formatter( std::move( format ) );
+        cata::string_formatter formatter( format );
         formatter.parse( std::forward<Args>( args )... );
         return formatter.get_output();
     } catch( ... ) {

--- a/src/string_id.h
+++ b/src/string_id.h
@@ -137,11 +137,11 @@ class string_identity_static
 #endif
         {}
 
-        inline const std::string &str() const {
+        const std::string &str() const {
             return get_interned_string( _id );
         }
 
-        inline bool is_empty() const {
+        bool is_empty() const {
             return _id == empty_interned_string();
         }
 
@@ -179,11 +179,11 @@ class string_identity_dynamic
         template<typename S> requires std::is_convertible_v<S, std::string>
         explicit string_identity_dynamic( S &&id ) : _id( std::forward<S>( id ) )  {}
 
-        inline const std::string &str() const {
+        const std::string &str() const {
             return _id;
         }
 
-        inline bool is_empty() const {
+        bool is_empty() const {
             return _id.empty();
         }
 
@@ -356,7 +356,7 @@ class string_id
         // structure that captures the actual "identity" of this string_id
         Identity _id;
 
-        inline void set_cid_version( int cid, int64_t version ) const {
+        void set_cid_version( int cid, int64_t version ) const {
             _cid = cid;
             _version = version;
         }

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -17,8 +17,8 @@ bool lcmatch( const std::string &str, const std::string &qry )
         std::wstring wneedle = utf8_to_wstr( qry );
         std::wstring whaystack = utf8_to_wstr( str );
 
-        f.tolower( &whaystack[0], &whaystack[0] + whaystack.size() );
-        f.tolower( &wneedle[0], &wneedle[0] + wneedle.size() );
+        f.tolower( whaystack.data(), whaystack.data() + whaystack.size() );
+        f.tolower( wneedle.data(), wneedle.data() + wneedle.size() );
 
         return whaystack.find( wneedle ) != std::wstring::npos;
     }
@@ -219,7 +219,7 @@ std::string to_upper_case( const std::string &s )
     if( temp_locale.name() != "en_US.UTF-8" && temp_locale.name() != "C" ) {
         const auto &f = std::use_facet<std::ctype<wchar_t>>( temp_locale );
         std::wstring wstr = utf8_to_wstr( s );
-        f.toupper( &wstr[0], &wstr[0] + wstr.size() );
+        f.toupper( wstr.data(), wstr.data() + wstr.size() );
         return wstr_to_utf8( wstr );
     }
     std::string res;
@@ -235,7 +235,7 @@ std::string to_lower_case( const std::string &s )
     if( temp_locale.name() != "en_US.UTF-8" && temp_locale.name() != "C" ) {
         const auto &f = std::use_facet<std::ctype<wchar_t>>( temp_locale );
         std::wstring wstr = utf8_to_wstr( s );
-        f.tolower( &wstr[0], &wstr[0] + wstr.size() );
+        f.tolower( wstr.data(), wstr.data() + wstr.size() );
         return wstr_to_utf8( wstr );
     }
     std::string res;

--- a/src/submap.h
+++ b/src/submap.h
@@ -55,7 +55,7 @@ struct spawn_point {
     // helper function to convert internal disposition into a binary bool value.
     // This is required to preserve save game compatibility because submaps store/load
     // their spawn_points using a boolean flag.
-    bool is_friendly( void ) const {
+    bool is_friendly( ) const {
         return disposition != spawn_disposition::SpawnDisp_Default;
     }
 
@@ -263,7 +263,7 @@ struct maptile {
         submap *const sm;
         point pos_;
 
-        inline point pos() const {
+        point pos() const {
             return pos_;
         }
 

--- a/src/translations.h
+++ b/src/translations.h
@@ -253,7 +253,7 @@ class translation
         /**
          * Get raw untranslated string for debug purposes.
          */
-        inline std::string_view debug_get_raw() const {
+        std::string_view debug_get_raw() const {
             return raw;
         }
 

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -773,7 +773,7 @@ bool trapfunc::pit( const tripoint &p, Creature *c, item * )
             if( damage > 0 ) {
                 n->add_msg_if_player( m_bad, _( "You hurt yourself!" ) );
                 // like the message says \-:
-                n->hurtall( rng( static_cast<int>( damage / 2 ), damage ), n );
+                n->hurtall( rng( ( damage / 2 ), damage ), n );
                 n->deal_damage( nullptr, bodypart_id( "leg_l" ), damage_instance( DT_BASH, damage ) );
                 n->deal_damage( nullptr, bodypart_id( "leg_r" ), damage_instance( DT_BASH, damage ) );
             } else {

--- a/src/turret.cpp
+++ b/src/turret.cpp
@@ -135,13 +135,13 @@ const itype *turret_data::ammo_data() const
 itype_id turret_data::ammo_current() const
 {
     auto opts = ammo_options();
-    if( opts.count( part->ammo_pref ) ) {
+    if( opts.contains( part->ammo_pref ) ) {
         return part->ammo_pref;
     }
-    if( opts.count( part->info().default_ammo ) ) {
+    if( opts.contains( part->info().default_ammo ) ) {
         return part->info().default_ammo;
     }
-    if( opts.count( part->base->ammo_default() ) ) {
+    if( opts.contains( part->base->ammo_default() ) ) {
         return part->base->ammo_default();
     }
     return opts.empty() ? itype_id::NULL_ID() : *opts.begin();
@@ -163,7 +163,7 @@ std::set<itype_id> turret_data::ammo_options() const
     } else {
         for( const auto &e : veh->fuels_left() ) {
             const itype *fuel = &*e.first;
-            if( fuel->ammo && part->base->ammo_types().count( fuel->ammo->type ) &&
+            if( fuel->ammo && part->base->ammo_types().contains( fuel->ammo->type ) &&
                 e.second >= part->base->ammo_required() ) {
 
                 opts.insert( fuel->get_id() );
@@ -176,7 +176,7 @@ std::set<itype_id> turret_data::ammo_options() const
 
 bool turret_data::ammo_select( const itype_id &ammo )
 {
-    if( !ammo_options().count( ammo ) ) {
+    if( !ammo_options().contains( ammo ) ) {
         return false;
     }
 

--- a/src/type_id_implement.h
+++ b/src/type_id_implement.h
@@ -13,13 +13,13 @@
     template<>                                                  \
     bool string_id<T>::is_valid() const                         \
     {                                                           \
-        return factory.is_valid(*this);                         \
+        return (factory).is_valid(*this);                         \
     }                                                           \
     /** @relates string_id */                                   \
     template<>                                                  \
     const T& string_id<T>::obj() const                          \
     {                                                           \
-        return factory.obj(*this);                              \
+        return (factory).obj(*this);                              \
     }
 
 // Implement int_id<T> operations
@@ -27,12 +27,12 @@
     template<>                                                  \
     bool int_id<T>::is_valid() const                            \
     {                                                           \
-        return factory.is_valid(*this);                         \
+        return (factory).is_valid(*this);                         \
     }                                                           \
     template<>                                                  \
     const T& int_id<T>::obj() const                             \
     {                                                           \
-        return factory.obj(*this);                              \
+        return (factory).obj(*this);                              \
     }
 
 // Implement string_id<T> <-> int_id<T> conversions
@@ -41,7 +41,7 @@
     template<>                                                  \
     int_id<T> string_id<T>::id() const                          \
     {                                                           \
-        return factory.convert(*this, int_id<T>(-1));           \
+        return (factory).convert(*this, int_id<T>(-1));           \
     }                                                           \
     template<>                                                  \
     int_id<T>::int_id(const string_id<T>& id)                   \
@@ -51,7 +51,7 @@
     template<>                                                  \
     const string_id<T>& int_id<T>::id() const                   \
     {                                                           \
-        return factory.convert(*this);                          \
+        return (factory).convert(*this);                          \
     }
 
 // Implement string_id<T> and int_id<T> operations, as well as conversions between them

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -522,7 +522,7 @@ void uilist::setup()
         while( next_free_hotkey < hotkeys.size() ) {
             const int setkey = hotkeys[next_free_hotkey];
             next_free_hotkey++;
-            if( keymap.count( setkey ) == 0 ) {
+            if( !keymap.contains( setkey ) ) {
                 entries[*it].hotkey = setkey;
                 keymap[setkey] = *it;
                 break;
@@ -614,12 +614,12 @@ void uilist::setup()
     }
 
     if( !w_x_setup.fun ) {
-        w_x = static_cast<int>( ( TERMX - w_width ) / 2 );
+        w_x = ( ( TERMX - w_width ) / 2 );
     } else {
         w_x = w_x_setup.fun( w_width );
     }
     if( !w_y_setup.fun ) {
-        w_y = static_cast<int>( ( TERMY - w_height ) / 2 );
+        w_y = ( ( TERMY - w_height ) / 2 );
     } else {
         w_y  = w_y_setup.fun( w_height );
     }

--- a/src/units_angle.h
+++ b/src/units_angle.h
@@ -17,34 +17,34 @@ class angle_in_radians_tag
 using angle = quantity<double, angle_in_radians_tag>;
 
 template<typename value_type>
-inline constexpr quantity<value_type, angle_in_radians_tag> from_radians( const value_type v )
+constexpr quantity<value_type, angle_in_radians_tag> from_radians( const value_type v )
 {
     return quantity<value_type, angle_in_radians_tag>( v, angle_in_radians_tag{} );
 }
 
-inline constexpr double to_radians( const units::angle v )
+constexpr double to_radians( const units::angle v )
 {
     return v.value();
 }
 
 template<typename value_type>
-inline constexpr quantity<double, angle_in_radians_tag> from_degrees( const value_type v )
+constexpr quantity<double, angle_in_radians_tag> from_degrees( const value_type v )
 {
     return from_radians( v * M_PI / 180 );
 }
 
-inline constexpr double to_degrees( const units::angle v )
+constexpr double to_degrees( const units::angle v )
 {
     return to_radians( v ) * 180 / M_PI;
 }
 
 template<typename value_type>
-inline constexpr quantity<double, angle_in_radians_tag> from_arcmin( const value_type v )
+constexpr quantity<double, angle_in_radians_tag> from_arcmin( const value_type v )
 {
     return from_degrees( v / 60.0 );
 }
 
-inline constexpr double to_arcmin( const units::angle v )
+constexpr double to_arcmin( const units::angle v )
 {
     return to_degrees( v ) * 60;
 }
@@ -71,42 +71,42 @@ inline units::angle atan2( double y, double x )
 
 } // namespace units
 
-inline constexpr units::angle operator"" _radians( const long double v )
+constexpr units::angle operator"" _radians( const long double v )
 {
     return units::from_radians( v );
 }
 
-inline constexpr units::angle operator"" _radians( const unsigned long long v )
+constexpr units::angle operator"" _radians( const unsigned long long v )
 {
     return units::from_radians( v );
 }
 
-inline constexpr units::angle operator"" _pi_radians( const long double v )
+constexpr units::angle operator"" _pi_radians( const long double v )
 {
     return units::from_radians( v * M_PI );
 }
 
-inline constexpr units::angle operator"" _pi_radians( const unsigned long long v )
+constexpr units::angle operator"" _pi_radians( const unsigned long long v )
 {
     return units::from_radians( v * M_PI );
 }
 
-inline constexpr units::angle operator"" _degrees( const long double v )
+constexpr units::angle operator"" _degrees( const long double v )
 {
     return units::from_degrees( v );
 }
 
-inline constexpr units::angle operator"" _degrees( const unsigned long long v )
+constexpr units::angle operator"" _degrees( const unsigned long long v )
 {
     return units::from_degrees( v );
 }
 
-inline constexpr units::angle operator"" _arcmin( const long double v )
+constexpr units::angle operator"" _arcmin( const long double v )
 {
     return units::from_arcmin( v );
 }
 
-inline constexpr units::angle operator"" _arcmin( const unsigned long long v )
+constexpr units::angle operator"" _arcmin( const unsigned long long v )
 {
     return units::from_arcmin( v );
 }

--- a/src/units_def.h
+++ b/src/units_def.h
@@ -138,13 +138,13 @@ struct quantity_details {
 };
 
 template<Arithmetic V, typename U>
-inline constexpr auto fabs( quantity<V, U> q ) -> quantity<V, U>
+constexpr auto fabs( quantity<V, U> q ) -> quantity<V, U>
 {
     return quantity<V, U>( std::fabs( q.value() ), U{} );
 }
 
 template<Arithmetic V, typename U>
-inline constexpr auto fmod( quantity<V, U> num, quantity<V, U> den ) -> quantity<V, U>
+constexpr auto fmod( quantity<V, U> num, quantity<V, U> den ) -> quantity<V, U>
 {
     return quantity<V, U>( std::fmod( num.value(), den.value() ), U{} );
 }
@@ -192,7 +192,7 @@ inline constexpr auto fmod( quantity<V, U> num, quantity<V, U> den ) -> quantity
 
 // scalar * quantity<foo, unit> == quantity<decltype(foo * scalar), unit>
 template<Arithmetic lvt, typename ut, Arithmetic st>
-inline constexpr auto operator*( const st &factor, const quantity<lvt, ut> &rhs )
+constexpr auto operator*( const st &factor, const quantity<lvt, ut> &rhs )
 {
     static_assert( quantity_details<ut>::common_zero_point::value,
                    "Units with multiple scales with different zero should not be multiplied/divided/etc.  directly." );
@@ -201,7 +201,7 @@ inline constexpr auto operator*( const st &factor, const quantity<lvt, ut> &rhs 
 
 // same as above only with inverse order of operands: quantity * scalar
 template<Arithmetic lvt, typename ut, Arithmetic st>
-inline constexpr auto operator*( const quantity<lvt, ut> &lhs, const st &factor )
+constexpr auto operator*( const quantity<lvt, ut> &lhs, const st &factor )
 {
     static_assert( quantity_details<ut>::common_zero_point::value,
                    "Units with multiple scales with different zero should not be multiplied/divided/etc.  directly." );
@@ -210,20 +210,20 @@ inline constexpr auto operator*( const quantity<lvt, ut> &lhs, const st &factor 
 
 // Explicit "yes, I know what I'm doing" multiplication
 template<Arithmetic lvt, typename ut, Arithmetic st>
-inline constexpr auto multiply_any_unit( const quantity<lvt, ut> &lhs, const st &factor )
+constexpr auto multiply_any_unit( const quantity<lvt, ut> &lhs, const st &factor )
 {
     return quantity{ lhs.value() *factor, ut{} };
 }
 
 template<typename t, Arithmetic st>
-inline constexpr auto multiply_any_unit( const t &lhs, const st &factor )
+constexpr auto multiply_any_unit( const t &lhs, const st &factor )
 {
     return lhs * factor;
 }
 
 // quantity<foo, unit> * quantity<bar, unit> is not supported
 template<Arithmetic lvt, typename ut, Arithmetic rvt>
-inline void operator*( quantity<lvt, ut>, quantity<rvt, ut> ) = delete;
+void operator*( quantity<lvt, ut>, quantity<rvt, ut> ) = delete;
 
 // operator *=
 template<Arithmetic lvt, typename ut, Arithmetic st>
@@ -236,18 +236,18 @@ inline auto operator*=( quantity<lvt, ut> &lhs, const st &factor ) -> quantity<l
 // and the revers of the multiplication above:
 // quantity<foo, unit> / scalar == quantity<decltype(foo / scalar), unit>
 template<Arithmetic lvt, typename ut, Arithmetic rvt>
-inline constexpr auto operator/( const quantity<lvt, ut> &lhs, const rvt &divisor )
+constexpr auto operator/( const quantity<lvt, ut> &lhs, const rvt &divisor )
 {
     return quantity{ lhs.value() / divisor, ut{} };
 }
 
 // scalar / quantity<foo, unit> is not supported
 template<Arithmetic lvt, typename ut, Arithmetic rvt>
-inline void operator/( lvt, quantity<rvt, ut> ) = delete;
+void operator/( lvt, quantity<rvt, ut> ) = delete;
 
 // quantity<foo, unit> / quantity<bar, unit> == decltype(foo / bar)
 template<Arithmetic lvt, typename ut, Arithmetic rvt>
-inline constexpr auto operator/( const quantity<lvt, ut> &lhs, const quantity<rvt, ut> &rhs )
+constexpr auto operator/( const quantity<lvt, ut> &lhs, const quantity<rvt, ut> &rhs )
 {
     return lhs.value() / rhs.value();
 }
@@ -263,18 +263,18 @@ inline auto operator/=( quantity<lvt, ut> &lhs, const st &divisor ) -> quantity<
 // remainder:
 // quantity<foo, unit> % scalar == quantity<decltype(foo % scalar), unit>
 template<Arithmetic lvt, typename ut, Arithmetic rvt>
-inline constexpr auto operator%( const quantity<lvt, ut> &lhs, const rvt &divisor )
+constexpr auto operator%( const quantity<lvt, ut> &lhs, const rvt &divisor )
 {
     return quantity{ lhs.value() % divisor, ut{} };
 }
 
 // scalar % quantity<foo, unit> is not supported
 template<Arithmetic lvt, typename ut, Arithmetic rvt>
-inline void operator%( lvt, quantity<rvt, ut> ) = delete;
+void operator%( lvt, quantity<rvt, ut> ) = delete;
 
 // quantity<foo, unit> % quantity<bar, unit> == decltype(foo % bar)
 template<Arithmetic lvt, typename ut, Arithmetic rvt>
-inline constexpr auto operator%( const quantity<lvt, ut> &lhs, const quantity<rvt, ut> &rhs )
+constexpr auto operator%( const quantity<lvt, ut> &lhs, const quantity<rvt, ut> &rhs )
 {
     return quantity{ lhs.value() % rhs.value(), ut{} };
 }

--- a/src/units_energy.h
+++ b/src/units_energy.h
@@ -22,14 +22,14 @@ const energy energy_max = units::energy( std::numeric_limits<units::energy::valu
                           units::energy::unit_type{} );
 
 template<typename value_type>
-inline constexpr quantity<value_type, energy_in_joule_tag> from_joule(
+constexpr quantity<value_type, energy_in_joule_tag> from_joule(
     const value_type v )
 {
     return quantity<value_type, energy_in_joule_tag>( v, energy_in_joule_tag{} );
 }
 
 template<typename value_type>
-inline constexpr quantity<value_type, energy_in_joule_tag> from_kilojoule( const value_type v )
+constexpr quantity<value_type, energy_in_joule_tag> from_kilojoule( const value_type v )
 {
     const value_type max_energy_joules = std::numeric_limits<value_type>::max() / 1000;
     value_type energy = v * 1000 > max_energy_joules ? max_energy_joules : v * 1000;
@@ -37,36 +37,36 @@ inline constexpr quantity<value_type, energy_in_joule_tag> from_kilojoule( const
 }
 
 template<typename value_type>
-inline constexpr value_type to_joule( const quantity<value_type, energy_in_joule_tag> &v )
+constexpr value_type to_joule( const quantity<value_type, energy_in_joule_tag> &v )
 {
     return v / from_joule<value_type>( 1 );
 }
 
 template<typename value_type>
-inline constexpr value_type to_kilojoule( const quantity<value_type, energy_in_joule_tag> &v )
+constexpr value_type to_kilojoule( const quantity<value_type, energy_in_joule_tag> &v )
 {
     return to_joule( v ) / 1000.0;
 }
 
 } // namespace units
 
-inline constexpr units::energy operator"" _J( const unsigned long long v )
+constexpr units::energy operator"" _J( const unsigned long long v )
 {
     return units::from_joule( v );
 }
 
-inline constexpr units::quantity<double, units::energy_in_joule_tag> operator"" _J(
+constexpr units::quantity<double, units::energy_in_joule_tag> operator"" _J(
     const long double v )
 {
     return units::from_joule( v );
 }
 
-inline constexpr units::energy operator"" _kJ( const unsigned long long v )
+constexpr units::energy operator"" _kJ( const unsigned long long v )
 {
     return units::from_kilojoule( v );
 }
 
-inline constexpr units::quantity<double, units::energy_in_joule_tag> operator"" _kJ(
+constexpr units::quantity<double, units::energy_in_joule_tag> operator"" _kJ(
     const long double v )
 {
     return units::from_kilojoule( v );

--- a/src/units_mass.h
+++ b/src/units_mass.h
@@ -31,53 +31,53 @@ constexpr mass mass_max = units::mass( std::numeric_limits<units::mass::value_ty
 
 
 template<typename value_type>
-inline constexpr quantity<value_type, mass_in_milligram_tag> from_milligram(
+constexpr quantity<value_type, mass_in_milligram_tag> from_milligram(
     const value_type v )
 {
     return quantity<value_type, mass_in_milligram_tag>( v, mass_in_milligram_tag{} );
 }
 
 template<typename value_type>
-inline constexpr quantity<value_type, mass_in_milligram_tag> from_gram(
+constexpr quantity<value_type, mass_in_milligram_tag> from_gram(
     const value_type v )
 {
     return from_milligram( v * 1000 );
 }
 
 template<typename value_type>
-inline constexpr quantity<value_type, mass_in_milligram_tag> from_kilogram(
+constexpr quantity<value_type, mass_in_milligram_tag> from_kilogram(
     const value_type v )
 {
     return from_gram( v * 1000 );
 }
 
 template<typename value_type>
-inline constexpr quantity<value_type, mass_in_milligram_tag> from_newton(
+constexpr quantity<value_type, mass_in_milligram_tag> from_newton(
     const value_type v )
 {
     return from_kilogram( v / GRAVITY_OF_EARTH );
 }
 
 template<typename value_type>
-inline constexpr value_type to_milligram( const quantity<value_type, mass_in_milligram_tag> &v )
+constexpr value_type to_milligram( const quantity<value_type, mass_in_milligram_tag> &v )
 {
     return v.value();
 }
 
 template<typename value_type>
-inline constexpr value_type to_gram( const quantity<value_type, mass_in_milligram_tag> &v )
+constexpr value_type to_gram( const quantity<value_type, mass_in_milligram_tag> &v )
 {
     return v.value() / 1000.0;
 }
 
 template<typename value_type>
-inline constexpr value_type to_kilogram( const quantity<value_type, mass_in_milligram_tag> &v )
+constexpr value_type to_kilogram( const quantity<value_type, mass_in_milligram_tag> &v )
 {
     return v.value() / 1000000.0;
 }
 
 template<typename value_type>
-inline constexpr value_type to_newton( const quantity<value_type, mass_in_milligram_tag> &v )
+constexpr value_type to_newton( const quantity<value_type, mass_in_milligram_tag> &v )
 {
     return to_kilogram( v ) * GRAVITY_OF_EARTH;
 }
@@ -85,45 +85,45 @@ inline constexpr value_type to_newton( const quantity<value_type, mass_in_millig
 } // namespace units
 
 // Implicitly converted to mass, which has int as value_type!
-inline constexpr units::mass operator"" _milligram( const unsigned long long v )
+constexpr units::mass operator"" _milligram( const unsigned long long v )
 {
     return units::from_milligram( v );
 }
 
-inline constexpr units::mass operator"" _gram( const unsigned long long v )
+constexpr units::mass operator"" _gram( const unsigned long long v )
 {
     return units::from_gram( v );
 }
 
-inline constexpr units::mass operator"" _kilogram( const unsigned long long v )
+constexpr units::mass operator"" _kilogram( const unsigned long long v )
 {
     return units::from_kilogram( v );
 }
 
-inline constexpr units::mass operator"" _newton( const unsigned long long v )
+constexpr units::mass operator"" _newton( const unsigned long long v )
 {
     return units::from_newton( v );
 }
 
-inline constexpr units::quantity<double, units::mass_in_milligram_tag> operator"" _milligram(
+constexpr units::quantity<double, units::mass_in_milligram_tag> operator"" _milligram(
     const long double v )
 {
     return units::from_milligram( v );
 }
 
-inline constexpr units::quantity<double, units::mass_in_milligram_tag> operator"" _gram(
+constexpr units::quantity<double, units::mass_in_milligram_tag> operator"" _gram(
     const long double v )
 {
     return units::from_gram( v );
 }
 
-inline constexpr units::quantity<double, units::mass_in_milligram_tag> operator"" _kilogram(
+constexpr units::quantity<double, units::mass_in_milligram_tag> operator"" _kilogram(
     const long double v )
 {
     return units::from_kilogram( v );
 }
 
-inline constexpr units::quantity<double, units::mass_in_milligram_tag> operator"" _newton(
+constexpr units::quantity<double, units::mass_in_milligram_tag> operator"" _newton(
     const long double v )
 {
     return units::from_newton( v );

--- a/src/units_money.h
+++ b/src/units_money.h
@@ -22,72 +22,72 @@ const money money_max = units::money( std::numeric_limits<units::money::value_ty
                                       units::money::unit_type{} );
 
 template<typename value_type>
-inline constexpr quantity<value_type, money_in_cent_tag> from_cent(
+constexpr quantity<value_type, money_in_cent_tag> from_cent(
     const value_type v )
 {
     return quantity<value_type, money_in_cent_tag>( v, money_in_cent_tag{} );
 }
 
 template<typename value_type>
-inline constexpr quantity<value_type, money_in_cent_tag> from_usd( const value_type v )
+constexpr quantity<value_type, money_in_cent_tag> from_usd( const value_type v )
 {
     return from_cent<value_type>( v * 100 );
 }
 
 template<typename value_type>
-inline constexpr quantity<value_type, money_in_cent_tag> from_kusd( const value_type v )
+constexpr quantity<value_type, money_in_cent_tag> from_kusd( const value_type v )
 {
     return from_usd<value_type>( v * 1000 );
 }
 
 template<typename value_type>
-inline constexpr value_type to_cent( const quantity<value_type, money_in_cent_tag> &v )
+constexpr value_type to_cent( const quantity<value_type, money_in_cent_tag> &v )
 {
     return v / from_cent<value_type>( 1 );
 }
 
 template<typename value_type>
-inline constexpr value_type to_usd( const quantity<value_type, money_in_cent_tag> &v )
+constexpr value_type to_usd( const quantity<value_type, money_in_cent_tag> &v )
 {
     return to_cent( v ) / 100.0;
 }
 
 template<typename value_type>
-inline constexpr value_type to_kusd( const quantity<value_type, money_in_cent_tag> &v )
+constexpr value_type to_kusd( const quantity<value_type, money_in_cent_tag> &v )
 {
     return to_usd( v ) / 1000.0;
 }
 
 } // namespace units
 
-inline constexpr units::money operator"" _cent( const unsigned long long v )
+constexpr units::money operator"" _cent( const unsigned long long v )
 {
     return units::from_cent( v );
 }
 
-inline constexpr units::quantity<double, units::money_in_cent_tag> operator"" _cent(
+constexpr units::quantity<double, units::money_in_cent_tag> operator"" _cent(
     const long double v )
 {
     return units::from_cent( v );
 }
 
-inline constexpr units::money operator"" _USD( const unsigned long long v )
+constexpr units::money operator"" _USD( const unsigned long long v )
 {
     return units::from_usd( v );
 }
 
-inline constexpr units::quantity<double, units::money_in_cent_tag> operator"" _USD(
+constexpr units::quantity<double, units::money_in_cent_tag> operator"" _USD(
     const long double v )
 {
     return units::from_usd( v );
 }
 
-inline constexpr units::money operator"" _kUSD( const unsigned long long v )
+constexpr units::money operator"" _kUSD( const unsigned long long v )
 {
     return units::from_kusd( v );
 }
 
-inline constexpr units::quantity<double, units::money_in_cent_tag> operator"" _kUSD(
+constexpr units::quantity<double, units::money_in_cent_tag> operator"" _kUSD(
     const long double v )
 {
     return units::from_kusd( v );

--- a/src/units_probability.h
+++ b/src/units_probability.h
@@ -22,7 +22,7 @@ const probability probability_max = units::probability(
                                         units::probability::unit_type{} );
 
 template<typename value_type>
-inline constexpr quantity<value_type, probability_in_one_in_million_tag>
+constexpr quantity<value_type, probability_in_one_in_million_tag>
 from_one_in_million(
     const value_type v )
 {
@@ -31,7 +31,7 @@ from_one_in_million(
 }
 
 template<typename value_type>
-inline constexpr quantity<value_type, probability_in_one_in_million_tag>
+constexpr quantity<value_type, probability_in_one_in_million_tag>
 from_percent(
     const value_type v )
 {
@@ -40,25 +40,25 @@ from_percent(
 }
 
 template<typename value_type>
-inline constexpr value_type to_one_in_million( const
-        quantity<value_type, probability_in_one_in_million_tag> &v )
+constexpr value_type to_one_in_million( const
+                                        quantity<value_type, probability_in_one_in_million_tag> &v )
 {
     return v / from_one_in_million<value_type>( 1 );
 }
 
 } // namespace units
 
-inline constexpr units::probability operator"" _pm( const unsigned long long v )
+constexpr units::probability operator"" _pm( const unsigned long long v )
 {
     return units::from_one_in_million<int>( v );
 }
 
-inline constexpr units::probability operator"" _pct( const unsigned long long v )
+constexpr units::probability operator"" _pct( const unsigned long long v )
 {
     return units::from_one_in_million<int>( v * 10000 );
 }
 
-inline constexpr units::probability operator"" _pct( const long double v )
+constexpr units::probability operator"" _pct( const long double v )
 {
     return units::from_one_in_million<int>( v * 10000 );
 }

--- a/src/units_temperature.h
+++ b/src/units_temperature.h
@@ -76,7 +76,7 @@ const temperature temperature_max = units::temperature(
                                         units::temperature::unit_type{} );
 
 template<typename value_type>
-inline constexpr quantity<value_type, temperature_in_millidegree_celsius_tag>
+constexpr quantity<value_type, temperature_in_millidegree_celsius_tag>
 from_millidegree_celsius(
     const value_type v )
 {
@@ -85,7 +85,7 @@ from_millidegree_celsius(
 }
 
 template<typename value_type>
-inline constexpr quantity<value_type, temperature_in_millidegree_celsius_tag> from_celsius(
+constexpr quantity<value_type, temperature_in_millidegree_celsius_tag> from_celsius(
     const value_type v )
 {
     const value_type max_temperature_celsius = std::numeric_limits<value_type>::max() / 1000;
@@ -94,7 +94,7 @@ inline constexpr quantity<value_type, temperature_in_millidegree_celsius_tag> fr
 }
 
 template<typename value_type>
-inline constexpr quantity<value_type, temperature_in_millidegree_celsius_tag> from_fahrenheit(
+constexpr quantity<value_type, temperature_in_millidegree_celsius_tag> from_fahrenheit(
     const value_type v )
 {
     // Explicit casts to silence warnings about lossy conversions
@@ -107,53 +107,53 @@ inline constexpr quantity<value_type, temperature_in_millidegree_celsius_tag> fr
 }
 
 template<typename value_type>
-inline constexpr value_type to_millidegree_celsius( const
+constexpr value_type to_millidegree_celsius( const
         quantity<value_type, temperature_in_millidegree_celsius_tag> &v )
 {
     return v / from_millidegree_celsius<value_type>( 1 );
 }
 
 template<typename value_type>
-inline constexpr value_type to_celsius( const
-                                        quantity<value_type, temperature_in_millidegree_celsius_tag> &v )
+constexpr value_type to_celsius( const
+                                 quantity<value_type, temperature_in_millidegree_celsius_tag> &v )
 {
     return to_millidegree_celsius( v ) / 1000.0;
 }
 
 template<typename value_type>
-inline constexpr value_type to_fahrenheit( const
-        quantity<value_type, temperature_in_millidegree_celsius_tag> &v )
+constexpr value_type to_fahrenheit( const
+                                    quantity<value_type, temperature_in_millidegree_celsius_tag> &v )
 {
     return celsius_to_fahrenheit( to_millidegree_celsius( v ) / 1000.0 );
 }
 
 template<typename value_type>
-inline constexpr value_type to_kelvins( const
-                                        quantity<value_type, temperature_in_millidegree_celsius_tag> &v )
+constexpr value_type to_kelvins( const
+                                 quantity<value_type, temperature_in_millidegree_celsius_tag> &v )
 {
     return celsius_to_kelvin( to_millidegree_celsius( v ) / 1000.0 );
 }
 
 } // namespace units
 
-inline constexpr units::temperature operator"" _mc( const unsigned long long v )
+constexpr units::temperature operator"" _mc( const unsigned long long v )
 {
     // Cast to int because fahrenheit conversion needs it
     // Rest gets it for consistency
     return units::from_millidegree_celsius<int>( v );
 }
 
-inline constexpr units::temperature operator"" _c( const unsigned long long v )
+constexpr units::temperature operator"" _c( const unsigned long long v )
 {
     return units::from_celsius<int>( v );
 }
 
-inline constexpr units::temperature operator"" _c( const long double v )
+constexpr units::temperature operator"" _c( const long double v )
 {
     return units::from_celsius<double>( static_cast<double>( v ) );
 }
 
-inline constexpr units::temperature operator"" _f( const unsigned long long v )
+constexpr units::temperature operator"" _f( const unsigned long long v )
 {
     return units::from_fahrenheit<int>( v );
 }

--- a/src/units_volume.h
+++ b/src/units_volume.h
@@ -22,25 +22,25 @@ const volume volume_max = units::volume( std::numeric_limits<units::volume::valu
                           units::volume::unit_type{} );
 
 template<typename value_type>
-inline constexpr quantity<value_type, volume_in_milliliter_tag> from_milliliter(
+constexpr quantity<value_type, volume_in_milliliter_tag> from_milliliter(
     const value_type v )
 {
     return quantity<value_type, volume_in_milliliter_tag>( v, volume_in_milliliter_tag{} );
 }
 
 template<typename value_type>
-inline constexpr quantity<value_type, volume_in_milliliter_tag> from_liter( const value_type v )
+constexpr quantity<value_type, volume_in_milliliter_tag> from_liter( const value_type v )
 {
     return from_milliliter<value_type>( v * 1000 );
 }
 
 template<typename value_type>
-inline constexpr value_type to_milliliter( const quantity<value_type, volume_in_milliliter_tag> &v )
+constexpr value_type to_milliliter( const quantity<value_type, volume_in_milliliter_tag> &v )
 {
     return v / from_milliliter<value_type>( 1 );
 }
 
-inline constexpr double to_liter( const volume &v )
+constexpr double to_liter( const volume &v )
 {
     return v.value() / 1000.0;
 }
@@ -52,24 +52,24 @@ static constexpr volume legacy_volume_factor = from_milliliter( 250 );
 } // namespace units
 
 // Implicitly converted to volume, which has int as value_type!
-inline constexpr units::volume operator"" _ml( const unsigned long long v )
+constexpr units::volume operator"" _ml( const unsigned long long v )
 {
     return units::from_milliliter( v );
 }
 
-inline constexpr units::quantity<double, units::volume_in_milliliter_tag> operator"" _ml(
+constexpr units::quantity<double, units::volume_in_milliliter_tag> operator"" _ml(
     const long double v )
 {
     return units::from_milliliter( v );
 }
 
 // Implicitly converted to volume, which has int as value_type!
-inline constexpr units::volume operator"" _liter( const unsigned long long v )
+constexpr units::volume operator"" _liter( const unsigned long long v )
 {
     return units::from_milliliter( v * 1000 );
 }
 
-inline constexpr units::quantity<double, units::volume_in_milliliter_tag> operator"" _liter(
+constexpr units::quantity<double, units::volume_in_milliliter_tag> operator"" _liter(
     const long double v )
 {
     return units::from_milliliter( v * 1000 );

--- a/src/url_utility.h
+++ b/src/url_utility.h
@@ -25,4 +25,4 @@ void open_url( const std::string &url );
  */
 std::string encode_url( const std::string &text );
 
-#endif
+#endif // CATA_SRC_URL_UTILITY_H

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -563,7 +563,7 @@ task_reason veh_interact::cant_do( char mode )
         case 'i':
             // install mode
             enough_morale = you.has_morale_to_craft();
-            valid_target = !can_mount.empty() && 0 == veh->tags.count( "convertible" );
+            valid_target = !can_mount.empty() && !veh->tags.contains( "convertible" );
             //tool checks processed later
             enough_light = character_funcs::can_see_fine_details( you );
             has_tools = true;
@@ -605,7 +605,7 @@ task_reason veh_interact::cant_do( char mode )
         case 'o':
             // remove mode
             enough_morale = you.has_morale_to_craft();
-            valid_target = cpart >= 0 && 0 == veh->tags.count( "convertible" );
+            valid_target = cpart >= 0 && !veh->tags.contains( "convertible" );
             part_free = parts_here.size() > 1 || ( cpart >= 0 && veh->can_unmount( cpart ) );
             //tool and skill checks processed later
             has_tools = true;
@@ -784,7 +784,7 @@ bool veh_interact::update_part_requirements()
             }
         }
 
-        if( !axles.empty() && axles.count( -dd.x ) == 0 ) {
+        if( !axles.empty() && !axles.contains( -dd.x ) ) {
             // Installing more than one steerable axle is hard
             // (but adding a wheel to an existing axle isn't)
             // As with engines, cap at the actual maximum skill.

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -143,7 +143,7 @@ static DynamicDataLoader::deferred_json deferred;
 template<>
 bool string_id<vpart_info>::is_valid() const
 {
-    return vpart_info_all.count( *this );
+    return vpart_info_all.contains( *this );
 }
 
 /** @relates string_id */
@@ -940,7 +940,7 @@ const vehicle_prototype &string_id<vehicle_prototype>::obj() const
 template<>
 bool string_id<vehicle_prototype>::is_valid() const
 {
-    return vtypes.count( *this ) > 0;
+    return vtypes.contains( *this );
 }
 
 vehicle_prototype::vehicle_prototype() = default;
@@ -1109,7 +1109,7 @@ void vehicle_prototype::finalize()
 
             } else {
                 for( const itype_id &e : pt.ammo_types ) {
-                    if( !e->ammo && base->gun->ammo.count( e->ammo->type ) ) {
+                    if( !e->ammo && base->gun->ammo.contains( e->ammo->type ) ) {
                         debugmsg( "init_vehicles: turret %s has invalid ammo_type %s in %s",
                                   pt.part.c_str(), e.c_str(), id.c_str() );
                     }
@@ -1138,7 +1138,7 @@ void vehicle_prototype::finalize()
         blueprint.enable_refresh();
 
         for( auto &i : proto.item_spawns ) {
-            if( cargo_spots.count( i.pos ) == 0 ) {
+            if( !cargo_spots.contains( i.pos ) ) {
                 debugmsg( "Invalid spawn location (no CARGO vpart) in %s (%d, %d): %d%%",
                           proto.name, i.pos.x, i.pos.y, i.chance );
             }

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -334,7 +334,7 @@ class vpart_info
             return flags;
         }
         bool has_flag( const std::string &flag ) const {
-            return flags.count( flag ) != 0;
+            return flags.contains( flag );
         }
         bool has_flag( const vpart_bitflags flag ) const {
             return bitflags.test( flag );

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -488,11 +488,11 @@ class vehicle
         void suspend_refresh();
         void enable_refresh();
 
-        inline void attach() {
+        void attach() {
             attached = true;
         }
 
-        inline void detach() {
+        void detach() {
             attached = false;
         }
 
@@ -1193,7 +1193,7 @@ class vehicle
         // turn vehicle left (negative) or right (positive), degrees
         void turn( units::angle deg );
 
-        inline void set_facing( units::angle deg, bool refresh = true ) {
+        void set_facing( units::angle deg, bool refresh = true ) {
             turn_dir = deg;
             face.init( deg );
             pivot_rotation[0] = deg;
@@ -1202,7 +1202,7 @@ class vehicle
             }
         }
 
-        inline void set_pivot( point pivot, bool refresh = true ) {
+        void set_pivot( point pivot, bool refresh = true ) {
             pivot_cache = pivot;
             pivot_anchor[0] = pivot;
             if( refresh ) {
@@ -1210,7 +1210,7 @@ class vehicle
             }
         }
 
-        inline void set_facing_and_pivot( units::angle deg, point pivot, bool refresh = true ) {
+        void set_facing_and_pivot( units::angle deg, point pivot, bool refresh = true ) {
             set_facing( deg, false );
             set_pivot( pivot, refresh );
         }

--- a/src/vehicle_group.cpp
+++ b/src/vehicle_group.cpp
@@ -50,7 +50,7 @@ point VehicleLocation::pick_point() const
 template<>
 bool string_id<VehicleGroup>::is_valid() const
 {
-    return vgroups.count( *this ) > 0;
+    return vgroups.contains( *this );
 }
 
 template<>
@@ -68,7 +68,7 @@ const VehiclePlacement &string_id<VehiclePlacement>::obj() const
 template<>
 bool string_id<VehiclePlacement>::is_valid() const
 {
-    return vplacements.count( *this ) > 0;
+    return vplacements.contains( *this );
 }
 
 void VehicleGroup::load( const JsonObject &jo )
@@ -170,7 +170,7 @@ const VehicleSpawn &string_id<VehicleSpawn>::obj() const
 template<>
 bool string_id<VehicleSpawn>::is_valid() const
 {
-    return vspawns.count( *this ) > 0;
+    return vspawns.contains( *this );
 }
 
 void VehicleSpawn::load( const JsonObject &jo )
@@ -181,7 +181,7 @@ void VehicleSpawn::load( const JsonObject &jo )
             JsonObject vjo = type.get_object( "vehicle_json" );
             spawn.add( type.get_float( "weight" ), make_shared_fast<VehicleFunction_json>( vjo ) );
         } else if( type.has_string( "vehicle_function" ) ) {
-            if( builtin_functions.count( type.get_string( "vehicle_function" ) ) == 0 ) {
+            if( !builtin_functions.contains( type.get_string( "vehicle_function" ) ) ) {
                 type.throw_error( "load_vehicle_spawn: unable to find builtin function", "vehicle_function" );
             }
 

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -487,7 +487,7 @@ std::set<fault_id> vehicle_part::faults_potential() const
 
 bool vehicle_part::fault_set( const fault_id &f )
 {
-    if( !faults_potential().count( f ) ) {
+    if( !faults_potential().contains( f ) ) {
         return false;
     }
     base->faults.insert( f );
@@ -579,7 +579,7 @@ bool vehicle_part::is_tank() const
 
 bool vehicle_part::is_battery() const
 {
-    return base->is_magazine() && base->ammo_types().count( ammotype( "battery" ) );
+    return base->is_magazine() && base->ammo_types().contains( ammotype( "battery" ) );
 }
 
 bool vehicle_part::is_reactor() const

--- a/src/vehicle_part.h
+++ b/src/vehicle_part.h
@@ -339,4 +339,4 @@ struct vehicle_part {
         std::vector<detached_ptr<item>> pieces_for_broken_part() const;
 };
 
-#endif
+#endif // CATA_SRC_VEHICLE_PART_H

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -395,7 +395,7 @@ void vehicle::control_engines()
 {
     int e_toggle = 0;
     //count active engines
-    const int fuel_count = std::accumulate( engines.begin(), engines.end(), int{0},
+    const int fuel_count = std::accumulate( engines.begin(), engines.end(), 0,
     [&]( int acc, int e ) {
         return acc + static_cast<int>( part_info( e ).engine_fuel_opts().size() );
     } );
@@ -807,7 +807,7 @@ void vehicle::use_controls( const tripoint &pos )
                           keybind( "TOGGLE_TRACKING" ) );
     actions.emplace_back( [&] { toggle_tracking(); } );
 
-    if( ( is_foldable() || tags.count( "convertible" ) ) && !remote ) {
+    if( ( is_foldable() || tags.contains( "convertible" ) ) && !remote ) {
         options.emplace_back( string_format( _( "Fold %s" ), name ), keybind( "FOLD_VEHICLE" ) );
         actions.emplace_back( [&] { fold_up(); } );
     }
@@ -887,7 +887,7 @@ void vehicle::use_controls( const tripoint &pos )
 bool vehicle::fold_up()
 {
     const bool can_be_folded = is_foldable();
-    const bool is_convertible = ( tags.count( "convertible" ) > 0 );
+    const bool is_convertible = ( tags.contains( "convertible" ) );
     if( !( can_be_folded || is_convertible ) ) {
         debugmsg( _( "Tried to fold non-folding vehicle %s" ), name );
         return false;
@@ -974,7 +974,7 @@ double vehicle::engine_cold_factor( const int e ) const
     }
 
     int eff_temp = units::to_fahrenheit( get_weather().get_temperature( g->u.pos() ) );
-    if( !parts[ engines[ e ] ].faults().count( fault_glowplug ) ) {
+    if( !parts[ engines[ e ] ].faults().contains( fault_glowplug ) ) {
         eff_temp = std::min( eff_temp, 20 );
     }
 
@@ -1061,7 +1061,7 @@ bool vehicle::start_engine( const int e )
     }
 
     // Immobilizers need removing before the vehicle can be started
-    if( eng.faults().count( fault_immobiliser ) ) {
+    if( eng.faults().contains( fault_immobiliser ) ) {
         sounds::sound( pos, 5, sounds::sound_t::alarm,
                        string_format( _( "the %s making a long beep" ), eng.name() ), true, "vehicle",
                        "fault_immobiliser_beep" );
@@ -1069,8 +1069,8 @@ bool vehicle::start_engine( const int e )
     }
 
     // Engine with starter motors can fail on both battery and starter motor
-    if( eng.faults_potential().count( fault_starter ) ) {
-        if( eng.faults().count( fault_starter ) ) {
+    if( eng.faults_potential().contains( fault_starter ) ) {
+        if( eng.faults().contains( fault_starter ) ) {
             sounds::sound( pos, noise, sounds::sound_t::alarm,
                            string_format( _( "the %s clicking once" ), eng.name() ), true, "vehicle",
                            "engine_single_click_fail" );
@@ -1089,7 +1089,7 @@ bool vehicle::start_engine( const int e )
     }
 
     // Engines always fail to start with faulty fuel pumps
-    if( eng.faults().count( fault_pump ) || eng.faults().count( fault_diesel ) ) {
+    if( eng.faults().contains( fault_pump ) || eng.faults().contains( fault_diesel ) ) {
         sounds::sound( pos, noise, sounds::sound_t::movement,
                        string_format( _( "the %s quickly stuttering out." ), eng.name() ), true, "vehicle",
                        "engine_stutter_fail" );
@@ -1537,7 +1537,7 @@ void vehicle::alarm()
                     _( "WHOOP WHOOP" ), _( "NEEeu NEEeu NEEeu" ), _( "BLEEEEEEP" ), _( "WREEP" )
                 }
             };
-            sounds::sound( global_pos3(), static_cast<int>( rng( 45, 80 ) ),
+            sounds::sound( global_pos3(), rng( 45, 80 ),
                            sounds::sound_t::alarm,  random_entry_ref( sound_msgs ), false, "vehicle", "car_alarm" );
             if( one_in( 1000 ) ) {
                 is_alarm_on = false;
@@ -1979,7 +1979,7 @@ void vehicle::interact_with( const tripoint &pos, int interact_part )
     const int cargo_part = part_with_feature( interact_part, "CARGO", false );
     const bool from_vehicle = cargo_part >= 0 && !get_items( cargo_part ).empty();
     const bool can_be_folded = is_foldable();
-    const bool is_convertible = tags.count( "convertible" ) > 0;
+    const bool is_convertible = tags.contains( "convertible" );
     const int autoclave_part = avail_part_with_feature( interact_part, "AUTOCLAVE", true );
     const bool has_autoclave = autoclave_part >= 0;
     const int autodoc_part = avail_part_with_feature( interact_part, "AUTODOC", true );

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -152,7 +152,7 @@ static int has_quality_internal( const T &self, const quality_id &qual, int leve
 
     self.visit_items( [&qual, level, &limit, &qty]( const item * e ) {
         if( e->get_quality( qual ) >= level ) {
-            qty = sum_no_wrap( qty, static_cast<int>( e->count() ) );
+            qty = sum_no_wrap( qty, e->count() );
             if( qty >= limit ) {
                 // found sufficient items
                 return VisitResponse::ABORT;

--- a/src/vitamin.cpp
+++ b/src/vitamin.cpp
@@ -20,7 +20,7 @@ static std::map<vitamin_id, vitamin> vitamins_all;
 template<>
 bool string_id<vitamin>::is_valid() const
 {
-    return vitamins_all.count( *this );
+    return vitamins_all.contains( *this );
 }
 
 /** @relates string_id */

--- a/src/vitamin.h
+++ b/src/vitamin.h
@@ -50,7 +50,7 @@ class vitamin
         }
 
         bool has_flag( const std::string &flag ) const {
-            return flags_.count( flag ) > 0;
+            return flags_.contains( flag );
         }
 
         /** Disease effect with increasing intensity proportional to vitamin deficiency */

--- a/src/vpart_position.h
+++ b/src/vpart_position.h
@@ -104,7 +104,7 @@ class optional_vpart_position : public std::optional<vpart_position>
 {
     public:
         optional_vpart_position( std::optional<vpart_position> p ) : std::optional<vpart_position>
-            ( std::move( p ) ) { }
+            ( p ) { }
 
         std::optional<std::string> get_label() const {
             return has_value() ? value().get_label() : std::nullopt;

--- a/src/wisheffect.cpp
+++ b/src/wisheffect.cpp
@@ -188,7 +188,7 @@ class effect_select_callback : public uilist_callback
             const int width = menu->w_width - start.x;
             std::stringstream ss;
             ss << string_format( "ID: %s\n", all_effects[selected].str() );
-            const auto eff_type = all_effects[static_cast<size_t>( selected )];
+            const auto eff_type = all_effects[ selected];
             ss << string_format( "[%s] <bold>Body part</bold>: %s\n",
                                  ctxt.get_desc( "CHANGE_BODY_PART" ),
                                  last_val.bodypart

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -349,7 +349,7 @@ void worldfactory::init()
 
 bool worldfactory::has_world( const std::string &name ) const
 {
-    return all_worlds.count( name ) > 0;
+    return all_worlds.contains( name );
 }
 
 std::vector<std::string> worldfactory::all_worldnames() const

--- a/tests/catalua_test.cpp
+++ b/tests/catalua_test.cpp
@@ -106,7 +106,7 @@ TEST_CASE( "lua_called_from_cpp", "[lua]" )
     REQUIRE( out_data["s"].valid() );
 
     CHECK( out_data["i"] == 0 );
-    CHECK( out_data.get<std::string>( "s" ) == "" );
+    CHECK( out_data.get<std::string>( "s" ).empty() );
 
     // Execute function
     ret = lua_func( 4, "Bright " );

--- a/tests/char_healing_test.cpp
+++ b/tests/char_healing_test.cpp
@@ -5,7 +5,6 @@
 #include "avatar.h"
 #include "bodypart.h"
 #include "calendar.h"
-#include "catch/catch.hpp"
 #include "character.h"
 #include "int_id.h"
 #include "options.h"

--- a/tests/make_static_test.cpp
+++ b/tests/make_static_test.cpp
@@ -22,7 +22,7 @@ TEST_CASE( "make_static_macro_test", "[make_static_macro]" )
     CHECK( &get_static() == &get_static() );
 
     const auto test11 = STATIC( "test11" );
-    static_assert( std::is_same<std::decay_t<decltype( test11 )>, std::string>::value,
+    static_assert( std::is_same_v<std::decay_t<decltype( test11 )>, std::string>,
                    "type must be std::string" );
 
     CHECK( test11 == "test11" );

--- a/tests/name_test.cpp
+++ b/tests/name_test.cpp
@@ -11,7 +11,7 @@ class IsOneOf : public Catch::MatcherBase<std::string>
     public:
         IsOneOf( std::set< std::string > v ): values{v} {}
         bool match( std::string const &s ) const override {
-            return values.count( s ) > 0;
+            return values.contains( s );
         }
         std::string describe() const override {
             std::string s = "is one of {";

--- a/tests/player_test.cpp
+++ b/tests/player_test.cpp
@@ -7,7 +7,6 @@
 
 #include "avatar.h"
 #include "avatar_action.h"
-#include "catch/catch.hpp"
 #include "player.h"
 #include "units_temperature.h"
 #include "weather.h"
@@ -17,7 +16,6 @@
 #include "player_helpers.h"
 #include "map.h"
 #include "map_helpers.h"
-#include "weather.h"
 #include "game.h"
 #include "units.h"
 #include "hash_utils.h"
@@ -144,7 +142,7 @@ static decltype( player::temp_cur ) converge_temperature( player &p, size_t iter
         for( const auto &pr : parts ) {
             current_iter_temperature.emplace_back( pr.first, p.temp_cur[pr.first->token] );
         }
-        if( history.count( current_iter_temperature ) != 0 ) {
+        if( history.contains( current_iter_temperature ) ) {
             converged = true;
             break;
         }

--- a/tests/requirements_test.cpp
+++ b/tests/requirements_test.cpp
@@ -16,7 +16,7 @@ TEST_CASE( "No book grant a recipe at skill levels above autolearn", "[recipe]" 
         // Booklearning requires only one skill - the primary one
         // If autolearn requires any other skill, booklearn is not 100% useless
         if( rec->autolearn_requirements.size() > 1 ||
-            rec->autolearn_requirements.count( rec->skill_used ) < 1 ) {
+            !rec->autolearn_requirements.contains( rec->skill_used ) ) {
             continue;
         }
         for( const auto &p : rec->booksets ) {

--- a/tests/stomach_contents_test.cpp
+++ b/tests/stomach_contents_test.cpp
@@ -7,7 +7,6 @@
 
 #include "avatar.h"
 #include "calendar.h"
-#include "catch/catch.hpp"
 #include "game.h"
 #include "item.h"
 #include "player.h"

--- a/tests/string_formatter_test.cpp
+++ b/tests/string_formatter_test.cpp
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <limits>
+#include <numbers>
 #include <string>
 #include <utility>
 
@@ -197,8 +198,8 @@ TEST_CASE( "string_formatter" )
     /* 58: anti-test */
     // importet_test( 59, "%(foo", "%(foo" ); // format is invalid
     importet_test( 60, " foo", "%*s", 4, "foo" );
-    importet_test( 61, "      3.14", "%*.*f", 10, 2, 3.14159265 );
-    importet_test( 63, "3.14      ", "%-*.*f", 10, 2, 3.14159265 );
+    importet_test( 61, "      3.14", "%*.*f", 10, 2, std::numbers::pi );
+    importet_test( 63, "3.14      ", "%-*.*f", 10, 2, std::numbers::pi );
     /* 64: anti-test */
     /* 65: anti-test */
     importet_test( 66, "+hello+", "+%s+", "hello" );

--- a/tests/test_statistics.h
+++ b/tests/test_statistics.h
@@ -79,8 +79,8 @@ class statistics
         // Outside of this class, this should only be used for debugging
         // purposes.
         template<typename U = T>
-        std::enable_if_t< std::is_same_v< U, bool >, double >
-        margin_of_error() {
+        double
+        margin_of_error() requires( std::is_same_v< U, bool > ) {
             if( _error != invalid_err ) {
                 return _error;
             }
@@ -101,8 +101,8 @@ class statistics
         // Outside of this class, this should only be used for debugging purposes.
         // https://measuringu.com/ci-five-steps/
         template<typename U = T>
-        std::enable_if_t < ! std::is_same_v< U, bool >, double >
-        margin_of_error() {
+        double
+        margin_of_error() requires( ! std::is_same_v< U, bool > ) {
             if( _error != invalid_err ) {
                 return _error;
             }

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -110,7 +110,7 @@ static std::map<itype_id, int> set_vehicle_fuel( vehicle &v, const float veh_fue
     // We re-add battery because we want it accounted for, just not in the section above
     actually_used.insert( itype_id( "battery" ) );
     for( auto iter = ret.begin(); iter != ret.end(); ) {
-        if( iter->second <= 0 || actually_used.count( iter->first ) == 0 ) {
+        if( iter->second <= 0 || !actually_used.contains( iter->first ) ) {
             iter = ret.erase( iter );
         } else {
             ++iter;

--- a/tests/vehicle_ramp_test.cpp
+++ b/tests/vehicle_ramp_test.cpp
@@ -29,7 +29,6 @@
 #include "item.h"
 #include "line.h"
 #include "mapdata.h"
-#include "map_helpers.h"
 #include "monster.h"
 #include "mtype.h"
 #include "units.h"
@@ -37,7 +36,6 @@
 #include "point.h"
 #include "vpart_position.h"
 #include "player_helpers.h"
-#include "map_helpers.h"
 #include "state_helpers.h"
 
 static void set_ramp( const int transit_x, bool use_ramp, bool up )


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

## Purpose of change

~stacked on top of #5538, needs to be rebased once it's merged~
apply all clang-tidy fixes so the codebase is cleaner

## Describe the solution

```sh
$ parallel ./build-scripts/clang-tidy-wrapper.sh {} -fix ::: src/*.{cpp,h} tests/*.{cpp,h}; make astyle; ninja -C build -j 10 -k 0 cataclysm-bn-tiles cata_test-tiles CataAnalyzerPlugin; ./cata_test-tiles
```

## Describe alternatives you've considered

disable unfixable warnings?

## Testing

local tests passed.

## Additional context

maybe run clang-tidy for edited files not affected files in future?