### PR TITLE
feat(port): add support for martial art buffs/tecs being restricted by weapon category

### DIFF
--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -687,6 +687,7 @@
     "melee_allowed": true,
     "crit_tec": true,
     "weapon_damage_requirements": [ { "type": "bash", "min": 8 } ],
+    "weapon_categories_allowed": [ "STILETTOS", "KNIVES", "SHORT_SWORDS", "BATONS", "TONFAS" ],
     "stun_dur": 1,
     "mult_bonuses": [
       { "stat": "movecost", "scale": 0.6 },
@@ -1310,6 +1311,7 @@
     "skill_requirements": [ { "name": "melee", "level": 5 } ],
     "unarmed_allowed": true,
     "melee_allowed": true,
+    "weapon_categories_allowed": [ "STILETTOS", "KNIVES", "1H_HOOKED", "SHORT_SWORDS", "1H_SWORDS", "JAPANESE_SWORDS", "BIONIC_WEAPONRY" ],
     "crit_tec": true,
     "stun_dur": 1,
     "mult_bonuses": [

--- a/doc/src/content/docs/en/mod/json/reference/creatures/martialart_json.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/martialart_json.md
@@ -42,6 +42,7 @@ title: Martial arts & techniques
 "name" : "phasing strike",  // In-game name displayed
 "unarmed_allowed" : true,   // Can an unarmed character use this technique
 "unarmed_weapons_allowed" : true,    // Does this technique require the character to be actually unarmed or does it allow unarmed weapons
+"weapon_categories_allowed" : [ "BLADES", "KNIVES" ], // Restrict technique to only these categories of weapons. If omitted, all weapon categories are allowed. Empty hands are always allowed if unarmed_allowed is true.
 "melee_allowed" : true,     // Means that ANY melee weapon can be used, NOT just the martial art's weapons
 "skill_requirements": [ { "name": "melee", "level": 3 } ],     // Skills and their minimum levels required to use this technique. Can be any skill.
 "weapon_damage_requirements": [ { "type": "bash", "min": 5 } ],     // Minimum weapon damage required to use this technique. Can be any damage type.
@@ -82,7 +83,8 @@ title: Martial arts & techniques
 "description" : "+Strength bash armor, +Dexterity acid armor, +Intelligence electricity armor, +Perception fire armor.",    // In-game description
 "buff_duration": 2,                 // Duration in turns that this buff lasts
 "unarmed_allowed" : true,           // Can this buff be applied to an unarmed character
-"unarmed_allowed" : false,          // Can this buff be applied to an armed character
+"melee_allowed" : false,          // Can this buff be applied to an armed character
+"weapon_categories_allowed" : [ "BLADES", "KNIVES" ], // Restrict buff to only these categories of weapons. If omitted, all weapon categories are allowed. Empty hands are always allowed if unarmed_allowed is true.
 "unarmed_weapons_allowed" : true,          // Does this buff require the character to be actually unarmed. If true, allows unarmed weapons (brass knuckles, punch daggers)
 "max_stacks" : 8,                   // Maximum number of stacks on the buff. Buff bonuses are multiplied by current buff intensity
 "bonus_blocks": 1       // Extra blocks per turn

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -25,6 +25,7 @@
 #include "itype.h"
 #include "json.h"
 #include "map.h"
+#include "messages.h"
 #include "output.h"
 #include "pimpl.h"
 #include "player.h"
@@ -520,6 +521,18 @@ bool ma_requirements::is_valid_character( const Character &u ) const
         }
     }
 
+    if( !weapon_categories_allowed.empty() && is_armed ) {
+        bool valid_weap_cat = false;
+        for( const weapon_category_id &w_cat : weapon_categories_allowed ) {
+            if( u.used_weapon().typeId()->weapon_category.count( w_cat ) > 0 ) {
+                valid_weap_cat = true;
+            }
+        }
+        if( !valid_weap_cat ) {
+            return false;
+        }
+    }
+
     return true;
 }
 
@@ -532,11 +545,6 @@ bool ma_requirements::is_valid_weapon( const item &i ) const
     }
     for( const auto &pr : min_damage ) {
         if( i.damage_melee( pr.first ) < pr.second ) {
-            return false;
-        }
-    }
-    for( const weapon_category_id &weap : weapon_categories_allowed ) {
-        if( !i.type.weapon_category.count( weap ) ) {
             return false;
         }
     }

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -177,7 +177,8 @@ void ma_requirements::load( const JsonObject &jo, const std::string & )
 
     optional( jo, was_loaded, "skill_requirements", min_skill, ma_skill_reader {} );
     optional( jo, was_loaded, "weapon_damage_requirements", min_damage, ma_weapon_damage_reader {} );
-    optional( jo, was_loaded, "weapon_categories_allowed", weapon_categories_allowed, auto_flags_reader<weapon_category_id> {} );
+    optional( jo, was_loaded, "weapon_categories_allowed", weapon_categories_allowed,
+              auto_flags_reader<weapon_category_id> {} );
 }
 
 void ma_technique::load( const JsonObject &jo, const std::string &src )
@@ -588,7 +589,7 @@ std::string ma_requirements::get_description( bool buff ) const
 
     if( !weapon_categories_allowed.empty() ) {
         dump += vgettext( "<bold>Weapon category required: </bold>",
-                           "<bold>Weapon categories required: </bold>", weapon_categories_allowed.size() );
+                          "<bold>Weapon categories required: </bold>", weapon_categories_allowed.size() );
         dump += enumerate_as_string( weapon_categories_allowed.begin(),
         weapon_categories_allowed.end(), []( const weapon_category_id & w_cat ) {
             if( !w_cat.is_valid() ) {

--- a/src/martialarts.h
+++ b/src/martialarts.h
@@ -61,6 +61,9 @@ struct ma_requirements {
     bool strictly_unarmed; // Ignore force_unarmed?
     bool wall_adjacent; // Does it only work near a wall?
 
+    /** Weapon categories compatible with this requirement. If empty, allow any weapon category. */
+    std::vector<weapon_category_id> weapon_categories_allowed;
+
     /** Minimum amount of given skill to trigger this bonus */
     std::vector<std::pair<skill_id, int>> min_skill;
 


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

I was idly thinking that some martial arts, potentially in vanilla but especially Arcana (Via Gladium et Malleo being a style for example that has entirely different buffs and tecs depending on whether you use swords or blunt weapons), could perhaps make use of the ability to restrict martial arts effects based on weapon category.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

C++ changes:
1. In martial_arts.cpp and martial_arts.h, defined JSON property `weapon_categories_allowed` in `ma_requirements::load`.
2. Also in martial_arts.cpp, set `ma_requirements::is_valid_character` to check for weapon categories if `weapon_categories_allowed` is defined. In addition, it's been tweaked to not bother checking if the player isn't armed, as if the current buff/technique is explicitly set to permit unarmed use we logically want it to not cause it to unituitively weapon-lock the buff.
3. And in martial_arts.cpp, set `ma_requirements::get_description` to mention required weapon categories if present.

JSON changes:
1. Set Eskrima's Puño Strike technique to use weapon categories to disallow haft-striking with fist weapons or staves.
2. Set Ninjutsu's Assassinate technique to use weapon categories to exclude batons and staves from being used for attempted sneak attack stuff.

Documentation changes:
1. Documented new feature in martialart_json.md.
2. Misc: Lil typofix I spotted right next to where I put a new line in the above file.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Making use of it for something else? Might come in handy if I ever rework Tai Chi to include things like jians.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON files for syntax and lint errors.
2. Compiled and load-tested.
3. Gave myself Eskrima and all skills, confirmed puño strikes would trigger with a baton but not a quarterstaff.
4. Temporarily added Arcana with a WIP update, confirmed that only hammer-related buffs showed up when using a luminous hammer and Via Gladium et Malleo.
5. Confirmed that ninjutsu still lets me neck-snap people when unarmed.
6. Checked affected C++ files for astyle.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Source PR, "Required weapon categories for buffs & techniques" by @dseguin: https://github.com/CleverRaven/Cataclysm-DDA/pull/52788