### PR TITLE
fix: remove floating roofs above `p_resort_1mm`

### DIFF
--- a/data/json/mapgen/private_resort.json
+++ b/data/json/mapgen/private_resort.json
@@ -320,7 +320,7 @@
     "om_terrain": [ "p_resort_1mm" ],
     "weight": 1000,
     "object": {
-      "fill_ter": "t_floor",
+      "fill_ter": "t_concrete",
       "rows": [
         "W..PP..............PP..W",
         "W..PP..............PP..W",


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Fix #5545
## Describe the solution
Change the `fill_ter` of `p_resort_1mm` to place `t_concrete` under the furniture around the pool.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/96576666-65b6-4952-81e6-d334fbe03200">
After:
<img width="960" alt="image2" src="https://github.com/user-attachments/assets/459267ad-d653-4f4a-bce8-7b1dc9cb1d6e">