### PR TITLE
fix: change debug level of field count mismatch to DL::Warn

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2787,7 +2787,7 @@ void map::decay_fields_and_scent( const time_duration &amount )
 
             if( to_proc > 0 ) {
                 cur_submap->field_count = cur_submap->field_count - to_proc;
-                dbg( DL::Error ) << "map::decay_fields_and_scent: submap at "
+                dbg( DL::Warn ) << "map::decay_fields_and_scent: submap at "
                                  << abs_sub + tripoint( smx, smy, 0 )
                                  << "has " << cur_submap->field_count - to_proc << "fields, but "
                                  << cur_submap->field_count << " field_count";

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2788,9 +2788,9 @@ void map::decay_fields_and_scent( const time_duration &amount )
             if( to_proc > 0 ) {
                 cur_submap->field_count = cur_submap->field_count - to_proc;
                 dbg( DL::Warn ) << "map::decay_fields_and_scent: submap at "
-                                 << abs_sub + tripoint( smx, smy, 0 )
-                                 << "has " << cur_submap->field_count - to_proc << "fields, but "
-                                 << cur_submap->field_count << " field_count";
+                                << abs_sub + tripoint( smx, smy, 0 )
+                                << "has " << cur_submap->field_count - to_proc << "fields, but "
+                                << cur_submap->field_count << " field_count";
             }
         }
     }


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
`DL::Error` should be reserved for situations that are exceptional and consequential. In the case of `submap::field_count` it's used to determine if a submap should have fields processed to early out rather than iterate over the submap's field array member. As long as the value is greater than zero the array will be iterated over. The actual value barely matters.
<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution
Change `DL::Error` to `DL::Warn` so we can still see occurences in debug.log (if the `Map` context is enabled) but without generating a stack trace.
<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

## Describe alternatives you've considered
Change `submap::field_count` into a boolean that is only ever set to `true` when fields are added to the submap and only ever reset to `false` during field processing. That is planned future work, and beyond the immediate scope of removing an unexceptional error.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing
Employed the standard Mk 1 Eyeball. `DL::Warn` cannot emit stack traces, so it cannot fail the PR's purpose.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context
This all came up due to some weirdness in how explosion queue processing adds and removes fields. A mismatch in the real number of fields and the predicted number recorded in `submap::field_count` can be made, and can cause a `mininuke` explosion while raining to spend 30 seconds on my machine to emit the stack trace.
The stack trace emitted in `map::decay_fields_and_scent` gives very little usable information beyond "there's a mismatch for some reason," and if I did not already know that it was due to the explosion I would not understand why the game suddenly lagged for 30 seconds. It's not helpful without a lot of surrounding context that is not provided due to the cause and point of emission being separated.

Future work will be in implementing the alternative described above, and make this PR effectively useless.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
