### PR TITLE
fix: mapgen grenades stop inserting null items.

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1151,7 +1151,8 @@ bool item::merge_charges( detached_ptr<item> &&rhs, bool force )
 
 void item::put_in( detached_ptr<item> &&payload )
 {
-    if( !payload ) {
+    if( !payload || payload->typeId() == itype_id::NULL_ID() ) {
+        debugmsg( "Tried to insert non-item into %s", debug_name() );
         return;
     }
     if( &*payload == this ) {

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -6272,7 +6272,8 @@ std::vector<item *> map::place_items( const item_group_id &loc, const int chance
     }
     for( auto e : res ) {
         if( e->is_tool() || e->is_gun() || e->is_magazine() ) {
-            if( rng( 0, 99 ) < magazine && !e->magazine_integral() && !e->magazine_current() ) {
+            if( rng( 0, 99 ) < magazine && !e->magazine_current() &&
+                e->magazine_default() != itype_id::NULL_ID() ) {
                 e->put_in( item::spawn( e->magazine_default(), e->birthday() ) );
             }
             if( rng( 0, 99 ) < ammo && e->ammo_remaining() == 0 ) {


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

- Extension of #5515. Map extras like supply drop were having the same issue due to faulty code in `place_item()`

## Describe the solution

- See #5515 solution.
- Add a debugmsg when `put_in()` is fed an invalid item to insert.

## Describe alternatives you've considered

- Revert precipitating changes in #5283.
  - If someone desires.

## Testing

- [x] Map extra supply drop flashbang/grenade no longer causes errors on pickup or spawn with none item contained.

## Additional context

Someone needs to play a bit with this change to confirm that we don't feed `put_in()` null items as a norm.