### PR TITLE
fix: Stop muscle engines failing sounding like a V8

### DIFF
--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1097,7 +1097,8 @@ bool vehicle::start_engine( const int e )
     }
 
     // Damaged non-electric engines have a chance of failing to start
-    if( !(is_engine_type( e, fuel_type_battery ) || is_engine_type(e, fuel_type_muscle)) && x_in_y( dmg * 100, 120 ) ) {
+    if( !( is_engine_type( e, fuel_type_battery ) || is_engine_type( e, fuel_type_muscle ) ) &&
+        x_in_y( dmg * 100, 120 ) ) {
         sounds::sound( pos, noise, sounds::sound_t::movement,
                        string_format( _( "the %s clanking and grinding" ), eng.name() ), true, "vehicle",
                        "engine_clanking_fail" );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1097,7 +1097,7 @@ bool vehicle::start_engine( const int e )
     }
 
     // Damaged non-electric engines have a chance of failing to start
-    if( !is_engine_type( e, fuel_type_battery ) && x_in_y( dmg * 100, 120 ) ) {
+    if( !(is_engine_type( e, fuel_type_battery ) || is_engine_type(e, fuel_type_muscle)) && x_in_y( dmg * 100, 120 ) ) {
         sounds::sound( pos, noise, sounds::sound_t::movement,
                        string_format( _( "the %s clanking and grinding" ), eng.name() ), true, "vehicle",
                        "engine_clanking_fail" );


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

As noted in the Discord, the engine fail noise for non-battery engines was a clanking noise that generally sounds more appropriate for a v8 than a foot pedal in most soundpacks. This fix silences these woes.

## Describe the solution

Modify the check to also make sure the engine isn't muscle-powered

## Describe alternatives you've considered

- Wait for KorG or someone similar to make a better fix / JSONize everything
- Meme on foot pedals secretly being incredibly tiny v8 engines

## Testing

None, it's an if statement logic change.

## Additional context

This doesn't cause a regression in notice of a bike failing to start for non-soundpack players because it didn't print a failure message in the first place. Also, how often is a bike in such bad footpedal condition without basically being in pieces anyway?
