### PR TITLE
feat(balance): update max survival skill from foraging

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -6416,7 +6416,7 @@ iexamine_function iexamine_function_from_string( const std::string &function_nam
 void iexamine::practice_survival_while_foraging( player *p )
 {
     ///\EFFECT_INT Intelligence caps survival skill gains from foraging
-    const int max_forage_skill = p->int_cur / 3 + 1;
+    const int max_forage_skill = p->int_cur / 2 + 1;
     ///\EFFECT_SURVIVAL decreases survival skill gain from foraging (NEGATIVE)
     const int max_exp = 2 * ( max_forage_skill - p->get_skill_level( skill_survival ) );
     // Award experience for foraging attempt regardless of success


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

In an effort to encourage skill training without grinding crafting recipes, I have discovered that foraging bushes is capped by your int score. The current formula seems to be Intelligence divided by 3, plus 1. That means at 12 intelligence you can gain 4 survival from foraging. That's kinda bad as you can grind recipes to level 6 thanks to flint and steel being mainlined. Additionally a 4 int character can only go to level 2.

## Describe the solution

The formula is set to intelligence divided by 2 plus one. That means at intelligence 12 you can go to 7, and at int 4 you can go to 3. This also means at level 8 intelligence you can go to level 5, which is around the baseline.

This should allow you to gain more survival without being stuck in a bunker doing crafting, and we can tweak it to be more favorable if that's desired.

## Describe alternatives you've considered

Remove the cap by setting it to int divided by 1 + 1, or use int divided by 2 + 2 so it can be respectively at 4, 6, and 8 skill cap. Something for @chaosvolt to consider.

## Testing

Tests, because I changed one number on a formula, and I already observed that currently 40 int lets you go to 10 survival.

## Additional context

Watch the tests fail because of this. Just watch.
