### PR TITLE
fix: use regional terrain for `s_pizza_parlor_1`

### DIFF
--- a/data/json/mapgen/pizza_parlor.json
+++ b/data/json/mapgen/pizza_parlor.json
@@ -184,23 +184,9 @@
         "|...|                   "
       ],
       "terrain": {
-        " ": [
-          "t_dirt",
-          "t_dirt",
-          "t_grass",
-          "t_grass",
-          "t_grass",
-          "t_grass",
-          "t_dirt",
-          "t_grass",
-          "t_grass",
-          "t_dirt",
-          "t_grass",
-          "t_grass",
-          "t_shrub"
-        ],
+        " ": "t_region_groundcover_urban",
         "S": "t_sidewalk",
-        "*": "t_shrub",
+        "*": "t_region_shrub_decorative",
         "#": "t_linoleum_white",
         "D": "t_door_locked",
         "+": "t_door_c",
@@ -211,7 +197,7 @@
         "G": "t_door_glass_c",
         "L": "t_linoleum_white",
         "O": "t_linoleum_white",
-        "R": "t_railing_v",
+        "R": "t_railing",
         "c": "t_concrete",
         "f": "t_fencegate_c",
         "m": "t_sandbox",
@@ -246,7 +232,7 @@
         "W": "f_water_heater",
         "{": "f_rack"
       },
-      "mapping": { "Y": { "terrain": [ "t_dirt", "t_grass" ], "furniture": "f_street_light" } },
+      "mapping": { "Y": { "terrain": [ "t_region_groundcover_urban" ], "furniture": "f_street_light" } },
       "items": {
         "C": { "item": "pizza_trash", "chance": 50, "repeat": [ 7, 9 ] },
         "F": { "item": "pizza_fridge", "chance": 80, "repeat": [ 9, 10 ] },


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Use regional terrain for the mapgen `s_pizza_parlor_1`
## Describe the solution
Replace non-regional terrain with regional pseudo terrain.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/627922ff-cdfb-498b-a412-3f1978ab3b90">
After:
<img width="960" alt="image2" src="https://github.com/user-attachments/assets/f1fc0d7b-d584-4f33-8077-c1ec045ab2b6">