### PR TITLE
fix: Make rags consume their charges/delete themselves.

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7764,6 +7764,12 @@ bool Character::invoke_item( item *used, const std::string &method, const tripoi
     } else if( used->is_bionic() || used->is_deployable() || method == "place_trap" ) {
         used->detach();
         return true;
+    } else if( used->count_by_charges() ) {
+        used->charges -= charges_used;
+        if( used->charges <= 0 ) {
+            used->detach();
+        }
+        return true;
     }
 
     return false;


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

- fix #5588 which was because the `Character::invoke_item()` doesn't have a consideration for an item that isn't a tool and isn't a comestible.

## Describe the solution

- Add a consideration such that non-tool, non-comestible items that are `count_by_charges` will consume itself.

## Describe alternatives you've considered

## Testing

- [x] Rags used on a bleeding wound will consume the rag, and delete itself if the rag charges are used up.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
