### PR TITLE
fix: Remove ammo types from Taurus Raging Bull revolver

### DIFF
--- a/data/json/items/gun/454.json
+++ b/data/json/items/gun/454.json
@@ -13,7 +13,7 @@
     "bashing": 12,
     "material": [ "steel", "plastic" ],
     "color": "light_gray",
-    "ammo": [ "454", "410shot", "45colt" ],
+    "ammo": "454",
     "dispersion": 280,
     "blackpowder_tolerance": 56,
     "clip_size": 5,
@@ -36,6 +36,7 @@
     "description": "The Taurus Raging Judge Magnum is a 6-shot revolver chambered in .454 Casull.  It can fire .410 shotshells and .45 Colt cartridges as well.",
     "weight": "2070 g",
     "volume": "1175 ml",
+    "ammo": [ "454", "410shot", "45colt" ],
     "clip_size": 6,
     "magazines": [ [ "454", [ "454_speedloader6" ] ] ]
   }

--- a/data/json/items/magazine/454.json
+++ b/data/json/items/magazine/454.json
@@ -4,7 +4,7 @@
     "looks_like": "38_speedloader",
     "type": "MAGAZINE",
     "name": { "str": ".454 5-round speedloader" },
-    "description": "This speedloader can hold 5 rounds of .454, .45 Colt or .410 bore and quickly reload a compatible revolver.",
+    "description": "This speedloader can hold 5 rounds of .454 and quickly reload a compatible revolver.",
     "weight": "108 g",
     "volume": "250 ml",
     "price": "22 USD",
@@ -12,7 +12,7 @@
     "material": "steel",
     "symbol": "#",
     "color": "light_gray",
-    "ammo_type": [ "454", "45colt", "410shot" ],
+    "ammo_type": "454",
     "capacity": 5,
     "flags": [ "SPEEDLOADER" ]
   },
@@ -22,6 +22,7 @@
     "type": "MAGAZINE",
     "name": { "str": ".454 6-round speedloader" },
     "description": "This speedloader can hold 5 rounds of .454, .45 Colt or .410 bore and quickly reload a compatible revolver.",
+    "ammo_type": [ "454", "45colt", "410shot" ],
     "capacity": 6
   }
 ]


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change
The Taurus Raging Bull is a five cylinder revolver in .454 casull. In-game, it also fires .45 colt and .410 shot, but according to the [Wikipedia article](https://en.wikipedia.org/wiki/Taurus_Raging_Bull), only the Judge Magnum variant can do that. The rounds have the same diameter, but .45 colt and .410 shot are noticeably longer. It's pretty obvious when looking at photos of the guns, the Judge Magnum is _HUGE_.

Since the Raging Judge Magnum is in the game, and about twice the size of the Raging Bull, It's pretty clear that the Raging Bull is specifically meant to be the smaller variant.
<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution
Removed .45 colt and .410 shot from permitted ammo types of the Taurus Raging Bull. Explicitly added them to Raging Judge Magnum, which used `copy-from`. Likewise removed .45 colt and .410 shot from the 5-round .454 speedloader, added them to 6-round .454 speedloader.

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

## Describe alternatives you've considered
Could also just remove one of the guns. Besides the Judge Magnum having one extra cylinder and being much chonkier, they were basically identical. Like, if the Judge Magnum doesn't have more permitted ammo types than the Bull, then it's really just a worse version of it, being impossible to fit inside a standard holster.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing
Loaded game with no errors, loaded gun with no errors.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context
I presume that IRL you could fit .45 colt into a .454 speedloader just fine, but the Raging Bull is the only 5-round .454 revolver in the game right now - the Judge Magnum has six cylinders. Also, there doesn't seem to be a check to prevent using a speedloader to load a revolver with incompatible ammo. If the speedloader was left unchanged, you could use it to load .410 shot into the Raging Bull, even though you still couldn't fire it.

Not sure if that's really an error - the bullets _are_ the same diameter, or close enough, and you _could_ probably shove them into the cylinder, you just couldn't close it up with them sticking out the front. It is a bit of a UI problem though, since there's no warning that you're loading the gun with incompatible ammo, so for now the 5-round speedloader is only for .454.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
