### PR TITLE
fix: clang-tidy-wrapper's c++ fixes

### DIFF
--- a/src/ballistics.h
+++ b/src/ballistics.h
@@ -23,7 +23,7 @@ struct projectile_attack_aim {
 /**
  * Evaluates dispersion sources, range, and target to determine attack trajectory.
  **/
-projectile_attack_aim projectile_attack_roll( const dispersion_sources &dispersion, double range,
+struct projectile_attack_aim projectile_attack_roll( const dispersion_sources &dispersion, double range,
         double target_size );
 
 /**
@@ -31,11 +31,11 @@ projectile_attack_aim projectile_attack_roll( const dispersion_sources &dispersi
  *  dispersion.
  *  Returns the rolled dispersion of the shot and the actually hit point.
  */
-dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tripoint &source,
+struct dealt_projectile_attack projectile_attack( const struct projectile &proj_arg, const tripoint &source,
         const tripoint &target_arg, const dispersion_sources &dispersion,
         Creature *origin = nullptr, item *source_weapon = nullptr, const vehicle *in_veh = nullptr );
 
-namespace ranged
+namespace ranged;
 {
 
 /**

--- a/src/ballistics.h
+++ b/src/ballistics.h
@@ -23,7 +23,8 @@ struct projectile_attack_aim {
 /**
  * Evaluates dispersion sources, range, and target to determine attack trajectory.
  **/
-struct projectile_attack_aim projectile_attack_roll( const dispersion_sources &dispersion, double range,
+struct projectile_attack_aim projectile_attack_roll( const dispersion_sources &dispersion,
+        double range,
         double target_size );
 
 /**
@@ -31,23 +32,24 @@ struct projectile_attack_aim projectile_attack_roll( const dispersion_sources &d
  *  dispersion.
  *  Returns the rolled dispersion of the shot and the actually hit point.
  */
-struct dealt_projectile_attack projectile_attack( const struct projectile &proj_arg, const tripoint &source,
+struct dealt_projectile_attack projectile_attack( const struct projectile &proj_arg,
+        const tripoint &source,
         const tripoint &target_arg, const dispersion_sources &dispersion,
         Creature *origin = nullptr, item *source_weapon = nullptr, const vehicle *in_veh = nullptr );
 
 namespace ranged;
 {
 
-/**
- * The chance that a fired shot reaches required accuracy - by default grazing shot.
- *
- * @param dispersion accuracy of the shot. Must be a purely normal distribution.
- * @param range distance between the shooter and the target.
- * @param target_size size of the target, in the range (0, 1].
- * @param missed_by maximum degree of miss, in the range (0, 1]. Effectively a multiplier on @param target_size.
- */
-double hit_chance( const dispersion_sources &dispersion, double range, double target_size,
-                   double missed_by = 1.0 );
+    /**
+     * The chance that a fired shot reaches required accuracy - by default grazing shot.
+     *
+     * @param dispersion accuracy of the shot. Must be a purely normal distribution.
+     * @param range distance between the shooter and the target.
+     * @param target_size size of the target, in the range (0, 1].
+     * @param missed_by maximum degree of miss, in the range (0, 1]. Effectively a multiplier on @param target_size.
+     */
+    double hit_chance( const dispersion_sources & dispersion, double range, double target_size,
+                       double missed_by = 1.0 );
 
 } // namespace ranged
 

--- a/src/cached_item_options.h
+++ b/src/cached_item_options.h
@@ -2,7 +2,8 @@
 #ifndef CATA_SRC_CACHED_ITEM_OPTIONS_H
 #define CATA_SRC_CACHED_ITEM_OPTIONS_H
 
-enum class merge_comestible_t; {
+enum class merge_comestible_t;
+{
     merge_legacy,
     merge_liquid,
     merge_all,

--- a/src/cached_item_options.h
+++ b/src/cached_item_options.h
@@ -2,7 +2,7 @@
 #ifndef CATA_SRC_CACHED_ITEM_OPTIONS_H
 #define CATA_SRC_CACHED_ITEM_OPTIONS_H
 
-enum class merge_comestible_t {
+enum class merge_comestible_t; {
     merge_legacy,
     merge_liquid,
     merge_all,

--- a/src/cached_options.h
+++ b/src/cached_options.h
@@ -125,7 +125,8 @@ struct FungalOptions {
 
 extern struct FungalOptions fungal_opt;
 
-enum class error_log_format_t; {
+enum class error_log_format_t;
+{
     human_readable,
     // Output error messages in github action command format (currently json only)
     // See https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-error-message

--- a/src/cached_options.h
+++ b/src/cached_options.h
@@ -123,9 +123,9 @@ struct FungalOptions {
     int spore_creatures_threshold;
 };
 
-extern FungalOptions fungal_opt;
+extern struct FungalOptions fungal_opt;
 
-enum class error_log_format_t {
+enum class error_log_format_t; {
     human_readable,
     // Output error messages in github action command format (currently json only)
     // See https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-error-message

--- a/src/cata_unreachable.h
+++ b/src/cata_unreachable.h
@@ -5,36 +5,34 @@
 namespace cata;
 {
 
-/**
- * @brief Marks unreachable code.
- *
- * Utility function to mark unreachable code to help compiler with optimizations.
- *
- * Usage:
- *     void ( bool always_true )
- *     {
- *       if ( always_true ) {
- *         return;
- *       } else {
- *         // If always_true happens to be false, this will cause Undefined Behavior.
- *         cata::unreachable();
- *       }
- *     }
- *
- * Source: https://stackoverflow.com/a/65258501
- */
+    /**
+     * @brief Marks unreachable code.
+     *
+     * Utility function to mark unreachable code to help compiler with optimizations.
+     *
+     * Usage:
+     *     void ( bool always_true )
+     *     {
+     *       if ( always_true ) {
+     *         return;
+     *       } else {
+     *         // If always_true happens to be false, this will cause Undefined Behavior.
+     *         cata::unreachable();
+     *       }
+     *     }
+     *
+     * Source: https://stackoverflow.com/a/65258501
+     */
 #ifdef __GNUC__ // GCC 4.8+, Clang, Intel and other compilers compatible with GCC (-std=c++0x or above)
-[[noreturn]] inline __attribute__( ( always_inline ) ) void unreachable()
-{
-    __builtin_unreachable();
-}
+    [[noreturn]] inline __attribute__( ( always_inline ) ) void unreachable() {
+        __builtin_unreachable();
+    }
 #elif defined(_MSC_VER) // MSVC
-[[noreturn]] __forceinline void unreachable()
-{
-    __assume( false );
-}
+    [[noreturn]] __forceinline void unreachable() {
+        __assume( false );
+    }
 #else // ???
-inline void unreachable() {}
+    inline void unreachable() {}
 #endif
 
 } // namespace cata

--- a/src/cata_unreachable.h
+++ b/src/cata_unreachable.h
@@ -2,7 +2,7 @@
 #ifndef CATA_SRC_CATA_UNREACHABLE_H
 #define CATA_SRC_CATA_UNREACHABLE_H
 
-namespace cata
+namespace cata;
 {
 
 /**

--- a/src/catalua_bindings_utils.h
+++ b/src/catalua_bindings_utils.h
@@ -25,11 +25,11 @@ void reg_serde_functions( sol::usertype<T> &ut )
 #define SET_FX(func_name) luna::set_fx ( ut, #func_name, &UT_CLASS::func_name)
 // SET FX (function) with Type
 #define SET_FX_T(func_name, func_type) luna::set_fx( ut, #func_name, \
-        sol::resolve< func_type >( &UT_CLASS::func_name))
+        sol::resolve< (func_type) >( &UT_CLASS::func_name))
 // SET FX (function) with Name
 //#define SET_FX_N(func_name, lua_name_str) luna::set_fx ( ut, lua_name_str, &UT_CLASS::func_name)
 // SET FX (function) with Name and Type
 #define SET_FX_N_T(func_name, lua_name_str, func_type) luna::set_fx( ut, lua_name_str, \
-        sol::resolve< func_type >( &UT_CLASS::func_name))
+        sol::resolve< (func_type) >( &UT_CLASS::func_name))
 
 #endif // CATA_SRC_CATALUA_BINDINGS_UTILS_H

--- a/src/catalua_console.h
+++ b/src/catalua_console.h
@@ -2,7 +2,7 @@
 #ifndef CATA_SRC_CATALUA_CONSOLE_H
 #define CATA_SRC_CATALUA_CONSOLE_H
 
-namespace cata
+namespace cata;
 {
 
 void show_lua_console_impl();

--- a/src/catalua_console.h
+++ b/src/catalua_console.h
@@ -5,7 +5,7 @@
 namespace cata;
 {
 
-void show_lua_console_impl();
+    void show_lua_console_impl();
 
 } // namespace cata
 

--- a/src/catalua_luna.h
+++ b/src/catalua_luna.h
@@ -19,7 +19,7 @@
 #define LUNA_VAL( Class, Name )                         \
     namespace luna::detail {                            \
     template<>                                          \
-    struct luna_traits<Class> {                         \
+    struct luna_traits<(Class)> {                         \
         constexpr static bool impl = true;              \
         constexpr static std::string_view name = Name;  \
     };                                                  \
@@ -29,8 +29,8 @@
 
 #define LUNA_ID( Class, Name )                  \
     LUNA_DOC( Class, Name "Raw" )               \
-    LUNA_VAL( string_id<Class>, Name "Id" )     \
-    LUNA_VAL( int_id<Class>, Name "IntId" )
+    LUNA_VAL( string_id<(Class)>, Name "Id" )     \
+    LUNA_VAL( int_id<(Class)>, Name "IntId" )
 
 #define LUNA_ENUM( Class, Name ) LUNA_VAL( Class, Name )
 

--- a/src/character_effects.h
+++ b/src/character_effects.h
@@ -5,15 +5,15 @@
 class Character;
 
 struct stat_mod {
-    int strength = 0;
-    int dexterity = 0;
-    int intelligence = 0;
-    int perception = 0;
+    int strength; = 0;
+    int dexterity; = 0;
+    int intelligence; = 0;
+    int perception; = 0;
 
-    int speed = 0;
+    int speed; = 0;
 };
 
-namespace character_effects
+namespace character_effects;
 {
 
 /** Returns the effect of pain on stats */

--- a/src/character_effects.h
+++ b/src/character_effects.h
@@ -5,43 +5,48 @@
 class Character;
 
 struct stat_mod {
-    int strength; = 0;
-    int dexterity; = 0;
-    int intelligence; = 0;
-    int perception; = 0;
+    int strength;
+        = 0;
+    int dexterity;
+        = 0;
+    int intelligence;
+        = 0;
+    int perception;
+        = 0;
 
-    int speed; = 0;
+    int speed;
+        = 0;
 };
 
 namespace character_effects;
 {
 
-/** Returns the effect of pain on stats */
-stat_mod get_pain_penalty( const Character &ch );
+    /** Returns the effect of pain on stats */
+    stat_mod get_pain_penalty( const Character & ch );
 
-/** Returns the penalty to speed from starvation */
-int get_kcal_speed_penalty( float kcal_percent );
+    /** Returns the penalty to speed from starvation */
+    int get_kcal_speed_penalty( float kcal_percent );
 
-/** Returns the penalty to speed from thirst */
-int get_thirst_speed_penalty( int thirst );
+    /** Returns the penalty to speed from thirst */
+    int get_thirst_speed_penalty( int thirst );
 
-/** Calculates character's morale cap due to fatigue */
-int calc_morale_fatigue_cap( int fatigue );
+    /** Calculates character's morale cap due to fatigue */
+    int calc_morale_fatigue_cap( int fatigue );
 
-/** Returns the modifier value used for vomiting effects */
-double vomit_mod( const Character &ch );
+    /** Returns the modifier value used for vomiting effects */
+    double vomit_mod( const Character & ch );
 
-/** Returns a value used when attempting to convince NPC's of something */
-int talk_skill( const Character &ch );
+    /** Returns a value used when attempting to convince NPC's of something */
+    int talk_skill( const Character & ch );
 
-/** Returns a value used when attempting to intimidate NPC's */
-int intimidation( const Character &ch );
+    /** Returns a value used when attempting to intimidate NPC's */
+    int intimidation( const Character & ch );
 
-/** Uses morale, pain and fatigue to return the player's focus target goto value */
-int calc_focus_equilibrium( const Character &who );
+    /** Uses morale, pain and fatigue to return the player's focus target goto value */
+    int calc_focus_equilibrium( const Character & who );
 
-/** Calculates actual focus gain/loss value from focus equilibrium*/
-int calc_focus_change( const Character &who );
+    /** Calculates actual focus gain/loss value from focus equilibrium*/
+    int calc_focus_change( const Character & who );
 
 } // namespace character_effects
 

--- a/src/character_turn.h
+++ b/src/character_turn.h
@@ -5,7 +5,7 @@
 class Character;
 struct w_point;
 
-namespace character_funcs
+namespace character_funcs;
 {
 
 /** Maintains body wetness and handles the rate at which the player dries */

--- a/src/character_turn.h
+++ b/src/character_turn.h
@@ -8,17 +8,17 @@ struct w_point;
 namespace character_funcs;
 {
 
-/** Maintains body wetness and handles the rate at which the player dries */
-void update_body_wetness( Character &who, const w_point &weather );
+    /** Maintains body wetness and handles the rate at which the player dries */
+    void update_body_wetness( Character & who, const w_point & weather );
 
-/** Do pause action ('.' key). */
-void do_pause( Character &who );
+    /** Do pause action ('.' key). */
+    void do_pause( Character & who );
 
-/** Search surrounding squares for traps (and maybe other things in the future). */
-void search_surroundings( Character &who );
+    /** Search surrounding squares for traps (and maybe other things in the future). */
+    void search_surroundings( Character & who );
 
-/** Uses calc_focus_change to update the player's current focus */
-void update_mental_focus( Character &who );
+    /** Uses calc_focus_change to update the player's current focus */
+    void update_mental_focus( Character & who );
 
 } // namespace character_funcs
 

--- a/src/fmtlib_core.h
+++ b/src/fmtlib_core.h
@@ -1758,7 +1758,7 @@ using wformat_context = buffer_context<wchar_t>;
 
 // Workaround an alias issue: https://stackoverflow.com/q/62767544/471164.
 #define FMT_BUFFER_CONTEXT(Char) \
-    basic_format_context<detail::buffer_appender<Char>, Char>
+    basic_format_context<detail::buffer_appender<(Char)>, (Char)>
 
 /**
   \rst

--- a/src/fmtlib_format.h
+++ b/src/fmtlib_format.h
@@ -3971,7 +3971,7 @@ struct formatter < T, Char,
     struct formatter<Type, Char> : formatter<Base, Char> {                      \
         template <typename FormatContext>                                         \
         auto format(Type const& val, FormatContext& ctx) -> decltype(ctx.out()) { \
-            return formatter<Base, Char>::format(val, ctx);                         \
+            return formatter<(Base), Char>::format(val, ctx);                         \
         }                                                                         \
     }
 

--- a/src/fungal_effects.h
+++ b/src/fungal_effects.h
@@ -7,7 +7,7 @@ class map;
 class game;
 class Creature;
 
-class fungal_effects
+class fungal_effects;
 {
     private:
         // Dependency injection to try to be less global

--- a/src/fungal_effects.h
+++ b/src/fungal_effects.h
@@ -9,22 +9,22 @@ class Creature;
 
 class fungal_effects;
 {
-    private:
-        // Dependency injection to try to be less global
-        game &gm;
-        map &m;
-    public:
-        fungal_effects( game &g, map &mp );
-        fungal_effects( const fungal_effects & ) = delete;
-        fungal_effects( fungal_effects && ) = delete;
+private:
+    // Dependency injection to try to be less global
+    game &gm;
+    map &m;
+public:
+    fungal_effects( game & g, map & mp );
+    fungal_effects( const fungal_effects & ) = delete;
+    fungal_effects( fungal_effects && ) = delete;
 
-        void marlossify( const tripoint &p );
-        /** Makes spores at p. source is used for kill counting */
-        void create_spores( const tripoint &p, Creature *origin = nullptr );
-        void fungalize( const tripoint &p, Creature *origin = nullptr, double spore_chance = 0.0 );
+    void marlossify( const tripoint & p );
+    /** Makes spores at p. source is used for kill counting */
+    void create_spores( const tripoint & p, Creature *origin = nullptr );
+    void fungalize( const tripoint & p, Creature *origin = nullptr, double spore_chance = 0.0 );
 
-        void spread_fungus( const tripoint &p );
-        void spread_fungus_one_tile( const tripoint &p, int growth );
+    void spread_fungus( const tripoint & p );
+    void spread_fungus_one_tile( const tripoint & p, int growth );
 };
 
 #endif // CATA_SRC_FUNGAL_EFFECTS_H

--- a/src/game_ui.h
+++ b/src/game_ui.h
@@ -4,7 +4,7 @@
 
 namespace game_ui;
 {
-void init_ui();
+    void init_ui();
 } // namespace game_ui
 
 // defined in sdltiles.cpp

--- a/src/game_ui.h
+++ b/src/game_ui.h
@@ -2,7 +2,7 @@
 #ifndef CATA_SRC_GAME_UI_H
 #define CATA_SRC_GAME_UI_H
 
-namespace game_ui
+namespace game_ui;
 {
 void init_ui();
 } // namespace game_ui

--- a/src/ime.h
+++ b/src/ime.h
@@ -13,17 +13,17 @@ void disable_ime();
  */
 class ime_sentry;
 {
-    public:
-        enum mode {
-            enable = 0,
-            disable = 1,
-            keep = 2,
-        };
+public:
+    enum mode {
+        enable = 0,
+        disable = 1,
+        keep = 2,
+    };
 
-        ime_sentry( mode m = enable );
-        ~ime_sentry();
-    private:
-        bool previously_enabled;
+    ime_sentry( mode m = enable );
+    ~ime_sentry();
+private:
+    bool previously_enabled;
 };
 
 #endif // CATA_SRC_IME_H

--- a/src/ime.h
+++ b/src/ime.h
@@ -11,7 +11,7 @@ void disable_ime();
 /**
  * used before text input to change IME mode and auto-restore IME mode when leaving the scope
  */
-class ime_sentry
+class ime_sentry;
 {
     public:
         enum mode {

--- a/src/io_tags.h
+++ b/src/io_tags.h
@@ -5,26 +5,26 @@
 namespace io;
 {
 
-class JsonArrayInputArchive;
-class JsonArrayOutputArchive;
-class JsonObjectInputArchive;
-class JsonObjectOutputArchive;
+    class JsonArrayInputArchive;
+    class JsonArrayOutputArchive;
+    class JsonObjectInputArchive;
+    class JsonObjectOutputArchive;
 
-/**
- * Tag that indicates the class is stored in a JSON array.
- */
-struct array_archive_tag {
-    using InputArchive = JsonArrayInputArchive;
-    using OutputArchive = JsonArrayOutputArchive;
-};
+    /**
+     * Tag that indicates the class is stored in a JSON array.
+     */
+    struct array_archive_tag {
+        using InputArchive = JsonArrayInputArchive;
+        using OutputArchive = JsonArrayOutputArchive;
+    };
 
-/**
- * Tag that indicates the class is stored in a JSON object.
- */
-struct object_archive_tag {
-    using InputArchive = JsonObjectInputArchive;
-    using OutputArchive = JsonObjectOutputArchive;
-};
+    /**
+     * Tag that indicates the class is stored in a JSON object.
+     */
+    struct object_archive_tag {
+        using InputArchive = JsonObjectInputArchive;
+        using OutputArchive = JsonObjectOutputArchive;
+    };
 
 } // namespace io
 

--- a/src/io_tags.h
+++ b/src/io_tags.h
@@ -2,7 +2,7 @@
 #ifndef CATA_SRC_IO_TAGS_H
 #define CATA_SRC_IO_TAGS_H
 
-namespace io
+namespace io;
 {
 
 class JsonArrayInputArchive;

--- a/src/iuse_software_snake.h
+++ b/src/iuse_software_snake.h
@@ -4,17 +4,17 @@
 
 namespace catacurses;
 {
-class window;
+    class window;
 } // namespace catacurses
 
 class snake_game;
 {
-    public:
-        snake_game();
-        void print_score( const catacurses::window &w_snake, int iScore );
-        void print_header( const catacurses::window &w_snake, bool show_shortcut = true );
-        void snake_over( const catacurses::window &w_snake, int iScore );
-        int start_game();
+public:
+    snake_game();
+    void print_score( const catacurses::window & w_snake, int iScore );
+    void print_header( const catacurses::window & w_snake, bool show_shortcut = true );
+    void snake_over( const catacurses::window & w_snake, int iScore );
+    int start_game();
 };
 
 #endif // CATA_SRC_IUSE_SOFTWARE_SNAKE_H

--- a/src/iuse_software_snake.h
+++ b/src/iuse_software_snake.h
@@ -2,12 +2,12 @@
 #ifndef CATA_SRC_IUSE_SOFTWARE_SNAKE_H
 #define CATA_SRC_IUSE_SOFTWARE_SNAKE_H
 
-namespace catacurses
+namespace catacurses;
 {
 class window;
 } // namespace catacurses
 
-class snake_game
+class snake_game;
 {
     public:
         snake_game();

--- a/src/melee.h
+++ b/src/melee.h
@@ -13,17 +13,17 @@ struct attack_statblock;
  * statistics data for melee attacks, used for test purposes
  */
 struct melee_statistic_data {
-    int attack_count = 0;
-    int hit_count = 0;
-    int double_crit_count = 0;
-    int crit_count = 0;
-    int actual_crit_count = 0;
-    double double_crit_chance = 0.0;
-    double crit_chance = 0.0;
-    int damage_amount = 0;
+    int attack_count; = 0;
+    int hit_count; = 0;
+    int double_crit_count; = 0;
+    int crit_count; = 0;
+    int actual_crit_count; = 0;
+    double double_crit_chance; = 0.0;
+    double crit_chance; = 0.0;
+    int damage_amount; = 0;
 };
 
-namespace melee
+namespace melee;
 {
 
 constexpr double accuracy_roll_stddev = 5.0;

--- a/src/melee.h
+++ b/src/melee.h
@@ -13,57 +13,65 @@ struct attack_statblock;
  * statistics data for melee attacks, used for test purposes
  */
 struct melee_statistic_data {
-    int attack_count; = 0;
-    int hit_count; = 0;
-    int double_crit_count; = 0;
-    int crit_count; = 0;
-    int actual_crit_count; = 0;
-    double double_crit_chance; = 0.0;
-    double crit_chance; = 0.0;
-    int damage_amount; = 0;
+    int attack_count;
+        = 0;
+    int hit_count;
+        = 0;
+    int double_crit_count;
+        = 0;
+    int crit_count;
+        = 0;
+    int actual_crit_count;
+        = 0;
+    double double_crit_chance;
+        = 0.0;
+    double crit_chance;
+        = 0.0;
+    int damage_amount;
+        = 0;
 };
 
 namespace melee;
 {
 
-constexpr double accuracy_roll_stddev = 5.0;
+    constexpr double accuracy_roll_stddev = 5.0;
 
-float melee_hit_range( float accuracy );
-melee_statistic_data get_stats();
-void clear_stats();
-extern melee_statistic_data melee_stats;
+    float melee_hit_range( float accuracy );
+    melee_statistic_data get_stats();
+    void clear_stats();
+    extern melee_statistic_data melee_stats;
 
-/**
- * What is the chance that melee attack with given accuracy hits?
- * @param acc Final to-hit of the attack minus attacker's dodge
- * See @ref melee_hit_range
- */
-float hit_chance( float acc );
+    /**
+     * What is the chance that melee attack with given accuracy hits?
+     * @param acc Final to-hit of the attack minus attacker's dodge
+     * See @ref melee_hit_range
+     */
+    float hit_chance( float acc );
 
-// If average == true, adds expected values of random rolls instead of rolling.
-/** Adds all 3 types of physical damage to instance */
-void roll_all_damage( const Character &c, bool crit, damage_instance &di, bool average,
-                      const item &weap, const attack_statblock &attack );
-/** Adds player's total bash damage to the damage instance */
-void roll_bash_damage( const Character &c, bool crit, damage_instance &di, bool average,
-                       const item &weap, const attack_statblock &attack );
-/** Adds player's total cut damage to the damage instance */
-void roll_cut_damage( const Character &c, bool crit, damage_instance &di, bool average,
-                      const item &weap, const attack_statblock &attack );
-/** Adds player's total stab damage to the damage instance */
-void roll_stab_damage( const Character &c, bool crit, damage_instance &di, bool average,
-                       const item &weap, const attack_statblock &attack );
+    // If average == true, adds expected values of random rolls instead of rolling.
+    /** Adds all 3 types of physical damage to instance */
+    void roll_all_damage( const Character & c, bool crit, damage_instance & di, bool average,
+                          const item & weap, const attack_statblock & attack );
+    /** Adds player's total bash damage to the damage instance */
+    void roll_bash_damage( const Character & c, bool crit, damage_instance & di, bool average,
+                           const item & weap, const attack_statblock & attack );
+    /** Adds player's total cut damage to the damage instance */
+    void roll_cut_damage( const Character & c, bool crit, damage_instance & di, bool average,
+                          const item & weap, const attack_statblock & attack );
+    /** Adds player's total stab damage to the damage instance */
+    void roll_stab_damage( const Character & c, bool crit, damage_instance & di, bool average,
+                           const item & weap, const attack_statblock & attack );
 
-// Temporary function that returns any attack from the weapon
-// TODO: Remove
-const attack_statblock &default_attack( const item &it );
+    // Temporary function that returns any attack from the weapon
+    // TODO: Remove
+    const attack_statblock &default_attack( const item & it );
 
-const attack_statblock &pick_attack( const Character &c, const item &weapon,
-                                     const Creature &target );
-const attack_statblock &pick_attack( const Character &c, const item &weapon,
-                                     const monster &target );
-const attack_statblock &pick_attack( const Character &c, const item &weapon,
-                                     const Character &target );
+    const attack_statblock &pick_attack( const Character & c, const item & weapon,
+                                         const Creature & target );
+    const attack_statblock &pick_attack( const Character & c, const item & weapon,
+                                         const monster & target );
+    const attack_statblock &pick_attack( const Character & c, const item & weapon,
+                                         const Character & target );
 
 } // namespace melee
 

--- a/src/monattack.h
+++ b/src/monattack.h
@@ -7,133 +7,133 @@ class Creature;
 
 namespace mattack;
 {
-bool none( monster *z );
-bool eat_crop( monster *z );
-bool eat_food( monster *z );
-bool antqueen( monster *z );
-bool shriek( monster *z );
-bool shriek_alert( monster *z );
-bool shriek_stun( monster *z );
-bool howl( monster *z );
-bool rattle( monster *z );
-bool acid( monster *z );
-bool acid_accurate( monster *z );
-bool acid_barf( monster *z );
-bool shockstorm( monster *z );
-bool shocking_reveal( monster *z );
-bool pull_metal_weapon( monster *z );
-bool boomer( monster *z );
-bool boomer_glow( monster *z );
-bool resurrect( monster *z );
-bool smash( monster *z );
-void smash_specific( monster *z, Creature *target );
-bool science( monster *z );
-bool growplants( monster *z );
-bool grow_vine( monster *z );
-bool vine( monster *z );
-bool spit_sap( monster *z );
-bool triffid_heartbeat( monster *z );
-/// Generic fungal spore-launch
-bool fungus( monster *z );
-/// Advanced spore-launch (for mods). Uses different spore spawn formula.
-/// Spore chance will be proportionally decreased as nearby creatures count
-/// will pass the FUNGUS_SPORE_CREATURES_THRESHOLD threshold.
-bool fungus_advanced( monster *z );
-/// Used by Crazy Cataclysm; spawns SpOreos(tm).
-bool fungus_corporate( monster *z );
-/// Broadly scatter aerobics
-bool fungus_haze( monster *z );
-/// Aerobic & anaerobic, as needed
-bool fungus_big_blossom( monster *z );
-/// Directly inject the spores
-bool fungus_inject( monster *z );
-/// Fungal hedgerow rake & inject
-bool fungus_bristle( monster *z );
-/// Sporeling -> fungal creature
-bool fungus_growth( monster *z );
-/// Grow fungal walls
-bool fungus_sprout( monster *z );
-/// Grow fungal hedgerows
-bool fungus_fortify( monster *z );
-bool impale( monster *z );
-bool dermatik( monster *z );
-bool dermatik_growth( monster *z );
-bool fungal_trail( monster *z );
-bool plant( monster *z );
-bool disappear( monster *z );
-bool formblob( monster *z );
-bool callblobs( monster *z );
-bool jackson( monster *z );
-bool dance( monster *z );
-bool dogthing( monster *z );
-bool tentacle( monster *z );
-bool vortex( monster *z );
-bool gene_sting( monster *z );
-bool para_sting( monster *z );
-bool triffid_growth( monster *z );
-bool stare( monster *z );
-bool fear_paralyze( monster *z );
-bool nurse_check_up( monster *z );
-bool nurse_assist( monster *z );
-bool nurse_operate( monster *z );
-bool check_money_left( monster *z );
-bool photograph( monster *z );
-bool tazer( monster *z );
-bool flamethrower( monster *z );
-bool searchlight( monster *z );
-bool copbot( monster *z );
-/// Pick from tazer, M4, MGL
-bool chickenbot( monster *z );
-/// Tazer, flame, M4, MGL, or 120mm!
-bool multi_robot( monster *z );
-bool ratking( monster *z );
-bool generator( monster *z );
-bool upgrade( monster *z );
-bool breathe( monster *z );
-bool brandish( monster *z );
-bool flesh_golem( monster *z );
-bool absorb_meat( monster *z );
-bool lunge( monster *z );
-bool longswipe( monster *z );
-bool parrot( monster *z );
-bool parrot_at_danger( monster *parrot );
-bool darkman( monster *z );
-bool slimespring( monster *z );
-bool evolve_kill_strike( monster *z );
-bool leech_spawner( monster *z );
-bool mon_leech_evolution( monster *z );
-bool tindalos_teleport( monster *z );
-bool flesh_tendril( monster *z );
-bool bio_op_random_biojutsu( monster *z );
-bool bio_op_takedown( monster *z );
-bool bio_op_impale( monster *z );
-bool bio_op_disarm( monster *z );
-bool ranged_pull( monster *z );
-bool grab( monster *z );
-bool grab_drag( monster *z );
-bool suicide( monster *z );
-/// handles zombie getting thrown when u.is_throw_immune()
-bool thrown_by_judo( monster *z );
-bool riotbot( monster *z );
-bool stretch_attack( monster *z );
-bool stretch_bite( monster *z );
-bool kamikaze( monster *z );
-bool grenadier( monster *z );
-bool grenadier_elite( monster *z );
-bool doot( monster *z );
-bool zombie_fuse( monster *z );
-bool command_buff( monster *z );
+    bool none( monster * z );
+    bool eat_crop( monster * z );
+    bool eat_food( monster * z );
+    bool antqueen( monster * z );
+    bool shriek( monster * z );
+    bool shriek_alert( monster * z );
+    bool shriek_stun( monster * z );
+    bool howl( monster * z );
+    bool rattle( monster * z );
+    bool acid( monster * z );
+    bool acid_accurate( monster * z );
+    bool acid_barf( monster * z );
+    bool shockstorm( monster * z );
+    bool shocking_reveal( monster * z );
+    bool pull_metal_weapon( monster * z );
+    bool boomer( monster * z );
+    bool boomer_glow( monster * z );
+    bool resurrect( monster * z );
+    bool smash( monster * z );
+    void smash_specific( monster * z, Creature * target );
+    bool science( monster * z );
+    bool growplants( monster * z );
+    bool grow_vine( monster * z );
+    bool vine( monster * z );
+    bool spit_sap( monster * z );
+    bool triffid_heartbeat( monster * z );
+    /// Generic fungal spore-launch
+    bool fungus( monster * z );
+    /// Advanced spore-launch (for mods). Uses different spore spawn formula.
+    /// Spore chance will be proportionally decreased as nearby creatures count
+    /// will pass the FUNGUS_SPORE_CREATURES_THRESHOLD threshold.
+    bool fungus_advanced( monster * z );
+    /// Used by Crazy Cataclysm; spawns SpOreos(tm).
+    bool fungus_corporate( monster * z );
+    /// Broadly scatter aerobics
+    bool fungus_haze( monster * z );
+    /// Aerobic & anaerobic, as needed
+    bool fungus_big_blossom( monster * z );
+    /// Directly inject the spores
+    bool fungus_inject( monster * z );
+    /// Fungal hedgerow rake & inject
+    bool fungus_bristle( monster * z );
+    /// Sporeling -> fungal creature
+    bool fungus_growth( monster * z );
+    /// Grow fungal walls
+    bool fungus_sprout( monster * z );
+    /// Grow fungal hedgerows
+    bool fungus_fortify( monster * z );
+    bool impale( monster * z );
+    bool dermatik( monster * z );
+    bool dermatik_growth( monster * z );
+    bool fungal_trail( monster * z );
+    bool plant( monster * z );
+    bool disappear( monster * z );
+    bool formblob( monster * z );
+    bool callblobs( monster * z );
+    bool jackson( monster * z );
+    bool dance( monster * z );
+    bool dogthing( monster * z );
+    bool tentacle( monster * z );
+    bool vortex( monster * z );
+    bool gene_sting( monster * z );
+    bool para_sting( monster * z );
+    bool triffid_growth( monster * z );
+    bool stare( monster * z );
+    bool fear_paralyze( monster * z );
+    bool nurse_check_up( monster * z );
+    bool nurse_assist( monster * z );
+    bool nurse_operate( monster * z );
+    bool check_money_left( monster * z );
+    bool photograph( monster * z );
+    bool tazer( monster * z );
+    bool flamethrower( monster * z );
+    bool searchlight( monster * z );
+    bool copbot( monster * z );
+    /// Pick from tazer, M4, MGL
+    bool chickenbot( monster * z );
+    /// Tazer, flame, M4, MGL, or 120mm!
+    bool multi_robot( monster * z );
+    bool ratking( monster * z );
+    bool generator( monster * z );
+    bool upgrade( monster * z );
+    bool breathe( monster * z );
+    bool brandish( monster * z );
+    bool flesh_golem( monster * z );
+    bool absorb_meat( monster * z );
+    bool lunge( monster * z );
+    bool longswipe( monster * z );
+    bool parrot( monster * z );
+    bool parrot_at_danger( monster * parrot );
+    bool darkman( monster * z );
+    bool slimespring( monster * z );
+    bool evolve_kill_strike( monster * z );
+    bool leech_spawner( monster * z );
+    bool mon_leech_evolution( monster * z );
+    bool tindalos_teleport( monster * z );
+    bool flesh_tendril( monster * z );
+    bool bio_op_random_biojutsu( monster * z );
+    bool bio_op_takedown( monster * z );
+    bool bio_op_impale( monster * z );
+    bool bio_op_disarm( monster * z );
+    bool ranged_pull( monster * z );
+    bool grab( monster * z );
+    bool grab_drag( monster * z );
+    bool suicide( monster * z );
+    /// handles zombie getting thrown when u.is_throw_immune()
+    bool thrown_by_judo( monster * z );
+    bool riotbot( monster * z );
+    bool stretch_attack( monster * z );
+    bool stretch_bite( monster * z );
+    bool kamikaze( monster * z );
+    bool grenadier( monster * z );
+    bool grenadier_elite( monster * z );
+    bool doot( monster * z );
+    bool zombie_fuse( monster * z );
+    bool command_buff( monster * z );
 
-void taze( monster *z, Creature *target );
-/// Automated M4
-void rifle( monster *z, Creature *target );
-/// Automated MGL
-void frag( monster *z, Creature *target );
-/// Tankbot primary
-void tankgun( monster *z, Creature *target );
-void flame( monster *z, Creature *target );
+    void taze( monster * z, Creature * target );
+    /// Automated M4
+    void rifle( monster * z, Creature * target );
+    /// Automated MGL
+    void frag( monster * z, Creature * target );
+    /// Tankbot primary
+    void tankgun( monster * z, Creature * target );
+    void flame( monster * z, Creature * target );
 
-bool dodge_check( monster *z, Creature *target );
+    bool dodge_check( monster * z, Creature * target );
 } //namespace mattack
 
 #endif // CATA_SRC_MONATTACK_H

--- a/src/monattack.h
+++ b/src/monattack.h
@@ -5,7 +5,7 @@
 class monster;
 class Creature;
 
-namespace mattack
+namespace mattack;
 {
 bool none( monster *z );
 bool eat_crop( monster *z );

--- a/src/mondeath.h
+++ b/src/mondeath.h
@@ -4,7 +4,7 @@
 
 class monster;
 
-namespace mdeath
+namespace mdeath;
 {
 // Drop a body
 void normal( monster &z );

--- a/src/mondeath.h
+++ b/src/mondeath.h
@@ -6,83 +6,83 @@ class monster;
 
 namespace mdeath;
 {
-// Drop a body
-void normal( monster &z );
-// Overkill splatter (also part of normal under conditions)
-void splatter( monster &z );
-// Acid instead of a body
-void acid( monster &z );
-// Explodes in vomit :3
-void boomer( monster &z );
-// Explodes in vomit :3
-void boomer_glow( monster &z );
-// Kill all nearby vines
-void kill_vines( monster &z );
-// Kill adjacent vine if it's cut
-void vine_cut( monster &z );
-// Destroy all roots
-void triffid_heart( monster &z );
-// Explodes in spores D:
-void fungus( monster &z );
-// Falls apart
-void disintegrate( monster &z );
-// Screams loudly
-void shriek( monster &z );
-// Wolf's howling
-void howl( monster &z );
-// Rattles like a rattlesnake
-void rattle( monster &z );
-// Spawns 2 half-worms
-void worm( monster &z );
-// Hallucination disappears
-void disappear( monster &z );
-// Morale penalty
-void guilt( monster &z );
-// Frees blobs, redirects to blobsplit
-void brainblob( monster &z );
-// Creates more blobs
-void blobsplit( monster &z );
-// Reverts dancers
-void jackson( monster &z );
-// Normal death, but melts
-void melt( monster &z );
-// Removes hypnosis if last one
-void amigara( monster &z );
-// Turn into a full thing
-void thing( monster &z );
-// Damaging explosion
-void explode( monster &z );
-// Blinding ray
-void focused_beam( monster &z );
-// Broken robot drop
-void broken( monster &z );
-// Cure verminitis
-void ratking( monster &z );
-// Sight returns to normal
-void darkman( monster &z );
-// Explodes in toxic gas
-void gas( monster &z );
-// All breathers die
-void kill_breathers( monster &z );
-// Explode like a huge smoke bomb.
-void smokeburst( monster &z );
-// Explode releasing fungal haze.
-void fungalburst( monster &z );
-// Snicker-snack!
-void jabberwock( monster &z );
-// Take the enemy with you
-void detonate( monster &z );
-// Breaks ammo and then itself
-void broken_ammo( monster &z );
-// Spawns 1-3 roach nymphs
-void preg_roach( monster &z );
-// Explodes in fire
-void fireball( monster &z );
-// Similar to above but bigger and guaranteed.
-void conflagration( monster &z );
+    // Drop a body
+    void normal( monster & z );
+    // Overkill splatter (also part of normal under conditions)
+    void splatter( monster & z );
+    // Acid instead of a body
+    void acid( monster & z );
+    // Explodes in vomit :3
+    void boomer( monster & z );
+    // Explodes in vomit :3
+    void boomer_glow( monster & z );
+    // Kill all nearby vines
+    void kill_vines( monster & z );
+    // Kill adjacent vine if it's cut
+    void vine_cut( monster & z );
+    // Destroy all roots
+    void triffid_heart( monster & z );
+    // Explodes in spores D:
+    void fungus( monster & z );
+    // Falls apart
+    void disintegrate( monster & z );
+    // Screams loudly
+    void shriek( monster & z );
+    // Wolf's howling
+    void howl( monster & z );
+    // Rattles like a rattlesnake
+    void rattle( monster & z );
+    // Spawns 2 half-worms
+    void worm( monster & z );
+    // Hallucination disappears
+    void disappear( monster & z );
+    // Morale penalty
+    void guilt( monster & z );
+    // Frees blobs, redirects to blobsplit
+    void brainblob( monster & z );
+    // Creates more blobs
+    void blobsplit( monster & z );
+    // Reverts dancers
+    void jackson( monster & z );
+    // Normal death, but melts
+    void melt( monster & z );
+    // Removes hypnosis if last one
+    void amigara( monster & z );
+    // Turn into a full thing
+    void thing( monster & z );
+    // Damaging explosion
+    void explode( monster & z );
+    // Blinding ray
+    void focused_beam( monster & z );
+    // Broken robot drop
+    void broken( monster & z );
+    // Cure verminitis
+    void ratking( monster & z );
+    // Sight returns to normal
+    void darkman( monster & z );
+    // Explodes in toxic gas
+    void gas( monster & z );
+    // All breathers die
+    void kill_breathers( monster & z );
+    // Explode like a huge smoke bomb.
+    void smokeburst( monster & z );
+    // Explode releasing fungal haze.
+    void fungalburst( monster & z );
+    // Snicker-snack!
+    void jabberwock( monster & z );
+    // Take the enemy with you
+    void detonate( monster & z );
+    // Breaks ammo and then itself
+    void broken_ammo( monster & z );
+    // Spawns 1-3 roach nymphs
+    void preg_roach( monster & z );
+    // Explodes in fire
+    void fireball( monster & z );
+    // Similar to above but bigger and guaranteed.
+    void conflagration( monster & z );
 
-// Game over!  Defense mode
-void gameover( monster &z );
+    // Game over!  Defense mode
+    void gameover( monster & z );
 } //namespace mdeath
 
 void make_mon_corpse( monster &z, int damageLvl );

--- a/src/mondefense.h
+++ b/src/mondefense.h
@@ -8,18 +8,18 @@ struct dealt_projectile_attack;
 
 namespace mdefense;
 {
-/**
-    * @param m The monster the defends itself.
-    * @param source The attacker
-    * @param proj The projectile it was hit by or NULL if it
-    * was attacked with a melee attack.
-    */
-void zapback( monster &m, Creature *source, const dealt_projectile_attack *proj );
-void acidsplash( monster &m, Creature *source, const dealt_projectile_attack *proj );
-void return_fire( monster &m, Creature *source, const dealt_projectile_attack *proj );
-void revenge_aggro( monster &m, Creature *source, const dealt_projectile_attack *proj );
+    /**
+        * @param m The monster the defends itself.
+        * @param source The attacker
+        * @param proj The projectile it was hit by or NULL if it
+        * was attacked with a melee attack.
+        */
+    void zapback( monster & m, Creature * source, const dealt_projectile_attack * proj );
+    void acidsplash( monster & m, Creature * source, const dealt_projectile_attack * proj );
+    void return_fire( monster & m, Creature * source, const dealt_projectile_attack * proj );
+    void revenge_aggro( monster & m, Creature * source, const dealt_projectile_attack * proj );
 
-void none( monster &, Creature *, const dealt_projectile_attack * );
+    void none( monster &, Creature *, const dealt_projectile_attack * );
 } //namespace mdefense
 
 #endif // CATA_SRC_MONDEFENSE_H

--- a/src/mondefense.h
+++ b/src/mondefense.h
@@ -6,7 +6,7 @@ class monster;
 class Creature;
 struct dealt_projectile_attack;
 
-namespace mdefense
+namespace mdefense;
 {
 /**
     * @param m The monster the defends itself.

--- a/src/monexamine.h
+++ b/src/monexamine.h
@@ -4,7 +4,7 @@
 
 class monster;
 
-namespace monexamine
+namespace monexamine;
 {
 bool pet_menu( monster &z );
 bool mech_hack( monster &z );

--- a/src/monexamine.h
+++ b/src/monexamine.h
@@ -6,41 +6,41 @@ class monster;
 
 namespace monexamine;
 {
-bool pet_menu( monster &z );
-bool mech_hack( monster &z );
-bool pay_bot( monster &z );
-bool mfriend_menu( monster &z );
-void remove_battery( monster &z );
-void insert_battery( monster &z );
-void push( monster &z );
-void rename_pet( monster &z );
-void attach_bag_to( monster &z );
-void remove_bag_from( monster &z );
-void dump_items( monster &z );
-bool give_items_to( monster &z );
-void take_items_from( monster &z );
-bool add_armor( monster &z );
-void remove_armor( monster &z );
-void remove_harness( monster &z );
-void play_with( monster &z );
-void kill_zslave( monster &z );
-void add_leash( monster &z );
-void remove_leash( monster &z );
-void start_leading( monster &z );
-void stop_leading( monster &z );
-void toggle_ignore_targets( monster &z );
-void tie_pet( monster &z );
-void untie_pet( monster &z );
-void shear_animal( monster &z );
-void mount_pet( monster &z );
-void attach_or_remove_saddle( monster &z );
-void deactivate_pet( monster &z );
+    bool pet_menu( monster & z );
+    bool mech_hack( monster & z );
+    bool pay_bot( monster & z );
+    bool mfriend_menu( monster & z );
+    void remove_battery( monster & z );
+    void insert_battery( monster & z );
+    void push( monster & z );
+    void rename_pet( monster & z );
+    void attach_bag_to( monster & z );
+    void remove_bag_from( monster & z );
+    void dump_items( monster & z );
+    bool give_items_to( monster & z );
+    void take_items_from( monster & z );
+    bool add_armor( monster & z );
+    void remove_armor( monster & z );
+    void remove_harness( monster & z );
+    void play_with( monster & z );
+    void kill_zslave( monster & z );
+    void add_leash( monster & z );
+    void remove_leash( monster & z );
+    void start_leading( monster & z );
+    void stop_leading( monster & z );
+    void toggle_ignore_targets( monster & z );
+    void tie_pet( monster & z );
+    void untie_pet( monster & z );
+    void shear_animal( monster & z );
+    void mount_pet( monster & z );
+    void attach_or_remove_saddle( monster & z );
+    void deactivate_pet( monster & z );
 
-/*
-*Manages the milking and milking cool down of monsters.
-*Milked item uses starting_ammo, where ammo type is the milked item
-*and amount the times per day you can milk the monster.
-*/
-void milk_source( monster &source_mon );
+    /*
+    *Manages the milking and milking cool down of monsters.
+    *Milked item uses starting_ammo, where ammo type is the milked item
+    *and amount the times per day you can milk the monster.
+    */
+    void milk_source( monster & source_mon );
 } // namespace monexamine
 #endif // CATA_SRC_MONEXAMINE_H

--- a/src/rot.h
+++ b/src/rot.h
@@ -2,12 +2,12 @@
 #ifndef CATA_SRC_ROT_H
 #define CATA_SRC_ROT_H
 
-enum class temperature_flag : int;
+enum class temperature_flag ; int;
 
-class map;
-class item;
+enum class map;
+enum class item;
 
-namespace rot
+namespace rot;
 {
 
 // TODO: Move to item_location method?

--- a/src/rot.h
+++ b/src/rot.h
@@ -2,7 +2,8 @@
 #ifndef CATA_SRC_ROT_H
 #define CATA_SRC_ROT_H
 
-enum class temperature_flag ; int;
+enum class temperature_flag ;
+int;
 
 enum class map;
 enum class item;
@@ -10,8 +11,8 @@ enum class item;
 namespace rot;
 {
 
-// TODO: Move to item_location method?
-auto temperature_flag_for_location( const map &m, const item &loc ) -> temperature_flag;
+    // TODO: Move to item_location method?
+    auto temperature_flag_for_location( const map & m, const item & loc ) -> temperature_flag;
 
 } // namespace rot
 

--- a/src/sets_intersect.h
+++ b/src/sets_intersect.h
@@ -4,25 +4,24 @@
 namespace cata;
 {
 
-template<typename SetL, typename SetR>
-bool sets_intersect( const SetL &l, const SetR &r )
-{
-    // There are two reasonable implementation strategies for ordered sets, but
-    // only one for unordered sets.  We use the approach that works for both,
-    // but if both sets were ordered you can instead step though them in
-    // parallel looking for a dupe.
-    if( l.size() > r.size() ) {
-        return sets_intersect( r, l );
-    }
-
-    for( const auto &elem : l ) {
-        if( r.count( elem ) ) {
-            return true;
+    template<typename SetL, typename SetR>
+    bool sets_intersect( const SetL & l, const SetR & r ) {
+        // There are two reasonable implementation strategies for ordered sets, but
+        // only one for unordered sets.  We use the approach that works for both,
+        // but if both sets were ordered you can instead step though them in
+        // parallel looking for a dupe.
+        if( l.size() > r.size() ) {
+            return sets_intersect( r, l );
         }
-    }
 
-    return false;
-}
+        for( const auto &elem : l ) {
+            if( r.count( elem ) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
 } // namespace cata
 

--- a/src/sets_intersect.h
+++ b/src/sets_intersect.h
@@ -1,7 +1,7 @@
 #ifndef CATA_SRC_SETS_INTERSECT_H
 #define CATA_SRC_SETS_INTERSECT_H
 
-namespace cata
+namespace cata;
 {
 
 template<typename SetL, typename SetR>

--- a/src/teleport.h
+++ b/src/teleport.h
@@ -6,12 +6,12 @@ class Creature;
 
 namespace teleport;
 {
-/** Teleports a creature to a tile within min_distance and max_distance tiles. Limited to 2D.
-*bool safe determines wether the teleported creature can telefrag others/itself.
-*/
-bool teleport( Creature &critter, int min_distance = 2, int max_distance = 12,
-               bool safe = false,
-               bool add_teleglow = true );
+    /** Teleports a creature to a tile within min_distance and max_distance tiles. Limited to 2D.
+    *bool safe determines wether the teleported creature can telefrag others/itself.
+    */
+    bool teleport( Creature & critter, int min_distance = 2, int max_distance = 12,
+                   bool safe = false,
+                   bool add_teleglow = true );
 } // namespace teleport
 
 #endif // CATA_SRC_TELEPORT_H

--- a/src/teleport.h
+++ b/src/teleport.h
@@ -4,7 +4,7 @@
 
 class Creature;
 
-namespace teleport
+namespace teleport;
 {
 /** Teleports a creature to a tile within min_distance and max_distance tiles. Limited to 2D.
 *bool safe determines wether the teleported creature can telefrag others/itself.

--- a/src/type_id_implement.h
+++ b/src/type_id_implement.h
@@ -17,7 +17,7 @@
     }                                                           \
     /** @relates string_id */                                   \
     template<>                                                  \
-    const T& string_id<T>::obj() const                          \
+    const T& string_id<(T)>::obj() const                          \
     {                                                           \
         return (factory).obj(*this);                              \
     }
@@ -30,7 +30,7 @@
         return (factory).is_valid(*this);                         \
     }                                                           \
     template<>                                                  \
-    const T& int_id<T>::obj() const                             \
+    const T& int_id<(T)>::obj() const                             \
     {                                                           \
         return (factory).obj(*this);                              \
     }
@@ -41,15 +41,15 @@
     template<>                                                  \
     int_id<T> string_id<T>::id() const                          \
     {                                                           \
-        return (factory).convert(*this, int_id<T>(-1));           \
+        return (factory).convert(*this, int_id<(T)>(-1));           \
     }                                                           \
     template<>                                                  \
-    int_id<T>::int_id(const string_id<T>& id)                   \
+    int_id<(T)>::int_id(const string_id<(T)>& id)                   \
     {                                                           \
         *this = id.id();                                        \
     }                                                           \
     template<>                                                  \
-    const string_id<T>& int_id<T>::id() const                   \
+    const string_id<(T)>& int_id<(T)>::id() const                   \
     {                                                           \
         return (factory).convert(*this);                          \
     }

--- a/src/wdirent.h
+++ b/src/wdirent.h
@@ -347,12 +347,10 @@ static WIN32_FIND_DATAW *dirent_first( _WDIR *dirp );
 static WIN32_FIND_DATAW *dirent_next( _WDIR *dirp );
 
 static int dirent_mbstowcs_s(
-    size_t *pReturnValue, wchar_t *wcstr, size_t sizeInWords,
-    const char *mbstr, size_t count );
+    size_t *pReturnValue, wchar_t *wcstr, const char *mbstr, size_t count );
 
 static int dirent_wcstombs_s(
-    size_t *pReturnValue, char *mbstr, size_t sizeInBytes,
-    const wchar_t *wcstr, size_t count );
+    size_t *pReturnValue, char *mbstr, const wchar_t *wcstr, size_t count );
 
 #if !defined(_MSC_VER) || _MSC_VER < 1400
 static void dirent_set_errno( int error );
@@ -710,7 +708,7 @@ exit_failure:
 /* Convert multi-byte string to wide character string */
 static int dirent_mbstowcs_s(
     size_t *pReturnValue, wchar_t *wcstr,
-    size_t sizeInWords, const char *mbstr, size_t /*count*/ )
+    const char *mbstr, size_t /*count*/ )
 {
     const int required_size = MultiByteToWideChar( CP_UTF8, 0, mbstr, -1, NULL, 0 ) + 1;
     if( required_size > static_cast<int>( sizeInWords ) ) {
@@ -730,7 +728,7 @@ static int dirent_mbstowcs_s(
 /* Convert wide-character string to multi-byte string */
 static int dirent_wcstombs_s(
     size_t *pReturnValue, char *mbstr,
-    size_t sizeInBytes, const wchar_t *wcstr, size_t /*count*/ )
+    const wchar_t *wcstr, size_t /*count*/ )
 {
     const int required_size = WideCharToMultiByte( CP_UTF8, 0, wcstr, -1, NULL, 0, NULL, 0 ) + 1;
     if( required_size > static_cast<int>( sizeInBytes ) ) {


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Better code practices are nice, and this will hopefully prevent yelling at us by clang in the future.

## Describe the solution

Uses the included script by Scarf that acts as a wrapper for clang-tidy

## Describe alternatives you've considered

- Explode
- Implode
- Wait for someone else to do it

The script itself seemed to have some bugs (I had to change which flag it was using to tell it to fix the bugs for one, but it also complained about some missing files). However, any improvement is good

## Testing

I ***hope*** clang-tidy isn't going to break anything, or else we've got some very bad news for the project as a whole.

## Additional context

Thanks for RoyalFox asking me to run the script in the first place

Feel free to update the semantic title category as needed

Updated run command for the script:
```bash
$ parallel ./build-scripts/clang-tidy-wrapper.sh {} -fix-errors ::: src/*.{c,h}
```
