### PR TITLE
fix: tainted blood isn't cannibalism

### DIFF
--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -774,7 +774,7 @@
     "calories": 43,
     "description": "Blood that's obviously unhealthy.  You could drink it, but it will poison you.",
     "price": "0 cent",
-    "material": "hflesh",
+    "material": "flesh",
     "volume": "250 ml",
     "phase": "liquid",
     "fun": -50,


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/5602 by setting tainted blood to not be human. This is the easiest way to do it, and tainted flesh doesn't count as human due to recipes like tainted tornado.

## Describe the solution

![image](https://github.com/user-attachments/assets/e56a796d-e9ef-49cb-8ad6-69363fb22c7f)
## Describe alternatives you've considered

Deal with recipe nutrient overrides on a few dozen recipes.

## Testing

Nah

## Additional context


