### PR TITLE
feat(balance): use `trash_dumpster` for the dumpster of the convention center

### DIFF
--- a/data/json/mapgen_palettes/convention_center_palette.json
+++ b/data/json/mapgen_palettes/convention_center_palette.json
@@ -87,7 +87,7 @@
       "d": { "item": "SUS_office_desk", "chance": 33 },
       "l": { "item": "SUS_janitors_closet", "chance": 100 },
       "a": { "item": "trash", "chance": 33, "repeat": [ 1, 3 ] },
-      "A": { "item": "trash", "chance": 75, "repeat": [ 1, 5 ] }
+      "A": { "item": "trash_dumpster", "chance": 80 }
     },
     "liquids": { "g": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
     "vendingmachines": { "D": { "item_group": "vending_drink" }, "F": { "item_group": "vending_food" } },


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Since `trash_dumpster` is used to fill most dumpsters in cities, I think it can also be used for the convention center dumpsters.
## Describe the solution
Use `trash_dumpster`
## Describe alternatives you've considered
none
## Additional context
none