### PR TITLE
feat(balance): Allow police duty belts to holster expandable batons

### DIFF
--- a/data/json/items/armor/belts.json
+++ b/data/json/items/armor/belts.json
@@ -169,7 +169,7 @@
       "type": "holster",
       "holster_prompt": "Attach what to holder?",
       "holster_msg": "You attach your %s to your %s.",
-      "min_volume": "600 ml",
+      "min_volume": "250 ml",
       "max_volume": "2250 ml",
       "max_weight": "3600 g",
       "flags": [ "BELT_CLIP" ]


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

600 mililiters on the police duty belt does not allow expandable batons to be holstered without being extended, and blocks blackjacks and makeshift saps, the previous change did make it better but you have to expand a baton to holster it and still can't holster the blackjack or sap.

I primarily think it is important to be able to holster a retracted baton so players don't get confused thinking it isn't able to be stored at all.

![image](https://github.com/user-attachments/assets/7e2f73a5-f021-411d-88ee-702053560456)

## Describe the solution

250 mililiters, this also allows blackjacks, makeshift saps, and batons that aren't extended

## Describe alternatives you've considered

A better holster system

## Testing

Tests

## Additional context
