### PR TITLE
feat(balance): stop requesting frames lost on deconstruct

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -4505,11 +4505,7 @@
     "time": "30 m",
     "qualities": [ [ { "id": "DRILL", "level": 2 } ], [ { "id": "SCREW", "level": 1 } ] ],
     "using": [ [ "soldering_standard", 20 ] ],
-    "components": [
-      [ [ "steel_chunk", 5 ] ],
-      [ [ "plastic_chunk", 2 ] ],
-      [ [ "xl_wind_turbine", 1 ] ]
-    ],
+    "components": [ [ [ "steel_chunk", 5 ] ], [ [ "plastic_chunk", 2 ] ], [ [ "xl_wind_turbine", 1 ] ] ],
     "pre_note": "Will only work if constructed on a roof.  Also needs a building that has an electric grid with a mounted battery.",
     "pre_flags": [ "ROOF", "FLAT" ],
     "post_furniture": "f_xl_turbine_unit"

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -4474,10 +4474,10 @@
     "group": "install_wind_turbine",
     "category": "WORKSHOP",
     "required_skills": [ [ "fabrication", 4 ], [ "electronics", 1 ] ],
-    "time": "70 m",
-    "qualities": [ [ { "id": "WRENCH", "level": 2 } ], [ { "id": "SCREW", "level": 1 } ] ],
+    "time": "30 m",
+    "qualities": [ [ { "id": "DRILL", "level": 2 } ], [ { "id": "SCREW", "level": 1 } ] ],
     "using": [ [ "soldering_standard", 10 ] ],
-    "components": [ [ [ "steel_chunk", 5 ] ], [ [ "plastic_chunk", 2 ] ], [ [ "wind_turbine", 1 ] ], [ [ "frame", 1 ] ] ],
+    "components": [ [ [ "steel_chunk", 5 ] ], [ [ "plastic_chunk", 2 ] ], [ [ "wind_turbine", 1 ] ] ],
     "pre_note": "Will only work if constructed on a roof.  Also needs a building that has an electric grid with a mounted battery.",
     "pre_flags": [ "ROOF", "FLAT" ],
     "post_furniture": "f_turbine_unit"
@@ -4502,14 +4502,13 @@
     "group": "install_xl_wind_turbine",
     "category": "WORKSHOP",
     "required_skills": [ [ "fabrication", 4 ], [ "electronics", 1 ] ],
-    "time": "70 m",
-    "qualities": [ [ { "id": "WRENCH", "level": 2 } ], [ { "id": "SCREW", "level": 1 } ] ],
+    "time": "30 m",
+    "qualities": [ [ { "id": "DRILL", "level": 2 } ], [ { "id": "SCREW", "level": 1 } ] ],
     "using": [ [ "soldering_standard", 20 ] ],
     "components": [
       [ [ "steel_chunk", 5 ] ],
       [ [ "plastic_chunk", 2 ] ],
-      [ [ "xl_wind_turbine", 1 ] ],
-      [ [ "frame", 2 ], [ "hdframe", 1 ] ]
+      [ [ "xl_wind_turbine", 1 ] ]
     ],
     "pre_note": "Will only work if constructed on a roof.  Also needs a building that has an electric grid with a mounted battery.",
     "pre_flags": [ "ROOF", "FLAT" ],


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
## Purpose of change

Wind turbines and XL wind turbines eat extra steel frames if constructed on roofs, take 40 minutes longer, and requires a wrench. None of that makes sense to me, you additionally lose those frames on deconstruction because its the same terrain ID.

## Describe the solution

I set it to the same time, requiring a drill instead, and not taking frames.

## Describe alternatives you've considered

None

## Testing

Tests

## Additional context

Each day we stray closer to madness