### PR TITLE
fix: only display compatible magazines if they are not empty

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2222,6 +2222,14 @@ void item::ammo_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
     }
 }
 
+namespace
+{
+auto nname( const itype_id &id ) -> std::string
+{
+    return item::nname( id );
+}
+} // namespace
+
 void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminfo_query *parts,
                      int /* batch */, bool /* debug */ ) const
 {
@@ -2539,12 +2547,12 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
     }
 
     if( !magazine_integral() && parts->test( iteminfo_parts::GUN_ALLOWED_MAGAZINES ) ) {
-        insert_separation_line( info );
-        const std::set<itype_id> compat = magazine_compatible();
-        info.emplace_back( "DESCRIPTION", _( "<bold>Compatible magazines</bold>: " ) +
-        enumerate_as_string( compat.begin(), compat.end(), []( const itype_id & id ) {
-            return item::nname( id );
-        } ) );
+        const auto &compat = magazine_compatible();
+        if( !compat.empty() ) {
+            insert_separation_line( info );
+            info.emplace_back( "DESCRIPTION", _( "<bold>Compatible magazines</bold>: " )
+                               + enumerate_as_string( compat, ::nname ) );
+        }
     }
 
     if( !gun.valid_mod_locations.empty() && parts->test( iteminfo_parts::DESCRIPTION_GUN_MODS ) ) {
@@ -3174,11 +3182,11 @@ void item::tool_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
         }
 
         if( parts->test( iteminfo_parts::TOOL_MAGAZINE_COMPATIBLE ) ) {
-            const std::set<itype_id> compat = magazine_compatible();
-            info.emplace_back( "TOOL", _( "Compatible magazines: " ),
-            enumerate_as_string( compat.begin(), compat.end(), []( const itype_id & id ) {
-                return item::nname( id );
-            } ) );
+            const auto &compat = magazine_compatible();
+            if( !compat.empty() ) {
+                info.emplace_back( "TOOL", _( "Compatible magazines: " )
+                                   + enumerate_as_string( compat, ::nname ) );
+            }
         }
     } else if( ammo_capacity() != 0 && parts->test( iteminfo_parts::TOOL_CAPACITY ) ) {
         std::string tmp;


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

fixes #5612

## Describe the solution

same as title.

## Testing

left: before, right: after (this PR)

### m16a4

![image](https://github.com/user-attachments/assets/c3f9a342-4527-4753-ac7d-00026e3e32ed)

### ski mask

![image](https://github.com/user-attachments/assets/5667eb39-0ae1-4880-a6ff-19b8df91b8a6)

### electric lighter
![image](https://github.com/user-attachments/assets/e028e261-0424-471b-aca0-399a4bc2bb95)
