### PR TITLE
fix(i18n): ignore lua translation errors

### DIFF
--- a/lang/extract_json_strings.py
+++ b/lang/extract_json_strings.py
@@ -1289,19 +1289,23 @@ class LuaCallVisitor(ast.ASTVisitor):
             return None
 
     def visit_Call(self, node):
-        found = False
-        if isinstance(node.func, astnodes.Name):
-            func_id = node.func.id
-            func_line = node.func.first_token.line
-            func_args = node.args
-            found = True
-        elif isinstance(node.func, astnodes.Index):
-            if isinstance(node.func.idx, astnodes.Name):
-                func_id = node.func.idx.id
-                func_line = node.func.idx.first_token.line
+        try:
+            found = False
+            if isinstance(node.func, astnodes.Name):
+                func_id = node.func.id
+                func_line = node.func.first_token.line
                 func_args = node.args
                 found = True
-        if not found:
+            elif isinstance(node.func, astnodes.Index):
+                if isinstance(node.func.idx, astnodes.Name):
+                    func_id = node.func.idx.id
+                    func_line = node.func.idx.first_token.line
+                    func_args = node.args
+                    found = True
+            if not found:
+                return
+        except Exception as E:
+            print(f"WARNING: {E}")
             return
         write = False
         msgctxt = None

--- a/lang/extract_json_strings.py
+++ b/lang/extract_json_strings.py
@@ -1427,13 +1427,7 @@ def extract_all_from_lua_file(state, lua_file):
     with open(lua_file, encoding="utf-8") as fp:
         luadata_raw = fp.read()
 
-    try:
-        extract_lua(state, luadata_raw)
-    except Exception as E:
-        print(f"---\nFile: '{lua_file}'")
-        print(E)
-        exit(1)
-
+    extract_lua(state, luadata_raw)
 
 def prepare_git_file_list():
     command_str = "git ls-files"

--- a/lang/update_pot.sh
+++ b/lang/update_pot.sh
@@ -17,7 +17,7 @@ then
 fi
 
 echo "> Extracting strings from json"
-if ! lang/bn_extract_json_strings.sh --output $TEMP_POT_FROM_JSON
+if ! lang/bn_extract_json_strings.sh "$@" --output $TEMP_POT_FROM_JSON
 then
     echo "Error in extract_json_strings.py. Aborting"
     exit 1


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

![image](https://github.com/user-attachments/assets/1ee93300-aea4-40c7-9ccc-d7a403917964)

translation extractor has been always failing.

```
Traceback (most recent call last):
  File "/run/media/home/scarf/repo/cata/Cataclysm/lang/extract_json_strings.py", line 1501, in <module>
    extract_all_from_dir(state, i)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/run/media/home/scarf/repo/cata/Cataclysm/lang/extract_json_strings.py", line 1399, in extract_all_from_dir
    extract_all_from_dir(state, os.path.join(dir, d))
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/run/media/home/scarf/repo/cata/Cataclysm/lang/extract_json_strings.py", line 1393, in extract_all_from_dir
    extract_all_from_lua_file(state, full_name)
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/run/media/home/scarf/repo/cata/Cataclysm/lang/extract_json_strings.py", line 1430, in extract_all_from_lua_file
    extract_lua(state, luadata_raw)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/run/media/home/scarf/repo/cata/Cataclysm/lang/extract_json_strings.py", line 1359, in extract_lua
    visitor.visit(tree)
    ~~~~~~~~~~~~~^^^^^^
  File "/run/media/home/scarf/repo/cata/Cataclysm/.venv/lib/python3.13t/site-packages/luaparser/ast.py", line 96, in visit
    tree_visitor(node)
    ~~~~~~~~~~~~^^^^^^
  File "/run/media/home/scarf/repo/cata/Cataclysm/lang/extract_json_strings.py", line 1301, in visit_Call
    func_line = node.func.idx.first_token.line
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

```

## Describe the solution

attempts to workaround the issue by blatantly ignoring all AST errors
