### PR TITLE
feat(content): add a new post-apoc profession for starting with scaleskin/tooth gear

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -288,6 +288,18 @@
     "entries": [ { "item": "shot_00", "charges": 18 } ]
   },
   {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "quiver_monster_hunter_1",
+    "entries": [ { "item": "arrow_tooth", "charges": 20 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "quiver_monster_hunter_2",
+    "entries": [ { "item": "arrow_stinger", "charges": 20 } ]
+  },
+  {
     "type": "profession_item_substitutions",
     "trait": "WOOLALLERGY",
     "sub": [
@@ -3909,6 +3921,49 @@
       },
       "male": [ "boxer_shorts" ],
       "female": [ "sports_bra", "panties" ]
+    },
+    "flags": [ "SCEN_ONLY" ]
+  },
+  {
+    "type": "profession",
+    "id": "monster_hunter",
+    "name": "Monster Hunter",
+    "description": "With the fall of civilization, you took to living off the land and grew into a competent hunter.  The abominations that thrive in this new world may not be good eating, but their hides and bones make for quite practical trophies.",
+    "points": 6,
+    "skills": [
+      { "level": 5, "name": "tailor" },
+      { "level": 4, "name": "fabrication" },
+      { "level": 2, "name": "gun" },
+      { "level": 3, "name": "archery" },
+      { "level": 3, "name": "survival" },
+      { "level": 2, "name": "melee" },
+      { "level": 1, "name": "stabbing" },
+      { "level": 3, "name": "dodge" },
+      { "level": 3, "name": "cooking" }
+    ],
+    "items": {
+      "both": {
+        "items": [
+          "armor_scute",
+          "armguard_scute",
+          "backpack_leather",
+          "boots_scute",
+          "gauntlets_scute",
+          "helmet_scute",
+          "clay_pot",
+          "waterskin",
+          "needle_bone",
+          "fire_drill"
+        ],
+        "entries": [
+          { "item": "knife_stinger", "container-item": "sheath" },
+          { "item": "quiver", "contents-group": "quiver_monster_hunter_1" },
+          { "item": "quiver", "contents-group": "quiver_monster_hunter_2" },
+          { "item": "compositebow_short", "custom-flags": [ "auto_wield" ] }
+        ]
+      },
+      "male": [ "chestwrap_fur", "loincloth_fur" ],
+      "female": [ "bikini_top_fur", "hot_pants_fur" ]
     },
     "flags": [ "SCEN_ONLY" ]
   },

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -365,7 +365,8 @@
       "hardened_survivor",
       "road_warrior",
       "waste_ranger",
-      "player_bandit"
+      "player_bandit",
+      "monster_hunter"
     ]
   },
   {
@@ -397,7 +398,8 @@
       "hardened_survivor",
       "road_warrior",
       "waste_ranger",
-      "player_bandit"
+      "player_bandit",
+      "monster_hunter"
     ]
   },
   {
@@ -483,7 +485,7 @@
     "description": "You find yourself in the most alien place you've ever seen.  The hot humid air and the organic aspect of the structure makes you feel like you're trapped inside a giant creature.  Whatever it is, you need to get out of here before They find you.",
     "allowed_locs": [ "sloc_mi-go_camp" ],
     "start_name": "Mi-Go Camp",
-    "professions": [ "captive", "rescuer" ],
+    "professions": [ "captive", "rescuer", "monster_hunter" ],
     "flags": [ "LONE_START", "CHALLENGE", "WIN_START" ]
   },
   {

--- a/data/mods/DinoMod/scenarios.json
+++ b/data/mods/DinoMod/scenarios.json
@@ -8,7 +8,9 @@
     "start_name": "Wilderness",
     "allowed_locs": [ "sloc_field", "sloc_forest", "sloc_swamp", "sloc_campsite", "sloc_campground" ],
     "flags": [ "LONE_START" ],
-    "surround_groups": [ [ "GROUP_DINOSAUR_MEGA_CARNIVORE", 70.0 ] ]
+    "surround_groups": [ [ "GROUP_DINOSAUR_MEGA_CARNIVORE", 70.0 ] ],
+    "add_professions": true,
+    "professions": [ "monster_hunter" ]
   },
   {
     "type": "scenario",


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This adds a profession to post-apoc-focused scenarios aimed towards showcasing the content added in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/5466.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Added a monster hunter profession, a `SCEN_ONLY` profession that starts with appropriate innawoods gear along with a full set of scaleskin armor, a stinger dagger, composite shortbow, and two quivers to choose between tooth arrows or stinger arrows depending on the situation. Non-combat skills aim to be exactly enough to make all the items they spawn with and any components needed to make those.
2. Added the new profession to Next Summer, Ambushed, and for flavor Mi-go challenge (since rescuer profession similarly is dressed in furs and has post-apoc getup, and the scenario is quite lacking in profession options currently).
3. For flavor, added to Dinomod's surrounded by dinos scenario.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Going for more of a wasteland barbarian style for the profession, making them more melee-focused and favoring the bone club or the leiomano. Maybe if in the future I re-implement bone armor (which will likely favor heavy bones) then that can be a melee-focused foil to this profession.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Looked at recipes for items in the new profession's inventory to confirm it was all stuff their current skill spread allows them to make.
2. Checked affected files for syntax and lint errors.
3. Load-tested in compiled test build, confirmed the profession looked right.
4. Loaded up a world with Dinomod added, confirmed the change to the scenario didn't mess with it inheriting the default profession list.

![image](https://github.com/user-attachments/assets/877c81bd-2a0a-4bf7-907f-6f410d192849)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Obligatory @LyleSY ping since this touches something in Dinomod too.