### PR TITLE
refactor: Remove usage of hp_part from bandaging and disinfection

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1641,7 +1641,6 @@ void activity_handlers::firstaid_finish( player_activity *act, player *p )
     // TODO: Store the patient somehow, retrieve here
     player &patient = *p;
     const bodypart_str_id healed = bodypart_str_id( act->str_values[0] );
-    debugmsg( "%s", healed.c_str() );
     const int charges_consumed = actor->finish_using( *p, patient, *used_tool, healed );
     p->consume_charges( it, charges_consumed );
 

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1640,7 +1640,8 @@ void activity_handlers::firstaid_finish( player_activity *act, player *p )
 
     // TODO: Store the patient somehow, retrieve here
     player &patient = *p;
-    const hp_part healed = static_cast<hp_part>( act->values[0] );
+    const bodypart_str_id healed = bodypart_str_id( act->str_values[0] );
+    debugmsg( "%s", healed.c_str() );
     const int charges_consumed = actor->finish_using( *p, patient, *used_tool, healed );
     p->consume_charges( it, charges_consumed );
 

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -189,7 +189,6 @@ class bodypart
         int hp_max;
 
         int healed_total = 0;
-        /** Not used yet*/
         int damage_bandaged = 0;
         int damage_disinfected = 0;
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -409,8 +409,6 @@ Character &get_player_character()
 Character::Character() :
     location_visitable<Character>(),
     worn(new worn_item_location(this)),
-    damage_bandaged( {{ 0 }} ),
-    damage_disinfected( {{ 0 }} ),
     cached_time( calendar::before_time_starts ),
     inv(new character_item_location(this)),
     id( -1 ),
@@ -497,7 +495,6 @@ void Character::move_operator_common( Character &&source ) noexcept
     male = source.male ;
 
     worn = std::move( source.worn );
-    damage_disinfected = source.damage_disinfected ;
     in_vehicle = source.in_vehicle ;
     hauling = source.hauling ;
 
@@ -4966,18 +4963,19 @@ void Character::regen( int rate_multiplier )
         healed_bp( i, healing_apply );
         heal( bp, healing_apply );
 
-        if( damage_bandaged[i] > 0 ) {
-            damage_bandaged[i] -= healing_apply;
-            if( damage_bandaged[i] <= 0 ) {
-                damage_bandaged[i] = 0;
+        bodypart &part = get_part( bp );
+        if( part.get_damage_bandaged() > 0 ) {
+            part.set_damage_bandaged( part.get_damage_bandaged() - healing_apply );
+            if( part.get_damage_bandaged() <= 0 ) {
+                part.set_damage_bandaged( 0 );
                 remove_effect( effect_bandaged, bp.id() );
                 add_msg_if_player( _( "Bandaged wounds on your %s healed." ), body_part_name( bp ) );
             }
         }
-        if( damage_disinfected[i] > 0 ) {
-            damage_disinfected[i] -= healing_apply;
-            if( damage_disinfected[i] <= 0 ) {
-                damage_disinfected[i] = 0;
+        if( part.get_damage_disinfected() > 0 ) {
+            part.set_damage_disinfected( part.get_damage_disinfected() - healing_apply );
+            if( part.get_damage_disinfected() <= 0 ) {
+                part.set_damage_disinfected( 0 );
                 remove_effect( effect_disinfected, bp.id() );
                 add_msg_if_player( _( "Disinfected wounds on your %s healed." ), body_part_name( bp ) );
             }
@@ -4985,12 +4983,12 @@ void Character::regen( int rate_multiplier )
 
         // remove effects if the limb was healed by other way
         if( has_effect( effect_bandaged, bp.id() ) && ( get_part( bp ).is_at_max_hp() ) ) {
-            damage_bandaged[i] = 0;
+            part.set_damage_bandaged( 0 );
             remove_effect( effect_bandaged, bp.id() );
             add_msg_if_player( _( "Bandaged wounds on your %s healed." ), body_part_name( bp ) );
         }
         if( has_effect( effect_disinfected, bp.id() ) && ( get_part( bp ).is_at_max_hp() ) ) {
-            damage_disinfected[i] = 0;
+            part.set_damage_disinfected( 0 );
             remove_effect( effect_disinfected, bp.id() );
             add_msg_if_player( _( "Disinfected wounds on your %s healed." ), body_part_name( bp ) );
         }
@@ -6112,10 +6110,10 @@ float Character::get_hit_base() const
     return get_dex() / 4.0f;
 }
 
-hp_part Character::body_window( const std::string &menu_header,
-                                bool show_all, bool precise,
-                                int normal_bonus, int head_bonus, int torso_bonus,
-                                float bleed, float bite, float infect, float bandage_power, float disinfectant_power ) const
+bodypart_str_id Character::body_window( const std::string &menu_header,
+                                        bool show_all, bool precise,
+                                        int normal_bonus, int head_bonus, int torso_bonus,
+                                        float bleed, float bite, float infect, float bandage_power, float disinfectant_power ) const
 {
     /* This struct establishes some kind of connection between the hp_part (which can be healed and
      * have HP) and the body_part. Note that there are more body_parts than hp_parts. For example:
@@ -6123,19 +6121,18 @@ hp_part Character::body_window( const std::string &menu_header,
     struct healable_bp {
         mutable bool allowed;
         bodypart_id bp;
-        hp_part hp;
         std::string name; // Translated name as it appears in the menu.
         int bonus;
     };
     /* The array of the menu entries show to the player. The entries are displayed in this order,
      * it may be changed here. */
     std::array<healable_bp, num_hp_parts> parts = { {
-            { false, bodypart_id( "head" ), hp_head, _( "Head" ), head_bonus },
-            { false, bodypart_id( "torso" ), hp_torso, _( "Torso" ), torso_bonus },
-            { false, bodypart_id( "arm_l" ), hp_arm_l, _( "Left Arm" ), normal_bonus },
-            { false, bodypart_id( "arm_r" ), hp_arm_r, _( "Right Arm" ), normal_bonus },
-            { false, bodypart_id( "leg_l" ), hp_leg_l, _( "Left Leg" ), normal_bonus },
-            { false, bodypart_id( "leg_r" ), hp_leg_r, _( "Right Leg" ), normal_bonus },
+            { false, bodypart_id( "head" ), _( "Head" ), head_bonus },
+            { false, bodypart_id( "torso" ), _( "Torso" ), torso_bonus },
+            { false, bodypart_id( "arm_l" ), _( "Left Arm" ), normal_bonus },
+            { false, bodypart_id( "arm_r" ), _( "Right Arm" ), normal_bonus },
+            { false, bodypart_id( "leg_l" ), _( "Left Leg" ), normal_bonus },
+            { false, bodypart_id( "leg_r" ), _( "Right Leg" ), normal_bonus },
         }
     };
 
@@ -6312,9 +6309,9 @@ hp_part Character::body_window( const std::string &menu_header,
     bmenu.query();
     if( bmenu.ret >= 0 && static_cast<size_t>( bmenu.ret ) < parts.size() &&
         parts[bmenu.ret].allowed ) {
-        return parts[bmenu.ret].hp;
+        return parts[bmenu.ret].bp.id();
     } else {
-        return num_hp_parts;
+        return bodypart_str_id::NULL_ID();
     }
 }
 
@@ -6815,30 +6812,9 @@ float Character::rest_quality() const
     return has_effect( effect_sleep ) ? 1.0f : 0.0f;
 }
 
-hp_part Character::bp_to_hp( const bodypart_str_id &bp )
+bodypart_str_id Character::bp_to_hp( const bodypart_str_id &bp )
 {
-    switch( bp->token ) {
-        case bp_head:
-        case bp_eyes:
-        case bp_mouth:
-            return hp_head;
-        case bp_torso:
-            return hp_torso;
-        case bp_arm_l:
-        case bp_hand_l:
-            return hp_arm_l;
-        case bp_arm_r:
-        case bp_hand_r:
-            return hp_arm_r;
-        case bp_leg_l:
-        case bp_foot_l:
-            return hp_leg_l;
-        case bp_leg_r:
-        case bp_foot_r:
-            return hp_leg_r;
-        default:
-            return num_hp_parts;
-    }
+    return bp->main_part;
 }
 
 const bodypart_str_id &Character::hp_to_bp( const hp_part hpart )

--- a/src/character.h
+++ b/src/character.h
@@ -743,7 +743,7 @@ class Character : public Creature, public location_visitable<Character>
         void mutation_spend_resources( const trait_id &mut );
 
         /** Converts a bodypart_str_id to an hp_part */
-        static hp_part bp_to_hp( const bodypart_str_id &bp );
+        static bodypart_str_id bp_to_hp( const bodypart_str_id &bp );
         /** Converts an hp_part to a bodypart_str_id */
         static const bodypart_str_id &hp_to_bp( hp_part hpart );
 
@@ -793,10 +793,10 @@ class Character : public Creature, public location_visitable<Character>
          * bandage_power - quality of bandage
          * disinfectant_power - quality of disinfectant
          */
-        hp_part body_window( const std::string &menu_header,
-                             bool show_all, bool precise,
-                             int normal_bonus, int head_bonus, int torso_bonus,
-                             float bleed, float bite, float infect, float bandage_power, float disinfectant_power ) const;
+        bodypart_str_id body_window( const std::string &menu_header,
+                                     bool show_all, bool precise,
+                                     int normal_bonus, int head_bonus, int torso_bonus,
+                                     float bleed, float bite, float infect, float bandage_power, float disinfectant_power ) const;
 
         // Returns color which this limb would have in healing menus
         nc_color limb_color( const bodypart_id &bp, bool bleed, bool bite, bool infect ) const;
@@ -1629,7 +1629,6 @@ class Character : public Creature, public location_visitable<Character>
         bool male = true;
 
         location_vector<item> worn;
-        std::array<int, num_hp_parts> damage_bandaged, damage_disinfected;
         // Means player sit inside vehicle on the tile he is now
         bool in_vehicle = false;
         bool hauling = false;

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -611,9 +611,6 @@ void ExplosionProcess::project_shrapnel( const tripoint position )
         // Humans get hit in all body parts
         if( critter->is_player() ) {
             for( bodypart_id bp : bps ) {
-                if( Character::bp_to_hp( bp.id() ) == num_hp_parts ) {
-                    continue;
-                }
                 // TODO: Apply projectile effects
                 // TODO: Penalize low coverage armor
                 // Halve damage to be closer to what monsters take
@@ -1121,10 +1118,6 @@ static std::map<const Creature *, int> legacy_shrapnel( const tripoint &src,
             // Humans get hit in all body parts
             if( critter->is_player() ) {
                 for( bodypart_id bp : bps ) {
-                    // TODO: This shouldn't be needed, get_bps should do it
-                    if( Character::bp_to_hp( bp.id() ) == num_hp_parts ) {
-                        continue;
-                    }
                     // TODO: Apply projectile effects
                     // TODO: Penalize low coverage armor
                     // Halve damage to be closer to what monsters take

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -5250,9 +5250,9 @@ void iexamine::autodoc( player &p, const tripoint &examp )
                     patient.add_effect( effect_disinfected, 1_turns, bp_healed );
                     effect &e = patient.get_effect( effect_disinfected, bp_healed );
                     e.set_duration( e.get_int_dur_factor() * disinfectant_intensity );
-                    hp_part target_part = player::bp_to_hp( bp_healed );
-                    patient.damage_disinfected[target_part] =
-                        patient.get_part_hp_max( bp_healed ) - patient.get_part_hp_cur( bp_healed );
+                    bodypart_str_id target_part = player::bp_to_hp( bp_healed );
+                    bodypart &part = patient.get_part( target_part );
+                    part.set_damage_disinfected( part.get_hp_max() - part.get_hp_cur() );
 
                 }
             }

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -1037,15 +1037,15 @@ class heal_actor : public iuse_actor
         std::set<flag_id> used_up_item_flags;
 
         /** How much hp would `healer` heal using this actor on `healed` body part. */
-        int get_heal_value( const Character &healer, hp_part healed ) const;
+        int get_heal_value( const Character &healer, const bodypart_str_id &healed ) const;
         /** How many intensity levels will be applied using this actor by `healer`. */
         int get_bandaged_level( const Character &healer ) const;
         /** How many intensity levels will be applied using this actor by `healer`. */
         int get_disinfected_level( const Character &healer ) const;
         /** Does the actual healing. Used by both long and short actions. Returns charges used. */
-        int finish_using( player &healer, player &patient, item &it, hp_part healed ) const;
+        int finish_using( player &healer, player &patient, item &it, const bodypart_str_id &healed ) const;
 
-        hp_part use_healing_item( player &healer, player &patient, item &it, bool force ) const;
+        bodypart_str_id use_healing_item( player &healer, player &patient, item &it, bool force ) const;
 
         heal_actor( const std::string &type = "heal" ) : iuse_actor( type ) {}
 

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -183,8 +183,6 @@ void print_action( const char *prepend, npc_action action );
 
 bool compare_sound_alert( const dangerous_sound &sound_a, const dangerous_sound &sound_b );
 
-hp_part most_damaged_hp_part( const Character &c );
-
 bool compare_sound_alert( const dangerous_sound &sound_a, const dangerous_sound &sound_b )
 {
     if( sound_a.type != sound_b.type ) {

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -34,7 +34,6 @@
 #include "value_ptr.h"
 #include "profile.h"
 
-static const activity_id ACT_FIRSTAID( "ACT_FIRSTAID" );
 static const activity_id ACT_GAME( "ACT_GAME" );
 static const activity_id ACT_PICKAXE( "ACT_PICKAXE" );
 static const activity_id ACT_START_FIRE( "ACT_START_FIRE" );
@@ -71,25 +70,6 @@ void player_activity::resolve_active()
         active = false;
     } else {
         delete this;
-    }
-}
-
-
-void player_activity::migrate_item_position( Character &guy )
-{
-    const bool simple_action_replace =
-        type == ACT_FIRSTAID || type == ACT_GAME ||
-        type == ACT_PICKAXE || type == ACT_START_FIRE ||
-        type == ACT_HAND_CRANK || type == ACT_VIBE ||
-        type == ACT_OXYTORCH || type == ACT_FISH ||
-        type == ACT_ATM;
-
-    if( simple_action_replace ) {
-        targets.emplace_back( &guy.i_at( position ) );
-    } else if( type == ACT_GUNMOD_ADD ) {
-        // this activity has two indices; "position" = gun and "values[0]" = mod
-        targets.emplace_back( &guy.i_at( position ) );
-        targets.emplace_back( &guy.i_at( values[0] ) );
     }
 }
 

--- a/src/player_activity.h
+++ b/src/player_activity.h
@@ -131,9 +131,6 @@ class player_activity
 
         void serialize( JsonOut &json ) const;
         void deserialize( JsonIn &jsin );
-        // used to migrate the item indices to item_location
-        // obsolete after 0.F stable
-        void migrate_item_position( Character &guy );
 
         /**
          * Preform necessary initialization to start or resume the activity. Must be

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -505,8 +505,6 @@ void Character::load( const JsonObject &data )
     data.read( "stim", stim );
     data.read( "stamina", stamina );
 
-    data.read( "damage_bandaged", damage_bandaged );
-    data.read( "damage_disinfected", damage_disinfected );
     data.read( "magic", magic );
     JsonArray parray;
 
@@ -820,9 +818,6 @@ void player::store( JsonOut &json ) const
     json.member( "in_vehicle", in_vehicle );
     json.member( "id", getID() );
 
-    // potential incompatibility with future expansion
-    json.member( "damage_bandaged", damage_bandaged );
-    json.member( "damage_disinfected", damage_disinfected );
     // "Looks like I picked the wrong week to quit smoking." - Steve McCroskey
     json.member( "addictions", addictions );
     json.member( "followers", follower_ids );


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

Slowly creeping towards removable/addable body parts

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution

Replaces `hp_part` usage from bandaging/disinfecting `iuse_actor` and regen. For a given body part, its `hp_part` corresponds to its `bodypart::main_part`, but `hp_part` is a separate enum.

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing

* Spawn character, bandages, antiseptic powder
* Hurt character, bandage some wounds, disinfect others
* Save+load
* Parts stay bandaged/disinfected after load
* Set body part hp to full for some bandaged/disinfected parts
* Sleep for one "sleep tick" (nearest 5 minute interval)
* Get a message about "bandaged/disinfected body part healed"
* Set hp of all parts to some value below max
* Bandage/disinfect some
* Sleep for some set time
* Notice bandaged/disinfected wounds healing faster than ones with no treatment

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Possibly fixed a bug with inconsistent usage of `bodypart::damage_bandaged` vs `Character::damage_bandaged`.
