### PR TITLE
fix: `magazine_integral` - The Final Fix???

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8082,11 +8082,10 @@ itype_id item::magazine_default( bool conversion ) const
                     }
                 }
             }
-        } else {
-            auto mag = type->magazine_default.find( ammotype( *ammo_types( conversion ).begin() ) );
-            if( mag != type->magazine_default.end() && !mag->second->has_flag( flag_SPEEDLOADER ) ) {
-                return mag->second;
-            }
+        }
+        auto mag = type->magazine_default.find( ammotype( *ammo_types( conversion ).begin() ) );
+        if( mag != type->magazine_default.end() && !mag->second->has_flag( flag_SPEEDLOADER ) ) {
+            return mag->second;
         }
     }
     return itype_id::NULL_ID();

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8056,21 +8056,17 @@ std::string item::ammo_sort_name() const
 
 bool item::magazine_integral() const
 {
-    for( const item *m : is_gun() ? gunmods() : toolmods() ) {
-        if( !m->type->mod->magazine_adaptor.empty() ) {
-            return false;
-        }
-    }
-    if( is_gun() ) {
+    // If it has a default magazine, it can't have an integral magazine.
+    if( magazine_default() ) {
+        return false;
+    } else if( is_gun() ) {
         // We have an integral magazine if we're a gun with an ammo capacity (clip)
         return type->gun->clip;
     } else if( is_tool() ) {
         // Or we are a tool with max_charges defined
         return type->tool->max_charges;
     }
-
-    // Or we're a non-gun/tool item with no magazines.
-    return ( type->magazines.empty() );
+    return true;
 }
 
 itype_id item::magazine_default( bool conversion ) const
@@ -8080,15 +8076,17 @@ itype_id item::magazine_default( bool conversion ) const
             for( const item *m : is_gun() ? gunmods() : toolmods() ) {
                 if( !m->type->mod->magazine_adaptor.empty() ) {
                     auto mags = m->type->mod->magazine_adaptor.find( ammotype( *ammo_types( conversion ).begin() ) );
-                    if( mags != m->type->mod->magazine_adaptor.end() ) {
+                    if( mags != m->type->mod->magazine_adaptor.end() &&
+                        !( *mags->second.begin() )->has_flag( flag_SPEEDLOADER ) ) {
                         return *( mags->second.begin() );
                     }
                 }
             }
-        }
-        auto mag = type->magazine_default.find( ammotype( *ammo_types( conversion ).begin() ) );
-        if( mag != type->magazine_default.end() ) {
-            return mag->second;
+        } else {
+            auto mag = type->magazine_default.find( ammotype( *ammo_types( conversion ).begin() ) );
+            if( mag != type->magazine_default.end() && !mag->second->has_flag( flag_SPEEDLOADER ) ) {
+                return mag->second;
+            }
         }
     }
     return itype_id::NULL_ID();


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

- fix #5636 which was caused by my changes to `magazine_integral()` in #5283 revealing more weird code. In this scenario `magazine_integral()` looks for a magazine adaptor and if true returns that it is false, but this doesn't account for speedloader "magazines" that don't change the fundamental nature of the gun.

## Describe the solution

- `magazine_default()` will now only return non-speedloader magazines, I'm assuming here that if a gun accepts speedloaders it doesn't accept normal magazines, I don't know any mod that does this at the moment, and if some madman does decide to do this they'll be on their own for a few months since fixing this was exhausting as is.
- `magazine_integral()` now piggybacks off `magazine_default()`, so anything that can be loaded with a magazine that isn't a speedloader automatically counts as a non-integral magazine gun. This might be slightly more expensive, but it's more accurate so fuck it.

## Describe alternatives you've considered

- We return to the rather shitty if combinations that `magazine_integral()` used prior to me touching it in #5283.
  - I'm tempted, but the code looked fucky anyway so there's probably jank regardless of my choices.

## Testing

- Spawn a Remington Wingmaster 870 and a speedloader chute.
  - [x] Check that it can unload as is and reload as is without issue.
  - [x] Install the speedloader chute, no errors.
  - [x] Check that you can unload the Wingmaster 870 properly (no ammo remains in the gun), and reload it without the use of a speedloader.
  - [x] Check that you can reload it with a speedloader.

## Additional context

This seems to also have fixed the debug menu item spawns complaining about inserting null items, though I can't imagine how.
