### PR TITLE
feat(balance): no monotony penalty for stimulants or depressants

### DIFF
--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2260,7 +2260,10 @@ void Item_factory::load( islot_comestible &slot, const JsonObject &jo, const std
             is_not_boring = is_not_boring || m == "junk";
         }
     }
-    // Junk food never gets old by default, but this can still be overridden.
+    if( jo.has_member( "stim" ) ) {
+        is_not_boring = is_not_boring || jo.get_int( "stim" ) != 0;
+    }
+    // Junk food, stimulants and depressants never get old by default, but this can still be overridden.
     if( is_not_boring ) {
         slot.monotony_penalty = 0;
     }


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change
The morale bonus from eating a specific food drops by two every time you eat it, and slowly returns over time, to represent the PC getting bored of a particular food. The exception to this is things with the `junk_food` material, meaning candy, chips, sugary soft drinks and that sort of thing. It also doesn't apply to things that aren't considered "food" - cigarettes, chewing gum and heroin never get boring.

I think alcohol and coffee should behave more like drugs in this regard. Right now, if you drink three cups of coffee, you lose your ability to enjoy coffee, and won't get it back unless you wait several days before taking more coffee. Given that many people drink several cups per day, I don't think it really gets boring like that.
<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution
Made food items with nonzero `stim` value default to zero `monotony_penalty`. This currently includes:
- all types of alcohol
- all types coffee and tea
- some types of herbal tea, including bee balm and chamomile but not literal "herbal tea"
- alien fronds, leech flowers and leech bark
- cacao nibs and cacao pods
- coca leaves

It can be overridden on a per-item basis, though there are no items that do that right now.
<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

## Describe alternatives you've considered
It would also be possible to add a check for the "alcohol" material, and set `monotony_penalty` manually for coffee and tea, but I think checking for `stim` gets a pretty good list. Cacao nibs actually contain caffeine in game, though cacao pods don't. The alien plants are the weird one, but given how they're described, I think it's reasonable to assume that they're at least somewhat psychoactive and not just really tasty. If there are items there that should still get a `monotony_penalty`, there's fewer of them than there are types of coffee and tea.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing
Compiled and loaded game. Drank three cups of coffee, coffee still tasted good. Drank three shots of whiskey, still tasted good. 
Since the `monotony_penalty` value wasn't used anywhere, temporarily gave sake a penalty of 10. Morale bonus decreased by 10 for each sip.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
