### PR TITLE
feat(content): Add bimbibap to the game

### DIFF
--- a/data/json/items/comestibles/meat_dishes.json
+++ b/data/json/items/comestibles/meat_dishes.json
@@ -1382,5 +1382,21 @@
     "calories": 206,
     "vitamins": [ [ "vitC", 0 ], [ "calcium", 1 ], [ "iron", 100 ], [ "vitB", 0 ] ],
     "flags": [ "EATEN_HOT", "NUTRIENT_OVERRIDE" ]
+  },
+  {
+    "id": "bibimbap",
+    "name": { "str_sp": "bibimbap" },
+    "type": "COMESTIBLE",
+    "description": "A mixed meat and rice dish from Korea, often with eggs and various veggies.",
+    "weight": "250 g",
+    "volume": "300 ml",
+    "//": "Very rough estimation",
+    "color": "white",
+    "spoils_in": "2 days 12 hours",
+    "comestible_type": "FOOD",
+    "symbol": "%",
+    "calories": 680,
+    "material": [ "veggy", "flesh" ],
+    "fun": 10
   }
 ]

--- a/data/json/items/comestibles/meat_dishes.json
+++ b/data/json/items/comestibles/meat_dishes.json
@@ -1397,6 +1397,7 @@
     "symbol": "%",
     "calories": 680,
     "material": [ "veggy", "flesh" ],
-    "fun": 10
+    "fun": 10,
+    "looks_like": "rice_cooked"
   }
 ]

--- a/data/json/items/comestibles/spice.json
+++ b/data/json/items/comestibles/spice.json
@@ -160,6 +160,7 @@
     "type": "COMESTIBLE",
     "name": { "str_sp": "gochujang" },
     "description": "A spicy and sweet Korean condiment, quite often used throughout Korean cooking.",
-    "color": "red"
+    "color": "red",
+    "looks_like": "chilly-p"
   }
 ]

--- a/data/json/items/comestibles/spice.json
+++ b/data/json/items/comestibles/spice.json
@@ -153,5 +153,13 @@
     "name": { "str_sp": "mustard powder" },
     "description": "A fragnant yellow powder.  Not edible in this form.",
     "color": "red"
+  },
+  {
+    "id": "gochujang",
+    "copy-from": "spice",
+    "type": "COMESTIBLE",
+    "name": { "str_sp": "gochujang" },
+    "description": "A spicy and sweet Korean condiment, quite often used throughout Korean cooking.",
+    "color": "red"
   }
 ]

--- a/data/json/recipes/food/meat.json
+++ b/data/json/recipes/food/meat.json
@@ -3106,5 +3106,33 @@
     "time": "15 s",
     "autolearn": true,
     "components": [ [ [ "sausage_cooked", 1, "LIST" ] ], [ [ "condiment_lite", 1, "LIST" ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "bibimbap",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_MEAT",
+    "skill_used": "cooking",
+    "difficulty": 5,
+    "book_learn": [ [ "cookbook_sushi", 4 ] ],
+    "time": "10 m",
+    "autolearn": true,
+    "charges": 2,
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "CONTAIN", "level": 1 } ],
+    "components": [
+      [ [ "meat_red", 1, "LIST" ] ],
+      [ [ "rice_cooked", 4 ] ],
+      [ [ "eggs_small", 4, "LIST" ] ],
+      [ [ "garlic_clove", 4 ] ],
+      [ [ "soysauce", 2 ] ],
+      [ [ "honey_bottled", 1 ] ],
+      [ [ "carrot", 2 ], [ "irradiated_carrot", 2 ], [ "carrot_wild", 2 ] ],
+      [ [ "mushroom", 8 ], [ "mushroom_morel", 8 ] ],
+      [ [ "cooking_oil", 3 ] ],
+      [ [ "salt", 1 ] ],
+      [ [ "sugar", 20 ] ],
+      [ [ "gochujang", 24 ] ],
+      [ [ "vinegar", 2 ] ]
+    ]
   }
 ]

--- a/data/json/recipes/food/other.json
+++ b/data/json/recipes/food/other.json
@@ -2222,5 +2222,48 @@
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "tools": [ [ [ "surface_heat", 5, "LIST" ] ] ],
     "components": [ [ [ "bag_plastic", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "gochujang",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_OTHER",
+    "skill_used": "cooking",
+    "difficulty": 3,
+    "time": "20 m",
+    "batch_time_factors": [ 50, 3 ],
+    "charges": 20,
+    "autolearn": true,
+    "tools": [ [ [ "rock_quern", -1 ], [ "clay_quern", -1 ] ] ],
+    "components": [
+      [ [ "soybean", 1 ] ],
+      [ [ "syrup", 1 ] ],
+      [ [ "chilly-p", 5 ] ],
+      [ [ "soysauce", 1 ] ],
+      [ [ "garlic_clove", 3 ] ],
+      [ [ "water", 1 ], [ "water_clean", 1 ] ]
+    ]
+  },
+  {
+    "type": "recipe",
+    "result": "gochujang",
+    "id_suffix": "with_food_processor",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_OTHER",
+    "skill_used": "cooking",
+    "difficulty": 3,
+    "time": "5 m",
+    "batch_time_factors": [ 50, 3 ],
+    "charges": 20,
+    "autolearn": true,
+    "tools": [ [ [ "food_processor", 20 ] ] ],
+    "components": [
+      [ [ "soybean", 1 ] ],
+      [ [ "syrup", 1 ] ],
+      [ [ "chilly-p", 5 ] ],
+      [ [ "soysauce", 1 ] ],
+      [ [ "garlic_clove", 3 ] ],
+      [ [ "water", 1 ], [ "water_clean", 1 ] ]
+    ]
   }
 ]


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

The food you could make with rice did not inspire joy. Bimbibap, on the other hand, inspires much joy.

In other words: There were relatively few rice dishes available in-game, and I saw the opportunity to add one of my personal favorites.

## Describe the solution

Adds bimbibap, a korean dish. Also adds gochujang, a new spice that is integral to bimbibap

## Describe alternatives you've considered

- Less big recipe for the bimbibap

Fair, but it's based on an IRL recipe I found online and besides, we can always do with tasty culinary flexes.

- Some other rice dish
- Implosion

## Testing

Loads on my save

## Additional context

Unsure of what groups / cooking requirements, if any, to add these to. Very much so open to input.

If the comestibles test screams at the bimbibap, I shall scream into its ears in kind.
