### PR TITLE
feat(balance): Update Dodge modifier calculations, books train you more

### DIFF
--- a/data/json/items/book/dodge.json
+++ b/data/json/items/book/dodge.json
@@ -11,7 +11,7 @@
     "price_postapoc": "250 cent",
     "color": "pink",
     "skill": "dodge",
-    "max_level": 1,
+    "max_level": 2,
     "intelligence": 2,
     "time": "8 m",
     "fun": 1
@@ -28,7 +28,8 @@
     "price_postapoc": "750 cent",
     "color": "green",
     "skill": "dodge",
-    "max_level": 3,
+    "required_level": 3,
+    "max_level": 5,
     "intelligence": 7,
     "time": "20 m"
   },
@@ -44,7 +45,7 @@
     "price_postapoc": "5 USD",
     "color": "white",
     "skill": "dodge",
-    "max_level": 1,
+    "max_level": 3,
     "intelligence": 1,
     "time": "6 m",
     "fun": 1

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6104,7 +6104,7 @@ float Character::get_dodge_base() const
 {
     /** @EFFECT_DEX increases dodge base */
     /** @EFFECT_DODGE increases dodge_base */
-    return get_dex() / 2.0f + get_skill_level( skill_dodge );
+    return get_dex() / 4.0f + get_skill_level( skill_dodge );
 }
 float Character::get_hit_base() const
 {

--- a/tests/melee_dodge_hit_test.cpp
+++ b/tests/melee_dodge_hit_test.cpp
@@ -106,57 +106,57 @@ TEST_CASE( "Character::get_dodge_base", "[character][melee][dodge][dex][skill]" 
     avatar &dummy = g->u;
     clear_character( dummy );
 
-    // Character::get_dodge_base is simply DEXTERITY / 2 + DODGE_SKILL
+    // Character::get_dodge_base is simply DEXTERITY / 4 + DODGE_SKILL
     // Even with average dexterity, you can become really good at dodging
     GIVEN( "character has 8 DEX and no dodge skill" ) {
-        THEN( "base dodge is 4" ) {
-            CHECK( dodge_base_with_dex_and_skill( dummy, 8, 0 ) == 4.0f );
+        THEN( "base dodge is 2" ) {
+            CHECK( dodge_base_with_dex_and_skill( dummy, 8, 0 ) == 2.0f );
         }
 
         WHEN( "their dodge skill increases to 2" ) {
-            THEN( "base dodge is 6" ) {
-                CHECK( dodge_base_with_dex_and_skill( dummy, 8, 2 ) == 6.0f );
+            THEN( "base dodge is 4" ) {
+                CHECK( dodge_base_with_dex_and_skill( dummy, 8, 2 ) == 4.0f );
             }
         }
 
         AND_WHEN( "their dodge skill increases to 8" ) {
-            THEN( "base dodge is 12" ) {
-                CHECK( dodge_base_with_dex_and_skill( dummy, 8, 8 ) == 12.0f );
+            THEN( "base dodge is 10" ) {
+                CHECK( dodge_base_with_dex_and_skill( dummy, 8, 8 ) == 10.0f );
             }
         }
     }
 
     // More generally
 
-    SECTION( "character get_dodge_base increases by 1/2 for each point of DEX" ) {
-        CHECK( dodge_base_with_dex_and_skill( dummy, 1, 0 ) == 0.5f );
-        CHECK( dodge_base_with_dex_and_skill( dummy, 2, 0 ) == 1.0f );
-        CHECK( dodge_base_with_dex_and_skill( dummy, 3, 0 ) == 1.5f );
-        CHECK( dodge_base_with_dex_and_skill( dummy, 4, 0 ) == 2.0f );
-        CHECK( dodge_base_with_dex_and_skill( dummy, 5, 0 ) == 2.5f );
-        CHECK( dodge_base_with_dex_and_skill( dummy, 6, 0 ) == 3.0f );
-        CHECK( dodge_base_with_dex_and_skill( dummy, 7, 0 ) == 3.5f );
-        CHECK( dodge_base_with_dex_and_skill( dummy, 8, 0 ) == 4.0f );
-        CHECK( dodge_base_with_dex_and_skill( dummy, 9, 0 ) == 4.5f );
-        CHECK( dodge_base_with_dex_and_skill( dummy, 10, 0 ) == 5.0f );
+    SECTION( "character get_dodge_base increases by 1/4 for each point of DEX" ) {
+        CHECK( dodge_base_with_dex_and_skill( dummy, 1, 0 ) == 0.25f );
+        CHECK( dodge_base_with_dex_and_skill( dummy, 2, 0 ) == 0.5f );
+        CHECK( dodge_base_with_dex_and_skill( dummy, 3, 0 ) == 0.75f );
+        CHECK( dodge_base_with_dex_and_skill( dummy, 4, 0 ) == 1.0f );
+        CHECK( dodge_base_with_dex_and_skill( dummy, 5, 0 ) == 1.25f );
+        CHECK( dodge_base_with_dex_and_skill( dummy, 6, 0 ) == 1.5f );
+        CHECK( dodge_base_with_dex_and_skill( dummy, 7, 0 ) == 1.75f );
+        CHECK( dodge_base_with_dex_and_skill( dummy, 8, 0 ) == 2.0f );
+        CHECK( dodge_base_with_dex_and_skill( dummy, 9, 0 ) == 2.25f );
+        CHECK( dodge_base_with_dex_and_skill( dummy, 10, 0 ) == 2.50f );
     }
 
     SECTION( "character get_dodge_base increases by 1 for each level of dodge skill" ) {
-        CHECK( dodge_base_with_dex_and_skill( dummy, 8, 0 ) == 4.0f );
-        CHECK( dodge_base_with_dex_and_skill( dummy, 8, 1 ) == 5.0f );
-        CHECK( dodge_base_with_dex_and_skill( dummy, 8, 2 ) == 6.0f );
-        CHECK( dodge_base_with_dex_and_skill( dummy, 8, 3 ) == 7.0f );
-        CHECK( dodge_base_with_dex_and_skill( dummy, 8, 4 ) == 8.0f );
+        CHECK( dodge_base_with_dex_and_skill( dummy, 8, 0 ) == 2.0f );
+        CHECK( dodge_base_with_dex_and_skill( dummy, 8, 1 ) == 3.0f );
+        CHECK( dodge_base_with_dex_and_skill( dummy, 8, 2 ) == 4.0f );
+        CHECK( dodge_base_with_dex_and_skill( dummy, 8, 3 ) == 5.0f );
+        CHECK( dodge_base_with_dex_and_skill( dummy, 8, 4 ) == 6.0f );
 
-        CHECK( dodge_base_with_dex_and_skill( dummy, 6, 2 ) == 5.0f );
-        CHECK( dodge_base_with_dex_and_skill( dummy, 6, 4 ) == 7.0f );
-        CHECK( dodge_base_with_dex_and_skill( dummy, 6, 6 ) == 9.0f );
-        CHECK( dodge_base_with_dex_and_skill( dummy, 6, 8 ) == 11.0f );
+        CHECK( dodge_base_with_dex_and_skill( dummy, 6, 2 ) == 3.5f );
+        CHECK( dodge_base_with_dex_and_skill( dummy, 6, 4 ) == 5.5f );
+        CHECK( dodge_base_with_dex_and_skill( dummy, 6, 6 ) == 6.5f );
+        CHECK( dodge_base_with_dex_and_skill( dummy, 6, 8 ) == 9.5f );
 
-        CHECK( dodge_base_with_dex_and_skill( dummy, 10, 7 ) == 12.0f );
-        CHECK( dodge_base_with_dex_and_skill( dummy, 10, 8 ) == 13.0f );
-        CHECK( dodge_base_with_dex_and_skill( dummy, 10, 9 ) == 14.0f );
-        CHECK( dodge_base_with_dex_and_skill( dummy, 10, 10 ) == 15.0f );
+        CHECK( dodge_base_with_dex_and_skill( dummy, 10, 7 ) == 9.5f );
+        CHECK( dodge_base_with_dex_and_skill( dummy, 10, 8 ) == 10.0f );
+        CHECK( dodge_base_with_dex_and_skill( dummy, 10, 9 ) == 11.0f );
+        CHECK( dodge_base_with_dex_and_skill( dummy, 10, 10 ) == 12.0f );
     }
 }
 

--- a/tests/melee_dodge_hit_test.cpp
+++ b/tests/melee_dodge_hit_test.cpp
@@ -150,13 +150,13 @@ TEST_CASE( "Character::get_dodge_base", "[character][melee][dodge][dex][skill]" 
 
         CHECK( dodge_base_with_dex_and_skill( dummy, 6, 2 ) == 3.5f );
         CHECK( dodge_base_with_dex_and_skill( dummy, 6, 4 ) == 5.5f );
-        CHECK( dodge_base_with_dex_and_skill( dummy, 6, 6 ) == 6.5f );
+        CHECK( dodge_base_with_dex_and_skill( dummy, 6, 6 ) == 7.5f );
         CHECK( dodge_base_with_dex_and_skill( dummy, 6, 8 ) == 9.5f );
 
         CHECK( dodge_base_with_dex_and_skill( dummy, 10, 7 ) == 9.5f );
-        CHECK( dodge_base_with_dex_and_skill( dummy, 10, 8 ) == 10.0f );
-        CHECK( dodge_base_with_dex_and_skill( dummy, 10, 9 ) == 11.0f );
-        CHECK( dodge_base_with_dex_and_skill( dummy, 10, 10 ) == 12.0f );
+        CHECK( dodge_base_with_dex_and_skill( dummy, 10, 8 ) == 10.5f );
+        CHECK( dodge_base_with_dex_and_skill( dummy, 10, 9 ) == 11.5f );
+        CHECK( dodge_base_with_dex_and_skill( dummy, 10, 10 ) == 12.5f );
     }
 }
 

--- a/tests/melee_dodge_hit_test.cpp
+++ b/tests/melee_dodge_hit_test.cpp
@@ -199,11 +199,9 @@ TEST_CASE( "Character::get_dodge", "[player][melee][dodge]" )
     const float base_dodge = dummy.get_dodge_base();
 
     SECTION( "each dodge after the first subtracts 2 points" ) {
-        // Simulate some dodges, so dodges_left will go to 0, -1
+        // Simulate a dodge
         dummy.on_dodge( nullptr, 0 );
         CHECK( dummy.get_dodge() == base_dodge - 2 );
-        dummy.on_dodge( nullptr, 0 );
-        CHECK( dummy.get_dodge() == base_dodge - 4 );
 
         // Reset dodges_left, so subsequent tests are not affected
         dummy.set_moves( 100 );


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Base dodge is incredibly high without training, with training you become impossible to hit. We don't want to stop dodge builds from existing, but the earlygame math without mutations is too stacked from dex

## Describe the solution

Every 2 points in dex would raise dodge modifier by 1. This sets it to every 4 points. This means at 8 dexterity you will have 2 modifier without training instead of 4, and at level 10 you wall have 12 modifier. At level 10 you ensure melee 7 enemies only can hit at a 16% chance. This is also before we calculate mutations or CBMs. At level 16 Dexterity it's back to 4 modifier and 14 at level 10.

In an effort to make it easier to train dodge the books now go to 2, 3, and 5. Dodge only trains on success, this is basically mandatory until someone sets it to train on failure.

## Describe alternatives you've considered

N/A

## Testing

I've done a fair bit of math on it, but you can too. Matching enemy melee skill is a 50% dodge chance. With the dodge 2 magazine you can gain 4 modifier and most enemies are between 3 and 5 earlygame.

The dodge tests will probably break. They have to be ran.

## Additional context

Someone is going to be mad with me, but I think the dodge books is quality of life enough to make up for this.
