### PR TITLE
fix: Upgrade MacOS from 12 to 14 to avoid build failure

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -116,14 +116,14 @@ jobs:
             ext: tar.gz
             content: application/gzip
           - name: osx-curses-x64
-            os: macos-12
+            os: macos-14
             mxe: none
             tiles: 0
             artifact: osx-curses-x64
             ext: dmg
             content: application/x-apple-diskimage
           - name: osx-tiles-x64
-            os: macos-12
+            os: macos-14
             mxe: none
             tiles: 1
             artifact: osx-tiles-x64

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -109,7 +109,7 @@ jobs:
 
           # - title: Clang 14, macOS 12, Tiles, Sound, Localize, Lua
           #   compiler: clang++
-          #   os: macos-12
+          #   os: macos-14
           #   cmake: 0
           #   tiles: 1
           #   sound: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,14 +141,14 @@ jobs:
             ext: tar.gz
             content: application/gzip
           - name: osx-curses-x64
-            os: macos-12
+            os: macos-14
             mxe: none
             tiles: 0
             artifact: osx-curses-x64
             ext: dmg
             content: application/x-apple-diskimage
           - name: osx-tiles-x64
-            os: macos-12
+            os: macos-14
             mxe: none
             tiles: 1
             artifact: osx-tiles-x64

--- a/build-scripts/gha_compile_only.sh
+++ b/build-scripts/gha_compile_only.sh
@@ -57,20 +57,20 @@ then
 
     make -j$num_jobs -C build
 else
-    if [ "$OS" == "macos-12" ]
+    if [ "$OS" == "macos-14" ]
     then
         export NATIVE=osx
         # if OSX_MIN we specify here is lower than 11 then linker is going
         # to throw warnings because uncaught_exceptions, SDL and gettext libraries installed from
         # Homebrew are built with minimum target osx version 11
-        export OSX_MIN=11
+        export OSX_MIN=14
     else
         export BACKTRACE=1
     fi
     make -j "$num_jobs" RELEASE=1 CCACHE=1 CROSS="$CROSS_COMPILATION" LINTJSON=0 FRAMEWORK=1
 
     # For CI on macOS, patch the test binary so it can find SDL2 libraries.
-    if [[ ! -z "$OS" && "$OS" = "macos-12" ]]
+    if [[ ! -z "$OS" && "$OS" = "macos-14" ]]
     then
         file tests/cata_test
         install_name_tool -add_rpath "$HOME"/Library/Frameworks tests/cata_test


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Github is deprecating MacOS12. We don't have a choice. https://github.com/actions/runner-images/issues/10721

## Describe the solution

Well, I hope its as easy as doing macos-14 where macos-11 was. I don't get paid enough for this.

## Describe alternatives you've considered

Do Mac players even exist? Sorry that was rhetorical, don't answer.

## Testing

Nobody I know runs a Mac. We're going to run the tests and get mad in a minute if/when they've failed.

## Additional context

God doesn't let me be happy, he makes me work with the build matrix.
