### PR TITLE
feat(content): Add simple bimbibap

### DIFF
--- a/data/json/items/comestibles/meat_dishes.json
+++ b/data/json/items/comestibles/meat_dishes.json
@@ -1420,7 +1420,7 @@
     "spoils_in": "2 days 12 hours",
     "comestible_type": "FOOD",
     "symbol": "%",
-    "calories": 340,
+    "calories": 420,
     "material": [ "veggy", "flesh" ],
     "fun": 5,
     "looks_like": "rice_cooked"

--- a/data/json/items/comestibles/meat_dishes.json
+++ b/data/json/items/comestibles/meat_dishes.json
@@ -1391,7 +1391,7 @@
       { "type": "COMPONENT_ID", "condition": "fish", "name": "sashimi %s" }
     ],
     "type": "COMESTIBLE",
-    "description": "A mixed meat and rice dish from Korea, often with eggs and various veggies.",
+    "description": "A mixed meat and rice dish from Korea, often with eggs and various veggies.  This version has gone for a full-house of ingredients, making it extra tasty.",
     "weight": "250 g",
     "volume": "300 ml",
     "//": "Very rough estimation",
@@ -1402,6 +1402,27 @@
     "calories": 680,
     "material": [ "veggy", "flesh" ],
     "fun": 10,
+    "looks_like": "rice_cooked"
+  },
+  {
+    "id": "bibimbap_simple",
+    "name": { "str_sp": "simple bibimbap" },
+    "conditional_names": [
+      { "type": "FLAG", "condition": "CANNIBALISM", "name": "saram %s" },
+      { "type": "COMPONENT_ID", "condition": "fish", "name": "sashimi %s" }
+    ],
+    "type": "COMESTIBLE",
+    "description": "A mixed meat and rice dish from Korea, often with eggs and various veggies.",
+    "weight": "250 g",
+    "volume": "300 ml",
+    "//": "Very rough estimation",
+    "color": "white",
+    "spoils_in": "2 days 12 hours",
+    "comestible_type": "FOOD",
+    "symbol": "%",
+    "calories": 340,
+    "material": [ "veggy", "flesh" ],
+    "fun": 5,
     "looks_like": "rice_cooked"
   },
   {

--- a/data/json/items/comestibles/meat_dishes.json
+++ b/data/json/items/comestibles/meat_dishes.json
@@ -1420,7 +1420,7 @@
     "spoils_in": "2 days 12 hours",
     "comestible_type": "FOOD",
     "symbol": "%",
-    "calories": 450,
+    "calories": 555,
     "material": [ "veggy", "flesh" ],
     "fun": 5,
     "looks_like": "rice_cooked"

--- a/data/json/items/comestibles/meat_dishes.json
+++ b/data/json/items/comestibles/meat_dishes.json
@@ -1420,7 +1420,7 @@
     "spoils_in": "2 days 12 hours",
     "comestible_type": "FOOD",
     "symbol": "%",
-    "calories": 420,
+    "calories": 450,
     "material": [ "veggy", "flesh" ],
     "fun": 5,
     "looks_like": "rice_cooked"

--- a/data/json/recipes/food/meat.json
+++ b/data/json/recipes/food/meat.json
@@ -3120,7 +3120,7 @@
     "charges": 2,
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "CONTAIN", "level": 1 } ],
     "components": [
-      [ [ "meat_red_cooked", 1, "LIST" ], [ "fish", 1 ] ],
+      [ [ "meat_red", 1, "LIST" ], [ "fish", 1 ] ],
       [ [ "rice_cooked", 4 ] ],
       [ [ "eggs_small", 4, "LIST" ] ],
       [ [ "garlic_clove", 4 ] ],
@@ -3134,6 +3134,27 @@
       [ [ "sugar", 20 ] ],
       [ [ "gochujang", 24 ] ],
       [ [ "vinegar", 2 ] ]
+    ]
+  },
+  {
+    "type": "recipe",
+    "result": "bibimbap_simple",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_MEAT",
+    "skill_used": "cooking",
+    "difficulty": 3,
+    "book_learn": [ [ "cookbook_sushi", 2 ] ],
+    "time": "10 m",
+    "autolearn": true,
+    "charges": 2,
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "CONTAIN", "level": 1 } ],
+    "components": [
+      [ [ "meat_red", 1, "LIST" ], [ "fish", 1 ] ],
+      [ [ "rice_cooked", 4 ] ],
+      [ [ "eggs_small", 2, "LIST" ] ],
+      [ [ "veggy_green", 2, "LIST" ] ],
+      [ [ "cooking_oil", 3 ] ],
+      [ [ "gochujang", 12 ] ]
     ]
   },
   {


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

The bimbibap added previously was unrealistic for most survivors to actually obtain. Thus, the joy of bimbibap will be spread further by making simple bimbibap in addition to deluxe bimbibap

Also reverted the red meat part of the recipe to being raw since the fish was, and the reasoning for changing it to being cooked was never noted in the PR that changed it.

## Describe the solution

Adds simple bimbibap, a much easier recipe to make

## Describe alternatives you've considered

- Implode

## Testing

It loads on my machine

## Additional context

Would not be surprised if the caloric tests become angy on this one

Still no itemgroup additions, sorry.
