### PR TITLE
feat(balance): add support for clothing mods being modified by item volume, convert pocket mod to use that instead of thickness

### DIFF
--- a/data/json/clothing_mods.json
+++ b/data/json/clothing_mods.json
@@ -113,7 +113,7 @@
     "implement_prompt": "Add pockets",
     "destroy_prompt": "Remove pockets",
     "mod_value": [
-      { "type": "encumbrance", "value": 2, "proportion": [ "coverage" ] },
+      { "type": "encumbrance", "value": 1, "round_up": true, "proportion": [ "volume", "coverage" ] }
       { "type": "storage", "value": 1, "round_up": true, "proportion": [ "volume" ] }
     ]
   }

--- a/data/json/clothing_mods.json
+++ b/data/json/clothing_mods.json
@@ -113,7 +113,7 @@
     "implement_prompt": "Add pockets",
     "destroy_prompt": "Remove pockets",
     "mod_value": [
-      { "type": "encumbrance", "value": 1, "round_up": true, "proportion": [ "volume", "coverage" ] }
+      { "type": "encumbrance", "value": 1, "round_up": true, "proportion": [ "volume", "coverage" ] },
       { "type": "storage", "value": 1, "round_up": true, "proportion": [ "volume" ] }
     ]
   }

--- a/data/json/clothing_mods.json
+++ b/data/json/clothing_mods.json
@@ -114,7 +114,7 @@
     "destroy_prompt": "Remove pockets",
     "mod_value": [
       { "type": "encumbrance", "value": 2, "proportion": [ "coverage" ] },
-      { "type": "storage", "value": 3, "round_up": true, "proportion": [ "thickness", "coverage" ] }
+      { "type": "storage", "value": 1, "round_up": true, "proportion": [ "volume" ] }
     ]
   }
 ]

--- a/doc/src/content/docs/en/mod/json/reference/json_info.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_info.md
@@ -3433,8 +3433,9 @@ The following actions are available as defined in trapfunc.cpp:
         "value": 1,       // value of effect.
         "round_up": false // (optional) round up value of effect. defaults to false.
         "proportion": [   // (optional) value of effect propotions to clothing's parameter.
-            "thickness",  //            "thickness" and "coverage" is available.
-            "coverage"
+            "thickness",  //            Add value for every layer of "material_thickness" the item has.
+            "volume",     //            Add value for every liter of baseline volume the item has.
+            "coverage"    //            Reduce value by percentage of average coverage the item has.
         ]
     }
 ]

--- a/src/clothing_mod.cpp
+++ b/src/clothing_mod.cpp
@@ -83,6 +83,8 @@ void clothing_mod::load( const JsonObject &jo, const std::string & )
             const std::string &str = entry.get_string();
             if( str == "thickness" ) {
                 mv.thickness_propotion = true;
+            } else if( str == "volume" ) {
+                mv.volume_propotion = true;
             } else if( str == "coverage" ) {
                 mv.coverage_propotion = true;
             } else {
@@ -97,12 +99,16 @@ float clothing_mod::get_mod_val( const clothing_mod_type &type, const item &it )
 {
     const int thickness = it.get_thickness();
     const int coverage = it.get_avg_coverage();
+    const int vol = it.base_volume() / 1_liter;
     float result = 0.0f;
     for( const mod_value &mv : mod_values ) {
         if( mv.type == type ) {
             float tmp = mv.value;
             if( mv.thickness_propotion ) {
                 tmp *= thickness;
+            }
+            if( mv.volume_propotion ) {
+                tmp *= vol;
             }
             if( mv.coverage_propotion ) {
                 tmp *= coverage / 100.0f;

--- a/src/clothing_mod.h
+++ b/src/clothing_mod.h
@@ -36,6 +36,7 @@ struct mod_value {
     float value = 0.0f;
     bool round_up = false;
     bool thickness_propotion = false;
+    bool volume_propotion = false;
     bool coverage_propotion = false;
 };
 


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Lil thing I had in mind as an immediate follow-up to https://github.com/cataclysmbnteam/Cataclysm-BN/pull/5671, since coverage alone doesn't seem like an ideal control for adding pockets to clothes.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

C++ changes:
1. In clothing_mod.cpp, updated `clothing_mod::load` to support `volume` as a valid modifier for clothing mod effects.
2. Also in clothing_mod.cpp, updated `clothing_mod::get_mod_val` so that volume modifiers work like thickness, except it bases it on the item's base volume in liters (should be rounded down if my understanding of the `int` definition is correct) instead of material thickness.
3. Added definition and default value of `volume_propotion` to definitions in clothing_mod.h.

JSON changes:
1. Nerfed the amount of storage `value` for the new pocket clothing mod from 3 to 1 (.75 liters to .25 liters), and changed it to use volume instead of thickness.
2. Per feedback, set encumbrance penalty to scale with volume and coverage, reduced baseline value from 2 to 1 now that it scales instead of being fixed.

Documentation changes:
1. Documented all three clothing mod modifiers in json_info.md, now with actual explainations of what each does.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Making it base off weight instead, or adding support for clothing mods being proportioned by weight and just not using it yet.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON file for syntax and lint errors.
3. Compiled and load-tested.
4. Got the storage changes of several armor items before and after changing the clothing mod, found the results felt more consistent in my opinion. Lil survivor helms don't gain more storage than a full-on suit just because it's thicker, for example.
5. Confirmed that loading a tac vest with the bulkiest mags possible doesn't change how much storage it'd gain, only gaining .25 liters even after 4 thompson drum mags bumps its effective volume from 1.25 liters to 6.25 liters.
6. Checked affected C++ files for astyle.

Some examples:

Item | Vol gain, before | Vol gain, after
--- | --- | ---
MBR vest (ceramic) | +5.75 L | +1.5 L
Swat armor | +2.75 L | +3.25 L
Heavy survivor suit | +1.5 L | +3 L
Heavy survivor helmet |+2.25 L | +0.5 L

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

I just noticed while writing the PR text that `thickness_propotion `, `coverage_propotion ` and the like in the code misspells "proportion" derp.