### PR TITLE
feat(balance): sanity-check EXP gain of several activities

### DIFF
--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1109,7 +1109,7 @@ void complete_construction( Character &ch )
     const auto award_xp = [&]( player & c ) {
         for( const auto &pr : built.required_skills ) {
             const float built_time = to_moves<int>( built.time );
-            const float built_base = to_moves<int>( 30_minutes );
+            const float built_base = to_moves<int>( 10_minutes );
             c.practice( pr.first, static_cast<int>(
                             ( 10 + 15 * pr.second ) * ( 1.0f + built_time / built_base )
                         ), static_cast<int>( pr.second * 1.25 ) );
@@ -1415,6 +1415,9 @@ void construct::done_deconstruct( const tripoint &p )
             add_msg( m_info, _( "That %s can not be disassembled!" ), f.name() );
             return;
         }
+        if( f.active ) {
+            g->u.practice( skill_electronics, 20, 4 );
+        }
         if( f.deconstruct.furn_set.str().empty() ) {
             here.furn_set( p, f_null );
         } else {
@@ -1443,16 +1446,6 @@ void construct::done_deconstruct( const tripoint &p )
                 return;
             }
             done_deconstruct( top );
-        }
-        if( t.id == ter_str_id( "t_console_broken" ) )  {
-            if( g->u.get_skill_level( skill_electronics ) >= 1 ) {
-                g->u.practice( skill_electronics, 20, 4 );
-            }
-        }
-        if( t.id == ter_str_id( "t_console" ) )  {
-            if( g->u.get_skill_level( skill_electronics ) >= 1 ) {
-                g->u.practice( skill_electronics, 40, 8 );
-            }
         }
         here.ter_set( p, t.deconstruct.ter_set );
         add_msg( _( "The %s is disassembled." ), t.name() );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -6417,8 +6417,7 @@ void iexamine::practice_survival_while_foraging( player *p )
 {
     ///\EFFECT_INT Intelligence caps survival skill gains from foraging
     const int max_forage_skill = p->int_cur / 2 + 1;
-    ///\EFFECT_SURVIVAL decreases survival skill gain from foraging (NEGATIVE)
-    const int max_exp = 2 * ( max_forage_skill - p->get_skill_level( skill_survival ) );
+    const int max_exp = 2 * max_forage_skill;
     // Award experience for foraging attempt regardless of success
     p->practice( skill_survival, rng( 1, max_exp ), max_forage_skill );
 }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -3440,7 +3440,7 @@ repair_item_actor::attempt_hint repair_item_actor::repair( player &pl, item &too
     const int current_skill_level = pl.get_skill_level( used_skill );
     const auto action = default_action( fix, current_skill_level );
     const auto chance = repair_chance( pl, fix, action );
-    int practice_amount = repair_recipe_difficulty( pl, fix, true ) / 2 + 1;
+    int practice_amount = std::max( repair_recipe_difficulty( pl, fix, true ), 1 );
     float roll_value = rng_float( 0.0, 1.0 );
     enum roll_result {
         SUCCESS,
@@ -3834,7 +3834,7 @@ int heal_actor::finish_using( player &healer, player &patient, item &it,
         e.set_duration( e.get_int_dur_factor() * bandages_intensity );
         patient.get_part( healed ).set_damage_bandaged( patient.get_part_hp_max(
                     bp ) - patient.get_part_hp_cur( bp ) );
-        practice_amount += 2 * bandages_intensity;
+        practice_amount += 3 * bandages_intensity;
     }
     if( disinfectant_power > 0 ) {
         int disinfectant_intensity = get_disinfected_level( healer );
@@ -3843,7 +3843,7 @@ int heal_actor::finish_using( player &healer, player &patient, item &it,
         e.set_duration( e.get_int_dur_factor() * disinfectant_intensity );
         patient.get_part( healed ).set_damage_disinfected( patient.get_part_hp_max(
                     bp ) - patient.get_part_hp_cur( bp ) );
-        practice_amount += 2 * disinfectant_intensity;
+        practice_amount += 3 * disinfectant_intensity;
     }
     practice_amount = std::max( 9.0f, practice_amount );
 

--- a/src/veh_utils.cpp
+++ b/src/veh_utils.cpp
@@ -41,17 +41,13 @@ int calc_xp_gain( const vpart_info &vp, const skill_id &sk, const Character &who
 
     // how many levels are we above the requirement?
     const int lvl = std::max( who.get_skill_level( sk ) - iter->second, 1 );
+    // also track the objective difficulty of requirement
+    const int diff = std::max( iter->second, 1 );
 
-    // scale xp gain per hour according to relative level
-    // 0-1: 60 xp /h
-    //   2: 15 xp /h
-    //   3:  6 xp /h
-    //   4:  4 xp /h
-    //   5:  3 xp /h
-    //   6:  2 xp /h
-    //  7+:  1 xp /h
+    // xp gain per hour starts at 60 times difficulty of installation
+    // as your level exceeds this, divide exp gain by the level difference squared
     return std::ceil( static_cast<double>( vp.install_moves ) /
-                      to_moves<int>( 1_minutes * std::pow( lvl, 2 ) ) );
+                      to_moves<int>( 1_minutes * std::pow( lvl, 2 ) ) * diff );
 }
 
 vehicle_part &most_repairable_part( vehicle &veh, Character &who, bool only_repairable )


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This aims to tackle several cases where the EXP gain of certain actions pale in comparison to craft-grinding and book-grinding, when I want to generally encourage gaining skills by actually using them during gameplay.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. In construction.cpp, set the time scaling for EXP gain in `complete_construction` to a value closer to the scaling used by crafting, dividing the duration of construction by 10 minutes (crafting seems to divide by 5, so should scale up at half the rate of crafting) instead of 30 to get the EXP multiplier.
2. Also in construction.cpp, removed the old hardcoded checks in `construct::done_deconstruct` that give you electronics EXP for taking apart a very narrow specific range of terrain, and instead have it grant it for any deconstruction where the furniture being removed has `active` info, so any grid furniture will give electronics EXP when salvaged.
3. In iexamine.cpp, changed `iexamine::practice_survival_while_foraging` to not penalize the player's EXP for having more survival skill, since EXP per level ALREADY goes up exponentially!
4. In iuse_actor.cpp, changed how the EXP gain in `repair_item_actor::repair` is determined. Instead of 1 + half the item's repair difficulty, it now uses the item's repair difficulty as-isv (`std::max`'d against 1 so that level-zero items don't give nothing).
5. Also in iuse_actor.cpp, updated `heal_actor::finish_using` so that the EXP gain from using healing items values bandage and disinfectant stacks at the same 3x multiplier it values the old instant-healing, instead of only a 2x multiplier.
6. In veh_utils.cpp, set `calc_xp_gain` to multiply the EXP gain formula by the skill requirement, so that more advanced installation and repair will grant proportionately more EXP.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Screaming.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Spawned in a vehicle and tested a level-1 hour-long installation, still get 60% of the way to next level as expected.
3. Retested with a level-2 hour-long installation, confirmed I get more EXP from it.
4. Inserted a message into repair actions temporaily, practice amount for one instance of repairing a messenger bag went from 2 to 3.
5. Observed that applying a single banadage to an injury at level zero first aid went from granting 9 EXP to 12 EXP. The `std::max` in the function means the actual before value was probably 8 and got bumped up to a minimum of 9.
6. Tested deconstructing furniture, confirmed that fabrication progress from level zero went from 16% to 30%, compare ice cream (also a 20-minute, level-zero recipe) getting cooking to 47%.
7. Confirmed I got some electronics EXP for taking apart the solar panel on the roof.
8. Checked to confirm that deconstructing a random old bench or other non-grid furniture wouldn't give me electronics EXP.
9. Checked affected files for astyle.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
