### PR TITLE
fix: styrofoam gives scraps and not chunks

### DIFF
--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -3585,7 +3585,7 @@
     "result": "styrofoam_cup",
     "type": "uncraft",
     "time": "6 s",
-    "components": [ [ [ "cardboard", 2 ] ], [ [ "plastic_chunk", 2 ] ] ],
+    "components": [ [ [ "cardboard", 2 ] ], [ [ "plastic_scrap", 2 ] ] ],
     "flags": [ "BLIND_EASY" ]
   },
   {


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
## Purpose of change
![image](https://github.com/user-attachments/assets/e6b59ef6-7672-4c0d-8442-bc45a439aefc)

## Describe the solution

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/5691

## Describe alternatives you've considered

Lament

## Testing

Tests

## Additional context

That's it, I'm going to bed.
