### PR TITLE
feat(UI): add a flag for displaying basic description of newspapers and similar items to illiterate characters in place of snippet contents

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -1915,6 +1915,11 @@
     "context": [  ]
   },
   {
+    "id": "SNIPPET_NEEDS_LITERACY",
+    "type": "json_flag",
+    "context": [  ]
+  },
+  {
     "id": "SOLARPACK",
     "type": "json_flag",
     "context": [  ]

--- a/data/json/items/armor/torso_clothes.json
+++ b/data/json/items/armor/torso_clothes.json
@@ -330,7 +330,7 @@
     "copy-from": "tshirt",
     "type": "ARMOR",
     "name": { "str": "Linux t-shirt" },
-    "description": "A t-shirt with a picture of the Tux mascot on it.  Underneath it says \"You wouldn't buy a car with the hood welded shut.\"",
+    "description": "A t-shirt with a Linux logo on it and a pithy slogan of some sort.",
     "price": "20 USD",
     "price_postapoc": "50 cent",
     "color": "dark_gray",
@@ -368,7 +368,7 @@
         "text": "A t-shirt with the Debian logo on it, underneath it says \"The Universal Operating System\""
       }
     ],
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE", "SNIPPET_NEEDS_LITERACY" ]
   },
   {
     "id": "longshirt",
@@ -608,6 +608,7 @@
     "repairs_like": "tshirt",
     "copy-from": "tshirt",
     "name": { "str": "t-shirt" },
+    "description": "A short-sleeved cotton shirt.  It's got some text printed on it.",
     "type": "ARMOR",
     "color": "white",
     "snippet_category": [
@@ -615,7 +616,8 @@
         "id": "allyourbase",
         "text": "A short-sleeved cotton shirt with the text \"chown -R us ~your/base\" printed on the front."
       }
-    ]
+    ],
+    "extend": { "flags": "SNIPPET_NEEDS_LITERACY" }
   },
   {
     "id": "tshirt_tour",

--- a/data/json/items/book/misc.json
+++ b/data/json/items/book/misc.json
@@ -176,7 +176,8 @@
         "id": "fairyat_2025",
         "text": "Titled \"The Fleeing Pancake\", this collection of silly folk tales is suitable for small children."
       }
-    ]
+    ],
+    "extend": { "flags": "SNIPPET_NEEDS_LITERACY" }
   },
   {
     "id": "mag_gaming",
@@ -487,7 +488,8 @@
         "id": "scifi1_61",
         "text": "This is a well-worn copy of \"The Hitchhikers Guide to the Galaxy\" by Douglas Adams."
       }
-    ]
+    ],
+    "extend": { "flags": "SNIPPET_NEEDS_LITERACY" }
   },
   {
     "id": "novel_sports",
@@ -693,7 +695,8 @@
       },
       { "id": "philosophy45", "text": "This is a copy of \"Anti-Capitalist Mentality\" by Ludwig von Mises." }
     ],
-    "price": "1250 cent"
+    "price": "1250 cent",
+    "extend": { "flags": "SNIPPET_NEEDS_LITERACY" }
   },
   {
     "id": "phonebook",
@@ -874,7 +877,8 @@
       { "id": "classic53", "text": "This is a copy of \"Peter Simple\" by Frederick Marryat." }
     ],
     "price": "20 USD",
-    "looks_like": "tall_tales"
+    "looks_like": "tall_tales",
+    "extend": { "flags": "SNIPPET_NEEDS_LITERACY" }
   },
   {
     "type": "BOOK",
@@ -957,6 +961,7 @@
     ],
     "price": "4550 cent",
     "looks_like": "tall_tales",
-    "fun": 3
+    "fun": 3,
+    "extend": { "flags": "SNIPPET_NEEDS_LITERACY" }
   }
 ]

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -139,22 +139,25 @@
     "id": "log_immersion27",
     "copy-from": "file",
     "name": { "str": "INCIDENT REPORT: IMMERSION-27A" },
-    "description": "A white piece of paper, with the logo of XEDRA printed on its upper left corner.  It seems to be an internal report of some kind.",
-    "snippet_category": "log_immersion27"
+    "description": "A white piece of paper, with a fancy-looking logo printed on its upper left corner.  It'd probably be very fascinating reading material.",
+    "snippet_category": "log_immersion27",
+    "extend": { "flags": "SNIPPET_NEEDS_LITERACY" }
   },
   {
     "type": "GENERIC",
     "id": "report_t_substrate",
     "copy-from": "log_immersion27",
     "name": { "str": "MATERIAL: T-SUBSTRATE" },
-    "snippet_category": "t-substrate"
+    "snippet_category": "t-substrate",
+    "extend": { "flags": "SNIPPET_NEEDS_LITERACY" }
   },
   {
     "type": "GENERIC",
     "id": "HAADF_t_substrate",
     "copy-from": "log_immersion27",
     "name": { "str": "HAADF MICROGRAPH: T-SUBSTRATE" },
-    "snippet_category": "HAADF_t-substrate"
+    "snippet_category": "HAADF_t-substrate",
+    "extend": { "flags": "SNIPPET_NEEDS_LITERACY" }
   },
   {
     "type": "GENERIC",

--- a/data/json/items/generic/dining_kitchen.json
+++ b/data/json/items/generic/dining_kitchen.json
@@ -188,7 +188,8 @@
       },
       { "id": "mug15", "text": "The side of the mug reads 'I wish this was wine!'" },
       { "id": "mug16", "text": "The side of the mug reads 'CasUaL aLcoHoLiSm'" }
-    ]
+    ],
+    "extend": { "flags": "SNIPPET_NEEDS_LITERACY" }
   },
   {
     "type": "GENERIC",

--- a/data/json/items/newspaper.json
+++ b/data/json/items/newspaper.json
@@ -7,10 +7,11 @@
     "color": "white",
     "name": { "str": "flyer" },
     "snippet_category": "flier",
-    "description": "A scrap of paper.",
+    "description": "A scrap of paper.  It's got stuff depicted on it, and a lot of boring words.  The stuff looks neat at least, but they probably don't make it anymore.",
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "material": "paper",
+    "flags": [ "TRADER_AVOID", "SNIPPET_NEEDS_LITERACY" ],
     "weight": "3 g",
     "volume": "5 ml"
   },
@@ -26,7 +27,7 @@
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "material": "paper",
-    "flags": [ "TRADER_AVOID" ],
+    "flags": [ "TRADER_AVOID", "SNIPPET_NEEDS_LITERACY" ],
     "weight": "3 g",
     "volume": "1 ml"
   },
@@ -38,12 +39,12 @@
     "color": "white",
     "name": { "str": "character sheet" },
     "snippet_category": "charsheet",
-    "description": "A Dungeons & Dragons character sheet.",
+    "description": "You're fairly certain this is a character sheet for some sort of game, either that or some poor kid's math homework.",
     "looks_like": "survnote",
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "material": "paper",
-    "flags": [ "TRADER_AVOID" ],
+    "flags": [ "TRADER_AVOID", "SNIPPET_NEEDS_LITERACY" ],
     "weight": "3 g",
     "volume": "5 ml"
   },
@@ -55,10 +56,11 @@
     "color": "white",
     "name": { "str": "newspaper page" },
     "snippet_category": "newest_news",
-    "description": "A single sheet of newspaper broadsheet.  It is possibly one of the last issues printed before New England was overwhelmed.  Most of the information on there is terribly trivial, or out of date, but one thing catches your eye briefly.",
+    "description": "A single sheet of newspaper broadsheet.  It is possibly one of the last issues printed before New England was overwhelmed.  No doubt filled with trivial and out-of-date information, who even reads these things anymore?",
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "material": "paper",
+    "flags": [ "TRADER_AVOID", "SNIPPET_NEEDS_LITERACY" ],
     "weight": "3 g",
     "volume": "1 ml"
   },
@@ -70,10 +72,11 @@
     "color": "white",
     "name": { "str": "newspaper page" },
     "snippet_category": "many_years_old_news",
-    "description": "A single sheet of newspaper broadsheet.  It seems to date from several years ago, and you've NO idea how it lasted this long.  Most of the information on there is terribly trivial, or out of date, but one thing catches your eye briefly.",
+    "description": "A single sheet of newspaper broadsheet.  It seems to date from several years ago, and you've NO idea how it lasted this long.  No doubt filled with trivial and out-of-date information, who even reads these things anymore?",
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "material": "paper",
+    "flags": [ "TRADER_AVOID", "SNIPPET_NEEDS_LITERACY" ],
     "weight": "3 g",
     "volume": "1 ml"
   },
@@ -85,10 +88,11 @@
     "color": "white",
     "name": { "str": "newspaper page" },
     "snippet_category": "years_old_news",
-    "description": "A single sheet of newspaper broadsheet.  It seems to date from a few years ago--amazing it has lasted this long.  Most of the information on there is terribly trivial, or out of date, but one thing catches your eye briefly.",
+    "description": "A single sheet of newspaper broadsheet.  It seems to date from a few years ago--amazing it has lasted this long.  No doubt filled with trivial and out-of-date information, who even reads these things anymore?",
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "material": "paper",
+    "flags": [ "TRADER_AVOID", "SNIPPET_NEEDS_LITERACY" ],
     "weight": "3 g",
     "volume": "1 ml"
   },
@@ -100,10 +104,11 @@
     "color": "white",
     "name": { "str": "newspaper page" },
     "snippet_category": "one_year_old_news",
-    "description": "A single sheet of newspaper broadsheet.  It was printed more than a year ago.  Most of the information on there is terribly trivial, or out of date, but one thing catches your eye briefly.",
+    "description": "A single sheet of newspaper broadsheet.  It was printed more than a year ago.  No doubt filled with trivial and out-of-date information, who even reads these things anymore?",
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "material": "paper",
+    "flags": [ "TRADER_AVOID", "SNIPPET_NEEDS_LITERACY" ],
     "weight": "3 g",
     "volume": "1 ml"
   },
@@ -115,10 +120,11 @@
     "color": "white",
     "name": { "str": "newspaper page" },
     "snippet_category": "months_old_news",
-    "description": "A single sheet of newspaper broadsheet.  It was printed in the months leading up to the Cataclysm.  Most of the information on there is terribly trivial, or out of date, but one thing catches your eye briefly.",
+    "description": "A single sheet of newspaper broadsheet.  It was printed in the months leading up to the Cataclysm.  No doubt filled with trivial and out-of-date information, who even reads these things anymore?",
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "material": "paper",
+    "flags": [ "TRADER_AVOID", "SNIPPET_NEEDS_LITERACY" ],
     "weight": "3 g",
     "volume": "1 ml"
   },
@@ -130,10 +136,11 @@
     "color": "white",
     "name": { "str": "newspaper page" },
     "snippet_category": "weeks_old_news",
-    "description": "A single sheet of newspaper broadsheet.  It was printed in the weeks leading up to the Cataclysm.  Most of the information on there is terribly trivial, or out of date, but one thing catches your eye briefly.",
+    "description": "A single sheet of newspaper broadsheet.  It was printed in the weeks leading up to the Cataclysm.  No doubt filled with trivial and out-of-date information, who even reads these things anymore?",
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "material": "paper",
+    "flags": [ "TRADER_AVOID", "SNIPPET_NEEDS_LITERACY" ],
     "weight": "3 g",
     "volume": "1 ml"
   },
@@ -145,10 +152,11 @@
     "color": "white",
     "name": { "str": "vault leaflet" },
     "snippet_category": "necropolis_intro",
-    "description": "A folded glossy handout that appears to be an introduction to living in a massive underground complex.",
+    "description": "A folded glossy handout with a cross-section of a massive underground complex depicted on the first page.",
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "material": "paper",
+    "flags": [ "TRADER_AVOID", "SNIPPET_NEEDS_LITERACY" ],
     "weight": "1 g",
     "volume": "1 ml"
   },
@@ -165,7 +173,7 @@
     "price_postapoc": "0 cent",
     "looks_like": "survnote",
     "material": "paper",
-    "flags": [ "TRADER_AVOID" ],
+    "flags": [ "TRADER_AVOID", "SNIPPET_NEEDS_LITERACY" ],
     "weight": "3 g",
     "volume": "10 ml"
   },
@@ -174,13 +182,19 @@
     "id": "evac_pamphlet",
     "category": "books",
     "name": { "str": "FEMA evacuation pamphlet" },
-    "description": "Welcome to your Emergency Survival Shelter.  We hope your stay here will be short and comfortable.  Provided are an emergency blanket, high visibility jacket, gas mask, and food and water rations for one day, as well as an emergency lighter and flashlight.  There are further supplies in the communal cabinets should the facility be over its intended capacity.  These resources are checked and updated by FEMA on a regular basis, but if you find some items missing, please contact a FEMA supervisor at your earliest convenience.\n\nPlease wait in the shelter until an official evacuation transport arrives to take you to your homes or, in the event of a major disaster, to the nearest evacuation gathering point.\n\nIn the event that you have been evacuated under violent circumstances, FEMA recommends taking cover in the shelter's basement until help arrives.  Remember: if you leave the shelter, we cannot find you to take you to safety.",
+    "description": "A scrap of paper with a lot of words printed on it.  Something about femurs?",
+    "snippet_category": [
+      {
+        "id": "fema_intro",
+        "text": "Welcome to your Emergency Survival Shelter.  We hope your stay here will be short and comfortable.  Provided are an emergency blanket, high visibility jacket, gas mask, and food and water rations for one day, as well as an emergency lighter and flashlight.  There are further supplies in the communal cabinets should the facility be over its intended capacity.  These resources are checked and updated by FEMA on a regular basis, but if you find some items missing, please contact a FEMA supervisor at your earliest convenience.\n\nPlease wait in the shelter until an official evacuation transport arrives to take you to your homes or, in the event of a major disaster, to the nearest evacuation gathering point.\n\nIn the event that you have been evacuated under violent circumstances, FEMA recommends taking cover in the shelter's basement until help arrives.  Remember: if you leave the shelter, we cannot find you to take you to safety."
+      }
+    ],
     "weight": "5 g",
     "volume": "15 ml",
     "material": [ "paper" ],
     "looks_like": "newest_newspaper",
     "color": "white",
     "symbol": "?",
-    "flags": [ "TRADER_AVOID" ]
+    "flags": [ "TRADER_AVOID", "SNIPPET_NEEDS_LITERACY" ]
   }
 ]

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -296,6 +296,7 @@ const flag_id flag_SLOWS_THIRST( "SLOWS_THIRST" );
 const flag_id flag_SLOW_WIELD( "SLOW_WIELD" );
 const flag_id flag_SMOKABLE( "SMOKABLE" );
 const flag_id flag_SMOKED( "SMOKED" );
+const flag_id flag_SNIPPET_NEEDS_LITERACY( "SNIPPET_NEEDS_LITERACY" );
 const flag_id flag_SOLARPACK( "SOLARPACK" );
 const flag_id flag_SOLARPACK_ON( "SOLARPACK_ON" );
 const flag_id flag_SPAWN_FRIENDLY( "SPAWN_FRIENDLY" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -300,6 +300,7 @@ extern const flag_id flag_SLOWS_THIRST;
 extern const flag_id flag_SLOW_WIELD;
 extern const flag_id flag_SMOKABLE;
 extern const flag_id flag_SMOKED;
+extern const flag_id flag_SNIPPET_NEEDS_LITERACY;
 extern const flag_id flag_SOLARPACK;
 extern const flag_id flag_SOLARPACK_ON;
 extern const flag_id flag_SPAWN_FRIENDLY;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -168,6 +168,7 @@ static const trait_flag_str_id trait_flag_CANNIBAL( "CANNIBAL" );
 static const bionic_id bio_digestion( "bio_digestion" );
 
 static const trait_id trait_CARNIVORE( "CARNIVORE" );
+static const trait_id trait_ILLITERATE( "ILLITERATE" );
 static const trait_id trait_LIGHTWEIGHT( "LIGHTWEIGHT" );
 static const trait_id trait_SAPROVORE( "SAPROVORE" );
 static const trait_id trait_SQUEAMISH( "SQUEAMISH" );
@@ -1700,7 +1701,8 @@ void item::basic_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
         const std::map<std::string, std::string>::const_iterator idescription =
             item_vars.find( "description" );
         const std::optional<translation> snippet = SNIPPET.get_snippet_by_id( snip_id );
-        if( snippet.has_value() ) {
+        if( snippet.has_value() && ( !get_avatar().has_trait( trait_ILLITERATE ) ||
+                                     !has_flag( flag_SNIPPET_NEEDS_LITERACY ) ) ) {
             // Just use the dynamic description
             info.emplace_back( "DESCRIPTION", snippet.value().translated() );
         } else if( idescription != item_vars.end() ) {


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

A lil flavor idea that came to mind.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

C++ changes:
1. In flag.cpp and flag.h, added a new item flag, `SNIPPET_NEEDS_LITERACY`.
2. In item.cpp, `item::basic_info` now skips out on printing snippet contents if the player-character has the Illiterate trait and the offending item has the `SNIPPET_NEEDS_LITERACY` flag, in which case it will instead show the item's baseline item description which normally goes unused.

JSON changes:
1. Added new item flag to flag JSON.
2. Added new flag `SNIPPET_NEEDS_LITERACY` to several note, newspaper, and such items that have snippet categories assigned. Generally most stuff whose snippets imply being able to read.
3. Updated the baseline description for several items to not imply an illiterate character can tell what's in it, since the description only shows up in this context.
4. Shifted the description of the FEMA pamphlet to an internal snippet so that it won't give you the full spiel to an illiterate player.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Shifting more books to doing this sort of thing to further torment players who pick this trait. :D

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON files for syntax and lint errors.
2. Compiled and load-tested.
3. Walked over to a FEMA pamphlet and confirmed it showed the expected text.
4. Gave myself illiterate trait, it now shows the item description instead.
5. Removed trait, it's back to normal.
6. Checked affected C++ files for astyle.

What it shows to normal characters:
![image](https://github.com/user-attachments/assets/119e38a9-a230-4319-8d10-e3ddfc99e1e7)

What illiterate characters see:
![image](https://github.com/user-attachments/assets/5bea14fa-76f0-4373-90c7-7b2cce4337f8)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Checked DDA, as of build `2024-11-11-0430` they don't seem to have any feature like this currently.