### PR TITLE
feat(balance): bring back support for effects modifying monster bash/cut/size, use modifiers in more effects, assorted effect immunity fixes

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -350,7 +350,7 @@
     "max_intensity": 10,
     "int_add_val": 2,
     "max_duration": "10 m",
-    "base_mods": { "per_mod": [ -5 ], "dex_mod": [ -2 ] },
+    "base_mods": { "per_mod": [ -5 ], "dex_mod": [ -2 ], "hit_mod": [ -2 ], "dodge_mod": [ -2 ] },
     "scaling_mods": { "speed_mod": [ -3 ] },
     "show_in_info": true
   },
@@ -470,7 +470,11 @@
       "pain_min": [ 1 ],
       "pain_chance": [ 150, 900 ],
       "hurt_min": [ 1 ],
-      "hurt_chance": [ 450, 2700 ]
+      "hurt_chance": [ 450, 2700 ],
+      "hit_mod": [ -1, -1 ],
+      "dodge_mod": [ -1, -1 ],
+      "bash_mod": [ -2, 0 ],
+      "cut_mod": [ -2, 0 ]
     },
     "show_in_info": true,
     "blood_analysis_description": "Poison"
@@ -497,7 +501,11 @@
       "pain_chance": [ 100, 500 ],
       "hurt_min": [ 1 ],
       "hurt_max": [ 2 ],
-      "hurt_chance": [ 300, 1800 ]
+      "hurt_chance": [ 300, 1800 ],
+      "hit_mod": [ -2 ],
+      "dodge_mod": [ -2 ],
+      "bash_mod": [ -3, -1 ],
+      "cut_mod": [ -3, -1 ]
     },
     "show_in_info": true,
     "blood_analysis_description": "Poison"
@@ -530,7 +538,9 @@
       "hurt_chance": [ 13, 100 ],
       "hurt_tick": [ 30 ]
     },
-    "scaling_mods": { "pain_min": [ 0.05, 0.01 ], "pain_chance": [ -0.15, -0.8 ], "hurt_chance": [ -0.11, -0.81 ] }
+    "scaling_mods": { "pain_min": [ 0.05, 0.01 ], "pain_chance": [ -0.15, -0.8 ], "hurt_chance": [ -0.11, -0.81 ] },
+    "show_in_info": true,
+    "blood_analysis_description": "Cytotoxic Venom"
   },
   {
     "id": "venom_weaken",
@@ -556,15 +566,25 @@
       "stamina_chance": [ 4.5, 10 ],
       "speed_mod": [ -10, 0 ],
       "vomit_chance": [ 15, 150 ],
-      "vomit_tick": [ 1200 ]
+      "vomit_tick": [ 1200 ],
+      "bash_mod": [ -2, 0 ],
+      "cut_mod": [ -2, 0 ],
+      "hit_mod": [ -2, 0 ],
+      "dodge_mod": [ -2, 0 ]
     },
     "scaling_mods": {
       "str_mod": [ -0.05, -0.04 ],
       "dex_mod": [ -0.05, -0.04 ],
       "stamina_min": [ -0.351, -0.151 ],
       "stamina_chance": [ -0.021, -0.051 ],
-      "speed_mod": [ -0.31, -0.21 ]
-    }
+      "speed_mod": [ -0.31, -0.21 ],
+      "bash_mod": [ -0.05, -0.04 ],
+      "cut_mod": [ -0.05, -0.04 ],
+      "hit_mod": [ -0.05, -0.04 ],
+      "dodge_mod": [ -0.05, -0.04 ]
+    },
+    "show_in_info": true,
+    "blood_analysis_description": "Neurotoxic Poison"
   },
   {
     "type": "effect_type",
@@ -607,7 +627,11 @@
       "hurt_min": [ 2 ],
       "hurt_chance": [ 450, 2700 ],
       "speed_mod": [ -10 ],
-      "cough_chance": [ 10 ]
+      "cough_chance": [ 10 ],
+      "hit_mod": [ -1, -1 ],
+      "dodge_mod": [ -1, -1 ],
+      "bash_mod": [ -2, 0 ],
+      "cut_mod": [ -2, 0 ]
     },
     "show_in_info": true,
     "blood_analysis_description": "Unknown Organic Toxin"
@@ -646,8 +670,8 @@
     "resist_effects": [ "antitoxin" ],
     "int_add_val": 1,
     "int_decay_tick": 600,
-    "base_mods": { "dex_mod": [ -0.34, -0.17 ], "speed_mod": [ -5, -3 ] },
-    "scaling_mods": { "dex_mod": [ -0.34, -0.17 ], "speed_mod": [ -5, -3 ] },
+    "base_mods": { "dex_mod": [ -0.34, -0.17 ], "speed_mod": [ -5, -3 ], "hit_mod": [ -0.34, -0.17 ], "dodge_mod": [ -0.34, -0.17 ] },
+    "scaling_mods": { "dex_mod": [ -0.34, -0.17 ], "speed_mod": [ -5, -3 ], "hit_mod": [ -0.34, -0.17 ], "dodge_mod": [ -0.34, -0.17 ] },
     "show_in_info": true,
     "blood_analysis_description": "Paralyzing Poison"
   },
@@ -747,7 +771,15 @@
     "miss_messages": [ [ "Your lungs burn from the smoke.", 1 ] ],
     "harmful_cough": true,
     "max_duration": "10 m",
-    "base_mods": { "str_mod": [ -1 ], "dex_mod": [ -1 ], "cough_chance": [ 10 ] },
+    "base_mods": {
+      "str_mod": [ -1 ],
+      "dex_mod": [ -1 ],
+      "cough_chance": [ 10 ],
+      "hit_mod": [ -1 ],
+      "dodge_mod": [ -1 ],
+      "bash_mod": [ -1 ],
+      "cut_mod": [ -1 ]
+    },
     "show_in_info": true
   },
   {
@@ -760,7 +792,17 @@
     "miss_messages": [ [ "Your eyes burn from the tear gas.", 2 ] ],
     "harmful_cough": true,
     "max_duration": "30 m",
-    "base_mods": { "str_mod": [ -2 ], "dex_mod": [ -2 ], "per_mod": [ -5 ], "speed_mod": [ -10 ], "cough_chance": [ 5 ] },
+    "base_mods": {
+      "str_mod": [ -2 ],
+      "dex_mod": [ -2 ],
+      "per_mod": [ -5 ],
+      "speed_mod": [ -10 ],
+      "cough_chance": [ 5 ],
+      "hit_mod": [ -2 ],
+      "dodge_mod": [ -2 ],
+      "bash_mod": [ -2 ],
+      "cut_mod": [ -2 ]
+    },
     "show_in_info": true
   },
   {
@@ -1112,7 +1154,7 @@
     "max_intensity": 3,
     "int_decay_tick": 120,
     "int_add_val": 1,
-    "base_mods": { "str_mod": [ -1 ], "per_mod": [ -1 ] },
+    "base_mods": { "str_mod": [ -1 ], "per_mod": [ -1 ], "bash_mod": [ -1 ], "cut_mod": [ -1 ] },
     "show_in_info": true
   },
   {
@@ -1123,7 +1165,7 @@
     "apply_message": "You're covered in thick goo!",
     "rating": "bad",
     "miss_messages": [ [ "This goo makes you slip", 2 ] ],
-    "base_mods": { "dex_mod": [ -2 ], "speed_mod": [ -25 ], "vomit_chance": [ 2100 ] },
+    "base_mods": { "dex_mod": [ -2 ], "speed_mod": [ -25 ], "vomit_chance": [ 2100 ], "hit_mod": [ -2 ], "dodge_mod": [ -2 ] },
     "show_in_info": true
   },
   {
@@ -1777,7 +1819,7 @@
     "rating": "bad",
     "max_duration": "2 s",
     "dur_add_perc": 20,
-    "base_mods": { "speed_mod": [ -1000 ], "dex_mod": [ -100 ] },
+    "base_mods": { "speed_mod": [ -1000 ], "dex_mod": [ -100 ], "hit_mod": [ -100 ], "dodge_mod": [ -100 ] },
     "show_in_info": true
   },
   {
@@ -2106,7 +2148,7 @@
   {
     "type": "effect_type",
     "id": "grown_of_fuse",
-    "name": [ "Grown of Fusion" ],
+    "name": [ "Fused" ],
     "desc": [ "AI effect to increase stats after fusing with another critter. 1 stack means one absorbed max_hp." ],
     "//": "stats modified by the zombie_fuse special attack.",
     "//1": "scaling:",
@@ -2121,6 +2163,7 @@
       "bash_mod": [ 0.08333 ],
       "size_mod": [ 0.00625 ]
     },
+    "show_in_info": true,
     "int_decay_step": 0
   },
   {
@@ -2149,7 +2192,11 @@
       "int_mod": [ -0.75 ],
       "speed_mod": [ -10 ],
       "vomit_chance": [ 10 ],
-      "cough_chance": [ 501 ]
+      "cough_chance": [ 501 ],
+      "hit_mod": [ -0.25 ],
+      "dodge_mod": [ -0.25 ],
+      "bash_mod": [ -0.25 ],
+      "cut_mod": [ -0.25 ]
     },
     "show_in_info": true
   },

--- a/data/mods/Aftershock/effects.json
+++ b/data/mods/Aftershock/effects.json
@@ -76,8 +76,8 @@
     "max_intensity": 10,
     "int_add_val": 1,
     "int_decay_tick": 600,
-    "base_mods": { "dex_mod": [ -0.34, -0.17 ], "speed_mod": [ -15 ] },
-    "scaling_mods": { "dex_mod": [ -0.34, -0.17 ], "speed_mod": [ -15 ] },
+    "base_mods": { "dex_mod": [ -0.34, -0.17 ], "speed_mod": [ -15 ], "hit_mod": [ -0.34, -0.17 ], "dodge_mod": [ -0.34, -0.17 ] },
+    "scaling_mods": { "dex_mod": [ -0.34, -0.17 ], "speed_mod": [ -15 ], "hit_mod": [ -0.34, -0.17 ], "dodge_mod": [ -0.34, -0.17 ] },
     "show_in_info": true
   },
   {

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -58,7 +58,16 @@
     "apply_message": "You are filled with energy that improves everything you do!",
     "remove_message": "Your energy fades.",
     "rating": "good",
-    "base_mods": { "per_mod": [ 2 ], "dex_mod": [ 2 ], "str_mod": [ 2, 2 ], "speed_mod": [ 20 ] }
+    "base_mods": {
+      "per_mod": [ 2 ],
+      "dex_mod": [ 2 ],
+      "str_mod": [ 2, 2 ],
+      "speed_mod": [ 20 ],
+      "hit_mod": [ 2 ],
+      "dodge_mod": [ 2 ],
+      "bash_mod": [ 2 ],
+      "cut_mod": [ 2 ]
+    }
   },
   {
     "type": "effect_type",
@@ -257,7 +266,23 @@
     "rating": "bad",
     "max_intensity": 20,
     "int_dur_factor": "30 s",
-    "base_mods": { "str_mod": [ -1 ], "dex_mod": [ -0.17 ], "speed_mod": [ -3 ] },
-    "scaling_mods": { "str_mod": [ -0.07 ], "dex_mod": [ -0.17 ], "speed_mod": [ -3 ] }
+    "base_mods": {
+      "str_mod": [ -1 ],
+      "dex_mod": [ -0.17 ],
+      "speed_mod": [ -3 ],
+      "bash_mod": [ -1 ],
+      "cut_mod": [ -1 ],
+      "hit_mod": [ -0.17 ],
+      "dodge_mod": [ -0.17 ]
+    },
+    "scaling_mods": {
+      "str_mod": [ -0.07 ],
+      "dex_mod": [ -0.17 ],
+      "speed_mod": [ -3 ],
+      "bash_mod": [ -0.07 ],
+      "cut_mod": [ -0.07 ],
+      "hit_mod": [ -0.17 ],
+      "dodge_mod": [ -0.17 ]
+    }
   }
 ]

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -65,8 +65,7 @@
       "speed_mod": [ 20 ],
       "hit_mod": [ 2 ],
       "dodge_mod": [ 2 ],
-      "bash_mod": [ 2 ],
-      "cut_mod": [ 2 ]
+      "bash_mod": [ 2 ]
     }
   },
   {

--- a/doc/src/content/docs/en/mod/json/reference/creatures/effects_json.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/effects_json.md
@@ -587,6 +587,14 @@ Valid arguments:
 "healing_torso"     - Percentage of healing value for torso
 
 "morale"            - Amount of morale provided. Must be a single number (resistance not supported).
+
+This following effects only apply to monsters:
+
+"hit_mod"           - Raises or lowers monster melee_skill
+"dodge_mod"         - Raises or lowers monster dodge rating
+"bash_mod"          - Raises or lowers bashing damage dealt by basic attacks and melee special attacks, lowering it to zero will make it deal no damage
+"cut_mod"           - Raises or lowers cutting damage dealt by basic attacks and melee special attacks, lowering it to zero will make it deal no damage
+"size_mod"          - Shrinks or grows a monster's size, can't make a monster smaller than tiny or larger than huge
 ```
 
 Each argument can also take either one or two values.

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -204,6 +204,9 @@ void Creature::reset_bonuses()
     dodge_bonus = 0;
     block_bonus = 0;
     hit_bonus = 0;
+    bash_bonus = 0;
+    cut_bonus = 0;
+    size_bonus = 0;
 }
 
 void Creature::process_turn()
@@ -1876,6 +1879,14 @@ float Creature::get_hit_bonus() const
 {
     return hit_bonus; //base is 0
 }
+int Creature::get_bash_bonus() const
+{
+    return bash_bonus;
+}
+int Creature::get_cut_bonus() const
+{
+    return cut_bonus;
+}
 
 void Creature::mod_stat( const std::string &stat, float modifier )
 {
@@ -1887,6 +1898,10 @@ void Creature::mod_stat( const std::string &stat, float modifier )
         mod_block_bonus( modifier );
     } else if( stat == "hit" ) {
         mod_hit_bonus( modifier );
+    } else if( stat == "bash" ) {
+        mod_bash_bonus( modifier );
+    } else if( stat == "cut" ) {
+        mod_cut_bonus( modifier );
     } else if( stat == "pain" ) {
         mod_pain( modifier );
     } else if( stat == "moves" ) {
@@ -1962,6 +1977,18 @@ void Creature::mod_block_bonus( int nblock )
 void Creature::mod_hit_bonus( float nhit )
 {
     hit_bonus += nhit;
+}
+void Creature::mod_bash_bonus( int nbash )
+{
+    bash_bonus += nbash;
+}
+void Creature::mod_cut_bonus( int ncut )
+{
+    cut_bonus += ncut;
+}
+void Creature::mod_size_bonus( int nsize )
+{
+    size_bonus += nsize;
 }
 
 units::mass Creature::weight_capacity() const

--- a/src/creature.h
+++ b/src/creature.h
@@ -661,6 +661,8 @@ class Creature
         virtual float get_hit_base() const = 0;
         virtual float get_dodge_bonus() const;
         virtual float get_hit_bonus() const;
+        virtual int get_bash_bonus() const;
+        virtual int get_cut_bonus() const;
 
         virtual bool has_grab_break_tec() const = 0;
 
@@ -684,6 +686,9 @@ class Creature
         virtual void mod_speed_bonus( int nspeed );
         virtual void mod_speed_mult( float nspeed );
         virtual void mod_block_bonus( int nblock );
+        virtual void mod_bash_bonus( int nbash );
+        virtual void mod_cut_bonus( int ncut );
+        virtual void mod_size_bonus( int nsize );
 
         virtual void set_dodge_bonus( float ndodge );
         virtual void set_hit_bonus( float nhit );
@@ -958,6 +963,9 @@ class Creature
         float dodge_bonus = 0.0;
         int block_bonus = 0;
         float hit_bonus = 0.0;
+        int bash_bonus;
+        int cut_bonus;
+        int size_bonus;
 
         bool fake = false;
         Creature();

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -313,6 +313,8 @@ bool melee_actor::call( monster &z ) const
     }
 
     damage_instance damage = damage_max_instance;
+    damage.add_damage( DT_BASH, z.get_bash_bonus() );
+    damage.add_damage( DT_CUT, z.get_cut_bonus() );
 
     double multiplier = rng_float( min_mul, max_mul );
     damage.mult_damage( multiplier );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3043,6 +3043,9 @@ void Creature::store( JsonOut &jsout ) const
     jsout.member( "dodge_bonus", dodge_bonus );
     jsout.member( "block_bonus", block_bonus );
     jsout.member( "hit_bonus", hit_bonus );
+    jsout.member( "bash_bonus", bash_bonus );
+    jsout.member( "cut_bonus", cut_bonus );
+    jsout.member( "size_bonus", size_bonus );
 
     jsout.member( "underwater", underwater );
 
@@ -3099,6 +3102,9 @@ void Creature::load( const JsonObject &jsin )
     jsin.read( "dodge_bonus", dodge_bonus );
     jsin.read( "block_bonus", block_bonus );
     jsin.read( "hit_bonus", hit_bonus );
+    jsin.read( "bash_bonus", bash_bonus );
+    jsin.read( "cut_bonus", cut_bonus );
+    jsin.read( "size_bonus", size_bonus );
 
     jsin.read( "underwater", underwater );
 


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

So, a while back https://github.com/cataclysmbnteam/Cataclysm-BN/pull/89 removed code effects for some effect properties that're still used in effect JSON. Plus it'd be nice to have for the benefit of modders. On top of that, I figured I'd go ahead and use the effects for some more stuff as well.

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/5705

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

C++ changes:
1. In creature.cpp and creature.h, re-added `bash_bonus`, `cut_bonus`, and `size_bonus` updates to `Creature::reset_bonuses`, re-added functions `Creature::get_bash_bonus` `Creature::get_cut_bonus` `Creature::mod_bash_bonus` `Creature::mod_cut_bonus` and `Creature::mod_size_bonus`, re-added ability to mod bash/cut bonus in `Creature::mod_stat`.
2. In mattack_actors.cpp, set it so `melee_actor::call` takes bash and cut bonuses from effects into account.
3. In monster.cpp, re-added calls to bonus modifier functions removed from `monster::process_one_effect`, and re-added effect of size bonus to `monster::get_size`. The size bonus has also been tweaked to `std::min` it, since I discovered in testing that too big a bonus to an effect's `size_mod` can cause the game to crash since the monster's size was pushed out of range. Set `monster::is_immune_effect` to make stun-immune monsters immune to being dazed (and monsters unable to hear immune to deafness, used to prevent being dazed by screechers), fixed smoke/gas effects potentially being able to affect monsters with `NO_BREATHE`, and made sure bleed can't effect creatures not made of flesh. Finally, `monster::melee_attack` set to take into account bash and cut bonuses from effects.
4. In savegame.json, re-added bash and cut bonuses to `Creature::store` and `Creature::load`.

JSON changes:
1. Set fusion effect to show in monster info and gave a less odd name, to make it visible which devourers have been affected by this.
2. All effects applicable to monsters that debuff strength now affect monster `bash_mod` and `cut_mod` by the same amount, and likewise all dex penalties affect monster `hit_mod` and `dodge_mod` by the same amounts.
3. Updated effects in mods accordingly. Foamcreate can mess with monsters dodging, casting bless on a pet will buff its attacks too, etc.

Documentaton changes:
1. Actually document monster-specific effects in effect_json.md

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Making monsters with `NO_BREATHE` flat-out immune to poison and bleeding, this would make stinger arrows less useful though.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON files for syntax and lint errors.
2. Compiled and load-tested.
3. Observed a dissoluted devourer, it goes up in size after eating enough zeds.
4. Pushed the size_mod bonus for fusion effect up higher, confirmed that it no longer crashes on examining a monster boosted past the limits of sanity. Also confirmed that making it shrink the target to an absurd amount also worked with no crashing.
5. Tested giving fusion a much bigger `bash_mod` bonus and as expected get pasted in one hit, also tested that negative values correctly cause it to deal no damage.
6. Confirmed `cut_mod` works the same way, and that negative cut values don't do anything weird. Also confirmed it correctly affected claw attacks.
7. Tested that dodge and hit mods work as expected by confirming a devourer given absurdly high bonuses by a modified effect becomes untouchable and able to hit a player with 10 dodge.
8. Waited out the fusion duration with bash bonus set stupid high and the code temporarily set to not give 10 whole days of fusion, don't get pulped after it wears off.
9. Tested and confirmed screechers can no longer daze each other with their screams, and zombies can no longer suffer smoke inhalation from being hotboxed.
10. Checked affected C++ files for astyle.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
