### PR TITLE
feat(balance): Overhaul military drops

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/map_extras.json
+++ b/data/json/itemgroups/Locations_MapExtras/map_extras.json
@@ -18,7 +18,7 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "map_extra_military",
-    "entries": [ { "group": "mon_zombie_soldier_death_drops" }, { "item": "corpse", "damage": 3 } ]
+    "entries": [ { "group": "military_corpse_extra_items" }, { "item": "corpse", "damage": 3 } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -176,7 +176,7 @@
     "id": "infantry_common_gear",
     "subtype": "collection",
     "entries": [
-      { "item": "e_tool", "prob": 60 },
+      { "item": "e_tool", "prob": 50 },
       { "item": "mask_gas", "prob": 20 },
       { "item": "two_way_radio", "prob": 60 },
       { "item": "sheath", "contents-item": "knife_combat", "prob": 80 }
@@ -186,16 +186,16 @@
     "type": "item_group",
     "id": "infantry_officer_gear",
     "subtype": "collection",
-    "entries": [ { "item": "binoculars", "prob": 90 }, { "item": "id_military", "prob": 90 } ]
+    "entries": [ { "item": "binoculars", "prob": 90 }, { "item": "id_military", "prob": 40 } ]
   },
   {
     "type": "item_group",
     "id": "infantry_medical_gear",
     "subtype": "collection",
     "entries": [
-      { "item": "1st_aid", "prob": 90 },
-      { "item": "quikclot", "prob": 60 },
-      { "collection": [ { "item": "morphine" }, { "item": "syringe" } ], "prob": 30 }
+      { "item": "1st_aid", "prob": 80 },
+      { "item": "quikclot", "prob": 70 },
+      { "collection": [ { "item": "morphine" }, { "item": "syringe" } ], "prob": 40 }
     ]
   },
   {

--- a/data/json/monsterdrops/zombie_soldier.json
+++ b/data/json/monsterdrops/zombie_soldier.json
@@ -13,12 +13,35 @@
         ]
       },
       { "group": "infantry_common_gear" },
-      { "group": "military_standard_guns", "prob": 10, "damage": [ 0, 3 ], "dirt": [ 1500, 7050 ] },
+      { "group": "military_standard_guns", "prob": 20, "damage": [ 1, 3 ], "dirt": [ 1500, 7050 ] },
       { "item": "holster" },
-      { "group": "military_standard_pistols", "prob": 30, "damage": [ 0, 2 ], "dirt": [ 0, 1500 ] },
       { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 20 },
+      { "group": "military_standard_pistols", "prob": 50, "damage": [ 0, 2 ], "dirt": [ 0, 1500 ] },
       { "group": "military_patrol_food" },
-      { "distribution": [ { "group": "infantry_officer_gear" }, { "group": "infantry_medical_gear" } ], "prob": 25 },
+      { "distribution": [ { "group": "infantry_officer_gear" }, { "group": "infantry_medical_gear" } ], "prob": 40 },
+      { "item": "cash_card", "prob": 10, "charges": [ 0, 50000 ] },
+      { "group": "misc_smoking", "prob": 40 }
+    ]
+  },
+  {
+    "id": "military_corpse_extra_items",
+    "type": "item_group",
+    "subtype": "collection",
+    "magazine": 100,
+    "ammo": 60,
+    "entries": [
+      {
+        "distribution": [
+          { "group": "clothing_soldier_set", "prob": 65, "damage": [ 1, 4 ] },
+          { "group": "clothing_soldier_winter_set", "prob": 35, "damage": [ 1, 4 ] }
+        ]
+      },
+      { "group": "infantry_common_gear" },
+      { "group": "military_standard_guns_no_explosives", "prob": 20, "damage": [ 1, 3 ], "dirt": [ 1500, 7050 ] },
+      { "item": "holster" },
+      { "group": "military_standard_pistols", "prob": 50, "damage": [ 0, 2 ], "dirt": [ 0, 1500 ] },
+      { "group": "military_patrol_food", "prob": 80 },
+      { "distribution": [ { "group": "infantry_officer_gear" }, { "group": "infantry_medical_gear" } ], "prob": 20 },
       { "item": "cash_card", "prob": 10, "charges": [ 0, 50000 ] },
       { "group": "misc_smoking", "prob": 30 }
     ]
@@ -68,6 +91,18 @@
       { "group": "military_standard_sniper_rifles", "prob": 10 },
       { "group": "military_standard_shotguns", "prob": 5 },
       { "group": "military_standard_antitank", "prob": 5 }
+    ]
+  },
+  {
+    "id": "military_standard_guns_no_explosives",
+    "type": "item_group",
+    "subtype": "distribution",
+    "//": "Let's dial back random corpses spawning with rocket launchers, the other group still spawns in other locations as of writing",
+    "entries": [
+      { "group": "military_standard_assault_rifles", "prob": 60 },
+      { "group": "military_standard_lmgs", "prob": 20 },
+      { "group": "military_standard_sniper_rifles", "prob": 15 },
+      { "group": "military_standard_shotguns", "prob": 5 }
     ]
   },
   {


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Military corpse drops needed checking. They had issues with what they spawned and how often

## Describe the solution

Split soldier zeds with pre-existing corpses:

**Both** groups have less shovels, keycards, and first aid kits, but more hemostatic powder and morphine

Soldier Zeds have more guns but damage is guaranteed on the primary weapon spawn. Because you fight them they can keep grenades and rockets.

Corpses have more handguns and a higher chance for primary weapon but can't spawn with grenades, rocket launchers, or grenade launchers. Those are too powerful for corpse spawns. They also have a little less food and medicals.

Overall you're going to find more hardware but less super powered weapons, less free items, and if you find a primary it will have damage.

## Describe alternatives you've considered

MORE GUNS, LESS GUNS, Make Chaos do it!

## Testing

Should work perfectly.

## Additional context

0.5% chance per corpse for a rocket launcher. Insane.
