### PR TITLE
feat(balance): Gate map extra nether enemy spawns by time, campers get handguns

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/map_extras.json
+++ b/data/json/itemgroups/Locations_MapExtras/map_extras.json
@@ -28,6 +28,7 @@
       { "group": "default_zombie_clothes" },
       { "group": "bags", "damage": [ 1, 4 ] },
       { "group": "default_zombie_items_pockets", "prob": 50 },
+      { "group": "carried_guns_pistol_common", "prob": 5 },
       { "group": "camping", "prob": 75, "count": [ 1, 2 ] },
       {
         "distribution": [ { "group": "fridge_alcohol_random", "prob": 75 }, { "group": "smokedrugs", "prob": 25 } ],
@@ -97,7 +98,7 @@
           { "group": "guns_hunting", "prob": 75, "damage": [ 0, 2 ], "dirt": [ 0, 1000 ] },
           { "group": "archery_hunting", "prob": 25, "damage": [ 0, 2 ] }
         ],
-        "prob": 25
+        "prob": 75
       },
       { "item": "corpse", "damage": 3 }
     ]

--- a/data/json/monstergroups/nether.json
+++ b/data/json/monstergroups/nether.json
@@ -66,11 +66,11 @@
     "name": "GROUP_NETHER_CAPTURED",
     "default": "mon_gracke",
     "monsters": [
-      { "monster": "mon_gelatin", "freq": 250, "cost_multiplier": 0 },
-      { "monster": "mon_mi_go", "freq": 250, "cost_multiplier": 0 },
+      { "monster": "mon_gelatin", "freq": 250, "cost_multiplier": 0, "starts": 240 },
+      { "monster": "mon_mi_go", "freq": 250, "cost_multiplier": 0, "starts": 720 },
       { "monster": "mon_mi_go_scout", "freq": 250, "cost_multiplier": 0, "starts": 840 },
-      { "monster": "mon_kreck", "freq": 250, "cost_multiplier": 0 },
-      { "monster": "mon_gracke", "freq": 250, "cost_multiplier": 0 }
+      { "monster": "mon_kreck", "freq": 250, "cost_multiplier": 0, "starts": 480 },
+      { "monster": "mon_gracke", "freq": 250, "cost_multiplier": 0, "starts": 240 }
     ]
   },
   {


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Camper map extra is likely the worst in the game, it spawns mi-gos on day 1 and no firearms. Nobody loots them, except as an act of desperation or if the Mi-go got lost. Sometimes a kreck will be the problem instead so you can club those but it's not usually worth taking a kreck for the existing loot.

## Describe the solution

Gatekeep all the spawns in GROUP_NETHER_CAPTURED by time, according to Chaos this will gate it and mi-go scouts were gated correctly. Adds a 5% roll for handguns on all campers, so 1 in 20 college students were camping with hardware.

It's going to become a tiny source of early game weapons that teeters off in usefulness lategame and in general make map extras a lot safer for fresh spawns.

Also, hunters are much more likely to ACTUALLY HAVE A WEAPON TO HUNT WITH. It's almost like sane individuals use ranged weaponry to hunt. Hunters are a potential outcome of the campers but are not that frequent.

## Describe alternatives you've considered

Gate the map extras by start and end time, but this is code requirements we don't have

## Testing

Tests

## Additional context

Someone pisses me off but I don't know who did day 1 mi-go's outside of evac shelters. It's the owlbear of baseline gameplay.