### PR TITLE
feat: Allow power armor weapon racks to sheath spears

### DIFF
--- a/data/json/items/armor/power_armor.json
+++ b/data/json/items/armor/power_armor.json
@@ -436,7 +436,7 @@
       "max_volume": "10 L",
       "min_volume": "1500 ml",
       "draw_cost": 150,
-      "flags": [ "SHEATH_SWORD", "SHEATH_AXE" ],
+      "flags": [ "SHEATH_SWORD", "SHEATH_AXE", "SHEATH_SPEAR" ],
       "skills": [ "smg", "shotgun", "rifle", "launcher" ]
     },
     "flags": [ "POWERARMOR_MOD", "COMPACT", "BELTED", "NO_QUICKDRAW", "ONLY_ONE" ]


### PR DESCRIPTION
## Checklist
### Required

* [x]  I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
* [ ]  I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
* [ ]  I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
* [x]  I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.


## Purpose of change
The power armor weapon rack has the maximum volume required to sheath a lucerne hammer (and is the *only* sheath with this distinction), and seems to be set up to allow storing nearly any melee weapon, but a missing flag prevents this.

## Describe the solution
Add ``"SHEATH_SPEAR"`` to ``power_armor_back_hardpoint``'s ``"use_action"/"flags"`` field.

## Testing
Inserted and removed a lucerne hammer and survivor naginata without issue.