### PR TITLE
feat(content): Add domestic window variants on request for tilesets

### DIFF
--- a/data/json/furniture_and_terrain/terrain-windows.json
+++ b/data/json/furniture_and_terrain/terrain-windows.json
@@ -58,7 +58,7 @@
     "close": "t_curtains",
     "open": "t_window_open",
     "deconstruct": {
-      "ter_set": "t_window_empty",
+      "ter_set": "t_window_empty_domestic",
       "items": [
         { "item": "stick", "count": 1 },
         { "item": "sheet", "count": 2 },
@@ -87,7 +87,7 @@
       "break_sound": "glass breaking!",
       "difficulty": 11,
       "new_ter_type": "t_window_open",
-      "break_ter_type": "t_window_frame",
+      "break_ter_type": "t_window_frame_domestic",
       "break_items": [
         { "item": "glass_shard", "count": [ 1, 3 ] },
         { "item": "sheet", "count": 2 },
@@ -121,7 +121,7 @@
       "break_sound": "glass breaking!",
       "difficulty": 11,
       "new_ter_type": "t_window_no_curtains_open",
-      "break_ter_type": "t_window_frame",
+      "break_ter_type": "t_window_frame_domestic",
       "break_items": [ { "item": "glass_shard", "count": [ 1, 3 ] } ]
     }
   },
@@ -219,7 +219,7 @@
     "open": "t_window_domestic",
     "examine_action": "curtains",
     "deconstruct": {
-      "ter_set": "t_window_empty",
+      "ter_set": "t_window_empty_domestic",
       "items": [
         { "item": "stick", "count": 1 },
         { "item": "sheet", "count": 2 },
@@ -248,7 +248,7 @@
       "break_sound": "glass breaking!",
       "difficulty": 11,
       "new_ter_type": "t_window_open",
-      "break_ter_type": "t_window_frame",
+      "break_ter_type": "t_window_frame_domestic",
       "break_items": [
         { "item": "glass_shard", "count": [ 1, 3 ] },
         { "item": "sheet", "count": 2 },
@@ -314,8 +314,66 @@
   },
   {
     "type": "terrain",
+    "id": "t_window_empty_domestic",
+    "looks_like": "t_window_empty",
+    "name": "empty domestic window",
+    "roof": "t_flat_roof",
+    "description": "An empty window frame consisting of two by fours and nails.  You could install a sheet of glass, or even board it up for protection.  You could also convert it into a wall if you took the time to construct it.",
+    "symbol": "0",
+    "color": "yellow",
+    "move_cost": 4,
+    "coverage": 60,
+    "flags": [
+      "TRANSPARENT",
+      "NOITEM",
+      "FLAMMABLE",
+      "SUPPORTS_ROOF",
+      "MOUNTABLE",
+      "CONNECT_TO_WALL",
+      "THIN_OBSTACLE",
+      "SMALL_PASSAGE",
+      "PERMEABLE"
+    ],
+    "bash": {
+      "str_min": 10,
+      "str_max": 70,
+      "sound": "crunch!",
+      "sound_fail": "whump!",
+      "ter_set": "t_null",
+      "items": [
+        { "item": "2x4", "count": [ 0, 5 ] },
+        { "item": "nail", "charges": [ 0, 5 ] },
+        { "item": "splinter", "count": [ 5, 10 ] }
+      ]
+    }
+  },
+  {
+    "type": "terrain",
     "id": "t_window_frame",
     "name": "window frame",
+    "description": "A wooden window frame that has shattered glass around it.  You'll probably get hurt if you crawled through the sharp and jagged shards.  You could smash out the remaining pieces, or take your time and quietly clean them up.",
+    "symbol": "0",
+    "color": "light_cyan",
+    "move_cost": 8,
+    "coverage": 60,
+    "roof": "t_flat_roof",
+    "bash": {
+      "str_min": 1,
+      "str_max": 1,
+      "sound": "glass crunching!",
+      "sound_fail": "whack!",
+      "sound_vol": 12,
+      "sound_fail_vol": 8,
+      "ter_set": "t_window_empty",
+      "items": [ { "item": "glass_shard", "count": [ 0, 1 ] } ]
+    },
+    "flags": [ "TRANSPARENT", "SHARP", "FLAMMABLE", "NOITEM", "MOUNTABLE", "CONNECT_TO_WALL", "SMALL_PASSAGE", "PERMEABLE" ]
+  },
+  {
+    "type": "terrain",
+    "id": "t_window_frame_domestic",
+    "looks_like": "t_window_frame",
+    "name": "domestic window frame",
     "description": "A wooden window frame that has shattered glass around it.  You'll probably get hurt if you crawled through the sharp and jagged shards.  You could smash out the remaining pieces, or take your time and quietly clean them up.",
     "symbol": "0",
     "color": "light_cyan",


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

There was a request to add another variant of broken and empty window frame for tilesets.

## Describe the solution

Two new variants, with specific windows using the new variant based on request.

## Describe alternatives you've considered

More?

## Testing

Tests. They have looks_like so nothing to see

## Additional context