### PR TITLE
fix: Stop electric chainsaw lajatangs from reverting to gasoline

### DIFF
--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -1592,7 +1592,7 @@
     "charges_per_use": 0,
     "revert_to": "ecs_lajatang_off",
     "revert_msg": "Your chainsaw lajatang goes quiet",
-    "use_action": { "type": "transform", "target": "cs_lajatang_off", "msg": "You turn off the chainsaw lajatang." },
+    "use_action": { "type": "transform", "target": "ecs_lajatang_off", "msg": "You turn off the chainsaw lajatang." },
     "qualities": [ [ "BUTCHER", -250 ] ],
     "flags": [ "MESSY", "DURABLE_MELEE", "TRADER_AVOID", "NONCONDUCTIVE", "ALWAYS_TWOHAND", "WATER_DISABLE" ],
     "magazine_well": "1000 ml"


### PR DESCRIPTION
## Checklist

### Required
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Presently, turning off an electric chainsaw (ECS) lajatang turns it into a normal chainsaw (CS) lajatang; i.e., it transforms into one that uses gasoline. If you ever turn off an ECS lajatang, it ceases to be an ECS lajatang and can't be restored.

## Describe the solution
Fixed a typo in ``items/melee/swords_and_blades.json``; the ECS lajatang (on)'s ``use_action`` specified it should become ``cs_lajatang_off`` instead of ``ecs_lajatang_off``.

## Testing
Turned an ECS lajatang off and on again to confirm resolution of its identity crisis.

## Additional context
![image](https://github.com/user-attachments/assets/14c94a0e-d31f-4d7d-aebd-dbe3aab23d0a)
Interestingly, if the ECS lajatang had a UPS mod installed, it will 'charge' the CS lajatang's gasoline tank when not in use.