### PR TITLE
fix: make grid plut gens deconstructible again

### DIFF
--- a/data/json/deconstruction.json
+++ b/data/json/deconstruction.json
@@ -896,7 +896,7 @@
   },
   {
     "type": "construction",
-    "id": "constr_remove_plut_generator",
+    "id": "constr_remove_grid_plut_generator",
     "//": "Removes a Plut Gen from grid.",
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 2 ], [ "electronics", 6 ] ],


### PR DESCRIPTION
## Checklist
### Required

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [ ] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
## Purpose of change

When I did the last PR on electrical terrain deconstruction I did a new recipe to deconstruct grid gens which was a copy paste. I didn't rename it and nobody caught it in testing that we had identical deconstructs. We also lack a test to ensure no duplicate ID's in the same document or in the main project as a whole.

## Describe the solution

Add grid_ to the name of the other deconstruct

## Describe alternatives you've considered

Make Chaos do it, It's graveyard day and I'm watching the dumpster fire of Stalker 2 right now.

## Testing

Tests because this is trivial

## Additional context