### PR TITLE
fix: electrosense CBM's voltmeter can be used in advanced deconstruction

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1301,6 +1301,7 @@
     "name": { "str": "Electrosense Voltmeter" },
     "description": "Using this bionic allows you to check the status of any local grid connections or battery charge in your surroundings, as well as make modifications to grid connections.",
     "act_cost": "10 J",
+    "fake_item": "voltmeter_bionic",
     "included": true
   },
   {

--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -48,6 +48,16 @@
     ]
   },
   {
+    "id": "voltmeter_bionic",
+    "sub": "voltmeter",
+    "copy-from": "fake_item",
+    "type": "TOOL",
+    "name": { "str": "integrated voltmeter" },
+    "flags": [ "TRADER_AVOID", "USES_BIONIC_POWER" ],
+    "max_charges": 10000,
+    "use_action": [ "REPORT_GRID_CHARGE", "REPORT_GRID_CONNECTIONS", "MODIFY_GRID_CONNECTIONS" ]
+  },
+  {
     "id": "fake_goggles",
     "copy-from": "fake_item",
     "type": "TOOL",

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1096,7 +1096,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
     } else if( bio.id == bio_electrosense_voltmeter ) {
         add_msg_activate();
         item *vtm;
-        vtm = item::spawn_temporary( "voltmeter", calendar::start_of_cataclysm );
+        vtm = item::spawn_temporary( "voltmeter_bionic", calendar::start_of_cataclysm );
         invoke_item( vtm );
     } else {
         add_msg_activate();

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -203,6 +203,7 @@ static const itype_id itype_rope_6( "rope_6" );
 static const itype_id itype_snare_trigger( "snare_trigger" );
 static const itype_id itype_string_36( "string_36" );
 static const itype_id itype_toolset( "toolset" );
+static const itype_id itype_voltmeter_bionic( "voltmeter_bionic" );
 static const itype_id itype_UPS( "UPS" );
 static const itype_id itype_UPS_off( "UPS_off" );
 static const itype_id itype_power_storage( "bio_power_storage" );
@@ -10044,6 +10045,10 @@ std::vector<detached_ptr<item>> Character::use_charges( const itype_id &what, in
 {
     std::vector<detached_ptr<item>> res;
     if( qty <= 0 ) {
+        return res;
+
+    } else if( what == itype_voltmeter_bionic ) {
+        mod_power_level( units::from_kilojoule( -qty ) );
         return res;
 
     } else if( what == itype_toolset ) {

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -89,6 +89,7 @@ static const trait_id trait_BURROW( "BURROW" );
 static const trait_id trait_DEBUG_HS( "DEBUG_HS" );
 static const trait_id trait_HYPEROPIC( "HYPEROPIC" );
 
+static const flag_id flag_BIONIC_TOGGLED( "BIONIC_TOGGLED" );
 static const std::string flag_BLIND_EASY( "BLIND_EASY" );
 static const std::string flag_BLIND_HARD( "BLIND_HARD" );
 static const std::string flag_FULL_MAGAZINE( "FULL_MAGAZINE" );
@@ -562,7 +563,7 @@ const inventory &Character::crafting_inventory( const tripoint &src_pos, int rad
     cached_crafting_inventory += worn;
     for( const bionic &bio : *my_bionics ) {
         const bionic_data &bio_data = bio.info();
-        if( ( !bio_data.activated || bio.powered ) &&
+        if( ( !bio_data.has_flag( flag_BIONIC_TOGGLED ) || bio.powered ) &&
             !bio_data.fake_item.is_empty() ) {
             cached_crafting_inventory += *item::spawn_temporary( bio.info().fake_item,
                                          calendar::turn, units::to_kilojoule( get_power_level() ) );

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -35,6 +35,7 @@
 static const itype_id itype_apparatus( "apparatus" );
 static const itype_id itype_adv_UPS_off( "adv_UPS_off" );
 static const itype_id itype_toolset( "toolset" );
+static const itype_id itype_voltmeter_bionic( "voltmeter_bionic" );
 static const itype_id itype_UPS( "UPS" );
 static const itype_id itype_UPS_off( "UPS_off" );
 static const itype_id itype_bio_armor( "bio_armor" );
@@ -42,6 +43,7 @@ static const itype_id itype_bio_armor( "bio_armor" );
 static const quality_id qual_BUTCHER( "BUTCHER" );
 
 static const bionic_id bio_tools( "bio_tools" );
+static const bionic_id bio_electrosense_voltmeter( "bio_electrosense_voltmeter" );
 static const bionic_id bio_ups( "bio_ups" );
 
 static const flag_id flag_BIONIC_ARMOR_INTERFACE( "BIONIC_ARMOR_INTERFACE" );
@@ -1054,6 +1056,14 @@ int visitable<Character>::charges_of( const itype_id &what, int limit,
         }
     }
 
+    if( what == itype_voltmeter_bionic ) {
+        if( p && p->has_bionic( bio_electrosense_voltmeter ) ) {
+            return std::min( units::to_kilojoule( p->get_power_level() ), limit );
+        } else {
+            return 0;
+        }
+    }
+
     if( what == itype_bio_armor ) {
         float efficiency = 1;
         int power_charges = 0;
@@ -1164,6 +1174,10 @@ int visitable<Character>::amount_of( const itype_id &what, bool pseudo, int limi
     auto self = static_cast<const Character *>( this );
 
     if( what == itype_toolset && pseudo && self->has_active_bionic( bio_tools ) ) {
+        return 1;
+    }
+
+    if( what == itype_voltmeter_bionic && pseudo && self->has_bionic( bio_electrosense_voltmeter ) ) {
         return 1;
     }
 


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Now that we have a case where the voltmeter's actually being used as a tool, it'd be good to extend the voltmeter function of the electrosense CBM to be usable for that too.

As a side bonus it comes with taking us another step closer to being able to do more with JSONized bionic functions.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

C++ changes:
1. In bionics.cpp, set it so that electrosense's voltmeter uses a different fake item specified below. Nothing really changes with this in how the bionic works when activated, but good for consistency and for later plans I had in mind involving JSONization of activating bionics.
2. In character.cpp, updated `Character::use_charges` to handle charge use when drawing on electrosenses' voltmeter as a tool.
3. In crafting.cpp, set `Character::crafting_inventory` so that the check for bionic fake items looks for static fake items that lack the `BIONIC_TOGGLED` flag, instead of demanding the bionic can't be toggle-able AT ALL. This is needed so that the electrosense's voltmeter function still allows being activated to access the voltmeter's use action without the presence of `act_cost` breaking its `fake_item`, but as a side benefit this will allow us to assign fake items to any bionic with existing hardcoded on-activate effects if desired, and potentially allow for JSONizing on-activate bionics by one day letting them just access a fake item's use action info.
4. In visitable.cpp, updated `visitable<Character>::charges_of` and `visitable<Character>::amount_of` to take electrosense voltmeter into account.

JSON changes:
1. Defined a fake item for electrosense to use that draws from bionic power. Counts as a substitute tool for the voltmeter.
2. Gave the electrosense bionic's voltmeter function the integrated voltmeter as `fake_item`, so it can be used as one for tool purposes (like deconstructing high-voltage electronics).

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Reworking voltmeters to need power to activate at some point in the future. This can probably wait until after Kheir's joule rework.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON files for syntax and lint errors.
2. Compiled and load-tested.
3. Gave myself bionic power and electrosense CBM. Confirmed it still works as expected when activated, and that it counts as a voltmeter for the purpose of deconstructing a plutonium generator.
4. Confirmed electrosense lets me deconstruct a plutonium generated, and it drains 10 kj as expected.
5. Confirmed if I don't have enough bionic power I can't attempt the deconstruct, and that nothing weird happens if I leave hydraulic muscles running while I deconstruct stuff.
6. Re-tested as a razor boy, confirmed I still have razors for the sake of butchering and dissecting.
7. Tested installing a bionic blade on a normal character, confirmed that toggling it on still works and that I don't gain access to its cutting quality unless it's deployed, as before.
8. Checked affected C++ files for astyle.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

One thing I could follow up on this with would be taking advantage of now being able to assign fake items to activatable bionics and defining a fake item that'd allow dielectric capacitance to serve as a substitute for rubber gloves in the relevant crafting requirement, though this might require me to build up more support for charge consumption of JSONized bionic fake items.