### PR TITLE
fix: change the scooter position in `res_backyard_scooter`

### DIFF
--- a/data/json/mapgen/nested/residential_lawn_nested.json
+++ b/data/json/mapgen/nested/residential_lawn_nested.json
@@ -672,8 +672,8 @@
         "___"
       ],
       "terrain": { "_": "t_null" },
-      "place_vehicles": [ { "vehicle": "scooter_electric", "x": 0, "y": 3, "chance": 50, "status": 1, "rotation": 0 } ],
-      "place_loot": [ { "item": "tarp", "x": 1, "y": 3 } ]
+      "place_vehicles": [ { "vehicle": "scooter_electric", "x": 1, "y": 2, "chance": 50, "status": 1, "rotation": 0 } ],
+      "place_loot": [ { "item": "tarp", "x": 2, "y": 2 } ]
     }
   },
   {


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
because the scooter and its tarpaulin are placed outside the nested mapgen boundary.
## Describe the solution
I changed the position of the scooter and the tarpaulin.
## Describe alternatives you've considered
none
## Additional context
Before:
![image1](https://github.com/user-attachments/assets/3e991e0d-f909-44bf-9712-40286644ff6e)
After:
![image2](https://github.com/user-attachments/assets/5379a424-0638-45d0-985e-32a326b33e96)