### PR TITLE
fix: remove `cash` property from `player` class to use `cash` from `Character` for Lua

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -33,6 +33,7 @@
     "jsr:@std/toml@^1.0.1": "1.0.2",
     "jsr:@std/yaml@^1.0.5": "1.0.5",
     "jsr:@valibot/valibot@*": "0.42.1",
+    "npm:dprint@*": "0.47.5",
     "npm:ts-pattern@5.0.5": "5.0.5",
     "npm:type-fest@*": "4.27.0"
   },
@@ -154,6 +155,43 @@
     }
   },
   "npm": {
+    "@dprint/darwin-arm64@0.47.5": {
+      "integrity": "sha512-aVa3F//dkvEeNA7DCSlVcLxB0CV6zXpfbJZ/xsd+xgbayCXFuFr7qt0M6T4WP3gkQn5D7Zu8/pbXfRXQXo9qlQ=="
+    },
+    "@dprint/darwin-x64@0.47.5": {
+      "integrity": "sha512-84lmSLM/idIQ4UBkBHU1chP0WTldRjzLOEN22/XbdB1JGOIVN1pJIIU0lsmVWXaNI4SvGfty+thhGn73SSlQwA=="
+    },
+    "@dprint/linux-arm64-glibc@0.47.5": {
+      "integrity": "sha512-Zk7Ut9Trgl2ssGWx0u3YegnRQFXivKaK1fPEimg/uMwdaLtWFGvNs6DACAJk34d883zmDkTQvllqY1kc78CeBg=="
+    },
+    "@dprint/linux-arm64-musl@0.47.5": {
+      "integrity": "sha512-KmCu1yX5+/2MbT9n0iAgSK1gc6sQBcDayq8QRO7TRSs+gTDAZ/yQXHkhLdlk5fWsTR1mDQPVRG+2nAjHDhk8EA=="
+    },
+    "@dprint/linux-x64-glibc@0.47.5": {
+      "integrity": "sha512-oBwENMikvcM+eT6JdliMIM+TOiV4VuBJGK+AN1sTOW45VeiYvmzGPOQwCxVeFq4MnZkMfrycC/PAY3C7Vcuh6w=="
+    },
+    "@dprint/linux-x64-musl@0.47.5": {
+      "integrity": "sha512-B1IGyaP0k25JDhqmR/UpvgyNtnclBoXV7ZNQbvygehBkTeC69afwzpUxjQ2pKj2F9bl1Rby//fhsAFOg60PzsA=="
+    },
+    "@dprint/win32-arm64@0.47.5": {
+      "integrity": "sha512-tKSPwGWsKc+QAdsx6UQav9AY8WXm+B5Mx23ujliJJMRss6Dnlmg17NjbAnSBSqXSrfqaMeQx6d4gujPpOS3F9A=="
+    },
+    "@dprint/win32-x64@0.47.5": {
+      "integrity": "sha512-ljbrGv5rDR00ziBFY6V+qLhtLHm2dsjgiFG9OU7kr3vHEj4eN31nwxU5W2mh0eMoRk7IbcJ5ahTJDLgoYdvfgw=="
+    },
+    "dprint@0.47.5": {
+      "integrity": "sha512-EAP3OLYZXiW66HKMlhu6Gu0o7mzBVTWyMyuAAgT7dBtMX+W+pPJmIwyRUnTRQNyyFO4S7bAaa21rzIgo97Bg9A==",
+      "dependencies": [
+        "@dprint/darwin-arm64",
+        "@dprint/darwin-x64",
+        "@dprint/linux-arm64-glibc",
+        "@dprint/linux-arm64-musl",
+        "@dprint/linux-x64-glibc",
+        "@dprint/linux-x64-musl",
+        "@dprint/win32-arm64",
+        "@dprint/win32-x64"
+      ]
+    },
     "ts-pattern@5.0.5": {
       "integrity": "sha512-tL0w8U/pgaacOmkb9fRlYzWEUDCfVjjv9dD4wHTgZ61MjhuMt46VNWTG747NqW6vRzoWIKABVhFSOJ82FvXrfA=="
     },

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -104,7 +104,6 @@ player::player()
     blocks_left = 1;
     set_power_level( 0_kJ );
     set_max_power_level( 0_kJ );
-    cash = 0;
     scent = 500;
     male = true;
     remove_primary_weapon();

--- a/src/player.h
+++ b/src/player.h
@@ -242,7 +242,6 @@ class player : public Character
         // Save favorite ammo location
         //TODO!: check this
         safe_reference<item> ammo_location;
-        int cash = 0;
         int movecounter = 0;
 
         bool manual_examine = false;


### PR DESCRIPTION
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have committed my changes to new branch that isn't `main`.

## Purpose of change

Lua currently only binds the `cash` property of `Character`, not `player`, therefore Lua cannot access the actual cash value of NPCs and avatar. Removing the duplicate `cash` from `player` will make C++ use `Character`'s `cash` and for the Lua to work.

## Describe alternatives you've considered

- None.

## Testing

1. Testing whether existing characters retain their cash:
   1. Made a new character with a version of the game prior to this change;
   2. Placed an ATM terrain and spawned a cash card item;
   3. Deposited some cash into the ATM;
   4. Saved and exited the game;
   5. Loaded the character in a version with the changes;
   6. Checked the ATM;
   7. The cash amount displayed by the ATM didn't change.
2. Testing whether LUA can change the cash amount now:
   1. Loaded a character;
   2. Placed an ATM terrain;
   3. Checked the current cash amount through the ATM;
   4. Opened the Lua console;
   5. Changed the cash amount through Lua to be different, e.g. `gapi.get_avatar().cash = 50`;
   6. Checked the current cash amount through the ATM and found it to be the new value.

### Additional context
 - [Complaint made about being unable to set the player's cash through Lua in the Discord server](https://discord.com/channels/830879262763909202/830916451517857894/1287218816249757706).