### PR TITLE
feat(UI, port): Port hiding traits/mutations from DDA

### DIFF
--- a/data/raw/keybindings/keybindings.json
+++ b/data/raw/keybindings/keybindings.json
@@ -1885,6 +1885,13 @@
   },
   {
     "type": "keybinding",
+    "id": "TOGGLE_SPRITE",
+    "category": "MUTATIONS",
+    "name": "Toggle sprite",
+    "bindings": [ { "input_method": "keyboard", "key": "," } ]
+  },
+  {
+    "type": "keybinding",
     "name": "View/Activate Mutations",
     "category": "DEFAULTMODE",
     "id": "mutations",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3662,6 +3662,9 @@ std::vector<std::string> Character::get_overlay_ids() const
 
     // then get mutations
     for( const std::pair<const trait_id, char_trait_data> &mut : my_mutations ) {
+        if( !mut.second.show_sprite ) {
+            continue;
+        }
         overlay_id = ( mut.second.powered ? "active_" : "" ) + mut.first.str();
         order = get_overlay_order_of_mutation( overlay_id );
         mutation_sorting.insert( std::pair<int, std::string>( order, overlay_id ) );

--- a/src/character.h
+++ b/src/character.h
@@ -218,6 +218,7 @@ struct char_trait_data {
      * is reset to @ref mutation_branch::cooldown.
      */
     int charge = 0;
+    bool show_sprite = true;
     void serialize( JsonOut &json ) const;
     void deserialize( JsonIn &jsin );
 };

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -616,6 +616,9 @@ detail::mutations_ui_result detail::show_mutations_ui_internal( Character &who )
                             // Describing mutations, not activating them!
                             examine_id = mut_id;
                             break;
+                        case mutation_menu_mode::hidding:
+                            who.my_mutations[mut_id].show_sprite = !who.my_mutations[mut_id].show_sprite;
+                            break;
                     }
                 }
             } else if( action == "REASSIGN" ) {

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -39,7 +39,7 @@ enum class mutation_menu_mode {
     activating,
     examining,
     reassigning,
-    hidding,
+    hiding,
 };
 enum class mutation_tab_mode {
     active,
@@ -79,8 +79,8 @@ static void show_mutations_titlebar( const catacurses::window &window,
                           c_light_blue ) + "  " + shortcut_desc( _( "%s to activate mutation, " ),
                                   ctxt.get_desc( "TOGGLE_EXAMINE" ) );
     }
-    if( menu_mode == mutation_menu_mode::hidding ) {
-        desc += colorize( _( "Hidding" ), c_cyan ) + "  " + shortcut_desc( _( "%s to activate mutation, " ),
+    if( menu_mode == mutation_menu_mode::hiding ) {
+        desc += colorize( _( "Hiding" ), c_cyan ) + "  " + shortcut_desc( _( "%s to activate mutation, " ),
                 ctxt.get_desc( "TOGGLE_EXAMINE" ) );
     }
     if( menu_mode != mutation_menu_mode::reassigning ) {
@@ -451,7 +451,7 @@ detail::mutations_ui_result detail::show_mutations_ui_internal( Character &who )
                         // Describing mutations, not activating them!
                         examine_id = mut_id;
                         break;
-                    case mutation_menu_mode::hidding:
+                    case mutation_menu_mode::hiding:
                         who.my_mutations[*mut_id].show_sprite = !who.my_mutations[*mut_id].show_sprite;
                         break;
                 }
@@ -616,7 +616,7 @@ detail::mutations_ui_result detail::show_mutations_ui_internal( Character &who )
                             // Describing mutations, not activating them!
                             examine_id = mut_id;
                             break;
-                        case mutation_menu_mode::hidding:
+                        case mutation_menu_mode::hiding:
                             who.my_mutations[mut_id].show_sprite = !who.my_mutations[mut_id].show_sprite;
                             break;
                     }
@@ -630,7 +630,7 @@ detail::mutations_ui_result detail::show_mutations_ui_internal( Character &who )
                             mutation_menu_mode::examining : mutation_menu_mode::activating;
                 examine_id = std::nullopt;
             } else if( action == "TOGGLE_SPRITE" ) {
-                menu_mode = mutation_menu_mode::hidding;
+                menu_mode = mutation_menu_mode::hiding;
                 examine_id = std::nullopt;
             } else if( action == "QUIT" ) {
                 ret.cmd = mutations_ui_cmd::exit;

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -80,8 +80,8 @@ static void show_mutations_titlebar( const catacurses::window &window,
                                   ctxt.get_desc( "TOGGLE_EXAMINE" ) );
     }
     if( menu_mode == mutation_menu_mode::hidding ) {
-    desc += colorize( _( "Hidding" ), c_cyan ) + "  " + shortcut_desc( _( "%s to activate mutation, " ),
-            ctxt.get_desc( "TOGGLE_EXAMINE" ) );
+        desc += colorize( _( "Hidding" ), c_cyan ) + "  " + shortcut_desc( _( "%s to activate mutation, " ),
+                ctxt.get_desc( "TOGGLE_EXAMINE" ) );
     }
     if( menu_mode != mutation_menu_mode::reassigning ) {
         desc += shortcut_desc( _( "%s to reassign invlet, " ), ctxt.get_desc( "REASSIGN" ) );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -336,6 +336,7 @@ void char_trait_data::serialize( JsonOut &json ) const
     json.member( "key", key );
     json.member( "charge", charge );
     json.member( "powered", powered );
+    json.member( "show_sprite", show_sprite );
     json.end_object();
 }
 
@@ -346,6 +347,7 @@ void char_trait_data::deserialize( JsonIn &jsin )
     data.read( "key", key );
     data.read( "charge", charge );
     data.read( "powered", powered );
+    data.read( "show_sprite", show_sprite );
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This PR ports commits from DDA or other cataclysm forks.
  - [x] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [x] I have linked the URL of original PR(s) in the description.
- [x] This is a C++ PR that modifies JSON loading or behavior.

## Purpose of change

Much like with hiding clothing, hiding traits and mutations is a much-desired feature for various reasons. Considering how much it's desired and how simple it was to port, I see no reason not to bring it in.

## Describe the solution

Ports https://github.com/CleverRaven/Cataclysm-DDA/pull/52058 from DDA.

## Describe alternatives you've considered

- Reinvent the wheel
- Implode
- Explode
- Wait for someone else to do it

## Testing

It builds, it works (on my machine anyway)
![image](https://github.com/user-attachments/assets/90618701-f6ca-406d-8b10-1f07fa7dc583)
![image](https://github.com/user-attachments/assets/f7c2cea6-d37a-49b2-8fc5-22e3fe9f1f6c)


## Additional context

2/3 of the hiding visuals ports that RoyalFox threw at us done. Next up, Bionics! (For whoever ends up taking that one on)

Don't worry Chaos, this time I made sure the keybind was BN-ified the first time ;P
