### PR TITLE
feat: add generalized monster spawning on death

### DIFF
--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -249,7 +249,9 @@
     "dodge": 3,
     "harvest": "exempt",
     "special_attacks": [ [ "DOGTHING", 40 ] ],
-    "death_function": [ "THING" ],
+    "on_death": {
+      "spawn_mon": "mon_thing"
+    },
     "petfood": {
       "food": [ "DOGFOOD" ],
       "feed": "If you're seeing this message it's a bug.",
@@ -436,7 +438,9 @@
     "dodge": 4,
     "harvest": "exempt",
     "special_attacks": [ [ "TENTACLE", 5 ] ],
-    "death_function": [ "THING" ],
+    "on_death": {
+      "spawn_mon": "mon_thing"
+    },
     "flags": [ "SEES", "SMELLS", "HEARS", "BASHES" ]
   },
   {

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -249,9 +249,7 @@
     "dodge": 3,
     "harvest": "exempt",
     "special_attacks": [ [ "DOGTHING", 40 ] ],
-    "on_death": {
-      "spawn_mon": "mon_thing"
-    },
+    "on_death": { "spawn_mon": "mon_thing" },
     "petfood": {
       "food": [ "DOGFOOD" ],
       "feed": "If you're seeing this message it's a bug.",
@@ -438,9 +436,7 @@
     "dodge": 4,
     "harvest": "exempt",
     "special_attacks": [ [ "TENTACLE", 5 ] ],
-    "on_death": {
-      "spawn_mon": "mon_thing"
-    },
+    "on_death": { "spawn_mon": "mon_thing" },
     "flags": [ "SEES", "SMELLS", "HEARS", "BASHES" ]
   },
   {

--- a/doc/src/content/docs/en/mod/json/reference/creatures/monsters.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/monsters.md
@@ -318,6 +318,62 @@ see ITEM_SPAWN.md. The default subtype is "distribution".
 How the monster behaves on death. See JSON_FLAGS.md for a list of possible functions. One can add or
 remove entries in mods via "add:death_function" and "remove:death_function".
 
+## "on_death"
+
+(dictionary, optional)
+
+A collection of behaviors to apply on death. Can embed "death_function" within. If this field is
+present the field "death_function" will be skipped.
+
+```json
+"on_death": {
+  "death_function": [ "THING" ]
+}
+```
+
+Also supports
+
+### "spawn_mon"
+
+(string, optional) Spawns a single monster at the location of the dying monster
+
+```json
+"on_death": {
+  "spawn_mon": "mon_thing"
+}
+```
+
+### "spawn_mon_near"
+
+(dictionary, optional)
+
+Made up of two values:
+
+- "distance": (integer, required) maximum distance from death location to allow a monster to spawn
+- "ids": (string or array of strings, optional) ids of monsters to try to spawn within set distance
+
+Can spawn a single monster
+
+```json
+"on_death": {
+  "spawn_mon_near": {
+    "distance": 5,
+    "ids": "mon_thing"
+  }
+}
+```
+
+or multiple monsters
+
+```json
+"on_death": {
+  "spawn_mon_near": {
+    "distance": 3,
+    "ids": [ "mon_thing", "mon_zombie", "mon_zombie_anklebiter" ]
+  }
+}
+```
+
 ## "harvest"
 
 (string, optional)

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2651,6 +2651,10 @@ void monster::die( Creature *nkiller )
     for( const auto &deathfunction : type->dies ) {
         deathfunction( *this );
     }
+    // Process other on-death triggers (spawn monster(s), etc)
+    for( const auto &deathfunction : type->on_death ) {
+        deathfunction( *this );
+    }
 
     // If our species fears seeing one of our own die, process that
     int anger_adjust = 0;

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -25,6 +25,7 @@
 #include "mondeath.h"
 #include "mondefense.h"
 #include "monfaction.h"
+#include "monster.h"
 #include "mtype.h"
 #include "options.h"
 #include "pathfinding.h"
@@ -856,9 +857,52 @@ void mtype::load( const JsonObject &jo, const std::string &src )
 
     assign( jo, "harvest", harvest );
 
-    const auto death_reader = make_flag_reader( gen.death_map, "monster death function" );
-    optional( jo, was_loaded, "death_function", dies, death_reader );
-    if( dies.empty() ) {
+    /* Load "on_death": object */
+    if( jo.has_object( "on_death" ) ) {
+        JsonObject od = jo.get_object( "on_death" );
+        // on_death::death_function
+        const auto death_reader = make_flag_reader( gen.death_map, "monster death function" );
+        optional( od, was_loaded, "death_function", dies, death_reader );
+
+        // on_death::spawn_mon
+        std::vector<std::pair<int, mtype_id>> mon_spawns;
+        if( od.has_string( "spawn_mon" ) ) {
+            mtype_id spawn_mon = mtype_id::NULL_ID();
+            assign( od, "spawn_mon", spawn_mon );
+
+            mon_spawns.emplace_back( 0, spawn_mon );
+        }
+
+        // on_death::spawn_mon_near
+        if( od.has_object( "spawn_mon_near" ) ) {
+            JsonObject od_smn = od.get_object( "spawn_mon_near" );
+            int dist;
+            assign( od_smn, "distance", dist );
+
+            std::vector<mtype_id> mons;
+            optional( od_smn, was_loaded, "ids", mons, auto_flags_reader<mtype_id> {} );
+
+            for( const auto &id : mons ) {
+                mon_spawns.emplace_back( dist, id );
+            }
+        }
+
+        // Set the function that generates the spawns.
+        if( !mon_spawns.empty() ) {
+            on_death.emplace_back( [mon_spawns]( monster & z ) {
+                for( const auto &pair : mon_spawns ) {
+                    g->place_critter_around( pair.second, z.pos(), pair.first );
+                }
+            } );
+        }
+    }
+    /* Load "death_function": instead*/
+    else {
+        const auto death_reader = make_flag_reader( gen.death_map, "monster death function" );
+        optional( jo, was_loaded, "death_function", dies, death_reader );
+    }
+
+    if( dies.empty() && on_death.empty() ) {
         // TODO: really needed? Is an empty `dies` container not allowed?
         dies.push_back( mdeath::normal );
     }

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -337,6 +337,7 @@ struct mtype {
         std::vector<std::string> special_attacks_names; // names of attacks, in json load order
 
         std::vector<mon_action_death>  dies;       // What happens when this monster dies
+        std::vector<std::function<void( monster & )>> on_death;
 
         // This monster's special "defensive" move that may trigger when the monster is attacked.
         // Note that this can be anything, and is not necessarily beneficial to the monster


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `doc/` folder.
  - [x] If documentation for this feature does not exist, please write it or at least note its lack in PR description.

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change
@RoyalFox2140 mentioned a desire for a more generic way to spawn a monster on death similar to how `mon_dog` and `mon_tentacle_dog` spawn `mon_thing` on death using the `"THING"` death function which calls `mdeath::thing`.

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution
Added a new JSON field to contain actions to take on monster death, including but not limited to spawning monsters. The solution keeps the current `mtype::dies` functionality using pointers to `mdeath::` functions. Spawning a single zombie is done using:
```json
"on_death": {
  "spawn_mon": "mon_zombie"
}
```
and multiple zombies can be spawned using:
```json
"on_death": {
  "spawn_mon_near": {
    "distance": 3,
    "ids": [ "mon_zombie", "mon_zombie", "mon_zombie_anklebiter" ]
  }
}
```
When using `"on_death"` and need to specify `"death_function"` values they can be embedded in the object:
```
json
"on_death": {
  "death_function": [ "DETONATE" ]
}
```

Documentation for the new field is in `monsters.md`

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing
Debug spawned both `mon_dog_thing` and `mon_headless_dog_thing` and then used `Kill in area` debug action to kill them. Both spawned `mon_thing`s.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context
Example of multiple monster spawning from debug killing a `"mon_dog_thing"` with this `"on_death"` object set
![Screenshot from 2024-11-26 04-57-47](https://github.com/user-attachments/assets/b246decf-8116-44e0-9b46-6279fd2e43e9)
![Screenshot from 2024-11-26 04-55-17](https://github.com/user-attachments/assets/89761ea4-02bd-4ca0-ae62-b1a40ff2e8ee)
![Screenshot from 2024-11-26 04-56-00](https://github.com/user-attachments/assets/8a26328c-07f0-4f48-8e90-256bb893aef5)


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
