### PR TITLE
feat: Add Lua bindings to toggle mutations on/off

### DIFF
--- a/src/catalua_bindings_creature.cpp
+++ b/src/catalua_bindings_creature.cpp
@@ -453,6 +453,9 @@ void cata::detail::reg_character( sol::state &lua )
         SET_FX_T( set_mutation, void( const trait_id & ) );
         SET_FX_T( unset_mutation, void( const trait_id & ) );
 
+        SET_FX_T( activate_mutation, void( const trait_id & ) );
+        SET_FX_T( deactivate_mutation, void( const trait_id & ) );
+
         SET_FX_T( can_mount, bool( const monster & critter ) const );
         SET_FX_T( mount_creature, void( monster & z ) );
         SET_FX_T( is_mounted, bool() const );

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -466,6 +466,11 @@ bool Character::can_install_cbm_on_bp( const std::vector<bodypart_id> &bps ) con
 
 void Character::activate_mutation( const trait_id &mut )
 {
+    // Make sure we actually have the mutation, and it's inactive.
+    if( !( has_trait( mut ) && !my_mutations[mut].powered ) ) {
+        return;
+    }
+
     const mutation_branch &mdata = mut.obj();
     char_trait_data &tdata = my_mutations[mut];
     // You can take yourself halfway to Near Death levels of hunger/thirst.
@@ -593,6 +598,11 @@ void Character::activate_mutation( const trait_id &mut )
 
 void Character::deactivate_mutation( const trait_id &mut )
 {
+    // No-op if we don't have the required mutation.
+    if( !has_active_mutation( mut ) ) {
+        return;
+    }
+
     my_mutations[mut].powered = false;
 
     // Handle stat changes from deactivation


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Current Lua bindings for Creature objects are somewhat incomplete. In particular, there is no way to cleanly disable a mutation, or enable one at all.

## Describe the solution
Added a couple of lines in ``src/catalua_bindings_creature.cpp``. Now we can do this:
```lua
muti = MutationBranchId.new("WEB_WEAVER")       -- pick a disruptive example
gapi.get_avatar():set_mutation(muti)            -- force it onto the player
gapi.get_avatar():activate_mutation(muti)       -- weave a tangled web
gapi.get_avatar():deactivate_mutation(muti)     -- free the player from themselves
```

I also added a few lines in ``src/mutation.cpp``. Its corresponding activate/deactivate_mutation functions now check if the player has the necessary target—i.e., they have the mutation and it is (in)active.

## Describe alternatives you've considered
The alternative looks roughly like this:

```lua
muti = MutationBranchId.new("WEB_WEAVER")   -- pick a disruptive example
gapi.get_avatar():set_mutation(muti)        -- force it onto the player
-- Close console, open mutations menu, activate Web Weaver per example
gapi.get_avatar():unset_mutation(muti)      -- unceremoniously remove mutation
gapi.get_avatar():set_mutation(muti)        -- give mutation back, now off by default
```
It is exactly as awful as it seems.

## Testing
See "Describe the solution", but also:
```lua
gapi.get_avatar():deactivate_mutation(MutationBranchId.new("BIOLUM1"))
gapi.get_avatar():activate_mutation(MutationBranchId.new("BIOLUM2"))
```
These should no longer error on a character without the specified mutations.

## Additional context
If there's any code that needed to activate mutations multiple times without de-'``power``'-ing them...sorry! I don't know of anything else this could possibly break.