### PR TITLE
fix: internal-mag guns that lack `RELOAD_ONE` no longer massively inflate reload cost

### DIFF
--- a/data/json/items/classes/gun.json
+++ b/data/json/items/classes/gun.json
@@ -23,7 +23,7 @@
     "skill": "launcher",
     "ammo": "flammable",
     "ammo_effects": [ "FLARE" ],
-    "reload": 4,
+    "reload": 400,
     "flags": [ "FIRE_100", "NEVER_JAMS", "FIRESTARTER", "PYROMANIAC_WEAPON" ],
     "use_action": { "type": "firestarter", "moves": 200 },
     "faults": [  ]

--- a/data/json/items/gun/misc.json
+++ b/data/json/items/gun/misc.json
@@ -45,7 +45,7 @@
     "handling": 40,
     "modes": [ [ "DEFAULT", "burst", 4 ] ],
     "clip_size": 100,
-    "reload": 0,
+    "reload": 500,
     "loudness": 5,
     "valid_mod_locations": [ [ "sling", 1 ] ]
   }

--- a/data/json/items/gun/nail.json
+++ b/data/json/items/gun/nail.json
@@ -19,7 +19,7 @@
     "dispersion": 800,
     "loudness": 10,
     "clip_size": 20,
-    "reload": 50,
+    "reload": 200,
     "ranged_damage": { "damage_type": "stab", "amount": 1 },
     "valid_mod_locations": [ [ "grip", 1 ], [ "rail", 1 ], [ "sights", 1 ], [ "stock", 1 ], [ "underbarrel", 1 ] ]
   },

--- a/data/json/items/gun/ups.json
+++ b/data/json/items/gun/ups.json
@@ -208,6 +208,7 @@
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "AUTO", "auto", 5 ] ],
     "ammo": "water",
     "clip_size": 80,
+    "reload": 300,
     "extend": { "flags": [ "MOUNTED_GUN", "NO_RECOVER_AMMO" ] },
     "delete": { "flags": [ "NO_UNLOAD" ] }
   }

--- a/data/json/items/magazine/chemical_spray.json
+++ b/data/json/items/magazine/chemical_spray.json
@@ -15,7 +15,7 @@
     "ammo_type": "chemical_spray",
     "capacity": 800,
     "reliability": 9,
-    "reload_time": 3,
+    "reload_time": 1,
     "flags": [ "MAG_BULKY" ]
   }
 ]

--- a/data/json/items/magazine/liquid.json
+++ b/data/json/items/magazine/liquid.json
@@ -15,7 +15,7 @@
     "ammo_type": "flammable",
     "capacity": 3000,
     "reliability": 9,
-    "reload_time": 3,
+    "reload_time": 1,
     "flags": [ "MAG_BULKY" ]
   },
   {
@@ -34,7 +34,7 @@
     "ammo_type": "flammable",
     "capacity": 500,
     "reliability": 9,
-    "reload_time": 3,
+    "reload_time": 1,
     "flags": [ "MAG_BULKY" ]
   },
   {
@@ -53,7 +53,7 @@
     "ammo_type": "flammable",
     "capacity": 2000,
     "reliability": 10,
-    "reload_time": 3,
+    "reload_time": 1,
     "flags": [ "MAG_BULKY" ]
   },
   {
@@ -72,7 +72,7 @@
     "ammo_type": "flammable",
     "capacity": 4000,
     "reliability": 10,
-    "reload_time": 3,
+    "reload_time": 1,
     "flags": [ "MAG_BULKY" ]
   }
 ]

--- a/data/json/items/ranged/pneumatic.json
+++ b/data/json/items/ranged/pneumatic.json
@@ -53,7 +53,8 @@
     "recoil": 350,
     "durability": 7,
     "clip_size": 10,
-    "loudness": 16
+    "loudness": 16,
+    "extend": { "flags": [ "RELOAD_ONE" ] }
   },
   {
     "id": "tihar",
@@ -104,7 +105,7 @@
     "durability": 7,
     "modes": [ [ "DEFAULT", "single", 1 ], [ "DOUBLE", "double", 2 ] ],
     "clip_size": 2,
-    "reload": 6000,
+    "reload": 1000,
     "loudness": 22,
     "valid_mod_locations": [
       [ "accessories", 4 ],

--- a/data/json/items/ranged/spearguns.json
+++ b/data/json/items/ranged/spearguns.json
@@ -87,7 +87,7 @@
     "dispersion": 105,
     "durability": 8,
     "clip_size": 4,
-    "reload": 6000,
+    "reload": 1000,
     "loudness": 11,
     "valid_mod_locations": [
       [ "accessories", 4 ],

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11534,7 +11534,8 @@ int Character::item_reload_cost( const item &it, item &ammo, int qty ) const
     /** @EFFECT_SHOTGUN decreases time taken to reload a shotgun */
     /** @EFFECT_LAUNCHER decreases time taken to reload a launcher */
 
-    int cost = ( it.is_gun() ? it.get_reload_time() : it.type->magazine->reload_time ) * qty;
+    // If we're topping off an internal magazine in a gun, only use base reload time, magazines use time per round.
+    int cost = ( it.is_gun() ? it.get_reload_time() : it.type->magazine->reload_time ) * ( it.is_gun() ? 1 : qty );
 
     skill_id sk = it.is_gun() ? it.type->gun->skill_used : skill_gun;
     mv += cost / ( 1.0f + std::min( get_skill_level( sk ) * 0.1f, 1.0f ) );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11535,7 +11535,8 @@ int Character::item_reload_cost( const item &it, item &ammo, int qty ) const
     /** @EFFECT_LAUNCHER decreases time taken to reload a launcher */
 
     // If we're topping off an internal magazine in a gun, only use base reload time, magazines use time per round.
-    int cost = ( it.is_gun() ? it.get_reload_time() : it.type->magazine->reload_time ) * ( it.is_gun() ? 1 : qty );
+    int cost = ( it.is_gun() ? it.get_reload_time() : it.type->magazine->reload_time ) *
+               ( it.is_gun() ? 1 : qty );
 
     skill_id sk = it.is_gun() ? it.type->gun->skill_used : skill_gun;
     mv += cost / ( 1.0f + std::min( get_skill_level( sk ) * 0.1f, 1.0f ) );


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This fixes weapons like the BB gun saying they only take 500 moves to reload but then taking entire minutes due to weird code stuff.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

C++ changes:
1. In character.cpp, `Character::item_reload_cost` now only multiplies the reload rate of an item by how many bullets it has to insert if the item's a magazine. Guns will always use just the reload rate. This doesn't affect guns swapping mags or `RELOAD_ONE` guns, but instead the few weapons that still use clip size but reload all ammo at once.

JSON changes:
1. Changed reload rate of flamethrower base class from 4 to 400. Flamethrowers no longer have internal mags anymore but use magazines, so the low time it seems was likely a hack for when they used clip size.
2. Set pneumatic speargun's reload rate from an absurd 6000 moves to 1000, to be only a bit slower than the base class for pnematic guns. This was even more wacky back when it was multiplied by the number of rounds, but still felt it excessive for this fairly mid-tier weapon.
3. Lower reload rate per round of pneumatic shotgun from 6000 moves to 1000, as above.
4. Gave pneumatic bolt driver `RELOAD_ONE` so it still forces the extra delay of dealing with the (now lower) reload cost per each bolt.
5. Pneumatic assault rifle meanwhile gets to use that fixed time for the entire load of 20 rounds since it only fires pebbles, and has much lower damage than the pneumatic bolt driver, making it more comparable to the BB gun.
6. Water cannon given a reload rate of 500 now that it's not per round.
7. Nailgun reload rate bumped up from 50 to 200.
8. Autolaser given a reload rate of 300 for topping off the water jacket.
9. Per feedback by Royalfox, reload rate for flamethrower and chemical sprayer tank magazines reduced from 3 to 1, since these typically have massive capacities and refilling a tank with liquid or gas fuel should absolutely be smoother than loading a firearm magazine.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Hacking around this by giving relevant guns very low reload rates.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Spawned in a BB gun, confirmed it no longer takes ages to unload and reload.
3. Spawned in a pressurized fuel tank. As expected, reloading it with fresh fuel still takes time. Interestingly, unloading it only takes a couple seconds.
4. Spawned in a glock, confirmed that swapping mags still takes the expected time, and loading an empty mag while it's loaded in it correctly takes several seconds.
5. Spawned a revolver, reloading one round at a time still works as expected.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
