### PR TITLE
refactor: Clean up world saving/loading codepath (Phase 1 of v2 save format)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ cata_test
 cata_test-tiles
 cataclysm
 cataclysm-tiles
+cataclysm-bn-tiles
+json_formatter
 *.exe.manifest
 cataclysm-vcpkg
 cataclysmdda-*

--- a/src/artifact.cpp
+++ b/src/artifact.cpp
@@ -1088,7 +1088,7 @@ std::string artifact_name( const std::string &type )
 
 void load_artifacts( const std::string &path )
 {
-    read_from_file_optional_json( path, []( JsonIn & artifact_json ) {
+    read_from_file_json( path, []( JsonIn & artifact_json ) {
         artifact_json.start_array();
         while( !artifact_json.end_array() ) {
             JsonObject jo = artifact_json.get_object();
@@ -1101,7 +1101,7 @@ void load_artifacts( const std::string &path )
                 jo.throw_error( "unrecognized artifact type.", "type" );
             }
         }
-    } );
+    }, true );
 }
 
 void it_artifact_tool::deserialize( const JsonObject &jo )

--- a/src/artifact.cpp
+++ b/src/artifact.cpp
@@ -1087,7 +1087,7 @@ std::string artifact_name( const std::string &type )
 
 /* Json Loading and saving */
 
-void load_artifacts( world* world, const std::string &path )
+void load_artifacts( world *world, const std::string &path )
 {
     world->read_from_file_json( path, []( JsonIn & artifact_json ) {
         artifact_json.start_array();
@@ -1267,7 +1267,7 @@ void it_artifact_armor::deserialize( const JsonObject &jo )
     }
 }
 
-bool save_artifacts( world* world, const std::string &path )
+bool save_artifacts( world *world, const std::string &path )
 {
     return world->write_to_file( path, [&]( std::ostream & fout ) {
         JsonOut json( fout, true );

--- a/src/artifact.cpp
+++ b/src/artifact.cpp
@@ -1087,7 +1087,7 @@ std::string artifact_name( const std::string &type )
 
 /* Json Loading and saving */
 
-void load_artifacts( world *world, const std::string &path )
+void load_artifacts( const world *world, const std::string &path )
 {
     world->read_from_file_json( path, []( JsonIn & artifact_json ) {
         artifact_json.start_array();
@@ -1267,7 +1267,7 @@ void it_artifact_armor::deserialize( const JsonObject &jo )
     }
 }
 
-bool save_artifacts( world *world, const std::string &path )
+bool save_artifacts( const world *world, const std::string &path )
 {
     return world->write_to_file( path, [&]( std::ostream & fout ) {
         JsonOut json( fout, true );

--- a/src/artifact.cpp
+++ b/src/artifact.cpp
@@ -27,6 +27,7 @@
 #include "type_id.h"
 #include "units.h"
 #include "value_ptr.h"
+#include "world.h"
 
 template<typename V, typename B>
 inline units::quantity<V, B> rng( const units::quantity<V, B> &min,
@@ -1086,9 +1087,9 @@ std::string artifact_name( const std::string &type )
 
 /* Json Loading and saving */
 
-void load_artifacts( const std::string &path )
+void load_artifacts( world* world, const std::string &path )
 {
-    read_from_file_json( path, []( JsonIn & artifact_json ) {
+    world->read_from_file_json( path, []( JsonIn & artifact_json ) {
         artifact_json.start_array();
         while( !artifact_json.end_array() ) {
             JsonObject jo = artifact_json.get_object();
@@ -1266,9 +1267,9 @@ void it_artifact_armor::deserialize( const JsonObject &jo )
     }
 }
 
-bool save_artifacts( const std::string &path )
+bool save_artifacts( world* world, const std::string &path )
 {
-    return write_to_file( path, [&]( std::ostream & fout ) {
+    return world->write_to_file( path, [&]( std::ostream & fout ) {
         JsonOut json( fout, true );
         json.start_array();
         // We only want runtime types, otherwise static artifacts are loaded twice (on init and then on game load)

--- a/src/artifact.h
+++ b/src/artifact.h
@@ -7,6 +7,7 @@
 #include "enums.h"
 #include "itype.h"
 #include "relic.h"
+#include "world.h"
 
 class JsonObject;
 class JsonOut;
@@ -126,9 +127,9 @@ itype_id new_artifact();
 itype_id new_natural_artifact( artifact_natural_property prop );
 
 // note: needs to be called by main() before MAPBUFFER.load
-void load_artifacts( const std::string &path );
+void load_artifacts( world* world, const std::string &path );
 // save artifact definitions to json, path must be the same as for loading.
-bool save_artifacts( const std::string &path );
+bool save_artifacts( world* world, const std::string &path );
 
 bool check_art_charge_req( item &it );
 

--- a/src/artifact.h
+++ b/src/artifact.h
@@ -127,9 +127,9 @@ itype_id new_artifact();
 itype_id new_natural_artifact( artifact_natural_property prop );
 
 // note: needs to be called by main() before MAPBUFFER.load
-void load_artifacts( world *world, const std::string &path );
+void load_artifacts( const world *world, const std::string &path );
 // save artifact definitions to json, path must be the same as for loading.
-bool save_artifacts( world *world, const std::string &path );
+bool save_artifacts( const world *world, const std::string &path );
 
 bool check_art_charge_req( item &it );
 

--- a/src/artifact.h
+++ b/src/artifact.h
@@ -127,9 +127,9 @@ itype_id new_artifact();
 itype_id new_natural_artifact( artifact_natural_property prop );
 
 // note: needs to be called by main() before MAPBUFFER.load
-void load_artifacts( world* world, const std::string &path );
+void load_artifacts( world *world, const std::string &path );
 // save artifact definitions to json, path must be the same as for loading.
-bool save_artifacts( world* world, const std::string &path );
+bool save_artifacts( world *world, const std::string &path );
 
 bool check_art_charge_req( item &it );
 

--- a/src/auto_note.cpp
+++ b/src/auto_note.cpp
@@ -89,7 +89,8 @@ void auto_note_settings::load()
         }
     };
 
-    if( !g->get_active_world()->read_from_player_file_json( ".ano.json", parseJson, true ) ) {
+    if( !g->get_active_world()->read_from_player_file_json( ".ano.json", parseJson,
+            true ) ) {
         default_initialize();
         save();
     }

--- a/src/auto_note.cpp
+++ b/src/auto_note.cpp
@@ -92,7 +92,7 @@ void auto_note_settings::load()
         }
     };
 
-    if( !read_from_file_optional_json( build_save_path(), parseJson ) ) {
+    if( !read_from_file_json( build_save_path(), parseJson, true ) ) {
         default_initialize();
         save();
     }

--- a/src/auto_note.cpp
+++ b/src/auto_note.cpp
@@ -22,11 +22,6 @@
 
 namespace auto_notes
 {
-std::string auto_note_settings::build_save_path() const
-{
-    return g->get_active_world()->get_player_base_save_path() + ".ano.json";
-}
-
 void auto_note_settings::clear()
 {
     autoNoteEnabled.clear();
@@ -35,11 +30,11 @@ void auto_note_settings::clear()
 bool auto_note_settings::save()
 {
     world* world = g->get_active_world();
-    if( !world->file_exist( world->get_player_base_save_path() + ".sav" ) ) {
+    if( !world->player_file_exist( ".sav" ) ) {
         return true;
     }
 
-    return world->write_to_file( build_save_path(), [&]( std::ostream & fstr ) {
+    return world->write_to_player_file( ".ano.json", [&]( std::ostream & fstr ) {
         JsonOut jout{ fstr, true };
 
         jout.start_object();
@@ -94,7 +89,7 @@ void auto_note_settings::load()
         }
     };
 
-    if( !g->get_active_world()->read_from_file_json( build_save_path(), parseJson, true ) ) {
+    if( !g->get_active_world()->read_from_player_file_json( ".ano.json", parseJson, true ) ) {
         default_initialize();
         save();
     }

--- a/src/auto_note.cpp
+++ b/src/auto_note.cpp
@@ -29,7 +29,7 @@ void auto_note_settings::clear()
 
 bool auto_note_settings::save()
 {
-    world* world = g->get_active_world();
+    world *world = g->get_active_world();
     if( !world->player_file_exist( ".sav" ) ) {
         return true;
     }

--- a/src/auto_note.cpp
+++ b/src/auto_note.cpp
@@ -18,12 +18,13 @@
 #include "point.h"
 #include "translations.h"
 #include "ui_manager.h"
+#include "world.h"
 
 namespace auto_notes
 {
 std::string auto_note_settings::build_save_path() const
 {
-    return g->get_player_base_save_path() + ".ano.json";
+    return g->get_active_world()->get_player_base_save_path() + ".ano.json";
 }
 
 void auto_note_settings::clear()
@@ -33,11 +34,12 @@ void auto_note_settings::clear()
 
 bool auto_note_settings::save()
 {
-    if( !file_exist( g->get_player_base_save_path() + ".sav" ) ) {
+    world* world = g->get_active_world();
+    if( !world->file_exist( world->get_player_base_save_path() + ".sav" ) ) {
         return true;
     }
 
-    return write_to_file( build_save_path(), [&]( std::ostream & fstr ) {
+    return world->write_to_file( build_save_path(), [&]( std::ostream & fstr ) {
         JsonOut jout{ fstr, true };
 
         jout.start_object();
@@ -92,7 +94,7 @@ void auto_note_settings::load()
         }
     };
 
-    if( !read_from_file_json( build_save_path(), parseJson, true ) ) {
+    if( !g->get_active_world()->read_from_file_json( build_save_path(), parseJson, true ) ) {
         default_initialize();
         save();
     }

--- a/src/auto_note.h
+++ b/src/auto_note.h
@@ -73,10 +73,6 @@ class auto_note_settings
         void default_initialize();
 
     private:
-        /// Build string containing path to the auto notes save file for the active player.
-        std::string build_save_path() const;
-
-    private:
         /// This set contains the ID strings of all map extras that have auto note enabled.
         std::unordered_set<string_id<map_extra>> autoNoteEnabled;
 

--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -714,7 +714,7 @@ bool player_settings::save_global()
 }
 
 bool player_settings::save( const bool bCharacter )
-{   
+{
     if( bCharacter ) {
         //Character not saved yet.
         if( !g->get_active_world()->player_file_exist( ".sav" ) ) {

--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -749,9 +749,9 @@ void player_settings::load( const bool bCharacter )
         sFile = g->get_player_base_save_path() + ".apu.json";
     }
 
-    read_from_file_optional_json( sFile, [&]( JsonIn & jsin ) {
+    read_from_file_json( sFile, [&]( JsonIn & jsin ) {
         ( bCharacter ? character_rules : global_rules ).deserialize( jsin );
-    } );
+    }, true );
 
     invalidate();
 }

--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -716,16 +716,12 @@ bool player_settings::save_global()
 bool player_settings::save( const bool bCharacter )
 {   
     if( bCharacter ) {
-        world* world = g->get_active_world();
-
-        const std::string player_save = world->get_player_base_save_path() + ".sav";
         //Character not saved yet.
-        if( !world->file_exist( player_save ) ) {
+        if( !g->get_active_world()->player_file_exist( ".sav" ) ) {
             return true;
         }
 
-        return world->write_to_file( world->get_player_base_save_path() + ".apu.json", 
-        [&]( std::ostream & fout ) {
+        return g->get_active_world()->write_to_player_file( ".apu.json", [&]( std::ostream & fout ) {
             JsonOut jout( fout, true );
             ( bCharacter ? character_rules : global_rules ).serialize( jout );
         }, _( "autopickup configuration" ) );
@@ -750,10 +746,7 @@ void player_settings::load_global()
 void player_settings::load( const bool bCharacter )
 {
     if( bCharacter ) {
-        world* world = g->get_active_world();
-
-        world->read_from_file_json( world->get_player_base_save_path() + ".apu.json", 
-        [&]( JsonIn & jsin ) {
+        g->get_active_world()->read_from_player_file_json( ".apu.json", [&]( JsonIn & jsin ) {
             ( bCharacter ? character_rules : global_rules ).deserialize( jsin );
         }, true );
     } else {

--- a/src/cata_utility.cpp
+++ b/src/cata_utility.cpp
@@ -457,7 +457,7 @@ std::istream *cata_ifstream::operator->()
     return &*_stream;
 }
 
-bool write_to_file( const std::string &path, file_write_cb &writer, const char *const fail_message)
+bool write_to_file( const std::string &path, file_write_cb &writer, const char *const fail_message )
 {
     try {
         // Any of the below may throw. ofstream_wrapper will clean up the temporary path on its own.
@@ -469,7 +469,7 @@ bool write_to_file( const std::string &path, file_write_cb &writer, const char *
         if( fail_message ) {
             popup( _( "Failed to write %1$s to \"%2$s\": %3$s" ), fail_message, path.c_str(), err.what() );
         } else {
-            std::throw_with_nested(std::runtime_error( "file write failed: " + path ));
+            std::throw_with_nested( std::runtime_error( "file write failed: " + path ) );
         }
         return false;
     }
@@ -520,7 +520,7 @@ std::istream &safe_getline( std::istream &ins, std::string &str )
 
 bool read_from_file( const std::string &path, file_read_cb reader, bool optional )
 {
-    if (optional && !file_exist(path)) {
+    if( optional && !file_exist( path ) ) {
         return false;
     }
 

--- a/src/cata_utility.cpp
+++ b/src/cata_utility.cpp
@@ -469,7 +469,7 @@ std::istream *cata_ifstream::operator->()
  * @param fail_message The message to display if the write fails.
  * @return True if the write was successful, false otherwise.
  */
-bool write_to_file( const std::string &path, file_write_cb &writer, const char *const fail_message )
+bool write_to_file( const std::string &path, file_write_fn &writer, const char *const fail_message )
 {
     try {
         // Any of the below may throw. ofstream_wrapper will clean up the temporary path on its own.
@@ -530,7 +530,7 @@ std::istream &safe_getline( std::istream &ins, std::string &str )
     }
 }
 
-bool read_from_file( const std::string &path, file_read_cb reader, bool optional )
+bool read_from_file( const std::string &path, file_read_fn reader, bool optional )
 {
     if( optional && !file_exist( path ) ) {
         return false;
@@ -553,7 +553,7 @@ bool read_from_file( const std::string &path, file_read_cb reader, bool optional
     }
 }
 
-bool read_from_file_json( const std::string &path, file_read_json_cb reader, bool optional )
+bool read_from_file_json( const std::string &path, file_read_json_fn reader, bool optional )
 {
     return read_from_file( path, [&]( std::istream & fin ) {
         JsonIn jsin( fin, path );

--- a/src/cata_utility.cpp
+++ b/src/cata_utility.cpp
@@ -457,6 +457,18 @@ std::istream *cata_ifstream::operator->()
     return &*_stream;
 }
 
+/**
+ * If fail_message is provided, this method will eat any exceptions and display a popup with the
+ * exception detail and the message. If fail_message is not provided, the exception will be
+ * propagated.
+ *
+ * To eat any exceptions and not display a popup, pass the empty string as fail_message.
+ *
+ * @param path The path to write to.
+ * @param writer The function that writes to the file.
+ * @param fail_message The message to display if the write fails.
+ * @return True if the write was successful, false otherwise.
+ */
 bool write_to_file( const std::string &path, file_write_cb &writer, const char *const fail_message )
 {
     try {
@@ -466,9 +478,9 @@ bool write_to_file( const std::string &path, file_write_cb &writer, const char *
         fout.close();
         return true;
     } catch( const std::exception &err ) {
-        if( fail_message ) {
+        if( fail_message && fail_message[0] != '\0' ) {
             popup( _( "Failed to write %1$s to \"%2$s\": %3$s" ), fail_message, path.c_str(), err.what() );
-        } else {
+        } else if( fail_message == nullptr ) {
             std::throw_with_nested( std::runtime_error( "file write failed: " + path ) );
         }
         return false;

--- a/src/cata_utility.cpp
+++ b/src/cata_utility.cpp
@@ -457,24 +457,19 @@ std::istream *cata_ifstream::operator->()
     return &*_stream;
 }
 
-void write_to_file( const std::string &path, const std::function<void( std::ostream & )> &writer )
-{
-    // Any of the below may throw. ofstream_wrapper will clean up the temporary path on its own.
-    ofstream_wrapper fout( path, cata_ios_mode::binary );
-    writer( fout.stream() );
-    fout.close();
-}
-
-bool write_to_file( const std::string &path, const std::function<void( std::ostream & )> &writer,
-                    const char *const fail_message )
+bool write_to_file( const std::string &path, file_write_cb &writer, const char *const fail_message)
 {
     try {
-        write_to_file( path, writer );
+        // Any of the below may throw. ofstream_wrapper will clean up the temporary path on its own.
+        ofstream_wrapper fout( path, cata_ios_mode::binary );
+        writer( fout.stream() );
+        fout.close();
         return true;
-
     } catch( const std::exception &err ) {
         if( fail_message ) {
             popup( _( "Failed to write %1$s to \"%2$s\": %3$s" ), fail_message, path.c_str(), err.what() );
+        } else {
+            std::throw_with_nested(std::runtime_error( "file write failed: " + path ));
         }
         return false;
     }
@@ -523,8 +518,12 @@ std::istream &safe_getline( std::istream &ins, std::string &str )
     }
 }
 
-bool read_from_file( const std::string &path, const std::function<void( std::istream & )> &reader )
+bool read_from_file( const std::string &path, file_read_cb reader, bool optional )
 {
+    if (optional && !file_exist(path)) {
+        return false;
+    }
+
     try {
         cata_ifstream fin = std::move( cata_ifstream().mode( cata_ios_mode::binary ).open( path ) );
         if( !fin.is_open() ) {
@@ -542,44 +541,12 @@ bool read_from_file( const std::string &path, const std::function<void( std::ist
     }
 }
 
-bool read_from_file_json( const std::string &path, const std::function<void( JsonIn & )> &reader )
+bool read_from_file_json( const std::string &path, file_read_json_cb reader, bool optional )
 {
     return read_from_file( path, [&]( std::istream & fin ) {
         JsonIn jsin( fin, path );
         reader( jsin );
-    } );
-}
-
-bool read_from_file( const std::string &path, JsonDeserializer &reader )
-{
-    return read_from_file_json( path, [&reader]( JsonIn & jsin ) {
-        reader.deserialize( jsin );
-    } );
-}
-
-bool read_from_file_optional( const std::string &path,
-                              const std::function<void( std::istream & )> &reader )
-{
-    // Note: slight race condition here, but we'll ignore it. Worst case: the file
-    // exists and got removed before reading it -> reading fails with a message
-    // Or file does not exists, than everything works fine because it's optional anyway.
-    return file_exist( path ) && read_from_file( path, reader );
-}
-
-bool read_from_file_optional_json( const std::string &path,
-                                   const std::function<void( JsonIn & )> &reader )
-{
-    return read_from_file_optional( path, [&]( std::istream & fin ) {
-        JsonIn jsin( fin, path );
-        reader( jsin );
-    } );
-}
-
-bool read_from_file_optional( const std::string &path, JsonDeserializer &reader )
-{
-    return read_from_file_optional_json( path, [&reader]( JsonIn & jsin ) {
-        reader.deserialize( jsin );
-    } );
+    }, optional );
 }
 
 void ofstream_wrapper::open( cata_ios_mode mode )

--- a/src/catalua.cpp
+++ b/src/catalua.cpp
@@ -61,12 +61,12 @@ void debug_write_lua_backtrace( std::ostream &/*out*/ )
     // Nothing to do here
 }
 
-bool save_world_lua_state( world *world, const std::string & )
+bool save_world_lua_state( const world *world, const std::string & )
 {
     return true;
 }
 
-bool load_world_lua_state( world *world, const std::string & )
+bool load_world_lua_state( const world *world, const std::string & )
 {
     return true;
 }
@@ -194,7 +194,7 @@ static sol::table get_mod_storage_table( lua_state &state )
     return state.lua.globals()["game"]["cata_internal"]["mod_storage"];
 }
 
-bool save_world_lua_state( world *world, const std::string &path )
+bool save_world_lua_state( const world *world, const std::string &path )
 {
     lua_state &state = *DynamicDataLoader::get_instance().lua;
 
@@ -217,7 +217,7 @@ bool save_world_lua_state( world *world, const std::string &path )
     return ret;
 }
 
-bool load_world_lua_state( world *world, const std::string &path )
+bool load_world_lua_state( const world *world, const std::string &path )
 {
     lua_state &state = *DynamicDataLoader::get_instance().lua;
     const mod_management::t_mod_list &mods = world_generator->active_world->info->active_mod_order;

--- a/src/catalua.cpp
+++ b/src/catalua.cpp
@@ -61,12 +61,12 @@ void debug_write_lua_backtrace( std::ostream &/*out*/ )
     // Nothing to do here
 }
 
-bool save_world_lua_state( world* world, const std::string & )
+bool save_world_lua_state( world *world, const std::string & )
 {
     return true;
 }
 
-bool load_world_lua_state( world* world, const std::string & )
+bool load_world_lua_state( world *world, const std::string & )
 {
     return true;
 }
@@ -194,7 +194,7 @@ static sol::table get_mod_storage_table( lua_state &state )
     return state.lua.globals()["game"]["cata_internal"]["mod_storage"];
 }
 
-bool save_world_lua_state( world* world, const std::string &path )
+bool save_world_lua_state( world *world, const std::string &path )
 {
     lua_state &state = *DynamicDataLoader::get_instance().lua;
 
@@ -217,7 +217,7 @@ bool save_world_lua_state( world* world, const std::string &path )
     return ret;
 }
 
-bool load_world_lua_state( world* world, const std::string &path )
+bool load_world_lua_state( world *world, const std::string &path )
 {
     lua_state &state = *DynamicDataLoader::get_instance().lua;
     const mod_management::t_mod_list &mods = world_generator->active_world->info->active_mod_order;

--- a/src/catalua.cpp
+++ b/src/catalua.cpp
@@ -166,7 +166,7 @@ void show_lua_console()
 void reload_lua_code()
 {
     cata::lua_state &state = *DynamicDataLoader::get_instance().lua;
-    const auto &packs = world_generator->active_world->active_mod_order;
+    const auto &packs = world_generator->active_world->info->active_mod_order;
     try {
         init::load_main_lua_scripts( state, packs );
     } catch( std::runtime_error &e ) {
@@ -198,7 +198,7 @@ bool save_world_lua_state( const std::string &path )
 {
     lua_state &state = *DynamicDataLoader::get_instance().lua;
 
-    const mod_management::t_mod_list &mods = world_generator->active_world->active_mod_order;
+    const mod_management::t_mod_list &mods = world_generator->active_world->info->active_mod_order;
     sol::table t = get_mod_storage_table( state );
     run_on_game_save_hooks( state );
     bool ret = write_to_file( path, [&]( std::ostream & stream ) {
@@ -220,7 +220,7 @@ bool save_world_lua_state( const std::string &path )
 bool load_world_lua_state( const std::string &path )
 {
     lua_state &state = *DynamicDataLoader::get_instance().lua;
-    const mod_management::t_mod_list &mods = world_generator->active_world->active_mod_order;
+    const mod_management::t_mod_list &mods = world_generator->active_world->info->active_mod_order;
     sol::table t = get_mod_storage_table( state );
 
     bool ret = read_from_file_optional( path, [&]( std::istream & stream ) {

--- a/src/catalua.cpp
+++ b/src/catalua.cpp
@@ -223,7 +223,7 @@ bool load_world_lua_state( const std::string &path )
     const mod_management::t_mod_list &mods = world_generator->active_world->info->active_mod_order;
     sol::table t = get_mod_storage_table( state );
 
-    bool ret = read_from_file_optional( path, [&]( std::istream & stream ) {
+    bool ret = read_from_file( path, [&]( std::istream & stream ) {
         JsonIn jsin( stream );
         JsonObject jsobj = jsin.get_object();
 
@@ -239,7 +239,7 @@ bool load_world_lua_state( const std::string &path )
             JsonObject mod_obj = jsobj.get_object( mod.str() );
             deserialize_lua_table( t[mod.str()], mod_obj );
         }
-    } );
+    }, true );
 
     run_on_game_load_hooks( state );
     return ret;

--- a/src/catalua.cpp
+++ b/src/catalua.cpp
@@ -61,12 +61,12 @@ void debug_write_lua_backtrace( std::ostream &/*out*/ )
     // Nothing to do here
 }
 
-bool save_world_lua_state( const std::string & )
+bool save_world_lua_state( world* world, const std::string & )
 {
     return true;
 }
 
-bool load_world_lua_state( const std::string & )
+bool load_world_lua_state( world* world, const std::string & )
 {
     return true;
 }
@@ -194,14 +194,14 @@ static sol::table get_mod_storage_table( lua_state &state )
     return state.lua.globals()["game"]["cata_internal"]["mod_storage"];
 }
 
-bool save_world_lua_state( const std::string &path )
+bool save_world_lua_state( world* world, const std::string &path )
 {
     lua_state &state = *DynamicDataLoader::get_instance().lua;
 
     const mod_management::t_mod_list &mods = world_generator->active_world->info->active_mod_order;
     sol::table t = get_mod_storage_table( state );
     run_on_game_save_hooks( state );
-    bool ret = write_to_file( path, [&]( std::ostream & stream ) {
+    bool ret = world->write_to_file( path, [&]( std::ostream & stream ) {
         JsonOut jsout( stream );
         jsout.start_object();
         for( const mod_id &mod : mods ) {
@@ -217,13 +217,13 @@ bool save_world_lua_state( const std::string &path )
     return ret;
 }
 
-bool load_world_lua_state( const std::string &path )
+bool load_world_lua_state( world* world, const std::string &path )
 {
     lua_state &state = *DynamicDataLoader::get_instance().lua;
     const mod_management::t_mod_list &mods = world_generator->active_world->info->active_mod_order;
     sol::table t = get_mod_storage_table( state );
 
-    bool ret = read_from_file( path, [&]( std::istream & stream ) {
+    bool ret = world->read_from_file( path, [&]( std::istream & stream ) {
         JsonIn jsin( stream );
         JsonObject jsobj = jsin.get_object();
 

--- a/src/catalua.h
+++ b/src/catalua.h
@@ -28,8 +28,8 @@ void show_lua_console();
 void reload_lua_code();
 void debug_write_lua_backtrace( std::ostream &out );
 
-bool save_world_lua_state( world* world, const std::string &path );
-bool load_world_lua_state( world* world, const std::string &path );
+bool save_world_lua_state( world *world, const std::string &path );
+bool load_world_lua_state( world *world, const std::string &path );
 
 std::unique_ptr<lua_state, lua_state_deleter> make_wrapped_state();
 

--- a/src/catalua.h
+++ b/src/catalua.h
@@ -28,8 +28,8 @@ void show_lua_console();
 void reload_lua_code();
 void debug_write_lua_backtrace( std::ostream &out );
 
-bool save_world_lua_state( world *world, const std::string &path );
-bool load_world_lua_state( world *world, const std::string &path );
+bool save_world_lua_state( const world *world, const std::string &path );
+bool load_world_lua_state( const world *world, const std::string &path );
 
 std::unique_ptr<lua_state, lua_state_deleter> make_wrapped_state();
 

--- a/src/catalua.h
+++ b/src/catalua.h
@@ -10,6 +10,7 @@ class Item_factory;
 class map;
 class time_point;
 struct tripoint;
+class world;
 
 namespace cata
 {
@@ -27,8 +28,8 @@ void show_lua_console();
 void reload_lua_code();
 void debug_write_lua_backtrace( std::ostream &out );
 
-bool save_world_lua_state( const std::string &path );
-bool load_world_lua_state( const std::string &path );
+bool save_world_lua_state( world* world, const std::string &path );
+bool load_world_lua_state( world* world, const std::string &path );
 
 std::unique_ptr<lua_state, lua_state_deleter> make_wrapped_state();
 

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -40,6 +40,7 @@
 #include "vehicle.h"
 #include "vehicle_part.h"
 #include "vpart_position.h"
+#include "world.h"
 
 static const item_category_id itcat_food( "food" );
 
@@ -1182,12 +1183,13 @@ void zone_data::deserialize( JsonIn &jsin )
 
 bool zone_manager::save_zones()
 {
-    std::string savefile = g->get_player_base_save_path() + ".zones.json";
+    world* world = g->get_active_world();
+    std::string savefile = world->get_player_base_save_path() + ".zones.json";
 
     added_vzones.clear();
     changed_vzones.clear();
     removed_vzones.clear();
-    return write_to_file( savefile, [&]( std::ostream & fout ) {
+    return world->write_to_file( savefile, [&]( std::ostream & fout ) {
         JsonOut jsout( fout );
         serialize( jsout );
     }, _( "zones date" ) );
@@ -1195,9 +1197,10 @@ bool zone_manager::save_zones()
 
 void zone_manager::load_zones()
 {
-    std::string savefile = g->get_player_base_save_path() + ".zones.json";
+    world* world = g->get_active_world();
+    std::string savefile = world->get_player_base_save_path() + ".zones.json";
 
-    read_from_file( savefile, [&]( std::istream & fin ) {
+    world->read_from_file( savefile, [&]( std::istream & fin ) {
         JsonIn jsin( fin );
         deserialize( jsin );
     }, true );

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -1183,24 +1183,18 @@ void zone_data::deserialize( JsonIn &jsin )
 
 bool zone_manager::save_zones()
 {
-    world* world = g->get_active_world();
-    std::string savefile = world->get_player_base_save_path() + ".zones.json";
-
     added_vzones.clear();
     changed_vzones.clear();
     removed_vzones.clear();
-    return world->write_to_file( savefile, [&]( std::ostream & fout ) {
+    return g->get_active_world()->write_to_player_file( ".zones.json", [&]( std::ostream & fout ) {
         JsonOut jsout( fout );
         serialize( jsout );
     }, _( "zones date" ) );
 }
 
 void zone_manager::load_zones()
-{
-    world* world = g->get_active_world();
-    std::string savefile = world->get_player_base_save_path() + ".zones.json";
-
-    world->read_from_file( savefile, [&]( std::istream & fin ) {
+{   
+    g->get_active_world()->read_from_player_file( ".zones.json", [&]( std::istream & fin ) {
         JsonIn jsin( fin );
         deserialize( jsin );
     }, true );

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -1193,7 +1193,7 @@ bool zone_manager::save_zones()
 }
 
 void zone_manager::load_zones()
-{   
+{
     g->get_active_world()->read_from_player_file( ".zones.json", [&]( std::istream & fin ) {
         JsonIn jsin( fin );
         deserialize( jsin );

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -1197,10 +1197,10 @@ void zone_manager::load_zones()
 {
     std::string savefile = g->get_player_base_save_path() + ".zones.json";
 
-    read_from_file_optional( savefile, [&]( std::istream & fin ) {
+    read_from_file( savefile, [&]( std::istream & fin ) {
         JsonIn jsin( fin );
         deserialize( jsin );
-    } );
+    }, true );
     revert_vzones();
     added_vzones.clear();
     changed_vzones.clear();

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -1040,9 +1040,9 @@ void color_manager::load_custom( const std::string &sPath )
 {
     const auto file = sPath.empty() ? PATH_INFO::custom_colors() : sPath;
 
-    read_from_file_optional_json( file, [this]( JsonIn & jsonin ) {
+    read_from_file_json( file, [this]( JsonIn & jsonin ) {
         deserialize( jsonin );
-    } );
+    }, true );
     finalize(); // Need to finalize regardless of success
 }
 

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -1774,7 +1774,7 @@ std::string game_info::mods_loaded()
         return "No active world";
     }
 
-    const std::vector<mod_id> &mod_ids = world_generator->active_world->active_mod_order;
+    const std::vector<mod_id> &mod_ids = world_generator->active_world->info->active_mod_order;
     if( mod_ids.empty() ) {
         return "No loaded mods";
     }

--- a/src/diary.cpp
+++ b/src/diary.cpp
@@ -748,9 +748,9 @@ void diary::delete_page()
 void diary::export_to_md( bool last_export )
 {
     std::ofstream myfile;
-    std::string path = last_export 
-        ? PATH_INFO::memorialdir() 
-        : (g->get_active_world() ? g->get_active_world()->info->folder_path() : PATH_INFO::savedir());
+    std::string path = last_export
+                       ? PATH_INFO::memorialdir()
+                       : ( g->get_active_world() ? g->get_active_world()->info->folder_path() : PATH_INFO::savedir() );
     path += "/" + owner + "s_diary.md";
     myfile.open( path );
 

--- a/src/diary.cpp
+++ b/src/diary.cpp
@@ -748,7 +748,9 @@ void diary::delete_page()
 void diary::export_to_md( bool last_export )
 {
     std::ofstream myfile;
-    std::string path = last_export ? PATH_INFO::memorialdir() : g->get_world_base_save_path();
+    std::string path = last_export 
+        ? PATH_INFO::memorialdir() 
+        : (g->get_active_world() ? g->get_active_world()->info->folder_path() : PATH_INFO::savedir());
     path += "/" + owner + "s_diary.md";
     myfile.open( path );
 

--- a/src/diary.cpp
+++ b/src/diary.cpp
@@ -28,6 +28,7 @@
 #include "type_id.h"
 #include "overmap_ui.h"
 #include "units.h"
+#include "world.h"
 
 diary_page::diary_page() = default;
 
@@ -775,9 +776,13 @@ void diary::export_to_md( bool last_export )
 
 bool diary::store()
 {
+    if( !g->get_active_world() ) {
+        return false;
+    }
+
     std::string name = base64_encode( get_avatar().get_save_id() + "_diary" );
-    std::string path = g->get_world_base_save_path() + "/" + name + ".json";
-    const bool is_writen = write_to_file( path, [&]( std::ostream & fout ) {
+    const bool is_writen = g->get_active_world()->write_to_file( name + ".json", [&](
+    std::ostream & fout ) {
         serialize( fout );
     }, _( "diary data" ) );
     return is_writen;
@@ -826,10 +831,13 @@ void diary::serialize( JsonOut &jsout )
 
 void diary::load()
 {
+    if( !g->get_active_world() ) {
+        return;
+    }
+
     std::string name = base64_encode( get_avatar().get_save_id() + "_diary" );
-    std::string path = g->get_world_base_save_path() + "/" + name + ".json";
-    if( file_exist( path ) ) {
-        read_from_file( path, [&]( std::istream & fin ) {
+    if( g->get_active_world()->file_exist( name + ".json" ) ) {
+        g->get_active_world()->read_from_file( name + ".json", [&]( std::istream & fin ) {
             deserialize( fin );
         } );
     }

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -150,10 +150,10 @@ void edit_json( SAVEOBJ &it )
         } else if( tmret == 2 ) {
             write_to_file( "save/jtest-1j.txt", [&]( std::ostream & fout ) {
                 fout << osave1;
-            }, nullptr );
+            }, "" );
             write_to_file( "save/jtest-2j.txt", [&]( std::ostream & fout ) {
                 fout << serialize( it );
-            }, nullptr );
+            }, "" );
         }
         tm.addentry( 0, true, 'r', pgettext( "item manipulation debug menu entry", "rehash" ) );
         tm.addentry( 1, true, 'e', pgettext( "item manipulation debug menu entry", "edit" ) );

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -468,7 +468,7 @@ bool copy_file( const std::string &source_path, const std::string &dest_path )
     }
     bool res = write_to_file( dest_path, [&]( std::ostream & dest_stream ) {
         dest_stream << source_stream->rdbuf();
-    }, nullptr );
+    }, "" );
     return res && !source_stream.fail();
 }
 
@@ -513,7 +513,7 @@ bool can_write_to_dir( const std::string &dir_path )
         s << CBN << '\n';
     };
 
-    if( !write_to_file( dummy_file, writer, nullptr ) ) {
+    if( !write_to_file( dummy_file, writer, "" ) ) {
         return false;
     }
 

--- a/src/fstream_utils.h
+++ b/src/fstream_utils.h
@@ -100,6 +100,11 @@ struct cata_ifstream {
 #endif
 };
 
+
+using file_read_cb = const std::function<void( std::istream & )> &;
+using file_read_json_cb = const std::function<void( JsonIn & )> &;
+using file_write_cb = const std::function<void( std::ostream & )> &;
+
 /**
  * Open a file for writing, calls the writer on that stream.
  *
@@ -111,11 +116,7 @@ struct cata_ifstream {
  * @throw The void function throws when writing failes or when the @p writer throws.
  * The other function catches all exceptions and returns false.
  */
-///@{
-bool write_to_file( const std::string &path, const std::function<void( std::ostream & )> &writer,
-                    const char *fail_message );
-void write_to_file( const std::string &path, const std::function<void( std::ostream & )> &writer );
-///@}
+bool write_to_file( const std::string &path, file_write_cb &writer, const char *fail_message = nullptr);
 
 class JsonDeserializer;
 
@@ -139,15 +140,9 @@ class JsonDeserializer;
  * @return `true` is the file was read without any errors, `false` upon any error.
  */
 /**@{*/
-bool read_from_file( const std::string &path, const std::function<void( std::istream & )> &reader );
-bool read_from_file_json( const std::string &path, const std::function<void( JsonIn & )> &reader );
-bool read_from_file( const std::string &path, JsonDeserializer &reader );
+bool read_from_file( const std::string &path, file_read_cb reader, bool optional = false );
+bool read_from_file_json( const std::string &path, file_read_json_cb reader, bool optional = false );
 
-bool read_from_file_optional( const std::string &path,
-                              const std::function<void( std::istream & )> &reader );
-bool read_from_file_optional_json( const std::string &path,
-                                   const std::function<void( JsonIn & )> &reader );
-bool read_from_file_optional( const std::string &path, JsonDeserializer &reader );
 /**@}*/
 /**
  * Wrapper around std::ofstream that handles error checking and throws on errors.

--- a/src/fstream_utils.h
+++ b/src/fstream_utils.h
@@ -116,7 +116,8 @@ using file_write_cb = const std::function<void( std::ostream & )> &;
  * @throw The void function throws when writing failes or when the @p writer throws.
  * The other function catches all exceptions and returns false.
  */
-bool write_to_file( const std::string &path, file_write_cb &writer, const char *fail_message = nullptr);
+bool write_to_file( const std::string &path, file_write_cb &writer,
+                    const char *fail_message = nullptr );
 
 class JsonDeserializer;
 
@@ -141,7 +142,8 @@ class JsonDeserializer;
  */
 /**@{*/
 bool read_from_file( const std::string &path, file_read_cb reader, bool optional = false );
-bool read_from_file_json( const std::string &path, file_read_json_cb reader, bool optional = false );
+bool read_from_file_json( const std::string &path, file_read_json_cb reader,
+                          bool optional = false );
 
 /**@}*/
 /**

--- a/src/fstream_utils.h
+++ b/src/fstream_utils.h
@@ -101,9 +101,9 @@ struct cata_ifstream {
 };
 
 
-using file_read_cb = const std::function<void( std::istream & )> &;
-using file_read_json_cb = const std::function<void( JsonIn & )> &;
-using file_write_cb = const std::function<void( std::ostream & )> &;
+using file_read_fn = const std::function<void( std::istream & )> &;
+using file_read_json_fn = const std::function<void( JsonIn & )> &;
+using file_write_fn = const std::function<void( std::ostream & )> &;
 
 /**
  * Open a file for writing, calls the writer on that stream.
@@ -116,7 +116,7 @@ using file_write_cb = const std::function<void( std::ostream & )> &;
  * @throw The void function throws when writing failes or when the @p writer throws.
  * The other function catches all exceptions and returns false.
  */
-bool write_to_file( const std::string &path, file_write_cb &writer,
+bool write_to_file( const std::string &path, file_write_fn &writer,
                     const char *fail_message = nullptr );
 
 class JsonDeserializer;
@@ -141,8 +141,9 @@ class JsonDeserializer;
  * @return `true` is the file was read without any errors, `false` upon any error.
  */
 /**@{*/
-bool read_from_file( const std::string &path, file_read_cb reader, bool optional = false );
-bool read_from_file_json( const std::string &path, file_read_json_cb reader,
+bool read_from_file( const std::string &path, file_read_fn reader,
+                     bool optional = false );
+bool read_from_file_json( const std::string &path, file_read_json_fn reader,
                           bool optional = false );
 
 /**@}*/

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2679,18 +2679,16 @@ bool game::save_maps()
 bool game::save_player_data()
 {
     world* world = get_active_world();
-    const std::string playerfile = world->get_player_base_save_path();
-
-    const bool saved_data = world->write_to_file( playerfile + SAVE_EXTENSION, [&]( std::ostream & fout ) {
+    const bool saved_data = world->write_to_player_file( SAVE_EXTENSION, [&]( std::ostream & fout ) {
         serialize( fout );
     }, _( "player data" ) );
     const bool saved_map_memory = u.save_map_memory();
-    const bool saved_log = world->write_to_file( playerfile + SAVE_EXTENSION_LOG, [&](
+    const bool saved_log = world->write_to_player_file( SAVE_EXTENSION_LOG, [&](
     std::ostream & fout ) {
         fout << memorial().dump();
     }, _( "player memorial" ) );
 #if defined(__ANDROID__)
-    const bool saved_shortcuts = world->write_to_file( playerfile + SAVE_EXTENSION_SHORTCUTS, [&](
+    const bool saved_shortcuts = world->write_to_player_file( SAVE_EXTENSION_SHORTCUTS, [&](
     std::ostream & fout ) {
         save_shortcuts( fout );
     }, _( "quick shortcuts" ) );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7181,13 +7181,13 @@ bool game::take_screenshot()
     }
 }
 #else
-bool game::take_screenshot( const std::string &/*path*/ ) const
+bool game::take_screenshot( const std::string &/*path*/ )
 {
     popup( _( "This binary was not compiled with tiles support." ) );
     return false;
 }
 
-bool game::take_screenshot() const
+bool game::take_screenshot()
 {
     popup( _( "This binary was not compiled with tiles support." ) );
     return false;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2727,7 +2727,7 @@ spell_events &game::spell_events_subscriber()
     return *spell_events_ptr;
 }
 
-bool game::save_uistate_data()
+bool game::save_uistate_data() const
 {
     return get_active_world()->write_to_file( "uistate.json", [&]( std::ostream & fout ) {
         JsonOut jsout( fout );
@@ -7150,12 +7150,12 @@ int game::get_user_action_counter() const
 }
 
 #if defined(TILES)
-bool game::take_screenshot( const std::string &path )
+bool game::take_screenshot( const std::string &path ) const
 {
     return save_screenshot( path );
 }
 
-bool game::take_screenshot()
+bool game::take_screenshot() const
 {
     // check that the current '<world>/screenshots' directory exists
     std::string map_directory = get_active_world()->info->folder_path() + "/screenshots/";
@@ -7181,13 +7181,13 @@ bool game::take_screenshot()
     }
 }
 #else
-bool game::take_screenshot( const std::string &/*path*/ )
+bool game::take_screenshot( const std::string &/*path*/ ) const
 {
     popup( _( "This binary was not compiled with tiles support." ) );
     return false;
 }
 
-bool game::take_screenshot()
+bool game::take_screenshot() const
 {
     popup( _( "This binary was not compiled with tiles support." ) );
     return false;
@@ -12133,7 +12133,7 @@ Creature *game::get_creature_if( const std::function<bool( const Creature & )> &
     return nullptr;
 }
 
-world *game::get_active_world()
+world *game::get_active_world() const
 {
     return world_generator->active_world.get();
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2507,7 +2507,7 @@ void game::load_master()
 {
     using namespace std::placeholders;
     const auto datafile = get_world_base_save_path() + "/" + SAVE_MASTER;
-    read_from_file_optional( datafile, std::bind( &game::unserialize_master, this, _1 ) );
+    read_from_file( datafile, std::bind( &game::unserialize_master, this, _1 ), true );
 }
 
 bool game::load( const std::string &world )
@@ -2562,12 +2562,12 @@ bool game::load( const save_t &name )
 
     get_weather().nextweather = calendar::turn;
 
-    read_from_file_optional( worldpath + name.base_path() + SAVE_EXTENSION_LOG,
-                             std::bind( &memorial_logger::load, &memorial(), _1 ) );
+    read_from_file( worldpath + name.base_path() + SAVE_EXTENSION_LOG,
+                             std::bind( &memorial_logger::load, &memorial(), _1 ), true );
 
 #if defined(__ANDROID__)
-    read_from_file_optional( worldpath + name.base_path() + SAVE_EXTENSION_SHORTCUTS,
-                             std::bind( &game::load_shortcuts, this, _1 ) );
+    read_from_file( worldpath + name.base_path() + SAVE_EXTENSION_SHORTCUTS,
+                             std::bind( &game::load_shortcuts, this, _1 ), true );
 #endif
 
     // Now that the player's worn items are updated, their sight limits need to be
@@ -2586,10 +2586,10 @@ bool game::load( const save_t &name )
     get_auto_notes_settings().load();   // Load character auto notes settings
     get_safemode().load_character(); // Load character safemode rules
     zone_manager::get_manager().load_zones(); // Load character world zones
-    read_from_file_optional( get_world_base_save_path() + "/uistate.json", []( std::istream & stream ) {
+    read_from_file( get_world_base_save_path() + "/uistate.json", []( std::istream & stream ) {
         JsonIn jsin( stream );
         uistate.deserialize( jsin );
-    } );
+    }, true );
     reload_npcs();
     validate_npc_followers();
     validate_mounted_npcs();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2506,13 +2506,14 @@ void game::move_save_to_graveyard( const std::string &dirname )
 void game::load_master()
 {
     using namespace std::placeholders;
-    get_active_world()->read_from_file( SAVE_MASTER, std::bind( &game::unserialize_master, this, _1 ), true );
+    get_active_world()->read_from_file( SAVE_MASTER, std::bind( &game::unserialize_master, this, _1 ),
+                                        true );
 }
 
 bool game::load( const std::string &world )
 {
     world_generator->init();
-    WORLDINFO* wptr = world_generator->get_world( world );
+    WORLDINFO *wptr = world_generator->get_world( world );
     if( !wptr ) {
         return false;
     }
@@ -2549,8 +2550,8 @@ bool game::load( const save_t &name )
     u.recalc_hp();
     u.set_save_id( name.decoded_name() );
     u.name = name.decoded_name();
-    if( !get_active_world()->read_from_file( name.base_path() + SAVE_EXTENSION, 
-                                             std::bind( &game::unserialize, this, _1 ) ) ) {
+    if( !get_active_world()->read_from_file( name.base_path() + SAVE_EXTENSION,
+            std::bind( &game::unserialize, this, _1 ) ) ) {
         return false;
     }
 
@@ -2560,11 +2561,11 @@ bool game::load( const save_t &name )
     get_weather().nextweather = calendar::turn;
 
     get_active_world()->read_from_file( name.base_path() + SAVE_EXTENSION_LOG,
-                             std::bind( &memorial_logger::load, &memorial(), _1 ), true );
+                                        std::bind( &memorial_logger::load, &memorial(), _1 ), true );
 
 #if defined(__ANDROID__)
     get_active_world()->read_from_file( name.base_path() + SAVE_EXTENSION_SHORTCUTS,
-                             std::bind( &game::load_shortcuts, this, _1 ), true );
+                                        std::bind( &game::load_shortcuts, this, _1 ), true );
 #endif
 
     // Now that the player's worn items are updated, their sight limits need to be
@@ -2678,7 +2679,7 @@ bool game::save_maps()
 
 bool game::save_player_data()
 {
-    world* world = get_active_world();
+    world *world = get_active_world();
     const bool saved_data = world->write_to_player_file( SAVE_EXTENSION, [&]( std::ostream & fout ) {
         serialize( fout );
     }, _( "player data" ) );
@@ -2736,8 +2737,8 @@ bool game::save_uistate_data()
 
 bool game::save( bool quitting )
 {
-    world* world = get_active_world();
-    if ( !world ) {
+    world *world = get_active_world();
+    if( !world ) {
         return false;
     }
 
@@ -11417,7 +11418,7 @@ void game::quicksave()
 
 void game::quickload()
 {
-    world* active_world = get_active_world();
+    world *active_world = get_active_world();
     if( active_world == nullptr ) {
         return;
     }
@@ -12132,7 +12133,7 @@ Creature *game::get_creature_if( const std::function<bool( const Creature & )> &
     return nullptr;
 }
 
-world* game::get_active_world()
+world *game::get_active_world()
 {
     return world_generator->active_world.get();
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -474,7 +474,7 @@ void game::setup()
 {
     loading_ui ui( true );
 
-    init::load_world_modfiles( ui, get_world_base_save_path() + "/" + SAVE_ARTIFACTS );
+    init::load_world_modfiles( ui, get_active_world(), SAVE_ARTIFACTS );
 
     m = map();
 
@@ -2467,7 +2467,7 @@ void game::win_screen()
 
 void game::move_save_to_graveyard( const std::string &dirname )
 {
-    const std::string save_dir           = get_world_base_save_path();
+    const std::string save_dir           = get_active_world()->info->folder_path();
     const std::string graveyard_dir      = PATH_INFO::graveyarddir() + "/";
     const std::string graveyard_save_dir = graveyard_dir + dirname + "/";
     const std::string &prefix            = base64_encode( u.get_save_id() ) + ".";
@@ -2506,8 +2506,7 @@ void game::move_save_to_graveyard( const std::string &dirname )
 void game::load_master()
 {
     using namespace std::placeholders;
-    const auto datafile = get_world_base_save_path() + "/" + SAVE_MASTER;
-    read_from_file( datafile, std::bind( &game::unserialize_master, this, _1 ), true );
+    get_active_world()->read_from_file( SAVE_MASTER, std::bind( &game::unserialize_master, this, _1 ), true );
 }
 
 bool game::load( const std::string &world )
@@ -2544,16 +2543,14 @@ bool game::load( const save_t &name )
 
     using namespace std::placeholders;
 
-    const std::string worldpath = get_world_base_save_path() + "/";
-    const std::string playerpath = worldpath + name.base_path();
-
     // Now load up the master game data; factions (and more?)
     load_master();
     u = avatar();
     u.recalc_hp();
     u.set_save_id( name.decoded_name() );
     u.name = name.decoded_name();
-    if( !read_from_file( playerpath + SAVE_EXTENSION, std::bind( &game::unserialize, this, _1 ) ) ) {
+    if( !get_active_world()->read_from_file( name.base_path() + SAVE_EXTENSION, 
+                                             std::bind( &game::unserialize, this, _1 ) ) ) {
         return false;
     }
 
@@ -2562,11 +2559,11 @@ bool game::load( const save_t &name )
 
     get_weather().nextweather = calendar::turn;
 
-    read_from_file( worldpath + name.base_path() + SAVE_EXTENSION_LOG,
+    get_active_world()->read_from_file( name.base_path() + SAVE_EXTENSION_LOG,
                              std::bind( &memorial_logger::load, &memorial(), _1 ), true );
 
 #if defined(__ANDROID__)
-    read_from_file( worldpath + name.base_path() + SAVE_EXTENSION_SHORTCUTS,
+    get_active_world()->read_from_file( name.base_path() + SAVE_EXTENSION_SHORTCUTS,
                              std::bind( &game::load_shortcuts, this, _1 ), true );
 #endif
 
@@ -2586,7 +2583,7 @@ bool game::load( const save_t &name )
     get_auto_notes_settings().load();   // Load character auto notes settings
     get_safemode().load_character(); // Load character safemode rules
     zone_manager::get_manager().load_zones(); // Load character world zones
-    read_from_file( get_world_base_save_path() + "/uistate.json", []( std::istream & stream ) {
+    get_active_world()->read_from_file( "uistate.json", []( std::istream & stream ) {
         JsonIn jsin( stream );
         uistate.deserialize( jsin );
     }, true );
@@ -2619,7 +2616,7 @@ bool game::load( const save_t &name )
 
     u.reset();
 
-    cata::load_world_lua_state( get_world_base_save_path() + "/lua_state.json" );
+    cata::load_world_lua_state( get_active_world(), "lua_state.json" );
 
     cata::run_on_game_load_hooks( *DynamicDataLoader::get_instance().lua );
 
@@ -2656,16 +2653,14 @@ void game::reset_npc_dispositions()
 //Saves all factions and missions and npcs.
 bool game::save_factions_missions_npcs()
 {
-    std::string masterfile = get_world_base_save_path() + "/" + SAVE_MASTER;
-    return write_to_file( masterfile, [&]( std::ostream & fout ) {
+    return get_active_world()->write_to_file( SAVE_MASTER, [&]( std::ostream & fout ) {
         serialize_master( fout );
     }, _( "factions data" ) );
 }
 
 bool game::save_artifacts()
 {
-    std::string artfilename = get_world_base_save_path() + "/" + SAVE_ARTIFACTS;
-    return ::save_artifacts( artfilename );
+    return ::save_artifacts( get_active_world(), SAVE_ARTIFACTS );
 }
 
 bool game::save_maps()
@@ -2683,18 +2678,19 @@ bool game::save_maps()
 
 bool game::save_player_data()
 {
-    const std::string playerfile = get_player_base_save_path();
+    world* world = get_active_world();
+    const std::string playerfile = world->get_player_base_save_path();
 
-    const bool saved_data = write_to_file( playerfile + SAVE_EXTENSION, [&]( std::ostream & fout ) {
+    const bool saved_data = world->write_to_file( playerfile + SAVE_EXTENSION, [&]( std::ostream & fout ) {
         serialize( fout );
     }, _( "player data" ) );
     const bool saved_map_memory = u.save_map_memory();
-    const bool saved_log = write_to_file( playerfile + SAVE_EXTENSION_LOG, [&](
+    const bool saved_log = world->write_to_file( playerfile + SAVE_EXTENSION_LOG, [&](
     std::ostream & fout ) {
         fout << memorial().dump();
     }, _( "player memorial" ) );
 #if defined(__ANDROID__)
-    const bool saved_shortcuts = write_to_file( playerfile + SAVE_EXTENSION_SHORTCUTS, [&](
+    const bool saved_shortcuts = world->write_to_file( playerfile + SAVE_EXTENSION_SHORTCUTS, [&](
     std::ostream & fout ) {
         save_shortcuts( fout );
     }, _( "quick shortcuts" ) );
@@ -2732,9 +2728,9 @@ spell_events &game::spell_events_subscriber()
     return *spell_events_ptr;
 }
 
-static bool save_uistate_data( const game &g )
+bool game::save_uistate_data()
 {
-    return write_to_file( g.get_world_base_save_path() + "/uistate.json", [&]( std::ostream & fout ) {
+    return get_active_world()->write_to_file( "uistate.json", [&]( std::ostream & fout ) {
         JsonOut jsout( fout );
         uistate.serialize( jsout );
     }, _( "uistate data" ) );
@@ -2742,6 +2738,13 @@ static bool save_uistate_data( const game &g )
 
 bool game::save( bool quitting )
 {
+    world* world = get_active_world();
+    if ( !world ) {
+        return false;
+    }
+
+    world->start_save_tx();
+
     cata::run_on_game_save_hooks( *DynamicDataLoader::get_instance().lua );
     try {
         reset_save_ids( time( nullptr ), quitting );
@@ -2752,8 +2755,8 @@ bool game::save( bool quitting )
             !get_auto_pickup().save_character() ||
             !get_auto_notes_settings().save() ||
             !get_safemode().save_character() ||
-            !cata::save_world_lua_state( g->get_world_base_save_path() + "/lua_state.json" ) ||
-            !save_uistate_data( *this )
+            !cata::save_world_lua_state( get_active_world(), "lua_state.json" ) ||
+            !save_uistate_data()
           ) {
             return false;
         } else {
@@ -2761,6 +2764,9 @@ bool game::save( bool quitting )
             world_generator->last_character_name = u.name;
             world_generator->save_last_world_info();
             world_generator->active_world->info->add_save( save_t::from_save_id( u.get_save_id() ) );
+
+            auto duration = world->commit_save_tx();
+            add_msg( m_info, _( "World Saved (took %dms)." ), duration );
             return true;
         }
     } catch( std::ios::failure &err ) {
@@ -7145,15 +7151,15 @@ int game::get_user_action_counter() const
 }
 
 #if defined(TILES)
-bool game::take_screenshot( const std::string &path ) const
+bool game::take_screenshot( const std::string &path )
 {
     return save_screenshot( path );
 }
 
-bool game::take_screenshot() const
+bool game::take_screenshot()
 {
     // check that the current '<world>/screenshots' directory exists
-    std::string map_directory = get_world_base_save_path() + "/screenshots/";
+    std::string map_directory = get_active_world()->info->folder_path() + "/screenshots/";
     assure_dir_exist( map_directory );
 
     // build file name: <map_dir>/screenshots/[<character_name>]_<date>.png
@@ -12126,19 +12132,6 @@ Creature *game::get_creature_if( const std::function<bool( const Creature & )> &
         }
     }
     return nullptr;
-}
-
-std::string game::get_player_base_save_path() const
-{
-    return get_world_base_save_path() + "/" + base64_encode( get_avatar().get_save_id() );
-}
-
-std::string game::get_world_base_save_path() const
-{
-    if( world_generator->active_world == nullptr ) {
-        return PATH_INFO::savedir();
-    }
-    return world_generator->active_world->info->folder_path();
 }
 
 world* game::get_active_world()

--- a/src/game.h
+++ b/src/game.h
@@ -159,7 +159,7 @@ class game
         /**
          * @return The current world database, or nullptr if no world is loaded.
          */
-        world* get_active_world();
+        world *get_active_world();
 
         /**
          * @brief Should be invoked whenever options change.

--- a/src/game.h
+++ b/src/game.h
@@ -157,17 +157,6 @@ class game
         void load_static_data();
 
         /**
-         * Base path for saving player data. Just add a suffix (unique for
-         * the thing you want to save) and use the resulting path.
-         * Example: `save_ui_data(get_player_base_save_path()+".ui")`
-         */
-        std::string get_player_base_save_path() const;
-        /**
-         * Base path for saving world data. This yields a path to a folder.
-         */
-        std::string get_world_base_save_path() const;
-
-        /**
          * @return The current world database, or nullptr if no world is loaded.
          */
         world* get_active_world();
@@ -606,12 +595,12 @@ class game
         * @note: Only works for SDL/TILES (otherwise the function returns `false`). A window (more precisely, a viewport) must already exist and the SDL renderer must be valid.
         * @returns `true` if the screenshot generation was successful, `false` otherwise.
         */
-        bool take_screenshot( const std::string &file_path ) const;
+        bool take_screenshot( const std::string &file_path );
         /** Saves a screenshot of the current viewport, as a PNG file. Filesystem location is derived from the current world and character.
         * @note: Only works for SDL/TILES (otherwise the function returns `false`). A window (more precisely, a viewport) must already exist and the SDL renderer must be valid.
         * @returns `true` if the screenshot generation was successful, `false` otherwise.
         */
-        bool take_screenshot() const;
+        bool take_screenshot();
 
         /**
          * The top left corner of the reality bubble (in submaps coordinates). This is the same
@@ -932,6 +921,7 @@ class game
 
         void move_save_to_graveyard( const std::string &dirname );
         bool save_player_data();
+        bool save_uistate_data();
         // ########################## DATA ################################
     private:
         // May be a bit hacky, but it's probably better than the header spaghetti

--- a/src/game.h
+++ b/src/game.h
@@ -99,9 +99,8 @@ class stats_tracker;
 template<typename Tripoint>
 class tripoint_range;
 class vehicle;
-struct WORLD;
-
-using WORLDPTR = WORLD *;
+struct WORLDINFO;
+class world;
 class live_view;
 class loading_ui;
 class overmap;
@@ -167,6 +166,11 @@ class game
          * Base path for saving world data. This yields a path to a folder.
          */
         std::string get_world_base_save_path() const;
+
+        /**
+         * @return The current world database, or nullptr if no world is loaded.
+         */
+        world* get_active_world();
 
         /**
          * @brief Should be invoked whenever options change.

--- a/src/game.h
+++ b/src/game.h
@@ -159,7 +159,7 @@ class game
         /**
          * @return The current world database, or nullptr if no world is loaded.
          */
-        world *get_active_world();
+        world *get_active_world() const;
 
         /**
          * @brief Should be invoked whenever options change.
@@ -595,12 +595,12 @@ class game
         * @note: Only works for SDL/TILES (otherwise the function returns `false`). A window (more precisely, a viewport) must already exist and the SDL renderer must be valid.
         * @returns `true` if the screenshot generation was successful, `false` otherwise.
         */
-        bool take_screenshot( const std::string &file_path );
+        bool take_screenshot( const std::string &file_path ) const;
         /** Saves a screenshot of the current viewport, as a PNG file. Filesystem location is derived from the current world and character.
         * @note: Only works for SDL/TILES (otherwise the function returns `false`). A window (more precisely, a viewport) must already exist and the SDL renderer must be valid.
         * @returns `true` if the screenshot generation was successful, `false` otherwise.
         */
-        bool take_screenshot();
+        bool take_screenshot() const;
 
         /**
          * The top left corner of the reality bubble (in submaps coordinates). This is the same
@@ -921,7 +921,7 @@ class game
 
         void move_save_to_graveyard( const std::string &dirname );
         bool save_player_data();
-        bool save_uistate_data();
+        bool save_uistate_data() const;
         // ########################## DATA ################################
     private:
         // May be a bit hacky, but it's probably better than the header spaghetti

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2379,7 +2379,7 @@ bool game::handle_action()
                 break;
 
             case ACTION_WORLD_MODS:
-                world_generator->show_active_world_mods( world_generator->active_world->active_mod_order );
+                world_generator->show_active_world_mods( world_generator->active_world->info->active_mod_order );
                 break;
 
             case ACTION_DEBUG:

--- a/src/help.cpp
+++ b/src/help.cpp
@@ -36,9 +36,9 @@ help &get_help()
 
 void help::load()
 {
-    read_from_file_optional_json( PATH_INFO::help(), [&]( JsonIn & jsin ) {
+    read_from_file_json( PATH_INFO::help(), [&]( JsonIn & jsin ) {
         deserialize( jsin );
-    } );
+    }, true );
 }
 
 void help::deserialize( JsonIn &jsin )

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -942,11 +942,11 @@ void init::load_core_bn_modfiles()
     );
 }
 
-void init::load_world_modfiles( loading_ui &ui, const std::string &artifacts_file )
+void init::load_world_modfiles( loading_ui &ui, world* world, const std::string &artifacts_file )
 {
     clear_loaded_data();
 
-    mod_management::t_mod_list &mods = world_generator->active_world->info->active_mod_order;
+    mod_management::t_mod_list &mods = world->info->active_mod_order;
 
     // remove any duplicates whilst preserving order (fixes #19385)
     std::set<mod_id> found;
@@ -967,7 +967,7 @@ void init::load_world_modfiles( loading_ui &ui, const std::string &artifacts_fil
     }
 
     // TODO: get rid of artifacts
-    load_artifacts( artifacts_file );
+    load_artifacts( world, artifacts_file );
 
     // this code does not care about mod dependencies,
     // it assumes that those dependencies are static and

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -946,7 +946,7 @@ void init::load_world_modfiles( loading_ui &ui, const std::string &artifacts_fil
 {
     clear_loaded_data();
 
-    mod_management::t_mod_list &mods = world_generator->active_world->active_mod_order;
+    mod_management::t_mod_list &mods = world_generator->active_world->info->active_mod_order;
 
     // remove any duplicates whilst preserving order (fixes #19385)
     std::set<mod_id> found;
@@ -1025,7 +1025,7 @@ bool init::check_mods_for_errors( loading_ui &ui, const std::vector<mod_id> &opt
         world_generator->set_active_world( nullptr );
         world_generator->init();
         const std::vector<mod_id> mods_empty;
-        WORLDPTR test_world = world_generator->make_new_world( mods_empty );
+        WORLDINFO* test_world = world_generator->make_new_world( mods_empty );
         if( !test_world ) {
             std::cerr << "Failed to generate test world." << '\n';
             return false;
@@ -1045,7 +1045,7 @@ bool init::check_mods_for_errors( loading_ui &ui, const std::vector<mod_id> &opt
             std::cerr << "Error loading data: " << err.what() << '\n';
         }
 
-        std::string world_name = world_generator->active_world->world_name;
+        std::string world_name = world_generator->active_world->info->world_name;
         world_generator->delete_world( world_name, true );
 
         // TODO: Why would we need these calls?

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -942,7 +942,8 @@ void init::load_core_bn_modfiles()
     );
 }
 
-void init::load_world_modfiles( loading_ui &ui, world *world, const std::string &artifacts_file )
+void init::load_world_modfiles( loading_ui &ui, const world *world,
+                                const std::string &artifacts_file )
 {
     clear_loaded_data();
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -942,7 +942,7 @@ void init::load_core_bn_modfiles()
     );
 }
 
-void init::load_world_modfiles( loading_ui &ui, world* world, const std::string &artifacts_file )
+void init::load_world_modfiles( loading_ui &ui, world *world, const std::string &artifacts_file )
 {
     clear_loaded_data();
 
@@ -1025,7 +1025,7 @@ bool init::check_mods_for_errors( loading_ui &ui, const std::vector<mod_id> &opt
         world_generator->set_active_world( nullptr );
         world_generator->init();
         const std::vector<mod_id> mods_empty;
-        WORLDINFO* test_world = world_generator->make_new_world( mods_empty );
+        WORLDINFO *test_world = world_generator->make_new_world( mods_empty );
         if( !test_world ) {
             std::cerr << "Failed to generate test world." << '\n';
             return false;

--- a/src/init.h
+++ b/src/init.h
@@ -200,7 +200,7 @@ void load_core_bn_modfiles();
  * @param artifact_file file with per-world artifact definitions
  * @throw std::exception if the loaded data is not valid.
  */
-void load_world_modfiles( loading_ui &ui, world* world, const std::string &artifacts_file );
+void load_world_modfiles( loading_ui &ui, world *world, const std::string &artifacts_file );
 
 /**
  * Load soundpack.

--- a/src/init.h
+++ b/src/init.h
@@ -200,7 +200,7 @@ void load_core_bn_modfiles();
  * @param artifact_file file with per-world artifact definitions
  * @throw std::exception if the loaded data is not valid.
  */
-void load_world_modfiles( loading_ui &ui, world *world, const std::string &artifacts_file );
+void load_world_modfiles( loading_ui &ui, const world *world, const std::string &artifacts_file );
 
 /**
  * Load soundpack.

--- a/src/init.h
+++ b/src/init.h
@@ -17,6 +17,7 @@
 class loading_ui;
 class JsonObject;
 class JsonIn;
+class world;
 
 /**
  * This class is used to load (and unload) the dynamic
@@ -199,7 +200,7 @@ void load_core_bn_modfiles();
  * @param artifact_file file with per-world artifact definitions
  * @throw std::exception if the loaded data is not valid.
  */
-void load_world_modfiles( loading_ui &ui, const std::string &artifacts_file );
+void load_world_modfiles( loading_ui &ui, world* world, const std::string &artifacts_file );
 
 /**
  * Load soundpack.

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -84,7 +84,7 @@ bool is_mouse_enabled()
 std::string get_input_string_from_file( const std::string &fname )
 {
     std::string ret;
-    read_from_file_optional( fname, [&ret]( std::istream & fin ) {
+    read_from_file( fname, [&ret]( std::istream & fin ) {
         getline( fin, ret );
         //remove utf8 bmm
         if( !ret.empty() && static_cast<unsigned char>( ret[0] ) == 0xef ) {
@@ -93,7 +93,7 @@ std::string get_input_string_from_file( const std::string &fname )
         while( !ret.empty() && ( ret.back() == '\r' ||  ret.back() == '\n' ) ) {
             ret.erase( ret.size() - 1, 1 );
         }
-    } );
+    }, true );
     return ret;
 }
 

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -504,7 +504,7 @@ static bool add_mod_catalogues( std::vector<trans_catalogue> &list, const std::s
         return false;
     }
 
-    const std::vector<mod_id> &mods = world_generator->active_world->active_mod_order;
+    const std::vector<mod_id> &mods = world_generator->active_world->info->active_mod_order;
     for( const mod_id &mod : mods ) {
         add_mod_catalogue_if_exists( list, lang_id, mod->path );
     }

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -218,7 +218,7 @@ void main_menu::display_sub_menu( int sel, const point &bottom_left, int sel_lin
             }
             std::vector<std::string> all_worldnames = world_generator->all_worldnames();
             for( int i = 0; static_cast<size_t>( i ) < all_worldnames.size(); i++ ) {
-                WORLDPTR world = world_generator->get_world( all_worldnames[i] );
+                WORLDINFO* world = world_generator->get_world( all_worldnames[i] );
                 int savegames_count = world->world_saves.size();
                 nc_color clr = c_white;
                 std::string txt = all_worldnames[i];
@@ -894,7 +894,7 @@ bool main_menu::new_character_tab()
     } );
     g->gamemode.reset();
 
-    WORLDPTR world;
+    WORLDINFO* world;
     if( sel2 == 5 ) {
         g->gamemode = get_special_game( special_game_type::TUTORIAL );
         world = world_generator->make_new_world( special_game_type::TUTORIAL );
@@ -961,7 +961,7 @@ bool main_menu::new_character_tab()
 
 bool main_menu::load_character_tab( const std::string &worldname )
 {
-    WORLDPTR world = world_generator->get_world( worldname );
+    WORLDINFO* world = world_generator->get_world( worldname );
     savegames = world->world_saves;
     if( MAP_SHARING::isSharing() ) {
         auto new_end = std::remove_if( savegames.begin(), savegames.end(), []( const save_t &str ) {
@@ -1083,7 +1083,7 @@ void main_menu::world_tab( const std::string &worldname )
                               "If you have just started playing, consider creating new world instead.\n"
                               "Proceed?"
                           ) ) ) {
-                WORLDPTR world = world_generator->get_world( worldname );
+                WORLDINFO* world = world_generator->get_world( worldname );
                 world_generator->edit_active_world_mods( world );
             }
             break;

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -218,7 +218,7 @@ void main_menu::display_sub_menu( int sel, const point &bottom_left, int sel_lin
             }
             std::vector<std::string> all_worldnames = world_generator->all_worldnames();
             for( int i = 0; static_cast<size_t>( i ) < all_worldnames.size(); i++ ) {
-                WORLDINFO* world = world_generator->get_world( all_worldnames[i] );
+                WORLDINFO *world = world_generator->get_world( all_worldnames[i] );
                 int savegames_count = world->world_saves.size();
                 nc_color clr = c_white;
                 std::string txt = all_worldnames[i];
@@ -894,7 +894,7 @@ bool main_menu::new_character_tab()
     } );
     g->gamemode.reset();
 
-    WORLDINFO* world;
+    WORLDINFO *world;
     if( sel2 == 5 ) {
         g->gamemode = get_special_game( special_game_type::TUTORIAL );
         world = world_generator->make_new_world( special_game_type::TUTORIAL );
@@ -961,7 +961,7 @@ bool main_menu::new_character_tab()
 
 bool main_menu::load_character_tab( const std::string &worldname )
 {
-    WORLDINFO* world = world_generator->get_world( worldname );
+    WORLDINFO *world = world_generator->get_world( worldname );
     savegames = world->world_saves;
     if( MAP_SHARING::isSharing() ) {
         auto new_end = std::remove_if( savegames.begin(), savegames.end(), []( const save_t &str ) {
@@ -1083,7 +1083,7 @@ void main_menu::world_tab( const std::string &worldname )
                               "If you have just started playing, consider creating new world instead.\n"
                               "Proceed?"
                           ) ) ) {
-                WORLDINFO* world = world_generator->get_world( worldname );
+                WORLDINFO *world = world_generator->get_world( worldname );
                 world_generator->edit_active_world_mods( world );
             }
             break;

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -364,7 +364,7 @@ std::vector<std::string> main_menu::load_file( const std::string &path,
         const std::string &alt_text ) const
 {
     std::vector<std::string> result;
-    read_from_file_optional( path, [&result]( std::istream & fin ) {
+    read_from_file( path, [&result]( std::istream & fin ) {
         std::string line;
         while( std::getline( fin, line ) ) {
             if( !line.empty() && line[0] == '#' ) {
@@ -372,7 +372,7 @@ std::vector<std::string> main_menu::load_file( const std::string &path,
             }
             result.push_back( line );
         }
-    } );
+    }, true );
     if( result.empty() ) {
         result.push_back( alt_text );
     }
@@ -427,14 +427,14 @@ void main_menu::init_strings()
 
     // Credits
     mmenu_credits.clear();
-    read_from_file_optional( PATH_INFO::credits(), [&]( std::istream & stream ) {
+    read_from_file( PATH_INFO::credits(), [&]( std::istream & stream ) {
         std::string line;
         while( std::getline( stream, line ) ) {
             if( line[0] != '#' ) {
                 mmenu_credits += ( line.empty() ? " " : line ) + "\n";
             }
         }
-    } );
+    }, true );
 
     if( mmenu_credits.empty() ) {
         mmenu_credits = _( "No credits information found." );

--- a/src/map_memory.cpp
+++ b/src/map_memory.cpp
@@ -295,7 +295,7 @@ void map_memory::load( const tripoint &pos )
 bool map_memory::save( const tripoint &pos )
 {
     tripoint sm_center = coord_pair( pos ).sm;
-    
+
     clear_cache();
 
     dbg( DL::Info ) << "N submaps before save: " << submaps.size();

--- a/src/map_memory.cpp
+++ b/src/map_memory.cpp
@@ -250,7 +250,7 @@ shared_ptr_fast<mm_submap> map_memory::load_submap( const tripoint &sm_pos )
     };
 
     try {
-        if( !read_from_file_optional_json( path, loader ) ) {
+        if( !read_from_file_json( path, loader, true ) ) {
             // Region not found
             return nullptr;
         }
@@ -308,9 +308,9 @@ void map_memory::load( const tripoint &pos )
         const std::string legacy_file = find_legacy_mm_file();
         if( file_exist( legacy_file ) ) {
             try {
-                read_from_file_optional_json( legacy_file, [&]( JsonIn & jsin ) {
+                read_from_file_json( legacy_file, [&]( JsonIn & jsin ) {
                     this->load_legacy( jsin );
-                } );
+                }, true );
             } catch( const std::exception &err ) {
                 debugmsg( "Failed to load legacy memory map file: %s", err.what() );
             }

--- a/src/map_memory.cpp
+++ b/src/map_memory.cpp
@@ -9,6 +9,7 @@
 #include "line.h"
 #include "translations.h"
 #include "map.h"
+#include "world.h"
 const memorized_terrain_tile mm_submap::default_tile { "", 0, 0 };
 const int mm_submap::default_symbol = 0;
 
@@ -18,12 +19,14 @@ const int mm_submap::default_symbol = 0;
 
 static std::string find_legacy_mm_file()
 {
-    return g->get_player_base_save_path() + ".mm";
+    return g->get_active_world()->info->folder_path() + "/" 
+        + g->get_active_world()->get_player_base_save_path() + ".mm";
 }
 
 static std::string find_mm_dir()
 {
-    return string_format( "%s.mm1", g->get_player_base_save_path() );
+    return string_format( "%s.mm1", g->get_active_world()->info->folder_path() + "/" 
+        + g->get_active_world()->get_player_base_save_path() );
 }
 
 static std::string find_region_path( const std::string &dirname, const tripoint &p )

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -260,8 +260,8 @@ submap *mapbuffer::unserialize_submaps( const tripoint &p )
     }
 
     using namespace std::placeholders;
-    if( !g->get_active_world()->read_from_file_optional_json( quad_path, std::bind( &mapbuffer::deserialize,
-            this, _1 ) ) ) {
+    if( !g->get_active_world()->read_from_file_json( quad_path, std::bind( &mapbuffer::deserialize,
+            this, _1 ), true ) ) {
         // If it doesn't exist, trigger generating it.
         return nullptr;
     }

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -125,7 +125,7 @@ void mapbuffer::save( bool delete_after_save )
         // A segment is a chunk of 32x32 submap quads.
         // We're breaking them into subdirectories so there aren't too many files per directory.
         // Might want to make a set for this one too so it's only checked once per save().
-        
+
         // delete_on_save deletes everything, otherwise delete submaps
         // outside the current map.
         const bool zlev_del = !map_has_zlevels && om_addr.z != g->get_levz();

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -26,18 +26,6 @@
 #include "ui_manager.h"
 #include "world.h"
 
-static std::string find_quad_path( const std::string &dirname, const tripoint &om_addr )
-{
-    return string_format( "%s/%d.%d.%d.map", dirname, om_addr.x, om_addr.y, om_addr.z );
-}
-
-static std::string find_dirname( const tripoint &om_addr )
-{
-    const tripoint segment_addr = omt_to_seg_copy( om_addr );
-    return string_format( "maps/%d.%d.%d", segment_addr.x,
-                          segment_addr.y, segment_addr.z );
-}
-
 mapbuffer MAPBUFFER;
 
 mapbuffer::mapbuffer() = default;
@@ -98,8 +86,6 @@ submap *mapbuffer::lookup_submap( const tripoint &p )
 
 void mapbuffer::save( bool delete_after_save )
 {
-    assure_dir_exist( g->get_world_base_save_path() + "/maps" );
-
     int num_saved_submaps = 0;
     int num_total_submaps = submaps.size();
 
@@ -139,13 +125,11 @@ void mapbuffer::save( bool delete_after_save )
         // A segment is a chunk of 32x32 submap quads.
         // We're breaking them into subdirectories so there aren't too many files per directory.
         // Might want to make a set for this one too so it's only checked once per save().
-        const std::string dirname = find_dirname( om_addr );
-        const std::string quad_path = find_quad_path( dirname, om_addr );
-
+        
         // delete_on_save deletes everything, otherwise delete submaps
         // outside the current map.
         const bool zlev_del = !map_has_zlevels && om_addr.z != g->get_levz();
-        save_quad( quad_path, om_addr, submaps_to_delete,
+        save_quad( om_addr, submaps_to_delete,
                    delete_after_save || zlev_del ||
                    om_addr.x < map_origin.x || om_addr.y < map_origin.y ||
                    om_addr.x > map_origin.x + HALF_MAPSIZE ||
@@ -159,8 +143,7 @@ void mapbuffer::save( bool delete_after_save )
     get_distribution_grid_tracker().on_saved();
 }
 
-void mapbuffer::save_quad( const std::string &filename,
-                           const tripoint &om_addr, std::list<tripoint> &submaps_to_delete,
+void mapbuffer::save_quad( const tripoint &om_addr, std::list<tripoint> &submaps_to_delete,
                            bool delete_after_save )
 {
     std::vector<point> offsets;
@@ -199,8 +182,7 @@ void mapbuffer::save_quad( const std::string &filename,
         return;
     }
 
-    assure_dir_exist( g->get_world_base_save_path() + "/" + find_dirname( om_addr ) );
-    g->get_active_world()->write_to_file( filename, [&]( std::ostream & fout ) {
+    g->get_active_world()->write_map_quad( om_addr, [&]( std::ostream & fout ) {
         JsonOut jsout( fout );
         jsout.start_array();
         for( auto &submap_addr : submap_addrs ) {
@@ -244,30 +226,16 @@ submap *mapbuffer::unserialize_submaps( const tripoint &p )
 {
     // Map the tripoint to the submap quad that stores it.
     const tripoint om_addr = sm_to_omt_copy( p );
-    const std::string dirname = find_dirname( om_addr );
-    std::string quad_path = find_quad_path( dirname, om_addr );
-
-    if( !g->get_active_world()->file_exist( quad_path ) ) {
-        // Fix for old saves where the path was generated using std::stringstream, which
-        // did format the number using the current locale. That formatting may insert
-        // thousands separators, so the resulting path is "map/1,234.7.8.map" instead
-        // of "map/1234.7.8.map".
-        std::ostringstream buffer;
-        buffer << dirname << "/" << om_addr.x << "." << om_addr.y << "." << om_addr.z << ".map";
-        if( g->get_active_world()->file_exist( buffer.str() ) ) {
-            quad_path = buffer.str();
-        }
-    }
 
     using namespace std::placeholders;
-    if( !g->get_active_world()->read_from_file_json( quad_path, std::bind( &mapbuffer::deserialize,
-            this, _1 ), true ) ) {
+    if( !g->get_active_world()->read_map_quad( om_addr, std::bind( &mapbuffer::deserialize,
+            this, _1 ) ) ) {
         // If it doesn't exist, trigger generating it.
         return nullptr;
     }
     if( !submaps.contains( p ) ) {
-        debugmsg( "file %s did not contain the expected submap %d,%d,%d",
-                  quad_path, p.x, p.y, p.z );
+        debugmsg( "file did not contain the expected submap %d,%d,%d",
+                  p.x, p.y, p.z );
         return nullptr;
     }
     return submaps[ p ].get();

--- a/src/mapbuffer.h
+++ b/src/mapbuffer.h
@@ -79,8 +79,7 @@ class mapbuffer
         void remove_submap( tripoint addr );
         submap *unserialize_submaps( const tripoint &p );
         void deserialize( JsonIn &jsin );
-        void save_quad( const std::string &filename,
-                        const tripoint &om_addr, std::list<tripoint> &submaps_to_delete,
+        void save_quad( const tripoint &om_addr, std::list<tripoint> &submaps_to_delete,
                         bool delete_after_save );
         submap_map_t submaps;
 };

--- a/src/mapbuffer.h
+++ b/src/mapbuffer.h
@@ -79,7 +79,7 @@ class mapbuffer
         void remove_submap( tripoint addr );
         submap *unserialize_submaps( const tripoint &p );
         void deserialize( JsonIn &jsin );
-        void save_quad( const std::string &dirname, const std::string &filename,
+        void save_quad( const std::string &filename,
                         const tripoint &om_addr, std::list<tripoint> &submaps_to_delete,
                         bool delete_after_save );
         submap_map_t submaps;

--- a/src/mod_manager.cpp
+++ b/src/mod_manager.cpp
@@ -413,12 +413,12 @@ bool mod_manager::set_default_mods( const t_mod_list &mods )
     return mod_management::save_mod_list( mods, PATH_INFO::mods_user_default() );
 }
 
-std::string mod_manager::get_mods_list_file( WORLDINFO* world )
+std::string mod_manager::get_mods_list_file( WORLDINFO *world )
 {
     return world->folder_path() + "/mods.json";
 }
 
-void mod_manager::save_mods_list( WORLDINFO* world ) const
+void mod_manager::save_mods_list( WORLDINFO *world ) const
 {
     if( world == nullptr ) {
         return;
@@ -436,7 +436,7 @@ void mod_manager::save_mods_list( WORLDINFO* world ) const
     }, _( "list of mods" ) );
 }
 
-void mod_manager::load_mods_list( WORLDINFO* world ) const
+void mod_manager::load_mods_list( WORLDINFO *world ) const
 {
     if( world == nullptr ) {
         return;

--- a/src/mod_manager.cpp
+++ b/src/mod_manager.cpp
@@ -413,12 +413,12 @@ bool mod_manager::set_default_mods( const t_mod_list &mods )
     return mod_management::save_mod_list( mods, PATH_INFO::mods_user_default() );
 }
 
-std::string mod_manager::get_mods_list_file( const WORLDPTR world )
+std::string mod_manager::get_mods_list_file( WORLDINFO* world )
 {
     return world->folder_path() + "/mods.json";
 }
 
-void mod_manager::save_mods_list( WORLDPTR world ) const
+void mod_manager::save_mods_list( WORLDINFO* world ) const
 {
     if( world == nullptr ) {
         return;
@@ -436,7 +436,7 @@ void mod_manager::save_mods_list( WORLDPTR world ) const
     }, _( "list of mods" ) );
 }
 
-void mod_manager::load_mods_list( WORLDPTR world ) const
+void mod_manager::load_mods_list( WORLDINFO* world ) const
 {
     if( world == nullptr ) {
         return;

--- a/src/mod_manager.cpp
+++ b/src/mod_manager.cpp
@@ -102,14 +102,14 @@ const std::map<std::string, std::string> &get_mod_list_cat_tab()
 
 void mod_manager::load_replacement_mods( const std::string &path )
 {
-    read_from_file_optional_json( path, [&]( JsonIn & jsin ) {
+    read_from_file_json( path, [&]( JsonIn & jsin ) {
         jsin.start_array();
         while( !jsin.end_array() ) {
             auto arr = jsin.get_array();
             mod_replacements.emplace( mod_id( arr.get_string( 0 ) ),
                                       mod_id( arr.size() > 1 ? arr.get_string( 1 ) : "" ) );
         }
-    } );
+    }, true );
 }
 
 mod_manager::mod_manager()
@@ -308,7 +308,7 @@ std::optional<MOD_INFORMATION> load_modfile( const JsonObject &jo, const std::st
 void load_mod_info( const std::string &info_file_path, std::vector<MOD_INFORMATION> &out )
 {
     const std::string main_path = info_file_path.substr( 0, info_file_path.find_last_of( "/\\" ) );
-    read_from_file_optional_json( info_file_path, [&]( JsonIn & jsin ) {
+    read_from_file_json( info_file_path, [&]( JsonIn & jsin ) {
         if( jsin.test_object() ) {
             // find type and dispatch single object
             JsonObject jo = jsin.get_object();
@@ -334,7 +334,7 @@ void load_mod_info( const std::string &info_file_path, std::vector<MOD_INFORMATI
             // not an object or an array?
             jsin.error( "expected array or object" );
         }
-    } );
+    }, true );
 }
 
 bool save_mod_list( const t_mod_list &list, const std::string &path )
@@ -353,7 +353,7 @@ std::optional<t_mod_list> load_mod_list( const std::string &path )
         jsin.read( res, true );
     };
 
-    if( read_from_file_optional_json( path, reader ) ) {
+    if( read_from_file_json( path, reader, true ) ) {
         return { std::move( res ) };
     } else {
         return std::nullopt;
@@ -444,7 +444,7 @@ void mod_manager::load_mods_list( WORLDINFO* world ) const
     std::vector<mod_id> &amo = world->active_mod_order;
     amo.clear();
     bool obsolete_mod_found = false;
-    read_from_file_optional_json( get_mods_list_file( world ), [&]( JsonIn & jsin ) {
+    read_from_file_json( get_mods_list_file( world ), [&]( JsonIn & jsin ) {
         for( const std::string line : jsin.get_array() ) {
             const mod_id mod( line );
             if( std::find( amo.begin(), amo.end(), mod ) != amo.end() ) {
@@ -460,7 +460,7 @@ void mod_manager::load_mods_list( WORLDINFO* world ) const
             }
             amo.push_back( mod );
         }
-    } );
+    }, true );
     if( obsolete_mod_found ) {
         // If we found an obsolete mod, overwrite the mod list without the obsolete one.
         save_mods_list( world );

--- a/src/mod_manager.h
+++ b/src/mod_manager.h
@@ -14,9 +14,7 @@
 #include "ret_val.h"
 #include "type_id.h"
 
-struct WORLD;
-
-using WORLDPTR = WORLD *;
+struct WORLDINFO;
 class JsonObject;
 class dependency_tree;
 class mod_manager;
@@ -165,12 +163,12 @@ class mod_manager
          * Save list of mods that are active in that world to
          * the world folder.
          */
-        void save_mods_list( WORLDPTR world ) const;
+        void save_mods_list( WORLDINFO* world ) const;
         /**
          * Load list of mods that should be active in that
          * world.
          */
-        void load_mods_list( WORLDPTR world ) const;
+        void load_mods_list( WORLDINFO* world ) const;
         const t_mod_list &get_default_mods() const;
         bool set_default_mods( const t_mod_list &mods );
         std::vector<mod_id> get_all_sorted() const;
@@ -184,7 +182,7 @@ class mod_manager
          * @returns path of a file in the world folder that contains
          * the list of mods that should be loaded for this world.
          */
-        static std::string get_mods_list_file( WORLDPTR world );
+        static std::string get_mods_list_file( WORLDINFO* world );
 
         /**
          * Add mods from given list to the pool.

--- a/src/mod_manager.h
+++ b/src/mod_manager.h
@@ -163,12 +163,12 @@ class mod_manager
          * Save list of mods that are active in that world to
          * the world folder.
          */
-        void save_mods_list( WORLDINFO* world ) const;
+        void save_mods_list( WORLDINFO *world ) const;
         /**
          * Load list of mods that should be active in that
          * world.
          */
-        void load_mods_list( WORLDINFO* world ) const;
+        void load_mods_list( WORLDINFO *world ) const;
         const t_mod_list &get_default_mods() const;
         bool set_default_mods( const t_mod_list &mods );
         std::vector<mod_id> get_all_sorted() const;
@@ -182,7 +182,7 @@ class mod_manager
          * @returns path of a file in the world folder that contains
          * the list of mods that should be loaded for this world.
          */
-        static std::string get_mods_list_file( WORLDINFO* world );
+        static std::string get_mods_list_file( WORLDINFO *world );
 
         /**
          * Add mods from given list to the pool.

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -225,7 +225,7 @@ void avatar::randomize( const bool random_scenario, points_left &points, bool pl
     init_age = rng( 16, 55 );
     // if adjusting min and max height from 145 and 200, make sure to see set_description()
     init_height = rng( 145, 200 );
-    bool cities_enabled = world_generator->active_world->WORLD_OPTIONS["CITY_SIZE"].getValue() != "0";
+    bool cities_enabled = world_generator->active_world->info->WORLD_OPTIONS["CITY_SIZE"].getValue() != "0";
     if( random_scenario ) {
         std::vector<const scenario *> scenarios;
         for( const auto &scen : scenario::get_all() ) {
@@ -455,7 +455,7 @@ bool avatar::create( character_type type, const std::string &tempname )
     }
 
     auto nameExists = [&]( const std::string & name ) {
-        return world_generator->active_world->save_exists( save_t::from_save_id( name ) ) &&
+        return world_generator->active_world->info->save_exists( save_t::from_save_id( name ) ) &&
                !query_yn( _( "A save with the name '%s' already exists in this world.\n"
                              "Saving will overwrite the already existing character.\n\n"
                              "Continue anyways?" ), name );
@@ -2338,7 +2338,7 @@ tab_direction set_scenario( avatar &u, points_left &points,
     do {
         if( recalc_scens ) {
             sorted_scens.clear();
-            auto &wopts = world_generator->active_world->WORLD_OPTIONS;
+            auto &wopts = world_generator->active_world->info->WORLD_OPTIONS;
             for( const auto &scen : scenario::get_all() ) {
                 if( scen.scen_is_blacklisted() ) {
                     continue;

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -225,7 +225,8 @@ void avatar::randomize( const bool random_scenario, points_left &points, bool pl
     init_age = rng( 16, 55 );
     // if adjusting min and max height from 145 and 200, make sure to see set_description()
     init_height = rng( 145, 200 );
-    bool cities_enabled = world_generator->active_world->info->WORLD_OPTIONS["CITY_SIZE"].getValue() != "0";
+    bool cities_enabled = world_generator->active_world->info->WORLD_OPTIONS["CITY_SIZE"].getValue() !=
+                          "0";
     if( random_scenario ) {
         std::vector<const scenario *> scenarios;
         for( const auto &scen : scenario::get_all() ) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2748,7 +2748,7 @@ static void refresh_tiles( bool used_tiles_changed, bool pixel_minimap_height_ch
 
             tilecontext->load_tileset(
                 get_option<std::string>( "TILES" ),
-                ingame ? world_generator->active_world->active_mod_order : dummy,
+                ingame ? world_generator->active_world->info->active_mod_order : dummy,
                 /*precheck=*/false,
                 /*force=*/force_tile_change,
                 /*pump_events=*/true
@@ -3309,8 +3309,8 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
 
             save();
             if( ingame && world_options_changed ) {
-                world_generator->active_world->WORLD_OPTIONS = ACTIVE_WORLD_OPTIONS;
-                world_generator->active_world->save();
+                world_generator->active_world->info->WORLD_OPTIONS = ACTIVE_WORLD_OPTIONS;
+                world_generator->active_world->info->save();
             }
             g->on_options_changed();
         } else {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3478,9 +3478,9 @@ bool options_manager::save()
 void options_manager::load()
 {
     const auto file = PATH_INFO::options();
-    read_from_file_optional_json( file, [&]( JsonIn & jsin ) {
+    read_from_file_json( file, [&]( JsonIn & jsin ) {
         deserialize( jsin );
-    } );
+    }, true );
 
     cache_to_globals();
 }

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6116,7 +6116,7 @@ void overmap::save() const
         serialize_view( stream );
     } );
 
-    g->get_active_world()->write_overmap( loc, [&](std::ostream & stream ) {
+    g->get_active_world()->write_overmap( loc, [&]( std::ostream & stream ) {
         serialize( stream );
     } );
 }

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6087,12 +6087,12 @@ void overmap::open( overmap_special_batch &enabled_specials )
         overmap::unserialize( fin, terfilename );
     };
 
-    if( g->get_active_world()->read_from_file_optional( terfilename, ter_reader ) ) {
+    if( g->get_active_world()->read_from_file( terfilename, ter_reader, true ) ) {
         const std::string plrfilename = overmapbuffer::player_filename( loc );
         const auto plr_reader = [&]( std::istream & fin ) {
             overmap::unserialize_view( fin, plrfilename );
         };
-        read_from_file_optional( plrfilename, plr_reader );
+        read_from_file( plrfilename, plr_reader, true );
     } else { // No map exists!  Prepare neighbors, and generate one.
         std::vector<const overmap *> pointers;
         // Fetch south and north

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6081,18 +6081,18 @@ void overmap::place_radios()
 
 void overmap::open( overmap_special_batch &enabled_specials )
 {
-    const std::string terfilename = overmapbuffer::terrain_filename( loc );
+    // const std::string terfilename = overmapbuffer::terrain_filename( loc );
 
     const auto ter_reader = [&]( std::istream & fin ) {
-        overmap::unserialize( fin, terfilename );
+        overmap::unserialize( fin, string_format( "overmap terrain %d.%d", loc.x(), loc.y() ) );
     };
 
-    if( g->get_active_world()->read_from_file( terfilename, ter_reader, true ) ) {
-        const std::string plrfilename = overmapbuffer::player_filename( loc );
+    if( g->get_active_world()->read_overmap( loc, ter_reader ) ) {
+        // const std::string plrfilename = overmapbuffer::player_filename( loc );
         const auto plr_reader = [&]( std::istream & fin ) {
-            overmap::unserialize_view( fin, plrfilename );
+            overmap::unserialize_view( fin, string_format( "overmap visibility %d.%d", loc.x(), loc.y() ) );
         };
-        read_from_file( plrfilename, plr_reader, true );
+        g->get_active_world()->read_overmap_player_visibility( loc, plr_reader );
     } else { // No map exists!  Prepare neighbors, and generate one.
         std::vector<const overmap *> pointers;
         // Fetch south and north
@@ -6112,12 +6112,11 @@ void overmap::open( overmap_special_batch &enabled_specials )
 // Note: this may throw io errors from std::ofstream
 void overmap::save() const
 {
-    write_to_file( overmapbuffer::player_filename( loc ), [&]( std::ostream & stream ) {
+    g->get_active_world()->write_overmap_player_visibility( loc, [&]( std::ostream & stream ) {
         serialize_view( stream );
     } );
 
-    g->get_active_world()->write_to_file( overmapbuffer::terrain_filename( loc ), [&](
-    std::ostream & stream ) {
+    g->get_active_world()->write_overmap( loc, [&](std::ostream & stream ) {
         serialize( stream );
     } );
 }

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -60,6 +60,7 @@
 #include "string_utils.h"
 #include "text_snippets.h"
 #include "translations.h"
+#include "world.h"
 
 static const efftype_id effect_pet( "pet" );
 
@@ -6086,7 +6087,7 @@ void overmap::open( overmap_special_batch &enabled_specials )
         overmap::unserialize( fin, terfilename );
     };
 
-    if( read_from_file_optional( terfilename, ter_reader ) ) {
+    if( g->get_active_world()->read_from_file_optional( terfilename, ter_reader ) ) {
         const std::string plrfilename = overmapbuffer::player_filename( loc );
         const auto plr_reader = [&]( std::istream & fin ) {
             overmap::unserialize_view( fin, plrfilename );
@@ -6115,7 +6116,8 @@ void overmap::save() const
         serialize_view( stream );
     } );
 
-    write_to_file( overmapbuffer::terrain_filename( loc ), [&]( std::ostream & stream ) {
+    g->get_active_world()->write_to_file( overmapbuffer::terrain_filename( loc ), [&](
+    std::ostream & stream ) {
         serialize( stream );
     } );
 }

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -67,15 +67,6 @@ omt_find_params::~omt_find_params() = default;
 
 omt_route_params::~omt_route_params() = default;
 
-std::string overmapbuffer::terrain_filename( const point_abs_om &p )
-{
-    return string_format( "o.%d.%d", p.x(), p.y() );
-}
-
-std::string overmapbuffer::player_filename( const point_abs_om &p )
-{
-    return string_format( "%s.seen.%d.%d", g->get_player_base_save_path(), p.x(), p.y() );
-}
 
 overmap &overmapbuffer::get( const point_abs_om &p )
 {
@@ -268,7 +259,7 @@ overmap *overmapbuffer::get_existing( const point_abs_om &p )
         // checked in a previous call of this function).
         return nullptr;
     }
-    if( g->get_active_world() && g->get_active_world()->file_exist( terrain_filename( p ) ) ) {
+    if( g->get_active_world() && g->get_active_world()->overmap_exists( p ) ) {
         // File exists, load it normally (the get function
         // indirectly call overmap::open to do so).
         return &get( p );

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -44,6 +44,7 @@
 #include "vehicle.h"
 #include "vehicle_part.h"
 #include "profile.h"
+#include "world.h"
 
 class map_extra;
 
@@ -68,7 +69,7 @@ omt_route_params::~omt_route_params() = default;
 
 std::string overmapbuffer::terrain_filename( const point_abs_om &p )
 {
-    return string_format( "%s/o.%d.%d", g->get_world_base_save_path(), p.x(), p.y() );
+    return string_format( "o.%d.%d", p.x(), p.y() );
 }
 
 std::string overmapbuffer::player_filename( const point_abs_om &p )
@@ -267,7 +268,7 @@ overmap *overmapbuffer::get_existing( const point_abs_om &p )
         // checked in a previous call of this function).
         return nullptr;
     }
-    if( file_exist( terrain_filename( p ) ) ) {
+    if( g->get_active_world() && g->get_active_world()->file_exist( terrain_filename( p ) ) ) {
         // File exists, load it normally (the get function
         // indirectly call overmap::open to do so).
         return &get( p );

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -151,9 +151,6 @@ class overmapbuffer
     public:
         overmapbuffer();
 
-        static std::string terrain_filename( const point_abs_om & );
-        static std::string player_filename( const point_abs_om & );
-
         /**
          * Uses overmap coordinates, that means x and y are directly
          * compared with the position of the overmap.

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -2226,9 +2226,9 @@ bool panel_manager::save()
 
 bool panel_manager::load()
 {
-    return read_from_file_optional_json( PATH_INFO::panel_options(), [&]( JsonIn & jsin ) {
+    return read_from_file_json( PATH_INFO::panel_options(), [&]( JsonIn & jsin ) {
         deserialize( jsin );
-    } );
+    }, true );
 }
 
 void panel_manager::serialize( JsonOut &json )

--- a/src/safemode_ui.cpp
+++ b/src/safemode_ui.cpp
@@ -772,7 +772,7 @@ bool safemode::save( const bool is_character_in )
     };
 
     if( is_character ) {
-        world* world = g->get_active_world();
+        world *world = g->get_active_world();
         if( !world->player_file_exist( ".sav" ) ) {
             return true; //Character not saved yet.
         }

--- a/src/safemode_ui.cpp
+++ b/src/safemode_ui.cpp
@@ -29,6 +29,7 @@
 #include "string_utils.h"
 #include "translations.h"
 #include "ui_manager.h"
+#include "world.h"
 
 safemode &get_safemode()
 {
@@ -761,23 +762,32 @@ bool safemode::save_global()
 bool safemode::save( const bool is_character_in )
 {
     is_character = is_character_in;
-    auto file = PATH_INFO::safemode();
 
     if( is_character ) {
-        file = g->get_player_base_save_path() + ".sfm.json";
-        if( !file_exist( g->get_player_base_save_path() + ".sav" ) ) {
+        world* world = g->get_active_world();
+        if( !world->file_exist( world->get_player_base_save_path() + ".sav" ) ) {
             return true; //Character not saved yet.
         }
+
+        return world->write_to_file( world->get_player_base_save_path() + ".sfm.json", 
+        [&]( std::ostream & fout ) {
+            JsonOut jout( fout, true );
+            serialize( jout );
+
+            if( !is_character ) {
+                create_rules();
+            }
+        }, _( "safemode configuration" ) );
+    } else {
+        return write_to_file( PATH_INFO::safemode(), [&]( std::ostream & fout ) {
+            JsonOut jout( fout, true );
+            serialize( jout );
+
+            if( !is_character ) {
+                create_rules();
+            }
+        }, _( "safemode configuration" ) );
     }
-
-    return write_to_file( file, [&]( std::ostream & fout ) {
-        JsonOut jout( fout, true );
-        serialize( jout );
-
-        if( !is_character ) {
-            create_rules();
-        }
-    }, _( "safemode configuration" ) );
 }
 
 void safemode::load_character()
@@ -793,25 +803,22 @@ void safemode::load_global()
 void safemode::load( const bool is_character_in )
 {
     is_character = is_character_in;
-
-    std::ifstream fin;
-    std::string file = PATH_INFO::safemode();
-    if( is_character ) {
-        file = g->get_player_base_save_path() + ".sfm.json";
-    }
-
-    fin.open( file.c_str(), std::ifstream::in | std::ifstream::binary );
-
-    if( fin.good() ) {
+    auto loader = [&]( JsonIn & jsin ) {
         try {
-            JsonIn jsin( fin );
             deserialize( jsin );
         } catch( const JsonError &e ) {
-            debugmsg( "Error while loading safemode settings: %s", e.what() );
+            debugmsg( "Error loading safemode settings: %s", e.c_str() );
         }
+    };
+
+    std::ifstream fin;
+    if( is_character ) {
+        world* world = g->get_active_world();
+        world->read_from_file_json( world->get_player_base_save_path() + ".sfm.json", loader, true );
+    } else {
+        read_from_file_json( PATH_INFO::safemode(), loader, true );
     }
 
-    fin.close();
     create_rules();
 }
 

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3590,7 +3590,7 @@ void load_tileset()
     }
     tilecontext->load_tileset(
         get_option<std::string>( "TILES" ),
-        world_generator->active_world->active_mod_order,
+        world_generator->active_world->info->active_mod_order,
         /*precheck=*/false,
         /*force=*/false,
         /*pump_events=*/true

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -180,8 +180,8 @@ world::world( WORLDINFO *info )
     : info( info )
     , save_tx_start_ts( 0 )
 {
-    if( !assure_dir_exist( info->folder_path() )
-        || assure_dir_exist( info->folder_path() + "/maps" ) ) {
+    if( !assure_dir_exist( "" )
+        || !assure_dir_exist( "/maps" ) ) {
         dbg( DL::Error ) << "Unable to create or open world directory structure: " << info->folder_path();
     }
 

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -1,0 +1,106 @@
+#include "world.h"
+
+#include <sstream>
+#include <cstring>
+
+#include "debug.h"
+#include "cata_utility.h"
+#include "filesystem.h"
+#include "json.h"
+#include "output.h"
+#include "fstream_utils.h"
+#include "worldfactory.h"
+
+#define dbg(x) DebugLogFL((x),DC::Main)
+
+world::world( WORLDINFO* info )
+    : info( info )
+{
+    if( !assure_dir_exist( info->folder_path() ) ) {
+        dbg( DL::Error ) << "Unable to create or open world directory for saving: " << info->folder_path();
+    }
+
+    // std::string db_path = path + "/world.db";
+    // int ret;
+
+    // if( SQLITE_OK != ( ret = sqlite3_initialize() ) ) {
+    //     dbg( DL::Error ) << "Failed to initialize sqlite3 (Error " << ret << ")";
+    //     throw std::runtime_error( "Failed to initialize sqlite3" );
+    // }
+
+    // if( SQLITE_OK != ( ret = sqlite3_open_v2( db_path.c_str(), &db,
+    //                          SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, NULL ) ) ) {
+    //     dbg( DL::Error ) << "Failed to open db" << db_path << " (Error " << ret << ")";
+    //     throw std::runtime_error( "Failed to open db" );
+    // }
+
+    // auto sql = "CREATE TABLE IF NOT EXISTS files ("  \
+    //            "path           TEXT PRIMARY KEY NOT NULL," \
+    //            "parent         TEXT NOT NULL," \
+    //            "compression    TEXT DEFAULT NULL," \
+    //            "data           BLOB NOT NULL" \
+    //            ");";
+
+
+    // char *sqlErrMsg = 0;
+    // if( SQLITE_OK != ( ret = sqlite3_exec( db, sql, NULL, NULL, &sqlErrMsg ) ) ) {
+    //     dbg( DL::Error ) << "Failed to init db" << db_path << " (" << sqlErrMsg << ")";
+    //     throw std::runtime_error( "Failed to open db" );
+    // }
+}
+
+world::~world()
+{
+    // sqlite3_close( db );
+}
+
+bool world::file_exist( const std::string &path )
+{
+    return ::file_exist( info->folder_path() + "/" + path );
+}
+
+void world::write_to_file( const std::string &path,
+                             const std::function<void( std::ostream & )> &writer )
+{
+    ::write_to_file( info->folder_path() + "/" + path, writer );
+}
+
+bool world::write_to_file( const std::string &path,
+                             const std::function<void( std::ostream & )> &writer,
+                             const char *const fail_message )
+{
+    try {
+        write_to_file( path, writer );
+        return true;
+
+    } catch( const std::exception &err ) {
+        if( fail_message ) {
+            popup( _( "Failed to write %1$s to \"%2$s\": %3$s" ), fail_message, path.c_str(), err.what() );
+        }
+        return false;
+    }
+}
+
+bool world::read_from_file( const std::string &path,
+                              const std::function<void( std::istream & )> &reader )
+{
+    return ::read_from_file( info->folder_path() + "/" + path, reader );
+}
+
+bool world::read_from_file_optional( const std::string &path,
+                                       const std::function<void( std::istream & )> &reader )
+{
+    // Note: slight race condition here, but we'll ignore it. Worst case: the file
+    // exists and got removed before reading it -> reading fails with a message
+    // Or file does not exists, than everything works fine because it's optional anyway.
+    return file_exist( path ) && read_from_file( path, reader );
+}
+
+bool world::read_from_file_optional_json( const std::string &path,
+        const std::function<void( JsonIn & )> &reader )
+{
+    return read_from_file_optional( path, [&]( std::istream & fin ) {
+        JsonIn jsin( fin, path );
+        reader( jsin );
+    } );
+}

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -176,9 +176,9 @@ void load_external_option( const JsonObject &jo )
     }
 }
 
-world::world( WORLDINFO* info )
+world::world( WORLDINFO *info )
     : info( info )
-    ,save_tx_start_ts( 0 )
+    , save_tx_start_ts( 0 )
 {
     if( !assure_dir_exist( info->folder_path() )
         || assure_dir_exist( info->folder_path() + "/maps" ) ) {
@@ -221,22 +221,22 @@ world::~world()
 
 void world::start_save_tx()
 {
-    if (save_tx_start_ts != 0) {
+    if( save_tx_start_ts != 0 ) {
         throw std::runtime_error( "Attempted to start a save transaction while one was already in progress" );
     }
     save_tx_start_ts = std::chrono::duration_cast< std::chrono::milliseconds >(
-        std::chrono::system_clock::now().time_since_epoch()
-    ).count();
+                           std::chrono::system_clock::now().time_since_epoch()
+                       ).count();
 }
 
 long long world::commit_save_tx()
 {
-    if (save_tx_start_ts == 0) {
+    if( save_tx_start_ts == 0 ) {
         throw std::runtime_error( "Attempted to commit a save transaction while none was in progress" );
     }
     long long now = std::chrono::duration_cast< std::chrono::milliseconds >(
-        std::chrono::system_clock::now().time_since_epoch()
-    ).count();
+                        std::chrono::system_clock::now().time_since_epoch()
+                    ).count();
     long long duration = now - save_tx_start_ts;
     save_tx_start_ts = 0;
     return duration;
@@ -257,7 +257,7 @@ static std::string get_quad_filename( const tripoint &om_addr )
     return string_format( "%d.%d.%d.map", om_addr.x, om_addr.y, om_addr.z );
 }
 
-bool world::read_map_quad( const tripoint &om_addr, file_read_json_cb reader ) 
+bool world::read_map_quad( const tripoint &om_addr, file_read_json_cb reader )
 {
     const std::string dirname = get_quad_dirname( om_addr );
     std::string quad_path = dirname + "/" + get_quad_filename( om_addr );
@@ -277,7 +277,7 @@ bool world::read_map_quad( const tripoint &om_addr, file_read_json_cb reader )
     return read_from_file_json( quad_path, reader, true );
 }
 
-bool world::write_map_quad( const tripoint &om_addr, file_write_cb &writer ) 
+bool world::write_map_quad( const tripoint &om_addr, file_write_cb &writer )
 {
     const std::string dirname = get_quad_dirname( om_addr );
     std::string quad_path = dirname + "/" + get_quad_filename( om_addr );
@@ -300,29 +300,29 @@ std::string world::overmap_player_filename( const point_abs_om &p ) const
     return string_format( ".seen.%d.%d", p.x(), p.y() );
 }
 
-bool world::overmap_exists( const point_abs_om &p ) 
+bool world::overmap_exists( const point_abs_om &p )
 {
-    return file_exist( overmap_terrain_filename(p) );
+    return file_exist( overmap_terrain_filename( p ) );
 }
 
-bool world::read_overmap( const point_abs_om &p, file_read_cb reader ) 
+bool world::read_overmap( const point_abs_om &p, file_read_cb reader )
 {
-    return read_from_file( overmap_terrain_filename(p), reader, true );
+    return read_from_file( overmap_terrain_filename( p ), reader, true );
 }
 
-bool world::read_overmap_player_visibility( const point_abs_om &p, file_read_cb reader ) 
+bool world::read_overmap_player_visibility( const point_abs_om &p, file_read_cb reader )
 {
-    return read_from_player_file( overmap_player_filename(p), reader, true );
+    return read_from_player_file( overmap_player_filename( p ), reader, true );
 }
 
-bool world::write_overmap( const point_abs_om &p, file_write_cb writer ) 
+bool world::write_overmap( const point_abs_om &p, file_write_cb writer )
 {
-    return write_to_file( overmap_terrain_filename(p), writer );
+    return write_to_file( overmap_terrain_filename( p ), writer );
 }
 
-bool world::write_overmap_player_visibility( const point_abs_om &p, file_write_cb writer ) 
+bool world::write_overmap_player_visibility( const point_abs_om &p, file_write_cb writer )
 {
-    return write_to_player_file( overmap_player_filename(p), writer );
+    return write_to_player_file( overmap_player_filename( p ), writer );
 }
 
 /**
@@ -335,17 +335,17 @@ static std::string get_mm_filename( const tripoint &p )
 
 bool world::read_player_mm_quad( const tripoint &p, file_read_json_cb reader )
 {
-    return read_from_player_file_json(".mm1/" + get_mm_filename(p), reader, true);
+    return read_from_player_file_json( ".mm1/" + get_mm_filename( p ), reader, true );
 }
 
 bool world::write_player_mm_quad( const tripoint &p, file_write_cb &writer )
 {
     const std::string descr = string_format(
-        _( "memory map region for (%d,%d,%d)" ),
-        p.x, p.y, p.z
-    );
+                                  _( "memory map region for (%d,%d,%d)" ),
+                                  p.x, p.y, p.z
+                              );
     assure_dir_exist( get_player_path() + ".mm1" );
-    return write_to_player_file(".mm1/" + get_mm_filename(p), writer, descr.c_str());
+    return write_to_player_file( ".mm1/" + get_mm_filename( p ), writer, descr.c_str() );
 }
 
 /**
@@ -362,7 +362,8 @@ bool world::player_file_exist( const std::string &path )
     return file_exist( get_player_path() + path );
 }
 
-bool world::write_to_player_file( const std::string &path, file_write_cb &writer, const char *fail_message )
+bool world::write_to_player_file( const std::string &path, file_write_cb &writer,
+                                  const char *fail_message )
 {
     return write_to_file( get_player_path() + path, writer, fail_message );
 }
@@ -372,7 +373,8 @@ bool world::read_from_player_file( const std::string &path, file_read_cb reader,
     return read_from_file( get_player_path() + path, reader, optional );
 }
 
-bool world::read_from_player_file_json( const std::string &path, file_read_json_cb reader, bool optional )
+bool world::read_from_player_file_json( const std::string &path, file_read_json_cb reader,
+                                        bool optional )
 {
     return read_from_file_json( get_player_path() + path, reader, optional );
 }
@@ -391,7 +393,8 @@ bool world::file_exist( const std::string &path )
     return ::file_exist( info->folder_path() + "/" + path );
 }
 
-bool world::write_to_file( const std::string &path, file_write_cb &writer, const char *fail_message )
+bool world::write_to_file( const std::string &path, file_write_cb &writer,
+                           const char *fail_message )
 {
     return ::write_to_file( info->folder_path() + "/" + path, writer, fail_message );
 }

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -2,21 +2,187 @@
 
 #include <sstream>
 #include <cstring>
+#include <chrono>
 
+#include "game.h"
+#include "avatar.h"
 #include "debug.h"
 #include "cata_utility.h"
 #include "filesystem.h"
-#include "json.h"
 #include "output.h"
 #include "worldfactory.h"
+#include "mod_manager.h"
+#include "path_info.h"
 
 #define dbg(x) DebugLogFL((x),DC::Main)
 
+save_t::save_t( const std::string &name ): name( name ) {}
+
+std::string save_t::decoded_name() const
+{
+    return name;
+}
+
+std::string save_t::base_path() const
+{
+    return base64_encode( name );
+}
+
+save_t save_t::from_save_id( const std::string &save_id )
+{
+    return save_t( save_id );
+}
+
+save_t save_t::from_base_path( const std::string &base_path )
+{
+    return save_t( base64_decode( base_path ) );
+}
+
+std::string WORLDINFO::folder_path() const
+{
+    return PATH_INFO::savedir() + world_name;
+}
+
+WORLDINFO::WORLDINFO()
+{
+    world_name = world_generator->get_next_valid_worldname();
+    WORLD_OPTIONS = get_options().get_world_defaults();
+
+    world_saves.clear();
+    active_mod_order = world_generator->get_mod_manager().get_default_mods();
+}
+
+void WORLDINFO::COPY_WORLD( const WORLDINFO *world_to_copy )
+{
+    world_name = world_to_copy->world_name + "_copy";
+    WORLD_OPTIONS = world_to_copy->WORLD_OPTIONS;
+    active_mod_order = world_to_copy->active_mod_order;
+}
+
+bool WORLDINFO::needs_lua() const
+{
+    for( const mod_id &mod : active_mod_order ) {
+        if( mod.is_valid() && mod->lua_api_version ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool WORLDINFO::save_exists( const save_t &name ) const
+{
+    return std::find( world_saves.begin(), world_saves.end(), name ) != world_saves.end();
+}
+
+void WORLDINFO::add_save( const save_t &name )
+{
+    if( !save_exists( name ) ) {
+        world_saves.push_back( name );
+    }
+}
+
+void WORLDINFO::load_options( JsonIn &jsin )
+{
+    auto &opts = get_options();
+
+    jsin.start_array();
+    while( !jsin.end_array() ) {
+        JsonObject jo = jsin.get_object();
+        jo.allow_omitted_members();
+        const std::string name = opts.migrateOptionName( jo.get_string( "name" ) );
+        const std::string value = opts.migrateOptionValue( jo.get_string( "name" ),
+                                  jo.get_string( "value" ) );
+
+        if( opts.has_option( name ) && opts.get_option( name ).getPage() == "world_default" ) {
+            WORLD_OPTIONS[ name ].setValue( value );
+        }
+    }
+}
+
+void WORLDINFO::load_legacy_options( std::istream &fin )
+{
+    auto &opts = get_options();
+
+    //load legacy txt
+    std::string sLine;
+    while( !fin.eof() ) {
+        getline( fin, sLine );
+        if( !sLine.empty() && sLine[0] != '#' && std::count( sLine.begin(), sLine.end(), ' ' ) == 1 ) {
+            size_t ipos = sLine.find( ' ' );
+            // make sure that the option being loaded is part of the world_default page in OPTIONS
+            // In 0.C some lines consisted of a space and nothing else
+            const std::string name = opts.migrateOptionName( sLine.substr( 0, ipos ) );
+            const std::string value = opts.migrateOptionValue( sLine.substr( 0, ipos ), sLine.substr( ipos + 1,
+                                      sLine.length() ) );
+
+            if( ipos != 0 && opts.get_option( name ).getPage() == "world_default" ) {
+                WORLD_OPTIONS[name].setValue( value );
+            }
+        }
+    }
+}
+
+bool WORLDINFO::load_options()
+{
+    WORLD_OPTIONS = get_options().get_world_defaults();
+
+    using namespace std::placeholders;
+    const auto path = folder_path() + "/" + PATH_INFO::worldoptions();
+    return read_from_file_json( path, [&]( JsonIn & jsin ) {
+        load_options( jsin );
+    }, true );
+}
+
+void load_world_option( const JsonObject &jo )
+{
+    auto arr = jo.get_array( "options" );
+    if( arr.empty() ) {
+        jo.throw_error( "no options specified", "options" );
+    }
+    for( const std::string line : arr ) {
+        get_options().get_option( line ).setValue( "true" );
+    }
+}
+
+//load external option from json
+void load_external_option( const JsonObject &jo )
+{
+    auto name = jo.get_string( "name" );
+    auto stype = jo.get_string( "stype" );
+    options_manager &opts = get_options();
+    if( !opts.has_option( name ) ) {
+        auto sinfo = jo.get_string( "info" );
+        opts.add_external( name, "external_options", stype, sinfo, sinfo );
+    }
+    options_manager::cOpt &opt = opts.get_option( name );
+    if( stype == "float" ) {
+        opt.setValue( static_cast<float>( jo.get_float( "value" ) ) );
+    } else if( stype == "int" ) {
+        opt.setValue( jo.get_int( "value" ) );
+    } else if( stype == "bool" ) {
+        if( jo.get_bool( "value" ) ) {
+            opt.setValue( "true" );
+        } else {
+            opt.setValue( "false" );
+        }
+    } else if( stype == "string" ) {
+        opt.setValue( jo.get_string( "value" ) );
+    } else {
+        jo.throw_error( "Unknown or unsupported stype for external option", "stype" );
+    }
+    // Just visit this member if it exists
+    if( jo.has_member( "info" ) ) {
+        jo.get_string( "info" );
+    }
+}
+
 world::world( WORLDINFO* info )
     : info( info )
+    ,save_tx_start_ts( 0 )
 {
-    if( !assure_dir_exist( info->folder_path() ) ) {
-        dbg( DL::Error ) << "Unable to create or open world directory for saving: " << info->folder_path();
+    if( !assure_dir_exist( info->folder_path() )
+        || assure_dir_exist( info->folder_path() + "/maps" ) ) {
+        dbg( DL::Error ) << "Unable to create or open world directory structure: " << info->folder_path();
     }
 
     // std::string db_path = path + "/world.db";
@@ -51,6 +217,102 @@ world::world( WORLDINFO* info )
 world::~world()
 {
     // sqlite3_close( db );
+}
+
+void world::start_save_tx()
+{
+    if (save_tx_start_ts != 0) {
+        throw std::runtime_error( "Attempted to start a save transaction while one was already in progress" );
+    }
+    save_tx_start_ts = std::chrono::duration_cast< std::chrono::milliseconds >(
+        std::chrono::system_clock::now().time_since_epoch()
+    ).count();
+}
+
+long long world::commit_save_tx()
+{
+    if (save_tx_start_ts == 0) {
+        throw std::runtime_error( "Attempted to commit a save transaction while none was in progress" );
+    }
+    long long now = std::chrono::duration_cast< std::chrono::milliseconds >(
+        std::chrono::system_clock::now().time_since_epoch()
+    ).count();
+    long long duration = now - save_tx_start_ts;
+    save_tx_start_ts = 0;
+    return duration;
+}
+
+static std::string get_quad_dirname( const tripoint &om_addr )
+{
+    const tripoint segment_addr = omt_to_seg_copy( om_addr );
+    return string_format( "maps/%d.%d.%d", segment_addr.x, segment_addr.y, segment_addr.z );
+}
+
+static std::string get_quad_filename( const tripoint &om_addr )
+{
+    return string_format( "%d.%d.%d.map", om_addr.x, om_addr.y, om_addr.z );
+}
+
+bool world::read_map_quad( const tripoint &om_addr, file_read_json_cb reader ) {
+    const std::string dirname = get_quad_dirname( om_addr );
+    std::string quad_path = dirname + "/" + get_quad_filename( om_addr );
+
+    if( !file_exist( quad_path ) ) {
+        // Fix for old saves where the path was generated using std::stringstream, which
+        // did format the number using the current locale. That formatting may insert
+        // thousands separators, so the resulting path is "map/1,234.7.8.map" instead
+        // of "map/1234.7.8.map".
+        std::ostringstream buffer;
+        buffer << dirname << "/" << om_addr.x << "." << om_addr.y << "." << om_addr.z << ".map";
+        if( file_exist( buffer.str() ) ) {
+            quad_path = buffer.str();
+        }
+    }
+
+    return ::read_from_file_json( info->folder_path() + "/" + quad_path, reader, true );
+}
+
+std::string world::get_player_base_save_path() const
+{
+    return base64_encode( g->u.get_save_id() );
+}
+
+bool world::write_map_quad( const tripoint &om_addr, file_write_cb &writer ) {
+    const std::string dirname = get_quad_dirname( om_addr );
+    std::string quad_path = dirname + "/" + get_quad_filename( om_addr );
+
+    assure_dir_exist( info->folder_path() + "/" + dirname );
+    return ::write_to_file( info->folder_path() + "/" + quad_path, writer );
+}
+
+std::string world::overmap_terrain_filename( const point_abs_om &p ) const
+{
+    return string_format( "o.%d.%d", p.x(), p.y() );
+}
+
+std::string world::overmap_player_filename( const point_abs_om &p ) const
+{
+    return string_format( "%s.seen.%d.%d", get_player_base_save_path(), p.x(), p.y() );
+}
+
+bool world::overmap_exists( const point_abs_om &p ) {
+    return file_exist( overmap_terrain_filename(p) );
+}
+
+bool world::read_overmap( const point_abs_om &p, file_read_cb reader ) {
+    return ::read_from_file( info->folder_path() + "/" + overmap_terrain_filename(p), reader, true );
+}
+
+bool world::read_overmap_player_visibility( const point_abs_om &p, file_read_cb reader ) {
+    return ::read_from_file( info->folder_path() + "/" + overmap_player_filename(p), reader, true );
+}
+
+bool world::write_overmap( const point_abs_om &p, file_write_cb writer ) {
+    return ::write_to_file( info->folder_path() + "/" + overmap_terrain_filename(p), writer );
+}
+
+bool world::write_overmap_player_visibility( const point_abs_om &p, file_write_cb writer ) {
+    return ::write_to_file( info->folder_path() + "/" + overmap_player_filename(p), writer );
 }
 
 bool world::file_exist( const std::string &path )

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -8,7 +8,6 @@
 #include "filesystem.h"
 #include "json.h"
 #include "output.h"
-#include "fstream_utils.h"
 #include "worldfactory.h"
 
 #define dbg(x) DebugLogFL((x),DC::Main)
@@ -59,48 +58,17 @@ bool world::file_exist( const std::string &path )
     return ::file_exist( info->folder_path() + "/" + path );
 }
 
-void world::write_to_file( const std::string &path,
-                             const std::function<void( std::ostream & )> &writer )
+bool world::write_to_file( const std::string &path, file_write_cb &writer, const char *fail_message )
 {
-    ::write_to_file( info->folder_path() + "/" + path, writer );
+    return ::write_to_file( info->folder_path() + "/" + path, writer, fail_message );
 }
 
-bool world::write_to_file( const std::string &path,
-                             const std::function<void( std::ostream & )> &writer,
-                             const char *const fail_message )
+bool world::read_from_file( const std::string &path, file_read_cb reader, bool optional )
 {
-    try {
-        write_to_file( path, writer );
-        return true;
-
-    } catch( const std::exception &err ) {
-        if( fail_message ) {
-            popup( _( "Failed to write %1$s to \"%2$s\": %3$s" ), fail_message, path.c_str(), err.what() );
-        }
-        return false;
-    }
+    return ::read_from_file( info->folder_path() + "/" + path, reader, optional );
 }
 
-bool world::read_from_file( const std::string &path,
-                              const std::function<void( std::istream & )> &reader )
+bool world::read_from_file_json( const std::string &path, file_read_json_cb reader, bool optional )
 {
-    return ::read_from_file( info->folder_path() + "/" + path, reader );
-}
-
-bool world::read_from_file_optional( const std::string &path,
-                                       const std::function<void( std::istream & )> &reader )
-{
-    // Note: slight race condition here, but we'll ignore it. Worst case: the file
-    // exists and got removed before reading it -> reading fails with a message
-    // Or file does not exists, than everything works fine because it's optional anyway.
-    return file_exist( path ) && read_from_file( path, reader );
-}
-
-bool world::read_from_file_optional_json( const std::string &path,
-        const std::function<void( JsonIn & )> &reader )
-{
-    return read_from_file_optional( path, [&]( std::istream & fin ) {
-        JsonIn jsin( fin, path );
-        reader( jsin );
-    } );
+    return ::read_from_file_json( info->folder_path() + "/" + path, reader, optional );
 }

--- a/src/world.h
+++ b/src/world.h
@@ -38,7 +38,7 @@ class save_t
 
 /**
  * Structure containing metadata about a world. No actual world data is processed here.
- * 
+ *
  * The actual instances are owned by the worldfactory class. All other classes should
  * only have a pointer to one of these owned instances.
  */
@@ -78,16 +78,16 @@ struct WORLDINFO {
 class world
 {
     public:
-        world( WORLDINFO* info );
+        world( WORLDINFO *info );
         ~world();
 
-        WORLDINFO* info;
+        WORLDINFO *info;
 
         /**
          * Right now, each file write is independent of the others. Once we start
          * migrating to SQLite, each save would happen in a single transaction. This
          * gives two benefits: (1) atomicity, and (2) performance.
-         * 
+         *
          * When using the V1 non-sqlite save system, this merely records some metadata
          * so we can print how long the save took.
          */
@@ -117,9 +117,11 @@ class world
          * Player-specific file operations. Paths will be prefixed with the player's save ID.
          */
         bool player_file_exist( const std::string &path );
-        bool write_to_player_file( const std::string &path, file_write_cb &writer, const char *fail_message = nullptr );
+        bool write_to_player_file( const std::string &path, file_write_cb &writer,
+                                   const char *fail_message = nullptr );
         bool read_from_player_file( const std::string &path, file_read_cb reader, bool optional = false );
-        bool read_from_player_file_json( const std::string &path, file_read_json_cb reader, bool optional = false );
+        bool read_from_player_file_json( const std::string &path, file_read_json_cb reader,
+                                         bool optional = false );
 
         /*
          * Generic file operations, acting as a catch-all for miscellaneous save files
@@ -127,10 +129,12 @@ class world
          */
         bool assure_dir_exist( const std::string &path );
         bool file_exist( const std::string &path );
-        bool write_to_file( const std::string &path, file_write_cb &writer, const char *fail_message = nullptr );
+        bool write_to_file( const std::string &path, file_write_cb &writer,
+                            const char *fail_message = nullptr );
         bool read_from_file( const std::string &path, file_read_cb reader, bool optional = false );
-        bool read_from_file_json( const std::string &path, file_read_json_cb reader, bool optional = false );
-    
+        bool read_from_file_json( const std::string &path, file_read_json_cb reader,
+                                  bool optional = false );
+
     private:
         /** If non-zero, indicates we're in the middle of a save event */
         long long save_tx_start_ts = 0;

--- a/src/world.h
+++ b/src/world.h
@@ -100,7 +100,7 @@ class world
          */
         /**@{*/
         void start_save_tx();
-        long long commit_save_tx();
+        int64_t commit_save_tx();
         /**@}*/
 
         /*
@@ -108,34 +108,35 @@ class world
          * lay out files differently, so centralize file placement logic here rather than
          * scattering it throughout the codebase.
          */
-        bool read_map_quad( const tripoint &om_addr, file_read_json_cb reader );
-        bool write_map_quad( const tripoint &om_addr, file_write_cb writer );
+        bool read_map_quad( const tripoint &om_addr, file_read_json_fn reader ) const;
+        bool write_map_quad( const tripoint &om_addr, file_write_fn writer ) const;
 
-        bool overmap_exists( const point_abs_om &p );
-        bool read_overmap( const point_abs_om &p, file_read_cb reader );
-        bool read_overmap_player_visibility( const point_abs_om &p, file_read_cb reader );
-        bool write_overmap( const point_abs_om &p, file_write_cb writer );
-        bool write_overmap_player_visibility( const point_abs_om &p, file_write_cb writer );
+        bool overmap_exists( const point_abs_om &p ) const;
+        bool read_overmap( const point_abs_om &p, file_read_fn reader ) const;
+        bool read_overmap_player_visibility( const point_abs_om &p, file_read_fn reader );
+        bool write_overmap( const point_abs_om &p, file_write_fn writer ) const;
+        bool write_overmap_player_visibility( const point_abs_om &p, file_write_fn writer );
 
-        bool read_player_mm_quad( const tripoint &p, file_read_json_cb reader );
-        bool write_player_mm_quad( const tripoint &p, file_write_cb writer );
+        bool read_player_mm_quad( const tripoint &p, file_read_json_fn reader );
+        bool write_player_mm_quad( const tripoint &p, file_write_fn writer );
 
         /*
          * Player-specific file operations. Paths will be prefixed with the player's save ID.
          */
         bool player_file_exist( const std::string &path );
-        bool write_to_player_file( const std::string &path, file_write_cb writer,
+        bool write_to_player_file( const std::string &path, file_write_fn writer,
                                    const char *fail_message = nullptr );
-        bool read_from_player_file( const std::string &path, file_read_cb reader, bool optional = false );
-        bool read_from_player_file_json( const std::string &path, file_read_json_cb reader,
-                                         bool optional = false );
+        bool read_from_player_file( const std::string &path, file_read_fn reader,
+                                    bool optional = true );
+        bool read_from_player_file_json( const std::string &path, file_read_json_fn reader,
+                                         bool optional = true );
 
         /*
          * Generic file operations, acting as a catch-all for miscellaneous save files
          * living in the root of the world directory.
          */
-        bool assure_dir_exist( const std::string &path );
-        bool file_exist( const std::string &path );
+        bool assure_dir_exist( const std::string &path ) const;
+        bool file_exist( const std::string &path ) const;
 
         /**
          * If fail_message is provided, this method will eat any exceptions and display a popup with the
@@ -149,15 +150,16 @@ class world
          * @param fail_message The message to display if the write fails.
          * @return True if the write was successful, false otherwise.
          */
-        bool write_to_file( const std::string &path, file_write_cb writer,
-                            const char *fail_message = nullptr );
-        bool read_from_file( const std::string &path, file_read_cb reader, bool optional = false );
-        bool read_from_file_json( const std::string &path, file_read_json_cb reader,
-                                  bool optional = false );
+        bool write_to_file( const std::string &path, file_write_fn writer,
+                            const char *fail_message = nullptr ) const;
+        bool read_from_file( const std::string &path, file_read_fn reader,
+                             bool optional = true ) const;
+        bool read_from_file_json( const std::string &path, file_read_json_fn reader,
+                                  bool optional = true ) const;
 
     private:
         /** If non-zero, indicates we're in the middle of a save event */
-        long long save_tx_start_ts = 0;
+        int64_t save_tx_start_ts = 0;
 
         std::string overmap_terrain_filename( const point_abs_om &p ) const;
         std::string overmap_player_filename( const point_abs_om &p ) const;

--- a/src/world.h
+++ b/src/world.h
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef CATA_SRC_WORLDDB_H
-#define CATA_SRC_WORLDDB_H
+#ifndef CATA_SRC_WORLD_H
+#define CATA_SRC_WORLD_H
 
 #include <functional>
 #include <string>
@@ -36,6 +36,11 @@ class save_t
         save_t &operator=( const save_t & ) = default;
 };
 
+enum save_format : int {
+    /** Original save layout; uncompressed JSON as loose files */
+    V1 = 0,
+};
+
 /**
  * Structure containing metadata about a world. No actual world data is processed here.
  *
@@ -54,6 +59,8 @@ struct WORLDINFO {
         std::string world_name;
         options_manager::options_container WORLD_OPTIONS;
         std::vector<save_t> world_saves;
+        save_format world_save_format;
+
         /**
          * A (possibly empty) list of (idents of) mods that
          * should be loaded for this world.
@@ -102,7 +109,7 @@ class world
          * scattering it throughout the codebase.
          */
         bool read_map_quad( const tripoint &om_addr, file_read_json_cb reader );
-        bool write_map_quad( const tripoint &om_addr, file_write_cb &writer );
+        bool write_map_quad( const tripoint &om_addr, file_write_cb writer );
 
         bool overmap_exists( const point_abs_om &p );
         bool read_overmap( const point_abs_om &p, file_read_cb reader );
@@ -111,13 +118,13 @@ class world
         bool write_overmap_player_visibility( const point_abs_om &p, file_write_cb writer );
 
         bool read_player_mm_quad( const tripoint &p, file_read_json_cb reader );
-        bool write_player_mm_quad( const tripoint &p, file_write_cb &writer );
+        bool write_player_mm_quad( const tripoint &p, file_write_cb writer );
 
         /*
          * Player-specific file operations. Paths will be prefixed with the player's save ID.
          */
         bool player_file_exist( const std::string &path );
-        bool write_to_player_file( const std::string &path, file_write_cb &writer,
+        bool write_to_player_file( const std::string &path, file_write_cb writer,
                                    const char *fail_message = nullptr );
         bool read_from_player_file( const std::string &path, file_read_cb reader, bool optional = false );
         bool read_from_player_file_json( const std::string &path, file_read_json_cb reader,
@@ -142,7 +149,7 @@ class world
          * @param fail_message The message to display if the write fails.
          * @return True if the write was successful, false otherwise.
          */
-        bool write_to_file( const std::string &path, file_write_cb &writer,
+        bool write_to_file( const std::string &path, file_write_cb writer,
                             const char *fail_message = nullptr );
         bool read_from_file( const std::string &path, file_read_cb reader, bool optional = false );
         bool read_from_file_json( const std::string &path, file_read_json_cb reader,
@@ -155,6 +162,7 @@ class world
         std::string overmap_terrain_filename( const point_abs_om &p ) const;
         std::string overmap_player_filename( const point_abs_om &p ) const;
         std::string get_player_path() const;
+
 };
 
-#endif // CATA_SRC_WORLDDB_H
+#endif // CATA_SRC_WORLD_H

--- a/src/world.h
+++ b/src/world.h
@@ -5,6 +5,7 @@
 #include <functional>
 #include <string>
 #include "json.h"
+#include "fstream_utils.h"
 
 struct WORLDINFO;
 
@@ -18,21 +19,9 @@ class world
 
         bool file_exist( const std::string &path );
 
-        void write_to_file( const std::string &path,
-                            const std::function<void( std::ostream & )> &writer );
-
-        bool write_to_file( const std::string &path, const std::function<void( std::ostream & )> &writer,
-                            const char *const fail_message );
-
-        bool read_from_file( const std::string &path,
-                             const std::function<void( std::istream & )> &reader );
-        bool read_from_file_optional( const std::string &path,
-                                      const std::function<void( std::istream & )> &reader );
-        bool read_from_file_optional_json( const std::string &path,
-                                           const std::function<void( JsonIn & )> &reader );
-
-    private:
-        const std::string worlddir;
+        bool write_to_file( const std::string &path, file_write_cb &writer, const char *fail_message = nullptr );
+        bool read_from_file( const std::string &path, file_read_cb reader, bool optional = false );
+        bool read_from_file_json( const std::string &path, file_read_json_cb reader, bool optional = false );
 };
 
 #endif // CATA_SRC_WORLDDB_H

--- a/src/world.h
+++ b/src/world.h
@@ -1,0 +1,38 @@
+#pragma once
+#ifndef CATA_SRC_WORLDDB_H
+#define CATA_SRC_WORLDDB_H
+
+#include <functional>
+#include <string>
+#include "json.h"
+
+struct WORLDINFO;
+
+class world
+{
+    public:
+        world( WORLDINFO* info );
+        ~world();
+
+        WORLDINFO* info;
+
+        bool file_exist( const std::string &path );
+
+        void write_to_file( const std::string &path,
+                            const std::function<void( std::ostream & )> &writer );
+
+        bool write_to_file( const std::string &path, const std::function<void( std::ostream & )> &writer,
+                            const char *const fail_message );
+
+        bool read_from_file( const std::string &path,
+                             const std::function<void( std::istream & )> &reader );
+        bool read_from_file_optional( const std::string &path,
+                                      const std::function<void( std::istream & )> &reader );
+        bool read_from_file_optional_json( const std::string &path,
+                                           const std::function<void( JsonIn & )> &reader );
+
+    private:
+        const std::string worlddir;
+};
+
+#endif // CATA_SRC_WORLDDB_H

--- a/src/world.h
+++ b/src/world.h
@@ -129,6 +129,19 @@ class world
          */
         bool assure_dir_exist( const std::string &path );
         bool file_exist( const std::string &path );
+
+        /**
+         * If fail_message is provided, this method will eat any exceptions and display a popup with the
+         * exception detail and the message. If fail_message is not provided, the exception will be
+         * propagated.
+         *
+         * To eat any exceptions and not display a popup, pass the empty string as fail_message.
+         *
+         * @param path The path to write to.
+         * @param writer The function that writes to the file.
+         * @param fail_message The message to display if the write fails.
+         * @return True if the write was successful, false otherwise.
+         */
         bool write_to_file( const std::string &path, file_write_cb &writer,
                             const char *fail_message = nullptr );
         bool read_from_file( const std::string &path, file_read_cb reader, bool optional = false );

--- a/src/world.h
+++ b/src/world.h
@@ -110,26 +110,34 @@ class world
         bool write_overmap( const point_abs_om &p, file_write_cb writer );
         bool write_overmap_player_visibility( const point_abs_om &p, file_write_cb writer );
 
+        bool read_player_mm_quad( const tripoint &p, file_read_json_cb reader );
+        bool write_player_mm_quad( const tripoint &p, file_write_cb &writer );
+
         /*
-         * Generic file operations, acting as a catch-all for miscellaneous save files.
+         * Player-specific file operations. Paths will be prefixed with the player's save ID.
          */
+        bool player_file_exist( const std::string &path );
+        bool write_to_player_file( const std::string &path, file_write_cb &writer, const char *fail_message = nullptr );
+        bool read_from_player_file( const std::string &path, file_read_cb reader, bool optional = false );
+        bool read_from_player_file_json( const std::string &path, file_read_json_cb reader, bool optional = false );
+
+        /*
+         * Generic file operations, acting as a catch-all for miscellaneous save files
+         * living in the root of the world directory.
+         */
+        bool assure_dir_exist( const std::string &path );
         bool file_exist( const std::string &path );
         bool write_to_file( const std::string &path, file_write_cb &writer, const char *fail_message = nullptr );
         bool read_from_file( const std::string &path, file_read_cb reader, bool optional = false );
         bool read_from_file_json( const std::string &path, file_read_json_cb reader, bool optional = false );
-
-        /**
-         * Base path for saving player data. Just add a suffix (unique for
-         * the thing you want to save) and use the resulting path.
-         * Example: `save_ui_data(get_player_base_save_path()+".ui")`
-         */
-        std::string overmap_terrain_filename( const point_abs_om &p ) const;
-        std::string overmap_player_filename( const point_abs_om &p ) const;
-        std::string get_player_base_save_path() const;
     
     private:
         /** If non-zero, indicates we're in the middle of a save event */
         long long save_tx_start_ts = 0;
+
+        std::string overmap_terrain_filename( const point_abs_om &p ) const;
+        std::string overmap_player_filename( const point_abs_om &p ) const;
+        std::string get_player_path() const;
 };
 
 #endif // CATA_SRC_WORLDDB_H

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -1648,9 +1648,9 @@ bool WORLDINFO::load_options()
 
     using namespace std::placeholders;
     const auto path = folder_path() + "/" + PATH_INFO::worldoptions();
-    return read_from_file_optional_json( path, [&]( JsonIn & jsin ) {
+    return read_from_file_json( path, [&]( JsonIn & jsin ) {
         load_options( jsin );
-    } );
+    }, true );
 }
 
 void load_world_option( const JsonObject &jo )

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -59,7 +59,7 @@ worldfactory::worldfactory()
 
 worldfactory::~worldfactory() = default;
 
-WORLDINFO* worldfactory::add_world( std::unique_ptr<WORLDINFO> retworld )
+WORLDINFO *worldfactory::add_world( std::unique_ptr<WORLDINFO> retworld )
 {
     if( !retworld->save() ) {
         return nullptr;
@@ -67,14 +67,14 @@ WORLDINFO* worldfactory::add_world( std::unique_ptr<WORLDINFO> retworld )
     return ( all_worlds[ retworld->world_name ] = std::move( retworld ) ).get();
 }
 
-WORLDINFO* worldfactory::make_new_world( const std::vector<mod_id> &mods )
+WORLDINFO *worldfactory::make_new_world( const std::vector<mod_id> &mods )
 {
     std::unique_ptr<WORLDINFO> retworld = std::make_unique<WORLDINFO>();
     retworld->active_mod_order = mods;
     return add_world( std::move( retworld ) );
 }
 
-WORLDINFO* worldfactory::make_new_world( bool show_prompt, const std::string &world_to_copy )
+WORLDINFO *worldfactory::make_new_world( bool show_prompt, const std::string &world_to_copy )
 {
     // World to return after generating
     std::unique_ptr<WORLDINFO> retworld = std::make_unique<WORLDINFO>();
@@ -119,7 +119,7 @@ WORLDINFO* worldfactory::make_new_world( bool show_prompt, const std::string &wo
     return add_world( std::move( retworld ) );
 }
 
-WORLDINFO* worldfactory::make_new_world( special_game_type special_type )
+WORLDINFO *worldfactory::make_new_world( special_game_type special_type )
 {
     std::string worldname;
     switch( special_type ) {
@@ -151,9 +151,10 @@ WORLDINFO* worldfactory::make_new_world( special_game_type special_type )
     return ( all_worlds[worldname] = std::move( special_world ) ).get();
 }
 
-void worldfactory::set_active_world( WORLDINFO* new_world )
+void worldfactory::set_active_world( WORLDINFO *new_world )
 {
-    DebugLog( DL::Info, DC::Main ) << "Setting active world to " << ( new_world ? new_world->folder_path() : "NULL" );
+    DebugLog( DL::Info, DC::Main ) << "Setting active world to " << ( new_world ?
+                                   new_world->folder_path() : "NULL" );
 
     if( new_world ) {
         get_options().set_world_options( &new_world->WORLD_OPTIONS );
@@ -200,7 +201,7 @@ bool WORLDINFO::save( const bool is_conversion ) const
         }
     }
 
-    world_generator->get_mod_manager().save_mods_list( const_cast<WORLDINFO*>( this ) );
+    world_generator->get_mod_manager().save_mods_list( const_cast<WORLDINFO *>( this ) );
     return true;
 }
 
@@ -293,7 +294,7 @@ std::vector<std::string> worldfactory::all_worldnames() const
     return result;
 }
 
-WORLDINFO* worldfactory::pick_world( bool show_prompt, bool empty_only )
+WORLDINFO *worldfactory::pick_world( bool show_prompt, bool empty_only )
 {
     std::vector<std::string> world_names = all_worldnames();
 
@@ -416,7 +417,7 @@ WORLDINFO* worldfactory::pick_world( bool show_prompt, bool empty_only )
             wmove( w_worlds, point( 4, static_cast<int>( i ) ) );
 
             std::string world_name = ( world_pages[selpage] )[i];
-            WORLDINFO* world = get_world( world_name );
+            WORLDINFO *world = get_world( world_name );
             size_t saves_num = world->world_saves.size();
 
             std::string text = string_format( "%s (%d)", world_name, saves_num );
@@ -506,7 +507,7 @@ WORLDINFO* worldfactory::pick_world( bool show_prompt, bool empty_only )
                 }
             } while( world_pages[selpage].empty() );
         } else if( action == "CONFIRM" ) {
-            WORLDINFO* world = get_world( world_pages[selpage][sel] );
+            WORLDINFO *world = get_world( world_pages[selpage][sel] );
             if( !( world->needs_lua() && !cata::has_lua() ) ) {
                 return world;
             }
@@ -520,7 +521,7 @@ void worldfactory::remove_world( const std::string &worldname )
 {
     auto it = all_worlds.find( worldname );
     if( it != all_worlds.end() ) {
-        WORLDINFO* wptr = it->second.get();
+        WORLDINFO *wptr = it->second.get();
         if( active_world && active_world->info == wptr ) {
             set_active_world( nullptr );
         }
@@ -570,7 +571,7 @@ std::string worldfactory::get_next_valid_worldname()
     return worldname;
 }
 
-int worldfactory::show_worldgen_tab_options( const catacurses::window &, WORLDINFO* world,
+int worldfactory::show_worldgen_tab_options( const catacurses::window &, WORLDINFO *world,
         const std::function<bool()> &on_quit )
 {
     get_options().set_world_options( &world->WORLD_OPTIONS );
@@ -788,7 +789,7 @@ void worldfactory::show_active_world_mods( const std::vector<mod_id> &world_mods
     }
 }
 
-void worldfactory::edit_active_world_mods( WORLDINFO* world )
+void worldfactory::edit_active_world_mods( WORLDINFO *world )
 {
     // set up window
     catacurses::window wf_win;
@@ -821,7 +822,7 @@ void worldfactory::edit_active_world_mods( WORLDINFO* world )
     }
 }
 
-int worldfactory::show_worldgen_tab_modselection( const catacurses::window &win, WORLDINFO* world,
+int worldfactory::show_worldgen_tab_modselection( const catacurses::window &win, WORLDINFO *world,
         const std::function<bool()> &on_quit )
 {
     return show_modselection_window( win, world->active_mod_order, on_quit, on_quit, false );
@@ -1294,7 +1295,7 @@ int worldfactory::show_modselection_window( const catacurses::window &win,
     return tab_output;
 }
 
-int worldfactory::show_worldgen_tab_confirm( const catacurses::window &win, WORLDINFO* world,
+int worldfactory::show_worldgen_tab_confirm( const catacurses::window &win, WORLDINFO *world,
         const std::function<bool()> &on_quit )
 {
     catacurses::window w_confirmation;
@@ -1542,7 +1543,7 @@ mod_manager &worldfactory::get_mod_manager()
     return *mman;
 }
 
-WORLDINFO* worldfactory::get_world( const std::string &name )
+WORLDINFO *worldfactory::get_world( const std::string &name )
 {
     const auto iter = all_worlds.find( name );
     if( iter == all_worlds.end() ) {

--- a/src/worldfactory.h
+++ b/src/worldfactory.h
@@ -37,21 +37,21 @@ class worldfactory
         ~worldfactory();
 
         // Generate a world
-        WORLDINFO* make_new_world( bool show_prompt = true, const std::string &world_to_copy = "" );
-        WORLDINFO* make_new_world( special_game_type special_type );
+        WORLDINFO *make_new_world( bool show_prompt = true, const std::string &world_to_copy = "" );
+        WORLDINFO *make_new_world( special_game_type special_type );
         // Used for unit tests - does NOT verify if the mods can be loaded
-        WORLDINFO* make_new_world( const std::vector<mod_id> &mods );
+        WORLDINFO *make_new_world( const std::vector<mod_id> &mods );
         // Returns the *existing* world of given name.
-        WORLDINFO* get_world( const std::string &name );
+        WORLDINFO *get_world( const std::string &name );
         // Returns index for world name, 0 if world cannot be found.
         size_t get_world_index( const std::string &name );
         bool has_world( const std::string &name ) const;
 
-        void set_active_world( WORLDINFO* world );
+        void set_active_world( WORLDINFO *world );
 
         void init();
 
-        WORLDINFO* pick_world( bool show_prompt = true, bool empty_only = false );
+        WORLDINFO *pick_world( bool show_prompt = true, bool empty_only = false );
 
         std::unique_ptr<world> active_world;
 
@@ -77,7 +77,7 @@ class worldfactory
 
         static void draw_worldgen_tabs( const catacurses::window &w, size_t current );
         void show_active_world_mods( const std::vector<mod_id> &world_mods );
-        void edit_active_world_mods( WORLDINFO* world );
+        void edit_active_world_mods( WORLDINFO *world );
 
     private:
         std::map<std::string, std::unique_ptr<WORLDINFO>> all_worlds;
@@ -85,11 +85,11 @@ class worldfactory
         void load_last_world_info();
 
         std::string pick_random_name();
-        int show_worldgen_tab_options( const catacurses::window &win, WORLDINFO* world,
+        int show_worldgen_tab_options( const catacurses::window &win, WORLDINFO *world,
                                        const std::function<bool()> &on_quit );
-        int show_worldgen_tab_modselection( const catacurses::window &win, WORLDINFO* world,
+        int show_worldgen_tab_modselection( const catacurses::window &win, WORLDINFO *world,
                                             const std::function<bool()> &on_quit );
-        int show_worldgen_tab_confirm( const catacurses::window &win, WORLDINFO* world,
+        int show_worldgen_tab_confirm( const catacurses::window &win, WORLDINFO *world,
                                        const std::function<bool()> &on_quit );
 
         int show_modselection_window( const catacurses::window &win, std::vector<mod_id> &active_mod_order,
@@ -103,12 +103,12 @@ class worldfactory
                             const std::vector<mod_id> &mods, bool is_active_list, const std::string &text_if_empty,
                             const catacurses::window &w_shift );
 
-        WORLDINFO* add_world( std::unique_ptr<WORLDINFO> retworld );
+        WORLDINFO *add_world( std::unique_ptr<WORLDINFO> retworld );
 
         pimpl<mod_manager> mman;
         pimpl<mod_ui> mman_ui;
 
-        using worldgen_display = std::function<int ( const catacurses::window &, WORLDINFO*,
+        using worldgen_display = std::function<int ( const catacurses::window &, WORLDINFO *,
                                  const std::function<bool()> )>;
 
         std::vector<worldgen_display> tabs;

--- a/src/worldfactory.h
+++ b/src/worldfactory.h
@@ -25,68 +25,6 @@ namespace catacurses
 class window;
 } // namespace catacurses
 
-class save_t
-{
-    private:
-        std::string name;
-
-        save_t( const std::string &name );
-
-    public:
-        std::string decoded_name() const;
-        std::string base_path() const;
-
-        static save_t from_save_id( const std::string &save_id );
-        static save_t from_base_path( const std::string &base_path );
-
-        bool operator==( const save_t &rhs ) const {
-            return name == rhs.name;
-        }
-        bool operator!=( const save_t &rhs ) const {
-            return !operator==( rhs );
-        }
-        save_t( const save_t & ) = default;
-        save_t &operator=( const save_t & ) = default;
-};
-
-/**
- * Structure containing metadata about a world. No actual world data is processed here.
- * 
- * The actual instances are owned by the worldfactory class. All other classes should
- * only have a pointer to one of these owned instances.
- */
-struct WORLDINFO {
-    public:
-        /**
-         * @returns A path to a folder in the file system that should contain
-         * all the world specific files. It depends on @ref world_name,
-         * changing that will also change the result of this function.
-         */
-        std::string folder_path() const;
-
-        std::string world_name;
-        options_manager::options_container WORLD_OPTIONS;
-        std::vector<save_t> world_saves;
-        /**
-         * A (possibly empty) list of (idents of) mods that
-         * should be loaded for this world.
-         */
-        std::vector<mod_id> active_mod_order;
-
-        WORLDINFO();
-        void COPY_WORLD( const WORLDINFO *world_to_copy );
-
-        bool needs_lua() const;
-
-        bool save_exists( const save_t &name ) const;
-        void add_save( const save_t &name );
-
-        bool save( bool is_conversion = false ) const;
-
-        void load_options( JsonIn &jsin );
-        bool load_options();
-        void load_legacy_options( std::istream &fin );
-};
 
 class mod_manager;
 class mod_ui;
@@ -128,6 +66,7 @@ class worldfactory
 
         void remove_world( const std::string &worldname );
         bool valid_worldname( const std::string &name, bool automated = false );
+        std::string get_next_valid_worldname();
 
         /**
          * @param delete_folder If true: delete all the files and directories  of the given

--- a/tests/filesystem_test.cpp
+++ b/tests/filesystem_test.cpp
@@ -7,6 +7,7 @@
 #include "string_formatter.h"
 #include "path_info.h"
 #include "game.h"
+#include "world.h"
 #include "cata_utility.h"
 
 static std::string str_to_hex( const std::string &s )
@@ -31,7 +32,7 @@ static void filesystem_test_group( int serial, const std::string &s1, const std:
     CAPTURE( str_to_hex( s3 ) );
 
     // Make sure there's no interference from e.g. uncleaned old runs
-    std::string base = g->get_world_base_save_path() + "/fs_test_" +
+    std::string base = g->get_active_world()->info->folder_path() + "/fs_test_" +
                        get_pid_string() + "_" + std::to_string( serial ) + "/";
     CAPTURE( base );
     REQUIRE( !dir_exist( base ) );

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -156,7 +156,7 @@ static void init_global_game_state( const std::vector<mod_id> &mods,
     calendar::set_season_length( get_option<int>( "SEASON_LENGTH" ) );
 
     loading_ui ui( false );
-    init::load_world_modfiles( ui, g->get_world_base_save_path() + "/" + SAVE_ARTIFACTS );
+    init::load_world_modfiles( ui, g->get_active_world(), SAVE_ARTIFACTS );
 
     g->u = avatar();
     g->u.create( character_type::NOW );

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -147,7 +147,7 @@ static void init_global_game_state( const std::vector<mod_id> &mods,
 
     world_generator->set_active_world( nullptr );
     world_generator->init();
-    WORLDPTR test_world = world_generator->make_new_world( mods );
+    WORLDINFO* test_world = world_generator->make_new_world( mods );
     assert( test_world != nullptr );
     world_generator->set_active_world( test_world );
     assert( world_generator->active_world != nullptr );
@@ -352,7 +352,7 @@ int main( int argc, const char *argv[] )
 
     clear_all_state();
 
-    auto world_name = world_generator->active_world->world_name;
+    auto world_name = world_generator->active_world->info->world_name;
     if( result == 0 || dont_save ) {
         world_generator->delete_world( world_name, true );
     } else {

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -147,7 +147,7 @@ static void init_global_game_state( const std::vector<mod_id> &mods,
 
     world_generator->set_active_world( nullptr );
     world_generator->init();
-    WORLDINFO* test_world = world_generator->make_new_world( mods );
+    WORLDINFO *test_world = world_generator->make_new_world( mods );
     assert( test_world != nullptr );
     world_generator->set_active_world( test_world );
     assert( world_generator->active_world != nullptr );


### PR DESCRIPTION
## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style). => Awaiting CI bot
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

This PR is Phase 1 of #5771.

It refactors much of the world and player save read/write logic, with a particular focus on consolidating the business logic of what gets saved where. The purpose is to create a clean environment where we can add on support for different save formats in a subsequent PR.

**This PR should not change the on-disk format. Everything should continue to work normally.** The actual SQLite+compression implementation will happen on top of this refactored backend in a later PR.


## Describe the solution

 * Clean up and refactor `worldfactory` and `world`.
   * The old `WORLD` struct is now renamed `WORLDINFO` to better reflect its actual purpose.
   * Get rid of the `WORLDPTR = WORLD*` convention. This isn't the Windows API, and nothing else in the codebase does this.
 * Move file saving logic into a new class called `world`, meant to encapsulate the idea of a loaded world. All reads and writes to world and player files now go through this class, which forms the foundation for future changes to the save format. 
 * Simplified the I/O utility methods `read_from_file*` and `write_to_file*` found in `cata_utility.cpp`. This replaces the 2 write and 6 read methods with 1 write and 2 read. This simplification is needed because future save loaders will need to provide their own implementations of these methods.
      * The `_optional` variants can be replaced with default arguments.
      * The `JsonDeserializer` variants are never used.
      * The `_json` variants do save some boilerplate (`path`) so I'll keep that in for now.

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Awaiting CI signals.
I tested by loading & saving a couple of existing worlds, without obvious issues thus far.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
