### PR TITLE
fix: update antique shops, elephant guns are now reasonably obtainable

### DIFF
--- a/data/json/itemgroups/art_antiques_crafts.json
+++ b/data/json/itemgroups/art_antiques_crafts.json
@@ -215,6 +215,19 @@
     "entries": [
       { "item": "trex_gun", "prob": 4 },
       { "item": "spiral_stone", "prob": 2 },
+      { "item": "pistol_flintlock", "prob": 3 },
+      { "item": "carbine_flintlock", "prob": 3 },
+      { "item": "rifle_flintlock", "prob": 3 },
+      { "item": "longrifle_flintlock", "prob": 3 },
+      { "item": "shotgun_paper", "prob": 4 },
+      { "group": "antique_medieval_arms", "prob": 20 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "antique_medieval_arms",
+    "subtype": "distribution",
+    "entries": [
       { "item": "cutlass", "prob": 2 },
       { "item": "broadsword", "prob": 2 },
       { "item": "nodachi", "prob": 2 },
@@ -257,11 +270,6 @@
       { "item": "wakizashi_fake", "prob": 4 },
       { "item": "wakizashi_inferior", "prob": 8 },
       { "item": "kris_fake", "prob": 8 },
-      { "item": "pistol_flintlock", "prob": 3 },
-      { "item": "carbine_flintlock", "prob": 3 },
-      { "item": "rifle_flintlock", "prob": 3 },
-      { "item": "longrifle_flintlock", "prob": 3 },
-      { "item": "shotgun_paper", "prob": 4 },
       { "item": "petrified_eye", "prob": 2 },
       { "item": "ji", "prob": 1 },
       { "item": "dao", "prob": 3 },


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Elephant guns are the only weapon to fire .700 nitro express and they were incredibly rare due to being buried in distributions. Your local antique shop now doubles as an elephant protection shop.

## Describe the solution

All medieval weapons in antique_rare got moved to antique_medieval_arms which means now antique_rare is funny rocks and guns.

## Describe alternatives you've considered

Convert to Collection but Chaos screamed in pain.

## Testing

![image](https://github.com/user-attachments/assets/a0a3a63f-1682-4e9a-a1bf-b9cbf57d7a4b)


## Additional context

I own an elephant gun for home protection because that's what the founding monster hunters intended. Four dragons break into my house "What the devil?" As I grab my elephant gun and funny baseball cap with an inappropriate slogan that won't age well. Blow a golf-ball size hole in the first dragon, its dead on the spot. 
