### PR TITLE
feat: Military ID cards can deactivate plutonium generator security for retrieval

### DIFF
--- a/data/json/furniture_and_terrain/terrain-manufactured.json
+++ b/data/json/furniture_and_terrain/terrain-manufactured.json
@@ -708,7 +708,7 @@
     "type": "terrain",
     "id": "t_plut_generator",
     "name": "plutonium generator",
-    "description": "This imposing apparatus harnesses the power of the atom, configured to provide nearly limitless backup power from the nuclear fuel installed in it.  It's not doing much good here though.  It has a complicated security system that is dangerous and difficult to bypass without the code.",
+    "description": "This imposing apparatus harnesses the power of the atom, configured to provide nearly limitless backup power from the nuclear fuel installed in it.  It's not doing much good here though.  It has a complicated security system that is dangerous and difficult to bypass without authorization; a small slot suggests that it can accept some form of ID card.",
     "symbol": "0",
     "color": "light_green",
     "looks_like": "t_machinery_electronic",

--- a/data/json/furniture_and_terrain/terrain-manufactured.json
+++ b/data/json/furniture_and_terrain/terrain-manufactured.json
@@ -729,7 +729,8 @@
       ],
       "//": "Variable reduction, destroy_threshold equal to str_min instead of str_max due to delicate electronics",
       "ranged": { "reduction": [ 25, 50 ], "destroy_threshold": 50, "block_unaimed_chance": "50%" }
-    }
+    },
+    "examine_action": "cardreader_plutgen"
   },
   {
     "type": "terrain",

--- a/data/json/recipes/other/other.json
+++ b/data/json/recipes/other/other.json
@@ -512,6 +512,7 @@
     "skill_used": "fabrication",
     "difficulty": 5,
     "decomp_learn": 5,
+    "book_learn": [ [ "textbook_mechanics", 5 ], [ "manual_mechanics", 5 ], [ "textbook_fabrication", 5 ] ],
     "time": "50 m",
     "reversible": true,
     "using": [ [ "soldering_standard", 20 ], [ "welding_standard", 3 ] ],

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -6332,7 +6332,7 @@ void iexamine::cardreader_plutgen( player &p, const tripoint &examp ) {
         here.ter_set( examp, t_concrete );
         here.add_item_or_charges( examp, item::spawn( itype_plut_generator_item, calendar::turn ) );
     } else {
-        add_msg( _( "The plutonium generator has significant security measures in place. If you don't have the necessary ID card, you'll have to remove it by hand." ) );
+        add_msg( _( "The plutonium generator has significant security measures in place. Without the necessary ID, you'll have to remove it by hand." ) );
     }
 }
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -6320,7 +6320,8 @@ void iexamine::migo_nerve_cluster( player &p, const tripoint &examp )
     }
 }
 
-void iexamine::cardreader_plutgen( player &p, const tripoint &examp ) {
+void iexamine::cardreader_plutgen( player &p, const tripoint &examp )
+{
     map &here = get_map();
     itype_id card_type = itype_id_military;
     if( p.has_amount( card_type, 1 ) && query_yn( _( "Swipe your ID card?" ) ) ) {
@@ -6328,7 +6329,8 @@ void iexamine::cardreader_plutgen( player &p, const tripoint &examp ) {
         p.mod_moves( -100 );
         p.use_amount( card_type, 1 );
         add_msg( _( "You insert your ID card." ) );
-        add_msg( m_good, _( "The plutonium generator beeps twice, then disengages from the surrounding conduits with a series of mechanical clunks." ) );
+        add_msg( m_good,
+                 _( "The plutonium generator beeps twice, then disengages from the surrounding conduits with a series of mechanical clunks." ) );
         here.ter_set( examp, t_concrete );
         here.add_item_or_charges( examp, item::spawn( itype_plut_generator_item, calendar::turn ) );
     } else {
@@ -6430,7 +6432,7 @@ iexamine_function iexamine_function_from_string( const std::string &function_nam
             { "dimensional_portal", &iexamine::dimensional_portal },
             { "check_power", &iexamine::check_power },
             { "migo_nerve_cluster", &iexamine::migo_nerve_cluster },
-            { "cardreader_plutgen", &iexamine::cardreader_plutgen }, 
+            { "cardreader_plutgen", &iexamine::cardreader_plutgen },
         }
     };
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -152,6 +152,7 @@ static const itype_id itype_marloss_seed( "marloss_seed" );
 static const itype_id itype_mycus_fruit( "mycus_fruit" );
 static const itype_id itype_nail( "nail" );
 static const itype_id itype_petrified_eye( "petrified_eye" );
+static const itype_id itype_plut_generator_item( "plut_generator_item" );
 static const itype_id itype_sheet( "sheet" );
 static const itype_id itype_stick( "stick" );
 static const itype_id itype_string_36( "string_36" );
@@ -6319,6 +6320,22 @@ void iexamine::migo_nerve_cluster( player &p, const tripoint &examp )
     }
 }
 
+void iexamine::cardreader_plutgen( player &p, const tripoint &examp ) {
+    map &here = get_map();
+    itype_id card_type = itype_id_military;
+    if( p.has_amount( card_type, 1 ) && query_yn( _( "Swipe your ID card?" ) ) ) {
+        // The duration taken may need modification.
+        p.mod_moves( -100 );
+        p.use_amount( card_type, 1 );
+        add_msg( _( "You insert your ID card." ) );
+        add_msg( m_good, _( "The plutonium generator beeps twice, then disengages from the surrounding conduits with a series of mechanical clunks." ) );
+        here.ter_set( examp, t_concrete );
+        here.add_item_or_charges( examp, item::spawn( itype_plut_generator_item, calendar::turn ) );
+    } else {
+        add_msg( _( "The plutonium generator has significant security measures in place. If you don't have the necessary ID card, you'll have to remove it by hand." ) );
+    }
+}
+
 /**
  * Given then name of one of the above functions, returns the matching function
  * pointer. If no match is found, defaults to iexamine::none but prints out a
@@ -6413,6 +6430,7 @@ iexamine_function iexamine_function_from_string( const std::string &function_nam
             { "dimensional_portal", &iexamine::dimensional_portal },
             { "check_power", &iexamine::check_power },
             { "migo_nerve_cluster", &iexamine::migo_nerve_cluster },
+            { "cardreader_plutgen", &iexamine::cardreader_plutgen }, 
         }
     };
 

--- a/src/iexamine.h
+++ b/src/iexamine.h
@@ -115,6 +115,7 @@ void workbench( player &p, const tripoint &examp );
 void dimensional_portal( player &p, const tripoint &examp );
 void check_power( player &p, const tripoint &examp );
 void migo_nerve_cluster( player &p, const tripoint &examp );
+void cardreader_plutgen( player &p, const tripoint &examp );
 
 detached_ptr<item> pour_into_keg( const tripoint &pos, detached_ptr<item> &&liquid );
 std::optional<tripoint> getGasPumpByNumber( const tripoint &p, int number );


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
The [recent changes to Advanced Deconstruction](https://github.com/cataclysmbnteam/Cataclysm-BN/pull/5722) make plutonium generators significantly more irritating to retrieve. While this *is* a good change overall, for those of us who took them and disassembled them (instead of installing them somewhere), it's a little frustrating.

## Describe the solution
I've added a few functions, and adjusted the terrain object's JSON, so that military ID cards can be used to turn the terrain into an item without deconstructing it. I think this is reasonable: military ID cards are typically used to claim military items, so spending one to gain access to a military generator (instead of a military *armory*) seems fair.

Note that this does not give the other items that deconstruction would. The idea is that the generator separates itself (ejects plugs, closes, hatches, that kind of thing), which isn't as tidy for the surrounding wiring.

## Describe alternatives you've considered
None, really. Having talked this out with others, it seems like a solid idea.

## Testing
Set terrain to ``t_plut_generator`` → int``e``ract with it → if the player has at least one military ID card, they'll be prompted to use it. If not, they'll get a message suggesting that they'll have to disconnect it manually.

Changing the terrain (under the player) for testing can be done by pasting this *(**excruciatingly** ugly)* line of Lua into the console:
```lua
gapi.get_map():set_ter_at(gapi.get_avatar():get_pos_ms(), TerIntId.new(TerId.new("t_plut_generator")))
```

## Additional context
![image](https://github.com/user-attachments/assets/16a9860d-5ce1-426e-8d34-60887a9f9dce)
![image](https://github.com/user-attachments/assets/fceff983-1014-4e5b-b7de-8947347a73a6)