### PR TITLE
feat(UI): always show book's skill cap even if the PC has passed it

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3026,7 +3026,8 @@ void item::book_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
             const std::string skill_name = book.skill->name();
             std::string fmt = string_format( _( "Can bring <info>%s skill to</info> "
                                                 "<num>." ), skill_name );
-            info.emplace_back( "BOOK", "", fmt, iteminfo::no_flags, book.level );
+            info.emplace_back( "BOOK", "", skill.can_train() ? fmt : colorize( fmt, c_brown ),
+                               iteminfo::no_flags, book.level );
             fmt = string_format( _( "Your current <stat>%s skill</stat> is <num>." ),
                                  skill_name );
             info.emplace_back( "BOOK", "", fmt, iteminfo::no_flags, skill.level() );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3024,13 +3024,13 @@ void item::book_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
         const SkillLevel &skill = you.get_skill_level_object( book.skill );
         if( parts->test( iteminfo_parts::BOOK_SKILLRANGE_MAX ) ) {
             const std::string skill_name = book.skill->name();
-            std::string fmt = string_format( _( "Can bring <info>%s skill to</info> "
-                                                "<num>." ), skill_name );
+            const std::string fmt = string_format( _( "Can bring <info>%s skill to</info> "
+                                                   "<num>." ), skill_name );
             info.emplace_back( "BOOK", "", skill.can_train() ? fmt : colorize( fmt, c_brown ),
                                iteminfo::no_flags, book.level );
-            fmt = string_format( _( "Your current <stat>%s skill</stat> is <num>." ),
-                                 skill_name );
-            info.emplace_back( "BOOK", "", fmt, iteminfo::no_flags, skill.level() );
+            info.emplace_back( "BOOK", "",
+                               string_format( _( "Your current <stat>%s skill</stat> is <num>." ), skill_name ),
+                               iteminfo::no_flags, skill.level() );
         }
 
         if( book.req != 0 && parts->test( iteminfo_parts::BOOK_SKILLRANGE_MIN ) ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2235,7 +2235,6 @@ auto nname( const itype_id &id ) -> std::string
 void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminfo_query *parts,
                      int /* batch */, bool /* debug */ ) const
 {
-    const std::string space = "  ";
     const islot_gun &gun = *mod->type->gun;
     const Skill &skill = *mod->gun_skill();
     avatar &viewer = get_avatar();

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3023,9 +3023,9 @@ void item::book_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
     }
     if( book.skill ) {
         const SkillLevel &skill = you.get_skill_level_object( book.skill );
-        if( skill.can_train() && parts->test( iteminfo_parts::BOOK_SKILLRANGE_MAX ) ) {
+        if( parts->test( iteminfo_parts::BOOK_SKILLRANGE_MAX ) ) {
             const std::string skill_name = book.skill->name();
-            std::string fmt = string_format( _( "Can bring your <info>%s skill to</info> "
+            std::string fmt = string_format( _( "Can bring <info>%s skill to</info> "
                                                 "<num>." ), skill_name );
             info.emplace_back( "BOOK", "", fmt, iteminfo::no_flags, book.level );
             fmt = string_format( _( "Your current <stat>%s skill</stat> is <num>." ),


### PR DESCRIPTION
## Checklist

### Required
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Currently, books stop showing how far they can teach once they can no longer teach the PC. They're still useful for teaching NPCs, though; after that point, only the ``R``ead command will show the skill they can teach to.
This synchronizes that functionality for the sake of convenience.

## Describe the solution
I made a few very minor edits to ``item::book_info()``.

## Describe alternatives you've considered
N/A. This was pretty simple.

## Testing
Spawn a book → look at the book → set your skill level higher than the book's cap → look at the book again.

## Additional context
![image](https://github.com/user-attachments/assets/c95d655b-cab9-48f4-9c75-68774d6db2fe)