### PR TITLE
fix: Fix RPGdie iuse

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3960,7 +3960,7 @@ int iuse::rpgdie( player *you, item *die, bool, const tripoint & )
     if( roll == num_sides ) {
         add_msg( m_good, _( "Critical!" ) );
     }
-    return roll;
+    return 0;
 }
 
 int iuse::dive_tank( player *p, item *it, bool t, const tripoint & )


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

- Fix #5789 which was a bug exposed by #5589. iuse actions in `iuse.cpp` return an int value that indicates charges to be used from an item, but this wasn't properly being used due to a lack of consideration in `use_charges()`.
- The RPG die iuse returns the roll value for no reason whatsoever, as nothing the iuse does is contingent on that return. It's likely some legacy thing from when each iuse had it's own special return function.

## Describe the solution

- `iuse::rpgdie` now returns 0 in all cases, preventing charges of rpgdie from being used.

## Describe alternatives you've considered

- Reverting #5589 
  - Would be a dumb idea given that the behaviour it fixes is not expected behaviour.
- Rework `iuse::rpgdie`
  - It's on my list, as of current, the die faces and values are totally random, I'll likely convert it into an `iuse_actor` later on so that you can define individual dice with fixed sides instead of each die being set randomly to being a d4, d8, d20, d50 etc.

## Testing

- [x] Spawn and roll die and confirm they aren't being used up.

## Additional context

I shudder to think what other bugs have been uncovered in the process. Most _should_ be fixed with the energy rework, but that's going to break 50 other things I didn't account for I'm sure.