### PR TITLE
fix(balance): Move 3 small shotguns to shotguns skill

### DIFF
--- a/data/json/items/gun/20x66mm.json
+++ b/data/json/items/gun/20x66mm.json
@@ -80,7 +80,6 @@
     "material": [ "superalloy", "ceramic" ],
     "color": "dark_gray",
     "ammo": "20x66mm",
-    "skill": "pistol",
     "dispersion": 400,
     "durability": 9,
     "default_mods": [ "pistol_stock" ],

--- a/data/json/items/gun/shot.json
+++ b/data/json/items/gun/shot.json
@@ -331,7 +331,6 @@
     "ascii_picture": "remington870mcs",
     "material": [ "steel", "plastic" ],
     "ranged_damage": { "damage_type": "bullet", "amount": -3 },
-    "skill": "pistol",
     "modes": [ [ "DEFAULT", "single", 1 ] ],
     "//": "dispersion should be 300 moa, but CDDA exaggerates dispersion.",
     "sight_dispersion": 750,
@@ -655,7 +654,6 @@
     "durability": 6,
     "clip_size": 6,
     "reload": 120,
-    "skill": "pistol",
     "modes": [ [ "DEFAULT", "single", 1 ] ],
     "valid_mod_locations": [
       [ "accessories", 2 ],


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

As agreed by others in the Discord, it makes little sense for even sawn-off shotguns such as these to be classified as 'pistols' skill, especially when they're marked down as shotguns for weapon category purposes.

## Describe the solution

Changes them over to shotguns skill instead (by just making them not overwrite their copy-from's entry)

## Describe alternatives you've considered

- Let it be

## Testing

None, other than the eyeball test

## Additional context

Just because the terminator can flip-cycle a sawn-off lever action shotgun (with a modified lever mind you) doesn't mean it's now legally classified as a pistol. Shotguns Arnold is an outlier and should be excluded.
