### PR TITLE
fix: Stop letting unlicensed zombie contractors break stairs

### DIFF
--- a/data/json/furniture_and_terrain/terrain-doors.json
+++ b/data/json/furniture_and_terrain/terrain-doors.json
@@ -213,7 +213,7 @@
       ]
     },
     "bash": {
-      "str_min": 8,
+      "str_min": 10,
       "str_max": 80,
       "str_min_blocked": 15,
       "str_max_blocked": 100,
@@ -252,7 +252,7 @@
       ]
     },
     "bash": {
-      "str_min": 8,
+      "str_min": 10,
       "str_max": 80,
       "str_min_blocked": 15,
       "str_max_blocked": 100,
@@ -291,7 +291,7 @@
       ]
     },
     "bash": {
-      "str_min": 8,
+      "str_min": 10,
       "str_max": 80,
       "str_min_blocked": 15,
       "str_max_blocked": 100,
@@ -330,7 +330,7 @@
       ]
     },
     "bash": {
-      "str_min": 8,
+      "str_min": 10,
       "str_max": 80,
       "str_min_blocked": 15,
       "str_max_blocked": 100,
@@ -369,7 +369,7 @@
       ]
     },
     "bash": {
-      "str_min": 8,
+      "str_min": 10,
       "str_max": 80,
       "str_min_blocked": 15,
       "str_max_blocked": 100,
@@ -408,7 +408,7 @@
       ]
     },
     "bash": {
-      "str_min": 8,
+      "str_min": 10,
       "str_max": 80,
       "str_min_blocked": 15,
       "str_max_blocked": 100,

--- a/data/json/furniture_and_terrain/terrain-doors.json
+++ b/data/json/furniture_and_terrain/terrain-doors.json
@@ -226,7 +226,7 @@
         { "item": "splinter", "count": [ 1, 2 ] },
         { "item": "nail", "charges": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 8, 8 ], "destroy_threshold": 80 }
+      "ranged": { "reduction": [ 10, 10 ], "destroy_threshold": 80 }
     }
   },
   {
@@ -265,7 +265,7 @@
         { "item": "splinter", "count": [ 1, 2 ] },
         { "item": "nail", "charges": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 8, 8 ], "destroy_threshold": 80 }
+      "ranged": { "reduction": [ 10, 10 ], "destroy_threshold": 80 }
     }
   },
   {
@@ -304,7 +304,7 @@
         { "item": "splinter", "count": [ 1, 2 ] },
         { "item": "nail", "charges": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 8, 8 ], "destroy_threshold": 80 }
+      "ranged": { "reduction": [ 10, 10 ], "destroy_threshold": 80 }
     }
   },
   {
@@ -343,7 +343,7 @@
         { "item": "splinter", "count": [ 1, 2 ] },
         { "item": "nail", "charges": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 8, 8 ], "destroy_threshold": 80 }
+      "ranged": { "reduction": [ 10, 10 ], "destroy_threshold": 80 }
     }
   },
   {
@@ -382,7 +382,7 @@
         { "item": "splinter", "count": [ 1, 2 ] },
         { "item": "nail", "charges": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 8, 8 ], "destroy_threshold": 80 }
+      "ranged": { "reduction": [ 10, 10 ], "destroy_threshold": 80 }
     }
   },
   {
@@ -421,7 +421,7 @@
         { "item": "splinter", "count": [ 1, 2 ] },
         { "item": "nail", "charges": [ 0, 2 ] }
       ],
-      "ranged": { "reduction": [ 8, 8 ], "destroy_threshold": 80 }
+      "ranged": { "reduction": [ 10, 10 ], "destroy_threshold": 80 }
     }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -38,7 +38,7 @@
     "roof": "t_flat_roof",
     "flags": [ "FLAMMABLE_HARD", "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
     "bash": {
-      "str_min": 30,
+      "str_min": 40,
       "str_max": 210,
       "sound": "crash!",
       "sound_fail": "whump!",
@@ -126,8 +126,8 @@
     ],
     "deconstruct": { "ter_set": "t_floor", "items": [ { "item": "2x4", "count": 10 }, { "item": "nail", "charges": 20 } ] },
     "bash": {
-      "str_min": 8,
-      "str_max": 20,
+      "str_min": 15,
+      "str_max": 30,
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_null",
@@ -158,7 +158,7 @@
       "BLOCK_WIND"
     ],
     "bash": {
-      "str_min": 30,
+      "str_min": 40,
       "str_max": 210,
       "sound": "crash!",
       "sound_fail": "whump!",
@@ -191,7 +191,7 @@
       "BLOCK_WIND"
     ],
     "bash": {
-      "str_min": 30,
+      "str_min": 40,
       "str_max": 210,
       "sound": "crash!",
       "sound_fail": "whump!",
@@ -224,7 +224,7 @@
       "BLOCK_WIND"
     ],
     "bash": {
-      "str_min": 30,
+      "str_min": 40,
       "str_max": 210,
       "sound": "crash!",
       "sound_fail": "whump!",
@@ -257,7 +257,7 @@
       "BLOCK_WIND"
     ],
     "bash": {
-      "str_min": 30,
+      "str_min": 40,
       "str_max": 210,
       "sound": "crash!",
       "sound_fail": "whump!",
@@ -290,7 +290,7 @@
       "BLOCK_WIND"
     ],
     "bash": {
-      "str_min": 30,
+      "str_min": 40,
       "str_max": 210,
       "sound": "crash!",
       "sound_fail": "whump!",
@@ -322,7 +322,7 @@
       "BLOCK_WIND"
     ],
     "bash": {
-      "str_min": 30,
+      "str_min": 40,
       "str_max": 210,
       "sound": "crash!",
       "sound_fail": "whump!",
@@ -355,7 +355,7 @@
       "BLOCK_WIND"
     ],
     "bash": {
-      "str_min": 30,
+      "str_min": 40,
       "str_max": 210,
       "sound": "crash!",
       "sound_fail": "whump!",

--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -45,7 +45,7 @@
       "ter_set": "t_null",
       "items": "wall_bash_results",
       "//": "Variable reduction since might hit more or less material.",
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 210 }
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 210 }
     }
   },
   {
@@ -132,7 +132,7 @@
       "sound_fail": "whump!",
       "ter_set": "t_null",
       "items": "wall_bash_results",
-      "ranged": { "reduction": [ 8, 8 ], "destroy_threshold": 20, "block_unaimed_chance": "50%" }
+      "ranged": { "reduction": [ 15, 15 ], "destroy_threshold": 30, "block_unaimed_chance": "50%" }
     }
   },
   {
@@ -165,7 +165,7 @@
       "ter_set": "t_null",
       "items": "wall_bash_results",
       "//": "Variable reduction since might hit more or less material.",
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 210 }
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 210 }
     }
   },
   {
@@ -198,7 +198,7 @@
       "ter_set": "t_null",
       "items": "wall_bash_results",
       "//": "Variable reduction since might hit more or less material.",
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 210 }
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 210 }
     }
   },
   {
@@ -231,7 +231,7 @@
       "ter_set": "t_null",
       "items": "wall_bash_results",
       "//": "Variable reduction since might hit more or less material.",
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 210 }
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 210 }
     }
   },
   {
@@ -264,7 +264,7 @@
       "ter_set": "t_null",
       "items": "wall_bash_results",
       "//": "Variable reduction since might hit more or less material.",
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 210 }
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 210 }
     }
   },
   {
@@ -297,7 +297,7 @@
       "ter_set": "t_null",
       "items": "wall_bash_results",
       "//": "Variable reduction since might hit more or less material.",
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 210 }
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 210 }
     }
   },
   {
@@ -329,7 +329,7 @@
       "ter_set": "t_null",
       "items": "wall_bash_results",
       "//": "Variable reduction since might hit more or less material.",
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 210 }
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 210 }
     }
   },
   {
@@ -362,7 +362,7 @@
       "ter_set": "t_null",
       "items": "wall_bash_results",
       "//": "Variable reduction since might hit more or less material.",
-      "ranged": { "reduction": [ 15, 30 ], "destroy_threshold": 210 }
+      "ranged": { "reduction": [ 20, 40 ], "destroy_threshold": 210 }
     }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-zlevel-transitions.json
+++ b/data/json/furniture_and_terrain/terrain-zlevel-transitions.json
@@ -9,7 +9,7 @@
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "GOES_DOWN", "INDOORS", "PLACE_ITEM" ],
     "bash": {
-      "str_min": 10,
+      "str_min": 40,
       "str_max": 70,
       "sound": "crunch!",
       "sound_fail": "whump!",
@@ -36,7 +36,7 @@
       "items": [ { "item": "nail", "charges": [ 12, 20 ] }, { "item": "2x4", "count": [ 2, 6 ] } ]
     },
     "bash": {
-      "str_min": 10,
+      "str_min": 20,
       "str_max": 70,
       "sound": "crunch!",
       "sound_fail": "whump!",
@@ -58,7 +58,7 @@
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "PLACE_ITEM" ],
     "bash": {
-      "str_min": 8,
+      "str_min": 20,
       "str_max": 110,
       "sound": "crunch!",
       "sound_fail": "whump!",
@@ -90,7 +90,7 @@
       ]
     },
     "bash": {
-      "str_min": 12,
+      "str_min": 40,
       "str_max": 150,
       "sound": "crunch!",
       "sound_fail": "whump!",
@@ -174,7 +174,7 @@
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "GOES_UP", "GOES_DOWN", "PLACE_ITEM", "DIFFICULT_Z" ],
     "bash": {
-      "str_min": 25,
+      "str_min": 45,
       "str_max": 150,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
@@ -192,7 +192,7 @@
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "GOES_UP", "PLACE_ITEM", "DIFFICULT_Z" ],
     "bash": {
-      "str_min": 25,
+      "str_min": 45,
       "str_max": 150,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
@@ -210,7 +210,7 @@
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "GOES_DOWN", "PLACE_ITEM", "DIFFICULT_Z" ],
     "bash": {
-      "str_min": 25,
+      "str_min": 45,
       "str_max": 150,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
@@ -338,7 +338,7 @@
     "move_cost": 4,
     "flags": [ "TRANSPARENT", "BASHABLE", "FLAMMABLE", "PLACE_ITEM", "RAMP", "SEEN_FROM_ABOVE" ],
     "bash": {
-      "str_min": 12,
+      "str_min": 32,
       "str_max": 50,
       "sound": "crunch!",
       "sound_fail": "whump!",
@@ -360,7 +360,7 @@
     "move_cost": 0,
     "flags": [ "BASHABLE", "FLAMMABLE", "PLACE_ITEM", "RAMP", "RAMP_END", "SEEN_FROM_ABOVE" ],
     "bash": {
-      "str_min": 20,
+      "str_min": 32,
       "str_max": 50,
       "sound": "crunch!",
       "sound_fail": "whump!",


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Because I made zombies do more damage, they started breaking stairs and ladders, trapping players in basements to die of starvation.

Also, wooden doors and walls are easier to smash which causes problems.

## Describe the solution

A number of sweeping bash min buffs, just to quickly hotfix this problem out so it stops happening.

## Describe alternatives you've considered

Let's just overview the 500 door and wall variants we have, and fix all in one PR. That would be fun.

## Testing

Tests. I know that zombies do 8-12 damage as is so I know this will work. This isn't going to stop evolutions either, not all of them. You shouldn't get in a basement trap unless its late game evolution, maybe midgame.

## Additional context

You got a license to fix those stairs, m8?
