### PR TITLE
feat(balance): Put bibimbap in itemgroups

### DIFF
--- a/data/json/itemgroups/Food/food.json
+++ b/data/json/itemgroups/Food/food.json
@@ -116,7 +116,8 @@
       { "item": "soysauce", "prob": 25 },
       { "item": "horseradish", "prob": 15 },
       { "item": "honey_bottled", "prob": 35 },
-      { "item": "honey_glassed", "prob": 35 }
+      { "item": "honey_glassed", "prob": 35 },
+      { "item": "gochujang", "prob": 15 }
     ]
   },
   {
@@ -562,7 +563,8 @@
       { "item": "pie_veggy", "prob": 18 },
       { "item": "pie_meat", "prob": 18 },
       { "item": "pie_maple", "prob": 9 },
-      { "group": "dessert", "prob": 20 }
+      { "group": "dessert", "prob": 20 },
+      { "item": "bibimbap", "prob": 4 }
     ]
   },
   {
@@ -679,7 +681,8 @@
       { "item": "sandwich_deluxe_nocheese", "charges": [ 1, 2 ], "prob": 10 },
       { "item": "sandwich_t", "charges": [ 1, 2 ], "prob": 10 },
       { "item": "junk_burrito", "prob": 10 },
-      { "item": "chili", "charges": [ 1, 2 ], "prob": 10 }
+      { "item": "chili", "charges": [ 1, 2 ], "prob": 10 },
+      { "item": "bibimbap", "prob": 10 }
     ]
   },
   {


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

 Make bibimbap (and gochujang) more accessible

## Describe the solution

- Places gochujang into the `condiments` itemgroup at a similar rate to horseradish
- Puts bibimbap into `fridgesnacks` and `fridge_leftovers_random`

## Describe alternatives you've considered

- Put together / wait for a different, more specific itemgroup
- Let someone else decide where to put 'em

## Testing

None, I don't think adding an item to these itemgroups should ever bork things

## Additional context

I keep thinking it's "bimbibap" rather than "bibimbap" because that's what I called it for the longest time.
