### PR TITLE
feat(balance): prussian blue and iodide effects visble on status screen, increase effectiveness of prussian blue

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -1116,13 +1116,19 @@
   {
     "type": "effect_type",
     "id": "pblue",
-    "base_mods": { "rad_chance": [ 600 ], "rad_min": [ -1 ] },
+    "name": [ "Took Prussian blue" ],
+    "desc": [ "You consumed Prussian blue, to help remove radioactive contaminants from your body more quickly." ],
+    "//": "Roughly 36 rads lost per hour, baseline per character.cpp is 72/hour so +50% increase",
+    "base_mods": { "rad_chance": [ 100 ], "rad_min": [ -1 ] },
     "blood_analysis_description": "Prussian Blue",
     "rating": "good"
   },
   {
     "type": "effect_type",
     "id": "iodine",
+    "name": [ "Took potassium iodide" ],
+    "desc": [ "You consumed potassium iodide, reducing the amount of contaminants you'll accumulate during radiation exposure." ],
+    "//": "Effects are in suffer.cpp, reduces rad gain by 40-70% depending on if you have any of the the Radioactive mutations",
     "rating": "good",
     "blood_analysis_description": "Potassium Iodide"
   },


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

A suggestion that came up in the BN discord was making the prussian blue and iodine effects visible on the effects screen since it can be hard to tell it's doing anything otherwise, and since antibiotics in BN are directly visible instead of hidden we don't have to fiddle with abstracting it behind a separate dosage-tracker effect.

Along the way I noticed the effect also really doesn't seem like it recovers very much radiation, and after some quick math uh...yeah.
![image](https://github.com/user-attachments/assets/271a80d3-97b9-45d1-8352-8ea09dc4eba5)

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

1. Added names and descriptions to the prussian blue and iodine effects.
2. Reduced `chance_min` of prussian blue from 600 to 100. This should make it recover roughly 36 rads across an hour, which combined with the natural recovery rate makes for a 50% increase over just toughing it out (before it made you lose rads ~8.333% faster). Compare iodine reducing incoming radiation by 70% with no radiation mutations (https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/src/suffer.cpp#L1630), this makes it better than useless but reducing incoming rads is still more effective.
3. Misc: Added JSON comments to both effects outlining how effective they are with references to the relevant code.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Buffing the effect even more. Random wikipedia claim (https://en.wikipedia.org/wiki/Prussian_blue#Medicine) says we could go up to making it as much as +66.667% more effective than baseline rads but that's only for one type of isotope's presence in the body, while the radiation is problably all of them plus continued side effects while the body recovers from cell death and the like so eh, +50% is plenty.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected file for syntax and lint errors.
2. Suffered the curse of doing the math above. :<
3. Load-tested in compiled test build and tested taking a dose of each, they show up on the effects screen now.

![image](https://github.com/user-attachments/assets/6cb61000-7749-4980-85c7-9256d16f848e)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Checked DDA and predictably the effects are still hidden, and prussian blue is still as useless as ever: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/data/json/effects.json#L1118