### PR TITLE
feat: `Prompt on death` quickloads instead of going to main menu

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2392,7 +2392,7 @@ bool game::is_game_over()
     if( u.is_dead_state() ) {
         if( get_option<bool>( "PROMPT_ON_CHARACTER_DEATH" ) &&
             !query_yn(
-                _( "Your character is dead, do you accept this?\n\nSelect Yes to abandon the character to their fate, select No to return to main menu." ) ) ) {
+                _( "Your character is dead, do you accept this?\n\nSelect Yes to abandon the character to their fate, select No to return to try again." ) ) ) {
             g->quickload();
             return false;
         }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -470,11 +470,13 @@ void game::reenter_fullscreen()
 /*
  * Initialize more stuff after mapbuffer is loaded.
  */
-void game::setup()
+void game::setup( bool load_world_modfiles )
 {
     loading_ui ui( true );
 
-    init::load_world_modfiles( ui, get_active_world(), SAVE_ARTIFACTS );
+    if( load_world_modfiles ) {
+        init::load_world_modfiles( ui, get_active_world(), SAVE_ARTIFACTS );
+    }
 
     m = map();
 
@@ -11428,51 +11430,8 @@ void game::quickload()
         MAPBUFFER.clear();
         overmap_buffer.clear();
         try {
-            // This is just setup() without `init::load_world_modfiles( ui, get_active_world(), SAVE_ARTIFACTS )`;
-            // Because we are already in this world
-            m = map();
-
-            next_npc_id = character_id( 1 );
-            next_mission_id = 1;
-            new_game = true;
-            uquit = QUIT_NO;   // We haven't quit the game
-            bVMonsterLookFire = true;
-
-            // invalidate calendar caches in case we were previously playing
-            // a different world
-            calendar::set_eternal_season( ::get_option<bool>( "ETERNAL_SEASON" ) );
-            calendar::set_season_length( ::get_option<int>( "SEASON_LENGTH" ) );
-
-            get_weather().weather_id = weather_type_id::NULL_ID();
-            get_weather().nextweather = calendar::before_time_starts;
-
-            turnssincelastmon = 0; //Auto safe mode init
-
-            sounds::reset_sounds();
-            clear_zombies();
-            coming_to_stairs.clear();
-            active_npc.clear();
-            faction_manager_ptr->clear();
-            mission::clear_all();
-            Messages::clear_messages();
-            timed_events = timed_event_manager();
-            explosion_handler::get_explosion_queue().clear();
-
-            SCT.vSCT.clear(); //Delete pending messages
-
-            stats().clear();
-            // reset kill counts
-            get_kill_tracker().clear();
-            achievements_tracker_ptr->clear();
-            // reset follower list
-            follower_ids.clear();
-            scent.reset();
-
-            remoteveh_cache_time = calendar::before_time_starts;
-            remoteveh_cache = nullptr;
-
-            token_provider_ptr->clear();
-            // back to menu for save loading, new game etc
+            // Doesn't need to load mod files again for the same world
+            setup( false );
         } catch( const std::exception &err ) {
             debugmsg( "Error: %s", err.what() );
         }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2553,7 +2553,7 @@ bool game::load( const save_t &name )
             std::bind( &game::unserialize, this, _1 ) ) ) {
         return false;
     }
-    // This needs to be here for some reason for quickload() to wo
+    // This needs to be here for some reason for quickload() to work
     ui_manager::redraw();
     refresh_display();
     u.load_map_memory();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2392,7 +2392,7 @@ bool game::is_game_over()
     if( u.is_dead_state() ) {
         if( get_option<bool>( "PROMPT_ON_CHARACTER_DEATH" ) &&
             !query_yn(
-                _( "Your character is dead, do you accept this?\n\nSelect Yes to abandon the character to their fate, select No to return to try again." ) ) ) {
+                _( "Your character is dead, do you accept this?\n\nSelect Yes to abandon the character to their fate, select No to try again." ) ) ) {
             g->quickload();
             return false;
         }

--- a/src/game.h
+++ b/src/game.h
@@ -167,7 +167,7 @@ class game
         void on_options_changed();
 
     public:
-        void setup();
+        void setup( bool load_world_modfiles = true );
         /** Saving and loading functions. */
         void serialize( std::ostream &fout ); // for save
         void unserialize( std::istream &fin ); // for load

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1222,7 +1222,7 @@ void options_manager::add_options_general()
     };
 
     add( "PROMPT_ON_CHARACTER_DEATH", general, translate_marker( "Prompt on character death" ),
-         translate_marker( "If enabled, when your character dies, the player is given a prompt that gives the option to cancel savefile deletion and other death effects, returning to the main menu without saving instead." ),
+         translate_marker( "If enabled, when your character dies, the player is given a prompt that gives the option to reload the last saved game instead of dying." ),
          false
        );
 


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.



<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change
The option "Prompt on death" gives the player the option to keep it's save when dying instead of deleting it, however the prompt it gives for that it's a bit unclear asking if you want to return to the main menu or abandon your character to their fate, it's also a bit of chore having to load the save again from the main menu.

As for the quickload option that's found in `game.cpp` this action seems to have been broken for a long time according to searches in the Discord. 
<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution
Now on selecting 'No' it uses the `game::quickload()` function to load the last saved game.

The `game::quickload()` function was fixed by  copying a version of `game::setup()` and replacing the one used by the quickload, this version is the same except it doesn't load the world mod files since they are already loaded and it's the same world.

To fix the quickload function it was also needed to move code for ui redrawing a few lines below in `game::load( const save_t &name )`, why this was crashing the game it's black sorcery beyond my comprehension.


<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

## Describe alternatives you've considered
Simply edit the prompt to say something like "... press No to keep your save".
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing
Compiled the game, quicksaved and let my character die, also using the quickload keybind.


https://github.com/user-attachments/assets/6213b2f3-bd5e-48fc-a078-5f0a27b83052


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context
As it can be seen in the video, for some reason when quickloading the player's field of view it's not updated until you move so i guess someone can open an issue if they find it too bothersome.

Also since the crashes were pretty unclear about why `game::quickload()` was not working i would like if people can test whether it works or not in their distros since i only tested this on Windows.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
