### PR TITLE
fix: replace the wooden floor under the standing tanks of the small cabin

### DIFF
--- a/data/json/mapgen/chemical_lab.json
+++ b/data/json/mapgen/chemical_lab.json
@@ -32,6 +32,7 @@
         "........................"
       ],
       "palettes": [ "cabin_palette" ],
+      "terrain": { "0": [ [ "t_region_groundcover_barren", 3 ], "t_region_groundcover" ] },
       "faction_owner": [ { "id": "wasteland_scavengers", "x": [ 1, 23 ], "y": [ 1, 23 ] } ],
       "items": { "C": [ { "item": "cabin_chemist_sell", "chance": 100, "repeat": [ 4, 5 ] } ] },
       "npcs": { "@": { "class": "NPC_cabin_chemist" } }


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Replace the wooden floor under the small cabin standing tanks with outdoor terrain.
## Describe the solution
Set "0" in the mapgen `chemical_lab_ocu` to use the same terrain as "~"
## Describe alternatives you've considered
none
## Additional context
Before:
![image1](https://github.com/user-attachments/assets/4dd142d4-cf60-463c-ac06-f1d38e8317ee)
After:
![image2](https://github.com/user-attachments/assets/b9d2b65c-8f0e-47ff-97ce-4eff2cadf443)