### PR TITLE
feat(balance): Make Stylish trait the default behavior, add Unstylish trait

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -265,7 +265,7 @@
     "id": "FANCY",
     "type": "json_flag",
     "context": [ "ARMOR", "TOOL_ARMOR" ],
-    "//": "Wearing this clothing gives a morale bonus if the player has the Stylish trait.",
+    "//": "Wearing this clothing gives a morale bonus if the player doesn't have the Fashion Deficient trait.",
     "info": "This clothing is <info>fancy</info>.",
     "conflicts": [ "SUPER_FANCY" ]
   },
@@ -798,7 +798,7 @@
     "id": "SUPER_FANCY",
     "type": "json_flag",
     "context": [ "ARMOR", "TOOL_ARMOR" ],
-    "//": "Gives an additional moral bonus over FANCY if the player has the Stylish trait.",
+    "//": "Gives an additional moral bonus over FANCY if the player doesn't have the Fashion Deficient trait.",
     "info": "This clothing is <info>very fancy</info>.",
     "conflicts": [ "FANCY" ]
   },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -502,10 +502,10 @@
   },
   {
     "type": "mutation",
-    "id": "STYLISH",
-    "name": { "str": "Stylish" },
-    "points": 2,
-    "description": "Practicality is far less important than style.  Your morale is improved by wearing fashionable and attractive clothing.",
+    "id": "UNSTYLISH",
+    "name": { "str": "Fashion Deficient" },
+    "points": -1,
+    "description": "You have no sense of style, and don't care about wearing anything 'fancy';  you'd be perfectly happy to wear non-matching socks, or wear socks and sandals.  You get no morale bonus from fancy equipment.",
     "starting_trait": true,
     "valid": false
   },

--- a/data/json/npcs/starting_traits.json
+++ b/data/json/npcs/starting_traits.json
@@ -44,7 +44,7 @@
       { "trait": "ROBUST", "prob": 10 },
       { "trait": "SELFAWARE", "prob": 10 },
       { "trait": "SPIRITUAL", "prob": 10 },
-      { "trait": "STYLISH", "prob": 10 },
+      { "trait": "UNSTYLISH", "prob": 10 },
       { "trait": "TERRIFYING", "prob": 10 },
       { "trait": "ALBINO", "prob": 1 },
       { "trait": "ASTHMA", "prob": 10 },

--- a/data/json/obsoletion/mutations.json
+++ b/data/json/obsoletion/mutations.json
@@ -238,5 +238,13 @@
     "points": 1,
     "description": "This mutation has been obsoleted due to the hidden movement speed penalty being removed.  If you see this on a profession or mutate this trait, this is a bug.",
     "valid": false
+  },
+  {
+    "type": "mutation",
+    "id": "STYLISH",
+    "name": { "str": "Stylish" },
+    "points": 2,
+    "description": "Obsoleted due to becoming default behavior.",
+    "valid": false
   }
 ]

--- a/data/mods/Aftershock/npcs/Backgrounds/trait_groups.json
+++ b/data/mods/Aftershock/npcs/Backgrounds/trait_groups.json
@@ -893,7 +893,7 @@
       { "trait": "ROBUST", "prob": 10 },
       { "trait": "SELFAWARE", "prob": 10 },
       { "trait": "SPIRITUAL", "prob": 10 },
-      { "trait": "STYLISH", "prob": 10 },
+      { "trait": "UNSTYLISH", "prob": 10 },
       { "trait": "ALBINO", "prob": 5 },
       { "trait": "ASTHMA", "prob": 5 },
       { "trait": "CHEMIMBALANCE", "prob": 10 },

--- a/data/mods/Aftershock/npcs/mutant_npcs/trait_groups.json
+++ b/data/mods/Aftershock/npcs/mutant_npcs/trait_groups.json
@@ -899,7 +899,7 @@
       { "trait": "ROBUST", "prob": 10 },
       { "trait": "SELFAWARE", "prob": 10 },
       { "trait": "SPIRITUAL", "prob": 10 },
-      { "trait": "STYLISH", "prob": 10 },
+      { "trait": "UNSTYLISH", "prob": 10 },
       { "trait": "ALBINO", "prob": 5 },
       { "trait": "ASTHMA", "prob": 5 },
       { "trait": "CHEMIMBALANCE", "prob": 10 },

--- a/doc/src/content/docs/en/mod/json/reference/json_flags.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_flags.md
@@ -200,7 +200,8 @@ to find which flags work elsewhere.
 - `COLLAR` This piece of clothing has a wide collar that can keep your mouth warm.
 - `DEAF` Makes the player deaf.
 - `ELECTRIC_IMMUNE` This gear completely protects you from electric discharges.
-- `FANCY` Wearing this clothing gives a morale bonus if the player doesn't have the `Fashion Deficient` trait.
+- `FANCY` Wearing this clothing gives a morale bonus if the player doesn't have the
+  `Fashion Deficient` trait.
 - `FIX_FARSIGHT` This gear corrects farsightedness.
 - `FIX_NEARSIGHT` This gear corrects nearsightedness.
 - `FLOTATION` Prevents the player from drowning in deep water. Also prevents diving underwater.
@@ -249,7 +250,8 @@ to find which flags work elsewhere.
   0.70.
 - `STURDY` This clothing is a lot more resistant to damage than normal.
 - `SUN_GLASSES` Prevents glaring when in sunlight.
-- `SUPER_FANCY` Gives an additional moral bonus over `FANCY` if the player doesn't have the `Fashion Deficient` trait.
+- `SUPER_FANCY` Gives an additional moral bonus over `FANCY` if the player doesn't have the
+  `Fashion Deficient` trait.
 - `SWIM_GOGGLES` Allows you to see much further under water.
 - `THERMOMETER` This gear is equipped with an accurate thermometer (which is used to measure
   temperature).

--- a/doc/src/content/docs/en/mod/json/reference/json_flags.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_flags.md
@@ -200,7 +200,7 @@ to find which flags work elsewhere.
 - `COLLAR` This piece of clothing has a wide collar that can keep your mouth warm.
 - `DEAF` Makes the player deaf.
 - `ELECTRIC_IMMUNE` This gear completely protects you from electric discharges.
-- `FANCY` Wearing this clothing gives a morale bonus if the player has the `Stylish` trait.
+- `FANCY` Wearing this clothing gives a morale bonus if the player doesn't have the `Fashion Deficient` trait.
 - `FIX_FARSIGHT` This gear corrects farsightedness.
 - `FIX_NEARSIGHT` This gear corrects nearsightedness.
 - `FLOTATION` Prevents the player from drowning in deep water. Also prevents diving underwater.
@@ -249,7 +249,7 @@ to find which flags work elsewhere.
   0.70.
 - `STURDY` This clothing is a lot more resistant to damage than normal.
 - `SUN_GLASSES` Prevents glaring when in sunlight.
-- `SUPER_FANCY` Gives an additional moral bonus over `FANCY` if the player has the `Stylish` trait.
+- `SUPER_FANCY` Gives an additional moral bonus over `FANCY` if the player doesn't have the `Fashion Deficient` trait.
 - `SWIM_GOGGLES` Allows you to see much further under water.
 - `THERMOMETER` This gear is equipped with an accurate thermometer (which is used to measure
   temperature).

--- a/src/morale.cpp
+++ b/src/morale.cpp
@@ -289,8 +289,8 @@ player_morale::player_morale() :
                                          std::bind( set_badtemper, _1, -9 ),
                                          std::bind( set_badtemper, _1, 0 ) );
     mutations[trait_UNSTYLISH]       = mutation_data(
-                                         std::bind( set_stylish, _1, false ),
-                                         std::bind( set_stylish, _1, true ) );
+                                           std::bind( set_stylish, _1, false ),
+                                           std::bind( set_stylish, _1, true ) );
     mutations[trait_FLOWERS]       = mutation_data( update_constrained );
     mutations[trait_ROOTS1]         = mutation_data( update_constrained );
     mutations[trait_ROOTS2]        = mutation_data( update_constrained );

--- a/src/morale.cpp
+++ b/src/morale.cpp
@@ -48,7 +48,7 @@ static const trait_id trait_OPTIMISTIC( "OPTIMISTIC" );
 static const trait_id trait_ROOTS1( "ROOTS1" );
 static const trait_id trait_ROOTS2( "ROOTS2" );
 static const trait_id trait_ROOTS3( "ROOTS3" );
-static const trait_id trait_STYLISH( "STYLISH" );
+static const trait_id trait_UNSTYLISH( "UNSTYLISH" );
 
 namespace io
 {
@@ -269,7 +269,7 @@ player_morale::player_morale() :
     level_is_valid( false ),
     took_prozac( false ),
     took_prozac_bad( false ),
-    stylish( false ),
+    stylish( true ),
     perceived_pain( 0 )
 {
     using namespace std::placeholders;
@@ -288,9 +288,9 @@ player_morale::player_morale() :
     mutations[trait_BADTEMPER]     = mutation_data(
                                          std::bind( set_badtemper, _1, -9 ),
                                          std::bind( set_badtemper, _1, 0 ) );
-    mutations[trait_STYLISH]       = mutation_data(
-                                         std::bind( set_stylish, _1, true ),
-                                         std::bind( set_stylish, _1, false ) );
+    mutations[trait_UNSTYLISH]       = mutation_data(
+                                         std::bind( set_stylish, _1, false ),
+                                         std::bind( set_stylish, _1, true ) );
     mutations[trait_FLOWERS]       = mutation_data( update_constrained );
     mutations[trait_ROOTS1]         = mutation_data( update_constrained );
     mutations[trait_ROOTS2]        = mutation_data( update_constrained );
@@ -892,7 +892,7 @@ void player_morale::clear()
     }
     took_prozac = false;
     took_prozac_bad = false;
-    stylish = false;
+    stylish = true;
     super_fancy_items.clear();
 
     invalidate();

--- a/tests/morale_test.cpp
+++ b/tests/morale_test.cpp
@@ -179,13 +179,18 @@ TEST_CASE( "player_morale", "[morale]" )
         m.on_item_wear( heels );
 
         WHEN( "not a stylish person" ) {
+            m.on_mutation_gain( trait_id( "UNSTYLISH" ) );
             THEN( "just don't care (even if man)" ) {
                 CHECK( m.get_level() == 0 );
+            }
+
+            AND_WHEN( "not anymore" ) {
+                m.on_mutation_loss( trait_id( "UNSTYLISH" ) );
+                CHECK( m.get_level() == 19 );
             }
         }
 
         WHEN( "a stylish person" ) {
-            m.on_mutation_gain( trait_id( "STYLISH" ) );
 
             CHECK( m.get_level() == 19 );
 
@@ -215,10 +220,6 @@ TEST_CASE( "player_morale", "[morale]" )
                 THEN( "there's a limit" ) {
                     CHECK( m.get_level() == 20 );
                 }
-            }
-            AND_WHEN( "not anymore" ) {
-                m.on_mutation_loss( trait_id( "STYLISH" ) );
-                CHECK( m.get_level() == 0 );
             }
         }
     }


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `doc/` folder.
- [x] This is a PR that removes JSON entities.
  - [x] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.

## Purpose of change

It felt a little silly to have to spend two whole points on your character appreciating wearing fancy clothing. Plus, it generally makes more sense for liking fancy clothing to be the default behavior.

## Describe the solution

- Obsoletes `Stylish`, making its behavior the default state
- Adds `Fashion Deficient`, a new negative trait that takes away the morale boost for 1 extra point during character creation.
- Updates the relevant docs on JSON flags (and comments in the json file itself)
- Updates the NPC trait generation lists to instead be `UNSTYLISH` instead of the now-obsolete `STYLISH` (except No Hope, because it's funny)

## Describe alternatives you've considered

- Do nothing
- Just reduce the cost of `Stylish`

Still feels a bit weird to have to spend points on what *should be* default behavior (and a 0-point trait would just be weird)
- Increase points gained by `Fashion Deficient` to 2 to match `Stylish`'s old cost

I just don't think it's particularly worth 2 points, but I'm perfectly happy to change it to be 2 points if that's what's preferred.

## Testing

It builds, it functions, it works on my machine.

## Additional context

Any suggestions for more starting traits that could use an inversion are appreciated.

Considering at least taking the first step towards making `Self Aware` default behavior
