### PR TITLE
fix: Stop accidental plut gen destruction

### DIFF
--- a/data/json/deconstruction.json
+++ b/data/json/deconstruction.json
@@ -903,10 +903,9 @@
     "time": "30 m",
     "using": [ [ "advanced_electronics_high_voltage", 1 ] ],
     "byproducts": [
-      { "item": "scrap", "count": [ 1, 4 ] },
-      { "item": "scrap_copper", "count": [ 10, 20 ] },
-      { "item": "cable", "charges": [ 20, 100 ] },
-      { "item": "pipe", "count": [ 1, 2 ] }
+      { "item": "plut_generator_item", "charges": [ 1, 1 ] },
+      { "item": "power_supply", "charges": [ 3, 3 ] },
+      { "item": "cable", "charges": [ 15, 15 ] }
     ],
     "pre_furniture": "f_grid_plut_generator",
     "post_furniture": "f_null",

--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -2508,7 +2508,7 @@
     "move_cost_mod": -1,
     "coverage": 60,
     "required_str": -1,
-    "flags": [ "TRANSPARENT", "NOITEM", "REDUCE_SCENT", "PERMEABLE", "EASY_DECONSTRUCT" ],
+    "flags": [ "TRANSPARENT", "NOITEM", "REDUCE_SCENT", "PERMEABLE" ],
     "bash": {
       "str_min": 50,
       "str_max": 400,


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
## Purpose of change

There was a way to deconstruct the grid plut gen into components through construction. This takes it out

## Describe the solution

Sets it so the resources granted on deconstruction of grid generator correctly drops the generator and its power converter/wiring.

## Describe alternatives you've considered

More Coffee

## Testing

Tests

## Additional context

I don't even know how this happened, and I don't think I want to know.
