### PR TITLE
feat(balance): add more items to `s_petstore_1`, replace `cleaning` with `SUS_janitors_closet`

### DIFF
--- a/data/json/mapgen/petstore.json
+++ b/data/json/mapgen/petstore.json
@@ -146,13 +146,13 @@
         " |CC+....|++|......#..| ",
         " |---..............#A.| ",
         " |CCW..............#..| ",
-        " |CC+...{..........-D-| ",
-        " |---...{.............| ",
-        " |CCW...{.............| ",
-        " |CCW...{.............| ",
-        " |CC+...{.............| ",
-        " |---...{......{{{{{{{| ",
-        " |CCW...{.....--------| ",
+        " |CC+...{.{........-D-| ",
+        " |---...{.{...........| ",
+        " |CCW...{.{...}.}.}.}.| ",
+        " |CCW...{.{...}.}.}.}.| ",
+        " |CC+...{.{...........| ",
+        " |---...{.{...{{{{{{{{| ",
+        " |CCW...{.{...--------| ",
         " |CCW.................| ",
         " |CC+.................| ",
         " |||||||||||||b||-...-| ",
@@ -190,20 +190,25 @@
         "{": "f_rack",
         "f": "f_filing_cabinet",
         "A": "f_stool",
-        "l": "f_locker"
+        "l": "f_locker",
+        "}": "f_counter"
       },
       "toilets": { "T": {  } },
       "place_item": [
-        { "item": "pet_carrier", "repeat": 1, "x": 21, "y": 9 },
-        { "item": "pet_carrier", "repeat": 1, "x": 21, "y": 10 },
-        { "item": "pet_carrier", "repeat": 1, "x": 8, "y": 14 },
+        { "item": "pet_carrier", "x": 8, "y": 14 },
+        { "item": "pet_carrier", "x": 10, "y": 14 },
         { "item": "bathroom_scale", "x": 21, "y": 19 }
       ],
       "place_items": [
         { "chance": 15, "item": "vet_softdrug", "x": 21, "y": 6 },
         { "chance": 30, "item": "vet_utility", "x": [ 20, 21 ], "y": 3 }
       ],
-      "items": { "l": { "item": "cleaning", "chance": 30 }, "T": { "item": "softdrugs", "chance": 30 } },
+      "items": {
+        "{": { "item": "petstore_shelves", "chance": 70, "repeat": [ 2, 8 ] },
+        "}": { "item": "petstore_misc", "chance": 70, "repeat": [ 2, 8 ] },
+        "l": { "item": "SUS_janitors_closet", "chance": 100 },
+        "T": { "item": "softdrugs", "chance": 30 }
+      },
       "place_monster": [
         { "monster": "mon_cat", "x": 2, "y": 3 },
         { "monster": "mon_rabbit", "x": 2, "y": 7 },


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Add more items to `s_petstore_1` because there's virtually no loot here if we compare this pet store with the others.
## Describe the solution
Took some of the `items` defined in `s_petstore` and used them here.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/08a5d191-739b-4836-b72d-d7c9e781583a" />
After:
<img width="960" alt="image2" src="https://github.com/user-attachments/assets/d9a45c49-5e5e-4658-95d6-8d8fdfec2ce2" />