### PR TITLE
fix: stop showing `loffice_tower_16` as open air on the overmap

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain_commercial.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_commercial.json
@@ -1175,7 +1175,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": [ "loffice_tower_16", "loffice_tower_17", "loffice_tower_18", "loffice_tower_19", "loffice_tower_20" ],
+    "id": [ "loffice_tower_17", "loffice_tower_18", "loffice_tower_19", "loffice_tower_20" ],
     "name": "open air",
     "sym": ".",
     "color": "blue"


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Stop showing `loffice_tower_16` as open air on the overmap because like `loffice_tower_13`, `loffice_tower_14` and `loffice_tower_15` `loffice_tower_16` is supposed to be named on the overmap Large Office Tower
## Describe the solution
Deleted the duplication of `loffice_tower_16` on line 1178 of overmap_terrain_commercial.json
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/d731cd5e-d52e-4128-a74e-5fa6e41fad85" />
After:
<img width="671" alt="image2" src="https://github.com/user-attachments/assets/002411b5-6f0e-4322-8725-d8b59a946d31" />
<img width="960" alt="image3" src="https://github.com/user-attachments/assets/a4237092-694d-45c2-bf9f-2112ae975710" />