### PR TITLE
fix: Let tarps actually shelter fires, let fire rings be used more

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -3577,7 +3577,6 @@
     "qualities": [ { "id": "DIG", "level": 1 } ],
     "components": [ [ [ "rock", 20 ] ] ],
     "pre_note": "Can be deconstructed without tools.",
-    "pre_terrain": "t_dirt",
     "dark_craftable": true,
     "post_furniture": "f_firering"
   },

--- a/data/json/furniture_and_terrain/terrain-manufactured.json
+++ b/data/json/furniture_and_terrain/terrain-manufactured.json
@@ -1417,7 +1417,7 @@
       "ter_set": "t_dirt",
       "items": [ { "item": "pointy_stick", "count": 4 }, { "item": "string_6", "count": 4 }, { "item": "tarp", "count": 1 } ]
     },
-    "flags": [ "TRANSPARENT", "FLAMMABLE", "THIN_OBSTACLE", "INDOORS", "MOUNTABLE", "EASY_DECONSTRUCT" ]
+    "flags": [ "TRANSPARENT", "FLAMMABLE", "THIN_OBSTACLE", "INDOORS", "MOUNTABLE", "EASY_DECONSTRUCT", "FLAT" ]
   },
   {
     "type": "terrain",


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

The tarp lean-to's description said it could be used to shelter a fire, but it could not. This lets it be accurate to its description (and have other furniture too I guess)

The fire ring was restricted to only being placeable on specifically dirt and nothing else. This felt like an unnecessary restriction (and didn't allow for the fire ring to be sheltered by the tarp), so I opted to just let it be constructed on any (`FLAT`) terrain.

## Describe the solution

- Adds `FLAT` to the tarp lean-to
- Removes the pre-terrain requirement in the fire ring's construction

## Describe alternatives you've considered

- Specifically allow the fire ring to also be constructed on the tarp lean-to

This doesn't actually solve the issue, because there are innumerable sensible `FLAT` terrain options that it could be put on, and manually adding them all would be ridiculous. Also, it's not like having a fire ring on any of these terrain types is an actual balance issue.

## Testing

It works, but it looks silly
![image](https://github.com/user-attachments/assets/dc74114b-aeb0-4231-b9f1-ff4938e04511)


## Additional context

Maybe we should have a flag that can be put on terrain that says to put the terrain's sprite on a higher layer than the furniture sprite for situations like this.
