### PR TITLE
feat(mods/Monster_Girls,content): Add Kitsunes to Monster Girls Mutations

### DIFF
--- a/data/mods/Monster_Girls/categories.json
+++ b/data/mods/Monster_Girls/categories.json
@@ -91,5 +91,14 @@
     "mutagen_message": "You feel the woods calling to you.",
     "iv_message": "You feel like you could live forever, just like the trees!",
     "memorial_message": "Spoke with the trees."
+  },
+  {
+    "type": "mutation_category",
+    "id": "KITSUNE",
+    "name": "Kitsune",
+    "threshold_mut": "THRESH_KITSUNE",
+    "mutagen_message": "You suddenly have an indescribable craving for chicken...",
+    "iv_message": "Your blood runs wild with mischief and merriment as the mutagen flows through it.",
+    "memorial_message": "Learned what the fox says."
   }
 ]

--- a/data/mods/Monster_Girls/dreams.json
+++ b/data/mods/Monster_Girls/dreams.json
@@ -148,7 +148,7 @@
     "messages": [
       "You have a vivid dream of hunting in the woods.",
       "You have a vivid dream of sneaking up to a chicken coop.",
-      "Whilst dreaming, you see yourself... but with a pair of fox ears on your head?"
+      "Whilst dreaming, you see yourself… but with a pair of fox ears on your head?"
     ],
     "category": "KITSUNE",
     "strength": 2
@@ -241,7 +241,7 @@
     "type": "dream",
     "messages": [
       "You vividly dream of running away from a chicken coop, your prey held by the neck between your teeth.",
-      "You vividly dream of... a wedding altar?!?"
+      "You vividly dream of… a wedding altar?!?"
     ],
     "category": "KITSUNE",
     "strength": 3

--- a/data/mods/Monster_Girls/dreams.json
+++ b/data/mods/Monster_Girls/dreams.json
@@ -61,6 +61,12 @@
   },
   {
     "type": "dream",
+    "messages": [ "You have a strange dream about foxes.", "Your dreams give you a mischievous furry feeling." ],
+    "category": "KITSUNE",
+    "strength": 1
+  },
+  {
+    "type": "dream",
     "messages": [
       "You have strange dreams of soaring through the sky.",
       "In a dream, you see a curiously harpy-like reflection of yourself."
@@ -135,6 +141,16 @@
     "type": "dream",
     "messages": [ "You dream of… sneaking.", "You dream of a cold winter night.  Your jacket is too big to put on." ],
     "category": "MOUSEGIRL",
+    "strength": 2
+  },
+  {
+    "type": "dream",
+    "messages": [
+      "You have a vivid dream of hunting in the woods.",
+      "You have a vivid dream of sneaking up to a chicken coop.",
+      "Whilst dreaming, you see yourself... but with a pair of fox ears on your head?"
+    ],
+    "category": "KITSUNE",
     "strength": 2
   },
   {
@@ -219,6 +235,15 @@
       "Once you finish your tasty dinner of seeds, you look around for your drink, but you already ate it."
     ],
     "category": "MOUSEGIRL",
+    "strength": 3
+  },
+  {
+    "type": "dream",
+    "messages": [
+      "You vividly dream of running away from a chicken coop, your prey held by the neck between your teeth.",
+      "You vividly dream of... a wedding altar?!?"
+    ],
+    "category": "KITSUNE",
     "strength": 3
   },
   {
@@ -316,6 +341,16 @@
       "You hear the sirens again, but this time you stay in your hole in the wall.  Nobody will think to look there!"
     ],
     "category": "MOUSEGIRL",
+    "strength": 4
+  },
+  {
+    "type": "dream",
+    "messages": [
+      "You vividly dream of committing tax fraud: the ultimate trick!",
+      "You find yourself subconsciously moving your head from your normal pillow to your tail as you sleep.",
+      "You dream of sharing your love of mischief with a partner."
+    ],
+    "category": "KITSUNE",
     "strength": 4
   }
 ]

--- a/data/mods/Monster_Girls/migration.json
+++ b/data/mods/Monster_Girls/migration.json
@@ -192,12 +192,12 @@
   {
     "id": "mutagen_beast",
     "type": "MIGRATION",
-    "replace": "mutagen"
+    "replace": "mutagen_kitsune"
   },
   {
     "id": "iv_mutagen_beast",
     "type": "MIGRATION",
-    "replace": "iv_mutagen"
+    "replace": "iv_mutagen_kitsune"
   },
   {
     "id": "mutagen_fish",

--- a/data/mods/Monster_Girls/mutagens.json
+++ b/data/mods/Monster_Girls/mutagens.json
@@ -151,7 +151,7 @@
     "type": "COMESTIBLE",
     "copy-from": "iv_mutagen_beast",
     "name": "Kitsune serum",
-    "description": "A super-concentrated mutagen the color of amber.  You need a syringe to inject it... if you really want to?",
+    "description": "A super-concentrated mutagen the color of amber.  You need a syringe to inject it… if you really want to?",
     "use_action": { "type": "mutagen_iv", "mutation_category": "KITSUNE" }
   }
 ]

--- a/data/mods/Monster_Girls/mutagens.json
+++ b/data/mods/Monster_Girls/mutagens.json
@@ -138,5 +138,20 @@
     "copy-from": "iv_mutagen_elfa",
     "name": "Fey serum",
     "use_action": { "type": "mutagen_iv", "mutation_category": "ELF" }
+  },
+  {
+    "id": "mutagen_kitsune",
+    "type": "COMESTIBLE",
+    "copy-from": "mutagen_beast",
+    "name": "Kitsune mutagen",
+    "use_action": { "type": "mutagen", "mutation_category": "KITSUNE" }
+  },
+  {
+    "id": "iv_mutagen_kitsune",
+    "type": "COMESTIBLE",
+    "copy-from": "iv_mutagen_beast",
+    "name": "Kitsune serum",
+    "description": "A super-concentrated mutagen the color of amber.  You need a syringe to inject it... if you really want to?",
+    "use_action": { "type": "mutagen_iv", "mutation_category": "KITSUNE" }
   }
 ]

--- a/data/mods/Monster_Girls/recipes.json
+++ b/data/mods/Monster_Girls/recipes.json
@@ -122,5 +122,17 @@
     "result": "mutagen_elf",
     "copy-from": "mutagen_elfa",
     "components": [ [ [ "mutagen_slime", 2 ], [ "iv_mutagen_slime", 1 ] ], [ [ "mutagen_plant", 1 ] ], [ [ "mutagen_bird", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "iv_mutagen_kitsune",
+    "copy-from": "iv_mutagen_beast",
+    "components": [ [ [ "mutagen_kitsune", 2 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "mutagen_kitsune",
+    "copy-from": "mutagen_beast",
+    "components": [ [ [ "mutagen", 1 ] ], [ [ "animal_blood_concentrate", 9 ] ], [ [ "ammonia", 1 ], [ "lye_powder", 100 ] ] ]
   }
 ]

--- a/data/mods/Monster_Girls/thresh_mutation.json
+++ b/data/mods/Monster_Girls/thresh_mutation.json
@@ -108,5 +108,16 @@
     "purifiable": false,
     "threshold": true,
     "mutagen_target_modifier": 10
+  },
+  {
+    "type": "mutation",
+    "id": "THRESH_KITSUNE",
+    "name": { "str": "Kitsune" },
+    "points": 1,
+    "description": "While you may not have gained the magical powers of the japanese fox spirits, you embody their mischievous nature perfectly.  Perhaps one day, you'll find that special partner-in-crime to live up to the other reputation Kitsunes have.",
+    "valid": false,
+    "purifiable": false,
+    "threshold": true,
+    "mutagen_target_modifier": 10
   }
 ]

--- a/data/mods/Monster_Girls/vanilla_mutations.json
+++ b/data/mods/Monster_Girls/vanilla_mutations.json
@@ -144,7 +144,7 @@
     "id": "DEFT",
     "copy-from": "DEFT",
     "delete": { "category": [ "BIRD", "BEAST", "RAPTOR", "MOUSE", "FELINE" ] },
-    "extend": { "category": [ "NEKO", "MOUSEGIRL", "HARPY" ] }
+    "extend": { "category": [ "NEKO", "MOUSEGIRL", "HARPY", "KITSUNE" ] }
   },
   {
     "type": "mutation",
@@ -179,7 +179,7 @@
     "id": "ADRENALINE",
     "copy-from": "ADRENALINE",
     "delete": { "category": [ "BEAST", "CHIMERA" ] },
-    "valid": false
+    "extend": { "category": [ "KITSUNE" ] }
   },
   {
     "type": "mutation",
@@ -228,7 +228,7 @@
     "id": "PRETTY",
     "copy-from": "PRETTY",
     "delete": { "category": [ "ALPHA", "FELINE", "LUPINE" ] },
-    "extend": { "category": [ "NEKO", "DOGGIRL" ] }
+    "extend": { "category": [ "NEKO", "DOGGIRL", "KITSUNE" ] }
   },
   {
     "type": "mutation",
@@ -249,7 +249,7 @@
     "id": "SLEEPY",
     "copy-from": "SLEEPY",
     "delete": { "category": [ "BEAST", "CHIMERA", "MOUSE" ] },
-    "extend": { "category": [ "MOUSEGIRL" ] }
+    "extend": { "category": [ "MOUSEGIRL", "KITSUNE" ] }
   },
   {
     "type": "mutation",
@@ -340,7 +340,7 @@
     "id": "ANIMALDISCORD",
     "copy-from": "ANIMALDISCORD",
     "delete": { "category": [ "LUPINE", "BEAST", "RAPTOR", "INSECT" ] },
-    "extend": { "category": [ "DOGGIRL" ] }
+    "extend": { "category": [ "DOGGIRL", "KITSUNE" ] }
   },
   {
     "type": "mutation",
@@ -417,7 +417,7 @@
     "id": "NIGHTVISION2",
     "copy-from": "NIGHTVISION2",
     "delete": { "category": [ "FISH", "BEAST", "INSECT", "RAT", "CHIMERA", "LUPINE", "MOUSE", "FELINE", "URSINE" ] },
-    "extend": { "category": [ "NEKO", "DOGGIRL", "MOUSEGIRL", "BEARGIRL" ] }
+    "extend": { "category": [ "NEKO", "DOGGIRL", "MOUSEGIRL", "BEARGIRL", "KITSUNE" ] }
   },
   {
     "type": "mutation",
@@ -445,7 +445,7 @@
     "id": "FEL_EYE",
     "copy-from": "FEL_EYE",
     "delete": { "category": [ "FELINE", "BEAST" ] },
-    "extend": { "category": [ "NEKO" ] }
+    "extend": { "category": [ "NEKO", "KITSUNE" ] }
   },
   {
     "type": "mutation",
@@ -1187,7 +1187,7 @@
     "id": "TAIL_FLUFFY",
     "copy-from": "TAIL_FLUFFY",
     "delete": { "category": [ "BEAST", "LUPINE" ] },
-    "extend": { "category": [ "DOGGIRL" ] }
+    "extend": { "category": [ "DOGGIRL", "KITSUNE" ] }
   },
   {
     "type": "mutation",
@@ -1334,7 +1334,7 @@
     "id": "LUPINE_EARS",
     "copy-from": "LUPINE_EARS",
     "delete": { "category": [ "LUPINE" ] },
-    "valid": false
+    "extend": { "category": [ "KITSUNE" ] }
   },
   {
     "type": "mutation",
@@ -1810,7 +1810,7 @@
     "id": "HUNGER",
     "copy-from": "HUNGER",
     "delete": { "category": [ "RAT", "ALPHA", "MEDICAL", "ELFA", "BEAST", "SLIME", "RAPTOR", "CHIMERA", "MOUSE" ] },
-    "extend": { "category": [ "MOUSEGIRL", "SLIMEGIRL", "ELF" ] }
+    "extend": { "category": [ "MOUSEGIRL", "SLIMEGIRL", "ELF", "KITSUNE" ] }
   },
   {
     "type": "mutation",
@@ -1824,7 +1824,7 @@
     "id": "HUNGER2",
     "copy-from": "HUNGER2",
     "delete": { "category": [ "BEAST", "SLIME", "RAPTOR" ] },
-    "extend": { "category": [ "SLIMEGIRL" ] }
+    "extend": { "category": [ "SLIMEGIRL", "KITSUNE" ] }
   },
   {
     "type": "mutation",
@@ -2349,6 +2349,6 @@
     "id": "FELINE_FLEXIBILITY",
     "copy-from": "FELINE_FLEXIBILITY",
     "delete": { "category": [ "FELINE" ] },
-    "extend": { "category": [ "NEKO" ], "threshreq": [ "THRESH_NEKO" ] }
+    "extend": { "category": [ "NEKO", "KITSUNE" ], "threshreq": [ "THRESH_NEKO", "THRESH_KITSUNE" ] }
   }
 ]


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

More monster girl mutation paths is better so as to avoid overly narrowing player choice.

Kitsunes seemed like a fitting choice for a sort-of beast equivalent, being a bit of a mix between dogs and cats.

## Describe the solution

Adds the Kitsune mutation tree, basing them off of the existing Beast tree (and a little bit of Feline)

## Describe alternatives you've considered

- Implode
- See if a mod has done a good Kitsune path and politely ask to base the monster girl one off of theirs

I tried looking for Shard's one, but couldn't find it (and by the sounds of things, that one got left in WIP hell)

## Testing

It loads on my machine, and the linter didn't complain

## Additional context

Kitsune-Neko alliance goes hard

I should probably make proper orange ears / tail in the future. (even if it's just recolors of what I'm using right now)
