### PR TITLE
fix: inventories not saving locations properly when removing things

### DIFF
--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -726,7 +726,7 @@ void location_visitable<location_inventory>::remove_items_with( const
 
         for( auto istack_iter = istack.begin(); istack_iter != istack.end() &&
              last != VisitResponse::ABORT; ) {
-
+			location<item>* saved_loc=(*istack_iter)->loc;
             ( *istack_iter )->remove_location();
             detached_ptr<item> t( *istack_iter );
 
@@ -747,7 +747,7 @@ void location_visitable<location_inventory>::remove_items_with( const
 
             if( t ) {
                 t.release();
-                ( *istack_iter )->set_location( &*inv->loc );
+                ( *istack_iter )->set_location( saved_loc );
                 istack_iter++;
             }
         }

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -726,7 +726,7 @@ void location_visitable<location_inventory>::remove_items_with( const
 
         for( auto istack_iter = istack.begin(); istack_iter != istack.end() &&
              last != VisitResponse::ABORT; ) {
-			location<item>* saved_loc=(*istack_iter)->loc;
+            location<item> *saved_loc = ( *istack_iter )->loc;
             ( *istack_iter )->remove_location();
             detached_ptr<item> t( *istack_iter );
 


### PR DESCRIPTION
### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Fixes #5026

## Describe the solution

The inventory now correctly stores the items current location and resets it to that rather than just using itself when it's removing things. 

## Testing

I managed to reproduce #5026 reliably. The random aspect is due to the call to x_in_y in item.cpp:10013. If you force that to true the bug will happen. 

## Additional context

I'm going to go through the code this afternoon and make sure there's nowhere else that I got it wrong like that.
