### PR TITLE
fix(UI): re-register hiding clothes as an action

### DIFF
--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -542,6 +542,7 @@ void show_armor_layers_ui( Character &who )
     ctxt.register_action( "NEXT_TAB" );
     ctxt.register_action( "MOVE_ARMOR" );
     ctxt.register_action( "CHANGE_SIDE" );
+    ctxt.register_action( "TOGGLE_CLOTH" );
     ctxt.register_action( "ASSIGN_INVLETS" );
     ctxt.register_action( "SORT_ARMOR" );
     ctxt.register_action( "EQUIP_ARMOR" );


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Fix #5840 being caused by #5721 accidentally unregistering the hiding clothes option

## Describe the solution

Re-adds the registration line

## Describe alternatives you've considered

- Let someone else do it

## Testing

If it built before, it shall build again.

## Additional context

Mmm, tasty regression fixing.
~~Coolthulu's coolness rating has gone down 1.4 points~~
