### PR TITLE
fix: replace the linoleum tile under the dumpsters of the homeless shelter with concrete

### DIFF
--- a/data/json/mapgen/homeless_shelter.json
+++ b/data/json/mapgen/homeless_shelter.json
@@ -52,7 +52,8 @@
       "v": "t_window_bars",
       "f": "t_chainfence",
       "g": "t_chaingate_l",
-      "n": "t_dirtmound"
+      "n": "t_dirtmound",
+      "D": "t_concrete"
     },
     "furniture": {
       "]": "f_street_light",


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Replace the linoleum tile under the dumpsters of the homeless shelter with concrete because it seems more logical to me that concrete should be under these dumpsters.
## Describe the solution
Modify `homeless_palette` to place concrete floor under the dumpsters.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/7d63207a-b71b-438e-a422-d27a0e60030e" />
After:
<img width="718" alt="image2" src="https://github.com/user-attachments/assets/708b7bfe-e099-4c28-b7ac-967382e41521" />