### PR TITLE
fix: folding vehicles fold up into proper item

### DIFF
--- a/data/json/vehicles/carts.json
+++ b/data/json/vehicles/carts.json
@@ -296,7 +296,7 @@
   {
     "id": "wheelchair",
     "type": "vehicle",
-    "name": "Foldable wheelchair",
+    "name": "Wheelchair",
     "blueprint": [ "#" ],
     "parts": [
       { "x": 0, "y": 0, "part": "folding_frame" },

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -912,7 +912,7 @@ bool vehicle::fold_up()
         add_msg( _( "You let go of %s as you fold it." ), name );
     }
 
-    std::string itype_id = "folding_bicycle";
+    std::string itype_id = "generic_folded_vehicle";
     for( const auto &elem : tags ) {
         if( elem.compare( 0, 12, "convertible:" ) == 0 ) {
             itype_id = elem.substr( 12 );
@@ -920,17 +920,9 @@ bool vehicle::fold_up()
         }
     }
 
-    // Decide the spawn type based on item and folding state
-    // we're going to switch to using can_be_folded for this, as it has the same functionality and is less hard-coded
-    std::string spawn_type;
-    if( !can_be_folded ) {
-        spawn_type = itype_id;
-    } else {
-        spawn_type = "generic_folded_vehicle";  // Handle unexpected cases
-    }
-
     // Create the item
-    detached_ptr<item> folding_veh_item = item::spawn( spawn_type, calendar::turn );
+    detached_ptr<item> folding_veh_item = item::spawn( can_be_folded ? "generic_folded_vehicle" :
+                                          itype_id, calendar::turn );
 
     // Drop stuff in containers on ground
     for( const vpart_reference &vp : get_any_parts( "CARGO" ) ) {

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -920,10 +920,17 @@ bool vehicle::fold_up()
         }
     }
 
-    // create a folding [non]bicycle item
-    detached_ptr<item> bicycle = item::spawn( can_be_folded ? "generic_folded_vehicle" :
-                                 "folding_bicycle",
-                                 calendar::turn );
+    // Decide the spawn type based on item and folding state
+    // we're going to switch to using can_be_folded for this, as it has the same functionality and is less hard-coded
+    std::string spawn_type;
+    if( !can_be_folded ) {
+        spawn_type = itype_id;
+    } else {
+        spawn_type = "generic_folded_vehicle";  // Handle unexpected cases
+    }
+
+    // Create the item
+    detached_ptr<item> folding_veh_item = item::spawn( spawn_type, calendar::turn );
 
     // Drop stuff in containers on ground
     for( const vpart_reference &vp : get_any_parts( "CARGO" ) ) {
@@ -944,21 +951,25 @@ bool vehicle::fold_up()
         std::ostringstream veh_data;
         JsonOut json( veh_data );
         json.write( parts );
-        bicycle->set_var( "folding_bicycle_parts", veh_data.str() );
+        folding_veh_item->set_var( "folding_bicycle_parts", veh_data.str() );
     } catch( const JsonError &e ) {
         debugmsg( "Error storing vehicle: %s", e.c_str() );
     }
 
+    // evalautes to true on foldable items (folding_bicycle, skateboard)
+    // and false on vehicles with folding flags (wheelchair, unicycle)
     if( can_be_folded ) {
-        bicycle->set_var( "weight", to_milligram( total_mass() ) );
-        bicycle->set_var( "volume", total_folded_volume() / units::legacy_volume_factor );
-        bicycle->set_var( "name", string_format( _( "folded %s" ), name ) );
-        bicycle->set_var( "vehicle_name", name );
+        folding_veh_item->set_var( "weight", to_milligram( total_mass() ) );
+        folding_veh_item->set_var( "volume", total_folded_volume() / units::legacy_volume_factor );
+        // remove "folded" from name to allow for more flexibility with folded vehicle names. also lowers first character
+        folding_veh_item->set_var( "name", string_format( _( "%s" ), ( name.empty() ? name : std::string( 1,
+                                   std::tolower( name[0] ) ) + name.substr( 1 ) ) ) );
+        folding_veh_item->set_var( "vehicle_name", name );
         // TODO: a better description?
-        bicycle->set_var( "description", string_format( _( "A folded %s." ), name ) );
+        folding_veh_item->set_var( "description", string_format( _( "A folded %s." ), name ) );
     }
 
-    g->m.add_item_or_charges( global_part_pos3( 0 ), std::move( bicycle ) );
+    g->m.add_item_or_charges( global_part_pos3( 0 ), std::move( folding_veh_item ) );
     g->m.destroy_vehicle( this );
 
     // TODO: take longer to fold bigger vehicles


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Allows folding a vehicle to work (presumably) as intended, and return the specified item. Previously, if someone added a new item `"skateboard"` and refolded it after placing it down, it would return a folding_bicycle item. Now it will return the `"skateboard`" item. Also changes name of the folding wheelchair, and the way folding vehicle names are created. Previously it would fold into "folded Folding wheelchair" now just into "wheelchair."

## Describe the solution

Unhardcode the string `"folding_bicycle"` and make it return `itype_id` instead when specifying the `folding_veh_item`.

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing

Spawned unicycle and wheelchair, they work as expected upon folding/unfolding. Spawned a folding_bicycle item, works as expected. Created a test item folding_flatbed which unfolds into a flatbed truck, and upon it being refolded it correctly returns the folding_flatbed.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
