### PR TITLE
feat(balance): Allow for use of multiple sleep aids

### DIFF
--- a/src/character_functions.cpp
+++ b/src/character_functions.cpp
@@ -248,7 +248,7 @@ comfort_response_t base_comfort_value( const Character &who, const tripoint &p )
                     if( items_it->has_flag( STATIC( flag_id( "SLEEP_AID" ) ) ) ) {
                         // Note: BED + SLEEP_AID = 9 pts, or 1 pt below very_comfortable
                         comfort += 1 + static_cast<int>( comfort_level::slightly_comfortable );
-                        comfort_response.aid.push_back(items_it);
+                        comfort_response.aid.push_back( items_it );
                     }
                 }
             }
@@ -284,7 +284,7 @@ comfort_response_t base_comfort_value( const Character &who, const tripoint &p )
                 if( items_it->has_flag( STATIC( flag_id( "SLEEP_AID" ) ) ) ) {
                     // Note: BED + SLEEP_AID = 9 pts, or 1 pt below very_comfortable
                     comfort += 1 + static_cast<int>( comfort_level::slightly_comfortable );
-                    comfort_response.aid.push_back(items_it);
+                    comfort_response.aid.push_back( items_it );
                 }
             }
         }
@@ -341,8 +341,9 @@ int rate_sleep_spot( const Character &who, const tripoint &p )
     const int current_stim = who.get_stim();
     const comfort_response_t comfort_info = base_comfort_value( who, p );
     if( !comfort_info.aid.empty() ) {
-        for ( item *comfort_item:comfort_info.aid)
-        who.add_msg_if_player( m_info, _( "You use your %s for comfort." ), comfort_item->tname() );
+        for( item *comfort_item : comfort_info.aid ) {
+            who.add_msg_if_player( m_info, _( "You use your %s for comfort." ), comfort_item->tname() );
+        }
     }
 
     int sleepy = static_cast<int>( comfort_info.level );

--- a/src/character_functions.cpp
+++ b/src/character_functions.cpp
@@ -340,11 +340,9 @@ int rate_sleep_spot( const Character &who, const tripoint &p )
 {
     const int current_stim = who.get_stim();
     const comfort_response_t comfort_info = base_comfort_value( who, p );
-    if( !comfort_info.aid.empty() ) {
-        for( item *comfort_item : comfort_info.aid ) {
-            who.add_msg_if_player( m_info, _( "You use your %s for comfort." ), comfort_item->tname() );
-        }
-    }
+      for( item *comfort_item : comfort_info.aid ) {
+        who.add_msg_if_player( m_info, _( "You use your %s for comfort." ), comfort_item->tname() );
+      }
 
     int sleepy = static_cast<int>( comfort_info.level );
     bool watersleep = who.has_trait( trait_WATERSLEEP );

--- a/src/character_functions.cpp
+++ b/src/character_functions.cpp
@@ -340,9 +340,9 @@ int rate_sleep_spot( const Character &who, const tripoint &p )
 {
     const int current_stim = who.get_stim();
     const comfort_response_t comfort_info = base_comfort_value( who, p );
-      for( item *comfort_item : comfort_info.aid ) {
+    for( item *comfort_item : comfort_info.aid ) {
         who.add_msg_if_player( m_info, _( "You use your %s for comfort." ), comfort_item->tname() );
-      }
+    }
 
     int sleepy = static_cast<int>( comfort_info.level );
     bool watersleep = who.has_trait( trait_WATERSLEEP );

--- a/src/character_functions.cpp
+++ b/src/character_functions.cpp
@@ -215,7 +215,6 @@ comfort_response_t base_comfort_value( const Character &who, const tripoint &p )
     int comfort = 0;
 
     comfort_response_t comfort_response;
-    comfort_response.aid.clear();
 
     bool plantsleep = who.has_trait( trait_CHLOROMORPH );
     bool fungaloid_cosplay = who.has_trait( trait_M_SKIN3 );

--- a/src/character_functions.cpp
+++ b/src/character_functions.cpp
@@ -215,6 +215,7 @@ comfort_response_t base_comfort_value( const Character &who, const tripoint &p )
     int comfort = 0;
 
     comfort_response_t comfort_response;
+    comfort_response.aid.clear();
 
     bool plantsleep = who.has_trait( trait_CHLOROMORPH );
     bool fungaloid_cosplay = who.has_trait( trait_M_SKIN3 );
@@ -243,12 +244,11 @@ comfort_response_t base_comfort_value( const Character &who, const tripoint &p )
             const std::optional<vpart_reference> board = vp.part_with_feature( "BOARDABLE", true );
             if( carg ) {
                 const vehicle_stack items = vp->vehicle().get_items( carg->part_index() );
-                for( const item *items_it : items ) {
+                for( item *items_it : items ) {
                     if( items_it->has_flag( STATIC( flag_id( "SLEEP_AID" ) ) ) ) {
                         // Note: BED + SLEEP_AID = 9 pts, or 1 pt below very_comfortable
                         comfort += 1 + static_cast<int>( comfort_level::slightly_comfortable );
-                        comfort_response.aid = items_it;
-                        break; // prevents using more than 1 sleep aid
+                        comfort_response.aid.push_back(items_it);
                     }
                 }
             }
@@ -278,14 +278,13 @@ comfort_response_t base_comfort_value( const Character &who, const tripoint &p )
             comfort -= here.move_cost( p );
         }
 
-        if( comfort_response.aid == nullptr ) {
+        if( comfort_response.aid.empty() ) {
             const map_stack items = here.i_at( p );
-            for( const item *items_it : items ) {
+            for( item *items_it : items ) {
                 if( items_it->has_flag( STATIC( flag_id( "SLEEP_AID" ) ) ) ) {
                     // Note: BED + SLEEP_AID = 9 pts, or 1 pt below very_comfortable
                     comfort += 1 + static_cast<int>( comfort_level::slightly_comfortable );
-                    comfort_response.aid = items_it;
-                    break; // prevents using more than 1 sleep aid
+                    comfort_response.aid.push_back(items_it);
                 }
             }
         }
@@ -341,8 +340,9 @@ int rate_sleep_spot( const Character &who, const tripoint &p )
 {
     const int current_stim = who.get_stim();
     const comfort_response_t comfort_info = base_comfort_value( who, p );
-    if( comfort_info.aid != nullptr ) {
-        who.add_msg_if_player( m_info, _( "You use your %s for comfort." ), comfort_info.aid->tname() );
+    if( !comfort_info.aid.empty() ) {
+        for ( item *comfort_item:comfort_info.aid)
+        who.add_msg_if_player( m_info, _( "You use your %s for comfort." ), comfort_item->tname() );
     }
 
     int sleepy = static_cast<int>( comfort_info.level );

--- a/src/character_functions.h
+++ b/src/character_functions.h
@@ -96,7 +96,7 @@ enum class comfort_level {
 
 struct comfort_response_t {
     comfort_level level = comfort_level::neutral;
-    const item *aid = nullptr;
+    std::vector<item *> aid;
 };
 
 /** Rate point's ability to serve as a bed. Only takes certain mutations into account, and not fatigue nor stimulants. */


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

As expressed by many, not allowing the survivor to use a pillow and a teddy bear at the same time is ridiculous. People use multiple pillows, cuddle a stuffed animal or body pillow while using a normal pillow, etc. As such, this is clearly a highly-desired change and is in-fact more realistic than how it was before.

Also, if any balance hinges on only one sleep aid being allowed, we have bigger problems.

## Describe the solution

- Removes the `break` lines that prevent multiple sleep aids from being used
- Converts `comfort_response.aid` into a vector instead of an item pointer
- Prints out each comfort aid you're making use of instead of just one

## Describe alternatives you've considered

- Pillow (not body pillow) specific flag to allow you to use a pillow and a normal sleep aid

Doesn't adequately account for the use cases.
- Simply adjust the limit to be higher
- Implode
- Let someone else do it

## Testing

It builds and it works on my machine
![image](https://github.com/user-attachments/assets/20d5586c-62e4-4ad9-9b2f-736b1cb532c0)


## Additional context

I hope my conversion of `comfort_response.aid` to a vector isn't bad code.
Can't wait for the pillow-stacking meta of sleep comfort
