### PR TITLE
fix: symbol orientation of the light industry roof and data center roof of the industrial center

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain_industrial.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_industrial.json
@@ -986,9 +986,8 @@
   {
     "type": "overmap_terrain",
     "id": "industrial_center_light_industry_roof",
-    "copy-from": "generic_city_building_no_sidewalk",
-    "name": "light industry roof",
-    "color": "dark_gray"
+    "copy-from": "industrial_center_light_industry",
+    "name": "light industry roof"
   },
   {
     "type": "overmap_terrain",
@@ -1048,9 +1047,8 @@
   {
     "type": "overmap_terrain",
     "id": "industrial_center_data_center_roof",
-    "name": "data center roof",
-    "copy-from": "generic_city_building_no_sidewalk",
-    "color": "light_gray"
+    "copy-from": "industrial_center_data_center",
+    "name": "data center roof"
   },
   {
     "type": "overmap_terrain",
@@ -1063,8 +1061,8 @@
   {
     "type": "overmap_terrain",
     "id": "industrial_center_admin_roof",
-    "name": "administration roof",
-    "copy-from": "industrial_center_admin"
+    "copy-from": "industrial_center_admin",
+    "name": "administration roof"
   },
   {
     "type": "overmap_terrain",


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Ensure that the symbol for the light industry roof and the symbol for the data center roof of the industrial center are correctly oriented.
## Describe the solution
I changed the `copy-from` of `industrial_center_light_industry_roof` and `industrial_center_data_center_roof`
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="245" alt="image2" src="https://github.com/user-attachments/assets/faec81ec-fc75-40f5-88eb-c6d824f38a1e" />
<img width="355" alt="image1" src="https://github.com/user-attachments/assets/36c089e4-d5be-4543-83ce-783752879703" />
After:
<img width="323" alt="image3" src="https://github.com/user-attachments/assets/004f38eb-8b8b-41a8-be21-8e849bf30d0c" />
<img width="340" alt="image4" src="https://github.com/user-attachments/assets/a265f8b0-00ec-4fe6-9d48-44a268ff2d41" />