### PR TITLE
fix: Handle "relative" and "proportional" with encumbrance

### DIFF
--- a/data/json/items/armor/ballistic_armor.json
+++ b/data/json/items/armor/ballistic_armor.json
@@ -57,7 +57,6 @@
     "price_postapoc": "15 USD",
     "//": "Mono-material as it likely would need to be taken apart to repair, plus the material of the vest is less of a factor on resistances.",
     "material": [ "soil" ],
-    "coverage": 85,
     "encumbrance": 45,
     "material_thickness": 6,
     "extend": { "flags": [ "OVERSIZE", "FRAGILE" ] },

--- a/data/json/items/armor/torso_armor.json
+++ b/data/json/items/armor/torso_armor.json
@@ -440,7 +440,6 @@
     "description": "A cuirass made from large pieces of carved bone, laced together like lamellar armor.  Tough but stiff, and a bit brittle.",
     "material": [ "bone_heavy" ],
     "color": "white",
-    "encumbrance": 12,
     "warmth": 12,
     "environmental_protection": 1,
     "valid_mods": [  ],

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -785,5 +785,35 @@
     "name": { "str": "damageable anti-bullet armor" },
     "description": "This armor protects from bullets, but can be damaged to protect a bit less.",
     "material_thickness": 10
+  },
+  {
+    "id": "test_override_armor_copyfrom_encumbrance",
+    "repairs_like": "survivor_suit",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str": "copyable armor with encumbrance" },
+    "description": "This armor has some encumbrance.",
+    "weight": "100 g",
+    "volume": "1 L",
+    "price": 1,
+    "price_postapoc": 1,
+    "symbol": "[",
+    "looks_like": "touring_suit",
+    "color": "dark_gray",
+    "material": [ "cotton" ],
+    "warmth": 0,
+    "material_thickness": 1,
+    "encumbrance": 10,
+    "coverage": 100,
+    "covers": [ "torso", "arm_l", "arm_r", "head", "leg_l", "leg_r" ]
+  },
+  {
+    "id": "test_override_armor_copyfrom_proportional_encumbrance",
+    "copy-from": "test_override_armor_copyfrom_encumbrance",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str": "proportionally encumbering armor" },
+    "description": "This armor has half the encumbrance of some other armor.",
+    "proportional": { "weight": 0.5, "encumbrance": 0.5, "price": 10, "warmth": 2 }
   }
 ]

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2035,15 +2035,21 @@ void Item_factory::load( islot_armor &slot, const JsonObject &jo, const std::str
             assign_coverage_from_json( jo, "covers", temp_cover_data, slot.sided );
             slot.data[0].covers = temp_cover_data;
         } else { // This item has copy-from and already has taken data from parent
+            if( slot.data.size() > 1 && ( jo.has_int( "encumbrance" ) ||
+                                          jo.has_int( "max_encumbrance" ) ||
+                                          jo.has_int( "coverage" ) ) ) {
+                jo.throw_error( "Legacy armor format only supported for items with exactly 1 armor data entry.  Use \"armor_portion_data\" instead." );
+            }
             if( jo.has_int( "encumbrance" ) ) {
-                slot.data[0].encumber = jo.get_int( "encumbrance" );
+                assign( jo, "encumbrance", slot.data[0].encumber );
                 slot.data[0].max_encumber = slot.data[0].encumber;
             }
             if( jo.has_int( "max_encumbrance" ) ) {
-                slot.data[0].max_encumber = jo.get_int( "max_encumbrance" );
+                assign( jo, "max_encumbrance", slot.data[0].max_encumber );
+
             }
             if( jo.has_int( "coverage" ) ) {
-                slot.data[0].coverage = jo.get_int( "coverage" );
+                assign( jo, "coverage", slot.data[0].coverage );
             }
             body_part_set temp_cover_data;
             assign_coverage_from_json( jo, "covers", temp_cover_data, slot.sided );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2040,17 +2040,15 @@ void Item_factory::load( islot_armor &slot, const JsonObject &jo, const std::str
                                           jo.has_int( "coverage" ) ) ) {
                 jo.throw_error( "Legacy armor format only supported for items with exactly 1 armor data entry.  Use \"armor_portion_data\" instead." );
             }
-            if( jo.has_int( "encumbrance" ) ) {
-                assign( jo, "encumbrance", slot.data[0].encumber );
+            // DISGUSTING hack
+            int old_encumbrance = slot.data[0].encumber;
+            assign( jo, "encumbrance", slot.data[0].encumber, strict );
+            if( old_encumbrance != slot.data[0].encumber ) {
                 slot.data[0].max_encumber = slot.data[0].encumber;
             }
-            if( jo.has_int( "max_encumbrance" ) ) {
-                assign( jo, "max_encumbrance", slot.data[0].max_encumber );
+            assign( jo, "max_encumbrance", slot.data[0].max_encumber, strict );
 
-            }
-            if( jo.has_int( "coverage" ) ) {
-                assign( jo, "coverage", slot.data[0].coverage );
-            }
+            assign( jo, "coverage", slot.data[0].coverage, strict );
             body_part_set temp_cover_data;
             assign_coverage_from_json( jo, "covers", temp_cover_data, slot.sided );
             if( temp_cover_data.any() ) {


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

Fix #3861

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

## Describe the solution

Use `assign` in a hacky way to have it handle the fields properly.

* [x] Add tests that confirm it works

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

## Describe alternatives you've considered

Revert the armor portions thing - it won't help us much, but it is certain to cause trouble until we rewrite the jsons to the new format.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

## Testing

* Spawn chitin gauntlets and biosilicified chitin gauntlets
* Compare encumbrance - biosilicified should have 15 encumbrance, while regular should have 10
* Load world with Magiclysm
* Spawn chitin gauntlets and demon chitin gauntlets
* Demon chitin gauntlets should have 9 encumbrance, while regular should have 10

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
