### PR TITLE
docs: `cast_spell` doesn't exist, correct function is `spell`

### DIFF
--- a/doc/src/content/docs/en/mod/json/reference/json_info.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_info.md
@@ -3422,9 +3422,9 @@ The following actions are available as defined in trapfunc.cpp:
   processed as the mapgen update could just as easily remove the trap, change it to something else,
   or do any number of things that would otherwise disrupt the trap cleanup function.
 - `drain` - Deals a tiny amount of damage to the target, ignores armor and immunities.
-- `spell` - Casts the spell specified by the trap's `spell_data`, centered on whatever set it
-  off. Note that the spell used generally requires a `min_aoe` defined to work successfully, and not
-  all spell effects can be expected to work properly with this.
+- `spell` - Casts the spell specified by the trap's `spell_data`, centered on whatever set it off.
+  Note that the spell used generally requires a `min_aoe` defined to work successfully, and not all
+  spell effects can be expected to work properly with this.
 - `snake` - Similar to `shadow` trap effect, summons shadow snakes nearby. Main difference is NPCs
   and monsters are capable of setting it off.
 

--- a/doc/src/content/docs/en/mod/json/reference/json_info.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_info.md
@@ -3422,7 +3422,7 @@ The following actions are available as defined in trapfunc.cpp:
   processed as the mapgen update could just as easily remove the trap, change it to something else,
   or do any number of things that would otherwise disrupt the trap cleanup function.
 - `drain` - Deals a tiny amount of damage to the target, ignores armor and immunities.
-- `cast_spell` - Casts the spell specified by the trap's `spell_data`, centered on whatever set it
+- `spell` - Casts the spell specified by the trap's `spell_data`, centered on whatever set it
   off. Note that the spell used generally requires a `min_aoe` defined to work successfully, and not
   all spell effects can be expected to work properly with this.
 - `snake` - Similar to `shadow` trap effect, summons shadow snakes nearby. Main difference is NPCs


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
## Purpose of change

DEBUG    : Could not find a trapfunc function matching 'cast_spell'!

 FUNCTION : const trap_function& trap_function_from_string(const std::string&)
 FILE     : src/trapfunc.cpp
 LINE     : 1522
 VERSION  : BN 22673e8

![image](https://github.com/user-attachments/assets/ac78bb23-0073-49d1-b119-15a0275bfc6d)
![image](https://github.com/user-attachments/assets/189bf204-4b03-4e6c-aaca-d130265de4b8)

## Describe the solution

![image](https://github.com/user-attachments/assets/7ab2a018-6075-462e-9e35-61ff9acd1ac4)


## Describe alternatives you've considered

~~Maybe everyone should suffer as much as I do~~

## Testing

My own traps work.

## Additional context