### PR TITLE
docs: `burst_modifier` is orphaned, use `mode_modifier`

### DIFF
--- a/doc/src/content/docs/en/mod/json/reference/json_info.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_info.md
@@ -1982,7 +1982,7 @@ Gun mods can be defined like this:
 "install_time": "30 s",        // Optional time installation takes. Installation is instantaneous if unspecified. An integer will be read as moves or a time string can be used.
 "ammo_modifier": [ "57" ],     // Optional field which if specified modifies parent gun to use these ammo types
 "magazine_adaptor": [ [ "223", [ "stanag30" ] ] ], // Optional field which changes the types of magazines the parent gun accepts
-"burst_modifier": 3,           // Optional field increasing or decreasing base gun burst size
+"mode_modifier": [ [ "AUTO", "auto", 5 ] ]         // Optional field which adds new firing mods to a weapon
 "damage_modifier": -1,         // Optional field increasing or decreasing base gun damage
 "dispersion_modifier": 15,     // Optional field increasing or decreasing base gun dispersion
 "loudness_modifier": 4,        // Optional field increasing or decreasing base guns loudness

--- a/doc/src/content/docs/en/mod/json/reference/json_info.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_info.md
@@ -1982,7 +1982,7 @@ Gun mods can be defined like this:
 "install_time": "30 s",        // Optional time installation takes. Installation is instantaneous if unspecified. An integer will be read as moves or a time string can be used.
 "ammo_modifier": [ "57" ],     // Optional field which if specified modifies parent gun to use these ammo types
 "magazine_adaptor": [ [ "223", [ "stanag30" ] ] ], // Optional field which changes the types of magazines the parent gun accepts
-"mode_modifier": [ [ "AUTO", "auto", 5 ] ]         // Optional field which adds new firing mods to a weapon
+"mode_modifier": [ [ "AUTO", "auto", 5 ] ]         // Optional field which adds new firing modes to a weapon
 "damage_modifier": -1,         // Optional field increasing or decreasing base gun damage
 "dispersion_modifier": 15,     // Optional field increasing or decreasing base gun dispersion
 "loudness_modifier": 4,        // Optional field increasing or decreasing base guns loudness


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

![image](https://github.com/user-attachments/assets/f53074c4-cd3c-4f65-aff8-462b7f7110cf)

This is invalid, it causes errors if you use it. I don't know why it was removed, I need to ask.

## Describe the solution

![image](https://github.com/user-attachments/assets/81c57d46-711c-417a-9694-778171f2151e)

![image](https://github.com/user-attachments/assets/af48e569-297a-4a3b-9a0d-35004cd1bf14)


## Describe alternatives you've considered

Some secrets are best left buried?

## Testing

Mine work, the auto sear works.

## Additional context