### PR TITLE
fix: More charge usage shenanigans (fireweapon edition)

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2273,6 +2273,7 @@ int fireweapon_on_actor::use( player &p, item &it, bool t, const tripoint & ) co
     if( extinguish ) {
         it.revert( &p, false );
         it.deactivate();
+        return 0;
 
     } else if( one_in( noise_chance ) ) {
         if( noise > 0 ) {


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

- Fix #5868 which is due to #5589 which makes iuse actors/iuse returns actually consume charges the way they're supposed to. Exposing code that was written with returns that returned values that _didn't fucking do anything._

## Describe the solution

- fireweapon iuse code now properly returns 0 if the item is reverted/deactivated instead of trying to consume it's charges.

## Describe alternatives you've considered

- Remove fireweapon code.
  - That's on the docket and part of the energy rework, but I don't want to produce any conflicts at the moment given that the energy rework is already a monumental PR that will be hell to test.

## Testing

@chaosvolt Help me test please I have work.
- [ ] Fireweapons shouldn't fucking consume themselves when a revert is specified.

## Additional context

I fucking hate when fixing code causes issues.

https://github.com/cataclysmbnteam/Cataclysm-BN/blob/c75fb01f4983c9ab57355e3f0cf0fd39b43b3ba2/src/iuse_actor.cpp#L2260-L2271

Dear lord in heaven why is this code?