### PR TITLE
revert: "raise amount of itemgroup tests from 100 -> 1000"

### DIFF
--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -3473,9 +3473,9 @@ void item_group::debug_spawn()
         if( index >= static_cast<int>( groups.size() ) || index < 0 ) {
             break;
         }
-        // Spawn items from the group 1000 times
+        // Spawn items from the group 100 times
         std::map<std::string, int> itemnames;
-        for( size_t a = 0; a < 1000; a++ ) {
+        for( size_t a = 0; a < 100; a++ ) {
             const auto items = items_from( groups[index], calendar::turn );
             for( auto &it : items ) {
                 itemnames[it->display_name()]++;
@@ -3487,7 +3487,7 @@ void item_group::debug_spawn()
             itemnames2.insert( std::pair<int, std::string>( e.second, e.first ) );
         }
         uilist menu2;
-        menu2.text = _( "Result of 1000 spawns:" );
+        menu2.text = _( "Result of 100 spawns:" );
         for( const auto &e : itemnames2 ) {
             menu2.entries.emplace_back( static_cast<int>( menu2.entries.size() ), true, -2,
                                         string_format( _( "%d x %s" ), e.first, e.second ) );


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
## Purpose of change

The previous PR set it so item groups were tested at 1000 hits. This isn't useful to us for getting an accurate picture of what will likely spawn in a run. This has caused difficulty for Chaosvolt and I to work on item groups, and caused Chaosvolt to overlook a flaw in my drugdeal itemgroup PR where he disagreed with my specific spawnrates.

## Describe the solution

Github Revert

## Describe alternatives you've considered

Make Oren code it to be configurable.

## Testing

Don't need to, it's an automatic Git Revert.

## Additional context
https://github.com/cataclysmbnteam/Cataclysm-BN/pull/5033