### PR TITLE
feat: Allow mutant-spawned liquids to be stored/consumed

### DIFF
--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -585,10 +585,10 @@ void Character::activate_mutation( const trait_id &mut )
         }
     } else if( !mdata.spawn_item.is_empty() ) {
         detached_ptr<item> granted = item::spawn( mdata.spawn_item );
-        if (granted->made_of(LIQUID)){
+        if( granted->made_of( LIQUID ) ) {
             liquid_handler::consume_liquid( std::move( granted ), 1 );
-        } else{
-            i_add_or_drop( std::move(granted) );
+        } else {
+            i_add_or_drop( std::move( granted ) );
         }
         add_msg_if_player( mdata.spawn_item_message() );
         tdata.powered = false;

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -20,6 +20,7 @@
 #include "event_bus.h"
 #include "field_type.h"
 #include "game.h"
+#include "handle_liquid.h"
 #include "item.h"
 #include "item_contents.h"
 #include "itype.h"
@@ -583,7 +584,12 @@ void Character::activate_mutation( const trait_id &mut )
             return;
         }
     } else if( !mdata.spawn_item.is_empty() ) {
-        i_add_or_drop( item::spawn( mdata.spawn_item ) );
+        detached_ptr<item> granted = item::spawn( mdata.spawn_item );
+        if (granted->made_of(LIQUID)){
+            liquid_handler::consume_liquid( std::move( granted ), 1 );
+        } else{
+            i_add_or_drop( std::move(granted) );
+        }
         add_msg_if_player( mdata.spawn_item_message() );
         tdata.powered = false;
         return;


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

If spells can do it, so should mutations be able to. Plus, it's weird having all the liquids spill on the floor for no good reason.

## Describe the solution

Basically just yoinks the solution in #3637 by adding a check if the spawned item is a liquid.

## Describe alternatives you've considered

- Implode
- Add the rest of the checks from spells spawning items

Not a bad idea, but unsure if all of them are actually desired. Liquids, on the other hand, are clearly wanted.

## Testing

It builds on my machine, and it works on my machine too.
![image](https://github.com/user-attachments/assets/c6dfa884-613c-4ca4-9255-4694d4cbaf4a)


## Additional context

If you choose the option to store it in a container but have no valid container, it just exits out of the menu without putting it in your inventory, consuming it, or spilling it on the floor.

Unsure if I should give co-authorship to Vollch or not for this, so I opted to credit him in the commit message and split the difference.

Altered mutations JSON file with the test mutation in question can be added / provided if desired.
