### PR TITLE
fix: Properly add human flesh vitamins to several comestibles

### DIFF
--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -55,7 +55,7 @@
     "name": "human stomach",
     "description": "The stomach of a human.  It is surprisingly durable.",
     "material": [ "hflesh" ],
-    "vitamins": [ [ "meat_allergen", 1 ] ]
+    "vitamins": [ [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 100 ] ]
   },
   {
     "id": "hstomach_large",
@@ -72,7 +72,7 @@
     "name": { "str": "chunk of human fat", "str_pl": "chunks of human fat" },
     "description": "Freshly harvested from a human body.",
     "material": [ "hflesh" ],
-    "vitamins": [ [ "meat_allergen", 1 ] ]
+    "vitamins": [ [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 100 ] ]
   },
   {
     "type": "COMESTIBLE",
@@ -83,7 +83,7 @@
     "price": "5 USD",
     "//": "*May* have been commercially traded.",
     "material": [ "hflesh" ],
-    "vitamins": [ [ "meat_allergen", 1 ] ]
+    "vitamins": [ [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 100 ] ]
   },
   {
     "type": "COMESTIBLE",
@@ -186,7 +186,7 @@
     "name": "mutant humanoid meat",
     "description": "Freshly butchered from the body of a heavily mutated creature that was unsettlingly humanoid in appearance.  It smells like a failed chemical experiment.  You'd have to be crazy or starving to eat this.",
     "material": [ "hflesh" ],
-    "vitamins": [ [ "meat_allergen", 1 ] ]
+    "vitamins": [ [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 100 ] ]
   },
   {
     "id": "mutant_human_cooked",
@@ -578,7 +578,7 @@
     "fun": -50,
     "flags": [ "IS_BLOOD" ],
     "drop_action": { "type": "emit_actor", "emits": [ "emit_drop_blood" ], "scale_qty": true },
-    "vitamins": [ [ "meat_allergen", 1 ] ]
+    "vitamins": [ [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 100 ] ]
   },
   {
     "type": "COMESTIBLE",
@@ -750,7 +750,7 @@
     "name": { "str": "chunk of mutant humanoid fat", "str_pl": "chunks of mutant humanoid fat" },
     "description": "Freshly butchered fat from a heavily mutated humanoid.",
     "material": [ "hflesh" ],
-    "vitamins": [ [ "meat_allergen", 1 ] ]
+    "vitamins": [ [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 100 ] ]
   },
   {
     "type": "COMESTIBLE",
@@ -759,7 +759,7 @@
     "copy-from": "mutant_tallow",
     "description": "A smooth white block of cleaned and rendered fat sourced from a mutant humanoid.  It won't rot for a very long time, and can be used as an ingredient in many foods and projects.",
     "material": [ "hflesh" ],
-    "vitamins": [ [ "meat_allergen", 1 ] ]
+    "vitamins": [ [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 100 ] ]
   },
   {
     "type": "COMESTIBLE",
@@ -924,7 +924,7 @@
     "name": { "str": "boiled large human stomach" },
     "description": "A boiled stomach from a large humanoid creature, nothing else.  It looks all but appetizing.",
     "material": [ "hflesh" ],
-    "vitamins": [ [ "meat_allergen", 1 ] ]
+    "vitamins": [ [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 100 ] ]
   },
   {
     "type": "COMESTIBLE",
@@ -952,7 +952,7 @@
     "name": { "str": "boiled human stomach" },
     "description": "A small boiled stomach from a human, nothing else.  It looks all but appetizing.",
     "material": [ "hflesh" ],
-    "vitamins": [ [ "meat_allergen", 1 ] ]
+    "vitamins": [ [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 100 ] ]
   },
   {
     "type": "COMESTIBLE",
@@ -996,7 +996,7 @@
     "name": "raw human skin",
     "description": "A carefully folded raw skin harvested from a human.  You can cure it for storage and tanning, or eat it if you're desperate enough.",
     "material": [ "hflesh" ],
-    "vitamins": [ [ "meat_allergen", 1 ] ]
+    "vitamins": [ [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 100 ] ]
   },
   {
     "type": "COMESTIBLE",
@@ -1041,7 +1041,7 @@
     "name": "raw human pelt",
     "description": "A carefully folded raw skin harvested from a fur-bearing mutant human.  It still has the fur attached.  You can cure it for storage and tanning, or eat it if you're desperate enough.",
     "material": [ "fur", "hflesh" ],
-    "vitamins": [ [ "meat_allergen", 1 ] ]
+    "vitamins": [ [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 100 ] ]
   },
   {
     "type": "COMESTIBLE",

--- a/data/json/items/comestibles/mutagen.json
+++ b/data/json/items/comestibles/mutagen.json
@@ -495,7 +495,7 @@
     "material": [ "hflesh" ],
     "volume": "250 ml",
     "fun": -60,
-    "vitamins": [ [ "meat_allergen", 1 ] ]
+    "vitamins": [ [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 100 ] ]
   },
   {
     "type": "COMESTIBLE",
@@ -517,7 +517,7 @@
     "material": [ "hflesh" ],
     "volume": "2 L",
     "fun": -20,
-    "vitamins": [ [ "meat_allergen", 1 ] ]
+    "vitamins": [ [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 100 ] ]
   },
   {
     "type": "COMESTIBLE",
@@ -539,7 +539,7 @@
     "material": [ "hflesh" ],
     "volume": "5 L",
     "fun": -20,
-    "vitamins": [ [ "meat_allergen", 1 ] ]
+    "vitamins": [ [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 100 ] ]
   },
   {
     "type": "COMESTIBLE",

--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -564,7 +564,15 @@
     "healthy": -20,
     "quench": -47,
     "calories": 78,
-    "vitamins": [ [ "vitA", 0 ], [ "vitC", 2 ], [ "calcium", 1 ], [ "iron", 8 ], [ "vitB", 54 ], [ "meat_allergen", 1 ] ],
+    "vitamins": [
+      [ "vitA", 0 ],
+      [ "vitC", 2 ],
+      [ "calcium", 1 ],
+      [ "iron", 8 ],
+      [ "vitB", 54 ],
+      [ "meat_allergen", 1 ],
+      [ "human_flesh_vitamin", 100 ]
+    ],
     "description": "This is a human brain soaked in a solution of highly toxic formaldehyde.  Eating this would be a terrible idea.",
     "price": "80 cent",
     "price_postapoc": "0 cent",


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Human fat and several other items got missed in my initial sweep.

## Describe the solution

Adjusts my local copy of the vitaminer script to lazily add the human flesh vitamins

## Describe alternatives you've considered

- Leave it be
- Create a python script instead

## Testing

I looked at the changes with my eyes and made sure they make sense

## Additional context

Thanks Royal, I can't believe I missed them.
