### PR TITLE
docs: Properly link to custom clang-tidy plugin instructions

### DIFF
--- a/doc/src/content/docs/en/dev/reference/tooling.md
+++ b/doc/src/content/docs/en/dev/reference/tooling.md
@@ -144,8 +144,8 @@ command-line.
 ## Custom clang-tidy plugin
 
 We have written our own clang-tidy checks in a custom plugin. refer to
-[clang-tidy.yml](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/.github/workflows/clang-tidy.yml) for the exact steps to build the plugin on
-ubuntu 24.04.
+[clang-tidy.yml](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/.github/workflows/clang-tidy.yml)
+for the exact steps to build the plugin on ubuntu 24.04.
 
 ### Build plugin on Ubuntu 24.04
 

--- a/doc/src/content/docs/en/dev/reference/tooling.md
+++ b/doc/src/content/docs/en/dev/reference/tooling.md
@@ -144,7 +144,7 @@ command-line.
 ## Custom clang-tidy plugin
 
 We have written our own clang-tidy checks in a custom plugin. refer to
-[clang-tidy.yml](/.github/workflows/clang-tidy.yml) for the exact steps to build the plugin on
+[clang-tidy.yml](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/.github/workflows/clang-tidy.yml) for the exact steps to build the plugin on
 ubuntu 24.04.
 
 ### Build plugin on Ubuntu 24.04


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Docs hasn't been deploying since[ approximately 3 months ago](https://github.com/cataclysmbnteam/Cataclysm-BN/pull/5497), meaning any documentation changes in the meantime just never showed up on the website.

## Describe the solution

Fixes the invalid link by properly linking to it instead of trying to do a relative path.

## Describe alternatives you've considered

- Let Scarf know and have him fix it
- Weh

## Testing

Unable

## Additional context

I find it really funny that Scarf literally made the docs, but also made the PR that stopped them from deploying for 3 months
