### PR TITLE
feat: Stagger item categories for modder support

### DIFF
--- a/data/mods/Item_Category_Overhaul/categories.json
+++ b/data/mods/Item_Category_Overhaul/categories.json
@@ -1,59 +1,87 @@
 [
   {
+    "id": "guns",
+    "type": "ITEM_CATEGORY",
+    "name": { "str": "GUNS" },
+    "zone": "LOOT_GUNS",
+    "sort_rank": -42
+  },
+  {
+    "id": "magazines",
+    "type": "ITEM_CATEGORY",
+    "name": { "str": "MAGAZINES" },
+    "zone": "LOOT_MAGAZINES",
+    "sort_rank": -39
+  },
+  {
+    "id": "ammo",
+    "type": "ITEM_CATEGORY",
+    "name": { "str": "AMMO" },
+    "zone": "LOOT_AMMO",
+    "sort_rank": -36
+  },
+  {
+    "id": "weapons",
+    "type": "ITEM_CATEGORY",
+    "name": { "str": "WEAPONS" },
+    "zone": "LOOT_WEAPONS",
+    "sort_rank": -33
+  },
+  {
     "id": "tools",
     "type": "ITEM_CATEGORY",
     "name": { "str": "OTHER TOOLS" },
     "zone": "LOOT_TOOLS",
-    "sort_rank": -19
+    "sort_rank": -30
   },
   {
     "id": "tools_entry",
     "type": "ITEM_CATEGORY",
     "name": { "str": "ENTRY TOOLS" },
     "zone": "LOOT_ENTRY_TOOLS",
-    "sort_rank": -18
+    "sort_rank": -27
   },
   {
     "id": "tools_workshop",
     "type": "ITEM_CATEGORY",
     "name": { "str": "WORKSHOP TOOLS" },
     "zone": "LOOT_WORKSHOP_TOOLS",
-    "sort_rank": -17
+    "sort_rank": -24
   },
   {
     "id": "tools_cooking",
     "type": "ITEM_CATEGORY",
     "name": { "str": "COOKING TOOLS" },
     "zone": "LOOT_COOKING_TOOLS",
-    "sort_rank": -16
+    "sort_rank": -21
   },
   {
     "id": "tools_chemistry",
     "type": "ITEM_CATEGORY",
     "name": { "str": "CHEMISTRY TOOLS" },
     "zone": "LOOT_CHEMISTRY_TOOLS",
-    "sort_rank": -15
+    "sort_rank": -18
   },
   {
     "id": "tools_farming",
     "type": "ITEM_CATEGORY",
     "name": { "str": "FARM TOOLS" },
     "zone": "LOOT_FARM_TOOLS",
-    "sort_rank": -14
+    "sort_rank": -15
   },
   {
     "id": "deployables",
     "type": "ITEM_CATEGORY",
     "name": { "str": "DEPLOYABLES" },
     "zone": "LOOT_DEPLOYABLES",
-    "sort_rank": -13
+    "sort_rank": -12
   },
   {
     "id": "electronics",
     "type": "ITEM_CATEGORY",
     "name": { "str": "ELECTRONICS" },
     "zone": "LOOT_ELECTRONICS",
-    "sort_rank": -12
+    "sort_rank": -9
   },
   {
     "id": "clothing",
@@ -61,205 +89,202 @@
     "name": { "str": "CLOTHING" },
     "priority_zones": [ { "id": "LOOT_FCLOTHING", "filthy": true } ],
     "zone": "LOOT_CLOTHING",
-    "sort_rank": -11
+    "sort_rank": -6
   },
   {
     "id": "food",
     "type": "ITEM_CATEGORY",
     "name": { "str": "FOOD" },
     "//": "zone is hardcoded",
-    "sort_rank": -10
+    "sort_rank": -3
   },
   {
     "id": "cooking_ingredients",
     "type": "ITEM_CATEGORY",
     "name": { "str": "COOKING INGREDIENTS" },
     "zone": "LOOT_COOKING_INGREDIENTS",
-    "sort_rank": -9
+    "sort_rank": 1
   },
   {
     "id": "drugs",
     "type": "ITEM_CATEGORY",
     "name": { "str": "DRUGS" },
     "zone": "LOOT_DRUGS",
-    "sort_rank": -8
+    "sort_rank": 4
   },
   {
     "id": "books",
     "type": "ITEM_CATEGORY",
     "name": { "str": "BOOKS" },
     "zone": "LOOT_BOOKS",
-    "sort_rank": -7
+    "sort_rank": 7
   },
   {
     "id": "spellbooks",
     "type": "ITEM_CATEGORY",
     "name": { "str": "SPELLBOOKS" },
     "zone": "LOOT_SPELLBOOKS",
-    "sort_rank": -6
+    "sort_rank": 10
   },
   {
     "id": "mods",
     "type": "ITEM_CATEGORY",
     "name": { "str": "MODS" },
     "zone": "LOOT_MODS",
-    "sort_rank": -5
+    "sort_rank": 13
   },
   {
     "id": "mutagen",
     "type": "ITEM_CATEGORY",
     "name": { "str": "MUTAGENS" },
     "zone": "LOOT_MUTAGENS",
-    "sort_rank": -4
+    "sort_rank": 16
   },
   {
     "id": "bionics",
     "type": "ITEM_CATEGORY",
     "name": { "str": "BIONICS" },
     "zone": "LOOT_BIONICS",
-    "sort_rank": -3
+    "sort_rank": 19
   },
   {
     "id": "veh_parts",
     "type": "ITEM_CATEGORY",
     "name": { "str": "VEHICLE PARTS" },
     "zone": "LOOT_VEHICLE_PARTS",
-    "sort_rank": -2
+    "sort_rank": 22
   },
   {
     "id": "other",
     "type": "ITEM_CATEGORY",
     "name": { "str": "OTHER" },
     "zone": "LOOT_OTHER",
-    "sort_rank": -1
+    "sort_rank": 25
   },
   {
     "id": "fuel",
     "type": "ITEM_CATEGORY",
     "name": { "str": "FUEL" },
     "zone": "LOOT_FUEL",
-    "sort_rank": 1
+    "sort_rank": 28
   },
   {
     "id": "seeds",
     "type": "ITEM_CATEGORY",
     "name": { "str": "SEEDS" },
     "zone": "LOOT_SEEDS",
-    "sort_rank": 2
+    "sort_rank": 31
   },
   {
     "id": "chems",
     "type": "ITEM_CATEGORY",
     "name": { "str": "CHEMICAL STUFF" },
     "zone": "LOOT_CHEMICAL",
-    "sort_rank": 5
+    "sort_rank": 34
   },
   {
     "id": "battery",
     "type": "ITEM_CATEGORY",
     "name": { "str": "BATTERIES" },
     "zone": "LOOT_BATTERY",
-    "sort_rank": 6
+    "sort_rank": 37
   },
   {
     "id": "spare_parts",
     "type": "ITEM_CATEGORY",
     "name": { "str": "SPARE PARTS" },
     "zone": "LOOT_SPARE_PARTS",
-    "sort_rank": 8
+    "sort_rank": 40
   },
   {
     "id": "scrap_metal",
     "type": "ITEM_CATEGORY",
     "name": { "str": "METAL SCRAP" },
     "zone": "LOOT_SCRAP_METAL",
-    "sort_rank": 9
+    "sort_rank": 43
   },
   {
     "id": "scrap_electronics",
     "type": "ITEM_CATEGORY",
     "name": { "str": "ELECTRONIC SCRAP" },
     "zone": "LOOT_SCRAP_ELECTRONICS",
-    "sort_rank": 10
+    "sort_rank": 46
   },
   {
     "id": "scrap_fabric",
     "type": "ITEM_CATEGORY",
     "name": { "str": "FABRICS" },
     "zone": "LOOT_SCRAP_FABRIC",
-    "sort_rank": 11
+    "sort_rank": 49
   },
   {
     "id": "scrap_wood",
     "type": "ITEM_CATEGORY",
     "name": { "str": "WOOD SCRAP" },
     "zone": "LOOT_SCRAP_WOOD",
-    "sort_rank": 12
+    "sort_rank": 52
   },
   {
     "id": "scrap_plastic",
     "type": "ITEM_CATEGORY",
     "name": { "str": "PLASTIC SCRAP" },
     "zone": "LOOT_SCRAP_PLASTIC",
-    "sort_rank": 13
+    "sort_rank": 55
   },
   {
     "id": "scrap_ceramics",
     "type": "ITEM_CATEGORY",
     "name": { "str": "CERAMIC SCRAP" },
     "zone": "LOOT_SCRAP_CERAMICS",
-    "sort_rank": 14
+    "sort_rank": 58
   },
   {
     "id": "scrap_glass",
     "type": "ITEM_CATEGORY",
     "name": { "str": "GLASS SCRAP" },
     "zone": "LOOT_SCRAP_GLASS",
-    "sort_rank": 15
+    "sort_rank": 61
   },
   {
     "id": "valuables",
     "type": "ITEM_CATEGORY",
     "name": { "str": "VALUABLES" },
     "zone": "LOOT_VALUABLES",
-    "sort_rank": 16
+    "sort_rank": 64
   },
   {
     "id": "rocks",
     "type": "ITEM_CATEGORY",
     "name": { "str": "ROCKS" },
     "zone": "LOOT_ROCKS",
-    "sort_rank": 17
+    "sort_rank": 67
   },
   {
     "id": "soil",
     "type": "ITEM_CATEGORY",
     "name": { "str": "SOIL" },
     "zone": "LOOT_SOIL",
-    "sort_rank": 18
+    "sort_rank": 70
   },
   {
     "id": "container",
     "type": "ITEM_CATEGORY",
     "name": { "str": "CONTAINERS" },
     "zone": "LOOT_CONTAINERS",
-    "//": "Please don't touch the sort rank, I did this so these are always on bottom.",
-    "sort_rank": 48
+    "sort_rank": 73
   },
   {
     "id": "artifacts",
     "type": "ITEM_CATEGORY",
     "name": { "str": "ARTIFACTS" },
     "zone": "LOOT_ARTIFACTS",
-    "//": "Please don't touch the sort rank, I did this so these are always on bottom.",
-    "sort_rank": 49
+    "sort_rank": 76
   },
   {
     "id": "maps",
     "type": "ITEM_CATEGORY",
     "name": { "str": "MAPS" },
     "zone": "LOOT_MAP",
-    "//": "Mods can inject themselves before containers maps and artifacts, 19 through 47.",
-    "sort_rank": 50
+    "sort_rank": 80
   }
 ]


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

We don't want stuff to overlap. Item categories were all 1 after the other. Modders couldn't put stuff where they want.

## Describe the solution

I staggered every category by 3. Now you get 2 categories to inject between any other. Nothing changed under the hood

Mods can fight if they want, I'm not a cop but maybe try not to use categories unless you **have** to.

## Describe alternatives you've considered

Suffering. Making others suffer by figuring out a code-based solution that lets users sort categories themselves.

## Testing
![image](https://github.com/user-attachments/assets/9e3cf282-a646-4cd9-bdf7-1f6b34f508c1)
![image](https://github.com/user-attachments/assets/d25d1f01-a028-45bf-a212-0163b3665506)
![image](https://github.com/user-attachments/assets/15cf7c51-21b3-4796-a9ac-111bb01e1374)

## Additional context
Someone should code it so users can organize their own categories, but I can't.