### PR TITLE
feat(balance): House solar odds lowered from 33% per home to 15%

### DIFF
--- a/data/json/mapgen/nested/roof_nested.json
+++ b/data/json/mapgen/nested/roof_nested.json
@@ -507,7 +507,7 @@
       "terrain": { "_": "t_null" },
       "place_nested": [
         {
-          "chunks": [ [ "null", 30 ], [ "solar_panels_4X4", 5 ], [ "solar_panels_2X4", 5 ], [ "solar_panels_3X3", 5 ] ],
+          "chunks": [ [ "null", 85 ], [ "solar_panels_4X4", 2 ], [ "solar_panels_2X4", 8 ], [ "solar_panels_3X3", 5 ] ],
           "x": 0,
           "y": 0
         }


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
## Purpose of change

Solar roofs go from 8, to 9, to 16 panels on residential homes. They're also very common. I think dialing it back should be okay, houses are something you spend all game securing and looting.

## Describe the solution

The odds were at a distribution with 30 odds of nothing, and 5 odds for 8, 9, and 16 panels respectively. This is 11% chance per solar odd, and a total of 33% for any solar. I think this is too high.

I've set a 15% chance for solar panels, at 2% odds for 16 panels, 8% for 8 panels, and 5% for 9 panels. This is still a significantly large amount as 8 panels is amazing to find. at 15% chance per house you're generally going to find one house in a neighborhood of 10 homes that has these panels. Whereas before every third house would have solar statistically (For each home which calls this nested mapgen specifically)

## Describe alternatives you've considered

A lot of other stuff. Let's just take a small and easy approach.

## Testing
They still do spawn.
![image](https://github.com/user-attachments/assets/fef1a157-335d-4336-8045-d816c9a0be77)

## Additional context
That's it until we get more data, and until I can steal Chaos for power balancing.