### PR TITLE
feat(port): increase default search range for mission placement, sanity-check search properties for scenario missions

### DIFF
--- a/data/json/npcs/missiondef.json
+++ b/data/json/npcs/missiondef.json
@@ -623,7 +623,13 @@
     "difficulty": 1,
     "value": 0,
     "start": {
-      "assign_mission_target": { "om_terrain": "mansion_c3", "om_special": "Mansion_Wild", "reveal_radius": 1, "search_range": 200, "min_distance": 45 }
+      "assign_mission_target": {
+        "om_terrain": "mansion_c3",
+        "om_special": "Mansion_Wild",
+        "reveal_radius": 1,
+        "search_range": 200,
+        "min_distance": 45
+      }
     },
     "origins": [ "ORIGIN_GAME_START" ]
   },

--- a/data/json/npcs/missiondef.json
+++ b/data/json/npcs/missiondef.json
@@ -9,7 +9,7 @@
     "value": 50000,
     "start": {
       "effect": [ "follow", { "u_buy_item": "sarcophagus_access_code" } ],
-      "assign_mission_target": { "om_terrain": "haz_sar_1_1", "om_special": "Hazardous Waste Sarcophagus", "reveal_radius": 3, "search_range": 360 }
+      "assign_mission_target": { "om_terrain": "haz_sar_1_1", "om_special": "Hazardous Waste Sarcophagus", "reveal_radius": 3 }
     },
     "origins": [ "ORIGIN_SECONDARY" ],
     "destination": "haz_sar_b_1",
@@ -129,10 +129,7 @@
     "difficulty": 2,
     "value": 150000,
     "item": "black_box_transcript",
-    "start": {
-      "effect": { "u_buy_item": "black_box" },
-      "assign_mission_target": { "om_terrain": "lab", "reveal_radius": 3, "search_range": 360 }
-    },
+    "start": { "effect": { "u_buy_item": "black_box" }, "assign_mission_target": { "om_terrain": "lab", "reveal_radius": 3 } },
     "origins": [ "ORIGIN_SECONDARY" ],
     "followup": "MISSION_EXPLORE_SARCOPHAGUS",
     "dialogue": {
@@ -339,7 +336,7 @@
     "item": "software_blood_data",
     "start": {
       "effect": [ { "u_buy_item": "vacutainer" }, { "u_buy_item": "usb_drive" } ],
-      "assign_mission_target": { "om_terrain": "hospital_2", "om_special": "hospital", "reveal_radius": 3, "search_range": 360 }
+      "assign_mission_target": { "om_terrain": "hospital_2", "om_special": "hospital", "reveal_radius": 3 }
     },
     "origins": [ "ORIGIN_SECONDARY" ],
     "dialogue": {
@@ -362,9 +359,7 @@
     "difficulty": 2,
     "value": 150000,
     "item": "etched_skull",
-    "start": {
-      "assign_mission_target": { "om_terrain": "cabin_strange", "om_special": "Strange Cabin", "reveal_radius": 3, "search_range": 360 }
-    },
+    "start": { "assign_mission_target": { "om_terrain": "cabin_strange", "om_special": "Strange Cabin", "reveal_radius": 3 } },
     "origins": [ "ORIGIN_SECONDARY" ],
     "followup": "MISSION_INVESTIGATE_PRISON_VISIONARY",
     "dialogue": {
@@ -388,7 +383,7 @@
     "value": 150000,
     "item": "visions_solitude",
     "start": {
-      "assign_mission_target": { "om_terrain": "prison_1_4", "om_special": "Prison", "reveal_radius": 3, "search_range": 360 },
+      "assign_mission_target": { "om_terrain": "prison_1_4", "om_special": "Prison", "reveal_radius": 3 },
       "update_mapgen": {
         "set": [ { "point": "terrain", "id": "t_door_bar_o", "x": 12, "y": 19 } ],
         "place_fields": [
@@ -580,10 +575,7 @@
     "goal": "MGOAL_GO_TO_TYPE",
     "difficulty": 2,
     "value": 60000,
-    "start": {
-      "effect": "follow_only",
-      "assign_mission_target": { "om_terrain": "fema_entrance", "reveal_radius": 3, "search_range": 256 }
-    },
+    "start": { "effect": "follow_only", "assign_mission_target": { "om_terrain": "fema_entrance", "reveal_radius": 3 } },
     "origins": [ "ORIGIN_SECONDARY" ],
     "followup": "MISSION_REACH_FARM_HOUSE",
     "destination": "fema_entrance",
@@ -608,9 +600,7 @@
     "destination": "s_air_hangars",
     "difficulty": 1,
     "value": 0,
-    "start": {
-      "assign_mission_target": { "om_terrain": "s_air_hangars", "reveal_radius": 5, "om_special": "o_airport", "search_range": 100 }
-    },
+    "start": { "assign_mission_target": { "om_terrain": "s_air_hangars", "reveal_radius": 5, "om_special": "o_airport" } },
     "origins": [ "ORIGIN_GAME_START" ]
   },
   {
@@ -632,7 +622,9 @@
     "destination": "mansion_c3",
     "difficulty": 1,
     "value": 0,
-    "start": { "assign_mission_target": { "om_terrain": "mansion_c3", "om_special": "Mansion_Wild", "search_range": 200 } },
+    "start": {
+      "assign_mission_target": { "om_terrain": "mansion_c3", "om_special": "Mansion_Wild", "reveal_radius": 1, "search_range": 200, "min_distance": 45 }
+    },
     "origins": [ "ORIGIN_GAME_START" ]
   },
   {
@@ -842,8 +834,7 @@
         "om_terrain": "s_air_term",
         "om_special": "o_airport",
         "reveal_radius": 6,
-        "random": true,
-        "search_range": 90,
+        "search_range": 200,
         "min_distance": 45,
         "z": 0
       },

--- a/data/json/npcs/necropolis/NPC_Old_Guard_Captain.json
+++ b/data/json/npcs/necropolis/NPC_Old_Guard_Captain.json
@@ -159,9 +159,7 @@
     "difficulty": 5,
     "value": 250000,
     "monster_type": "mon_charred_nightmare",
-    "start": {
-      "assign_mission_target": { "om_terrain": "necropolis_c_44", "om_special": "Necropolis", "z": -2, "search_range": 360 }
-    },
+    "start": { "assign_mission_target": { "om_terrain": "necropolis_c_44", "om_special": "Necropolis", "z": -2 } },
     "monster_kill_goal": 20,
     "origins": [ "ORIGIN_SECONDARY" ],
     "dialogue": {

--- a/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_shopkeep.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_shopkeep.json
@@ -628,7 +628,7 @@
     "value": 50000,
     "item": "commune_prospectus",
     "start": {
-      "assign_mission_target": { "om_terrain": "ranch_camp_67", "om_special": "ranch_camp", "reveal_radius": 1, "search_range": 200 },
+      "assign_mission_target": { "om_terrain": "ranch_camp_67", "om_special": "ranch_camp", "reveal_radius": 1 },
       "update_mapgen": {
         "place_npcs": [
           { "class": "ranch_foreman", "x": 16, "y": 15, "target": true, "add_trait": "NPC_MISSION_LEV_1" },

--- a/data/json/npcs/refugee_center/surface_visitors/NPC_old_guard_representative.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_old_guard_representative.json
@@ -118,7 +118,7 @@
     "difficulty": 5,
     "value": 50000,
     "start": {
-      "assign_mission_target": { "om_terrain": "bandit_cabin", "om_special": "bandit_cabin", "reveal_radius": 1, "search_range": 60 },
+      "assign_mission_target": { "om_terrain": "bandit_cabin", "om_special": "bandit_cabin", "reveal_radius": 1 },
       "update_mapgen": {
         "set": [
           { "point": "trap", "id": "tr_landmine_buried", "x": 7, "y": 6 },
@@ -214,13 +214,7 @@
     "difficulty": 10,
     "value": 300000,
     "start": {
-      "assign_mission_target": {
-        "om_terrain": "bandit_camp_1",
-        "om_special": "bandit_camp",
-        "reveal_radius": 1,
-        "min_distance": 10,
-        "search_range": 120
-      },
+      "assign_mission_target": { "om_terrain": "bandit_camp_1", "om_special": "bandit_camp", "reveal_radius": 1, "min_distance": 10 },
       "update_mapgen": { "place_npcs": [ { "class": "bandit", "x": 17, "y": 9, "target": true } ] },
       "effect": [
         { "u_buy_item": "ruger_redhawk" },
@@ -253,9 +247,7 @@
     "difficulty": 8,
     "value": 200000,
     "item": "necropolis_datasheet",
-    "start": {
-      "assign_mission_target": { "om_terrain": "necropolis_a_29", "om_special": "Necropolis", "reveal_radius": 5, "search_range": 360 }
-    },
+    "start": { "assign_mission_target": { "om_terrain": "necropolis_a_29", "om_special": "Necropolis", "reveal_radius": 5 } },
     "origins": [ "ORIGIN_SECONDARY" ],
     "followup": "MISSION_FREE_MERCHANTS_EVAC_4",
     "dialogue": {

--- a/data/json/npcs/robofac/NPC_ROBOFAC_MERC_1.json
+++ b/data/json/npcs/robofac/NPC_ROBOFAC_MERC_1.json
@@ -300,7 +300,7 @@
     "difficulty": 0,
     "value": 0,
     "start": {
-      "assign_mission_target": { "om_terrain": "robofachq_surface_entrance", "om_special": "hub_01", "reveal_radius": 1, "search_range": 90, "z": 0 }
+      "assign_mission_target": { "om_terrain": "robofachq_surface_entrance", "om_special": "hub_01", "reveal_radius": 1, "z": 0 }
     },
     "end": {
       "effect": [

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -578,7 +578,7 @@
     "start_name": "A Stop On The Road",
     "allowed_locs": [ "sloc_gas_station" ],
     "missions": [ "MISSION_LAST_DELIVERY" ],
-    "flags": [ "LONE_START" ]
+    "flags": [ "LONE_START", "CITY_START" ]
   },
   {
     "type": "scenario",

--- a/src/mission.h
+++ b/src/mission.h
@@ -152,7 +152,7 @@ struct mission_target_params {
     bool cant_see = false;
     bool random = false;
     bool create_if_necessary = true;
-    int search_range = OMAPX;
+    int search_range = OMAPX * 14;
     std::optional<int> z;
     npc *guy = nullptr;
 };

--- a/src/mission_util.cpp
+++ b/src/mission_util.cpp
@@ -235,7 +235,8 @@ static std::optional<tripoint_abs_omt> find_or_create_om_terrain(
     // If we got here and this is still invalid, it means that we couldn't find it nor create it
     // on any overmap (new or existing) within the allowed search range.
     if( target_pos == overmap::invalid_tripoint ) {
-        debugmsg( "Unable to find and assign mission target %s.", params.overmap_terrain );
+        debugmsg( "Unable to find and assign mission target %s within %d tiles.",
+                  params.overmap_terrain, find_params.search_range );
         return std::nullopt;
     }
     return target_pos;


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

<!--
With a few sentences, describe your reasons for making this change. If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.

Please note that describing what's done does not satisfy as the purpose of change! That's for `Describe the solution` section.

If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: "Fixes #1234".  This will make GitHub automatically close the issue once the PR is merged.  For multiple issues, repeat 'Fixes' multiple times: "Fixes #1234, Fixes #5678".

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This extends the range of mission search if search range is undefined, along with some other improvements ported from DDA. Shifting missions to not be limited in search radius will be useful for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/5723 is merged, as it may become a drunken crapshoot how far off a true-unique location will end up being.

## Describe the solution

<!--
How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.

If this is a port or adaptation of DDA content, provide the link to the original PR (or PRs, if there were multiple) and explain what additional changes, if any, you made to the behavior.

Remember to attribute the original author(s): if you've just copied over the changes, add "Co-Authored-By: Author Name <author_email@example.com>" to the commit message (not the PR description!).  If you've cherry-picked the commits, which is the recommended way of porting, git should preserve the authorship information for you.
-->

C++ changes:
1. In mission.h, set the default search range to the expanded value used in the above DDA PR. I don't think it's actually unlimited but it is de-facto vastly more than a playthrough will be able to exceed.
2. In mission_util.cpp, ported over the message change where failure to find a mission target now tells you the distance it was told to search.

JSON changes:
1. Removed no longer nessecary search ranges from all missions where location is non-random, since the default search range will be much higher than the values being used.
2. The Last Delivery scenario given some hangup protection by being set to a max distance of 200 tiles, also defining reveal radius and min distance.
3. Misc: Expanded search radius of One Last Assassination to 200 tiles, set to be non-random.

## Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Doing it closer to how DDA's implementation does it would have it also print a load error for even bother to use search radius for non-random mission targets. While the feature is not strictly needed now that the default search range is huge, there is the possibility that for performance one might want to limit search range for missions where the mission designer can be reasonably certain the target location will be found within that range.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->


1. Checked affected JSON files for syntax and lint errors.
2. Compiled and load-tested in a zero city size world.
3. Spawned in a refugee center, which I know in this world setting will be the only one to exist.
4. Warped a few overmap chunks away from the center and spawned in an occupied lumbermill.
5. Advanced through missions, they were able to find the refugee center despite it being 361 map tiles away.
6. Checked affected C++ files for astyle.

![image](https://github.com/user-attachments/assets/e6282cea-b5a0-4d70-9ead-feac81296ae7)

One thing I noticed during testing: If a scenario is set to start a mission, it can hang up and take forever to search if it's using a big enough search distance:
![image](https://github.com/user-attachments/assets/57c2f45d-4b66-4ca2-846d-ede35c0a3693)

One Last Assassination and The Last Delivery should be more likely just fail with a quick skippable error message and break the mission instead of being stuck searching forever with these mission settings when used on particular finicky city size settings, which is still not ideal but better than it being stuck loading forever. Checked in my old desktop build (still on build `2024-11-26`) to confirm that the mission can already fail on oddball city size/distance settings in existing builds.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

PR being ported, "Remove mission search radius from most missions" by @RenechCDDA: https://github.com/CleverRaven/Cataclysm-DDA/pull/78949
