### PR TITLE
fix: multiple vehicle faucets no longer multiply supposedly-available crafting materials

### DIFF
--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -577,7 +577,7 @@ void inventory::form_from_map( map &m, std::vector<tripoint> pts, const Characte
             continue;
         }
         vehicle *const veh = &vp->vehicle();
-        if( auto ovi = checked_vehi.find( veh ); ovi == checked_vehi.end() ) {
+        if( !checked_vehi.contains( veh ) ) {
             // We haven't worked with this vehicle yet.
             checked_vehi[veh] = std::unordered_set<const vpart_reference *>();
         }

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -581,7 +581,7 @@ void inventory::form_from_map( map &m, std::vector<tripoint> pts, const Characte
             // We haven't worked with this vehicle yet.
             checked_vehi[veh] = std::unordered_set<const vpart_reference *>();
         }
-        // Make sure we're ready to record 
+        // Make sure we're ready to record
         std::unordered_set<const vpart_reference *> &found_parts = checked_vehi[veh];
 
         //Adds faucet to kitchen stuff; may be horribly wrong to do such....


### PR DESCRIPTION
## Checklist

### Required
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
- fixes #3885

Bugfixing! Multiple faucets (and things that act like faucets, such as the kitchen vehicle part(s)) in a vehicle will, when all within crafting range, *each* report the vehicle's entire quantity of various liquids available...meaning you can get told that you have 2×, 3×, 4×, or more of whatever you need to make something.
Obviously suboptimal.

## Describe the solution
Made inventory::form_from_map keep a mapping of vehicles and their relevant parts that it has checked (and accepted as providing features), and made each successful vpart_reference check add to the set of parts for that vehicle.

## Describe alternatives you've considered
Crying quietly.

## Testing
Make or find a vehicle with a liquid used to craft; check the crafting menu to see the expected amount of fluid there is to work with; add 2+ water faucets; watch as the found (available) crafting mats don't multiply.

## Additional context
This should also head off some potential issues with vehicle_part features, but those weren't my priority and that system could use updating anyway.