### PR TITLE
build: fix packages aged out of mirrors breaking MSVC build

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -202,11 +202,6 @@ jobs:
           appendedCacheKey: ${{ hashFiles( 'msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/**' ) }}-${{ matrix.arch }}-1
           setupOnly: true
           vcpkgDirectory: "${{ runner.workspace }}/b/vcpkg"
-          # We have to use at least this version of vcpkg to include fixes for
-          # various issues we've encountered over time. Keep it in sync with the builtin-baseline
-          # field in vcpkg.json. Caching happens as a post-action which runs at the end of
-          # the whole workflow, after vcpkg install happens during msbuild run.
-          vcpkgGitCommitId: "66444e13a86da7087ee24c342f91801cc6eb9877"
       - name: Install dependencies (windows msvc) (3/3)
         if: runner.os == 'Windows'
         run: |

--- a/.github/workflows/msvc-full-features-cmake.yml
+++ b/.github/workflows/msvc-full-features-cmake.yml
@@ -75,11 +75,10 @@ jobs:
       uses: lukka/get-cmake@latest
 
     - name: Install vcpkg
-      uses: lukka/run-vcpkg@v11
+      uses: lukka/run-vcpkg@main
       id: runvcpkg
       with:
         vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
-        vcpkgGitCommitId: "66444e13a86da7087ee24c342f91801cc6eb9877"
 
     - name: Integrate vcpkg
       run: |

--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -1,4 +1,4 @@
-name: Cataclysm Windows build (CMake + MSVC)
+name: Cataclysm Windows build (MSVC)
 
 on:
   push:
@@ -34,7 +34,7 @@ on:
 
 # We only care about the latest revision, so cancel previous instances.
 concurrency:
-  group: msvc-cmake-build-${{ github.ref_name }}
+  group: msvc-build-${{ github.ref_name }}
   cancel-in-progress: true
 
 env:
@@ -43,7 +43,6 @@ env:
   # Have to use github.workspace because runner namespace isn't available yet.
   VCPKG_OVERLAY_TRIPLETS: ${{ github.workspace }}\.github\vcpkg_triplets
   ZSTD_CLEVEL: 17
-  CMAKE_PRESET: windows-tiles-sounds-x64-msvc
 
 jobs:
   build_catatclysm:
@@ -71,8 +70,14 @@ jobs:
         echo =========================
         echo $env:PATH
 
-    - name: Install stable CMake
-      uses: lukka/get-cmake@latest
+    - name: Setup msys2 (windows msvc)
+      if: runner.os == 'Windows'
+      uses: msys2/setup-msys2@v2
+      with: { msystem: mingw64, install: gettext }
+
+    - name: Compile translations (windows msvc)
+      shell: msys2 {0}
+      run: lang/compile_mo.sh all
 
     - name: Install vcpkg
       uses: lukka/run-vcpkg@main
@@ -85,26 +90,10 @@ jobs:
         vcpkg integrate install
 
     - uses: ammaraskar/msvc-problem-matcher@master
-    - name: Configure
-      run: |
-          cmake -DTESTS=ON --preset $env:CMAKE_PRESET
-
-    - uses: ammaraskar/msvc-problem-matcher@master
     - name: Build
       run: |
-          cmake --build out/build/$env:CMAKE_PRESET --config RelWithDebInfo
-
-    - name: Dump logs if build failed
-      if: failure()
-      run: |
-        echo =================================================
-        Get-ChildItem "${{ runner.workspace }}/Cataclysm-BN/out/build/$env:CMAKE_PRESET" -Recurse
-        echo =================================================
-
-    - name: Compile .mo files for localization
-      run: |
-          cmake --build out/build/$env:CMAKE_PRESET --target translations_compile --config RelWithDebInfo
+        msbuild -m -p:Configuration=Release -p:Platform=x64 "-target:Cataclysm-vcpkg-static;JsonFormatter-vcpkg-static;Cataclysm-test-vcpkg-static" msvc-full-features\Cataclysm-vcpkg-static.sln
 
     - name: Run tests
       run: |
-          .\RelWithDebInfo\cata_test-tiles.exe --rng-seed time
+        .\Cataclysm-test-vcpkg-static-Release-x64.exe --rng-seed time

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,7 +229,6 @@ jobs:
         id: runvcpkg
         with:
           vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
-          vcpkgGitCommitId: "66444e13a86da7087ee24c342f91801cc6eb9877"
 
       - name: Integrate vcpkg
         if: runner.os == 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,7 +225,7 @@ jobs:
         uses: lukka/get-cmake@latest
 
       - name: Install vcpkg
-        uses: lukka/run-vcpkg@v11
+        uses: lukka/run-vcpkg@main
         id: runvcpkg
         with:
           vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'

--- a/msvc-full-features/vcpkg.json
+++ b/msvc-full-features/vcpkg.json
@@ -13,7 +13,7 @@
         },
         "sdl2-ttf"
     ],
-    "builtin-baseline": "c9aba300923c8ec0ab190e2bff23085209925c97",
+    "builtin-baseline": "b322364f06308bdd24823f9d8f03fe0cc86fd46f",
     "vcpkg-configuration": {
         "overlay-ports": [
             "../.github/vcpkg_ports"


### PR DESCRIPTION
<!--
HOW TO USE: Under each "## Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.

CODE STYLE: The game uses automatic code formatting tools to keep code style consistent.  If your PR does not adhere to the style, the autofix.ci app will format the code for you and push the changes as a new commit.  You can also format the code yourself before committing it, it's faster that way and avoids the hurdle of keeping your branch up to date.  See relevant guides for more information: https://docs.cataclysmbn.org/en/contribute/contributing/#code-style

WARNING: If autofix.ci app did the formatting for you, YOU MUST DO EITHER OF THE FOLLOWING:
- Run `git pull` to merge the automated commit into your local PR branch.
- Format your code locally, and force push to your PR branch. 
If you don't do this, your following work will be based on the old commit, and may cause MERGE CONFLICT.
If you use GitHub's web editor to edit files, you shouldn't need to do this as the web editor works directly on the remote branch.

PR TITLE: Please follow Conventional Commits: https://www.conventionalcommits.org
This makes it clear at a glance what the PR is about.
For example:
    feat(content,mods/DinoMod): new dinosaur species
For more info on which categories are available, see: https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/
If the PR is a port or adaptation of DDA content, please indicate it by adding "port" in PR title, like:
    feat(port): <feature name> from DDA
-->

## Checklist

<!--
Certain common types of PRs may need additional code or documentation changes that are easy to forget about or may not be obvious if you're a new contributor.  The checklists below should help you track down what else may need to be done.

Please uncomment any relevant checklists, follow their steps and tick the checkboxes once you're done.  If your PR does not fall under these categories, you can ignore these lists.  If you have any questions or advice on how to improve these, feel free to contact us on our Discord server.
--->

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.

- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->

## Purpose of change

MSVC builds are breaking because vcpkg is pinned to a 1y+ old version, and some of the packages
in its package list just aged out of retention on package mirrors.

Updating `vcpkg` reveals a secondary issue where both nightly and manual release pipelines work but the CI for PRs break. This is because both the first two trigger the build via `msbuild` while the PR one uses `cmake`, which seems to cause dependency resolution problems.

## Describe the solution

1. Update the pin to the latest release: https://github.com/microsoft/vcpkg/releases/tag/2024.12.16

Newer versions of the `lukka/run-vcpkg` workflow step can read the pin from the `vcpkg.json` so we can avoid repeating ourselves across many files.

2. Change the `msvc-full-features-cmake` build (used for PRs) to use `msbuild`, to mirror the behavior of the actual release pipelines. We also build the `Cataclysm-test-vcpkg-static` target, which is skipped in the release builds. 

Note: We're building in Release mode as the hacking way we're pulling in some SDL and ttf libraries doesn't seem to support Debug builds.

## Describe alternatives you've considered

It looks like a specific version is necessary, so we'll need to bump this every year or so.
