### PR TITLE
fix: remove flying flat roofs in the glassblower craft shop

### DIFF
--- a/data/json/mapgen/Glassblower.json
+++ b/data/json/mapgen/Glassblower.json
@@ -161,9 +161,9 @@
         "                        ",
         "                        ",
         "       ****%%v%%v%%%    ",
-        "       *y_h%ssscY_Fv    ",
-        "       *y__+__scY_ev4   ",
-        "       *yh_%______Sv    ",
+        "       *y,h%ssscY_Fv    ",
+        "       *y,,+__scY_ev4   ",
+        "       *yh,%______Sv    ",
         "       ****%_wwwKww%    ",
         "           %_+_w__@%    ",
         "           %>wTwDt@%    ",
@@ -181,7 +181,10 @@
         "=": "t_flat_roof",
         "&": "t_flat_roof",
         "A": "t_flat_roof",
-        ">": "t_stairs_down"
+        ">": "t_stairs_down",
+        ",": "t_floor_noroof",
+        "h": "t_floor_noroof",
+        "y": "t_floor_noroof"
       },
       "furniture": { "@": "f_bed", "K": "f_beaded_door", "h": "f_camp_chair", "D": "f_dresser" },
       "items": {
@@ -217,17 +220,16 @@
         "                        ",
         "                        ",
         "           ---------    ",
-        "        BBB-.......-    ",
-        "        BBB-..:....5    ",
-        "        BBB-.......-    ",
+        "           -.......-    ",
+        "           -..:....5    ",
+        "           -.......-    ",
         "           -....&..-    ",
         "           -.......-    ",
         "           -.......-    ",
         "           ---------    ",
         "                        "
       ],
-      "palettes": [ "roof_palette" ],
-      "terrain": { "B": "t_open_air_rooved" }
+      "palettes": [ "roof_palette" ]
     }
   }
 ]


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Fix because there are flying flat roofs without support on level 3 of the glassblower craft shop.
## Describe the solution
Replace the wooden floor, `t_floor` on the `craft_shop_roof` patio with `t_floor_noroof`
Remove `t_open_air_rooved` from the mapgen `craft_shop_upper_roof`
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/c23e2833-4e88-41e1-967c-ddb8e421f927" />
After:
<img width="960" alt="image2" src="https://github.com/user-attachments/assets/408db83b-392f-4914-8676-cf46f49740bc" />