### PR TITLE
fix: Migrate worlds with Magiclysm to Magical Nights Properly

### DIFF
--- a/data/mods/replacements.json
+++ b/data/mods/replacements.json
@@ -129,6 +129,7 @@
     "sleepdeprivation"
   ],
   [
-    "magiclysm"
+    "magiclysm",
+    "MagicalNights"
   ]
 ]


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

As pointed out by Oren, I literally touched a solution that's meant to replace mods we deleted... but I didn't actually set it up to replace Magiclysm with Magical Nights. My bad!

## Describe the solution

Actually marks Magical Nights as a replacement for Magiclysm in the file

## Describe alternatives you've considered

- Watch as the world(s) burn
- Explode

## Testing

I made sure the Magical Nights ID is correct

## Additional context

Thanks Oren!

A day late is better than never, right? 
