### PR TITLE
fix: sidewalk instead of wooden floor under the vending machines of `craft_shop_2`

### DIFF
--- a/data/json/mapgen/Pottery_Sewing_Shops.json
+++ b/data/json/mapgen/Pottery_Sewing_Shops.json
@@ -36,6 +36,8 @@
         ".": "t_floor",
         "s": "t_sidewalk",
         "u": "t_sidewalk",
+        "D": "t_sidewalk",
+        "F": "t_sidewalk",
         "_": "t_pavement",
         "'": "t_pavement",
         "U": "t_pavement",


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Sidewalk instead of wooden floor under the vending machines of `craft_shop_2`, because it's obvious that wooden floor has no place under these vending machines.
## Describe the solution
Place sidewalk under the vending machines.
## Describe alternatives you've considered
none
## Additional context
Before:
<img width="909" alt="image1" src="https://github.com/user-attachments/assets/5292552f-1e69-4aca-96d6-43a23a553b41" />
After:
<img width="960" alt="image2" src="https://github.com/user-attachments/assets/c6801710-e38f-4435-aa70-532584e775a7" />