### PR TITLE
feat(mods/Magical_Nights, balance): Discourage spear cheese against plastic golems

### DIFF
--- a/data/mods/Magical_Nights/Spells/monsterspells.json
+++ b/data/mods/Magical_Nights/Spells/monsterspells.json
@@ -182,7 +182,7 @@
     "id": "mon_magic_missile",
     "type": "SPELL",
     "name": { "str": "Magic Missile" },
-    "description": "They cast Magic Missile at your puny head! (Monster Spell)",
+    "description": "They cast Magic Missile at your puny head!  (Monster Spell)",
     "valid_targets": [ "hostile" ],
     "flags": [ "SOMATIC", "NO_LEGS", "SILENT" ],
     "min_damage": 10,

--- a/data/mods/Magical_Nights/Spells/monsterspells.json
+++ b/data/mods/Magical_Nights/Spells/monsterspells.json
@@ -179,6 +179,26 @@
     "aoe_increment": 5
   },
   {
+    "id": "mon_magic_missile",
+    "type": "SPELL",
+    "name": { "str": "Magic Missile" },
+    "description": "They cast Magic Missile at your puny head! (Monster Spell)",
+    "valid_targets": [ "hostile" ],
+    "flags": [ "SOMATIC", "NO_LEGS", "SILENT" ],
+    "min_damage": 10,
+    "damage_increment": 2,
+    "damage_type": "none",
+    "max_damage": 50,
+    "min_range": 5,
+    "base_energy_cost": 50,
+    "spell_class": "MAGUS",
+    "difficulty": 1,
+    "max_level": 20,
+    "base_casting_time": 100,
+    "energy_source": "MANA",
+    "effect": "target_attack"
+  },
+  {
     "id": "monster_pain_split",
     "type": "SPELL",
     "name": { "str": "Monster Pain Split" },

--- a/data/mods/Magical_Nights/monsters/golems.json
+++ b/data/mods/Magical_Nights/monsters/golems.json
@@ -55,6 +55,7 @@
     "melee_dice": 3,
     "melee_dice_sides": 6,
     "melee_cut": 3,
+    "special_attacks": [ { "type": "spell", "spell_data": { "id": "mon_magic_missile", "min_level": 1 }, "cooldown": 15 } ],
     "vision_day": 30,
     "vision_night": 30,
     "anger_triggers": [ "PLAYER_CLOSE", "HURT" ],


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

Plastic golems were notoriously cheesable with a spear and a window frame, and this aims to discourage that.

## Describe the solution

Gives the plastic golems a version of the Magic Missile spell, that way they can attack you at ranged

## Describe alternatives you've considered

- Give them the rocket punch from stone golems
- Make them smoler and able to fit through windows
- Let them break walls for the funny

## Testing

The golems can indeed cast the spells, and it seems to either do considerable damage or very little damage depending on your luck and how exactly you encounter them

## Additional context

Resin golems are still a theoretical infinite skill farm, but that's a separate issue that I'd need to look at (then again, there's a good chance they'll spawn with plastic golems around anyway).

They seem to love targeting the head

Further golem reworks (adding a new clay golem evolution, diversifying the monster group more and potentially adding a new one for higher tier golems) are also planned. In general, looking to balance out the challenge v.s. reward a bit more
