### PR TITLE
feat(content): Relic_data expanded to support aboveground as a condition

### DIFF
--- a/data/json/artifact/premade_artifacts.json
+++ b/data/json/artifact/premade_artifacts.json
@@ -15,6 +15,27 @@
     }
   },
   {
+    "id": "radiation_triangle",
+    "type": "TOOL",
+    "name": { "str": "The irradiation triangle" },
+    "description": "Who so ever dares to hold this triangle inside inventory when not underground shall gain 1 to 3 irradiation every 10 minutes.",
+    "weight": "1 g",
+    "volume": "1 ml",
+    "material": [ "iron" ],
+    "symbol": "]",
+    "color": "light_gray",
+    "flags": [ "TRADER_AVOID" ],
+    "relic_data": {
+      "passive_effects": [
+        {
+          "has": "HELD",
+          "condition": "ABOVEGROUND",
+          "ench_effects": [ { "effect": "debug_irradiation", "intensity": 1 } ]
+        }
+      ]
+    }
+  },
+  {
     "id": "chaos_dagger",
     "type": "GENERIC",
     "category": "weapons",

--- a/data/json/artifact/premade_artifacts.json
+++ b/data/json/artifact/premade_artifacts.json
@@ -26,13 +26,7 @@
     "color": "light_gray",
     "flags": [ "TRADER_AVOID" ],
     "relic_data": {
-      "passive_effects": [
-        {
-          "has": "HELD",
-          "condition": "ABOVEGROUND",
-          "ench_effects": [ { "effect": "debug_irradiation", "intensity": 1 } ]
-        }
-      ]
+      "passive_effects": [ { "has": "HELD", "condition": "ABOVEGROUND", "ench_effects": [ { "effect": "debug_irradiation", "intensity": 1 } ] } ]
     }
   },
   {

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -841,6 +841,13 @@
   },
   {
     "type": "effect_type",
+    "id": "debug_irradiation",
+    "name": [ "Irradiation triangle" ],
+    "desc": [ "This irradiates you every 15 minutes while aboveground so long as you have it in your inventory!" ],
+    "base_mods": { "rad_min": [ 1 ], "rad_max": [ 3 ], "rad_tick": [ 900 ] }
+  },
+  {
+    "type": "effect_type",
     "id": "took_xanax",
     "name": [ "Took Xanax" ],
     "desc": [ "You took Xanax some time ago and you might still be under its influence." ],

--- a/doc/src/content/docs/en/mod/json/reference/creatures/magic.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/magic.md
@@ -370,6 +370,7 @@ Values:
 
 - `ALWAYS` (default) - Always active
 - `UNDERGROUND` - When the owner of the item is below Z-level 0
+- `ABOVEGROUND` - When the owner of the item is below Z-level 0
 - `UNDERWATER` - When the owner is in swimmable terrain
 - `NIGHT` - When it is night time
 - `DUSK` - When it is dusk

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -60,6 +60,7 @@ namespace io
         switch ( data ) {
         case enchantment::condition::ALWAYS: return "ALWAYS";
         case enchantment::condition::UNDERGROUND: return "UNDERGROUND";
+        case enchantment::condition::ABOVEGROUND: return "ABOVEGROUND";
         case enchantment::condition::UNDERWATER: return "UNDERWATER";
         case enchantment::condition::DAY: return "DAY";
         case enchantment::condition::NIGHT: return "NIGHT";
@@ -211,6 +212,10 @@ bool enchantment::is_active( const Character &guy, const bool active ) const
 
     if( active_conditions.second == condition::UNDERGROUND ) {
         return guy.pos().z < 0;
+    }
+
+    if( active_conditions.second == condition::ABOVEGROUND ) {
+        return guy.pos().z > -1;
     }
 
     if( active_conditions.second == condition::UNDERWATER ) {

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -83,6 +83,7 @@ class enchantment
         enum condition {
             ALWAYS,
             UNDERGROUND,
+            ABOVEGROUND,
             UNDERWATER,
             NIGHT,
             DAY,


### PR DESCRIPTION
## Checklist
### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional
  - [x] I have documented the changes in the appropriate location in the `doc/` folder.

## Purpose of change

I couldn't apply irradiation on players for being in sunlight, this lets me apply irradiation for players above ground if they're carrying an item.

## Describe the solution

I checked the underground relic_data condition and wrote one for aboveground. It's incredibly self-explanatory that even I know what I'm doing here.

## Describe alternatives you've considered

Make Someone else do it.

Get sunlight as a valid condition. (I'll make someone else do that later)

## Testing

THE IRRADIATION TRIANGLE IS HERE D: A new debug object was supplied for testing purposes and example artifacts which apply conditions on carrying while above ground.
![image](https://github.com/user-attachments/assets/7daf1f1d-80e0-459b-9a69-a8c7c6ec1144)
![image](https://github.com/user-attachments/assets/e88ff1e2-85fb-41eb-bf6f-42e30ee4c1dd)
![image](https://github.com/user-attachments/assets/2eb999cb-36b4-4ef9-b3e1-2331b6c50a06)


## Additional context

THAT'S A REALLY MEAN LOOKING TRIANGLE!