### PR TITLE
fix: replace `t_dirt` with `t_rock` in the mapgen `skate_park_down`

### DIFF
--- a/data/json/mapgen/park_skate.json
+++ b/data/json/mapgen/park_skate.json
@@ -140,7 +140,7 @@
         "########################"
       ],
       "terrain": {
-        "#": "t_dirt",
+        "#": "t_rock",
         "│": "t_concrete_wall",
         ".": "t_concrete",
         "<": "t_concrete_ramp_up_high",


### PR DESCRIPTION
## Checklist

### Required

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [X] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change
Because `t_dirt` is the wrong terrain to use as a substitute for `t_soil`
## Describe the solution
Replace `t_dirt` with `t_rock` in the mapgen `skate_park_down`
## Describe alternatives you've considered
port https://github.com/CleverRaven/Cataclysm-DDA/pull/49658
## Additional context
Before:
<img width="960" alt="image1" src="https://github.com/user-attachments/assets/f12313a0-700c-413d-89ef-c02e76b9a566" />
After:
<img width="960" alt="image2" src="https://github.com/user-attachments/assets/afd10ac9-1ee9-4aaf-9847-a3024841160f" />