### PR TITLE
chore(mods/Magical_Nights): Add an acknowledgement for sources of certain tiles

### DIFF
--- a/data/mods/Magical_Nights/tileset-acknowledgement.txt
+++ b/data/mods/Magical_Nights/tileset-acknowledgement.txt
@@ -1,0 +1,11 @@
+Part of the graphic tiles used in this mod are from the public domain roguelike tileset "RLTiles".
+Some of the tiles have been modified.
+
+You can find the original tileset at:
+http://rltiles.sf.net
+
+Some of the graphic tiles used are from the CC0-licensed portion of Dungeon Crawl: Stone Soup's tileset.
+Many of these tiles have been recolored and had small alterations.
+
+You can find Dungeon Crawl: Stone Soup at:
+https://github.com/crawl/crawl


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Purpose of change

As it turns out, the tileset we had for Magiclysm (and that Magical Nights thusly inherited) used a bunch of recolors of Dungeon Crawl: Stone Soup and RLTiles item sprites for the wands (if not more). While the wand sprites recolored are under CC0 and public domain for both sources respectively, it still feels best to acknowledge them.

## Describe the solution

Adds an acknowledgement of where the tiles came from, as RLTiles politely requests and as DCSS likely appreciates.

## Describe alternatives you've considered

- Also include a notice asking people to please reach out first if they think they see any violations
- Do nothing, CC0 (and public domain) don't legally require attribution in the first place

## Testing

I read it and it is indeed intelligible English.

## Additional context

I swear, if there's a tile in the tileset that MN inherited that turns out to be copyright infringement, I'm gonna weh so hard I'll give Chaos a run for his money.

Hopefully all parties should be reasonable if such an event ever does happen though
