### PR TITLE
build: Fix MSVC builds while preserving PRs' CMake build

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -202,11 +202,6 @@ jobs:
           appendedCacheKey: ${{ hashFiles( 'msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/**' ) }}-${{ matrix.arch }}-1
           setupOnly: true
           vcpkgDirectory: "${{ runner.workspace }}/b/vcpkg"
-          # We have to use at least this version of vcpkg to include fixes for
-          # various issues we've encountered over time. Keep it in sync with the builtin-baseline
-          # field in vcpkg.json. Caching happens as a post-action which runs at the end of
-          # the whole workflow, after vcpkg install happens during msbuild run.
-          vcpkgGitCommitId: "66444e13a86da7087ee24c342f91801cc6eb9877"
       - name: Install dependencies (windows msvc) (3/3)
         if: runner.os == 'Windows'
         run: |

--- a/.github/workflows/msvc-full-features-cmake.yml
+++ b/.github/workflows/msvc-full-features-cmake.yml
@@ -75,11 +75,10 @@ jobs:
       uses: lukka/get-cmake@latest
 
     - name: Install vcpkg
-      uses: lukka/run-vcpkg@v11
+      uses: lukka/run-vcpkg@main
       id: runvcpkg
       with:
         vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
-        vcpkgGitCommitId: "66444e13a86da7087ee24c342f91801cc6eb9877"
 
     - name: Integrate vcpkg
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,11 +225,10 @@ jobs:
         uses: lukka/get-cmake@latest
 
       - name: Install vcpkg
-        uses: lukka/run-vcpkg@v11
+        uses: lukka/run-vcpkg@main
         id: runvcpkg
         with:
           vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
-          vcpkgGitCommitId: "66444e13a86da7087ee24c342f91801cc6eb9877"
 
       - name: Integrate vcpkg
         if: runner.os == 'Windows'

--- a/msvc-full-features/vcpkg.json
+++ b/msvc-full-features/vcpkg.json
@@ -8,6 +8,9 @@
     "sdl2-ttf"
   ],
   "builtin-baseline": "b322364f06308bdd24823f9d8f03fe0cc86fd46f",
+  "overrides": [
+    { "name": "sdl2-mixer", "version": "2.6.3#1" }
+  ],
   "vcpkg-configuration": {
     "overlay-ports": [ "../.github/vcpkg_ports" ]
   }

--- a/msvc-full-features/vcpkg.json
+++ b/msvc-full-features/vcpkg.json
@@ -1,22 +1,14 @@
 {
-    "name": "bn-vcpkg-dependencies",
-    "version-string": "experimental",
-    "dependencies": [
-        "sdl2",
-        {
-          "name": "sdl2-image",
-          "features": [ "libjpeg-turbo" ]
-        },
-        {
-          "name": "sdl2-mixer",
-          "features": [ "libflac", "mpg123", "libmodplug" ]
-        },
-        "sdl2-ttf"
-    ],
-    "builtin-baseline": "c9aba300923c8ec0ab190e2bff23085209925c97",
-    "vcpkg-configuration": {
-        "overlay-ports": [
-            "../.github/vcpkg_ports"
-        ]
-    }
+  "name": "bn-vcpkg-dependencies",
+  "version-string": "experimental",
+  "dependencies": [
+    "sdl2",
+    { "name": "sdl2-image", "features": [ "libjpeg-turbo" ] },
+    { "name": "sdl2-mixer", "features": [ "libflac", "mpg123", "libmodplug" ] },
+    "sdl2-ttf"
+  ],
+  "builtin-baseline": "b322364f06308bdd24823f9d8f03fe0cc86fd46f",
+  "vcpkg-configuration": {
+    "overlay-ports": [ "../.github/vcpkg_ports" ]
+  }
 }


### PR DESCRIPTION
## Checklist

### Required

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) so it can be closed automatically.
- [x] I have [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This is a PR that modifies build process or code organization.

## Purpose of change

#5910 converted the CMake + MSVC builds on PRs into a non-CMake build due to build failures regarding SDL2-Mixer not being able to find its dependency of libxmp. However, this is undesirable as we ultimately want to migrate as fully to CMake as possible at some point.

After looking into it, I figured out a solution to the problem which lets us keep our builds!

## Describe the solution

- Take the first commit from #5910 plus the release.yml change in the second commit as a base
- Pin SDL2-mixer to version 2.6.3#1 in the vcpkg.json file (the version we are currently using, which is before the libxmp mess)

## Describe alternatives you've considered

- Commit directly to the other PR

Advised against

- Suggest the changes one-by-one

I had to revert most of the second commit to it, so that would have been pain

## Testing

The [PR test works on my fork](https://github.com/RobbieNeko/Cataclysm-BN/pull/1), and I didn't touch any of the changes to the proper releases.

## Additional context

I don't even *use* MSVC builds, but I hated the idea of losing CMake so much I learned how to fix our issue

Only minor drawback to this solution is that it's now pinned to a certain version, but by the time we run into any issues from that it'll hopefully be fixed upstream and/or we'll have more experts on Windows builds. vcpkg seems to keep old versions around for a really long time, they have 2.0.1 from 2016 still kicking around
