### PR TITLE
feat(balance): sanity-check half-life of sludge trail fields

### DIFF
--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -211,7 +211,7 @@
     "description_affix": "covered_in",
     "is_splattering": true,
     "priority": 2,
-    "half_life": "6 hours",
+    "half_life": "10 minutes",
     "phase": "liquid",
     "display_field": true,
     "looks_like": "fd_sap"

--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -210,6 +210,7 @@
     ],
     "description_affix": "covered_in",
     "is_splattering": true,
+    "accelerated_decay": true,
     "priority": 2,
     "half_life": "10 minutes",
     "underwater_age_speedup": "10 minutes",

--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -212,6 +212,7 @@
     "is_splattering": true,
     "priority": 2,
     "half_life": "10 minutes",
+    "underwater_age_speedup": "10 minutes",
     "phase": "liquid",
     "display_field": true,
     "looks_like": "fd_sap"


### PR DESCRIPTION
## Why should this PR be merged?

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

It was pointed out that sludge trials remain an annoyance for vastly longer than they have any right to be, are just as weirdly widespread in water, and their half-life is long enough that

## What does this PR do?

<!-- e.g nerfs monster A -->

1. Toned the half-life of sludge trails way the hell down from 6 hours to 10 minutes.
2. Additionally, like with acid and other liquid fields, defined an underwater age speedup of an amount equal to its half-life.
3. Per Oren's advice, also added accelerated decay for out-of-bubble sludge.

## Steps to test and verify this PR

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected file for syntax and lint errors.
2. Load-tested in compiled test build.
4. Spawned in a pupa zed and let it goop around a lil.
5. Waited 15-20 minutes after killing it, slime was gone.
6. Spawned another and lured it into water, slime is even less persistent.

![image](https://github.com/user-attachments/assets/fe04d160-1e52-451e-92bd-b2c855786c91)

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
