### PR TITLE
fix: recovering beehives grow into correct furniture, use external tileset sprite for item form

### DIFF
--- a/data/json/external_tileset/External_Tileset_DP_Normal.json
+++ b/data/json/external_tileset/External_Tileset_DP_Normal.json
@@ -26,7 +26,10 @@
           { "id": [ "overlay_worn_shield_leather_large", "overlay_wielded_shield_leather_large" ], "fg": 17 },
           { "id": "shield_banded_large", "fg": 18 },
           { "id": [ "overlay_worn_shield_banded_large", "overlay_wielded_shield_banded_large" ], "fg": 19 },
-          { "id": [ "f_hive_young", "f_hive_growing", "f_hive_recovering" ], "fg": 20 },
+          {
+            "id": [ "beehive_empty", "overlay_wielded_beehive_empty", "f_hive_young", "f_hive_growing", "f_hive_recovering" ],
+            "fg": 20
+          },
           { "id": "f_hive_ready", "fg": 21 },
           { "id": "razor_macuahuitl", "fg": 22 },
           { "id": "overlay_wielded_razor_macuahuitl", "fg": 23 },

--- a/data/json/furniture_and_terrain/furniture-rural.json
+++ b/data/json/furniture_and_terrain/furniture-rural.json
@@ -138,7 +138,7 @@
     "description": "A traditional beehive, buzzing with activity.  The colony is still recovering from last harvest.",
     "symbol": "^",
     "color": "brown",
-    "transforms_into": "f_hive_regrowing",
+    "transforms_into": "f_hive_ready",
     "deconstruct": { "items": [ { "item": "beehive_empty", "count": 1 }, { "item": "honeycomb", "count": [ 1, 2 ] } ] },
     "bash": {
       "str_min": 12,


### PR DESCRIPTION
## Why should this PR be merged?

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/5943 plus a couple external tileset improvements.

## What does this PR do?

<!-- e.g nerfs monster A -->

1. Fixed what furniture ID recovering beehives grow into.
2. Assigned the external tileset sprite used by beehives to also be used for the item, as with anvils for example.

## Steps to test and verify this PR

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Used my fucking eyes for once and confirmed the recovering hive is set to grow into the correct furniture ID.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
