### PR TITLE
feat(balance): sanity-check fatigue gain from infections

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -1008,8 +1008,9 @@
       "str_mod": [ -1 ],
       "dex_mod": [ -1 ],
       "vomit_chance": [ 1000, 1200 ],
-      "fatigue_min": [ 360, 180 ],
-      "fatigue_chance": [ -102 ]
+      "fatigue_min": [ 2, 1 ],
+      "fatigue_chance": [ -102 ],
+      "fatigue_tick": [ 6 ]
     },
     "scaling_mods": {
       "pain_max_val": [ 30, 20 ],
@@ -1035,7 +1036,7 @@
       "str_mod": [ -1 ],
       "dex_mod": [ -1 ],
       "vomit_chance": [ 1000 ],
-      "fatigue_min": [ 360 ],
+      "fatigue_min": [ 2 ],
       "fatigue_chance": [ -102 ],
       "fatigue_tick": [ 6 ],
       "pain_tick": [ 6 ],


### PR DESCRIPTION
## Why should this PR be merged?

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

This sanity-checks the fatigue gain from late-stage infections. Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/641

## What does this PR do?

<!-- e.g nerfs monster A -->

1. Reduces `fatigue_min` of infection status from 360/180 to 2/1, and added `fatigue_tick` of 6.
2. Likewise also reduced `fatigue_min` of recovering from infection status from 360 to 2.

As noted in the related issue, previously you were gaining an average of 3.6 fatigue per second, which is absolutely absurd (1080 extra fatigue across 5 minutes when normally you get 1 fatigue across 5 minutes). These changes reduce average fatigue gain to an average of 1 extra fatigue gain per 5 minutes, which is enough to double your default fatigue rate gain.

## Steps to test and verify this PR

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected file for syntax and lint errors.
2. Suffered doing math.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
