### PR TITLE
feat(balance): Buff supply drop items, rework their item spawning

### DIFF
--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -746,7 +746,7 @@ static bool mx_bandits_block( map &m, const tripoint &abs_sub )
 
 static bool mx_supplydrop( map &m, const tripoint &/*abs_sub*/ )
 {
-    int num_crates = rng( 1, 5 );
+    int num_crates = rng( 3, 7 );
     for( int i = 0; i < num_crates; i++ ) {
         const auto p = random_point( m, [&m]( const tripoint & n ) {
             return m.passable( n );
@@ -755,34 +755,35 @@ static bool mx_supplydrop( map &m, const tripoint &/*abs_sub*/ )
             break;
         }
         m.furn_set( p->xy(), f_crate_c );
-        std::string item_group;
-        switch( rng( 1, 10 ) ) {
-            case 1:
-            case 2:
-            case 3:
-            case 4:
-                item_group = "mil_food";
-                break;
-            case 5:
-            case 6:
-            case 7:
-                item_group = "grenades";
-                break;
-            case 8:
-            case 9:
-                item_group = "mil_armor";
-                break;
-            case 10:
-                item_group = "guns_rifle_milspec";
-                break;
+        std::vector<std::string> item_groups;
+        for( int i = 0; i < 4; i++ ) {
+            switch( rng( 1, 10 ) ) {
+                case 1:
+                case 2:
+                case 3:
+                case 4:
+                    item_groups.push_back("mil_food");
+                    break;
+                case 5:
+                case 6:
+                case 7:
+                    item_groups.push_back("grenades");
+                    break;
+                case 8:
+                case 9:
+                    item_groups.push_back("mil_armor");
+                    break;
+                case 10:
+                    item_groups.push_back("guns_rifle_milspec");
+                    break;
+            }
         }
         int items_created = 0;
-        for( int i = 0; i < 10 && items_created < 2; i++ ) {
-            items_created += m.place_items( item_group_id( item_group ), 80, *p, *p, true,
-                                            calendar::start_of_cataclysm,
-                                            100 ).size();
+        for( int i = 0; i < 4; i++ ) {
+            items_created += m.put_items_from_loc( item_group_id( item_groups[i] ), *p,
+                                            calendar::start_of_cataclysm ).size();
         }
-        if( m.i_at( *p ).empty() ) {
+        if( m.i_at( *p ).empty() || items_created == 0 ) {
             m.destroy( *p, true );
         }
     }

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -762,26 +762,26 @@ static bool mx_supplydrop( map &m, const tripoint &/*abs_sub*/ )
                 case 2:
                 case 3:
                 case 4:
-                    item_groups.push_back("mil_food");
+                    item_groups.push_back( "mil_food" );
                     break;
                 case 5:
                 case 6:
                 case 7:
-                    item_groups.push_back("grenades");
+                    item_groups.push_back( "grenades" );
                     break;
                 case 8:
                 case 9:
-                    item_groups.push_back("mil_armor");
+                    item_groups.push_back( "mil_armor" );
                     break;
                 case 10:
-                    item_groups.push_back("guns_rifle_milspec");
+                    item_groups.push_back( "guns_rifle_milspec" );
                     break;
             }
         }
         int items_created = 0;
         for( int i = 0; i < 4; i++ ) {
             items_created += m.put_items_from_loc( item_group_id( item_groups[i] ), *p,
-                                            calendar::start_of_cataclysm ).size();
+                                                   calendar::start_of_cataclysm ).size();
         }
         if( m.i_at( *p ).empty() || items_created == 0 ) {
             m.destroy( *p, true );


### PR DESCRIPTION
## Why should this PR be merged?

Supply drops are known for spawning very few items, and in general being very inconsistent on their value. This changes that by buffing their spawned items a good amount and getting rid of some of the silliness that they had with spawning their items. Should hopefully cut down on the disappointing crates.

## What does this PR do?

- Changes the number of crates spawned from 1-5 to 3-7
- Rolls multiple times for itemgroups for the same crate
  - Places the itemgroup ids into a vector, then iterates over that vector when it comes time to spawn items
- Rolls for 4 items instead of 2, and does it infinitely more sensibly
- Makes sure that the return of the item-placing function isn't discarded and the variable to put a use for it isn't unused.

## Steps to test and verify this PR

- Compile test
- Load into the game
- Spawn a supply drop
- Examine the crates
- See the loot

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Additional notes
Compiled and tested on my machine, it works for me
![image](https://github.com/user-attachments/assets/7709801b-13c2-4ed8-9047-a304232b4f9f)

I'm leaving the balancing of the itemgroups to someone else