### PR TITLE
feat(content): More clothing recipes

### DIFF
--- a/data/json/recipes/armor/feet.json
+++ b/data/json/recipes/armor/feet.json
@@ -646,5 +646,17 @@
     "book_learn": [ [ "textbook_tailor", 3 ], [ "tailor_portfolio", 3 ] ],
     "using": [ [ "sewing_standard", 24 ] ],
     "components": [ [ [ "scute_piece", 9 ] ], [ [ "fabric_hides_proper", 9, "LIST" ] ] ]
+  },
+  {
+    "result": "dress_shoes",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_FEET",
+    "skill_used": "tailor",
+    "difficulty": 2,
+    "time": "30 m",
+    "autolearn": true,
+    "using": [ [ "sewing_standard", 4 ] ],
+    "components": [ [ [ "leather", 4 ] ] ]
   }
 ]

--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -1555,7 +1555,7 @@
     "skill_used": "tailor",
     "difficulty": 4,
     "time": "30 m",
-    "book_learn": [ [ "textbook_tailor", 3 ] ],
+    "autolearn": true,
     "using": [ [ "sewing_standard", 3 ] ],
     "components": [ [ [ "rag", 4 ] ] ]
   },

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -1408,5 +1408,29 @@
       [ [ "cordage", 4, "LIST" ] ],
       [ [ "fabric_standard", 9, "LIST" ], [ "fabric_hides_any", 9, "LIST" ] ]
     ]
+  },
+  {
+    "result": "camisole",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_TORSO",
+    "skill_used": "tailor",
+    "difficulty": 2,
+    "time": "20 m",
+    "autolearn": true,
+    "using": [ [ "sewing_standard", 3 ] ],
+    "components": [ [ [ "rag", 4 ] ] ]
+  },
+  {
+    "result": "corset",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_TORSO",
+    "skill_used": "tailor",
+    "difficulty": 4,
+    "time": "1 h",
+    "autolearn": true,
+    "using": [ [ "sewing_standard", 6 ] ],
+    "components": [ [ [ "leather", 8 ] ] ]
   }
 ]


### PR DESCRIPTION
## Why should this PR be merged?

There's no reason clothing made from cloth or leather should be uncraftable.

## What does this PR do?

Adds autolearned recipes for the camisole, corset, and dress shoes. Makes maid hat autolearn.

## Steps to test and verify this PR

Load the game

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
