### PR TITLE
ci: Pin SDL2 used for OSX builds

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -233,10 +233,10 @@ jobs:
         if: runner.os == 'macOS'
         uses: BrettDong/setup-sdl2-frameworks@v1
         with:
-          sdl2: latest
-          sdl2-ttf: latest
-          sdl2-image: latest
-          sdl2-mixer: latest
+          sdl2: 2.30.11
+          sdl2-ttf: 2.24.0
+          sdl2-image: 2.8.4
+          sdl2-mixer: 2.8.0
       - name: Install build dependencies (mac)
         if: runner.os == 'macOS'
         run: |

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -73,10 +73,10 @@ jobs:
       - name: Install runtime dependencies
         uses: BrettDong/setup-sdl2-frameworks@v1
         with:
-          sdl2: latest
-          sdl2-ttf: latest
-          sdl2-image: latest
-          sdl2-mixer: latest
+          sdl2: 2.30.11
+          sdl2-ttf: 2.24.0
+          sdl2-image: 2.8.4
+          sdl2-mixer: 2.8.0
         
       - name: Install build dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,10 +268,10 @@ jobs:
         if: runner.os == 'macOS'
         uses: BrettDong/setup-sdl2-frameworks@v1
         with:
-          sdl2: latest
-          sdl2-ttf: latest
-          sdl2-image: latest
-          sdl2-mixer: latest
+          sdl2: 2.30.11
+          sdl2-ttf: 2.24.0
+          sdl2-image: 2.8.4
+          sdl2-mixer: 2.8.0
       - name: Install build dependencies (mac)
         if: runner.os == 'macOS'
         run: |


### PR DESCRIPTION
## Why should this PR be merged?

Otherwise the Mac builds will fail because SDL3 just got officially released and Brett's action tries to grab SDL3 and gets very confused when there is no SDL2 framework in SDL3

Fixes issues discovered in Royal Fox's PR, #5957 

## What does this PR do?

Pins all the SDL versions used for OSX builds to actual SDL2 versions everywhere I could find them

## Steps to test and verify this PR

Watch to see if the mac builds succeed

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

## Additional Notes
Hopefully Brett will fix it upstream so that it targets SDL2 builds only in the first place (given that they should in theory get *some* bug fixes still)

At some point we probably should look into whether SDL2-compat (which runs using SDL3) will be a good fit given that [distros like Fedora are already considering changing over to it](https://discussion.fedoraproject.org/t/f42-change-proposal-replace-sdl-2-with-sdl2-compat-using-sdl-3-self-contained/138987)
