### PR TITLE
feat(content):  Remove dialogue that references specific years

### DIFF
--- a/data/json/npcs/refugee_center/beggars/BEGGAR_4_Brandon_Garder.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_4_Brandon_Garder.json
@@ -214,7 +214,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_BEGGAR_4_LIFEBEFORE1",
-    "dynamic_line": "Well, I used to be a roofer, but I had a bad fall and wrecked my back around '06.  Tried to get into other kinds of carpentry but I just don't have the head for it.  My wife managed to support both of us with the extra bit I made from odd jobs, but she had a stroke in 2016 and left me on my own the last few years slowly draining my savings dry while I work whatever junk jobs I can handle.  Couple days before <the_cataclysm> I got the notice that the bank was going to foreclose on my crappy little trailer.",
+    "dynamic_line": "Well, I used to be a roofer, but ten years ago I had a bad fall and wrecked my back.  Tried to get into other kinds of carpentry and construction but I just don't have the head for it and my back still hurt.  My wife managed to support both of us with the extra bit I made from odd jobs, but she had a stroke and I was on my own the last few years slowly draining my savings dry while I work whatever junk jobs I can handle.  Couple days before <the_cataclysm> I got the notice that the bank was going to foreclose on my crappy little trailer.",
     "responses": [
       { "text": "You have any kids?", "topic": "TALK_REFUGEE_BEGGAR_4_LIFEBEFORE2" },
       {


### PR DESCRIPTION


## Why should this PR be merged?
It removes dialogue that makes the game … dated
<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## What does this PR do?
changes a few lines in `data/json/npcs/refugee_center/beggars/BEGGAR_4_Brandon_Garder.json`
<!-- e.g nerfs monster A -->

## Steps to test and verify this PR
![image](https://github.com/user-attachments/assets/b28880a0-d117-459f-99cb-6c54d94589fb)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
