### PR TITLE
fix: cables duplication

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -119,7 +119,7 @@
   {
     "id": "DESTROY_ON_DECHARGE",
     "type": "json_flag",
-    "context": [ ]
+    "context": [  ]
   },
   {
     "id": "DIAMOND",

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -117,6 +117,11 @@
     "conflicts": [ "PARTIAL_DEAF" ]
   },
   {
+    "id": "DESTROY_ON_DECHARGE",
+    "type": "json_flag",
+    "context": [ ]
+  },
+  {
     "id": "DIAMOND",
     "type": "json_flag",
     "context": [ "GENERIC", "TOOL" ],

--- a/data/json/items/classes/book.json
+++ b/data/json/items/classes/book.json
@@ -26,6 +26,6 @@
     "color": "green",
     "use_action": "MA_MANUAL",
     "book_data": { "time": 10, "intelligence": 9 },
-    "flags": [ "DESTROY_ON_DECHARGE"]
+    "flags": [ "DESTROY_ON_DECHARGE" ]
   }
 ]

--- a/data/json/items/classes/book.json
+++ b/data/json/items/classes/book.json
@@ -25,6 +25,7 @@
     "symbol": "?",
     "color": "green",
     "use_action": "MA_MANUAL",
-    "book_data": { "time": 10, "intelligence": 9 }
+    "book_data": { "time": 10, "intelligence": 9 },
+    "flags": [ "DESTROY_ON_DECHARGE"]
   }
 ]

--- a/data/json/items/tool/deployable.json
+++ b/data/json/items/tool/deployable.json
@@ -175,7 +175,7 @@
     "symbol": "/",
     "color": "light_gray",
     "use_action": "UNFOLD_GENERIC",
-    "flags": [ "ALLOWS_REMOTE_USE" ]
+    "flags": [ "ALLOWS_REMOTE_USE", "DESTROY_ON_DECHARGE" ]
   },
   {
     "id": "metal_butcher_rack",

--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -1021,7 +1021,7 @@
     "use_action": "MOLOTOV_LIT",
     "revert_to": "molotov",
     "revert_msg": "Your lit molotov goes out.",
-    "flags": [ "LIGHT_20", "TRADER_AVOID", "NPC_THROW_NOW", "NO_REPAIR", "WATER_EXTINGUISH", "ACT_ON_RANGED_HIT" ]
+    "flags": [ "LIGHT_20", "TRADER_AVOID", "NPC_THROW_NOW", "NO_REPAIR", "WATER_EXTINGUISH", "ACT_ON_RANGED_HIT", "DESTROY_ON_DECHARGE" ]
   },
   {
     "id": "improvised_pipebomb",

--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -1021,7 +1021,15 @@
     "use_action": "MOLOTOV_LIT",
     "revert_to": "molotov",
     "revert_msg": "Your lit molotov goes out.",
-    "flags": [ "LIGHT_20", "TRADER_AVOID", "NPC_THROW_NOW", "NO_REPAIR", "WATER_EXTINGUISH", "ACT_ON_RANGED_HIT", "DESTROY_ON_DECHARGE" ]
+    "flags": [
+      "LIGHT_20",
+      "TRADER_AVOID",
+      "NPC_THROW_NOW",
+      "NO_REPAIR",
+      "WATER_EXTINGUISH",
+      "ACT_ON_RANGED_HIT",
+      "DESTROY_ON_DECHARGE"
+    ]
   },
   {
     "id": "improvised_pipebomb",

--- a/data/json/items/tool/firefighting.json
+++ b/data/json/items/tool/firefighting.json
@@ -106,7 +106,7 @@
   },
   {
     "id": "throw_extinguisher",
-    "type": "GENERIC",
+    "type": "TOOL",
     "category": "tools",
     "name": { "str": "throwable fire extinguisher" },
     "description": "This is a fire extinguisher in grenade form.  While not as effective as a regular fire extinguisher, you can use it from a distance.  It is activated by heat, so just throw it into the flames.",
@@ -120,7 +120,7 @@
     "symbol": "*",
     "color": "blue",
     "use_action": "THROWABLE_EXTINGUISHER_ACT",
-    "flags": [ "ACT_IN_FIRE" ]
+    "flags": [ "ACT_IN_FIRE", "DESTROY_ON_DECHARGE" ]
   },
   {
     "id": "pike_pole",

--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -725,7 +725,7 @@
     "symbol": "H",
     "color": "brown",
     "use_action": "LADDER",
-    "flags": [ "DESTROY_ON_DECHARGE"]
+    "flags": [ "DESTROY_ON_DECHARGE" ]
   },
   {
     "id": "survival_marker",

--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -724,7 +724,8 @@
     "material": "wood",
     "symbol": "H",
     "color": "brown",
-    "use_action": "LADDER"
+    "use_action": "LADDER",
+    "flags": [ "DESTROY_ON_DECHARGE"]
   },
   {
     "id": "survival_marker",

--- a/data/json/items/tool/radio_tools.json
+++ b/data/json/items/tool/radio_tools.json
@@ -93,7 +93,7 @@
     "symbol": ";",
     "color": "dark_gray",
     "use_action": "RADIO_MOD",
-    "flags": [ "DESTROY_ON_DECHARGE"]
+    "flags": [ "DESTROY_ON_DECHARGE" ]
   },
   {
     "id": "radio",

--- a/data/json/items/tool/radio_tools.json
+++ b/data/json/items/tool/radio_tools.json
@@ -92,7 +92,8 @@
     "material": "steel",
     "symbol": ";",
     "color": "dark_gray",
-    "use_action": "RADIO_MOD"
+    "use_action": "RADIO_MOD",
+    "flags": [ "DESTROY_ON_DECHARGE"]
   },
   {
     "id": "radio",

--- a/data/json/items/vehicle/cables.json
+++ b/data/json/items/vehicle/cables.json
@@ -17,7 +17,7 @@
     "max_charges": 3,
     "initial_charges": 3,
     "use_action": "CABLE_ATTACH",
-    "flags": [ "CABLE_SPOOL" ]
+    "flags": [ "CABLE_SPOOL", "DESTROY_ON_DECHARGE" ]
   },
   {
     "type": "TOOL",
@@ -37,7 +37,7 @@
     "max_charges": 6,
     "initial_charges": 6,
     "use_action": "TOW_ATTACH",
-    "flags": [ "CABLE_SPOOL", "TOW_CABLE" ]
+    "flags": [ "CABLE_SPOOL", "TOW_CABLE", "DESTROY_ON_DECHARGE" ]
   },
   {
     "type": "TOOL",

--- a/doc/src/content/docs/en/mod/json/reference/json_flags.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_flags.md
@@ -709,6 +709,7 @@ List of known flags, used in both `terrain.json` and `furniture.json`.
 - `DANGEROUS` ... NPCs will not accept this item. Explosion iuse actor implies this flag. Implies
   "NPC_THROW_NOW".
 - `DETERGENT` ... This item can be used as a detergent in a washing machine.
+- `DESTROY_ON_DECHARGE` ... This item should be destroyed if loses charges.
 - `DURABLE_MELEE` ... Item is made to hit stuff and it does it well, so it's considered to be a lot
   tougher than other weapons made of the same materials.
 - `FAKE_MILL` ... Item is a fake item, to denote a partially milled product by @ref

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7838,7 +7838,7 @@ bool Character::consume_charges( item &used, int qty )
         } else {
             use_charges( itype_UPS, qty );
         }
-    } else if( used.is_tool() && used.units_remaining( *this ) == 0 && !used.ammo_required() ) {
+    } else if( used.is_tool() &&  !used.ammo_required() ) {
         // Tools which don't require ammo are instead destroyed.
         // Put here cause tools may have use actions that require charges without charges_per_use
         used.detach();

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7803,6 +7803,12 @@ bool Character::consume_charges( item &used, int qty )
         return false;
     }
 
+    //Destroy items with specific flag
+    if( used.has_flag( flag_DESTROY_ON_DECHARGE ) ) {
+        used.detach();
+        return true;
+    }
+
     if( !used.is_tool() && !used.is_food() && !used.is_medication() ) {
         debugmsg( "Tried to consume charges for non-tool, non-food, non-med item" );
         return false;
@@ -7838,11 +7844,6 @@ bool Character::consume_charges( item &used, int qty )
         } else {
             use_charges( itype_UPS, qty );
         }
-    } else if( used.is_tool() && !used.ammo_required() && used.get_use( "transform" ) == nullptr ) {
-        // Tools which don't require ammo are instead destroyed.
-        // Put here cause tools may have use actions that require charges without charges_per_use
-        used.detach();
-        return true;
     } else {
         used.ammo_consume( std::min( qty, used.ammo_remaining() ), pos() );
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7804,7 +7804,7 @@ bool Character::consume_charges( item &used, int qty )
     }
 
     //Destroy items with specific flag
-    if( used.has_flag( flag_DESTROY_ON_DECHARGE ) ) {
+    if( used.has_flag( flag_DESTROY_ON_DECHARGE ) || used.get_use( "place_monster" ) != nullptr ) {
         used.detach();
         return true;
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7838,7 +7838,7 @@ bool Character::consume_charges( item &used, int qty )
         } else {
             use_charges( itype_UPS, qty );
         }
-    } else if( used.is_tool() &&  !used.ammo_required() ) {
+    } else if( used.is_tool() && !used.ammo_required() && used.get_use( "transform" ) == nullptr ) {
         // Tools which don't require ammo are instead destroyed.
         // Put here cause tools may have use actions that require charges without charges_per_use
         used.detach();

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -74,6 +74,7 @@ const flag_id flag_CUSTOM_EXPLOSION( "CUSTOM_EXPLOSION" );
 const flag_id flag_CUT_IMMUNE( "CUT_IMMUNE" );
 const flag_id flag_DANGEROUS( "DANGEROUS" );
 const flag_id flag_DEAF( "DEAF" );
+const flag_id flag_DESTROY_ON_DECHARGE( "DESTROY_ON_DECHARGE" );
 const flag_id flag_DIAMOND( "DIAMOND" );
 const flag_id flag_DIG_TOOL( "DIG_TOOL" );
 const flag_id flag_DIMENSIONAL_ANCHOR( "DIMENSIONAL_ANCHOR" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -77,6 +77,7 @@ extern const flag_id flag_CUSTOM_EXPLOSION;
 extern const flag_id flag_CUT_IMMUNE;
 extern const flag_id flag_DANGEROUS;
 extern const flag_id flag_DEAF;
+extern const flag_id flag_DESTROY_ON_DECHARGE;
 extern const flag_id flag_DIAMOND;
 extern const flag_id flag_DIG_TOOL;
 extern const flag_id flag_DIMENSIONAL_ANCHOR;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3298,7 +3298,6 @@ int iuse::throwable_extinguisher_act( player *, item *it, bool, const tripoint &
                 g->m.mod_field_intensity( dest, fd_fire, 0 - rng( 0, 2 ) );
             }
         }
-        it->charges = -1;
         return 1;
     }
     it->deactivate();
@@ -3572,9 +3571,6 @@ int iuse::molotov_lit( player *p, item *it, bool t, const tripoint &pos )
             p->add_msg_if_player( m_good, _( "Fire…  Good…" ) );
         }
         // If you exploded it on yourself through activation.
-        if( it->has_position() ) {
-            it->detach();
-        }
         return 1;
     } else if( p->has_item( *it ) && it->charges == 0 ) {
         return 0;


### PR DESCRIPTION
## Why should this PR be merged?

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->
- fixes #5122 

## What does this PR do?

<!-- e.g nerfs monster A -->
Fixes cables not being removed after linking vehicles, by revisiting some of the logic changes from #4968, without disturbing the work done

## Steps to test and verify this PR

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->
"Using" things that use charges and should or should not "disappear" after.
## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
