### PR TITLE
feat: Add `INACTIVE` condition for enchantments

### DIFF
--- a/doc/src/content/docs/en/mod/json/reference/creatures/magic.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/magic.md
@@ -380,6 +380,7 @@ Values:
 - `DAWN` - When it is dawn
 - `ACTIVE` - whenever the item, mutation, bionic, or whatever the enchantment is attached to is
   active.
+- `INACTIVE` - the opposite of `ACTIVE`
 
 ### emitter
 

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -67,6 +67,7 @@ namespace io
         case enchantment::condition::DUSK: return "DUSK";
         case enchantment::condition::DAWN: return "DAWN";
         case enchantment::condition::ACTIVE: return "ACTIVE";
+        case enchantment::condition::INACTIVE: return "INACTIVE";
         case enchantment::condition::NUM_CONDITION: break;
         }
         debugmsg( "Invalid enchantment::condition" );
@@ -188,6 +189,10 @@ bool enchantment::is_active( const Character &guy, const bool active ) const
 {
     if( active_conditions.second == condition::ACTIVE ) {
         return active;
+    }
+
+    if( active_conditions.second == condition::INACTIVE ) {
+        return !active;
     }
 
     if( active_conditions.second == condition::ALWAYS ) {

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -90,6 +90,7 @@ class enchantment
             DUSK,
             DAWN,
             ACTIVE, // the item, mutation, etc. is active
+            INACTIVE,
             NUM_CONDITION
         };
 


### PR DESCRIPTION
## Why should this PR be merged?

This is a desired condition among the community to be used for applications where you care about something *not* being active (perhaps as a debuff of some kind?). Besides, more conditions are better, and if we have an `ACTIVE` we might as well have its opposite.

## What does this PR do?

Adds `INACTIVE` as a condition, the opposite of `ACTIVE`

## Steps to test and verify this PR

- Build-test
- Add an enchantment with the `INACTIVE` condition onto something that can be used to test it, like a mutation.
- Check to see if the enchantment effects are indeed only working when it is *not* active.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `doc/` folder.

