### PR TITLE
feat(balance): dissoluted devourer buff scales more slowly, cut max bashing bonus in half

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -2168,17 +2168,11 @@
     "desc": [ "AI effect to increase stats after fusing with another critter. 1 stack means one absorbed max_hp." ],
     "//": "stats modified by the zombie_fuse special attack.",
     "//1": "scaling:",
-    "//2": "/48 HP: +0,5 melee_skill, +0,5 dodge_skill (unexpected movement), +5 Speed (bigger steps&more to attack with), +4 bash",
-    "//3": "/160 HP: +1 size",
-    "max_intensity": 480,
-    "base_mods": { "hit_mod": [ 0.0104 ], "dodge_mod": [ 0.0104 ], "speed_mod": [ 0.1042 ], "bash_mod": [ 0.08333 ] },
-    "scaling_mods": {
-      "hit_mod": [ 0.0104 ],
-      "dodge_mod": [ 0.0104 ],
-      "speed_mod": [ 0.1042 ],
-      "bash_mod": [ 0.08333 ],
-      "size_mod": [ 0.00625 ]
-    },
+    "//2": "/100 HP: +0,5 melee_skill, +0,5 dodge_skill (unexpected movement), +5 Speed (bigger steps&more to attack with), +2 bash",
+    "//3": "/333 HP: +1 size",
+    "max_intensity": 1000,
+    "base_mods": { "hit_mod": [ 0.005 ], "dodge_mod": [ 0.005 ], "speed_mod": [ 0.05 ], "bash_mod": [ 0.02 ] },
+    "scaling_mods": { "hit_mod": [ 0.005 ], "dodge_mod": [ 0.005 ], "speed_mod": [ 0.05 ], "bash_mod": [ 0.02 ], "size_mod": [ 0.003 ] },
     "show_in_info": true,
     "int_decay_step": 0
   },


### PR DESCRIPTION
## Why should this PR be merged?

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

This implements some belated adjustments to how the dissoluted devourer's effect scales. In particular make it scale up more slowly so that it takes more HP of absorbed zombies to max out the effects, but also make the recently-ish-restored bash bonuses less massive.

## What does this PR do?

<!-- e.g nerfs monster A -->

1. Increased max intensity from 480 to 1000.
2. Reduced the numbers of all bonuses so they hit their original max values at this new max, which combined with step one make them essentially scale a bit more than twice as slowly. Size mod scaling additionally was shifted just enough to be a lil more 100% sure it won't be an even +3 bonus at max intensity, since that's one size more than exists in the game due to starting off as a medium creature.
3. On top of that, `bash_mod` given an additional cut in half so that damage bonus at max intensity is +20 instead of +40, noting that this is a fixed bonus that gets tacked onto its original damage roll.
4. Comments in the effect JSON updated accordingly.

## Steps to test and verify this PR

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->


1. Checked affected file for syntax and lint errors.
2. Did math. :<
3. Load-tested and spawned in a dissoluted devourer.
4. Fed it tough zombies, confirmed intensity can go past 480 but maxes out at 1000. Also confirmed that it hits huge in the late 600s as expected, and doesn't implode the game if examined at max intensity.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
