### PR TITLE
fix: Fireweapons stop being destroyed when running out of charges.

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2260,6 +2260,8 @@ int fireweapon_on_actor::use( player &p, item &it, bool t, const tripoint & ) co
     bool extinguish = true;
     if( it.charges == 0 ) {
         p.add_msg_if_player( m_bad, _( charges_extinguish_message ) );
+        // Revert when it runs out of charges is handled in process_tool.
+        extinguish = false;
     } else if( p.is_underwater() ) {
         p.add_msg_if_player( m_bad, _( water_extinguish_message ) );
     } else if( auto_extinguish_chance > 0 && one_in( auto_extinguish_chance ) ) {
@@ -2274,7 +2276,6 @@ int fireweapon_on_actor::use( player &p, item &it, bool t, const tripoint & ) co
         it.revert( &p, false );
         it.deactivate();
         return 0;
-
     } else if( one_in( noise_chance ) ) {
         if( noise > 0 ) {
             sounds::sound( p.pos(), noise, sounds::sound_t::combat, _( noise_message ) );


### PR DESCRIPTION
## Why should this PR be merged?

- fixes #5868 due to #5297 making them get removed like grenades because it gets reverted in iuse_actor code and then tries to get reverted again in process_tool code, which fails and destroys the item.

## What does this PR do?

Removes the extinguish when it hits zero charges, that is handled by process_tool. It just needs to check to proc it's special message.

## Steps to test and verify this PR

- [x] Rising Sun stops disappearing when out of charges.
  - [x] Rising Sun doesn't disappear but still extinguishes in water/rain/wind/whatever.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
