### PR TITLE
feat: Trees can be harvested for long sticks

### DIFF
--- a/data/json/furniture_and_terrain/terrain-flora.json
+++ b/data/json/furniture_and_terrain/terrain-flora.json
@@ -13,10 +13,13 @@
     "transforms_into": "t_tree_walnut_harvested",
     "examine_action": "harvest_ter",
     "looks_like": "t_tree_hickory",
-    "harvest_by_season": [ { "seasons": [ "autumn" ], "entries": [ { "drop": "walnut", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
-      "seasons": [ "spring", "summer", "winter" ],
-      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
-    } ],
+    "harvest_by_season": [
+      {
+        "seasons": [ "autumn" ],
+        "entries": [ { "drop": "walnut", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+      },
+      { "seasons": [ "spring", "summer", "winter" ], "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }
+    ],
     "bash": {
       "str_min": 80,
       "str_max": 180,
@@ -66,7 +69,10 @@
     "transforms_into": "t_tree_blackjack_harvested",
     "examine_action": "harvest_ter",
     "harvest_by_season": [
-      { "seasons": [ "spring", "summer", "autumn", "winter" ], "entries": [ { "drop": "tanbark", "base_num": [ 2, 8 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }
+      {
+        "seasons": [ "spring", "summer", "autumn", "winter" ],
+        "entries": [ { "drop": "tanbark", "base_num": [ 2, 8 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+      }
     ],
     "bash": {
       "str_min": 80,
@@ -115,10 +121,16 @@
     "transforms_into": "t_tree_chestnut_harvested",
     "examine_action": "harvest_ter",
     "looks_like": "t_tree_hickory",
-    "harvest_by_season": [ { "seasons": [ "autumn" ], "entries": [ { "drop": "chestnut", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
-      "seasons": [ "spring", "summer", "winter" ],
-      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
-    } ],
+    "harvest_by_season": [
+      {
+        "seasons": [ "autumn" ],
+        "entries": [
+          { "drop": "chestnut", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] },
+          { "drop": "stick_long", "base_num": [ 1, 2 ] }
+        ]
+      },
+      { "seasons": [ "spring", "summer", "winter" ], "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }
+    ],
     "bash": {
       "str_min": 80,
       "str_max": 180,
@@ -166,10 +178,16 @@
     "transforms_into": "t_tree_beech_harvested",
     "examine_action": "harvest_ter",
     "looks_like": "t_tree_hickory",
-    "harvest_by_season": [ { "seasons": [ "autumn" ], "entries": [ { "drop": "beech_nuts", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
-      "seasons": [ "spring", "summer", "winter" ],
-      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
-    } ],
+    "harvest_by_season": [
+      {
+        "seasons": [ "autumn" ],
+        "entries": [
+          { "drop": "beech_nuts", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] },
+          { "drop": "stick_long", "base_num": [ 1, 2 ] }
+        ]
+      },
+      { "seasons": [ "spring", "summer", "winter" ], "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }
+    ],
     "bash": {
       "str_min": 80,
       "str_max": 180,
@@ -218,10 +236,16 @@
     "transforms_into": "t_tree_hazelnut_harvested",
     "examine_action": "harvest_ter",
     "looks_like": "t_tree_hickory",
-    "harvest_by_season": [ { "seasons": [ "autumn" ], "entries": [ { "drop": "hazelnut", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
-      "seasons": [ "spring", "summer", "winter" ],
-      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
-    } ],
+    "harvest_by_season": [
+      {
+        "seasons": [ "autumn" ],
+        "entries": [
+          { "drop": "hazelnut", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] },
+          { "drop": "stick_long", "base_num": [ 1, 2 ] }
+        ]
+      },
+      { "seasons": [ "spring", "summer", "winter" ], "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }
+    ],
     "bash": {
       "str_min": 80,
       "str_max": 180,
@@ -269,12 +293,13 @@
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "TREE", "REDUCE_SCENT", "CLIMBABLE" ],
     "transforms_into": "t_tree_harvested",
     "examine_action": "harvest_ter",
-    "harvest_by_season": [ 
-      { "seasons": [ "autumn" ], "entries": [ { "drop": "acorns", "base_num": [ 1, 3 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, 
+    "harvest_by_season": [
       {
-      "seasons": [ "spring", "summer", "winter" ],
-      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
-    } ],
+        "seasons": [ "autumn" ],
+        "entries": [ { "drop": "acorns", "base_num": [ 1, 3 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+      },
+      { "seasons": [ "spring", "summer", "winter" ], "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }
+    ],
     "bash": {
       "str_min": 80,
       "str_max": 180,
@@ -411,10 +436,13 @@
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "TREE", "REDUCE_SCENT", "CLIMBABLE" ],
     "transforms_into": "t_tree_apple_harvested",
     "examine_action": "harvest_ter_nectar",
-    "harvest_by_season": [ { "seasons": [ "autumn" ], "entries": [ { "drop": "apple", "base_num": [ 2, 5 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
-      "seasons": [ "spring", "summer", "winter" ],
-      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
-    } ],
+    "harvest_by_season": [
+      {
+        "seasons": [ "autumn" ],
+        "entries": [ { "drop": "apple", "base_num": [ 2, 5 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+      },
+      { "seasons": [ "spring", "summer", "winter" ], "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }
+    ],
     "bash": {
       "str_min": 80,
       "str_max": 180,
@@ -465,10 +493,13 @@
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "TREE", "REDUCE_SCENT", "CLIMBABLE" ],
     "transforms_into": "t_tree_pear_harvested",
     "examine_action": "harvest_ter_nectar",
-    "harvest_by_season": [ { "seasons": [ "autumn" ], "entries": [ { "drop": "pear", "base_num": [ 2, 5 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
-      "seasons": [ "spring", "summer", "winter" ],
-      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
-    } ],
+    "harvest_by_season": [
+      {
+        "seasons": [ "autumn" ],
+        "entries": [ { "drop": "pear", "base_num": [ 2, 5 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+      },
+      { "seasons": [ "spring", "summer", "winter" ], "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }
+    ],
     "bash": {
       "str_min": 80,
       "str_max": 180,
@@ -524,13 +555,11 @@
         "seasons": [ "autumn" ],
         "entries": [
           { "drop": "coffee_pod", "base_num": [ 4, 10 ], "scale_num": [ 0, 0.5 ] },
-          { "drop": "tea_raw", "base_num": [ 1, 3 ], "scale_num": [ 0, 0.5 ] }, 
+          { "drop": "tea_raw", "base_num": [ 1, 3 ], "scale_num": [ 0, 0.5 ] },
           { "drop": "stick_long", "base_num": [ 1, 2 ] }
         ]
-      }, {
-        "seasons": [ "spring", "summer", "winter" ],
-        "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
-      }
+      },
+      { "seasons": [ "spring", "summer", "winter" ], "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }
     ],
     "bash": {
       "str_min": 80,
@@ -582,10 +611,16 @@
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "TREE", "REDUCE_SCENT", "CLIMBABLE" ],
     "transforms_into": "t_tree_cherry_harvested",
     "examine_action": "harvest_ter_nectar",
-    "harvest_by_season": [ { "seasons": [ "spring" ], "entries": [ { "drop": "cherries", "base_num": [ 6, 18 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
-      "seasons": [ "summer", "autumn", "winter" ],
-      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
-    } ],
+    "harvest_by_season": [
+      {
+        "seasons": [ "spring" ],
+        "entries": [
+          { "drop": "cherries", "base_num": [ 6, 18 ], "scale_num": [ 0, 0.5 ] },
+          { "drop": "stick_long", "base_num": [ 1, 2 ] }
+        ]
+      },
+      { "seasons": [ "summer", "autumn", "winter" ], "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }
+    ],
     "bash": {
       "str_min": 80,
       "str_max": 180,
@@ -639,11 +674,12 @@
     "harvest_by_season": [
       {
         "seasons": [ "autumn", "winter" ],
-        "entries": [ { "drop": "juniper", "base_num": [ 12, 24 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
-      }, {
-        "seasons": [ "spring", "summer" ],
-        "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
-      }
+        "entries": [
+          { "drop": "juniper", "base_num": [ 12, 24 ], "scale_num": [ 0, 0.5 ] },
+          { "drop": "stick_long", "base_num": [ 1, 2 ] }
+        ]
+      },
+      { "seasons": [ "spring", "summer" ], "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }
     ],
     "bash": {
       "str_min": 80,
@@ -695,10 +731,13 @@
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "TREE", "REDUCE_SCENT", "CLIMBABLE" ],
     "transforms_into": "t_tree_peach_harvested",
     "examine_action": "harvest_ter_nectar",
-    "harvest_by_season": [ { "seasons": [ "summer" ], "entries": [ { "drop": "peach", "base_num": [ 2, 5 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
-      "seasons": [ "spring", "autumn", "winter" ],
-      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
-    } ],
+    "harvest_by_season": [
+      {
+        "seasons": [ "summer" ],
+        "entries": [ { "drop": "peach", "base_num": [ 2, 5 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+      },
+      { "seasons": [ "spring", "autumn", "winter" ], "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }
+    ],
     "bash": {
       "str_min": 80,
       "str_max": 180,
@@ -749,10 +788,13 @@
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "TREE", "REDUCE_SCENT", "CLIMBABLE" ],
     "transforms_into": "t_tree_apricot_harvested",
     "examine_action": "harvest_ter_nectar",
-    "harvest_by_season": [ { "seasons": [ "summer" ], "entries": [ { "drop": "apricot", "base_num": [ 2, 5 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
-      "seasons": [ "spring", "autumn", "winter" ],
-      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
-    } ],
+    "harvest_by_season": [
+      {
+        "seasons": [ "summer" ],
+        "entries": [ { "drop": "apricot", "base_num": [ 2, 5 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+      },
+      { "seasons": [ "spring", "autumn", "winter" ], "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }
+    ],
     "bash": {
       "str_min": 80,
       "str_max": 180,
@@ -803,10 +845,13 @@
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "TREE", "REDUCE_SCENT", "CLIMBABLE" ],
     "transforms_into": "t_tree_plum_harvested",
     "examine_action": "harvest_ter_nectar",
-    "harvest_by_season": [ { "seasons": [ "summer" ], "entries": [ { "drop": "plums", "base_num": [ 2, 5 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
-      "seasons": [ "spring", "autumn", "winter" ],
-      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
-    } ],
+    "harvest_by_season": [
+      {
+        "seasons": [ "summer" ],
+        "entries": [ { "drop": "plums", "base_num": [ 2, 5 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+      },
+      { "seasons": [ "spring", "autumn", "winter" ], "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }
+    ],
     "bash": {
       "str_min": 80,
       "str_max": 180,
@@ -865,10 +910,8 @@
           { "drop": "stick_long", "base_num": [ 1, 2 ] },
           { "drop": "seed_mulberries", "base_num": [ 3, 5 ], "scale_num": [ 0, 0.25 ] }
         ]
-      }, {
-        "seasons": [ "spring", "autumn", "winter" ],
-        "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
-      }
+      },
+      { "seasons": [ "spring", "autumn", "winter" ], "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }
     ],
     "bash": {
       "str_min": 80,
@@ -928,10 +971,8 @@
           { "drop": "stick_long", "base_num": [ 1, 2 ] },
           { "drop": "seed_elderberries", "base_num": [ 3, 5 ], "scale_num": [ 0, 0.25 ] }
         ]
-      }, {
-        "seasons": [ "spring", "autumn", "winter" ],
-        "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
-      }
+      },
+      { "seasons": [ "spring", "autumn", "winter" ], "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }
     ],
     "bash": {
       "str_min": 80,
@@ -985,7 +1026,11 @@
     "harvest_by_season": [
       {
         "seasons": [ "spring", "summer", "autumn", "winter" ],
-        "entries": [ { "drop": "pine_bough", "base_num": [ 2, 8 ] }, { "drop": "pinecone", "base_num": [ 1, 4 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+        "entries": [
+          { "drop": "pine_bough", "base_num": [ 2, 8 ] },
+          { "drop": "pinecone", "base_num": [ 1, 4 ] },
+          { "drop": "stick_long", "base_num": [ 1, 2 ] }
+        ]
       }
     ],
     "bash": {
@@ -1049,7 +1094,10 @@
     "examine_action": "harvest_ter",
     "transforms_into": "t_tree_birch_harvested",
     "harvest_by_season": [
-      { "seasons": [ "spring", "summer", "autumn", "winter" ], "entries": [ { "drop": "birchbark", "base_num": [ 2, 8 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }
+      {
+        "seasons": [ "spring", "summer", "autumn", "winter" ],
+        "entries": [ { "drop": "birchbark", "base_num": [ 2, 8 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+      }
     ],
     "bash": {
       "str_min": 80,
@@ -1099,7 +1147,10 @@
     "examine_action": "harvest_ter",
     "transforms_into": "t_tree_willow_harvested",
     "harvest_by_season": [
-      { "seasons": [ "spring", "summer", "autumn", "winter" ], "entries": [ { "drop": "willowbark", "base_num": [ 2, 8 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }
+      {
+        "seasons": [ "spring", "summer", "autumn", "winter" ],
+        "entries": [ { "drop": "willowbark", "base_num": [ 2, 8 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+      }
     ],
     "bash": {
       "str_min": 80,
@@ -1194,10 +1245,14 @@
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "TREE", "REDUCE_SCENT", "CLIMBABLE" ],
     "examine_action": "tree_hickory",
     "harvest_by_season": [
-      { "seasons": [ "autumn" ], "entries": [ { "drop": "hickory_nut", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
-        "seasons": [ "spring", "summer", "winter" ],
-        "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
-      }
+      {
+        "seasons": [ "autumn" ],
+        "entries": [
+          { "drop": "hickory_nut", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] },
+          { "drop": "stick_long", "base_num": [ 1, 2 ] }
+        ]
+      },
+      { "seasons": [ "spring", "summer", "winter" ], "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }
     ],
     "transforms_into": "t_tree_hickory_harvested",
     "bash": {
@@ -1249,10 +1304,16 @@
     "roof": "t_treetop",
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "TREE", "REDUCE_SCENT", "CLIMBABLE" ],
     "examine_action": "harvest_ter",
-    "harvest_by_season": [ { "seasons": [ "autumn" ], "entries": [ { "drop": "pistachio", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
-      "seasons": [ "spring", "summer", "winter" ],
-      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
-    } ],
+    "harvest_by_season": [
+      {
+        "seasons": [ "autumn" ],
+        "entries": [
+          { "drop": "pistachio", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] },
+          { "drop": "stick_long", "base_num": [ 1, 2 ] }
+        ]
+      },
+      { "seasons": [ "spring", "summer", "winter" ], "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }
+    ],
     "transforms_into": "t_tree_pistachio_harvested",
     "bash": {
       "str_min": 80,
@@ -1302,10 +1363,13 @@
     "roof": "t_treetop",
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "TREE", "REDUCE_SCENT", "CLIMBABLE" ],
     "examine_action": "harvest_ter",
-    "harvest_by_season": [ { "seasons": [ "autumn" ], "entries": [ { "drop": "almond", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
-      "seasons": [ "spring", "summer", "winter" ],
-      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
-    } ],
+    "harvest_by_season": [
+      {
+        "seasons": [ "autumn" ],
+        "entries": [ { "drop": "almond", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+      },
+      { "seasons": [ "spring", "summer", "winter" ], "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }
+    ],
     "transforms_into": "t_tree_almond_harvested",
     "bash": {
       "str_min": 80,
@@ -1355,10 +1419,13 @@
     "roof": "t_treetop",
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "TREE", "REDUCE_SCENT", "CLIMBABLE" ],
     "examine_action": "harvest_ter",
-    "harvest_by_season": [ { "seasons": [ "autumn" ], "entries": [ { "drop": "pecan", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
-      "seasons": [ "spring", "summer", "winter" ],
-      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
-    } ],
+    "harvest_by_season": [
+      {
+        "seasons": [ "autumn" ],
+        "entries": [ { "drop": "pecan", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+      },
+      { "seasons": [ "spring", "summer", "winter" ], "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }
+    ],
     "transforms_into": "t_tree_pecan_harvested",
     "bash": {
       "str_min": 80,
@@ -2295,10 +2362,16 @@
     "transforms_into": "t_tree_cacao_harvested",
     "examine_action": "harvest_ter",
     "looks_like": "t_tree_hickory",
-    "harvest_by_season": [ { "seasons": [ "summer" ], "entries": [ { "drop": "cacao_pod", "base_num": [ 2, 5 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
-      "seasons": [ "spring", "autumn", "winter" ],
-      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
-    } ],
+    "harvest_by_season": [
+      {
+        "seasons": [ "summer" ],
+        "entries": [
+          { "drop": "cacao_pod", "base_num": [ 2, 5 ], "scale_num": [ 0, 0.5 ] },
+          { "drop": "stick_long", "base_num": [ 1, 2 ] }
+        ]
+      },
+      { "seasons": [ "spring", "autumn", "winter" ], "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }
+    ],
     "bash": {
       "str_min": 80,
       "str_max": 180,

--- a/data/json/furniture_and_terrain/terrain-flora.json
+++ b/data/json/furniture_and_terrain/terrain-flora.json
@@ -13,7 +13,10 @@
     "transforms_into": "t_tree_walnut_harvested",
     "examine_action": "harvest_ter",
     "looks_like": "t_tree_hickory",
-    "harvest_by_season": [ { "seasons": [ "autumn" ], "entries": [ { "drop": "walnut", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] } ] } ],
+    "harvest_by_season": [ { "seasons": [ "autumn" ], "entries": [ { "drop": "walnut", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
+      "seasons": [ "spring", "summer", "winter" ],
+      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+    } ],
     "bash": {
       "str_min": 80,
       "str_max": 180,
@@ -63,7 +66,7 @@
     "transforms_into": "t_tree_blackjack_harvested",
     "examine_action": "harvest_ter",
     "harvest_by_season": [
-      { "seasons": [ "spring", "summer", "autumn", "winter" ], "entries": [ { "drop": "tanbark", "base_num": [ 2, 8 ] } ] }
+      { "seasons": [ "spring", "summer", "autumn", "winter" ], "entries": [ { "drop": "tanbark", "base_num": [ 2, 8 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }
     ],
     "bash": {
       "str_min": 80,
@@ -112,7 +115,10 @@
     "transforms_into": "t_tree_chestnut_harvested",
     "examine_action": "harvest_ter",
     "looks_like": "t_tree_hickory",
-    "harvest_by_season": [ { "seasons": [ "autumn" ], "entries": [ { "drop": "chestnut", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] } ] } ],
+    "harvest_by_season": [ { "seasons": [ "autumn" ], "entries": [ { "drop": "chestnut", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
+      "seasons": [ "spring", "summer", "winter" ],
+      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+    } ],
     "bash": {
       "str_min": 80,
       "str_max": 180,
@@ -160,7 +166,10 @@
     "transforms_into": "t_tree_beech_harvested",
     "examine_action": "harvest_ter",
     "looks_like": "t_tree_hickory",
-    "harvest_by_season": [ { "seasons": [ "autumn" ], "entries": [ { "drop": "beech_nuts", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] } ] } ],
+    "harvest_by_season": [ { "seasons": [ "autumn" ], "entries": [ { "drop": "beech_nuts", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
+      "seasons": [ "spring", "summer", "winter" ],
+      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+    } ],
     "bash": {
       "str_min": 80,
       "str_max": 180,
@@ -209,7 +218,10 @@
     "transforms_into": "t_tree_hazelnut_harvested",
     "examine_action": "harvest_ter",
     "looks_like": "t_tree_hickory",
-    "harvest_by_season": [ { "seasons": [ "autumn" ], "entries": [ { "drop": "hazelnut", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] } ] } ],
+    "harvest_by_season": [ { "seasons": [ "autumn" ], "entries": [ { "drop": "hazelnut", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
+      "seasons": [ "spring", "summer", "winter" ],
+      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+    } ],
     "bash": {
       "str_min": 80,
       "str_max": 180,
@@ -257,7 +269,12 @@
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "TREE", "REDUCE_SCENT", "CLIMBABLE" ],
     "transforms_into": "t_tree_harvested",
     "examine_action": "harvest_ter",
-    "harvest_by_season": [ { "seasons": [ "autumn" ], "entries": [ { "drop": "acorns", "base_num": [ 1, 3 ], "scale_num": [ 0, 0.5 ] } ] } ],
+    "harvest_by_season": [ 
+      { "seasons": [ "autumn" ], "entries": [ { "drop": "acorns", "base_num": [ 1, 3 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, 
+      {
+      "seasons": [ "spring", "summer", "winter" ],
+      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+    } ],
     "bash": {
       "str_min": 80,
       "str_max": 180,
@@ -394,7 +411,10 @@
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "TREE", "REDUCE_SCENT", "CLIMBABLE" ],
     "transforms_into": "t_tree_apple_harvested",
     "examine_action": "harvest_ter_nectar",
-    "harvest_by_season": [ { "seasons": [ "autumn" ], "entries": [ { "drop": "apple", "base_num": [ 2, 5 ], "scale_num": [ 0, 0.5 ] } ] } ],
+    "harvest_by_season": [ { "seasons": [ "autumn" ], "entries": [ { "drop": "apple", "base_num": [ 2, 5 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
+      "seasons": [ "spring", "summer", "winter" ],
+      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+    } ],
     "bash": {
       "str_min": 80,
       "str_max": 180,
@@ -445,7 +465,10 @@
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "TREE", "REDUCE_SCENT", "CLIMBABLE" ],
     "transforms_into": "t_tree_pear_harvested",
     "examine_action": "harvest_ter_nectar",
-    "harvest_by_season": [ { "seasons": [ "autumn" ], "entries": [ { "drop": "pear", "base_num": [ 2, 5 ], "scale_num": [ 0, 0.5 ] } ] } ],
+    "harvest_by_season": [ { "seasons": [ "autumn" ], "entries": [ { "drop": "pear", "base_num": [ 2, 5 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
+      "seasons": [ "spring", "summer", "winter" ],
+      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+    } ],
     "bash": {
       "str_min": 80,
       "str_max": 180,
@@ -501,8 +524,12 @@
         "seasons": [ "autumn" ],
         "entries": [
           { "drop": "coffee_pod", "base_num": [ 4, 10 ], "scale_num": [ 0, 0.5 ] },
-          { "drop": "tea_raw", "base_num": [ 1, 3 ], "scale_num": [ 0, 0.5 ] }
+          { "drop": "tea_raw", "base_num": [ 1, 3 ], "scale_num": [ 0, 0.5 ] }, 
+          { "drop": "stick_long", "base_num": [ 1, 2 ] }
         ]
+      }, {
+        "seasons": [ "spring", "summer", "winter" ],
+        "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
       }
     ],
     "bash": {
@@ -555,7 +582,10 @@
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "TREE", "REDUCE_SCENT", "CLIMBABLE" ],
     "transforms_into": "t_tree_cherry_harvested",
     "examine_action": "harvest_ter_nectar",
-    "harvest_by_season": [ { "seasons": [ "spring" ], "entries": [ { "drop": "cherries", "base_num": [ 6, 18 ], "scale_num": [ 0, 0.5 ] } ] } ],
+    "harvest_by_season": [ { "seasons": [ "spring" ], "entries": [ { "drop": "cherries", "base_num": [ 6, 18 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
+      "seasons": [ "summer", "autumn", "winter" ],
+      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+    } ],
     "bash": {
       "str_min": 80,
       "str_max": 180,
@@ -609,7 +639,10 @@
     "harvest_by_season": [
       {
         "seasons": [ "autumn", "winter" ],
-        "entries": [ { "drop": "juniper", "base_num": [ 12, 24 ], "scale_num": [ 0, 0.5 ] } ]
+        "entries": [ { "drop": "juniper", "base_num": [ 12, 24 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+      }, {
+        "seasons": [ "spring", "summer" ],
+        "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
       }
     ],
     "bash": {
@@ -662,7 +695,10 @@
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "TREE", "REDUCE_SCENT", "CLIMBABLE" ],
     "transforms_into": "t_tree_peach_harvested",
     "examine_action": "harvest_ter_nectar",
-    "harvest_by_season": [ { "seasons": [ "summer" ], "entries": [ { "drop": "peach", "base_num": [ 2, 5 ], "scale_num": [ 0, 0.5 ] } ] } ],
+    "harvest_by_season": [ { "seasons": [ "summer" ], "entries": [ { "drop": "peach", "base_num": [ 2, 5 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
+      "seasons": [ "spring", "autumn", "winter" ],
+      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+    } ],
     "bash": {
       "str_min": 80,
       "str_max": 180,
@@ -713,7 +749,10 @@
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "TREE", "REDUCE_SCENT", "CLIMBABLE" ],
     "transforms_into": "t_tree_apricot_harvested",
     "examine_action": "harvest_ter_nectar",
-    "harvest_by_season": [ { "seasons": [ "summer" ], "entries": [ { "drop": "apricot", "base_num": [ 2, 5 ], "scale_num": [ 0, 0.5 ] } ] } ],
+    "harvest_by_season": [ { "seasons": [ "summer" ], "entries": [ { "drop": "apricot", "base_num": [ 2, 5 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
+      "seasons": [ "spring", "autumn", "winter" ],
+      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+    } ],
     "bash": {
       "str_min": 80,
       "str_max": 180,
@@ -764,7 +803,10 @@
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "TREE", "REDUCE_SCENT", "CLIMBABLE" ],
     "transforms_into": "t_tree_plum_harvested",
     "examine_action": "harvest_ter_nectar",
-    "harvest_by_season": [ { "seasons": [ "summer" ], "entries": [ { "drop": "plums", "base_num": [ 2, 5 ], "scale_num": [ 0, 0.5 ] } ] } ],
+    "harvest_by_season": [ { "seasons": [ "summer" ], "entries": [ { "drop": "plums", "base_num": [ 2, 5 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
+      "seasons": [ "spring", "autumn", "winter" ],
+      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+    } ],
     "bash": {
       "str_min": 80,
       "str_max": 180,
@@ -820,8 +862,12 @@
         "seasons": [ "summer" ],
         "entries": [
           { "drop": "mulberries", "base_num": [ 8, 20 ], "scale_num": [ 0, 0.5 ] },
+          { "drop": "stick_long", "base_num": [ 1, 2 ] },
           { "drop": "seed_mulberries", "base_num": [ 3, 5 ], "scale_num": [ 0, 0.25 ] }
         ]
+      }, {
+        "seasons": [ "spring", "autumn", "winter" ],
+        "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
       }
     ],
     "bash": {
@@ -879,8 +925,12 @@
         "seasons": [ "summer" ],
         "entries": [
           { "drop": "elderberries", "base_num": [ 8, 20 ], "scale_num": [ 0, 0.5 ] },
+          { "drop": "stick_long", "base_num": [ 1, 2 ] },
           { "drop": "seed_elderberries", "base_num": [ 3, 5 ], "scale_num": [ 0, 0.25 ] }
         ]
+      }, {
+        "seasons": [ "spring", "autumn", "winter" ],
+        "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
       }
     ],
     "bash": {
@@ -935,7 +985,7 @@
     "harvest_by_season": [
       {
         "seasons": [ "spring", "summer", "autumn", "winter" ],
-        "entries": [ { "drop": "pine_bough", "base_num": [ 2, 8 ] }, { "drop": "pinecone", "base_num": [ 1, 4 ] } ]
+        "entries": [ { "drop": "pine_bough", "base_num": [ 2, 8 ] }, { "drop": "pinecone", "base_num": [ 1, 4 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
       }
     ],
     "bash": {
@@ -999,7 +1049,7 @@
     "examine_action": "harvest_ter",
     "transforms_into": "t_tree_birch_harvested",
     "harvest_by_season": [
-      { "seasons": [ "spring", "summer", "autumn", "winter" ], "entries": [ { "drop": "birchbark", "base_num": [ 2, 8 ] } ] }
+      { "seasons": [ "spring", "summer", "autumn", "winter" ], "entries": [ { "drop": "birchbark", "base_num": [ 2, 8 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }
     ],
     "bash": {
       "str_min": 80,
@@ -1049,7 +1099,7 @@
     "examine_action": "harvest_ter",
     "transforms_into": "t_tree_willow_harvested",
     "harvest_by_season": [
-      { "seasons": [ "spring", "summer", "autumn", "winter" ], "entries": [ { "drop": "willowbark", "base_num": [ 2, 8 ] } ] }
+      { "seasons": [ "spring", "summer", "autumn", "winter" ], "entries": [ { "drop": "willowbark", "base_num": [ 2, 8 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }
     ],
     "bash": {
       "str_min": 80,
@@ -1144,7 +1194,10 @@
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "TREE", "REDUCE_SCENT", "CLIMBABLE" ],
     "examine_action": "tree_hickory",
     "harvest_by_season": [
-      { "seasons": [ "autumn" ], "entries": [ { "drop": "hickory_nut", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] } ] }
+      { "seasons": [ "autumn" ], "entries": [ { "drop": "hickory_nut", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
+        "seasons": [ "spring", "summer", "winter" ],
+        "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+      }
     ],
     "transforms_into": "t_tree_hickory_harvested",
     "bash": {
@@ -1196,7 +1249,10 @@
     "roof": "t_treetop",
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "TREE", "REDUCE_SCENT", "CLIMBABLE" ],
     "examine_action": "harvest_ter",
-    "harvest_by_season": [ { "seasons": [ "autumn" ], "entries": [ { "drop": "pistachio", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] } ] } ],
+    "harvest_by_season": [ { "seasons": [ "autumn" ], "entries": [ { "drop": "pistachio", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
+      "seasons": [ "spring", "summer", "winter" ],
+      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+    } ],
     "transforms_into": "t_tree_pistachio_harvested",
     "bash": {
       "str_min": 80,
@@ -1246,7 +1302,10 @@
     "roof": "t_treetop",
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "TREE", "REDUCE_SCENT", "CLIMBABLE" ],
     "examine_action": "harvest_ter",
-    "harvest_by_season": [ { "seasons": [ "autumn" ], "entries": [ { "drop": "almond", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] } ] } ],
+    "harvest_by_season": [ { "seasons": [ "autumn" ], "entries": [ { "drop": "almond", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
+      "seasons": [ "spring", "summer", "winter" ],
+      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+    } ],
     "transforms_into": "t_tree_almond_harvested",
     "bash": {
       "str_min": 80,
@@ -1296,7 +1355,10 @@
     "roof": "t_treetop",
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "TREE", "REDUCE_SCENT", "CLIMBABLE" ],
     "examine_action": "harvest_ter",
-    "harvest_by_season": [ { "seasons": [ "autumn" ], "entries": [ { "drop": "pecan", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] } ] } ],
+    "harvest_by_season": [ { "seasons": [ "autumn" ], "entries": [ { "drop": "pecan", "base_num": [ 5, 12 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
+      "seasons": [ "spring", "summer", "winter" ],
+      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+    } ],
     "transforms_into": "t_tree_pecan_harvested",
     "bash": {
       "str_min": 80,
@@ -2233,7 +2295,10 @@
     "transforms_into": "t_tree_cacao_harvested",
     "examine_action": "harvest_ter",
     "looks_like": "t_tree_hickory",
-    "harvest_by_season": [ { "seasons": [ "summer" ], "entries": [ { "drop": "cacao_pod", "base_num": [ 2, 5 ], "scale_num": [ 0, 0.5 ] } ] } ],
+    "harvest_by_season": [ { "seasons": [ "summer" ], "entries": [ { "drop": "cacao_pod", "base_num": [ 2, 5 ], "scale_num": [ 0, 0.5 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] } ] }, {
+      "seasons": [ "spring", "autumn", "winter" ],
+      "entries": [ { "drop": "stick_long", "base_num": [ 1, 2 ] } ]
+    } ],
     "bash": {
       "str_min": 80,
       "str_max": 180,


### PR DESCRIPTION
## Purpose of change

It's hard to get renewable sticks, bashing saplings is a nonrenewable way to do it.

## Describe the solution

Every tree can be harvested for sticks year round.

## Describe alternatives you've considered

Making Chaos do it.

## Testing

It loads, it works.

![image](https://github.com/user-attachments/assets/a09a5c1d-55d0-40e0-a6a4-10bac7ddc0e2)


## Additional context

Maybe now we can make wattle and daub.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I fed the autofix tree so it wouldn't starve to death.
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
