### PR TITLE
feat: Allow martial arts to require mutations

### DIFF
--- a/doc/src/content/docs/en/mod/json/reference/creatures/martialart_json.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/martialart_json.md
@@ -20,19 +20,20 @@ title: Martial arts & techniques
     "id" : "debug_elem_resist",
     "heat_arm_per" : 1.0
 ],
-"ondodge_buffs" : []        // List of buffs that are automatically applied on successful dodge
-"onattack_buffs" : []       // List of buffs that are automatically applied after any attack, hit or miss
-"onhit_buffs" : []          // List of buffs that are automatically applied on successful hit
-"onmove_buffs" : []         // List of buffs that are automatically applied on movement
-"onmiss_buffs" : []         // List of buffs that are automatically applied on a miss
-"oncrit_buffs" : []         // List of buffs that are automatically applied on a crit
-"onkill_buffs" : []         // List of buffs that are automatically applied upon killing an enemy
+"ondodge_buffs" : [],        // List of buffs that are automatically applied on successful dodge
+"onattack_buffs" : [],       // List of buffs that are automatically applied after any attack, hit or miss
+"onhit_buffs" : [],          // List of buffs that are automatically applied on successful hit
+"onmove_buffs" : [],         // List of buffs that are automatically applied on movement
+"onmiss_buffs" : [],         // List of buffs that are automatically applied on a miss
+"oncrit_buffs" : [],         // List of buffs that are automatically applied on a crit
+"onkill_buffs" : [],         // List of buffs that are automatically applied upon killing an enemy
 "techniques" : [            // List of techniques available when this martial art is used
     "tec_debug_slow",
     "tec_debug_arpen"
-]
-"weapons": [ "tonfa" ]      // List of weapons usable with this art
+],
+"weapons": [ "tonfa" ],      // List of weapons usable with this art
 "weapon_category": [ "WEAPON_CAT1" ], // Weapons that have one of the categories in here are usable with this art.
+"mutation": [ "UNSTYLISH" ] // A list of mutations, at least 1 of which is needed to use this art
 ```
 
 ### Techniques
@@ -72,7 +73,8 @@ title: Martial arts & techniques
     "You phase-strike %s",
     "<npcname> phase-strikes %s"
 ]
-"movecost_mult" : 0.3       // Any bonuses, as described below
+"movecost_mult" : 0.3,       // Any bonuses, as described below
+"mutations_required": [ "MASOCHIST" ] // List of mutations, at least 1 of which is required to use the technique
 ```
 
 ### Buffs

--- a/src/character_martial_arts.cpp
+++ b/src/character_martial_arts.cpp
@@ -39,6 +39,11 @@ bool character_martial_arts::selected_strictly_melee() const
     return style_selected->strictly_melee;
 }
 
+std::set<trait_id> character_martial_arts::selected_mutations() const
+{
+    return style_selected->mutation;
+}
+
 bool character_martial_arts::selected_has_weapon( const itype_id &weap ) const
 {
     return style_selected->has_weapon( weap );

--- a/src/character_martial_arts.h
+++ b/src/character_martial_arts.h
@@ -37,6 +37,7 @@ class character_martial_arts
 
         bool knows_selected_style() const;
         bool selected_strictly_melee() const;
+        std::set<trait_id> selected_mutations() const;
         bool selected_allow_melee() const;
         bool selected_has_weapon( const itype_id &weap ) const;
         bool selected_force_unarmed() const;

--- a/src/character_martial_arts.h
+++ b/src/character_martial_arts.h
@@ -37,7 +37,7 @@ class character_martial_arts
 
         bool knows_selected_style() const;
         bool selected_strictly_melee() const;
-        std::set<trait_id> selected_mutations() const;
+        std::set<trait_id> selected_mutations() const; // returns a list of the selected style's required mutations
         bool selected_allow_melee() const;
         bool selected_has_weapon( const itype_id &weap ) const;
         bool selected_force_unarmed() const;

--- a/src/character_martial_arts.h
+++ b/src/character_martial_arts.h
@@ -37,7 +37,8 @@ class character_martial_arts
 
         bool knows_selected_style() const;
         bool selected_strictly_melee() const;
-        std::set<trait_id> selected_mutations() const; // returns a list of the selected style's required mutations
+        std::set<trait_id> selected_mutations()
+        const; // returns a list of the selected style's required mutations
         bool selected_allow_melee() const;
         bool selected_has_weapon( const itype_id &weap ) const;
         bool selected_force_unarmed() const;

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -329,7 +329,7 @@ void martialart::load( const JsonObject &jo, const std::string & )
     optional( jo, was_loaded, "techniques", techniques, auto_flags_reader<matec_id> {} );
     optional( jo, was_loaded, "weapons", weapons, auto_flags_reader<itype_id> {} );
     optional( jo, was_loaded, "weapon_category", weapon_category, auto_flags_reader<weapon_category_id> {} );
-    optional( jo, was_loaded, "mutation", mutation, auto_flags_reader<trait_id> {});
+    optional( jo, was_loaded, "mutation", mutation, auto_flags_reader<trait_id> {} );
 
     optional( jo, was_loaded, "strictly_melee", strictly_melee, false );
     optional( jo, was_loaded, "strictly_unarmed", strictly_unarmed, false );
@@ -410,8 +410,8 @@ void check_martialarts()
                 debugmsg( "Weapon category %s in style %s is invalid.", weap_cat.c_str(), ma.name );
             }
         }
-        for( const trait_id &mut : ma.mutation) {
-            if (!mut.is_valid()) {
+        for( const trait_id &mut : ma.mutation ) {
+            if( !mut.is_valid() ) {
                 debugmsg( "Mutation %s in style %s is invalid.", mut.c_str(), ma.name );
             }
         }
@@ -543,14 +543,14 @@ bool ma_requirements::is_valid_character( const Character &u ) const
         }
     }
 
-    if( !mutations_required.empty()) {
+    if( !mutations_required.empty() ) {
         bool valid_mut = false;
-        for(const trait_id &mut : mutations_required) {
-            if (u.has_trait(mut)) {
+        for( const trait_id &mut : mutations_required ) {
+            if( u.has_trait( mut ) ) {
                 valid_mut = true;
             }
         }
-        if (!valid_mut){
+        if( !valid_mut ) {
             return false;
         }
     }
@@ -620,7 +620,7 @@ std::string ma_requirements::get_description( bool buff ) const
         } ) + "\n";
     }
 
-    if (!mutations_required.empty()) {
+    if( !mutations_required.empty() ) {
         dump += vgettext( "<bold>Mutation required: </bold>",
                           "<bold>Mutations required: </bold>", mutations_required.size() );
         dump += enumerate_as_string( mutations_required.begin(),
@@ -1658,16 +1658,17 @@ bool ma_style_callback::key( const input_context &ctxt, const input_event &event
                 buffer += enumerate_as_string( weapons );
             }
         }
-        if ( !ma.mutation.empty()) {
+        if( !ma.mutation.empty() ) {
             Character &player = get_player_character();
             buffer += _( "<bold>Mutations:</bold>" ) + std::string( "\n" );
             std::vector<std::string> mutations;
-            for (const trait_id &mut : ma.mutation) {
-                std::string mutname = player.has_trait(mut) ? colorize(mut->name() + _(" [have]"), c_light_cyan) : mut->name();
-                mutations.push_back(mutname);
+            for( const trait_id &mut : ma.mutation ) {
+                std::string mutname = player.has_trait( mut ) ? colorize( mut->name() + _( " [have]" ),
+                                      c_light_cyan ) : mut->name();
+                mutations.push_back( mutname );
             }
-            std::sort(mutations.begin(), mutations.end(), localized_compare);
-            buffer += enumerate_as_string(mutations);
+            std::sort( mutations.begin(), mutations.end(), localized_compare );
+            buffer += enumerate_as_string( mutations );
         }
 
         catacurses::window w;

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -1658,6 +1658,17 @@ bool ma_style_callback::key( const input_context &ctxt, const input_event &event
                 buffer += enumerate_as_string( weapons );
             }
         }
+        if ( !ma.mutation.empty()) {
+            Character &player = get_player_character();
+            buffer += _( "<bold>Mutations:</bold>" ) + std::string( "\n" );
+            std::vector<std::string> mutations;
+            for (const trait_id &mut : ma.mutation) {
+                std::string mutname = player.has_trait(mut) ? colorize(mut->name() + _(" [have]"), c_light_cyan) : mut->name();
+                mutations.push_back(mutname);
+            }
+            std::sort(mutations.begin(), mutations.end(), localized_compare);
+            buffer += enumerate_as_string(mutations);
+        }
 
         catacurses::window w;
 

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <generic_readers.h>
 #include <iterator>
 #include <map>
 #include <memory>
@@ -26,6 +27,7 @@
 #include "json.h"
 #include "map.h"
 #include "messages.h"
+#include "mutation.h"
 #include "output.h"
 #include "pimpl.h"
 #include "player.h"
@@ -179,6 +181,7 @@ void ma_requirements::load( const JsonObject &jo, const std::string & )
     optional( jo, was_loaded, "weapon_damage_requirements", min_damage, ma_weapon_damage_reader {} );
     optional( jo, was_loaded, "weapon_categories_allowed", weapon_categories_allowed,
               auto_flags_reader<weapon_category_id> {} );
+    optional( jo, was_loaded, "mutations_required", mutations_required, auto_flags_reader<trait_id> {} );
 }
 
 void ma_technique::load( const JsonObject &jo, const std::string &src )
@@ -326,6 +329,7 @@ void martialart::load( const JsonObject &jo, const std::string & )
     optional( jo, was_loaded, "techniques", techniques, auto_flags_reader<matec_id> {} );
     optional( jo, was_loaded, "weapons", weapons, auto_flags_reader<itype_id> {} );
     optional( jo, was_loaded, "weapon_category", weapon_category, auto_flags_reader<weapon_category_id> {} );
+    optional( jo, was_loaded, "mutation", mutation, auto_flags_reader<trait_id> {});
 
     optional( jo, was_loaded, "strictly_melee", strictly_melee, false );
     optional( jo, was_loaded, "strictly_unarmed", strictly_unarmed, false );
@@ -404,6 +408,11 @@ void check_martialarts()
         for( const weapon_category_id &weap_cat : ma.weapon_category ) {
             if( !weap_cat.is_valid() ) {
                 debugmsg( "Weapon category %s in style %s is invalid.", weap_cat.c_str(), ma.name );
+            }
+        }
+        for( const trait_id &mut : ma.mutation) {
+            if (!mut.is_valid()) {
+                debugmsg( "Mutation %s in style %s is invalid.", mut.c_str(), ma.name );
             }
         }
     }
@@ -534,6 +543,18 @@ bool ma_requirements::is_valid_character( const Character &u ) const
         }
     }
 
+    if( !mutations_required.empty()) {
+        bool valid_mut = false;
+        for(const trait_id &mut : mutations_required) {
+            if (u.has_trait(mut)) {
+                valid_mut = true;
+            }
+        }
+        if (!valid_mut){
+            return false;
+        }
+    }
+
     return true;
 }
 
@@ -596,6 +617,18 @@ std::string ma_requirements::get_description( bool buff ) const
                 return w_cat.str();
             }
             return w_cat->name().translated();
+        } ) + "\n";
+    }
+
+    if (!mutations_required.empty()) {
+        dump += vgettext( "<bold>Mutation required: </bold>",
+                          "<bold>Mutations required: </bold>", mutations_required.size() );
+        dump += enumerate_as_string( mutations_required.begin(),
+        mutations_required.end(), []( const trait_id & mut ) {
+            if( !mut.is_valid() ) {
+                return mut.str();
+            }
+            return mut->name();
         } ) + "\n";
     }
 

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -510,6 +510,7 @@ bool ma_requirements::is_valid_character( const Character &u ) const
     bool weapon_ok = is_valid_weapon( u.primary_weapon() );
     bool style_weapon = u.martial_arts_data->selected_has_weapon( u.primary_weapon().typeId() );
     bool all_weapons = u.martial_arts_data->selected_allow_melee();
+    std::set<trait_id> style_muts = u.martial_arts_data->selected_mutations();
 
     bool unarmed_ok = !is_armed || ( unarmed_weapon && unarmed_weapons_allowed );
     bool melee_ok = melee_allowed && weapon_ok && ( style_weapon || all_weapons );
@@ -519,6 +520,18 @@ bool ma_requirements::is_valid_character( const Character &u ) const
 
     if( !valid_unarmed && !valid_melee ) {
         return false;
+    }
+
+    if(!style_muts.empty()) {
+        bool valid_mut = false;
+        for(const trait_id &mut : style_muts) {
+            if (u.has_trait(mut)) {
+                valid_mut = true;
+            }
+        }
+        if(!valid_mut){
+            return false;
+        }
     }
 
     if( wall_adjacent && !get_map().is_wall_adjacent( u.pos() ) ) {

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -522,14 +522,14 @@ bool ma_requirements::is_valid_character( const Character &u ) const
         return false;
     }
 
-    if(!style_muts.empty()) {
+    if( !style_muts.empty() ) {
         bool valid_mut = false;
-        for(const trait_id &mut : style_muts) {
-            if (u.has_trait(mut)) {
+        for( const trait_id &mut : style_muts ) {
+            if( u.has_trait( mut ) ) {
                 valid_mut = true;
             }
         }
-        if(!valid_mut){
+        if( !valid_mut ) {
             return false;
         }
     }

--- a/src/martialarts.h
+++ b/src/martialarts.h
@@ -64,6 +64,8 @@ struct ma_requirements {
     /** Weapon categories compatible with this requirement. If empty, allow any weapon category. */
     std::vector<weapon_category_id> weapon_categories_allowed;
 
+    std::vector<trait_id> mutations_required;
+
     /** Minimum amount of given skill to trigger this bonus */
     std::vector<std::pair<skill_id, int>> min_skill;
 
@@ -286,6 +288,7 @@ class martialart
         std::set<matec_id> techniques; // all available techniques
         std::set<itype_id> weapons; // all style weapons
         std::set<weapon_category_id> weapon_category; // all style weapon categories
+        std::set<trait_id> mutation;
         bool strictly_unarmed = false; // Punch daggers etc.
         bool strictly_melee = false; // Must have a weapon.
         bool allow_melee = false; // Can use unarmed or with ANY weapon

--- a/src/martialarts.h
+++ b/src/martialarts.h
@@ -63,8 +63,8 @@ struct ma_requirements {
 
     /** Weapon categories compatible with this requirement. If empty, allow any weapon category. */
     std::vector<weapon_category_id> weapon_categories_allowed;
-    
-    // A list of mutations that are compatible with the technique (i.e. without them no technique usage for you) 
+
+    // A list of mutations that are compatible with the technique (i.e. without them no technique usage for you)
     std::vector<trait_id> mutations_required;
 
     /** Minimum amount of given skill to trigger this bonus */
@@ -289,7 +289,8 @@ class martialart
         std::set<matec_id> techniques; // all available techniques
         std::set<itype_id> weapons; // all style weapons
         std::set<weapon_category_id> weapon_category; // all style weapon categories
-        std::set<trait_id> mutation; // style-based necessary mutations (if set, need at least 1 to use style)
+        std::set<trait_id>
+        mutation; // style-based necessary mutations (if set, need at least 1 to use style)
         bool strictly_unarmed = false; // Punch daggers etc.
         bool strictly_melee = false; // Must have a weapon.
         bool allow_melee = false; // Can use unarmed or with ANY weapon

--- a/src/martialarts.h
+++ b/src/martialarts.h
@@ -63,7 +63,8 @@ struct ma_requirements {
 
     /** Weapon categories compatible with this requirement. If empty, allow any weapon category. */
     std::vector<weapon_category_id> weapon_categories_allowed;
-
+    
+    // A list of mutations that are compatible with the technique (i.e. without them no technique usage for you) 
     std::vector<trait_id> mutations_required;
 
     /** Minimum amount of given skill to trigger this bonus */
@@ -288,7 +289,7 @@ class martialart
         std::set<matec_id> techniques; // all available techniques
         std::set<itype_id> weapons; // all style weapons
         std::set<weapon_category_id> weapon_category; // all style weapon categories
-        std::set<trait_id> mutation;
+        std::set<trait_id> mutation; // style-based necessary mutations (if set, need at least 1 to use style)
         bool strictly_unarmed = false; // Punch daggers etc.
         bool strictly_melee = false; // Must have a weapon.
         bool allow_melee = false; // Can use unarmed or with ANY weapon


### PR DESCRIPTION
## Purpose of change

Sometimes, especially in mods, it'd be nice if you could restrict certain techniques (or entire martial arts styles) to characters with specific traits / mutations.

## Describe the solution

- Adds a new field to martial arts and techniques that takes a list of mutation ids to be required
- Prevents usage by players without these requirements
- Prints notices of these requirements in the normal places

## Describe alternatives you've considered

- Ask someone else to do it
- Just leave it be

## Testing

- Compiled, it did indeed compile
- Loaded into a world as a character, it did indeed load
- Added a requirement to Barbaran Montante as well as the impaling technique within.
  - The requirement on the technique did work, only letting me impale when I had the trait I set as a requirement
  - The requirement on the martial art also worked, including restricting the buffs! It doesn't print any message to let you know that you're missing the requirements atm, and still gives the regular activation message though.
- Took a look at the printed text, looks how you'd expect it to. 

## Additional context

Unsure of the preferred method to go about implementing a message warning users that they don't meet the requirements for the martial art.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `doc/` folder.
  - [x] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [x] If applicable, add checks on game load that would validate the loaded data. (I think?)