### PR TITLE
feat(balance): vary up AoE range of shotshells more, fix paper shot lacking AoE

### DIFF
--- a/data/json/items/ammo/20x66mm.json
+++ b/data/json/items/ammo/20x66mm.json
@@ -135,7 +135,7 @@
     "//": "2.5x the Generic Rate of $1/shot",
     "description": "20x66mm caseless shotgun rounds, buckshot type.  Proprietary ammunition for Rivtech shotguns.  Being caseless rounds, these cannot be disassembled or reloaded.",
     "range": 0,
-    "shape": [ "cone", { "half_angle": 15, "length": 12 } ]
+    "shape": [ "cone", { "half_angle": 5, "length": 24 } ]
   },
   {
     "id": "20x66_slug",

--- a/data/json/items/ammo/410shot.json
+++ b/data/json/items/ammo/410shot.json
@@ -16,7 +16,7 @@
     "ammo_type": "410shot",
     "casing": "410shot_hull",
     "range": 0,
-    "shape": [ "cone", { "half_angle": 10, "length": 12 } ],
+    "shape": [ "cone", { "half_angle": 10, "length": 16 } ],
     "damage": { "damage_type": "bullet", "amount": 30 },
     "recoil": 1350,
     "loudness": 90,

--- a/data/json/items/ammo/shot.json
+++ b/data/json/items/ammo/shot.json
@@ -98,7 +98,7 @@
     "name": { "str": "00 shot" },
     "description": "A shell filled with metal pellets.  Extremely damaging, plus the spread makes it very accurate at short range.  Favored by SWAT forces.",
     "range": 0,
-    "shape": [ "cone", { "half_angle": 10, "length": 12 } ]
+    "shape": [ "cone", { "half_angle": 8, "length": 20 } ]
   },
   {
     "id": "shot_beanbag",
@@ -125,7 +125,7 @@
     "range": 0,
     "damage": { "damage_type": "bullet", "amount": 50, "armor_multiplier": 3 },
     "loudness": 80,
-    "shape": [ "cone", { "half_angle": 15, "length": 8 } ],
+    "shape": [ "cone", { "half_angle": 15, "length": 10 } ],
     "extend": { "effects": [ "NOGIB" ] }
   },
   {

--- a/data/json/items/ammo/shotpaper.json
+++ b/data/json/items/ammo/shotpaper.json
@@ -27,6 +27,8 @@
     "copy-from": "shot_paper_abstract",
     "type": "AMMO",
     "name": { "str": "20ga paper shot" },
+    "range": 0,
+    "shape": [ "cone", { "half_angle": 8, "length": 20 } ],
     "description": "A paper cartridge containing a premeasured amount of black powder and an equal volume of 00 buckshot."
   },
   {
@@ -37,6 +39,8 @@
     "description": "A paper cartridge containing a premeasured amount of black powder and an equal volume of birdshot.  Used mostly for hunting small game or fowl.",
     "damage": { "damage_type": "bullet", "amount": 40, "armor_multiplier": 3 },
     "proportional": { "recoil": 0.6, "loudness": 0.8 },
+    "range": 0,
+    "shape": [ "cone", { "half_angle": 15, "length": 10 } ],
     "extend": { "effects": [ "NOGIB" ] }
   },
   {
@@ -48,7 +52,7 @@
     "damage": { "damage_type": "heat", "amount": 24 },
     "proportional": { "recoil": 0.6, "loudness": 0.8, "dispersion": 1.2 },
     "range": 0,
-    "shape": [ "cone", { "half_angle": 15, "length": 8 } ],
+    "shape": [ "cone", { "half_angle": 15, "length": 10 } ],
     "extend": { "effects": [ "INCENDIARY", "STREAM", "NOGIB" ] }
   },
   {


### PR DESCRIPTION
## Purpose of change

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

One annoying consequence of https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4950 is it came with a giant nerf to ranges for affected ammo, which in turn makes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/2793 a bit more bothersome. This aims to make things more tolerable at the expense of a bit of width on the AoE cones.

## Describe the solution

<!-- e.g nerfs monster A -->

1. Increased 20mm shot's AoE range from 12 tiles to 24, while reducing width from 10 to 5.
2. Increased regular 00 shot's AoE range from 12 tiles to 20, and reduced width from 10 to 8.
3. Increased .410 shot's AoE range from 12 to 16. Allowed to stay at 10 width since shorter range than 00 shot.
4. Increased range of 12 gauge birdshot from 8 to 10, to be exactly half that of buckshot and to be more distinct compared to .22 ratshot and 12 gauge dragon's breath.
4. Misc: Fixed paper 00 and birdshot cartridges not using AoE.

Idea here was to bump the ranges for 00 shot back up to the original value, but then instead of having 20mm and .410 all be the exact same value like they used to be (they were all set to 20 before) tweak them to values that vary by a few tiles to make them more distinct.

## Describe alternatives you've considered

For consistency, maybe we oughta mess with the range of 40mm buckshot loads too I wonder. It's a bit odd that they lack very short range, but that was the range they had before the AoE change anyway so hmm.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested and checked what the AoE cone on 00 shot looks like.

Before:
![before](https://github.com/user-attachments/assets/d44774d2-c777-47b3-9ea0-732e430ae861)

After:
![after](https://github.com/user-attachments/assets/c0be5d03-b119-4e81-a040-b9b1fad79cf6)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Ekarus also mentioned another possible AoE bug: they're evidently stopped by chain link fences? (#5981)

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
