### PR TITLE
fix(mods/MagicalNights): Attempt to limit mapgen placing things in towns when it shouldn't

### DIFF
--- a/data/mods/Magical_Nights/worldgen/overmap_specials.json
+++ b/data/mods/Magical_Nights/worldgen/overmap_specials.json
@@ -157,7 +157,7 @@
       { "point": [ 0, 0, 3 ], "overmap": "wizardtower1_study_north" },
       { "point": [ 0, 0, 4 ], "overmap": "wizardtower1_roof_north" }
     ],
-    "locations": [ "wilderness" ],
+    "locations": [ "forest" ],
     "city_distance": [ 25, -1 ],
     "city_sizes": [ 0, 10 ],
     "occurrences": [ 1, 4 ],
@@ -173,7 +173,7 @@
       { "point": [ 0, 0, 3 ], "overmap": "wizardtower2_study_north" },
       { "point": [ 0, 0, 4 ], "overmap": "wizardtower2_roof_north" }
     ],
-    "locations": [ "wilderness" ],
+    "locations": [ "forest" ],
     "city_distance": [ 25, -1 ],
     "city_sizes": [ 0, 10 ],
     "occurrences": [ 1, 4 ],

--- a/data/mods/Magical_Nights/worldgen/overmap_specials.json
+++ b/data/mods/Magical_Nights/worldgen/overmap_specials.json
@@ -7,9 +7,9 @@
       { "point": [ 0, 0, 1 ], "overmap": "magic_cabin_roof_north" }
     ],
     "locations": [ "wilderness" ],
-    "city_distance": [ 20, -1 ],
-    "city_sizes": [ 0, 20 ],
-    "occurrences": [ 0, 5 ],
+    "city_distance": [ 25, -1 ],
+    "city_sizes": [ 0, 10 ],
+    "occurrences": [ 1, 5 ],
     "flags": [ "ELECTRIC_GRID" ]
   },
   {
@@ -121,17 +121,17 @@
     "id": "goblin_camp",
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "goblin_camp_north" } ],
     "locations": [ "wilderness" ],
-    "city_distance": [ 20, -1 ],
-    "city_sizes": [ 0, 20 ],
-    "occurrences": [ 0, 5 ]
+    "city_distance": [ 25, -1 ],
+    "city_sizes": [ 0, 10 ],
+    "occurrences": [ 1, 4 ]
   },
   {
     "type": "overmap_special",
     "id": "orc_camp",
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "orc_camp_north" } ],
     "locations": [ "wilderness" ],
-    "city_distance": [ 20, -1 ],
-    "city_sizes": [ 0, 20 ],
+    "city_distance": [ 25, -1 ],
+    "city_sizes": [ 0, 10 ],
     "occurrences": [ 0, 2 ]
   },
   {
@@ -158,9 +158,9 @@
       { "point": [ 0, 0, 4 ], "overmap": "wizardtower1_roof_north" }
     ],
     "locations": [ "wilderness" ],
-    "city_distance": [ 20, -1 ],
-    "city_sizes": [ 0, 20 ],
-    "occurrences": [ 0, 5 ],
+    "city_distance": [ 25, -1 ],
+    "city_sizes": [ 0, 10 ],
+    "occurrences": [ 1, 4 ],
     "flags": [ "ELECTRIC_GRID" ]
   },
   {
@@ -174,14 +174,14 @@
       { "point": [ 0, 0, 4 ], "overmap": "wizardtower2_roof_north" }
     ],
     "locations": [ "wilderness" ],
-    "city_distance": [ 20, -1 ],
-    "city_sizes": [ 0, 20 ],
-    "occurrences": [ 0, 5 ],
+    "city_distance": [ 25, -1 ],
+    "city_sizes": [ 0, 10 ],
+    "occurrences": [ 1, 4 ],
     "flags": [ "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
-    "id": "forest_tomb",
+    "id": "magic_academy",
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "magic_academy_ground_north" },
       { "point": [ 0, 0, 1 ], "overmap": "magic_academy_2nd_north" },
@@ -195,8 +195,8 @@
       { "point": [ 0, 0, -1 ], "overmap": "magic_academy_basement_north" }
     ],
     "locations": [ "wilderness" ],
-    "city_distance": [ 20, -1 ],
-    "city_sizes": [ 0, 20 ],
+    "city_distance": [ 30, -1 ],
+    "city_sizes": [ 0, 10 ],
     "occurrences": [ 0, 1 ],
     "flags": [ "ELECTRIC_GRID" ]
   }


### PR DESCRIPTION
## Purpose of change (The Why)

Wizard Towers and many similar mapgen features in the mod are NOT SUPPOSED TO SPAWN IN TOWNS.
And yet, thanks to very drunk mapgen, they do. This causes problems for wizard towers in particular thanks to how they place their plastic golems, leading to a very painful time if the tower is in the city (especially with the new anti-spear-cheese)

## Describe the solution (The How)

- Further edit the mapgen values of a bunch of the overmap specials to encourage mapgen to stop being an idiot
- Bump the occurrences of certain specials for the sake of encouraging them to spawn more
- Put wizard towers in forests so that they are even less likely to show up inside of towns
- Also fixes an oversight where forest tombs didn't spawn anymore because of copy-paste error on putting in magic academies

## Describe alternatives you've considered

- Fix mapgen myself
- Wait for someone else to fix mapgen
- Implode

## Testing

It loads, and it has the desired effect on wizard towers

## Additional context

Mapgen is *highly drunk*

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

