### PR TITLE
docs: Reduce alarmism about docs being outdated

### DIFF
--- a/doc/src/content/docs/en/mod/json/tutorial/modding.md
+++ b/doc/src/content/docs/en/mod/json/tutorial/modding.md
@@ -4,8 +4,8 @@ title: Modding guide
 
 :::caution{title="Some documentation is not complete"}
 
-Some parts of the documentation are incomplete or have not been properly updated from older documentation.
-Contributions to fix this are greatly appreciated.
+Some parts of the documentation are incomplete or have not been properly updated from older
+documentation. Contributions to fix this are greatly appreciated.
 
 :::
 

--- a/doc/src/content/docs/en/mod/json/tutorial/modding.md
+++ b/doc/src/content/docs/en/mod/json/tutorial/modding.md
@@ -2,10 +2,10 @@
 title: Modding guide
 ---
 
-:::danger{title="Most of the documentations are not up-to date"}
+:::caution{title="Some documentation is not complete"}
 
-Most of the documentations are outdated (unchanged since fork from CDDA) and may not work as
-expected. Updates are welcome.
+Some parts of the documentation are incomplete or have not been properly updated from older documentation.
+Contributions to fix this are greatly appreciated.
 
 :::
 


### PR DESCRIPTION
## Purpose of change (The Why)

This alarmism harms the credibility of the docs unnecessarily and evidently scares off some people from using them.

## Describe the solution (The How)

Reduce it to a caution from a warning, and in general is less alarmist about the docs being outdated while acknowledging that some parts of them likely are.

## Describe alternatives you've considered

- Remove it altogether

## Testing

I read it with my eyes

## Additional context

I know at least one modder was scared off of using them by it.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
