### PR TITLE
feat(balance): move battleaxe to `2H_AXES`category, obsolete `HAND_AXES` in favor of `1H_AXES`

### DIFF
--- a/data/json/items/melee/axes.json
+++ b/data/json/items/melee/axes.json
@@ -3,7 +3,7 @@
     "id": "battleaxe",
     "type": "GENERIC",
     "category": "weapons",
-    "weapon_category": [ "1H_AXES" ],
+    "weapon_category": [ "2H_AXES" ],
     "name": { "str": "battle axe" },
     "description": "This is a huge axe designed for warfare.  Though intended for use as a weapon, it can also be pressed into service as a rather clumsy woodcutting tool.",
     "weight": "2002 g",

--- a/data/json/items/tool/entry_tools.json
+++ b/data/json/items/tool/entry_tools.json
@@ -56,7 +56,7 @@
     "id": "iceaxe",
     "type": "GENERIC",
     "category": "tools_entry",
-    "weapon_category": [ "HAND_AXES" ],
+    "weapon_category": [ "1H_AXES" ],
     "name": { "str": "ice axe" },
     "description": "This is an ice axe with hammer on its head, a multi-purpose hiking and climbing tool used by mountaineers.  It is sturdy enough to pry open closed doors or lift manhole covers.",
     "weight": "500 g",

--- a/data/json/items/tool/firefighting.json
+++ b/data/json/items/tool/firefighting.json
@@ -3,7 +3,7 @@
     "id": "crash_axe",
     "type": "GENERIC",
     "category": "tools_entry",
-    "weapon_category": [ "HAND_AXES" ],
+    "weapon_category": [ "1H_AXES" ],
     "symbol": ";",
     "color": "light_gray",
     "name": { "str": "crash axe" },

--- a/data/json/items/tool/woodworking.json
+++ b/data/json/items/tool/woodworking.json
@@ -151,7 +151,7 @@
     "id": "hatchet",
     "type": "GENERIC",
     "category": "weapons",
-    "weapon_category": [ "HAND_AXES" ],
+    "weapon_category": [ "1H_AXES" ],
     "symbol": ";",
     "color": "light_gray",
     "name": { "str": "hatchet" },

--- a/data/json/obsoletion/uncategorized.json
+++ b/data/json/obsoletion/uncategorized.json
@@ -421,5 +421,11 @@
       "//": "destroy_threshold equal to str_min instead of str_max due to delicate electronics",
       "ranged": { "reduction": [ 16, 32 ], "destroy_threshold": 32, "block_unaimed_chance": "50%" }
     }
+  },
+  {
+    "type": "weapon_category",
+    "id": "HAND_AXES",
+    "name": "Hand Axes",
+    "//": "Axe with a short handle, typically wielded in one hand, ocassionally thrown."
   }
 ]

--- a/data/json/weapon_categories.json
+++ b/data/json/weapon_categories.json
@@ -109,21 +109,15 @@
   },
   {
     "type": "weapon_category",
-    "id": "HAND_AXES",
-    "name": "Hand Axes",
-    "//": "Axe with a short handle, typically wielded in one hand, ocassionally thrown."
-  },
-  {
-    "type": "weapon_category",
     "id": "1H_AXES",
     "name": "One-handed Axes",
-    "//": "Axes meant to be wielded with one hand, typically with a handle longer than the handaxe."
+    "//": "Axes meant to be wielded with one hand."
   },
   {
     "type": "weapon_category",
     "id": "2H_AXES",
     "name": "Two-handed Axes",
-    "//": "Axes meant to be wielded with two hands."
+    "//": "Axes with a handle long enough to allow or require wielding with two hands."
   },
   {
     "type": "weapon_category",

--- a/data/mods/CRT_EXPANSION/items/crt_tools.json
+++ b/data/mods/CRT_EXPANSION/items/crt_tools.json
@@ -209,7 +209,7 @@
   {
     "type": "GENERIC",
     "id": "crt_hatchet_extended",
-    "weapon_category": [ "1H_AXES" ],
+    "weapon_category": [ "2H_AXES" ],
     "symbol": ";",
     "color": "light_gray",
     "name": "C.R.I.T axe",

--- a/data/mods/MMA/martialarts.json
+++ b/data/mods/MMA/martialarts.json
@@ -197,7 +197,7 @@
       "mma_tec_iron_heart_wide",
       "mma_tec_iron_heart_wide_crit"
     ],
-    "weapon_category": [ "HAND_AXES", "2H_SWORDS", "1H_SWORDS" ]
+    "weapon_category": [ "1H_AXES", "2H_AXES", "2H_SWORDS", "1H_SWORDS" ]
   },
   {
     "type": "martial_art",
@@ -576,6 +576,6 @@
       }
     ],
     "techniques": [ "mma_tec_tiger_claw_break" ],
-    "weapon_category": [ "1H_AXES", "FIST_WEAPONS", "KNIVES", "HAND_AXES" ]
+    "weapon_category": [ "1H_AXES", "FIST_WEAPONS", "KNIVES" ]
   }
 ]

--- a/data/mods/Magical_Nights/items/class_items.json
+++ b/data/mods/Magical_Nights/items/class_items.json
@@ -190,7 +190,7 @@
     "id": "rune_stormshaper_weapon",
     "type": "GENERIC",
     "name": { "str": "Stormshaper axe" },
-    "weapon_category": [ "1H_AXES" ],
+    "weapon_category": [ "2H_AXES" ],
     "//": "Equivalent to copper ax +1, with volume reduction so it can be sheathed like the other school weapons.  Metals chosen for being two most conductive metals + balancing reasons",
     "description": "A forged copper axe with silver trimmings and a wooden handle.  There is a Stormshaper rune embedded in the eye.",
     "weight": "3330 g",


### PR DESCRIPTION
## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

Most melee weapon types tend to only really need a one-handed and two-handed category, aside from more complex stuff like swords and polearms. In particular it seems like it'd be better to narrow down the categories for axes and get a fix on what goes well, which in the process also fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/5965

## Describe the solution (The How)

1. Per request, set battle axes to category `2H_AXES` instead of `1H_AXES`, as size-wise it's much closer to 
2. Moved hatchet, crash axe, and ice axe from `HAND_AXES` to `1H_AXE`, where you find the simularly-sized tomahawks.
3. Updated Iron Heart style in MMA mod to use one and two-handed axes instead of hand axes, since it allows one and two-handed swords.
4. Removed hand axes from Tiger Claw style in MMA mod since it already has one-handed axes in the weapon list and seems to be focused on those.
5. Moved `HAND_AXES` category to obsoletion folder, adjusted comments for axe categories accordingly.
6. Misc: Changed stormshaper axe from one-handed category to two-handed, since it seems closer to battle axe in appearance.
7. Misc: Moved extended CRIT axe from one-hand to two-handed, so that expanding it makes it actually different as a weapon.

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

Now that battle axes are in the two-handed category, we could consider removing access to one-handed axes from Fior Di Battaglia. If we do, we may also wish to remove access to one-handed hammers as well?

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Checked affected files for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
