### PR TITLE
revert: Remove infinite book morale stacking

### DIFF
--- a/src/character_effects.cpp
+++ b/src/character_effects.cpp
@@ -178,6 +178,18 @@ int calc_focus_equilibrium( const Character &who )
 {
     int focus_equilibrium = 100;
 
+    if( who.activity->id() == ACT_READ ) {
+        safe_reference<item> loc = who.activity->targets[0];
+        if( loc && loc->is_book() ) {
+            auto &bt = *loc->type->book;
+            // apply a penalty when we're actually learning something
+            const SkillLevel &skill_level = who.get_skill_level_object( bt.skill );
+            if( skill_level.can_train() && skill_level < bt.level ) {
+                focus_equilibrium -= 50;
+            }
+        }
+    }
+
     int eff_morale = who.get_morale_level();
     // Factor in perceived pain, since it's harder to rest your mind while your body hurts.
     // Cenobites don't mind, though

--- a/src/character_effects.cpp
+++ b/src/character_effects.cpp
@@ -22,6 +22,7 @@
 #include "weather_gen.h"
 #include "weather.h"
 
+static const activity_id ACT_READ( "ACT_READ" );
 static const trait_id trait_CENOBITE( "CENOBITE" );
 static const trait_id trait_INT_SLIME( "INT_SLIME" );
 static const trait_id trait_NAUSEA( "NAUSEA" );


### PR DESCRIPTION
## Purpose of change (The Why)

I can't read negative morale books without stacking food and either drugs or very fancy jewelry.

![image](https://github.com/user-attachments/assets/5dac5790-3e60-40ec-a079-6931e4fe03e9)

## Describe the solution (The How)

Partial revert of https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4391 Which will specifically revert the infinite stacking portion. Focus will still recover 10x faster after this. This was done using the Github revert feature but with the lines on focus recovery being kept.

I also had to do a revert of https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4394/files To add back ACT_READ. This is necessary for it to be used.

## Describe alternatives you've considered

Nothing else is within my capability of C++ wrangling.

## Testing

The previous behavior did work, so tests will just need to pass.

## Additional context

![image](https://github.com/user-attachments/assets/6fd5b092-927e-4fc4-9be2-df0f528fbfe9)
![image](https://github.com/user-attachments/assets/ed271966-b2c2-4035-ab70-14740104d005)


## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I fed the autofix tree so it wouldn't starve to death.
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
