### PR TITLE
feat(UI): make max skill level limit configurable

### DIFF
--- a/src/cached_options.cpp
+++ b/src/cached_options.cpp
@@ -19,6 +19,7 @@ int fov_3d_z_range;
 bool tile_iso;
 bool pixel_minimap_option = false;
 int PICKUP_RANGE;
+int MAX_SKILL;
 
 FungalOptions fungal_opt;
 

--- a/src/cached_options.h
+++ b/src/cached_options.h
@@ -84,6 +84,8 @@ extern int PICKUP_RANGE;
  */
 extern bool dont_debugmsg;
 
+// Maximum (effective) level for a skill.
+extern int MAX_SKILL;
 
 /* Options related to fungal activity */
 struct FungalOptions {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3793,7 +3793,7 @@ void Character::practice( const skill_id &id, int amount, int cap, bool suppress
 
     if( !level.can_train() && !in_sleep_state() ) {
         // If leveling is disabled, don't train, don't drain focus, don't print anything
-        // This also checks if your skill level is maxed out at the cap of 10.
+        // This also checks if your skill level is maxed out.
         return;
     }
 
@@ -8764,7 +8764,6 @@ void Character::on_hit( Creature *source, bodypart_id bp_hit,
     bool in_skater_vehicle = in_vehicle && veh_part.part_with_feature( "SEAT_REQUIRES_BALANCE", false );
 
     if( ( worn_with_flag( flag_REQUIRES_BALANCE ) || in_skater_vehicle ) && !is_on_ground() ) {
-        int rolls = 4;
         if( worn_with_flag( flag_ROLLER_ONE ) && !in_skater_vehicle ) {
             if( worn_with_flag( flag_REQUIRES_BALANCE ) && !has_effect( effect_downed ) ) {
                 int rolls = 4;

--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -113,9 +113,6 @@ static constexpr units::mass JACK_LIMIT = 8500_kilogram;
 // Slowest speed at which a gun can be aimed.
 static constexpr int MAX_AIM_COST = 10;
 
-// Maximum (effective) level for a skill.
-static constexpr int MAX_SKILL = 10;
-
 // Maximum (effective) level for a stat.
 static constexpr int MAX_STAT = 20;
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2226,8 +2226,8 @@ void options_manager::add_options_debug()
          0.0, 100.0, 1.0, 0.1
        );
 
-    add( "MAX_SKILL_LEVEL", debug, translate_marker("Max Skill Level"),
-         translate_marker("The maximum level a skill can be trained to."),
+    add( "MAX_SKILL_LEVEL", debug, translate_marker( "Max Skill Level" ),
+         translate_marker( "The maximum level a skill can be trained to." ),
          0, 1000, 10
        );
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2226,6 +2226,11 @@ void options_manager::add_options_debug()
          0.0, 100.0, 1.0, 0.1
        );
 
+    add( "MAX_SKILL_LEVEL", debug, translate_marker("Max Skill Level"),
+         translate_marker("The maximum level a skill can be trained to."),
+         0, 1000, 10
+       );
+
     add( "SKILL_RUST", debug, translate_marker( "Skill rust" ),
          translate_marker( "Set the level of skill rust.  Vanilla: Vanilla Cataclysm - Capped: Capped at skill levels 2 - Int: Intelligence dependent - IntCap: Intelligence dependent, capped - Off: None at all." ),
          //~ plain, default, normal
@@ -3448,6 +3453,7 @@ void options_manager::cache_to_globals()
     fov_3d_z_range = ::get_option<int>( "FOV_3D_Z_RANGE" );
     static_z_effect = ::get_option<bool>( "STATICZEFFECT" );
     PICKUP_RANGE = ::get_option<int>( "PICKUP_RANGE" );
+    MAX_SKILL = ::get_option<int>( "MAX_SKILL_LEVEL" );
 
     merge_comestible_mode = ( [] {
         const auto opt = ::get_option<std::string>( "MERGE_COMESTIBLES" );

--- a/src/skill.cpp
+++ b/src/skill.cpp
@@ -9,7 +9,7 @@
 
 #include "cata_utility.h"
 #include "debug.h"
-#include "game_constants.h"
+#include "cached_options.h"
 #include "item.h"
 #include "json.h"
 #include "options.h"

--- a/tests/throwing_test.cpp
+++ b/tests/throwing_test.cpp
@@ -164,10 +164,12 @@ static void test_throwing_player_versus(
     CHECK( dmg_thresh_met );
 }
 
+constexpr int DEFAULT_MAX_SKILL = 10;
+
 constexpr throw_test_pstats lo_skill_base_stats = { 0, 8, 8, 8 };
-constexpr throw_test_pstats mid_skill_base_stats = { MAX_SKILL / 2, 8, 8, 8 };
-constexpr throw_test_pstats hi_skill_base_stats = { MAX_SKILL, 8, 8, 8 };
-constexpr throw_test_pstats hi_skill_athlete_stats = { MAX_SKILL, 12, 12, 12 };
+constexpr throw_test_pstats mid_skill_base_stats = { DEFAULT_MAX_SKILL / 2, 8, 8, 8 };
+constexpr throw_test_pstats hi_skill_base_stats = { DEFAULT_MAX_SKILL, 8, 8, 8 };
+constexpr throw_test_pstats hi_skill_athlete_stats = { DEFAULT_MAX_SKILL, 12, 12, 12 };
 
 TEST_CASE( "basic_throwing_sanity_tests", "[throwing],[balance]" )
 {


### PR DESCRIPTION
## Purpose of change (The Why)

after #3720, [people wanted to train skill levels higher than 10](https://old.reddit.com/r/cataclysmbn/comments/1i5qlg2/is_there_a_way_to_get_a_skill_more_than_10/). why not?

## Describe the solution (The How)

made max skill configurable in debug settings. 1000 should probably be enough i guess.

## Testing

![image](https://github.com/user-attachments/assets/44334abc-90bd-4555-808f-514b29856ae2)
![image](https://github.com/user-attachments/assets/e5912078-67d7-4837-a0c4-bfd491c8dd9d)
![image](https://github.com/user-attachments/assets/a07e037d-b987-4d6b-b964-745fcce7ce13)

1. increase max skill level to 100
2. set all skill level to 10
3. kill hulks with rifle
4. rifle level is increased

## Additional context

discord talk: https://discord.com/channels/830879262763909202/830916451517857894/1331465767211892796

i can't run astyle because newer version doesn't support some options project uses.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

