### PR TITLE
chore: fix my auto-included headers

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -11,7 +11,6 @@
 #include <optional>
 #include <string>
 #include <tuple>
-#include <type_id.h>
 
 #include "activity_handlers.h"
 #include "addiction.h"
@@ -45,6 +44,7 @@
 #include "stomach.h"
 #include "string_formatter.h"
 #include "translations.h"
+#include "type_id.h"
 #include "units.h"
 #include "vitamin.h"
 #include "weather.h"

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cstdlib>
-#include <generic_readers.h>
 #include <iterator>
 #include <map>
 #include <memory>
@@ -20,6 +19,7 @@
 #include "effect.h"
 #include "enums.h"
 #include "generic_factory.h"
+#include "generic_readers.h"
 #include "input.h"
 #include "item.h"
 #include "item_factory.h"


### PR DESCRIPTION
## Purpose of change (The Why)

Delta Epsilon in the Discord had troubles building thanks to these two. For whatever reason, clangd just *loves* choosing to use angle braces on the automatic includes instead of quotation marks. I intend to try and fix this one way or another.

## Describe the solution (The How)

- Changes the hostile lines to nice double-quotes

## Describe alternatives you've considered

- Go directly for trying to put in a .clangd file in the project to explicitly try and prevent this from happening

## Testing

I should *hope* changing includes to be the correct type doesn't break anything!

## Additional context

Auto-includes with clangd seem to be defaulting to <> instead of "" for me, which is very annoying.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
