### PR TITLE
chore: survivor hiking backpack description typo fix

### DIFF
--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -874,7 +874,7 @@
     "id": "survivor_hiking_backpack",
     "type": "ARMOR",
     "name": { "str": "survivor hiking backpack" },
-    "description": "A custom-built backpack hiking.  Durable and carefully crafted to hold as much stuff as possible.",
+    "description": "A custom-built hiking backpack.  Durable and carefully crafted to hold as much stuff as possible.",
     "weight": "2500 g",
     "volume": "15000 ml",
     "price": "150 USD",


### PR DESCRIPTION
## Purpose of change (The Why)

The description of the Survivor Hiking Backpack reads as follows.
"A custom-built backpack hiking.  Durable and carefully crafted to hold as much stuff as possible."

"backpack hiking" didn't quite look right to me, and since I don't go outside too often, I totally looked up the parts of a hiking backpack to see if this is just some uniquely named bit. It's not (as far as I am aware). 

The next conclusion is that it was a typo, so I made an edit.

## Describe the solution (The How)

I swapped the location of the words "hiking" and "backpack" around in the `.json` file.

## Describe alternatives you've considered

Telling someone in the Discord, or leaving it be.

## Testing

I changed the `.json`, loaded in, and saw that the description was changed.

Before:
![image](https://github.com/user-attachments/assets/a80927ad-8611-4893-a8c2-76f2bf3b6a03)

After:
![image](https://github.com/user-attachments/assets/fcfc2cfa-8ad8-40b2-9d58-1e55ea4908b6)

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
