### PR TITLE
fix: crafted items no longer try to set default ammotype for items spawned empty

### DIFF
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1150,6 +1150,10 @@ void complete_craft( player &p, item &craft, const bench_location & )
             food_contained.set_owner( p.get_faction()->id );
         }
 
+        // If we created a tool that spawns empty, don't preset its ammotype.
+        if( !newit->ammo_remaining() ) {
+            newit->ammo_unset();
+        }
         if( newit->made_of( LIQUID ) ) {
             liquid_handler::handle_all_liquid( std::move( newit ), PICKUP_RANGE );
         } else {


### PR DESCRIPTION
## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/4860 by making it so crafting tools won't create a weird situation where the item is empty but counts as having an ammotype assigned under the hood.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

In crafting.cpp, added a check in the `complete_craft` where it asks if the item being created has no ammo loaded into it, and if so makes sure to unset the ammotype from it so it won't be in a paradoxical "I'm loaded but empty" situation which is only possible to clear by loading the exact ammo it wants and then unloading it.

## Describe alternatives you've considered

I was real tempted to be lazy and just fix any items affected by this stupid bug in JSON by removing use of `initial_charges` from offending items...

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Gave myself debug hammerspace and all recipes.
3. Crafted an alcohol-fueled soldering item, confirmed I can now load ethanol into it.
4. Crafted a candle, signal flare, gasoline lantern, and medium plutonium battery to be sure that various other types of craft are still created correctly.
5. Itemgroup tested `home_hw` to confirm that soda can stove kits still spawn fully-loaded in it.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
