### PR TITLE
feat(port): JSONize ammo consumption per shot, allow gunmods to modify ammo use, add a flamethrower gunmod to demonstrate ammo use modifier

### DIFF
--- a/data/json/items/classes/gun.json
+++ b/data/json/items/classes/gun.json
@@ -24,7 +24,8 @@
     "ammo": "flammable",
     "ammo_effects": [ "FLARE" ],
     "reload": 400,
-    "flags": [ "FIRE_100", "NEVER_JAMS", "FIRESTARTER", "PYROMANIAC_WEAPON" ],
+    "ammo_to_fire": 100,
+    "flags": [ "NEVER_JAMS", "FIRESTARTER", "PYROMANIAC_WEAPON" ],
     "use_action": { "type": "firestarter", "moves": 200 },
     "faults": [  ]
   },
@@ -495,7 +496,8 @@
     "bashing": 9,
     "skill": "launcher",
     "ammo": "chemical_spray",
-    "flags": [ "FIRE_50", "NEVER_JAMS", "NON_FOULING" ],
+    "ammo_to_fire": 50,
+    "flags": [ "NEVER_JAMS", "NON_FOULING" ],
     "valid_mod_locations": [
       [ "accessories", 4 ],
       [ "grip", 1 ],

--- a/data/json/items/gun/flammable.json
+++ b/data/json/items/gun/flammable.json
@@ -43,8 +43,8 @@
     "loudness": 3,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "AUTO", "auto", 4 ] ],
     "valid_mod_locations": [ [ "accessories", 4 ], [ "rail", 1 ], [ "grip", 1 ], [ "sling", 1 ], [ "stock", 1 ], [ "underbarrel", 1 ] ],
-    "extend": { "flags": [ "FIRE_20", "MODE_BURST", "NON_FOULING" ] },
-    "delete": { "flags": [ "FIRE_100" ] },
+    "ammo_to_fire": 20,
+    "extend": { "flags": [ "MODE_BURST", "NON_FOULING" ] },
     "magazines": [ [ "flammable", [ "rm4502", "rm4504" ] ] ]
   }
 ]

--- a/data/json/items/gun/flammable.json
+++ b/data/json/items/gun/flammable.json
@@ -21,7 +21,8 @@
       [ "rail", 1 ],
       [ "stock", 1 ],
       [ "sights", 1 ],
-      [ "underbarrel", 1 ]
+      [ "underbarrel", 1 ],
+      [ "muzzle", 1 ]
     ],
     "magazines": [ [ "flammable", [ "pressurized_tank" ] ] ]
   },
@@ -42,7 +43,15 @@
     "durability": 9,
     "loudness": 3,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "AUTO", "auto", 4 ] ],
-    "valid_mod_locations": [ [ "accessories", 4 ], [ "rail", 1 ], [ "grip", 1 ], [ "sling", 1 ], [ "stock", 1 ], [ "underbarrel", 1 ] ],
+    "valid_mod_locations": [
+      [ "accessories", 4 ],
+      [ "rail", 1 ],
+      [ "grip", 1 ],
+      [ "sling", 1 ],
+      [ "stock", 1 ],
+      [ "underbarrel", 1 ],
+      [ "muzzle", 1 ]
+    ],
     "ammo_to_fire": 20,
     "extend": { "flags": [ "MODE_BURST", "NON_FOULING" ] },
     "magazines": [ [ "flammable", [ "rm4502", "rm4504" ] ] ]

--- a/data/json/items/gunmod/muzzle.json
+++ b/data/json/items/gunmod/muzzle.json
@@ -246,5 +246,25 @@
     "install_time": "0 m",
     "handling_modifier": 3,
     "loudness_modifier": -50
+  },
+  {
+    "id": "mod_flamethrower_nozzle",
+    "type": "GUNMOD",
+    "name": { "str": "high-pressure combustion nozzle" },
+    "description": "An attachment resembling a rocket nozzle along with parts from a pump assembly.  Installing this on a flamethrower will increase its maximum range and damage, but increase fuel consumption.",
+    "looks_like": "pump_complex",
+    "weight": "700 g",
+    "volume": "250 ml",
+    "price": "100 USD",
+    "price_postapoc": "5 USD",
+    "material": [ "steel" ],
+    "symbol": ":",
+    "color": "light_gray",
+    "location": "muzzle",
+    "mod_target_category": [ [ "FLAMETHROWERS" ] ],
+    "install_time": "5 m",
+    "damage_modifier": [ { "damage_type": "heat", "amount": 5 } ],
+    "range_modifier": 5,
+    "ammo_to_fire_multiplier": 1.25
   }
 ]

--- a/data/json/recipes/weapon/mods.json
+++ b/data/json/recipes/weapon/mods.json
@@ -963,5 +963,19 @@
       [ [ "steel_lump", 1 ] ],
       [ [ "RAM", 1 ] ]
     ]
+  },
+  {
+    "type": "recipe",
+    "result": "mod_flamethrower_nozzle",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_MODS",
+    "skill_used": "mechanics",
+    "difficulty": 5,
+    "skills_required": [ [ "fabrication", 4 ] ],
+    "time": "45 m",
+    "book_learn": [ [ "textbook_gaswarfare", 5 ], [ "book_icef", 5 ], [ "textbook_anarch", 6 ], [ "manual_launcher", 4 ] ],
+    "using": [ [ "welding_standard", 10 ], [ "steel_tiny", 1 ] ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 1 }, { "id": "SCREW", "level": 1 } ],
+    "components": [ [ [ "pipe", 1 ] ], [ [ "sheet_metal_small", 2 ] ], [ [ "pump_complex", 1 ] ] ]
   }
 ]

--- a/doc/src/content/docs/en/mod/json/reference/json_flags.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_flags.md
@@ -780,8 +780,8 @@ List of known flags, used in both `terrain.json` and `furniture.json`.
 - `DISABLE_SIGHTS` Prevents use of the base weapon sights
 - `FIRE_20` Uses 20 shots per firing.
 - `FIRE_50` Uses 50 shots per firing.
-- `FIRE_100` Uses 100 shots per firing. See also the `ammo_to_fire` property to specify any amount of ammo
-   usage per shot desired. These flags will override `ammo_to_fire` if present.
+- `FIRE_100` Uses 100 shots per firing. See also the `ammo_to_fire` property to specify any amount
+  of ammo usage per shot desired. These flags will override `ammo_to_fire` if present.
 - `HEAVY_WEAPON_SUPPORT` Wearing this will let you hip-fire heavy weapons without needing terrain
   support, like Large or Huge mutants can.
 - `FIRE_TWOHAND` Gun can only be fired if player has two free hands.

--- a/doc/src/content/docs/en/mod/json/reference/json_flags.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_flags.md
@@ -778,8 +778,10 @@ List of known flags, used in both `terrain.json` and `furniture.json`.
 - `CROSSBOW` Counts as a crossbow for the purpose of gunmod compatibility. Default behavior is to
   match the skill used by that weapon.
 - `DISABLE_SIGHTS` Prevents use of the base weapon sights
-- `FIRE_100` Uses 100 shots per firing.
+- `FIRE_20` Uses 20 shots per firing.
 - `FIRE_50` Uses 50 shots per firing.
+- `FIRE_100` Uses 100 shots per firing. See also the `ammo_to_fire` property to specify any amount of ammo
+   usage per shot desired. These flags will override `ammo_to_fire` if present.
 - `HEAVY_WEAPON_SUPPORT` Wearing this will let you hip-fire heavy weapons without needing terrain
   support, like Large or Huge mutants can.
 - `FIRE_TWOHAND` Gun can only be fired if player has two free hands.

--- a/doc/src/content/docs/en/mod/json/reference/json_info.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_info.md
@@ -1992,6 +1992,8 @@ Gun mods can be defined like this:
 "recoil_modifier": -100,       // Optional field increasing or decreasing base gun recoil
 "ups_charges_modifier": 200,   // Optional field increasing or decreasing base gun UPS consumption (per shot) by adding given value
 "ups_charges_multiplier": 2.5, // Optional field increasing or decreasing base gun UPS consumption (per shot) by multiplying by given value
+"ammo_to_fire_modifier": 200,   // Optional field increasing or decreasing amount of main ammo consumed per shot by adding given value
+"ammo_to_fire_multiplier": 2.5, // Optional field increasing or decreasing main ammo consumed per shot by multiplying by given value
 "reload_modifier": -10,        // Optional field increasing or decreasing base gun reload time in percent
 "min_str_required_mod": 14,    // Optional field increasing or decreasing minimum strength required to use gun
 ```

--- a/doc/src/content/docs/en/mod/json/reference/json_info.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_info.md
@@ -1911,6 +1911,8 @@ Guns can be defined like this:
 "burst": 5,                // Number of shots fired in burst mode
 "clip_size": 100,          // Maximum amount of ammo that can be loaded
 "ups_charges": 0,          // Additionally to the normal ammo (if any), a gun can require some charges from an UPS. This also works on mods. Attaching a mod with ups_charges will add/increase ups drain on the weapon.
+"ammo_to_fire" 1,          // Amount of ammo used per shot, separate from any UPS cost that may be given to the weapon.
+// The legacy item flags `FIRE_20`, `FIRE_50`, and `FIRE_100` are still permitted and will override `ammo_to_fire` if present.
 "reload": 450,             // Amount of time to reload, 100 = 1 second = 1 "turn". Default 100.
 "built_in_mods": ["m203"], // An array of mods that will be integrated in the weapon using the IRREMOVABLE tag.
 "default_mods": ["m203"]   // An array of mods that will be added to a weapon on spawn.

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7906,7 +7906,13 @@ int item::ammo_required() const
         } else if( has_flag( flag_FIRE_20 ) ) {
             return 20;
         } else {
-            return type->gun->ammo_to_fire;
+            int modifier = 0;
+            float multiplier = 1.0f;
+            for( const item *mod : gunmods() ) {
+                modifier += mod->type->gunmod->ammo_to_fire_modifier;
+                multiplier *= mod->type->gunmod->ammo_to_fire_multiplier;
+            }
+            return ( type->gun->ammo_to_fire * multiplier ) + modifier;
         }
     }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7906,7 +7906,7 @@ int item::ammo_required() const
         } else if( has_flag( flag_FIRE_20 ) ) {
             return 20;
         } else {
-            return 1;
+            return type->gun->ammo_to_fire;
         }
     }
 

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2392,6 +2392,8 @@ void Item_factory::load( islot_gunmod &slot, const JsonObject &jo, const std::st
     assign( jo, "ammo_effects", slot.ammo_effects, strict );
     assign( jo, "ups_charges_multiplier", slot.ups_charges_multiplier );
     assign( jo, "ups_charges_modifier", slot.ups_charges_modifier );
+    assign( jo, "ammo_to_fire_multiplier", slot.ammo_to_fire_multiplier );
+    assign( jo, "ammo_to_fire_modifier", slot.ammo_to_fire_modifier );
     assign( jo, "weight_multiplier", slot.weight_multiplier );
     if( jo.has_int( "install_time" ) ) {
         slot.install_time = jo.get_int( "install_time" );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1885,6 +1885,7 @@ void Item_factory::load( islot_gun &slot, const JsonObject &jo, const std::strin
     assign( jo, "blackpowder_tolerance", slot.blackpowder_tolerance, strict, 0 );
     assign( jo, "min_cycle_recoil", slot.min_cycle_recoil, strict, 0 );
     assign( jo, "ammo_effects", slot.ammo_effects, strict );
+    assign( jo, "ammo_to_fire", slot.ammo_to_fire, strict, 1 );
 
     if( jo.has_array( "valid_mod_locations" ) ) {
         slot.valid_mod_locations.clear();

--- a/src/itype.h
+++ b/src/itype.h
@@ -562,6 +562,9 @@ struct islot_gun : common_ranged_data {
      *  @note useful for adding recoil effect to guns which otherwise consume no ammo
      */
     int recoil = 0;
+
+    /** How much ammo is consumed per shot. */
+    int ammo_to_fire = 1;
 };
 
 struct islot_gunmod : common_ranged_data {

--- a/src/itype.h
+++ b/src/itype.h
@@ -599,6 +599,12 @@ struct islot_gunmod : common_ranged_data {
     /** Increases base gun UPS consumption by this value per shot */
     int ups_charges_modifier = 0;
 
+    /** Increases base gun ammo to fire by this many times per shot */
+    float ammo_to_fire_multiplier = 1.0f;
+
+    /** Increases base gun ammo to fire by this value per shot */
+    int ammo_to_fire_modifier = 0;
+
     /** Increases gun weight by this many times */
     float weight_multiplier = 1.0f;
 


### PR DESCRIPTION
## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

Finally got reminded to look into porting the ability to set exactly how much ammo one wants to use on firing a weapon instead of the old legacy flags, which will make things easier and more flexible for mods.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

C++ changes:
1. In item.cpp, ported over the change to `item::ammo_required` to make guns cite `ammo_to_fire` instead of a fixed 1 ammo per shot. Unlike the DDA PR, I opted to keep the legacy flags for now because it's literally just changing a number in the `else` at the end, we don't have to break mods immediately. Also includes the support for modifiers and multipliers from gunmods.
2. In item_factory.cpp and itype.h, ported definition of `ammo_to_fire` in `Item_factory::load` (gun version) and `islot_gun : common_ranged_data` with default of one.
3. Also in item_factory.cpp and itype.h, ported definitions for `ammo_to_fire_multiplier` and `ammo_to_fire_modifier` to `Item_factory::load` (gunmod version) and `islot_gunmod : common_ranged_data`.

JSON changes:
1. Converted flamethrowers and chemical sprayers to use the new property instead of the old `FIRE_X` flags.
2. Added a gunmod to showcase `ammo_to_fire_multiplier`, the high-pressure combustion nozzle. Increased ammo used by shot by 25%, but adds +5 damage and range.
3. Added associated recipe for above item.
4. Added muzzle slot to standard flamethrower and RM451 to allow the new gunmod to be installable on it.

Documentation changes:
1. Ported documentation of `ammo_to_fire` along with mentioning that the `FIRE_X` flags are still present for now.
2. Wrote my own documentation of the gunmod properties since no documentation was included in Candlebury's PR.

## Describe alternatives you've considered

1. Removing the flags now instead of saving them for legacy compatibility, like DDA did.
2. Could test giving ammo to fire multipliers to the laser gunmods just in case a mod uses them on battery-fed guns, but currently no guns in Aftershock do this in the BN version so I'd have to glom onto Cata++ most likely and see if it works well for the battery pistol/rifle, Omnitech guns, or the UPS crank rifle.
3. Adding in support for range multipliers and making the flamethrower gunmod use that.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected JSON for syntax and lint errors.
2. Compiled and load-tested.
3. Spawned a normal gun, confirmed it still only uses 1 bullet per shot.
4. Spawned a flamethrower, it uses 100 ammo per shot as before.
5. Spawned an RM451, confirmed it only eats up 20 ammo per shot as before.
6. Installed nozzle mods on both, confirmed ammo consumption went up to 125 and 25 per shot.
7. Checked affected C++ files for astyle.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Source PRs:
1. Support for `ammo_to_fire`: `[AFTERSHOCK] Re-working some old items, and adding new toys.` by @Mom-Bun: https://github.com/CleverRaven/Cataclysm-DDA/pull/46200
2. Gunmod modifer/multiplier support: `Gunmods can modify a gun's "ammo to fire"` by @John-Candlebury: https://github.com/CleverRaven/Cataclysm-DDA/pull/47196

Aftershock stuff was not ported over since we're planning to mainline and/or obsolete more of it in the future at some point.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
