### PR TITLE
refactor: fix compiler warnings

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8764,7 +8764,6 @@ void Character::on_hit( Creature *source, bodypart_id bp_hit,
     bool in_skater_vehicle = in_vehicle && veh_part.part_with_feature( "SEAT_REQUIRES_BALANCE", false );
 
     if( ( worn_with_flag( flag_REQUIRES_BALANCE ) || in_skater_vehicle ) && !is_on_ground() ) {
-        int rolls = 4;
         if( worn_with_flag( flag_ROLLER_ONE ) && !in_skater_vehicle ) {
             if( worn_with_flag( flag_REQUIRES_BALANCE ) && !has_effect( effect_downed ) ) {
                 int rolls = 4;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8534,7 +8534,7 @@ void game::butcher()
                 disassembly_stacks_res.emplace_back( stack.first->typeId(), stack.second );
             }
 
-            for( int i = 0; i < disassembly_stacks_res.size(); i++ ) {
+            for( int i = 0; i < static_cast<int>( disassembly_stacks_res.size() ); i++ ) {
                 const auto dis = recipe_dictionary::get_uncraft( disassembly_stacks_res[i].first );
                 time_to_disassemble_rec += dis.time * disassembly_stacks_res[i].second;
                 //uses default craft materials to estimate recursive disassembly time

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -602,7 +602,7 @@ std::function<bool( const item & )> recipe::get_component_filter(
     };
 }
 
-static std::string dump_requirements(
+[[maybe_unused]] static std::string dump_requirements(
     const requirement_data &reqs,
     int move_cost,
     const std::map<skill_id, int> &skills )

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -656,13 +656,6 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
     // 0.001 -> 1 meter. Left modifiable so that armor or other parts can affect it.
     float deformation_distance = density_factor / 100;
 
-    //Calculates mass factor. Depreciated, maintained for stats.
-    // factor = -25 if mass is much greater than mass2
-    // factor = +25 if mass2 is much greater than mass
-    const float weight_factor = mass >= mass2 ?
-                                -25 * ( std::log( mass ) - std::log( mass2 ) ) / std::log( mass ) :
-                                25 * ( std::log( mass2 ) - std::log( mass ) ) / std::log( mass2 );
-
     bool smashed = true;
     const std::string snd = _( "smash!" );
     float part_dmg = 0;


### PR DESCRIPTION
## Purpose of change (The Why)

those compiler warnings were annoying and kept hiding other important errors

## Describe the solution (The How)

do as the compiler says.

## Describe alternatives you've considered

## Testing

it builds without errors.

## Additional context

```
[121/495] Building CXX object src/CMakeFiles/cataclysm-bn-tiles-common.dir/character.cpp.o
/var/home/scarf/repo/cata/Cataclysm/src/character.cpp:8767:13: warning: unused variable 'rolls' [-Wunused-variable]
 8767 |         int rolls = 4;
      |             ^~~~~
1 warning generated.
[178/495] Building CXX object src/CMakeFiles/cataclysm-bn-tiles-common.dir/game.cpp.o
/var/home/scarf/repo/cata/Cataclysm/src/game.cpp:8537:31: warning: comparison of integers of different signs: 'int' and 'size_type' (aka 'unsigned long') [-Wsign-compare]
 8537 |             for( int i = 0; i < disassembly_stacks_res.size(); i++ ) {
      |                             ~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
[311/495] Building CXX object src/CMakeFiles/cataclysm-bn-tiles-common.dir/recipe.cpp.o
/var/home/scarf/repo/cata/Cataclysm/src/recipe.cpp:605:20: warning: unused function 'dump_requirements' [-Wunused-function]
  605 | static std::string dump_requirements(
      |                    ^~~~~~~~~~~~~~~~~
1 warning generated.
[346/495] Building CXX object src/CMakeFiles/cataclysm-bn-tiles-common.dir/vehicle_move.cpp.o
/var/home/scarf/repo/cata/Cataclysm/src/vehicle_move.cpp:662:17: warning: unused variable 'weight_factor' [-Wunused-variable]
  662 |     const float weight_factor = mass >= mass2 ?
      |                 ^~~~~~~~~~~~~
1 warning generated.
```

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
