### PR TITLE
build: fix clang-tidy plugin build failure

### DIFF
--- a/tools/clang-tidy-plugin/TextStyleCheck.cpp
+++ b/tools/clang-tidy-plugin/TextStyleCheck.cpp
@@ -89,8 +89,8 @@ void TextStyleCheck::check( const MatchFinder::MatchResult &Result )
         const SourceLocation &loc = text.getStrTokenLoc( i );
         if( loc.isInvalid() ) {
             return;
-        } else if( StringRef( SrcMgr.getPresumedLoc( SrcMgr.getSpellingLoc(
-                                  loc ) ).getFilename() ).equals( "<scratch space>" ) ) {
+        } else if( StringRef( SrcMgr.getPresumedLoc( SrcMgr.getSpellingLoc( loc ) ).getFilename() )
+                   .equals_insensitive( "<scratch space>" ) ) {
             return;
         }
     }


### PR DESCRIPTION
## Purpose of change (The Why)

```
/var/home/scarf/repo/cata/Cataclysm/tools/clang-tidy-plugin/TextStyleCheck.cpp:93:59: error: no member named 'equals' in 'llvm::StringRef'
   92 |         } else if( StringRef( SrcMgr.getPresumedLoc( SrcMgr.getSpellingLoc(
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   93 |                                   loc ) ).getFilename() ).equals( "<scratch space>" ) ) {
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~ ^
1 error generated.
ninja: build stopped: cannot make progress due to previous errors.
```

```sh
$ llvm-config --version
19.1.5
```

equals seems to be removed in recent LLVM (at least since 19) and thus it's not possible to build clang-tidy plugin.

## Describe the solution (The How)

use `equals_insensitive`. see https://llvm.org/doxygen/classllvm_1_1StringRef.html#ae46058c90a3c703357331a6501b32f1c for details.

## Testing

builds on local machine.

## Additional context

for some reason LLVM doxygen isn't versioned so i can't find out which exact version removed `equals`.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
