### PR TITLE
fix: convert strict JSON errors to warning

### DIFF
--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -8,7 +8,7 @@ void report_strict_violation( const JsonObject &jo, const std::string &message,
         jo.throw_error( message, name );
     } catch( const JsonError &err ) {
         // And catch the exception so the loading continues like normal.
-        debugmsg( "(json-error)\n%s", err.what() );
+        debugmsg_of( DL::Warn, "(json-error)\n%s", err.what() );
     }
 }
 

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -455,7 +455,7 @@ static repetition_folder rep_folder;
 static void output_repetitions( std::ostream &out );
 
 void realDebugmsg( const char *filename, const char *line, const char *funcname,
-                   const std::string &text )
+                   const DL debug_level, const std::string &text )
 {
     assert( filename != nullptr );
     assert( line != nullptr );
@@ -465,7 +465,7 @@ void realDebugmsg( const char *filename, const char *line, const char *funcname,
         captured += text;
     } else {
         if( !rep_folder.test( filename, line, funcname, text ) ) {
-            *detail::realDebugLog( DL::Error, DC::DebugMsg, filename, line, funcname ) << text;
+            *detail::realDebugLog( debug_level, DC::DebugMsg, filename, line, funcname ) << text;
             rep_folder.set( filename, line, funcname, text );
         } else {
             rep_folder.increment_count();

--- a/src/debug.h
+++ b/src/debug.h
@@ -67,69 +67,6 @@ template<typename E> class enum_bitset;
 #define __FUNCTION_NAME__ __func__
 #endif
 
-/**
- * Debug message of level DL::Error and class DC::DebugMsg, also includes the source
- * file name and line, uses varg style arguments, the first argument must be
- * a printf style format string.
- */
-#define debugmsg(...) realDebugmsg(__FILE__, STRING(__LINE__), __FUNCTION_NAME__, __VA_ARGS__)
-
-// Don't use this, use debugmsg instead.
-void realDebugmsg( const char *filename, const char *line, const char *funcname,
-                   const std::string &text );
-template<typename ...Args>
-inline void realDebugmsg( const char *const filename, const char *const line,
-                          const char *const funcname, const char *const mes, Args &&... args )
-{
-    return realDebugmsg( filename, line, funcname, string_format( mes,
-                         std::forward<Args>( args )... ) );
-}
-
-// A fatal error for use in constexpr functions
-// This exists for compatibility reasons.  On gcc 5.3 we need a
-// different implementation that is messier.
-// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67371
-// Pass a placeholder return value to be used on gcc 5.3 (it won't
-// actually be returned, it's just needed for the type), and then
-// args as if to debugmsg for the remaining args.
-#if defined(__GNUC__) && __GNUC__ < 6
-#define constexpr_fatal(ret, ...) \
-    do { return false ? ( ret ) : ( abort(), ( ret ) ); } while(false)
-#else
-#define constexpr_fatal(ret, ...) \
-    do { debugmsg(__VA_ARGS__); abort(); } while(false)
-#endif
-
-/**
- * Used to generate game report information.
- */
-namespace game_info
-{
-/** Return the name of the current operating system.
- */
-std::string operating_system();
-/** Return a detailed version of the operating system; e.g. "Ubuntu 18.04" or "(Windows) 10 1809".
- */
-std::string operating_system_version();
-/** Return the "bitness" of the game (not necessarily of the operating system); either: 64, 32 or nullopt.
- */
-std::optional<int> bitness();
-/** Return the "bitness" string of the game (not necessarily of the operating system); either: 64-bit, 32-bit or Unknown.
- */
-std::string bitness_string();
-/** Return the game version, as in the entry screen.
- */
-std::string game_version();
-/** Return the underlying graphics version used by the game; either Tiles or Curses.
-*/
-std::string graphics_version();
-/** Return a list of the loaded mods, including the mod full name and its id name in brackets, e.g. "Dark Days Ahead [dda]".
-*/
-std::string mods_loaded();
-/** Generate a game report, including the information returned by all of the other functions.
- */
-std::string game_report();
-} // namespace game_info
 
 // Enumerations                                                     {{{1
 // ---------------------------------------------------------------------
@@ -203,6 +140,70 @@ enum class DebugOutput {
     std_err,
     file,
 };
+
+/**
+ * Debug message of level DL::Error and class DC::DebugMsg, also includes the source
+ * file name and line, uses varg style arguments, the first argument must be
+ * a printf style format string.
+ */
+#define debugmsg(...) realDebugmsg(__FILE__, STRING(__LINE__), __FUNCTION_NAME__, __VA_ARGS__)
+
+// Don't use this, use debugmsg instead.
+void realDebugmsg( const char *filename, const char *line, const char *funcname,
+                   const std::string &text );
+template<typename ...Args>
+inline void realDebugmsg( const char *const filename, const char *const line,
+                          const char *const funcname, const char *const mes, Args &&... args )
+{
+    return realDebugmsg( filename, line, funcname, string_format( mes,
+                         std::forward<Args>( args )... ) );
+}
+
+// A fatal error for use in constexpr functions
+// This exists for compatibility reasons.  On gcc 5.3 we need a
+// different implementation that is messier.
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67371
+// Pass a placeholder return value to be used on gcc 5.3 (it won't
+// actually be returned, it's just needed for the type), and then
+// args as if to debugmsg for the remaining args.
+#if defined(__GNUC__) && __GNUC__ < 6
+#define constexpr_fatal(ret, ...) \
+    do { return false ? ( ret ) : ( abort(), ( ret ) ); } while(false)
+#else
+#define constexpr_fatal(ret, ...) \
+    do { debugmsg(__VA_ARGS__); abort(); } while(false)
+#endif
+
+/**
+ * Used to generate game report information.
+ */
+namespace game_info
+{
+/** Return the name of the current operating system.
+ */
+std::string operating_system();
+/** Return a detailed version of the operating system; e.g. "Ubuntu 18.04" or "(Windows) 10 1809".
+ */
+std::string operating_system_version();
+/** Return the "bitness" of the game (not necessarily of the operating system); either: 64, 32 or nullopt.
+ */
+std::optional<int> bitness();
+/** Return the "bitness" string of the game (not necessarily of the operating system); either: 64-bit, 32-bit or Unknown.
+ */
+std::string bitness_string();
+/** Return the game version, as in the entry screen.
+ */
+std::string game_version();
+/** Return the underlying graphics version used by the game; either Tiles or Curses.
+*/
+std::string graphics_version();
+/** Return a list of the loaded mods, including the mod full name and its id name in brackets, e.g. "Dark Days Ahead [dda]".
+*/
+std::string mods_loaded();
+/** Generate a game report, including the information returned by all of the other functions.
+ */
+std::string game_report();
+} // namespace game_info
 
 /** Initializes the debugging system, called exactly once from main() */
 void setupDebug( DebugOutput );

--- a/src/debug.h
+++ b/src/debug.h
@@ -141,21 +141,22 @@ enum class DebugOutput {
     file,
 };
 
+#define debugmsg_of(debug_level, ...) realDebugmsg(__FILE__, STRING(__LINE__), __FUNCTION_NAME__, debug_level, __VA_ARGS__)
+
 /**
  * Debug message of level DL::Error and class DC::DebugMsg, also includes the source
  * file name and line, uses varg style arguments, the first argument must be
  * a printf style format string.
  */
-#define debugmsg(...) realDebugmsg(__FILE__, STRING(__LINE__), __FUNCTION_NAME__, __VA_ARGS__)
-
+#define debugmsg(...) debugmsg_of(DL::Error, __VA_ARGS__)
 // Don't use this, use debugmsg instead.
 void realDebugmsg( const char *filename, const char *line, const char *funcname,
-                   const std::string &text );
+                   const DL debug_level, const std::string &text );
 template<typename ...Args>
 inline void realDebugmsg( const char *const filename, const char *const line,
-                          const char *const funcname, const char *const mes, Args &&... args )
+                          const char *const funcname, const DL debug_level, const char *const mes, Args &&... args )
 {
-    return realDebugmsg( filename, line, funcname, string_format( mes,
+    return realDebugmsg( filename, line, funcname, debug_level, string_format( mes,
                          std::forward<Args>( args )... ) );
 }
 


### PR DESCRIPTION
## Purpose of change (The Why)

```
Json error: data/json/items/generic/bathroom_house.json:27:14: cannot assign explicit value the same as default or inherited value

    "price_postapoc": "150 cent",
    "//": "the end of the world doesn't mean everyone is okay with having ZZ Top beards.  disposable razors are a hot commodity.",
    "weight":
             ^
              "100 g",
    "material": [ "plastic", "steel" ],
    "cutting": 2,
```

Hints like this should be an warning, not errors that break builds that has been running for 20 minutes, which is highly annoying.

## Describe the solution (The How)

adds new macro, `debugmsg_of` which accepts debug level as first parameter.

## Describe alternatives you've considered

<img src="https://github.com/user-attachments/assets/eb7d1fc9-35bb-4214-8c69-f4f3312677b6" width="50%">

## Testing

```
21:18:32.078 WARNING DEBUGMSG : /var/home/scarf/repo/cata/Cataclysm/src/assign.cpp:11 [void report_strict_violation(const JsonObject &, const std::string &, const std::string &)] (json-error)
Json error: data/json/items/generic/bathroom_house.json:27:14: cannot assign explicit value the same as default or inherited value

    "price_postapoc": "150 cent",
    "//": "the end of the world doesn't mean everyone is okay with having ZZ Top beards.  disposable razors are a hot commodity.",
    "weight":
             ^
              "100 g",
    "material": [ "plastic", "steel" ],
    "cutting": 2,


Starting the actual test at Thu Jan 30 21:18:40 2025
[sol2] An exception occurred: Exception thrown on Cpp side!
21:19:56.941 INFO : Language set to 'en_US'
21:19:56.941 INFO : C locale set to 'en_US.UTF-8'
21:19:56.941 INFO : C++ locale set to 'en_US.UTF-8'
21:19:57.148 INFO : Language set to 'fr_FR'
21:19:57.151 INFO : C locale set to 'fr_FR.UTF-8'
21:19:57.151 INFO : C++ locale set to 'fr_FR.UTF-8'
21:19:57.389 INFO : Language set to 'ru_RU'
21:19:57.392 INFO : C locale set to 'ru_RU.UTF-8'
21:19:57.393 INFO : C++ locale set to 'ru_RU.UTF-8'
21:19:57.554 INFO : Language set to 'en_US'
21:19:57.554 INFO : C locale set to 'en_US.UTF-8'
21:19:57.554 INFO : C++ locale set to 'en_US.UTF-8'
===============================================================================
All tests passed (7243965 assertions in 545 test cases)

21:21:14.289 INFO : Setting active world to NULL
Ended test at Thu Jan 30 21:21:14 2025
The test took 153.842 seconds
```
- caused duplicate value on purpose
- tests passes

## Additional context

#6014 bring me here

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
