### PR TITLE
ci: bump artifact actions to v4.6.0

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -252,13 +252,13 @@ jobs:
 
       - name: emit success artifact
         if: ${{ success() && matrix.upload-artifact == 'true' }}
-        uses:  actions/upload-artifact@v3.1.3
+        uses:  actions/upload-artifact@v4.6.0
         with:
           name: ${{ github.event.number }}
           path: ${{ github.event.number }}
 
       - name: upload artifacts if failed
-        uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v4.6.0
         if: failure()
         with:
           name: cata_test


### PR DESCRIPTION
## Purpose of change (The Why)

Artifact actions v3 are retired now and make builds auto-fail

## Describe the solution (The How)

Bumps the versions used to 4.6.0 (the latest)

## Describe alternatives you've considered

- Bump to an older version for potential stability purposes

## Testing

Built on my fork

## Additional context

Bomp

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.


