### PR TITLE
feat: Rifle and pistol uncrafts

### DIFF
--- a/data/json/uncraft/ammo/pistol ammo.json
+++ b/data/json/uncraft/ammo/pistol ammo.json
@@ -1,0 +1,788 @@
+[
+  {
+    "result": "bp_9mm",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "9mm_casing", 1 ] ], [ [ "chem_black_powder", 4 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "bp_9mmfmj",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 2 ] ],
+      [ [ "smpistol_primer", 1 ] ],
+      [ [ "9mm_casing", 1 ] ],
+      [ [ "chem_black_powder", 4 ] ],
+      [ [ "copper", 1 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "bp_40fmj",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 2 ] ],
+      [ [ "40_casing", 1 ] ],
+      [ [ "smpistol_primer", 1 ] ],
+      [ [ "chem_black_powder", 6 ] ],
+      [ [ "copper", 1 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "bp_40sw",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "40_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "chem_black_powder", 6 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "bp_32_acp",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "32_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "chem_black_powder", 3 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "bp_38_fmj",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 2 ] ],
+      [ [ "38_casing", 1 ] ],
+      [ [ "smpistol_primer", 1 ] ],
+      [ [ "chem_black_powder", 3 ] ],
+      [ [ "copper", 1 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "bp_44fmj",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 4 ] ],
+      [ [ "44_casing", 1 ] ],
+      [ [ "lgpistol_primer", 1 ] ],
+      [ [ "chem_black_powder", 9 ] ],
+      [ [ "copper", 2 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "bp_45_acp",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 3 ] ],
+      [ [ "45_casing", 1 ] ],
+      [ [ "lgpistol_primer", 1 ] ],
+      [ [ "chem_black_powder", 6 ] ],
+      [ [ "copper", 2 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "bp_45_jhp",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 3 ] ], [ [ "45_casing", 1 ] ], [ [ "lgpistol_primer", 1 ] ], [ [ "chem_black_powder", 6 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "bp_46mm",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 2 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "46mm_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "chem_black_powder", 6 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "bp_460_fmj",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 3 ] ],
+      [ [ "460_casing", 1 ] ],
+      [ [ "lgpistol_primer", 1 ] ],
+      [ [ "chem_black_powder", 9 ] ],
+      [ [ "copper", 2 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "bp_460_rowland",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 3 ] ], [ [ "460_casing", 1 ] ], [ [ "lgpistol_primer", 1 ] ], [ [ "chem_black_powder", 9 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "bp_500_Magnum",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 5 ] ],
+      [ [ "500_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "chem_black_powder", 12 ] ],
+      [ [ "copper", 2 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "bp_762_25",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 2 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "762_25_casing", 1 ] ], [ [ "chem_black_powder", 6 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "bp_9x18mm",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "9x18mm_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "chem_black_powder", 4 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "bp_9x18mmfmj",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 2 ] ],
+      [ [ "9x18mm_casing", 1 ] ],
+      [ [ "smpistol_primer", 1 ] ],
+      [ [ "chem_black_powder", 4 ] ],
+      [ [ "copper", 1 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "bp_380_JHP",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "380_casing", 1 ] ], [ [ "chem_black_powder", 3 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "bp_380_FMJ",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 2 ] ],
+      [ [ "smpistol_primer", 1 ] ],
+      [ [ "380_casing", 1 ] ],
+      [ [ "chem_black_powder", 3 ] ],
+      [ [ "copper", 1 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "bp_57mm",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 2 } ],
+    "components": [
+      [ [ "lead", 2 ] ],
+      [ [ "smpistol_primer", 1 ] ],
+      [ [ "57mm_casing", 1 ] ],
+      [ [ "chem_black_powder", 3 ] ],
+      [ [ "copper", 1 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "32_acp",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "32_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 2 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "38_fmj",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "38_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 2 ] ], [ [ "copper", 1 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "38_special",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "38_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 2 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "38_super",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "38super_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 3 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "38super_fmj",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 2 ] ],
+      [ [ "38super_casing", 1 ] ],
+      [ [ "smpistol_primer", 1 ] ],
+      [ [ "gunpowder", 3 ] ],
+      [ [ "copper", 1 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "357sig_fmj",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 2 } ],
+    "components": [
+      [ [ "lead", 2 ] ],
+      [ [ "357sig_casing", 1 ] ],
+      [ [ "smpistol_primer", 1 ] ],
+      [ [ "gunpowder", 5 ] ],
+      [ [ "copper", 1 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "357sig_jhp",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 2 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "357sig_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 5 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "357mag_fmj",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 2 ] ],
+      [ [ "357mag_casing", 1 ] ],
+      [ [ "lgpistol_primer", 1 ] ],
+      [ [ "gunpowder", 5 ] ],
+      [ [ "copper", 1 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "357mag_jhp",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "357mag_casing", 1 ] ], [ [ "lgpistol_primer", 1 ] ], [ [ "gunpowder", 5 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "bp_357mag_fmj",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 2 ] ],
+      [ [ "357mag_casing", 1 ] ],
+      [ [ "lgpistol_primer", 1 ] ],
+      [ [ "chem_black_powder", 8 ] ],
+      [ [ "copper", 1 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "bp_357mag_jhp",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "357mag_casing", 1 ] ], [ [ "lgpistol_primer", 1 ] ], [ [ "chem_black_powder", 8 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "bp_357sig_fmj",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 2 } ],
+    "components": [
+      [ [ "lead", 2 ] ],
+      [ [ "357sig_casing", 1 ] ],
+      [ [ "smpistol_primer", 1 ] ],
+      [ [ "chem_black_powder", 7 ] ],
+      [ [ "copper", 1 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "bp_357sig_jhp",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 2 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "357sig_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "chem_black_powder", 8 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "bp_38_special",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "38_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "chem_black_powder", 3 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "bp_38_super",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "38super_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "chem_black_powder", 5 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "bp_38super_fmj",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 2 ] ],
+      [ [ "38super_casing", 1 ] ],
+      [ [ "smpistol_primer", 1 ] ],
+      [ [ "chem_black_powder", 5 ] ],
+      [ [ "copper", 1 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "40fmj",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "40_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 4 ] ], [ [ "copper", 1 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "40sw",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "40_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 4 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "10mm_fmj",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "10mm_casing", 1 ] ], [ [ "lgpistol_primer", 1 ] ], [ [ "gunpowder", 5 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "bp_10mm_fmj",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "10mm_casing", 1 ] ], [ [ "lgpistol_primer", 1 ] ], [ [ "chem_black_powder", 8 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "44fmj",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 4 ] ], [ [ "44_casing", 1 ] ], [ [ "lgpistol_primer", 1 ] ], [ [ "gunpowder", 6 ] ], [ [ "copper", 2 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "44magnum",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 5 ] ], [ [ "44_casing", 1 ] ], [ [ "lgpistol_primer", 1 ] ], [ [ "gunpowder", 6 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "bp_44magnum",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 5 ] ], [ [ "44_casing", 1 ] ], [ [ "lgpistol_primer", 1 ] ], [ [ "chem_black_powder", 9 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "45_acp",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 3 ] ], [ [ "45_casing", 1 ] ], [ [ "lgpistol_primer", 1 ] ], [ [ "gunpowder", 4 ] ], [ [ "copper", 2 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "45_jhp",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 3 ] ], [ [ "45_casing", 1 ] ], [ [ "lgpistol_primer", 1 ] ], [ [ "gunpowder", 4 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "45_super",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 3 ] ], [ [ "45_casing", 1 ] ], [ [ "lgpistol_primer", 1 ] ], [ [ "gunpowder", 5 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "454_Casull",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 4 ] ], [ [ "454_casing", 1 ] ], [ [ "smrifle_primer", 1 ] ], [ [ "gunpowder", 6 ] ], [ [ "copper", 2 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "bp_454_Casull",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 4 ] ],
+      [ [ "454_casing", 1 ] ],
+      [ [ "smrifle_primer", 1 ] ],
+      [ [ "chem_black_powder", 9 ] ],
+      [ [ "copper", 2 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "45colt_jhp",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 4 ] ], [ [ "45colt_casing", 1 ] ], [ [ "lgpistol_primer", 1 ] ], [ [ "gunpowder", 4 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "bp_45colt_jhp",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 5 ] ], [ [ "45colt_casing", 1 ] ], [ [ "lgpistol_primer", 1 ] ], [ [ "chem_black_powder", 5 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "46mm",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 2 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "46mm_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 4 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "460_fmj",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 3 ] ],
+      [ [ "460_casing", 1 ] ],
+      [ [ "lgpistol_primer", 1 ] ],
+      [ [ "gunpowder", 6 ] ],
+      [ [ "copper", 2 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "460_rowland",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 3 ] ], [ [ "460_casing", 1 ] ], [ [ "lgpistol_primer", 1 ] ], [ [ "gunpowder", 6 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "500_Magnum",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 5 ] ], [ [ "500_casing", 1 ] ], [ [ "lgrifle_primer", 1 ] ], [ [ "gunpowder", 8 ] ], [ [ "copper", 2 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "762_25",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 2 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "762_25_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 4 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "762_25hot",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 2 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "762_25_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 5 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "762_25typeP",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 2 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "762_25_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 5 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "9mm",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "9mm_casing", 1 ] ], [ [ "gunpowder", 3 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "9mmP",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "9mm_casing", 1 ] ], [ [ "gunpowder", 4 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "9mmP2",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "9mm_casing", 1 ] ], [ [ "gunpowder", 5 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "9mmfmj",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 2 ] ],
+      [ [ "smpistol_primer", 1 ] ],
+      [ [ "9mm_casing", 1 ] ],
+      [ [ "gunpowder", 3 ] ],
+      [ [ "copper", 1 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "9x18mm",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "9x18mm_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 3 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "9x18mmfmj",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 2 ] ],
+      [ [ "9x18mm_casing", 1 ] ],
+      [ [ "smpistol_primer", 1 ] ],
+      [ [ "gunpowder", 3 ] ],
+      [ [ "copper", 1 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "9x18mmP2",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "9x18mm_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 5 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "380_JHP",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "380_casing", 1 ] ], [ [ "gunpowder", 2 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "380_p",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "380_casing", 1 ] ], [ [ "gunpowder", 3 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "380_FMJ",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 2 ] ],
+      [ [ "smpistol_primer", 1 ] ],
+      [ [ "380_casing", 1 ] ],
+      [ [ "gunpowder", 2 ] ],
+      [ [ "copper", 1 ] ]
+    ],
+    "charges": 1
+  }
+]

--- a/data/json/uncraft/ammo/rifle ammo.json
+++ b/data/json/uncraft/ammo/rifle ammo.json
@@ -35,7 +35,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [ [ [ "lead", 3 ] ], [ [ "copper", 1 ] ], [ [ "223_casing", 1 ] ], [ [ "smrifle_primer", 1 ] ], [ [ "gunpowder", 4 ] ] ],
     "charges": 1
   },
@@ -45,7 +45,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 3 ] ],
       [ [ "copper", 1 ] ],
@@ -61,7 +61,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 5 ] ],
       [ [ "270win_casing", 1 ] ],
@@ -77,7 +77,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 5 ] ],
       [ [ "copper", 3 ] ],
@@ -93,7 +93,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 8 ] ],
       [ [ "copper", 4 ] ],
@@ -109,7 +109,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 8 ] ],
       [ [ "copper", 4 ] ],
@@ -125,7 +125,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 8 ] ],
       [ [ "copper", 4 ] ],
@@ -141,7 +141,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 8 ] ],
       [ [ "copper", 4 ] ],
@@ -157,7 +157,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "10 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 8 ] ],
       [ [ "copper", 4 ] ],
@@ -174,7 +174,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 8 ] ],
       [ [ "copper", 4 ] ],
@@ -190,7 +190,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 8 ] ],
       [ [ "copper", 4 ] ],
@@ -206,7 +206,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "10 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 8 ] ],
       [ [ "copper", 4 ] ],
@@ -223,7 +223,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [ [ [ "lead", 6 ] ], [ [ "copper", 3 ] ], [ [ "308_casing", 1 ] ], [ [ "lgrifle_primer", 1 ] ], [ [ "gunpowder", 8 ] ] ],
     "charges": 1
   },
@@ -233,7 +233,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 6 ] ],
       [ [ "copper", 3 ] ],
@@ -291,7 +291,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 3 ] ],
       [ [ "5x50_hull", 1 ] ],
@@ -307,7 +307,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [ [ [ "lead", 2 ] ], [ [ "5x50_hull", 1 ] ], [ [ "smrifle_primer", 1 ] ], [ [ "gunpowder", 4 ] ], [ [ "scrap", 1 ] ] ],
     "charges": 1
   },
@@ -317,7 +317,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "7 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 12 ] ],
       [ [ "copper", 6 ] ],
@@ -333,7 +333,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "15 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 15 ] ],
       [ [ "copper", 6 ] ],
@@ -350,7 +350,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "7 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 12 ] ],
       [ [ "copper", 6 ] ],
@@ -367,7 +367,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "7 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 12 ] ],
       [ [ "copper", 6 ] ],
@@ -383,7 +383,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "15 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 15 ] ],
       [ [ "copper", 6 ] ],
@@ -400,7 +400,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "7 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 12 ] ],
       [ [ "copper", 6 ] ],
@@ -417,7 +417,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [ [ [ "lead", 3 ] ], [ [ "copper", 1 ] ], [ [ "545_casing", 1 ] ], [ [ "smrifle_primer", 1 ] ], [ [ "gunpowder", 5 ] ] ],
     "charges": 1
   },
@@ -427,7 +427,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [ [ [ "lead", 3 ] ], [ [ "copper", 1 ] ], [ [ "545_casing", 1 ] ], [ [ "smrifle_primer", 1 ] ], [ [ "gunpowder", 6 ] ] ],
     "charges": 1
   },
@@ -437,7 +437,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 3 ] ],
       [ [ "copper", 1 ] ],
@@ -453,7 +453,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 3 ] ],
       [ [ "copper", 1 ] ],
@@ -469,7 +469,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 5 ] ],
       [ [ "copper", 2 ] ],
@@ -485,7 +485,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 5 ] ],
       [ [ "copper", 2 ] ],
@@ -501,7 +501,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [ [ [ "lead", 3 ] ], [ [ "copper", 1 ] ], [ [ "223_casing", 1 ] ], [ [ "smrifle_primer", 1 ] ], [ [ "gunpowder", 6 ] ] ],
     "charges": 1
   },
@@ -511,7 +511,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "12 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 3 ] ],
       [ [ "copper", 1 ] ],
@@ -528,7 +528,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 3 ] ],
       [ [ "copper", 1 ] ],
@@ -544,7 +544,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "12 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 3 ] ],
       [ [ "copper", 1 ] ],
@@ -593,7 +593,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 6 ] ],
       [ [ "copper", 3 ] ],
@@ -609,7 +609,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "10 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 6 ] ],
       [ [ "copper", 3 ] ],
@@ -626,7 +626,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 6 ] ],
       [ [ "copper", 3 ] ],
@@ -642,7 +642,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "10 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 6 ] ],
       [ [ "copper", 3 ] ],
@@ -659,7 +659,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 7 ] ],
       [ [ "copper", 3 ] ],
@@ -675,7 +675,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 7 ] ],
       [ [ "copper", 3 ] ],
@@ -691,7 +691,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [ [ [ "lead", 4 ] ], [ [ "copper", 1 ] ], [ [ "762_casing", 1 ] ], [ [ "lgrifle_primer", 1 ] ], [ [ "gunpowder", 8 ] ] ],
     "charges": 1
   },
@@ -701,7 +701,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [ [ [ "lead", 4 ] ], [ [ "copper", 1 ] ], [ [ "762_casing", 1 ] ], [ [ "lgrifle_primer", 1 ] ], [ [ "gunpowder", 8 ] ] ],
     "charges": 1
   },
@@ -711,7 +711,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 4 ] ],
       [ [ "copper", 1 ] ],
@@ -727,7 +727,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "gun", 1 ],
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [
       [ [ "lead", 4 ] ],
       [ [ "copper", 1 ] ],

--- a/data/json/uncraft/ammo/rifle ammo.json
+++ b/data/json/uncraft/ammo/rifle ammo.json
@@ -1,0 +1,740 @@
+[
+  {
+    "result": "22_cphp",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "4 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "copper", 1 ] ], [ [ "22_casing_new", 1 ] ], [ [ "gunpowder", 2 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "22_lr",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "4 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "22_casing_new", 1 ] ], [ [ "gunpowder", 2 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "bp_22_cphp",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "copper", 1 ] ], [ [ "22_casing_new", 1 ] ], [ [ "chem_black_powder", 3 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "223",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 3 ] ], [ [ "copper", 1 ] ], [ [ "223_casing", 1 ] ], [ [ "smrifle_primer", 1 ] ], [ [ "gunpowder", 4 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "bp_223",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 3 ] ],
+      [ [ "copper", 1 ] ],
+      [ [ "223_casing", 1 ] ],
+      [ [ "smrifle_primer", 1 ] ],
+      [ [ "chem_black_powder", 6 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "270win_jsp",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 5 ] ],
+      [ [ "270win_casing", 1 ] ],
+      [ [ "copper", 3 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "gunpowder", 10 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "bp_270win_jsp",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 5 ] ],
+      [ [ "copper", 3 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "270win_casing", 1 ] ],
+      [ [ "chem_black_powder", 15 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "300_winmag",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 8 ] ],
+      [ [ "copper", 4 ] ],
+      [ [ "300_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "gunpowder", 16 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "bp_300_winmag",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 8 ] ],
+      [ [ "copper", 4 ] ],
+      [ [ "300_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "chem_black_powder", 24 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "3006",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 8 ] ],
+      [ [ "copper", 4 ] ],
+      [ [ "3006_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "gunpowder", 12 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "3006fmj",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 8 ] ],
+      [ [ "copper", 4 ] ],
+      [ [ "3006_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "gunpowder", 12 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "3006_incendiary",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "10 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 8 ] ],
+      [ [ "copper", 4 ] ],
+      [ [ "3006_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "gunpowder", 12 ] ],
+      [ [ "incendiary", 8 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "bp_3006",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 8 ] ],
+      [ [ "copper", 4 ] ],
+      [ [ "3006_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "chem_black_powder", 18 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "bp_3006fmj",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 8 ] ],
+      [ [ "copper", 4 ] ],
+      [ [ "3006_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "chem_black_powder", 18 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "bp_3006_incendiary",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "10 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 8 ] ],
+      [ [ "copper", 4 ] ],
+      [ [ "3006_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "chem_black_powder", 18 ] ],
+      [ [ "incendiary", 8 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "308",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 6 ] ], [ [ "copper", 3 ] ], [ [ "308_casing", 1 ] ], [ [ "lgrifle_primer", 1 ] ], [ [ "gunpowder", 8 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "bp_308",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 6 ] ],
+      [ [ "copper", 3 ] ],
+      [ [ "308_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "chem_black_powder", 12 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "4570_sp",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 8 ] ],
+      [ [ "copper", 2 ] ],
+      [ [ "4570_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "gunpowder", 15 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "4570_pen",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 8 ] ],
+      [ [ "copper", 7 ] ],
+      [ [ "4570_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "gunpowder", 17 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "4570_low",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 8 ] ], [ [ "4570_casing", 1 ] ], [ [ "lgrifle_primer", 1 ] ], [ [ "gunpowder", 12 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "5x50dart",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 3 ] ],
+      [ [ "5x50_hull", 1 ] ],
+      [ [ "smrifle_primer", 1 ] ],
+      [ [ "gunpowder", 3 ] ],
+      [ [ "combatnail", 1 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "5x50heavy",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "5x50_hull", 1 ] ], [ [ "smrifle_primer", 1 ] ], [ [ "gunpowder", 4 ] ], [ [ "scrap", 1 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "50bmg",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "7 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 12 ] ],
+      [ [ "copper", 6 ] ],
+      [ [ "50_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "gunpowder", 30 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "50_incendiary",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "15 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 15 ] ],
+      [ [ "copper", 6 ] ],
+      [ [ "50_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "gunpowder", 30 ] ],
+      [ [ "incendiary", 20 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "50ss",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "7 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 12 ] ],
+      [ [ "copper", 6 ] ],
+      [ [ "50_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "gunpowder", 30 ] ],
+      [ [ "scrap", 1 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "bp_50bmg",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "7 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 12 ] ],
+      [ [ "copper", 6 ] ],
+      [ [ "50_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "chem_black_powder", 45 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "bp_50_incendiary",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "15 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 15 ] ],
+      [ [ "copper", 6 ] ],
+      [ [ "50_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "chem_black_powder", 45 ] ],
+      [ [ "incendiary", 20 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "bp_50ss",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "7 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 12 ] ],
+      [ [ "copper", 6 ] ],
+      [ [ "50_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "chem_black_powder", 45 ] ],
+      [ [ "scrap", 1 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "545",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 3 ] ], [ [ "copper", 1 ] ], [ [ "545_casing", 1 ] ], [ [ "smrifle_primer", 1 ] ], [ [ "gunpowder", 5 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "545_ap",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 3 ] ], [ [ "copper", 1 ] ], [ [ "545_casing", 1 ] ], [ [ "smrifle_primer", 1 ] ], [ [ "gunpowder", 6 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "bp_545",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 3 ] ],
+      [ [ "copper", 1 ] ],
+      [ [ "545_casing", 1 ] ],
+      [ [ "smrifle_primer", 1 ] ],
+      [ [ "chem_black_powder", 8 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "bp_545_ap",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 3 ] ],
+      [ [ "copper", 1 ] ],
+      [ [ "545_casing", 1 ] ],
+      [ [ "smrifle_primer", 1 ] ],
+      [ [ "chem_black_powder", 9 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "300blk",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 5 ] ],
+      [ [ "copper", 2 ] ],
+      [ [ "smrifle_primer", 1 ] ],
+      [ [ "300blk_casing", 1 ] ],
+      [ [ "gunpowder", 4 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "bp_300blk",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 5 ] ],
+      [ [ "copper", 2 ] ],
+      [ [ "smrifle_primer", 1 ] ],
+      [ [ "300blk_casing", 1 ] ],
+      [ [ "chem_black_powder", 6 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "556",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 3 ] ], [ [ "copper", 1 ] ], [ [ "223_casing", 1 ] ], [ [ "smrifle_primer", 1 ] ], [ [ "gunpowder", 6 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "556_incendiary",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "12 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 3 ] ],
+      [ [ "copper", 1 ] ],
+      [ [ "223_casing", 1 ] ],
+      [ [ "smrifle_primer", 1 ] ],
+      [ [ "gunpowder", 6 ] ],
+      [ [ "incendiary", 2 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "bp_556",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 3 ] ],
+      [ [ "copper", 1 ] ],
+      [ [ "223_casing", 1 ] ],
+      [ [ "smrifle_primer", 1 ] ],
+      [ [ "chem_black_powder", 9 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "bp_556_incendiary",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "12 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 3 ] ],
+      [ [ "copper", 1 ] ],
+      [ [ "223_casing", 1 ] ],
+      [ [ "smrifle_primer", 1 ] ],
+      [ [ "chem_black_powder", 9 ] ],
+      [ [ "incendiary", 2 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "700nx",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "7 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 10 ] ],
+      [ [ "copper", 5 ] ],
+      [ [ "700nx_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "gunpowder", 30 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "bp_700nx",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "7 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 10 ] ],
+      [ [ "copper", 5 ] ],
+      [ [ "700nx_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "chem_black_powder", 45 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "762_51",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 6 ] ],
+      [ [ "copper", 3 ] ],
+      [ [ "762_51_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "gunpowder", 10 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "762_51_incendiary",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "10 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 6 ] ],
+      [ [ "copper", 3 ] ],
+      [ [ "762_51_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "gunpowder", 10 ] ],
+      [ [ "incendiary", 6 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "bp_762_51",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 6 ] ],
+      [ [ "copper", 3 ] ],
+      [ [ "762_51_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "chem_black_powder", 15 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "bp_762_51_incendiary",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "10 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 6 ] ],
+      [ [ "copper", 3 ] ],
+      [ [ "762_51_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "chem_black_powder", 15 ] ],
+      [ [ "incendiary", 6 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "762_54R",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 7 ] ],
+      [ [ "copper", 3 ] ],
+      [ [ "762R_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "gunpowder", 10 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "bp_762_54R",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 7 ] ],
+      [ [ "copper", 3 ] ],
+      [ [ "762R_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "chem_black_powder", 15 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "762_m43",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 4 ] ], [ [ "copper", 1 ] ], [ [ "762_casing", 1 ] ], [ [ "lgrifle_primer", 1 ] ], [ [ "gunpowder", 8 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "762_m87",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "lead", 4 ] ], [ [ "copper", 1 ] ], [ [ "762_casing", 1 ] ], [ [ "lgrifle_primer", 1 ] ], [ [ "gunpowder", 8 ] ] ],
+    "charges": 1
+  },
+  {
+    "result": "bp_762_m43",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 4 ] ],
+      [ [ "copper", 1 ] ],
+      [ [ "762_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "chem_black_powder", 12 ] ]
+    ],
+    "charges": 1
+  },
+  {
+    "result": "bp_762_m87",
+    "type": "uncraft",
+    "skill_used": "fabrication",
+    "skills_required": [ "gun", 1 ],
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [
+      [ [ "lead", 4 ] ],
+      [ [ "copper", 1 ] ],
+      [ [ "762_casing", 1 ] ],
+      [ [ "lgrifle_primer", 1 ] ],
+      [ [ "chem_black_powder", 12 ] ]
+    ],
+    "charges": 1
+  }
+]


### PR DESCRIPTION
## Purpose of change (The Why)

The yes :
It takes 2 minutes to dissasemble most of the ammo types ive thrown into these files. 2 minutes to wiggle a bullet free which isn't really what most of the people in the discord said, or the random yt tutorials of people wiggling bullets free using a spent casing. 
<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
More u crafts! 
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Even if we add speedups to dissasembly and make higher quality of tools speed it up, it would be a balance nightmare :
If you make the tool quality affect it too much, some other thing is going to be broke broke. 
As for speedups - even if its slashed to half, it taking a minute is very unrealistic. 

## Testing

The game didn't crash for me, I've gone through all recipes listed in here twice and they all matched to the recipes. If something did slip past it's either very minor or something that can be adjusted. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

Most of them are a 5 second dissasembles, incendinaries are 10 to 15, some bigger bullets that i know are 6 and 7 like 700 nitro express and 50bmg

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically. (there's none so this gets auto checked yes?) 
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
