### PR TITLE
fix: Fix cone shot not going through fences

### DIFF
--- a/src/ranged_aoe.cpp
+++ b/src/ranged_aoe.cpp
@@ -53,7 +53,7 @@ void execute_shaped_attack( const shape &sh, const projectile &proj, Creature &a
     const auto aoe_permeable = [&here]( const tripoint & p ) {
         return here.passable( p ) ||
                // Necessary evil. TODO: Make map::shoot not evil.
-               ( here.is_transparent( p ) && here.has_flag_furn( TFLAG_PERMEABLE, p ) );
+               ( here.is_transparent( p ) && here.has_flag_ter( TFLAG_PERMEABLE, p ) );
     };
     const tripoint &origin = sh.get_origin();
     std::priority_queue<tripoint_distance> queue;
@@ -179,7 +179,7 @@ std::map<tripoint, double> expected_coverage( const shape &sh, const map &here, 
         double current_coverage = parent_coverage;
         if( here.passable( p ) ||
             // Necessary evil. TODO: Make map::shoot not evil.
-            ( here.is_transparent( p ) && here.has_flag_furn( TFLAG_PERMEABLE, p ) ) ) {
+            ( here.is_transparent( p ) && here.has_flag_ter( TFLAG_PERMEABLE, p ) ) ) {
             // noop
         } else {
             int bash_str = here.bash_strength( p );


### PR DESCRIPTION
## Purpose of change (The Why)

Fix #5981

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Check for `PERMEABLE` flag on terrain instead of furniture.

## Describe alternatives you've considered

Check for furniture as well. Might be preferred, but we barely have `PERMEABLE` furniture and the check might be a bit complicated. The issue is that we'd have to check passability separately for terrain and furniture and then "confirm" it with their specific flags.

## Testing

* Spawn 00 shotgun (pipe shotgun) + birdshot
* Load shotgun with birdshot
* Spawn a chainlink fence and a monster behind it
* Shoot at the monster through chainlink
* Monster should be hit for full damage

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
