### PR TITLE
feat(balance): make AoE damage falloff based on range

### DIFF
--- a/src/ranged_aoe.cpp
+++ b/src/ranged_aoe.cpp
@@ -43,6 +43,19 @@ struct aoe_flood_node {
 namespace ranged
 {
 
+namespace
+{
+
+auto falloff_damage_multiplier( const shape &sh, const dealt_projectile_attack &atk ) -> double
+{
+    const float dist = trig_dist( sh.get_origin(), atk.end_point );
+    const float range = std::max( 1, atk.proj.range );
+
+    return 1 - ( 0.5 * ( std::max( 0.0f, dist - 1 ) / range ) );
+}
+
+} // namespace
+
 void execute_shaped_attack( const shape &sh, const projectile &proj, Creature &attacker,
                             item *source_weapon, const vehicle *in_veh )
 {
@@ -136,6 +149,7 @@ void execute_shaped_attack( const shape &sh, const projectile &proj, Creature &a
             atk.end_point = point;
             atk.hit_critter = critter;
             atk.proj = proj;
+            atk.proj.impact.mult_damage( falloff_damage_multiplier( sh, atk ) );
             atk.missed_by = rng_float( 0.15, 0.45 );
             critter->deal_projectile_attack( &attacker, source_weapon, atk );
         }


### PR DESCRIPTION
## Purpose of change (The Why)

- resolves #6028

## Describe the solution (The How)

see: https://github.com/cataclysmbnteam/Cataclysm-BN/issues/6028#issuecomment-2628740689

falloff is limited to at most 50% of damage

## Describe alternatives you've considered

- add UI for it but the formula is simple enough so we could add them later.
- could also make falloff begin at half the max range but then it'd need UI to communicate the falloff so it's not in scope of the PR.

## Testing

https://github.com/user-attachments/assets/31d21112-5890-4454-a895-0825a21e469a

![image](https://github.com/user-attachments/assets/b36de79d-aa1a-4f03-9d9b-b9c615c77f68)
1. spawn zombies
2. fire saiga
3. see that far away zombies take less damage

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
