### PR TITLE
Add 2 new smaller compasses for the UI. Compact and Simple.

### DIFF
--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -1796,7 +1796,7 @@ static void draw_simple_compass( avatar &u, const catacurses::window &w )
         enemies_text += entry.first + "(" + std::to_string( entry.second ) + ") ";
     }
 
-    mvwprintz( w, point( 1, 0 ), c_white, enemies_text );
+    mvwprintz( w, point( 0, 0 ), c_white, enemies_text );
     wnoutrefresh( w );
 }
 

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -1781,7 +1781,7 @@ static void draw_simple_compass( avatar &u, const catacurses::window &w )
 {
     werase( w );
 
-    const auto &visible_creatures = u.get_visible_creatures( -1 );
+    const auto &visible_creatures = u.get_visible_creatures( 200 );
     std::map<std::string, int> direction_count;
     const tripoint player_pos = u.pos();
 

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -1755,6 +1755,18 @@ static void draw_compass( avatar &, const catacurses::window &w )
     g->mon_info( w );
     wnoutrefresh( w );
 }
+static void draw_compact_compass( avatar &u, const catacurses::window &w ) {
+    werase( w );
+
+    const auto &visible_creatures = u.get_visible_creatures( 60 );
+    std::string enemies_text;
+    for( const auto &creature : visible_creatures ) {
+        enemies_text += creature->disp_name() + " ";
+    }
+
+    mvwprintz( w, point( 1, 0 ), c_white, enemies_text );
+    wnoutrefresh( w );
+}
 
 static void draw_compass_padding( avatar &, const catacurses::window &w )
 {
@@ -2032,6 +2044,7 @@ bool default_render()
 static std::vector<window_panel> initialize_default_classic_panels()
 {
     std::vector<window_panel> ret;
+ret.emplace_back( draw_compact_compass, translate_marker( "Compact Compass" ), 8, 44, true );
 
     ret.emplace_back( draw_health_classic, translate_marker( "Health" ), 7, 44, true );
     ret.emplace_back( draw_location_classic, translate_marker( "Location" ), 1, 44,


### PR DESCRIPTION
## Purpose of change (The Why)
While the old Compass was good and informative, smaller screens (phones, tablets) had their problems of using it.
<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Add the comp. Compass which is just a shorter regular compass. And the simple Compass, which is just one line of where Creatures are in any direction of the player.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing
Works as intended, code may be wonky, but that is the best effort I could muster yet.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->
![grafik](https://github.com/user-attachments/assets/761e12c4-8815-4628-99ef-20afe389b2e6)
Just the Compact version
![grafik](https://github.com/user-attachments/assets/ce8957fb-8105-4cbc-8ca4-fcd3929b972a)
Simple version
![grafik](https://github.com/user-attachments/assets/3d387e21-16ff-4ed1-8417-72da13cf29a2)


### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.