### PR TITLE
feat: show save file version in game report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -72,7 +72,8 @@ body:
         - OS: [e.g. iOS 8 or Windows 10 or Ubuntu 18.04]
         - Game Version: [from the main menu, e.g. 0.C-29938-g90f5268437]
         - Graphics version: [Tiles or Terminal]
-        - Ingame language: [Arabic or Bulgarian or Chinese (Simplified) or Chinese (Traditional) or Dutch or Esperanto or French or German or Italian (Italy) or Japanese or Korean or Polish or Portuguese (Brazil) or Russian or Serbian or Spanish (Argentina) or Spanish (Spain) or Turkish]
+        - Save File Version: [V1 or V2]
+        - Game language: [Arabic or Bulgarian or Chinese (Simplified) or Chinese (Traditional) or Dutch or Esperanto or French or German or Italian (Italy) or Japanese or Korean or Polish or Portuguese (Brazil) or Russian or Serbian or Spanish (Argentina) or Spanish (Spain) or Turkish]
         - Mods loaded: [e.g.dda, boats, hacktheplanet, StatsThroughSkills]
     validations:
       required: true

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -1768,6 +1768,24 @@ std::string game_info::graphics_version()
 #endif
 }
 
+std::string game_info::save_file_version()
+{
+    const auto &world = world_generator->active_world;
+    if( world == nullptr ) {
+        return "No active world";
+    }
+    const auto *info = world->info;
+    if( info == nullptr ) {
+        return "No world info";
+    }
+    switch( info->world_save_format ) {
+        case save_format::V1:
+            return "V1";
+        case save_format::V2_COMPRESSED_SQLITE3:
+            return "V2 (compressed with sqlite 3)";
+    }
+}
+
 std::string game_info::mods_loaded()
 {
     if( world_generator->active_world == nullptr ) {
@@ -1815,6 +1833,7 @@ std::string game_info::game_report()
            "- Game Version: " << game_version() << " [" << bitness_string() << "]\n" <<
            "- Graphics Version: " << graphics_version() << "\n" <<
            "- LAPI Version: " << cata::get_lapi_version_string() << "\n" <<
+           "- Save File Version: " << save_file_version() << "\n" <<
            "- Game Language: " << lang_translated << " [" << lang << "]\n" <<
            "- Mods loaded: [\n    " << mods_loaded() << "\n]\n";
 

--- a/src/debug.h
+++ b/src/debug.h
@@ -204,6 +204,9 @@ std::string mods_loaded();
 /** Generate a game report, including the information returned by all of the other functions.
  */
 std::string game_report();
+/** Current world save file version
+ */
+std::string save_file_version();
 } // namespace game_info
 
 /** Initializes the debugging system, called exactly once from main() */


### PR DESCRIPTION
## Purpose of change (The Why)

make debugging issues related to save files easier (e.g #6032)

## Describe the solution (The How)

when generating game report, also display save file version (V1 or V2 - sqlite)

## Testing

mine:

```
- OS: Linux
    - OS Version: LSB Version: n/a; Distributor ID: Fedora; Description: Fedora Linux 41 (Container Image); Release: 41; Codename: n/a; 
- Game Version: 70e9157554 [64-bit]
- Graphics Version: Tiles
- LAPI Version: 2
- Save File Version: V2 (compressed with sqlite 3)
- Game Language: English [en_US]
- Mods loaded: [
    Bright Nights [bn],
    Disable NPC Needs [no_npc_food],
    Simplified Nutrition [novitamins],
    No Rail Stations [No_Rail_Stations],
    Prevent Zombie Revivication [no_reviving_zombies],
    Limit Fungal Growth [limit_fungal_growth]
]
```

## Additional context

i never get why report functions are in `debug.h`, adding one function causes recompiling entirety of project smh

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
