### PR TITLE
feat(balance): The Springening

### DIFF
--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -2352,7 +2352,7 @@
     "type": "uncraft",
     "time": "2 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "plastic_chunk", 3 ] ], [ [ "scrap", 1 ] ], [ [ "wire", 5 ] ] ]
+    "components": [ [ [ "plastic_chunk", 3 ] ], [ [ "scrap", 1 ] ], [ [ "wire", 5 ] ], [ [ "spring", 1 ] ] ]
   },
   {
     "result": "umbrella",


### PR DESCRIPTION
Adds spring to telescopic umbrella

## Purpose of change (The Why)

Telescoping umbrellas do indeed have springs, and gives players a way to get springs 

## Describe the solution (The How)

Adds a spring to telescoping umbrellas so you can spring while you sproing

## Describe alternatives you've considered

Not adding a spring 🔥 

## Testing

Spawned in telescoping umbrella, cut it up, got spring

## Additional context

![7418debbe4ab946a75ae05c61c2d59b621a94ac58a42313dfb5787dbae1bd7e1_3](https://github.com/user-attachments/assets/edc40df0-4839-432f-a862-eacec858368e)


## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.