### PR TITLE
chore(mods/MagicalNights): Fix lore issue with orichalcum fire axes

### DIFF
--- a/data/mods/Magical_Nights/items/melee.json
+++ b/data/mods/Magical_Nights/items/melee.json
@@ -80,9 +80,9 @@
     "type": "TOOL",
     "id": "orich_fire_ax",
     "name": { "str": "orichalcum fire axe" },
-    "description": "A fire axe made with orichalcum instead of steel.  This makes it possible to chop through harder materials, and in the very well-funded fire stations is preferred.",
+    "description": "A fire axe made with orichalcum instead of steel.  This allows the axe to be just as effective as its steal counterpart at chopping, with less weight to tire the arms.",
     "material": [ "orichalcum_metal" ],
-    "proportional": { "cutting": 1.1, "price": 5 },
+    "proportional": { "cutting": 1.1, "price": 5, "weight": 0.99 },
     "color": "yellow"
   },
   {


### PR DESCRIPTION
## Purpose of change (The Why)

Orichalcum fire axes made a claim that doesn't mesh with MN's direction.

## Describe the solution (The How)

Fixes the lore, and also gives it the weight reduction it was for some reason missing.

## Describe alternatives you've considered

- Leave out the weight adjustment but increase bash or cutting by a little

## Testing

Text-editing and copy-paste of a relative field got the eyeball test.

## Additional context

Easing my way back into MN contributions after my C++ adventures.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
