### PR TITLE
feat(UI): item category audit for comestibles

### DIFF
--- a/data/json/items/comestibles/brewing.json
+++ b/data/json/items/comestibles/brewing.json
@@ -2,6 +2,7 @@
   {
     "type": "COMESTIBLE",
     "abstract": "brew_base",
+    "category": "cooking_ingredients",
     "name": "base brew",
     "price": "0 cent",
     "price_postapoc": "10 cent",

--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -560,6 +560,7 @@
   {
     "type": "COMESTIBLE",
     "id": "blood",
+    "category": "other",
     "name": { "str_sp": "blood" },
     "weight": "265 g",
     "color": "red",
@@ -667,6 +668,7 @@
   {
     "type": "COMESTIBLE",
     "id": "fat",
+    "category": "cooking_ingredients",
     "name": { "str": "chunk of fat", "str_pl": "chunks of fat" },
     "weight": "220 g",
     "color": "pink",
@@ -690,6 +692,7 @@
   {
     "type": "COMESTIBLE",
     "id": "tallow",
+    "category": "cooking_ingredients",
     "name": "tallow",
     "weight": "110 g",
     "color": "white",
@@ -1046,6 +1049,7 @@
   {
     "type": "COMESTIBLE",
     "comestible_type": "FOOD",
+    "category": "other",
     "id": "flesh_golem_heart",
     "name": "seeping heart",
     "weight": "2035 g",
@@ -1066,6 +1070,7 @@
   {
     "type": "COMESTIBLE",
     "comestible_type": "FOOD",
+    "category": "other",
     "id": "jabberwock_heart",
     "name": "putrid heart",
     "weight": "4535 g",
@@ -1086,6 +1091,7 @@
   {
     "type": "COMESTIBLE",
     "comestible_type": "FOOD",
+    "category": "other",
     "id": "jabberwock_heart_desiccated",
     "name": "desiccated putrid heart",
     "weight": "1360 g",
@@ -1115,6 +1121,7 @@
   {
     "id": "leech_flower",
     "type": "COMESTIBLE",
+    "category": "drugs",
     "comestible_type": "FOOD",
     "name": "leech flower",
     "color": "blue",

--- a/data/json/items/comestibles/drink_other.json
+++ b/data/json/items/comestibles/drink_other.json
@@ -2,6 +2,7 @@
   {
     "type": "COMESTIBLE",
     "id": "sauce_red",
+    "category": "cooking_ingredients",
     "name": "red sauce",
     "weight": "64 g",
     "color": "red",
@@ -49,6 +50,7 @@
   },
   {
     "id": "mayonnaise",
+    "category": "cooking_ingredients",
     "type": "COMESTIBLE",
     "symbol": "~",
     "color": "white",
@@ -70,6 +72,7 @@
   },
   {
     "id": "ketchup",
+    "category": "cooking_ingredients",
     "type": "COMESTIBLE",
     "symbol": "~",
     "color": "red",
@@ -91,6 +94,7 @@
   },
   {
     "id": "mustard",
+    "category": "cooking_ingredients",
     "type": "COMESTIBLE",
     "symbol": "~",
     "color": "yellow",
@@ -112,6 +116,7 @@
   },
   {
     "id": "honey_bottled",
+    "category": "cooking_ingredients",
     "type": "COMESTIBLE",
     "symbol": "~",
     "color": "yellow",
@@ -134,6 +139,7 @@
   },
   {
     "id": "peanutbutter",
+    "category": "cooking_ingredients",
     "type": "COMESTIBLE",
     "symbol": "~",
     "color": "brown",
@@ -165,6 +171,7 @@
   {
     "type": "COMESTIBLE",
     "id": "vinegar",
+    "category": "cooking_ingredients",
     "name": { "str_sp": "vinegar" },
     "weight": "15 g",
     "color": "white",
@@ -184,6 +191,7 @@
   {
     "type": "COMESTIBLE",
     "id": "cooking_oil",
+    "category": "cooking_ingredients",
     "name": { "str_sp": "vegetable cooking oil" },
     "weight": "15 g",
     "color": "yellow",
@@ -207,6 +215,7 @@
   {
     "type": "COMESTIBLE",
     "id": "cooking_oil2",
+    "category": "cooking_ingredients",
     "name": { "str_sp": "animal cooking oil" },
     "//": "Can't copy-from the vegetable oil because it extends vitamins instead of overwriting them",
     "weight": "15 g",
@@ -230,6 +239,7 @@
   },
   {
     "type": "COMESTIBLE",
+    "category": "cooking_ingredients",
     "id": "molasses",
     "name": { "str_sp": "molasses" },
     "weight": "89 g",
@@ -253,6 +263,7 @@
   },
   {
     "id": "horseradish",
+    "category": "cooking_ingredients",
     "type": "COMESTIBLE",
     "symbol": "~",
     "color": "white",
@@ -275,6 +286,7 @@
   },
   {
     "type": "COMESTIBLE",
+    "category": "cooking_ingredients",
     "id": "coffee_syrup",
     "name": { "str_sp": "coffee syrup" },
     "weight": "32 g",

--- a/data/json/items/comestibles/fruit_dishes.json
+++ b/data/json/items/comestibles/fruit_dishes.json
@@ -202,6 +202,7 @@
   {
     "type": "COMESTIBLE",
     "id": "jam_fruit",
+    "category": "cooking_ingredients",
     "name": { "str_sp": "jam" },
     "conditional_names": [
       { "type": "COMPONENT_ID", "condition": "apple", "name": { "str_sp": "apple %s" } },

--- a/data/json/items/comestibles/junkfood.json
+++ b/data/json/items/comestibles/junkfood.json
@@ -87,6 +87,7 @@
   {
     "type": "COMESTIBLE",
     "id": "kernels",
+    "category": "cooking_ingredients",
     "name": { "str_sp": "popcorn kernels" },
     "weight": "32 g",
     "color": "brown",
@@ -418,6 +419,7 @@
   {
     "type": "COMESTIBLE",
     "id": "syrup",
+    "category": "cooking_ingredients",
     "name": { "str_sp": "maple syrup" },
     "weight": "21 g",
     "color": "brown",
@@ -438,6 +440,7 @@
   },
   {
     "type": "COMESTIBLE",
+    "category": "cooking_ingredients",
     "id": "beet_syrup",
     "name": { "str_sp": "sugar beet syrup" },
     "weight": "15 g",

--- a/data/json/items/comestibles/nuts.json
+++ b/data/json/items/comestibles/nuts.json
@@ -385,6 +385,7 @@
   {
     "type": "COMESTIBLE",
     "id": "acorns",
+    "category": "cooking_ingredients",
     "name": { "str_sp": "acorns" },
     "weight": "30 g",
     "color": "brown",
@@ -407,6 +408,7 @@
   {
     "type": "COMESTIBLE",
     "id": "acorn_roasted",
+    "category": "food",
     "name": { "str_sp": "roasted acorns" },
     "copy-from": "acorns",
     "healthy": 1,

--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -35,6 +35,7 @@
   {
     "type": "COMESTIBLE",
     "id": "honeycomb",
+    "category": "cooking_ingredients",
     "name": "honey comb",
     "weight": "150 g",
     "color": "yellow",
@@ -53,6 +54,7 @@
   {
     "type": "COMESTIBLE",
     "id": "wax",
+    "category": "other",
     "name": { "str_pl": "waxes", "str": "wax" },
     "weight": "97 g",
     "color": "white",
@@ -71,7 +73,7 @@
     "type": "COMESTIBLE",
     "id": "royal_jelly",
     "name": { "str": "royal jelly", "str_pl": "royal jellies" },
-    "category": "food",
+    "category": "drugs",
     "weight": "150 g",
     "color": "white",
     "comestible_type": "FOOD",
@@ -182,6 +184,7 @@
   {
     "type": "COMESTIBLE",
     "id": "meal_bone",
+    "category": "other",
     "name": { "str_sp": "bone meal" },
     "weight": "112 g",
     "color": "white",
@@ -199,6 +202,7 @@
   {
     "type": "COMESTIBLE",
     "id": "meal_bone_tainted",
+    "category": "other",
     "name": { "str_sp": "tainted bone meal" },
     "weight": "112 g",
     "color": "white",
@@ -218,6 +222,7 @@
   {
     "type": "COMESTIBLE",
     "id": "meal_chitin_piece",
+    "category": "other",
     "name": { "str_sp": "chitin powder" },
     "weight": "112 g",
     "color": "brown",
@@ -276,6 +281,7 @@
   {
     "type": "COMESTIBLE",
     "id": "dry_beans",
+    "category": "cooking_ingredients",
     "name": { "str_sp": "dried beans" },
     "weight": "56 g",
     "color": "light_gray",
@@ -422,6 +428,7 @@
   {
     "type": "COMESTIBLE",
     "id": "dry_lentils",
+    "category": "cooking_ingredients",
     "name": { "str_sp": "dried lentils" },
     "weight": "132 g",
     "color": "light_gray",
@@ -462,6 +469,7 @@
   {
     "type": "COMESTIBLE",
     "id": "lentils_cooked",
+    "category": "food",
     "name": { "str_sp": "cooked lentils" },
     "weight": "198 g",
     "copy-from": "dry_lentils",
@@ -478,6 +486,7 @@
   {
     "type": "COMESTIBLE",
     "id": "coffee_raw",
+    "category": "cooking_ingredients",
     "name": { "str_sp": "coffee powder" },
     "weight": "14 g",
     "color": "brown",
@@ -512,6 +521,7 @@
   {
     "id": "honey_glassed",
     "type": "COMESTIBLE",
+    "category": "cooking_ingredients",
     "symbol": "~",
     "color": "yellow",
     "name": { "str_sp": "candied honey" },
@@ -554,6 +564,7 @@
   {
     "type": "COMESTIBLE",
     "id": "human_brain_embalmed",
+    "category": "other",
     "name": { "str": "embalmed human brain" },
     "weight": "56 g",
     "color": "pink",
@@ -584,6 +595,7 @@
   {
     "id": "cattlefodder",
     "type": "COMESTIBLE",
+    "category": "tools_farming",
     "comestible_type": "FOOD",
     "name": { "str_sp": "cattle fodder" },
     "description": "What cattle eat.  Mainly made of grass, silage or legumes.  It's perfect for ruminants.",
@@ -607,6 +619,7 @@
   {
     "id": "birdfood",
     "type": "COMESTIBLE",
+    "category": "tools_farming",
     "comestible_type": "FOOD",
     "name": { "str_sp": "bird food" },
     "description": "What birds eat.  Mainly made of seeds, silage or legumes.  It's perfect for small birds.",
@@ -629,6 +642,7 @@
   {
     "id": "dogfood",
     "type": "COMESTIBLE",
+    "category": "tools_farming",
     "comestible_type": "FOOD",
     "name": { "str_sp": "dog food" },
     "description": "This is food for dogs.  It smells strange, but dogs seem to love it.",
@@ -654,6 +668,7 @@
   {
     "id": "catfood",
     "type": "COMESTIBLE",
+    "category": "tools_farming",
     "comestible_type": "FOOD",
     "name": { "str_sp": "cat food" },
     "description": "This is food for cats.  It smells strange, but cats seem to love it.",

--- a/data/json/items/comestibles/protein.json
+++ b/data/json/items/comestibles/protein.json
@@ -30,6 +30,7 @@
     "id": "protein_powder",
     "type": "COMESTIBLE",
     "comestible_type": "FOOD",
+    "category": "cooking_ingredients",
     "name": { "str_sp": "protein powder" },
     "conditional_names": [
       { "type": "VITAMIN", "condition": "human_flesh_vitamin", "name": { "str_sp": "soylent green powder" } },

--- a/data/json/items/comestibles/raw_veggy.json
+++ b/data/json/items/comestibles/raw_veggy.json
@@ -2,6 +2,7 @@
   {
     "type": "COMESTIBLE",
     "id": "barley",
+    "category": "cooking_ingredients",
     "name": { "str": "barley" },
     "weight": "211 g",
     "color": "brown",
@@ -24,6 +25,7 @@
   {
     "type": "COMESTIBLE",
     "id": "bee_balm",
+    "category": "cooking_ingredients",
     "name": { "str": "bee balm" },
     "description": "A snow-white flower also known as wild bergamot.  Smells faintly of mint.",
     "comestible_type": "FOOD",
@@ -62,6 +64,7 @@
   {
     "type": "COMESTIBLE",
     "id": "buckwheat",
+    "category": "cooking_ingredients",
     "name": { "str_sp": "buckwheat" },
     "weight": "180 g",
     "color": "brown",
@@ -389,6 +392,7 @@
   {
     "type": "COMESTIBLE",
     "id": "dogbane",
+    "category": "other",
     "name": "dogbane",
     "description": "A stalk of dogbane.  It has very fibrous stems and is mildly poisonous.",
     "comestible_type": "FOOD",
@@ -431,6 +435,7 @@
   {
     "type": "COMESTIBLE",
     "id": "hops",
+    "category": "cooking_ingredients",
     "name": { "str": "hops flower" },
     "weight": "92 g",
     "color": "light_green",
@@ -492,6 +497,7 @@
   {
     "type": "COMESTIBLE",
     "id": "mugwort",
+    "category": "cooking_ingredients",
     "name": "mugwort",
     "description": "A stalk of mugwort.  Smells wonderful.",
     "comestible_type": "FOOD",
@@ -724,6 +730,7 @@
   {
     "type": "COMESTIBLE",
     "id": "tea_raw",
+    "category": "cooking_ingredients",
     "name": { "str": "tea leaf", "str_pl": "tea leaves" },
     "weight": "2 g",
     "color": "green",
@@ -747,6 +754,7 @@
   {
     "type": "COMESTIBLE",
     "id": "coca_leaf",
+    "category": "drugs",
     "looks_like": "raw_edamame",
     "name": { "str": "coca leaf", "str_pl": "coca leaves" },
     "weight": "2 g",
@@ -861,6 +869,7 @@
   {
     "type": "COMESTIBLE",
     "id": "canola",
+    "category": "cooking_ingredients",
     "name": "canola",
     "description": "A pretty stalk of canola.  Its seeds can be pressed into oil.",
     "comestible_type": "FOOD",

--- a/data/json/items/comestibles/veggy_dishes.json
+++ b/data/json/items/comestibles/veggy_dishes.json
@@ -15,6 +15,7 @@
   {
     "type": "COMESTIBLE",
     "id": "starch",
+    "category": "cooking_ingredients",
     "name": { "str_sp": "starch" },
     "weight": "180 g",
     "color": "light_gray",
@@ -194,6 +195,7 @@
   {
     "type": "COMESTIBLE",
     "id": "buckwheat_cooked",
+    "category": "food",
     "name": { "str_sp": "cooked buckwheat" },
     "copy-from": "buckwheat",
     "spoils_in": "20 days",
@@ -246,6 +248,7 @@
   {
     "type": "COMESTIBLE",
     "id": "cornmeal",
+    "category": "cooking_ingredients",
     "name": { "str_sp": "cornmeal" },
     "weight": "19 g",
     "color": "yellow",
@@ -287,6 +290,7 @@
   {
     "type": "COMESTIBLE",
     "id": "dry_rice",
+    "category": "cooking_ingredients",
     "name": { "str_sp": "dried rice" },
     "weight": "40 g",
     "color": "white",
@@ -311,6 +315,7 @@
   {
     "type": "COMESTIBLE",
     "id": "rice_cooked",
+    "category": "food",
     "name": { "str_sp": "cooked rice" },
     "copy-from": "dry_rice",
     "weight": "62 g",
@@ -699,6 +704,7 @@
   {
     "type": "COMESTIBLE",
     "id": "dried_salad",
+    "category": "cooking_ingredients",
     "name": "dried salad",
     "copy-from": "veggy_salad",
     "weight": "150 g",

--- a/data/json/items/comestibles/wheat.json
+++ b/data/json/items/comestibles/wheat.json
@@ -23,6 +23,7 @@
   {
     "type": "COMESTIBLE",
     "id": "wheat",
+    "category": "cooking_ingredients",
     "name": { "str_sp": "wheat" },
     "weight": "203 g",
     "color": "brown",
@@ -65,6 +66,7 @@
   {
     "type": "COMESTIBLE",
     "id": "spaghetti_raw",
+    "category": "cooking_ingredients",
     "name": { "str_sp": "raw spaghetti pasta" },
     "weight": "60 g",
     "color": "yellow",
@@ -84,6 +86,7 @@
   {
     "type": "COMESTIBLE",
     "id": "lasagne_raw",
+    "category": "cooking_ingredients",
     "name": { "str_sp": "raw lasagne pasta" },
     "weight": "60 g",
     "color": "yellow",
@@ -123,6 +126,7 @@
   {
     "type": "COMESTIBLE",
     "id": "macaroni_raw",
+    "category": "cooking_ingredients",
     "name": { "str_sp": "raw macaroni" },
     "weight": "60 g",
     "color": "yellow",
@@ -163,6 +167,7 @@
   {
     "type": "COMESTIBLE",
     "id": "flour",
+    "category": "cooking_ingredients",
     "name": { "str_sp": "flour" },
     "weight": "13 g",
     "color": "white",
@@ -184,6 +189,7 @@
   {
     "type": "COMESTIBLE",
     "id": "oatmeal",
+    "category": "cooking_ingredients",
     "name": { "str_sp": "oatmeal" },
     "weight": "50 g",
     "color": "light_gray",
@@ -206,6 +212,7 @@
   {
     "type": "COMESTIBLE",
     "id": "oats",
+    "category": "cooking_ingredients",
     "name": { "str_sp": "oats" },
     "weight": "86 g",
     "color": "brown",


### PR DESCRIPTION
## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

This moves more items out of the food item category and into cooking ingredients (or other, in a handful of cases).

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Added `cooking_ingredients` category to:
1. Unfermented brew items such as whiskey wash and the like.
2. Raw fat/tallow/lard
3. Misc. drinkable stuff like honey, peanut butter, condiments, and other sauces. Also jam.
4. Vinegar and cooking oil
5. Maple syrup and beet syrup
6. Unpopped popcorn kernals
7. Raw acorns
8. Honeycombs and wax
9. Dried beans, lentils, rice and the like.
10. Coffee powder
11. Protein powder
12. Raw cereal grains such as barley, wheat, and oats.
13. Bee balm, hops flowers, dogbane, and raw mugwort
14. Raw tea leaves
15. Canola stalks
16. Starch
17. Items such as flour, cornmeal, and raw oatmeal
18. Dried salad
19. Uncocked pastas, fast noodles was left as an exception because for some reason it's flavored as being perfectly edible raw. o.O

Added `other` category to:
1. Blood, same vein as bones being placed in other.
2. Jabberwock heart materials
3. Bone and chitin meal
4. Enbalmed human brain

Added `drugs` category to:
1. Coca leaves
2. Leech flowers
3. Royal jelly now that it actually does stuff

Added `tools_farming` category to:
1. Cattlefodder and other animal-taming items

Re-added `food` category to:
1. Cooked acorns, due to inheriting from raw acorns.
2. Cooked lentils, due to inheriting from dried lentils.
3. Cooked buckwheat, inheriting from buckwheat.
4. Cooked rice, inheriting from dried rice.

## Describe alternatives you've considered

1. Jabberwock hearts could be `mutagen` category instead, but note that mutated limbs and fetuses are also in other category.
2. I'd also be tempted to move all raw meat type items to the ingredients category, but we can do that as a followup maybe.
3. Moving alcohol to drugs category?
4. We could make fast noodles need to be cooked first like all other pasta items, derp.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
