### PR TITLE
chore(mods/aftershock): fix typo "robot_carrier" -> "robot carrier"

### DIFF
--- a/data/mods/Aftershock/vehicles/vehicle_parts.json
+++ b/data/mods/Aftershock/vehicles/vehicle_parts.json
@@ -449,7 +449,7 @@
   {
     "type": "vehicle_part",
     "id": "robot_cargo",
-    "name": "robot_carrier",
+    "name": "robot carrier",
     "symbol": "=",
     "categories": [ "Cargo" ],
     "color": "light_gray",


### PR DESCRIPTION
## Purpose of change (The Why)

Cleaner text = happier players.

## Describe the solution (The How)

Removed the underscore.

## Describe alternatives you've considered

Leaving it in for that chic jank.

## Testing

Made the change, loaded the game, looked inside. Since the ID didn't change, no loading errors or anything, despite the fact that I was loading from a save with the typo.

## Additional context

![image](https://github.com/user-attachments/assets/c51e7fc5-7861-4ba0-8ed0-e1887e5febfe)


## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
