### PR TITLE
feat(balance, mods/MagicalNights): Buff legendary weapons, fix typo

### DIFF
--- a/data/mods/Magical_Nights/Spells/item_only.json
+++ b/data/mods/Magical_Nights/Spells/item_only.json
@@ -104,5 +104,17 @@
     "spell_class": "NONE",
     "message": "Your veins feel like they are on fire!\nYou start regenerating mana!",
     "extra_effects": [ { "id": "potion_recover_mana" } ]
+  },
+  {
+    "id": "gungnir_apply",
+    "type": "SPELL",
+    "name": { "str": "Apply Gungnir Effect" },
+    "description": "You probably shouldn't be seeing this",
+    "valid_targets": [ "hostile" ],
+    "flags": [ "SILENT", "NO_LEGS", "NO_HANDS", "NO_EXPLOSION_VFX" ],
+    "effect": "target_attack",
+    "effect_str": "gungnir_debuff",
+    "min_duration": 600000,
+    "spell_class": "NONE"
   }
 ]

--- a/data/mods/Magical_Nights/effects/effects.json
+++ b/data/mods/Magical_Nights/effects/effects.json
@@ -263,5 +263,13 @@
     "max_duration": "10 second",
     "rating": "bad",
     "base_mods": { "pain_amount": [ 20 ] }
+  },
+  {
+    "id": "gungnir_debuff",
+    "type": "effect_type",
+    "desc": [ "Let's see this foe try and dodge the powerful Gungnir NOW!" ],
+    "rating": "bad",
+    "//": "This is the best I can do in terms of making it 'never miss' generally",
+    "base_mods": { "dodge_mod": [ -10 ] }
   }
 ]

--- a/data/mods/Magical_Nights/effects/enchantments.json
+++ b/data/mods/Magical_Nights/effects/enchantments.json
@@ -10,5 +10,42 @@
     "has": "WORN",
     "ench_effects": [ { "effect": "enchant_windrun", "intensity": 1 } ],
     "values": [ { "value": "MOVE_COST", "multiply": -0.5 } ]
+  },
+  {
+    "id": "ench_mjolnir",
+    "type": "enchantment",
+    "has": "WIELD",
+    "hit_you_effect": [
+      { "id": "lightning_bolt", "hit_self": false, "once_in": 5, "message": "Mjolnir's lightning arcs out and pierces %2$s!" }
+    ],
+    "values": [ { "value": "ARMOR_ELEC", "add": 90 } ]
+  },
+  {
+    "id": "ench_gungnir",
+    "type": "enchantment",
+    "has": "WIELD",
+    "hit_you_effect": [
+      {
+        "id": "gungnir_apply",
+        "hit_self": false,
+        "message": "Gungnir's incredible balance makes it so that your foe may not evade thine strikes!"
+      }
+    ]
+  },
+  {
+    "id": "ench_laevateinn",
+    "type": "enchantment",
+    "has": "WIELD",
+    "hit_you_effect": [
+      { "id": "ethereal_grasp", "hit_self": false, "once_in": 5, "message": "The trickster's staff hobbles thine enemies!" },
+      { "id": "summon_lemon", "once_in": 5, "message": "The trickster's staff summons a lemon!" },
+      {
+        "id": "chilling_touch",
+        "hit_self": false,
+        "once_in": 5,
+        "message": "The trickster's staff chills your enemies to the bone!"
+      }
+    ],
+    "values": [ { "value": "INTELLIGENCE", "add": 5 } ]
   }
 ]

--- a/data/mods/Magical_Nights/effects/enchantments.json
+++ b/data/mods/Magical_Nights/effects/enchantments.json
@@ -27,7 +27,7 @@
     "hit_you_effect": [
       {
         "id": "gungnir_apply",
-        "hit_self": false,
+        "hit_self": true,
         "message": "Gungnir's incredible balance makes it so that your foe may not evade thine strikes!"
       }
     ]
@@ -38,7 +38,7 @@
     "has": "WIELD",
     "hit_you_effect": [
       { "id": "ethereal_grasp", "hit_self": false, "once_in": 5, "message": "The trickster's staff hobbles thine enemies!" },
-      { "id": "summon_lemon", "once_in": 5, "message": "The trickster's staff summons a lemon!" },
+      { "id": "summon_lemon", "once_in": 5, "hit_self": true, "message": "The trickster's staff summons a lemon!" },
       {
         "id": "chilling_touch",
         "hit_self": false,

--- a/data/mods/Magical_Nights/items/melee.json
+++ b/data/mods/Magical_Nights/items/melee.json
@@ -10,7 +10,8 @@
     "material": [ "orichalcum_metal", "wood", "gold" ],
     "techniques": [ "WBLOCK_2", "BRUTAL" ],
     "volume": "3750 ml",
-    "bashing": 45,
+    "bashing": 50,
+    "cutting": 0,
     "price": "2 kUSD"
   },
   {
@@ -24,7 +25,7 @@
     "techniques": [ "WBLOCK_1", "IMPALE", "SWEEP" ],
     "volume": "3250 ml",
     "bashing": 10,
-    "cutting": 35,
+    "cutting": 40,
     "price": "2 kUSD"
   },
   {
@@ -37,7 +38,7 @@
     "material": [ "orichalcum_metal", "steel", "leather" ],
     "techniques": [ "WBLOCK_2", "PRECISE", "VORPAL" ],
     "volume": "2500 ml",
-    "cutting": 45,
+    "cutting": 50,
     "price": "2 kUSD"
   },
   {
@@ -51,8 +52,8 @@
     "flags": [ "MAGIC_FOCUS" ],
     "techniques": [ "WBLOCK_2", "SPIN", "RAPID", "SWEEP" ],
     "weight": "1860 g",
-    "bashing": 20,
-    "cutting": 35,
+    "bashing": 30,
+    "cutting": 10,
     "use_action": { "type": "cast_spell", "spell_id": "ethereal_grasp", "no_fail": true, "level": 10, "need_wielding": true }
   },
   {
@@ -80,7 +81,7 @@
     "type": "TOOL",
     "id": "orich_fire_ax",
     "name": { "str": "orichalcum fire axe" },
-    "description": "A fire axe made with orichalcum instead of steel.  This allows the axe to be just as effective as its steal counterpart at chopping, with less weight to tire the arms.",
+    "description": "A fire axe made with orichalcum instead of steel.  This allows the axe to be just as effective as its steel counterpart at chopping, with less weight to tire the arms.",
     "material": [ "orichalcum_metal" ],
     "proportional": { "cutting": 1.1, "price": 5, "weight": 0.99 },
     "color": "yellow"

--- a/data/mods/Magical_Nights/items/melee.json
+++ b/data/mods/Magical_Nights/items/melee.json
@@ -8,10 +8,12 @@
     "weight": "1731 g",
     "color": "light_gray",
     "material": [ "orichalcum_metal", "wood", "gold" ],
-    "techniques": [ "WBLOCK_2", "BRUTAL" ],
+    "techniques": [ "WBLOCK_2", "BRUTAL", "SWEEP" ],
+    "relic_data": { "passive_effects": [ { "id": "ench_mjolnir" } ] },
     "volume": "3750 ml",
     "bashing": 50,
     "cutting": 0,
+    "to_hit": 2,
     "price": "2 kUSD"
   },
   {
@@ -23,9 +25,11 @@
     "weight": "1854 g",
     "material": [ "orichalcum_metal", "wood", "gold" ],
     "techniques": [ "WBLOCK_1", "IMPALE", "SWEEP" ],
+    "relic_data": { "passive_effects": [ { "id": "ench_gungnir" } ] },
     "volume": "3250 ml",
     "bashing": 10,
     "cutting": 40,
+    "to_hit": 3,
     "price": "2 kUSD"
   },
   {
@@ -38,7 +42,9 @@
     "material": [ "orichalcum_metal", "steel", "leather" ],
     "techniques": [ "WBLOCK_2", "PRECISE", "VORPAL" ],
     "volume": "2500 ml",
-    "cutting": 50,
+    "//": "Extra-sharp because it is thus in mythos and also to compensate for lack of sick magic",
+    "cutting": 80,
+    "to_hit": 2,
     "price": "2 kUSD"
   },
   {
@@ -51,10 +57,10 @@
     "material": [ "steel", "gold", "orichalcum_metal" ],
     "flags": [ "MAGIC_FOCUS" ],
     "techniques": [ "WBLOCK_2", "SPIN", "RAPID", "SWEEP" ],
+    "relic_data": { "passive_effects": [ { "id": "ench_laevateinn" } ] },
     "weight": "1860 g",
     "bashing": 30,
-    "cutting": 10,
-    "use_action": { "type": "cast_spell", "spell_id": "ethereal_grasp", "no_fail": true, "level": 10, "need_wielding": true }
+    "cutting": 10
   },
   {
     "copy-from": "knife_combat",


### PR DESCRIPTION
## Purpose of change (The Why)

The "legendary" weapons from Norse mythos were considered pretty crappy and not-epic by everyone, and I agree. Thus, I felt the need to buff these items to the status they deserve.

Also, in a previous PR (#6043) I used "steal" instead of "steel" in the orichalcum fire axe's new description, somehow, so I fixed that while I was in the file.

## Describe the solution (The How)

- Generally buffs the melee damage and `to_hit` of the relevant weapons
- Adds enchantments to Mjolnir, Gungnir, and Laevateinn
- Gives Gram extra sharpness to match mythos and to partially compensate for lack of cool enchantments
- Fixes the type in the fire axe description

## Describe alternatives you've considered

- Get rid of them

I don't want to deal with the migration and also that seems like a bad idea
- Get rid of Gungnir and Gram, replace them with some non-Norse weapons

I'm far more amicable to this idea, but I think the better solution is to just add the non-Norse weapons *in addition* to the Norse instead of replacing

## Testing

Loaded in, confirmed the enchantments work appropriately

## Additional context

Gram is probably kinda disappointing, but I wanted to keep it fairly mythos accurate.

Gungnir's effect is the best I can do without making it an item cast or making a flag like `NO_MISS` for melee attacks, with this solution making it so that if you hit once you hit every time afterwards basically.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
