### PR TITLE
feat: add rabbit mutation to Mr_Lapin

### DIFF
--- a/data/json/npcs/holdouts/Mr_Lapin.json
+++ b/data/json/npcs/holdouts/Mr_Lapin.json
@@ -49,7 +49,7 @@
       { "text": "What are you doing here?", "topic": "TALK_WARRENER_DOING" },
       { "text": "Heard anything about the outside world?", "topic": "TALK_WARRENER_WORLD" },
       { "text": "You look different?", "topic": "TALK_WARRENER_MUTATION" },
-      { "text": "Anything I can help with?", "topic": "TALK_MISSION_LIST" },	  
+      { "text": "Anything I can help with?", "topic": "TALK_MISSION_LIST" },
       { "text": "Well, bye.", "topic": "TALK_DONE" }
     ]
   },

--- a/data/json/npcs/holdouts/Mr_Lapin.json
+++ b/data/json/npcs/holdouts/Mr_Lapin.json
@@ -33,8 +33,11 @@
       [ "GOODHEARING", 100 ],
       [ "DEFT", 100 ],
       [ "ANIMALEMPATH2", 100 ],
-      [ "LIGHTFUR", 100 ],
-      [ "HOOVES", 100 ]
+      [ "RABBIT_NOSE", 100 ],
+      [ "RABBIT_FUR", 100 ],
+      [ "TAIL_RABBIT", 100 ],
+      [ "RABBIT_EARS", 100 ],
+      [ "THRESH_RABBIT", 100 ]
     ]
   },
   {
@@ -46,7 +49,7 @@
       { "text": "What are you doing here?", "topic": "TALK_WARRENER_DOING" },
       { "text": "Heard anything about the outside world?", "topic": "TALK_WARRENER_WORLD" },
       { "text": "You look different?", "topic": "TALK_WARRENER_MUTATION" },
-      { "text": "Anything I can help with?", "topic": "TALK_MISSION_LIST" },
+      { "text": "Anything I can help with?", "topic": "TALK_MISSION_LIST" },	  
       { "text": "Well, bye.", "topic": "TALK_DONE" }
     ]
   },
@@ -81,7 +84,7 @@
     "type": "talk_topic",
     "id": "TALK_WARRENER_MUTATION",
     "dynamic_line": {
-      "u_has_any_trait": [ "CANINE_EARS", "LUPINE_EARS", "FELINE_EARS", "URSINE_EARS", "ELFA_EARS", "LIGHTFUR" ],
+      "u_has_any_trait": [ "RABBIT_EARS", "CANINE_EARS", "LUPINE_EARS", "FELINE_EARS", "URSINE_EARS", "ELFA_EARS", "LIGHTFUR" ],
       "yes": "Same way you got yours, I bet.",
       "no": "CRISPR?  Radiation?  Something in the water?  Maybe it was bunnies."
     },
@@ -94,7 +97,7 @@
     "type": "talk_topic",
     "id": "TALK_WARRENER_MUTATION_INSULT",
     "dynamic_line": {
-      "u_has_any_trait": [ "CANINE_EARS", "LUPINE_EARS", "FELINE_EARS", "URSINE_EARS", "ELFA_EARS", "LIGHTFUR" ],
+      "u_has_any_trait": [ "RABBIT_EARS", "CANINE_EARS", "LUPINE_EARS", "FELINE_EARS", "URSINE_EARS", "ELFA_EARS", "LIGHTFUR" ],
       "yes": "I'm very sorry to tell you this, but you should look in a mirror.",
       "no": "Insulting people who could help you is unlikely to aid survival."
     },


### PR DESCRIPTION
## Purpose of change (The Why)
When Rabbit Mutations were added to the game, they weren't added to the game's only Rabbit NPC
<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
I added them
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing
![image](https://github.com/user-attachments/assets/0b3a5c6c-c836-470c-a817-77303ae247c6)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
