### PR TITLE
feat: make more overmaps with unique NPC globally unique

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -332,7 +332,7 @@
     "locations": [ "forest" ],
     "city_distance": [ 25, -1 ],
     "occurrences": [ 40, 100 ],
-    "flags": [ "CLASSIC", "WILDERNESS", "GLOBALLY_UNIQUE", "UNIQUE", "ELECTRIC_GRID" ]
+    "flags": [ "CLASSIC", "WILDERNESS", "GLOBALLY_UNIQUE", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -615,7 +615,7 @@
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 1, -1 ],
     "occurrences": [ 10, 100 ],
-    "flags": [ "GLOBALLY_UNIQUE", "UNIQUE", "FARM", "ELECTRIC_GRID" ]
+    "flags": [ "GLOBALLY_UNIQUE", "FARM", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -5080,7 +5080,7 @@
     "city_distance": [ 15, -1 ],
     "occurrences": [ 20, 100 ],
     "connections": [ { "point": [ -1, 15, 0 ], "connection": "local_road", "from": [ 0, 15, 0 ] } ],
-    "flags": [ "CLASSIC", "FARM", "GLOBALLY_UNIQUE", "UNIQUE" ]
+    "flags": [ "CLASSIC", "FARM", "GLOBALLY_UNIQUE" ]
   },
   {
     "id": "airliner_crashed",

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -331,7 +331,7 @@
     ],
     "locations": [ "forest" ],
     "city_distance": [ 25, -1 ],
-    "occurrences": [ 40, 100 ],
+    "occurrences": [ 75, 100 ],
     "flags": [ "CLASSIC", "WILDERNESS", "GLOBALLY_UNIQUE", "ELECTRIC_GRID" ]
   },
   {
@@ -614,7 +614,7 @@
     "locations": [ "field" ],
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 1, -1 ],
-    "occurrences": [ 10, 100 ],
+    "occurrences": [ 50, 100 ],
     "flags": [ "GLOBALLY_UNIQUE", "FARM", "ELECTRIC_GRID" ]
   },
   {
@@ -5078,7 +5078,7 @@
     ],
     "locations": [ "land" ],
     "city_distance": [ 15, -1 ],
-    "occurrences": [ 20, 100 ],
+    "occurrences": [ 50, 100 ],
     "connections": [ { "point": [ -1, 15, 0 ], "connection": "local_road", "from": [ 0, 15, 0 ] } ],
     "flags": [ "CLASSIC", "FARM", "GLOBALLY_UNIQUE" ]
   },
@@ -6591,7 +6591,7 @@
     "locations": [ "forest" ],
     "city_distance": [ 5, 10 ],
     "city_sizes": [ 4, -1 ],
-    "occurrences": [ 0, 1 ],
+    "occurrences": [ 50, 100 ],
     "flags": [ "CLASSIC", "WILDERNESS", "ELECTRIC_GRID", "GLOBALLY_UNIQUE" ]
   },
   {
@@ -6602,7 +6602,7 @@
     "locations": [ "field" ],
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 1, -1 ],
-    "occurrences": [ 0, 1 ],
+    "occurrences": [ 50, 100 ],
     "flags": [ "CLASSIC", "ELECTRIC_GRID", "GLOBALLY_UNIQUE" ]
   },
   {
@@ -6633,7 +6633,7 @@
     "locations": [ "forest" ],
     "city_distance": [ 5, 60 ],
     "city_sizes": [ 4, -1 ],
-    "occurrences": [ 0, 2 ],
+    "occurrences": [ 50, 100 ],
     "flags": [ "CLASSIC", "WILDERNESS", "ELECTRIC_GRID", "ELECTRIC_GRID", "GLOBALLY_UNIQUE" ]
   },
   {

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -332,7 +332,7 @@
     "locations": [ "forest" ],
     "city_distance": [ 25, -1 ],
     "occurrences": [ 40, 100 ],
-    "flags": [ "CLASSIC", "WILDERNESS", "UNIQUE", "ELECTRIC_GRID" ]
+    "flags": [ "CLASSIC", "WILDERNESS", "GLOBALLY_UNIQUE", "UNIQUE", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -615,7 +615,7 @@
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 1, -1 ],
     "occurrences": [ 10, 100 ],
-    "flags": [ "UNIQUE", "FARM", "ELECTRIC_GRID" ]
+    "flags": [ "GLOBALLY_UNIQUE", "UNIQUE", "FARM", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -5080,7 +5080,7 @@
     "city_distance": [ 15, -1 ],
     "occurrences": [ 20, 100 ],
     "connections": [ { "point": [ -1, 15, 0 ], "connection": "local_road", "from": [ 0, 15, 0 ] } ],
-    "flags": [ "CLASSIC", "FARM", "UNIQUE" ]
+    "flags": [ "CLASSIC", "FARM", "GLOBALLY_UNIQUE", "UNIQUE" ]
   },
   {
     "id": "airliner_crashed",
@@ -6592,7 +6592,7 @@
     "city_distance": [ 5, 10 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 0, 1 ],
-    "flags": [ "CLASSIC", "WILDERNESS", "ELECTRIC_GRID" ]
+    "flags": [ "CLASSIC", "WILDERNESS", "ELECTRIC_GRID", "GLOBALLY_UNIQUE" ]
   },
   {
     "type": "overmap_special",
@@ -6603,7 +6603,7 @@
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 1, -1 ],
     "occurrences": [ 0, 1 ],
-    "flags": [ "CLASSIC" ]
+    "flags": [ "CLASSIC", "ELECTRIC_GRID", "GLOBALLY_UNIQUE" ]
   },
   {
     "type": "overmap_special",
@@ -6634,7 +6634,7 @@
     "city_distance": [ 5, 60 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 0, 2 ],
-    "flags": [ "CLASSIC", "WILDERNESS", "ELECTRIC_GRID" ]
+    "flags": [ "CLASSIC", "WILDERNESS", "ELECTRIC_GRID", "ELECTRIC_GRID", "GLOBALLY_UNIQUE" ]
   },
   {
     "type": "overmap_special",

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -52,7 +52,7 @@ TEST_CASE( "default_overmap_generation_always_succeeds", "[overmap][slow]" )
         overmap_buffer.create_custom_overmap( candidate_addr, test_specials );
         for( const auto &special_placement : test_specials ) {
             auto special = special_placement.special_details;
-            if( special->has_flag( "UNIQUE" ) ) {
+            if( special->has_flag( "UNIQUE" ) || special->has_flag( "GLOBALLY_UNIQUE" ) ) {
                 continue;
             }
             INFO( "In attempt #" << overmaps_to_construct


### PR DESCRIPTION
## Purpose of change (The Why)
prevent the spawning of the same NPC (specifically no multiple Mr. Lapins)
<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
In order to prevent NPC's being duplicated, this pull request adds the flag  "GLOBALLY_UNIQUE" to the following overmaps:
- "Cabin_Lapin"
- "Isherwood Farms"
- "St_Johns_farm"
- "Occupied Chem Lab"
- "Occupied Lumbermill"
- "Occupied Scrap Yard"

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
I had considered not adding the flag to the occupied sites, however since there are tie-ins to the Evac Center's Merchant missions I felt they should be added.
## Testing
Ran a bunch of random starts and they didn't appear to duplicate.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
