### PR TITLE
ci: Fix cross-compiled Windows builds and manual-release tiles OSX builds

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -212,7 +212,8 @@ jobs:
           sudo apt update
           sudo apt install astyle autoconf automake autopoint bash bison bzip2 cmake flex gettext git g++ gperf intltool \
             libffi-dev libgdk-pixbuf2.0-dev libtool libltdl-dev libssl-dev libxml-parser-perl lzip make mingw-w64 openssl \
-            p7zip-full patch perl pkg-config python3 ruby scons sed unzip wget xz-utils g++-multilib libc6-dev-i386 libtool-bin
+            p7zip-full patch perl pkg-config python3 ruby scons sed unzip wget xz-utils g++-multilib libc6-dev-i386 libtool-bin \
+            libsqlite3-dev zlib1g-dev
       - name: Install MXE
         if: matrix.mxe != 'none'
         run: |
@@ -269,7 +270,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           source ./venv/bin/activate
-          make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} LUA=1 RELEASE=1 LANGUAGES=all USE_HOME_DIR=1 OSX_MIN=11 PCH=0 COMPILER=$(brew --prefix llvm)/bin/clang++ dmgdist
+          make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LUA=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=0 PCH=0 USE_HOME_DIR=1 OSX_MIN=11 FRAMEWORK=1 COMPILER=$(brew --prefix llvm)/bin/clang++ dmgdist
           mv CataclysmBN-${{ env.VERSION }}.dmg cbn-${{ matrix.artifact }}-${{ env.VERSION }}.dmg
       - name: Set up JDK 11 (android)
         if: runner.os == 'Linux' && matrix.android != 'none' && matrix.mxe == 'none'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,7 +241,8 @@ jobs:
           sudo apt update
           sudo apt install astyle autoconf automake autopoint bash bison bzip2 cmake flex gettext git g++ gperf intltool \
             libffi-dev libgdk-pixbuf2.0-dev libtool libltdl-dev libssl-dev libxml-parser-perl lzip make mingw-w64 openssl \
-            p7zip-full patch perl pkg-config python3 ruby scons sed unzip wget xz-utils g++-multilib libc6-dev-i386 libtool-bin
+            p7zip-full patch perl pkg-config python3 ruby scons sed unzip wget xz-utils g++-multilib libc6-dev-i386 libtool-bin \
+            libsqlite3-dev zlib1g-dev
 
       - name: Install MXE
         if: matrix.mxe != 'none'


### PR DESCRIPTION
## Purpose of change (The Why)

In the words of CGP Grey: "1 is none. 2 is one. If it's important, have a backup."

SQLite-save PR passed over the non-MSVC Windows builds, and as it turns out the manual release's build command on OSX builds has been broken the entire time? (Or at least for 2 years). Having a redundant Windows build is a great idea for when MSVC is being weird, and I'm sure the OSX users would like 

## Describe the solution (The How)

- Add SQLite dependencies to the cross-compile build for Windows
- Copy over the Nightly release's build command for OSX manual releases

## Describe alternatives you've considered

- Let them suffer, it builds character!

## Testing

I used my eyes and made sure I was copy-pasting the right things.

Proper testing shall come with actual build attempts

## Additional context

At least OSX users have the Nightlies already

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

