### PR TITLE
ci: ignore markdown changes

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,7 +14,9 @@ on:
       - "tools/**"
       - "!tools/format/**"
       - "utilities/**"
-      - 'scripts/**'
+      - "scripts/**"
+      - "**.md"
+      - "**.mdx"
 
 # We only care about the latest revision of a PR, so cancel previous instances.
 concurrency:

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -3,10 +3,10 @@ name: General build matrix
 on:
   push:
     branches: [main]
-    paths-ignore: [doc/**, scripts/**]
+    paths-ignore: [doc/**, scripts/**, "**.md", "**.mdx"]
   pull_request:
     branches: [main]
-    paths-ignore: [doc/**, scripts/**]
+    paths-ignore: [doc/**, scripts/**, "**.md", "**.mdx"]
     types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
 

--- a/.github/workflows/msvc-full-features-cmake.yml
+++ b/.github/workflows/msvc-full-features-cmake.yml
@@ -16,6 +16,8 @@ on:
     - '!tools/format/**'
     - 'utilities/**'
     - 'scripts/**'
+    - "**.md"
+    - "**.mdx"
   pull_request:
     branches:
     - main
@@ -31,7 +33,8 @@ on:
     - '!tools/format/**'
     - 'utilities/**'
     - 'scripts/**'
-
+    - "**.md"
+    - "**.mdx"
 # We only care about the latest revision, so cancel previous instances.
 concurrency:
   group: msvc-cmake-build-${{ github.ref_name }}

--- a/.github/workflows/msys2-cmake.yml
+++ b/.github/workflows/msys2-cmake.yml
@@ -15,7 +15,8 @@ on:
     - '!tools/format/**'
     - 'utilities/**'
     - 'scripts/**'
-
+    - "**.md"
+    - "**.mdx"
 # We only care about the latest revision, so cancel previous instances.
 concurrency:
   group: msys2-cmake-build-${{ github.ref_name }}

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -16,7 +16,8 @@ on:
       - "!tools/format/**"
       - "utilities/**"
       - 'scripts/**'
-
+      - "**.md"
+      - "**.mdx"
 # We only care about the latest revision of a PR, so cancel previous instances.
 concurrency:
   group: osx-build-${{ github.event.pull_request.number || github.ref_name }}
@@ -63,13 +64,13 @@ jobs:
 
     env:
       ZSTD_CLEVEL: 17
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-        
+
       - name: Install runtime dependencies
         uses: BrettDong/setup-sdl2-frameworks@v1
         with:
@@ -77,7 +78,7 @@ jobs:
           sdl2-ttf: 2.24.0
           sdl2-image: 2.8.4
           sdl2-mixer: 2.8.0
-        
+
       - name: Install build dependencies
         run: |
           HOMEBREW_NO_AUTO_UPDATE=yes HOMEBREW_NO_INSTALL_CLEANUP=yes brew install sdl2 sdl2_image sdl2_ttf sdl2_mixer gettext ccache parallel llvm astyle sqlite3 zlib


### PR DESCRIPTION
## Purpose of change (The Why)

no need to run build matrix only to edit markdown files.

## Describe the solution (The How)

update [`paths-ignore`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore) to ignore all files with [markdown (`.md` and `.mdx`) file extension.](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-including-paths)

## Describe alternatives you've considered

wait hours on documentation-only changes

## Testing

shouldn't fail

## Additional context

deno can now format YAML files too, now to format these `.github/` workflows...

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
