### PR TITLE
fix(mods/MagicalNights): Upgraded dbone weapons take their base versions

### DIFF
--- a/data/mods/Magical_Nights/recipes/weapons.json
+++ b/data/mods/Magical_Nights/recipes/weapons.json
@@ -420,7 +420,7 @@
     "time": "8 h",
     "book_learn": [ [ "textbook_weapwest", 8 ], [ "recipe_melee", 7 ] ],
     "using": [ [ "blacksmithing_advanced", 12 ] ],
-    "components": [ [ [ "black_dragon_tanned_hide", 2 ] ], [ [ "dragon_essence", 1 ] ] ]
+    "components": [ [ [ "black_dragon_tanned_hide", 2 ] ], [ [ "dragon_essence", 1 ] ], [ [ "dbone_battleaxe", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -433,7 +433,7 @@
     "time": "8 h",
     "book_learn": [ [ "textbook_weapeast", 7 ] ],
     "using": [ [ "blacksmithing_advanced", 8 ] ],
-    "components": [ [ [ "black_dragon_tanned_hide", 1 ] ], [ [ "dragon_essence", 1 ] ] ]
+    "components": [ [ [ "black_dragon_tanned_hide", 1 ] ], [ [ "dragon_essence", 1 ] ], [ [ "dbone_tachi", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -446,7 +446,7 @@
     "time": "7 h",
     "book_learn": [ [ "textbook_weapwest", 7 ] ],
     "using": [ [ "blacksmithing_advanced", 16 ] ],
-    "components": [ [ [ "black_dragon_tanned_hide", 1 ] ], [ [ "dragon_essence", 1 ] ] ]
+    "components": [ [ [ "black_dragon_tanned_hide", 1 ] ], [ [ "dragon_essence", 1 ] ], [ [ "dbone_longsword", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -459,7 +459,7 @@
     "time": "7 h 40 m",
     "book_learn": [ [ "textbook_armschina", 6 ] ],
     "using": [ [ "blacksmithing_advanced", 4 ] ],
-    "components": [ [ [ "black_dragon_tanned_hide", 2 ] ], [ [ "dragon_essence", 1 ] ] ]
+    "components": [ [ [ "black_dragon_tanned_hide", 2 ] ], [ [ "dragon_essence", 1 ] ], [ [ "dbone_qiang", 1 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
## Purpose of change (The Why)

Obviously an upgraded weapon should take its base version as a material

## Describe the solution (The How)

Adds the relevant components to the recipes

## Describe alternatives you've considered

## Testing

I read it and linted it

## Additional context

AAAAAAAA why didn't I fix this the last time it got brought up

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)

