### PR TITLE
style: format `.github` directories

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,11 +26,19 @@ NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive
 
 ### Mandatory
 
-- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
-- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
-- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
-- [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
-- [ ] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)
+- [ ] I wrote the PR title in
+      [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
+- [ ] I ran the
+      [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
+- [ ] I linked any relevant issues using
+      [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes)
+      like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed
+      automatically.
+- [ ] I've
+      [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes)
+      so it won't cause conflict when updating `main` branch later.
+- [ ] I understand that, unless specified otherwise,
+      [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)
 
 <!--
 please remove sections irrelevant to this PR.

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -6,7 +6,7 @@
 # Validate the PR title, and ignore all commit messages
 enabled: true
 titleOnly: true
-targetUrl: 'https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/'
+targetUrl: "https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/"
 types:
   - feat
   - fix

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,4 +1,4 @@
-name: autofix.ci  # needed to securely identify the workflow
+name: autofix.ci # needed to securely identify the workflow
 
 on:
   pull_request:

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -6,7 +6,19 @@ on:
   #   paths: [ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "build-scripts/**","tools/clang-tidy-plugin/**", ".github/workflows/clang-tidy.yml", "**/.clang-tidy" ]
   pull_request:
     branches: [main]
-    paths: [ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "build-scripts/**", "tools/clang-tidy-plugin/**", ".github/workflows/clang-tidy.yml", "**/.clang-tidy" ]
+    paths: [
+      "**.cpp",
+      "**.h",
+      "**.c",
+      "**/CMakeLists.txt",
+      "**/Makefile",
+      "**.hpp",
+      "**.cmake",
+      "build-scripts/**",
+      "tools/clang-tidy-plugin/**",
+      ".github/workflows/clang-tidy.yml",
+      "**/.clang-tidy",
+    ]
 
 # We only care about the latest revision of a PR, so cancel all previous instances.
 concurrency:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -6,7 +6,6 @@ on:
     paths: [doc/**]
   workflow_dispatch:
 
-
 defaults:
   run:
     working-directory: doc

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -107,18 +107,18 @@ jobs:
         #    ccache_limit: 2G
         #    ccache_key: linux-llvm-14-asan
 
-          # - title: Clang 14, macOS 12, Tiles, Sound, Localize, Lua
-          #   compiler: clang++
-          #   os: macos-14
-          #   cmake: 0
-          #   tiles: 1
-          #   sound: 1
-          #   lua: 1
-          #   test-stage: 1
-          #   native: osx
-          #   grep_clang_version_rxp: "14\\.[0-9]+\\.[0-9]+"
-          #   ccache_limit: 1G # avg. 980MB~1100MB
-          #   ccache_key: macos-llvm-14
+    # - title: Clang 14, macOS 12, Tiles, Sound, Localize, Lua
+    #   compiler: clang++
+    #   os: macos-14
+    #   cmake: 0
+    #   tiles: 1
+    #   sound: 1
+    #   lua: 1
+    #   test-stage: 1
+    #   native: osx
+    #   grep_clang_version_rxp: "14\\.[0-9]+\\.[0-9]+"
+    #   ccache_limit: 1G # avg. 980MB~1100MB
+    #   ccache_key: macos-llvm-14
 
     name: ${{ matrix.title }}
     runs-on: ${{ matrix.os }}
@@ -162,7 +162,7 @@ jobs:
       - name: install SDL2 dependencies (ubuntu)
         if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && matrix.tiles == 1 }}
         run: |
-            sudo apt-get install libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libpulse-dev libflac-dev
+          sudo apt-get install libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libpulse-dev libflac-dev
 
       # === Temporarily disabled because of #3664 ===
       # - name: set up a mock GCC toolchain root for Clang (Ubuntu)
@@ -252,7 +252,7 @@ jobs:
 
       - name: emit success artifact
         if: ${{ success() && matrix.upload-artifact == 'true' }}
-        uses:  actions/upload-artifact@v4.6.0
+        uses: actions/upload-artifact@v4.6.0
         with:
           name: ${{ github.event.number }}
           path: ${{ github.event.number }}

--- a/.github/workflows/msvc-full-features-cmake.yml
+++ b/.github/workflows/msvc-full-features-cmake.yml
@@ -3,38 +3,38 @@ name: Cataclysm Windows build (CMake + MSVC)
 on:
   push:
     branches:
-    - main
+      - main
     paths-ignore:
-    - 'android/**'
-    - 'build-data/osx/**'
-    - 'doc/**'
-    - 'doxygen_doc/**'
-    - 'gfx/**'
-    - 'lang/**'
-    - 'lgtm/**'
-    - 'tools/**'
-    - '!tools/format/**'
-    - 'utilities/**'
-    - 'scripts/**'
-    - "**.md"
-    - "**.mdx"
+      - "android/**"
+      - "build-data/osx/**"
+      - "doc/**"
+      - "doxygen_doc/**"
+      - "gfx/**"
+      - "lang/**"
+      - "lgtm/**"
+      - "tools/**"
+      - "!tools/format/**"
+      - "utilities/**"
+      - "scripts/**"
+      - "**.md"
+      - "**.mdx"
   pull_request:
     branches:
-    - main
+      - main
     paths-ignore:
-    - 'android/**'
-    - 'build-data/osx/**'
-    - 'doc/**'
-    - 'doxygen_doc/**'
-    - 'gfx/**'
-    - 'lang/**'
-    - 'lgtm/**'
-    - 'tools/**'
-    - '!tools/format/**'
-    - 'utilities/**'
-    - 'scripts/**'
-    - "**.md"
-    - "**.mdx"
+      - "android/**"
+      - "build-data/osx/**"
+      - "doc/**"
+      - "doxygen_doc/**"
+      - "gfx/**"
+      - "lang/**"
+      - "lgtm/**"
+      - "tools/**"
+      - "!tools/format/**"
+      - "utilities/**"
+      - "scripts/**"
+      - "**.md"
+      - "**.mdx"
 # We only care about the latest revision, so cancel previous instances.
 concurrency:
   group: msvc-cmake-build-${{ github.ref_name }}
@@ -55,59 +55,59 @@ jobs:
     if: github.event.pull_request.draft == false
 
     steps:
-    - name: checkout repository
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 1
+      - name: checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
-    - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.3.1
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.3.1
 
-    - name: Remove Strawberry Perl from PATH
-      run: |
-        echo $env:PATH
-        echo =========================
-        $env:PATH = $env:PATH -replace "C:\\Strawberry\\c\\bin;", ""
-        $env:PATH = $env:PATH -replace "C:\\Strawberry\\perl\\site\\bin;", ""
-        $env:PATH = $env:PATH -replace "C:\\Strawberry\\perl\\bin;", ""
-        "PATH=$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Append
-        echo =========================
-        echo $env:PATH
+      - name: Remove Strawberry Perl from PATH
+        run: |
+          echo $env:PATH
+          echo =========================
+          $env:PATH = $env:PATH -replace "C:\\Strawberry\\c\\bin;", ""
+          $env:PATH = $env:PATH -replace "C:\\Strawberry\\perl\\site\\bin;", ""
+          $env:PATH = $env:PATH -replace "C:\\Strawberry\\perl\\bin;", ""
+          "PATH=$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo =========================
+          echo $env:PATH
 
-    - name: Install stable CMake
-      uses: lukka/get-cmake@latest
+      - name: Install stable CMake
+        uses: lukka/get-cmake@latest
 
-    - name: Install vcpkg
-      uses: lukka/run-vcpkg@main
-      id: runvcpkg
-      with:
-        vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
+      - name: Install vcpkg
+        uses: lukka/run-vcpkg@main
+        id: runvcpkg
+        with:
+          vcpkgDirectory: "${{ runner.workspace }}/b/vcpkg"
 
-    - name: Integrate vcpkg
-      run: |
-        vcpkg integrate install
+      - name: Integrate vcpkg
+        run: |
+          vcpkg integrate install
 
-    - uses: ammaraskar/msvc-problem-matcher@master
-    - name: Configure
-      run: |
+      - uses: ammaraskar/msvc-problem-matcher@master
+      - name: Configure
+        run: |
           cmake -DTESTS=ON --preset $env:CMAKE_PRESET
 
-    - uses: ammaraskar/msvc-problem-matcher@master
-    - name: Build
-      run: |
+      - uses: ammaraskar/msvc-problem-matcher@master
+      - name: Build
+        run: |
           cmake --build out/build/$env:CMAKE_PRESET --config RelWithDebInfo
 
-    - name: Dump logs if build failed
-      if: failure()
-      run: |
-        echo =================================================
-        Get-ChildItem "${{ runner.workspace }}/Cataclysm-BN/out/build/$env:CMAKE_PRESET" -Recurse
-        echo =================================================
+      - name: Dump logs if build failed
+        if: failure()
+        run: |
+          echo =================================================
+          Get-ChildItem "${{ runner.workspace }}/Cataclysm-BN/out/build/$env:CMAKE_PRESET" -Recurse
+          echo =================================================
 
-    - name: Compile .mo files for localization
-      run: |
+      - name: Compile .mo files for localization
+        run: |
           cmake --build out/build/$env:CMAKE_PRESET --target translations_compile --config RelWithDebInfo
 
-    - name: Run tests
-      run: |
+      - name: Run tests
+        run: |
           .\RelWithDebInfo\cata_test-tiles.exe --rng-seed time

--- a/.github/workflows/msys2-cmake.yml
+++ b/.github/workflows/msys2-cmake.yml
@@ -3,20 +3,20 @@ name: Windows build (CMake + MSYS2)
 on:
   push:
     branches:
-    - main
+      - main
     paths-ignore:
-    - 'android/**'
-    - 'build-data/osx/**'
-    - 'doc/**'
-    - 'doxygen_doc/**'
-    - 'gfx/**'
-    - 'lang/**'
-    - 'tools/**'
-    - '!tools/format/**'
-    - 'utilities/**'
-    - 'scripts/**'
-    - "**.md"
-    - "**.mdx"
+      - "android/**"
+      - "build-data/osx/**"
+      - "doc/**"
+      - "doxygen_doc/**"
+      - "gfx/**"
+      - "lang/**"
+      - "tools/**"
+      - "!tools/format/**"
+      - "utilities/**"
+      - "scripts/**"
+      - "**.md"
+      - "**.mdx"
 # We only care about the latest revision, so cancel previous instances.
 concurrency:
   group: msys2-cmake-build-${{ github.ref_name }}
@@ -33,57 +33,57 @@ jobs:
         shell: msys2 {0}
 
     steps:
-    - name: checkout repository
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 1
+      - name: checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
-    - name: Setup MSYS2
-      # Will by default install MINGW64
-      uses: msys2/setup-msys2@v2
-      with:
-        update: true
-        install: |
-          git
-          make
-          gettext
-          mingw-w64-x86_64-libmad
-          mingw-w64-x86_64-libwebp
-          mingw-w64-x86_64-pkg-config
-          mingw-w64-x86_64-SDL2
-          mingw-w64-x86_64-SDL2_image
-          mingw-w64-x86_64-SDL2_mixer
-          mingw-w64-x86_64-SDL2_ttf
-          mingw-w64-x86_64-toolchain
-          mingw-w64-x86_64-cmake
-          mingw-w64-x86_64-sqlite3
-          mingw-w64-x86_64-zstd
+      - name: Setup MSYS2
+        # Will by default install MINGW64
+        uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          install: |
+            git
+            make
+            gettext
+            mingw-w64-x86_64-libmad
+            mingw-w64-x86_64-libwebp
+            mingw-w64-x86_64-pkg-config
+            mingw-w64-x86_64-SDL2
+            mingw-w64-x86_64-SDL2_image
+            mingw-w64-x86_64-SDL2_mixer
+            mingw-w64-x86_64-SDL2_ttf
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-cmake
+            mingw-w64-x86_64-sqlite3
+            mingw-w64-x86_64-zstd
 
-    - name: Create build directory
-      run: mkdir build
+      - name: Create build directory
+        run: mkdir build
 
-    - name: Configure
-      run: |
-        cd build
-        cmake.exe \
-          -DTILES=ON \
-          -DSOUND=ON \
-          -DLUA=ON \
-          -DTESTS=ON \
-          -DDYNAMIC_LINKING=ON \
-          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-          -DCMAKE_CXX_FLAGS="-w" \
-          -G "Ninja" \
-          ..
+      - name: Configure
+        run: |
+          cd build
+          cmake.exe \
+            -DTILES=ON \
+            -DSOUND=ON \
+            -DLUA=ON \
+            -DTESTS=ON \
+            -DDYNAMIC_LINKING=ON \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_CXX_FLAGS="-w" \
+            -G "Ninja" \
+            ..
 
-    - name: Build
-      run: |
-        cmake.exe --build build -j$((`nproc`+0))
+      - name: Build
+        run: |
+          cmake.exe --build build -j$((`nproc`+0))
 
-    - name: Compile translations
-      run: |
-        cmake.exe --build build --target translations_compile
+      - name: Compile translations
+        run: |
+          cmake.exe --build build --target translations_compile
 
-    - name: Run tests
-      run: |
+      - name: Run tests
+        run: |
           ./build/tests/cata_test-tiles.exe --rng-seed time

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -15,7 +15,7 @@ on:
       - "tools/**"
       - "!tools/format/**"
       - "utilities/**"
-      - 'scripts/**'
+      - "scripts/**"
       - "**.md"
       - "**.mdx"
 # We only care about the latest revision of a PR, so cancel previous instances.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,7 +228,7 @@ jobs:
         uses: lukka/run-vcpkg@main
         id: runvcpkg
         with:
-          vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
+          vcpkgDirectory: "${{ runner.workspace }}/b/vcpkg"
 
       - name: Integrate vcpkg
         if: runner.os == 'Windows'

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -13,7 +13,7 @@
   "lint": { "include": ["scripts"] },
   "fmt": {
     "exclude": ["doc/dist", "doc/.astro", "doc/pnpm-lock.yaml"],
-    "include": ["scripts", "doc", "*.md"],
+    "include": ["scripts", "doc", "*.md", ".github"],
     "semiColons": false,
     "lineWidth": 100
   },


### PR DESCRIPTION
## Purpose of change (The Why)

Deno can format yaml files as of v1.46.0, no need to format yaml files manually.

## Describe the solution (The How)

includes `.github` directory for formatting.

## Describe alternatives you've considered

run it fully on `data/` but BFN doesn't like it because it makes porting stuff from DDA harder

## Testing

style only changes

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)
