### PR TITLE
chore: Fix the sqlite and zlib `include`s in world.cpp

### DIFF
--- a/src/world.cpp
+++ b/src/world.cpp
@@ -3,8 +3,6 @@
 #include <sstream>
 #include <cstring>
 #include <chrono>
-#include <sqlite3.h>
-#include <zlib.h>
 
 #include "game.h"
 #include "avatar.h"
@@ -16,6 +14,8 @@
 #include "mod_manager.h"
 #include "path_info.h"
 #include "compress.h"
+#include "sqlite3.h"
+#include "zlib.h"
 
 #define dbg(x) DebugLogFL((x),DC::Main)
 static sqlite3 *open_db( const std::string &path )


### PR DESCRIPTION
## Purpose of change (The Why)

Otherwise cross-compile Windows is very unhappy, and others might also encounter issues compiling.

## Describe the solution (The How)

`<>` -> `""`

## Describe alternatives you've considered

- Make someone else do it

## Testing

None

## Additional context

Trying to get 0.8 out but the MSYS2 builds keep pissing themselves

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)


