### PR TITLE
style: fix prose wrap in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,19 +26,11 @@ NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive
 
 ### Mandatory
 
-- [ ] I wrote the PR title in
-      [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
-- [ ] I ran the
-      [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
-- [ ] I linked any relevant issues using
-      [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes)
-      like `closes #1234` in [Summary of the PR](#why-should-this-pr-be-merged) so it can be closed
-      automatically.
-- [ ] I've
-      [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes)
-      so it won't cause conflict when updating `main` branch later.
-- [ ] I understand that, unless specified otherwise,
-      [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)
+- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
+- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
+- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
+- [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
+- [ ] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)
 
 <!--
 please remove sections irrelevant to this PR.

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -15,7 +15,8 @@
     "exclude": ["doc/dist", "doc/.astro", "doc/pnpm-lock.yaml"],
     "include": ["scripts", "doc", "*.md", ".github"],
     "semiColons": false,
-    "lineWidth": 100
+    "lineWidth": 100,
+    "proseWrap": "preserve"
   },
   "imports": {
     "$asynciter/": "https://deno.land/x/asynciter@0.0.18/",


### PR DESCRIPTION
## Purpose of change (The Why)

#6062 uglified checkboxes in PR template so this fixes it

## Describe the solution (The How)

use [`"proseWrap": "preserve"`](https://docs.deno.com/runtime/fundamentals/linting_and_formatting/#available-options) to keep the prose unwrapped.

## Describe alternatives you've considered

originally wanted to use "proseWrap": "never" but i remember olanti saying it made writing docs hard.

## Testing

style only changes.

## Additional context

i really need to revamp docs site aaaaahhhhh

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)
