### PR TITLE
feat(mods/MagicalNights): Move krabgeks to swamps, adjust swamp spawns

### DIFF
--- a/data/mods/Magical_Nights/monstergroups.json
+++ b/data/mods/Magical_Nights/monstergroups.json
@@ -36,9 +36,10 @@
       { "monster": "mon_wisp", "freq": 1, "cost_multiplier": 10, "conditions": [ "NIGHT" ], "pack_size": [ 1, 3 ] },
       { "monster": "mon_dragon_black_wyrmling", "freq": 2, "cost_multiplier": 50 },
       { "monster": "mon_dragon_black_young", "freq": 1, "cost_multiplier": 65 },
-      { "monster": "mon_lizardfolk_warrior", "freq": 20, "cost_multiplier": 1, "pack_size": [ 2, 4 ] },
-      { "monster": "mon_lizardfolk_hunter", "freq": 30, "cost_multiplier": 4, "pack_size": [ 1, 2 ] },
-      { "monster": "mon_lizardfolk_shaman", "freq": 10, "cost_multiplier": 30 }
+      { "monster": "mon_lizardfolk_warrior", "freq": 10, "cost_multiplier": 1, "pack_size": [ 1, 3 ] },
+      { "monster": "mon_lizardfolk_hunter", "freq": 10, "cost_multiplier": 4, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_lizardfolk_shaman", "freq": 5, "cost_multiplier": 30 },
+      { "monster": "mon_krabgek", "freq": 10, "cost_multiplier": 2 }
     ]
   },
   {

--- a/data/mods/Magical_Nights/worldgen/used_bookstore.json
+++ b/data/mods/Magical_Nights/worldgen/used_bookstore.json
@@ -52,7 +52,7 @@
         "d": "f_dumpster",
         "C": "f_counter"
       },
-      "monster": { "O": { "monster": "mon_krabgek", "chance": 100 }, "z": { "monster": "mon_krabgek", "chance": 33 } },
+      "monster": { "O": { "monster": "mon_resingolem_fresh", "chance": 100 }, "z": { "monster": "mon_resingolem_half", "chance": 20 } },
       "toilets": { "&": {  } },
       "items": { "M": { "item": "spellbook_loot_1", "chance": 60 }, "N": { "item": "novels", "chance": 60, "repeat": [ 1, 3 ] } }
     }


### PR DESCRIPTION
## Purpose of change (The Why)

Krabgeks in confined spaces are known to be very painful, and don't even make much sense to be in book stores in the first place.

Lizardfolk spawn in swamps a little too much for my liking, and I figured I might as well greb them while I'm at it.

## Describe the solution (The How)

Moves krabgeks into the swamps, replaces them in used book stores with resin golems to still offer a challenge but with less cheap shots.

Reduced frequency of lizardmen spawns by a good amount to be in line with the rest of the swamp additions in MN

## Describe alternatives you've considered

- Split the lizardmen changes off for extra atomicity and commit count

Laziness

## Testing

It loads, and *seems* to work.

## Additional context

![image](https://github.com/user-attachments/assets/aca7f04f-3d6d-4693-8851-528a6e5afb01)


## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or **CC-BY-SA 4.0** licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)
