### PR TITLE
chore: Obsolete No Hope and Generic Guns

### DIFF
--- a/data/mods/Generic_Guns/modinfo.json
+++ b/data/mods/Generic_Guns/modinfo.json
@@ -7,6 +7,7 @@
     "maintainers": [  ],
     "description": "Replaces guns and ammo with generic types.  Warning: can cause issues with other gun mods.",
     "category": "items",
-    "dependencies": [ "bn" ]
+    "dependencies": [ "bn" ],
+    "obsolete": true
   }
 ]

--- a/data/mods/No_Hope/modinfo.json
+++ b/data/mods/No_Hope/modinfo.json
@@ -4,11 +4,12 @@
     "id": "no_hope",
     "name": "No Hope",
     "authors": [ "Night_Pryanik" ],
-    "maintainers": [ "Night_Pryanik" ],
+    "maintainers": [  ],
     "description": "- No more guaranteed loot spawns anywhere.\n- Loot spawn in buildings is drastically reduced, especially for food, tools, guns etc.\n- Most buildings are destroyed, vandalized, or looted.\n- Most cars are destroyed or at least damaged.  Intact cars are nearly impossible to find.\n- Fuel is much harder to find, almost all cars have no fuel in tanks.\n- Marauders, looters, and bandits everywhere.\n\nSee extended description in README.md.",
     "category": "content",
     "dependencies": [ "bn" ],
-    "version": "3.0"
+    "version": "3.0",
+    "obsolete": true
   },
   {
     "type": "monster_adjustment",


### PR DESCRIPTION
## Purpose of change (The Why)

Both of these mods are generally unmaintained, they both are likely broken in some capacity at the moment, and we already don't recommend playing with either of them. It's time to bite the bullet.

## Describe the solution (The How)

`"obsolete": true` added to both modinfos, removed Pryanik from the maintainer slot of No Hope since I don't think he's been maintaining it here in ages in the first place?

## Describe alternatives you've considered

- Delete them outright

Even if we don't recommend it, I'm sure *someone* is running these mods still, and this way they can serve as examples for someone looking to create a better solution for them in the future.

## Testing

Linted, made sure that I'm not misspelling the field.

## Additional context

We ought to have done this even earlier tbh

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)
