### PR TITLE
feat(balance, mods/MagicalNights): Change magic academy spawning conditions, change door type

### DIFF
--- a/data/mods/Magical_Nights/worldgen/magic_academy.json
+++ b/data/mods/Magical_Nights/worldgen/magic_academy.json
@@ -37,6 +37,7 @@
         "[": [ [ "t_region_tree_fruit", 2 ], [ "t_region_tree_nut", 2 ], "t_region_tree_shade" ],
         " ": "t_floor",
         "#": "t_rock_wall",
+        "*": [ [ "t_door_locked_peep", 2 ], [ "t_door_locked", 10 ] ],
         ",": "t_concrete",
         "~": "t_water_pool_shallow_outdoors",
         "=": "t_grass_golf",

--- a/data/mods/Magical_Nights/worldgen/overmap_specials.json
+++ b/data/mods/Magical_Nights/worldgen/overmap_specials.json
@@ -158,7 +158,7 @@
       { "point": [ 0, 0, 4 ], "overmap": "wizardtower1_roof_north" }
     ],
     "locations": [ "forest" ],
-    "city_distance": [ 25, -1 ],
+    "city_distance": [ 20, -1 ],
     "city_sizes": [ 0, 10 ],
     "occurrences": [ 1, 4 ],
     "flags": [ "ELECTRIC_GRID" ]
@@ -174,7 +174,7 @@
       { "point": [ 0, 0, 4 ], "overmap": "wizardtower2_roof_north" }
     ],
     "locations": [ "forest" ],
-    "city_distance": [ 25, -1 ],
+    "city_distance": [ 20, -1 ],
     "city_sizes": [ 0, 10 ],
     "occurrences": [ 1, 4 ],
     "flags": [ "ELECTRIC_GRID" ]
@@ -194,8 +194,8 @@
       { "point": [ 0, 0, 8 ], "overmap": "magic_academy_roof_north" },
       { "point": [ 0, 0, -1 ], "overmap": "magic_academy_basement_north" }
     ],
-    "locations": [ "wilderness" ],
-    "city_distance": [ 30, -1 ],
+    "locations": [ "forest" ],
+    "city_distance": [ 20, -1 ],
     "city_sizes": [ 0, 10 ],
     "occurrences": [ 0, 1 ],
     "flags": [ "ELECTRIC_GRID" ]


### PR DESCRIPTION
## Purpose of change (The Why)

Magic academies might be getting a little too discouraged by their current spawning conditions, which are a little overly cautious.

Also, the doors could be alarmed which would cause eyebots to spawn which is very much so anti-lore

## Describe the solution (The How)

- Changes minimum distance from cities to 20 (from 30, not like mapgen cares anyway)
- Changed wizard tower distances to align (having them at 25 still would be weird)
- Changed magic academies to forests to better encourage not spawning in cities
- Overwrote the default domestic pallete's door selection to not include the alarmed variety in academies

## Describe alternatives you've considered

- Make magic academies globally unique

I don't think they quite meet that standard yet, but could rise there later

## Testing

It loads, the doors don't seem to show up alarmed, academies seem to spawn a little more often

## Additional context

None

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or ***CC-BY-SA 4.0*** licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)
