### PR TITLE
fix: Animal blood isn't cannibalism

### DIFF
--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -584,10 +584,25 @@
   {
     "type": "COMESTIBLE",
     "id": "animal_blood",
-    "copy-from": "blood",
+    "category": "other",
     "name": { "str_sp": "animal blood" },
+    "weight": "265 g",
+    "color": "red",
+    "container": "bag_iv",
+    "comestible_type": "DRINK",
+    "symbol": "~",
+    "quench": 5,
+    "healthy": -8,
+    "price_postapoc": "10 cent",
+    "calories": 43,
     "description": "Blood extracted from a living creature.",
     "material": [ "flesh" ],
+    "price": "0 cent",
+    "volume": "250 ml",
+    "phase": "liquid",
+    "fun": -50,
+    "flags": [ "IS_BLOOD" ],
+    "drop_action": { "type": "emit_actor", "emits": [ "emit_drop_blood" ], "scale_qty": true },
     "vitamins": [ [ "meat_allergen", 1 ] ]
   },
   {
@@ -605,13 +620,17 @@
   {
     "type": "COMESTIBLE",
     "id": "animal_blood_concentrate",
-    "copy-from": "blood_concentrate",
+    "copy-from": "animal_blood",
     "name": { "str_sp": "concentrated animal blood" },
+    "weight": "65 g",
+    "container": "bottle_glass",
+    "quench": 1,
     "description": "Blood extracted from a living creature, concentrated by some means.",
     "material": [ "flesh" ],
+    "price_postapoc": "20 cent",
     "//": "Wouldn't be good to run it through a centrifuge",
     "delete": { "flags": [ "IS_BLOOD" ] },
-    "vitamins": [ [ "meat_allergen", 1 ] ]
+    "volume": "62 ml"
   },
   {
     "type": "COMESTIBLE",


### PR DESCRIPTION
## Purpose of change (The Why)

Animal blood should obviously not be cannibalism

## Describe the solution (The How)

Removes the `copy-from` from animal blood so that it isn't inheriting human flesh vitamins, and changes the concentrated stuff to `copy-from` animal_blood

## Describe alternatives you've considered

- Hunt down the code that causes vitamins to be inherited instead of overwritten and fix it at the source

## Testing

Copy-pasting values, so testing was simply making sure it linted and my editor was happy with it as JSON.

## Additional context

Aaaaaaa

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)

