### PR TITLE
fix: Enemies now bash vehicles and furniture in the way

### DIFF
--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -25,6 +25,7 @@
 #include "game_constants.h"
 #include "int_id.h"
 #include "line.h"
+#include "make_static.h"
 #include "map.h"
 #include "map_iterator.h"
 #include "mapdata.h"
@@ -1467,7 +1468,7 @@ bool monster::bash_at( const tripoint &p )
     bool is_obstructed_by_ter_furn = here.impassable_ter_furn( p );
     bool is_obstructed_by_veh = here.veh_at( p ).obstacle_at_part().has_value();
     bool is_obstructed = is_obstructed_by_ter_furn || is_obstructed_by_veh;
-    bool is_flat_ground = here.has_flag( "ROAD", p ) || here.has_flag( "FLAT", p );
+    bool is_flat_ground = here.has_flag( TFLAG_FLAT, p );
 
     if( !is_obstructed && is_flat_ground ) {
         bool can_bash_ter = g->m.is_bashable_ter( p );

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1462,8 +1462,14 @@ bool monster::bash_at( const tripoint &p )
         return false;
     }
 
-    bool flat_ground = g->m.has_flag( "ROAD", p ) || g->m.has_flag( "FLAT", p );
-    if( flat_ground && !g->m.is_bashable_furn( p ) ) {
+    map &here = get_map();
+
+    bool is_obstructed_by_ter_furn = here.impassable_ter_furn( p );
+    bool is_obstructed_by_veh = here.veh_at( p ).obstacle_at_part().has_value();
+    bool is_obstructed = is_obstructed_by_ter_furn || is_obstructed_by_veh;
+    bool is_flat_ground = here.has_flag( "ROAD", p ) || here.has_flag( "FLAT", p );
+
+    if( !is_obstructed && is_flat_ground ) {
         bool can_bash_ter = g->m.is_bashable_ter( p );
         bool try_bash_ter = one_in( 50 );
         if( !( can_bash_ter && try_bash_ter ) ) {


### PR DESCRIPTION
## Purpose of change (The Why)
Monsters will not bash vehicles whose parts are located on flat ground such as roads and what not. This fixes it.

## Describe the solution (The How)
It's a replication of a 5 year old DDA commit: https://github.com/CleverRaven/Cataclysm-DDA/pull/45035

## Describe alternatives you've considered
N/A

## Testing
Just basic normal testing by seeing that things do in fact get bashed.

## Additional context
N/A

## Checklist
### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [X] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)

### Optional

- [X] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [X] I have linked the URL of original PR(s) in the description.
  - [ ] I have made sure to preserve the correct license for the ported content by adding a code or JSON comment to the ported sections indicating their original license

