### PR TITLE
feat(balance): consistency update for blackpowder tolerance of firearms

### DIFF
--- a/data/json/items/classes/gun.json
+++ b/data/json/items/classes/gun.json
@@ -108,6 +108,7 @@
     "name": { "str": "single shot pistols" },
     "extend": { "flags": [ "RELOAD_ONE", "RELOAD_EJECT", "NEVER_JAMS" ] },
     "//": "More reliable than other pistols because it uses no magazine and has no loading/cycling mechanisms.",
+    "blackpowder_tolerance": 72,
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ]
   },
   {
@@ -122,6 +123,7 @@
     "proportional": { "reload": 0.7 },
     "extend": { "flags": [ "RELOAD_ONE", "RELOAD_EJECT", "NEVER_JAMS" ] },
     "//": "Revolvers exclude the muzzle location preventing installation of suppressors",
+    "blackpowder_tolerance": 48,
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ],
     "valid_mod_locations": [
       [ "accessories", 2 ],
@@ -145,6 +147,7 @@
     "extend": { "flags": [ "NO_UNLOAD" ] },
     "delete": { "flags": [ "NEVER_JAMS" ] },
     "//": "Slower reloads, no unloading.  Base, unskilled person should take 1.5 seconds per chamber.  No underbarrel mods, that's where the ram goes.",
+    "blackpowder_tolerance": 72,
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ],
     "valid_mod_locations": [ [ "accessories", 2 ], [ "barrel", 1 ], [ "bore", 1 ], [ "grip", 1 ], [ "stock", 1 ], [ "rail", 1 ], [ "sights", 1 ] ]
   },
@@ -217,6 +220,7 @@
     "weapon_category": [ "RIFLES", "MANUAL_ACTION" ],
     "name": { "str": "rifle with manual actions", "str_pl": "rifles with manual actions" },
     "//": "Slightly more reliable than autoloading actions.",
+    "blackpowder_tolerance": 48,
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ]
   },
   {
@@ -237,6 +241,7 @@
     "type": "GUN",
     "weapon_category": [ "RIFLES", "1SHOT" ],
     "name": { "str": "single shot rifle" },
+    "blackpowder_tolerance": 72,
     "flags": [ "RELOAD_ONE", "RELOAD_EJECT", "NEVER_JAMS" ]
   },
   {
@@ -248,7 +253,7 @@
     "ranged_damage": { "damage_type": "bullet", "amount": 1 },
     "dispersion": 550,
     "durability": 6,
-    "blackpowder_tolerance": 60,
+    "blackpowder_tolerance": 72,
     "loudness": 25,
     "clip_size": 1,
     "reload": 200,
@@ -386,6 +391,7 @@
     "weapon_category": [ "SHOTGUNS", "1SHOT" ],
     "name": { "str": "single shot shotguns" },
     "extend": { "flags": [ "RELOAD_ONE", "RELOAD_EJECT" ] },
+    "blackpowder_tolerance": 72,
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ]
   },
   {
@@ -396,6 +402,7 @@
     "name": { "str": "pump action shotgun" },
     "reload_noise": "chuk chuk.",
     "extend": { "flags": [ "RELOAD_ONE", "PUMP_ACTION" ] },
+    "blackpowder_tolerance": 48,
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ]
   },
   {
@@ -471,6 +478,7 @@
     "handling": 60,
     "valid_mod_locations": [ [ "brass catcher", 1 ], [ "sling", 1 ], [ "rail", 1 ], [ "sights", 1 ] ],
     "flags": [ "MOUNTED_GUN" ],
+    "blackpowder_tolerance": 48,
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ]
   },
   {

--- a/data/json/items/gun/10mm.json
+++ b/data/json/items/gun/10mm.json
@@ -17,7 +17,7 @@
     "symbol": "(",
     "color": "dark_gray",
     "ammo": "10mm",
-    "blackpowder_tolerance": 48,
+    "blackpowder_tolerance": 24,
     "min_cycle_recoil": 570,
     "magazines": [ [ "10mm", [ "glock20mag", "glock20bigmag", "glock20drum50rd" ] ] ]
   },

--- a/data/json/items/gun/22.json
+++ b/data/json/items/gun/22.json
@@ -37,7 +37,7 @@
     "ammo": "22",
     "ranged_damage": { "damage_type": "bullet", "amount": 5 },
     "dispersion": 90,
-    "blackpowder_tolerance": 56,
+    "blackpowder_tolerance": 72,
     "clip_size": 19,
     "magazines": [ [ "22", [ "marlin_tubeloader" ] ] ],
     "flags": [ "RELOAD_ONE" ]
@@ -89,6 +89,7 @@
     "material": [ "steel", "wood" ],
     "color": "brown",
     "ammo": "22",
+    "blackpowder_tolerance": 96,
     "barrel_length": "500 ml"
   },
   {

--- a/data/json/items/gun/223.json
+++ b/data/json/items/gun/223.json
@@ -624,7 +624,6 @@
     "ranged_damage": { "damage_type": "bullet", "amount": -4 },
     "dispersion": 550,
     "durability": 6,
-    "blackpowder_tolerance": 32,
     "loudness": 25,
     "reload": 200,
     "valid_mod_locations": [

--- a/data/json/items/gun/270win.json
+++ b/data/json/items/gun/270win.json
@@ -14,7 +14,6 @@
     "color": "brown",
     "ammo": "270win",
     "dispersion": 70,
-    "blackpowder_tolerance": 24,
     "clip_size": 4,
     "barrel_length": "750 ml",
     "flags": [ "RELOAD_ONE", "NEVER_JAMS" ]

--- a/data/json/items/gun/300.json
+++ b/data/json/items/gun/300.json
@@ -33,7 +33,6 @@
     "color": "brown",
     "ammo": "300",
     "dispersion": 110,
-    "blackpowder_tolerance": 24,
     "clip_size": 3,
     "barrel_length": "750 ml",
     "flags": [ "RELOAD_ONE" ]
@@ -52,7 +51,6 @@
     "color": "brown",
     "ammo": "300",
     "dispersion": 90,
-    "blackpowder_tolerance": 24,
     "clip_size": 3,
     "barrel_length": "750 ml",
     "flags": [ "RELOAD_ONE" ]

--- a/data/json/items/gun/3006.json
+++ b/data/json/items/gun/3006.json
@@ -15,7 +15,6 @@
     "ranged_damage": { "damage_type": "bullet", "amount": -1 },
     "dispersion": 90,
     "durability": 7,
-    "blackpowder_tolerance": 24,
     "barrel_length": "500 ml",
     "magazine_well": "250 ml",
     "magazines": [ [ "3006", [ "blrmag" ] ] ]
@@ -67,7 +66,6 @@
     "color": "brown",
     "ammo": "3006",
     "dispersion": 120,
-    "blackpowder_tolerance": 60,
     "clip_size": 5,
     "barrel_length": "1000 ml",
     "valid_mod_locations": [
@@ -122,7 +120,6 @@
     "color": "brown",
     "ammo": "3006",
     "dispersion": 90,
-    "blackpowder_tolerance": 24,
     "clip_size": 4,
     "barrel_length": "750 ml",
     "flags": [ "RELOAD_ONE", "NEVER_JAMS" ]

--- a/data/json/items/gun/308.json
+++ b/data/json/items/gun/308.json
@@ -56,7 +56,6 @@
     "ups_charges": 1,
     "ranged_damage": { "damage_type": "bullet", "amount": -1 },
     "durability": 9,
-    "blackpowder_tolerance": 96,
     "modes": [ [ "DEFAULT", "low auto", 6 ], [ "AUTO", "high auto", 18 ] ],
     "magazines": [ [ "308", [ "belt308" ] ] ],
     "extend": { "flags": [ "NEVER_JAMS" ] }
@@ -219,7 +218,6 @@
     "ranged_damage": { "damage_type": "bullet", "amount": -5 },
     "dispersion": 550,
     "durability": 6,
-    "blackpowder_tolerance": 60,
     "reload": 200,
     "barrel_length": "500 ml",
     "valid_mod_locations": [
@@ -254,7 +252,6 @@
     "dispersion": 90,
     "durability": 9,
     "handling": 50,
-    "blackpowder_tolerance": 24,
     "clip_size": 3,
     "barrel_length": "750 ml",
     "flags": [ "RELOAD_ONE", "NEVER_JAMS" ]

--- a/data/json/items/gun/36paper.json
+++ b/data/json/items/gun/36paper.json
@@ -14,7 +14,6 @@
     "ammo": "36paper",
     "dispersion": 450,
     "durability": 7,
-    "blackpowder_tolerance": 96,
     "proportional": { "reload": 2 }
   }
 ]

--- a/data/json/items/gun/38.json
+++ b/data/json/items/gun/38.json
@@ -18,7 +18,6 @@
     "ammo": "38",
     "dispersion": 620,
     "durability": 3,
-    "blackpowder_tolerance": 60,
     "clip_size": 2,
     "reload": 200,
     "valid_mod_locations": [ [ "accessories", 4 ], [ "grip", 1 ], [ "sights", 1 ], [ "underbarrel", 1 ], [ "rail", 1 ], [ "stock", 1 ] ],
@@ -40,7 +39,6 @@
     "range": 3,
     "dispersion": 520,
     "durability": 6,
-    "blackpowder_tolerance": 96,
     "clip_size": 4,
     "valid_mod_locations": [
       [ "accessories", 2 ],
@@ -68,7 +66,6 @@
     "material": [ "steel", "wood" ],
     "color": "dark_gray",
     "ammo": "38",
-    "blackpowder_tolerance": 56,
     "magazines": [ [ "38", [ "38_speedloader6" ] ] ]
   },
   {
@@ -103,7 +100,6 @@
     "ammo": "38",
     "ranged_damage": { "damage_type": "bullet", "amount": -2 },
     "durability": 10,
-    "blackpowder_tolerance": 56,
     "clip_size": 5,
     "magazines": [ [ "38", [ "38_speedloader5" ] ] ],
     "valid_mod_locations": [
@@ -136,7 +132,6 @@
     "ammo": [ "357mag", "38" ],
     "dispersion": 320,
     "durability": 10,
-    "blackpowder_tolerance": 56,
     "clip_size": 7,
     "magazines": [ [ "38", [ "38_speedloader" ] ] ],
     "valid_mod_locations": [
@@ -171,7 +166,6 @@
     "dispersion": 280,
     "durability": 10,
     "bashing": 9,
-    "blackpowder_tolerance": 48,
     "valid_mod_locations": [
       [ "accessories", 2 ],
       [ "barrel", 1 ],
@@ -200,7 +194,6 @@
     "ammo": [ "357mag", "38" ],
     "ranged_damage": { "damage_type": "bullet", "amount": 2 },
     "dispersion": 160,
-    "blackpowder_tolerance": 56,
     "clip_size": 9,
     "range": 10,
     "flags": [ "RELOAD_ONE" ],

--- a/data/json/items/gun/380.json
+++ b/data/json/items/gun/380.json
@@ -46,6 +46,7 @@
     "ammo": "380",
     "durability": 7,
     "min_cycle_recoil": 270,
+    "blackpowder_tolerance": 24,
     "magazines": [ [ "380", [ "fn1910mag" ] ] ]
   },
   {

--- a/data/json/items/gun/38super.json
+++ b/data/json/items/gun/38super.json
@@ -17,7 +17,7 @@
     "dispersion": 520,
     "durability": 7,
     "min_cycle_recoil": 225,
-    "blackpowder_tolerance": 48,
+    "blackpowder_tolerance": 24,
     "handling": 25,
     "modes": [ [ "DEFAULT", "double", 2 ] ],
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt", "fault_gun_chamber_spent" ],
@@ -54,6 +54,7 @@
     "ammo": "38super",
     "durability": 7,
     "magazine_well": "250 ml",
+    "blackpowder_tolerance": 24,
     "magazines": [ [ "38super", [ "m1911mag_10rd_38super" ] ] ]
   }
 ]

--- a/data/json/items/gun/40.json
+++ b/data/json/items/gun/40.json
@@ -36,7 +36,7 @@
     "ammo": "40",
     "ranged_damage": { "damage_type": "bullet", "amount": 1 },
     "durability": 6,
-    "blackpowder_tolerance": 48,
+    "blackpowder_tolerance": 24,
     "min_cycle_recoil": 425,
     "valid_mod_locations": [
       [ "accessories", 2 ],
@@ -179,7 +179,6 @@
     "ranged_damage": { "damage_type": "bullet", "amount": -1 },
     "dispersion": 620,
     "durability": 6,
-    "blackpowder_tolerance": 60,
     "loudness": 25,
     "magazines": [ [ "40", [ "40_speedloader6" ] ] ],
     "reload": 285,
@@ -213,7 +212,6 @@
     "ammo": [ "10mm", "40" ],
     "ranged_damage": { "damage_type": "bullet", "amount": 1 },
     "dispersion": 320,
-    "blackpowder_tolerance": 56,
     "magazines": [ [ "40", [ "40_speedloader6" ] ] ],
     "valid_mod_locations": [
       [ "accessories", 2 ],

--- a/data/json/items/gun/410shot.json
+++ b/data/json/items/gun/410shot.json
@@ -15,6 +15,7 @@
     "barrel_length": "750 ml",
     "magazine_well": "250 ml",
     "ammo": "410shot",
+    "blackpowder_tolerance": 24,
     "magazines": [ [ "410shot", [ "saiga410mag_10rd", "saiga410mag_30rd" ] ] ],
     "flags": [ "NEVER_JAMS" ]
   },
@@ -28,7 +29,6 @@
     "volume": "1748 ml",
     "price": "100 USD",
     "price_postapoc": "20 USD",
-    "blackpowder_tolerance": 80,
     "ammo": "410shot",
     "material": [ "steel", "wood" ],
     "dispersion": 210,

--- a/data/json/items/gun/44.json
+++ b/data/json/items/gun/44.json
@@ -49,7 +49,6 @@
     "ammo": "44",
     "ranged_damage": { "damage_type": "bullet", "amount": 2 },
     "dispersion": 180,
-    "blackpowder_tolerance": 32,
     "clip_size": 10,
     "valid_mod_locations": [
       [ "accessories", 2 ],
@@ -100,7 +99,6 @@
     "color": "dark_gray",
     "ammo": "44",
     "dispersion": 280,
-    "blackpowder_tolerance": 56,
     "magazines": [ [ "44", [ "44_speedloader6" ] ] ],
     "valid_mod_locations": [
       [ "accessories", 2 ],
@@ -131,7 +129,6 @@
     "ammo": "44",
     "ranged_damage": { "damage_type": "bullet", "amount": -1 },
     "dispersion": 280,
-    "blackpowder_tolerance": 56,
     "magazines": [ [ "44", [ "44_speedloader6" ] ] ],
     "valid_mod_locations": [
       [ "accessories", 2 ],

--- a/data/json/items/gun/44paper.json
+++ b/data/json/items/gun/44paper.json
@@ -13,8 +13,7 @@
     "material": [ "steel", "wood" ],
     "ammo": "44paper",
     "dispersion": 400,
-    "durability": 7,
-    "blackpowder_tolerance": 96
+    "durability": 7
   },
   {
     "id": "lemat_revolver",
@@ -32,7 +31,6 @@
     "ammo": "44paper",
     "dispersion": 420,
     "durability": 6,
-    "blackpowder_tolerance": 56,
     "clip_size": 9,
     "valid_mod_locations": [
       [ "accessories", 2 ],

--- a/data/json/items/gun/45.json
+++ b/data/json/items/gun/45.json
@@ -41,6 +41,7 @@
     "ranged_damage": { "damage_type": "bullet", "amount": 1 },
     "dispersion": 240,
     "min_cycle_recoil": 540,
+    "blackpowder_tolerance": 24,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "AUTO", "auto", 4 ] ],
     "magazines": [ [ "45", [ "ump45mag", "ump45_makeshiftmag" ] ] ]
   },
@@ -63,7 +64,7 @@
     "ammo": "45",
     "durability": 7,
     "min_cycle_recoil": 540,
-    "blackpowder_tolerance": 48,
+    "blackpowder_tolerance": 24,
     "magazine_well": "250 ml",
     "magazines": [ [ "45", [ "m1911mag", "m1911bigmag" ] ] ]
   },
@@ -178,7 +179,6 @@
     "ranged_damage": { "damage_type": "bullet", "amount": 2 },
     "dispersion": 620,
     "durability": 7,
-    "blackpowder_tolerance": 60,
     "loudness": 25,
     "clip_size": 5
   },
@@ -279,7 +279,7 @@
     "material": [ "plastic", "steel" ],
     "color": "dark_gray",
     "ammo": "45",
-    "blackpowder_tolerance": 48,
+    "blackpowder_tolerance": 24,
     "min_cycle_recoil": 450,
     "magazine_well": "250 ml",
     "magazines": [ [ "45", [ "glock_21mag", "glock_21mag26", "glock21drum40rd" ] ] ]

--- a/data/json/items/gun/454.json
+++ b/data/json/items/gun/454.json
@@ -15,7 +15,6 @@
     "color": "light_gray",
     "ammo": [ "454", "45colt" ],
     "dispersion": 280,
-    "blackpowder_tolerance": 56,
     "clip_size": 5,
     "magazines": [ [ "454", [ "454_speedloader5" ] ] ],
     "valid_mod_locations": [

--- a/data/json/items/gun/4570.json
+++ b/data/json/items/gun/4570.json
@@ -15,6 +15,7 @@
     "ammo": [ "4570" ],
     "dispersion": 200,
     "clip_size": 7,
+    "blackpowder_tolerance": 72,
     "valid_mod_locations": [
       [ "accessories", 4 ],
       [ "brass catcher", 1 ],
@@ -47,6 +48,7 @@
     "ranged_damage": { "damage_type": "bullet", "amount": -15 },
     "dispersion": 180,
     "clip_size": 5,
+    "blackpowder_tolerance": 72,
     "valid_mod_locations": [
       [ "accessories", 2 ],
       [ "barrel", 1 ],
@@ -76,6 +78,7 @@
     "ranged_damage": { "damage_type": "bullet", "amount": 4 },
     "dispersion": 100,
     "clip_size": 1,
+    "blackpowder_tolerance": 96,
     "built_in_mods": [ "match_trigger" ],
     "valid_mod_locations": [
       [ "accessories", 2 ],
@@ -106,7 +109,7 @@
     "color": "yellow",
     "ammo": "4570",
     "dispersion": 400,
-    "blackpowder_tolerance": 80,
+    "blackpowder_tolerance": 72,
     "valid_mod_locations": [ [ "brass catcher", 1 ], [ "rail", 1 ], [ "sights", 1 ] ],
     "modes": [ [ "DEFAULT", "single", 1 ], [ "AUTO", "burst", 3 ] ],
     "//": "If speedloaders get fixed to allow topping off a partially-loaded gun, adding the more common Bruce feed (40 round feed tray topped off with 20-round blocks) would be an option.",

--- a/data/json/items/gun/45colt.json
+++ b/data/json/items/gun/45colt.json
@@ -16,7 +16,7 @@
     "dispersion": 520,
     "durability": 6,
     "clip_size": 2,
-    "blackpowder_tolerance": 80,
+    "blackpowder_tolerance": 96,
     "valid_mod_locations": [
       [ "accessories", 2 ],
       [ "barrel", 1 ],
@@ -45,7 +45,7 @@
     "dispersion": 180,
     "durability": 7,
     "clip_size": 14,
-    "blackpowder_tolerance": 56,
+    "blackpowder_tolerance": 72,
     "reload_noise": "chik chik.",
     "flags": [ "RELOAD_ONE" ]
   },
@@ -64,7 +64,7 @@
     "material": [ "steel", "wood" ],
     "ammo": "45colt",
     "dispersion": 360,
-    "blackpowder_tolerance": 56,
+    "blackpowder_tolerance": 72,
     "proportional": { "reload": 1.5 }
   },
   {

--- a/data/json/items/gun/500.json
+++ b/data/json/items/gun/500.json
@@ -14,7 +14,6 @@
     "ammo": "500",
     "ranged_damage": { "damage_type": "bullet", "amount": 2 },
     "dispersion": 180,
-    "blackpowder_tolerance": 32,
     "clip_size": 7,
     "valid_mod_locations": [
       [ "accessories", 2 ],
@@ -47,7 +46,6 @@
     "color": "light_gray",
     "ammo": "500",
     "dispersion": 280,
-    "blackpowder_tolerance": 56,
     "clip_size": 5,
     "magazines": [ [ "500", [ "500_speedloader5" ] ] ],
     "valid_mod_locations": [

--- a/data/json/items/gun/545x39.json
+++ b/data/json/items/gun/545x39.json
@@ -18,6 +18,7 @@
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "AUTO", "auto", 4 ] ],
     "barrel_length": "250 ml",
     "magazines": [ [ "545x39", [ "ak74mag", "rpk74mag" ] ] ],
+    "blackpowder_tolerance": 24,
     "flags": [ "NEVER_JAMS" ]
   },
   {

--- a/data/json/items/gun/762.json
+++ b/data/json/items/gun/762.json
@@ -16,6 +16,7 @@
     "dispersion": 180,
     "durability": 9,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "AUTO", "auto", 4 ] ],
+    "blackpowder_tolerance": 24,
     "valid_mod_locations": [
       [ "accessories", 4 ],
       [ "barrel", 1 ],
@@ -72,6 +73,7 @@
     "dispersion": 90,
     "clip_size": 10,
     "barrel_length": "500 ml",
+    "blackpowder_tolerance": 24,
     "built_in_mods": [ "inter_bayonet" ],
     "magazines": [ [ "762", [ "762x39_clip" ] ] ],
     "flags": [ "RELOAD_ONE", "NEVER_JAMS" ]
@@ -92,6 +94,7 @@
     "ammo": "762",
     "dispersion": 180,
     "modes": [ [ "DEFAULT", "semi", 1 ] ],
+    "blackpowder_tolerance": 24,
     "valid_mod_locations": [
       [ "accessories", 4 ],
       [ "barrel", 1 ],
@@ -126,6 +129,7 @@
     "ranged_damage": { "damage_type": "bullet", "amount": -5 },
     "durability": 7,
     "modes": [ [ "DEFAULT", "semi", 1 ] ],
+    "blackpowder_tolerance": 24,
     "valid_mod_locations": [
       [ "accessories", 4 ],
       [ "barrel", 1 ],

--- a/data/json/items/gun/762R.json
+++ b/data/json/items/gun/762R.json
@@ -59,6 +59,7 @@
     "durability": 10,
     "clip_size": 5,
     "barrel_length": "1000 ml",
+    "blackpowder_tolerance": 72,
     "valid_mod_locations": [
       [ "accessories", 4 ],
       [ "barrel", 1 ],

--- a/data/json/items/gun/9mm.json
+++ b/data/json/items/gun/9mm.json
@@ -84,7 +84,7 @@
     "ammo": "9mm",
     "ranged_damage": { "damage_type": "bullet", "amount": -1 },
     "durability": 6,
-    "blackpowder_tolerance": 48,
+    "blackpowder_tolerance": 24,
     "min_cycle_recoil": 380,
     "magazine_well": "250 ml",
     "magazines": [ [ "9mm", [ "glockmag", "glockbigmag", "glock17_17", "glock17_22", "glock_drum_50rd", "glock_drum_100rd" ] ] ]
@@ -107,7 +107,7 @@
     "ranged_damage": { "damage_type": "bullet", "amount": 1 },
     "dispersion": 240,
     "min_cycle_recoil": 450,
-    "blackpowder_tolerance": 32,
+    "blackpowder_tolerance": 24,
     "modes": [ [ "DEFAULT", "semi", 1 ], [ "BURST", "burst", 3 ], [ "AUTO", "auto", 4 ] ],
     "valid_mod_locations": [
       [ "accessories", 3 ],
@@ -434,7 +434,7 @@
     "ranged_damage": { "damage_type": "bullet", "amount": -1 },
     "dispersion": 400,
     "durability": 9,
-    "blackpowder_tolerance": 48,
+    "blackpowder_tolerance": 24,
     "min_cycle_recoil": 450,
     "magazine_well": "250 ml",
     "magazines": [ [ "9mm", [ "usp9mag" ] ] ]
@@ -482,7 +482,7 @@
     "ammo": "9mm",
     "ranged_damage": { "damage_type": "bullet", "amount": -1 },
     "durability": 6,
-    "blackpowder_tolerance": 48,
+    "blackpowder_tolerance": 24,
     "min_cycle_recoil": 380,
     "magazine_well": "250 ml",
     "//2": "Glock 17s cannot load a 15 round magazine. See http://guns-of-fun.com/portals/0/LiveContent/Mounts/Glock-Mags-Comp.jpg and #33038",

--- a/data/json/items/gun/combination.json
+++ b/data/json/items/gun/combination.json
@@ -12,7 +12,7 @@
     "ammo": "3006",
     "weight": "4200 g",
     "volume": "3 L",
-    "blackpowder_tolerance": 56,
+    "blackpowder_tolerance": 72,
     "clip_size": 1,
     "barrel_length": "500 ml",
     "built_in_mods": [ "combination_gun_shotgun" ],

--- a/data/json/items/gun/shot.json
+++ b/data/json/items/gun/shot.json
@@ -70,6 +70,7 @@
     "dispersion": 425,
     "durability": 6,
     "clip_size": 5,
+    "blackpowder_tolerance": 24,
     "extend": { "flags": [ "RELOAD_ONE" ] }
   },
   {
@@ -432,6 +433,7 @@
       [ "sights", 1 ],
       [ "underbarrel", 1 ]
     ],
+    "blackpowder_tolerance": 48,
     "flags": [ "RELOAD_ONE", "RELOAD_EJECT", "NEVER_JAMS" ]
   },
   {
@@ -461,6 +463,7 @@
       [ "sights", 1 ],
       [ "underbarrel", 1 ]
     ],
+    "blackpowder_tolerance": 24,
     "magazines": [ [ "shot", [ "saiga10mag", "saiga30mag" ] ] ]
   },
   {
@@ -507,6 +510,7 @@
       [ "rail", 1 ],
       [ "underbarrel", 1 ]
     ],
+    "blackpowder_tolerance": 96,
     "extend": { "flags": [ "NEVER_JAMS" ] }
   },
   {
@@ -670,6 +674,7 @@
       [ "sights", 1 ],
       [ "underbarrel", 1 ]
     ],
+    "blackpowder_tolerance": 72,
     "flags": [ "RELOAD_ONE" ]
   },
   {
@@ -703,6 +708,7 @@
       [ "sights", 1 ],
       [ "underbarrel", 1 ]
     ],
+    "blackpowder_tolerance": 72,
     "default_mods": [ "sword_bayonet" ],
     "flags": [ "RELOAD_ONE" ]
   }

--- a/data/json/items/gunmod/underbarrel.json
+++ b/data/json/items/gunmod/underbarrel.json
@@ -62,7 +62,15 @@
     "color": "light_red",
     "location": "underbarrel",
     "mod_target_category": [ [ "RIFLES" ], [ "MACHINE_GUNS" ], [ "GATLING_GUNS" ] ],
-    "gun_data": { "ammo": "shot", "skill": "shotgun", "range": 2, "dispersion": 345, "durability": 10, "clip_size": 2 },
+    "gun_data": {
+      "ammo": "shot",
+      "skill": "shotgun",
+      "range": 2,
+      "dispersion": 345,
+      "durability": 10,
+      "blackpowder_tolerance": 72,
+      "clip_size": 2
+    },
     "flags": [ "IRREMOVABLE", "RELOAD_ONE", "RELOAD_EJECT" ]
   },
   {
@@ -80,7 +88,7 @@
     "color": "light_red",
     "location": "underbarrel",
     "mod_target_category": [ [ "RIFLES" ], [ "MACHINE_GUNS" ], [ "GATLING_GUNS" ] ],
-    "gun_data": { "ammo": "shot", "skill": "shotgun", "dispersion": 480, "durability": 6, "clip_size": 2 },
+    "gun_data": { "ammo": "shot", "skill": "shotgun", "dispersion": 480, "durability": 6, "blackpowder_tolerance": 72, "clip_size": 2 },
     "flags": [ "IRREMOVABLE", "RELOAD_ONE", "NEVER_JAMS", "RELOAD_EJECT" ]
   },
   {
@@ -173,6 +181,7 @@
       "dispersion": 425,
       "durability": 7,
       "clip_size": 7,
+      "blackpowder_tolerance": 48,
       "reload": 120
     },
     "flags": [ "RELOAD_ONE", "IRREMOVABLE" ]
@@ -198,6 +207,7 @@
       "dispersion": 425,
       "durability": 7,
       "clip_size": 12,
+      "blackpowder_tolerance": 48,
       "reload": 120
     },
     "flags": [ "RELOAD_ONE", "IRREMOVABLE" ]
@@ -307,6 +317,7 @@
       "dispersion": 600,
       "durability": 10,
       "reload": 150,
+      "blackpowder_tolerance": 96,
       "clip_size": 1
     },
     "flags": [ "RELOAD_ONE", "NO_UNLOAD", "IRREMOVABLE" ]
@@ -396,7 +407,15 @@
     "color": "light_red",
     "location": "underbarrel",
     "mod_target_category": [ [ "RIFLES" ], [ "MACHINE_GUNS" ], [ "GATLING_GUNS" ] ],
-    "gun_data": { "ammo": "shot", "skill": "shotgun", "range": 1, "dispersion": 320, "durability": 10, "clip_size": 1 },
+    "gun_data": {
+      "ammo": "shot",
+      "skill": "shotgun",
+      "range": 1,
+      "dispersion": 320,
+      "durability": 10,
+      "blackpowder_tolerance": 72,
+      "clip_size": 1
+    },
     "flags": [ "RELOAD_EJECT" ]
   },
   {
@@ -436,7 +455,7 @@
     "color": "light_red",
     "location": "underbarrel",
     "mod_target_category": [ [ "RIFLES" ], [ "MACHINE_GUNS" ], [ "GATLING_GUNS" ], [ "M_XBOWS" ] ],
-    "gun_data": { "ammo": "shot", "skill": "shotgun", "dispersion": 330, "durability": 10, "clip_size": 4 },
+    "gun_data": { "ammo": "shot", "skill": "shotgun", "dispersion": 330, "durability": 10, "blackpowder_tolerance": 72, "clip_size": 4 },
     "flags": [ "RELOAD_ONE" ]
   },
   {


### PR DESCRIPTION
## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

This unifies and standardizes the `blackpowder_tolerance` stats for different types of firearm a bit more.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Adjusted blackpowder tolerance values, with more of them being moved to gun templates where possible. Notable values picked:
1. Most autoloading guns are stuck with the default value as usual (8 according to hardcode, or 185 fouling per shot), but autoloaders previously called out as having a notable degree of tolerance (AKs, glocks, homemade SMGs) were standardized at 24 tolerance (153 fouling per shot).
2. Repeating, manual-action firearms in general (bolt-action, revolvers, pump-action, etc) made with modern cartridges standardized at 48 tolerance (105 fouling per shot).
3. Single-shot firearms made for modern cartridges, and repeating firearms designed with gunpowder in mind (e.g. cap-and-ball revolvers, .45 Colt, antique shotguns, other yeehaw guns) standardized at 72 tolerance (57 fouling per shot).
4. Finally, single-shot blackpowder guns (flintlocks, 20ga shotgun, etc). all left at 96 as they already tended to be (9 fouling per shot).

Double-barrels, combination guns, derringers and the like allowed to count as single shot for this since it's just multiple barrels, while gatlings were counted as repeating since there's still a mechanism to drive the barrels. Several guns got their blackpowder tolerance defs deleted since they'll now inherit a specific value from the abstract they inherit from, while some got tolerance added where they had none previously (generally antiques/repros of guns whose calibers existed in the black powder era and AK variants).

Additionally, firable gunmods finally got this added to some of them, most notably the LeMat's secondary barrel and combination gun underbarrel. The KSG second mag was given it to be consistent with other pump-action guns, but note that https://github.com/cataclysmbnteam/Cataclysm-BN/pull/6083 will render this reundant when it's merged.

## Describe alternatives you've considered

1. Rounding the tolerance values up to multiples of 25. This would buff flintlocks and the like up to 100, which would mean only gaining a single unit of fouling per shot (formula is buried here: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/src/ranged.cpp#L719 and basically translates to 1 fouling per shot, plus 2 fouling for every blackpowder tolerance below 100, with the itemdef code specifying a default tolerance of 8).
2. Not letting moist nuggets gain an extra tier of tolerance other normal bolt-actions since they technically showed up at the razor's edge of the transitional era between blackpowder and smokeless firearms, and unlike .22 rimfire or 12 gauge 7.62x54mmR technically never had a historical blackpowder load made for it as far as I could find from casual searching.
3. Adding tolerance values to 40mm guns, since while they don't CURRENTLY have any blackpowder loads it's always possible we might add some later on, or people might mod them in.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Ported JSON changes to laptop playthrough and load-tested to confirm I didn't miss any "same definition" errors and that gunmods don't complain about having tolerance specified.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
  - [ ] I have made sure to preserve the correct license for the ported content by adding a code or JSON comment to the ported sections indicating their original license
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
