### PR TITLE
feat(UI): further audit of item category

### DIFF
--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -155,7 +155,7 @@
   {
     "type": "AMMO",
     "id": "duct_tape",
-    "category": "tools_workshop",
+    "category": "other",
     "price": "20 USD",
     "price_postapoc": "250 cent",
     "name": { "str": "duct tape" },
@@ -892,7 +892,7 @@
   {
     "id": "fish_bait",
     "type": "AMMO",
-    "category": "tools_farming",
+    "category": "other",
     "name": { "str": "fish bait" },
     "description": "A bait used in traps to lure fish.",
     "weight": "1 g",

--- a/data/json/items/comestibles/alcohol.json
+++ b/data/json/items/comestibles/alcohol.json
@@ -2,6 +2,7 @@
   {
     "type": "COMESTIBLE",
     "id": "wine_mycus",
+    "category": "drugs",
     "name": { "str_sp": "marloss wine" },
     "weight": "33 g",
     "color": "white",
@@ -29,6 +30,7 @@
   {
     "type": "COMESTIBLE",
     "id": "wine_riesling",
+    "category": "drugs",
     "name": { "str_sp": "Riesling" },
     "weight": "50 g",
     "color": "white",
@@ -56,6 +58,7 @@
   {
     "type": "COMESTIBLE",
     "id": "wine_chardonnay",
+    "category": "drugs",
     "name": { "str_sp": "Chardonnay" },
     "weight": "50 g",
     "color": "white",
@@ -83,6 +86,7 @@
   {
     "type": "COMESTIBLE",
     "id": "wine_cabernet",
+    "category": "drugs",
     "name": { "str_sp": "Cabernet Sauvignon" },
     "weight": "50 g",
     "color": "red",
@@ -108,6 +112,7 @@
   {
     "type": "COMESTIBLE",
     "id": "wine_noir",
+    "category": "drugs",
     "name": { "str_sp": "pinot noir" },
     "weight": "50 g",
     "color": "red",
@@ -134,6 +139,7 @@
   {
     "type": "COMESTIBLE",
     "id": "wine_marsala",
+    "category": "drugs",
     "name": { "str_sp": "marsala" },
     "weight": "50 g",
     "color": "red",
@@ -160,6 +166,7 @@
   {
     "type": "COMESTIBLE",
     "id": "wine_vermouth",
+    "category": "drugs",
     "name": { "str_sp": "vermouth" },
     "weight": "50 g",
     "color": "red",
@@ -186,6 +193,7 @@
   {
     "type": "COMESTIBLE",
     "id": "wine_barley",
+    "category": "drugs",
     "name": { "str_sp": "barley wine" },
     "weight": "249 g",
     "color": "brown",
@@ -213,6 +221,7 @@
   {
     "type": "COMESTIBLE",
     "id": "whiskey",
+    "category": "drugs",
     "name": { "str_sp": "whiskey" },
     "weight": "33 g",
     "color": "brown",
@@ -240,6 +249,7 @@
   {
     "type": "COMESTIBLE",
     "id": "vodka",
+    "category": "drugs",
     "name": { "str_sp": "vodka" },
     "weight": "33 g",
     "color": "light_cyan",
@@ -266,6 +276,7 @@
   {
     "type": "COMESTIBLE",
     "id": "gin",
+    "category": "drugs",
     "name": { "str_sp": "gin" },
     "weight": "33 g",
     "color": "light_cyan",
@@ -292,6 +303,7 @@
   {
     "type": "COMESTIBLE",
     "id": "rum",
+    "category": "drugs",
     "name": { "str_sp": "rum" },
     "weight": "33 g",
     "color": "light_cyan",
@@ -318,6 +330,7 @@
   {
     "type": "COMESTIBLE",
     "id": "tequila",
+    "category": "drugs",
     "name": { "str_sp": "tequila" },
     "weight": "34 g",
     "color": "yellow",
@@ -344,6 +357,7 @@
   {
     "type": "COMESTIBLE",
     "id": "triple_sec",
+    "category": "drugs",
     "name": { "str_sp": "triple sec" },
     "weight": "30 g",
     "color": "light_cyan",
@@ -370,6 +384,7 @@
   {
     "type": "COMESTIBLE",
     "id": "bum_wine",
+    "category": "drugs",
     "name": { "str_sp": "cheap wine" },
     "weight": "35 g",
     "color": "red",
@@ -397,6 +412,7 @@
   {
     "type": "COMESTIBLE",
     "id": "mixed_alcohol_strong",
+    "category": "drugs",
     "name": { "str_sp": "strong mixed alcohol" },
     "weight": "34 g",
     "color": "red",
@@ -422,6 +438,7 @@
   {
     "type": "COMESTIBLE",
     "id": "mixed_alcohol_weak",
+    "category": "drugs",
     "name": { "str_sp": "weak mixed alcohol" },
     "weight": "248 g",
     "color": "light_red",
@@ -448,6 +465,7 @@
   {
     "type": "COMESTIBLE",
     "id": "fruit_wine",
+    "category": "drugs",
     "name": { "str_sp": "fruit wine" },
     "weight": "36 g",
     "color": "light_red",
@@ -475,6 +493,7 @@
   {
     "type": "COMESTIBLE",
     "id": "brandy",
+    "category": "drugs",
     "name": { "str_sp": "brandy" },
     "weight": "34 g",
     "color": "light_red",
@@ -501,6 +520,7 @@
   {
     "type": "COMESTIBLE",
     "id": "irish_coffee",
+    "category": "drugs",
     "name": { "str_sp": "Irish coffee" },
     "weight": "260 g",
     "color": "brown",
@@ -528,6 +548,7 @@
   {
     "type": "COMESTIBLE",
     "id": "long_island",
+    "category": "drugs",
     "name": { "str_sp": "Long Island iced tea" },
     "weight": "232 g",
     "color": "brown",
@@ -556,6 +577,7 @@
   {
     "type": "COMESTIBLE",
     "id": "drink_screwdriver",
+    "category": "drugs",
     "name": "screwdriver cocktail",
     "weight": "258 g",
     "color": "yellow",
@@ -583,6 +605,7 @@
   {
     "type": "COMESTIBLE",
     "id": "drink_wild_apple",
+    "category": "drugs",
     "name": { "str_sp": "wild apple" },
     "weight": "258 g",
     "color": "brown",
@@ -610,6 +633,7 @@
   {
     "type": "COMESTIBLE",
     "id": "drink_rumcola",
+    "category": "drugs",
     "name": { "str_sp": "rum & cola" },
     "weight": "251 g",
     "color": "brown",
@@ -637,6 +661,7 @@
   {
     "type": "COMESTIBLE",
     "id": "beer",
+    "category": "drugs",
     "name": { "str_sp": "beer" },
     "weight": "251 g",
     "color": "brown",
@@ -663,6 +688,7 @@
   {
     "type": "COMESTIBLE",
     "id": "mead",
+    "category": "drugs",
     "name": { "str_sp": "spiced mead" },
     "weight": "36 g",
     "color": "yellow",
@@ -689,6 +715,7 @@
   {
     "type": "COMESTIBLE",
     "id": "dandelion_wine",
+    "category": "drugs",
     "name": { "str_sp": "dandelion wine" },
     "weight": "35 g",
     "color": "yellow",
@@ -716,6 +743,7 @@
   {
     "type": "COMESTIBLE",
     "id": "burdock_wine",
+    "category": "drugs",
     "name": { "str_sp": "burdock wine" },
     "weight": "247 g",
     "color": "yellow",
@@ -742,6 +770,7 @@
   {
     "type": "COMESTIBLE",
     "id": "pine_wine",
+    "category": "drugs",
     "name": { "str_sp": "pine wine" },
     "weight": "35 g",
     "color": "light_green",
@@ -769,6 +798,7 @@
   {
     "type": "COMESTIBLE",
     "id": "hb_beer",
+    "category": "drugs",
     "name": { "str_sp": "homebrew beer" },
     "weight": "249 g",
     "color": "brown",
@@ -795,6 +825,7 @@
   {
     "type": "COMESTIBLE",
     "id": "moonshine",
+    "category": "drugs",
     "name": { "str_sp": "moonshine" },
     "weight": "35 g",
     "color": "brown",
@@ -821,6 +852,7 @@
   {
     "type": "COMESTIBLE",
     "id": "european_pilsner",
+    "category": "drugs",
     "name": { "str_sp": "European pilsner" },
     "weight": "249 g",
     "color": "brown",
@@ -848,6 +880,7 @@
   {
     "type": "COMESTIBLE",
     "id": "pale_ale",
+    "category": "drugs",
     "name": { "str_sp": "American pale ale" },
     "weight": "249 g",
     "color": "brown",
@@ -875,6 +908,7 @@
   {
     "type": "COMESTIBLE",
     "id": "india_pale_ale",
+    "category": "drugs",
     "name": { "str_sp": "India pale ale" },
     "weight": "249 g",
     "color": "brown",
@@ -902,6 +936,7 @@
   {
     "type": "COMESTIBLE",
     "id": "stout",
+    "category": "drugs",
     "name": { "str_sp": "stout" },
     "weight": "205 g",
     "color": "brown",
@@ -929,6 +964,7 @@
   {
     "type": "COMESTIBLE",
     "id": "belgian_ale",
+    "category": "drugs",
     "name": { "str_sp": "Belgian ale" },
     "weight": "249 g",
     "color": "brown",
@@ -956,6 +992,7 @@
   {
     "type": "COMESTIBLE",
     "id": "imperial_stout",
+    "category": "drugs",
     "name": { "str_sp": "imperial stout" },
     "weight": "249 g",
     "color": "brown",
@@ -983,6 +1020,7 @@
   {
     "type": "COMESTIBLE",
     "id": "drink_strawberry_surprise",
+    "category": "drugs",
     "name": "strawberry surprise",
     "weight": "43 g",
     "color": "pink",
@@ -1011,6 +1049,7 @@
   {
     "type": "COMESTIBLE",
     "id": "drink_boozeberry",
+    "category": "drugs",
     "name": { "str": "boozeberry", "str_pl": "boozeberries" },
     "weight": "43 g",
     "color": "cyan",
@@ -1039,6 +1078,7 @@
   {
     "type": "COMESTIBLE",
     "id": "single_malt_whiskey",
+    "category": "drugs",
     "name": { "str_sp": "single malt whiskey" },
     "weight": "33 g",
     "color": "brown",
@@ -1096,6 +1136,7 @@
   {
     "type": "COMESTIBLE",
     "id": "sherry",
+    "category": "drugs",
     "name": { "str_sp": "sherry" },
     "weight": "120 g",
     "color": "brown",
@@ -1142,6 +1183,7 @@
   {
     "type": "COMESTIBLE",
     "id": "drink_hobo",
+    "category": "drugs",
     "name": { "str_sp": "fancy hobo" },
     "weight": "50 g",
     "color": "yellow",
@@ -1170,6 +1212,7 @@
   {
     "type": "COMESTIBLE",
     "id": "drink_kalimotxo",
+    "category": "drugs",
     "name": { "str_sp": "kalimotxo" },
     "weight": "250 g",
     "color": "red",
@@ -1198,6 +1241,7 @@
   {
     "type": "COMESTIBLE",
     "id": "drink_beeknees",
+    "category": "drugs",
     "name": { "str_sp": "bee's knees" },
     "weight": "248 g",
     "color": "yellow",
@@ -1223,6 +1267,7 @@
   {
     "type": "COMESTIBLE",
     "id": "drink_wsour",
+    "category": "drugs",
     "name": "whiskey sour",
     "weight": "249 g",
     "color": "yellow",
@@ -1248,6 +1293,7 @@
   {
     "type": "COMESTIBLE",
     "id": "honey_gold",
+    "category": "drugs",
     "name": "honeygold brew",
     "weight": "259 g",
     "color": "yellow",
@@ -1273,6 +1319,7 @@
   {
     "type": "COMESTIBLE",
     "id": "honey_ant",
+    "category": "drugs",
     "name": "honey ball",
     "weight": "178 g",
     "color": "yellow",
@@ -1299,6 +1346,7 @@
   {
     "type": "COMESTIBLE",
     "id": "eggnog_spiked",
+    "category": "drugs",
     "name": "spiked eggnog",
     "weight": "132 g",
     "color": "white",
@@ -1328,6 +1376,7 @@
   {
     "type": "COMESTIBLE",
     "id": "drink_martini",
+    "category": "drugs",
     "name": "martini",
     "weight": "49600 mg",
     "color": "white",
@@ -1354,6 +1403,7 @@
   {
     "type": "COMESTIBLE",
     "id": "sake",
+    "category": "drugs",
     "name": { "str_sp": "sake" },
     "weight": "36 g",
     "color": "light_red",

--- a/data/json/items/comestibles/dairy.json
+++ b/data/json/items/comestibles/dairy.json
@@ -207,6 +207,7 @@
   {
     "type": "COMESTIBLE",
     "id": "milk_powder",
+    "category": "cooking_ingredients",
     "name": { "str_sp": "powdered milk" },
     "weight": "30 g",
     "color": "white",

--- a/data/json/items/comestibles/drink_other.json
+++ b/data/json/items/comestibles/drink_other.json
@@ -2,7 +2,6 @@
   {
     "type": "COMESTIBLE",
     "id": "sauce_red",
-    "category": "cooking_ingredients",
     "name": "red sauce",
     "weight": "64 g",
     "color": "red",
@@ -27,6 +26,7 @@
   {
     "id": "maple_sap",
     "type": "COMESTIBLE",
+    "category": "cooking_ingredients",
     "symbol": "~",
     "color": "light_cyan",
     "name": { "str_sp": "maple sap" },
@@ -50,7 +50,6 @@
   },
   {
     "id": "mayonnaise",
-    "category": "cooking_ingredients",
     "type": "COMESTIBLE",
     "symbol": "~",
     "color": "white",
@@ -72,7 +71,6 @@
   },
   {
     "id": "ketchup",
-    "category": "cooking_ingredients",
     "type": "COMESTIBLE",
     "symbol": "~",
     "color": "red",
@@ -94,7 +92,6 @@
   },
   {
     "id": "mustard",
-    "category": "cooking_ingredients",
     "type": "COMESTIBLE",
     "symbol": "~",
     "color": "yellow",
@@ -116,7 +113,6 @@
   },
   {
     "id": "honey_bottled",
-    "category": "cooking_ingredients",
     "type": "COMESTIBLE",
     "symbol": "~",
     "color": "yellow",
@@ -139,7 +135,6 @@
   },
   {
     "id": "peanutbutter",
-    "category": "cooking_ingredients",
     "type": "COMESTIBLE",
     "symbol": "~",
     "color": "brown",
@@ -239,7 +234,6 @@
   },
   {
     "type": "COMESTIBLE",
-    "category": "cooking_ingredients",
     "id": "molasses",
     "name": { "str_sp": "molasses" },
     "weight": "89 g",
@@ -263,7 +257,6 @@
   },
   {
     "id": "horseradish",
-    "category": "cooking_ingredients",
     "type": "COMESTIBLE",
     "symbol": "~",
     "color": "white",
@@ -286,7 +279,6 @@
   },
   {
     "type": "COMESTIBLE",
-    "category": "cooking_ingredients",
     "id": "coffee_syrup",
     "name": { "str_sp": "coffee syrup" },
     "weight": "32 g",

--- a/data/json/items/comestibles/egg.json
+++ b/data/json/items/comestibles/egg.json
@@ -299,6 +299,7 @@
   {
     "type": "COMESTIBLE",
     "id": "powder_eggs",
+    "category": "cooking_ingredients",
     "name": { "str": "powdered egg" },
     "weight": "7 g",
     "color": "yellow",

--- a/data/json/items/comestibles/fruit_dishes.json
+++ b/data/json/items/comestibles/fruit_dishes.json
@@ -131,6 +131,7 @@
   {
     "type": "COMESTIBLE",
     "id": "lemonade_powder",
+    "category": "cooking_ingredients",
     "name": { "str_sp": "lemonade drink mix" },
     "weight": "19 g",
     "color": "yellow",

--- a/data/json/items/comestibles/fruit_dishes.json
+++ b/data/json/items/comestibles/fruit_dishes.json
@@ -202,7 +202,6 @@
   {
     "type": "COMESTIBLE",
     "id": "jam_fruit",
-    "category": "cooking_ingredients",
     "name": { "str_sp": "jam" },
     "conditional_names": [
       { "type": "COMPONENT_ID", "condition": "apple", "name": { "str_sp": "apple %s" } },

--- a/data/json/items/comestibles/junkfood.json
+++ b/data/json/items/comestibles/junkfood.json
@@ -419,7 +419,6 @@
   {
     "type": "COMESTIBLE",
     "id": "syrup",
-    "category": "cooking_ingredients",
     "name": { "str_sp": "maple syrup" },
     "weight": "21 g",
     "color": "brown",
@@ -440,7 +439,6 @@
   },
   {
     "type": "COMESTIBLE",
-    "category": "cooking_ingredients",
     "id": "beet_syrup",
     "name": { "str_sp": "sugar beet syrup" },
     "weight": "15 g",

--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -164,6 +164,7 @@
   {
     "type": "COMESTIBLE",
     "id": "yeast",
+    "category": "cooking_ingredients",
     "name": { "str_sp": "yeast" },
     "weight": "11 g",
     "color": "white",

--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -35,7 +35,6 @@
   {
     "type": "COMESTIBLE",
     "id": "honeycomb",
-    "category": "cooking_ingredients",
     "name": "honey comb",
     "weight": "150 g",
     "color": "yellow",
@@ -521,7 +520,6 @@
   {
     "id": "honey_glassed",
     "type": "COMESTIBLE",
-    "category": "cooking_ingredients",
     "symbol": "~",
     "color": "yellow",
     "name": { "str_sp": "candied honey" },

--- a/data/mods/TEST_DATA/TALK_TEST.json
+++ b/data/mods/TEST_DATA/TALK_TEST.json
@@ -603,7 +603,7 @@
         "response": { "text": "This is a repeated category books test response", "topic": "TALK_DONE" }
       },
       {
-        "for_category": [ "books", "food" ],
+        "for_category": [ "books", "food", "drugs" ],
         "response": { "text": "This is a repeated category books, food test response", "topic": "TALK_DONE" }
       }
     ]

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -630,6 +630,7 @@ TEST_CASE( "npc_talk_effects_advanced", "[npc_talk]" )
     player_character.remove_top_items_with( []( detached_ptr<item> &&it ) {
         return ( it->get_category().get_id() == item_category_id( "books" ) ||
                  it->get_category().get_id() == item_category_id( "food" ) ||
+                 it->get_category().get_id() == item_category_id( "drugs" ) ||
                  it->typeId() == itype_id( "bottle_glass" ) ) ? detached_ptr<item>() : std::move( it );
     } );
 

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -608,7 +608,7 @@ static bool has_item( Character &p, const std::string &id, int count )
 
 static bool has_beer_bottle( Character &p, int count )
 {
-    return has_item( p, "bottle_glass", 1 ) && has_item( p, "beer", count );
+    return has_item( p, "bottle_glass", 1 ) && has_item( p, "rootbeer", count );
 }
 
 static void give_item( Character &p, const std::string &id, int count )
@@ -754,7 +754,7 @@ TEST_CASE( "npc_talk_effects_advanced", "[npc_talk]" )
     }
 
     SECTION( "has_item" ) {
-        give_item( player_character, "beer", 2 );
+        give_item( player_character, "rootbeer", 2 );
         give_item( player_character, "bottle_glass", 1 );
         give_item( player_character, "manual_speech", 1 );
         give_item( player_character, "dnd_handbook", 1 );
@@ -772,7 +772,7 @@ TEST_CASE( "npc_talk_effects_advanced", "[npc_talk]" )
     }
 
     SECTION( "item_repeat" ) {
-        give_item( player_character, "beer", 2 );
+        give_item( player_character, "rootbeer", 2 );
         give_item( player_character, "bottle_glass", 1 );
         give_item( player_character, "manual_speech", 1 );
         give_item( player_character, "dnd_handbook", 1 );
@@ -780,7 +780,7 @@ TEST_CASE( "npc_talk_effects_advanced", "[npc_talk]" )
         d.add_topic( "TALK_TEST_ITEM_REPEAT" );
         gen_response_lines( d, 8 );
         CHECK( d.responses[0].text == "This is a repeated category books, food test response" );
-        CHECK( d.responses[0].success.next_topic.item_type == itype_id( "beer" ) );
+        CHECK( d.responses[0].success.next_topic.item_type == itype_id( "rootbeer" ) );
         CHECK( d.responses[1].text == "This is a repeated category books, food test response" );
         CHECK( d.responses[1].success.next_topic.item_type == itype_id( "dnd_handbook" ) );
         CHECK( d.responses[2].text == "This is a repeated category books, food test response" );
@@ -792,12 +792,12 @@ TEST_CASE( "npc_talk_effects_advanced", "[npc_talk]" )
         CHECK( d.responses[5].text == "This is a repeated item beer, bottle_glass test response" );
         CHECK( d.responses[5].success.next_topic.item_type == itype_id( "bottle_glass" ) );
         CHECK( d.responses[6].text == "This is a repeated item beer, bottle_glass test response" );
-        CHECK( d.responses[6].success.next_topic.item_type == itype_id( "beer" ) );
+        CHECK( d.responses[6].success.next_topic.item_type == itype_id( "rootbeer" ) );
         CHECK( d.responses[7].text == "This is a basic test response." );
     }
 
     SECTION( "sell_and_consume" ) {
-        give_item( player_character, "beer", 2 );
+        give_item( player_character, "rootbeer", 2 );
         give_item( player_character, "bottle_glass", 1 );
         give_item( player_character, "bottle_plastic", 1 );
 
@@ -812,20 +812,20 @@ TEST_CASE( "npc_talk_effects_advanced", "[npc_talk]" )
         talk_effect_t &effects = d.responses[1].success;
         effects.apply( d );
         CHECK_FALSE( has_item( player_character, "bottle_plastic", 1 ) );
-        CHECK_FALSE( has_item( player_character, "beer", 1 ) );
+        CHECK_FALSE( has_item( player_character, "rootbeer", 1 ) );
         CHECK( has_item( talker_npc, "bottle_plastic", 1 ) );
-        CHECK( has_item( talker_npc, "beer", 2 ) );
+        CHECK( has_item( talker_npc, "rootbeer", 2 ) );
         effects = d.responses[2].success;
         effects.apply( d );
-        CHECK_FALSE( has_item( talker_npc, "beer", 2 ) );
-        CHECK( has_item( talker_npc, "beer", 1 ) );
+        CHECK_FALSE( has_item( talker_npc, "rootbeer", 2 ) );
+        CHECK( has_item( talker_npc, "rootbeer", 1 ) );
         effects = d.responses[3].success;
         effects.apply( d );
-        CHECK( has_item( player_character, "beer", 1 ) );
+        CHECK( has_item( player_character, "rootbeer", 1 ) );
         effects = d.responses[4].success;
         effects.apply( d );
-        CHECK( has_item( player_character, "beer", 0 ) );
-        CHECK_FALSE( has_item( player_character, "beer", 1 ) );
+        CHECK( has_item( player_character, "rootbeer", 0 ) );
+        CHECK_FALSE( has_item( player_character, "rootbeer", 1 ) );
         // Ecash should NOT be used for trade
         REQUIRE( player_character.cash == 1000 );
     }

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -606,9 +606,9 @@ static bool has_item( Character &p, const std::string &id, int count )
     }
 }
 
-static bool has_beer_bottle( Character &p, int count )
+static bool has_rootbeer_bottle( Character &p, int count )
 {
-    return has_item( p, "bottle_glass", 1 ) && has_item( p, "beer", count );
+    return has_item( p, "bottle_glass", 1 ) && has_item( p, "rootbeer", count );
 }
 
 static void give_item( Character &p, const std::string &id, int count )
@@ -630,7 +630,6 @@ TEST_CASE( "npc_talk_effects_advanced", "[npc_talk]" )
     player_character.remove_top_items_with( []( detached_ptr<item> &&it ) {
         return ( it->get_category().get_id() == item_category_id( "books" ) ||
                  it->get_category().get_id() == item_category_id( "food" ) ||
-                 it->get_category().get_id() == item_category_id( "drugs" ) ||
                  it->typeId() == itype_id( "bottle_glass" ) ) ? detached_ptr<item>() : std::move( it );
     } );
 
@@ -693,13 +692,13 @@ TEST_CASE( "npc_talk_effects_advanced", "[npc_talk]" )
         gen_response_lines( d, 4 );
         // buying and spending
         talker_npc.op_of_u.owed = 1000;
-        REQUIRE_FALSE( has_beer_bottle( player_character, 2 ) );
+        REQUIRE_FALSE( has_rootbeer_bottle( player_character, 2 ) );
         REQUIRE( talker_npc.op_of_u.owed == 1000 );
         REQUIRE( player_character.cash == 1000 );
         talk_effect_t &effects = d.responses[1].success;
         effects.apply( d );
         CHECK( talker_npc.op_of_u.owed == 500 );
-        CHECK( has_beer_bottle( player_character, 2 ) );
+        CHECK( has_rootbeer_bottle( player_character, 2 ) );
         REQUIRE_FALSE( has_item( player_character, "bottle_plastic", 1 ) );
         effects = d.responses[2].success;
         effects.apply( d );
@@ -754,7 +753,7 @@ TEST_CASE( "npc_talk_effects_advanced", "[npc_talk]" )
     }
 
     SECTION( "has_item" ) {
-        give_item( player_character, "beer", 2 );
+        give_item( player_character, "rootbeer", 2 );
         give_item( player_character, "bottle_glass", 1 );
         give_item( player_character, "manual_speech", 1 );
         give_item( player_character, "dnd_handbook", 1 );
@@ -764,15 +763,15 @@ TEST_CASE( "npc_talk_effects_advanced", "[npc_talk]" )
         CHECK( d.responses[0].text == "This is a repeated item manual_speech test response" );
         CHECK( d.responses[0].success.next_topic.item_type == itype_id( "manual_speech" ) );
         CHECK( d.responses[1].text == "This is a basic test response." );
-        CHECK( d.responses[2].text == "This is a u_has_item beer test response." );
+        CHECK( d.responses[2].text == "This is a u_has_item rootbeer test response." );
         CHECK( d.responses[3].text == "This is a u_has_item bottle_glass test response." );
-        CHECK( d.responses[4].text == "This is a u_has_items beer test response." );
+        CHECK( d.responses[4].text == "This is a u_has_items rootbeer test response." );
         CHECK( d.responses[5].text == "This is a u_has_item_category books test response." );
         CHECK( d.responses[6].text == "This is a u_has_item_category books count 2 test response." );
     }
 
     SECTION( "item_repeat" ) {
-        give_item( player_character, "beer", 2 );
+        give_item( player_character, "rootbeer", 2 );
         give_item( player_character, "bottle_glass", 1 );
         give_item( player_character, "manual_speech", 1 );
         give_item( player_character, "dnd_handbook", 1 );
@@ -780,7 +779,7 @@ TEST_CASE( "npc_talk_effects_advanced", "[npc_talk]" )
         d.add_topic( "TALK_TEST_ITEM_REPEAT" );
         gen_response_lines( d, 8 );
         CHECK( d.responses[0].text == "This is a repeated category books, food test response" );
-        CHECK( d.responses[0].success.next_topic.item_type == itype_id( "beer" ) );
+        CHECK( d.responses[0].success.next_topic.item_type == itype_id( "rootbeer" ) );
         CHECK( d.responses[1].text == "This is a repeated category books, food test response" );
         CHECK( d.responses[1].success.next_topic.item_type == itype_id( "dnd_handbook" ) );
         CHECK( d.responses[2].text == "This is a repeated category books, food test response" );
@@ -792,12 +791,12 @@ TEST_CASE( "npc_talk_effects_advanced", "[npc_talk]" )
         CHECK( d.responses[5].text == "This is a repeated item beer, bottle_glass test response" );
         CHECK( d.responses[5].success.next_topic.item_type == itype_id( "bottle_glass" ) );
         CHECK( d.responses[6].text == "This is a repeated item beer, bottle_glass test response" );
-        CHECK( d.responses[6].success.next_topic.item_type == itype_id( "beer" ) );
+        CHECK( d.responses[6].success.next_topic.item_type == itype_id( "rootbeer" ) );
         CHECK( d.responses[7].text == "This is a basic test response." );
     }
 
     SECTION( "sell_and_consume" ) {
-        give_item( player_character, "beer", 2 );
+        give_item( player_character, "rootbeer", 2 );
         give_item( player_character, "bottle_glass", 1 );
         give_item( player_character, "bottle_plastic", 1 );
 
@@ -806,26 +805,26 @@ TEST_CASE( "npc_talk_effects_advanced", "[npc_talk]" )
         gen_response_lines( d, 5 );
         REQUIRE( player_character.cash == 1000 );
         REQUIRE( has_item( player_character, "bottle_plastic", 1 ) );
-        REQUIRE( has_beer_bottle( player_character, 2 ) );
+        REQUIRE( has_rootbeer_bottle( player_character, 2 ) );
         REQUIRE( player_character.wield( player_character.i_at( player_character.inv_position_by_type(
                                              itype_id( "bottle_glass" ) ) ) ) );
         talk_effect_t &effects = d.responses[1].success;
         effects.apply( d );
         CHECK_FALSE( has_item( player_character, "bottle_plastic", 1 ) );
-        CHECK_FALSE( has_item( player_character, "beer", 1 ) );
+        CHECK_FALSE( has_item( player_character, "rootbeer", 1 ) );
         CHECK( has_item( talker_npc, "bottle_plastic", 1 ) );
-        CHECK( has_item( talker_npc, "beer", 2 ) );
+        CHECK( has_item( talker_npc, "rootbeer", 2 ) );
         effects = d.responses[2].success;
         effects.apply( d );
-        CHECK_FALSE( has_item( talker_npc, "beer", 2 ) );
-        CHECK( has_item( talker_npc, "beer", 1 ) );
+        CHECK_FALSE( has_item( talker_npc, "rootbeer", 2 ) );
+        CHECK( has_item( talker_npc, "rootbeer", 1 ) );
         effects = d.responses[3].success;
         effects.apply( d );
-        CHECK( has_item( player_character, "beer", 1 ) );
+        CHECK( has_item( player_character, "rootbeer", 1 ) );
         effects = d.responses[4].success;
         effects.apply( d );
-        CHECK( has_item( player_character, "beer", 0 ) );
-        CHECK_FALSE( has_item( player_character, "beer", 1 ) );
+        CHECK( has_item( player_character, "rootbeer", 0 ) );
+        CHECK_FALSE( has_item( player_character, "rootbeer", 1 ) );
         // Ecash should NOT be used for trade
         REQUIRE( player_character.cash == 1000 );
     }

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -606,9 +606,9 @@ static bool has_item( Character &p, const std::string &id, int count )
     }
 }
 
-static bool has_rootbeer_bottle( Character &p, int count )
+static bool has_beer_bottle( Character &p, int count )
 {
-    return has_item( p, "bottle_glass", 1 ) && has_item( p, "rootbeer", count );
+    return has_item( p, "bottle_glass", 1 ) && has_item( p, "beer", count );
 }
 
 static void give_item( Character &p, const std::string &id, int count )
@@ -630,6 +630,7 @@ TEST_CASE( "npc_talk_effects_advanced", "[npc_talk]" )
     player_character.remove_top_items_with( []( detached_ptr<item> &&it ) {
         return ( it->get_category().get_id() == item_category_id( "books" ) ||
                  it->get_category().get_id() == item_category_id( "food" ) ||
+                 it->get_category().get_id() == item_category_id( "drugs" ) ||
                  it->typeId() == itype_id( "bottle_glass" ) ) ? detached_ptr<item>() : std::move( it );
     } );
 
@@ -692,13 +693,13 @@ TEST_CASE( "npc_talk_effects_advanced", "[npc_talk]" )
         gen_response_lines( d, 4 );
         // buying and spending
         talker_npc.op_of_u.owed = 1000;
-        REQUIRE_FALSE( has_rootbeer_bottle( player_character, 2 ) );
+        REQUIRE_FALSE( has_beer_bottle( player_character, 2 ) );
         REQUIRE( talker_npc.op_of_u.owed == 1000 );
         REQUIRE( player_character.cash == 1000 );
         talk_effect_t &effects = d.responses[1].success;
         effects.apply( d );
         CHECK( talker_npc.op_of_u.owed == 500 );
-        CHECK( has_rootbeer_bottle( player_character, 2 ) );
+        CHECK( has_beer_bottle( player_character, 2 ) );
         REQUIRE_FALSE( has_item( player_character, "bottle_plastic", 1 ) );
         effects = d.responses[2].success;
         effects.apply( d );
@@ -753,7 +754,7 @@ TEST_CASE( "npc_talk_effects_advanced", "[npc_talk]" )
     }
 
     SECTION( "has_item" ) {
-        give_item( player_character, "rootbeer", 2 );
+        give_item( player_character, "beer", 2 );
         give_item( player_character, "bottle_glass", 1 );
         give_item( player_character, "manual_speech", 1 );
         give_item( player_character, "dnd_handbook", 1 );
@@ -763,15 +764,15 @@ TEST_CASE( "npc_talk_effects_advanced", "[npc_talk]" )
         CHECK( d.responses[0].text == "This is a repeated item manual_speech test response" );
         CHECK( d.responses[0].success.next_topic.item_type == itype_id( "manual_speech" ) );
         CHECK( d.responses[1].text == "This is a basic test response." );
-        CHECK( d.responses[2].text == "This is a u_has_item rootbeer test response." );
+        CHECK( d.responses[2].text == "This is a u_has_item beer test response." );
         CHECK( d.responses[3].text == "This is a u_has_item bottle_glass test response." );
-        CHECK( d.responses[4].text == "This is a u_has_items rootbeer test response." );
+        CHECK( d.responses[4].text == "This is a u_has_items beer test response." );
         CHECK( d.responses[5].text == "This is a u_has_item_category books test response." );
         CHECK( d.responses[6].text == "This is a u_has_item_category books count 2 test response." );
     }
 
     SECTION( "item_repeat" ) {
-        give_item( player_character, "rootbeer", 2 );
+        give_item( player_character, "beer", 2 );
         give_item( player_character, "bottle_glass", 1 );
         give_item( player_character, "manual_speech", 1 );
         give_item( player_character, "dnd_handbook", 1 );
@@ -779,7 +780,7 @@ TEST_CASE( "npc_talk_effects_advanced", "[npc_talk]" )
         d.add_topic( "TALK_TEST_ITEM_REPEAT" );
         gen_response_lines( d, 8 );
         CHECK( d.responses[0].text == "This is a repeated category books, food test response" );
-        CHECK( d.responses[0].success.next_topic.item_type == itype_id( "rootbeer" ) );
+        CHECK( d.responses[0].success.next_topic.item_type == itype_id( "beer" ) );
         CHECK( d.responses[1].text == "This is a repeated category books, food test response" );
         CHECK( d.responses[1].success.next_topic.item_type == itype_id( "dnd_handbook" ) );
         CHECK( d.responses[2].text == "This is a repeated category books, food test response" );
@@ -791,12 +792,12 @@ TEST_CASE( "npc_talk_effects_advanced", "[npc_talk]" )
         CHECK( d.responses[5].text == "This is a repeated item beer, bottle_glass test response" );
         CHECK( d.responses[5].success.next_topic.item_type == itype_id( "bottle_glass" ) );
         CHECK( d.responses[6].text == "This is a repeated item beer, bottle_glass test response" );
-        CHECK( d.responses[6].success.next_topic.item_type == itype_id( "rootbeer" ) );
+        CHECK( d.responses[6].success.next_topic.item_type == itype_id( "beer" ) );
         CHECK( d.responses[7].text == "This is a basic test response." );
     }
 
     SECTION( "sell_and_consume" ) {
-        give_item( player_character, "rootbeer", 2 );
+        give_item( player_character, "beer", 2 );
         give_item( player_character, "bottle_glass", 1 );
         give_item( player_character, "bottle_plastic", 1 );
 
@@ -805,26 +806,26 @@ TEST_CASE( "npc_talk_effects_advanced", "[npc_talk]" )
         gen_response_lines( d, 5 );
         REQUIRE( player_character.cash == 1000 );
         REQUIRE( has_item( player_character, "bottle_plastic", 1 ) );
-        REQUIRE( has_rootbeer_bottle( player_character, 2 ) );
+        REQUIRE( has_beer_bottle( player_character, 2 ) );
         REQUIRE( player_character.wield( player_character.i_at( player_character.inv_position_by_type(
                                              itype_id( "bottle_glass" ) ) ) ) );
         talk_effect_t &effects = d.responses[1].success;
         effects.apply( d );
         CHECK_FALSE( has_item( player_character, "bottle_plastic", 1 ) );
-        CHECK_FALSE( has_item( player_character, "rootbeer", 1 ) );
+        CHECK_FALSE( has_item( player_character, "beer", 1 ) );
         CHECK( has_item( talker_npc, "bottle_plastic", 1 ) );
-        CHECK( has_item( talker_npc, "rootbeer", 2 ) );
+        CHECK( has_item( talker_npc, "beer", 2 ) );
         effects = d.responses[2].success;
         effects.apply( d );
-        CHECK_FALSE( has_item( talker_npc, "rootbeer", 2 ) );
-        CHECK( has_item( talker_npc, "rootbeer", 1 ) );
+        CHECK_FALSE( has_item( talker_npc, "beer", 2 ) );
+        CHECK( has_item( talker_npc, "beer", 1 ) );
         effects = d.responses[3].success;
         effects.apply( d );
-        CHECK( has_item( player_character, "rootbeer", 1 ) );
+        CHECK( has_item( player_character, "beer", 1 ) );
         effects = d.responses[4].success;
         effects.apply( d );
-        CHECK( has_item( player_character, "rootbeer", 0 ) );
-        CHECK_FALSE( has_item( player_character, "rootbeer", 1 ) );
+        CHECK( has_item( player_character, "beer", 0 ) );
+        CHECK_FALSE( has_item( player_character, "beer", 1 ) );
         // Ecash should NOT be used for trade
         REQUIRE( player_character.cash == 1000 );
     }

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -608,7 +608,7 @@ static bool has_item( Character &p, const std::string &id, int count )
 
 static bool has_beer_bottle( Character &p, int count )
 {
-    return has_item( p, "bottle_glass", 1 ) && has_item( p, "rootbeer", count );
+    return has_item( p, "bottle_glass", 1 ) && has_item( p, "beer", count );
 }
 
 static void give_item( Character &p, const std::string &id, int count )
@@ -754,7 +754,7 @@ TEST_CASE( "npc_talk_effects_advanced", "[npc_talk]" )
     }
 
     SECTION( "has_item" ) {
-        give_item( player_character, "rootbeer", 2 );
+        give_item( player_character, "beer", 2 );
         give_item( player_character, "bottle_glass", 1 );
         give_item( player_character, "manual_speech", 1 );
         give_item( player_character, "dnd_handbook", 1 );
@@ -772,7 +772,7 @@ TEST_CASE( "npc_talk_effects_advanced", "[npc_talk]" )
     }
 
     SECTION( "item_repeat" ) {
-        give_item( player_character, "rootbeer", 2 );
+        give_item( player_character, "beer", 2 );
         give_item( player_character, "bottle_glass", 1 );
         give_item( player_character, "manual_speech", 1 );
         give_item( player_character, "dnd_handbook", 1 );
@@ -780,7 +780,7 @@ TEST_CASE( "npc_talk_effects_advanced", "[npc_talk]" )
         d.add_topic( "TALK_TEST_ITEM_REPEAT" );
         gen_response_lines( d, 8 );
         CHECK( d.responses[0].text == "This is a repeated category books, food test response" );
-        CHECK( d.responses[0].success.next_topic.item_type == itype_id( "rootbeer" ) );
+        CHECK( d.responses[0].success.next_topic.item_type == itype_id( "beer" ) );
         CHECK( d.responses[1].text == "This is a repeated category books, food test response" );
         CHECK( d.responses[1].success.next_topic.item_type == itype_id( "dnd_handbook" ) );
         CHECK( d.responses[2].text == "This is a repeated category books, food test response" );
@@ -792,12 +792,12 @@ TEST_CASE( "npc_talk_effects_advanced", "[npc_talk]" )
         CHECK( d.responses[5].text == "This is a repeated item beer, bottle_glass test response" );
         CHECK( d.responses[5].success.next_topic.item_type == itype_id( "bottle_glass" ) );
         CHECK( d.responses[6].text == "This is a repeated item beer, bottle_glass test response" );
-        CHECK( d.responses[6].success.next_topic.item_type == itype_id( "rootbeer" ) );
+        CHECK( d.responses[6].success.next_topic.item_type == itype_id( "beer" ) );
         CHECK( d.responses[7].text == "This is a basic test response." );
     }
 
     SECTION( "sell_and_consume" ) {
-        give_item( player_character, "rootbeer", 2 );
+        give_item( player_character, "beer", 2 );
         give_item( player_character, "bottle_glass", 1 );
         give_item( player_character, "bottle_plastic", 1 );
 
@@ -812,20 +812,20 @@ TEST_CASE( "npc_talk_effects_advanced", "[npc_talk]" )
         talk_effect_t &effects = d.responses[1].success;
         effects.apply( d );
         CHECK_FALSE( has_item( player_character, "bottle_plastic", 1 ) );
-        CHECK_FALSE( has_item( player_character, "rootbeer", 1 ) );
+        CHECK_FALSE( has_item( player_character, "beer", 1 ) );
         CHECK( has_item( talker_npc, "bottle_plastic", 1 ) );
-        CHECK( has_item( talker_npc, "rootbeer", 2 ) );
+        CHECK( has_item( talker_npc, "beer", 2 ) );
         effects = d.responses[2].success;
         effects.apply( d );
-        CHECK_FALSE( has_item( talker_npc, "rootbeer", 2 ) );
-        CHECK( has_item( talker_npc, "rootbeer", 1 ) );
+        CHECK_FALSE( has_item( talker_npc, "beer", 2 ) );
+        CHECK( has_item( talker_npc, "beer", 1 ) );
         effects = d.responses[3].success;
         effects.apply( d );
-        CHECK( has_item( player_character, "rootbeer", 1 ) );
+        CHECK( has_item( player_character, "beer", 1 ) );
         effects = d.responses[4].success;
         effects.apply( d );
-        CHECK( has_item( player_character, "rootbeer", 0 ) );
-        CHECK_FALSE( has_item( player_character, "rootbeer", 1 ) );
+        CHECK( has_item( player_character, "beer", 0 ) );
+        CHECK_FALSE( has_item( player_character, "beer", 1 ) );
         // Ecash should NOT be used for trade
         REQUIRE( player_character.cash == 1000 );
     }


### PR DESCRIPTION
## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

Additional auditing of item categories.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Moved duct tape and fish bait out of tool categories and into other.
2. Moved all alcohol items to the drug category since generally most players won't treat them like normal drink items due to addiction effects.
3. Per feedback in the BN discord, moved some of the items I'd placed in ingredients back into their default food category, mainly stuff that's perfectly edible by itself (leaving fat/tallow, vingegar, condiments and other things that strongly should not go in your food pile as ingredients).
4. Did however move maple sap to ingredients category, as you'd likely want to process it into syrup before chugging it.
5. Added several inedible powder items  I missed last sweep to ingredient category.

## Describe alternatives you've considered

I still kinda want to put raw meat items in the ingredient category to make it less likely that players will eat them by accident...

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Load-tested in compiled test build.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
  - [ ] I have made sure to preserve the correct license for the ported content by adding a code or JSON comment to the ported sections indicating their original license
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
