### PR TITLE
feat(balance): stamina no longer affects walking movecost, instead affecting dodge rating and melee damage

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7506,7 +7506,7 @@ void Character::burn_move_stamina( int moves )
     if( move_mode == CMM_RUN ) {
         burn_ratio = burn_ratio * 7;
     }
-    mod_stamina( -( ( moves * burn_ratio ) / 100.0 ) * stamina_move_cost_modifier() );
+    mod_stamina( -( ( moves * burn_ratio ) / 100.0 ) );
     add_msg( m_debug, "Stamina burn: %d", -( ( moves * burn_ratio ) / 100 ) );
     // Chance to suffer pain if overburden and stamina runs out or has trait BADBACK
     // Starts at 1 in 25, goes down by 5 for every 50% more carried
@@ -7518,21 +7518,6 @@ void Character::burn_move_stamina( int moves )
             mod_pain( 1 );
         }
     }
-}
-
-float Character::stamina_move_cost_modifier() const
-{
-    // Both walk and run speed drop to half their maximums as stamina approaches 0.
-    // Convert stamina to a float first to allow for decimal place carrying
-    float stamina_modifier = ( static_cast<float>( get_stamina() ) / get_stamina_max() + 1 ) / 2;
-    if( move_mode == CMM_RUN && get_stamina() >= 0 ) {
-        // Rationale: Average running speed is 2x walking speed. (NOT sprinting)
-        stamina_modifier *= 2.0;
-    }
-    if( move_mode == CMM_CROUCH ) {
-        stamina_modifier *= 0.5;
-    }
-    return stamina_modifier;
 }
 
 void Character::update_stamina( int turns )
@@ -10610,7 +10595,6 @@ int Character::run_cost( int base_cost, bool diag ) const
         }
 
         movecost += bonus_from_enchantments( movecost, enchant_vals::mod::MOVE_COST );
-        movecost /= stamina_move_cost_modifier();
 
         if( movecost < 20.0 ) {
             movecost = 20.0;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7506,7 +7506,7 @@ void Character::burn_move_stamina( int moves )
     if( move_mode == CMM_RUN ) {
         burn_ratio = burn_ratio * 7;
     }
-    mod_stamina( -( ( moves * burn_ratio ) / 100.0 ) );
+    mod_stamina( -( ( moves * burn_ratio ) / 100.0 ) * stamina_burn_cost_modifier() );
     add_msg( m_debug, "Stamina burn: %d", -( ( moves * burn_ratio ) / 100 ) );
     // Chance to suffer pain if overburden and stamina runs out or has trait BADBACK
     // Starts at 1 in 25, goes down by 5 for every 50% more carried
@@ -7519,6 +7519,22 @@ void Character::burn_move_stamina( int moves )
         }
     }
 }
+
+float Character::stamina_burn_cost_modifier() const
+{
+    // We no longer modify movecost with stamina, but we do modify the stamina cost
+    // Convert stamina to a float first to allow for decimal place carrying
+    float stamina_modifier = ( static_cast<float>( get_stamina() ) / get_stamina_max() + 1 ) / 2;
+    if( move_mode == CMM_RUN && get_stamina() >= 0 ) {
+        // Rationale: Average running speed is 2x walking speed. (NOT sprinting)
+        stamina_modifier *= 2.0;
+    }
+    if( move_mode == CMM_CROUCH ) {
+        stamina_modifier *= 0.5;
+    }
+    return stamina_modifier;
+}
+
 
 void Character::update_stamina( int turns )
 {

--- a/src/character.h
+++ b/src/character.h
@@ -1808,7 +1808,6 @@ class Character : public Creature, public location_visitable<Character>
         void set_stamina( int new_stamina );
         void mod_stamina( int mod );
         void burn_move_stamina( int moves );
-        float stamina_move_cost_modifier() const;
         /** Regenerates stamina */
         void update_stamina( int turns );
 

--- a/src/character.h
+++ b/src/character.h
@@ -1808,6 +1808,7 @@ class Character : public Creature, public location_visitable<Character>
         void set_stamina( int new_stamina );
         void mod_stamina( int mod );
         void burn_move_stamina( int moves );
+        float stamina_burn_cost_modifier() const;
         /** Regenerates stamina */
         void update_stamina( int turns );
 

--- a/tests/char_stamina_test.cpp
+++ b/tests/char_stamina_test.cpp
@@ -15,50 +15,6 @@
 #include "type_id.h"
 #include "units.h"
 
-// These test cases cover stamina-related functions in the `Character` class, including:
-//
-// - stamina_move_cost_modifier
-// - burn_move_stamina
-// - mod_stamina
-// - update_stamina
-//
-// To run all tests in this file:
-//
-//     tests/cata_test [stamina]
-//
-// Other tags used include: [cost], [move], [burn], [update], [regen]. [encumbrance]
-
-// TODO: cover additional aspects of `burn_move_stamina` and `update_stamina`:
-// - stamina burn is modified by bionic muscles
-// - stamina recovery is modified by "bio_gills"
-// - stimulants (positive or negative) affect stamina recovery in mysterious ways
-
-// Helpers
-// -------
-
-// See also `clear_character` in `tests/player_helpers.cpp`
-
-// Return `stamina_move_cost_modifier` in the given move_mode with [0.0 .. 1.0] stamina remaining
-static float move_cost_mod( player &dummy, character_movemode move_mode,
-                            float stamina_proportion = 1.0 )
-{
-    // Reset and be able to run
-    clear_character( dummy );
-    REQUIRE( dummy.can_run() );
-
-    // Walk, run, or crouch
-    dummy.set_movement_mode( move_mode );
-    REQUIRE( dummy.movement_mode_is( move_mode ) );
-
-    // Adjust stamina to desired proportion and ensure it was set correctly
-    int new_stamina = static_cast<int>( stamina_proportion * dummy.get_stamina_max() );
-    dummy.set_stamina( new_stamina );
-    REQUIRE( dummy.get_stamina() == new_stamina );
-
-    // The point of it all: move cost modifier
-    return dummy.stamina_move_cost_modifier();
-}
-
 // Return amount of stamina burned per turn by `burn_move_stamina` in the given movement mode.
 static int actual_burn_rate( player &dummy, character_movemode move_mode )
 {
@@ -121,48 +77,6 @@ static float actual_regen_rate( player &dummy, int moves )
 
 // Test cases
 // ----------
-
-TEST_CASE( "stamina movement cost modifier", "[stamina][cost]" )
-{
-    clear_all_state();
-    player &dummy = g->u;
-
-    SECTION( "running cost is double walking cost for the same stamina level" ) {
-        CHECK( move_cost_mod( dummy, CMM_RUN, 1.0 ) == 2 * move_cost_mod( dummy, CMM_WALK, 1.0 ) );
-        CHECK( move_cost_mod( dummy, CMM_RUN, 0.5 ) == 2 * move_cost_mod( dummy, CMM_WALK, 0.5 ) );
-        CHECK( move_cost_mod( dummy, CMM_RUN, 0.0 ) == 2 * move_cost_mod( dummy, CMM_WALK, 0.0 ) );
-    }
-
-    SECTION( "walking cost is double crouching cost for the same stamina level" ) {
-        CHECK( move_cost_mod( dummy, CMM_WALK, 1.0 ) == 2 * move_cost_mod( dummy, CMM_CROUCH, 1.0 ) );
-        CHECK( move_cost_mod( dummy, CMM_WALK, 0.5 ) == 2 * move_cost_mod( dummy, CMM_CROUCH, 0.5 ) );
-        CHECK( move_cost_mod( dummy, CMM_WALK, 0.0 ) == 2 * move_cost_mod( dummy, CMM_CROUCH, 0.0 ) );
-    }
-
-    SECTION( "running cost goes from 2.0 to 1.0 as stamina goes to zero" ) {
-        CHECK( move_cost_mod( dummy, CMM_RUN, 1.00 ) == Approx( 2.00 ) );
-        CHECK( move_cost_mod( dummy, CMM_RUN, 0.75 ) == Approx( 1.75 ) );
-        CHECK( move_cost_mod( dummy, CMM_RUN, 0.50 ) == Approx( 1.50 ) );
-        CHECK( move_cost_mod( dummy, CMM_RUN, 0.25 ) == Approx( 1.25 ) );
-        CHECK( move_cost_mod( dummy, CMM_RUN, 0.00 ) == Approx( 1.00 ) );
-    }
-
-    SECTION( "walking cost goes from 1.0 to 0.5 as stamina goes to zero" ) {
-        CHECK( move_cost_mod( dummy, CMM_WALK, 1.00 ) == Approx( 1.000 ) );
-        CHECK( move_cost_mod( dummy, CMM_WALK, 0.75 ) == Approx( 0.875 ) );
-        CHECK( move_cost_mod( dummy, CMM_WALK, 0.50 ) == Approx( 0.750 ) );
-        CHECK( move_cost_mod( dummy, CMM_WALK, 0.25 ) == Approx( 0.625 ) );
-        CHECK( move_cost_mod( dummy, CMM_WALK, 0.00 ) == Approx( 0.500 ) );
-    }
-
-    SECTION( "crouching cost goes from 0.5 to 0.25 as stamina goes to zero" ) {
-        CHECK( move_cost_mod( dummy, CMM_CROUCH, 1.00 ) == Approx( 0.5000 ) );
-        CHECK( move_cost_mod( dummy, CMM_CROUCH, 0.75 ) == Approx( 0.4375 ) );
-        CHECK( move_cost_mod( dummy, CMM_CROUCH, 0.50 ) == Approx( 0.3750 ) );
-        CHECK( move_cost_mod( dummy, CMM_CROUCH, 0.25 ) == Approx( 0.3125 ) );
-        CHECK( move_cost_mod( dummy, CMM_CROUCH, 0.00 ) == Approx( 0.2500 ) );
-    }
-}
 
 TEST_CASE( "modify character stamina", "[stamina][modify]" )
 {


### PR DESCRIPTION
## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

Some balancing things that came up in discord. I noted that I did not like the way that stamina penalties seem to punish the player for trying to flee from a fight, but instead encourage the player to caveman their way through a fight if their stamina starts getting low (making their death inevitable if they suddenly realize they aren't going to win, due to movecost tanking horribly if your stamina is low).

In fact in retrospect, your effective move speed being cut in HALF at zero stamina might de-facto be why I tend to play with monster speed at 50% and with the faster stamina mod...

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. In character.cpp, removed the use of `stamina_move_cost_modifier()` from `Character::run_cost`, meaning low stamina will no longer affect how many moves it takes to walk around (run speed still scales steadily down to walking speed as your stamina peters out).
2. In character.cpp and character.h, renamed `stamina_move_cost_modifier` to `stamina_burn_cost_modifier`, as it's still used in `Character::burn_move_stamina` to determine how stamina cost increases the lower your stamina gets, whereas the name only made sense for its now-removed use in movecost penalties.
3. In melee.cpp, `Character::melee_attack` now checks your stamina when applying damge multipliers, kicking in if stamina is below 25% and scaling down to half damage at zero stamina.
4. Also in melee.cpp, `Character::get_dodge()` likewise checks your stamina starting at the 50% threshold, scaling it down to the point of disabling dodges at zero stamina.

## Describe alternatives you've considered

Screaming.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Compiled and load-tested.
2. Set my dodge skill to max, confirmed for a default character dodge rating starts at 11, goes down to 5.5 when I debug stamina to be 25%, and is 0 when I set stamina to zero.
3. Spawned in a big sword and a debug monster, confirmed that damage seems to be cut in half when I set stamina to zero, and that it's about the same when around 25%.
5. Tested walking around to confirm movecost no longer jumps up at zero stamina.
6. Checked affected files for astyle.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
  - [ ] I have made sure to preserve the correct license for the ported content by adding a code or JSON comment to the ported sections indicating their original license
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
