### PR TITLE
fix: add seeds for spurge flowers

### DIFF
--- a/data/json/furniture_and_terrain/furniture-flora.json
+++ b/data/json/furniture_and_terrain/furniture-flora.json
@@ -94,7 +94,7 @@
         "seasons": [ "spring", "summer", "autumn" ],
         "entries": [
           { "drop": "withered", "base_num": [ 1, 2 ] },
-          { "drop": "seed_flower", "base_num": [ 1, 2 ] },
+          { "drop": "seed_spurge", "base_num": [ 1, 2 ] },
           { "drop": "spurge", "base_num": [ 1, 4 ] }
         ]
       }

--- a/data/json/items/comestibles/seed.json
+++ b/data/json/items/comestibles/seed.json
@@ -820,5 +820,16 @@
     "use_action": "MYCUS",
     "seed_data": { "plant_name": "mycus fruit", "required_terrain_flag": "MUSHROOM_PLANTABLE", "fruit": "mycus_fruit", "grow": "7 days" },
     "extend": { "flags": [ "MYCUS_OK", "CAN_PLANT_UNDERGROUND" ] }
-  }
+  },
+  {
+    "id": "seed_spurge",
+    "copy-from": "seed",
+    "type": "COMESTIBLE",
+    "name": { "str_sp": "spurge seeds" },
+    "description": "Some spurge seeds.",
+    "price": "160 cent",
+    "charges": 2,
+    "stack_size": 8,
+    "seed_data": { "plant_name": "spurge", "fruit": "spurge", "byproducts": [ "withered" ], "grow": "14 days" }
+ }
 ]

--- a/data/json/items/comestibles/seed.json
+++ b/data/json/items/comestibles/seed.json
@@ -831,5 +831,5 @@
     "charges": 2,
     "stack_size": 8,
     "seed_data": { "plant_name": "spurge", "fruit": "spurge", "byproducts": [ "withered" ], "grow": "14 days" }
- }
+  }
 ]


### PR DESCRIPTION
## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

Close #5603

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Create new seeds for spurge flowers and change seed drops from spurge.

## Describe alternatives you've considered

None

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Find spurge flowers on your game flowers.
2. Harvest them.
3. Should drop its harvest with new seeds.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

I have no idea how to make poppy seeds drop, due its examine action being hardcoded.
Also I considered to make seeds for some mainline mods, if needed too.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
  - [ ] I have made sure to preserve the correct license for the ported content by adding a code or JSON comment to the ported sections indicating their original license
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
