### PR TITLE
feat(balance): use `trash_dumpster` for the dumpster of the mapgen `dollarstore`

### DIFF
--- a/data/json/mapgen/dollar_store.json
+++ b/data/json/mapgen/dollar_store.json
@@ -63,7 +63,7 @@
       "items": {
         "I": { "item": "office", "chance": 30 },
         "S": { "item": "office_paper", "chance": 30 },
-        "U": { "item": "trash", "chance": 20, "repeat": [ 2, 4 ] }
+        "U": { "item": "trash_dumpster", "chance": 80 }
       },
       "place_items": [
         { "chance": 10, "repeat": [ 1, 3 ], "item": "trash", "x": 20, "y": 6 },


### PR DESCRIPTION
## Purpose of change (The Why)
`trash_dumpster` is a better option.
## Describe the solution (The How)
"U": { "item": "trash_dumpster", "chance": 80 } instead of "U": { "item": "trash", "chance": 20, "repeat": [ 2, 4 ] }
## Describe alternatives you've considered
none
## Testing
No errors.
## Additional context
none
## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [X] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)
