### PR TITLE
ci: Install sol2 for msys2 build

### DIFF
--- a/.github/workflows/msys2-cmake.yml
+++ b/.github/workflows/msys2-cmake.yml
@@ -58,6 +58,7 @@ jobs:
             mingw-w64-x86_64-cmake
             mingw-w64-x86_64-sqlite3
             mingw-w64-x86_64-zstd
+            mingw-w64-x86_64-sol2
 
       - name: Create build directory
         run: mkdir build


### PR DESCRIPTION

## Purpose of change (The Why)

This build has been failing for 1-2 years now, and it's annoying.

This looks like a very simple fix, so simple I'm amazed we never did it in the first place.

## Describe the solution (The How)

- Actually install sol2 instead of assuming by some miracle it's already there

## Describe alternatives you've considered

- Throw the build in the trash

I was very tempted for a while, but it's a good idea to keep it around if it provides useful data

## Testing

I confirmed that the package exists on msys2's list

This is really difficult to test without just merging it

## Additional context

Why the hecc was sol2 never added to the package list in the first place, but SQLITE3 WAS??

This codebase is cursed lol

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)
