### PR TITLE
Move process_relic/artifact into process_internal

### DIFF
--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -191,12 +191,6 @@ void Character::process_turn()
     // Didn't just pick something up
     last_item = itype_id( "null" );
 
-    visit_items( [this]( item * e ) {
-        e->process_artifact( as_player(), pos() );
-        e->process_relic( *this );
-        return VisitResponse::NEXT;
-    } );
-
     suffer();
 
     // Handle player and NPC morale ticks

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10162,6 +10162,9 @@ detached_ptr<item> item::process_internal( detached_ptr<item> &&self, player *ca
         }
     }
 
+    self->process_artifact( carrier, pos );
+    self->process_relic( *carrier );
+
     if( self->faults.contains( fault_gun_blackpowder ) ) {
         return process_blackpowder_fouling( std::move( self ), carrier );
     }


### PR DESCRIPTION
## Purpose of change (The Why)

- #5283 showed a flaw in our processing where relics and the like require a separate "light" visit of the inventory at a surface level. Meaning that relic/artifacts don't function while loaded into other items (like a magazine with a recharge schema).

## Describe the solution (The How)

- Moves `process_artifact()` and `process_relic()` into `process_internal()`.

## Describe alternatives you've considered

- Rewriting the `process_relic()` and `process_artifact()` code to be more in line with stuff like `process_tool()` which is boolean.

## Testing

- [x] Ran into a mine and killed the tentacle dog, picked up an artifact that affected player stats, seems to work fine.
- [ ] Make a magazine with a recharge scheme to check if magazines with them will reload their contents while loaded into an appropriate gun. (Test later because I need to go out in like 3 minutes.

## Additional context

- There may be ramifications to not having them be boolean and return `std::move`, so while this is not a draft I'd like more eyes on how this is working out.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)