### PR TITLE
fix(balance): Adds Electrosense bionic scanner. Removes power draw from bionic scanner. Add trigger cost to bionic scanning.

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1308,7 +1308,7 @@
     "id": "bio_electrosense_bscanner",
     "type": "bionic",
     "name": { "str": "Electrosense Bionic Scanner" },
-    "description": "Activating this bionic scans nearby corpses for bionics at 750J per bionic. If you do not possess enough bionic power to scan 1 bionic, it deactivates.",
+    "description": "Activating this bionic scans nearby corpses for bionics at 750J per bionic.  If you do not possess enough bionic power to scan 1 bionic, it deactivates.",
     "flags": [ "BIONIC_TOGGLED" ],
     "trigger_cost": "750 J",
     "included": true

--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1287,13 +1287,13 @@
     "id": "bio_electrosense",
     "type": "bionic",
     "name": { "str": "Electrosense Scanner" },
-    "description": "Activating this bionic will allow you to see robots and other electric creatures through walls, and automatically scan nearby corpses for bionics that could be harvested, at the cost of steadily draining power.",
+    "description": "Activating this bionic will allow you to see robots and other electric creatures through walls, at the cost of steadily draining power.",
     "occupied_bodyparts": [ [ "head", 1 ] ],
     "flags": [ "BIONIC_TOGGLED" ],
     "act_cost": "20 J",
     "react_cost": "20 J",
     "time": 1,
-    "included_bionics": [ "bio_electrosense_voltmeter" ]
+    "included_bionics": [ "bio_electrosense_voltmeter", "bio_electrosense_bscanner" ]
   },
   {
     "id": "bio_electrosense_voltmeter",
@@ -1302,6 +1302,15 @@
     "description": "Using this bionic allows you to check the status of any local grid connections or battery charge in your surroundings, as well as make modifications to grid connections.",
     "act_cost": "10 J",
     "fake_item": "voltmeter_bionic",
+    "included": true
+  },
+  {
+    "id": "bio_electrosense_bscanner",
+    "type": "bionic",
+    "name": { "str": "Electrosense Bionic Scanner" },
+    "description": "Activating this bionic scans nearby corpses for bionics at 750J per bionic. If you do not possess enough bionic power to scan 1 bionic, it deactivates.",
+    "flags": [ "BIONIC_TOGGLED" ],
+    "trigger_cost": "750 J",
     "included": true
   },
   {

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -609,7 +609,6 @@
     "color": "magenta",
     "use_action": "NOTE_BIONICS",
     "revert_to": "bionic_scanner",
-    "power_draw": 10000,
     "revert_msg": "The %s shuts down."
   }
 ]


### PR DESCRIPTION
## Purpose of change (The Why)

- #4107 removes trigger cost for bionic scanner, but this runs counter to the original implementation philosophy. Bionic scanner was always meant to trigger cost based on the corpses scanned, not time based power draw.

## Describe the solution (The How)

- Remove `power_draw` from bionic scanner. In turn, make the bionic scanner use 1 charge per CBM in a corpse.
- If the tool lacks the charges needed for one of the corpses, print a message and continue to the next eligible corpse, deactivate if tool lacks charges needed for even a single CBM no matter the source.
- The bionic instead has a 750 J trigger cost, this can be manipulated freely by mods.

## Describe alternatives you've considered

## Testing

- [x] Kill an _assload_ of bio-operatives.
  - [x] Check that both bionic scanners correctly scan corpses, skipping over corpses when they lack power for them and deactivating if they run out of power.

## Additional context

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)
