### PR TITLE
fix: Washing activity now appropriately adds item if split.

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -805,6 +805,7 @@ void wash_activity_actor::finish( player_activity &act, Character &who )
         } else {
             detached_ptr<item> it2 = it.split( i.count );
             it2->item_tags.erase( flag_FILTHY );
+            who.i_add_or_drop( std::move( it2 ) );
         }
         who.on_worn_item_washed( it );
     }


### PR DESCRIPTION
## Purpose of change (The Why)

- fixes #6024, which is due to the washing activity working fine if an item is washed all at once but doesn't spawn the split portion of an item if they are only partially washed.

## Describe the solution (The How)

- Make the washing activity actually spawn the item it generates for the split.

## Describe alternatives you've considered

## Testing

- [x] Spawn 2 filthy leather patches and appropriate amounts of detergent/water/washboard
  - [x] Washing only 1 leaves you with 1 clean and 1 dirty.

## Additional context

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)