### PR TITLE
fix: `process_relic` exits early if not carried by a character.

### DIFF
--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -170,7 +170,7 @@ void enchantment::reset()
 
 bool enchantment::is_active( const Character &guy, const item &parent ) const
 {
-    if( !guy.has_item( parent ) ) {
+    if( !&guy || !guy.has_item( parent ) ) {
         return false;
     }
 


### PR DESCRIPTION
## Purpose of change (The Why)

- fixes #6110 which was caused by #6106 causing relics to also be marked to be processed if left unattended. This caused a nullptr situation in `enchantment::is_active` when it tries to check the carrier for wield, carry, etc.

## Describe the solution (The How)

- Adds an escape clause early to the function where if `guy` is a nullptr it returns false.

## Describe alternatives you've considered

## Testing

- [x] Loaded provided save from #6110 , walked to the end of the northern corridor, no crashing.

## Additional context

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)