### PR TITLE
feat(port): Blacklist certain special_attacks from difficulty assessment

### DIFF
--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -1024,6 +1024,7 @@ void mtype::load( const JsonObject &jo, const std::string &src )
         optional( jop, was_loaded, "avoid_sharp", path_settings.avoid_sharp, false );
     }
     
+    // blacklisted_specials was originally ported from DDA PRs 75716 and 75804 and thus CC-BY-SA 3.0
     std::unordered_set<std::string> blacklisted_specials {"PARROT", "PARROT_AT_DANGER", "EAT_CROP", "EAT_FOOD"};
     int special_attacks_diff = 0;
     for( const auto &special : special_attacks ) {

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -1023,9 +1023,17 @@ void mtype::load( const JsonObject &jo, const std::string &src )
         optional( jop, was_loaded, "allow_climb_stairs", path_settings.allow_climb_stairs, true );
         optional( jop, was_loaded, "avoid_sharp", path_settings.avoid_sharp, false );
     }
+    
+    std::unordered_set<std::string> blacklisted_specials {"PARROT", "PARROT_AT_DANGER"};
+    int special_attacks_diff = 0;
+    for( const auto &special : special_attacks ) {
+        if( !blacklisted_specials.contains( special.first ) ) {
+            special_attacks_diff++;
+        }
+    }
     difficulty = ( melee_skill + 1 ) * melee_dice * ( bonus_cut + melee_sides ) * 0.04 +
                  ( sk_dodge + 1 ) * ( 3 + armor_bash + armor_cut ) * 0.04 +
-                 ( difficulty_base + special_attacks.size() + 8 * emit_fields.size() );
+                 ( difficulty_base + special_attacks_diff + 8 * emit_fields.size() );
     difficulty *= ( hp + speed - attack_cost + ( morale + agro ) * 0.1 ) * 0.01 +
                   ( vision_day + 2 * vision_night ) * 0.01;
 }

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -1024,7 +1024,7 @@ void mtype::load( const JsonObject &jo, const std::string &src )
         optional( jop, was_loaded, "avoid_sharp", path_settings.avoid_sharp, false );
     }
     
-    std::unordered_set<std::string> blacklisted_specials {"PARROT", "PARROT_AT_DANGER"};
+    std::unordered_set<std::string> blacklisted_specials {"PARROT", "PARROT_AT_DANGER", "EAT_CROP", "EAT_FOOD"};
     int special_attacks_diff = 0;
     for( const auto &special : special_attacks ) {
         if( !blacklisted_specials.contains( special.first ) ) {

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -1023,7 +1023,7 @@ void mtype::load( const JsonObject &jo, const std::string &src )
         optional( jop, was_loaded, "allow_climb_stairs", path_settings.allow_climb_stairs, true );
         optional( jop, was_loaded, "avoid_sharp", path_settings.avoid_sharp, false );
     }
-    
+
     // blacklisted_specials was originally ported from DDA PRs 75716 and 75804 and thus CC-BY-SA 3.0
     std::unordered_set<std::string> blacklisted_specials {"PARROT", "PARROT_AT_DANGER", "EAT_CROP", "EAT_FOOD"};
     int special_attacks_diff = 0;


### PR DESCRIPTION
## Purpose of change (The Why)

Enemies talking or eating doesn't make them any more dangerous to the players.

Requested by "Good Guy" in the Discord

## Describe the solution (The How)

Ports two DDA PR's:
- https://github.com/CleverRaven/Cataclysm-DDA/pull/75716
- https://github.com/CleverRaven/Cataclysm-DDA/pull/75804

## Describe alternatives you've considered
- Instead handle this with a flag in the code/JSON for special attacks that causes them to not count towards difficulty

Too much work for too little gain.

## Testing

- Compiled
- Loaded in pre-changes: Killing a Mi-Go in a STK world gave me 68 EXP
- Loaded in post-changes: Killing a Mi-Go gave me 65 EXP

## Additional context

I also made sure to add a code comment explaining that the blacklisted_specials bit was ported from DDA, even though this probably falls under the "atomic PR's" idea of it being *just* a port anyway.

I changed the list of blacklisted special attacks to only include the ones we actually have, and I changed it from using `count` for checking membership to `contains` to satisfy clangd.

Let us hope that this satisfies everyone involved with the licensing of the contents of this commit.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt) (DDA port, CC-BY-SA 3.0)

### Optional

- [x] This PR ports commits from DDA or other cataclysm forks.
  - [x] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [x] I have linked the URL of original PR(s) in the description.
  - [x] I have made sure to preserve the correct license for the ported content by adding a code or JSON comment to the ported sections indicating their original license

