### PR TITLE
fix: Make `process_relic` take a pointer and stop crashing the game.

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9575,16 +9575,18 @@ std::vector<trait_id> item::mutations_from_wearing( const Character &guy ) const
     return muts;
 }
 
-void item::process_relic( Character &carrier )
+void item::process_relic( Character *carrier )
 {
     if( !is_relic() ) {
         return;
     }
     std::vector<enchantment> active_enchantments;
 
-    for( const enchantment &ench : get_enchantments() ) {
-        if( ench.is_active( carrier, *this ) ) {
-            active_enchantments.emplace_back( ench );
+    if( carrier ) {
+        for( const enchantment &ench : get_enchantments() ) {
+            if( ench.is_active( *carrier, *this ) ) {
+                active_enchantments.emplace_back( ench );
+            }
         }
     }
 
@@ -10175,7 +10177,7 @@ detached_ptr<item> item::process_internal( detached_ptr<item> &&self, player *ca
     }
 
     self->process_artifact( carrier, pos );
-    self->process_relic( *carrier );
+    self->process_relic( carrier );
 
     if( self->faults.contains( fault_gun_blackpowder ) ) {
         return process_blackpowder_fouling( std::move( self ), carrier );

--- a/src/item.h
+++ b/src/item.h
@@ -1229,7 +1229,7 @@ class item : public location_visitable<item>, public game_object<item>
          * @param pos The location of the artifact (should be the player location if carried).
          */
         void process_artifact( player *carrier, const tripoint &pos );
-        void process_relic( Character &carrier );
+        void process_relic( Character *carrier );
 
         bool destroyed_at_zero_charges() const;
         // Most of the is_whatever() functions call the same function in our itype

--- a/src/item.h
+++ b/src/item.h
@@ -2250,9 +2250,6 @@ class item : public location_visitable<item>, public game_object<item>
         /** Returns the type of location where the item is found */
         item_location_type where() const;
 
-        /** Returns the position where the item is found */
-        tripoint pos() const;
-
         /** Describes the item location
          *  @param ch if set description is relative to character location */
         std::string describe_location( const Character *ch = nullptr ) const;

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -170,23 +170,19 @@ void enchantment::reset()
 
 bool enchantment::is_active( const Character &guy, const item &parent ) const
 {
-    if( &guy ) {
-        if( !guy.has_item( parent ) ) {
-            return false;
-        }
-
-        if( active_conditions.first == has::WIELD && !guy.is_wielding( parent ) ) {
-            return false;
-        }
-
-        if( active_conditions.first == has::WORN && !guy.is_worn( parent ) ) {
-            return false;
-        }
-
-        return is_active( guy, parent.is_active() );
-    } else {
+    if( !guy.has_item( parent ) ) {
         return false;
     }
+
+    if( active_conditions.first == has::WIELD && !guy.is_wielding( parent ) ) {
+        return false;
+    }
+
+    if( active_conditions.first == has::WORN && !guy.is_worn( parent ) ) {
+        return false;
+    }
+
+    return is_active( guy, parent.is_active() );
 }
 
 bool enchantment::is_active( const Character &guy, const bool active ) const

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -347,7 +347,7 @@ bool check_recharge_reqs( const item &itm, const relic_recharge &rech, const Cha
             return carrier->has_effect( effect_sleep );
         }
         case relic_recharge_req::rad: {
-            return get_map().get_radiation( itm.pos() ) > 0 || ( possess && carrier->get_rad() > 0 );
+            return get_map().get_radiation( itm.position() ) > 0 || ( possess && carrier->get_rad() > 0 );
         }
         case relic_recharge_req::wet: {
             bool soaked = false;
@@ -362,12 +362,12 @@ bool check_recharge_reqs( const item &itm, const relic_recharge &rech, const Cha
                 if( !wt.rains || wt.acidic || wt.precip == precip_class::none ) {
                     return false;
                 }
-                soaked = get_map().is_outside( itm.pos() );
+                soaked = get_map().is_outside( itm.position() );
             }
             return soaked;
         }
         case relic_recharge_req::sky: {
-            return itm.pos().z > 0;
+            return itm.position().z > 0;
         }
         default: {
             std::abort();
@@ -390,7 +390,7 @@ bool process_recharge_entry( item &itm, const relic_recharge &rech, Character *c
             break;
         }
         case relic_recharge_type::solar: {
-            if( !g->is_in_sunlight( itm.pos() ) ) {
+            if( !g->is_in_sunlight( itm.position() ) ) {
                 return false;
             }
             break;
@@ -425,7 +425,7 @@ bool process_recharge_entry( item &itm, const relic_recharge &rech, Character *c
         }
         case relic_recharge_type::field: {
             bool consumed = false;
-            for( const tripoint &dest : here.points_in_radius( itm.pos(), 1 ) ) {
+            for( const tripoint &dest : here.points_in_radius( itm.position(), 1 ) ) {
                 field_entry *field_at = here.field_at( dest ).find_field( rech.field_type );
                 if( !field_at ) {
                     continue;
@@ -444,7 +444,7 @@ bool process_recharge_entry( item &itm, const relic_recharge &rech, Character *c
         }
         case relic_recharge_type::trap: {
             bool consumed = false;
-            for( const tripoint &dest : here.points_in_radius( itm.pos(), 1 ) ) {
+            for( const tripoint &dest : here.points_in_radius( itm.position(), 1 ) ) {
                 if( here.tr_at( dest ).id == rech.trap_type ) {
                     here.remove_trap( dest );
                     consumed = true;

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -273,30 +273,38 @@ void relic::check() const
 namespace relic_funcs
 {
 
-bool check_recharge_reqs( const item &itm, const relic_recharge &rech, const Character &carrier )
+bool check_recharge_reqs( const item &itm, const relic_recharge &rech, const Character *carrier )
 {
+    bool possess = carrier;
+
     switch( rech.req ) {
         case relic_recharge_req::none: {
             return true;
         }
         case relic_recharge_req::equipped: {
+            if( !possess ) {
+                return false;
+            }
             if( itm.is_armor() ) {
-                return carrier.is_wearing( itm );
+                return carrier->is_wearing( itm );
             } else {
-                return carrier.is_wielding( itm );
+                return carrier->is_wielding( itm );
             }
         }
         case relic_recharge_req::close_to_skin: {
+            if( !possess ) {
+                return false;
+            }
             if( itm.is_armor() ) {
-                if( !carrier.is_wearing( itm ) ) {
+                if( !carrier->is_wearing( itm ) ) {
                     return false;
                 }
-                for( const bodypart_id &bp : carrier.get_all_body_parts() ) {
+                for( const bodypart_id &bp : carrier->get_all_body_parts() ) {
                     if( !itm.covers( bp ) ) {
                         continue;
                     }
                     bool this_bp_good = true;
-                    for( const item *wi : carrier.worn ) {
+                    for( const item *wi : carrier->worn ) {
                         if( wi->get_coverage( bp ) == 0 ) {
                             continue;
                         }
@@ -313,12 +321,12 @@ bool check_recharge_reqs( const item &itm, const relic_recharge &rech, const Cha
                 }
                 return false;
             } else {
-                if( !carrier.is_wielding( itm ) ) {
+                if( !carrier->is_wielding( itm ) ) {
                     return false;
                 }
                 bool hand_l_ok = true;
                 bool hand_r_ok = true;
-                for( const item *wi : carrier.worn ) {
+                for( const item *wi : carrier->worn ) {
                     if( wi->get_coverage( body_part_hand_l ) == 0 && wi->get_coverage( body_part_hand_r ) == 0 ) {
                         continue;
                     }
@@ -333,28 +341,33 @@ bool check_recharge_reqs( const item &itm, const relic_recharge &rech, const Cha
             }
         }
         case relic_recharge_req::sleep: {
-            return carrier.has_effect( effect_sleep );
+            if( !possess ) {
+                return false;
+            }
+            return carrier->has_effect( effect_sleep );
         }
         case relic_recharge_req::rad: {
-            return get_map().get_radiation( carrier.pos() ) > 0 || carrier.get_rad() > 0;
+            return get_map().get_radiation( itm.pos() ) > 0 || ( possess && carrier->get_rad() > 0 );
         }
         case relic_recharge_req::wet: {
-            bool has_wet = std::any_of( carrier.get_body().begin(), carrier.get_body().end(),
-            []( const std::pair<const bodypart_str_id, bodypart> &elem ) {
-                return elem.second.get_wetness() != 0;
-            } );
-            if( has_wet ) {
-                return true;
-            } else {
+            bool soaked = false;
+            if( possess ) {
+                soaked = std::any_of( carrier->get_body().begin(), carrier->get_body().end(),
+                []( const std::pair<const bodypart_str_id, bodypart> &elem ) {
+                    return elem.second.get_wetness() != 0;
+                } );
+            }
+            if( !soaked ) {
                 const weather_type &wt = get_weather().weather_id.obj();
                 if( !wt.rains || wt.acidic || wt.precip == precip_class::none ) {
                     return false;
                 }
-                return get_map().is_outside( carrier.pos() );
+                soaked = get_map().is_outside( itm.pos() );
             }
+            return soaked;
         }
         case relic_recharge_req::sky: {
-            return carrier.posz() > 0;
+            return itm.pos().z > 0;
         }
         default: {
             std::abort();
@@ -363,7 +376,7 @@ bool check_recharge_reqs( const item &itm, const relic_recharge &rech, const Cha
     cata::unreachable();
 }
 
-bool process_recharge_entry( item &itm, const relic_recharge &rech, Character &carrier )
+bool process_recharge_entry( item &itm, const relic_recharge &rech, Character *carrier )
 {
     if( !calendar::once_every( rech.interval ) ) {
         return false;
@@ -377,30 +390,42 @@ bool process_recharge_entry( item &itm, const relic_recharge &rech, Character &c
             break;
         }
         case relic_recharge_type::solar: {
-            if( !g->is_in_sunlight( carrier.pos() ) ) {
+            if( !g->is_in_sunlight( itm.pos() ) ) {
                 return false;
             }
             break;
         }
         case relic_recharge_type::pain: {
-            carrier.add_msg_if_player( m_bad, _( "You suddenly feel sharp pain for no reason." ) );
-            carrier.mod_pain_noresist( rng( rech.intensity_min, rech.intensity_max ) );
+            if( carrier ) {
+                carrier->add_msg_if_player( m_bad, _( "You suddenly feel sharp pain for no reason." ) );
+                carrier->mod_pain_noresist( rng( rech.intensity_min, rech.intensity_max ) );
+            } else {
+                return false;
+            }
             break;
         }
         case relic_recharge_type::hp: {
-            carrier.add_msg_if_player( m_bad, _( "You feel your body decaying." ) );
-            carrier.hurtall( rng( rech.intensity_min, rech.intensity_max ), nullptr );
+            if( carrier ) {
+                carrier->add_msg_if_player( m_bad, _( "You feel your body decaying." ) );
+                carrier->hurtall( rng( rech.intensity_min, rech.intensity_max ), nullptr );
+            } else {
+                return false;
+            }
             break;
         }
         case relic_recharge_type::fatigue: {
-            carrier.add_msg_if_player( m_bad, _( "You feel fatigue seeping into your body." ) );
-            carrier.mod_fatigue( rng( rech.intensity_min, rech.intensity_max ) );
-            carrier.mod_stamina( -100 * rng( rech.intensity_min, rech.intensity_max ) );
+            if( carrier ) {
+                carrier->add_msg_if_player( m_bad, _( "You feel fatigue seeping into your body." ) );
+                carrier->mod_fatigue( rng( rech.intensity_min, rech.intensity_max ) );
+                carrier->mod_stamina( -100 * rng( rech.intensity_min, rech.intensity_max ) );
+            } else {
+                return false;
+            }
             break;
         }
         case relic_recharge_type::field: {
             bool consumed = false;
-            for( const tripoint &dest : here.points_in_radius( carrier.pos(), 1 ) ) {
+            for( const tripoint &dest : here.points_in_radius( itm.pos(), 1 ) ) {
                 field_entry *field_at = here.field_at( dest ).find_field( rech.field_type );
                 if( !field_at ) {
                     continue;
@@ -419,7 +444,7 @@ bool process_recharge_entry( item &itm, const relic_recharge &rech, Character &c
         }
         case relic_recharge_type::trap: {
             bool consumed = false;
-            for( const tripoint &dest : here.points_in_radius( carrier.pos(), 1 ) ) {
+            for( const tripoint &dest : here.points_in_radius( itm.pos(), 1 ) ) {
                 if( here.tr_at( dest ).id == rech.trap_type ) {
                     here.remove_trap( dest );
                     consumed = true;
@@ -448,12 +473,14 @@ bool process_recharge_entry( item &itm, const relic_recharge &rech, Character &c
         }
     }
     if( rech.message ) {
-        carrier.add_msg_if_player( _( *rech.message ) );
+        if( carrier ) {
+            carrier->add_msg_if_player( _( *rech.message ) );
+        }
     }
     return true;
 }
 
-void process_recharge( item &itm, Character &carrier )
+void process_recharge( item &itm, Character *carrier )
 {
     if( itm.is_tool() || itm.is_gun() || itm.is_magazine() ) {
         if( itm.ammo_remaining() >= itm.ammo_capacity() ) {

--- a/src/relic.h
+++ b/src/relic.h
@@ -141,10 +141,10 @@ class relic
 namespace relic_funcs
 {
 
-bool check_recharge_reqs( const item &itm, const relic_recharge &rech, const Character &carrier );
-bool process_recharge_entry( item &itm, const relic_recharge &rech, Character &carrier );
+bool check_recharge_reqs( const item &itm, const relic_recharge &rech, const Character *carrier );
+bool process_recharge_entry( item &itm, const relic_recharge &rech, Character *carrier );
 
-void process_recharge( item &itm, Character &carrier );
+void process_recharge( item &itm, Character *carrier );
 
 } // namespace relic_funcs
 


### PR DESCRIPTION
## Purpose of change (The Why)

- #6120 is due to #6106 which gives me massive headaches. It's mainly to do with C++ magic because `process_relic` is passing on a reference that may be generated from a nullptr, so the compiler is optimizing away any checks because it assumes we actually checked that the reference is actually valid. Far as I can tell the optimization only occurs on android builds.

## Describe the solution (The How)

`process_relic` now takes a pointer rather than a possibly invalid reference.

Recharge code can now properly handle all possible recharge options when off the player (except wet requiring being underwater, because for some reason we don't have code to check if an object is submerged, only if the player is.)

Active enchantments don't get checked at all if the relic isn't being carried.

## Describe alternatives you've considered

## Testing

I think it might be difficult to test this one because it seems the optimization mainly happens on android devices, and I have yet learned how to compile them myself.

- [ ] Test that all the recharge requirements work when on/off the player. @chaosvolt I choose you.

## Additional context

- Worth noting that the wet requirement only works if the player is wet or the item is outdoors in the rain. Because for some reason submerged is only a player variable, and cannot be checked easily on items.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)