### PR TITLE
fix: Allow UPS charge on/off no matter tools' charge

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7611,7 +7611,7 @@ bool Character::invoke_item( item *used, const std::string &method )
 
 bool Character::invoke_item( item *used, const std::string &method, const tripoint &pt )
 {
-    if( !has_enough_charges( *used, true ) ) {
+    if( method != "TOGGLE_UPS_CHARGING" && !has_enough_charges( *used, true ) ) {
         return false;
     }
 

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -841,7 +841,7 @@ class activatable_inventory_preset : public pickup_inventory_preset
                 return _( "Your biology is not compatible with that item." );
             }
 
-            if( !p.has_enough_charges( it, false ) ) {
+            if( !p.has_enough_charges( it, false ) && !uses.contains( "TOGGLE_UPS_CHARGING" ) ) {
                 return string_format(
                            vgettext( "Needs at least %d charge",
                                      "Needs at least %d charges", loc->ammo_required() ),


### PR DESCRIPTION
## Purpose of change (The Why)

- UPS compatible tools can be toggled on/off to use UPS as charger, BUT checks forbid doing that if tool is not charged enough, which is wrong.
- Closes #5536

## Describe the solution (The How)

<!-- e.g nerfs monster A -->
Omitting charge check for `TOGGLE_UPS_CHARGING` use

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Compile and start test;
2. Check if UPS can be toggle on/off;
3. Check that uses that need charges can't be invoked.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
  - [ ] I have made sure to preserve the correct license for the ported content by adding a code or JSON comment to the ported sections indicating their original license
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
