### PR TITLE
feat(UI): Draw lower z-level for overmap

### DIFF
--- a/gfx/MSX++UnDeadPeopleEdition/tile_config.json
+++ b/gfx/MSX++UnDeadPeopleEdition/tile_config.json
@@ -17227,11 +17227,7 @@
         { "id": "refctr_fence_N", "fg": [ 9636 ], "bg": [  ], "rotates": true },
         { "id": "refctr_fence_W", "fg": [ 9637 ], "bg": [  ], "rotates": true },
         {
-          "id": [
-            "refctr_fence_S",
-            "refctr_fence_entrance_L",
-            "refctr_fence_entrance_R"
-          ],
+          "id": [ "refctr_fence_S", "refctr_fence_entrance_L", "refctr_fence_entrance_R" ],
           "fg": [ 9638 ],
           "bg": [  ],
           "rotates": true
@@ -22010,13 +22006,7 @@
         { "id": "f_autoclave", "fg": 11583, "rotates": false },
         { "id": "f_autoclave_full", "fg": 11584, "rotates": false },
         { "id": "f_autodoc", "fg": [ 11587, 11588, 11586, 11585 ], "rotates": true },
-        {
-          "id": "vp_autodoc",
-          "fg": [ 11587, 11588, 11586, 11585 ],
-          "bg": 9122,
-          "rotates": true,
-          "multitile": true
-        },
+        { "id": "vp_autodoc", "fg": [ 11587, 11588, 11586, 11585 ], "bg": 9122, "rotates": true, "multitile": true },
         { "id": "f_autodoc_couch", "fg": [ 11591, 11592, 11590, 11589 ], "rotates": true },
         {
           "id": "vp_autodoc_couch",
@@ -35036,31 +35026,21 @@
       "file": "Temporary-maptiles.png",
       "tiles": [
         { "id": [ "s_hunting" ], "fg": 19337, "rotates": false },
-        { "id": [ "s_hunting_roof" ], "fg": 19338, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true},
+        { "id": [ "s_hunting_roof" ], "fg": 19338, "bg": 19346, "rotates": false, "has_om_transparency": true },
         { "id": [ "dojo" ], "fg": 19339, "rotates": false },
-        { "id": [ "dojo_roof" ], "fg": 19340, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
-        { "id": [ "dojo_upper_roof" ], "fg": 19340, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
+        { "id": [ "dojo_roof" ], "fg": 19340, "bg": 19346, "rotates": false, "has_om_transparency": true },
+        { "id": [ "dojo_upper_roof" ], "fg": 19340, "bg": 19346, "rotates": false, "has_om_transparency": true },
         { "id": [ "dojo_1" ], "fg": 19339, "rotates": false },
-        { "id": [ "dojo_roof_1" ], "fg": 19340, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
-        { "id": [ "dojo_upper_roof_1" ], "fg": 19340, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
+        { "id": [ "dojo_roof_1" ], "fg": 19340, "bg": 19346, "rotates": false, "has_om_transparency": true },
+        { "id": [ "dojo_upper_roof_1" ], "fg": 19340, "bg": 19346, "rotates": false, "has_om_transparency": true },
         { "id": [ "recyclecenter" ], "fg": 19341, "rotates": false },
-        { "id": [ "recyclecenter_roof" ], "fg": 19342, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
+        { "id": [ "recyclecenter_roof" ], "fg": 19342, "bg": 19346, "rotates": false, "has_om_transparency": true },
         { "id": [ "recyclecenter_1" ], "fg": 19341, "rotates": false },
-        { "id": [ "recyclecenter_roof_1" ], "fg": 19342, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
+        { "id": [ "recyclecenter_roof_1" ], "fg": 19342, "bg": 19346, "rotates": false, "has_om_transparency": true },
         { "id": [ "recyclecenter_2" ], "fg": 19341, "rotates": false },
-        { "id": [ "recyclecenter_roof_2" ], "fg": 19342, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
-        { "id": [ "pool_roof" ], "fg": 19344, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
-        { "id": [ "emptycommerciallot" ], "fg": 19345, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
+        { "id": [ "recyclecenter_roof_2" ], "fg": 19342, "bg": 19346, "rotates": false, "has_om_transparency": true },
+        { "id": [ "pool_roof" ], "fg": 19344, "bg": 19346, "rotates": false, "has_om_transparency": true },
+        { "id": [ "emptycommerciallot" ], "fg": 19345, "bg": 19346, "rotates": false, "has_om_transparency": true },
         {
           "id": [ "open_air", "cs_private_park_roof" ],
           "fg": [
@@ -35069,8 +35049,8 @@
             { "weight": 25, "sprite": 19348 },
             { "weight": 25, "sprite": 19349 }
           ],
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         {
           "id": [
@@ -35272,7 +35252,7 @@
           "fg": [ 19350, 19351, 19352, 19353 ],
           "bg": 19346,
           "rotates": true,
-          "has_om_transparency" : true
+          "has_om_transparency": true
         },
         {
           "id": [ "s_restaurant_coffee", "s_restaurant_coffee_1", "s_restaurant_coffee_2" ],
@@ -35284,38 +35264,33 @@
           "fg": 19355,
           "bg": 19346,
           "rotates": false,
-          "has_om_transparency" : true
+          "has_om_transparency": true
         },
         { "id": [ "bar_1" ], "fg": 19356, "rotates": false },
-        { "id": [ "bar_roof_1" ], "fg": 19357, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
+        { "id": [ "bar_roof_1" ], "fg": 19357, "bg": 19346, "rotates": false, "has_om_transparency": true },
         { "id": [ "bar" ], "fg": 19358, "rotates": false },
-        { "id": [ "bar_roof" ], "fg": 19359, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
+        { "id": [ "bar_roof" ], "fg": 19359, "bg": 19346, "rotates": false, "has_om_transparency": true },
         { "id": [ "s_grocery_1" ], "fg": 19360, "rotates": false },
-        { "id": [ "s_grocery_roof_1" ], "fg": 19361, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
+        { "id": [ "s_grocery_roof_1" ], "fg": 19361, "bg": 19346, "rotates": false, "has_om_transparency": true },
         { "id": [ "s_grocery" ], "fg": 19360, "rotates": false },
-        { "id": [ "s_grocery_roof" ], "fg": 19361, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
+        { "id": [ "s_grocery_roof" ], "fg": 19361, "bg": 19346, "rotates": false, "has_om_transparency": true },
         { "id": [ "s_electronics", "s_electronics_1", "s_electronics_2", "s_thrift" ], "fg": 19362, "rotates": false },
         {
           "id": [ "s_electronics_roof", "s_electronics_roof_1", "s_electronics_roof_2", "s_thrift_roof" ],
           "fg": 19363,
           "bg": 19346,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         { "id": [ "s_sports" ], "fg": 19364, "rotates": false },
-        { "id": [ "s_sports_roof" ], "fg": 19365, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
+        { "id": [ "s_sports_roof" ], "fg": 19365, "bg": 19346, "rotates": false, "has_om_transparency": true },
         { "id": [ "s_butcher", "s_butcher_1", "s_butcher_2" ], "fg": 19366, "rotates": false },
         {
           "id": [ "s_butcher_roof", "s_butcher_upper_roof", "s_butcher_roof_1", "s_butcher_upper_roof_1", "s_butcher_roof_2" ],
           "fg": 19367,
           "bg": 19346,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         {
           "id": [ "s_library", "s_library_1", "s_library_2", "s_bookstore", "s_bookstore_1", "s_bookstore_2" ],
@@ -35335,35 +35310,57 @@
           ],
           "fg": 19369,
           "bg": 19346,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         { "id": [ "craft_shop", "craft_shop_1", "craft_shop_2" ], "fg": 19370, "rotates": false },
         {
           "id": [ "craft_shop_roof", "craft_shop_upper_roof", "craft_shop_roof_1", "craft_shop_roof_2", "craft_shop_2ndfloor_2" ],
           "fg": 19371,
           "bg": 19346,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         { "id": [ "pawn", "pawn_1" ], "fg": 19372, "rotates": false },
-        { "id": [ "pawn_roof", "pawn_roof_1" ], "fg": 19373, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
-        { "id": [ "" ], "fg": 19374, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
+        {
+          "id": [ "pawn_roof", "pawn_roof_1" ],
+          "fg": 19373,
+          "bg": 19346,
+          "rotates": false,
+          "has_om_transparency": true
+        },
+        { "id": [ "" ], "fg": 19374, "bg": 19346, "rotates": false, "has_om_transparency": true },
         { "id": [ "construction_site" ], "fg": 19375, "rotates": false },
-        { "id": [ "BotanicalGarden_1b_roof" ], "fg": [ 19378, 19379, 19376, 19377 ], "bg": 19346, "rotates": true, 
-          "has_om_transparency" : true },
-        { "id": [ "BotanicalGarden_1a_roof" ], "fg": [ 19376, 19377, 19378, 19379 ], "bg": 19346, "rotates": true, 
-          "has_om_transparency" : true },
-        { "id": [ "sub_station_roof" ], "fg": 19380, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
-        { "id": [ "small_power_substation_roof" ], "fg": 19381, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
-        { "id": [ "pwr_sub_s_roof" ], "fg": 19381, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
-        { "id": [ "bank_roof", "bank_roof_1" ], "fg": 19382, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
+        {
+          "id": [ "BotanicalGarden_1b_roof" ],
+          "fg": [ 19378, 19379, 19376, 19377 ],
+          "bg": 19346,
+          "rotates": true,
+          "has_om_transparency": true
+        },
+        {
+          "id": [ "BotanicalGarden_1a_roof" ],
+          "fg": [ 19376, 19377, 19378, 19379 ],
+          "bg": 19346,
+          "rotates": true,
+          "has_om_transparency": true
+        },
+        { "id": [ "sub_station_roof" ], "fg": 19380, "bg": 19346, "rotates": false, "has_om_transparency": true },
+        {
+          "id": [ "small_power_substation_roof" ],
+          "fg": 19381,
+          "bg": 19346,
+          "rotates": false,
+          "has_om_transparency": true
+        },
+        { "id": [ "pwr_sub_s_roof" ], "fg": 19381, "bg": 19346, "rotates": false, "has_om_transparency": true },
+        {
+          "id": [ "bank_roof", "bank_roof_1" ],
+          "fg": 19382,
+          "bg": 19346,
+          "rotates": false,
+          "has_om_transparency": true
+        },
         {
           "id": [
             "cabin_roof",
@@ -35383,8 +35380,8 @@
           ],
           "fg": 19383,
           "bg": 19346,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         {
           "id": [
@@ -35418,35 +35415,38 @@
           ],
           "fg": 19384,
           "bg": 19346,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
-        { "id": [ "2silos_1", "2silos_2", "2silos_roof" ], "fg": 19385, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
-        { "id": [ "campground_roof" ], "fg": 19386, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
+        {
+          "id": [ "2silos_1", "2silos_2", "2silos_roof" ],
+          "fg": 19385,
+          "bg": 19346,
+          "rotates": false,
+          "has_om_transparency": true
+        },
+        { "id": [ "campground_roof" ], "fg": 19386, "bg": 19346, "rotates": false, "has_om_transparency": true },
         {
           "id": [ "moonshine_still_roof", "moonshine_still_roof_1", "moonshine_still_roof_2" ],
           "fg": 19387,
           "bg": 19346,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
-        { "id": [ "roadstop_roof" ], "fg": 19388, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
+        { "id": [ "roadstop_roof" ], "fg": 19388, "bg": 19346, "rotates": false, "has_om_transparency": true },
         {
           "id": [ "sewage_treatment_0_0_roof", "sewage_treatment_0_1_roof", "sewage_treatment_1_1_roof", "sewage_treatment_1_0_roof" ],
           "fg": 19389,
           "bg": 19346,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         {
           "id": [ "s_gun_roof_1", "s_gun_roof_2", "s_gun_roof_3", "s_gun_roof_4", "s_gun_2ndfloor_4", "s_gun_roof" ],
           "fg": 19390,
           "bg": 19346,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         {
           "id": [
@@ -35461,65 +35461,78 @@
           ],
           "fg": 19391,
           "bg": 19346,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
-        { "id": [ "s_pizza_parlor_roof", "s_pizza_parlor_roof_1" ], "fg": 19392, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
-        { "id": [ "fire_station_roof", "fire_station_roof_1" ], "fg": 19393, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
+        {
+          "id": [ "s_pizza_parlor_roof", "s_pizza_parlor_roof_1" ],
+          "fg": 19392,
+          "bg": 19346,
+          "rotates": false,
+          "has_om_transparency": true
+        },
+        {
+          "id": [ "fire_station_roof", "fire_station_roof_1" ],
+          "fg": 19393,
+          "bg": 19346,
+          "rotates": false,
+          "has_om_transparency": true
+        },
         {
           "id": [ "mil_surplus_roof", "mil_surplus_roof_1", "mil_surplus_roof_2" ],
           "fg": 19394,
           "bg": 19346,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         {
           "id": [ "police_roof", "police_roof_1", "police_roof_2", "police_2ndfloor_1", "police_upper_roof_2" ],
           "fg": 19395,
           "bg": 19346,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         { "id": [ "s_antique" ], "fg": 19396, "rotates": false },
-        { "id": [ "s_antique_roof" ], "fg": 19397, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
+        { "id": [ "s_antique_roof" ], "fg": 19397, "bg": 19346, "rotates": false, "has_om_transparency": true },
         {
           "id": [ "s_hardware_roof", "s_hardware_roof_1", "s_hardware_roof_2", "s_hardware_roof_3" ],
           "fg": 19398,
           "bg": 19346,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         {
           "id": [ "s_garage_roof", "s_garage_roof_1", "s_garage_roof_2", "s_garage_upper_roof_2" ],
           "fg": 19399,
           "bg": 19346,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         {
           "id": [ "office_doctor_roof", "office_doctor_roof_1", "office_doctor_roof_2", "office_doctor_upper_roof_2" ],
           "fg": 19400,
           "bg": 19346,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         { "id": [ "s_liquor" ], "fg": 19401, "rotates": false },
-        { "id": [ "s_liquor_roof" ], "fg": 19402, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
+        { "id": [ "s_liquor_roof" ], "fg": 19402, "bg": 19346, "rotates": false, "has_om_transparency": true },
         { "id": [ "s_bike_shop", "s_bike_shop_1" ], "fg": 19403, "rotates": false },
-        { "id": [ "s_bike_shop_roof", "s_bike_shop_roof_1" ], "fg": 19404, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
+        {
+          "id": [ "s_bike_shop_roof", "s_bike_shop_roof_1" ],
+          "fg": 19404,
+          "bg": 19346,
+          "rotates": false,
+          "has_om_transparency": true
+        },
         { "id": [ "skate_park" ], "fg": 19405, "rotates": false },
         { "id": [ "pavilion", "pavilion_1", "paintball_field", "paintball_field_1" ], "fg": 19406, "rotates": false },
         {
           "id": [ "pavilion_roof", "pavilion_roof_1", "paintball_field_roof", "paintball_field_roof_1" ],
           "fg": 19407,
           "bg": 19346,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         {
           "id": [
@@ -35547,60 +35560,74 @@
           ],
           "fg": 19409,
           "bg": 19346,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         { "id": [ "s_teashop", "s_teashop_1" ], "fg": 19410, "rotates": false },
         {
           "id": [ "s_teashop_roof", "s_teashop_roof_1", "s_teashop_upper_roof_1" ],
           "fg": 19411,
           "bg": 19346,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         { "id": [ "post_office", "post_office_1" ], "fg": 19412, "rotates": false },
-        { "id": [ "post_office_roof", "post_office_roof_1" ], "fg": 19413, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
+        {
+          "id": [ "post_office_roof", "post_office_roof_1" ],
+          "fg": 19413,
+          "bg": 19346,
+          "rotates": false,
+          "has_om_transparency": true
+        },
         { "id": [ "gambling_hall" ], "fg": 19414, "rotates": false },
-        { "id": [ "gambling_hall_roof", "gambling_hall_upper_roof" ], "fg": 19415, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
+        {
+          "id": [ "gambling_hall_roof", "gambling_hall_upper_roof" ],
+          "fg": 19415,
+          "bg": 19346,
+          "rotates": false,
+          "has_om_transparency": true
+        },
         { "id": [ "gym_fitness", "gym_fitness_1" ], "fg": 19416, "rotates": false },
         {
           "id": [ "gym_fitness_roof", "gym_fitness_2ndFloor_1", "gym_fitness_roof_1" ],
           "fg": 19417,
           "bg": 19346,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         { "id": [ "mortuary" ], "fg": 19418, "rotates": false },
-        { "id": [ "mortuary_roof" ], "fg": 19419, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
+        { "id": [ "mortuary_roof" ], "fg": 19419, "bg": 19346, "rotates": false, "has_om_transparency": true },
         { "id": [ "lancenter", "lancenter_1" ], "fg": 19420, "rotates": false },
-        { "id": [ "lancenter_roof", "lancenter_roof_1" ], "fg": 19421, "bg": 19346, "rotates": false, 
-          "has_om_transparency" : true },
+        {
+          "id": [ "lancenter_roof", "lancenter_roof_1" ],
+          "fg": 19421,
+          "bg": 19346,
+          "rotates": false,
+          "has_om_transparency": true
+        },
         { "id": [ "s_arcade", "cs_internet_cafe" ], "fg": 19422, "rotates": false },
         {
           "id": [ "s_arcade_roof", "cs_internet_cafe_roof", "cs_internet_cafe_upper_roof" ],
           "fg": 19423,
           "bg": 19346,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         { "id": [ "stripclub", "stripclub_1", "stripclub_2" ], "fg": 19424, "rotates": false },
         {
           "id": [ "stripclub_roof", "stripclub_roof_1", "stripclub_roof_2" ],
           "fg": 19425,
           "bg": 19346,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         { "id": [ "bakery" ], "fg": 19426, "rotates": false },
         {
           "id": [ "bakery_roof", "bakery_upper_roof", "bakery_upper_roof_1" ],
           "fg": 19427,
           "bg": 19347,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         {
           "id": [ "small_storage_units", "small_storage_units_1", "small_storage_units_2" ],
@@ -35611,26 +35638,23 @@
           "id": [ "small_storage_units_roof", "small_storage_units_roof_1", "small_storage_units_roof_2" ],
           "fg": 19429,
           "bg": 19347,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         { "id": [ "office_cubical", "office_cubical_1", "small_office" ], "fg": 19430, "rotates": false },
         {
           "id": [ "office_cubical_roof", "office_cubical_roof_1", "small_office_roof", "small_office_upper_roof" ],
           "fg": 19431,
           "bg": 19347,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         { "id": [ "s_daycare" ], "fg": 19432, "rotates": false },
-        { "id": [ "s_daycare_roof" ], "fg": 19433, "bg": 19347, "rotates": false, 
-          "has_om_transparency" : true },
+        { "id": [ "s_daycare_roof" ], "fg": 19433, "bg": 19347, "rotates": false, "has_om_transparency": true },
         { "id": [ "animalpound" ], "fg": 19434, "rotates": false },
-        { "id": [ "animalpound_roof" ], "fg": 19435, "bg": 19347, "rotates": false, 
-          "has_om_transparency" : true },
+        { "id": [ "animalpound_roof" ], "fg": 19435, "bg": 19347, "rotates": false, "has_om_transparency": true },
         { "id": [ "warehouse" ], "fg": 19436, "rotates": false },
-        { "id": [ "warehouse_roof" ], "fg": 19437, "bg": 19347, "rotates": false, 
-          "has_om_transparency" : true },
+        { "id": [ "warehouse_roof" ], "fg": 19437, "bg": 19347, "rotates": false, "has_om_transparency": true },
         {
           "id": [ "abandonedwarehouse", "abandonedwarehouse_1", "abandonedwarehouse_2", "abandonedwarehouse_3", "abandonedwarehouse_4" ],
           "fg": 19438,
@@ -35646,29 +35670,36 @@
           ],
           "fg": 19439,
           "bg": 19347,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         { "id": [ "home_improvement" ], "fg": 19440, "rotates": false },
-        { "id": [ "home_improvement_roof" ], "fg": 19441, "bg": 19347, "rotates": false, 
-          "has_om_transparency" : true },
+        { "id": [ "home_improvement_roof" ], "fg": 19441, "bg": 19347, "rotates": false, "has_om_transparency": true },
         { "id": [ "s_jewelry" ], "fg": 19442, "rotates": false },
-        { "id": [ "s_jewelry_roof" ], "fg": 19443, "bg": 19347, "rotates": false, 
-          "has_om_transparency" : true },
+        { "id": [ "s_jewelry_roof" ], "fg": 19443, "bg": 19347, "rotates": false, "has_om_transparency": true },
         {
           "id": [ "garage_gas_roof", "garage_gas_roof_1", "garage_gas_roof_2", "garage_gas_roof_3" ],
           "fg": 19444,
           "bg": 19347,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
-        { "id": [ "s_gas_roof", "s_gas_roof_1", "s_gas_rural_roof" ], "fg": 19445, "bg": 19347, "rotates": false, 
-          "has_om_transparency" : true },
+        {
+          "id": [ "s_gas_roof", "s_gas_roof_1", "s_gas_rural_roof" ],
+          "fg": 19445,
+          "bg": 19347,
+          "rotates": false,
+          "has_om_transparency": true
+        },
         { "id": [ "station_radio", "station_radio_1" ], "fg": 19446, "rotates": false },
-        { "id": [ "station_radio_roof", "station_radio_roof_1" ], "fg": 19447, "bg": 19347, "rotates": false, 
-          "has_om_transparency" : true },
-        { "id": [ "veterinarian_roof" ], "fg": 19448, "bg": 19347, "rotates": false, 
-          "has_om_transparency" : true },
+        {
+          "id": [ "station_radio_roof", "station_radio_roof_1" ],
+          "fg": 19447,
+          "bg": 19347,
+          "rotates": false,
+          "has_om_transparency": true
+        },
+        { "id": [ "veterinarian_roof" ], "fg": 19448, "bg": 19347, "rotates": false, "has_om_transparency": true },
         {
           "id": [ "dispensary", "dispensary_1", "dispensary_2", "headshop", "smoke_lounge", "smoke_lounge_1" ],
           "fg": 19449,
@@ -35686,131 +35717,209 @@
           ],
           "fg": 19450,
           "bg": 19347,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         { "id": [ "landscapingsupplyco_1b" ], "fg": 19451, "rotates": false },
         { "id": [ "landscapingsupplyco_1a" ], "fg": 19452, "rotates": false },
-        { "id": [ "landscapingsupplyco_1b_roof" ], "fg": 19453, "bg": 19347, "rotates": false, 
-          "has_om_transparency" : true },
-        { "id": [ "s_laundromat_roof", "s_laundromat_roof_1" ], "fg": 19454, "bg": 19347, "rotates": false, 
-          "has_om_transparency" : true },
-        { "id": [ "s_pharm_roof", "s_pharm_roof_1" ], "fg": 19455, "bg": 19347, "rotates": false, 
-          "has_om_transparency" : true },
+        {
+          "id": [ "landscapingsupplyco_1b_roof" ],
+          "fg": 19453,
+          "bg": 19347,
+          "rotates": false,
+          "has_om_transparency": true
+        },
+        {
+          "id": [ "s_laundromat_roof", "s_laundromat_roof_1" ],
+          "fg": 19454,
+          "bg": 19347,
+          "rotates": false,
+          "has_om_transparency": true
+        },
+        {
+          "id": [ "s_pharm_roof", "s_pharm_roof_1" ],
+          "fg": 19455,
+          "bg": 19347,
+          "rotates": false,
+          "has_om_transparency": true
+        },
         { "id": [ "abstorefront", "abstorefront_1", "abstorefront_2" ], "fg": 19456, "rotates": false },
         {
           "id": [ "abstorefront_roof", "abstorefront_roof_1", "abstorefront_roof_2" ],
           "fg": 19457,
           "bg": 19347,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         { "id": [ "icecream_shop" ], "fg": 19458, "rotates": false },
-        { "id": [ "icecream_shop_roof" ], "fg": 19459, "bg": 19347, "rotates": false, 
-          "has_om_transparency" : true },
+        { "id": [ "icecream_shop_roof" ], "fg": 19459, "bg": 19347, "rotates": false, "has_om_transparency": true },
         { "id": [ "s_petstore", "s_petstore_1", "s_petstore_2" ], "fg": 19460, "rotates": false },
         {
           "id": [ "s_petstore_roof", "s_petstore_roof_1", "s_petstore_roof_2" ],
           "fg": 19461,
           "bg": 19347,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         { "id": [ "animalshelter" ], "fg": 19462, "rotates": false },
-        { "id": [ "animalshelter_roof" ], "fg": 19463, "bg": 19347, "rotates": false, 
-          "has_om_transparency" : true },
+        { "id": [ "animalshelter_roof" ], "fg": 19463, "bg": 19347, "rotates": false, "has_om_transparency": true },
         { "id": [ "dollarstore", "dollarstore_1" ], "fg": 19464, "rotates": false },
-        { "id": [ "dollarstore_roof", "dollarstore_roof_1" ], "fg": 19465, "bg": 19347, "rotates": false, 
-          "has_om_transparency" : true },
+        {
+          "id": [ "dollarstore_roof", "dollarstore_roof_1" ],
+          "fg": 19465,
+          "bg": 19347,
+          "rotates": false,
+          "has_om_transparency": true
+        },
         { "id": [ "candy_shop", "candy_shop_1" ], "fg": 19466, "rotates": false },
-        { "id": [ "candy_shop_roof", "candy_shop_roof_1" ], "fg": 19467, "bg": 19347, "rotates": false, 
-          "has_om_transparency" : true },
+        {
+          "id": [ "candy_shop_roof", "candy_shop_roof_1" ],
+          "fg": 19467,
+          "bg": 19347,
+          "rotates": false,
+          "has_om_transparency": true
+        },
         { "id": [ "cs_market_small" ], "fg": 19468, "rotates": false },
         {
           "id": [ "bus_stat_0_roof", "bus_stat_1_roof", "mine_entrance_loading_zone_roof", "cs_gardening_allotment_roof" ],
           "fg": 19469,
           "bg": 19347,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
-        { "id": [ "mine_entrance_roof" ], "fg": 19470, "bg": 19347, "rotates": false, 
-          "has_om_transparency" : true },
+        { "id": [ "mine_entrance_roof" ], "fg": 19470, "bg": 19347, "rotates": false, "has_om_transparency": true },
         { "id": [ "music_venue", "music_venue_1", "s_music" ], "fg": 19471, "rotates": false },
         {
           "id": [ "music_venue_roof", "music_venue_1_roof", "music_venue_1_roof_top", "s_music_roof" ],
           "fg": 19472,
           "bg": 19347,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         { "id": [ "gym" ], "fg": 19473, "rotates": false },
-        { "id": [ "gym_roof", "gym_upper_roof" ], "fg": 19474, "bg": 19347, "rotates": false, 
-          "has_om_transparency" : true },
-        { "id": [ "cs_sex_shop_roof" ], "fg": 19475, "bg": 19347, "rotates": false, 
-          "has_om_transparency" : true },
+        {
+          "id": [ "gym_roof", "gym_upper_roof" ],
+          "fg": 19474,
+          "bg": 19347,
+          "rotates": false,
+          "has_om_transparency": true
+        },
+        { "id": [ "cs_sex_shop_roof" ], "fg": 19475, "bg": 19347, "rotates": false, "has_om_transparency": true },
         { "id": [ "house_2story_basement" ], "fg": 19476, "bg": 9477, "rotates": false },
         { "id": [ "s_baseballfield_a1" ], "fg": [ 19477 ], "rotates": true },
         { "id": [ "s_baseballfield_a2" ], "fg": [ 19481 ], "rotates": true },
         { "id": [ "s_baseballfield_b1" ], "fg": [ 19485 ], "rotates": true },
         { "id": [ "s_baseballfield_b2" ], "fg": [ 19489 ], "rotates": true },
         { "id": [ "cs_tire_shop" ], "fg": 19493, "rotates": false },
-        { "id": [ "cs_tire_shop_roof" ], "fg": 19494, "bg": 19347, "rotates": false, 
-          "has_om_transparency" : true },
+        { "id": [ "cs_tire_shop_roof" ], "fg": 19494, "bg": 19347, "rotates": false, "has_om_transparency": true },
         { "id": [ "s_gardening" ], "fg": 19495, "rotates": false },
-        { "id": [ "s_gardening_roof" ], "fg": 19496, "bg": 19347, "rotates": false, 
-          "has_om_transparency" : true },
+        { "id": [ "s_gardening_roof" ], "fg": 19496, "bg": 19347, "rotates": false, "has_om_transparency": true },
         { "id": [ "house_modern_1" ], "fg": [ 19497, 19498, 19499, 19500 ], "rotates": true },
-        { "id": [ "house_modern_1_roof" ], "fg": [ 19501, 19502, 19503, 19504 ], "bg": 19347, "rotates": true, 
-          "has_om_transparency" : true },
+        {
+          "id": [ "house_modern_1_roof" ],
+          "fg": [ 19501, 19502, 19503, 19504 ],
+          "bg": 19347,
+          "rotates": true,
+          "has_om_transparency": true
+        },
         { "id": [ "urban_1_1" ], "fg": [ 19505, 19506, 19507, 19512 ], "rotates": true },
         { "id": [ "urban_1_2" ], "fg": [ 19509, 19510, 19511, 19508 ], "rotates": true },
-        { "id": [ "urban_1_3", "urban_1_5" ], "fg": [ 19513, 19514, 19515, 19520 ], "bg": 19347, "rotates": true, 
-          "has_om_transparency" : true },
-        { "id": [ "urban_1_4", "urban_1_6" ], "fg": [ 19517, 19518, 19519, 19516 ], "bg": 19347, "rotates": true, 
-          "has_om_transparency" : true },
+        {
+          "id": [ "urban_1_3", "urban_1_5" ],
+          "fg": [ 19513, 19514, 19515, 19520 ],
+          "bg": 19347,
+          "rotates": true,
+          "has_om_transparency": true
+        },
+        {
+          "id": [ "urban_1_4", "urban_1_6" ],
+          "fg": [ 19517, 19518, 19519, 19516 ],
+          "bg": 19347,
+          "rotates": true,
+          "has_om_transparency": true
+        },
         { "id": [ "urban_2_1" ], "fg": [ 19505, 19506, 19507, 19512 ], "rotates": true },
         { "id": [ "urban_2_2" ], "fg": [ 19509, 19510, 19511, 19508 ], "rotates": true },
-        { "id": [ "urban_2_3", "urban_2_5" ], "fg": [ 19513, 19514, 19515, 19520 ], "bg": 19347, "rotates": true, 
-          "has_om_transparency" : true },
-        { "id": [ "urban_2_4", "urban_2_6" ], "fg": [ 19517, 19518, 19519, 19516 ], "bg": 19347, "rotates": true, 
-          "has_om_transparency" : true },
+        {
+          "id": [ "urban_2_3", "urban_2_5" ],
+          "fg": [ 19513, 19514, 19515, 19520 ],
+          "bg": 19347,
+          "rotates": true,
+          "has_om_transparency": true
+        },
+        {
+          "id": [ "urban_2_4", "urban_2_6" ],
+          "fg": [ 19517, 19518, 19519, 19516 ],
+          "bg": 19347,
+          "rotates": true,
+          "has_om_transparency": true
+        },
         { "id": [ "urban_3_1" ], "fg": [ 19505, 19506, 19507, 19512 ], "rotates": true },
         { "id": [ "urban_3_2" ], "fg": [ 19509, 19510, 19511, 19508 ], "rotates": true },
-        { "id": [ "urban_3_3", "urban_3_5" ], "fg": [ 19513, 19514, 19515, 19520 ], "bg": 19347, "rotates": true, 
-          "has_om_transparency" : true },
-        { "id": [ "urban_3_4", "urban_3_6" ], "fg": [ 19517, 19518, 19519, 19516 ], "bg": 19347, "rotates": true, 
-          "has_om_transparency" : true },
+        {
+          "id": [ "urban_3_3", "urban_3_5" ],
+          "fg": [ 19513, 19514, 19515, 19520 ],
+          "bg": 19347,
+          "rotates": true,
+          "has_om_transparency": true
+        },
+        {
+          "id": [ "urban_3_4", "urban_3_6" ],
+          "fg": [ 19517, 19518, 19519, 19516 ],
+          "bg": 19347,
+          "rotates": true,
+          "has_om_transparency": true
+        },
         { "id": [ "urban_5_1" ], "fg": [ 19505, 19506, 19507, 19512 ], "rotates": true },
         { "id": [ "urban_5_2" ], "fg": [ 19509, 19510, 19511, 19508 ], "rotates": true },
-        { "id": [ "urban_5_3", "urban_5_5" ], "fg": [ 19513, 19514, 19515, 19520 ], "bg": 19347, "rotates": true, 
-          "has_om_transparency" : true },
-        { "id": [ "urban_5_4", "urban_5_6" ], "fg": [ 19517, 19518, 19519, 19516 ], "bg": 19347, "rotates": true, 
-          "has_om_transparency" : true },
+        {
+          "id": [ "urban_5_3", "urban_5_5" ],
+          "fg": [ 19513, 19514, 19515, 19520 ],
+          "bg": 19347,
+          "rotates": true,
+          "has_om_transparency": true
+        },
+        {
+          "id": [ "urban_5_4", "urban_5_6" ],
+          "fg": [ 19517, 19518, 19519, 19516 ],
+          "bg": 19347,
+          "rotates": true,
+          "has_om_transparency": true
+        },
         { "id": [ "urban_4_3" ], "fg": [ 19505, 19506, 19507, 19512 ], "rotates": true },
         { "id": [ "urban_4_4" ], "fg": [ 19509, 19510, 19511, 19508 ], "rotates": true },
-        { "id": [ "urban_4_5", "urban_4_7" ], "fg": [ 19513, 19514, 19515, 19520 ], "bg": 19347, "rotates": true, 
-          "has_om_transparency" : true },
-        { "id": [ "urban_4_6", "urban_4_8" ], "fg": [ 19517, 19518, 19519, 19516 ], "bg": 19347, "rotates": true, 
-          "has_om_transparency" : true },
+        {
+          "id": [ "urban_4_5", "urban_4_7" ],
+          "fg": [ 19513, 19514, 19515, 19520 ],
+          "bg": 19347,
+          "rotates": true,
+          "has_om_transparency": true
+        },
+        {
+          "id": [ "urban_4_6", "urban_4_8" ],
+          "fg": [ 19517, 19518, 19519, 19516 ],
+          "bg": 19347,
+          "rotates": true,
+          "has_om_transparency": true
+        },
         { "id": [ "urban_6_1", "urban_7_1" ], "fg": [ 19505, 19506, 19507, 19512 ], "rotates": true },
         { "id": [ "urban_6_2", "urban_7_2" ], "fg": [ 19509, 19510, 19511, 19508 ], "rotates": true },
         {
           "id": [ "urban_6_3", "urban_7_3", "urban_6_5", "urban_7_5" ],
           "fg": [ 19513, 19514, 19515, 19520 ],
           "bg": 19347,
-          "rotates": true, 
-          "has_om_transparency" : true
+          "rotates": true,
+          "has_om_transparency": true
         },
         {
           "id": [ "urban_6_4", "urban_7_4", "urban_6_6", "urban_7_6" ],
           "fg": [ 19517, 19518, 19519, 19516 ],
           "bg": 19347,
-          "rotates": true, 
-          "has_om_transparency" : true
+          "rotates": true,
+          "has_om_transparency": true
         },
         { "id": [ "museum" ], "fg": [ 19521 ], "rotates": false },
-        { "id": [ "museum_roof" ], "fg": [ 19522 ], "bg": 19347, "rotates": false, 
-          "has_om_transparency" : true },
+        { "id": [ "museum_roof" ], "fg": [ 19522 ], "bg": 19347, "rotates": false, "has_om_transparency": true },
         {
           "id": [
             "urban_1_1_basement",
@@ -35852,17 +35961,21 @@
           ],
           "rotates": false
         },
-        { "id": [ "roadstop_b_roof" ], "fg": [ 19535 ], "bg": 19347, "rotates": false, 
-          "has_om_transparency" : true },
+        { "id": [ "roadstop_b_roof" ], "fg": [ 19535 ], "bg": 19347, "rotates": false, "has_om_transparency": true },
         { "id": [ "house_02" ], "fg": [ 19536, 19537, 19538, 19539 ], "rotates": true },
-        { "id": [ "house_02_roof" ], "fg": [ 19540, 19541, 19542, 19543 ], "bg": 19347, "rotates": true, 
-          "has_om_transparency" : true },
+        {
+          "id": [ "house_02_roof" ],
+          "fg": [ 19540, 19541, 19542, 19543 ],
+          "bg": 19347,
+          "rotates": true,
+          "has_om_transparency": true
+        },
         {
           "id": [ "public_works_NE_roof", "public_works_NW_roof", "public_works_SE_roof", "public_works_SW_roof" ],
           "fg": [ 19544 ],
           "bg": 19347,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         {
           "id": [ "mil_base_minefield_w" ],
@@ -35943,37 +36056,35 @@
       "file": "Temporary-Maptiles-Large.png",
       "tiles": [
         { "id": "cs_car_showroom", "fg": 19638, "rotates": false },
-        { "id": "cs_car_showroom_2ndfloor", "fg": 19639, "bg": 19637, "rotates": false, 
-          "has_om_transparency" : true },
-        { "id": "cs_car_showroom_roof", "fg": 19640, "bg": 19637, "rotates": false, 
-          "has_om_transparency" : true },
+        { "id": "cs_car_showroom_2ndfloor", "fg": 19639, "bg": 19637, "rotates": false, "has_om_transparency": true },
+        { "id": "cs_car_showroom_roof", "fg": 19640, "bg": 19637, "rotates": false, "has_om_transparency": true },
         {
           "id": [ "loffice_tower_7", "loffice_tower_11", "loffice_tower_15", "loffice_tower_19" ],
           "fg": [ 19643, 19644, 19642, 19641 ],
           "bg": 19637,
-          "rotates": true, 
-          "has_om_transparency" : true
+          "rotates": true,
+          "has_om_transparency": true
         },
         {
           "id": [ "loffice_tower_5", "loffice_tower_9", "loffice_tower_9b", "loffice_tower_13", "loffice_tower_17" ],
           "fg": [ 19641, 19643, 19644, 19642 ],
           "bg": 19637,
-          "rotates": true, 
-          "has_om_transparency" : true
+          "rotates": true,
+          "has_om_transparency": true
         },
         {
           "id": [ "loffice_tower_8", "loffice_tower_12", "loffice_tower_16", "loffice_tower_20" ],
           "fg": [ 19644, 19642, 19641, 19643 ],
           "bg": 19637,
-          "rotates": true, 
-          "has_om_transparency" : true
+          "rotates": true,
+          "has_om_transparency": true
         },
         {
           "id": [ "loffice_tower_6", "loffice_tower_10", "loffice_tower_10b", "loffice_tower_14", "loffice_tower_18" ],
           "fg": [ 19642, 19641, 19643, 19644 ],
           "bg": 19637,
-          "rotates": true, 
-          "has_om_transparency" : true
+          "rotates": true,
+          "has_om_transparency": true
         },
         {
           "id": [
@@ -35989,14 +36100,24 @@
           ],
           "fg": [ 19645 ],
           "bg": 19637,
-          "rotates": false, 
-          "has_om_transparency" : true
+          "rotates": false,
+          "has_om_transparency": true
         },
         { "id": "house_2story_base", "fg": [ 19647, 19648, 19646, 19649 ], "rotates": true },
-        { "id": "house_2story_second", "fg": [ 19651, 19652, 19650, 19653 ], "bg": 19637, "rotates": true, 
-          "has_om_transparency" : true },
-        { "id": "house_2story_roof", "fg": [ 19655, 19656, 19654, 19657 ], "bg": 19637, "rotates": true, 
-          "has_om_transparency" : true },
+        {
+          "id": "house_2story_second",
+          "fg": [ 19651, 19652, 19650, 19653 ],
+          "bg": 19637,
+          "rotates": true,
+          "has_om_transparency": true
+        },
+        {
+          "id": "house_2story_roof",
+          "fg": [ 19655, 19656, 19654, 19657 ],
+          "bg": 19637,
+          "rotates": true,
+          "has_om_transparency": true
+        },
         {
           "id": [ "city_block2_1", "city_block2_flr2_1", "city_block2_roof_1" ],
           "fg": [ 19658, 19661, 19660, 19659 ],

--- a/gfx/MSX++UnDeadPeopleEdition/tile_config.json
+++ b/gfx/MSX++UnDeadPeopleEdition/tile_config.json
@@ -35036,21 +35036,31 @@
       "file": "Temporary-maptiles.png",
       "tiles": [
         { "id": [ "s_hunting" ], "fg": 19337, "rotates": false },
-        { "id": [ "s_hunting_roof" ], "fg": 19338, "bg": 19346, "rotates": false },
+        { "id": [ "s_hunting_roof" ], "fg": 19338, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true},
         { "id": [ "dojo" ], "fg": 19339, "rotates": false },
-        { "id": [ "dojo_roof" ], "fg": 19340, "bg": 19346, "rotates": false },
-        { "id": [ "dojo_upper_roof" ], "fg": 19340, "bg": 19346, "rotates": false },
+        { "id": [ "dojo_roof" ], "fg": 19340, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
+        { "id": [ "dojo_upper_roof" ], "fg": 19340, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "dojo_1" ], "fg": 19339, "rotates": false },
-        { "id": [ "dojo_roof_1" ], "fg": 19340, "bg": 19346, "rotates": false },
-        { "id": [ "dojo_upper_roof_1" ], "fg": 19340, "bg": 19346, "rotates": false },
+        { "id": [ "dojo_roof_1" ], "fg": 19340, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
+        { "id": [ "dojo_upper_roof_1" ], "fg": 19340, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "recyclecenter" ], "fg": 19341, "rotates": false },
-        { "id": [ "recyclecenter_roof" ], "fg": 19342, "bg": 19346, "rotates": false },
+        { "id": [ "recyclecenter_roof" ], "fg": 19342, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "recyclecenter_1" ], "fg": 19341, "rotates": false },
-        { "id": [ "recyclecenter_roof_1" ], "fg": 19342, "bg": 19346, "rotates": false },
+        { "id": [ "recyclecenter_roof_1" ], "fg": 19342, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "recyclecenter_2" ], "fg": 19341, "rotates": false },
-        { "id": [ "recyclecenter_roof_2" ], "fg": 19342, "bg": 19346, "rotates": false },
-        { "id": [ "pool_roof" ], "fg": 19344, "bg": 19346, "rotates": false },
-        { "id": [ "emptycommerciallot" ], "fg": 19345, "bg": 19346, "rotates": false },
+        { "id": [ "recyclecenter_roof_2" ], "fg": 19342, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
+        { "id": [ "pool_roof" ], "fg": 19344, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
+        { "id": [ "emptycommerciallot" ], "fg": 19345, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
         {
           "id": [ "open_air", "cs_private_park_roof" ],
           "fg": [
@@ -35059,7 +35069,8 @@
             { "weight": 25, "sprite": 19348 },
             { "weight": 25, "sprite": 19349 }
           ],
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         {
           "id": [
@@ -35260,7 +35271,8 @@
           ],
           "fg": [ 19350, 19351, 19352, 19353 ],
           "bg": 19346,
-          "rotates": true
+          "rotates": true,
+          "has_om_transparency" : true
         },
         {
           "id": [ "s_restaurant_coffee", "s_restaurant_coffee_1", "s_restaurant_coffee_2" ],
@@ -35271,31 +35283,39 @@
           "id": [ "s_restaurant_coffee_roof", "s_restaurant_coffee_roof_1", "s_restaurant_coffee_roof_2" ],
           "fg": 19355,
           "bg": 19346,
-          "rotates": false
+          "rotates": false,
+          "has_om_transparency" : true
         },
         { "id": [ "bar_1" ], "fg": 19356, "rotates": false },
-        { "id": [ "bar_roof_1" ], "fg": 19357, "bg": 19346, "rotates": false },
+        { "id": [ "bar_roof_1" ], "fg": 19357, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "bar" ], "fg": 19358, "rotates": false },
-        { "id": [ "bar_roof" ], "fg": 19359, "bg": 19346, "rotates": false },
+        { "id": [ "bar_roof" ], "fg": 19359, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "s_grocery_1" ], "fg": 19360, "rotates": false },
-        { "id": [ "s_grocery_roof_1" ], "fg": 19361, "bg": 19346, "rotates": false },
+        { "id": [ "s_grocery_roof_1" ], "fg": 19361, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "s_grocery" ], "fg": 19360, "rotates": false },
-        { "id": [ "s_grocery_roof" ], "fg": 19361, "bg": 19346, "rotates": false },
+        { "id": [ "s_grocery_roof" ], "fg": 19361, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "s_electronics", "s_electronics_1", "s_electronics_2", "s_thrift" ], "fg": 19362, "rotates": false },
         {
           "id": [ "s_electronics_roof", "s_electronics_roof_1", "s_electronics_roof_2", "s_thrift_roof" ],
           "fg": 19363,
           "bg": 19346,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         { "id": [ "s_sports" ], "fg": 19364, "rotates": false },
-        { "id": [ "s_sports_roof" ], "fg": 19365, "bg": 19346, "rotates": false },
+        { "id": [ "s_sports_roof" ], "fg": 19365, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "s_butcher", "s_butcher_1", "s_butcher_2" ], "fg": 19366, "rotates": false },
         {
           "id": [ "s_butcher_roof", "s_butcher_upper_roof", "s_butcher_roof_1", "s_butcher_upper_roof_1", "s_butcher_roof_2" ],
           "fg": 19367,
           "bg": 19346,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         {
           "id": [ "s_library", "s_library_1", "s_library_2", "s_bookstore", "s_bookstore_1", "s_bookstore_2" ],
@@ -35315,25 +35335,35 @@
           ],
           "fg": 19369,
           "bg": 19346,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         { "id": [ "craft_shop", "craft_shop_1", "craft_shop_2" ], "fg": 19370, "rotates": false },
         {
           "id": [ "craft_shop_roof", "craft_shop_upper_roof", "craft_shop_roof_1", "craft_shop_roof_2", "craft_shop_2ndfloor_2" ],
           "fg": 19371,
           "bg": 19346,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         { "id": [ "pawn", "pawn_1" ], "fg": 19372, "rotates": false },
-        { "id": [ "pawn_roof", "pawn_roof_1" ], "fg": 19373, "bg": 19346, "rotates": false },
-        { "id": [ "" ], "fg": 19374, "bg": 19346, "rotates": false },
+        { "id": [ "pawn_roof", "pawn_roof_1" ], "fg": 19373, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
+        { "id": [ "" ], "fg": 19374, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "construction_site" ], "fg": 19375, "rotates": false },
-        { "id": [ "BotanicalGarden_1b_roof" ], "fg": [ 19378, 19379, 19376, 19377 ], "bg": 19346, "rotates": true },
-        { "id": [ "BotanicalGarden_1a_roof" ], "fg": [ 19376, 19377, 19378, 19379 ], "bg": 19346, "rotates": true },
-        { "id": [ "sub_station_roof" ], "fg": 19380, "bg": 19346, "rotates": false },
-        { "id": [ "small_power_substation_roof" ], "fg": 19381, "bg": 19346, "rotates": false },
-        { "id": [ "pwr_sub_s_roof" ], "fg": 19381, "bg": 19346, "rotates": false },
-        { "id": [ "bank_roof", "bank_roof_1" ], "fg": 19382, "bg": 19346, "rotates": false },
+        { "id": [ "BotanicalGarden_1b_roof" ], "fg": [ 19378, 19379, 19376, 19377 ], "bg": 19346, "rotates": true, 
+          "has_om_transparency" : true },
+        { "id": [ "BotanicalGarden_1a_roof" ], "fg": [ 19376, 19377, 19378, 19379 ], "bg": 19346, "rotates": true, 
+          "has_om_transparency" : true },
+        { "id": [ "sub_station_roof" ], "fg": 19380, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
+        { "id": [ "small_power_substation_roof" ], "fg": 19381, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
+        { "id": [ "pwr_sub_s_roof" ], "fg": 19381, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
+        { "id": [ "bank_roof", "bank_roof_1" ], "fg": 19382, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
         {
           "id": [
             "cabin_roof",
@@ -35353,7 +35383,8 @@
           ],
           "fg": 19383,
           "bg": 19346,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         {
           "id": [
@@ -35387,28 +35418,35 @@
           ],
           "fg": 19384,
           "bg": 19346,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
-        { "id": [ "2silos_1", "2silos_2", "2silos_roof" ], "fg": 19385, "bg": 19346, "rotates": false },
-        { "id": [ "campground_roof" ], "fg": 19386, "bg": 19346, "rotates": false },
+        { "id": [ "2silos_1", "2silos_2", "2silos_roof" ], "fg": 19385, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
+        { "id": [ "campground_roof" ], "fg": 19386, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
         {
           "id": [ "moonshine_still_roof", "moonshine_still_roof_1", "moonshine_still_roof_2" ],
           "fg": 19387,
           "bg": 19346,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
-        { "id": [ "roadstop_roof" ], "fg": 19388, "bg": 19346, "rotates": false },
+        { "id": [ "roadstop_roof" ], "fg": 19388, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
         {
           "id": [ "sewage_treatment_0_0_roof", "sewage_treatment_0_1_roof", "sewage_treatment_1_1_roof", "sewage_treatment_1_0_roof" ],
           "fg": 19389,
           "bg": 19346,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         {
           "id": [ "s_gun_roof_1", "s_gun_roof_2", "s_gun_roof_3", "s_gun_roof_4", "s_gun_2ndfloor_4", "s_gun_roof" ],
           "fg": 19390,
           "bg": 19346,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         {
           "id": [
@@ -35423,53 +35461,65 @@
           ],
           "fg": 19391,
           "bg": 19346,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
-        { "id": [ "s_pizza_parlor_roof", "s_pizza_parlor_roof_1" ], "fg": 19392, "bg": 19346, "rotates": false },
-        { "id": [ "fire_station_roof", "fire_station_roof_1" ], "fg": 19393, "bg": 19346, "rotates": false },
+        { "id": [ "s_pizza_parlor_roof", "s_pizza_parlor_roof_1" ], "fg": 19392, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
+        { "id": [ "fire_station_roof", "fire_station_roof_1" ], "fg": 19393, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
         {
           "id": [ "mil_surplus_roof", "mil_surplus_roof_1", "mil_surplus_roof_2" ],
           "fg": 19394,
           "bg": 19346,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         {
           "id": [ "police_roof", "police_roof_1", "police_roof_2", "police_2ndfloor_1", "police_upper_roof_2" ],
           "fg": 19395,
           "bg": 19346,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         { "id": [ "s_antique" ], "fg": 19396, "rotates": false },
-        { "id": [ "s_antique_roof" ], "fg": 19397, "bg": 19346, "rotates": false },
+        { "id": [ "s_antique_roof" ], "fg": 19397, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
         {
           "id": [ "s_hardware_roof", "s_hardware_roof_1", "s_hardware_roof_2", "s_hardware_roof_3" ],
           "fg": 19398,
           "bg": 19346,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         {
           "id": [ "s_garage_roof", "s_garage_roof_1", "s_garage_roof_2", "s_garage_upper_roof_2" ],
           "fg": 19399,
           "bg": 19346,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         {
           "id": [ "office_doctor_roof", "office_doctor_roof_1", "office_doctor_roof_2", "office_doctor_upper_roof_2" ],
           "fg": 19400,
           "bg": 19346,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         { "id": [ "s_liquor" ], "fg": 19401, "rotates": false },
-        { "id": [ "s_liquor_roof" ], "fg": 19402, "bg": 19346, "rotates": false },
+        { "id": [ "s_liquor_roof" ], "fg": 19402, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "s_bike_shop", "s_bike_shop_1" ], "fg": 19403, "rotates": false },
-        { "id": [ "s_bike_shop_roof", "s_bike_shop_roof_1" ], "fg": 19404, "bg": 19346, "rotates": false },
+        { "id": [ "s_bike_shop_roof", "s_bike_shop_roof_1" ], "fg": 19404, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "skate_park" ], "fg": 19405, "rotates": false },
         { "id": [ "pavilion", "pavilion_1", "paintball_field", "paintball_field_1" ], "fg": 19406, "rotates": false },
         {
           "id": [ "pavilion_roof", "pavilion_roof_1", "paintball_field_roof", "paintball_field_roof_1" ],
           "fg": 19407,
           "bg": 19346,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         {
           "id": [
@@ -35497,50 +35547,60 @@
           ],
           "fg": 19409,
           "bg": 19346,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         { "id": [ "s_teashop", "s_teashop_1" ], "fg": 19410, "rotates": false },
         {
           "id": [ "s_teashop_roof", "s_teashop_roof_1", "s_teashop_upper_roof_1" ],
           "fg": 19411,
           "bg": 19346,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         { "id": [ "post_office", "post_office_1" ], "fg": 19412, "rotates": false },
-        { "id": [ "post_office_roof", "post_office_roof_1" ], "fg": 19413, "bg": 19346, "rotates": false },
+        { "id": [ "post_office_roof", "post_office_roof_1" ], "fg": 19413, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "gambling_hall" ], "fg": 19414, "rotates": false },
-        { "id": [ "gambling_hall_roof", "gambling_hall_upper_roof" ], "fg": 19415, "bg": 19346, "rotates": false },
+        { "id": [ "gambling_hall_roof", "gambling_hall_upper_roof" ], "fg": 19415, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "gym_fitness", "gym_fitness_1" ], "fg": 19416, "rotates": false },
         {
           "id": [ "gym_fitness_roof", "gym_fitness_2ndFloor_1", "gym_fitness_roof_1" ],
           "fg": 19417,
           "bg": 19346,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         { "id": [ "mortuary" ], "fg": 19418, "rotates": false },
-        { "id": [ "mortuary_roof" ], "fg": 19419, "bg": 19346, "rotates": false },
+        { "id": [ "mortuary_roof" ], "fg": 19419, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "lancenter", "lancenter_1" ], "fg": 19420, "rotates": false },
-        { "id": [ "lancenter_roof", "lancenter_roof_1" ], "fg": 19421, "bg": 19346, "rotates": false },
+        { "id": [ "lancenter_roof", "lancenter_roof_1" ], "fg": 19421, "bg": 19346, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "s_arcade", "cs_internet_cafe" ], "fg": 19422, "rotates": false },
         {
           "id": [ "s_arcade_roof", "cs_internet_cafe_roof", "cs_internet_cafe_upper_roof" ],
           "fg": 19423,
           "bg": 19346,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         { "id": [ "stripclub", "stripclub_1", "stripclub_2" ], "fg": 19424, "rotates": false },
         {
           "id": [ "stripclub_roof", "stripclub_roof_1", "stripclub_roof_2" ],
           "fg": 19425,
           "bg": 19346,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         { "id": [ "bakery" ], "fg": 19426, "rotates": false },
         {
           "id": [ "bakery_roof", "bakery_upper_roof", "bakery_upper_roof_1" ],
           "fg": 19427,
           "bg": 19347,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         {
           "id": [ "small_storage_units", "small_storage_units_1", "small_storage_units_2" ],
@@ -35551,21 +35611,26 @@
           "id": [ "small_storage_units_roof", "small_storage_units_roof_1", "small_storage_units_roof_2" ],
           "fg": 19429,
           "bg": 19347,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         { "id": [ "office_cubical", "office_cubical_1", "small_office" ], "fg": 19430, "rotates": false },
         {
           "id": [ "office_cubical_roof", "office_cubical_roof_1", "small_office_roof", "small_office_upper_roof" ],
           "fg": 19431,
           "bg": 19347,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         { "id": [ "s_daycare" ], "fg": 19432, "rotates": false },
-        { "id": [ "s_daycare_roof" ], "fg": 19433, "bg": 19347, "rotates": false },
+        { "id": [ "s_daycare_roof" ], "fg": 19433, "bg": 19347, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "animalpound" ], "fg": 19434, "rotates": false },
-        { "id": [ "animalpound_roof" ], "fg": 19435, "bg": 19347, "rotates": false },
+        { "id": [ "animalpound_roof" ], "fg": 19435, "bg": 19347, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "warehouse" ], "fg": 19436, "rotates": false },
-        { "id": [ "warehouse_roof" ], "fg": 19437, "bg": 19347, "rotates": false },
+        { "id": [ "warehouse_roof" ], "fg": 19437, "bg": 19347, "rotates": false, 
+          "has_om_transparency" : true },
         {
           "id": [ "abandonedwarehouse", "abandonedwarehouse_1", "abandonedwarehouse_2", "abandonedwarehouse_3", "abandonedwarehouse_4" ],
           "fg": 19438,
@@ -35581,22 +35646,29 @@
           ],
           "fg": 19439,
           "bg": 19347,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         { "id": [ "home_improvement" ], "fg": 19440, "rotates": false },
-        { "id": [ "home_improvement_roof" ], "fg": 19441, "bg": 19347, "rotates": false },
+        { "id": [ "home_improvement_roof" ], "fg": 19441, "bg": 19347, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "s_jewelry" ], "fg": 19442, "rotates": false },
-        { "id": [ "s_jewelry_roof" ], "fg": 19443, "bg": 19347, "rotates": false },
+        { "id": [ "s_jewelry_roof" ], "fg": 19443, "bg": 19347, "rotates": false, 
+          "has_om_transparency" : true },
         {
           "id": [ "garage_gas_roof", "garage_gas_roof_1", "garage_gas_roof_2", "garage_gas_roof_3" ],
           "fg": 19444,
           "bg": 19347,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
-        { "id": [ "s_gas_roof", "s_gas_roof_1", "s_gas_rural_roof" ], "fg": 19445, "bg": 19347, "rotates": false },
+        { "id": [ "s_gas_roof", "s_gas_roof_1", "s_gas_rural_roof" ], "fg": 19445, "bg": 19347, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "station_radio", "station_radio_1" ], "fg": 19446, "rotates": false },
-        { "id": [ "station_radio_roof", "station_radio_roof_1" ], "fg": 19447, "bg": 19347, "rotates": false },
-        { "id": [ "veterinarian_roof" ], "fg": 19448, "bg": 19347, "rotates": false },
+        { "id": [ "station_radio_roof", "station_radio_roof_1" ], "fg": 19447, "bg": 19347, "rotates": false, 
+          "has_om_transparency" : true },
+        { "id": [ "veterinarian_roof" ], "fg": 19448, "bg": 19347, "rotates": false, 
+          "has_om_transparency" : true },
         {
           "id": [ "dispensary", "dispensary_1", "dispensary_2", "headshop", "smoke_lounge", "smoke_lounge_1" ],
           "fg": 19449,
@@ -35614,100 +35686,131 @@
           ],
           "fg": 19450,
           "bg": 19347,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         { "id": [ "landscapingsupplyco_1b" ], "fg": 19451, "rotates": false },
         { "id": [ "landscapingsupplyco_1a" ], "fg": 19452, "rotates": false },
-        { "id": [ "landscapingsupplyco_1b_roof" ], "fg": 19453, "bg": 19347, "rotates": false },
-        { "id": [ "s_laundromat_roof", "s_laundromat_roof_1" ], "fg": 19454, "bg": 19347, "rotates": false },
-        { "id": [ "s_pharm_roof", "s_pharm_roof_1" ], "fg": 19455, "bg": 19347, "rotates": false },
+        { "id": [ "landscapingsupplyco_1b_roof" ], "fg": 19453, "bg": 19347, "rotates": false, 
+          "has_om_transparency" : true },
+        { "id": [ "s_laundromat_roof", "s_laundromat_roof_1" ], "fg": 19454, "bg": 19347, "rotates": false, 
+          "has_om_transparency" : true },
+        { "id": [ "s_pharm_roof", "s_pharm_roof_1" ], "fg": 19455, "bg": 19347, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "abstorefront", "abstorefront_1", "abstorefront_2" ], "fg": 19456, "rotates": false },
         {
           "id": [ "abstorefront_roof", "abstorefront_roof_1", "abstorefront_roof_2" ],
           "fg": 19457,
           "bg": 19347,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         { "id": [ "icecream_shop" ], "fg": 19458, "rotates": false },
-        { "id": [ "icecream_shop_roof" ], "fg": 19459, "bg": 19347, "rotates": false },
+        { "id": [ "icecream_shop_roof" ], "fg": 19459, "bg": 19347, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "s_petstore", "s_petstore_1", "s_petstore_2" ], "fg": 19460, "rotates": false },
         {
           "id": [ "s_petstore_roof", "s_petstore_roof_1", "s_petstore_roof_2" ],
           "fg": 19461,
           "bg": 19347,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         { "id": [ "animalshelter" ], "fg": 19462, "rotates": false },
-        { "id": [ "animalshelter_roof" ], "fg": 19463, "bg": 19347, "rotates": false },
+        { "id": [ "animalshelter_roof" ], "fg": 19463, "bg": 19347, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "dollarstore", "dollarstore_1" ], "fg": 19464, "rotates": false },
-        { "id": [ "dollarstore_roof", "dollarstore_roof_1" ], "fg": 19465, "bg": 19347, "rotates": false },
+        { "id": [ "dollarstore_roof", "dollarstore_roof_1" ], "fg": 19465, "bg": 19347, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "candy_shop", "candy_shop_1" ], "fg": 19466, "rotates": false },
-        { "id": [ "candy_shop_roof", "candy_shop_roof_1" ], "fg": 19467, "bg": 19347, "rotates": false },
+        { "id": [ "candy_shop_roof", "candy_shop_roof_1" ], "fg": 19467, "bg": 19347, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "cs_market_small" ], "fg": 19468, "rotates": false },
         {
           "id": [ "bus_stat_0_roof", "bus_stat_1_roof", "mine_entrance_loading_zone_roof", "cs_gardening_allotment_roof" ],
           "fg": 19469,
           "bg": 19347,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
-        { "id": [ "mine_entrance_roof" ], "fg": 19470, "bg": 19347, "rotates": false },
+        { "id": [ "mine_entrance_roof" ], "fg": 19470, "bg": 19347, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "music_venue", "music_venue_1", "s_music" ], "fg": 19471, "rotates": false },
         {
           "id": [ "music_venue_roof", "music_venue_1_roof", "music_venue_1_roof_top", "s_music_roof" ],
           "fg": 19472,
           "bg": 19347,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         { "id": [ "gym" ], "fg": 19473, "rotates": false },
-        { "id": [ "gym_roof", "gym_upper_roof" ], "fg": 19474, "bg": 19347, "rotates": false },
-        { "id": [ "cs_sex_shop_roof" ], "fg": 19475, "bg": 19347, "rotates": false },
+        { "id": [ "gym_roof", "gym_upper_roof" ], "fg": 19474, "bg": 19347, "rotates": false, 
+          "has_om_transparency" : true },
+        { "id": [ "cs_sex_shop_roof" ], "fg": 19475, "bg": 19347, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "house_2story_basement" ], "fg": 19476, "bg": 9477, "rotates": false },
         { "id": [ "s_baseballfield_a1" ], "fg": [ 19477 ], "rotates": true },
         { "id": [ "s_baseballfield_a2" ], "fg": [ 19481 ], "rotates": true },
         { "id": [ "s_baseballfield_b1" ], "fg": [ 19485 ], "rotates": true },
         { "id": [ "s_baseballfield_b2" ], "fg": [ 19489 ], "rotates": true },
         { "id": [ "cs_tire_shop" ], "fg": 19493, "rotates": false },
-        { "id": [ "cs_tire_shop_roof" ], "fg": 19494, "bg": 19347, "rotates": false },
+        { "id": [ "cs_tire_shop_roof" ], "fg": 19494, "bg": 19347, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "s_gardening" ], "fg": 19495, "rotates": false },
-        { "id": [ "s_gardening_roof" ], "fg": 19496, "bg": 19347, "rotates": false },
+        { "id": [ "s_gardening_roof" ], "fg": 19496, "bg": 19347, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "house_modern_1" ], "fg": [ 19497, 19498, 19499, 19500 ], "rotates": true },
-        { "id": [ "house_modern_1_roof" ], "fg": [ 19501, 19502, 19503, 19504 ], "bg": 19347, "rotates": true },
+        { "id": [ "house_modern_1_roof" ], "fg": [ 19501, 19502, 19503, 19504 ], "bg": 19347, "rotates": true, 
+          "has_om_transparency" : true },
         { "id": [ "urban_1_1" ], "fg": [ 19505, 19506, 19507, 19512 ], "rotates": true },
         { "id": [ "urban_1_2" ], "fg": [ 19509, 19510, 19511, 19508 ], "rotates": true },
-        { "id": [ "urban_1_3", "urban_1_5" ], "fg": [ 19513, 19514, 19515, 19520 ], "bg": 19347, "rotates": true },
-        { "id": [ "urban_1_4", "urban_1_6" ], "fg": [ 19517, 19518, 19519, 19516 ], "bg": 19347, "rotates": true },
+        { "id": [ "urban_1_3", "urban_1_5" ], "fg": [ 19513, 19514, 19515, 19520 ], "bg": 19347, "rotates": true, 
+          "has_om_transparency" : true },
+        { "id": [ "urban_1_4", "urban_1_6" ], "fg": [ 19517, 19518, 19519, 19516 ], "bg": 19347, "rotates": true, 
+          "has_om_transparency" : true },
         { "id": [ "urban_2_1" ], "fg": [ 19505, 19506, 19507, 19512 ], "rotates": true },
         { "id": [ "urban_2_2" ], "fg": [ 19509, 19510, 19511, 19508 ], "rotates": true },
-        { "id": [ "urban_2_3", "urban_2_5" ], "fg": [ 19513, 19514, 19515, 19520 ], "bg": 19347, "rotates": true },
-        { "id": [ "urban_2_4", "urban_2_6" ], "fg": [ 19517, 19518, 19519, 19516 ], "bg": 19347, "rotates": true },
+        { "id": [ "urban_2_3", "urban_2_5" ], "fg": [ 19513, 19514, 19515, 19520 ], "bg": 19347, "rotates": true, 
+          "has_om_transparency" : true },
+        { "id": [ "urban_2_4", "urban_2_6" ], "fg": [ 19517, 19518, 19519, 19516 ], "bg": 19347, "rotates": true, 
+          "has_om_transparency" : true },
         { "id": [ "urban_3_1" ], "fg": [ 19505, 19506, 19507, 19512 ], "rotates": true },
         { "id": [ "urban_3_2" ], "fg": [ 19509, 19510, 19511, 19508 ], "rotates": true },
-        { "id": [ "urban_3_3", "urban_3_5" ], "fg": [ 19513, 19514, 19515, 19520 ], "bg": 19347, "rotates": true },
-        { "id": [ "urban_3_4", "urban_3_6" ], "fg": [ 19517, 19518, 19519, 19516 ], "bg": 19347, "rotates": true },
+        { "id": [ "urban_3_3", "urban_3_5" ], "fg": [ 19513, 19514, 19515, 19520 ], "bg": 19347, "rotates": true, 
+          "has_om_transparency" : true },
+        { "id": [ "urban_3_4", "urban_3_6" ], "fg": [ 19517, 19518, 19519, 19516 ], "bg": 19347, "rotates": true, 
+          "has_om_transparency" : true },
         { "id": [ "urban_5_1" ], "fg": [ 19505, 19506, 19507, 19512 ], "rotates": true },
         { "id": [ "urban_5_2" ], "fg": [ 19509, 19510, 19511, 19508 ], "rotates": true },
-        { "id": [ "urban_5_3", "urban_5_5" ], "fg": [ 19513, 19514, 19515, 19520 ], "bg": 19347, "rotates": true },
-        { "id": [ "urban_5_4", "urban_5_6" ], "fg": [ 19517, 19518, 19519, 19516 ], "bg": 19347, "rotates": true },
+        { "id": [ "urban_5_3", "urban_5_5" ], "fg": [ 19513, 19514, 19515, 19520 ], "bg": 19347, "rotates": true, 
+          "has_om_transparency" : true },
+        { "id": [ "urban_5_4", "urban_5_6" ], "fg": [ 19517, 19518, 19519, 19516 ], "bg": 19347, "rotates": true, 
+          "has_om_transparency" : true },
         { "id": [ "urban_4_3" ], "fg": [ 19505, 19506, 19507, 19512 ], "rotates": true },
         { "id": [ "urban_4_4" ], "fg": [ 19509, 19510, 19511, 19508 ], "rotates": true },
-        { "id": [ "urban_4_5", "urban_4_7" ], "fg": [ 19513, 19514, 19515, 19520 ], "bg": 19347, "rotates": true },
-        { "id": [ "urban_4_6", "urban_4_8" ], "fg": [ 19517, 19518, 19519, 19516 ], "bg": 19347, "rotates": true },
+        { "id": [ "urban_4_5", "urban_4_7" ], "fg": [ 19513, 19514, 19515, 19520 ], "bg": 19347, "rotates": true, 
+          "has_om_transparency" : true },
+        { "id": [ "urban_4_6", "urban_4_8" ], "fg": [ 19517, 19518, 19519, 19516 ], "bg": 19347, "rotates": true, 
+          "has_om_transparency" : true },
         { "id": [ "urban_6_1", "urban_7_1" ], "fg": [ 19505, 19506, 19507, 19512 ], "rotates": true },
         { "id": [ "urban_6_2", "urban_7_2" ], "fg": [ 19509, 19510, 19511, 19508 ], "rotates": true },
         {
           "id": [ "urban_6_3", "urban_7_3", "urban_6_5", "urban_7_5" ],
           "fg": [ 19513, 19514, 19515, 19520 ],
           "bg": 19347,
-          "rotates": true
+          "rotates": true, 
+          "has_om_transparency" : true
         },
         {
           "id": [ "urban_6_4", "urban_7_4", "urban_6_6", "urban_7_6" ],
           "fg": [ 19517, 19518, 19519, 19516 ],
           "bg": 19347,
-          "rotates": true
+          "rotates": true, 
+          "has_om_transparency" : true
         },
         { "id": [ "museum" ], "fg": [ 19521 ], "rotates": false },
-        { "id": [ "museum_roof" ], "fg": [ 19522 ], "bg": 19347, "rotates": false },
+        { "id": [ "museum_roof" ], "fg": [ 19522 ], "bg": 19347, "rotates": false, 
+          "has_om_transparency" : true },
         {
           "id": [
             "urban_1_1_basement",
@@ -35749,14 +35852,17 @@
           ],
           "rotates": false
         },
-        { "id": [ "roadstop_b_roof" ], "fg": [ 19535 ], "bg": 19347, "rotates": false },
+        { "id": [ "roadstop_b_roof" ], "fg": [ 19535 ], "bg": 19347, "rotates": false, 
+          "has_om_transparency" : true },
         { "id": [ "house_02" ], "fg": [ 19536, 19537, 19538, 19539 ], "rotates": true },
-        { "id": [ "house_02_roof" ], "fg": [ 19540, 19541, 19542, 19543 ], "bg": 19347, "rotates": true },
+        { "id": [ "house_02_roof" ], "fg": [ 19540, 19541, 19542, 19543 ], "bg": 19347, "rotates": true, 
+          "has_om_transparency" : true },
         {
           "id": [ "public_works_NE_roof", "public_works_NW_roof", "public_works_SE_roof", "public_works_SW_roof" ],
           "fg": [ 19544 ],
           "bg": 19347,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         {
           "id": [ "mil_base_minefield_w" ],
@@ -35837,31 +35943,37 @@
       "file": "Temporary-Maptiles-Large.png",
       "tiles": [
         { "id": "cs_car_showroom", "fg": 19638, "rotates": false },
-        { "id": "cs_car_showroom_2ndfloor", "fg": 19639, "bg": 19637, "rotates": false },
-        { "id": "cs_car_showroom_roof", "fg": 19640, "bg": 19637, "rotates": false },
+        { "id": "cs_car_showroom_2ndfloor", "fg": 19639, "bg": 19637, "rotates": false, 
+          "has_om_transparency" : true },
+        { "id": "cs_car_showroom_roof", "fg": 19640, "bg": 19637, "rotates": false, 
+          "has_om_transparency" : true },
         {
           "id": [ "loffice_tower_7", "loffice_tower_11", "loffice_tower_15", "loffice_tower_19" ],
           "fg": [ 19643, 19644, 19642, 19641 ],
           "bg": 19637,
-          "rotates": true
+          "rotates": true, 
+          "has_om_transparency" : true
         },
         {
           "id": [ "loffice_tower_5", "loffice_tower_9", "loffice_tower_9b", "loffice_tower_13", "loffice_tower_17" ],
           "fg": [ 19641, 19643, 19644, 19642 ],
           "bg": 19637,
-          "rotates": true
+          "rotates": true, 
+          "has_om_transparency" : true
         },
         {
           "id": [ "loffice_tower_8", "loffice_tower_12", "loffice_tower_16", "loffice_tower_20" ],
           "fg": [ 19644, 19642, 19641, 19643 ],
           "bg": 19637,
-          "rotates": true
+          "rotates": true, 
+          "has_om_transparency" : true
         },
         {
           "id": [ "loffice_tower_6", "loffice_tower_10", "loffice_tower_10b", "loffice_tower_14", "loffice_tower_18" ],
           "fg": [ 19642, 19641, 19643, 19644 ],
           "bg": 19637,
-          "rotates": true
+          "rotates": true, 
+          "has_om_transparency" : true
         },
         {
           "id": [
@@ -35877,11 +35989,14 @@
           ],
           "fg": [ 19645 ],
           "bg": 19637,
-          "rotates": false
+          "rotates": false, 
+          "has_om_transparency" : true
         },
         { "id": "house_2story_base", "fg": [ 19647, 19648, 19646, 19649 ], "rotates": true },
-        { "id": "house_2story_second", "fg": [ 19651, 19652, 19650, 19653 ], "bg": 19637, "rotates": true },
-        { "id": "house_2story_roof", "fg": [ 19655, 19656, 19654, 19657 ], "bg": 19637, "rotates": true },
+        { "id": "house_2story_second", "fg": [ 19651, 19652, 19650, 19653 ], "bg": 19637, "rotates": true, 
+          "has_om_transparency" : true },
+        { "id": "house_2story_roof", "fg": [ 19655, 19656, 19654, 19657 ], "bg": 19637, "rotates": true, 
+          "has_om_transparency" : true },
         {
           "id": [ "city_block2_1", "city_block2_flr2_1", "city_block2_roof_1" ],
           "fg": [ 19658, 19661, 19660, 19659 ],

--- a/src/cached_options.cpp
+++ b/src/cached_options.cpp
@@ -15,6 +15,7 @@ bool display_object_ids;
 bool trigdist;
 bool fov_3d;
 bool static_z_effect = false;
+bool overmap_transparency = true;
 int fov_3d_z_range;
 bool tile_iso;
 bool pixel_minimap_option = false;

--- a/src/cached_options.h
+++ b/src/cached_options.h
@@ -67,6 +67,9 @@ extern bool tile_iso;
 /** Static z level effect. */
 extern bool static_z_effect;
 
+/** Render overmap air as transparent and render tiles that are below. */
+extern bool overmap_transparency;
+
 /**
  * Whether to show the pixel minimap. Always false for ncurses build,
  * but can be toggled during game in sdl build.

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1249,7 +1249,7 @@ tile_type &tileset_loader::load_tile( const JsonObject &entry, const std::string
 
     load_tile_spritelists( entry, curr_subtile.fg, "fg" );
     load_tile_spritelists( entry, curr_subtile.bg, "bg" );
-    curr_subtile.has_om_transparency = entry.get_bool("has_om_transparency", false);
+    curr_subtile.has_om_transparency = entry.get_bool( "has_om_transparency", false );
 
     return ts.create_tile_type( id, std::move( curr_subtile ) );
 }
@@ -2345,16 +2345,17 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
         }
     }
 
-    //To make first layer of overlays more opaque and easy to distinguish 
-    overlay_count = overlay_count + (overlay_count > 0);
+    //To make first layer of overlays more opaque and easy to distinguish
+    overlay_count = overlay_count + ( overlay_count > 0 );
     //Overmap overlays usually have higher counts, so make them less opaque
     const int base_overlay_alpha = category == TILE_CATEGORY::C_OVERMAP_TERRAIN ? 12 : 24;
 
     //Let's branch transparent overmaps early if tranparency overlays are enabled
     //Because if tranparency is enabled then backgrounds should not be drawn
-    if (category == TILE_CATEGORY::C_OVERMAP_TERRAIN && display_tile.has_om_transparency && overmap_transparency) {
-        draw_sprite_at(display_tile, display_tile.fg, screen_pos, loc_rand, /*fg:*/ true, rota, ll,
-                apply_night_vision_goggles, height_3d, base_overlay_alpha * overlay_count);
+    if( category == TILE_CATEGORY::C_OVERMAP_TERRAIN && display_tile.has_om_transparency &&
+        overmap_transparency ) {
+        draw_sprite_at( display_tile, display_tile.fg, screen_pos, loc_rand, /*fg:*/ true, rota, ll,
+                        apply_night_vision_goggles, height_3d, base_overlay_alpha * overlay_count );
         return true;
     }
 
@@ -2375,24 +2376,27 @@ bool cata_tiles::draw_sprite_at(
                                        apply_night_vision_goggles, nullint, overlay_count );
 }
 
-void cata_tiles::draw_om_tile_recursively(const tripoint_abs_omt omp, const std::string& id, int rotation, int subtile, int base_z_offset) {
-    std::optional<tile_search_result> tt = tile_type_search(id, TILE_CATEGORY::C_OVERMAP_TERRAIN, "overmap_terrain", subtile, rotation);
-    if (tt == std::nullopt) {
+void cata_tiles::draw_om_tile_recursively( const tripoint_abs_omt omp, const std::string &id,
+        int rotation, int subtile, int base_z_offset )
+{
+    std::optional<tile_search_result> tt = tile_type_search( id, TILE_CATEGORY::C_OVERMAP_TERRAIN,
+                                           "overmap_terrain", subtile, rotation );
+    if( tt == std::nullopt ) {
         return;
     }
 
-    if (tt->tt->has_om_transparency) {
+    if( tt->tt->has_om_transparency ) {
         //So current tile has transparent pixels, so we need to render below one first
-        const tripoint_abs_omt new_pos = omp + tripoint(0, 0, -1);
+        const tripoint_abs_omt new_pos = omp + tripoint( 0, 0, -1 );
         int new_rotation = 0, new_subtile = 0;
-        std::string new_id = get_omt_id_rotation_and_subtile(new_pos, new_rotation, new_subtile);
-        draw_om_tile_recursively(new_pos, new_id, new_rotation, new_subtile, base_z_offset + 1);
+        std::string new_id = get_omt_id_rotation_and_subtile( new_pos, new_rotation, new_subtile );
+        draw_om_tile_recursively( new_pos, new_id, new_rotation, new_subtile, base_z_offset + 1 );
     }
 
-    const lit_level ll = overmap_buffer.is_explored(omp) ? lit_level::LOW : lit_level::LIT;
+    const lit_level ll = overmap_buffer.is_explored( omp ) ? lit_level::LOW : lit_level::LIT;
     int discarded = 0;
-    draw_from_id_string(id, TILE_CATEGORY::C_OVERMAP_TERRAIN, "overmap_terrain", omp.raw(),
-        subtile, rotation, ll, false, discarded, base_z_offset);
+    draw_from_id_string( id, TILE_CATEGORY::C_OVERMAP_TERRAIN, "overmap_terrain", omp.raw(),
+                         subtile, rotation, ll, false, discarded, base_z_offset );
 }
 
 bool cata_tiles::draw_sprite_at(
@@ -2473,7 +2477,7 @@ bool cata_tiles::draw_sprite_at(
     auto render = [&]( const int rotation, const SDL_RendererFlip flip ) {
         int ret = sprite_tex->render_copy_ex( renderer, &destination, rotation, nullptr, flip );
         if( !static_z_effect && overlay && overlay_alpha > 0 ) {
-            overlay->set_alpha_mod( std::min( 192, overlay_alpha));
+            overlay->set_alpha_mod( std::min( 192, overlay_alpha ) );
             overlay->render_copy_ex( renderer, &destination, rotation, nullptr, flip );
         }
         return ret;

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -80,6 +80,7 @@
 #include "vpart_position.h"
 #include "weather.h"
 #include "weighted_list.h"
+#include "overmapbuffer.h"
 
 #define dbg(x) DebugLogFL((x),DC::SDL)
 
@@ -1248,6 +1249,7 @@ tile_type &tileset_loader::load_tile( const JsonObject &entry, const std::string
 
     load_tile_spritelists( entry, curr_subtile.fg, "fg" );
     load_tile_spritelists( entry, curr_subtile.bg, "bg" );
+    curr_subtile.has_om_transparency = entry.get_bool("has_om_transparency", false);
 
     return ts.create_tile_type( id, std::move( curr_subtile ) );
 }
@@ -2343,9 +2345,22 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
         }
     }
 
+    //To make first layer of overlays more opaque and easy to distinguish 
+    overlay_count = overlay_count + (overlay_count > 0);
+    //Overmap overlays usually have higher counts, so make them less opaque
+    const int base_overlay_alpha = category == TILE_CATEGORY::C_OVERMAP_TERRAIN ? 12 : 24;
+
+    //Let's branch transparent overmaps early if tranparency overlays are enabled
+    //Because if tranparency is enabled then backgrounds should not be drawn
+    if (category == TILE_CATEGORY::C_OVERMAP_TERRAIN && display_tile.has_om_transparency && overmap_transparency) {
+        draw_sprite_at(display_tile, display_tile.fg, screen_pos, loc_rand, /*fg:*/ true, rota, ll,
+                apply_night_vision_goggles, height_3d, base_overlay_alpha * overlay_count);
+        return true;
+    }
+
     //draw it!
     draw_tile_at( display_tile, screen_pos, loc_rand, rota, ll,
-                  apply_night_vision_goggles, height_3d, overlay_count );
+                  apply_night_vision_goggles, height_3d, base_overlay_alpha * overlay_count );
 
     return true;
 }
@@ -2360,10 +2375,30 @@ bool cata_tiles::draw_sprite_at(
                                        apply_night_vision_goggles, nullint, overlay_count );
 }
 
+void cata_tiles::draw_om_tile_recursively(const tripoint_abs_omt omp, const std::string& id, int rotation, int subtile, int base_z_offset) {
+    std::optional<tile_search_result> tt = tile_type_search(id, TILE_CATEGORY::C_OVERMAP_TERRAIN, "overmap_terrain", subtile, rotation);
+    if (tt == std::nullopt) {
+        return;
+    }
+
+    if (tt->tt->has_om_transparency) {
+        //So current tile has transparent pixels, so we need to render below one first
+        const tripoint_abs_omt new_pos = omp + tripoint(0, 0, -1);
+        int new_rotation = 0, new_subtile = 0;
+        std::string new_id = get_omt_id_rotation_and_subtile(new_pos, new_rotation, new_subtile);
+        draw_om_tile_recursively(new_pos, new_id, new_rotation, new_subtile, base_z_offset + 1);
+    }
+
+    const lit_level ll = overmap_buffer.is_explored(omp) ? lit_level::LOW : lit_level::LIT;
+    int discarded = 0;
+    draw_from_id_string(id, TILE_CATEGORY::C_OVERMAP_TERRAIN, "overmap_terrain", omp.raw(),
+        subtile, rotation, ll, false, discarded, base_z_offset);
+}
+
 bool cata_tiles::draw_sprite_at(
     const tile_type &tile, const weighted_int_list<std::vector<int>> &svlist,
     point p, unsigned int loc_rand, bool rota_fg, int rota, lit_level ll,
-    bool apply_night_vision_goggles, int &height_3d, int overlay_count )
+    bool apply_night_vision_goggles, int &height_3d, int overlay_alpha )
 {
     auto picked = svlist.pick( loc_rand );
     if( !picked ) {
@@ -2413,7 +2448,7 @@ bool cata_tiles::draw_sprite_at(
                 sprite_tex = ptr;
             }
         }
-    } else if( overlay_count > 0 && static_z_effect ) {
+    } else if( overlay_alpha > 0 && static_z_effect ) {
         if( const auto ptr = tileset_ptr->get_z_overlay( spritelist[sprite_num] ) ) {
             sprite_tex = ptr;
         }
@@ -2437,8 +2472,8 @@ bool cata_tiles::draw_sprite_at(
 
     auto render = [&]( const int rotation, const SDL_RendererFlip flip ) {
         int ret = sprite_tex->render_copy_ex( renderer, &destination, rotation, nullptr, flip );
-        if( !static_z_effect && overlay && overlay_count > 0 ) {
-            overlay->set_alpha_mod( std::min( 192, ( 1 + overlay_count ) * 24 ) );
+        if( !static_z_effect && overlay && overlay_alpha > 0 ) {
+            overlay->set_alpha_mod( std::min( 192, overlay_alpha));
             overlay->render_copy_ex( renderer, &destination, rotation, nullptr, flip );
         }
         return ret;

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -38,6 +38,7 @@ struct tile_type {
     bool multitile = false;
     bool rotates = false;
     bool animated = false;
+    bool has_om_transparency = false;
     int height_3d = 0;
     point offset = point_zero;
 
@@ -450,6 +451,15 @@ class cata_tiles
                                   const std::string &subcategory, const tripoint &pos, int subtile, int rota,
                                   lit_level ll, bool apply_night_vision_goggles, int &height_3d, int overlay_count,
                                   bool as_independent_entity = false );
+        /**
+        * @brief Draw overmap tile, if it's transparent, then draw lower tile first
+        *
+        * @param id String id of the tile to draw.
+        * @param rotation { UP = 0, LEFT = 1, DOWN = 2, RIGHT = 3 }
+        * @param subtile variant of the tile
+        * @param base_z_offset Z offset from given position, used to calculate overlay opacity
+        */
+        void draw_om_tile_recursively(const tripoint_abs_omt omp, const std::string& id, int rotation, int subtile, int base_z_offset);
 
         /**
          * @brief draw_sprite_at() without height_3d
@@ -469,7 +479,7 @@ class cata_tiles
         bool draw_sprite_at(
             const tile_type &tile, const weighted_int_list<std::vector<int>> &svlist,
             point, unsigned int loc_rand, bool rota_fg, int rota, lit_level ll,
-            bool apply_night_vision_goggles, int &height_3d, int overlay_count );
+            bool apply_night_vision_goggles, int &height_3d, int overlay_alpha);
 
         /**
          * @brief Calls draw_sprite_at() twice each for foreground and background.

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -459,7 +459,8 @@ class cata_tiles
         * @param subtile variant of the tile
         * @param base_z_offset Z offset from given position, used to calculate overlay opacity
         */
-        void draw_om_tile_recursively(const tripoint_abs_omt omp, const std::string& id, int rotation, int subtile, int base_z_offset);
+        void draw_om_tile_recursively( const tripoint_abs_omt omp, const std::string &id, int rotation,
+                                       int subtile, int base_z_offset );
 
         /**
          * @brief draw_sprite_at() without height_3d
@@ -479,7 +480,7 @@ class cata_tiles
         bool draw_sprite_at(
             const tile_type &tile, const weighted_int_list<std::vector<int>> &svlist,
             point, unsigned int loc_rand, bool rota_fg, int rota, lit_level ll,
-            bool apply_night_vision_goggles, int &height_3d, int overlay_alpha);
+            bool apply_night_vision_goggles, int &height_3d, int overlay_alpha );
 
         /**
          * @brief Calls draw_sprite_at() twice each for foreground and background.

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1994,10 +1994,10 @@ void options_manager::add_options_graphics()
          false, COPT_CURSES_HIDE
        );
 
-    add("OVERMAP_TRANSPARENCY", graphics, translate_marker("Overmap air transparent"),
-        translate_marker("If true, overmap z levels with air are transparent, lower layers are rendered. Decreases rendering perfomance."),
-        true, COPT_CURSES_HIDE
-    );
+    add( "OVERMAP_TRANSPARENCY", graphics, translate_marker( "Overmap air transparent" ),
+         translate_marker( "If true, overmap z levels with air are transparent, lower layers are rendered. Decreases rendering perfomance." ),
+         true, COPT_CURSES_HIDE
+       );
 
     add_empty_line();
 
@@ -3452,7 +3452,7 @@ void options_manager::cache_to_globals()
     fov_3d = ::get_option<bool>( "FOV_3D" );
     fov_3d_z_range = ::get_option<int>( "FOV_3D_Z_RANGE" );
     static_z_effect = ::get_option<bool>( "STATICZEFFECT" );
-    overmap_transparency = ::get_option<bool>("OVERMAP_TRANSPARENCY");
+    overmap_transparency = ::get_option<bool>( "OVERMAP_TRANSPARENCY" );
     PICKUP_RANGE = ::get_option<int>( "PICKUP_RANGE" );
 
     merge_comestible_mode = ( [] {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1994,6 +1994,11 @@ void options_manager::add_options_graphics()
          false, COPT_CURSES_HIDE
        );
 
+    add("OVERMAP_TRANSPARENCY", graphics, translate_marker("Overmap air transparent"),
+        translate_marker("If true, overmap z levels with air are transparent, lower layers are rendered. Decreases rendering perfomance."),
+        true, COPT_CURSES_HIDE
+    );
+
     add_empty_line();
 
     add( "PIXEL_MINIMAP", graphics, translate_marker( "Pixel minimap" ),
@@ -3447,6 +3452,7 @@ void options_manager::cache_to_globals()
     fov_3d = ::get_option<bool>( "FOV_3D" );
     fov_3d_z_range = ::get_option<int>( "FOV_3D_Z_RANGE" );
     static_z_effect = ::get_option<bool>( "STATICZEFFECT" );
+    overmap_transparency = ::get_option<bool>("OVERMAP_TRANSPARENCY");
     PICKUP_RANGE = ::get_option<int>( "PICKUP_RANGE" );
 
     merge_comestible_mode = ( [] {

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -919,27 +919,26 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
                 }
             }
 
-            if (overmap_transparency) {
+            if( overmap_transparency ) {
                 int z_offset = 0;
-                while (id == "open_air") {
+                while( id == "open_air" ) {
                     z_offset++;
-                    const tripoint_abs_omt lower_omp = omp + tripoint(0, 0, -z_offset);
-                    const bool lower_see = has_debug_vision || overmap_buffer.seen(lower_omp);
-                    if (!lower_see) {
+                    const tripoint_abs_omt lower_omp = omp + tripoint( 0, 0, -z_offset );
+                    const bool lower_see = has_debug_vision || overmap_buffer.seen( lower_omp );
+                    if( !lower_see ) {
                         //actually really strange situation when above overmap is explored, but below one isn't
                         //so let's account for this just in case, drawing highest seen tile
                         z_offset--;
                         break;
                     }
-                    id = get_omt_id_rotation_and_subtile(lower_omp, rotation, subtile);
+                    id = get_omt_id_rotation_and_subtile( lower_omp, rotation, subtile );
                 }
-                draw_om_tile_recursively(omp + tripoint(0, 0, -z_offset), id, rotation, subtile, z_offset);
-            }
-            else {
-                const lit_level ll = overmap_buffer.is_explored(omp) ? lit_level::LOW : lit_level::LIT;
+                draw_om_tile_recursively( omp + tripoint( 0, 0, -z_offset ), id, rotation, subtile, z_offset );
+            } else {
+                const lit_level ll = overmap_buffer.is_explored( omp ) ? lit_level::LOW : lit_level::LIT;
                 // light level is now used for choosing between grayscale filter and normal lit tiles.
-                draw_from_id_string(id, TILE_CATEGORY::C_OVERMAP_TERRAIN, "overmap_terrain", omp.raw(),
-                    subtile, rotation, ll, false, height_3d, 0);
+                draw_from_id_string( id, TILE_CATEGORY::C_OVERMAP_TERRAIN, "overmap_terrain", omp.raw(),
+                                     subtile, rotation, ll, false, height_3d, 0 );
             }
 
 

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -919,10 +919,29 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
                 }
             }
 
-            const lit_level ll = overmap_buffer.is_explored( omp ) ? lit_level::LOW : lit_level::LIT;
-            // light level is now used for choosing between grayscale filter and normal lit tiles.
-            draw_from_id_string( id, TILE_CATEGORY::C_OVERMAP_TERRAIN, "overmap_terrain", omp.raw(),
-                                 subtile, rotation, ll, false, height_3d, 0 );
+            if (overmap_transparency) {
+                int z_offset = 0;
+                while (id == "open_air") {
+                    z_offset++;
+                    const tripoint_abs_omt lower_omp = omp + tripoint(0, 0, -z_offset);
+                    const bool lower_see = has_debug_vision || overmap_buffer.seen(lower_omp);
+                    if (!lower_see) {
+                        //actually really strange situation when above overmap is explored, but below one isn't
+                        //so let's account for this just in case, drawing highest seen tile
+                        z_offset--;
+                        break;
+                    }
+                    id = get_omt_id_rotation_and_subtile(lower_omp, rotation, subtile);
+                }
+                draw_om_tile_recursively(omp + tripoint(0, 0, -z_offset), id, rotation, subtile, z_offset);
+            }
+            else {
+                const lit_level ll = overmap_buffer.is_explored(omp) ? lit_level::LOW : lit_level::LIT;
+                // light level is now used for choosing between grayscale filter and normal lit tiles.
+                draw_from_id_string(id, TILE_CATEGORY::C_OVERMAP_TERRAIN, "overmap_terrain", omp.raw(),
+                    subtile, rotation, ll, false, height_3d, 0);
+            }
+
 
             if( see ) {
                 if( blink && uistate.overmap_debug_mongroup ) {


### PR DESCRIPTION
## Purpose of change (The Why)
Navigating while flying on helicopters is hard, because lower overmap layers are not visible, this PR implements overmap transparency.
- closes #1938

## Describe the solution (The How)

Algorithm is quite straitforward:
While rendering, if current tile is "open_air", then we should render lower tile with some blue overlay (like regular rendering)
But there is one problem - UDP tileset contains rooftops tiles with background of open air texture. If we'll just apply aforementioned method result will be quite ugly, Z0 level shows grass and roards and Z1 level shows only rooftop and open air below.
To fix that issue we need to introduce new JSON field for overmap tile textures, that states if this texture contains any transparent pixels on foreground.  If so we'll render tile below first and then render this texture without it's background (because it is "open air"). This results in recursive algorithm that renders all semitransparent tiles bottom to top. ( implemented at draw_om_tile_recursively)
Also cata_tiles::draw_sprite_at got small change -- overlay_cout was replace with overlay_alpha to provide more controll over overlay opacity to the caller, actual function behauvior apart from that was not changed.
Added toggle option overmap_transparency to switch overmap rendering behavior.

To conclude JSON changes: added new optional field for tileset tiles -- "has_om_transparency" -- by default it's false and does nothing, but if it's true, then overmap tile is considered semitransparent and game renderes does not render it's background + renders tile below it, if overmap_transparency  option is enabled.

I've updated UDP tileset as much as I can, but there are some problems still: 
some tiles does not have proper roofs, so do not render properly 
some tiles have roof with not transparent background
some roof tiles are missing while floor 2 or 3 are present, what results to strange looking building (missing floor texture is replaced by fallback one which is not transparent)

Other tilesets do not have transparent roofs so these changes does not affect them.
## Describe alternatives you've considered

draw_om_tile_recursively can be done  without recursion, using loop and stack (aka std::vector), but this recursion is bounded by world height limit hence is not deep, I think this recursion is safe enugh.

## Testing

Created some worlds, teleported my characted here and there, openned overmap.
Explored overmap through debug menu and openned overmap.

## Additional context

Before:
![изображение](https://github.com/user-attachments/assets/cf2603f0-55af-4cad-a64e-503dfa5438a0)
After:
![изображение](https://github.com/user-attachments/assets/f0bd773c-2a04-4a8f-a7ea-a3bf8fd82ad8)
(Still some tileset updating is required, but already useful)
## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)

### Optional
- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [x] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
