### PR TITLE
feat(balance): Purifier Smart Shot Crafting, Loot

### DIFF
--- a/data/json/itemgroups/science_and_tech.json
+++ b/data/json/itemgroups/science_and_tech.json
@@ -266,6 +266,7 @@
       [ "iv_mutagen_mouse", 2 ],
       [ "purifier", 10 ],
       [ "iv_purifier", 8 ],
+      [ "purifier_smart_shot", 2 ],
       [ "syringe", 8 ],
       { "item": "bleach", "prob": 20, "charges-min": 1 },
       { "item": "ammonia", "prob": 24, "charges-min": 10 },
@@ -338,6 +339,7 @@
       [ "iv_mutagen_lupine", 2 ],
       [ "purifier", 10 ],
       [ "iv_purifier", 8 ],
+      [ "purifier_smart_shot", 2 ],
       [ "syringe", 8 ]
     ]
   },

--- a/data/json/itemgroups/science_and_tech.json
+++ b/data/json/itemgroups/science_and_tech.json
@@ -266,7 +266,7 @@
       [ "iv_mutagen_mouse", 2 ],
       [ "purifier", 10 ],
       [ "iv_purifier", 8 ],
-      [ "purifier_smart_shot", 2 ],
+      [ "purifier_smart_shot", 1 ],
       [ "syringe", 8 ],
       { "item": "bleach", "prob": 20, "charges-min": 1 },
       { "item": "ammonia", "prob": 24, "charges-min": 10 },
@@ -339,7 +339,7 @@
       [ "iv_mutagen_lupine", 2 ],
       [ "purifier", 10 ],
       [ "iv_purifier", 8 ],
-      [ "purifier_smart_shot", 2 ],
+      [ "purifier_smart_shot", 1 ],
       [ "syringe", 8 ]
     ]
   },

--- a/data/json/recipes/chem/mutagen.json
+++ b/data/json/recipes/chem/mutagen.json
@@ -795,5 +795,19 @@
     "using": [ [ "serum_production_standard", 37 ] ],
     "components": [ [ [ "mutagen_rabbit", 2 ] ] ],
     "flags": [ "SECRET" ]
+  },
+  {
+    "type": "recipe",
+    "result": "purifier_smart_shot",
+    "category": "CC_CHEM",
+    "subcategory": "CSC_CHEM_MUTAGEN",
+    "skill_used": "cooking",
+    "skills_required": [ "firstaid", 6 ],
+    "difficulty": 10,
+    "time": 120000,
+    "tools": [ [ [ "surface_heat", 30, "LIST" ] ] ],
+    "book_learn": [ [ "recipe_alpha", 9 ], [ "recipe_serum", 9 ] ],
+    "qualities": [ { "id": "CHEM", "level": 3 } ],
+    "components": [ [ [ "iv_purifier", 3 ] ], [ [ "slime_scrap", 5 ] ], [ [ "syringe", 1 ] ] ]
   }
 ]

--- a/data/json/recipes/chem/mutagen.json
+++ b/data/json/recipes/chem/mutagen.json
@@ -795,20 +795,5 @@
     "using": [ [ "serum_production_standard", 37 ] ],
     "components": [ [ [ "mutagen_rabbit", 2 ] ] ],
     "flags": [ "SECRET" ]
-  },
-  {
-    "type": "recipe",
-    "result": "purifier_smart_shot",
-    "category": "CC_CHEM",
-    "subcategory": "CSC_CHEM_MUTAGEN",
-    "skill_used": "cooking",
-    "skills_required": [ "firstaid", 6 ],
-    "difficulty": 10,
-    "time": "2 h",
-    "batch_time_factors": [ 20, 5 ],
-    "book_learn": [ [ "recipe_serum", 9 ], [ "recipe_labchem", 9 ] ],
-    "using": [ [ "serum_production_standard", 37 ] ],
-    "components": [ [ [ "iv_purifier", 2 ], [ "purifier", 4 ] ] ],
-    "flags": [ "SECRET" ]
   }
 ]

--- a/data/json/recipes/chem/mutagen.json
+++ b/data/json/recipes/chem/mutagen.json
@@ -795,5 +795,20 @@
     "using": [ [ "serum_production_standard", 37 ] ],
     "components": [ [ [ "mutagen_rabbit", 2 ] ] ],
     "flags": [ "SECRET" ]
+  },
+  {
+    "type": "recipe",
+    "result": "purifier_smart_shot",
+    "category": "CC_CHEM",
+    "subcategory": "CSC_CHEM_MUTAGEN",
+    "skill_used": "cooking",
+    "skills_required": [ "firstaid", 6 ],
+    "difficulty": 10,
+    "time": "2 h",
+    "batch_time_factors": [ 20, 5 ],
+    "book_learn": [ [ "recipe_serum", 9 ], [ "recipe_labchem", 9 ] ],
+    "using": [ [ "serum_production_standard", 37 ] ],
+    "components": [ [ [ "iv_purifier", 2 ], [ "purifier", 4 ] ] ],
+    "flags": [ "SECRET" ]
   }
 ]

--- a/data/json/recipes/chem/mutagen.json
+++ b/data/json/recipes/chem/mutagen.json
@@ -804,7 +804,7 @@
     "skill_used": "cooking",
     "skills_required": [ "firstaid", 6 ],
     "difficulty": 10,
-    "time": 120000,
+    "time": "2 h",
     "tools": [ [ [ "surface_heat", 30, "LIST" ] ] ],
     "book_learn": [ [ "recipe_alpha", 9 ], [ "recipe_serum", 9 ] ],
     "qualities": [ { "id": "CHEM", "level": 3 } ],

--- a/data/mods/Aftershock/recipes/recipes.json
+++ b/data/mods/Aftershock/recipes/recipes.json
@@ -255,20 +255,6 @@
     "components": [ [ [ "plastic_chunk", 1 ] ], [ [ "processor", 1 ] ], [ [ "smart_phone", 1 ] ], [ [ "plut_cell", 1 ] ] ]
   },
   {
-    "type": "recipe",
-    "result": "purifier_smart_shot",
-    "category": "CC_CHEM",
-    "subcategory": "CSC_CHEM_MUTAGEN",
-    "skill_used": "cooking",
-    "skills_required": [ "firstaid", 6 ],
-    "difficulty": 10,
-    "time": 120000,
-    "tools": [ [ [ "surface_heat", 30, "LIST" ] ] ],
-    "book_learn": [ [ "recipe_alpha", 9 ], [ "recipe_serum", 9 ] ],
-    "qualities": [ { "id": "CHEM", "level": 3 } ],
-    "components": [ [ [ "iv_purifier", 3 ] ], [ [ "slime_scrap", 5 ] ], [ [ "syringe", 1 ] ] ]
-  },
-  {
     "result": "plut_cell",
     "type": "recipe",
     "category": "CC_ELECTRONIC",

--- a/data/mods/Aftershock/recipes/recipes.json
+++ b/data/mods/Aftershock/recipes/recipes.json
@@ -266,7 +266,7 @@
     "tools": [ [ [ "surface_heat", 30, "LIST" ] ] ],
     "book_learn": [ [ "recipe_alpha", 9 ], [ "recipe_serum", 9 ] ],
     "qualities": [ { "id": "CHEM", "level": 3 } ],
-    "components": [ [ [ "iv_purifier", 3 ] ], [ [ "royal_jelly", 1 ] ], [ [ "slime_scrap", 1 ] ], [ [ "syringe", 1 ] ] ]
+    "components": [ [ [ "iv_purifier", 3 ] ], [ [ "slime_scrap", 5 ] ], [ [ "syringe", 1 ] ] ]
   },
   {
     "result": "plut_cell",


### PR DESCRIPTION
Added a recipe and loot drops for the purifier smart shot. The recipe requires very high skills and the loot table drops are very low chances.

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

Although purifier smart shot existed in the code, it could only be attained through the lab finale or by crafting it with royal jelly, which itself is extremely rare.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Purifier smart shot's crafting recipe now requires no royal jelly and more slime, and can also be found in the 'mutagens' and 'mutagen lab' loot tables at a minimum chance.

## Describe alternatives you've considered

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
  - [ ] I have made sure to preserve the correct license for the ported content by adding a code or JSON comment to the ported sections indicating their original license
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
