### PR TITLE
feat(mods/MonsterGirls): Monstergirls don't get `BADBACK`

### DIFF
--- a/data/mods/Monster_Girls/vanilla_mutations.json
+++ b/data/mods/Monster_Girls/vanilla_mutations.json
@@ -256,7 +256,7 @@
     "id": "BADBACK",
     "copy-from": "BADBACK",
     "delete": { "category": [ "BIRD", "ELFA" ] },
-    "extend": { "category": [ "HARPY", "ELF" ] }
+    "valid": false
   },
   {
     "type": "mutation",


### PR DESCRIPTION
## Purpose of change (The Why)

35% carry weight reduction for no gain is undesirable, especially when these trees already have hollow bones to crater their carry weight.

## Describe the solution (The How)
Removes the `extend` from it and marks it as invalid

## Describe alternatives you've considered

- PR a change to the mutation in vanilla
- Give them strong backs instead

## Testing

If deleting the `extend` and marking it with the same invalid as other entries doesn't work, we have bigger issues

## Additional context

I'm kinda surprised I let it slide in the first place

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)
