### PR TITLE
feat(balance): more bionics can cancel out bad mutations

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1079,7 +1079,7 @@
     "id": "bio_jointservo",
     "type": "bionic",
     "name": { "str": "Joint Servo" },
-    "description": "Your leg joints have been equipped with servomotors that provide power-assisted movement.  They are optimized for running, but walking also requires less effort.  When unpowered, the bionic still improves your speed slightly by balancing your gait and preventing incorrect or excessive movements.",
+    "description": "Your leg joints have been equipped with servomotors that provide power-assisted movement.  They are optimized for running, but walking also requires less effort.  When unpowered, the bionic still improves your speed slightly by balancing your gait and preventing incorrect or excessive movements, even compensating for joint problems.",
     "occupied_bodyparts": [ [ "leg_l", 12 ], [ "leg_r", 12 ] ],
     "canceled_mutations": [ "BADKNEES" ],
     "flags": [ "BIONIC_TOGGLED" ],

--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1204,9 +1204,10 @@
     "id": "bio_weight",
     "type": "bionic",
     "name": { "str": "Skeletal Bracing" },
-    "description": "A framework of lightweight alloy bracing has been installed onto your elbows, knees, and spine, making them far better at handling strain.  Your carrying capacity is increased by 20 kilograms, or about 44 pounds.",
+    "description": "A framework of lightweight alloy bracing has been installed onto your elbows, knees, and spine, making them far better at handling strain and fixing any spinal issues.  Your carrying capacity is increased by 20 kilograms, or about 44 pounds.",
     "occupied_bodyparts": [ [ "torso", 8 ], [ "arm_l", 3 ], [ "arm_r", 3 ], [ "leg_l", 3 ], [ "leg_r", 3 ] ],
     "weight_capacity_bonus": "20 kg",
+    "canceled_mutations": [ "BADBACK" ],
     "flags": [ "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF" ]
   },
   {

--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -328,9 +328,10 @@
     "id": "bio_ears",
     "type": "bionic",
     "name": { "str": "Enhanced Hearing" },
-    "description": "When this bionic is active, your hearing will be drastically improved, allowing you to hear ten times better than the average person.  Additionally, high-intensity sounds will be automatically dampened before they can damage your hearing.",
+    "description": "When this bionic is active, your hearing will be drastically improved, allowing you to hear ten times better than the average person.  Additionally, high-intensity sounds will be automatically dampened before they can damage your hearing, and preexisting hearing problems will be fixed.",
     "occupied_bodyparts": [ [ "head", 3 ] ],
     "flags": [ "BIONIC_TOGGLED" ],
+    "canceled_mutations": [ "BADHEARING", "DEAF" ],
     "included_bionics": [ "bio_earplugs" ]
   },
   {
@@ -370,9 +371,10 @@
     "id": "bio_eye_enhancer",
     "type": "bionic",
     "name": { "str": "Diamond Cornea" },
-    "description": "Your vision is greatly enhanced, giving you a +2 bonus to perception.",
+    "description": "Your vision is greatly enhanced, giving you a +2 bonus to perception and fixing any vision problems.",
     "occupied_bodyparts": [ [ "eyes", 1 ] ],
     "stat_bonus": [ [ "PER", 2 ] ],
+    "canceled_mutations": [ "HYPEROPIC", "MYOPIC" ],
     "flags": [ "BIONIC_NPC_USABLE" ]
   },
   {
@@ -797,10 +799,11 @@
     "id": "bio_purifier",
     "type": "bionic",
     "name": { "str": "Air Filtration System (passive)" },
-    "description": "Surgically implanted in your trachea is an advanced filtration system.  In it's passive form it will protect you against smoke inhalation.  Once activated, it will prevent spores, toxins and diseases from being inhaled.",
+    "description": "Surgically implanted in your trachea is an advanced filtration system.  In it's passive form it will protect you against smoke inhalation and even particulate matter that triggers asthma attacks.  Once activated, it will prevent spores, toxins and diseases from being inhaled.",
     "occupied_bodyparts": [ [ "torso", 4 ], [ "mouth", 2 ] ],
     "env_protec": [ [ "mouth", 7 ] ],
     "flags": [ "BIONIC_NPC_USABLE" ],
+    "canceled_mutations": [ "ASTHMA" ],
     "included_bionics": [ "bio_purifier_active" ]
   },
   {
@@ -1078,6 +1081,7 @@
     "name": { "str": "Joint Servo" },
     "description": "Your leg joints have been equipped with servomotors that provide power-assisted movement.  They are optimized for running, but walking also requires less effort.  When unpowered, the bionic still improves your speed slightly by balancing your gait and preventing incorrect or excessive movements.",
     "occupied_bodyparts": [ [ "leg_l", 12 ], [ "leg_r", 12 ] ],
+    "canceled_mutations": [ "BADKNEES" ],
     "flags": [ "BIONIC_TOGGLED" ],
     "trigger_cost": "35 J"
   },


### PR DESCRIPTION
## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

Although the diamond cornea can cancel out bad vision traits, very few other CBMs currently do that despite their function implying they could.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

The Enhanced Hearing, Skeletal Bracing, Diamond Cornea, Air Filtration System, and Joint Servo CBMs have been modified to cancel bad hearing/deaf, bad back, hyperopic/myopic, asthma, and bad knees, respectively, while also leaving other CBMs which cancel out negative traits solely through their actual function untouched.

## Describe alternatives you've considered

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

It's mostly json, so unless I made a typo or broke one of the tests, it should be fine. That said, if I missed over specific CBMs that already cancel out a mutation via hardcode, please let me know.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Enhanced hearing replaces your ears' internals with machinery that hears better than natural human ears, so it would fix poor hearing and deafness. 

Skeletal bracing specifically mentions spinal reinforcements, which would reasonably cancel out spinal problems.

Air filtration system filters out smoke from your lungs, which means it filters out particulate in the air- which is the thing that triggers asthma. So even if you still technically have asthma with it installed, you can never have an asthma attack. And if the nicitating membrance CBM could stop asthma attacks when used, then the air filtration system can stop it entirely.

Diamond cornea replaces your corneas with more precise ones, which is the cause of half of all vision problems, the other half being the lens, which already canceled those traits. This is admittedly more of a gameplay simplification than the rest, but I stand by it.

The joint servo CBM description already states it compensates for poor gait and movements when moving, so much like the air filtration system, it would reasonably be able to stop your bad knees from being too rattled.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [ ] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
  - [ ] I have made sure to preserve the correct license for the ported content by adding a code or JSON comment to the ported sections indicating their original license
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
