### PR TITLE
docs: updated monster death functions and monster defense attacks

### DIFF
--- a/doc/src/content/docs/en/mod/json/reference/json_flags.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_flags.md
@@ -967,30 +967,42 @@ Flags used to describe monsters and define their properties and abilities.
 
 Multiple death functions can be used. Not all combinations make sense.
 
-- `ACID` Acid instead of a body. not the same as the ACID_BLOOD flag. In most cases you want both.
+- `ACID` Acid instead of a body. Not the same as the ACID_BLOOD flag. In most cases you want both.
 - `AMIGARA` Removes hypnosis if the last one.
 - `BLOBSPLIT` Creates more blobs.
+- `BOOMER_GLOW` Explodes in glowing vomit.
 - `BOOMER` Explodes in vomit.
+- `BRAINBLOB` Frees blobs.
+- `BROKEN_AMMO` Gives a message about destroying ammo and then calls "BROKEN".
 - `BROKEN` Spawns a broken robot item, its id calculated like this: the prefix "mon_" is removed
-  from the monster id, than the prefix "broken_" is added. Example: mon_eyebot -> broken_eyebot
+  from the monster id, than the prefix "broken_" is added. Example: mon_eyebot -> broken_eyebot.
+- `CONFLAGRATION` Explode in a huge fireball.
+- `DARKMAN` Sight returns to normal.
+- `DETONATE` Take them with you.
 - `DISAPPEAR` Hallucination disappears.
 - `DISINTEGRATE` Falls apart.
 - `EXPLODE` Damaging explosion.
 - `FIREBALL` 10 percent chance to explode in a fireball.
-- `FLAME_EXPLOSION` guaranteed to explode and starts fires.
+- `FOCUSEDBEAM` Blinding ray.
+- `FUNGALBURST` Explode with a cloud of fungal haze.
 - `FUNGUS` Explodes in spores.
 - `GAMEOVER` Game over man! Game over! Defense mode.
+- `GAS` Explodes in toxic gas.
 - `GUILT` Moral penalty. There is also a flag with a similar effect.
+- `JABBERWOCKY` Snicker-snack!
+- `JACKSON` Reverts dancers.
 - `KILL_BREATHERS` All breathers die.
 - `KILL_VINES` Kill all nearby vines.
 - `MELT` Normal death, but melts.
 - `NORMAL` Drop a body, leave gibs.
+- `PREG_ROACH` Spawn some cockroach nymphs.
 - `RATKING` Cure verminitis.
 - `SMOKEBURST` Explode like a huge smoke bomb.
+- `SPLATTER` Explodes in gibs and chunks.
 - `THING` Turn into a full thing.
 - `TRIFFID_HEART` Destroys all roots.
 - `VINE_CUT` Kill adjacent vine if it's cut.
-- `WORM` Spawns 2 half-worms
+- `WORM` Spawns 2 half-worms.
 
 ### Flags
 
@@ -1109,9 +1121,11 @@ Multiple death functions can be used. Not all combinations make sense.
 
 ### Monster Defense and Attacks
 
-- `ACIDSPLASH` Splash acid on the attacker
-- `NONE` No special attack-back
-- `ZAPBACK` Shock attacker on hit
+- `ACIDSPLASH` Splash acid on the attacker.
+- `NONE` No special attack-back.
+- `RETURN_FIRE` Blind fire on unseen attacker.
+- `REVENGE_AGGRO` Make allies aggro on target.
+- `ZAPBACK` Shock attacker on hit.
 
 ### Sizes
 

--- a/doc/src/content/docs/en/mod/json/reference/json_flags.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_flags.md
@@ -978,7 +978,7 @@ Multiple death functions can be used. Not all combinations make sense.
   from the monster id, then the prefix "broken_" is added. Example: mon_eyebot -> broken_eyebot.
 - `CONFLAGRATION` Explode in a huge fireball.
 - `DARKMAN` Sight returns to normal.
-- `DETONATE` Take them with you.
+- `DETONATE` Self destructs.
 - `DISAPPEAR` Hallucination disappears.
 - `DISINTEGRATE` Falls apart.
 - `EXPLODE` Damaging explosion.

--- a/doc/src/content/docs/en/mod/json/reference/json_flags.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_flags.md
@@ -972,7 +972,7 @@ Multiple death functions can be used. Not all combinations make sense.
 - `BLOBSPLIT` Creates more blobs.
 - `BOOMER_GLOW` Explodes in glowing vomit.
 - `BOOMER` Explodes in vomit.
-- `BRAINBLOB` Frees blobs.
+- `BRAINBLOB` Spawns 2 blobs.
 - `BROKEN_AMMO` Gives a message about destroying ammo and then calls "BROKEN".
 - `BROKEN` Spawns a broken robot item, its id calculated like this: the prefix "mon_" is removed
   from the monster id, then the prefix "broken_" is added. Example: mon_eyebot -> broken_eyebot.

--- a/doc/src/content/docs/en/mod/json/reference/json_flags.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_flags.md
@@ -975,7 +975,7 @@ Multiple death functions can be used. Not all combinations make sense.
 - `BRAINBLOB` Frees blobs.
 - `BROKEN_AMMO` Gives a message about destroying ammo and then calls "BROKEN".
 - `BROKEN` Spawns a broken robot item, its id calculated like this: the prefix "mon_" is removed
-  from the monster id, than the prefix "broken_" is added. Example: mon_eyebot -> broken_eyebot.
+  from the monster id, then the prefix "broken_" is added. Example: mon_eyebot -> broken_eyebot.
 - `CONFLAGRATION` Explode in a huge fireball.
 - `DARKMAN` Sight returns to normal.
 - `DETONATE` Take them with you.


### PR DESCRIPTION
## Purpose of change (The Why)

Update docs to contain up to date info
And I needed it anyway for updating [cbn-guide](https://github.com/ushkinaz/cbn-guide)

## Describe the solution (The How)

Copy values and descriptions from
- MonsterGenerator::init_death
- MonsterGenerator::init_defense

## Describe alternatives you've considered

## Testing

npm run dev

## Additional context


## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)
