### PR TITLE
fix: flying monsters wouldn't go down in general, non-flying monsters wouldn't go down ramps

### DIFF
--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -974,11 +974,11 @@ void monster::move()
             if( here.has_flag( TFLAG_RAMP_UP, candidate ) ) {
                 via_ramp = true;
                 candidate.z += 1;
-                ramp_offset = tripoint_above;
+                ramp_offset = tripoint_below;
             } else if( here.has_flag( TFLAG_RAMP_DOWN, candidate ) ) {
                 via_ramp = true;
                 candidate.z -= 1;
-                ramp_offset = tripoint_below;
+                ramp_offset = tripoint_above;
             }
             tripoint candidate_abs = g->m.getabs( candidate );
 

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -248,7 +248,7 @@ bool monster::can_reach_to( const tripoint &p ) const
     if( is_going_up ) {
         const bool has_up_ramp = here.has_flag( TFLAG_RAMP_UP, p + tripoint_below );
         const bool has_stairs = here.has_flag( TFLAG_GOES_UP, pos() );
-        const bool can_fly_there = this->flies() && here.has_flag( TFLAG_NO_FLOOR, this->pos() );
+        const bool can_fly_there = this->flies() && here.has_flag( TFLAG_NO_FLOOR, p );
 
         return has_up_ramp || has_stairs || can_fly_there;
     } else {

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -247,7 +247,7 @@ bool monster::can_reach_to( const tripoint &p ) const
             return false;
         }
     } else if( p.z < pos().z && z_is_valid( pos().z ) ) {
-        if( here.has_flag( TFLAG_RAMP_UP, p + tripoint_above ) ) {
+        if( here.has_flag( TFLAG_RAMP_DOWN, p + tripoint_above ) ) {
             return true;
         }
         if( !here.has_flag( TFLAG_GOES_DOWN, pos() ) ) {

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -239,7 +239,7 @@ bool monster::can_reach_to( const tripoint &p ) const
 {
     map &here = get_map();
     if( p.z > pos().z && z_is_valid( pos().z ) ) {
-        if( here.has_flag( TFLAG_RAMP_UP, tripoint( p.xy(), p.z - 1 ) ) ) {
+        if( here.has_flag( TFLAG_RAMP_UP, p + tripoint_below ) ) {
             return true;
         }
         if( !here.has_flag( TFLAG_GOES_UP, pos() ) && !here.has_flag( TFLAG_NO_FLOOR, p ) ) {
@@ -247,6 +247,9 @@ bool monster::can_reach_to( const tripoint &p ) const
             return false;
         }
     } else if( p.z < pos().z && z_is_valid( pos().z ) ) {
+        if( here.has_flag( TFLAG_RAMP_UP, p + tripoint_above ) ) {
+            return true;
+        }
         if( !here.has_flag( TFLAG_GOES_DOWN, pos() ) ) {
             // can't go through the floor
             // you would fall anyway if there was no floor, so no need to check for that here
@@ -967,12 +970,15 @@ void monster::move()
             }
 
             bool via_ramp = false;
+            tripoint ramp_offset = tripoint_zero;
             if( here.has_flag( TFLAG_RAMP_UP, candidate ) ) {
                 via_ramp = true;
                 candidate.z += 1;
+                ramp_offset = tripoint_above;
             } else if( here.has_flag( TFLAG_RAMP_DOWN, candidate ) ) {
                 via_ramp = true;
                 candidate.z -= 1;
+                ramp_offset = tripoint_below;
             }
             tripoint candidate_abs = g->m.getabs( candidate );
 
@@ -1065,7 +1071,7 @@ void monster::move()
                 }
             }
 
-            const float progress = distance_to_target - trig_dist( candidate, destination );
+            const float progress = distance_to_target - trig_dist( candidate + ramp_offset, destination );
             // The x2 makes the first (and most direct) path twice as likely,
             // since the chance of switching is 1/1, 1/4, 1/6, 1/8
             switch_chance += progress * 2;

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -237,26 +237,27 @@ bool monster::will_move_to( const tripoint &p ) const
 
 bool monster::can_reach_to( const tripoint &p ) const
 {
-    map &here = get_map();
-    if( p.z > pos().z && z_is_valid( pos().z ) ) {
-        if( here.has_flag( TFLAG_RAMP_UP, p + tripoint_below ) ) {
-            return true;
-        }
-        if( !here.has_flag( TFLAG_GOES_UP, pos() ) && !here.has_flag( TFLAG_NO_FLOOR, p ) ) {
-            // can't go through the roof
-            return false;
-        }
-    } else if( p.z < pos().z && z_is_valid( pos().z ) ) {
-        if( here.has_flag( TFLAG_RAMP_DOWN, p + tripoint_above ) ) {
-            return true;
-        }
-        if( !here.has_flag( TFLAG_GOES_DOWN, pos() ) ) {
-            // can't go through the floor
-            // you would fall anyway if there was no floor, so no need to check for that here
-            return false;
-        }
+    const map &here = get_map();
+
+    const bool is_z_move = p.z != pos().z;
+    if( !is_z_move ) {
+        return true;
     }
-    return true;
+
+    const bool is_going_up = p.z > pos().z;
+    if( is_going_up ) {
+        const bool has_up_ramp = here.has_flag( TFLAG_RAMP_UP, p + tripoint_below );
+        const bool has_stairs = here.has_flag( TFLAG_GOES_UP, pos() );
+        const bool can_fly_there = this->flies() && here.has_flag( TFLAG_NO_FLOOR, this->pos() );
+
+        return has_up_ramp || has_stairs || can_fly_there;
+    } else {
+        const bool has_down_ramp = here.has_flag( TFLAG_RAMP_DOWN, p + tripoint_above );
+        const bool has_stairs = here.has_flag( TFLAG_GOES_DOWN, pos() );
+        const bool can_fly_there = this->flies() && here.has_flag( TFLAG_NO_FLOOR, this->pos() );
+
+        return has_down_ramp || has_stairs || can_fly_there;
+    }
 }
 
 bool monster::can_squeeze_to( const tripoint &p ) const


### PR DESCRIPTION
## Purpose of change (The Why)
Flying mobs physically cannot go down, non-flying mobs can't go down ramps. Fix it.

## Describe the solution (The How)
Direct port of https://github.com/CleverRaven/Cataclysm-DDA/pull/68194 and https://github.com/CleverRaven/Cataclysm-DDA/pull/68213 with some extra changes

## Describe alternatives you've considered
N/A

## Testing
Tested that enemies do, in fact, go down ramps now.

## Additional context
N/A

## Checklist
### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [X] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)

### Optional

- [X] This PR ports commits from DDA or other cataclysm forks.
  - [X] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [X] I have linked the URL of original PR(s) in the description.
  - [ ] I have made sure to preserve the correct license for the ported content by adding a code or JSON comment to the ported sections indicating their original license