### PR TITLE
feat(balance): speedydex bonus takes effect avove 10 dex

### DIFF
--- a/data/mods/speedydex/modinfo.json
+++ b/data/mods/speedydex/modinfo.json
@@ -5,7 +5,7 @@
     "name": "SpeedyDex",
     "authors": [ "KorGgenT" ],
     "maintainers": [ "KorGgenT" ],
-    "description": "Speed increases or decreases if dexterity is above/below 8.",
+    "description": "Higher dex increases your speed.",
     "category": "rebalance",
     "dependencies": [ "bn" ]
   },
@@ -13,7 +13,7 @@
     "type": "EXTERNAL_OPTION",
     "name": "SPEEDYDEX_MIN_DEX",
     "stype": "int",
-    "value": 8
+    "value": 10
   },
   {
     "type": "EXTERNAL_OPTION",

--- a/data/mods/speedydex/modinfo.json
+++ b/data/mods/speedydex/modinfo.json
@@ -5,7 +5,7 @@
     "name": "SpeedyDex",
     "authors": [ "KorGgenT" ],
     "maintainers": [ "KorGgenT" ],
-    "description": "Higher dex increases your speed.",
+    "description": "Speed increases or decreases if dexterity is above/below 8.",
     "category": "rebalance",
     "dependencies": [ "bn" ]
   },
@@ -13,7 +13,7 @@
     "type": "EXTERNAL_OPTION",
     "name": "SPEEDYDEX_MIN_DEX",
     "stype": "int",
-    "value": 12
+    "value": 8
   },
   {
     "type": "EXTERNAL_OPTION",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4519,7 +4519,7 @@ int get_speedydex_bonus( const int dex )
     static const std::string speedydex_min_dex( "SPEEDYDEX_MIN_DEX" );
     static const std::string speedydex_dex_speed( "SPEEDYDEX_DEX_SPEED" );
     // this is the number to be multiplied by the increment
-    const int modified_dex = std::max( dex - get_option<int>( speedydex_min_dex ), 0 );
+    const int modified_dex = dex - get_option<int>( speedydex_min_dex );
     return modified_dex * get_option<int>( speedydex_dex_speed );
 }
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4519,7 +4519,7 @@ int get_speedydex_bonus( const int dex )
     static const std::string speedydex_min_dex( "SPEEDYDEX_MIN_DEX" );
     static const std::string speedydex_dex_speed( "SPEEDYDEX_DEX_SPEED" );
     // this is the number to be multiplied by the increment
-    const int modified_dex = dex - get_option<int>( speedydex_min_dex );
+    const int modified_dex = std::max( dex - get_option<int>( speedydex_min_dex ), 0 );
     return modified_dex * get_option<int>( speedydex_dex_speed );
 }
 


### PR DESCRIPTION
## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

It irked me a bit that speedydex has very little impact, mainly because the minimum dex required is so high.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

Changed the `SPEEDYDEX_MIN_DEX` setting in speedydex mod from 12 to 10, making its impact noticable a bit sooner.

## Describe alternatives you've considered

1. Originally I'd planned to make it so it kicks in above or below 8, with below-average dex penalizing you, as I felt this would be better for making the impact actually noticable to all characters, but this got axed.
2. Increasing `SPEEDYDEX_DEX_SPEED` from 2 to some other amount, dunno how much. If so I might be tempted to suggest additionally defining a `SPEEDYDEX_MAX_DEX` property that puts on a ceiling for how high speed can get if a player's dex gets wacky enough.
3. Mainlining this mod.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Autofix doesn't screm at me.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [X] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
  - [ ] I have made sure to preserve the correct license for the ported content by adding a code or JSON comment to the ported sections indicating their original license
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
