### PR TITLE
feat(balance): make smart shot require nanomaterial 

### DIFF
--- a/data/json/items/comestibles/mutagen.json
+++ b/data/json/items/comestibles/mutagen.json
@@ -478,7 +478,7 @@
     "comestible_type": "MED",
     "category": "mutagen",
     "name": "purifier smart shot",
-    "description": "An experimental stem cell treatment, offering limited control over which mutations are purified.  The liquid sloshes strangely inside of this syringe.",
+    "description": "An experimental stem cell treatment utilizing medical nanomachines, offering limited control over which mutations are purified.  The liquid sloshes strangely inside of this syringe.",
     "weight": "12 g",
     "volume": "10ml",
     "price": "12 kUSD",

--- a/data/json/recipes/chem/mutagen.json
+++ b/data/json/recipes/chem/mutagen.json
@@ -802,7 +802,7 @@
     "category": "CC_CHEM",
     "subcategory": "CSC_CHEM_MUTAGEN",
     "skill_used": "cooking",
-    "skills_required": [ "computers", 6 ],
+    "skills_required": [ "computer", 6 ],
     "difficulty": 10,
     "time": "2 h",
     "tools": [ [ [ "surface_heat", 30, "LIST" ] ], [ [ "control_laptop", -1 ] ] ],

--- a/data/json/recipes/chem/mutagen.json
+++ b/data/json/recipes/chem/mutagen.json
@@ -802,12 +802,12 @@
     "category": "CC_CHEM",
     "subcategory": "CSC_CHEM_MUTAGEN",
     "skill_used": "cooking",
-    "skills_required": [ "firstaid", 6 ],
+    "skills_required": [ "computers", 6 ],
     "difficulty": 10,
     "time": "2 h",
-    "tools": [ [ [ "surface_heat", 30, "LIST" ] ] ],
+    "tools": [ [ [ "surface_heat", 30, "LIST" ] ], [ [ "control_laptop", -1 ] ] ],
     "book_learn": [ [ "recipe_alpha", 9 ], [ "recipe_serum", 9 ] ],
     "qualities": [ { "id": "CHEM", "level": 3 } ],
-    "components": [ [ [ "iv_purifier", 3 ] ], [ [ "slime_scrap", 5 ] ], [ [ "syringe", 1 ] ] ]
+    "components": [ [ [ "iv_purifier", 3 ] ], [ [ "slime_scrap", 1 ] ], [ [ "nanomaterial", 1 ] ], [ [ "syringe", 1 ] ] ]
   }
 ]


### PR DESCRIPTION
## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

When I pulled the smart shot recipe from aftershock the other day, I removed the royal jelly, thinking that it was more difficult to get than it was. However, I believe that something called a 'smart shot' which can remove any one specific mutation (plus two other random ones) should require a more high-tech approach to making it.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->
Instead of smart shots requiring royal jelly, they now require nanomaterial as a material and a control laptop as a tool to craft.
## Describe alternatives you've considered

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
Smart shot implies that it's already technological to begin with rather than purely chemical. Furthermore, nanomaterial canisters are both more numerous than royal jelly, but are still largely found in lab finales and by disassembling CBMs, neatly slotting into the same role royal jelly did.
## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
  - [ ] I have made sure to preserve the correct license for the ported content by adding a code or JSON comment to the ported sections indicating their original license
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
