### PR TITLE
fix: Make the electrosense bionic scanner actually power down

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1843,6 +1843,7 @@ void Character::process_bionic( bionic &bio )
                 }
             }
             if( get_power_level() < bio.info().power_trigger ) {
+                bio.powered = false;
                 add_msg_if_player( m_bad, _( "Your %s doesn't have enough power and shuts down." ),
                                    bio.info().name );
                 deactivate_bionic( bio, true );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1146,11 +1146,13 @@ bool Character::deactivate_bionic( bionic &bio, bool eff_only )
             return false;
         }
 
-        //We can actually deactivate now, do deactivation-y things
+        // All checks green, get the deactivation cost and print the message.
         mod_power_level( -bio.info().power_deactivate );
-        bio.powered = false;
         add_msg_if_player( m_neutral, _( "You deactivate your %s." ), bio.info().name );
     }
+
+    // Deactivation is outwidth of the !eff_only block, as involuntary or voluntary it still needs to turn off.
+    bio.powered = false;
 
     // Deactivation effects go here
     if( bio.info().has_flag( flag_BIONIC_WEAPON ) ) {
@@ -1228,7 +1230,6 @@ bool Character::burn_fuel( bionic &bio, bool start )
                                    _( "Your %s runs out of fuel and turn off." ),
                                    _( "<npcname>'s %s runs out of fuel and turn off." ),
                                    bio.info().name );
-            bio.powered = false;
             deactivate_bionic( bio, true );
             return false;
         }
@@ -1279,7 +1280,6 @@ bool Character::burn_fuel( bionic &bio, bool start )
                                                bio.info().name );
                     }
                 }
-                bio.powered = false;
                 deactivate_bionic( bio, true );
                 return false;
             } else {
@@ -1352,8 +1352,6 @@ bool Character::burn_fuel( bionic &bio, bool start )
                                                _( "<npcname>'s %s runs out of fuel and turn off." ),
                                                bio.info().name );
                     }
-
-                    bio.powered = false;
                     deactivate_bionic( bio, true );
                     return false;
                 }
@@ -1626,7 +1624,6 @@ void Character::process_bionic( bionic &bio )
                 bool recharged = attempt_recharge( *this, bio, cost, discharge_factor, discharge_rate );
                 if( !recharged ) {
                     // No power to recharge, so deactivate
-                    bio.powered = false;
                     add_msg_if_player( m_neutral, _( "Your %s powers down." ), bio.info().name );
                     // This purposely bypasses the deactivation cost
                     deactivate_bionic( bio, true );
@@ -1843,7 +1840,6 @@ void Character::process_bionic( bionic &bio )
                 }
             }
             if( get_power_level() < bio.info().power_trigger ) {
-                bio.powered = false;
                 add_msg_if_player( m_bad, _( "Your %s doesn't have enough power and shuts down." ),
                                    bio.info().name );
                 deactivate_bionic( bio, true );


### PR DESCRIPTION
## Purpose of change (The Why)

- Updates #6108 to make electrosense bionic scanner actually shut off if power is insufficient.
  - I misunderstood the purpose of the `eff_only` argument being true, which is meant to only trigger the deactivation effect without actually running the check to see if the bionic can actually deactivate or deactivate the bionic. This is apparently done to simulate involuntary deactivations that have no relation to the other pre-reqs like deactivation cost.

## Describe the solution (The How)

- Change the structure of `deactivate_bionic()` such that it will always deactivate the bionic, with `eff_only` affecting whether this is considered an involuntary (no checks for `BIONIC_TOGGLED` or deactivation cost) or voluntary triggering of deactivation.
  - Did this because all the true calls needed to set the power off anyway, and I don't see a use case where it doesn't need to set it off.

## Describe alternatives you've considered

- Drinking some more.

## Testing

- [ ] Check that electrosense bionic scanner properly turns off when it runs out of power.

## Additional context

- ~~Why can't everything work the way I expect it to?~~

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)