### PR TITLE
feat(balance): reduce encumbrance of gloves and boots

### DIFF
--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -267,7 +267,7 @@
     "description": "A pair of customized Kevlar boots, heavily armored with superalloy and modified to provide maximum protection from harm, even when knee-deep in the dead.",
     "material": [ "kevlar", "superalloy" ],
     "color": "light_cyan",
-    "encumbrance": 27,
+    "encumbrance": 25,
     "proportional": { "weight": 0.6, "price": 2, "price_postapoc": 2 }
   },
   {

--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -1481,7 +1481,7 @@
   {
     "id": "boots_scute",
     "type": "ARMOR",
-    "name": { "str": "pair of scaleskin boots" },
+    "name": { "str": "pair of scaleskin boots", "str_pl": "pairs of scaleskin boots" },
     "description": "Boots made from the hardened scales of large reptiles.  It doesn't look quite like normal alligator skin boots due to the armored design.",
     "copy-from": "boots_larmor",
     "material": [ "scute" ],

--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -253,7 +253,7 @@
     "color": "dark_gray",
     "covers": [ "feet" ],
     "coverage": 100,
-    "encumbrance": 35,
+    "encumbrance": 30,
     "warmth": 15,
     "material_thickness": 6,
     "environmental_protection": 5,
@@ -267,7 +267,7 @@
     "description": "A pair of customized Kevlar boots, heavily armored with superalloy and modified to provide maximum protection from harm, even when knee-deep in the dead.",
     "material": [ "kevlar", "superalloy" ],
     "color": "light_cyan",
-    "encumbrance": 30,
+    "encumbrance": 27,
     "proportional": { "weight": 0.6, "price": 2, "price_postapoc": 2 }
   },
   {
@@ -345,7 +345,7 @@
     "color": "light_gray",
     "covers": [ "feet" ],
     "coverage": 100,
-    "encumbrance": 28,
+    "encumbrance": 27,
     "warmth": 20,
     "material_thickness": 4,
     "environmental_protection": 1,
@@ -379,7 +379,7 @@
     "color": "dark_gray",
     "covers": [ "feet" ],
     "coverage": 100,
-    "encumbrance": 30,
+    "encumbrance": 15,
     "warmth": 10,
     "material_thickness": 3,
     "environmental_protection": 12,
@@ -713,10 +713,9 @@
     "color": "brown",
     "covers": [ "feet" ],
     "coverage": 65,
-    "encumbrance": 2,
     "warmth": 5,
     "material_thickness": 1,
-    "flags": [ "SKINTIGHT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "SKINTIGHT", "COMPACT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ]
   },
   {
     "id": "footrags_fur",
@@ -733,10 +732,10 @@
     "color": "brown",
     "covers": [ "feet" ],
     "coverage": 65,
-    "encumbrance": 5,
+    "encumbrance": 4,
     "warmth": 20,
     "material_thickness": 1,
-    "flags": [ "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "SKINTIGHT", "COMPACT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ]
   },
   {
     "id": "footrags_leather",
@@ -753,10 +752,10 @@
     "color": "brown",
     "covers": [ "feet" ],
     "coverage": 65,
-    "encumbrance": 5,
+    "encumbrance": 3,
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "SKINTIGHT", "COMPACT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ]
   },
   {
     "id": "footrags_wool",
@@ -773,10 +772,10 @@
     "color": "blue",
     "covers": [ "feet" ],
     "coverage": 65,
-    "encumbrance": 5,
+    "encumbrance": 2,
     "warmth": 15,
     "material_thickness": 1,
-    "flags": [ "SKINTIGHT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "SKINTIGHT", "COMPACT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ]
   },
   {
     "id": "geta",
@@ -1141,7 +1140,7 @@
     "color": "dark_gray",
     "covers": [ "feet" ],
     "coverage": 100,
-    "encumbrance": 15,
+    "encumbrance": 13,
     "warmth": 30,
     "material_thickness": 2,
     "environmental_protection": 1,
@@ -1472,7 +1471,7 @@
   {
     "id": "carbon_boots",
     "type": "ARMOR",
-    "name": { "str": "carbon fiber boots" },
+    "name": { "str": "pair of carbon fiber boots" },
     "description": "A custom pair of boots made out of layered carbon fiber armor made using a 3D printer.  Its rigid plates are more comparable to a suit of armor than kevlar, but it's very protective and lightweight.",
     "copy-from": "boots_plarmor",
     "encumbrance": 22,
@@ -1482,7 +1481,7 @@
   {
     "id": "boots_scute",
     "type": "ARMOR",
-    "name": { "str": "scaleskin boots" },
+    "name": { "str": "pair of scaleskin boots" },
     "description": "Boots made from the hardened scales of large reptiles.  It doesn't look quite like normal alligator skin boots due to the armored design.",
     "copy-from": "boots_larmor",
     "material": [ "scute" ],

--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -1471,7 +1471,7 @@
   {
     "id": "carbon_boots",
     "type": "ARMOR",
-    "name": { "str": "pair of carbon fiber boots" },
+    "name": { "str": "pair of carbon fiber boots", "str_pl": "pairs of carbon fiber boots" },
     "description": "A custom pair of boots made out of layered carbon fiber armor made using a 3D printer.  Its rigid plates are more comparable to a suit of armor than kevlar, but it's very protective and lightweight.",
     "copy-from": "boots_plarmor",
     "encumbrance": 22,

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -804,7 +804,7 @@
     "encumbrance": 3,
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "SKINTIGHT", "COMPACT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "COMPACT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ]
   },
   {
     "id": "gloves_wraps_wool",

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -783,7 +783,7 @@
     "encumbrance": 4,
     "warmth": 20,
     "material_thickness": 1,
-    "flags": [ "SKINTIGHT", "OVERSIZE", "COMPACT", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "OVERSIZE", "COMPACT", "ALLOWS_NATURAL_ATTACKS" ]
   },
   {
     "id": "gloves_wraps_leather",

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -718,7 +718,7 @@
     "warmth": 25,
     "material_thickness": 3,
     "environmental_protection": 5,
-    "valid_mods": [ "steel_padded", "alloy_padded", "resized_large" ],
+    "valid_mods": [ "steel_padded", "alloy_padded" ],
     "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
   },
   {

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -681,7 +681,7 @@
     "encumbrance": 15,
     "warmth": 60,
     "material_thickness": 3,
-    "flags": [ "VARSIZE", "SKINTIGHT" ]
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "gloves_wool_fingerless",

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -681,7 +681,7 @@
     "encumbrance": 15,
     "warmth": 60,
     "material_thickness": 3,
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE", "SKINTIGHT" ]
   },
   {
     "id": "gloves_wool_fingerless",

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -804,7 +804,7 @@
     "encumbrance": 3,
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "COMPACT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "SKINTIGHT", "COMPACT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ]
   },
   {
     "id": "gloves_wraps_wool",

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -783,7 +783,7 @@
     "encumbrance": 4,
     "warmth": 20,
     "material_thickness": 1,
-    "flags": [ "OVERSIZE", "COMPACT", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "SKINTIGHT", "OVERSIZE", "COMPACT", "ALLOWS_NATURAL_ATTACKS" ]
   },
   {
     "id": "gloves_wraps_leather",

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -590,7 +590,7 @@
     "color": "yellow",
     "covers": [ "hands" ],
     "coverage": 100,
-    "encumbrance": 40,
+    "encumbrance": 15,
     "warmth": 10,
     "material_thickness": 3,
     "environmental_protection": 8,
@@ -678,10 +678,10 @@
     "color": "blue",
     "covers": [ "hands" ],
     "coverage": 95,
-    "encumbrance": 20,
+    "encumbrance": 15,
     "warmth": 60,
     "material_thickness": 3,
-    "valid_mods": [ "resized_large" ]
+    "valid_mods": [ "VARSIZE" ]
   },
   {
     "id": "gloves_wool_fingerless",
@@ -695,7 +695,7 @@
     "looks_like": "gloves_fingerless",
     "coverage": 50,
     "warmth": 24,
-    "encumbrance": 10,
+    "encumbrance": 7,
     "extend": { "flags": [ "ALLOWS_NATURAL_ATTACKS" ] }
   },
   {
@@ -714,12 +714,12 @@
     "color": "brown",
     "covers": [ "hands" ],
     "coverage": 95,
-    "encumbrance": 20,
+    "encumbrance": 10,
     "warmth": 25,
     "material_thickness": 3,
     "environmental_protection": 5,
     "valid_mods": [ "steel_padded", "alloy_padded", "resized_large" ],
-    "flags": [ "WATERPROOF", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY" ]
   },
   {
     "id": "gloves_cut_resistant",
@@ -738,7 +738,7 @@
     "color": "light_gray",
     "covers": [ "hands" ],
     "coverage": 95,
-    "encumbrance": 40,
+    "encumbrance": 15,
     "warmth": 10,
     "material_thickness": 4,
     "environmental_protection": 1,
@@ -762,7 +762,7 @@
     "coverage": 50,
     "warmth": 5,
     "material_thickness": 1,
-    "flags": [ "SKINTIGHT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "SKINTIGHT", "OVERSIZE", "COMPACT", "ALLOWS_NATURAL_ATTACKS" ]
   },
   {
     "id": "gloves_wraps_fur",
@@ -780,10 +780,10 @@
     "color": "white",
     "covers": [ "hands" ],
     "coverage": 50,
-    "encumbrance": 5,
+    "encumbrance": 4,
     "warmth": 20,
     "material_thickness": 1,
-    "flags": [ "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "SKINTIGHT", "OVERSIZE", "COMPACT", "ALLOWS_NATURAL_ATTACKS" ]
   },
   {
     "id": "gloves_wraps_leather",
@@ -801,10 +801,10 @@
     "color": "white",
     "covers": [ "hands" ],
     "coverage": 50,
-    "encumbrance": 5,
+    "encumbrance": 3,
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "SKINTIGHT", "COMPACT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ]
   },
   {
     "id": "gloves_wraps_wool",
@@ -825,7 +825,7 @@
     "encumbrance": 2,
     "warmth": 15,
     "material_thickness": 1,
-    "flags": [ "SKINTIGHT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "SKINTIGHT", "COMPACT", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ]
   },
   {
     "id": "gloves_wsurvivor",
@@ -843,7 +843,7 @@
     "color": "light_gray",
     "covers": [ "hands" ],
     "coverage": 100,
-    "encumbrance": 37,
+    "encumbrance": 25,
     "warmth": 75,
     "material_thickness": 4,
     "environmental_protection": 5,
@@ -886,7 +886,7 @@
     "color": "blue",
     "covers": [ "hands" ],
     "coverage": 100,
-    "encumbrance": 80,
+    "encumbrance": 17,
     "warmth": 70,
     "material_thickness": 4,
     "flags": [ "OVERSIZE", "OUTER" ]

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -420,7 +420,7 @@
     "warmth": 20,
     "material_thickness": 2,
     "valid_mods": [ "resized_large" ],
-    "flags": [ "WATER_FRIENDLY" ]
+    "flags": [ "WATER_FRIENDLY", "SKINTIGHT" ]
   },
   {
     "id": "gloves_light_fingerless",

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -886,7 +886,7 @@
     "color": "blue",
     "covers": [ "hands" ],
     "coverage": 100,
-    "encumbrance": 17,
+    "encumbrance": 30,
     "warmth": 70,
     "material_thickness": 4,
     "flags": [ "OVERSIZE", "OUTER" ]

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -420,7 +420,7 @@
     "warmth": 20,
     "material_thickness": 2,
     "valid_mods": [ "resized_large" ],
-    "flags": [ "WATER_FRIENDLY", "SKINTIGHT" ]
+    "flags": [ "WATER_FRIENDLY" ]
   },
   {
     "id": "gloves_light_fingerless",

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -681,7 +681,7 @@
     "encumbrance": 15,
     "warmth": 60,
     "material_thickness": 3,
-    "valid_mods": [ "VARSIZE" ]
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "gloves_wool_fingerless",

--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -268,8 +268,8 @@ TEST_CASE( "competent_shooter_accuracy", "[ranged] [balance]" )
 {
     clear_all_state();
     standard_npc shooter( "Shooter", shooter_pos, {}, 5, 10, 10, 10, 10 );
-    equip_shooter( shooter, { "cloak_wool", "footrags_wool", "gloves_wraps_fur", "glasses_safety", "balclava" } );
-    assert_encumbrance( shooter, 4 );
+    equip_shooter( shooter, { "cloak_wool", "footrags_wool", "gloves_wraps_wool", "gloves_wraps_leather", "glasses_safety", "balclava" } );
+    assert_encumbrance( shooter, 5 );
 
     SECTION( "a skilled shooter with an accurate pistol" ) {
         arm_character( shooter, "sw_619", { "red_dot_sight" } );

--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -268,7 +268,7 @@ TEST_CASE( "competent_shooter_accuracy", "[ranged] [balance]" )
 {
     clear_all_state();
     standard_npc shooter( "Shooter", shooter_pos, {}, 5, 10, 10, 10, 10 );
-    equip_shooter( shooter, { "cloak_wool", "footrags_wool", "gloves_wraps_wool", "gloves_wraps_leather", "glasses_safety", "balclava" } );
+    equip_shooter( shooter, { "cloak_wool", "footrags_wool", "footrags_leather", "gloves_wraps_wool", "gloves_wraps_leather", "glasses_safety", "balclava" } );
     assert_encumbrance( shooter, 5 );
 
     SECTION( "a skilled shooter with an accurate pistol" ) {

--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -269,7 +269,7 @@ TEST_CASE( "competent_shooter_accuracy", "[ranged] [balance]" )
     clear_all_state();
     standard_npc shooter( "Shooter", shooter_pos, {}, 5, 10, 10, 10, 10 );
     equip_shooter( shooter, { "cloak_wool", "footrags_wool", "gloves_wraps_fur", "glasses_safety", "balclava" } );
-    assert_encumbrance( shooter, 5 );
+    assert_encumbrance( shooter, 4 );
 
     SECTION( "a skilled shooter with an accurate pistol" ) {
         arm_character( shooter, "sw_619", { "red_dot_sight" } );


### PR DESCRIPTION
Adjusted encumbrance and flags of various gloves and footwear to be more sensible. Handwraps made of leather, fur, or wool are no longer more encumbering or harder to fit inside other gloves than nomex gloves, for example.

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->
For some godforsaken reason, a significant number of relatively simple to wear boots and gloves have ridiculously high encumbrance values and can never properly fit the player.
## Describe the solution (The How)
Adjusted the encumbrance and flags of multiple boots and gloves in order to make them a bit more sensible.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
  - [ ] I have made sure to preserve the correct license for the ported content by adding a code or JSON comment to the ported sections indicating their original license
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
