### PR TITLE
fix(mods/aftershock): energy saber  battery bug

### DIFF
--- a/data/mods/Aftershock/items/weapons.json
+++ b/data/mods/Aftershock/items/weapons.json
@@ -12,7 +12,6 @@
     "symbol": "[",
     "looks_like": "flashlight",
     "color": "light_gray",
-    "ammo": [ "battery" ],
     "use_action": {
       "menu_text": "Activate",
       "type": "transform",
@@ -23,22 +22,7 @@
       "need_charges_msg": "The energy saber is out of charge.",
       "active": true
     },
-    "flags": [ "USE_UPS", "NO_UNLOAD", "NO_RELOAD", "BELT_CLIP" ],
-    "magazines": [
-      [
-        "battery",
-        [
-          "light_battery_cell",
-          "light_minus_battery_cell",
-          "light_plus_battery_cell",
-          "light_minus_atomic_battery_cell",
-          "light_atomic_battery_cell",
-          "light_minus_disposable_cell",
-          "light_disposable_cell"
-        ]
-      ]
-    ],
-    "magazine_well": "250 ml"
+    "flags": [ "USE_UPS", "NO_UNLOAD", "NO_RELOAD", "BELT_CLIP" ]
   },
   {
     "id": "afs_energy_saber_on",
@@ -53,7 +37,6 @@
     "material": [ "superalloy", "diamond" ],
     "symbol": "[",
     "color": "light_blue",
-    "ammo": [ "battery" ],
     "turns_per_charge": 10,
     "cutting": 40,
     "to_hit": 2,
@@ -65,8 +48,7 @@
       "type": "transform",
       "target": "afs_energy_saber_off",
       "msg": "The blade dissipates into particles."
-    },
-    "magazine_well": "250 ml"
+    }
   },
   {
     "id": "afs_hardlight_longbow",


### PR DESCRIPTION
Removed the magazine and magazine well fields from the energy saber weapon and its on variant which were causing errors. I don't even know how that got there, the weapon was always powered by UPS.

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->
The aftershock item 'energy saber' was, somehow, coded to use both an internal battery magazine, and to be an non-reloadable UPS-powered weapon, causing errors whenever a player examined it or tried to pick it up.
## Describe the solution (The How)

<!-- e.g nerfs monster A -->
Removed the magazine well and magazine fields from the weapon and its 'on' counterpart, leaving it UPS draw intact.
## Describe alternatives you've considered

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->
It doesn't cause any errors on my end when tested.
## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
  - [ ] I have made sure to preserve the correct license for the ported content by adding a code or JSON comment to the ported sections indicating their original license
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
