### PR TITLE
feat(balance): use synthetic fabric in a few more items, recipes for seatbelts/webbing belts

### DIFF
--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -451,7 +451,7 @@
     "volume": "2250 ml",
     "price": "10 USD",
     "price_postapoc": "50 cent",
-    "material": [ "plastic", "cotton" ],
+    "material": [ "plastic", "nylon" ],
     "symbol": "[",
     "looks_like": "jacket_leather",
     "color": "cyan",

--- a/data/json/items/armor/undergarment.json
+++ b/data/json/items/armor/undergarment.json
@@ -161,7 +161,7 @@
     "volume": "250 ml",
     "price": "10 USD",
     "price_postapoc": "50 cent",
-    "material": [ "cotton" ],
+    "material": [ "nylon" ],
     "symbol": "[",
     "looks_like": "boxer_briefs",
     "color": "light_gray",

--- a/data/json/recipes/armor/legs.json
+++ b/data/json/recipes/armor/legs.json
@@ -37,7 +37,7 @@
     "autolearn": true,
     "book_learn": [ [ "mag_tailor", 1 ], [ "manual_tailor", 1 ] ],
     "using": [ [ "sewing_standard", 15 ] ],
-    "components": [ [ [ "rag", 3 ] ] ]
+    "components": [ [ [ "nylon", 3 ] ] ]
   },
   {
     "result": "boxer_briefs",

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -452,6 +452,20 @@
     "components": [ [ [ "leather", 6 ] ] ]
   },
   {
+    "result": "webbing_belt",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_STORAGE",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "time": "20 m",
+    "autolearn": true,
+    "reversible": true,
+    "using": [ [ "sewing_standard", 12 ] ],
+    "qualities": [ { "id": "HAMMER", "level": 2 } ],
+    "components": [ [ [ "nylon", 3 ] ], [ [ "scrap", 1 ] ] ]
+  },
+  {
     "result": "leather_pouch",
     "type": "recipe",
     "category": "CC_ARMOR",

--- a/data/json/recipes/other/vehicles.json
+++ b/data/json/recipes/other/vehicles.json
@@ -577,6 +577,20 @@
     "components": [ [ [ "leather", 6 ], [ "fur", 6 ] ], [ [ "wood_structural", 4, "LIST" ] ], [ [ "rope_natural_short", 4, "LIST" ] ] ]
   },
   {
+    "result": "seatbelt",
+    "type": "recipe",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_VEHICLE",
+    "skill_used": "fabrication",
+    "difficulty": 5,
+    "time": "30 m",
+    "autolearn": true,
+    "reversible": true,
+    "using": [ [ "sewing_standard", 20 ] ],
+    "qualities": [ { "id": "HAMMER", "level": 2 } ],
+    "components": [ [ [ "nylon", 10 ] ], [ [ "steel_tiny", 1, "LIST" ] ] ]
+  },
+  {
     "result": "five-point_harness",
     "type": "recipe",
     "category": "CC_OTHER",

--- a/data/json/uncraft/armor.json
+++ b/data/json/uncraft/armor.json
@@ -107,7 +107,7 @@
     "type": "uncraft",
     "time": "30 s",
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "rag", 1 ] ] ],
+    "components": [ [ [ "nylon", 1 ] ] ],
     "flags": [ "BLIND_EASY" ]
   },
   {

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -4787,14 +4787,6 @@
   },
   {
     "type": "uncraft",
-    "result": "seatbelt",
-    "time": "30 s",
-    "components": [ [ [ "nylon", 3 ] ] ],
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "flags": [ "BLIND_HARD" ]
-  },
-  {
-    "type": "uncraft",
     "result": "engine_block_tiny",
     "skill_used": "fabrication",
     "difficulty": 1,


### PR DESCRIPTION
## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

Some things to make synthetic fabric a touch easier to get ahold of, and expand on uses for it.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Added a recipe for webbing belts. Implemented as a reversible recipe, using an amount of material roughly consistent with the item's resulting weight. Level matches that of tool belt.
2. Replaced the uncraft for seatbelt with a reversible recipe for it, taking 1 `steel_tiny` and a fitting enough amount of synthetic fabric to make up the remaining weight. Set 2 levels higher than that of webbing belt.
3. Set boy shorts from cotton to nylon to add more variety to synthetic fabric items and to pair up with sports bra having been set to that material already.
4. Set emergency jacket from plastic/cotton to plastic/nylon to likewise help make it more distinct materials-wise.

## Describe alternatives you've considered

Making webbing belt recipe eat up more synthetic fabric and using an uncraft to return a fraction of it, the same way leather belts are set to work. Ech.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Checked affected files for syntax and lint errors.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [X] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
  - [ ] I have made sure to preserve the correct license for the ported content by adding a code or JSON comment to the ported sections indicating their original license
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
