### PR TITLE
fix: reloading magazine properly shows non-empty magazines with different, but compatible ammo

### DIFF
--- a/src/character_functions.cpp
+++ b/src/character_functions.cpp
@@ -1177,13 +1177,9 @@ void find_ammo_helper( T &src, const item &obj, bool empty, Output out, bool nes
             if( node->is_magazine() ) {
 
                 if( !node->contents.empty() ) {
-                    bool match = false;
-                    for( const ammotype &at : ammo ) {
-                        if( node->contents.front().ammo_type() == at ) {
-                            match = true;
-                            break;
-                        }
-                    }
+                    const bool match = std::ranges::any_of( ammo, [&]( const ammotype & at ) {
+                        return node->contents.front().ammo_type() == at;
+                    } );
                     if( !match ) {
                         return VisitResponse::SKIP;
                     }

--- a/src/character_functions.cpp
+++ b/src/character_functions.cpp
@@ -1177,10 +1177,15 @@ void find_ammo_helper( T &src, const item &obj, bool empty, Output out, bool nes
             if( node->is_magazine() ) {
 
                 if( !node->contents.empty() ) {
+                    bool match = false;
                     for( const ammotype &at : ammo ) {
-                        if( node->contents.front().ammo_type() != at ) {
-                            return VisitResponse::SKIP;
+                        if( node->contents.front().ammo_type() == at ) {
+                            match = true;
+                            break;
                         }
+                    }
+                    if( !match ) {
+                        return VisitResponse::SKIP;
                     }
                 }
 


### PR DESCRIPTION
## Purpose of change (The Why)

- Resolves #5623 
- Resolves #5594

## Describe the solution (The How)

Magazine selection logic had a minor iteration oversight:
Instead of considering accepting a non-empty magazine if the contained ammunition matched ***any*** of the supported ammo types, the magazine was rejected it if it didn't match ***all*** of them,

## Describe alternatives you've considered

Insert empty magazines in the weapon and magic-reload the rounds inside it without taking the magazine out.

## Testing

Vanilla:
* Loaded game, spawned 1911-460, and 3 mags, one empty, one with 460 and one with 45
* Reloading works as expected with any given combination

Modded:
* Tested with Modern Weapon Pack Extended SCAR-H, works as expected too.

## Additional context

![image](https://github.com/user-attachments/assets/ad2bb061-d5ff-4453-8d1d-af1b58e6e052)

![image](https://github.com/user-attachments/assets/e0984994-252d-49a9-9353-a0ae18a53d58)

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
  - [ ] I have made sure to preserve the correct license for the ported content by adding a code or JSON comment to the ported sections indicating their original license
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
