### PR TITLE
fix: regression introduced with magazine reload fix

### DIFF
--- a/src/character_functions.cpp
+++ b/src/character_functions.cpp
@@ -1,5 +1,3 @@
-#pragma optimize("", off)
-
 #include "character_functions.h"
 
 #include <utility>


### PR DESCRIPTION
## Purpose of change (The Why)

Went to look back at what broke the mag reloading in the first place, it was introduced with #4817 

#6174 partially reintroduced the issue, but in the form of you could then potentially load unsupported ammo into an empty magazine already inside a gun (300 Blackout on a STANAG on an AR-15)

## Describe the solution (The How)

This should solve that by further checking if the item being reloaded is a magazine, that is contained on a gun/mod that doesn't support said ammunition.

## Describe alternatives you've considered

N/A

## Testing

Vanilla:
* Spawn AR-15, Mags, 556 and 300blk ammo
* Can insert 300blk ammo on an empty mag
* Mag with 300blk can't be inserted in AR-15
* Insert empty mag on AR-15
* Can't load the empty mag with 300blk any longer
* Add underslug shotgun or M203
* Reloading still shows up shot/grenades as potential ammo to reload

Modded:
* Attach MWPE Six12 underslug shotgun (magazine fed) 
* Loose shot and magazines can be loaded as usual

## Additional context

![image](https://github.com/user-attachments/assets/b1159334-c3f4-40df-85cf-546f5d558020)


Should there be another check if the parent item is a gun / gunmod, instead of just checking if the magazine has a parent_item()? 
Since we don't have pockets on BN, i couldn't imagine a situation where that would not be the case.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
  - [ ] I have made sure to preserve the correct license for the ported content by adding a code or JSON comment to the ported sections indicating their original license
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
