### PR TITLE
fix: allows boarding up both domestic window frame and empty domestic window

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -654,6 +654,19 @@
   },
   {
     "type": "construction",
+    "id": "constr_window_boarded_noglass_empty_domestic",
+    "group": "board_up_window",
+    "//": "Board up empty window",
+    "category": "REINFORCE",
+    "required_skills": [ [ "fabrication", 0 ] ],
+    "time": "20 m",
+    "qualities": [ [ { "id": "HAMMER", "level": 2 } ] ],
+    "components": [ [ [ "2x4", 4 ] ], [ [ "nail", 8 ] ] ],
+    "pre_terrain": "t_window_empty_domestic",
+    "post_terrain": "t_window_boarded_noglass"
+  },
+  {
+    "type": "construction",
     "id": "constr_window_boarded_noglass_frame",
     "group": "board_up_window",
     "//": "Board up window frame only",
@@ -663,6 +676,19 @@
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ] ],
     "components": [ [ [ "2x4", 4 ] ], [ [ "nail", 8 ] ] ],
     "pre_terrain": "t_window_frame",
+    "post_terrain": "t_window_boarded_noglass"
+  },
+  {
+    "type": "construction",
+    "id": "constr_window_boarded_noglass_frame_domestic",
+    "group": "board_up_window",
+    "//": "Board up window frame only",
+    "category": "REINFORCE",
+    "required_skills": [ [ "fabrication", 0 ] ],
+    "time": "20 m",
+    "qualities": [ [ { "id": "HAMMER", "level": 2 } ] ],
+    "components": [ [ [ "2x4", 4 ] ], [ [ "nail", 8 ] ] ],
+    "pre_terrain": "t_window_frame_domestic",
     "post_terrain": "t_window_boarded_noglass"
   },
   {


### PR DESCRIPTION
Allows boarding up broken and empty domestic windows.

## Purpose of change (The Why)

resolves #5937
<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

Makes domestic window frame and empty domestic windows board-able. Move cost of domestic window frame was left as is since it matches window frame's move cost.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

## Testing

Replaced construction.json of my bn install with the modified one. Loaded into a world with evacuee start and followed the steps to reproduce found in #5937. Was able to board up the domestic windows (both with glass shards and without).
Also set fabrication to 3 to make sure the newly boarded windows could be reinforced (they can).
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
At least I think I did. Followed instructions for single file found in https://docs.cataclysmbn.org/en/mod/json/explanation/json_style/. Briefly opened a window but no message was shown. Hopefully it means the format was already ok.
- [x ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [x ] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
  - [ ] I have made sure to preserve the correct license for the ported content by adding a code or JSON comment to the ported sections indicating their original license
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
