### PR TITLE
fix: add GUTTER to "connects_to"

### DIFF
--- a/data/json/furniture_and_terrain/terrain-roofs.json
+++ b/data/json/furniture_and_terrain/terrain-roofs.json
@@ -49,7 +49,7 @@
     "color": "white",
     "move_cost": 3,
     "flags": [ "TRANSPARENT", "NOITEM", "THIN_OBSTACLE", "MOUNTABLE", "TINY", "AUTO_WALL_SYMBOL", "UNSTABLE" ],
-    "connects_to": "RAILING",
+    "connects_to": "GUTTER",
     "deconstruct": {
       "ter_set": "t_flat_roof",
       "items": [ { "item": "sheet_metal_small", "count": 2 }, { "item": "scrap", "count": [ 2, 3 ] } ]
@@ -73,7 +73,7 @@
     "color": "white",
     "move_cost": 3,
     "flags": [ "TRANSPARENT", "NOITEM", "THIN_OBSTACLE", "MOUNTABLE", "TINY", "AUTO_WALL_SYMBOL", "UNSTABLE", "CLIMBABLE" ],
-    "connects_to": "RAILING",
+    "connects_to": "GUTTER",
     "deconstruct": {
       "ter_set": "t_flat_roof",
       "items": [ { "item": "sheet_metal_small", "count": 2 }, { "item": "scrap", "count": [ 2, 3 ] } ]

--- a/doc/src/content/docs/en/mod/json/reference/json_info.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_info.md
@@ -3057,6 +3057,7 @@ Current values:
 - `WALL`
 - `WATER`
 - `WOODFENCE`
+- `GUTTER`
 
 Example: `-` , `|` , `X` and `Y` are terrain which share the same `connects_to` value. `O` does not
 have it. `X` and `Y` also have the `AUTO_WALL_SYMBOL` flag. `X` will be drawn as a T-intersection

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -215,6 +215,7 @@ static const std::unordered_map<std::string, ter_connects> ter_connects_map = { 
         { "WATER",                    TERCONN_WATER },
         { "PAVEMENT",                 TERCONN_PAVEMENT },
         { "RAIL",                     TERCONN_RAIL },
+        { "GUTTER",                     TERCONN_GUTTER },
         { "COUNTER",                     TERCONN_COUNTER },
     }
 };

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -331,6 +331,7 @@ enum ter_connects : int {
     TERCONN_WATER,
     TERCONN_PAVEMENT,
     TERCONN_RAIL,
+    TERCONN_GUTTER,
     TERCONN_COUNTER,
 };
 


### PR DESCRIPTION
## Purpose of change (The Why)
Add GUTTER to "connects_to" to prevent `t_gutter` and `t_gutter_drop` from connecting to terrain using the connects_to RAILING
## Describe the solution (The How)
Make the necessary changes to add GUTTER to the list of "connects_to"
Replace the "connects_to" of `t_gutter` and `t_gutter_drop` with GUTTER
## Describe alternatives you've considered
none
## Testing
I have no idea if this works or if it's the right approach, as my Visual Studio 2022 keeps failing to build a x64 release.
## Additional context

<details>
<summary>Screenshots:</summary>
<br>Before:
<br><a href="[https://github.com"><img src="https://github.com/user-attachments/assets/1a13ad2c-7571-47f0-b8ab-9f86556f8992"></a>
<br>After:
none
</details>

## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
- [X] I understand that, unless specified otherwise, [my contributions will fall under the AGPL v3.0 and/or CC-BY-SA 4.0 licenses](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/main/LICENSE.txt)

### Optional

- [X] This is a C++ PR that modifies JSON loading or behavior.
  - [X] I have documented the changes in the appropriate location in the `doc/` folder.