### PR TITLE
refactor: Make special attack code for monsters choose random special attacks instead of using order of insertion.

### DIFF
--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -772,14 +772,14 @@ void monster::move()
     // Special attack block code
     // First, from the special attack list, make a vector of usable special attacks.
     // TODO: Make code less clunky as it references both type->special_attacks and special_attacks.
-    std::vector < std::pair<const std::string, mtype_special_attack> > spec_attack_list;
+    std::vector < const std::pair< const std::string, mtype_special_attack> *> spec_attack_list;
 
     // Pacified creatures and hallucinations don't get options.
     if( !( pacified || is_hallucination() ) ) {
         for( const auto &sp_type : type->special_attacks ) {
             const auto sp_atk = special_attacks.find( sp_type.first )->second;
             if( sp_atk.enabled && sp_atk.cooldown == 0 ) {
-                spec_attack_list.push_back( sp_type );
+                spec_attack_list.push_back( &sp_type );
             }
         }
     }
@@ -792,7 +792,7 @@ void monster::move()
             int spec_iter = rng( 0, spec_attack_list.size() - 1 );
             const auto &sp_type = spec_attack_list[spec_iter];
 
-            if( sp_type.second->call( *this ) ) {
+            if( sp_type->second->call( *this ) ) {
                 sp_atk_used = true;
             } else {
                 // If not used, erase from list and try again.
@@ -803,8 +803,8 @@ void monster::move()
 
             // `special_attacks` might have changed at this point. Sadly `reset_special`
             // doesn't check the attack name, so we need to do it here.
-            if( special_attacks.contains( sp_type.first ) ) {
-                reset_special( sp_type.first );
+            if( special_attacks.contains( sp_type->first ) ) {
+                reset_special( sp_type->first );
             }
         }
     }

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -769,35 +769,43 @@ void monster::move()
 
     const bool pacified = has_effect( effect_pacified );
 
-    // First, use the special attack, if we can!
-    // The attack may change `monster::special_attacks` (e.g. by transforming
-    // this into another monster type). Therefore we can not iterate over it
-    // directly and instead iterate over the map from the monster type
-    // (properties of monster types should never change).
-    for( const auto &sp_type : type->special_attacks ) {
-        const std::string &special_name = sp_type.first;
-        const auto local_iter = special_attacks.find( special_name );
-        if( local_iter == special_attacks.end() ) {
-            continue;
-        }
-        mon_special_attack &local_attack_data = local_iter->second;
-        if( !local_attack_data.enabled ) {
-            continue;
-        }
+    // Special attack block code
+    // First, from the special attack list, make a vector of usable special attacks.
+    // TODO: Make code less clunky as it references both type->special_attacks and special_attacks.
+    std::vector < std::pair<const std::string, mtype_special_attack> > spec_attack_list;
 
-        // Cooldowns are decremented in monster::process_turn
+    // Pacified creatures and hallucinations don't get options.
+    if( !( pacified || is_hallucination() ) ) {
+        for( const auto &sp_type : type->special_attacks ) {
+            const auto sp_atk = special_attacks.find( sp_type.first )->second;
+            if( sp_atk.enabled && sp_atk.cooldown == 0 ) {
+                spec_attack_list.push_back( sp_type );
+            }
+        }
+    }
+    // Next, if spec_attack_list is not empty, roll randomly to decide which is used.
+    if( !spec_attack_list.empty() ) {
+        bool sp_atk_used = false;
+        // If it turns out the attack can't actually be used, try again while list remains non-empty.
+        while( !sp_atk_used && !spec_attack_list.empty() ) {
+            // For size is 1 it just returns 0
+            int spec_iter = rng( 0, spec_attack_list.size() - 1 );
+            const auto &sp_type = spec_attack_list[spec_iter];
 
-        if( local_attack_data.cooldown == 0 && !pacified && !is_hallucination() ) {
-            if( !sp_type.second->call( *this ) ) {
+            if( sp_type.second->call( *this ) ) {
+                sp_atk_used = true;
+            } else {
+                // If not used, erase from list and try again.
+                // continue; used here to prevent reseting of special attack.
+                spec_attack_list.erase( spec_attack_list.begin() + spec_iter );
                 continue;
             }
 
             // `special_attacks` might have changed at this point. Sadly `reset_special`
             // doesn't check the attack name, so we need to do it here.
-            if( !special_attacks.contains( special_name ) ) {
-                continue;
+            if( special_attacks.contains( sp_type.first ) ) {
+                reset_special( sp_type.first );
             }
-            reset_special( special_name );
         }
     }
 


### PR DESCRIPTION
## Purpose of change (The Why)

- Saw Cataclysm-TLG/Cataclysm-TLG#457 and... figured we could use a version that appeals to my code aesthetics.
- To reiterate, the old method makes it so that special attacks are attempted in the order they are written into the special attacks entry.
  - This meant that your first entry's cooldown decided the maximum number of special attacks you could theoretically give a monster before the first move came off cooldown and rendered the later ones impossible to trigger.

## Describe the solution (The How)

- Redoes the way special attacks are selected.
  - First it creates a vector of valid monster special attacks.
  - Then it rolls a random option from the vector and tries it.
    - If the special attack fails, that option is removed from the list and we retry.

## Describe alternatives you've considered

- Porting it?
  - I... don't like the way it's written, I don't like the weird offset being used and I feel like `pacified` and `is_hallucination()` should be checked _long_ before we reach the part where we consider valid special attack options.

## Testing

- [x] Find a monster with a multitude of special attacks, set them all to CD 0 and watch the chaos.

## Additional context

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.