### PR TITLE
feat(UI): input history on (adv) inventory, and disassembly

### DIFF
--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1481,7 +1481,7 @@ void advanced_inventory::display()
             filter_edit = true;
             if( ui ) {
                 spopup = std::make_unique<string_input_popup>();
-                spopup->max_length( 256 ).text( filter );
+                spopup->max_length( 256 ).text( filter ).identifier( "adv_inv" );
                 ui->mark_resize();
             }
 

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -875,7 +875,7 @@ const recipe *select_crafting_recipe( int &batch_size_out )
             .description( description )
             .desc_color( c_light_gray )
             .identifier( "craft_recipe_filter" )
-            .hist_use_uilist( false )
+            .hist_use_uilist( true )
             .edit( filterstring );
             recalc = true;
         } else if( action == "QUIT" ) {

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -1559,7 +1559,7 @@ void inventory_selector::refresh_window() const
 void inventory_selector::set_filter()
 {
     spopup = std::make_unique<string_input_popup>();
-    spopup->max_length( 256 )
+    spopup->max_length( 256 ).identifier( "inventory" )
     .text( filter );
 
     shared_ptr_fast<ui_adaptor> current_ui = ui.lock();


### PR DESCRIPTION
## Purpose of change (The Why)

Advanced Inventory Manager doesn't currently have filter history. The crafting filter's history scroll method is inefficient and doesn't allow entries to be removed.

## Describe the solution (The How)

Added an identifier for the AIM filter string_input_popup which enables history. Changed the crafting filter's string_input_popup's hist_use_uilist value.

## Describe alternatives you've considered

Not doing things efficiently?

## Testing

Tested in game that the filters were working as expected.

## Additional context
![image](https://github.com/user-attachments/assets/f3fc7963-2653-45fe-bbb6-fc8b4b686918)
![image](https://github.com/user-attachments/assets/1755486f-fc61-47b0-954e-d0659b71581f)



## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
