### PR TITLE
feat(UI): Maps now can be (re)used to display a nearby eligible revealed overmap tile

### DIFF
--- a/doc/src/content/docs/en/mod/json/reference/json_info.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_info.md
@@ -2439,8 +2439,8 @@ more structured function.
     "type": "reveal_map", // reveal specific terrains on the overmap
     "radius": 180, // radius around the player where things are revealed. A single overmap is 180x180 tiles.
     "terrain": ["s_gun", "hiway", "road"], // ids of overmap terrain types that should be revealed (as many as you want).
-	"terrain_view": ["s_gun"], // (optional) ids of overmap terrain types that should be shown on a prompt after using the map (as many as you want, ideally a subset of terrain).
-	"terrain_view_exclude": ["hiway", "road"], // (optional) ids of overmap terrain types that should NOT be shown on the prompt after using the map (as many as you want, ideally a subset of terrain_view).
+    "terrain_view": ["s_gun"], // (optional) ids of overmap terrain types that should be shown on a prompt after using the map (as many as you want, ideally a subset of terrain).
+    "terrain_view_exclude": ["hiway", "road"], // (optional) ids of overmap terrain types that should NOT be shown on the prompt after using the map (as many as you want, ideally a subset of terrain_view).
     "message": "You add roads and tourist attractions to your map." // Displayed after the revelation.
 },
 "use_action": {

--- a/doc/src/content/docs/en/mod/json/reference/json_info.md
+++ b/doc/src/content/docs/en/mod/json/reference/json_info.md
@@ -2438,7 +2438,9 @@ more structured function.
 "use_action": {
     "type": "reveal_map", // reveal specific terrains on the overmap
     "radius": 180, // radius around the player where things are revealed. A single overmap is 180x180 tiles.
-    "terrain": ["hiway", "road"], // ids of overmap terrain types that should be revealed (as many as you want).
+    "terrain": ["s_gun", "hiway", "road"], // ids of overmap terrain types that should be revealed (as many as you want).
+	"terrain_view": ["s_gun"], // (optional) ids of overmap terrain types that should be shown on a prompt after using the map (as many as you want, ideally a subset of terrain).
+	"terrain_view_exclude": ["hiway", "road"], // (optional) ids of overmap terrain types that should NOT be shown on the prompt after using the map (as many as you want, ideally a subset of terrain_view).
     "message": "You add roads and tourist attractions to your map." // Displayed after the revelation.
 },
 "use_action": {

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1484,6 +1484,7 @@ int reveal_map_actor::use( player &p, item &it, bool, const tripoint & ) const
         p.add_msg_if_player( m_good, "%s", _( message ) );
     }
     it.mark_as_used_by_player( p );
+    show_revealed( plrPos, mapPos );
     return 0;
 }
 

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1424,7 +1424,7 @@ void reveal_map_actor::show_revealed( player &p, item &item, const tripoint_abs_
 
     // TODO: Cluster tripoints to collapse direct neighbor tiles (helipads, etc)?
 
-    auto sz = std::distance( eqRange.first, eqRange.second );
+    const auto sz = std::distance( eqRange.first, eqRange.second );
 
     // Shouldn't ever be hit, since multimap shouldn't have an entry with no overmap tiles, but
     if( sz == 0 ) {
@@ -1459,7 +1459,7 @@ void reveal_map_actor::show_revealed( player &p, item &item, const tripoint_abs_
             auto db = trig_dist_squared( plrPos.raw(), b.second.raw() );
             return da < db;
         };
-        auto it = std::min_element( eqRange.first, eqRange.second, pred_dist );
+        const auto it = std::min_element( eqRange.first, eqRange.second, pred_dist );
         ui::omap::choose_point( it->second );
     }
 

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -62,6 +62,8 @@
 #include "mutation.h"
 #include "options.h"
 #include "output.h"
+#include "omdata.h"
+#include "overmap_ui.h"
 #include "overmapbuffer.h"
 #include "player.h"
 #include "player_activity.h"
@@ -1305,25 +1307,163 @@ void reveal_map_actor::load( const JsonObject &obj )
         }
         omt_types.emplace_back( ter, ter_match_type );
     }
+    if( obj.has_array( "terrain_view" ) ) {
+        for( const JsonValue entry : obj.get_array( "terrain_view" ) ) {
+            if( entry.test_string() ) {
+                ter = entry.get_string();
+                ter_match_type = ot_match_type::contains;
+            } else {
+                JsonObject jo = entry.get_object();
+                ter = jo.get_string( "om_terrain" );
+                ter_match_type = jo.get_enum_value<ot_match_type>( "om_terrain_match_type",
+                                 ot_match_type::contains );
+            }
+            omt_types_view.emplace_back( ter, ter_match_type );
+        }
+    } else {
+        omt_types_view = omt_types;
+    }
+    if( obj.has_array( "terrain_view_exclude" ) ) {
+        for( const JsonValue entry : obj.get_array( "terrain_view_exclude" ) ) {
+            if( entry.test_string() ) {
+                ter = entry.get_string();
+                ter_match_type = ot_match_type::contains;
+            } else {
+                JsonObject jo = entry.get_object();
+                ter = jo.get_string( "om_terrain" );
+                ter_match_type = jo.get_enum_value<ot_match_type>( "om_terrain_match_type",
+                                 ot_match_type::contains );
+            }
+            omt_types_view_exclude.emplace_back( ter, ter_match_type );
+        }
+    } else {
+        omt_types_view_exclude.emplace_back( "subway", ot_match_type::contains );
+        omt_types_view_exclude.emplace_back( "hiway", ot_match_type::contains );
+        omt_types_view_exclude.emplace_back( "road", ot_match_type::contains );
+        omt_types_view_exclude.emplace_back( "forest_trail", ot_match_type::contains );
+        omt_types_view_exclude.emplace_back( "bridge", ot_match_type::contains );
+        omt_types_view_exclude.emplace_back( "roof", ot_match_type::contains );
+    };
 }
 
-void reveal_map_actor::reveal_targets( const tripoint_abs_omt &center,
-                                       const std::pair<std::string, ot_match_type> &target,
-                                       int reveal_distance ) const
+void reveal_map_actor::reveal_targets( const tripoint_abs_omt &plr,
+                                       const tripoint_abs_omt &map ) const
 {
-    const auto places = overmap_buffer.find_all( center, target.first, radius, false,
-                        target.second );
-    for( auto &place : places ) {
-        overmap_buffer.reveal( place, reveal_distance );
+    omt_find_params params{};
+    params.search_range = radius;
+    params.types = omt_types;
+    params.must_see = false;
+    params.existing_only = false;
+
+    for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; z++ ) {
+        const auto places = overmap_buffer.find_all( tripoint_abs_omt( map.xy(), z ), params );
+        for( auto &place : places ) {
+            overmap_buffer.reveal( place, 0 );
+        }
     }
+}
+
+void reveal_map_actor::show_revealed( const tripoint_abs_omt &plr,
+                                      const tripoint_abs_omt &map ) const
+{
+    omt_find_params params{};
+    params.search_range = radius;
+    params.types = omt_types_view;
+    params.must_see = false;
+    params.existing_only = true;
+
+    const auto should_show = [&]( const tripoint_abs_omt & pt ) {
+        if( overmap_buffer.is_explored( pt ) ) {
+            return false;
+        }
+
+        const auto pred = [&]( const std::pair<std::string, ot_match_type> &x ) {
+            return overmap_buffer.check_ot_existing( x.first, x.second, pt );
+        };
+
+        if( std::any_of( omt_types_view_exclude.cbegin(), omt_types_view_exclude.cend(), pred ) ) {
+            return false;
+        }
+
+        return true;
+    };
+
+    std::vector<tripoint_abs_omt> places ;
+    for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; z++ ) {
+        const auto tmp = overmap_buffer.find_all( tripoint_abs_omt( map.xy(), z ), params );
+        std::copy_if( tmp.cbegin(), tmp.cend(), std::back_inserter( places ), should_show );
+    }
+
+    // Group tiles by name
+    std::multimap<std::string, tripoint_abs_omt> mm;
+    std::set<std::string> utypes;
+    for( auto &place : places ) {
+        auto desc = overmap_buffer.ter( place ).id().obj().get_name();
+        mm.insert( { desc, place } );
+        utypes.insert( desc );
+    }
+
+    // Show selector for each group
+    std::vector<std::string> otypes( utypes.begin(), utypes.end() );
+    uilist ui;
+    for( auto i = 0; i < otypes.size(); ++i ) {
+        auto &desc = otypes[i];
+        ui.addentry( i, true, MENU_AUTOASSIGN, string_format( "%s (%d)", desc, mm.count( desc ) ) );
+    }
+    ui.query();
+
+    if( ui.ret < 0 ) {
+        return;
+    }
+
+    auto it = mm.equal_range( otypes[ui.ret] );
+
+    // TODO: Cluster tripoints to collapse direct neighbor tiles (helipads, etc)?
+
+    auto sz = std::distance( it.first, it.second );
+
+    // Shouldn't ever be hit, since multimap shouldn't have an entry with no overmap tiles, but
+    if( sz == 0 ) {
+        return;
+    }
+
+    // Only one overmap tile of type
+    if( sz == 1 ) {
+        ui::omap::choose_point( it.first->second );
+        return;
+    }
+
+    ui.reset();
+    ui.addentry( 0, true, 'c', _( "Closest" ) );
+    ui.addentry( 1, true, 'r', _( "Random" ) );
+    ui.query();
+
+    if( ui.ret < 0 ) {
+        return;
+    }
+
+    if( ui.ret == 1 ) {
+        // Pick random
+        auto iter = it.first;
+        std::advance( iter, rng( 0, sz - 1 ) );
+        ui::omap::choose_point( iter->second );
+    } else {
+        // Pick closest
+        const auto pred_dist = [&]( const std::pair<std::string, tripoint_abs_omt> &a,
+        const std::pair<std::string, tripoint_abs_omt> &b ) {
+            auto da = trig_dist_squared( plr.raw(), a.second.raw() );
+            auto db = trig_dist_squared( plr.raw(), b.second.raw() );
+            return da < db;
+        };
+        auto iter = std::min_element( it.first, it.second, pred_dist );
+        ui::omap::choose_point( iter->second );
+    }
+
 }
 
 int reveal_map_actor::use( player &p, item &it, bool, const tripoint & ) const
 {
-    if( it.already_used_by_player( p ) ) {
-        p.add_msg_if_player( _( "There isn't anything new on the %s." ), it.tname() );
-        return 0;
-    } else if( g->get_levz() < 0 ) {
+    if( !it.already_used_by_player( p ) && g->get_levz() < 0 ) {
         p.add_msg_if_player( _( "You should read your %s when you get to the surface." ),
                              it.tname() );
         return 0;
@@ -1331,13 +1471,15 @@ int reveal_map_actor::use( player &p, item &it, bool, const tripoint & ) const
         p.add_msg_if_player( _( "It's too dark to read." ) );
         return 0;
     }
-    const tripoint_abs_omt center( it.get_var( "reveal_map_center_omt",
-                                   p.global_omt_location().raw() ) );
-    for( auto &omt : omt_types ) {
-        for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; z++ ) {
-            reveal_targets( tripoint_abs_omt( center.xy(), z ), omt, 0 );
-        }
+    const tripoint_abs_omt plrPos = p.global_omt_location();
+    const tripoint_abs_omt mapPos( it.get_var( "reveal_map_center_omt", plrPos.raw() ) );
+
+    if( it.already_used_by_player( p ) ) {
+        show_revealed( plrPos, mapPos );
+        return 0;
     }
+
+    reveal_targets( plrPos, mapPos );
     if( !message.empty() ) {
         p.add_msg_if_player( m_good, "%s", _( message ) );
     }

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -491,13 +491,18 @@ class reveal_map_actor : public iuse_actor
          */
         std::vector<std::pair<std::string, ot_match_type>> omt_types;
         /**
+        * Overmap terrain types that get listed (or excluded) on a used map.
+        */
+        std::vector<std::pair<std::string, ot_match_type>> omt_types_view;
+        std::vector<std::pair<std::string, ot_match_type>> omt_types_view_exclude;
+        /**
          * The message displayed after revealing.
          */
         std::string message;
 
-        void reveal_targets(
-            const tripoint_abs_omt &center, const std::pair<std::string, ot_match_type> &target,
-            int reveal_distance ) const;
+        void reveal_targets( const tripoint_abs_omt &plr, const tripoint_abs_omt &map ) const;
+
+        void show_revealed( const tripoint_abs_omt &plr, const tripoint_abs_omt &map ) const;
 
         reveal_map_actor( const std::string &type = "reveal_map" ) : iuse_actor( type ) {}
 

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -500,9 +500,9 @@ class reveal_map_actor : public iuse_actor
          */
         std::string message;
 
-        void reveal_targets( const tripoint_abs_omt &plr, const tripoint_abs_omt &map ) const;
+        void reveal_targets( const tripoint_abs_omt &map ) const;
 
-        void show_revealed( const tripoint_abs_omt &plr, const tripoint_abs_omt &map ) const;
+        void show_revealed( player &plr, item &, const tripoint_abs_omt &map ) const;
 
         reveal_map_actor( const std::string &type = "reveal_map" ) : iuse_actor( type ) {}
 


### PR DESCRIPTION
## Purpose of change (The Why)

Maps (and used maps by extension) are in a weird situation:
* Reading a map reveals the terrain, but you have no idea of what got revealed.
* A previously read map is useless.

## Describe the solution (The How)

This PR makes so that when using a map, and subsequent usages of said map, a prompt is shown to display a non-explored, revealed, eligible overmap tile centered around the map reveal origin and range.

This also introduces *optional* JSON changes for the map iuse_actor, to refine the prompt, in the form of two fields, similar to the existing `terrain` one:
* `terrain_view`: what kind of terrain should be shown on the prompt
    *  Defaults to the same as `terrain` if undefined.
* `terrain_view_exclude`: what kind of terrain should NOT be shown on the prompt.
    * Defaults to `subway`, `hiway`, `road`, `forest_trail`, `bridge`, `roof` if undefined.

## Testing

Load into game.
Spawn any kind of map.
Use it.
Select a tile kind and mark it as (E)xplored
Use it again, map should show one less item than before.
Fully (E)xploring a group of tiles should remove it from the menu.
Fully (E)xploring all the tiles on a map should say there's nothing new on usage, like a used map before this PR.

## Additional context

Ideally I'd rather show the revealed (groups) of tiles similar to the overmap search, but that would require a lot of refactoring on the overmap UI to allow for opening the map with a set of tripoints to iterate through, so the second best thing is showing a random or nearby location instead.

![image](https://github.com/user-attachments/assets/7d882102-b4ae-4a16-9ad6-4292a2d599d2)
![image](https://github.com/user-attachments/assets/4eeee7c6-9c85-4ee7-b829-3f9e9218c4c3)

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `doc/` folder.
