### PR TITLE
refactor: cleanup inventory / location_inventory classes, fix invlet issues along with it

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1296,7 +1296,7 @@ static bool are_requirements_nearby( const std::vector<tripoint> &loot_spots,
         if( elem->has_quality( qual_WELD ) ) {
             found_welder = true;
         }
-        temp_inv.add_item_keep_invlet(*elem);
+        temp_inv.add_item(*elem, true);
     }
     map &here = get_map();
     for( const tripoint &elem : loot_spots ) {
@@ -1323,7 +1323,7 @@ static bool are_requirements_nearby( const std::vector<tripoint> &loot_spots,
                     continue;
                 }
             }
-            temp_inv.add_item_keep_invlet(*elem2);
+            temp_inv.add_item(*elem2, true);
         }
         if( !in_loot_zones ) {
             if( const std::optional<vpart_reference> vp = here.veh_at( elem ).part_with_feature( "CARGO",
@@ -1331,7 +1331,7 @@ static bool are_requirements_nearby( const std::vector<tripoint> &loot_spots,
                 vehicle &src_veh = vp->vehicle();
                 int src_part = vp->part_index();
                 for( auto &it : src_veh.get_items( src_part ) ) {
-                    temp_inv.add_item_keep_invlet(*it);
+                    temp_inv.add_item(*it, true);
                 }
             }
         }

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1296,7 +1296,7 @@ static bool are_requirements_nearby( const std::vector<tripoint> &loot_spots,
         if( elem->has_quality( qual_WELD ) ) {
             found_welder = true;
         }
-        temp_inv.add_item(*elem, true);
+        temp_inv.add_item( *elem, true );
     }
     map &here = get_map();
     for( const tripoint &elem : loot_spots ) {
@@ -1323,7 +1323,7 @@ static bool are_requirements_nearby( const std::vector<tripoint> &loot_spots,
                     continue;
                 }
             }
-            temp_inv.add_item(*elem2, true);
+            temp_inv.add_item( *elem2, true );
         }
         if( !in_loot_zones ) {
             if( const std::optional<vpart_reference> vp = here.veh_at( elem ).part_with_feature( "CARGO",
@@ -1331,7 +1331,7 @@ static bool are_requirements_nearby( const std::vector<tripoint> &loot_spots,
                 vehicle &src_veh = vp->vehicle();
                 int src_part = vp->part_index();
                 for( auto &it : src_veh.get_items( src_part ) ) {
-                    temp_inv.add_item(*it, true);
+                    temp_inv.add_item( *it, true );
                 }
             }
         }

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1347,12 +1347,12 @@ static bool are_requirements_nearby( const std::vector<tripoint> &loot_spots,
                     item *welder = item::spawn_temporary( itype_welder, calendar::start_of_cataclysm );
                     welder->charges = veh.fuel_left( itype_battery, true );
                     welder->set_flag( flag_PSEUDO );
-                    temp_inv.add_item( *welder );
+                    temp_inv.add_item( *welder, false );
                     item *soldering_iron = item::spawn_temporary( itype_soldering_iron,
                                            calendar::start_of_cataclysm );
                     soldering_iron->charges = veh.fuel_left( itype_battery, true );
                     soldering_iron->set_flag( flag_PSEUDO );
-                    temp_inv.add_item( *soldering_iron );
+                    temp_inv.add_item( *soldering_iron, false );
                 }
             }
         }

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1296,7 +1296,7 @@ static bool are_requirements_nearby( const std::vector<tripoint> &loot_spots,
         if( elem->has_quality( qual_WELD ) ) {
             found_welder = true;
         }
-        temp_inv += *elem;
+        temp_inv.add_item_keep_invlet(*elem);
     }
     map &here = get_map();
     for( const tripoint &elem : loot_spots ) {
@@ -1323,7 +1323,7 @@ static bool are_requirements_nearby( const std::vector<tripoint> &loot_spots,
                     continue;
                 }
             }
-            temp_inv += *elem2;
+            temp_inv.add_item_keep_invlet(*elem2);
         }
         if( !in_loot_zones ) {
             if( const std::optional<vpart_reference> vp = here.veh_at( elem ).part_with_feature( "CARGO",
@@ -1331,7 +1331,7 @@ static bool are_requirements_nearby( const std::vector<tripoint> &loot_spots,
                 vehicle &src_veh = vp->vehicle();
                 int src_part = vp->part_index();
                 for( auto &it : src_veh.get_items( src_part ) ) {
-                    temp_inv += *it;
+                    temp_inv.add_item_keep_invlet(*it);
                 }
             }
         }

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1252,7 +1252,7 @@ bool avatar::wield( item &target )
     target.on_wield( *this, mv );
 
     inv.update_invlet( target );
-    inv.update_cache_with_item( target );
+    inv.update_invlet_cache_with_item( target );
 
     return true;
 }
@@ -1281,7 +1281,7 @@ detached_ptr<item> avatar::wield( detached_ptr<item> &&target )
 
 
     inv.update_invlet( obj );
-    inv.update_cache_with_item( obj );
+    inv.update_invlet_cache_with_item( obj );
     return detached_ptr<item>();
 }
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3396,7 +3396,7 @@ bool Character::takeoff( item &it, std::vector<detached_ptr<item>> *res )
         ( *iter )->on_takeoff( *this );
         detached_ptr<item> det;
         worn.erase( iter, &det );
-        inv.add_item_keep_invlet( std::move( det ) );
+        inv.add_item( std::move( det ), true );
     } else {
         ( *iter )->on_takeoff( *this );
         detached_ptr<item> det;
@@ -7673,7 +7673,7 @@ detached_ptr<item> Character::dispose_item( detached_ptr<item> &&obj, const std:
             }
 
             moves -= item_handling_cost( *obj );
-            inv.add_item_keep_invlet( std::move( obj ) );
+            inv.add_item( std::move( obj ), true );
             inv.unsort();
             return detached_ptr<item>();
         }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2400,7 +2400,7 @@ detached_ptr<item> Character::wear_item( detached_ptr<item> &&wear,
     to_wear.on_wear( *this );
 
     inv.update_invlet( to_wear );
-    inv.update_cache_with_item( to_wear );
+    inv.update_invlet_cache_with_item( to_wear );
 
     recalc_sight_limits();
     reset_encumbrance();
@@ -2418,7 +2418,7 @@ void Character::add_worn( detached_ptr<item> &&wear )
     worn.insert( pos, std::move( wear ) );
     to_wear.on_wear( *this );
     inv.update_invlet( to_wear );
-    inv.update_cache_with_item( to_wear );
+    inv.update_invlet_cache_with_item( to_wear );
     recalc_sight_limits();
     reset_encumbrance();
 }
@@ -2666,9 +2666,9 @@ void Character::inv_update_invlet( item &it )
     inv.update_invlet( it );
 }
 
-void Character::inv_update_cache_with_item( item &it )
+void Character::inv_update_invlet_cache_with_item( item &it )
 {
-    inv.update_cache_with_item( it );
+    inv.update_invlet_cache_with_item( it );
 }
 
 std::map<char, itype_id> &Character::inv_assigned_invlet()

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3927,15 +3927,15 @@ void Character::die( Creature *nkiller )
     set_killer( nkiller );
     set_time_died( calendar::turn );
     if( has_effect( effect_lightsnare ) ) {
-        inv.add_item( item::spawn( itype_string_36, calendar::start_of_cataclysm ) );
-        inv.add_item( item::spawn( itype_snare_trigger, calendar::start_of_cataclysm ) );
+        inv.add_item( item::spawn( itype_string_36, calendar::start_of_cataclysm ), false );
+        inv.add_item( item::spawn( itype_snare_trigger, calendar::start_of_cataclysm ), false );
     }
     if( has_effect( effect_heavysnare ) ) {
-        inv.add_item( item::spawn( itype_rope_6, calendar::start_of_cataclysm ) );
-        inv.add_item( item::spawn( itype_snare_trigger, calendar::start_of_cataclysm ) );
+        inv.add_item( item::spawn( itype_rope_6, calendar::start_of_cataclysm ), false );
+        inv.add_item( item::spawn( itype_snare_trigger, calendar::start_of_cataclysm ), false );
     }
     if( has_effect( effect_beartrap ) ) {
-        inv.add_item( item::spawn( itype_beartrap, calendar::start_of_cataclysm ) );
+        inv.add_item( item::spawn( itype_beartrap, calendar::start_of_cataclysm ), false );
     }
     mission::on_creature_death( *this );
 }

--- a/src/character.h
+++ b/src/character.h
@@ -1241,7 +1241,7 @@ class Character : public Creature, public location_visitable<Character>
 
         int inv_position_by_item( item *it ) const;
 
-        void inv_update_cache_with_item( item &it );
+        void inv_update_invlet_cache_with_item( item &it );
 
         int inv_invlet_to_position( char invlet ) const;
 

--- a/src/character_functions.cpp
+++ b/src/character_functions.cpp
@@ -580,7 +580,7 @@ bool try_wield_contents( Character &who, item &container, item *internal_item, b
 
     who.set_primary_weapon( internal_item->detach() );
     who.inv_update_invlet( *internal_item );
-    who.inv_update_cache_with_item( *internal_item );
+    who.inv_update_invlet_cache_with_item( *internal_item );
     who.last_item = internal_item->typeId();
 
     /**

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -553,20 +553,18 @@ const inventory &Character::crafting_inventory( const tripoint &src_pos, int rad
         return cached_crafting_inventory;
     }
     cached_crafting_inventory.form_from_map( inv_pos, radius, this, false, clear_path );
-    cached_crafting_inventory += inv;
-    cached_crafting_inventory += primary_weapon();
-    cached_crafting_inventory += worn;
+    cached_crafting_inventory.add_items(inv, true);
+    cached_crafting_inventory.add_item_keep_invlet(primary_weapon());
+    cached_crafting_inventory.add_items(worn, true);
     for( const bionic &bio : *my_bionics ) {
         const bionic_data &bio_data = bio.info();
-        if( ( !bio_data.has_flag( flag_BIONIC_TOGGLED ) || bio.powered ) &&
-            !bio_data.fake_item.is_empty() ) {
-            cached_crafting_inventory += *item::spawn_temporary( bio.info().fake_item,
-                                         calendar::turn, units::to_kilojoule( get_power_level() ) );
+        if( ( !bio_data.has_flag( flag_BIONIC_TOGGLED ) || bio.powered ) && !bio_data.fake_item.is_empty() ) {
+            cached_crafting_inventory.add_item_keep_invlet(*item::spawn_temporary(bio.info().fake_item, calendar::turn, units::to_kilojoule(get_power_level())));
         }
     }
     if( has_trait( trait_BURROW ) ) {
-        cached_crafting_inventory += *item::spawn_temporary( "pickaxe", calendar::turn );
-        cached_crafting_inventory += *item::spawn_temporary( "shovel", calendar::turn );
+        cached_crafting_inventory.add_item_keep_invlet(*item::spawn_temporary("pickaxe", calendar::turn));
+        cached_crafting_inventory.add_item_keep_invlet(*item::spawn_temporary("shovel", calendar::turn));
     }
 
     cached_moves = moves;

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -553,18 +553,20 @@ const inventory &Character::crafting_inventory( const tripoint &src_pos, int rad
         return cached_crafting_inventory;
     }
     cached_crafting_inventory.form_from_map( inv_pos, radius, this, false, clear_path );
-    cached_crafting_inventory.add_items(inv, true);
-    cached_crafting_inventory.add_item(primary_weapon(), true);
-    cached_crafting_inventory.add_items(worn, true);
+    cached_crafting_inventory.add_items( inv, true );
+    cached_crafting_inventory.add_item( primary_weapon(), true );
+    cached_crafting_inventory.add_items( worn, true );
     for( const bionic &bio : *my_bionics ) {
         const bionic_data &bio_data = bio.info();
-        if( ( !bio_data.has_flag( flag_BIONIC_TOGGLED ) || bio.powered ) && !bio_data.fake_item.is_empty() ) {
-            cached_crafting_inventory.add_item(*item::spawn_temporary(bio.info().fake_item, calendar::turn, units::to_kilojoule(get_power_level())), true);
+        if( ( !bio_data.has_flag( flag_BIONIC_TOGGLED ) || bio.powered ) &&
+            !bio_data.fake_item.is_empty() ) {
+            cached_crafting_inventory.add_item( *item::spawn_temporary( bio.info().fake_item, calendar::turn,
+                                                units::to_kilojoule( get_power_level() ) ), true );
         }
     }
     if( has_trait( trait_BURROW ) ) {
-        cached_crafting_inventory.add_item(*item::spawn_temporary("pickaxe", calendar::turn), true);
-        cached_crafting_inventory.add_item(*item::spawn_temporary("shovel", calendar::turn), true);
+        cached_crafting_inventory.add_item( *item::spawn_temporary( "pickaxe", calendar::turn ), true );
+        cached_crafting_inventory.add_item( *item::spawn_temporary( "shovel", calendar::turn ), true );
     }
 
     cached_moves = moves;

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -554,17 +554,17 @@ const inventory &Character::crafting_inventory( const tripoint &src_pos, int rad
     }
     cached_crafting_inventory.form_from_map( inv_pos, radius, this, false, clear_path );
     cached_crafting_inventory.add_items(inv, true);
-    cached_crafting_inventory.add_item_keep_invlet(primary_weapon());
+    cached_crafting_inventory.add_item(primary_weapon(), true);
     cached_crafting_inventory.add_items(worn, true);
     for( const bionic &bio : *my_bionics ) {
         const bionic_data &bio_data = bio.info();
         if( ( !bio_data.has_flag( flag_BIONIC_TOGGLED ) || bio.powered ) && !bio_data.fake_item.is_empty() ) {
-            cached_crafting_inventory.add_item_keep_invlet(*item::spawn_temporary(bio.info().fake_item, calendar::turn, units::to_kilojoule(get_power_level())));
+            cached_crafting_inventory.add_item(*item::spawn_temporary(bio.info().fake_item, calendar::turn, units::to_kilojoule(get_power_level())), true);
         }
     }
     if( has_trait( trait_BURROW ) ) {
-        cached_crafting_inventory.add_item_keep_invlet(*item::spawn_temporary("pickaxe", calendar::turn));
-        cached_crafting_inventory.add_item_keep_invlet(*item::spawn_temporary("shovel", calendar::turn));
+        cached_crafting_inventory.add_item(*item::spawn_temporary("pickaxe", calendar::turn), true);
+        cached_crafting_inventory.add_item(*item::spawn_temporary("shovel", calendar::turn), true);
     }
 
     cached_moves = moves;

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -1,4 +1,3 @@
-#pragma optimize("", off)
 #include "inventory.h"
 
 #include <climits>
@@ -344,12 +343,6 @@ item &inventory::add_item_by_items_type_cache( item &newit, bool keep_invlet, bo
     items_type_cache[type].push_back( &items.back() );
     return *items.back().back();
 }
-
-void inventory::add_item_keep_invlet( item &newit )
-{
-    add_item( newit, true );
-}
-
 
 #if defined(__ANDROID__)
 extern void remove_stale_inventory_quick_shortcuts();
@@ -1450,7 +1443,7 @@ void location_inventory::add_item_keep_invlet( detached_ptr<item> &&newit )
 
     newit.release();
     as_p->set_location( &*loc );
-    return inv.add_item_keep_invlet( *as_p );
+    inv.add_item( *as_p, true );
 }
 
 void location_inventory::restack( player &p )

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -1,3 +1,4 @@
+#pragma optimize("", off)
 #include "inventory.h"
 
 #include <climits>
@@ -1352,26 +1353,15 @@ void location_inventory::clear()
     return inv.clear();
 }
 
-void location_inventory::push_back( std::vector<detached_ptr<item>> &newits )
+
+void location_inventory::add_items(std::vector<detached_ptr<item>>& newits, bool keep_invlet, bool assign_invlet, bool should_stack)
 {
     for( detached_ptr<item> &it : newits ) {
-        if( !it ) {
-            continue;
-        }
-        item *as_p = it.release();
-        if( &*loc == as_p->saved_loc ) {
-            as_p->saved_loc = nullptr;
-            as_p->set_location( &*loc );
-        } else {
-            as_p->resolve_saved_loc();
-            as_p->set_location( &*loc );
-            inv.add_item(*as_p, true);
-        }
+        add_item(std::move(it), keep_invlet, assign_invlet, should_stack);
     }
 }
 
-item &location_inventory::add_item( detached_ptr<item> &&newit, bool keep_invlet,
-                                    bool assign_invlet, bool should_stack )
+item &location_inventory::add_item( detached_ptr<item> &&newit, bool keep_invlet, bool assign_invlet, bool should_stack )
 {
     if( !newit ) {
         return null_item_reference();
@@ -1461,25 +1451,6 @@ void location_inventory::add_item_keep_invlet( detached_ptr<item> &&newit )
     newit.release();
     as_p->set_location( &*loc );
     return inv.add_item_keep_invlet( *as_p );
-}
-
-void location_inventory::push_back( detached_ptr<item> &&newit )
-{
-    if( !newit ) {
-        return;
-    }
-
-    item *as_p = newit.release();
-    if( &*loc == as_p->saved_loc ) {
-        as_p->saved_loc = nullptr;
-        as_p->set_location( &*loc );
-        return;
-    }
-
-    as_p->resolve_saved_loc();
-    as_p->set_location( &*loc );
-    
-    inv.add_item( *as_p, true );
 }
 
 void location_inventory::restack( player &p )

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -218,7 +218,7 @@ inventory& inventory::add_items(const location_vector<item>& rhs, bool keep_invl
 }
 
 // This function keeps the invlet cache updated when a new item is added.
-void inventory::update_cache_with_item( item &newit )
+void inventory::update_invlet_cache_with_item( item &newit )
 {
     // This function does two things:
     // 1. It adds newit's invlet to the list of favorite letters for newit's item type.
@@ -271,7 +271,7 @@ namespace
                 if (!keep_invlet) {
                     inv.update_invlet(newit, assign_invlet);
                 }
-                inv.update_cache_with_item(newit);
+                inv.update_invlet_cache_with_item(newit);
                 it->invlet = newit.invlet;
             } else {
                 newit.invlet = it->invlet;
@@ -325,7 +325,7 @@ item& inventory::add_item_internal(item& newit, bool keep_invlet, bool assign_in
     if( !keep_invlet ) {
         update_invlet( newit, assign_invlet );
     }
-    update_cache_with_item( newit );
+    update_invlet_cache_with_item( newit );
 
     items.push_back( {&newit} );
 
@@ -1215,7 +1215,7 @@ void inventory::reassign_item( item &it, char invlet, bool remove_old )
         invlet_cache.erase( it.invlet );
     }
     it.invlet = invlet;
-    update_cache_with_item( it );
+    update_invlet_cache_with_item( it );
 }
 
 void inventory::update_invlet( item &newit, bool assign_invlet )
@@ -1545,9 +1545,9 @@ const itype_bin &location_inventory::get_binned_items() const
     return inv.get_binned_items();
 }
 
-void location_inventory::update_cache_with_item( item &newit )
+void location_inventory::update_invlet_cache_with_item( item &newit )
 {
-    return inv.update_cache_with_item( newit );
+    return inv.update_invlet_cache_with_item( newit );
 }
 
 enchantment location_inventory::get_active_enchantment_cache( const Character &owner ) const

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -1417,34 +1417,6 @@ item &location_inventory::add_item_by_items_type_cache( detached_ptr<item> &&new
     as_p->set_location( &*loc );
     return inv.add_item_by_items_type_cache( *as_p, keep_invlet, assign_invlet, should_stack );
 }
-void location_inventory::add_item_keep_invlet( detached_ptr<item> &&newit )
-{
-    if( !newit ) {
-        return;
-    }
-    item *as_p = &*newit;
-    if( &*loc == as_p->saved_loc ) {
-        newit.release();
-        as_p->saved_loc = nullptr;
-        as_p->set_location( &*loc );
-        return;
-    }
-
-    as_p->resolve_saved_loc();
-    for( auto &elem : inv.items ) {
-        item *&it = *elem.begin();
-        // NOLINTNEXTLINE(bugprone-use-after-move)
-        if( it->stacks_with( *newit ) ) {
-            if( it->merge_charges( std::move( newit ) ) ) {
-                return;
-            }
-        }
-    }
-
-    newit.release();
-    as_p->set_location( &*loc );
-    inv.add_item( *as_p, true );
-}
 
 void location_inventory::restack( player &p )
 {

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -183,20 +183,20 @@ inventory& inventory::add_items(const inventory& rhs, bool keep_invlet, bool ass
     return *this;
 }
 
-inventory& inventory::add_items(const std::vector<item*>& rhs, bool keep_invlet, bool assign_invlet, bool should_stack)
-{
-    for( const auto &it : rhs ) {
-        add_item( *it, keep_invlet, assign_invlet, should_stack);
-    }
-    return *this;
-}
-
 inventory& inventory::add_items(const item_stack& rhs, bool keep_invlet, bool assign_invlet, bool should_stack)
 {
     for( const auto &it : rhs ) {
         if( !it->made_of( LIQUID ) ) {
             add_item( *it, keep_invlet, assign_invlet, should_stack );
         }
+    }
+    return *this;
+}
+
+inventory& inventory::add_items(const std::vector<item*>& rhs, bool keep_invlet, bool assign_invlet, bool should_stack)
+{
+    for( const auto &it : rhs ) {
+        add_item( *it, keep_invlet, assign_invlet, should_stack);
     }
     return *this;
 }

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -400,7 +400,7 @@ void inventory::restack( player &p )
 
     //re-add non-matching items
     for( auto &elem : to_restack ) {
-        add_item( *elem );
+        add_item( *elem, false );
     }
 
     //Ensure that all items in the same stack have the same invlet.
@@ -587,81 +587,81 @@ void inventory::form_from_map( map &m, std::vector<tripoint> pts, const Characte
             hotplate.item_tags.insert( flag_PSEUDO );
             // TODO: Allow disabling
             hotplate.item_tags.insert( flag_HEATS_FOOD );
-            add_item_by_items_type_cache( hotplate );
+            add_item_by_items_type_cache( hotplate, false );
 
             item &pot = *item::spawn_temporary( "pot", bday );
             pot.set_flag( flag_PSEUDO );
-            add_item_by_items_type_cache( pot );
+            add_item_by_items_type_cache( pot, false );
             item &pan = *item::spawn_temporary( "pan", bday );
             pan.set_flag( flag_PSEUDO );
-            add_item_by_items_type_cache( pan );
+            add_item_by_items_type_cache( pan, false );
             found_parts.insert( &*kpart );
         }
         if( weldpart && !found_parts.contains( &*weldpart ) ) {
             item &welder = *item::spawn_temporary( "welder", bday );
             welder.charges = veh->fuel_left( itype_battery, true );
             welder.item_tags.insert( flag_PSEUDO );
-            add_item_by_items_type_cache( welder );
+            add_item_by_items_type_cache( welder, false );
 
             item &soldering_iron = *item::spawn_temporary( "soldering_iron", bday );
             soldering_iron.charges = veh->fuel_left( itype_battery, true );
             soldering_iron.item_tags.insert( flag_PSEUDO );
-            add_item_by_items_type_cache( soldering_iron );
+            add_item_by_items_type_cache( soldering_iron, false );
             found_parts.insert( &*weldpart );
         }
         if( craftpart && !found_parts.contains( &*craftpart ) ) {
             item &vac_sealer = *item::spawn_temporary( "vac_sealer", bday );
             vac_sealer.charges = veh->fuel_left( itype_battery, true );
             vac_sealer.item_tags.insert( flag_PSEUDO );
-            add_item_by_items_type_cache( vac_sealer );
+            add_item_by_items_type_cache( vac_sealer, false );
 
             item &dehydrator = *item::spawn_temporary( "dehydrator", bday );
             dehydrator.charges = veh->fuel_left( itype_battery, true );
             dehydrator.item_tags.insert( flag_PSEUDO );
-            add_item_by_items_type_cache( dehydrator );
+            add_item_by_items_type_cache( dehydrator, false );
 
             item &food_processor = *item::spawn_temporary( "food_processor", bday );
             food_processor.charges = veh->fuel_left( itype_battery, true );
             food_processor.item_tags.insert( flag_PSEUDO );
-            add_item_by_items_type_cache( food_processor );
+            add_item_by_items_type_cache( food_processor, false );
 
             item &press = *item::spawn_temporary( "press", bday );
             press.charges = veh->fuel_left( itype_battery, true );
             press.set_flag( flag_PSEUDO );
-            add_item_by_items_type_cache( press );
+            add_item_by_items_type_cache( press, false );
             found_parts.insert( &*craftpart );
         }
         if( forgepart && !found_parts.contains( &*forgepart ) ) {
             item &forge = *item::spawn_temporary( "forge", bday );
             forge.charges = veh->fuel_left( itype_battery, true );
             forge.item_tags.insert( flag_PSEUDO );
-            add_item_by_items_type_cache( forge );
+            add_item_by_items_type_cache( forge, false );
             found_parts.insert( &*forgepart );
         }
         if( kilnpart && !found_parts.contains( &*kilnpart ) ) {
             item &kiln = *item::spawn_temporary( "kiln", bday );
             kiln.charges = veh->fuel_left( itype_battery, true );
             kiln.item_tags.insert( flag_PSEUDO );
-            add_item_by_items_type_cache( kiln );
+            add_item_by_items_type_cache( kiln, false );
             found_parts.insert( &*kilnpart );
         }
         if( chempart && !found_parts.contains( &*chempart ) ) {
             item &chemistry_set = *item::spawn_temporary( "chemistry_set", bday );
             chemistry_set.charges = veh->fuel_left( itype_battery, true );
             chemistry_set.item_tags.insert( flag_PSEUDO );
-            add_item_by_items_type_cache( chemistry_set );
+            add_item_by_items_type_cache( chemistry_set, false );
 
             item &electrolysis_kit = *item::spawn_temporary( "electrolysis_kit", bday );
             electrolysis_kit.charges = veh->fuel_left( itype_battery, true );
             electrolysis_kit.item_tags.insert( flag_PSEUDO );
-            add_item_by_items_type_cache( electrolysis_kit );
+            add_item_by_items_type_cache( electrolysis_kit, false );
             found_parts.insert( &*chempart );
         }
         if( autoclavepart && !found_parts.contains( &*autoclavepart ) ) {
             item &autoclave = *item::spawn_temporary( "autoclave", bday );
             autoclave.charges = veh->fuel_left( itype_battery, true );
             autoclave.item_tags.insert( flag_PSEUDO );
-            add_item_by_items_type_cache( autoclave );
+            add_item_by_items_type_cache( autoclave, false );
             found_parts.insert( &*autoclavepart );
         }
     }

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -157,69 +157,6 @@ size_t inventory::size() const
     return items.size();
 }
 
-inventory &inventory::operator+= ( const inventory &rhs )
-{
-    for( size_t i = 0; i < rhs.size(); i++ ) {
-        push_back( rhs.const_stack( i ) );
-    }
-    return *this;
-}
-
-inventory &inventory::operator+= ( const location_inventory &rhs )
-{
-    for( size_t i = 0; i < rhs.size(); i++ ) {
-        push_back( rhs.const_stack( i ) );
-    }
-    return *this;
-}
-
-inventory &inventory::operator+= ( const location_vector<item> &rhs )
-{
-    for( item * const &it : rhs ) {
-        add_item( *it, true );
-    }
-    return *this;
-}
-
-inventory &inventory::operator+= ( const std::vector<item *> &rhs )
-{
-    for( const auto &rh : rhs ) {
-        add_item( *rh, true );
-    }
-    return *this;
-}
-
-inventory &inventory::operator+= ( item &rhs )
-{
-    add_item( rhs );
-    return *this;
-}
-
-inventory &inventory::operator+= ( const item_stack &rhs )
-{
-    for( const auto &p : rhs ) {
-        if( !p->made_of( LIQUID ) ) {
-            add_item( *p, true );
-        }
-    }
-    return *this;
-}
-
-inventory inventory::operator+ ( const inventory &rhs )
-{
-    return inventory( *this ) += rhs;
-}
-
-inventory inventory::operator+ ( const std::vector<item *> &rhs )
-{
-    return inventory( *this ) += rhs;
-}
-
-inventory inventory::operator+ ( item &rhs )
-{
-    return inventory( *this ) += rhs;
-}
-
 void inventory::unsort()
 {
     binned = false;
@@ -236,18 +173,6 @@ void inventory::clear()
     items.clear();
     binned = false;
     items_type_cached = false;
-}
-
-void inventory::push_back( const std::vector<item *> &newits )
-{
-    for( const auto &newit : newits ) {
-        add_item( *newit, true );
-    }
-}
-
-void inventory::push_back( item &newit )
-{
-    add_item( newit );
 }
 
 inventory& inventory::add_items(const inventory& rhs, bool keep_invlet, bool assign_invlet, bool should_stack)
@@ -1440,7 +1365,7 @@ void location_inventory::push_back( std::vector<detached_ptr<item>> &newits )
         } else {
             as_p->resolve_saved_loc();
             as_p->set_location( &*loc );
-            inv.push_back( *as_p );
+            inv.add_item(*as_p, true);
         }
     }
 }
@@ -1553,7 +1478,8 @@ void location_inventory::push_back( detached_ptr<item> &&newit )
 
     as_p->resolve_saved_loc();
     as_p->set_location( &*loc );
-    return inv.push_back( *as_p );
+    
+    inv.add_item( *as_p, true );
 }
 
 void location_inventory::restack( player &p )

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -245,6 +245,53 @@ void inventory::push_back( const std::vector<item *> &newits )
     }
 }
 
+void inventory::push_back( item &newit )
+{
+    add_item( newit );
+}
+
+inventory& inventory::add_items(const inventory& rhs, bool keep_invlet, bool assign_invlet, bool should_stack)
+{
+    for( size_t i = 0; i < rhs.size(); i++ ) {
+        add_items( rhs.const_stack( i ), keep_invlet, assign_invlet, should_stack );
+    }
+    return *this;
+}
+
+inventory& inventory::add_items(const std::vector<item*>& rhs, bool keep_invlet, bool assign_invlet, bool should_stack)
+{
+    for( const auto &it : rhs ) {
+        add_item( *it, keep_invlet, assign_invlet, should_stack);
+    }
+    return *this;
+}
+
+inventory& inventory::add_items(const item_stack& rhs, bool keep_invlet, bool assign_invlet, bool should_stack)
+{
+    for( const auto &it : rhs ) {
+        if( !it->made_of( LIQUID ) ) {
+            add_item( *it, keep_invlet, assign_invlet, should_stack );
+        }
+    }
+    return *this;
+}
+
+inventory& inventory::add_items(const location_inventory& rhs, bool keep_invlet, bool assign_invlet, bool should_stack)
+{
+    for( size_t i = 0; i < rhs.size(); i++ ) {
+        add_items( rhs.const_stack( i ), keep_invlet, assign_invlet, should_stack );
+    }
+    return *this;
+}
+
+inventory& inventory::add_items(const location_vector<item>& rhs, bool keep_invlet, bool assign_invlet, bool should_stack)
+{
+    for( item * const &it : rhs ) {
+        add_item( *it, keep_invlet, assign_invlet, should_stack );
+    }
+    return *this;
+}
+
 // This function keeps the invlet cache updated when a new item is added.
 void inventory::update_cache_with_item( item &newit )
 {
@@ -377,10 +424,6 @@ void inventory::add_item_keep_invlet( item &newit )
     add_item( newit, true );
 }
 
-void inventory::push_back( item &newit )
-{
-    add_item( newit );
-}
 
 #if defined(__ANDROID__)
 extern void remove_stale_inventory_quick_shortcuts();

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -175,7 +175,8 @@ void inventory::clear()
     items_type_cached = false;
 }
 
-inventory& inventory::add_items(const inventory& rhs, bool keep_invlet, bool assign_invlet, bool should_stack)
+inventory &inventory::add_items( const inventory &rhs, bool keep_invlet, bool assign_invlet,
+                                 bool should_stack )
 {
     for( size_t i = 0; i < rhs.size(); i++ ) {
         add_items( rhs.const_stack( i ), keep_invlet, assign_invlet, should_stack );
@@ -183,7 +184,8 @@ inventory& inventory::add_items(const inventory& rhs, bool keep_invlet, bool ass
     return *this;
 }
 
-inventory& inventory::add_items(const item_stack& rhs, bool keep_invlet, bool assign_invlet, bool should_stack)
+inventory &inventory::add_items( const item_stack &rhs, bool keep_invlet, bool assign_invlet,
+                                 bool should_stack )
 {
     for( const auto &it : rhs ) {
         if( !it->made_of( LIQUID ) ) {
@@ -193,15 +195,17 @@ inventory& inventory::add_items(const item_stack& rhs, bool keep_invlet, bool as
     return *this;
 }
 
-inventory& inventory::add_items(const std::vector<item*>& rhs, bool keep_invlet, bool assign_invlet, bool should_stack)
+inventory &inventory::add_items( const std::vector<item *> &rhs, bool keep_invlet,
+                                 bool assign_invlet, bool should_stack )
 {
     for( const auto &it : rhs ) {
-        add_item( *it, keep_invlet, assign_invlet, should_stack);
+        add_item( *it, keep_invlet, assign_invlet, should_stack );
     }
     return *this;
 }
 
-inventory& inventory::add_items(const location_inventory& rhs, bool keep_invlet, bool assign_invlet, bool should_stack)
+inventory &inventory::add_items( const location_inventory &rhs, bool keep_invlet,
+                                 bool assign_invlet, bool should_stack )
 {
     for( size_t i = 0; i < rhs.size(); i++ ) {
         add_items( rhs.const_stack( i ), keep_invlet, assign_invlet, should_stack );
@@ -209,7 +213,8 @@ inventory& inventory::add_items(const location_inventory& rhs, bool keep_invlet,
     return *this;
 }
 
-inventory& inventory::add_items(const location_vector<item>& rhs, bool keep_invlet, bool assign_invlet, bool should_stack)
+inventory &inventory::add_items( const location_vector<item> &rhs, bool keep_invlet,
+                                 bool assign_invlet, bool should_stack )
 {
     for( item * const &it : rhs ) {
         add_item( *it, keep_invlet, assign_invlet, should_stack );
@@ -263,38 +268,40 @@ void inventory::build_items_type_cache()
 
 namespace
 {
-    inline static bool add_item_stack_helper(inventory& inv, item& newit, std::vector<item*>& elem, bool keep_invlet, bool assign_invlet, item*& existing)
-    {
-        item*& it = *elem.begin();
-        if (it->stacks_with(newit)) {
-            if (it->invlet == '\0') {
-                if (!keep_invlet) {
-                    inv.update_invlet(newit, assign_invlet);
-                }
-                inv.update_invlet_cache_with_item(newit);
-                it->invlet = newit.invlet;
-            } else {
-                newit.invlet = it->invlet;
+inline static bool add_item_stack_helper( inventory &inv, item &newit, std::vector<item *> &elem,
+        bool keep_invlet, bool assign_invlet, item *&existing )
+{
+    item *&it = *elem.begin();
+    if( it->stacks_with( newit ) ) {
+        if( it->invlet == '\0' ) {
+            if( !keep_invlet ) {
+                inv.update_invlet( newit, assign_invlet );
             }
-            elem.push_back(&newit);
-            existing = elem.back();
-            return true;
-        } else if (keep_invlet && assign_invlet && it->invlet == newit.invlet &&
-            it->invlet != '\0') {
-            // If keep_invlet is true, we'll be forcing other items out of their current invlet.
-            inv.assign_empty_invlet(*it, g->u);
+            inv.update_invlet_cache_with_item( newit );
+            it->invlet = newit.invlet;
+        } else {
+            newit.invlet = it->invlet;
         }
-        return false;
+        elem.push_back( &newit );
+        existing = elem.back();
+        return true;
+    } else if( keep_invlet && assign_invlet && it->invlet == newit.invlet &&
+               it->invlet != '\0' ) {
+        // If keep_invlet is true, we'll be forcing other items out of their current invlet.
+        inv.assign_empty_invlet( *it, g->u );
     }
+    return false;
+}
 }
 
 template<bool IsCached>
-item& inventory::add_item_internal(item& newit, bool keep_invlet, bool assign_invlet, bool should_stack)
+item &inventory::add_item_internal( item &newit, bool keep_invlet, bool assign_invlet,
+                                    bool should_stack )
 {
     binned = false;
 
     itype_id type = newit.typeId();
-    if constexpr (IsCached) {
+    if constexpr( IsCached ) {
         if( !items_type_cached ) {
             debugmsg( "Tried to add item to inventory using cache without building the items_type_cache." );
             build_items_type_cache();
@@ -302,8 +309,8 @@ item& inventory::add_item_internal(item& newit, bool keep_invlet, bool assign_in
         if( should_stack ) {
             // See if we can't stack this item.
             for( auto &elem : items_type_cache[type] ) {
-                item* ex{};
-                if (::add_item_stack_helper(*this, newit, *elem, keep_invlet, assign_invlet, ex)) {
+                item *ex{};
+                if( ::add_item_stack_helper( *this, newit, *elem, keep_invlet, assign_invlet, ex ) ) {
                     return *ex;
                 }
             }
@@ -313,15 +320,15 @@ item& inventory::add_item_internal(item& newit, bool keep_invlet, bool assign_in
         if( should_stack ) {
             // See if we can't stack this item.
             for( auto &elem : items ) {
-                item* ex{};
-                if (::add_item_stack_helper(*this, newit, elem, keep_invlet, assign_invlet, ex)) {
+                item *ex{};
+                if( ::add_item_stack_helper( *this, newit, elem, keep_invlet, assign_invlet, ex ) ) {
                     return *ex;
                 }
             }
         }
     }
 
-     // Couldn't stack the item, proceed.
+    // Couldn't stack the item, proceed.
     if( !keep_invlet ) {
         update_invlet( newit, assign_invlet );
     }
@@ -329,8 +336,8 @@ item& inventory::add_item_internal(item& newit, bool keep_invlet, bool assign_in
 
     items.push_back( {&newit} );
 
-    if constexpr (IsCached) {
-        items_type_cache[type].push_back(&items.back());
+    if constexpr( IsCached ) {
+        items_type_cache[type].push_back( &items.back() );
     }
 
     return *items.back().back();
@@ -338,12 +345,13 @@ item& inventory::add_item_internal(item& newit, bool keep_invlet, bool assign_in
 
 item &inventory::add_item( item &newit, bool keep_invlet, bool assign_invlet, bool should_stack )
 {
-    return add_item_internal<false>(newit, keep_invlet, assign_invlet, should_stack);
+    return add_item_internal<false>( newit, keep_invlet, assign_invlet, should_stack );
 }
 
-item &inventory::add_item_by_items_type_cache( item &newit, bool keep_invlet, bool assign_invlet, bool should_stack )
+item &inventory::add_item_by_items_type_cache( item &newit, bool keep_invlet, bool assign_invlet,
+        bool should_stack )
 {
-    return add_item_internal<true>(newit, keep_invlet, assign_invlet, should_stack);
+    return add_item_internal<true>( newit, keep_invlet, assign_invlet, should_stack );
 }
 
 #if defined(__ANDROID__)
@@ -1348,15 +1356,17 @@ void location_inventory::clear()
     return inv.clear();
 }
 
-void location_inventory::add_items(std::vector<detached_ptr<item>>& newits, bool keep_invlet, bool assign_invlet, bool should_stack)
+void location_inventory::add_items( std::vector<detached_ptr<item>> &newits, bool keep_invlet,
+                                    bool assign_invlet, bool should_stack )
 {
     for( detached_ptr<item> &it : newits ) {
-        add_item(std::move(it), keep_invlet, assign_invlet, should_stack);
+        add_item( std::move( it ), keep_invlet, assign_invlet, should_stack );
     }
 }
 
 template<bool IsCached>
-item& location_inventory::add_item_internal( detached_ptr<item> &&newit, bool keep_invlet, bool assign_invlet, bool should_stack )
+item &location_inventory::add_item_internal( detached_ptr<item> &&newit, bool keep_invlet,
+        bool assign_invlet, bool should_stack )
 {
     if( !newit ) {
         return null_item_reference();
@@ -1387,21 +1397,23 @@ item& location_inventory::add_item_internal( detached_ptr<item> &&newit, bool ke
     newit.release();
     as_p->set_location( &*loc );
 
-    if constexpr (IsCached) {
+    if constexpr( IsCached ) {
         return inv.add_item_by_items_type_cache( *as_p, keep_invlet, assign_invlet, should_stack );
     } else {
         return inv.add_item( *as_p, keep_invlet, assign_invlet, should_stack );
     }
 }
 
-item &location_inventory::add_item( detached_ptr<item> &&newit, bool keep_invlet, bool assign_invlet, bool should_stack )
+item &location_inventory::add_item( detached_ptr<item> &&newit, bool keep_invlet,
+                                    bool assign_invlet, bool should_stack )
 {
-    return add_item_internal<false>(std::move(newit), keep_invlet, assign_invlet, should_stack);
+    return add_item_internal<false>( std::move( newit ), keep_invlet, assign_invlet, should_stack );
 }
 
-item &location_inventory::add_item_by_items_type_cache( detached_ptr<item> &&newit, bool keep_invlet, bool assign_invlet, bool should_stack )
+item &location_inventory::add_item_by_items_type_cache( detached_ptr<item> &&newit,
+        bool keep_invlet, bool assign_invlet, bool should_stack )
 {
-    return add_item_internal<true>(std::move(newit), keep_invlet, assign_invlet, should_stack);
+    return add_item_internal<true>( std::move( newit ), keep_invlet, assign_invlet, should_stack );
 }
 
 void location_inventory::restack( player &p )

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -212,7 +212,7 @@ class inventory : public temp_visitable<inventory>
          */
         const itype_bin &get_binned_items() const;
 
-        void update_cache_with_item( item &newit );
+        void update_invlet_cache_with_item( item &newit );
         // gets a singular enchantment that is an amalgamation of all items that have active enchantments
         enchantment get_active_enchantment_cache( const Character &owner ) const;
 
@@ -379,7 +379,7 @@ class location_inventory : public location_visitable<location_inventory>
          */
         const itype_bin &get_binned_items() const;
 
-        void update_cache_with_item( item &newit );
+        void update_invlet_cache_with_item( item &newit );
 
         // gets a singular enchantment that is an amalgamation of all items that have active enchantments
         enchantment get_active_enchantment_cache( const Character &owner ) const;

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -121,7 +121,6 @@ public:
         item &add_item_by_items_type_cache( item &newit, bool keep_invlet = false,
                                             bool assign_invlet = true,
                                             bool should_stack = true );
-        void add_item_keep_invlet( item &newit );
 
         /* Check all items for proper stacking, rearranging as needed
          * game pointer is not necessary, but if supplied, will ensure no overlap with

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -270,16 +270,15 @@ class location_inventory : public location_visitable<location_inventory>
 
         void unsort();
         void clear();
-        void push_back( std::vector<detached_ptr<item>> &newits );
+
+        void add_items( std::vector<detached_ptr<item>> &newits, bool keep_invlet = false, bool assign_invlet = true, bool should_stack = true );
         // returns a reference to the added item
-        item &add_item( detached_ptr<item> &&newit, bool keep_invlet = false, bool assign_invlet = true,
-                        bool should_stack = true );
+        item &add_item( detached_ptr<item> &&newit, bool keep_invlet = false, bool assign_invlet = true, bool should_stack = true );
         // use item type cache to speed up, remember to run build_items_type_cache() before using it
         item &add_item_by_items_type_cache( detached_ptr<item> &&newit, bool keep_invlet = false,
                                             bool assign_invlet = true,
                                             bool should_stack = true );
         void add_item_keep_invlet( detached_ptr<item> &&newit );
-        void push_back( detached_ptr<item> &&newit );
 
         /* Check all items for proper stacking, rearranging as needed
          * game pointer is not necessary, but if supplied, will ensure no overlap with

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -103,19 +103,6 @@ class inventory : public temp_visitable<inventory>
         inventory &operator=( inventory && ) = default;
         inventory &operator=( const inventory & ) = default;
 
-private:
-        inventory &operator+= ( const inventory &rhs );
-        inventory &operator+= ( item &rhs );
-        inventory &operator+= ( const location_inventory &rhs );
-        inventory &operator+= ( const location_vector<item> &rhs );
-        inventory &operator+= ( const std::vector<item *> &rhs );
-        inventory &operator+= ( const item_stack &rhs );
-        inventory  operator+ ( const inventory &rhs );
-        inventory  operator+ ( item &rhs );
-        inventory  operator+ ( const std::vector<item *> &rhs );
-        
-        void push_back( const std::vector<item *> &newits );
-        void push_back( item &newit );
 public:
 
         void unsort(); // flags the inventory as unsorted

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -91,7 +91,7 @@ class inventory : public temp_visitable<inventory>
 {
     private:
         template<bool IsCached>
-        item& add_item_internal(item &newit, bool keep_invlet, bool assign_invlet, bool should_stack);
+        item &add_item_internal( item &newit, bool keep_invlet, bool assign_invlet, bool should_stack );
 
     public:
         const_invslice const_slice() const;
@@ -111,18 +111,25 @@ class inventory : public temp_visitable<inventory>
         void clear();
 
         // --- Currently Unused - Kept since there was an add-assign overload before
-        inventory &add_items ( const inventory &rhs, bool keep_invlet, bool assign_invlet = true, bool should_stack = true ); 
-        inventory &add_items ( const item_stack &rhs , bool keep_invlet, bool assign_invlet = true, bool should_stack = true ); 
+        inventory &add_items( const inventory &rhs, bool keep_invlet, bool assign_invlet = true,
+                              bool should_stack = true );
+        inventory &add_items( const item_stack &rhs, bool keep_invlet, bool assign_invlet = true,
+                              bool should_stack = true );
         // ---
 
-        inventory &add_items ( const location_inventory &rhs , bool keep_invlet, bool assign_invlet = true, bool should_stack = true );
-        inventory &add_items ( const std::vector<item *> &rhs, bool keep_invlet, bool assign_invlet = true, bool should_stack = true );
-        inventory &add_items ( const location_vector<item> &rhs , bool keep_invlet, bool assign_invlet = true, bool should_stack = true );
+        inventory &add_items( const location_inventory &rhs, bool keep_invlet, bool assign_invlet = true,
+                              bool should_stack = true );
+        inventory &add_items( const std::vector<item *> &rhs, bool keep_invlet, bool assign_invlet = true,
+                              bool should_stack = true );
+        inventory &add_items( const location_vector<item> &rhs, bool keep_invlet, bool assign_invlet = true,
+                              bool should_stack = true );
 
         // returns a reference to the added item
-        item &add_item( item &newit, bool keep_invlet, bool assign_invlet = true, bool should_stack = true );
+        item &add_item( item &newit, bool keep_invlet, bool assign_invlet = true,
+                        bool should_stack = true );
         // use item type cache to speed up, remember to run build_items_type_cache() before using it
-        item &add_item_by_items_type_cache( item &newit, bool keep_invlet, bool assign_invlet = true, bool should_stack = true );
+        item &add_item_by_items_type_cache( item &newit, bool keep_invlet, bool assign_invlet = true,
+                                            bool should_stack = true );
 
         /* Check all items for proper stacking, rearranging as needed
          * game pointer is not necessary, but if supplied, will ensure no overlap with
@@ -255,7 +262,8 @@ class location_inventory : public location_visitable<location_inventory>
         friend visitable<location_inventory>;
 
         template<bool IsCached>
-        item& add_item_internal(detached_ptr<item> &&newit, bool keep_invlet, bool assign_invlet, bool should_stack);
+        item &add_item_internal( detached_ptr<item> &&newit, bool keep_invlet, bool assign_invlet,
+                                 bool should_stack );
     public:
 
         const_invslice const_slice() const;
@@ -275,11 +283,14 @@ class location_inventory : public location_visitable<location_inventory>
         void unsort();
         void clear();
 
-        void add_items( std::vector<detached_ptr<item>> &newits, bool keep_invlet, bool assign_invlet = true, bool should_stack = true );
+        void add_items( std::vector<detached_ptr<item>> &newits, bool keep_invlet,
+                        bool assign_invlet = true, bool should_stack = true );
         // returns a reference to the added item
-        item &add_item( detached_ptr<item> &&newit, bool keep_invlet, bool assign_invlet = true, bool should_stack = true );
+        item &add_item( detached_ptr<item> &&newit, bool keep_invlet, bool assign_invlet = true,
+                        bool should_stack = true );
         // use item type cache to speed up, remember to run build_items_type_cache() before using it
-        item &add_item_by_items_type_cache( detached_ptr<item> &&newit, bool keep_invlet, bool assign_invlet = true, bool should_stack = true );
+        item &add_item_by_items_type_cache( detached_ptr<item> &&newit, bool keep_invlet,
+                                            bool assign_invlet = true, bool should_stack = true );
 
         /* Check all items for proper stacking, rearranging as needed
          * game pointer is not necessary, but if supplied, will ensure no overlap with

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -108,11 +108,14 @@ public:
         void unsort(); // flags the inventory as unsorted
         void clear();
 
-        inventory &add_items ( const inventory &rhs, bool keep_invlet = true, bool assign_invlet = true, bool should_stack = true );
-        inventory &add_items ( const std::vector<item *> &rhs, bool keep_invlet = true, bool assign_invlet = true, bool should_stack = true );
-        inventory &add_items ( const item_stack &rhs , bool keep_invlet = true, bool assign_invlet = true, bool should_stack = true );
-        inventory &add_items ( const location_inventory &rhs , bool keep_invlet = true, bool assign_invlet = true, bool should_stack = true );
-        inventory &add_items ( const location_vector<item> &rhs , bool keep_invlet = true, bool assign_invlet = true, bool should_stack = true );
+        // --- Currently Unused - Kept since there was an add-assign overload before
+        inventory &add_items ( const inventory &rhs, bool keep_invlet, bool assign_invlet = true, bool should_stack = true ); 
+        inventory &add_items ( const item_stack &rhs , bool keep_invlet, bool assign_invlet = true, bool should_stack = true ); 
+        // ---
+
+        inventory &add_items ( const location_inventory &rhs , bool keep_invlet, bool assign_invlet = true, bool should_stack = true );
+        inventory &add_items ( const std::vector<item *> &rhs, bool keep_invlet, bool assign_invlet = true, bool should_stack = true );
+        inventory &add_items ( const location_vector<item> &rhs , bool keep_invlet, bool assign_invlet = true, bool should_stack = true );
 
         // returns a reference to the added item
         item &add_item( item &newit, bool keep_invlet = false, bool assign_invlet = true,

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -89,6 +89,10 @@ class invlet_favorites
 
 class inventory : public temp_visitable<inventory>
 {
+    private:
+        template<bool IsCached>
+        item& add_item_internal(item &newit, bool keep_invlet, bool assign_invlet, bool should_stack);
+
     public:
         const_invslice const_slice() const;
         const std::vector<item *> &const_stack( int i ) const;
@@ -252,6 +256,9 @@ class location_inventory : public location_visitable<location_inventory>
 
         friend location_visitable<location_inventory>;
         friend visitable<location_inventory>;
+
+        template<bool IsCached>
+        item& add_item_internal(detached_ptr<item> &&newit, bool keep_invlet, bool assign_invlet, bool should_stack);
     public:
 
         const_invslice const_slice() const;

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -277,7 +277,6 @@ class location_inventory : public location_visitable<location_inventory>
         item &add_item_by_items_type_cache( detached_ptr<item> &&newit, bool keep_invlet = false,
                                             bool assign_invlet = true,
                                             bool should_stack = true );
-        void add_item_keep_invlet( detached_ptr<item> &&newit );
 
         /* Check all items for proper stacking, rearranging as needed
          * game pointer is not necessary, but if supplied, will ensure no overlap with

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -103,8 +103,6 @@ class inventory : public temp_visitable<inventory>
         inventory &operator=( inventory && ) = default;
         inventory &operator=( const inventory & ) = default;
 
-public:
-
         void unsort(); // flags the inventory as unsorted
         void clear();
 

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -120,12 +120,9 @@ class inventory : public temp_visitable<inventory>
         inventory &add_items ( const location_vector<item> &rhs , bool keep_invlet, bool assign_invlet = true, bool should_stack = true );
 
         // returns a reference to the added item
-        item &add_item( item &newit, bool keep_invlet = false, bool assign_invlet = true,
-                        bool should_stack = true );
+        item &add_item( item &newit, bool keep_invlet, bool assign_invlet = true, bool should_stack = true );
         // use item type cache to speed up, remember to run build_items_type_cache() before using it
-        item &add_item_by_items_type_cache( item &newit, bool keep_invlet = false,
-                                            bool assign_invlet = true,
-                                            bool should_stack = true );
+        item &add_item_by_items_type_cache( item &newit, bool keep_invlet, bool assign_invlet = true, bool should_stack = true );
 
         /* Check all items for proper stacking, rearranging as needed
          * game pointer is not necessary, but if supplied, will ensure no overlap with
@@ -278,13 +275,11 @@ class location_inventory : public location_visitable<location_inventory>
         void unsort();
         void clear();
 
-        void add_items( std::vector<detached_ptr<item>> &newits, bool keep_invlet = false, bool assign_invlet = true, bool should_stack = true );
+        void add_items( std::vector<detached_ptr<item>> &newits, bool keep_invlet, bool assign_invlet = true, bool should_stack = true );
         // returns a reference to the added item
-        item &add_item( detached_ptr<item> &&newit, bool keep_invlet = false, bool assign_invlet = true, bool should_stack = true );
+        item &add_item( detached_ptr<item> &&newit, bool keep_invlet, bool assign_invlet = true, bool should_stack = true );
         // use item type cache to speed up, remember to run build_items_type_cache() before using it
-        item &add_item_by_items_type_cache( detached_ptr<item> &&newit, bool keep_invlet = false,
-                                            bool assign_invlet = true,
-                                            bool should_stack = true );
+        item &add_item_by_items_type_cache( detached_ptr<item> &&newit, bool keep_invlet, bool assign_invlet = true, bool should_stack = true );
 
         /* Check all items for proper stacking, rearranging as needed
          * game pointer is not necessary, but if supplied, will ensure no overlap with

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -103,6 +103,7 @@ class inventory : public temp_visitable<inventory>
         inventory &operator=( inventory && ) = default;
         inventory &operator=( const inventory & ) = default;
 
+private:
         inventory &operator+= ( const inventory &rhs );
         inventory &operator+= ( item &rhs );
         inventory &operator+= ( const location_inventory &rhs );
@@ -112,10 +113,20 @@ class inventory : public temp_visitable<inventory>
         inventory  operator+ ( const inventory &rhs );
         inventory  operator+ ( item &rhs );
         inventory  operator+ ( const std::vector<item *> &rhs );
+        
+        void push_back( const std::vector<item *> &newits );
+        void push_back( item &newit );
+public:
 
         void unsort(); // flags the inventory as unsorted
         void clear();
-        void push_back( const std::vector<item *> &newits );
+
+        inventory &add_items ( const inventory &rhs, bool keep_invlet = true, bool assign_invlet = true, bool should_stack = true );
+        inventory &add_items ( const std::vector<item *> &rhs, bool keep_invlet = true, bool assign_invlet = true, bool should_stack = true );
+        inventory &add_items ( const item_stack &rhs , bool keep_invlet = true, bool assign_invlet = true, bool should_stack = true );
+        inventory &add_items ( const location_inventory &rhs , bool keep_invlet = true, bool assign_invlet = true, bool should_stack = true );
+        inventory &add_items ( const location_vector<item> &rhs , bool keep_invlet = true, bool assign_invlet = true, bool should_stack = true );
+
         // returns a reference to the added item
         item &add_item( item &newit, bool keep_invlet = false, bool assign_invlet = true,
                         bool should_stack = true );
@@ -124,7 +135,6 @@ class inventory : public temp_visitable<inventory>
                                             bool assign_invlet = true,
                                             bool should_stack = true );
         void add_item_keep_invlet( item &newit );
-        void push_back( item &newit );
 
         /* Check all items for proper stacking, rearranging as needed
          * game pointer is not necessary, but if supplied, will ensure no overlap with

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8206,10 +8206,10 @@ int iuse::multicooker( player *p, item *it, bool t, const tripoint &pos )
             //add some tools and qualities. we can't add this qualities to json, because multicook must be used only by activating, not as component other crafts.
             const time_point bday = calendar::start_of_cataclysm;
 
-            crafting_inv.add_item( *item::spawn_temporary( "hotplate", bday ) ); //hotplate inside
-            crafting_inv.add_item( *item::spawn_temporary( "tongs", bday ) ); //some recipes requires tongs
-            crafting_inv.add_item( *item::spawn_temporary( "toolset", bday ) ); //toolset with CUT and other qualities inside
-            crafting_inv.add_item( *item::spawn_temporary( "pot", bday ) ); //good COOK, BOIL, CONTAIN qualities inside
+            crafting_inv.add_item( *item::spawn_temporary( "hotplate", bday ), false ); //hotplate inside
+            crafting_inv.add_item( *item::spawn_temporary( "tongs", bday ), false ); //some recipes requires tongs
+            crafting_inv.add_item( *item::spawn_temporary( "toolset", bday ), false ); //toolset with CUT and other qualities inside
+            crafting_inv.add_item( *item::spawn_temporary( "pot", bday ), false ); //good COOK, BOIL, CONTAIN qualities inside
 
             int counter = 0;
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8207,9 +8207,12 @@ int iuse::multicooker( player *p, item *it, bool t, const tripoint &pos )
             const time_point bday = calendar::start_of_cataclysm;
 
             crafting_inv.add_item( *item::spawn_temporary( "hotplate", bday ), false ); //hotplate inside
-            crafting_inv.add_item( *item::spawn_temporary( "tongs", bday ), false ); //some recipes requires tongs
-            crafting_inv.add_item( *item::spawn_temporary( "toolset", bday ), false ); //toolset with CUT and other qualities inside
-            crafting_inv.add_item( *item::spawn_temporary( "pot", bday ), false ); //good COOK, BOIL, CONTAIN qualities inside
+            crafting_inv.add_item( *item::spawn_temporary( "tongs", bday ),
+                                   false ); //some recipes requires tongs
+            crafting_inv.add_item( *item::spawn_temporary( "toolset", bday ),
+                                   false ); //toolset with CUT and other qualities inside
+            crafting_inv.add_item( *item::spawn_temporary( "pot", bday ),
+                                   false ); //good COOK, BOIL, CONTAIN qualities inside
 
             int counter = 0;
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8206,12 +8206,10 @@ int iuse::multicooker( player *p, item *it, bool t, const tripoint &pos )
             //add some tools and qualities. we can't add this qualities to json, because multicook must be used only by activating, not as component other crafts.
             const time_point bday = calendar::start_of_cataclysm;
 
-            crafting_inv.push_back( *item::spawn_temporary( "hotplate", bday ) ); //hotplate inside
-            crafting_inv.push_back( *item::spawn_temporary( "tongs", bday ) ); //some recipes requires tongs
-            crafting_inv.push_back( *item::spawn_temporary( "toolset",
-                                    bday ) ); //toolset with CUT and other qualities inside
-            crafting_inv.push_back( *item::spawn_temporary( "pot",
-                                    bday ) ); //good COOK, BOIL, CONTAIN qualities inside
+            crafting_inv.add_item( *item::spawn_temporary( "hotplate", bday ) ); //hotplate inside
+            crafting_inv.add_item( *item::spawn_temporary( "tongs", bday ) ); //some recipes requires tongs
+            crafting_inv.add_item( *item::spawn_temporary( "toolset", bday ) ); //toolset with CUT and other qualities inside
+            crafting_inv.add_item( *item::spawn_temporary( "pot", bday ) ); //good COOK, BOIL, CONTAIN qualities inside
 
             int counter = 0;
 

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -313,7 +313,7 @@ int iuse_transform::use( player &p, item &it, bool t, const tripoint &pos ) cons
         p.update_bodytemp( get_map(), get_weather() );
         p.on_item_wear( it );
     }
-    p.inv_update_cache_with_item( it );
+    p.inv_update_invlet_cache_with_item( it );
     // Update luminosity as object is "added"
     get_map().update_lum( it, true );
     it.item_counter = countdown > 0 ? countdown : it.type->countdown_interval;

--- a/src/locations.cpp
+++ b/src/locations.cpp
@@ -135,7 +135,7 @@ detached_ptr<item> npc_mission_item_location::detach( item *it )
 void npc_mission_item_location::attach( detached_ptr<item> &&obj )
 {
     npc *as_npc = static_cast<npc *>( holder );
-    as_npc->companion_mission_inv.add_item( std::move( obj ) );
+    as_npc->companion_mission_inv.add_item( std::move( obj ), false );
 }
 
 detached_ptr<item> wield_item_location::detach( item *it )

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -588,19 +588,19 @@ bool avatar::create( character_type type, const std::string &tempname )
         // TODO: debugmsg if food that isn't a seed is inedible
         if( it->has_flag( json_flag_no_auto_equip ) ) {
             it->unset_flag( json_flag_no_auto_equip );
-            inv.push_back( std::move( it ) );
+            inv.add_item( std::move( it ) );
         } else if( it->has_flag( json_flag_auto_wield ) ) {
             it->unset_flag( json_flag_auto_wield );
             if( !is_armed() ) {
                 wield( std::move( it ) );
             } else {
-                inv.push_back( std::move( it ) );
+                inv.add_item( std::move( it ) );
             }
         } else if( it->is_armor() ) {
             // TODO: debugmsg if wearing fails
             wear_item( std::move( it ), false );
         } else {
-            inv.push_back( std::move( it ) );
+            inv.add_item( std::move( it ) );
         }
     }
 

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -588,19 +588,19 @@ bool avatar::create( character_type type, const std::string &tempname )
         // TODO: debugmsg if food that isn't a seed is inedible
         if( it->has_flag( json_flag_no_auto_equip ) ) {
             it->unset_flag( json_flag_no_auto_equip );
-            inv.add_item( std::move( it ) );
+            inv.add_item( std::move( it ), false );
         } else if( it->has_flag( json_flag_auto_wield ) ) {
             it->unset_flag( json_flag_auto_wield );
             if( !is_armed() ) {
                 wield( std::move( it ) );
             } else {
-                inv.add_item( std::move( it ) );
+                inv.add_item( std::move( it ), false );
             }
         } else if( it->is_armor() ) {
             // TODO: debugmsg if wearing fails
             wear_item( std::move( it ), false );
         } else {
-            inv.add_item( std::move( it ) );
+            inv.add_item( std::move( it ), false );
         }
     }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1774,7 +1774,7 @@ void npc::shop_restock()
         for( map_cursor &cursor : map_selector( pos(), 0 ) ) {
             cursor.remove_top_items_with( [this]( detached_ptr<item> &&it ) {
                 if( it->is_owned_by( *this ) ) {
-                    inv.add_item( std::move( it ) );
+                    inv.add_item( std::move( it ), false );
                     return detached_ptr<item>();
                 } else {
                     return std::move( it );
@@ -1786,7 +1786,7 @@ void npc::shop_restock()
         // clear out inventory and add in restocked items
         has_new_items = true;
         inv.clear();
-        inv.add_items( ret );
+        inv.add_items( ret, false );
     }
 }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1774,7 +1774,7 @@ void npc::shop_restock()
         for( map_cursor &cursor : map_selector( pos(), 0 ) ) {
             cursor.remove_top_items_with( [this]( detached_ptr<item> &&it ) {
                 if( it->is_owned_by( *this ) ) {
-                    inv.push_back( std::move( it ) );
+                    inv.add_item( std::move( it ) );
                     return detached_ptr<item>();
                 } else {
                     return std::move( it );
@@ -1786,7 +1786,7 @@ void npc::shop_restock()
         // clear out inventory and add in restocked items
         has_new_items = true;
         inv.clear();
-        inv.push_back( ret );
+        inv.add_items( ret );
     }
 }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1241,7 +1241,7 @@ detached_ptr<item> npc::wield( detached_ptr<item> &&target )
 
 
     inv.update_invlet( obj );
-    inv.update_cache_with_item( obj );
+    inv.update_invlet_cache_with_item( obj );
     return detached_ptr<item>();
 }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2865,7 +2865,7 @@ bool npc::dispose_item( item &obj, const std::string & )
             item_handling_cost( obj ),
             [this, &obj] {
                 moves -= item_handling_cost( obj );
-                inv.add_item_keep_invlet( obj.detach() );
+                inv.add_item( obj.detach(), true );
                 inv.unsort();
             }
         } );

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -1176,7 +1176,7 @@ requirement_data requirement_data::continue_requirements( const std::vector<item
     location_inventory craft_components( new fake_item_location() );
     std::vector<detached_ptr<item>> comps_copy;
     for( item * const &it : remaining_comps ) {
-        craft_components.add_item( item::spawn( *it ) );
+        craft_components.add_item( item::spawn( *it ), false );
     }
 
     // Remove requirements that are completely fulfilled by current craft components


### PR DESCRIPTION
## Purpose of change (The Why)

`inventory` and `location_inventory` had a LOT of duplicate code under different functions doing the same thing.
Except when they didn't and reset all your inventory shortcut keys.

## Describe the solution (The How)

* Replace and all add-assign operators with explicit method calls (`add_item` and `add_items`)
* Remove default parameter for keep_invlet for the above methods, making it explicit on call-site if it's meant to reset invlet keys (or not)
    * Hopefully fixes #6203
    * Hopefully fixes #4837
* Renames `update_cache_with_item` to `update_invlet_cache_with_item` to better communicate which cache its refering to, since there is also a item type cache.
* Remove redundant / duplicated code on `add_item` and `add_item_by_items_type_cache` by pulling common code onto a templated IsCached private/internal method, since those only differed by small sections

## Testing

Load game.
Assign keybinds to weapons.
Muck around with (V)iew , (O)rganize zones, or other invlet destroying actions.
Your keybinds are still there still hopefully.

## Additional context

The actual changes are on `inventory.h` and `inventory.cpp`, but the unified final diff makes a mess of things, check the individual commits for a better sense of things.

The other files are changed only to reflect the changes made on those two files.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
