### PR TITLE
fix: change phrasing in monster_attacks.json.

### DIFF
--- a/data/json/monster_attacks.json
+++ b/data/json/monster_attacks.json
@@ -10,8 +10,8 @@
     "effects": [ { "id": "bleed", "duration": 100, "bp": "torso" }, { "id": "downed", "duration": 3 } ],
     "hit_dmg_u": "The %1$s impales your torso!",
     "hit_dmg_npc": "The %1$s impales <npcname>'s torso!",
-    "no_dmg_msg_u": "The %1$s tries to impale your torso, but fails to penetrate your armor!",
-    "no_dmg_msg_npc": "The %1$s tries to impale <npcname>'s torso, but fails to penetrate their armor!"
+    "no_dmg_msg_u": "The %1$s tries to impale you, but fails to.",
+    "no_dmg_msg_npc": "The %1$s tries to impale <npcname>, but fails to."
   },
   {
     "type": "monster_attack",
@@ -87,8 +87,8 @@
     "effects": [ { "id": "bleed", "duration": 10, "affect_hit_bp": true }, { "id": "poison", "duration": 30, "bp": "torso" } ],
     "hit_dmg_u": "The %1$s stabs you!",
     "hit_dmg_npc": "The %1$s stabs <npcname>!",
-    "no_dmg_msg_u": "The %1$s tries to stab you, but fails to penetrate your armor.",
-    "no_dmg_msg_npc": "The %1$s tries to stab <npcname>, but fails to penetrate their armor!."
+    "no_dmg_msg_u": "The %1$s tries to stab you, but fails to.",
+    "no_dmg_msg_npc": "The %1$s tries to stab <npcname>, but fails to."
   },
   {
     "type": "monster_attack",
@@ -103,8 +103,8 @@
     "hit_dmg_npc": "The %1$s stings <npcname>'s %2$s!",
     "miss_msg_u": "The %1$s tries to sting you, but you dodge!",
     "miss_msg_npc": "The %1$s tries to sting <npcname>, but they dodge!",
-    "no_dmg_msg_u": "The %1$s tries to sting your %2$s, but it fails to penetrate your armor.",
-    "no_dmg_msg_npc": "The %1$s tries to sting <npcname>'s %2$s, but it fails to penetrate their armor."
+    "no_dmg_msg_u": "The %1$s tries to sting your %2$s, but it fails to.",
+    "no_dmg_msg_npc": "The %1$s tries to sting <npcname>'s %2$s, but it fails to."
   },
   {
     "id": "acid_spray",


### PR DESCRIPTION
## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->
Close #5761

## Describe the solution (The How)

<!-- e.g nerfs monster A -->
Remove mentions of armor in monster_attacks.json
## Describe alternatives you've considered
None.
## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->
1. spawn a monster or create a monster with "BIO_OP_IMPALE" special attack
2. wait until the monster uses the attack on you
3. read the log to notice difference
## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
