### PR TITLE
fix(UI): Adds a hotkey for the save format in the main menu

### DIFF
--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -504,7 +504,7 @@ void main_menu::init_strings()
     vWorldSubItems.emplace_back( pgettext( "Main Menu|World", "Convert to V2 Save Format" ) );
     vWorldSubItems.emplace_back( pgettext( "Main Menu|World", "<= Return" ) );
 
-    vWorldHotkeys = { 'm', 'e', 's', 't', 'r', 'd', 'q' };
+    vWorldHotkeys = { 'm', 'e', 's', 't', 'r', 'd', 'f', 'q' };
 
     vSettingsSubItems.clear();
     vSettingsSubItems.emplace_back( pgettext( "Main Menu|Settings", "<O|o>ptions" ) );


### PR DESCRIPTION
## Purpose of change (The Why)

The hotkey for the new save format conversion option in the menu was missing. This leads to UB when it tries to access it. 

## Describe the solution (The How)

Give it a hotkey of 'f' for format.

## Testing

No UB there now.

