### PR TITLE
feat(UI): relocate history panels, add overmap search history

### DIFF
--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1548,6 +1548,7 @@ static bool search( const ui_adaptor &om_ui, tripoint_abs_omt &curs, const tripo
     std::string term = string_input_popup()
                        .title( _( "Search term:" ) )
                        .description( _( "Multiple entries separated with comma (,). Excludes starting with hyphen (-)." ) )
+                       .identifier( "overmap" )
                        .query_string();
     if( term.empty() ) {
         return false;

--- a/src/string_input_popup.cpp
+++ b/src/string_input_popup.cpp
@@ -603,6 +603,7 @@ string_input_popup &string_input_popup::window( const catacurses::window &w, poi
     _starty = start.y;
     _endx = endx;
     custom_window = true;
+    this->w_full = catacurses::newwin( 1, _endx - _startx, point( getbegx( w ) + _startx, _starty ) );
     return *this;
 }
 


### PR DESCRIPTION


## Purpose of change (The Why)

There were some complaints about the location of the history window (and I didn't like it either). Also, the map search needed history as well.

## Describe the solution (The How)

When defining a custom window area for string_input_popup, it wasn't defining the w_full window that the history popup relied upon so the window was being drawn at 0,0. I updated the window method to create the w_full regardless.

## Testing

Verified that the windows showed up in better locations (the best I could do without possibly breaking something else) and that the map's search history was functioning.

## Additional context
![image](https://github.com/user-attachments/assets/bb54295d-56bd-4be1-afa0-98717be34efe)
![image](https://github.com/user-attachments/assets/d1a1eea6-1ee4-47f0-9ab7-f9eba4244339)
![image](https://github.com/user-attachments/assets/b420917f-7cda-4b1f-b0da-3572cc7e7d1e)
![image](https://github.com/user-attachments/assets/6c1cd030-5f50-43d3-ae20-e04923715fe0)
![image](https://github.com/user-attachments/assets/dd737288-74d0-4df5-9044-4350048c4513)

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
