### PR TITLE
feat(UI): Adds new overmap option to default to Level 0 when map is opened.

### DIFF
--- a/data/raw/keybindings/keybindings.json
+++ b/data/raw/keybindings/keybindings.json
@@ -929,6 +929,13 @@
   },
   {
     "type": "keybinding",
+    "name": "Default map to level 0",
+    "category": "OVERMAP",
+    "id": "TOGGLE_DEFAULT_0",
+    "bindings": [ { "input_method": "keyboard", "key": "." } ]
+  },
+  {
+    "type": "keybinding",
     "id": "ROTATE",
     "category": "OVERMAP_EDITOR",
     "name": "Rotate",

--- a/data/raw/keybindings/keybindings.json
+++ b/data/raw/keybindings/keybindings.json
@@ -929,7 +929,7 @@
   },
   {
     "type": "keybinding",
-    "name": "Toggle Map Defaulting to level 0",
+    "name": "Toggle Map Defaulting to Level 0",
     "category": "OVERMAP",
     "id": "TOGGLE_DEFAULT_0",
     "bindings": [ { "input_method": "keyboard", "key": "." } ]

--- a/data/raw/keybindings/keybindings.json
+++ b/data/raw/keybindings/keybindings.json
@@ -929,7 +929,7 @@
   },
   {
     "type": "keybinding",
-    "name": "Default map to level 0",
+    "name": "Toggle Map Defaulting to level 0",
     "category": "OVERMAP",
     "id": "TOGGLE_DEFAULT_0",
     "bindings": [ { "input_method": "keyboard", "key": "." } ]

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1420,6 +1420,7 @@ static void draw_om_sidebar(
         print_hint( "TOGGLE_FAST_SCROLL", fast_scroll ? c_pink : c_magenta );
         print_hint( "TOGGLE_FOREST_TRAILS", uistate.overmap_show_forest_trails ? c_pink : c_magenta );
         print_hint( "TOGGLE_OVERMAP_WEATHER", uistate.overmap_visible_weather ? c_pink : c_magenta );
+        print_hint( "TOGGLE_DEFAULT_0", uistate.overmap_default_0 ? c_pink : c_magenta );
         print_hint( "HELP_KEYBINDINGS" );
         print_hint( "QUIT" );
     }
@@ -1989,6 +1990,7 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
     ictxt.register_action( "TOGGLE_OVERMAP_WEATHER" );
     ictxt.register_action( "TOGGLE_FOREST_TRAILS" );
     ictxt.register_action( "MISSIONS" );
+    ictxt.register_action( "TOGGLE_DEFAULT_0" );
 
     if( data.debug_editor ) {
         ictxt.register_action( "PLACE_TERRAIN" );
@@ -2003,7 +2005,9 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
     std::optional<tripoint> mouse_pos;
     std::chrono::time_point<std::chrono::steady_clock> last_blink = std::chrono::steady_clock::now();
     grids_draw_data grids_data;
-
+    if( uistate.overmap_default_0 ) {
+        curs.z() = 0;
+    }
 
     ui.on_redraw( [&]( ui_adaptor & ui ) {
         draw( ui, curs, orig, uistate.overmap_show_overlays,
@@ -2011,6 +2015,7 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
     } );
 
     do {
+
         ui_manager::redraw();
 #if (defined TILES || defined _WIN32 || defined WINDOWS )
         int scroll_timeout = get_option<int>( "EDGE_SCROLL" );
@@ -2131,6 +2136,13 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
             fast_scroll = !fast_scroll;
         } else if( action == "TOGGLE_FOREST_TRAILS" ) {
             uistate.overmap_show_forest_trails = !uistate.overmap_show_forest_trails;
+        } else if( action == "TOGGLE_DEFAULT_0" ) {
+            if( uistate.overmap_default_0 ) {
+                curs.z() = orig.z();
+            } else {
+                curs.z() = 0;
+            }
+            uistate.overmap_default_0 = !uistate.overmap_default_0;
         } else if( action == "SEARCH" ) {
             if( !search( ui, curs, orig ) ) {
                 continue;

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -109,6 +109,7 @@ class uistatedata
         bool overmap_show_city_labels = true;
         bool overmap_show_hordes = true;
         bool overmap_show_forest_trails = true;
+        bool overmap_default_0 = false;
         bool overmap_visible_weather = false;
         bool overmap_debug_weather = false;
         // draw monster groups on the overmap.


### PR DESCRIPTION
## Purpose of change (The Why)

While flying, when opening the map, you have to > a whole bunch to see any useful information. This resolves that.

## Describe the solution (The How)

Added a new toggle option that makes the map level default to 0 on opening.

## Testing

I had my character stand on a building and I opened my map. It worked as normal. I pressed "."  (the default key for this option) and the map immediately went to level 0. I closed the map and reopened and it reopened to level 0. I pressed "." again and the map level switched to my character level. Closing and opening the map again showed that it was still defaulting to my level when the option was disabled.

## Additional context
![image](https://github.com/user-attachments/assets/5449d0a4-df6e-449a-9c8a-e23eb055a210)
![image](https://github.com/user-attachments/assets/ae95a8af-8397-45f6-ae8e-00894458c7c2)


## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

