### PR TITLE
fix: Fix UPS usage again for bionic scanner.

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2268,6 +2268,9 @@ int iuse::note_bionics( player *p, item *it, bool t, const tripoint &pos )
         it->deactivate();
         return 0;
     }
+
+    // Try to minimize the use of has_enough_charges() because it's kind of expensive.
+    bool no_charges = false;
     for( const tripoint &pt : here.points_in_radius( pos, PICKUP_RANGE ) ) {
         if( !here.has_items( pt ) || !p->sees( pt ) ) {
             continue;
@@ -2292,10 +2295,11 @@ int iuse::note_bionics( player *p, item *it, bool t, const tripoint &pos )
                     charges = 0;
                 }
             }
-            if( charges > 0 ) {
+            if( charges ) {
                 p->add_msg_if_player( m_bad, "Your %s doesn't have enough power for the %s", it->tname(),
                                       corpse->display_name().c_str() );
-                if( it->ammo_remaining() == 0 ) {
+                if( !p->has_enough_charges( *it, false ) ) {
+                    no_charges = true;
                     break;
                 } else {
                     continue;
@@ -2318,7 +2322,7 @@ int iuse::note_bionics( player *p, item *it, bool t, const tripoint &pos )
                                     );
             }
         }
-        if( it->ammo_remaining() == 0 ) {
+        if( no_charges ) {
             it->revert( p );
             it->deactivate();
             return 0;


### PR DESCRIPTION
## Purpose of change (The Why)

- fix #6217 which was due to my refactor of bionic scanner back to it's intended functionality being done in haste.

## Describe the solution (The How)

- Instead of `ammo_remaining()`, the game properly calls `has_enough_charges()`

## Describe alternatives you've considered

- Removing the check entirely so it just spams the log with a failure to read bionics if it doesn't have enough power.
  - Less processing intensive but waaaaay more annoying to the player in my opinion.

## Testing

- Loaded up a game and tested that UPS consumption works fine and it doesn't automatically shut itself off.

## Additional context

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.