### PR TITLE
feat(balance): `UNIQUE`-ify Military Outposts, buff their spawn rate

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -716,8 +716,8 @@
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "outpost_north" }, { "point": [ 0, 0, 1 ], "overmap": "outpost_roof_north" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 15, -1 ],
-    "occurrences": [ 0, 1 ],
-    "flags": [ "MILITARY", "ELECTRIC_GRID" ]
+    "occurrences": [ 50, 100 ],
+    "flags": [ "MILITARY", "ELECTRIC_GRID", "UNIQUE" ]
   },
   {
     "type": "overmap_special",
@@ -725,8 +725,8 @@
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "outpost_1_north" }, { "point": [ 0, 0, 1 ], "overmap": "outpost_1_roof_north" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 15, -1 ],
-    "occurrences": [ 0, 1 ],
-    "flags": [ "MILITARY", "ELECTRIC_GRID" ]
+    "occurrences": [ 50, 100 ],
+    "flags": [ "MILITARY", "ELECTRIC_GRID", "UNIQUE" ]
   },
   {
     "type": "overmap_special",


### PR DESCRIPTION
## Purpose of change (The Why)

Companion to my musings in the comments of https://github.com/cataclysmbnteam/Cataclysm-BN/pull/6223#issuecomment-2742013379.
Make outposts more common again, like I seem to remember them.

## Describe the solution (The How)

Makes the two military outposts `UNIQUE` instead of just limiting their max occurrences to 1, that way percentages are easy to mess with

## Describe alternatives you've considered
- Try and mess with overmap terrain generation parameters to less-directly convince it to spawn them more often

## Testing

It loads, and seems to work rather well.

## Additional context

Given we have 3 mansion variants over 50%, with two of them being 75%+, I think this is relatively fine.
Didn't touch bunkers as they seem to somehow spawn more often anyway
Helipads could maybe do with a reduction

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

