### PR TITLE
fix: missing fridges in some of the nested mapgen of the research facility

### DIFF
--- a/data/json/mapgen/lab/lab_surface/lab_surface_nested.json
+++ b/data/json/mapgen/lab/lab_surface/lab_surface_nested.json
@@ -689,15 +689,15 @@
       "mapgensize": [ 5, 5 ],
       "rotation": [ 0, 3 ],
       "rows": [
-        "bb  ḟ",
-        "Hs  ḟ",
+        "bb  f",
+        "Hs  f",
         "     ",
         "os   ",
         "bbbbS"
       ],
       "items": {
         "b": { "item": "tools_science", "chance": 30, "repeat": [ 1, 2 ] },
-        "ḟ": { "item": "supplies_reagents_lab", "chance": 60, "repeat": [ 1, 5 ] },
+        "f": { "item": "supplies_reagents_lab", "chance": 60, "repeat": [ 1, 5 ] },
         "8": [
           { "item": "supplies_reagents_lab", "chance": 50, "repeat": [ 2, 5 ] },
           { "item": "supplies_samples_lab", "chance": 30, "repeat": [ 1, 3 ] }
@@ -1272,7 +1272,7 @@
       "mapgensize": [ 11, 11 ],
       "rotation": [ 0, 3 ],
       "rows": [
-        "ḟḟ8|bNb|FFb",
+        "ff8|bNb|FFb",
         "   |   |ssb",
         "::=|::=|  S",
         "          U",
@@ -1286,7 +1286,7 @@
       ],
       "items": {
         "b": { "item": "tools_science", "chance": 30, "repeat": [ 1, 2 ] },
-        "ḟ": { "item": "supplies_reagents_lab", "chance": 70, "repeat": [ 2, 5 ] },
+        "f": { "item": "supplies_reagents_lab", "chance": 70, "repeat": [ 2, 5 ] },
         "8": [
           { "item": "supplies_reagents_lab", "chance": 70, "repeat": [ 2, 5 ] },
           { "item": "supplies_samples_lab", "chance": 40, "repeat": [ 1, 3 ] }
@@ -1308,7 +1308,7 @@
       "mapgensize": [ 11, 11 ],
       "rotation": [ 0, 3 ],
       "rows": [
-        "ḟḟ8|hhh|8ḟḟ",
+        "ff8|hhh|8ff",
         "   |   |   ",
         "::=|A=A|:=:",
         "S         S",
@@ -1323,7 +1323,7 @@
       "furniture": { "H": "f_shower" },
       "items": {
         "b": { "item": "tools_science", "chance": 30, "repeat": [ 1, 2 ] },
-        "ḟ": { "item": "supplies_reagents_lab", "chance": 70, "repeat": [ 2, 5 ] },
+        "f": { "item": "supplies_reagents_lab", "chance": 70, "repeat": [ 2, 5 ] },
         "F": { "item": "dissection", "chance": 70, "repeat": [ 2, 5 ] },
         "8": [
           { "item": "supplies_reagents_lab", "chance": 70, "repeat": [ 2, 5 ] },
@@ -1346,7 +1346,7 @@
       "mapgensize": [ 11, 11 ],
       "rotation": [ 0, 3 ],
       "rows": [
-        "ḟḟ8|c O|c 0",
+        "ff8|c O|c 0",
         "   |  I|  I",
         "::-|-::|-::",
         "           ",
@@ -1364,7 +1364,7 @@
           { "item": "tools_science", "chance": 15, "repeat": [ 1, 2 ] },
           { "item": "hospital_lab", "chance": 15, "repeat": [ 1, 2 ] }
         ],
-        "ḟ": { "item": "supplies_reagents_lab", "chance": 70, "repeat": [ 2, 5 ] },
+        "f": { "item": "supplies_reagents_lab", "chance": 70, "repeat": [ 2, 5 ] },
         "F": { "item": "dissection", "chance": 70, "repeat": [ 2, 5 ] },
         "8": [
           { "item": "supplies_reagents_lab", "chance": 70, "repeat": [ 2, 5 ] },
@@ -1424,7 +1424,7 @@
       "mapgensize": [ 11, 11 ],
       "rotation": [ 0, 3 ],
       "rows": [
-        "bbi|hhh|ḟḟ8",
+        "bbi|hhh|ff8",
         "Fs |   |   ",
         "b  |A=A|=::",
         "Fs         ",
@@ -1438,7 +1438,7 @@
       ],
       "items": {
         "b": { "item": "tools_science", "chance": 30, "repeat": [ 1, 2 ] },
-        "ḟ": { "item": "supplies_reagents_lab", "chance": 70, "repeat": [ 2, 5 ] },
+        "f": { "item": "supplies_reagents_lab", "chance": 70, "repeat": [ 2, 5 ] },
         "8": [
           { "item": "supplies_reagents_lab", "chance": 70, "repeat": [ 2, 5 ] },
           { "item": "supplies_samples_lab", "chance": 40, "repeat": [ 1, 3 ] }
@@ -1534,7 +1534,7 @@
       "mapgensize": [ 11, 11 ],
       "rotation": [ 0, 3 ],
       "rows": [
-        "bFFb|N |ḟḟ8",
+        "bFFb|N |ff8",
         "bssb|:-|   ",
         "S      |-:|",
         "bs bMH   &b",
@@ -1548,7 +1548,7 @@
       ],
       "items": {
         "b": { "item": "tools_science", "chance": 30, "repeat": [ 1, 2 ] },
-        "ḟ": { "item": "supplies_reagents_lab", "chance": 70, "repeat": [ 2, 5 ] },
+        "f": { "item": "supplies_reagents_lab", "chance": 70, "repeat": [ 2, 5 ] },
         "8": [
           { "item": "supplies_reagents_lab", "chance": 70, "repeat": [ 2, 5 ] },
           { "item": "supplies_samples_lab", "chance": 40, "repeat": [ 1, 3 ] }


### PR DESCRIPTION
## Purpose of change (The Why)
Some of the nested mapgen used in the research facility used to have fridges, but after https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4036, said fridges no longer appear.
## Describe the solution (The How)
Changed all "ḟ" to "f" in every nested mapgen in lab_surface_nested.json that uses `lab_workspace_palette` ("f" in this palette is used to place fridge)
## Describe alternatives you've considered
none
## Testing
No errors when starting a new game.
## Additional context
none
## Checklist

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.