### PR TITLE
docs: Fix colon number in new files from #6232

### DIFF
--- a/doc/src/content/docs/en/mod/json/reference/items/item_creation.md
+++ b/doc/src/content/docs/en/mod/json/reference/items/item_creation.md
@@ -2,7 +2,7 @@
 title: Item Creation / Types
 ---
 
-::note
+:::note
 
 This page is currently under-construction and was recently split off from `JSON INFO`
 

--- a/doc/src/content/docs/en/mod/json/reference/mutations.md
+++ b/doc/src/content/docs/en/mod/json/reference/mutations.md
@@ -2,7 +2,7 @@
 title: Mutations & Traits
 ---
 
-::note
+:::note
 
 This page is currently under-construction and was recently split off from `JSON INFO`
 

--- a/doc/src/content/docs/en/mod/json/reference/vehicles/vehicle_parts.md
+++ b/doc/src/content/docs/en/mod/json/reference/vehicles/vehicle_parts.md
@@ -2,7 +2,7 @@
 title: Vehicles
 ---
 
-::note
+:::note
 
 This page is currently under-construction and was recently split off from `JSON INFO`
 


### PR DESCRIPTION
## Purpose of change (The Why)

I oopsied and did 2 colons at the top instead of 3, and thus the note didn't format correctly. My bad!

## Describe the solution (The How)

Adds missing colons

## Describe alternatives you've considered

Let someone else take the easy and tasty PR count

## Testing

Equipped better eyeballs

## Additional context

At least this motivates us to set up a proper preview on PR for docs changes I guess?

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

