### PR TITLE
feat(balance): Allow spells to hit arms and legs, change spell attacks' `missed_by`

### DIFF
--- a/doc/src/content/docs/en/mod/json/reference/creatures/magic.md
+++ b/doc/src/content/docs/en/mod/json/reference/creatures/magic.md
@@ -46,6 +46,9 @@ In `data/json/debug_spells.json` there is a template spell, copied here for your
   "min_range": 1, // range of the spell
   "max_range": 10,
   "range_increment": 2,
+  "min_accuracy": 50, // percentage "accuracy" of the spell. used for determining which body part was hit
+  "max_accuracy": 70,
+  "accuracy_increment": 2,
   "min_dot": 0, // damage over time (currently not implemented)
   "max_dot": 2,
   "dot_increment": 0.1,

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -786,7 +786,7 @@ void Creature::deal_projectile_attack( Creature *source, item *source_weapon,
     if( targetted_crit_allowed || magic ) { //default logic for selecting bodypart
         if( goodhit < accuracy_critical && hit_value <= 0.2 ) {
             bp_hit = bodypart_str_id( "head" );
-        } else if( hit_value <= 0.4 || magic ) {
+        } else if( hit_value <= 0.4 ) {
             bp_hit = bodypart_str_id( "torso" );
         } else if( one_in( 4 ) ) {
             if( one_in( 2 ) ) {

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -553,15 +553,16 @@ std::string spell::aoe_string() const
 int spell::accuracy() const
 {
     // default detection for special case
-    if (type->min_accuracy == -1) {
+    if( type->min_accuracy == -1 ) {
         return -1;
     }
-    
-    const int leveled_accuracy = type->min_accuracy + std::round( get_level() * type->accuracy_increment );
-    if (type-> max_accuracy >= type->min_accuracy) {
-        return std::min(leveled_accuracy, type->max_accuracy);
+
+    const int leveled_accuracy = type->min_accuracy + std::round( get_level() *
+                                 type->accuracy_increment );
+    if( type-> max_accuracy >= type->min_accuracy ) {
+        return std::min( leveled_accuracy, type->max_accuracy );
     } else {
-        return std::max(leveled_accuracy, type->max_accuracy);
+        return std::max( leveled_accuracy, type->max_accuracy );
     }
 }
 

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -294,6 +294,11 @@ void spell_type::load( const JsonObject &jo, const std::string & )
     optional( jo, was_loaded, "damage_increment", damage_increment, 0.0f );
     optional( jo, was_loaded, "max_damage", max_damage, 0 );
 
+    // minimum is defaulted to -1 for default detection reasons
+    optional( jo, was_loaded, "min_accuracy", min_accuracy, -1 );
+    optional( jo, was_loaded, "accuracy_increment", accuracy_increment, 0.0f );
+    optional( jo, was_loaded, "max_accuracy", max_accuracy, 100 );
+
     optional( jo, was_loaded, "min_range", min_range, 0 );
     optional( jo, was_loaded, "range_increment", range_increment, 0.0f );
     optional( jo, was_loaded, "max_range", max_range, 0 );
@@ -542,6 +547,21 @@ std::string spell::aoe_string() const
         return string_format( "%d-%d", min_leveled_aoe(), type->max_aoe );
     } else {
         return string_format( "%d", aoe() );
+    }
+}
+
+int spell::accuracy() const
+{
+    // default detection for special case
+    if (type->min_accuracy == -1) {
+        return -1;
+    }
+    
+    const int leveled_accuracy = type->min_accuracy + std::round( get_level() * type->accuracy_increment );
+    if (type-> max_accuracy >= type->min_accuracy) {
+        return std::min(leveled_accuracy, type->max_accuracy);
+    } else {
+        return std::max(leveled_accuracy, type->max_accuracy);
     }
 }
 

--- a/src/magic.h
+++ b/src/magic.h
@@ -197,6 +197,13 @@ class spell_type
         // max range this spell can achieve
         int max_range = 0;
 
+        // minimum "accuracy" of a spell
+        int min_accuracy = 0;
+        // amount of "accuracy" change per level
+        float accuracy_increment = 0.0f;
+        // maximum "accuracy"
+        int max_accuracy = 0;
+
         // minimum area of effect of a spell (radius)
         // 0 means the spell only affects the target
         int min_aoe = 0;
@@ -365,6 +372,8 @@ class spell
         damage_instance get_damage_instance() const;
         // how big is the spell's radius
         int aoe() const;
+        // "accuracy" of spells (used for determining body part hit)
+        int accuracy() const;
         // distance spell can be cast
         int range() const;
         // how much energy does the spell cost

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -502,7 +502,14 @@ static void damage_targets( const spell &sp, Creature &caster,
         atk.end_point = target;
         atk.hit_critter = cr;
         atk.proj = bolt;
-        atk.missed_by = 0.0;
+        if (sp.accuracy() == -1) {
+            // defaults to either great odds of hitting the head if it's the player or more reasonable accuracy if not
+            atk.missed_by = (caster.is_player()) ? 0.0 : 0.4;
+        } else {
+            // accuracy is an int and is meant to represent % to hit, so have to reverse it and divide
+            atk.missed_by = static_cast<double>(100 - sp.accuracy()) / 100.0;
+        }
+        
         if( !sp.effect_data().empty() ) {
             add_effect_to_target( target, sp );
         }

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -502,14 +502,14 @@ static void damage_targets( const spell &sp, Creature &caster,
         atk.end_point = target;
         atk.hit_critter = cr;
         atk.proj = bolt;
-        if (sp.accuracy() == -1) {
+        if( sp.accuracy() == -1 ) {
             // defaults to either great odds of hitting the head if it's the player or more reasonable accuracy if not
-            atk.missed_by = (caster.is_player()) ? 0.0 : 0.4;
+            atk.missed_by = ( caster.is_player() ) ? 0.0 : 0.4;
         } else {
             // accuracy is an int and is meant to represent % to hit, so have to reverse it and divide
-            atk.missed_by = static_cast<double>(100 - sp.accuracy()) / 100.0;
+            atk.missed_by = static_cast<double>( 100 - sp.accuracy() ) / 100.0;
         }
-        
+
         if( !sp.effect_data().empty() ) {
             add_effect_to_target( target, sp );
         }


### PR DESCRIPTION
## Purpose of change (The Why)

Plastic golems were known to be absolute head snipers, and looking into the code, it was the case that all spell attacks had about a 70% headshot rate and the remaining 30% was torso shots. Additionally, it seems desirable for spells to be better or worse at hitting vital areas.

Also, this sort-of sets up for future of spells actually missing.

## Describe the solution (The How)

- Removes the part of the torso's if-statement in body part determinations that would prevent arms and legs getting hit by magic attacks
- adds min, max, and increment fields for "accuracy" in spell JSON
- adds a function to get the accuracy of a spell, with a special return for if the accuracy was defaulted
- changes the `missed_by` portion of the spell attack construction to either use the spell's accuracy if set, or a default of either 0.0 for players or 0.4 for everything else
- updates docs

## Describe alternatives you've considered

- add in actual spell accuracy, i.e. missing

That sounds like a much bigger pain in the rear than this, and my goal was just to make monsters less of headshot-machines.

## Testing

- [x] Compiles
- [x] Loads
- [x] Spells can hit arms and legs now
- [x] Setting the accuracy in the spell JSON works
- [x] Default values also work  


## Additional context

Setting the plastic golems' magic missile to 0 accuracy makes them only hit legs and arms
![image](https://github.com/user-attachments/assets/6e14e59d-f449-4b27-a402-9472c444eb69)
![image](https://github.com/user-attachments/assets/7cb52b8c-4ec9-445a-a075-506e269fbd9e)

Setting rocket punch to 100 accuracy makes it hit heads consistently (Yes, this is two different casts of it)
![image](https://github.com/user-attachments/assets/73fe5856-009a-4ae7-8df1-b461309c5652)
![image](https://github.com/user-attachments/assets/78eeedfe-b429-48c4-8591-324f0031c567)

Demon spiders, with default hitting logic, hit both arms/legs and torso/head
![image](https://github.com/user-attachments/assets/b08ab61e-7541-4a23-bc26-4c029143a7fe)
![image](https://github.com/user-attachments/assets/5b57b913-dbf2-471d-9d5c-ee8182322e92)


Does not actually introduce any usage of the accuracy fields into MN yet.


## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `doc/` folder.
  - [x] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
