### PR TITLE
docs: lowercase 't' in "title" for plants page

### DIFF
--- a/doc/src/content/docs/en/mod/json/reference/tiles/plants.md
+++ b/doc/src/content/docs/en/mod/json/reference/tiles/plants.md
@@ -1,5 +1,5 @@
 ---
-Title: Plants
+title: Plants
 ---
 
 :::note


### PR DESCRIPTION
## Purpose of change (The Why)

Otherwise docs don't build because I was a goober

## Describe the solution (The How)

lowercase the 't' in "title"

## Describe alternatives you've considered

- Implode

## Testing

n/a

## Additional context

And here I was, thinking I got away with no formatting or other errors on that last one.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
