### PR TITLE
feat(UI): waiting allowed when flying high with options for shorter waits

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -922,17 +922,17 @@ static void wait()
             as_m.addentry( 12, true, 'w', _( "Wait until you catch your breath" ) );
             durations.emplace( 12, 15_minutes ); // to hide it from showing
         }
+        if( u.controlling_vehicle && u.pos().z > 3 ) {
+            add_menu_item( 14, 'x', "", 10_seconds );
+            add_menu_item( 15, 'y', "", 30_seconds );
+            add_menu_item( 16, 'z', "", 1_minutes );
+        }
         add_menu_item( 1, '1', "", 5_minutes );
         add_menu_item( 2, '2', "", 30_minutes );
         add_menu_item( 3, '3', "", 1_hours );
         add_menu_item( 4, '4', "", 2_hours );
         add_menu_item( 5, '5', "", 3_hours );
         add_menu_item( 6, '6', "", 6_hours );
-        if( u.controlling_vehicle && u.pos().z > 3 ) {
-            add_menu_item( 14, 'x', "", 10_seconds );
-            add_menu_item( 15, 'y', "", 30_seconds );
-            add_menu_item( 16, 'z', "", 1_minutes );
-        }
         as_m.addentry( 13, true, 'c', _( "Custom input" ) );
     }
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -928,12 +928,12 @@ static void wait()
         add_menu_item( 4, '4', "", 2_hours );
         add_menu_item( 5, '5', "", 3_hours );
         add_menu_item( 6, '6', "", 6_hours );
-        as_m.addentry( 13, true, 'c', _( "Custom input" ) );
         if( u.controlling_vehicle && u.pos().z > 3 ) {
-            add_menu_item( 14, 'a', "", 10_seconds );
-            add_menu_item( 15, 'b', "", 30_seconds );
-            add_menu_item( 16, 'c', "", 1_minutes );
+            add_menu_item( 14, 'x', "", 10_seconds );
+            add_menu_item( 15, 'y', "", 30_seconds );
+            add_menu_item( 16, 'z', "", 1_minutes );
         }
+        as_m.addentry( 13, true, 'c', _( "Custom input" ) );
     }
 
     if( g->get_levz() >= 0 || has_watch ) {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -880,7 +880,7 @@ static void wait()
     map &here = get_map();
 
     if( u.controlling_vehicle && ( here.veh_at( u.pos() )->vehicle().velocity ||
-                                   here.veh_at( u.pos() )->vehicle().cruise_velocity ) ) {
+                                   here.veh_at( u.pos() )->vehicle().cruise_velocity ) && u.pos().z < 4 ) {
         popup( _( "You can't pass time while controlling a moving vehicle." ) );
         return;
     }
@@ -929,6 +929,11 @@ static void wait()
         add_menu_item( 5, '5', "", 3_hours );
         add_menu_item( 6, '6', "", 6_hours );
         as_m.addentry( 13, true, 'c', _( "Custom input" ) );
+        if( u.controlling_vehicle && u.pos().z > 3 ) {
+            add_menu_item( 14, 'a', "", 10_seconds );
+            add_menu_item( 15, 'b', "", 30_seconds );
+            add_menu_item( 16, 'c', "", 1_minutes );
+        }
     }
 
     if( g->get_levz() >= 0 || has_watch ) {


### PR DESCRIPTION
… or above. Adds smaller wait options of 10 seconds, 30 seconds, and 1 minute if flying.

## Purpose of change (The Why)

Right now, flying can be a real pain, especially at high speeds. It takes the game so long to advance just one second and traveling long distance means holding the button for a long time.

## Describe the solution (The How)

This makes the wait menu usable while controlling a vehicle if the character's z-level is 4 or more. It also adds a few smaller increment wait times to the menu, only when flying. There are no fuel checks so it is important not to wait past your fuel reserves.

I did not update the menu text out of concern as to how that would affect translations.

## Testing
I flew a helicopter around trying to use the menu at levels below 4 (got the error message) and at 4+ (where it worked). I checked the timing on the new menu options and they wait the correct amount of time.

## Additional context

![image](https://github.com/user-attachments/assets/8aebee6f-7faf-4395-acd2-334b45e6516b)

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
