### PR TITLE
fix: remove obsolete mushroom spores from Bird food recipe

### DIFF
--- a/data/json/recipes/food/other.json
+++ b/data/json/recipes/food/other.json
@@ -1253,8 +1253,6 @@
         [ "seed_raw_dandelion", 10 ],
         [ "seed_raw_burdock", 10 ],
         [ "seed_rhubarb", 10 ],
-        [ "seed_mushroom", 10 ],
-        [ "seed_mushroom_morel", 10 ],
         [ "seed_celery", 10 ],
         [ "seed_oats", 10 ],
         [ "seed_wheat", 10 ],


### PR DESCRIPTION
## Purpose of change (The Why)

Mushroom spores were made obsolete and replaced by mushroom cultures but the recipe for Bird food still showed spores as a valid ingredient.
<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)

Removed mushroom spores (both regular and morel) from Bird food recipe.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

Replace spores by cultures in the recipe.
## Testing

Loaded into world with character who could craft Bird food.
Checked the recipe and saw spores were no longer an ingredient.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

Not a hundred percent certain if "fix" is the right prefix for this PR's title. Perhaps "chore" would have been more appropriate ?
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
Used the single file method since only other.json was edited.
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
Didn't find any issue for this.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.
