### PR TITLE
feat(UI): Add a total armor section to armor layering

### DIFF
--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -625,6 +625,16 @@ void show_armor_layers_ui( Character &who )
             }
         }
 
+        // Total armor for the given part (Ignoring the "All" condition)
+        if (bp.id()) {
+            mvwprintz( w_sort_left, point( 0, cont_h - 6 ), c_white, _( "Total Protection:" ) );
+            mvwprintz( w_sort_left, point( 2, cont_h - 5 ), c_light_gray, _( "Bash: " + std::to_string(who.get_armor_bash( bp ) ) ) );
+            mvwprintz( w_sort_left, point( 2, cont_h - 4 ), c_light_gray, _( "Cut: " + std::to_string(who.get_armor_cut( bp ) ) ) );
+            // Assuming that float armor values are rounded and not floored or truncated
+            mvwprintz( w_sort_left, point( 2, cont_h - 3 ), c_light_gray, _( "Stab: " + std::to_string(static_cast<int>( std::round( who.get_armor_cut( bp ) * 0.8f ) ) ) ) );
+            mvwprintz( w_sort_left, point( 2, cont_h - 2 ), c_light_gray, _( "Ballistic: " + std::to_string(who.get_armor_bullet( bp ) ) ) );
+        }
+        
         // Left footer
         mvwprintz( w_sort_left, point( 0, cont_h - 1 ), c_light_gray, _( "(Outermost)" ) );
         if( leftListOffset + leftListLines < leftListSize ) {

--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -626,15 +626,20 @@ void show_armor_layers_ui( Character &who )
         }
 
         // Total armor for the given part (Ignoring the "All" condition)
-        if (bp.id()) {
+        if( bp.id() ) {
             mvwprintz( w_sort_left, point( 0, cont_h - 6 ), c_white, _( "Total Protection:" ) );
-            mvwprintz( w_sort_left, point( 2, cont_h - 5 ), c_light_gray, _( "Bash: " + std::to_string(who.get_armor_bash( bp ) ) ) );
-            mvwprintz( w_sort_left, point( 2, cont_h - 4 ), c_light_gray, _( "Cut: " + std::to_string(who.get_armor_cut( bp ) ) ) );
+            mvwprintz( w_sort_left, point( 2, cont_h - 5 ), c_light_gray,
+                       _( "Bash: " + std::to_string( who.get_armor_bash( bp ) ) ) );
+            mvwprintz( w_sort_left, point( 2, cont_h - 4 ), c_light_gray,
+                       _( "Cut: " + std::to_string( who.get_armor_cut( bp ) ) ) );
             // Assuming that float armor values are rounded and not floored or truncated
-            mvwprintz( w_sort_left, point( 2, cont_h - 3 ), c_light_gray, _( "Stab: " + std::to_string(static_cast<int>( std::round( who.get_armor_cut( bp ) * 0.8f ) ) ) ) );
-            mvwprintz( w_sort_left, point( 2, cont_h - 2 ), c_light_gray, _( "Ballistic: " + std::to_string(who.get_armor_bullet( bp ) ) ) );
+            mvwprintz( w_sort_left, point( 2, cont_h - 3 ), c_light_gray,
+                       _( "Stab: " + std::to_string( static_cast<int>( std::round( who.get_armor_cut(
+                                   bp ) * 0.8f ) ) ) ) );
+            mvwprintz( w_sort_left, point( 2, cont_h - 2 ), c_light_gray,
+                       _( "Ballistic: " + std::to_string( who.get_armor_bullet( bp ) ) ) );
         }
-        
+
         // Left footer
         mvwprintz( w_sort_left, point( 0, cont_h - 1 ), c_light_gray, _( "(Outermost)" ) );
         if( leftListOffset + leftListLines < leftListSize ) {


### PR DESCRIPTION
## Purpose of change (The Why)

Fixes #6252 and provides a useful feature for people that don't want to manually go through all their clothing, mutations, and bionics to add it all up manually to see what their total armor value is.

## Describe the solution (The How)

Uses the armor-related functions of `Character` to get the relevant values, then adds them to the armor relayering UI somewhere that looked pretty empty

## Describe alternatives you've considered

- Account for coverage

This would necessitate either editing the functions in `character.cpp` or adding new ones, both of which I did not feel like

- Add acid, fire, and env protections

These protections do not work the same way as bash, cut, stab, and ballistic and also I don't want to take up too much space for just protections.

## Testing

- Compiles
- Loads
- Works for body parts with nothing on them and of course body parts with clothes
- Also accounts for mutations and bionics

## Additional context

On a character with Chitinous Armor and Alloy Plated Arms
![image](https://github.com/user-attachments/assets/c4061b2a-850e-4dd8-9703-5d35cae8558a)
![image](https://github.com/user-attachments/assets/5ef91dc0-da70-45d8-bda6-db065f029519)
![image](https://github.com/user-attachments/assets/61b7059a-a886-4219-8a5b-3b26b449f708)


## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

