### PR TITLE
feat: recipes for more grenades and fuzes, adjust C4 and landmine recipes

### DIFF
--- a/data/json/recipes/ammo/components.json
+++ b/data/json/recipes/ammo/components.json
@@ -1041,5 +1041,59 @@
     ],
     "charges": 1,
     "components": [ [ [ "cartridgebrass", 1 ] ], [ [ "plastic_scrap", 1 ] ] ]
+  },
+  {
+    "result": "impact_fuze",
+    "type": "recipe",
+    "category": "CC_AMMO",
+    "subcategory": "CSC_AMMO_COMPONENTS",
+    "skill_used": "mechanics",
+    "difficulty": 7,
+    "autolearn": [ [ "fabrication", 5 ] ],
+    "time": "10 m",
+    "reversible": true,
+    "decomp_learn": 8,
+    "book_learn": [ [ "manual_traps_mil", 5 ], [ "manual_launcher", 6 ], [ "textbook_anarch", 7 ] ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 2 } ],
+    "tools": [ [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ] ],
+    "//": "Components called for explicitly instead of volatile_explosive in order to use smaller amounts, and to place HTMD first",
+    "components": [
+      [ [ "copper", 1 ], [ "cartridgebrass", 2 ], [ "aluminum_foil", 2 ] ],
+      [
+        [ "smpistol_primer", 1 ],
+        [ "lgpistol_primer", 1 ],
+        [ "smrifle_primer", 1 ],
+        [ "lgrifle_primer", 1 ],
+        [ "shotgun_primer", 1 ]
+      ],
+      [ [ "chem_hmtd", 3 ], [ "gunpowder", 2 ], [ "chem_black_powder", 4 ], [ "chem_match_head_powder", 8 ] ]
+    ]
+  },
+  {
+    "result": "delay_fuze",
+    "type": "recipe",
+    "category": "CC_AMMO",
+    "subcategory": "CSC_AMMO_COMPONENTS",
+    "skill_used": "mechanics",
+    "difficulty": 8,
+    "autolearn": [ [ "fabrication", 6 ] ],
+    "time": "5 m",
+    "reversible": true,
+    "decomp_learn": 9,
+    "book_learn": [ [ "manual_traps_mil", 6 ], [ "manual_launcher", 7 ], [ "textbook_anarch", 8 ] ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 2 } ],
+    "tools": [ [ [ "swage", -1 ], [ "small_repairkit", -1 ], [ "large_repairkit", -1 ] ] ],
+    "components": [
+      [ [ "copper", 2 ], [ "cartridgebrass", 4 ], [ "aluminum_foil", 4 ] ],
+      [
+        [ "smpistol_primer", 1 ],
+        [ "lgpistol_primer", 1 ],
+        [ "smrifle_primer", 1 ],
+        [ "lgrifle_primer", 1 ],
+        [ "shotgun_primer", 1 ]
+      ],
+      [ [ "chem_hmtd", 3 ], [ "gunpowder", 2 ], [ "chem_black_powder", 4 ], [ "chem_match_head_powder", 8 ] ],
+      [ [ "fuse", 2 ] ]
+    ]
   }
 ]

--- a/data/json/recipes/ammo/components.json
+++ b/data/json/recipes/ammo/components.json
@@ -1077,7 +1077,7 @@
     "skill_used": "mechanics",
     "difficulty": 8,
     "autolearn": [ [ "fabrication", 6 ] ],
-    "time": "5 m",
+    "time": "10 m",
     "reversible": true,
     "decomp_learn": 9,
     "book_learn": [ [ "manual_traps_mil", 6 ], [ "manual_launcher", 7 ], [ "textbook_anarch", 8 ] ],

--- a/data/json/recipes/other/traps.json
+++ b/data/json/recipes/other/traps.json
@@ -214,31 +214,31 @@
     "components": [
       [ [ "adhesive", 1, "LIST" ] ],
       [
+        [ "canister_empty", 1 ],
         [ "scrap", 3 ],
         [ "steel_chunk", 1 ],
-        [ "canister_empty", 1 ],
         [ "clay_canister", 1 ],
         [ "can_food_unsealed", 1 ]
       ],
       [
+        [ "bearing", 50 ],
         [ "scrap", 10 ],
         [ "nail", 100 ],
         [ "bb", 200 ],
         [ "solder_wire", 100 ],
         [ "platinum_small", 40 ],
         [ "gold_small", 40 ],
-        [ "bearing", 50 ],
         [ "lead", 70 ],
         [ "silver_small", 70 ],
         [ "bismuth", 70 ],
         [ "shrapnel", 40 ]
       ],
       [
-        [ "volatile_explosive", 75, "LIST" ],
+        [ "military_explosive", 75, "LIST" ],
         [ "stable_explosive", 75, "LIST" ],
-        [ "military_explosive", 75, "LIST" ]
+        [ "volatile_explosive", 75, "LIST" ]
       ],
-      [ [ "delay_fuze", 1 ], [ "impact_fuze", 1 ], [ "fuse", 1 ] ]
+      [ [ "impact_fuze", 1 ], [ "delay_fuze", 1 ], [ "fuse", 1 ] ]
     ]
   },
   {

--- a/data/json/recipes/weapon/explosive.json
+++ b/data/json/recipes/weapon/explosive.json
@@ -20,12 +20,57 @@
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_EXPLOSIVE",
     "skill_used": "fabrication",
-    "skills_required": [ "electronics", 3 ],
+    "skills_required": [ "electronics", 4 ],
+    "difficulty": 6,
+    "time": "15 m",
+    "autolearn": true,
+    "reversible": true,
+    "book_learn": [ [ "textbook_anarch", 4 ], [ "manual_traps_mil", 3 ] ],
+    "//": "Using the contents of military_explosive separately to make RDX the preferred component for premade C4",
+    "components": [
+      [ [ "chem_rdx", 300 ], [ "chem_compositionb", 400 ] ],
+      [ [ "circuit", 1 ] ],
+      [ [ "cable", 10 ] ],
+      [ [ "delay_fuze", 1 ] ],
+      [ [ "motor_oil", 50, "NO_RECOVER" ], [ "lamp_oil", 50, "NO_RECOVER" ] ]
+    ],
+    "using": [ [ "soldering_standard", 5 ] ]
+  },
+  {
+    "result": "grenade",
+    "type": "recipe",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_EXPLOSIVE",
+    "skill_used": "fabrication",
+    "skills_required": [ "mechanics", 3 ],
     "difficulty": 4,
     "time": "15 m",
     "autolearn": true,
-    "components": [ [ [ "chem_rdx", 300 ] ], [ [ "e_scrap", 1 ] ], [ [ "cable", 10 ] ], [ [ "motor_oil", 50 ] ] ],
-    "using": [ [ "soldering_standard", 5 ] ]
+    "reversible": true,
+    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
+    "components": [
+      [ [ "military_explosive", 25, "LIST" ] ],
+      [ [ "delay_fuze", 1 ] ],
+      [ [ "canister_empty", 1 ], [ "can_drink_unsealed", 1 ], [ "clay_canister", 1 ], [ "can_food_unsealed", 1 ] ]
+    ]
+  },
+  {
+    "result": "grenade_inc",
+    "type": "recipe",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_EXPLOSIVE",
+    "skill_used": "fabrication",
+    "skills_required": [ "mechanics", 3 ],
+    "difficulty": 5,
+    "time": "15 m",
+    "autolearn": true,
+    "reversible": true,
+    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
+    "components": [
+      [ [ "incendiary", 150 ] ],
+      [ [ "delay_fuze", 1 ] ],
+      [ [ "canister_empty", 1 ], [ "can_drink_unsealed", 1 ], [ "clay_canister", 1 ], [ "can_food_unsealed", 1 ] ]
+    ]
   },
   {
     "result": "dynamite",

--- a/data/json/recipes/weapon/explosive.json
+++ b/data/json/recipes/weapon/explosive.json
@@ -51,7 +51,7 @@
     "components": [
       [ [ "military_explosive", 25, "LIST" ] ],
       [ [ "delay_fuze", 1 ] ],
-      [ [ "canister_empty", 1 ], [ "can_drink_unsealed", 1 ], [ "clay_canister", 1 ], [ "can_food_unsealed", 1 ] ]
+      [ [ "canister_empty", 1 ], [ "can_drink_unsealed", 1 ], [ "can_food_unsealed", 1 ] ]
     ]
   },
   {
@@ -69,7 +69,7 @@
     "components": [
       [ [ "incendiary", 150 ] ],
       [ [ "delay_fuze", 1 ] ],
-      [ [ "canister_empty", 1 ], [ "can_drink_unsealed", 1 ], [ "clay_canister", 1 ], [ "can_food_unsealed", 1 ] ]
+      [ [ "canister_empty", 1 ], [ "can_drink_unsealed", 1 ], [ "can_food_unsealed", 1 ] ]
     ]
   },
   {

--- a/data/json/requirements/explosives.json
+++ b/data/json/requirements/explosives.json
@@ -49,13 +49,13 @@
   {
     "id": "stable_explosive",
     "type": "requirement",
-    "//": "This should contain all the explosives you need to set off with an explosive primer, but can be used without casting in a crucible. 10g tnt equivalent.",
-    "components": [ [ [ "chem_ammonium_nitrate", 24 ], [ "chem_ammonium_nitrate_pellets", 24 ], [ "chem_anfo", 14 ], [ "chem_rdx", 6 ] ] ]
+    "//": "This should contain civilian-grade explosives you need to set off with an explosive primer, 10g tnt equivalent.",
+    "components": [ [ [ "chem_ammonium_nitrate", 24 ], [ "chem_ammonium_nitrate_pellets", 24 ], [ "chem_anfo", 14 ] ] ]
   },
   {
     "id": "military_explosive",
     "type": "requirement",
-    "//": "This should contain all the explosives you need to set off with an explosive primer or a fuze, and also need casting in a crucible. 10g tnt equivalent.",
-    "components": [ [ [ "chem_compositionb", 8 ] ] ]
+    "//": "This should contain military-grade explosives you need to set off with an explosive primer, 10g tnt equivalent.",
+    "components": [ [ [ "chem_compositionb", 8 ], [ "chem_rdx", 6 ] ] ]
   }
 ]

--- a/data/json/uncraft/weapon/explosive.json
+++ b/data/json/uncraft/weapon/explosive.json
@@ -1,33 +1,6 @@
 [
   {
     "type": "uncraft",
-    "result": "grenade",
-    "skill_used": "fabrication",
-    "difficulty": 3,
-    "time": "50 s",
-    "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "components": [ [ [ "delay_fuze", 1 ] ], [ [ "canister_empty", 1 ] ], [ [ "chem_compositionb", 200 ] ] ]
-  },
-  {
-    "type": "uncraft",
-    "result": "grenade_inc",
-    "skill_used": "fabrication",
-    "difficulty": 3,
-    "time": "50 s",
-    "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "components": [ [ [ "delay_fuze", 1 ] ], [ [ "canister_empty", 1 ] ], [ [ "incendiary", 150 ] ] ]
-  },
-  {
-    "type": "uncraft",
-    "result": "landmine",
-    "skill_used": "fabrication",
-    "difficulty": 4,
-    "time": "50 s",
-    "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "components": [ [ [ "delay_fuze", 1 ] ], [ [ "canister_empty", 1 ] ], [ [ "bearing", 50 ] ], [ [ "chem_compositionb", 600 ] ] ]
-  },
-  {
-    "type": "uncraft",
     "result": "LAW_Packed",
     "skill_used": "fabrication",
     "difficulty": 6,


### PR DESCRIPTION
## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

We've been able to craft landmines and flashbangs for a long time, and a while back C-4 was made craftable, but not some other basic grenades and related components.

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Added a recipe for standard frag grenades and for incendiary grenades, based on the uncrafts for them but with skill requirements bumped up a bit.
2. Accordingly, removed the uncrafts for frag and incendiary grenades as they're no longer needed, due to using reversible recipes.
3. Adjusted C-4 recipe some, bumping skill requirements up in exchange for adding booklearns. Now requires a circuit board and a proper delay fuse to craft, but in exchange it can now use lamp oil and comp-B as alternatives to the RDX and motor oil respectively, and also made reversible. Set it up such that it still returns RDX when taken apart by default.
4. Shifted order of components in landmine recipe to return the expected items on reversing the recipe (though tweaked a lil to use impact fuze as the primary component for variety), and accordingly removed the now-redundant uncraft.
5. Added high-level recipes for impact fuzes and delay fuzes, with the latter expanding on the impact fuze's recipe a bit.
6. Misc: Moved RDX from `stable_explosives` requirement to `military_explosive` and updated the comments, as we don't actually bother with casting plastic explosives in any of the recipes so the stated distinction is not used.

## Describe alternatives you've considered

1. Making landmines also require more stable explosives.
2. Adding a small amount of explosive and/or oxidizer to the recipe for incendiary grenade since there's nothing to actually ignite the incendiary and dust it all over the place aside from the charge in the fuze.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
