### PR TITLE
build: fix clang-tidy / clang-diagnostic error for StringMaker

### DIFF
--- a/tests/map_setup_helpers.h
+++ b/tests/map_setup_helpers.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "point.h"
+#include "catch/catch.hpp"
 
 namespace map_helpers
 {


### PR DESCRIPTION
## Purpose of change (The Why)
Fix CI error 
![image](https://github.com/user-attachments/assets/66630678-1938-4aab-b0b5-77bdfa8eed8d)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Add catch header to relevant file
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Move the specialization to a different file `tests/stringmaker.h`

## Testing
Testing live! If CI doesn't yell at me then it works :D
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
