### PR TITLE
feat(UI): Adds new dump loot zone for items not otherwise sorted.

### DIFF
--- a/data/json/loot_zones.json
+++ b/data/json/loot_zones.json
@@ -340,5 +340,11 @@
     "type": "LOOT_ZONE",
     "name": "NPC Investigation Area",
     "description": "Friendly NPCs will investigate unseen sounds only if they come from inside this area."
+  },
+  {
+    "id": "LOOT_DUMP",
+    "type": "LOOT_ZONE",
+    "name": "Loot: Dump",
+    "description": "Any item not otherwise sorted will be placed here if this zone is specified."
   }
 ]

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -55,6 +55,7 @@ static const zone_type_id zone_LOOT_PDRINK( "LOOT_PDRINK" );
 static const zone_type_id zone_LOOT_PFOOD( "LOOT_PFOOD" );
 static const zone_type_id zone_LOOT_SEEDS( "LOOT_SEEDS" );
 static const zone_type_id zone_LOOT_UNSORTED( "LOOT_UNSORTED" );
+static const zone_type_id zone_LOOT_DUMP( "LOOT_DUMP" );
 static const zone_type_id zone_LOOT_WOOD( "LOOT_WOOD" );
 static const zone_type_id zone_NO_AUTO_PICKUP( "NO_AUTO_PICKUP" );
 static const zone_type_id zone_NO_NPC_PICKUP( "NO_NPC_PICKUP" );
@@ -848,7 +849,7 @@ zone_type_id zone_manager::get_near_zone_type_for_item( const item &it,
         return *zone_check_first;
     }
 
-    if( cat.zone() ) {
+    if( cat.zone() && has_near( *cat.zone(), where, range ) ) {
         return *cat.zone();
     }
 
@@ -869,9 +870,15 @@ zone_type_id zone_manager::get_near_zone_type_for_item( const item &it,
                 return zone_LOOT_PFOOD;
             }
         }
-
-        return zone_LOOT_FOOD;
+        if( has_near( zone_LOOT_FOOD, where, range ) ) {
+            return zone_LOOT_FOOD;
+        }
     }
+
+    if( has_near( zone_LOOT_DUMP, where, range ) ) {
+        return zone_LOOT_DUMP;
+    }
+
 
     return zone_type_id();
 }


### PR DESCRIPTION
## Purpose of change (The Why)
The current best solution for an "everything else" loot zone is a blank Custom Filter zone, but that gets triggered before any other sorting is done. This adds a new zone, called Dump, that collects anything that doesn't have any other place to go after all the checks have been made.

## Describe the solution (The How)
I added a new loot zone type zone_LOOT_DUMP and added checks to the category sort code to check if there's a category zone in range. If not, but there's a zone_LOOT_DUMP in range, it uses that instead.

## Describe alternatives you've considered

I briefly considered moving the Custom Filter check to the end if it is blank, but it seems like it just makes more sense to have a new type.

## Testing
I tested sorting with several item and zone types (including P.Food and Food), both with and without dump zones, and behavior was as expected.

## Additional context

![image](https://github.com/user-attachments/assets/5c616f31-a76d-4eb4-8ba1-cc1a4b8fcb16)

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
