### PR TITLE
ci: Pin Windows CMake

### DIFF
--- a/.github/workflows/msvc-full-features-cmake.yml
+++ b/.github/workflows/msvc-full-features-cmake.yml
@@ -75,7 +75,7 @@ jobs:
           echo $env:PATH
 
       - name: Install stable CMake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@v3.31.6
 
       - name: Install vcpkg
         uses: lukka/run-vcpkg@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,7 +222,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1.3.1
 
       - name: Install stable CMake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@v3.31.6
 
       - name: Install vcpkg
         uses: lukka/run-vcpkg@main


### PR DESCRIPTION
## Purpose of change (The Why)

As noted in #6274 and #6275, vcpkg currently wants to commit die because of the latest CMake version. This is unacceptable.

## Describe the solution (The How)

Pins CMake used to the most recent version before CMake 4 (3.31.6)

## Describe alternatives you've considered

- [Wait Aeons for Microsoft to decide what they want to do about it](https://github.com/microsoft/vcpkg/pull/44273)

## Testing

It appears to work on my fork.

## Additional context

CMake 4 is a lil asshole and doesn't wanna support stuff configured for older CMake versions

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

