### PR TITLE
ci: Disable Lua on the MSYS build that runs on every commit

### DIFF
--- a/.github/workflows/msys2-cmake.yml
+++ b/.github/workflows/msys2-cmake.yml
@@ -58,7 +58,6 @@ jobs:
             mingw-w64-x86_64-cmake
             mingw-w64-x86_64-sqlite3
             mingw-w64-x86_64-zstd
-            mingw-w64-x86_64-sol2
 
       - name: Create build directory
         run: mkdir build
@@ -69,7 +68,7 @@ jobs:
           cmake.exe \
             -DTILES=ON \
             -DSOUND=ON \
-            -DLUA=ON \
+            -DLUA=OFF \
             -DTESTS=ON \
             -DDYNAMIC_LINKING=ON \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \


### PR DESCRIPTION
## Purpose of change (The Why)

Even after explicitly adding sol2 in the last go-around, it STILL refuses to build for Lua-related reasons that no-one can comprehend. At this point, it's either this or throw it out entirely imo, and having at least one test build without Lua seems like a great indicator for if we ever inadvertently make Lua mandatory in a PR without realizing it.

## Describe the solution (The How)

- Remove the sol2 package from its install script given it's pointless
- Turn Lua from ON to OFF in the cmake

## Describe alternatives you've considered

- Delete / retire it entirely

Tempting.

## Testing

Absolutely none other than using my eyes, but given the current status quo is it failing I consider that to be fine. (Also, testing can only be done by merging into main atm, and as such testing on my fork would be a lil too risky for my liking)

## Additional context

If some poor Windows soul ever decides to get a wild streak and try to fix it building with Lua, be my guest.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
