### PR TITLE
chore: Fix the latest errant angle-braces on non-system headers

### DIFF
--- a/src/crafting.h
+++ b/src/crafting.h
@@ -10,7 +10,7 @@
 #include "mapdata.h"
 #include "ret_val.h"
 #include "type_id.h"
-#include <veh_type.h>
+#include "veh_type.h"
 
 class avatar;
 class Character;


### PR DESCRIPTION
## Purpose of change (The Why)

Making the MSYS2 + CMake build not use Lua apparently woke it up about a random instance of bad braces. Why it didn't notice them before, I do not know.

For once, this one isn't my fault, but I'll still fix it nonetheless.

## Describe the solution (The How)

<> -> ""

## Describe alternatives you've considered

- Make the original author do it to atone for their sins

## Testing

Eyeballs confirmed that it's now "" instead of <>

## Additional context

In the process, I also noticed that for some reason we have both a `# pragma once` AND header guards in that header file... and the header guards have been updated more recently than the pragma! Given that we can assume any compiler that can compile the game will support pragma given our use of modern C++ features, we should probably shift to just pragma in the future.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

