### PR TITLE
refactor: remove layer backup from class overmap

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -2944,10 +2944,6 @@ void overmap::init_layers()
                 layer[k].visible[i][j] = false;
                 layer[k].explored[i][j] = false;
                 layer[k].path[i][j] = false;
-                layer_backup[k].terrain[i][j] = tid;
-                layer_backup[k].visible[i][j] = false;
-                layer_backup[k].explored[i][j] = false;
-                layer_backup[k].path[i][j] = false;
             }
         }
     }
@@ -4700,7 +4696,7 @@ void overmap::place_cities()
         // don't draw cities across the edge of the map, they will get clipped
         const tripoint_om_omt p{ rng( size - 1, OMAPX - size ), rng( size - 1, OMAPY - size ), 0 };
         //make a backup of the map
-        std::copy( std::begin( layer ), std::end( layer ), std::begin( layer_backup ) );
+        std::array<map_layer, 21UL> layer_backup = layer;
         tmp.finale_placed = false;
         int finale_attempts = 0;
         int finale_max_tries = 1500;
@@ -4730,7 +4726,7 @@ void overmap::place_cities()
 
                 //if the city finale failed to place, restore from last backup and try again at the top of the loop
                 if( !tmp.finale_placed  && tmp.attempt_finale && finale_attempts < finale_max_tries ) {
-                    std::copy( std::begin( layer_backup ), std::end( layer_backup ), std::begin( layer ) );
+                    layer = layer_backup;
                 }
             }
             finale_attempts++;

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -4663,6 +4663,9 @@ void overmap::place_cities()
     const int MAX_PLACEMENT_ATTEMTPS = OMAPX * OMAPY;
     int placement_attempts = 0;
     int finale_distance = 1;
+    std::unique_ptr<std::array<map_layer, OVERMAP_LAYERS>> layer_backup_p( new std::array<map_layer, OVERMAP_LAYERS>() );
+    std::array<map_layer, 21UL> &layer_backup = *layer_backup_p;
+
     // place a seed for NUM_CITIES cities, and maybe one more
     while( cities.size() < static_cast<size_t>( NUM_CITIES ) &&
            placement_attempts < MAX_PLACEMENT_ATTEMTPS ) {
@@ -4696,7 +4699,7 @@ void overmap::place_cities()
         // don't draw cities across the edge of the map, they will get clipped
         const tripoint_om_omt p{ rng( size - 1, OMAPX - size ), rng( size - 1, OMAPY - size ), 0 };
         //make a backup of the map
-        std::array<map_layer, 21UL> layer_backup = layer;
+        layer_backup = layer;
         tmp.finale_placed = false;
         int finale_attempts = 0;
         int finale_max_tries = 1500;

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -4663,7 +4663,8 @@ void overmap::place_cities()
     const int MAX_PLACEMENT_ATTEMTPS = OMAPX * OMAPY;
     int placement_attempts = 0;
     int finale_distance = 1;
-    std::unique_ptr<std::array<map_layer, OVERMAP_LAYERS>> layer_backup_p( new std::array<map_layer, OVERMAP_LAYERS>() );
+    std::unique_ptr<std::array<map_layer, OVERMAP_LAYERS>> layer_backup_p(
+                new std::array<map_layer, OVERMAP_LAYERS>() );
     std::array<map_layer, 21UL> &layer_backup = *layer_backup_p;
 
     // place a seed for NUM_CITIES cities, and maybe one more

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -362,7 +362,6 @@ class overmap
         point_abs_om loc;
 
         std::array<map_layer, OVERMAP_LAYERS> layer;
-        std::array<map_layer, OVERMAP_LAYERS> layer_backup;
         std::unordered_map<tripoint_abs_omt, scent_trace> scents;
 
         // Records the locations where a given overmap special was placed, which


### PR DESCRIPTION
## Purpose of change (The Why)
`overmap::layer_backup` is used in `overmap::place_cities` as temporary storage and nowhere else. Does not need to be a part of the class. `array<map_layer, OVERMAP_LAYERS>` is pretty large, around 4.7MB of data. Without `layer_backup` the `overmap` is still bloated quite a bit by `std::array<map_layer, OVERMAP_LAYERS> layer` but at least now we've dropped the size by just under half!

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Delete `layer_backup` from the class and make it entirely local to `overmap::place_cities`.
Copying an `std::array` is as simple as assignment, no need to use `std::copy` here so I got rid of that as well. There is nothing complex going on `map_layer`.

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
None, cutting the size of overmap almost in half with a few lines changed is great.

## Testing
Started a few new worlds with new characters, mapgen didn't explode, seems to work fine. No errors when placing cities so it's not exploding from stack allocating 4.7MB for the backup array.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context
The remaining `std::array<map_layer, OVERMAP_LAYERS> layer;` is still massive and takes up the vast majority of the size of `overmap` (all but ~600 bytes!) but we can't easily get rid of most of it since we kinda need the omt grid. Might be able to compress that some, at least for the z != 0 layers since the map at z>0 is *mostly* a single oter_id (air), and the map z<0 is *mostly* a single oter_id (rocky) and could benefit from some compression.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
