### PR TITLE
Chore: fixes typo for the "super electric motor"

### DIFF
--- a/data/json/items/vehicle/motors.json
+++ b/data/json/items/vehicle/motors.json
@@ -30,7 +30,7 @@
     "type": "GENERIC",
     "id": "motor_super",
     "name": { "str": "super electric motor" },
-    "description": "The most powerfull electric motor on the market.  Useful for crafting, and its advanced design means it won't suffer power loss if multiple are installed on a vehicle.",
+    "description": "The most powerful electric motor on the market.  Useful for crafting, and its advanced design means it won't suffer power loss if multiple are installed on a vehicle.",
     "weight": "125 kg",
     "volume": "25 L",
     "price": "800 USD",


### PR DESCRIPTION
## Purpose of change 
fixing typo's
## Describe the solution 
Removes an extra "L" on "powerful"
- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--


