### PR TITLE
feat(balance, mods/MagicalNights): Make infusion bracelets autolearn

### DIFF
--- a/data/mods/Magical_Nights/recipes/magic_tools.json
+++ b/data/mods/Magical_Nights/recipes/magic_tools.json
@@ -22,8 +22,9 @@
     "skill_used": "fabrication",
     "skills_required": [ "spellcraft", 2 ],
     "difficulty": 3,
+    "autolearn": true,
     "time": "20 m",
-    "book_learn": [ [ "alchemy_basic", 3 ], [ "necro_basic", 4 ], [ "techno_basic", 4 ] ],
+    "book_learn": [ [ "alchemy_basic", 1 ], [ "necro_basic", 2 ] ],
     "qualities": [ { "id": "CHISEL", "level": 1 } ],
     "components": [ [ [ "copper_bracelet", 1 ] ] ]
   },
@@ -35,8 +36,9 @@
     "skill_used": "fabrication",
     "skills_required": [ "spellcraft", 3 ],
     "difficulty": 4,
+    "autolearn": true,
     "time": "20 m",
-    "book_learn": [ [ "alchemy_basic", 3 ], [ "necro_basic", 4 ], [ "techno_basic", 4 ] ],
+    "book_learn": [ [ "alchemy_basic", 2 ], [ "necro_basic", 3 ] ],
     "qualities": [ { "id": "CHISEL", "level": 1 } ],
     "components": [ [ [ "silver_bracelet", 1 ] ] ]
   },


### PR DESCRIPTION
## Purpose of change (The Why)

They're useful and don't make much sense to be super-duper locked behind booklearn

## Describe the solution (The How)

Makes the infusion bracelets autolearn and also removes the technomancer booklearn from them.

## Describe alternatives you've considered

- Swap their primary and secondary skills

## Testing

It loads

## Additional context

Took me long enough to get around to it lol

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.


