### PR TITLE
feat: H&K G80 steel slugs, handmade coil capacitor, adjustments to coilgun and G80

### DIFF
--- a/data/json/items/ammo/12mm.json
+++ b/data/json/items/ammo/12mm.json
@@ -18,5 +18,14 @@
     "dispersion": 45,
     "loudness": 0,
     "recoil": 100
+  },
+  {
+    "id": "12mm_makeshift",
+    "type": "AMMO",
+    "name": { "str": "steel 12mm slug" },
+    "description": "A handmade steel slug measured exactly 12mm in diameter intended for use with railguns.  The H&K G80 normally uses rare earth metals like cobalt for its ammunition, but it's not exactly something easy- or possible- to get outside of what was once the Democratic Republic of the Congo.",
+    "copy-from": "12mm",
+    "weight": "18 g",
+    "damage": { "damage_type": "bullet", "amount": 40, "armor_penetration": 30 }
   }
 ]

--- a/data/json/items/ammo/12mm.json
+++ b/data/json/items/ammo/12mm.json
@@ -14,7 +14,7 @@
     "count": 20,
     "stack_size": 40,
     "ammo_type": "12mm",
-    "damage": { "damage_type": "bullet", "amount": 50, "armor_penetration": 40 },
+    "damage": { "damage_type": "bullet", "amount": 80, "armor_penetration": 60 },
     "dispersion": 45,
     "loudness": 0,
     "recoil": 100
@@ -26,6 +26,6 @@
     "description": "A handmade steel slug measured exactly 12mm in diameter intended for use with railguns.  The H&K G80 normally uses rare earth metals like cobalt for its ammunition, but it's not exactly something easy- or possible- to get outside of what was once the Democratic Republic of the Congo.",
     "copy-from": "12mm",
     "weight": "18 g",
-    "damage": { "damage_type": "bullet", "amount": 40, "armor_penetration": 30 }
+    "damage": { "damage_type": "bullet", "amount": 70, "armor_penetration": 40 }
   }
 ]

--- a/data/json/items/ammo/12mm.json
+++ b/data/json/items/ammo/12mm.json
@@ -14,7 +14,7 @@
     "count": 20,
     "stack_size": 40,
     "ammo_type": "12mm",
-    "damage": { "damage_type": "bullet", "amount": 80, "armor_penetration": 60 },
+    "damage": { "damage_type": "bullet", "amount": 50, "armor_penetration": 40 },
     "dispersion": 45,
     "loudness": 0,
     "recoil": 100
@@ -26,6 +26,6 @@
     "description": "A handmade steel slug measured exactly 12mm in diameter intended for use with railguns.  The H&K G80 normally uses rare earth metals like cobalt for its ammunition, but it's not exactly something easy- or possible- to get outside of what was once the Democratic Republic of the Congo.",
     "copy-from": "12mm",
     "weight": "18 g",
-    "damage": { "damage_type": "bullet", "amount": 70, "armor_penetration": 40 }
+    "damage": { "damage_type": "bullet", "amount": 40, "armor_penetration": 30 }
   }
 ]

--- a/data/json/items/gun/12mm.json
+++ b/data/json/items/gun/12mm.json
@@ -15,6 +15,7 @@
     "dispersion": 45,
     "ups_charges": 5,
     "loudness": 50,
+    "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "AUTO", "auto", 3 ] ],
     "magazines": [ [ "12mm", [ "hk_g80mag" ] ] ]
   }
 ]

--- a/data/json/items/gun/12mm.json
+++ b/data/json/items/gun/12mm.json
@@ -15,6 +15,7 @@
     "dispersion": 45,
     "ups_charges": 10,
     "loudness": 50,
+    "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "BURST", "auto", 3 ] ],
     "magazines": [ [ "12mm", [ "hk_g80mag" ] ] ]
   }
 ]

--- a/data/json/items/gun/12mm.json
+++ b/data/json/items/gun/12mm.json
@@ -13,9 +13,8 @@
     "ammo": "12mm",
     "range": 60,
     "dispersion": 45,
-    "ups_charges": 5,
+    "ups_charges": 10,
     "loudness": 50,
-    "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "BURST", "auto", 3 ] ],
     "magazines": [ [ "12mm", [ "hk_g80mag" ] ] ]
   }
 ]

--- a/data/json/items/gun/12mm.json
+++ b/data/json/items/gun/12mm.json
@@ -15,7 +15,7 @@
     "dispersion": 45,
     "ups_charges": 5,
     "loudness": 50,
-    "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "AUTO", "auto", 3 ] ],
+    "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "BURST", "auto", 3 ] ],
     "magazines": [ [ "12mm", [ "hk_g80mag" ] ] ]
   }
 ]

--- a/data/json/items/gun/12mm.json
+++ b/data/json/items/gun/12mm.json
@@ -13,7 +13,7 @@
     "ammo": "12mm",
     "range": 60,
     "dispersion": 45,
-    "ups_charges": 10,
+    "ups_charges": 5,
     "loudness": 50,
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "BURST", "auto", 3 ] ],
     "magazines": [ [ "12mm", [ "hk_g80mag" ] ] ]

--- a/data/json/items/gun/nail.json
+++ b/data/json/items/gun/nail.json
@@ -45,15 +45,6 @@
     "loudness": 5,
     "durability": 5,
     "ups_charges": 20,
-    "valid_mod_locations": [
-      [ "accessories", 4 ],
-      [ "grip", 1 ],
-      [ "sights", 1 ],
-      [ "sling", 1 ],
-      [ "stock", 1 ],
-      [ "rail", 1 ],
-      [ "underbarrel", 1 ]
-    ],
     "magazines": [ [ "nail", [ "nailmag" ] ] ]
   },
   {

--- a/data/json/items/gunmod/mechanism.json
+++ b/data/json/items/gunmod/mechanism.json
@@ -158,5 +158,23 @@
     "install_time": "5 m",
     "reload_modifier": -80,
     "ups_charges_modifier": 40
+  },
+  {
+    "id": "mod_makeshift_capacitor",
+    "type": "GUNMOD",
+    "name": { "str": "handmade coil capacitor" },
+    "description": "This particular modification is a handmade, but by no means crude, capacitor bank designed to increase transferrance efficiency as well as utilizing an atomic battery to reduce, but not eliminate, the power draw.  It was even rarer to see than the makeshift railgun weapons and firearm conversions during the protests before the Cataclysm, if only because of the sheer rarity of particular materials.  It unfortunately cannot effect makeshift accelerators thanks to them lacking the proper internal components.",
+    "looks_like": "high_density_capacitor",
+    "weight": "820 g",
+    "volume": "250 ml",
+    "price": "10 USD",
+    "price_postapoc": "10 USD",
+    "material": [ "steel", "copper" ],
+    "symbol": ":",
+    "color": "light_gray",
+    "location": "mechanism",
+    "install_time": "5 m",
+    "blacklist_mod": "emitter",
+    "ups_charges_multiplier": 0.5
   }
 ]

--- a/data/json/recipes/ammo/other.json
+++ b/data/json/recipes/ammo/other.json
@@ -185,5 +185,32 @@
     "book_learn": [ [ "textbook_computer", 2 ], [ "advanced_electronics", 2 ], [ "reference_fabrication1", 2 ] ],
     "using": [ [ "3d_printing_standard", 1 ], [ "blacksmithing_standard", 2 ], [ "steel_tiny", 2 ] ],
     "components": [ [ [ "carbon_fiber_filament", 5 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "12mm_makeshift",
+    "category": "CC_AMMO",
+    "subcategory": "CSC_AMMO_OTHER",
+    "id_suffix": "welding",
+    "skill_used": "fabrication",
+    "difficulty": 6,
+    "time": "15 m",
+    "batch_time_factors": [ 90, 1 ],
+    "autolearn": true,
+    "using": [ [ "welding_standard", 30 ], [ "steel_standard", 1 ] ],
+    "qualities": [ { "id": "SAW_M", "level": 1 } ]
+  },
+  {
+    "type": "recipe",
+    "result": "12mm_makeshift",
+    "category": "CC_AMMO",
+    "subcategory": "CSC_AMMO_OTHER",
+    "skill_used": "fabrication",
+    "difficulty": 3,
+    "time": "30 m",
+    "batch_time_factors": [ 70, 1 ],
+    "autolearn": true,
+    "using": [ [ "blacksmithing_intermediate", 16 ], [ "steel_standard", 1 ] ],
+    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
   }
 ]

--- a/data/json/recipes/weapon/magazines.json
+++ b/data/json/recipes/weapon/magazines.json
@@ -539,11 +539,7 @@
     "skills_required": [ "gun", 1 ],
     "time": "20 m",
     "autolearn": true,
-    "tools": [
-      [ [ "hk_g80", -1 ] ],
-      [ [ "12mm", -1 ], [ "12mm_makeshift", -1 ] ],
-      [ [ "small_repairkit", 10 ], [ "large_repairkit", 5 ] ]
-    ],
+    "tools": [ [ [ "12mm", -1 ], [ "12mm_makeshift", -1 ] ], [ [ "small_repairkit", 10 ], [ "large_repairkit", 5 ] ] ],
     "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "HAMMER", "level": 1 }, { "id": "SCREW_FINE", "level": 1 } ],
     "components": [ [ [ "sheet_metal_small", 1 ] ], [ [ "spring", 1 ] ], [ [ "duct_tape", 40 ] ] ]
   }

--- a/data/json/recipes/weapon/magazines.json
+++ b/data/json/recipes/weapon/magazines.json
@@ -528,19 +528,5 @@
     "book_learn": [ [ "textbook_computer", 3 ], [ "advanced_electronics", 3 ], [ "textbook_anarch", 3 ], [ "reference_fabrication1", 3 ] ],
     "using": [ [ "3d_printing_standard", 3 ] ],
     "components": [ [ [ "carbon_fiber_filament", 30 ] ] ]
-  },
-  {
-    "result": "hk_g80mag",
-    "type": "recipe",
-    "category": "CC_WEAPON",
-    "subcategory": "CSC_WEAPON_MAGAZINES",
-    "skill_used": "fabrication",
-    "difficulty": 4,
-    "skills_required": [ "gun", 1 ],
-    "time": "20 m",
-    "autolearn": true,
-    "tools": [ [ [ "12mm", -1 ], [ "12mm_makeshift", -1 ] ], [ [ "small_repairkit", 10 ], [ "large_repairkit", 5 ] ] ],
-    "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "HAMMER", "level": 1 }, { "id": "SCREW_FINE", "level": 1 } ],
-    "components": [ [ [ "sheet_metal_small", 1 ] ], [ [ "spring", 1 ] ], [ [ "duct_tape", 40 ] ] ]
   }
 ]

--- a/data/json/recipes/weapon/magazines.json
+++ b/data/json/recipes/weapon/magazines.json
@@ -528,5 +528,23 @@
     "book_learn": [ [ "textbook_computer", 3 ], [ "advanced_electronics", 3 ], [ "textbook_anarch", 3 ], [ "reference_fabrication1", 3 ] ],
     "using": [ [ "3d_printing_standard", 3 ] ],
     "components": [ [ [ "carbon_fiber_filament", 30 ] ] ]
+  },
+  {
+    "result": "hk_g80mag",
+    "type": "recipe",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_MAGAZINES",
+    "skill_used": "fabrication",
+    "difficulty": 4,
+    "skills_required": [ "gun", 1 ],
+    "time": "20 m",
+    "autolearn": true,
+    "tools": [
+      [ [ "hk_g80", -1 ] ],
+      [ [ "12mm", -1 ], [ "12mm_makeshift", -1 ] ],
+      [ [ "small_repairkit", 10 ], [ "large_repairkit", 5 ] ]
+    ],
+    "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "HAMMER", "level": 1 }, { "id": "SCREW_FINE", "level": 1 } ],
+    "components": [ [ [ "sheet_metal_small", 1 ] ], [ [ "spring", 1 ] ], [ [ "duct_tape", 40 ] ] ]
   }
 ]

--- a/data/json/recipes/weapon/mods.json
+++ b/data/json/recipes/weapon/mods.json
@@ -1002,5 +1002,30 @@
       [ [ "lens", 1 ] ],
       [ [ "amplifier", 1 ] ]
     ]
+  },
+  {
+    "result": "mod_makeshift_capacitor",
+    "type": "recipe",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_MODS",
+    "skill_used": "electronics",
+    "difficulty": 8,
+    "skills_required": [ [ "fabrication", 4 ], [ "gun", 2 ] ],
+    "time": "1 h",
+    "autolearn": true,
+    "reversible": true,
+    "book_learn": [ [ "textbook_robots", 6 ], [ "textbook_anarch", 3 ] ],
+    "using": [ [ "soldering_standard", 20 ] ],
+    "tools": [ [ [ "electrolysis_kit", 750 ] ] ],
+    "components": [
+      [ [ "e_scrap", 4 ] ],
+      [ [ "cable", 50 ] ],
+      [ [ "plut_cell", 2 ] ],
+      [ [ "light_minus_battery_cell", 1 ], [ "light_battery_cell", 1 ] ],
+      [ [ "plastic_chunk", 5 ] ],
+      [ [ "circuit", 1 ] ],
+      [ [ "amplifier", 5 ] ],
+      [ [ "RAM", 2 ] ]
+    ]
   }
 ]


### PR DESCRIPTION
## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->
The H&K G80, despite being one of the most effective railgun weapon types in terms of raw efficiency, is unfortunately very often outshined by the Rivtech weapons in terms of power due to the G80's lower fire rate, relative rarity of the G80 and its ammunition, and the fact that Rivtech ammo is craftable but G80 is not. 

Furthermore, many handmade ranged weapons in the game are designed to utilize reusable ammunition, but they sadly do not scale up to the level of a simple 9mm SMG or a 5.56 or 7.62 rifle, which are very easy to get more ammo for and can be given silencers to reduce their noise levels. Pneumatic weapons have the powered air pump to improve their reload speed, the area they are worst at, but there is no equivalent for the makeshift railguns we can make.
## Describe the solution (The How)
Added steel 12mm slug and corresponding recipes. Added new weapon modification to reduce UPS draw of non-laser weapons, the handmade coil capacitor, and corresponding recipe. Added burst-fire mode to G80. Coilgun weapon mod slots are now the default for magnetic weaponry, rather than lacking a mechanism slot.
<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
I could not for the life of me decide whether the G80 should be a sniper rifle or assault rifle, but ended up going with assault rifle to make the ferromagnetic rail rifle stand out in its role as sniper.
## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->
It's all json, so it's not that likely to fail, but I made sure it didn't throw any json errors. The handmade coil capacitor in particular is well done imo, since it uses a percentile change in UPS draw rather than a flat amount, allowing it to benefit high-power-draw weapons the most and providing less benefit for the G80 than its increased weight is worth.
## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
