### PR TITLE
feat(balance): add compact flag to more items

### DIFF
--- a/data/json/items/armor/bandolier.json
+++ b/data/json/items/armor/bandolier.json
@@ -43,7 +43,7 @@
       ],
       "draw_cost": 20
     },
-    "flags": [ "WATER_FRIENDLY", "WAIST", "OVERSIZE", "FANCY" ]
+    "flags": [ "WATER_FRIENDLY", "WAIST", "COMPACT", "OVERSIZE", "FANCY" ]
   },
   {
     "id": "bandolier_rifle",
@@ -84,7 +84,7 @@
       ],
       "draw_cost": 20
     },
-    "flags": [ "WATER_FRIENDLY", "WAIST", "OVERSIZE" ]
+    "flags": [ "WATER_FRIENDLY", "WAIST", "COMPACT", "OVERSIZE" ]
   },
   {
     "id": "bandolier_shotgun",
@@ -104,7 +104,7 @@
     "encumbrance": 2,
     "material_thickness": 1,
     "use_action": { "type": "bandolier", "capacity": 25, "ammo": [ "410shot", "shot", "20x66mm", "signal_flare" ], "draw_cost": 25 },
-    "flags": [ "WATER_FRIENDLY", "WAIST", "OVERSIZE" ]
+    "flags": [ "WATER_FRIENDLY", "WAIST", "COMPACT", "OVERSIZE" ]
   },
   {
     "id": "torso_bandolier_shotgun",
@@ -282,7 +282,7 @@
     "encumbrance": 1,
     "material_thickness": 1,
     "use_action": { "type": "bandolier", "capacity": 12, "ammo": [ "40x46mm", "40x53mm" ], "draw_cost": 20 },
-    "flags": [ "WATER_FRIENDLY", "WAIST", "OVERSIZE" ]
+    "flags": [ "WATER_FRIENDLY", "WAIST", "COMPACT", "OVERSIZE" ]
   },
   {
     "id": "bandolier_knife",
@@ -312,6 +312,6 @@
       "draw_cost": 50,
       "flags": [ "SHEATH_KNIFE" ]
     },
-    "flags": [ "WATER_FRIENDLY", "WAIST", "OVERSIZE" ]
+    "flags": [ "WATER_FRIENDLY", "WAIST", "COMPACT", "OVERSIZE" ]
   }
 ]

--- a/data/json/items/armor/belts.json
+++ b/data/json/items/armor/belts.json
@@ -27,7 +27,7 @@
       "flags": [ "BELT_CLIP" ]
     },
     "valid_mods": [ "resized_large" ],
-    "flags": [ "FANCY", "WAIST", "NO_QUICKDRAW", "WATER_FRIENDLY" ]
+    "flags": [ "FANCY", "WAIST", "COMPACT", "NO_QUICKDRAW", "WATER_FRIENDLY" ]
   },
   {
     "abstract": "judo_belt_abstract",
@@ -47,7 +47,7 @@
     "encumbrance": 2,
     "material_thickness": 5,
     "valid_mods": [ "resized_large" ],
-    "flags": [ "WAIST", "WATER_FRIENDLY" ]
+    "flags": [ "WAIST", "COMPACT", "WATER_FRIENDLY" ]
   },
   {
     "id": "judo_belt_black",
@@ -130,7 +130,7 @@
       "flags": [ "BELT_CLIP" ]
     },
     "valid_mods": [ "resized_large" ],
-    "flags": [ "WAIST", "WATER_FRIENDLY" ]
+    "flags": [ "WAIST", "COMPACT", "WATER_FRIENDLY" ]
   },
   {
     "id": "obi_gi",
@@ -175,7 +175,7 @@
       "flags": [ "BELT_CLIP" ]
     },
     "valid_mods": [ "resized_large" ],
-    "flags": [ "WAIST", "WATER_FRIENDLY" ]
+    "flags": [ "WAIST", "COMPACT", "WATER_FRIENDLY" ]
   },
   {
     "id": "survivor_belt_notools",
@@ -205,7 +205,7 @@
       "max_weight": "2500 g",
       "flags": [ "BELT_CLIP", "SHEATH_KNIFE", "SHEATH_SWORD" ]
     },
-    "flags": [ "WATER_FRIENDLY", "STURDY", "WAIST", "OVERSIZE" ]
+    "flags": [ "WATER_FRIENDLY", "STURDY", "WAIST", "COMPACT", "OVERSIZE" ]
   },
   {
     "id": "tool_belt",
@@ -238,7 +238,7 @@
       "flags": [ "BELT_CLIP", "SHEATH_KNIFE" ]
     },
     "valid_mods": [ "resized_large" ],
-    "flags": [ "WAIST", "NO_QUICKDRAW", "WATER_FRIENDLY" ]
+    "flags": [ "WAIST", "COMPACT", "NO_QUICKDRAW", "WATER_FRIENDLY" ]
   },
   {
     "id": "webbing_belt",
@@ -266,6 +266,6 @@
       "flags": [ "BELT_CLIP" ]
     },
     "valid_mods": [ "resized_large" ],
-    "flags": [ "WAIST", "WATER_FRIENDLY" ]
+    "flags": [ "WAIST", "COMPACT", "WATER_FRIENDLY" ]
   }
 ]

--- a/data/json/items/armor/holster.json
+++ b/data/json/items/armor/holster.json
@@ -202,7 +202,7 @@
     "material_thickness": 2,
     "use_action": { "type": "holster", "max_volume": "3750 ml", "min_volume": "1250 ml", "skills": [ "smg", "shotgun", "rifle" ] },
     "valid_mods": [ "steel_padded", "alloy_padded", "resized_large" ],
-    "flags": [ "WATER_FRIENDLY", "STURDY", "WAIST" ]
+    "flags": [ "WATER_FRIENDLY", "STURDY", "WAIST", "COMPACT" ]
   },
   {
     "id": "baldric_holster",

--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -359,7 +359,7 @@
     "storage": "3 L",
     "material_thickness": 1,
     "valid_mods": [ "resized_large" ],
-    "flags": [ "WAIST", "WATER_FRIENDLY" ]
+    "flags": [ "WAIST", "COMPACT", "WATER_FRIENDLY" ]
   },
   {
     "id": "fanny",
@@ -382,7 +382,7 @@
     "storage": "3 L",
     "material_thickness": 1,
     "valid_mods": [ "resized_large" ],
-    "flags": [ "WAIST", "WATER_FRIENDLY" ]
+    "flags": [ "WAIST", "COMPACT", "WATER_FRIENDLY" ]
   },
   {
     "id": "golf_bag",


### PR DESCRIPTION
Added compact to bandoliers, belts, holsters, and pouches that could reasonably be made to fit underneath or on top of other things in that slot.

## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->
Although several belt items in the game reasonably would be able to be adjusted on top of, underneath, or above or below similar items, they do not have the compact flag, leading to such utterly ridiculous results as the survivor harness- a harness which stretches across most of your upper body and thus would be completely adjustable- causing extra encumbrance when worn with a leather belt or a bandolier, two _other_ things that are completely adjustable and can be moved around.
## Describe the solution (The How)

<!-- e.g nerfs monster A -->
Added the COMPACT flag to a number of belted items which most likely could be worn next to other items on the same layer and body part.
## Describe alternatives you've considered

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
The back holster is compact but the survivor harness wasn't, despite the back holster being that much harder to reach when you have something else near it.
## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
