### PR TITLE
fix: bionic scanner multiplying values

### DIFF
--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -597,12 +597,10 @@
   },
   {
     "id": "bionic_scanner_on",
+    "copy-from": "bionic_scanner",
     "type": "TOOL",
-    "category": "electronics",
     "name": { "str": "bionic scanner (on)" },
     "description": "A small metal scanner specialized in detecting bionic hardware.  While in use it will steadily drain power, automatically scanning corpses near you for bionics.",
-    "weight": "141 g",
-    "volume": "250 ml",
     "price": "100 USD",
     "price_postapoc": "50 USD",
     "material": [ "plastic", "aluminum" ],


### PR DESCRIPTION
## Purpose of change (The Why)

Bionic scanner when on was multiplying it's value by it's battery charge count because it lacked ammo and magazine definitions.

## Describe the solution (The How)

Make it copy from the off bionic scanner to give it those definitions.

## Describe alternatives you've considered

Tossing it into the fiery pits of mordor or something.

## Testing

- [x] Spawned bionic scanner, it's price is sane.

## Additional context

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.