### PR TITLE
feat: even more lua item bindings

### DIFF
--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -327,32 +327,69 @@ void cata::detail::reg_item( sol::state &lua )
         DOC( "Erase all variables" );
         luna::set_fx( ut, "clear_vars", &item::clear_vars );
 
-        DOC( "Checks if this item is a tool" );
-        luna::set_fx( ut, "is_tool", &item::is_tool );
-
-        DOC( "Checks if this item is a container" );
-        luna::set_fx( ut, "is_container", &item::is_container );
-
-        DOC( "Checks if this item is a watertight container" );
-        luna::set_fx( ut, "is_watertight", &item::is_watertight_container );
-
-        DOC( "Checks if this item is ammo" );
+        luna::set_fx( ut, "is_null", &item::is_null );
+        luna::set_fx( ut, "is_unarmed_weapon", &item::is_unarmed_weapon );
+        luna::set_fx( ut, "is_sided", &item::is_sided );
+        luna::set_fx( ut, "is_power_armor", &item::is_power_armor );
+        luna::set_fx( ut, "is_money", &item::is_money );
+        luna::set_fx( ut, "is_gun", &item::is_gun );
+        luna::set_fx( ut, "is_firearm", &item::is_firearm );
+        luna::set_fx( ut, "is_silent", &item::is_silent );
+        luna::set_fx( ut, "is_gunmod", &item::is_gunmod );
+        luna::set_fx( ut, "is_bionic", &item::is_bionic );
+        luna::set_fx( ut, "is_ammo_belt", &item::is_ammo_belt );
+        luna::set_fx( ut, "is_bandolier", &item::is_bandolier );
+        luna::set_fx( ut, "is_holster", &item::is_holster );
         luna::set_fx( ut, "is_ammo", &item::is_ammo );
+        luna::set_fx( ut, "is_comestible", &item::is_comestible );
+        luna::set_fx( ut, "is_food", &item::is_food );
+        luna::set_fx( ut, "is_medication", &item::is_medication );
+        luna::set_fx( ut, "is_brewable", &item::is_brewable );
+        luna::set_fx( ut, "is_food_container", &item::is_food_container );
+        luna::set_fx( ut, "is_med_container", &item::is_med_container );
+        luna::set_fx( ut, "is_corpse", &item::is_corpse );
+        luna::set_fx( ut, "is_ammo_container", &item::is_ammo_container );
+        luna::set_fx( ut, "is_armor", &item::is_armor );
+        luna::set_fx( ut, "is_book", &item::is_book );
+        luna::set_fx( ut, "is_map", &item::is_map );
+        luna::set_fx( ut, "is_container", &item::is_container );
+        luna::set_fx( ut, "is_watertight_container", &item::is_watertight_container );
+        luna::set_fx( ut, "is_non_resealable_container", &item::is_non_resealable_container );
+        luna::set_fx( ut, "is_bucket", &item::is_bucket );
+        luna::set_fx( ut, "is_bucket_nonempty", &item::is_bucket_nonempty );
+        luna::set_fx( ut, "is_engine", &item::is_engine );
+        luna::set_fx( ut, "is_wheel", &item::is_wheel );
+        luna::set_fx( ut, "is_fuel", &item::is_fuel );
+        luna::set_fx( ut, "is_toolmod", &item::is_toolmod );
+        luna::set_fx( ut, "is_faulty", &item::is_faulty );
+        luna::set_fx( ut, "is_irremovable", &item::is_irremovable );
+        luna::set_fx( ut, "is_container_empty", &item::is_container_empty );
+        luna::set_fx( ut, "is_salvageable", &item::is_salvageable );
+        luna::set_fx( ut, "is_craft", &item::is_craft );
+        luna::set_fx( ut, "is_emissive", &item::is_emissive );
+        luna::set_fx( ut, "is_deployable", &item::is_deployable );
+        luna::set_fx( ut, "is_tool", &item::is_tool );
+        luna::set_fx( ut, "is_transformable", &item::is_transformable );
+        luna::set_fx( ut, "is_artifact", &item::is_artifact );
+        luna::set_fx( ut, "is_relic", &item::is_relic );
+        luna::set_fx( ut, "is_seed", &item::is_seed );
+        luna::set_fx( ut, "is_dangerous", &item::is_dangerous );
+        luna::set_fx( ut, "is_tainted", &item::is_tainted );
+        luna::set_fx( ut, "is_soft", &item::is_soft );
+        luna::set_fx( ut, "is_reloadable", &item::is_reloadable );
+        luna::set_fx( ut, "is_filthy", &item::is_filthy );
+        luna::set_fx( ut, "is_active", &item::is_active );
+        luna::set_fx( ut, "is_upgrade", &item::is_upgrade );
 
-        DOC( "Checks if this item is magazine" );
+        DOC( "Is this item an effective melee weapon for the given damage type?" );
+        luna::set_fx( ut, "is_melee", sol::resolve<bool( damage_type ) const>
+                      ( &item::is_melee ) );
+
+        DOC( "Is this a magazine? (batteries are magazines)" );
         luna::set_fx( ut, "is_magazine", &item::is_magazine );
 
-        DOC( "Checks if this item is a comestible" );
-        luna::set_fx( ut, "is_comestible", &item::is_comestible );
-
-        DOC( "Checks if this item is an empty container" );
-        luna::set_fx( ut, "is_empty", &item::is_container_empty );
-
-        DOC( "Checks if this item is a full container" );
-        luna::set_fx( ut, "is_full", &item::is_container_full );
-
-        DOC( "Checks if this item is food" );
-        luna::set_fx( ut, "is_food", &item::is_food );
+        DOC( "DEPRECATED: Is this a battery? (spoiler: it isn't)" );
+        luna::set_fx( ut, "is_battery", &item::is_battery );
 
         DOC( "Gets the TimeDuration until this item rots" );
         luna::set_fx( ut, "get_rot_time", &item::get_rot );

--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -467,6 +467,13 @@ void cata::detail::reg_item( sol::state &lua )
         DOC( "Checks if the item covers a bodypart" );
         luna::set_fx( ut, "covers", &item::covers );
 
+        luna::set_fx( ut, "set_flag", &item::set_flag );
+        luna::set_fx( ut, "unset_flag", &item::unset_flag );
+        luna::set_fx( ut, "has_flag", &item::has_flag );
+        luna::set_fx( ut, "has_own_flag", &item::has_own_flag );
+        luna::set_fx( ut, "set_flag_recursive", &item::set_flag_recursive );
+        luna::set_fx( ut, "unset_flags", &item::unset_flags );
+
         DOC( "Get variable as string" );
         luna::set_fx( ut, "get_var_str",
                       sol::resolve<std::string( const std::string &, const std::string & ) const>

--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -779,8 +779,8 @@ void cata::detail::reg_game_api( sol::state &lua )
         hooks.push_back( on_every_x_hooks{ interval, vec } );
     } );
 
-    luna::set_fx( lib, "create_item", []( const itype_id & itype, int count ) -> detached_ptr<item> {
-        return item::spawn( itype, calendar::turn, count );
+    luna::set_fx( lib, "create_item", []( const itype_id & itype, int count ) -> item {
+        return item( itype, calendar::turn, count );
     } );
 
     luna::set_fx( lib, "get_creature_at", []( const tripoint & p,

--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -393,6 +393,12 @@ void cata::detail::reg_item( sol::state &lua )
 
         luna::set_fx( ut, "conductive", &item::conductive );
 
+        luna::set( ut, "charges", &item::charges );
+
+        luna::set_fx( ut, "energy_remaining", &item::energy_remaining );
+
+        luna::set_fx( ut, "has_infinite_charges", &item::has_infinite_charges );
+
         luna::set_fx( ut, "mod_charges", &item::mod_charges );
 
         DOC( "Gets the TimeDuration until this item rots" );

--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -314,9 +314,6 @@ void cata::detail::reg_item( sol::state &lua )
 
         luna::set_fx( ut, "get_type", &item::typeId );
 
-        DOC( "Translated item name without prefixes" );
-        luna::set_fx( ut, "nname", &item::nname );
-
         DOC( "Translated item name with prefixes" );
         luna::set_fx( ut, "tname", &item::tname );
 

--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -339,6 +339,9 @@ void cata::detail::reg_item( sol::state &lua )
         DOC( "Checks if this item is ammo" );
         luna::set_fx( ut, "is_ammo", &item::is_ammo );
 
+        DOC( "Checks if this item is magazine" );
+        luna::set_fx( ut, "is_magazine", &item::is_magazine );
+
         DOC( "Checks if this item is a comestible" );
         luna::set_fx( ut, "is_comestible", &item::is_comestible );
 
@@ -376,18 +379,14 @@ void cata::detail::reg_item( sol::state &lua )
         DOC( "Gets maximum volume this item can hold (liquids, ammo, etc)" );
         luna::set_fx( ut, "total_capacity", &item::get_total_capacity );
 
-        DOC( "Gets an item contained by this one" );
-        luna::set_fx( ut, "get_contained", &item::get_contained );
-
         DOC( "Gets the current magazine" );
         luna::set_fx( ut, "current_magazine",
                       sol::resolve<const item*() const> ( &item::magazine_current ) );
 
-        DOC( "Gets charges of this item, or stack size for unchargeable items" );
-        luna::set( ut, "charges", &item::charges );
-
-        DOC( "Add or remove energy from a battery" );
-        luna::set_fx( ut, "mod_energy", &item::mod_energy );
+        DOC( "Gets the maximum capacity of a magazine" );
+        luna::set_fx( ut, "ammo_capacity",
+                      sol::resolve<int( const bool ) const>
+                      ( &item::ammo_capacity ) );
 
         DOC( "Get remaining ammo, works with batteries & stuff too" );
         luna::set_fx( ut, "ammo_remaining", &item::ammo_remaining );

--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -779,8 +779,8 @@ void cata::detail::reg_game_api( sol::state &lua )
         hooks.push_back( on_every_x_hooks{ interval, vec } );
     } );
 
-    luna::set_fx( lib, "create_item", []( const itype_id & itype, int count ) -> item {
-        return item( itype, calendar::turn, count );
+    luna::set_fx( lib, "create_item", []( const itype_id & itype, int count ) -> std::unique_ptr<item> {
+        return std::make_unique<item>( itype, calendar::turn, count );
     } );
 
     luna::set_fx( lib, "get_creature_at", []( const tripoint & p,

--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -314,6 +314,15 @@ void cata::detail::reg_item( sol::state &lua )
 
         luna::set_fx( ut, "get_type", &item::typeId );
 
+        DOC( "Translated item name without prefixes" );
+        luna::set_fx( ut, "nname", &item::nname );
+
+        DOC( "Translated item name with prefixes" );
+        luna::set_fx( ut, "tname", &item::tname );
+
+        DOC( "Display name with all bells and whistles like ammo and prefixes" );
+        luna::set_fx( ut, "display_name", &item::display_name );
+
         DOC( "Check for variable of any type" );
         luna::set_fx( ut, "has_var", &item::has_var );
         DOC( "Erase variable" );
@@ -321,15 +330,75 @@ void cata::detail::reg_item( sol::state &lua )
         DOC( "Erase all variables" );
         luna::set_fx( ut, "clear_vars", &item::clear_vars );
 
+        DOC( "Checks if this item is a tool" );
+        luna::set_fx( ut, "is_tool", &item::is_tool );
+
+        DOC( "Checks if this item is a container" );
+        luna::set_fx( ut, "is_container", &item::is_container );
+
+        DOC( "Checks if this item is a watertight container" );
+        luna::set_fx( ut, "is_watertight", &item::is_watertight_container );
+
+        DOC( "Checks if this item is ammo" );
+        luna::set_fx( ut, "is_ammo", &item::is_ammo );
+
+        DOC( "Checks if this item is a comestible" );
+        luna::set_fx( ut, "is_comestible", &item::is_comestible );
+
+        DOC( "Checks if this item is an empty container" );
+        luna::set_fx( ut, "is_empty", &item::is_container_empty );
+
+        DOC( "Checks if this item is a full container" );
+        luna::set_fx( ut, "is_full", &item::is_container_full );
+
+        DOC( "Checks if this item is food" );
+        luna::set_fx( ut, "is_food", &item::is_food );
+
+        DOC( "Gets the TimeDuration until this item rots" );
+        luna::set_fx( ut, "get_rot_time", &item::get_rot );
+
+        DOC( "Gets the category id this item is in" );
+        luna::set_fx( ut, "get_category_id", &item::get_category_id );
+
+        DOC( "Gets the faction id that owns this item" );
+        luna::set_fx( ut, "get_owner", &item::get_owner );
+
+        DOC( "Checks if this item can contain another" );
+        luna::set_fx( ut, "can_contain",
+                      sol::resolve<bool( const item & ) const>
+                      ( &item::can_contain ) );
+
+        DOC( "Checks if this item owned by a character" );
+        luna::set_fx( ut, "is_owned_by",
+                      sol::resolve<bool( const Character &, const bool ) const>
+                      ( &item::is_owned_by ) );
+
+        DOC( "Gets the remaining space available for a type of liquid" );
+        luna::set_fx( ut, "remaining_capacity_for_id", &item::get_remaining_capacity_for_id );
+
+        DOC( "Gets maximum volume this item can hold (liquids, ammo, etc)" );
+        luna::set_fx( ut, "total_capacity", &item::get_total_capacity );
+
+        DOC( "Gets an item contained by this one" );
+        luna::set_fx( ut, "get_contained", &item::get_contained );
+
+        DOC( "Gets the current magazine" );
+        luna::set_fx( ut, "current_magazine",
+                      sol::resolve<const item*() const> ( &item::magazine_current ) );
+
+        DOC( "Gets charges of this item, or stack size for unchargeable items" );
         luna::set( ut, "charges", &item::charges );
 
-        DOC( "Get item energy" );
-        luna::set_fx( ut, "energy_remaining", &item::energy_remaining );
+        DOC( "Add or remove energy from a battery" );
+        luna::set_fx( ut, "mod_energy", &item::mod_energy );
+
+        DOC( "Get remaining ammo, works with batteries & stuff too" );
+        luna::set_fx( ut, "ammo_remaining", &item::ammo_remaining );
 
         DOC( "Adds an item(s) to contents" );
         luna::set_fx( ut, "add_item_with_id", &item::add_item_with_id );
 
-        DOC( "Checks item contents for an ITypeId" );
+        DOC( "Checks item contents for a given item id" );
         luna::set_fx( ut, "has_item_with_id", &item::has_item_with_id );
 
         DOC( "Get variable as string" );
@@ -648,6 +717,10 @@ void cata::detail::reg_game_api( sol::state &lua )
         std::vector<sol::protected_function> vec;
         vec.push_back( f );
         hooks.push_back( on_every_x_hooks{ interval, vec } );
+    } );
+
+    luna::set_fx( lib, "create_item", []( const itype_id & itype, int count ) -> detached_ptr<item> {
+        return item::spawn( itype, calendar::turn, count );
     } );
 
     luna::set_fx( lib, "get_creature_at", []( const tripoint & p,

--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -391,8 +391,12 @@ void cata::detail::reg_item( sol::state &lua )
         DOC( "DEPRECATED: Is this a battery? (spoiler: it isn't)" );
         luna::set_fx( ut, "is_battery", &item::is_battery );
 
+        luna::set_fx( ut, "conductive", &item::conductive );
+
+        luna::set_fx( ut, "mod_charges", &item::mod_charges );
+
         DOC( "Gets the TimeDuration until this item rots" );
-        luna::set_fx( ut, "get_rot_time", &item::get_rot );
+        luna::set_fx( ut, "get_rot", &item::get_rot );
 
         DOC( "Gets the category id this item is in" );
         luna::set_fx( ut, "get_category_id", &item::get_category_id );
@@ -400,15 +404,25 @@ void cata::detail::reg_item( sol::state &lua )
         DOC( "Gets the faction id that owns this item" );
         luna::set_fx( ut, "get_owner", &item::get_owner );
 
+        DOC( "Sets the ownership of this item to a faction" );
+        luna::set_fx( ut, "set_owner",
+                      sol::resolve<void( const faction_id & )>
+                      ( &item::set_owner ) );
+
+        DOC( "Sets the ownership of this item to a character" );
+        luna::set_fx( ut, "set_owner",
+                      sol::resolve<void( const Character & )>
+                      ( &item::set_owner ) );
+
+        luna::set_fx( ut, "get_owner_name", &item::get_owner_name );
+
+        DOC( "Checks if this item owned by a character" );
+        luna::set_fx( ut, "is_owned_by", &item::is_owned_by );
+
         DOC( "Checks if this item can contain another" );
         luna::set_fx( ut, "can_contain",
                       sol::resolve<bool( const item & ) const>
                       ( &item::can_contain ) );
-
-        DOC( "Checks if this item owned by a character" );
-        luna::set_fx( ut, "is_owned_by",
-                      sol::resolve<bool( const Character &, const bool ) const>
-                      ( &item::is_owned_by ) );
 
         DOC( "Gets the remaining space available for a type of liquid" );
         luna::set_fx( ut, "remaining_capacity_for_id", &item::get_remaining_capacity_for_id );
@@ -428,11 +442,16 @@ void cata::detail::reg_item( sol::state &lua )
         DOC( "Get remaining ammo, works with batteries & stuff too" );
         luna::set_fx( ut, "ammo_remaining", &item::ammo_remaining );
 
+        luna::set_fx( ut, "get_reload_time", &item::get_reload_time );
+
         DOC( "Adds an item(s) to contents" );
         luna::set_fx( ut, "add_item_with_id", &item::add_item_with_id );
 
         DOC( "Checks item contents for a given item id" );
         luna::set_fx( ut, "has_item_with_id", &item::has_item_with_id );
+
+        DOC( "Checks if the item covers a bodypart" );
+        luna::set_fx( ut, "covers", &item::covers );
 
         DOC( "Get variable as string" );
         luna::set_fx( ut, "get_var_str",

--- a/src/catalua_bindings.cpp
+++ b/src/catalua_bindings.cpp
@@ -442,6 +442,14 @@ void cata::detail::reg_item( sol::state &lua )
         DOC( "Get remaining ammo, works with batteries & stuff too" );
         luna::set_fx( ut, "ammo_remaining", &item::ammo_remaining );
 
+        luna::set_fx( ut, "ammo_data", &item::ammo_data );
+        luna::set_fx( ut, "ammo_required", &item::ammo_required );
+        luna::set_fx( ut, "ammo_current", &item::ammo_current );
+
+        luna::set_fx( ut, "ammo_consume", &item::ammo_consume );
+        luna::set_fx( ut, "ammo_set", &item::ammo_set );
+        luna::set_fx( ut, "ammo_unset", &item::ammo_unset );
+
         luna::set_fx( ut, "get_reload_time", &item::get_reload_time );
 
         DOC( "Adds an item(s) to contents" );

--- a/src/catalua_bindings_creature.cpp
+++ b/src/catalua_bindings_creature.cpp
@@ -619,8 +619,13 @@ void cata::detail::reg_character( sol::state &lua )
 
         SET_FX_T( worn_with_flag, bool( const flag_id &, const bodypart_id & ) const );
 
+        SET_FX_T( worn_with_id, bool( const itype_id &, const bodypart_id & ) const );
+
         SET_FX_T( item_worn_with_flag,
                   const item * ( const flag_id &, const bodypart_id & ) const );
+
+        SET_FX_T( item_worn_with_id,
+                  const item * ( const itype_id &, const bodypart_id & ) const );
 
         SET_FX_T( get_skill_level, int( const skill_id & ) const );
 
@@ -667,13 +672,24 @@ void cata::detail::reg_character( sol::state &lua )
 
         SET_FX_T( is_hauling, bool() const );
 
+        DOC( "Adds an item with the given id and amount" );
         SET_FX_T( add_item_with_id, void( const itype_id & itype, int count ) );
 
+        DOC( "Checks for an item with the given id" );
         SET_FX_T( has_item_with_id, bool( const itype_id & itype, bool need_charges ) const );
 
+        DOC( "Gets the first occurrence of an item with the given id" );
+        SET_FX_T( get_item_with_id, const item * ( const itype_id & itype, bool need_charges ) const );
+
+        DOC( "Checks for an item with the given flag" );
         SET_FX_T( has_item_with_flag, bool( const flag_id & flag, bool need_charges ) const );
+
+        DOC( "Gets all items with the given flag" );
         SET_FX_T( all_items_with_flag,
-                  std::vector<item *>( const flag_id & flag ) const );
+                  std::vector<item *>( const flag_id & flag, bool need_charges ) const );
+
+        DOC( "Gets all items" );
+        SET_FX_T( all_items, std::vector<item *>( bool need_charges ) const );
 
         SET_FX_T( assign_activity,
                   void( const activity_id &, int, int, int, const std::string & ) );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3647,6 +3647,25 @@ const item *Character::item_worn_with_flag( const flag_id &flag, const bodypart_
     return nullptr;
 }
 
+bool Character::worn_with_id( const itype_id &item_id, const bodypart_id &bp ) const
+{
+    return std::any_of( worn.begin(), worn.end(), [&item_id, bp]( const item * const & it ) {
+        return it->typeId() == item_id && ( bp == bodypart_str_id::NULL_ID() ||
+                                            it->covers( bp ) );
+    } );
+}
+
+const item *Character::item_worn_with_id( const itype_id &item_id, const bodypart_id &bp ) const
+{
+    for( const item * const &it : worn ) {
+        if( it->typeId() == item_id && ( bp == bodypart_str_id::NULL_ID() ||
+                                         it->covers( bp ) ) ) {
+            return it;
+        }
+    }
+    return nullptr;
+}
+
 std::vector<std::string> Character::get_overlay_ids() const
 {
     std::vector<std::string> rval;
@@ -10054,15 +10073,46 @@ int Character::temp_corrected_by_climate_control( int temperature ) const
     return temperature;
 }
 
-void Character::add_item_with_id( const itype_id &itype, int count )
+const item *Character::get_item_with_id( const itype_id &item_id, bool need_charges ) const
 {
-    detached_ptr<item> new_item = item::spawn( itype, calendar::turn, count );
+    const item *ret = nullptr;
+
+    inv.visit_items( [&ret, &item_id, &need_charges]( const item * it ) {
+        if( it->typeId() == item_id ) {
+            if( it->is_tool() && need_charges ) {
+                if( it->type->tool->max_charges && it->charges <= 0 ) {
+                    return VisitResponse::SKIP;
+                }
+            }
+            ret = it;
+            return VisitResponse::ABORT;
+        }
+        return VisitResponse::NEXT;
+    } );
+
+    return ret;
+}
+
+void Character::add_item_with_id( const itype_id &item_id, int count )
+{
+    detached_ptr<item> new_item = item::spawn( item_id, calendar::turn, count );
     i_add( std::move( new_item ), true );
 }
 
 bool Character::has_item_with_id( const itype_id &item_id, bool need_charges ) const
 {
     return has_item_with( [&item_id, &need_charges]( const item & it ) {
+        if( it.is_tool() && need_charges ) {
+            return it.typeId() == item_id &&
+                   it.type->tool->max_charges ? it.charges > 0 : it.typeId() == item_id;
+        }
+        return it.typeId() == item_id;
+    } );
+}
+
+std::vector<item *> Character::all_items_with_id( const itype_id &item_id, bool need_charges ) const
+{
+    return items_with( [&item_id, &need_charges]( const item & it ) {
         if( it.is_tool() && need_charges ) {
             return it.typeId() == item_id &&
                    it.type->tool->max_charges ? it.charges > 0 : it.typeId() == item_id;
@@ -10081,10 +10131,23 @@ bool Character::has_item_with_flag( const flag_id &flag, bool need_charges ) con
     } );
 }
 
-std::vector<item *> Character::all_items_with_flag( const flag_id &flag ) const
+std::vector<item *> Character::all_items_with_flag( const flag_id &flag, bool need_charges ) const
 {
-    return items_with( [&flag]( const item & it ) {
+    return items_with( [&flag, &need_charges]( const item & it ) {
+        if( it.is_tool() && need_charges ) {
+            return it.has_flag( flag ) && it.type->tool->max_charges ? it.charges > 0 : it.has_flag( flag );
+        }
         return it.has_flag( flag );
+    } );
+}
+
+std::vector<item *> Character::all_items( bool need_charges ) const
+{
+    return items_with( [&need_charges]( const item & it ) {
+        if( it.is_tool() && need_charges ) {
+            return it.type->tool->max_charges ? it.charges > 0 : true;
+        }
+        return true;
     } );
 }
 

--- a/src/character.h
+++ b/src/character.h
@@ -1496,6 +1496,12 @@ class Character : public Creature, public location_visitable<Character>
         /** Returns the first worn item with a given flag. */
         const item *item_worn_with_flag( const flag_id &flag,
                                          const bodypart_id &bp = bodypart_str_id::NULL_ID() ) const;
+        /** Returns true if the player is wearing an item with the given id. */
+        bool worn_with_id( const itype_id &item_id,
+                           const bodypart_id &bp = bodypart_str_id::NULL_ID() ) const;
+        /** Returns the first worn item with a given id. */
+        const item *item_worn_with_id( const itype_id &item_id,
+                                       const bodypart_id &bp = bodypart_str_id::NULL_ID() ) const;
 
         // drawing related stuff
         /**
@@ -1688,6 +1694,9 @@ class Character : public Creature, public location_visitable<Character>
         void stop_hauling();
         bool is_hauling() const;
 
+        // Gets item in inventory with id
+        const item *get_item_with_id( const itype_id &item_id, bool need_charges = false ) const;
+
         // Adds item(s) to inventory
         void add_item_with_id( const itype_id &itype, int count );
 
@@ -1699,7 +1708,16 @@ class Character : public Creature, public location_visitable<Character>
         /**
          * All items that have the given flag (@ref item::has_flag).
          */
-        std::vector<item *> all_items_with_flag( const flag_id &flag ) const;
+        std::vector<item *> all_items_with_flag( const flag_id &flag, bool need_charges = false ) const;
+
+        // All items that have the given id
+        std::vector<item *> all_items_with_id( const itype_id &item_id, bool need_charges = false ) const;
+
+        /**
+         * All items in the character's inventory.
+         */
+        std::vector<item *> all_items( bool need_charges = false ) const;
+
 
         bool has_charges( const itype_id &it, int quantity,
                           const std::function<bool( const item & )> &filter = return_true<item> ) const;

--- a/src/character.h
+++ b/src/character.h
@@ -1698,7 +1698,7 @@ class Character : public Creature, public location_visitable<Character>
         const item *get_item_with_id( const itype_id &item_id, bool need_charges = false ) const;
 
         // Adds item(s) to inventory
-        void add_item_with_id( const itype_id &itype, int count );
+        void add_item_with_id( const itype_id &itype, int count = 1 );
 
         // Has a weapon, inventory item or worn item with id
         bool has_item_with_id( const itype_id &item_id, bool need_charges = false ) const;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7051,7 +7051,7 @@ bool item::is_magazine() const
 
 bool item::is_battery() const
 {
-    return !!type->magazine && get_category().id == item_category_id( "battery" );
+    return !!type->battery;
 }
 
 bool item::is_ammo_belt() const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7051,7 +7051,7 @@ bool item::is_magazine() const
 
 bool item::is_battery() const
 {
-    return !!type->battery;
+    return !!type->magazine && get_category().id == item_category_id( "battery" );
 }
 
 bool item::is_ammo_belt() const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1259,7 +1259,7 @@ void item::clear_vars()
 
 void item::add_item_with_id( const itype_id &itype, int count )
 {
-    detached_ptr<item> new_item = item::spawn( itype_id( itype ), calendar::turn, count );
+    detached_ptr<item> new_item = item::spawn( itype, calendar::turn, count );
     contents.insert_item( std::move( new_item ) );
 }
 
@@ -9016,6 +9016,31 @@ int item::get_remaining_capacity_for_liquid( const item &liquid, const Character
     return res;
 }
 
+int item::get_remaining_capacity_for_id( const itype_id &liquid, bool allow_buckets ) const
+{
+    int rem_cap = 0;
+    itype obj = liquid.obj();
+    if( !is_container() && is_reloadable_with( liquid ) ) {
+        if( ammo_remaining() != 0 && ammo_current() != liquid ) {
+            return 0;
+        }
+        rem_cap = ammo_capacity() - ammo_remaining();
+    } else if( is_container() ) {
+        if( !type->container->watertight ) {
+            return 0;
+        } else if( !type->container->seals && ( !allow_buckets || !is_bucket() ) ) {
+            return 0;
+        } else if( !contents.empty() && contents.front().typeId() != liquid ) {
+            return 0;
+        }
+        rem_cap = obj.charges_per_volume( get_container_capacity() );
+        if( !contents.empty() ) {
+            rem_cap -= contents.front().charges;
+        }
+    }
+    return rem_cap;
+}
+
 detached_ptr<item> item::use_amount( detached_ptr<item> &&self, const itype_id &it, int &quantity,
                                      std::vector<detached_ptr<item>> &used,
                                      const std::function<bool( const item & )> &filter )
@@ -9203,6 +9228,17 @@ void item::set_snippet( const snippet_id &id )
         return;
     }
     snip_id = id;
+}
+
+const std::string &item::get_category_id() const
+{
+    if( is_container() && !contents.empty() ) {
+        return contents.front().get_category().get_id().str();
+    }
+
+    static item_category null_category;
+    return type->category_force.is_valid() ? type->category_force.obj().get_id().str() :
+           null_category.get_id().str();
 }
 
 const item_category &item::get_category() const

--- a/src/item.h
+++ b/src/item.h
@@ -1517,7 +1517,7 @@ class item : public location_visitable<item>, public game_object<item>
         /** Removes all item variables. */
         void clear_vars();
         /** Adds child items to the contents of this one. */
-        void add_item_with_id( const itype_id &itype, int count );
+        void add_item_with_id( const itype_id &itype, int count = 1 );
         /** Checks if this item contains an item with itype. */
         bool has_item_with_id( const itype_id &itype ) const;
         /*@}*/

--- a/src/item.h
+++ b/src/item.h
@@ -575,6 +575,9 @@ class item : public location_visitable<item>, public game_object<item>
         /** Burns the item. Returns true if the item was destroyed. */
         bool burn( fire_data &frd );
 
+        // Returns the category id of this item as a string.
+        const std::string &get_category_id() const;
+
         // Returns the category of this item.
         const item_category &get_category() const;
 
@@ -815,6 +818,10 @@ class item : public location_visitable<item>, public game_object<item>
                                                std::string *err = nullptr ) const;
         int get_remaining_capacity_for_liquid( const item &liquid, const Character &p,
                                                std::string *err = nullptr ) const;
+        /**
+         * How many charges of a given item id this container can hold.
+         */
+        int get_remaining_capacity_for_id( const itype_id &liquid, bool allow_bucket ) const;
         /**
          * It returns the total capacity (volume) of the container for liquids.
          */


### PR DESCRIPTION
## Purpose of change (The Why)

There's always room for more lua bindings.

## Describe the solution (The How)

Added bindings for tname and display_name to items
Added all(?) of the "is_[something]" bindings for items
Ammo bindings for items
Some of the "get_[something]" bindings
create_item for lua item creation
docs/removed/fixed a few bindings from #6290

## Describe alternatives you've considered

## Testing

Tested most of them in the lua console, didn't run into any issues but as always ymmv.

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
