### PR TITLE
fix(mods/aftershock,balance): mainline plutonium fuel cell recipe, bump toxic waste dump plutonium slurry spawn chances

### DIFF
--- a/data/json/mapgen/toxic_dump.json
+++ b/data/json/mapgen/toxic_dump.json
@@ -3,9 +3,8 @@
     "id": "toxic_waste",
     "type": "item_group",
     "items": [
-      { "item": "plut_slurry", "container-item": "55gal_drum", "charges-min": 2, "charges-max": 28, "prob": 5 },
-      { "item": "plut_slurry_dense", "container-item": "55gal_drum", "charges-min": 1, "charges-max": 45, "prob": 2 },
-      { "item": "sewage", "container-item": "55gal_drum", "charges-min": 26, "charges-max": 126, "prob": 50 },
+      { "item": "plut_slurry", "container-item": "55gal_drum", "charges-min": 2, "charges-max": 28, "prob": 50 },
+      { "item": "plut_slurry_dense", "container-item": "55gal_drum", "charges-min": 1, "charges-max": 45, "prob": 50 },
       { "group": "sewer", "prob": 20 },
       { "item": "55gal_drum", "prob": 50 },
       { "item": "slime_scrap", "prob": 10 }

--- a/data/json/recipes/electronic/components.json
+++ b/data/json/recipes/electronic/components.json
@@ -442,5 +442,27 @@
     "using": [ [ "steel_standard", 1 ], [ "welding_standard", 20 ] ],
     "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "SAW_M_FINE", "level": 1 } ],
     "components": [ [ [ "sheet_metal", 2 ] ], [ [ "pipe", 4 ] ], [ [ "spring", 2 ] ], [ [ "material_aluminium_ingot", 2 ] ] ]
+  },
+  {
+    "result": "plut_cell",
+    "type": "recipe",
+    "category": "CC_ELECTRONIC",
+    "subcategory": "CSC_ELECTRONIC_COMPONENTS",
+    "id_suffix": "fuel",
+    "skill_used": "electronics",
+    "difficulty": 5,
+    "time": "6 m",
+    "autolearn": [ [ "electronics", 7 ] ],
+    "book_learn": [ [ "textbook_atomic", 5 ] ],
+    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
+    "using": [ [ "soldering_standard", 10 ] ],
+    "components": [
+      [ [ "nuclear_fuel", 2 ], [ "plut_slurry", 10 ], [ "plut_slurry_dense", 5 ] ],
+      [ [ "e_scrap", 5 ] ],
+      [ [ "lead", 25 ] ],
+      [ [ "plastic_chunk", 5 ] ],
+      [ [ "scrap", 5 ] ],
+      [ [ "can_drink_unsealed", 5 ], [ "can_food_unsealed", 5 ], [ "canister_empty", 5 ] ]
+    ]
   }
 ]

--- a/data/json/recipes/electronic/components.json
+++ b/data/json/recipes/electronic/components.json
@@ -452,7 +452,6 @@
     "skill_used": "electronics",
     "difficulty": 5,
     "time": "6 m",
-    "autolearn": [ [ "electronics", 7 ] ],
     "book_learn": [ [ "textbook_atomic_lab", 5 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
     "using": [ [ "soldering_standard", 10 ] ],

--- a/data/json/recipes/electronic/components.json
+++ b/data/json/recipes/electronic/components.json
@@ -448,7 +448,6 @@
     "type": "recipe",
     "category": "CC_ELECTRONIC",
     "subcategory": "CSC_ELECTRONIC_COMPONENTS",
-    "id_suffix": "fuel",
     "skill_used": "electronics",
     "difficulty": 5,
     "time": "6 m",

--- a/data/json/recipes/electronic/components.json
+++ b/data/json/recipes/electronic/components.json
@@ -453,7 +453,7 @@
     "difficulty": 5,
     "time": "6 m",
     "autolearn": [ [ "electronics", 7 ] ],
-    "book_learn": [ [ "textbook_atomic", 5 ] ],
+    "book_learn": [ [ "textbook_atomic_lab", 5 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
     "using": [ [ "soldering_standard", 10 ] ],
     "components": [

--- a/data/json/recipes/electronic/components.json
+++ b/data/json/recipes/electronic/components.json
@@ -462,7 +462,13 @@
       [ [ "lead", 25 ] ],
       [ [ "plastic_chunk", 5 ] ],
       [ [ "scrap", 5 ] ],
-      [ [ "can_drink_unsealed", 5 ], [ "can_food_unsealed", 5 ], [ "canister_empty", 5 ] ]
+      [
+        [ "can_drink_unsealed", 5 ],
+        [ "can_food_unsealed", 5 ],
+        [ "can_food_big", 5 ],
+        [ "can_medium_unsealed", 5 ],
+        [ "canister_empty", 5 ]
+      ]
     ]
   }
 ]

--- a/data/mods/Aftershock/recipes/recipes.json
+++ b/data/mods/Aftershock/recipes/recipes.json
@@ -40,19 +40,6 @@
     ]
   },
   {
-    "result": "plut_cell",
-    "type": "recipe",
-    "category": "CC_ELECTRONIC",
-    "subcategory": "CSC_ELECTRONIC_COMPONENTS",
-    "skill_used": "mechanics",
-    "skills_required": [ "electronics", 4 ],
-    "difficulty": 8,
-    "time": 30000,
-    "book_learn": [ [ "textbook_atomic_lab", 5 ] ],
-    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
-    "components": [ [ [ "canister_empty", 1 ] ], [ [ "plut_slurry", 10 ], [ "plut_slurry_dense", 5 ] ], [ [ "power_supply", 2 ] ] ]
-  },
-  {
     "result": "light_battery_cell",
     "id_suffix": "afs_plutonium_battery",
     "type": "recipe",
@@ -253,27 +240,6 @@
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "//": "Conversion of a normal smartphone into an atomic one by replacing the power supply.",
     "components": [ [ [ "plastic_chunk", 1 ] ], [ [ "processor", 1 ] ], [ [ "smart_phone", 1 ] ], [ [ "plut_cell", 1 ] ] ]
-  },
-  {
-    "result": "plut_cell",
-    "type": "recipe",
-    "category": "CC_ELECTRONIC",
-    "subcategory": "CSC_ELECTRONIC_COMPONENTS",
-    "skill_used": "electronics",
-    "difficulty": 5,
-    "time": 5000,
-    "autolearn": [ [ "electronics", 7 ] ],
-    "book_learn": [ [ "textbook_atomic", 5 ] ],
-    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
-    "tools": [ [ [ "soldering_iron", 50 ] ] ],
-    "components": [
-      [ [ "nuclear_fuel", 2 ] ],
-      [ [ "e_scrap", 5 ] ],
-      [ [ "lead", 25 ] ],
-      [ [ "plastic_chunk", 5 ] ],
-      [ [ "scrap", 5 ] ],
-      [ [ "can_drink_unsealed", 5 ], [ "can_food_unsealed", 5 ], [ "canister_empty", 5 ] ]
-    ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->
Aftershock contains two recipes for plutonium fuel cells, but one overrides the other and both are outdated by this point. Furthermore, toxic waste dumps- literally the only place plutonium slurry spawns- only spawn plutonium slurry at 5 or 2 probability depending on the type, while sewage, something that already has its place with sewage treatment facilities and sewers, has a 50 prob chance to spawn.
## Describe the solution (The How)

<!-- e.g nerfs monster A -->
Removes specified recipes from aftershock files, add new combined and corrected recipe for plutonium fuel cells to basegame. Removed sewage sample chance to spawn in toxic waste dumps and increased plutonium slurry and watery plutonium slurry chances to spawn.
## Describe alternatives you've considered

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->
It doesn't cause any json errors on my end.
## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
I'm not absolutely sure
## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
