### PR TITLE
feat: allow for lua once_every_x_hooks to remove themselves by returning false

### DIFF
--- a/src/catalua.cpp
+++ b/src/catalua.cpp
@@ -400,7 +400,8 @@ void run_on_every_x_hooks( lua_state &state )
                 try {
                     sol::protected_function_result res = func();
                     check_func_result( res );
-                    return !res.get<bool>(); // erase function if result is false
+                    // erase function only if it returns a boolean AND it's false
+                    return res.get_type() == sol::type::boolean && !res.get<bool>();
                 } catch( std::runtime_error &e ) {
                     debugmsg(
                         "Failed to run hook on_every_x(interval = %s): %s",


### PR DESCRIPTION
## Purpose of change (The Why)

I wrote a lua iuse_function that displays a message after a few minutes using gapi.add_on_every_x_hook, and I was under the impression that returning false would deregister the hook for a one-time use kind of thing. Testing it resulted in messages being repeated endlessly, and it seems like those hooks never get removed, so every call to add_on_every_x_hook adds another permanent hook to the save.

## Describe the solution (The How)

Change run_on_every_x_hooks to erase hooks that return false on the lua side, returning anything else should work the same as before.

## Describe alternatives you've considered

Writing a new function like add_one_time_hook, but this is way easier and requires less C++ knowledge.

## Testing

I tested an iuse_function returning different values:
return false: hook runs once and stops
return true: hook repeats forever
return 0: hook repeats forever
no return: hook repeats forever

## Additional context

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
