### PR TITLE
feat(UI): highlight overmap tiles revealed by map usage

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2545,6 +2545,24 @@ bool cata_tiles::draw_tile_at(
     return true;
 }
 
+bool cata_tiles::draw_color_at( const SDL_Color &color, point pos, SDL_BlendMode blend_mode )
+{
+    SDL_Rect rect{
+        pos.x,
+        pos.y,
+        tile_width,
+        tile_height
+    };
+
+    SDL_BlendMode old_blend_mode;
+    GetRenderDrawBlendMode( renderer, old_blend_mode );
+    SetRenderDrawBlendMode( renderer, blend_mode );
+    SetRenderDrawColor( renderer, color.r, color.g, color.b, color.a );
+    RenderFillRect( renderer, &rect );
+    SetRenderDrawBlendMode( renderer, old_blend_mode );
+    return true;
+}
+
 bool cata_tiles::would_apply_vision_effects( const visibility_type visibility ) const
 {
     return visibility != VIS_CLEAR;

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -499,6 +499,17 @@ class cata_tiles
         bool draw_tile_at( const tile_type &tile, point, unsigned int loc_rand, int rota,
                            lit_level ll, bool apply_night_vision_goggles, int &height_3d, int overlay_count );
 
+        /**
+         * @brief Draws a colored solid color tile at position, with optional blending
+         *
+         * @param color Color to draw.
+         * @param p Point to draw the tile at.
+         * @param blend_mode Blend mode to draw the tile with
+         * @return always true.
+         */
+        bool draw_color_at( const SDL_Color &color, point p,
+                            SDL_BlendMode blend_mode = SDL_BLENDMODE_NONE );
+
         /** Tile Picking */
         void get_tile_values( int t, const int *tn, int &subtile, int &rotation );
 

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -81,6 +81,7 @@
 #include "translations.h"
 #include "trap.h"
 #include "ui.h"
+#include "uistate.h"
 #include "units_utility.h"
 #include "value_ptr.h"
 #include "vehicle.h"
@@ -1399,6 +1400,8 @@ void reveal_map_actor::reveal_targets( const tripoint_abs_omt &map ) const
 
 void reveal_map_actor::show_revealed( player &p, item &item, const tripoint_abs_omt &center ) const
 {
+    uistate.overmap_highlighted_omts.clear();
+
     omt_find_params params{};
     params.search_range = { 0, radius };
     params.types = omt_types_view;
@@ -1468,6 +1471,11 @@ void reveal_map_actor::show_revealed( player &p, item &item, const tripoint_abs_
         return;
     }
 
+    std::transform(
+        eqRange.first, eqRange.second,
+        std::inserter( uistate.overmap_highlighted_omts, uistate.overmap_highlighted_omts.end() ),
+        []( const auto & e ) -> tripoint_abs_omt { return e.second; } );
+
     if( ui.ret == 1 ) {
         // Pick random
         auto it = eqRange.first;
@@ -1484,7 +1492,6 @@ void reveal_map_actor::show_revealed( player &p, item &item, const tripoint_abs_
         const auto it = std::min_element( eqRange.first, eqRange.second, pred_dist );
         ui::omap::choose_point( it->second );
     }
-
 }
 
 int reveal_map_actor::use( player &p, item &it, bool, const tripoint & ) const

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1456,6 +1456,11 @@ void reveal_map_actor::show_revealed( player &p, item &item, const tripoint_abs_
         return;
     }
 
+    std::transform(
+        eqRange.first, eqRange.second,
+        std::inserter( uistate.overmap_highlighted_omts, uistate.overmap_highlighted_omts.end() ),
+        []( const auto & e ) -> tripoint_abs_omt { return e.second; } );
+
     // Only one overmap tile of type
     if( sz == 1 ) {
         ui::omap::choose_point( eqRange.first->second );
@@ -1470,11 +1475,6 @@ void reveal_map_actor::show_revealed( player &p, item &item, const tripoint_abs_
     if( ui.ret < 0 ) {
         return;
     }
-
-    std::transform(
-        eqRange.first, eqRange.second,
-        std::inserter( uistate.overmap_highlighted_omts, uistate.overmap_highlighted_omts.end() ),
-        []( const auto & e ) -> tripoint_abs_omt { return e.second; } );
 
     if( ui.ret == 1 ) {
         // Pick random

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1003,6 +1003,9 @@ static void draw_ascii( ui_adaptor &ui,
             } else if( blink && overmap_buffer.is_path( omp ) ) {
                 ter_color = c_light_blue;
                 ter_sym = "!";
+            } else if( blink && uistate.overmap_highlighted_omts.contains( omp ) ) {
+                ter_color = c_pink;
+                ter_sym = "&";
             } else if( blink && showhordes && los &&
                        overmap_buffer.get_horde_size( omp ) >= HORDE_VISIBILITY_SIZE ) {
                 // Display Hordes only when within player line-of-sight
@@ -2129,6 +2132,7 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
             uistate.overmap_show_city_labels = !uistate.overmap_show_city_labels;
         } else if( action == "TOGGLE_EXPLORED" ) {
             overmap_buffer.toggle_explored( curs );
+            uistate.overmap_highlighted_omts.erase( curs );
         } else if( action == "TOGGLE_MARK_PATH" ) {
             overmap_buffer.toggle_path( curs );
         } else if( action == "TOGGLE_OVERMAP_WEATHER" ) {

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -4247,6 +4247,7 @@ void uistatedata::serialize( JsonOut &json ) const
     json.member( "overmap_show_city_labels", overmap_show_city_labels );
     json.member( "overmap_show_hordes", overmap_show_hordes );
     json.member( "overmap_show_forest_trails", overmap_show_forest_trails );
+    json.member( "overmap_highlighted_omts", overmap_highlighted_omts );
     json.member( "vmenu_show_items", vmenu_show_items );
     json.member( "list_item_sort", list_item_sort );
     json.member( "list_item_filter_active", list_item_filter_active );
@@ -4302,6 +4303,7 @@ void uistatedata::deserialize( const JsonObject &jo )
     jo.read( "overmap_show_city_labels", overmap_show_city_labels );
     jo.read( "overmap_show_hordes", overmap_show_hordes );
     jo.read( "overmap_show_forest_trails", overmap_show_forest_trails );
+    jo.read( "overmap_highlighted_omts", overmap_highlighted_omts );
     jo.read( "hidden_recipes", hidden_recipes );
     jo.read( "favorite_recipes", favorite_recipes );
     jo.read( "recent_recipes", recent_recipes );

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -65,6 +65,7 @@
 #include "rng.h"
 #include "sdl_wrappers.h"
 #include "sdl_geometry.h"
+#include "sdl_utils.h"
 #include "sdl_font.h"
 #include "sdlsound.h"
 #include "string_formatter.h"
@@ -941,6 +942,16 @@ void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bo
                                      subtile, rotation, ll, false, height_3d, 0 );
             }
 
+            if( blink && uistate.overmap_highlighted_omts.contains( omp ) ) {
+                if( tile_iso ) {
+                    draw_from_id_string( "highlight", omp.raw(), 0, 0, lit_level::LIT, false, 0 );
+                } else {
+                    SDL_Color c = curses_color_to_SDL( c_pink );
+                    c.a = c.a >> 1;
+                    auto p = player_to_screen( omp.raw().xy() );
+                    draw_color_at( c, p, SDL_BLENDMODE_BLEND );
+                }
+            }
 
             if( see ) {
                 if( blink && uistate.overmap_debug_mongroup ) {

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -114,6 +114,7 @@ class uistatedata
         bool overmap_debug_weather = false;
         // draw monster groups on the overmap.
         bool overmap_debug_mongroup = false;
+        std::set<tripoint_abs_omt> overmap_highlighted_omts;
 
         // V Menu Stuff
         int list_item_sort = 0;


### PR DESCRIPTION
## Purpose of change (The Why)

Highlight select tiles revealed by the (secondary) map usage action from https://github.com/cataclysmbnteam/Cataclysm-BN/pull/6204#issuecomment-2729904542

## Describe the solution (The How)

Using a map will now also highlight the selected POI kind from map usage, if in range.
Highlights are persistent, kept until cleared by:
* (E)xploring the tile
* Opening a map again, but aborting the action

## Describe alternatives you've considered

N/A

## Testing

Launch game.
Spawn any map.
Use it and select a POI kind, either random or closest.
All tiles of the selected kind in the map range will be highlighted on the overmap view.
(E)xploring the tiles will clear the highlight.
Reusing the map and aborting the action will clear all highlights.
Overmap highlights should be persistent (stored in uistate), and kept separate between saves/loads.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

Since it can be cleared by using any map, I found adding an additional hotkey to hide the highlights unnecessary, but I can add it if deemed so.

Highlight color is `c_pink`, with 50% opacity, pulled from the user's color scheme.

A new field on `uistate.json` was added to persist the highlighted tiles.

![image](https://github.com/user-attachments/assets/b9f686a8-5391-4cf7-b148-f6d8181abe53)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional
- [x] This is a C++ PR that modifies JSON loading or behavior.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
