### PR TITLE
fix: take into account mount carry capacity when calculating movecost

### DIFF
--- a/src/catalua.cpp
+++ b/src/catalua.cpp
@@ -391,19 +391,28 @@ void run_on_every_x_hooks( lua_state &state )
 {
     std::vector<cata::on_every_x_hooks> &master_table =
         state.lua["game"]["cata_internal"]["on_every_x_hooks"];
-    for( const auto &entry : master_table ) {
+    for( auto &entry : master_table ) {
         if( calendar::once_every( entry.interval ) ) {
-            for( auto &func : entry.functions ) {
+            entry.functions.erase(
+                std::remove_if(
+                    entry.functions.begin(), entry.functions.end(),
+            [&entry]( auto & func ) {
                 try {
                     sol::protected_function_result res = func();
                     check_func_result( res );
+                    // erase function only if it returns a boolean AND it's false
+                    return res.get_type() == sol::type::boolean && !res.get<bool>();
                 } catch( std::runtime_error &e ) {
                     debugmsg(
                         "Failed to run hook on_every_x(interval = %s): %s",
                         to_string( entry.interval ), e.what()
                     );
                 }
+                return false;
             }
+                ),
+            entry.functions.end()
+            );
         }
     }
 }

--- a/src/character.h
+++ b/src/character.h
@@ -225,6 +225,17 @@ struct char_trait_data {
 
 struct mutation_collection : std::unordered_map<trait_id, char_trait_data> {};
 
+struct mountable_status {
+    bool mountable;
+    bool skills;
+    bool size;
+    bool carry_weight;
+
+    inline bool can_mount() const {
+        return mountable && skills && size && carry_weight;
+    };
+};
+
 class Character : public Creature, public location_visitable<Character>
 {
     public:
@@ -754,6 +765,7 @@ class Character : public Creature, public location_visitable<Character>
         static bodypart_str_id bp_to_hp( const bodypart_str_id &bp );
 
         bool can_mount( const monster &critter ) const;
+        mountable_status get_mountable_status( const monster &critter ) const;
         void mount_creature( monster &z );
         bool is_mounted() const;
         bool check_mount_will_move( const tripoint &dest_loc );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8969,8 +8969,14 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp )
             add_msg( m_warning, _( "You cannot pass obstacles whilst mounted." ) );
             return false;
         }
-        const double base_moves = u.run_cost( mcost, diag ) * 100.0 / crit->get_speed();
-        const double encumb_moves = u.get_weight() / 4800.0_gram;
+
+        // u.run_cost(mcost, diag) while mounted just returns mcost itself
+        const double base_moves = mcost * 100.0 / crit->get_speed();
+        units::mass carried_weight = crit->get_carried_weight() + u.get_weight();
+        units::mass max_carry_weight = crit->weight_capacity();
+        units::mass weight_overload = std::max( 0_gram, carried_weight - max_carry_weight );
+        const double encumb_moves = weight_overload / 4800.0_gram;
+
         u.moves -= static_cast<int>( std::ceil( base_moves + encumb_moves ) );
         if( u.movement_mode_is( CMM_WALK ) ) {
             crit->use_mech_power( -2 );

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -202,22 +202,27 @@ bool monexamine::pet_menu( monster &z )
     }
 
     if( !z.has_flag( MF_RIDEABLE_MECH ) ) {
-        if( z.has_flag( MF_PET_MOUNTABLE ) && you.can_mount( z ) ) {
-            if( z.has_effect( effect_tied ) ) {
-                amenu.addentry( mount, true, 'r', _( "Untie and mount %s" ), pet_name );
+        if( z.has_flag( MF_PET_MOUNTABLE ) ) {
+            auto status = you.get_mountable_status( z );
+            if( status.can_mount() ) {
+                const auto msg = z.has_effect( effect_tied )
+                                 ? _( "Untie and mount %s" )
+                                 : _( "Mount %s" );
+                amenu.addentry( mount, true, 'r', msg, pet_name );
+            } else if( !status.size ) {
+                amenu.addentry( mount, false, 'r', _( "%s is too small to carry your weight" ), pet_name );
+            } else if( !status.carry_weight ) {
+                amenu.addentry( mount, false, 'r', _( "You are too heavy to mount %s" ), pet_name );
+            } else if( !status.skills && you.get_skill_level( skill_survival ) < 1 ) {
+                amenu.addentry( mount, false, 'r', _( "You have no knowledge of riding at all" ) );
+            } else if( !status.skills && you.get_skill_level( skill_survival ) < 4 &&
+                       !z.has_effect( effect_saddled ) ) {
+                amenu.addentry( mount, false, 'r', _( "You are not skilled enough to ride without a saddle" ) );
             } else {
-                amenu.addentry( mount, true, 'r', _( "Mount %s" ), pet_name );
+                amenu.addentry( mount, false, 'r', _( "%s cannot be mounted right now" ), pet_name );
             }
-        } else if( !z.has_flag( MF_PET_MOUNTABLE ) ) {
+        } else {
             amenu.addentry( mount, false, 'r', _( "%s cannot be mounted" ), pet_name );
-        } else if( z.get_size() <= you.get_size() ) {
-            amenu.addentry( mount, false, 'r', _( "%s is too small to carry your weight" ), pet_name );
-        } else if( you.get_skill_level( skill_survival ) < 1 ) {
-            amenu.addentry( mount, false, 'r', _( "You have no knowledge of riding at all" ) );
-        } else if( you.get_weight() >= z.get_weight() * z.get_mountable_weight_ratio() ) {
-            amenu.addentry( mount, false, 'r', _( "You are too heavy to mount %s" ), pet_name );
-        } else if( !z.has_effect( effect_saddled ) && you.get_skill_level( skill_survival ) < 4 ) {
-            amenu.addentry( mount, false, 'r', _( "You are not skilled enough to ride without a saddle" ) );
         }
     } else {
         const itype &type = *z.type->mech_battery;
@@ -606,17 +611,33 @@ void monexamine::attach_or_remove_saddle( monster &z )
 
 bool Character::can_mount( const monster &critter ) const
 {
+    auto status = get_mountable_status( critter );
+    return status.can_mount();
+}
+
+mountable_status Character::get_mountable_status( const monster &critter ) const
+{
     const auto &avoid = get_legacy_path_avoid();
     auto route = get_map().route( pos(), critter.pos(), get_legacy_pathfinding_settings(), avoid );
 
     if( route.empty() ) {
-        return false;
+        return {};
     }
-    return ( critter.has_flag( MF_PET_MOUNTABLE ) && critter.friendly == -1 &&
-             !critter.has_effect( effect_ridden ) ) &&
-           ( ( critter.has_effect( effect_saddled ) && get_skill_level( skill_survival ) >= 1 ) ||
-             get_skill_level( skill_survival ) >= 4 ) && ( critter.get_size() >= ( get_size() + 1 ) &&
-                     get_weight() <= critter.get_weight() * critter.get_mountable_weight_ratio() );
+
+    mountable_status status{};
+    status.mountable = critter.has_flag( MF_PET_MOUNTABLE )
+                       && critter.friendly == -1
+                       && !critter.has_effect( effect_ridden );
+    status.skills = (
+                        critter.has_effect( effect_saddled )
+                        && get_skill_level( skill_survival ) >= 1
+                    )
+                    || get_skill_level( skill_survival ) >= 4;
+    status.size = critter.get_size() >= ( get_size() + 1 );
+    status.carry_weight = ( get_weight() + critter.get_carried_weight() ) <=
+                          ( 4 * critter.weight_capacity() );
+
+    return status;
 }
 
 void monexamine::mount_pet( monster &z )

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3133,7 +3133,7 @@ void monster::add_msg_player_or_npc( const game_message_params &params,
     }
 }
 
-units::mass monster::get_carried_weight()
+units::mass monster::get_carried_weight() const
 {
     units::mass total_weight = 0_gram;
     if( tack_item ) {
@@ -3151,7 +3151,7 @@ units::mass monster::get_carried_weight()
     return total_weight;
 }
 
-units::volume monster::get_carried_volume()
+units::volume monster::get_carried_volume() const
 {
     units::volume total_volume = 0_ml;
     for( const item * const &it : inv ) {

--- a/src/monster.h
+++ b/src/monster.h
@@ -493,8 +493,8 @@ class monster : public Creature, public location_visitable<monster>
         Character *mounted_player = nullptr; // player that is mounting this creature
         character_id mounted_player_id; // id of player that is mounting this creature ( for save/load )
         character_id dragged_foe_id; // id of character being dragged by the monster
-        units::mass get_carried_weight();
-        units::volume get_carried_volume();
+        units::mass get_carried_weight() const;
+        units::volume get_carried_volume() const;
 
         // DEFINING VALUES
         int friendly;

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -297,12 +297,21 @@ void Character::suffer_from_addictions()
 
 void Character::suffer_while_awake( const int current_stim )
 {
-    if( !has_trait( trait_DEBUG_STORAGE ) &&
-        ( weight_carried() > 4 * weight_capacity() ) ) {
-        if( has_effect( effect_downed ) ) {
-            add_effect( effect_downed, 1_turns, bodypart_str_id::NULL_ID(), 0 );
-        } else {
-            add_effect( effect_downed, 2_turns, bodypart_str_id::NULL_ID(), 0 );
+    if( !has_trait( trait_DEBUG_STORAGE ) ) {
+        auto w_carry = weight_carried();
+        auto w_cap = weight_capacity();
+        if( is_mounted() ) {
+            auto &m = *mounted_creature;
+            w_carry += m.get_carried_weight();
+            w_cap = m.weight_capacity();
+        }
+
+        if( w_carry > 4 * w_cap ) {
+            if( has_effect( effect_downed ) ) {
+                add_effect( effect_downed, 1_turns, bodypart_str_id::NULL_ID(), 0 );
+            } else {
+                add_effect( effect_downed, 2_turns, bodypart_str_id::NULL_ID(), 0 );
+            }
         }
     }
     if( has_trait( trait_CHEMIMBALANCE ) ) {

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -298,15 +298,18 @@ void Character::suffer_from_addictions()
 void Character::suffer_while_awake( const int current_stim )
 {
     if( !has_trait( trait_DEBUG_STORAGE ) ) {
-        auto w_carry = weight_carried();
-        auto w_cap = weight_capacity();
+        units::mass w_carry;
+        units::mass w_cap;
         if( is_mounted() ) {
-            auto &m = *mounted_creature;
-            w_carry += m.get_carried_weight();
-            w_cap = m.weight_capacity();
+            auto &mount = *mounted_creature;
+            w_carry = mount.get_carried_weight() + this->get_weight();
+            w_cap = 4 * mount.weight_capacity();
+        } else {
+            w_carry = weight_carried();
+            w_cap = 4 * weight_capacity();
         }
 
-        if( w_carry > 4 * w_cap ) {
+        if( w_carry > w_cap ) {
             if( has_effect( effect_downed ) ) {
                 add_effect( effect_downed, 1_turns, bodypart_str_id::NULL_ID(), 0 );
             } else {


### PR DESCRIPTION
## Purpose of change (The Why)

Moves per turn calculation is reduced by player_weight / 4.8kg, regardless of how much the mount can carry (calculated from its weight * mountable_weight_ratio) 

## Describe the solution (The How)

* Makes calculation while mounted take into account how much the mount can carry, having only the weight past the mount capacity impact the move cost.
* Changes the downed triggers when overburdened to take into account if the player is mounted or not, and use the mount carry weight instead of the player's.
* Increases the checks for if a given critter is mountable due to weight to a higher threshold (same as player downed, 4*carry weight)

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered

N/A

## Testing

* Set survival skill to 4
* Spawn horse, 
  * Make it mountable with fooder.
* Spawn heavy duty frames and a large rucksack.
  * Get over-encumbered by moving frames to rucksack.
* Horse should only start to slowdown now at 225kg combined weight
  * Carry capacity: 750kg * 0.3 default ratio
  * Combined Weight: player itself + player and mount carried/equipped items.
* Mount horse, walk around
  * Optionally wield more heavy duty frames while mounted
    * Horse can walk ~9 tiles per second while at < 225kg
    * Horse can ~3 tiles per second while ~500kg

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

* Currently, the move cost demerit is a linear function of the exceeded weight
  * An exponential function, or a ~~higher~~ *smaller* linear constant might be desired for balance reasons.
  * Regardless of function, the player will stop being able to move at around 4 * carry weight due to being downed.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
