### PR TITLE
fix: keep invlet to the consumed item if it was split off from the main item stack

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1580,9 +1580,61 @@ void Character::consume( item &target )
     } );
 
     // Restack and sort so that we don't lie about target's invlet
+    auto old_invlet = target.invlet;
     if( inv_item ) {
         inv.restack( *this->as_player() );
+
+        // at this point, target *may* not have an invlet if it was split-off from a stack of items
+        // the main stack of items may have it instead
+        // in that case, re-assign
+        if( old_invlet != target.invlet ) {
+            auto oldStack = inv.items_with( [ = ]( const item & i ) {
+                return i.invlet == old_invlet;
+            } );
+            auto &newStack = was_in_container ? *comest.parent_item() : comest;
+
+            for( auto i : oldStack ) {
+                inv_reassign_item( *i, 0, true );
+            }
+            inv_reassign_item( newStack, old_invlet, true );
+        }
+
+        // it may also be the case that the item was in a container, but the container is now empty
+        // and the invlet is assigned to the now empty container
+        // so we find try to find a new container with a consumable of the same type, and re-assign to it
+        if( was_in_container && comest.count_by_charges() && comest.charges == 0 ) {
+            auto &cont_type = target.typeId();
+            auto &item_type = comest.typeId();
+
+            auto stacks = inv.const_slice();
+            const std::vector<item *> *next_stack = nullptr;
+            // find a non-empty container of the same type, with the same content type
+            for( auto &stack : stacks ) {
+                auto &c = stack->front();
+                if( c->typeId() != cont_type ) {
+                    continue;
+                }
+                if( !c->is_container() || c->contents.empty() ) {
+                    continue;
+                }
+                if( c->contents.front().typeId() != item_type ) {
+                    continue;
+                }
+                next_stack = stack;
+                break;
+            }
+
+            // remove the assignment from the now-empty container regardless,
+            // and assign it to the next container if found
+            inv_reassign_item( target, 0, true );
+            if( next_stack ) {
+                for( auto s : *next_stack ) {
+                    inv_reassign_item( *s, old_invlet, true );
+                }
+            }
+        }
     }
+
     if( consumed ) {
         if( was_in_container && wielding ) {
             add_msg_if_player( _( "You are now wielding an empty %s." ), primary_weapon().tname() );

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1585,22 +1585,6 @@ void Character::consume( item &target )
         inv.restack( *this->as_player() );
 
         if( !target.is_favorite ) {
-            // at this point, target *may* not have an invlet if it was split-off from a stack of items
-            // the main stack of items may have it instead
-            // in that case, re-assign
-
-            if( old_invlet != target.invlet ) {
-                auto oldStack = inv.items_with( [ = ]( const item & i ) {
-                    return i.invlet == old_invlet;
-                } );
-                auto &newStack = was_in_container ? *comest.parent_item() : comest;
-
-                for( auto i : oldStack ) {
-                    inv_reassign_item( *i, 0, true );
-                }
-                inv_reassign_item( newStack, old_invlet, true );
-            }
-
             // it may also be the case that the item was in a container, but the container is now empty
             // and the invlet is assigned to the now empty container
             // so we find try to find a new container with a consumable of the same type, and re-assign to it

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1593,7 +1593,6 @@ void Character::consume( item &target )
             auto &item_type = comest.typeId();
 
             auto stacks = inv.const_slice();
-            const std::vector<item *> *next_stack = nullptr;
             // find a non-empty container of the same type, with the same content type
             for( auto &stack : stacks ) {
                 auto &c = stack->front();

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1587,7 +1587,8 @@ void Character::consume( item &target )
         // in the case that the consumable was in a container, but the container is now empty (no more charges)
         // the invlet is lost
         // so we find try to find a new container with a consumable of the same type, and re-assign to it
-        if( !target.is_favorite && was_in_container && comest.count_by_charges() && comest.charges == 0 ) {
+        if( was_in_container && !target.is_favorite && comest.count_by_charges() && comest.charges == 0 &&
+            !is_wearing( target ) ) {
             auto &cont_type = target.typeId();
             auto &item_type = comest.typeId();
 

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1560,6 +1560,7 @@ void Character::consume( item &target )
     }
 
     item &comest = get_consumable_from( target );
+    const auto old_invlet = target.invlet;
 
     if( comest.is_null() || target.is_craft() ) {
         add_msg_if_player( m_info, _( "You can't eat your %s." ), target.tname() );
@@ -1580,44 +1581,36 @@ void Character::consume( item &target )
     } );
 
     // Restack and sort so that we don't lie about target's invlet
-    auto old_invlet = target.invlet;
     if( inv_item ) {
         inv.restack( *this->as_player() );
 
-        if( !target.is_favorite ) {
-            // it may also be the case that the item was in a container, but the container is now empty
-            // and the invlet is assigned to the now empty container
-            // so we find try to find a new container with a consumable of the same type, and re-assign to it
-            if( was_in_container && comest.count_by_charges() && comest.charges == 0 ) {
-                auto &cont_type = target.typeId();
-                auto &item_type = comest.typeId();
+        // in the case that the consumable was in a container, but the container is now empty (no more charges)
+        // the invlet is lost
+        // so we find try to find a new container with a consumable of the same type, and re-assign to it
+        if( !target.is_favorite && was_in_container && comest.count_by_charges() && comest.charges == 0 ) {
+            auto &cont_type = target.typeId();
+            auto &item_type = comest.typeId();
 
-                auto stacks = inv.const_slice();
-                const std::vector<item *> *next_stack = nullptr;
-                // find a non-empty container of the same type, with the same content type
-                for( auto &stack : stacks ) {
-                    auto &c = stack->front();
-                    if( c->typeId() != cont_type ) {
-                        continue;
-                    }
-                    if( !c->is_container() || c->contents.empty() ) {
-                        continue;
-                    }
-                    if( c->contents.front().typeId() != item_type ) {
-                        continue;
-                    }
-                    next_stack = stack;
-                    break;
+            auto stacks = inv.const_slice();
+            const std::vector<item *> *next_stack = nullptr;
+            // find a non-empty container of the same type, with the same content type
+            for( auto &stack : stacks ) {
+                auto &c = stack->front();
+                if( c->typeId() != cont_type ) {
+                    continue;
+                }
+                if( !c->is_container() || c->contents.empty() ) {
+                    continue;
+                }
+                if( c->contents.front().typeId() != item_type ) {
+                    continue;
                 }
 
                 // remove the assignment from the now-empty container regardless,
                 // and assign it to the next container if found
-                inv_reassign_item( target, 0, true );
-                if( next_stack ) {
-                    for( auto s : *next_stack ) {
-                        inv_reassign_item( *s, old_invlet, true );
-                    }
-                }
+                inv_reassign_item( *c, old_invlet, true );
+
+                break;
             }
         }
     }

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -371,6 +371,10 @@ void inventory::restack( player &p )
     int idx = 0;
     for( invstack::iterator iter = items.begin(); iter != items.end(); ++iter, ++idx ) {
         std::vector<item *> &stack = *iter;
+        // Sort the inner stack itself, so the most recently used item is at front and keeps the invlet
+        std::sort( stack.begin(), stack.end(), []( auto * lhs, auto * rhs ) {
+            return *lhs < *rhs;
+        } );
         item &topmost = *stack.front();
 
         const item *invlet_item = p.invlet_to_item( topmost.invlet );

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -1226,6 +1226,16 @@ void inventory::reassign_item( item &it, char invlet, bool remove_old )
     if( remove_old && it.invlet ) {
         invlet_cache.erase( it.invlet );
     }
+
+    // Remove invlet from other items beforehand, since restack may assign it to other items in the same stack.
+    auto fn = [ = ]( item * ii ) {
+        if( ii->invlet == invlet ) {
+            ii->invlet = 0;
+        }
+        return VisitResponse::SKIP;
+    };
+    visit_items( fn );
+
     it.invlet = invlet;
     update_invlet_cache_with_item( it );
 }


### PR DESCRIPTION
## Purpose of change (The Why)

* resolves #6305 

Consumables *sometimes*, will lose their assigned invlets.
This is because inventory_location::restack will re-group items and re-assign their invlets, but if the consumed item is not the first on its stack, it will lose its invlet while the rest of the stack keeps it.

## Describe the solution (The How)

Sort the individual item stacks before re-grouping, so the item with less charges is at the front.
Doing so will make so when re-stacking, the used item keeps the invlet, instead of the others.

As an aside, the invlet is applied to the container itself, and not its contents:
So I've made it when a consumable in a container is completely used, it will try to re-assign the invlet to another matching container that has the consumable type inside it, if not favorited or worn.

## Describe alternatives you've considered

N/A

## Testing

* Spawn multiple stacks of consumables: antiseptics, matchbooks, orange juices, etc.
* Assign invlet to the stack.
* Consume.
* Invlet should be kept in the consumed item
  * The bug itself was inconsistent, only happening if the used item was not the first of its stack
* Fully consuming a container consumable should move the invlet to another container, instead of being kept in the empty container
  * Container must be of the same kind for this effect to apply, also ignored by favoriting

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context

I tried, but couldn't easily add the same behavior of invlet transfer to non-consumables (tools, etc) when charges are empty.
So that'll be left for a future PR.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
