### PR TITLE
refactor: separate activity speed code from player activity

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -727,11 +727,11 @@ void disassemble_activity_actor::finish( player_activity &act, Character &who )
 }
 
 float disassemble_activity_actor::calc_bench_factor( const Character &who,
-        const std::optional<bench_loc> &bench ) const
+        const std::optional<bench_loc> &bench, item &target )
 {
     return bench
-           ? crafting::best_bench_here( *targets.front().loc, bench->position, true ).second
-           : crafting::best_bench_here( *targets.front().loc, who.pos(), true ).second;
+           ? crafting::best_bench_here( target, bench->position, true ).second
+           : crafting::best_bench_here( target, who.pos(), true ).second;
 
 }
 
@@ -2086,7 +2086,7 @@ void construction_activity_actor::start( player_activity &/*act*/, Character &/*
     pc = here.partial_con_at( local );
     auto &built = pc->id.obj();
 
-    std::string name = "";
+    std::string name;
 
     if( pc->id == deconstruct || pc->id == deconstruct_simple ||
         built.group == advanced_object_deconstruction ) {

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -109,9 +109,9 @@ inline void progress_counter::purge()
     targets.pop_front();
 }
 
-inline void activity_actor::recalc_all_moves( player_activity &act, Character &who )
+inline void activity_actor::calc_all_moves( player_activity &act, Character &who )
 {
-    act.recalc_all_moves( who );
+    act.speed.calc_all_moves( who );
 }
 
 aim_activity_actor::aim_activity_actor() : fake_weapon( new fake_item_location() )
@@ -670,11 +670,11 @@ inline void disassemble_activity_actor::process_target( player_activity &/*act*/
     progress.emplace( itm.tname( target.count ), moves_needed );
 }
 
-inline void disassemble_activity_actor::recalc_all_moves( player_activity &act, Character &who )
+inline void disassemble_activity_actor::calc_all_moves( player_activity &act, Character &who )
 {
     auto reqs = activity_reqs_adapter( recipe_dictionary::get_uncraft(
                                            targets.front().loc->typeId() ) );
-    act.recalc_all_moves( who, reqs );
+    act.speed.calc_all_moves( who, reqs );
 }
 
 void disassemble_activity_actor::start( player_activity &act, Character &who )
@@ -703,7 +703,7 @@ void disassemble_activity_actor::do_turn( player_activity &act, Character &who )
         progress.pop();
         if( !progress.empty() ) {
             if( try_start_single( act, who ) ) {
-                recalc_all_moves( act, who );
+                calc_all_moves( act, who );
             } else {
                 act.set_to_null();
             }
@@ -729,7 +729,7 @@ void disassemble_activity_actor::finish( player_activity &act, Character &who )
 float disassemble_activity_actor::calc_bench_factor( const Character &who,
         const std::optional<bench_loc> &bench ) const
 {
-    return bench.has_value()
+    return bench
            ? crafting::best_bench_here( *targets.front().loc, bench->position, true ).second
            : crafting::best_bench_here( *targets.front().loc, who.pos(), true ).second;
 
@@ -2062,7 +2062,7 @@ std::unique_ptr<activity_actor> wash_activity_actor::deserialize( JsonIn &jsin )
     return actor;
 }
 
-inline void construction_activity_actor::recalc_all_moves( player_activity &act, Character &who )
+inline void construction_activity_actor::calc_all_moves( player_activity &act, Character &who )
 {
     // Check if pc was lost for some reason, but actually still exists on map, e.g. save/load
     if( !pc ) {
@@ -2076,7 +2076,7 @@ inline void construction_activity_actor::recalc_all_moves( player_activity &act,
         return;
     }
     auto reqs = activity_reqs_adapter( pc->id.obj() );
-    act.recalc_all_moves( who, reqs );
+    act.speed.calc_all_moves( who, reqs );
 }
 
 void construction_activity_actor::start( player_activity &/*act*/, Character &/*who*/ )

--- a/src/activity_actor.h
+++ b/src/activity_actor.h
@@ -196,7 +196,7 @@ class activity_actor
          * Actor specific behaviour to recalc all speed values
          * Expected to be called once per target and on game load
          */
-        virtual void recalc_all_moves( player_activity &act, Character &who );
+        virtual void calc_all_moves( player_activity &act, Character &who );
 
         /**
          * Called once at the start of the activity.
@@ -288,7 +288,7 @@ class activity_actor
          * anything above 0 is a valid number
          * anything below 0 is invalid, promting to use default formula
         */
-        virtual float calc_morale_factor( int /*morale*/ ) const {
+        virtual float calc_morale_factor( const Character &/*who*/ ) const {
             return -1.0f;
         }
 

--- a/src/activity_actor.h
+++ b/src/activity_actor.h
@@ -9,6 +9,7 @@
 #include "activity_type.h"
 #include "calendar.h"
 #include "type_id.h"
+#include "units.h"
 
 class avatar;
 class Character;
@@ -17,6 +18,8 @@ class JsonOut;
 class player_activity;
 class inventory;
 struct bench_loc;
+
+using metric = std::pair<units::mass, units::volume>;
 
 struct simple_task {
     // Name of the target that's being processed
@@ -253,15 +256,7 @@ class activity_actor
             return msg;
         }
 
-        /*
-         * actor specific formula for speed factor based on workbench
-         * anything above 0 is a valid number
-         * anything below 0 is invalid, promting to use default formula
-        */
-        virtual float calc_bench_factor( const Character & /*who*/,
-                                         const std::optional<bench_loc> &/*bench*/ ) const {
-            return -1.0f;
-        }
+        virtual void adjust_bench_multiplier( bench_loc &bench, const metric & ) const;
 
         /*
          * actor specific formula for speed factor based on skills

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -242,12 +242,7 @@ class disassemble_activity_actor : public activity_actor
         void do_turn( player_activity &, Character & ) override;
         void finish( player_activity &act, Character &who ) override;
 
-        float calc_bench_factor( const Character &who,
-                                 const std::optional<bench_loc> &bench ) const override {
-            return calc_bench_factor( who, bench, *targets.front().loc );
-        }
-        static float calc_bench_factor( const Character &who,
-                                        const std::optional<bench_loc> &bench, item &targe );
+        void adjust_bench_multiplier( bench_loc &bench, const metric &metrics ) const override;
 
         void serialize( JsonOut &jsout ) const override;
         static std::unique_ptr<activity_actor> deserialize( JsonIn &jsin );

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -239,7 +239,7 @@ class disassemble_activity_actor : public activity_actor
         activity_id get_type() const override {
             return activity_id( "ACT_DISASSEMBLE" );
         }
-        void recalc_all_moves( player_activity &act, Character &who ) override;
+        void calc_all_moves( player_activity &act, Character &who ) override;
         void start( player_activity &act, Character &who ) override;
         void do_turn( player_activity &, Character & ) override;
         void finish( player_activity &act, Character &who ) override;
@@ -642,7 +642,7 @@ class construction_activity_actor : public activity_actor
             return activity_id( "ACT_BUILD" );
         }
 
-        void recalc_all_moves( player_activity &act, Character &who ) override;
+        void calc_all_moves( player_activity &act, Character &who ) override;
 
         void start( player_activity &act, Character &who ) override;
         void do_turn( player_activity &act, Character &who ) override;
@@ -662,7 +662,7 @@ class assist_activity_actor : public activity_actor
             return activity_id( "ACT_ASSIST" );
         }
 
-        void recalc_all_moves( player_activity & /*act*/, Character &/*who*/ ) override {};
+        void calc_all_moves( player_activity & /*act*/, Character &/*who*/ ) override {};
 
         void start( player_activity &act, Character &who ) override;
         void do_turn( player_activity &/*act*/, Character &/*who*/ ) override {};

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -11,8 +11,6 @@
 #include "locations.h"
 #include "memory_fast.h"
 #include "pickup_token.h"
-#include "location_ptr.h"
-#include "locations.h"
 #include "construction_partial.h"
 #include "point.h"
 #include "type_id.h"
@@ -245,7 +243,11 @@ class disassemble_activity_actor : public activity_actor
         void finish( player_activity &act, Character &who ) override;
 
         float calc_bench_factor( const Character &who,
-                                 const std::optional<bench_loc> &bench ) const override;
+                                 const std::optional<bench_loc> &bench ) const override {
+            return calc_bench_factor( who, bench, *targets.front().loc );
+        }
+        static float calc_bench_factor( const Character &who,
+                                        const std::optional<bench_loc> &bench, item &targe );
 
         void serialize( JsonOut &jsout ) const override;
         static std::unique_ptr<activity_actor> deserialize( JsonIn &jsin );

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -717,7 +717,7 @@ static void set_up_butchery_activity( player_activity &act, player &u, const but
 
     print_reasons();
     act.tools.clear();
-    act.recalc_all_moves( u );
+    act.speed.calc_all_moves( u );
     act.moves_left = setup.move_cost;
     act.moves_total = setup.move_cost;
     // We have a valid target, so preform the full finish function

--- a/src/activity_speed.cpp
+++ b/src/activity_speed.cpp
@@ -1,20 +1,22 @@
 #include "activity_speed.h"
 
 #include <optional>
+#include <utility>
+#include <vector>
 
+#include "activity_type.h"
 #include "character.h"
 #include "character_functions.h"
-#include "crafting.h"
+#include "character_stat.h"
 #include "construction.h"
+#include "crafting.h"
 #include "recipe.h"
-
+#include "type_id.h"
 
 static const skill_id stat_speech( "speech" );
 
 static const quality_id qual_BUTCHER( "BUTCHER" );
 static const quality_id qual_CUT_FINE( "CUT_FINE" );
-
-
 
 inline static float limit_factor( float factor, float min = 0.25f, float max = 2.0f )
 {
@@ -105,7 +107,6 @@ void activity_speed::calc_light_factor( const Character &who )
     light = limit_factor( 1.0f - darkness, 0.0f );
 }
 
-
 void activity_speed::calc_skill_factor( const Character &who,
                                         const std::vector<activity_req<skill_id>> &skill_req )
 {
@@ -181,18 +182,16 @@ void activity_speed::calc_assistants_factor( const Character &who )
 }
 
 
-void activity_speed::calc_bench_factor( const Character &who )
+void activity_speed::calc_bench_factor( const Character &/*who*/ )
 {
     bench_factor = bench
                    ? bench->wb_info.multiplier_adjusted
                    : 1.0f;
 }
 
-
-
 void activity_speed::calc_stats_factors( const Character &who )
 {
-    auto f = ( who, type->stats );
+    auto f = stats_factor_custom_formula( who, type->stats );
 
     if( !f.empty() ) {
         return;

--- a/src/activity_speed.cpp
+++ b/src/activity_speed.cpp
@@ -1,0 +1,307 @@
+#include "activity_speed.h"
+
+#include <optional>
+
+#include "character.h"
+#include "character_functions.h"
+#include "crafting.h"
+#include "construction.h"
+#include "recipe.h"
+
+
+static const skill_id stat_speech( "speech" );
+
+static const quality_id qual_BUTCHER( "BUTCHER" );
+static const quality_id qual_CUT_FINE( "CUT_FINE" );
+
+
+
+inline static float limit_factor( float factor, float min = 0.25f, float max = 2.0f )
+{
+    //constrain speed between min and max
+    factor = std::min( max, factor );
+    factor = std::max( min, factor );
+    return factor;
+}
+
+inline static float refine_factor( float speed, int denom = 1, float min = -75.0f,
+                                   float max = 100.0f )
+{
+    speed = limit_factor( speed, min, max );
+    denom = denom < 1.0f
+            ? 1.0f
+            : denom;
+    speed /= denom;
+
+    //speed to factor
+    return speed / 100.0f;
+}
+
+void activity_speed::calc_moves( const Character &who )
+{
+    if( type->light_affected() ) {
+        calc_light_factor( who );
+    }
+    if( type->speed_affected() ) {
+        player_speed = who.get_speed() / 100.0f;
+    }
+    if( type->stats_affected() ) {
+        calc_stats_factors( who );
+    }
+    if( type->morale_affected() ) {
+        calc_morale_factor( who );
+    }
+}
+
+void activity_speed::calc_all_moves( Character &who )
+{
+    if( type->bench_affected() ) {
+        calc_bench_factor( who );
+    }
+    if( type->tools_affected() ) {
+        calc_tools_factor( who, type->qualities );
+    }
+    if( type->skill_affected() ) {
+        calc_skill_factor( who, type->skills );
+    }
+    if( type->assistable() ) {
+        calc_assistants_factor( who );
+    }
+    calc_moves( who );
+}
+
+void activity_speed::calc_all_moves( Character &who, activity_reqs_adapter &reqs )
+{
+    if( type->bench_affected() ) {
+        calc_bench_factor( who );
+    }
+    if( type->tools_affected() ) {
+        calc_tools_factor( who, reqs.qualities );
+    }
+    if( type->skill_affected() ) {
+        calc_skill_factor( who, reqs.skills );
+    }
+    if( type->assistable() ) {
+        calc_assistants_factor( who );
+    }
+    calc_moves( who );
+}
+
+
+
+void activity_speed::calc_light_factor( const Character &who )
+{
+    if( character_funcs::can_see_fine_details( who ) ) {
+        light = 1.0f;
+        return;
+    }
+
+    // This value whould be within [0,1]
+    const float darkness =
+        (
+            character_funcs::fine_detail_vision_mod( who ) -
+            character_funcs::FINE_VISION_THRESHOLD
+        ) / 7.0f;
+    light = limit_factor( 1.0f - darkness, 0.0f );
+}
+
+
+void activity_speed::calc_skill_factor( const Character &who,
+                                        const std::vector<activity_req<skill_id>> &skill_req )
+{
+    float ac_f = skills_factor_custom_formula( who, skill_req );
+    //Any factor above 0 is valid, else - use default calc
+    if( ac_f > 0 ) {
+        skills = ac_f;
+        return;
+    }
+
+    float f = 1.0f;
+    std::vector<float> factors;
+    for( const auto &skill : skill_req ) {
+        int who_eff_skill = who.get_skill_level( skill.req ) - skill.threshold;
+        float bonus = 0;
+        if( who_eff_skill != 0 ) {
+            bonus = 0.02f * std::pow( who_eff_skill, 3 )
+                    - 0.5f * std::pow( who_eff_skill, 2 )
+                    + 6.0f * who_eff_skill + skill.mod;
+        }
+
+        factors.push_back( bonus );
+    }
+    std::sort( factors.begin(), factors.end(), std::greater<>() );
+
+    int denom = 0;
+    for( const auto &factor : factors ) {
+        f += refine_factor( factor, ++denom * 0.8f );
+    }
+
+    skills = limit_factor( f );
+}
+
+std::pair<character_stat, float> activity_speed::calc_single_stat( const Character &who,
+        const activity_req<character_stat> &stat )
+{
+    int who_stat = 0;
+    switch( stat.req ) {
+        case character_stat::STRENGTH:
+            who_stat = who.get_str();
+            break;
+        case character_stat::DEXTERITY:
+            who_stat = who.get_dex();
+            break;
+        case character_stat::INTELLIGENCE:
+            who_stat = who.get_int();
+            break;
+        case character_stat::PERCEPTION:
+            who_stat = who.get_per();
+            break;
+        default:
+            return std::pair<character_stat, float>( character_stat::DUMMY_STAT, 1.0f );
+    }
+    float f = 1.0f + refine_factor( stat.mod * ( who_stat - stat.threshold ) );
+    return std::pair<character_stat, float>( stat.req, f );
+}
+
+
+void activity_speed::calc_assistants_factor( const Character &who )
+{
+    if( assistant_count == 0 ) {
+        assist = 1.0f;
+    }
+
+    float f = 0.5f * std::pow( assistant_count, 3 )
+              - 7 * std::pow( assistant_count, 2 )
+              + 45 * assistant_count;
+
+    // range [0.8:1.2] based on speech
+    f *= 0.8f + 0.04f * who.get_skill_level( stat_speech );
+
+    assist = 1.0f + refine_factor( f, 1, 0.0f, 200.0f );
+}
+
+
+void activity_speed::calc_bench_factor( const Character &who )
+{
+    bench_factor = bench
+                   ? bench->wb_info.multiplier_adjusted
+                   : 1.0f;
+}
+
+
+
+void activity_speed::calc_stats_factors( const Character &who )
+{
+    auto f = ( who, type->stats );
+
+    if( !f.empty() ) {
+        return;
+    }
+
+    for( auto &stat : type->stats ) {
+        stats.emplace_back( calc_single_stat( who, stat ) );
+    }
+}
+
+float activity_speed::get_best_qual_mod( const activity_req<quality_id> &q,
+        const inventory &inv )
+{
+    int q_level = 0;
+    inv.visit_items( [&q, &q_level]( const item * itm ) {
+        int new_q = itm->get_quality( q.req );
+        if( new_q > q_level ) {
+            q_level = new_q;
+        }
+        return VisitResponse::NEXT;
+    } );
+    q_level = q_level - q.threshold;
+
+    if( q.req == qual_CUT_FINE ) {
+        float cut_fine_f = 2.0f * std::pow( q_level, 3 )
+                           - 10.0f * std::pow( q_level, 2 )
+                           + 32.0f * q_level + q.mod;
+        return cut_fine_f;
+    }
+
+    if( q_level == 0 ) {
+        return 0.0f;
+    }
+
+    if( q.req == qual_BUTCHER ) {
+        return q_level * q.mod;
+    }
+
+    return  q.mod * q_level / ( q_level + 1.75f );
+}
+
+void activity_speed::calc_tools_factor( Character &who,
+                                        const std::vector<activity_req<quality_id>> &quality_reqs )
+{
+    auto &inv = who.crafting_inventory();
+    float ac_f = tools_factor_custom_formula( quality_reqs, inv );
+    //Any factor above 0 is valid, else - use default calc
+    if( ac_f > 0 ) {
+        tools = ac_f;
+        return;
+    }
+
+    float f = 1;
+    std::vector<float> factors;
+    for( const auto &q : quality_reqs ) {
+        factors.push_back( get_best_qual_mod( q, inv ) );
+    }
+    std::sort( factors.begin(), factors.end(), std::greater<>() );
+
+    int denom = 0;
+    for( const auto &factor : factors ) {
+        f += refine_factor( factor, ++denom * 0.8f );
+    }
+
+    tools = limit_factor( f );
+}
+
+void activity_speed::calc_morale_factor( const Character &who )
+{
+    const int p_morale = who.get_morale_level();
+    float ac_morale = morale_factor_custom_formula( who );
+    //Any morale mod above 0 is valid, else - use default morale calc
+    if( ac_morale > 0 ) {
+        morale = ac_morale;
+        return;
+    }
+
+    //1% per 4 extra morale
+    if( morale > 20 ) {
+        morale = 0.95f + p_morale / 400.0f;
+    }
+    // 1% per 1 insuff morale
+    else if( morale < -20 ) {
+        morale = 1.20f + p_morale / 100.0f;
+    }
+    morale = 1.0f;
+}
+
+activity_reqs_adapter::activity_reqs_adapter( const recipe &rec )
+{
+    for( auto &qual : rec.simple_requirements().get_qualities() ) {
+        qualities.emplace_back( qual.front().type, qual.front().level );
+    }
+
+    skills.emplace_back( rec.skill_used, rec.difficulty );
+    for( auto &skill : rec.required_skills ) {
+        skills.emplace_back( skill.first, skill.second );
+    }
+}
+
+activity_reqs_adapter::activity_reqs_adapter( const construction &con )
+{
+
+    for( auto &qual : con.requirements->get_qualities() ) {
+        qualities.emplace_back( qual.front().type, qual.front().level );
+    }
+
+    for( auto &skill : con.required_skills ) {
+        skills.emplace_back( skill.first, skill.second );
+    }
+
+}

--- a/src/activity_speed.cpp
+++ b/src/activity_speed.cpp
@@ -21,9 +21,7 @@ static const quality_id qual_CUT_FINE( "CUT_FINE" );
 inline static float limit_factor( float factor, float min = 0.25f, float max = 2.0f )
 {
     //constrain speed between min and max
-    factor = std::min( max, factor );
-    factor = std::max( min, factor );
-    return factor;
+    return clamp<float>( factor, min, max );
 }
 
 inline static float refine_factor( float speed, int denom = 1, float min = -75.0f,

--- a/src/activity_speed.h
+++ b/src/activity_speed.h
@@ -1,0 +1,118 @@
+#pragma once
+#ifndef _ACTIVITY_SPEED_H
+#define _ACTIVITY_SPEED_H
+
+#include <vector>
+
+#include "character_stat.h"
+#include "activity_type.h"
+
+
+static const activity_id ACT_NULL = activity_id::NULL_ID();
+
+struct bench_loc;
+class Character;
+class inventory;
+
+
+
+struct activity_reqs_adapter {
+    std::vector<activity_req<quality_id>> qualities;
+    std::vector<activity_req<skill_id>> skills;
+
+    activity_reqs_adapter( const recipe &rec );
+
+    activity_reqs_adapter( const construction &con );
+};
+
+/*
+ * Struct to track activity speed by factors
+*/
+class activity_speed
+{
+    public:
+        const activity_id &type = ACT_NULL;
+        std::optional<bench_loc> bench = std::nullopt;
+        int assistant_count = 0;
+        const std::function<float( const Character & )> morale_factor_custom_formula = [](
+        const Character & ) {
+            return -1.f;
+        };
+
+        const std::function<float( const std::vector<activity_req<quality_id>>&,
+                                   const inventory & )> tools_factor_custom_formula = []( const std::vector<activity_req<quality_id>>
+        &, const inventory & ) {
+            return -1.f;
+        };
+
+
+        const std::function<std::vector<std::pair<character_stat, float>>( const Character &,
+                const std::vector<activity_req<character_stat>>& )> stats_factor_custom_formula = [](
+                            const Character &,
+        const std::vector<activity_req<character_stat>> & ) {
+            return std::vector<std::pair<character_stat, float>> {};
+        };
+
+        const std::function<float( const Character &,
+                                   const std::vector<activity_req<skill_id>>& )> skills_factor_custom_formula = [](
+                                               const Character &,
+        const std::vector<activity_req<skill_id>> & ) {
+            return -1.f;
+        };
+
+
+
+        float assist = 1.0f;
+        float bench_factor = 1.0f;
+        float player_speed = 1.0f;
+        float skills = 1.0f;
+        float tools = 1.0f;
+        float morale = 1.0f;
+        float light = 1.0f;
+        std::vector<std::pair<character_stat, float>> stats = {};
+
+        //Returns total product of all stats
+        inline float stats_total() const {
+            float acc = 1.0f;
+            for( auto &stat : stats ) {
+                acc *= stat.second;
+            }
+            return acc;
+        }
+
+        //Returns total product of all factors
+        inline float total() const {
+            return 1.0f * assist * bench_factor * player_speed * stats_total() * skills * tools * morale *
+                   light;
+        }
+
+        //Returns total amonut of moves based on factors
+        inline int total_moves() const {
+            return std::roundf( total() * 100.0f );
+        }
+
+        //Calculates all factors
+        void calc_all_moves( Character &who );
+        void calc_all_moves( Character &who, activity_reqs_adapter &reqs );
+
+
+        void calc_moves( const Character &who );
+
+        void calc_assistants_factor( const Character &who );
+        void calc_bench_factor( const Character &who );
+        void calc_light_factor( const Character &who );
+        void calc_morale_factor( const Character &who );
+        void calc_skill_factor( const Character &who,
+                                const std::vector<activity_req<skill_id>> &skill_req );
+
+        void calc_stats_factors( const Character &who );
+        static std::pair<character_stat, float> calc_single_stat( const Character &who,
+                const activity_req<character_stat> &stat );
+
+        void calc_tools_factor( Character &who,
+                                const std::vector<activity_req<quality_id>> &quality_reqs );
+        static float get_best_qual_mod( const activity_req<quality_id> &q,
+                                        const inventory &inv );
+};
+
+#endif // CATA_SRC_PLAYER_ACTIVITY_H

--- a/src/activity_speed.h
+++ b/src/activity_speed.h
@@ -1,20 +1,18 @@
 #pragma once
-#ifndef _ACTIVITY_SPEED_H
-#define _ACTIVITY_SPEED_H
+#ifndef ACTIVITY_SPEED_H
+#define ACTIVITY_SPEED_H
 
+#include <optional>
+#include <utility>
 #include <vector>
 
-#include "character_stat.h"
 #include "activity_type.h"
+#include "character_stat.h"
+#include "crafting.h"
+#include "type_id.h"
 
-
-static const activity_id ACT_NULL = activity_id::NULL_ID();
-
-struct bench_loc;
 class Character;
 class inventory;
-
-
 
 struct activity_reqs_adapter {
     std::vector<activity_req<quality_id>> qualities;
@@ -25,38 +23,35 @@ struct activity_reqs_adapter {
     activity_reqs_adapter( const construction &con );
 };
 
+using q_reqs = std::vector<activity_req<quality_id>>;
+using stat_reqs = std::vector<activity_req<character_stat>>;
+using stat_factors = std::vector<std::pair<character_stat, float>>;
+using skill_reqs = std::vector<activity_req<skill_id>>;
+
+using morale_factor_fn = std::function<float( const Character & )>;
+using tools_factor_fn = std::function<float( const q_reqs &, const inventory & )>;
+using stats_factor_fn = std::function<stat_factors( const Character &, const stat_reqs & )>;
+using skills_factor_fn = std::function<float( const Character &, const skill_reqs & )>;
+
 /*
  * Struct to track activity speed by factors
 */
 class activity_speed
 {
     public:
-        const activity_id &type = ACT_NULL;
-        std::optional<bench_loc> bench = std::nullopt;
+        activity_id type = activity_id::NULL_ID();
+        std::optional<bench_loc> bench;
         int assistant_count = 0;
-        const std::function<float( const Character & )> morale_factor_custom_formula = [](
-        const Character & ) {
+        morale_factor_fn morale_factor_custom_formula = []( const Character & ) {
             return -1.f;
         };
-
-        const std::function<float( const std::vector<activity_req<quality_id>>&,
-                                   const inventory & )> tools_factor_custom_formula = []( const std::vector<activity_req<quality_id>>
-        &, const inventory & ) {
+        tools_factor_fn tools_factor_custom_formula = []( const q_reqs &, const inventory & ) {
             return -1.f;
         };
-
-
-        const std::function<std::vector<std::pair<character_stat, float>>( const Character &,
-                const std::vector<activity_req<character_stat>>& )> stats_factor_custom_formula = [](
-                            const Character &,
-        const std::vector<activity_req<character_stat>> & ) {
-            return std::vector<std::pair<character_stat, float>> {};
+        stats_factor_fn stats_factor_custom_formula = []( const Character &, const stat_reqs & ) {
+            return stat_factors{};
         };
-
-        const std::function<float( const Character &,
-                                   const std::vector<activity_req<skill_id>>& )> skills_factor_custom_formula = [](
-                                               const Character &,
-        const std::vector<activity_req<skill_id>> & ) {
+        skills_factor_fn skills_factor_custom_formula = []( const Character &, const skill_reqs & ) {
             return -1.f;
         };
 
@@ -115,4 +110,4 @@ class activity_speed
                                         const inventory &inv );
 };
 
-#endif // CATA_SRC_PLAYER_ACTIVITY_H
+#endif // ACTIVITY_SPEED_H

--- a/src/activity_speed.h
+++ b/src/activity_speed.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef ACTIVITY_SPEED_H
-#define ACTIVITY_SPEED_H
 
 #include <optional>
 #include <utility>
@@ -109,5 +107,3 @@ class activity_speed
         static float get_best_qual_mod( const activity_req<quality_id> &q,
                                         const inventory &inv );
 };
-
-#endif // ACTIVITY_SPEED_H

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -41,9 +41,9 @@ struct workbench_info_wrapper {
     float multiplier = 1.0f;
     float multiplier_adjusted = multiplier;
     // Mass/volume allowed before a crafting speed penalty is applied
-    bench_type type = bench_type::ground;
     units::mass allowed_mass = 0_gram;
     units::volume allowed_volume = 0_ml;
+    bench_type type = bench_type::ground;
     workbench_info_wrapper( furn_workbench_info f_info ) : multiplier( f_info.multiplier ),
         allowed_mass( f_info.allowed_mass ),
         allowed_volume( f_info.allowed_volume ), type( bench_type::furniture ) {
@@ -159,5 +159,3 @@ bool disassemble_all( avatar &you, bool recursively );
 void complete_disassemble( Character &who, const iuse_location &target, const tripoint &pos );
 
 } // namespace crafting
-
-

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -19,6 +19,8 @@ class recipe;
 struct iuse_location;
 struct tool_comp;
 
+using metric = std::pair<units::mass, units::volume>;
+
 enum class cost_adjustment : int;
 
 enum class bench_type : int {
@@ -57,6 +59,8 @@ struct workbench_info_wrapper {
         : multiplier( multiplier ), allowed_mass( allowed_mass ), allowed_volume( allowed_volume ),
           type( type ) {
     }
+
+    void adjust_multiplier( const std::pair<units::mass, units::volume> &metrics );
 };
 
 struct bench_loc {

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -38,12 +38,12 @@ struct bench_location {
 
 struct workbench_info_wrapper {
     // Base multiplier applied for crafting here
-    float multiplier;
+    float multiplier = 1.0f;
     float multiplier_adjusted = multiplier;
     // Mass/volume allowed before a crafting speed penalty is applied
-    bench_type type;
-    units::mass allowed_mass;
-    units::volume allowed_volume;
+    bench_type type = bench_type::ground;
+    units::mass allowed_mass = 0_gram;
+    units::volume allowed_volume = 0_ml;
     workbench_info_wrapper( furn_workbench_info f_info ) : multiplier( f_info.multiplier ),
         allowed_mass( f_info.allowed_mass ),
         allowed_volume( f_info.allowed_volume ), type( bench_type::furniture ) {

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -39,26 +39,33 @@ struct bench_location {
 struct workbench_info_wrapper {
     // Base multiplier applied for crafting here
     float multiplier;
+    float multiplier_adjusted = multiplier;
     // Mass/volume allowed before a crafting speed penalty is applied
+    bench_type type;
     units::mass allowed_mass;
     units::volume allowed_volume;
     workbench_info_wrapper( furn_workbench_info f_info ) : multiplier( f_info.multiplier ),
         allowed_mass( f_info.allowed_mass ),
-        allowed_volume( f_info.allowed_volume ) {
+        allowed_volume( f_info.allowed_volume ), type( bench_type::furniture ) {
     }
     workbench_info_wrapper( vpslot_workbench v_info ) : multiplier( v_info.multiplier ),
         allowed_mass( v_info.allowed_mass ),
-        allowed_volume( v_info.allowed_volume ) {
+        allowed_volume( v_info.allowed_volume ), type( bench_type::vehicle ) {
+    }
+    workbench_info_wrapper( float multiplier, const units::mass &allowed_mass,
+                            const units::volume &allowed_volume, const bench_type &type )
+        : multiplier( multiplier ), allowed_mass( allowed_mass ), allowed_volume( allowed_volume ),
+          type( type ) {
     }
 };
 
 struct bench_loc {
-    explicit bench_loc( workbench_info_wrapper info, bench_type type, tripoint position )
-        : wb_info( info ), type( type ), position( position ) {
-    }
     workbench_info_wrapper wb_info;
-    bench_type type;
     tripoint position;
+
+    explicit bench_loc( workbench_info_wrapper info, tripoint position )
+        : wb_info( info ), position( position ) {
+    }
 };
 
 template<typename Type>

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -1,5 +1,4 @@
 #include "player_activity.h"
-#include "cata_utility.h"
 #include "player_activity_ptr.h"
 
 #include <algorithm>
@@ -13,16 +12,20 @@
 #include "activity_type.h"
 #include "avatar.h"
 #include "calendar.h"
+#include "cata_utility.h"
 #include "character.h"
 #include "character_turn.h"
 #include "color.h"
 #include "construction_partial.h"
 #include "crafting.h"
 #include "distraction_manager.h"
+#include "game.h"
 #include "item.h"
 #include "itype.h"
 #include "map.h"
+#include "npc.h"
 #include "player.h"
+#include "profile.h"
 #include "rng.h"
 #include "skill.h"
 #include "sounds.h"
@@ -30,13 +33,9 @@
 #include "string_id.h"
 #include "translations.h"
 #include "value_ptr.h"
-#include "profile.h"
 #include "veh_type.h"
 #include "vehicle_part.h"
 #include "vpart_position.h"
-#include "character_functions.h"
-#include "game.h"
-#include "npc.h"
 
 
 static const activity_id ACT_ADV_INVENTORY( "ACT_ADV_INVENTORY" );
@@ -195,6 +194,64 @@ void player_activity::get_assistants( const Character &who )
     }
 }
 
+static std::string craft_progress_message( const avatar &u, const player_activity &act )
+{
+    const item *craft = &*act.targets.front();
+    if( craft == nullptr ) {
+        // Should never happen (?)
+        return string_format( _( "%s…" ), act.get_verb().translated() );
+    }
+
+    // Horrid copypaste warning! TODO: Functions
+    const recipe &rec = craft->get_making();
+    const tripoint bench_pos = act.coords.front();
+    // Ugly
+    bench_type bench_t = bench_type( act.values[1] );
+
+    const bench_location bench{ bench_t, bench_pos };
+
+    const float light_mult = lighting_crafting_speed_multiplier( u, rec );
+    const float bench_mult = workbench_crafting_speed_multiplier( *craft, bench );
+    const float morale_mult = morale_crafting_speed_multiplier( u, rec );
+    const int assistants = u.available_assistant_count( craft->get_making() );
+    const float base_total_moves = std::max( 1, rec.batch_time( craft->charges, 1.0f, 0 ) );
+    const float assist_total_moves = std::max( 1, rec.batch_time( craft->charges, 1.0f, assistants ) );
+    const float assist_mult = base_total_moves / assist_total_moves;
+    const float speed_mult = u.get_speed() / 100.0f;
+    const float total_mult = light_mult * bench_mult * morale_mult * assist_mult * speed_mult;
+
+    const double remaining_percentage = 1.0 - craft->item_counter / 10'000'000.0;
+    int remaining_turns = remaining_percentage * base_total_moves / 100 / std::max( 0.01f, total_mult );
+    std::string time_desc = string_format( _( "Time left: %s" ),
+                                           to_string( time_duration::from_turns( remaining_turns ) ) );
+
+    const std::array<std::pair<float, std::string>, 6> mults_with_data = { {
+            { total_mult, _( "Total" ) },
+            { speed_mult, _( "Speed" ) },
+            { light_mult, _( "Light" ) },
+            { bench_mult, _( "Workbench" ) },
+            { morale_mult, _( "Morale" ) },
+            { assist_mult, _( "Assistants" ) },
+        }
+    };
+    std::string mults_desc = _( "Crafting speed multipliers:\n" );
+    // Hack to make sure total always shows
+    bool first = true;
+    for( const std::pair<float, std::string> &p : mults_with_data ) {
+        int percent = static_cast<int>( p.first * 100 );
+        if( first || percent != 100 ) {
+            nc_color col = percent > 100 ? c_green : c_red;
+            std::string colorized = colorize( std::to_string( percent ) + '%', col );
+            mults_desc += string_format( _( "%s: %s\n" ), p.second, colorized );
+        }
+        first = false;
+    }
+
+    return string_format( _( "%s: %s\n\n%s\n\n%s" ), act.get_verb().translated(), craft->tname(),
+                          time_desc,
+                          mults_desc );
+}
+
 static std::string format_spd( float level, std::string name, int indent = 0,
                                bool force_show = false )
 {
@@ -325,7 +382,9 @@ std::optional<std::string> player_activity::get_progress_message( const avatar &
     }
 
     std::string extra_info;
-    if( type == ACT_READ ) {
+    if( type == ACT_CRAFT ) {
+        return craft_progress_message( u, *this );
+    } else if( type == ACT_READ ) {
         if( const item *book = &*targets.front() ) {
             if( const auto &reading = book->type->book ) {
                 const skill_id &skill = reading->skill;

--- a/src/player_activity.h
+++ b/src/player_activity.h
@@ -178,8 +178,6 @@ class player_activity
         void get_assistants( const Character &who );
         static std::vector<npc *> get_assistants( const Character &who, unsigned short max );
 
-        bench_loc find_best_bench( const tripoint &pos );
-
         /**
          * Helper that returns an activity specific progress message.
          */

--- a/src/player_activity.h
+++ b/src/player_activity.h
@@ -170,7 +170,7 @@ class player_activity
         void init_all_moves( Character &who );
 
         //Calculates speed factors that may change every turn
-        inline void calc_moves( const Character &who ) {
+        void calc_moves( const Character &who ) {
             speed.calc_moves( who );
         }
 

--- a/src/player_activity.h
+++ b/src/player_activity.h
@@ -44,9 +44,9 @@ class player_activity
         /** Unlocks the activity, or deletes it if it's already gone. */
         void resolve_active();
 
-        std::vector<npc *> assistants_ = {};
+        std::vector<npc *> assistants_;
         //Cuz game code is borked
-        std::set<int> assistants_ids_ = {};
+        std::set<int> assistants_ids_;
 
     public:
         /** Total number of moves required to complete the activity */
@@ -56,10 +56,8 @@ class player_activity
         /** Controls whether this activity can be cancelled with 'pause' action */
         bool interruptable_with_kb = true;
 
-        activity_speed speed{
-            .type = type,
-        };
-        std::vector<safe_reference<item>> tools = {};
+        activity_speed speed;
+        std::vector<safe_reference<item>> tools;
 
         // The members in the following block are deprecated, prefer creating a new
         // activity_actor.
@@ -137,40 +135,10 @@ class player_activity
             return type->suspendable();
         }
 
-
         bool is_multi_type() const {
             return type->multi_activity();
         }
-        bool is_assistable() const {
-            return type->assistable();
-        }
-        bool is_bench_affected() const {
-            return type->bench_affected();
-        }
-        bool is_light_affected() const {
-            return type->light_affected();
-        }
-        bool is_skill_affected() const {
-            return type->skill_affected();
-        }
-        bool is_stats_affected() const {
-            return type->stats_affected();
-        }
-        bool is_speed_affected() const {
-            return type->speed_affected();
-        }
-        bool is_tools_affected() const {
-            return type->tools_affected();
-        }
-        bool is_morale_affected() const {
-            return type->morale_affected();
-        }
-        bool is_morale_blocked() const {
-            return type->morale_blocked();
-        }
-        bool is_verbose_tooltip() const {
-            return type->verbose_tooltip();
-        }
+
         /** This replaces the former usage `act.type = ACT_NULL` */
         void set_to_null();
 
@@ -199,19 +167,10 @@ class player_activity
          * Most of those are quite self-explanatory by the name
         */
 
-
-        inline void init_all_moves( Character &who ) {
-            get_assistants( who );
-            speed.assistant_count = assistants().size();
-            if( actor ) {
-                actor->calc_all_moves( *this, who );
-            } else {
-                speed.calc_all_moves( who );
-            }
-        }
+        void init_all_moves( Character &who );
 
         //Calculates speed factors that may change every turn
-        void calc_moves( const Character &who ) {
+        inline void calc_moves( const Character &who ) {
             speed.calc_moves( who );
         }
 


### PR DESCRIPTION
## Purpose of change (The Why)

Part of #6002 

Separating activity speed code should provide:
- cleaner player activity code;
- creation of a separate activity speed entity, that would allow calculating factor-based completion time for activities, for preview purposes.

## Describe the solution (The How)

Moving all `activity_speed` related code to a separate entity

## Testing

- Compile
- Start
- Check that activities perform same way as before, without crashing.

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
