### PR TITLE
feat: JSONize pulling nails

### DIFF
--- a/data/json/furniture_and_terrain/terrain-doors.json
+++ b/data/json/furniture_and_terrain/terrain-doors.json
@@ -1858,6 +1858,8 @@
     "coverage": 95,
     "roof": "t_flat_roof",
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "WALL", "NO_SCENT", "BLOCK_WIND" ],
+    "nail_pull_result": "t_door_c",
+    "nail_pull_items": [ 8, 4 ],
     "bash": {
       "str_min": 15,
       "str_max": 80,
@@ -1887,6 +1889,8 @@
     "coverage": 95,
     "roof": "t_flat_roof",
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "WALL", "REDUCE_SCENT" ],
+    "nail_pull_result": "t_door_b",
+    "nail_pull_items": [ 8, 4 ],
     "bash": {
       "str_min": 10,
       "str_max": 40,
@@ -1917,6 +1921,8 @@
     "roof": "t_flat_roof",
     "examine_action": "door_peephole",
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "WALL", "NO_SCENT", "BLOCK_WIND" ],
+    "nail_pull_result": "t_door_c_peep",
+    "nail_pull_items": [ 8, 4 ],
     "bash": {
       "str_min": 15,
       "str_max": 80,
@@ -1945,6 +1951,8 @@
     "coverage": 95,
     "roof": "t_flat_roof",
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "WALL", "NO_SCENT", "BLOCK_WIND" ],
+    "nail_pull_result": "t_rdoor_c",
+    "nail_pull_items": [ 8, 4 ],
     "bash": {
       "str_min": 25,
       "str_max": 60,
@@ -1974,6 +1982,8 @@
     "coverage": 95,
     "roof": "t_flat_roof",
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "WALL", "NO_SCENT" ],
+    "nail_pull_result": "t_rdoor_b",
+    "nail_pull_items": [ 8, 4 ],
     "bash": {
       "str_min": 20,
       "str_max": 50,
@@ -2004,6 +2014,8 @@
     "roof": "t_flat_roof",
     "examine_action": "door_peephole",
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "WALL", "NO_SCENT" ],
+    "nail_pull_result": "t_door_b_peep",
+    "nail_pull_items": [ 8, 4 ],
     "bash": {
       "str_min": 10,
       "str_max": 40,

--- a/data/json/furniture_and_terrain/terrain-fences-gates.json
+++ b/data/json/furniture_and_terrain/terrain-fences-gates.json
@@ -385,6 +385,8 @@
       "AUTO_WALL_SYMBOL",
       "BURROWABLE"
     ],
+    "nail_pull_result": "t_fence_post",
+    "nail_pull_items": [ 8, 5 ],
     "connects_to": "WOODFENCE",
     "deconstruct": { "ter_set": "t_fence_post", "items": [ { "item": "2x4", "count": 5 }, { "item": "nail", "charges": 8 } ] },
     "bash": {

--- a/data/json/furniture_and_terrain/terrain-windows.json
+++ b/data/json/furniture_and_terrain/terrain-windows.json
@@ -403,6 +403,8 @@
     "coverage": 95,
     "roof": "t_flat_roof",
     "flags": [ "FLAMMABLE", "NOITEM", "NO_SCENT", "CONNECT_TO_WALL", "BLOCK_WIND" ],
+    "nail_pull_result": "t_window_frame",
+    "nail_pull_items": [ 8, 4 ],
     "bash": {
       "str_min": 3,
       "str_max": 30,
@@ -427,6 +429,8 @@
     "coverage": 95,
     "roof": "t_flat_roof",
     "flags": [ "FLAMMABLE", "NOITEM", "NO_SCENT", "CONNECT_TO_WALL", "BLOCK_WIND" ],
+    "nail_pull_result": "t_window_empty",
+    "nail_pull_items": [ 8, 4 ],
     "bash": {
       "str_min": 3,
       "str_max": 30,
@@ -451,6 +455,8 @@
     "coverage": 95,
     "roof": "t_flat_roof",
     "flags": [ "FLAMMABLE", "NOITEM", "NO_SCENT", "CONNECT_TO_WALL", "BLOCK_WIND" ],
+    "nail_pull_result": "t_window_boarded",
+    "nail_pull_items": [ 16, 8 ],
     "bash": {
       "str_min": 12,
       "str_max": 30,
@@ -473,6 +479,8 @@
     "coverage": 95,
     "roof": "t_flat_roof",
     "flags": [ "FLAMMABLE", "NOITEM", "REDUCE_SCENT", "CONNECT_TO_WALL", "BLOCK_WIND" ],
+    "nail_pull_result": "t_window_boarded_noglass",
+    "nail_pull_items": [ 16, 8 ],
     "bash": {
       "str_min": 12,
       "str_max": 30,

--- a/doc/src/content/docs/en/mod/json/reference/tiles/furn_and_terrain.md
+++ b/doc/src/content/docs/en/mod/json/reference/tiles/furn_and_terrain.md
@@ -193,7 +193,7 @@ it for the purpose of surgery.
   "lockpick_result": "t_door_unlocked",
   "lockpick_message": "With a click, you unlock the door.",
   "nail_pull_result": "t_fence_post", // terrain ID to transform into when you use a hammer to pull the nails out
-  "nail_pull_items": [ 8, 5 ], // nails and planks (respectively) to drop as a result of pulling nails with a hammer. Defaults to 0,0 and thus technically optional even if you add a nail_pull_result.
+  "nail_pull_items": [8, 5], // nails and planks (respectively) to drop as a result of pulling nails with a hammer. Defaults to 0,0 and thus technically optional even if you add a nail_pull_result.
   "bash": "TODO",
   "deconstruct": "TODO",
   "harvestable": "blueberries",

--- a/doc/src/content/docs/en/mod/json/reference/tiles/furn_and_terrain.md
+++ b/doc/src/content/docs/en/mod/json/reference/tiles/furn_and_terrain.md
@@ -192,6 +192,8 @@ it for the purpose of surgery.
   "open": "t_foo_open",
   "lockpick_result": "t_door_unlocked",
   "lockpick_message": "With a click, you unlock the door.",
+  "nail_pull_result": "t_fence_post", // terrain ID to transform into when you use a hammer to pull the nails out
+  "nail_pull_items": [ 8, 5 ], // nails and planks (respectively) to drop as a result of pulling nails with a hammer. Defaults to 0,0 and thus technically optional even if you add a nail_pull_result.
   "bash": "TODO",
   "deconstruct": "TODO",
   "harvestable": "blueberries",

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -3810,7 +3810,7 @@ void activity_handlers::pry_nails_finish( player_activity *act, player *p )
     const ter_id type = here.ter( pnt );
 
     p->add_msg_if_player( _( "You pry out the nails from the terrain." ) );
-    
+
     p->practice( skill_fabrication, 1, 1 );
     here.spawn_item( p->pos(), itype_nail, 1, type->nail_pull_items[0] );
     here.spawn_item( p->pos(), itype_2x4, type->nail_pull_items[1] );

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -3809,58 +3809,12 @@ void activity_handlers::pry_nails_finish( player_activity *act, player *p )
     map &here = get_map();
     const ter_id type = here.ter( pnt );
 
-    int nails = 0;
-    int boards = 0;
-    ter_id newter;
-    if( type == t_fence ) {
-        nails = 6;
-        boards = 3;
-        newter = t_fence_post;
-        p->add_msg_if_player( _( "You pry out the fence post." ) );
-    } else if( type == t_window_reinforced_noglass ) {
-        nails = 16;
-        boards = 8;
-        newter = t_window_boarded_noglass;
-        p->add_msg_if_player( _( "You pry the boards from the window." ) );
-    } else if( type == t_window_reinforced ) {
-        nails = 16;
-        boards = 8;
-        newter = t_window_boarded;
-        p->add_msg_if_player( _( "You pry the boards from the window." ) );
-    } else if( type == t_window_boarded ) {
-        nails = 8;
-        boards = 4;
-        newter = t_window_frame;
-        p->add_msg_if_player( _( "You pry the boards from the window." ) );
-    } else if( type == t_window_boarded_noglass ) {
-        nails = 8;
-        boards = 4;
-        newter = t_window_empty;
-        p->add_msg_if_player( _( "You pry the boards from the window frame." ) );
-    } else if( type == t_door_boarded || type == t_door_boarded_damaged ||
-               type == t_rdoor_boarded || type == t_rdoor_boarded_damaged ||
-               type == t_door_boarded_peep || type == t_door_boarded_damaged_peep ) {
-        nails = 8;
-        boards = 4;
-        if( type == t_door_boarded ) {
-            newter = t_door_c;
-        } else if( type == t_door_boarded_damaged ) {
-            newter = t_door_b;
-        } else if( type == t_door_boarded_peep ) {
-            newter = t_door_c_peep;
-        } else if( type == t_door_boarded_damaged_peep ) {
-            newter = t_door_b_peep;
-        } else if( type == t_rdoor_boarded ) {
-            newter = t_rdoor_c;
-        } else { // if (type == t_rdoor_boarded_damaged)
-            newter = t_rdoor_b;
-        }
-        p->add_msg_if_player( _( "You pry the boards from the door." ) );
-    }
+    p->add_msg_if_player( _( "You pry out the nails from the terrain." ) );
+    
     p->practice( skill_fabrication, 1, 1 );
-    here.spawn_item( p->pos(), itype_nail, 0, nails );
-    here.spawn_item( p->pos(), itype_2x4, boards );
-    here.ter_set( pnt, newter );
+    here.spawn_item( p->pos(), itype_nail, 1, type->nail_pull_items[0] );
+    here.spawn_item( p->pos(), itype_2x4, type->nail_pull_items[1] );
+    here.ter_set( pnt, type->nail_pull_result );
     act->set_to_null();
 }
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2354,28 +2354,14 @@ int iuse::hammer( player *p, item *it, bool, const tripoint & )
         p->add_msg_if_player( m_info, _( "You cannot do that while mounted." ) );
         return 0;
     }
-    const std::set<ter_id> allowed_ter_id {
-        t_fence,
-        t_window_reinforced,
-        t_window_reinforced_noglass,
-        t_window_boarded,
-        t_window_boarded_noglass,
-        t_door_boarded,
-        t_door_boarded_damaged,
-        t_door_boarded_peep,
-        t_door_boarded_damaged_peep,
-        t_rdoor_boarded,
-        t_rdoor_boarded_damaged
-    };
 
-    const std::function<bool( const tripoint & )> f = [&allowed_ter_id]( const tripoint & pnt ) {
+    const std::function<bool( const tripoint & )> f = []( const tripoint & pnt ) {
         if( pnt == g->u.pos() ) {
             return false;
         }
         const ter_id ter = g->m.ter( pnt );
 
-        const bool is_allowed = allowed_ter_id.find( ter ) != allowed_ter_id.end();
-        return is_allowed;
+        return (ter->nail_pull_result != ter_str_id::NULL_ID());
     };
 
     const std::optional<tripoint> pnt_ = choose_adjacent_highlight(
@@ -2384,7 +2370,6 @@ int iuse::hammer( player *p, item *it, bool, const tripoint & )
         return 0;
     }
     const tripoint &pnt = *pnt_;
-    const ter_id type = g->m.ter( pnt );
     if( !f( pnt ) ) {
         if( pnt == p->pos() ) {
             p->add_msg_if_player( _( "You try to hit yourself with the hammer." ) );
@@ -2393,13 +2378,7 @@ int iuse::hammer( player *p, item *it, bool, const tripoint & )
             p->add_msg_if_player( m_info, _( "You can't pry that." ) );
         }
         return 0;
-    }
-
-    if( type == t_fence || type == t_window_boarded || type == t_window_boarded_noglass ||
-        type == t_window_reinforced || type == t_window_reinforced_noglass ||
-        type == t_door_boarded || type == t_door_boarded_damaged ||
-        type == t_rdoor_boarded || type == t_rdoor_boarded_damaged ||
-        type == t_door_boarded_peep || type == t_door_boarded_damaged_peep ) {
+    } else {
         // pry action
         std::unique_ptr<player_activity> act = std::make_unique<player_activity>( ACT_PRY_NAILS,
                                                to_moves<int>( 30_seconds ),
@@ -2407,8 +2386,6 @@ int iuse::hammer( player *p, item *it, bool, const tripoint & )
         act->placement = pnt;
         p->assign_activity( std::move( act ) );
         return it->type->charges_to_use();
-    } else {
-        return 0;
     }
 }
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2361,7 +2361,7 @@ int iuse::hammer( player *p, item *it, bool, const tripoint & )
         }
         const ter_id ter = g->m.ter( pnt );
 
-        return (ter->nail_pull_result != ter_str_id::NULL_ID());
+        return ( ter->nail_pull_result != ter_str_id::NULL_ID() );
     };
 
     const std::optional<tripoint> pnt_ = choose_adjacent_highlight(

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <generic_readers.h>
 #include <iterator>
 #include <map>
 #include <memory>
@@ -1348,6 +1349,8 @@ void ter_t::load( const JsonObject &jo, const std::string &src )
 
     optional( jo, was_loaded, "lockpick_result", lockpick_result, ter_str_id::NULL_ID() );
     optional( jo, was_loaded, "lockpick_message", lockpick_message, translation() );
+    optional(jo, was_loaded, "nail_pull_result", nail_pull_result, ter_str_id::NULL_ID());
+    optional( jo, was_loaded, "nail_pull_items", nail_pull_items, {0, 0} );
 
     oxytorch = cata::make_value<activity_data_ter>();
     if( jo.has_object( "oxytorch" ) ) {

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -1349,7 +1349,7 @@ void ter_t::load( const JsonObject &jo, const std::string &src )
 
     optional( jo, was_loaded, "lockpick_result", lockpick_result, ter_str_id::NULL_ID() );
     optional( jo, was_loaded, "lockpick_message", lockpick_message, translation() );
-    optional(jo, was_loaded, "nail_pull_result", nail_pull_result, ter_str_id::NULL_ID());
+    optional( jo, was_loaded, "nail_pull_result", nail_pull_result, ter_str_id::NULL_ID() );
     optional( jo, was_loaded, "nail_pull_items", nail_pull_items, {0, 0} );
 
     oxytorch = cata::make_value<activity_data_ter>();

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -540,6 +540,7 @@ struct ter_t : map_data_common_t {
     ter_str_id close; // Close action: transform into terrain with matching id
     ter_str_id lockpick_result; // Lockpick action: transform when successfully lockpicked
     translation lockpick_message; // Lockpick action: message when successfully lockpicked
+    
 
     cata::value_ptr<activity_data_ter> boltcut; // Bolt cutting action data
     cata::value_ptr<activity_data_ter> hacksaw; // Hacksaw action data
@@ -548,6 +549,9 @@ struct ter_t : map_data_common_t {
     std::string trap_id_str;     // String storing the id string of the trap.
     ter_str_id transforms_into; // Transform into what terrain?
     ter_str_id roof;            // What will be the floor above this terrain
+
+    ter_str_id  nail_pull_result; // Terrain to transform into after pulling out nails
+    std::array<short, 2> nail_pull_items; // Nails and planks given upon pulling nails (respectively).
 
     trap_id trap; // The id of the trap located at this terrain. Limit one trap per tile currently.
 

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -540,7 +540,7 @@ struct ter_t : map_data_common_t {
     ter_str_id close; // Close action: transform into terrain with matching id
     ter_str_id lockpick_result; // Lockpick action: transform when successfully lockpicked
     translation lockpick_message; // Lockpick action: message when successfully lockpicked
-    
+
 
     cata::value_ptr<activity_data_ter> boltcut; // Bolt cutting action data
     cata::value_ptr<activity_data_ter> hacksaw; // Hacksaw action data


### PR DESCRIPTION
## Purpose of change (The Why)

Prior to this PR, this section of the code was a big wall of hardcoded if statements and that was pretty shitty and did not allow for mods to add their own nail-pullable terrain. Naturally, people want this to change.

Also, generally, un-hardcoding things is good.

## Describe the solution (The How)

- Adds two new fields to terrain: `nail_pull_result` and `nail_pull_items`
- `nail_pull_result` holds a terrain ID that it should be transformed into when the nails are pulled
  - Defaults to some variety of NULL
- `nail_pull_items` is an array that holds the integer (short) number of nails and planks (in that order) to drop.
  - Defaults to {0,0}, and thus is *technically* optional if you don't want it to drop any nails or planks
- Un-hardcoded the check on the hammer itself to check for a non-null `nail_pull_result`
- Un-hardcoded and thus greatly shortened the activity handler for finishing up the action
- Also fixed a bug where the nails wouldn't get dropped, only the planks.
- ALSO fixed the fact that deconstructing `t_fence` gave more resources than pulling the nails from it
- Added the fields to the currently existing terrains so that functionality is maintained
- Added a lil to the docs

## Describe alternatives you've considered
- Use two different attributes for the nails and planks instead of an array
- Use `transform_into` instead of adding a new field for the terrain ID

Didn't seem like a good idea to overload `transform_into` too much, and also this way it's technically more compatible with weird edge cases where you want something that uses `transform_into` already and ALSO want to be able to pry nails.

## Testing
- Compiled
- Used a hammer on some boarded-up terrain
- Realized nails weren't dropping
- Checked for regression, turns out we had that bug already
- Fixed the bug
- Compiled again
- Used hammer on terrain again
- Drops both nails and planks now

## Additional context

Don't you just love when un-hardcoding something also reveals ~2 different bugs related to the feature.

Modders, rejoice!

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] I have documented the changes in the appropriate location in the `doc/` folder.
  - [x] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
