### PR TITLE
chore: Remove unused include in mapdata.cpp

### DIFF
--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cstdlib>
-#include <generic_readers.h>
 #include <iterator>
 #include <map>
 #include <memory>


### PR DESCRIPTION
## Purpose of change (The Why)

While testing my previous PR I briefly considered trying to use a reader to get the array values in (long story), so autoincludes fucked it up in VS Code / Clangd

Also, somehow the two readers in the file don't need it pulled in.

## Describe the solution (The How)

Remove offensive line to make msys2 build on commits happy

## Describe alternatives you've considered

- Just make it a "" include

## Testing

It worked before, and nothing in my previous PR actually used it in the final result

## Additional context

Aaaaa why does clangd/VS Code default to <> instead of ""

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
