### PR TITLE
build: auto-install libbacktrace on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(CMAKE_TLS_VERIFY ON)
 
 # Build options
 include(CMakeDependentOption)
+include(ExternalProject)
 option(TILES "Build graphical tileset version." "OFF")
 option(CURSES "Build curses version." "ON")
 option(SOUND "Support for in-game sounds & music." "OFF")
@@ -389,7 +390,52 @@ endif ()
 
 if (BACKTRACE)
     add_definitions(-DBACKTRACE)
-    if (LIBBACKTRACE)
+    if (LIBBACKTRACE AND NOT MSVC)
+        message(STATUS "Integrating libbacktrace build using ExternalProject")
+
+        set(LIBBACKTRACE_GIT_REPO https://github.com/ianlancetaylor/libbacktrace.git)
+        set(LIBBACKTRACE_GIT_TAG master)
+
+        set(LIBBACKTRACE_INSTALL_DIR "${CMAKE_BINARY_DIR}/libbacktrace/install")
+        SET(LIBBACKTRACE_LIBRARY "${LIBBACKTRACE_INSTALL_DIR}/lib/libbacktrace.a")
+
+        include(ProcessorCount)
+        ProcessorCount(NCPU)
+        if(NCPU EQUAL 0)
+            set(NCPU 1)
+        endif()
+
+        ExternalProject_Add(
+            libbacktrace_external
+            GIT_REPOSITORY ${LIBBACKTRACE_GIT_REPO}
+            GIT_TAG ${LIBBACKTRACE_GIT_TAG}
+            GIT_SHALLOW TRUE
+
+            SOURCE_DIR "${CMAKE_BINARY_DIR}/libbacktrace/src"
+            BINARY_DIR "${CMAKE_BINARY_DIR}/libbacktrace/build"
+
+            CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=${LIBBACKTRACE_INSTALL_DIR}
+
+            BUILD_COMMAND make -j${NCPU}
+
+            INSTALL_COMMAND make install
+
+            INSTALL_DIR ${LIBBACKTRACE_INSTALL_DIR}
+            BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libbacktrace.a
+
+            UPDATE_DISCONNECTED 1
+        )
+
+        add_library(backtrace SHARED IMPORTED)
+        set_target_properties(backtrace
+            PROPERTIES IMPORTED_LOCATION ${LIBBACKTRACE_LIBRARY}
+        )
+        # Hack to make it work, otherwise INTERFACE_INCLUDE_DIRECTORIES will not be propagated
+        file(MAKE_DIRECTORY "${LIBBACKTRACE_INSTALL_DIR}/include")
+        target_include_directories(backtrace INTERFACE
+            "${LIBBACKTRACE_INSTALL_DIR}/include"
+        )
+        add_dependencies(backtrace libbacktrace_external)
         add_definitions(-DLIBBACKTRACE)
     endif ()
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,6 +436,8 @@ if (BACKTRACE)
             "${LIBBACKTRACE_INSTALL_DIR}/include"
         )
         add_dependencies(backtrace libbacktrace_external)
+    endif ()
+    if (LIBBACKTRACE)
         add_definitions(-DLIBBACKTRACE)
     endif ()
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,7 +421,7 @@ if (BACKTRACE)
             INSTALL_COMMAND make install
 
             INSTALL_DIR ${LIBBACKTRACE_INSTALL_DIR}
-            BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libbacktrace.a
+            BUILD_BYPRODUCTS ${LIBBACKTRACE_LIBRARY}
 
             UPDATE_DISCONNECTED 1
         )


### PR DESCRIPTION
## Purpose of change (The Why)

- resolves #4983

## Describe the solution (The How)

(long and painful convo with gemini 2.5 pro)

1. uses https://cmake.org/cmake/help/latest/module/ExternalProject.html to clone https://github.com/ianlancetaylor/libbacktrace.git as `libbacktrace_external`
2. adds the build biproduct and include dir to `backtrace`

## Describe alternatives you've considered

tell people how you have to build and link libbacktrace manually to get enhanced backtrace speed

## Testing

```sh
$ mkdir -p build
$ cmake \
    -B build \
    -G Ninja \
    -DCATA_CCACHE=ON \
    -DCMAKE_C_COMPILER_LAUNCHER=ccache \
    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
    -DCMAKE_C_COMPILER=/usr/bin/clang-19 \
    -DCMAKE_CXX_COMPILER=/usr/bin/clang++-19 \
    -DCMAKE_INSTALL_PREFIX=$XDG_DATA_HOME \
    -DJSON_FORMAT=ON \
    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
    -DCURSES=OFF \
    -DTILES=ON \
    -DSOUND=ON \
    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
    -DCATA_CLANG_TIDY_PLUGIN=ON \
    -DLUA=ON \
    -DBACKTRACE=ON \
    -DLIBBACKTRACE=ON \
    -DLINKER=mold \
    -DUSE_XDG_DIR=ON \
    -DUSE_HOME_DIR=OFF \
    -DUSE_PREFIX_DATA_DIR=OFF

$ cmake --build build --target cataclysm-bn-tiles
```

above command worked on my machine (linux fedora 41) with tiles but should be tested on others machine too.
the only relevant part is to enable `BACKTRACE` and `LIBBACKTRACE`, rest is just my compilation setup.

## Additional context

to prevent further pain with cmake, read first:
- https://stackoverflow.com/questions/54866067/cmake-and-ninja-missing-and-no-known-rule-to-make-it
- https://stackoverflow.com/questions/45516209/cmake-how-to-use-interface-include-directories-with-externalproject

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
