### PR TITLE
ci: Disable clang-tidy header checks (Pragmatization 0/2)

### DIFF
--- a/tools/clang-tidy-plugin/CMakeLists.txt
+++ b/tools/clang-tidy-plugin/CMakeLists.txt
@@ -10,7 +10,6 @@ set(CataAnalyzerSrc
     CataTidyModule.cpp
     CombineLocalsIntoPointCheck.cpp
     DeterminismCheck.cpp
-    HeaderGuardCheck.cpp
     JsonTranslationInputCheck.cpp
     NoLongCheck.cpp
     NoStaticGettextCheck.cpp

--- a/tools/clang-tidy-plugin/CataTidyModule.cpp
+++ b/tools/clang-tidy-plugin/CataTidyModule.cpp
@@ -5,7 +5,6 @@
 #include <clang-tidy/ClangTidyModuleRegistry.h>
 #include "CombineLocalsIntoPointCheck.h"
 #include "DeterminismCheck.h"
-#include "HeaderGuardCheck.h"
 #include "JsonTranslationInputCheck.h"
 #include "NoLongCheck.h"
 #include "NoStaticGettextCheck.h"
@@ -45,7 +44,6 @@ class CataModule : public ClangTidyModule
             CheckFactories.registerCheck<CombineLocalsIntoPointCheck>(
                 "cata-combine-locals-into-point" );
             CheckFactories.registerCheck<DeterminismCheck>( "cata-determinism" );
-            CheckFactories.registerCheck<CataHeaderGuardCheck>( "cata-header-guard" );
             CheckFactories.registerCheck<JsonTranslationInputCheck>( "cata-json-translation-input" );
             CheckFactories.registerCheck<NoLongCheck>( "cata-no-long" );
             CheckFactories.registerCheck<NoStaticGettextCheck>( "cata-no-static-gettext" );


### PR DESCRIPTION
## Purpose of change (The Why)

This needs to go first so that the other two PRs can depend on it

## Describe the solution (The How)

Disable header guards being checked by clang-tidy

## Describe alternatives you've considered

- Just merge the previous PR despite clang tidy timing out

Evidently, opinion is against doing that.

## Testing

It worked before, it ought to work again

## Additional context

After this gets merged, the other 2 PRs will be opened

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

