### PR TITLE
style: Replace header guards with pragma in headers A-L (Pragmatization 1/2)

### DIFF
--- a/src/achievement.h
+++ b/src/achievement.h
@@ -1,5 +1,4 @@
-#ifndef CATA_SRC_ACHIEVEMENT_H
-#define CATA_SRC_ACHIEVEMENT_H
+#pragma once
 
 #include <array>
 #include <functional>
@@ -262,4 +261,3 @@ achievement_completion skill_req_completed( const achievement &ach );
 /** Uses comparator supplied to compare target and supplied value. Only works on integers.*/
 bool ach_compare( const achievement_comparison symbol, const int target, const int to_compare );
 
-#endif // CATA_SRC_ACHIEVEMENT_H

--- a/src/action.h
+++ b/src/action.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ACTION_H
-#define CATA_SRC_ACTION_H
 
 #include <functional>
 #include <map>
@@ -594,4 +592,3 @@ bool can_move_vertical_at( const tripoint &p, int movez );
  */
 bool can_examine_at( const tripoint &p );
 
-#endif // CATA_SRC_ACTION_H

--- a/src/active_item_cache.h
+++ b/src/active_item_cache.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ACTIVE_ITEM_CACHE_H
-#define CATA_SRC_ACTIVE_ITEM_CACHE_H
 
 #include <iosfwd>
 #include <list>
@@ -75,4 +73,3 @@ class active_item_cache
         std::vector<item *> get_special( special_item_type type );
 };
 
-#endif // CATA_SRC_ACTIVE_ITEM_CACHE_H

--- a/src/active_tile_data.h
+++ b/src/active_tile_data.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ACTIVE_TILE_DATA_H
-#define CATA_SRC_ACTIVE_TILE_DATA_H
 
 #include <string>
 #include "calendar.h"
@@ -62,4 +60,3 @@ T * furn_at( const tripoint_abs_ms &pos );
 
 } // namespace active_tiles
 
-#endif // CATA_SRC_ACTIVE_TILE_DATA_H

--- a/src/active_tile_data_def.h
+++ b/src/active_tile_data_def.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ACTIVE_TILE_DATA_DEF_H
-#define CATA_SRC_ACTIVE_TILE_DATA_DEF_H
 
 #include "active_tile_data.h"
 #include "point.h"
@@ -101,4 +99,3 @@ class vehicle_connector_tile : public active_tile_data
         void load( JsonObject &jo ) override;
 };
 
-#endif // CATA_SRC_ACTIVE_TILE_DATA_DEF_H

--- a/src/activity_actor.h
+++ b/src/activity_actor.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ACTIVITY_ACTOR_H
-#define CATA_SRC_ACTIVITY_ACTOR_H
 
 #include <deque>
 #include <memory>
@@ -317,4 +315,3 @@ deserialize_functions;
 void serialize( const std::unique_ptr<activity_actor> &actor, JsonOut &jsout );
 void deserialize( std::unique_ptr<activity_actor> &actor, JsonIn &jsin );
 
-#endif // CATA_SRC_ACTIVITY_ACTOR_H

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ACTIVITY_ACTOR_DEFINITIONS_H
-#define CATA_SRC_ACTIVITY_ACTOR_DEFINITIONS_H
 
 #include "activity_actor.h"
 
@@ -675,4 +673,3 @@ class assist_activity_actor : public activity_actor
 
 };
 
-#endif // CATA_SRC_ACTIVITY_ACTOR_DEFINITIONS_H

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ACTIVITY_HANDLERS_H
-#define CATA_SRC_ACTIVITY_HANDLERS_H
 
 #include <functional>
 #include <map>
@@ -312,4 +310,3 @@ void patch_activity_for_furniture( player_activity &activity,
 
 } // namespace activity_handlers
 
-#endif // CATA_SRC_ACTIVITY_HANDLERS_H

--- a/src/activity_type.h
+++ b/src/activity_type.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ACTIVITY_TYPE_H
-#define CATA_SRC_ACTIVITY_TYPE_H
 
 #include <string>
 #include <optional>
@@ -175,4 +173,3 @@ class activity_type
         LUA_TYPE_OPS( activity_type, id_ );
 };
 
-#endif // CATA_SRC_ACTIVITY_TYPE_H

--- a/src/addiction.h
+++ b/src/addiction.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ADDICTION_H
-#define CATA_SRC_ADDICTION_H
 
 #include <string>
 
@@ -27,4 +25,3 @@ add_type addiction_type( const std::string &name );
 
 std::string addiction_text( const addiction &cur );
 
-#endif // CATA_SRC_ADDICTION_H

--- a/src/advanced_inv.h
+++ b/src/advanced_inv.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ADVANCED_INV_H
-#define CATA_SRC_ADVANCED_INV_H
 
 #include <array>
 #include <cctype>
@@ -185,5 +183,3 @@ class advanced_inventory
         bool query_charges( aim_location destarea, const advanced_inv_listitem &sitem,
                             const std::string &action, int &amount );
 };
-
-#endif // CATA_SRC_ADVANCED_INV_H

--- a/src/advanced_inv_area.h
+++ b/src/advanced_inv_area.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ADVANCED_INV_AREA_H
-#define CATA_SRC_ADVANCED_INV_AREA_H
 
 #include "point.h"
 #include "units.h"
@@ -110,4 +108,3 @@ class advanced_inv_area
             return veh != nullptr && vstor >= 0;
         }
 };
-#endif // CATA_SRC_ADVANCED_INV_AREA_H

--- a/src/advanced_inv_listitem.h
+++ b/src/advanced_inv_listitem.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ADVANCED_INV_LISTITEM_H
-#define CATA_SRC_ADVANCED_INV_LISTITEM_H
 
 #include <list>
 #include <string>
@@ -104,4 +102,4 @@ class advanced_inv_listitem
         advanced_inv_listitem( const std::list<item *> &list, int index,
                                aim_location area, bool from_vehicle );
 };
-#endif // CATA_SRC_ADVANCED_INV_LISTITEM_H
+

--- a/src/advanced_inv_pane.h
+++ b/src/advanced_inv_pane.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ADVANCED_INV_PANE_H
-#define CATA_SRC_ADVANCED_INV_PANE_H
 
 #include <array>
 #include <cstddef>
@@ -128,4 +126,3 @@ class advanced_inventory_pane
 
         mutable std::map<std::string, std::function<bool( const item & )>> filtercache;
 };
-#endif // CATA_SRC_ADVANCED_INV_PANE_H

--- a/src/all_enum_values.h
+++ b/src/all_enum_values.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ALL_ENUM_VALUES_H
-#define CATA_SRC_ALL_ENUM_VALUES_H
 
 #include <cstddef>
 #include <utility>
@@ -27,4 +25,3 @@ auto all_enum_values() -> const std::array<E, num_enum_values<E>()> &
     return all_enum_values_helper<E>( std::make_index_sequence<num_enum_values<E>()> {} );
 }
 
-#endif // CATA_SRC_ALL_ENUM_VALUES_H

--- a/src/ammo.h
+++ b/src/ammo.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_AMMO_H
-#define CATA_SRC_AMMO_H
 
 #include <string>
 #include <utility>
@@ -31,4 +29,3 @@ class ammunition_type
         static void check_consistency();
 };
 
-#endif // CATA_SRC_AMMO_H

--- a/src/ammo_effect.h
+++ b/src/ammo_effect.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_AMMO_EFFECT_H
-#define CATA_SRC_AMMO_EFFECT_H
 
 #include <cstddef>
 #include <string>
@@ -67,4 +65,3 @@ const std::vector<ammo_effect> &get_all();
 
 extern ammo_effect_id AE_NULL;
 
-#endif // CATA_SRC_AMMO_EFFECT_H

--- a/src/anatomy.h
+++ b/src/anatomy.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ANATOMY_H
-#define CATA_SRC_ANATOMY_H
 
 #include <string>
 #include <vector>
@@ -57,5 +55,3 @@ class anatomy
 };
 
 extern anatomy_id human_anatomy;
-
-#endif // CATA_SRC_ANATOMY_H

--- a/src/animation.h
+++ b/src/animation.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ANIMATION_H
-#define CATA_SRC_ANIMATION_H
 
 #include <list>
 #include <map>
@@ -60,4 +58,3 @@ bucketed_points optimal_bucketing( const bucketed_points &buckets, size_t max_bu
 bool minimap_requires_animation();
 bool terrain_requires_animation();
 
-#endif // CATA_SRC_ANIMATION_H

--- a/src/armor_layers.h
+++ b/src/armor_layers.h
@@ -1,9 +1,6 @@
 #pragma once
-#ifndef CATA_SRC_ARMOR_LAYERS_H
-#define CATA_SRC_ARMOR_LAYERS_H
 
 class Character;
 
 void show_armor_layers_ui( Character &who );
 
-#endif // CATA_SRC_ARMOR_LAYERS_H

--- a/src/artifact.h
+++ b/src/artifact.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ARTIFACT_H
-#define CATA_SRC_ARTIFACT_H
 
 #include <string>
 
@@ -133,4 +131,3 @@ bool save_artifacts( const world *world, const std::string &path );
 
 bool check_art_charge_req( item &it );
 
-#endif // CATA_SRC_ARTIFACT_H

--- a/src/ascii_art.h
+++ b/src/ascii_art.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ASCII_ART_H
-#define CATA_SRC_ASCII_ART_H
 
 #include <string>
 #include <vector>
@@ -22,4 +20,4 @@ class ascii_art
         std::vector<std::string> picture;
 };
 
-#endif // CATA_SRC_ASCII_ART_H
+

--- a/src/assign.h
+++ b/src/assign.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ASSIGN_H
-#define CATA_SRC_ASSIGN_H
 
 #include <algorithm>
 #include <map>
@@ -574,4 +572,4 @@ bool assign( const JsonObject &jo,
                      float_max,
                      float_max,
                      float_max ) );
-#endif // CATA_SRC_ASSIGN_H
+

--- a/src/auto_note.h
+++ b/src/auto_note.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_AUTO_NOTE_H
-#define CATA_SRC_AUTO_NOTE_H
 
 #include <string>
 #include <unordered_map>
@@ -84,4 +82,4 @@ class auto_note_settings
 
 auto_notes::auto_note_settings &get_auto_notes_settings();
 
-#endif // CATA_SRC_AUTO_NOTE_H
+

--- a/src/auto_pickup.h
+++ b/src/auto_pickup.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_AUTO_PICKUP_H
-#define CATA_SRC_AUTO_PICKUP_H
 
 #include <functional>
 #include <iosfwd>
@@ -162,4 +160,4 @@ class npc_settings : public base_settings
 
 auto_pickup::player_settings &get_auto_pickup();
 
-#endif // CATA_SRC_AUTO_PICKUP_H
+

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_AVATAR_H
-#define CATA_SRC_AVATAR_H
 
 #include <cstddef>
 #include <memory>
@@ -278,4 +276,4 @@ class avatar : public player
 
 avatar &get_avatar();
 
-#endif // CATA_SRC_AVATAR_H
+

--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_AVATAR_ACTION_H
-#define CATA_SRC_AVATAR_ACTION_H
 
 #include <optional>
 
@@ -110,4 +108,4 @@ void plthrow( avatar &you, item *loc,
 void use_item( avatar &you, item *loc = nullptr );
 } // namespace avatar_action
 
-#endif // CATA_SRC_AVATAR_ACTION_H
+

--- a/src/avatar_functions.h
+++ b/src/avatar_functions.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_AVATAR_FUNCTIONS_H
-#define CATA_SRC_AVATAR_FUNCTIONS_H
 
 #include "calendar.h"
 #include "type_id.h"
@@ -68,4 +66,4 @@ bool handle_theft_witnesses( avatar &you, const faction_id &owners );
 
 } // namespace avatar_funcs
 
-#endif // CATA_SRC_AVATAR_FUNCTIONS_H
+

--- a/src/ballistics.h
+++ b/src/ballistics.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_BALLISTICS_H
-#define CATA_SRC_BALLISTICS_H
 
 class Creature;
 class item;
@@ -51,4 +49,4 @@ double hit_chance( const dispersion_sources &dispersion, double range, double ta
 
 } // namespace ranged
 
-#endif // CATA_SRC_BALLISTICS_H
+

--- a/src/behavior.h
+++ b/src/behavior.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_BEHAVIOR_H
-#define CATA_SRC_BEHAVIOR_H
 
 #include <functional>
 #include <string>
@@ -90,4 +88,4 @@ void check_consistency();
 
 } // namespace behavior
 
-#endif // CATA_SRC_BEHAVIOR_H
+

--- a/src/behavior_oracle.h
+++ b/src/behavior_oracle.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_BEHAVIOR_ORACLE_H
-#define CATA_SRC_BEHAVIOR_ORACLE_H
 
 #include <functional>
 #include <string>
@@ -26,4 +24,4 @@ status_t return_running( const oracle_t * );
 extern std::unordered_map<std::string, std::function<status_t( const oracle_t * )>> predicate_map;
 
 } // namespace behavior
-#endif // CATA_SRC_BEHAVIOR_ORACLE_H
+

--- a/src/behavior_strategy.h
+++ b/src/behavior_strategy.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_BEHAVIOR_STRATEGY_H
-#define CATA_SRC_BEHAVIOR_STRATEGY_H
 
 #include <unordered_map>
 #include <vector>
@@ -45,4 +43,4 @@ extern std::unordered_map<std::string, const strategy_t *> strategy_map;
 
 } // namespace behavior
 
-#endif // CATA_SRC_BEHAVIOR_STRATEGY_H
+

--- a/src/bionics.h
+++ b/src/bionics.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_BIONICS_H
-#define CATA_SRC_BIONICS_H
 
 #include <cstddef>
 #include <map>
@@ -234,4 +232,4 @@ int bionic_manip_cos( float adjusted_skill, int bionic_difficulty );
 std::vector<bionic_id> bionics_cancelling_trait( const std::vector<bionic_id> &bios,
         const trait_id &tid );
 
-#endif // CATA_SRC_BIONICS_H
+

--- a/src/bionics_ui.h
+++ b/src/bionics_ui.h
@@ -1,9 +1,7 @@
 #pragma once
-#ifndef CATA_SRC_BIONICS_UI_H
-#define CATA_SRC_BIONICS_UI_H
 
 class Character;
 
 void show_bionics_ui( Character &who );
 
-#endif // CATA_SRC_BIONICS_UI_H
+

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_BODYPART_H
-#define CATA_SRC_BODYPART_H
 
 #include <array>
 #include <bitset>
@@ -401,4 +399,4 @@ body_part opposite_body_part( body_part bp );
 /** Returns the matching body_part token from the corresponding body_part string. */
 body_part get_body_part_token( const std::string &id );
 
-#endif // CATA_SRC_BODYPART_H
+

--- a/src/bonuses.h
+++ b/src/bonuses.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_BONUSES_H
-#define CATA_SRC_BONUSES_H
 
 #include <map>
 #include <vector>
@@ -89,4 +87,4 @@ class bonus_container
         bonus_map bonuses_mult;
 };
 
-#endif // CATA_SRC_BONUSES_H
+

--- a/src/cached_item_options.h
+++ b/src/cached_item_options.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CACHED_ITEM_OPTIONS_H
-#define CATA_SRC_CACHED_ITEM_OPTIONS_H
 
 enum class merge_comestible_t {
     merge_legacy,
@@ -21,4 +19,4 @@ extern merge_comestible_t merge_comestible_mode;
  */
 extern float similarity_threshold;
 
-#endif // CATA_SRC_CACHED_ITEM_OPTIONS_H
+

--- a/src/cached_options.h
+++ b/src/cached_options.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CACHED_OPTIONS_H
-#define CATA_SRC_CACHED_OPTIONS_H
 
 // A collection of options which are accessed frequently enough that we don't
 // want to pay the overhead of a string lookup each time one is tested.
@@ -140,4 +138,4 @@ extern error_log_format_t error_log_format;
 constexpr error_log_format_t error_log_format = error_log_format_t::human_readable;
 #endif
 
-#endif // CATA_SRC_CACHED_OPTIONS_H
+

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CALENDAR_H
-#define CATA_SRC_CALENDAR_H
 
 #include <string>
 #include <utility>
@@ -619,4 +617,4 @@ enum class weekdays : int {
 
 weekdays day_of_week( const time_point &p );
 
-#endif // CATA_SRC_CALENDAR_H
+

--- a/src/cata_algo.h
+++ b/src/cata_algo.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CATA_ALGO_H
-#define CATA_SRC_CATA_ALGO_H
 
 #include <algorithm>
 #include <map>
@@ -161,4 +159,4 @@ auto group_by( const C &c, F && selector )
 
 } // namespace cata
 
-#endif // CATA_SRC_CATA_ALGO_H
+

--- a/src/cata_arena.h
+++ b/src/cata_arena.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CATA_ARENA_H
-#define CATA_SRC_CATA_ARENA_H
 
 #include <unordered_map>
 #include <set>
@@ -61,4 +59,4 @@ class cata_arena
 
 void cleanup_arenas();
 
-#endif // CATA_SRC_CATA_ARENA_H
+

--- a/src/cata_io.h
+++ b/src/cata_io.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CATA_IO_H
-#define CATA_SRC_CATA_IO_H
 
 #include <functional>
 #include <string>
@@ -468,4 +466,4 @@ class JsonArrayOutputArchive
 
 } // namespace io
 
-#endif // CATA_SRC_CATA_IO_H
+

--- a/src/cata_libintl.h
+++ b/src/cata_libintl.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CATA_LIBINTL_H
-#define CATA_SRC_CATA_LIBINTL_H
 
 #include <memory>
 #include <string>
@@ -226,4 +224,4 @@ class trans_library
 };
 } // namespace cata_libintl
 
-#endif // CATA_SRC_CATA_LIBINTL_H
+

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CATA_TILES_H
-#define CATA_SRC_CATA_TILES_H
 
 #include <cstddef>
 #include <map>
@@ -820,4 +818,4 @@ class cata_tiles
         std::string memory_map_mode = "color_pixel_sepia";
 };
 
-#endif // CATA_SRC_CATA_TILES_H
+

--- a/src/cata_unreachable.h
+++ b/src/cata_unreachable.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CATA_UNREACHABLE_H
-#define CATA_SRC_CATA_UNREACHABLE_H
 
 namespace cata
 {
@@ -39,4 +37,4 @@ inline void unreachable() {}
 
 } // namespace cata
 
-#endif // CATA_SRC_CATA_UNREACHABLE_H
+

--- a/src/cata_utility.h
+++ b/src/cata_utility.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CATA_UTILITY_H
-#define CATA_SRC_CATA_UTILITY_H
 
 #include <algorithm>
 #include <cstddef>
@@ -343,4 +341,4 @@ class restore_on_out_of_scope
 */
 holiday get_holiday_from_time( std::time_t time = 0, bool force_refresh = false );
 
-#endif // CATA_SRC_CATA_UTILITY_H
+

--- a/src/cata_variant.h
+++ b/src/cata_variant.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CATA_VARIANT_H
-#define CATA_SRC_CATA_VARIANT_H
 
 #include <array>
 #include <cstddef>
@@ -450,4 +448,4 @@ struct hash<cata_variant> {
 
 } // namespace std
 
-#endif // CATA_SRC_CATA_VARIANT_H
+

--- a/src/catacharset.h
+++ b/src/catacharset.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CATACHARSET_H
-#define CATA_SRC_CATACHARSET_H
 
 #include <cstddef>
 #include <cstdint>
@@ -173,4 +171,4 @@ class utf8_wrapper
         void init_utf8_wrapper();
 };
 
-#endif // CATA_SRC_CATACHARSET_H
+

--- a/src/catalua.h
+++ b/src/catalua.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CATALUA_H
-#define CATA_SRC_CATALUA_H
 
 #include "type_id.h"
 
@@ -48,4 +46,4 @@ void reg_lua_iuse_actors( lua_state &state, Item_factory &ifactory );
 
 } // namespace cata
 
-#endif // CATA_SRC_CATALUA_H
+

--- a/src/catalua_bindings.h
+++ b/src/catalua_bindings.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CATALUA_BINDINGS_H
-#define CATA_SRC_CATALUA_BINDINGS_H
 
 #include "catalua_sol_fwd.h"
 
@@ -53,4 +51,4 @@ void reg_all_bindings( sol::state &lua );
 
 } // namespace cata
 
-#endif // CATA_SRC_CATALUA_BINDINGS_H
+

--- a/src/catalua_bindings_utils.h
+++ b/src/catalua_bindings_utils.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CATALUA_BINDINGS_UTILS_H
-#define CATA_SRC_CATALUA_BINDINGS_UTILS_H
 
 #include "catalua_luna.h"
 #include "json.h"
@@ -36,4 +34,4 @@ void reg_serde_functions( sol::usertype<T> &ut )
 #define SET_FX_N_T(func_name, lua_name_str, func_type) luna::set_fx( ut, lua_name_str, \
         sol::resolve< func_type >( &UT_CLASS::func_name))
 
-#endif // CATA_SRC_CATALUA_BINDINGS_UTILS_H
+

--- a/src/catalua_console.h
+++ b/src/catalua_console.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CATALUA_CONSOLE_H
-#define CATA_SRC_CATALUA_CONSOLE_H
 
 namespace cata
 {
@@ -9,4 +7,3 @@ void show_lua_console_impl();
 
 } // namespace cata
 
-#endif // CATA_SRC_CATALUA_CONSOLE_H

--- a/src/catalua_impl.h
+++ b/src/catalua_impl.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CATALUA_IMPL_H
-#define CATA_SRC_CATALUA_IMPL_H
 
 #include "calendar.h"
 #include "catalua_sol.h"
@@ -66,4 +64,4 @@ bool compare_tables( sol::table a, sol::table b );
  */
 sol::object find_equivalent_key( const sol::table &t, sol::object desired_key );
 
-#endif // CATA_SRC_CATALUA_IMPL_H
+

--- a/src/catalua_iuse_actor.h
+++ b/src/catalua_iuse_actor.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CATALUA_IUSE_ACTOR_H
-#define CATA_SRC_CATALUA_IUSE_ACTOR_H
 
 #include "iuse.h"
 #include "catalua_sol.h"
@@ -21,4 +19,4 @@ class lua_iuse_actor : public iuse_actor
         std::unique_ptr<iuse_actor> clone() const override;
 };
 
-#endif // CATA_SRC_CATALUA_IUSE_ACTOR_H
+

--- a/src/catalua_log.h
+++ b/src/catalua_log.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CATALUA_LOG_H
-#define CATA_SRC_CATALUA_LOG_H
 
 #include <deque>
 #include <string>
@@ -48,4 +46,4 @@ lua_log_handler &get_lua_log_instance();
 
 } // namespace cata
 
-#endif // CATA_SRC_CATALUA_LOG_H
+

--- a/src/catalua_luna.h
+++ b/src/catalua_luna.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CATALUA_LUNA_H
-#define CATA_SRC_CATALUA_LUNA_H
 
 #include <array>
 #include <functional>
@@ -669,4 +667,4 @@ inline void doc( std::string_view doc )
 
 } // namespace luna
 
-#endif // CATA_SRC_CATALUA_LUNA_H
+

--- a/src/catalua_luna_doc.h
+++ b/src/catalua_luna_doc.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CATALUA_LUNA_DOC_H
-#define CATA_SRC_CATALUA_LUNA_DOC_H
 
 #include "catalua_luna.h"
 #include "type_id.h"
@@ -178,4 +176,4 @@ LUNA_ENUM( npc_need, "NpcNeed" )
 LUNA_ENUM( sfx::channel, "SfxChannel" )
 
 
-#endif // CATA_SRC_CATALUA_LUNA_DOC_H
+

--- a/src/catalua_readonly.h
+++ b/src/catalua_readonly.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CATALUA_READONLY_H
-#define CATA_SRC_CATALUA_READONLY_H
 
 #include "catalua_sol_fwd.h"
 
@@ -13,4 +11,4 @@ sol::table make_readonly_table( sol::state_view &lua, sol::table read_from,
 
 } // namespace cata
 
-#endif // CATA_SRC_CATALUA_READONLY_H
+

--- a/src/catalua_serde.h
+++ b/src/catalua_serde.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CATALUA_SERDE_H
-#define CATA_SRC_CATALUA_SERDE_H
 
 #include "catalua_sol_fwd.h"
 
@@ -15,4 +13,4 @@ void deserialize_lua_table( sol::table t, JsonObject &obj );
 
 } // namespace cata
 
-#endif // CATA_SRC_CATALUA_SERDE_H
+

--- a/src/catalua_sol.h
+++ b/src/catalua_sol.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CATALUA_SOL_H
-#define CATA_SRC_CATALUA_SOL_H
 
 #ifdef __clang__
 #  pragma clang diagnostic push
@@ -19,4 +17,4 @@
 #  pragma clang diagnostic pop
 #endif
 
-#endif // CATA_SRC_CATALUA_SOL_H
+

--- a/src/catalua_sol_fwd.h
+++ b/src/catalua_sol_fwd.h
@@ -1,7 +1,5 @@
 #pragma once
-#ifndef CATA_SRC_CATALUA_SOL_FWD_H
-#define CATA_SRC_CATALUA_SOL_FWD_H
 
 #include "sol/forward.hpp"
 
-#endif // CATA_SRC_CATALUA_SOL_FWD_H
+

--- a/src/catalua_type_operators.h
+++ b/src/catalua_type_operators.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CATALUA_TYPE_OPERATORS_H
-#define CATA_SRC_CATALUA_TYPE_OPERATORS_H
 
 /**
  * Due to some strange behavior in sol2, we need to define
@@ -30,4 +28,4 @@
         return (id_getter) < rhs.id_getter;               \
     }
 
-#endif // CATA_SRC_CATALUA_TYPE_OPERATORS_H
+

--- a/src/cellular_automata.h
+++ b/src/cellular_automata.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CELLULAR_AUTOMATA_H
-#define CATA_SRC_CELLULAR_AUTOMATA_H
 
 #include <vector>
 
@@ -44,4 +42,4 @@ std::vector<std::vector<int>> generate_cellular_automaton(
                                const int stasis_limit );
 } // namespace CellularAutomata
 
-#endif // CATA_SRC_CELLULAR_AUTOMATA_H
+

--- a/src/char_validity_check.h
+++ b/src/char_validity_check.h
@@ -1,7 +1,5 @@
 #pragma once
-#ifndef CATA_SRC_CHAR_VALIDITY_CHECK_H
-#define CATA_SRC_CHAR_VALIDITY_CHECK_H
 
 bool is_char_allowed( int ch );
 
-#endif // CATA_SRC_CHAR_VALIDITY_CHECK_H
+

--- a/src/character.h
+++ b/src/character.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CHARACTER_H
-#define CATA_SRC_CHARACTER_H
 
 #include <array>
 #include <bitset>
@@ -2435,4 +2433,4 @@ bool has_psy_protection( const Character &c, int partial_chance );
 /** Returns value of speedydex bonus if enabled */
 int get_speedydex_bonus( const int dex );
 
-#endif // CATA_SRC_CHARACTER_H
+

--- a/src/character_display.h
+++ b/src/character_display.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CHARACTER_DISPLAY_H
-#define CATA_SRC_CHARACTER_DISPLAY_H
 
 #include "character_stat.h"
 
@@ -43,4 +41,4 @@ int display_empty_handed_base_damage( const Character &you );
 } // namespace character_display
 
 
-#endif // CATA_SRC_CHARACTER_DISPLAY_H
+

--- a/src/character_effects.h
+++ b/src/character_effects.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CHARACTER_EFFECTS_H
-#define CATA_SRC_CHARACTER_EFFECTS_H
 
 class Character;
 
@@ -45,4 +43,4 @@ int calc_focus_change( const Character &who );
 
 } // namespace character_effects
 
-#endif // CATA_SRC_CHARACTER_EFFECTS_H
+

--- a/src/character_encumbrance.h
+++ b/src/character_encumbrance.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CHARACTER_ENCUMBRANCE_H
-#define CATA_SRC_CHARACTER_ENCUMBRANCE_H
 
 #include <array>
 #include <vector>
@@ -52,4 +50,4 @@ struct char_encumbrance_data {
     std::map<bodypart_str_id, encumbrance_data> elems;
 };
 
-#endif // CATA_SRC_CHARACTER_ENCUMBRANCE_H
+

--- a/src/character_functions.h
+++ b/src/character_functions.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CHARACTER_FUNCTIONS_H
-#define CATA_SRC_CHARACTER_FUNCTIONS_H
 
 #include "type_id.h"
 
@@ -235,4 +233,4 @@ void show_skill_capped_notice( const Character &who, const skill_id &id );
 
 } // namespace character_funcs
 
-#endif // CATA_SRC_CHARACTER_FUNCTIONS_H
+

--- a/src/character_id.h
+++ b/src/character_id.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CHARACTER_ID_H
-#define CATA_SRC_CHARACTER_ID_H
 
 #include <cassert>
 #include <ostream>
@@ -51,4 +49,4 @@ class character_id
         int value;
 };
 
-#endif // CATA_SRC_CHARACTER_ID_H
+

--- a/src/character_martial_arts.h
+++ b/src/character_martial_arts.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CHARACTER_MARTIAL_ARTS_H
-#define CATA_SRC_CHARACTER_MARTIAL_ARTS_H
 
 #include <string>
 #include <vector>
@@ -104,4 +102,4 @@ class character_martial_arts
         std::string selected_style_name( const Character &owner ) const;
 };
 
-#endif // CATA_SRC_CHARACTER_MARTIAL_ARTS_H
+

--- a/src/character_oracle.h
+++ b/src/character_oracle.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CHARACTER_ORACLE_H
-#define CATA_SRC_CHARACTER_ORACLE_H
 
 #include "behavior.h"
 #include "behavior_oracle.h"
@@ -32,4 +30,4 @@ class character_oracle_t : public oracle_t
 };
 
 } //namespace behavior
-#endif // CATA_SRC_CHARACTER_ORACLE_H
+

--- a/src/character_preview.h
+++ b/src/character_preview.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CHARACTER_PREVIEW_H
-#define CATA_SRC_CHARACTER_PREVIEW_H
 
 #include "cursesdef.h"
 #include "detached_ptr.h"
@@ -64,4 +62,4 @@ struct character_preview_window {
         auto calc_character_pos() const -> point ;
 };
 
-#endif // CATA_SRC_CHARACTER_PREVIEW_H
+

--- a/src/character_stat.h
+++ b/src/character_stat.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CHARACTER_STAT_H
-#define CATA_SRC_CHARACTER_STAT_H
 
 #include <string>
 
@@ -21,4 +19,4 @@ struct enum_traits<character_stat> {
 /**Get translated name of a stat*/
 std::string get_stat_name( character_stat Stat );
 
-#endif // CATA_SRC_CHARACTER_STAT_H
+

--- a/src/character_turn.h
+++ b/src/character_turn.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CHARACTER_TURN_H
-#define CATA_SRC_CHARACTER_TURN_H
 
 class Character;
 struct w_point;
@@ -22,4 +20,4 @@ void update_mental_focus( Character &who );
 
 } // namespace character_funcs
 
-#endif // CATA_SRC_CHARACTER_TURN_H
+

--- a/src/clone_ptr.h
+++ b/src/clone_ptr.h
@@ -1,5 +1,4 @@
-#ifndef CATA_SRC_CLONE_PTR_H
-#define CATA_SRC_CLONE_PTR_H
+#pragma once
 
 #include <memory>
 
@@ -62,4 +61,4 @@ class clone_ptr
 
 } // namespace cata
 
-#endif // CATA_SRC_CLONE_PTR_H
+

--- a/src/clothing_mod.h
+++ b/src/clothing_mod.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CLOTHING_MOD_H
-#define CATA_SRC_CLOTHING_MOD_H
 
 #include <array>
 #include <cstddef>
@@ -84,4 +82,4 @@ std::string string_from_clothing_mod_type( clothing_mod_type type );
 
 } // namespace clothing_mods
 
-#endif // CATA_SRC_CLOTHING_MOD_H
+

--- a/src/clothing_utils.h
+++ b/src/clothing_utils.h
@@ -1,5 +1,4 @@
-#ifndef CATA_SRC_CLOTHING_UTILS_H
-#define CATA_SRC_CLOTHING_UTILS_H
+#pragma once
 
 class Character;
 class item;
@@ -8,4 +7,4 @@ class item;
 /// without encumbrance penalty.
 auto is_compact( const item &it, const Character &c ) -> bool;
 
-#endif // CATA_SRC_CLOTHING_UTILS_H
+

--- a/src/clzones.h
+++ b/src/clzones.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CLZONES_H
-#define CATA_SRC_CLZONES_H
 
 #include <cstddef>
 #include <functional>
@@ -435,4 +433,4 @@ class zone_manager
         void deserialize( JsonIn &jsin );
 };
 
-#endif // CATA_SRC_CLZONES_H
+

--- a/src/color.h
+++ b/src/color.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_COLOR_H
-#define CATA_SRC_COLOR_H
 
 #include <array>
 #include <list>
@@ -512,4 +510,4 @@ std::string get_note_string_from_color( const nc_color &color );
 nc_color get_note_color( const std::string &note_id );
 std::list<std::pair<std::string, std::string>> get_note_color_names();
 
-#endif // CATA_SRC_COLOR_H
+

--- a/src/color_loader.h
+++ b/src/color_loader.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_COLOR_LOADER_H
-#define CATA_SRC_COLOR_LOADER_H
 
 #include <array>
 #include <fstream>
@@ -85,4 +83,4 @@ class color_loader
         }
 };
 
-#endif // CATA_SRC_COLOR_LOADER_H
+

--- a/src/compress.h
+++ b/src/compress.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_COMPRESS_H
-#define CATA_SRC_COMPRESS_H
 
 #include <string>
 
@@ -9,4 +7,4 @@
 void zlib_compress( const std::string &input, std::vector<std::byte> &output );
 void zlib_decompress( const void *compressed_data, int compressed_size, std::string &output );
 
-#endif // CATA_SRC_COMPRESS_H
+

--- a/src/computer.h
+++ b/src/computer.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_COMPUTER_H
-#define CATA_SRC_COMPUTER_H
 
 #include <string>
 #include <vector>
@@ -148,4 +146,4 @@ class computer
         void remove_option( computer_action action );
 };
 
-#endif // CATA_SRC_COMPUTER_H
+

--- a/src/computer_session.h
+++ b/src/computer_session.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_COMPUTER_SESSION_H
-#define CATA_SRC_COMPUTER_SESSION_H
 
 #include <map>
 #include <string>
@@ -142,4 +140,4 @@ class computer_session
         computer_failure_functions;
 };
 
-#endif // CATA_SRC_COMPUTER_SESSION_H
+

--- a/src/concepts_utility.h
+++ b/src/concepts_utility.h
@@ -1,9 +1,7 @@
 #pragma once
-#ifndef CATA_SRC_CONCEPTS_UTILITY_H
-#define CATA_SRC_CONCEPTS_UTILITY_H
 #include <cmath>
 
 template<typename T>
 concept Arithmetic = std::is_arithmetic_v<T>;
 
-#endif // CATA_SRC_CONCEPTS_UTILITY_H
+

--- a/src/condition.h
+++ b/src/condition.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CONDITION_H
-#define CATA_SRC_CONDITION_H
 
 #include <functional>
 #include <string>
@@ -151,4 +149,4 @@ extern template void read_condition<mission_goal_condition_context>( const JsonO
         std::function<bool( const mission_goal_condition_context & )> &condition, bool default_val );
 #endif
 
-#endif // CATA_SRC_CONDITION_H
+

--- a/src/consistency_report.h
+++ b/src/consistency_report.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CONSISTENCY_REPORT_H
-#define CATA_SRC_CONSISTENCY_REPORT_H
 
 #include <vector>
 #include <string>
@@ -53,4 +51,4 @@ class consistency_report
         }
 };
 
-#endif // CATA_SRC_CONSISTENCY_REPORT_H
+

--- a/src/construction.h
+++ b/src/construction.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CONSTRUCTION_H
-#define CATA_SRC_CONSTRUCTION_H
 
 #include <functional>
 #include <list>
@@ -132,4 +130,4 @@ bool can_construct( const construction &con, const tripoint &p );
 bool player_can_build( Character &ch, const inventory &inv, const construction &con );
 
 
-#endif // CATA_SRC_CONSTRUCTION_H
+

--- a/src/construction_category.h
+++ b/src/construction_category.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CONSTRUCTION_CATEGORY_H
-#define CATA_SRC_CONSTRUCTION_CATEGORY_H
 
 #include <cstddef>
 #include <string>
@@ -36,4 +34,4 @@ const std::vector<construction_category> &get_all();
 
 } // namespace construction_categories
 
-#endif // CATA_SRC_CONSTRUCTION_CATEGORY_H
+

--- a/src/construction_group.h
+++ b/src/construction_group.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CONSTRUCTION_GROUP_H
-#define CATA_SRC_CONSTRUCTION_GROUP_H
 
 #include <string>
 #include <vector>
@@ -34,4 +32,4 @@ const std::vector<construction_group> &get_all();
 
 } // namespace construction_groups
 
-#endif // CATA_SRC_CONSTRUCTION_GROUP_H
+

--- a/src/construction_partial.h
+++ b/src/construction_partial.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CONSTRUCTION_PARTIAL_H
-#define CATA_SRC_CONSTRUCTION_PARTIAL_H
 
 #include <list>
 
@@ -15,4 +13,4 @@ struct partial_con {
     construction_id id = construction_id( -1 );
 };
 
-#endif // CATA_SRC_CONSTRUCTION_PARTIAL_H
+

--- a/src/consumption.h
+++ b/src/consumption.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CONSUMPTION_H
-#define CATA_SRC_CONSUMPTION_H
 
 #include <list>
 
@@ -30,4 +28,4 @@ struct consumption_history_t {
 };
 bool query_consume_ownership( item &target, avatar &you );
 
-#endif // CATA_SRC_CONSUMPTION_H
+

--- a/src/coordinate_conversions.h
+++ b/src/coordinate_conversions.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_COORDINATE_CONVERSIONS_H
-#define CATA_SRC_COORDINATE_CONVERSIONS_H
 
 #include "game_constants.h"
 #include "point.h"
@@ -244,4 +242,4 @@ auto sm_to_mmr_remain( int &x, int &y ) -> point;
 // Note: this produces sm coords of top-left corner of the region.
 auto mmr_to_sm_copy( const tripoint &p ) -> tripoint;
 
-#endif // CATA_SRC_COORDINATE_CONVERSIONS_H
+

--- a/src/coordinates.h
+++ b/src/coordinates.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_COORDINATES_H
-#define CATA_SRC_COORDINATES_H
 
 #include <algorithm>
 #include <cstdlib>
@@ -642,4 +640,4 @@ struct real_coords {
         return point( abs_om.x * subs_in_om * tiles_in_sub, abs_om.y * subs_in_om * tiles_in_sub );
     }
 };
-#endif // CATA_SRC_COORDINATES_H
+

--- a/src/craft_command.h
+++ b/src/craft_command.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CRAFT_COMMAND_H
-#define CATA_SRC_CRAFT_COMMAND_H
 
 #include <string>
 #include <vector>
@@ -130,4 +128,4 @@ class craft_command
                              const std::vector<comp_selection<tool_comp>> &missing_tools );
 };
 
-#endif // CATA_SRC_CRAFT_COMMAND_H
+

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CRAFTING_H
-#define CATA_SRC_CRAFTING_H
 
 #include <list>
 #include <set>
@@ -155,4 +153,4 @@ void complete_disassemble( Character &who, const iuse_location &target, const tr
 
 } // namespace crafting
 
-#endif // CATA_SRC_CRAFTING_H
+

--- a/src/crafting_gui.h
+++ b/src/crafting_gui.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CRAFTING_GUI_H
-#define CATA_SRC_CRAFTING_GUI_H
 
 class recipe;
 class JsonObject;
@@ -10,4 +8,4 @@ const recipe *select_crafting_recipe( int &batch_size_out );
 void load_recipe_category( const JsonObject &jsobj );
 void reset_recipe_categories();
 
-#endif // CATA_SRC_CRAFTING_GUI_H
+

--- a/src/crash.h
+++ b/src/crash.h
@@ -1,8 +1,6 @@
 #pragma once
-#ifndef CATA_SRC_CRASH_H
-#define CATA_SRC_CRASH_H
 
 // Initialize crash handlers for windows
 void init_crash_handlers();
 
-#endif // CATA_SRC_CRASH_H
+

--- a/src/creature.h
+++ b/src/creature.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CREATURE_H
-#define CATA_SRC_CREATURE_H
 
 #include <climits>
 #include <map>
@@ -1034,4 +1032,4 @@ class Creature
         bool underwater = false;
 };
 
-#endif // CATA_SRC_CREATURE_H
+

--- a/src/creature_tracker.h
+++ b/src/creature_tracker.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CREATURE_TRACKER_H
-#define CATA_SRC_CREATURE_TRACKER_H
 
 #include <cstddef>
 #include <memory>
@@ -100,4 +98,4 @@ class Creature_tracker
         void remove_from_location_map( const monster &critter );
 };
 
-#endif // CATA_SRC_CREATURE_TRACKER_H
+

--- a/src/cube_direction.h
+++ b/src/cube_direction.h
@@ -1,5 +1,4 @@
-#ifndef CATA_SRC_CUBE_DIRECTION_H
-#define CATA_SRC_CUBE_DIRECTION_H
+#pragma once
 
 #include <functional>
 
@@ -46,4 +45,4 @@ cube_direction operator-( cube_direction, int i );
 
 tripoint displace( cube_direction d );
 
-#endif // CATA_SRC_CUBE_DIRECTION_H
+

--- a/src/cuboid_rectangle.h
+++ b/src/cuboid_rectangle.h
@@ -1,5 +1,4 @@
-#ifndef CATA_SRC_CUBOID_RECTANGLE_H
-#define CATA_SRC_CUBOID_RECTANGLE_H
+#pragma once
 
 #include "cata_utility.h"
 #include "point.h"
@@ -157,4 +156,4 @@ Tripoint clamp( const Tripoint &p, const inclusive_cuboid<Tripoint> &c )
 static constexpr rectangle<point> rectangle_zero( point_zero, point_zero );
 static constexpr cuboid<tripoint> cuboid_zero( tripoint_zero, tripoint_zero );
 
-#endif // CATA_SRC_CUBOID_RECTANGLE_H
+

--- a/src/cursesdef.h
+++ b/src/cursesdef.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CURSESDEF_H
-#define CATA_SRC_CURSESDEF_H
 
 #include <memory>
 #include <string>
@@ -138,4 +136,4 @@ int getcurx( const window &win );
 int getcury( const window &win );
 } // namespace catacurses
 
-#endif // CATA_SRC_CURSESDEF_H
+

--- a/src/cursesport.h
+++ b/src/cursesport.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_CURSESPORT_H
-#define CATA_SRC_CURSESPORT_H
 
 #include <utility>
 #if defined(TILES) || defined(_WIN32)
@@ -88,5 +86,5 @@ void resize_term( int cell_w, int cell_h );
 int get_scaling_factor();
 
 #endif
-#endif // CATA_SRC_CURSESPORT_H
+
 

--- a/src/damage.h
+++ b/src/damage.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_DAMAGE_H
-#define CATA_SRC_DAMAGE_H
 
 #include <array>
 #include <map>
@@ -150,4 +148,4 @@ resistances load_resistances_instance( const JsonObject &jo );
 // Handles some shorthands
 std::map<damage_type, float> load_damage_map( const JsonObject &jo );
 
-#endif // CATA_SRC_DAMAGE_H
+

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_DEBUG_H
-#define CATA_SRC_DEBUG_H
 
 /**
  *      debugmsg(msg, ...)
@@ -268,4 +266,4 @@ void debug_write_backtrace( std::ostream &out );
 #endif
 
 // vim:tw=72:sw=4:fdm=marker:fdl=0:
-#endif // CATA_SRC_DEBUG_H
+

--- a/src/debug_menu.h
+++ b/src/debug_menu.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_DEBUG_MENU_H
-#define CATA_SRC_DEBUG_MENU_H
 
 #include <optional>
 #include <string>
@@ -85,4 +83,4 @@ std::string iterable_to_string( const Container &values, const std::string_view 
 
 } // namespace debug_menu
 
-#endif // CATA_SRC_DEBUG_MENU_H
+

--- a/src/demangle.h
+++ b/src/demangle.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_DEMANGLE_H
-#define CATA_SRC_DEMANGLE_H
 
 #include <string>
 
@@ -9,4 +7,4 @@
  */
 auto demangle( const char *symbol ) -> std::string;
 
-#endif // CATA_SRC_DEMANGLE_H
+

--- a/src/dependency_tree.h
+++ b/src/dependency_tree.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_DEPENDENCY_TREE_H
-#define CATA_SRC_DEPENDENCY_TREE_H
 
 #include <map>
 #include <stack>
@@ -104,4 +102,4 @@ class dependency_tree
         void check_for_conflicting_dependencies();
 };
 
-#endif // CATA_SRC_DEPENDENCY_TREE_H
+

--- a/src/detached_ptr.h
+++ b/src/detached_ptr.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_DETACHED_PTR_H
-#define CATA_SRC_DETACHED_PTR_H
 
 template <typename T>
 class game_object;
@@ -50,4 +48,4 @@ class detached_ptr
         explicit detached_ptr( T *obj );
         T *release();
 };
-#endif // CATA_SRC_DETACHED_PTR_H
+

--- a/src/dialogue.h
+++ b/src/dialogue.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_DIALOGUE_H
-#define CATA_SRC_DIALOGUE_H
 
 #include <functional>
 #include <set>
@@ -439,4 +437,4 @@ class json_talk_topic
 void unload_talk_topics();
 void load_talk_topic( const JsonObject &jo );
 
-#endif // CATA_SRC_DIALOGUE_H
+

--- a/src/dialogue_win.h
+++ b/src/dialogue_win.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_DIALOGUE_WIN_H
-#define CATA_SRC_DIALOGUE_WIN_H
 
 #include <cstddef>
 #include <vector>
@@ -63,5 +61,5 @@ class dialogue_window
 
         std::string npc_name;
 };
-#endif // CATA_SRC_DIALOGUE_WIN_H
+
 

--- a/src/diary.h
+++ b/src/diary.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_DIARY_H
-#define CATA_SRC_DIARY_H
 
 #include <string>
 #include <list>
@@ -137,4 +135,4 @@ class diary
         /*method for adding changes to the changelist. with the possibility to connect a description*/
         void add_to_change_list( const std::string &entry, const std::string &desc = "" );
 };
-#endif // CATA_SRC_DIARY_H
+

--- a/src/disease.h
+++ b/src/disease.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_DISEASE_H
-#define CATA_SRC_DISEASE_H
 
 #include <optional>
 #include <set>
@@ -38,4 +36,4 @@ class disease_type
         LUA_TYPE_OPS( disease_type, id );
 
 };
-#endif // CATA_SRC_DISEASE_H
+

--- a/src/dispersion.h
+++ b/src/dispersion.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_DISPERSION_H
-#define CATA_SRC_DISPERSION_H
 
 #include <iosfwd>
 #include <vector>
@@ -30,4 +28,4 @@ class dispersion_sources
         friend std::ostream &operator<<( std::ostream &stream, const dispersion_sources &sources );
 };
 
-#endif // CATA_SRC_DISPERSION_H
+

--- a/src/distraction_manager.h
+++ b/src/distraction_manager.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_DISTRACTION_MANAGER_H
-#define CATA_SRC_DISTRACTION_MANAGER_H
 
 #include <string>
 #include <array>
@@ -29,4 +27,4 @@ class distraction_manager_gui
 
 distraction_manager::distraction_manager_gui &get_distraction_manager();
 
-#endif // CATA_SRC_DISTRACTION_MANAGER_H
+

--- a/src/distribution.h
+++ b/src/distribution.h
@@ -1,5 +1,4 @@
-#ifndef CATA_SRC_DISTRIBUTION_H
-#define CATA_SRC_DISTRIBUTION_H
+#pragma once
 
 #include "memory_fast.h"
 
@@ -24,4 +23,4 @@ class int_distribution
         shared_ptr_fast<int_distribution_impl> impl_;
 };
 
-#endif // CATA_SRC_DISTRIBUTION_H
+

--- a/src/distribution_grid.h
+++ b/src/distribution_grid.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_DISTRIBUTION_GRID_H
-#define CATA_SRC_DISTRIBUTION_GRID_H
 
 #include <cstdint>
 #include <vector>
@@ -222,4 +220,4 @@ constexpr traverse_visitor_result noop_visitor_veh( const vehicle & )
  */
 distribution_grid_tracker &get_distribution_grid_tracker();
 
-#endif // CATA_SRC_DISTRIBUTION_GRID_H
+

--- a/src/drawing_primitives.h
+++ b/src/drawing_primitives.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_DRAWING_PRIMITIVES_H
-#define CATA_SRC_DRAWING_PRIMITIVES_H
 
 #include <functional>
 
@@ -17,4 +15,4 @@ void draw_circle( const std::function<void( point )> &set, const rl_vec2d &p, do
 
 void draw_circle( const std::function<void( point )> &set, point p, int rad );
 
-#endif // CATA_SRC_DRAWING_PRIMITIVES_H
+

--- a/src/drop_token.h
+++ b/src/drop_token.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_DROP_TOKEN_H
-#define CATA_SRC_DROP_TOKEN_H
 
 #include <iostream>
 
@@ -72,4 +70,4 @@ drop_token_provider &get_provider();
 
 std::ostream &operator<<( std::ostream &os, const item_drop_token &dt );
 
-#endif // CATA_SRC_DROP_TOKEN_H
+

--- a/src/editmap.h
+++ b/src/editmap.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_EDITMAP_H
-#define CATA_SRC_EDITMAP_H
 
 #include <functional>
 #include <map>
@@ -120,4 +118,4 @@ class editmap
         game_draw_callback_t_container &draw_cb_container();
 };
 
-#endif // CATA_SRC_EDITMAP_H
+

--- a/src/effect.h
+++ b/src/effect.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_EFFECT_H
-#define CATA_SRC_EFFECT_H
 
 #include <set>
 #include <string>
@@ -408,4 +406,4 @@ class effects_map : public
 {
 };
 
-#endif // CATA_SRC_EFFECT_H
+

--- a/src/emit.h
+++ b/src/emit.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_EMIT_H
-#define CATA_SRC_EMIT_H
 
 #include <map>
 #include <string>
@@ -71,4 +69,4 @@ class emit
         std::string field_name;
 };
 
-#endif // CATA_SRC_EMIT_H
+

--- a/src/enum_bitset.h
+++ b/src/enum_bitset.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ENUM_BITSET_H
-#define CATA_SRC_ENUM_BITSET_H
 
 #include <bitset>
 #include <type_traits>
@@ -95,4 +93,4 @@ class enum_bitset
         std::bitset<enum_bitset<E>::size()> bits;
 };
 
-#endif // CATA_SRC_ENUM_BITSET_H
+

--- a/src/enum_conversions.h
+++ b/src/enum_conversions.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ENUM_CONVERSIONS_H
-#define CATA_SRC_ENUM_CONVERSIONS_H
 
 #include <unordered_map>
 
@@ -115,4 +113,4 @@ bool enum_is_valid( const std::string &data )
 /*@}*/
 } // namespace io
 
-#endif // CATA_SRC_ENUM_CONVERSIONS_H
+

--- a/src/enum_int_operators.h
+++ b/src/enum_int_operators.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ENUM_INT_OPERATORS_H
-#define CATA_SRC_ENUM_INT_OPERATORS_H
 
 #define DEFINE_INTEGER_OPERATORS(Type) \
     \
@@ -69,4 +67,4 @@
         return static_cast<int>(t);\
     }
 
-#endif // CATA_SRC_ENUM_INT_OPERATORS_H
+

--- a/src/enum_traits.h
+++ b/src/enum_traits.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ENUM_TRAITS_H
-#define CATA_SRC_ENUM_TRAITS_H
 
 #include <type_traits>
 
@@ -21,4 +19,4 @@ struct has_enum_traits : std::false_type {};
 template<typename E>
 struct has_enum_traits<E, enum_traits_detail::last_type<E>> : std::true_type {};
 
-#endif // CATA_SRC_ENUM_TRAITS_H
+

--- a/src/enums.h
+++ b/src/enums.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ENUMS_H
-#define CATA_SRC_ENUMS_H
 
 #include "enum_traits.h"
 
@@ -372,4 +370,4 @@ enum MULTITILE_TYPE {
     num_multitile_types
 };
 
-#endif // CATA_SRC_ENUMS_H
+

--- a/src/event.h
+++ b/src/event.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_EVENT_H
-#define CATA_SRC_EVENT_H
 
 #include <array>
 #include <cstddef>
@@ -627,4 +625,4 @@ struct make_event_helper<Type, std::index_sequence<I...>> {
 
 } // namespace cata
 
-#endif // CATA_SRC_EVENT_H
+

--- a/src/event_bus.h
+++ b/src/event_bus.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_EVENT_BUS_H
-#define CATA_SRC_EVENT_BUS_H
 
 #include <utility>
 #include <vector>
@@ -45,4 +43,4 @@ class event_bus
 
 event_bus &get_event_bus();
 
-#endif // CATA_SRC_EVENT_BUS_H
+

--- a/src/event_field_transformations.h
+++ b/src/event_field_transformations.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_EVENT_FIELD_TRANSFORMATIONS_H
-#define CATA_SRC_EVENT_FIELD_TRANSFORMATIONS_H
 
 #include <string>
 #include <unordered_map>
@@ -18,4 +16,4 @@ struct event_field_transformation {
 extern const std::unordered_map<std::string, event_field_transformation>
 event_field_transformations;
 
-#endif // CATA_SRC_EVENT_FIELD_TRANSFORMATIONS_H
+

--- a/src/event_statistics.h
+++ b/src/event_statistics.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_EVENT_STATISTICS_H
-#define CATA_SRC_EVENT_STATISTICS_H
 
 #include <memory>
 #include <string>
@@ -111,4 +109,4 @@ class score
         string_id<event_statistic> stat_;
 };
 
-#endif // CATA_SRC_EVENT_STATISTICS_H
+

--- a/src/examine_item_menu.h
+++ b/src/examine_item_menu.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_EXAMINE_ITEM_MENU_H
-#define CATA_SRC_EXAMINE_ITEM_MENU_H
 
 #include <functional>
 
@@ -48,4 +46,4 @@ hint_rating rate_action_disassemble( avatar &you, const item &it );
 
 } // namespace examine_item_menu
 
-#endif // CATA_SRC_EXAMINE_ITEM_MENU_H
+

--- a/src/explosion.h
+++ b/src/explosion.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_EXPLOSION_H
-#define CATA_SRC_EXPLOSION_H
 
 #include <optional>
 #include <string>
@@ -66,4 +64,4 @@ float blast_radius_from_legacy( int power, float distance_factor );
 
 explosion_data load_explosion_data( const JsonObject &jo );
 
-#endif // CATA_SRC_EXPLOSION_H
+

--- a/src/explosion_queue.h
+++ b/src/explosion_queue.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_EXPLOSION_QUEUE_H
-#define CATA_SRC_EXPLOSION_QUEUE_H
 
 #include "explosion.h"
 #include "point.h"
@@ -70,4 +68,4 @@ explosion_queue &get_explosion_queue();
 
 } // namespace explosion_handler
 
-#endif // CATA_SRC_EXPLOSION_QUEUE_H
+

--- a/src/faction.h
+++ b/src/faction.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_FACTION_H
-#define CATA_SRC_FACTION_H
 
 #include <bitset>
 #include <map>
@@ -141,4 +139,4 @@ class faction_manager
         faction *get( const faction_id &id, bool complain = true );
 };
 
-#endif // CATA_SRC_FACTION_H
+

--- a/src/fault.h
+++ b/src/fault.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_FAULT_H
-#define CATA_SRC_FAULT_H
 
 #include <map>
 #include <optional>
@@ -82,4 +80,4 @@ class fault
         std::set<std::string> flags;
 };
 
-#endif // CATA_SRC_FAULT_H
+

--- a/src/field.h
+++ b/src/field.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_FIELD_H
-#define CATA_SRC_FIELD_H
 
 #include <map>
 #include <string>
@@ -201,4 +199,4 @@ class field
         field_type_id _displayed_field_type;
 };
 
-#endif // CATA_SRC_FIELD_H
+

--- a/src/field_type.h
+++ b/src/field_type.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_FIELD_TYPE_H
-#define CATA_SRC_FIELD_TYPE_H
 
 #include <algorithm>
 #include <cstddef>
@@ -343,4 +341,4 @@ extern field_type_id fd_null,
        fd_tindalos_rift
        ;
 
-#endif // CATA_SRC_FIELD_TYPE_H
+

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_FILESYSTEM_H
-#define CATA_SRC_FILESYSTEM_H
 
 #include <string>
 #include <vector>
@@ -106,4 +104,4 @@ std::vector<std::string> get_directories_with( const std::string &pattern,
  */
 std::string ensure_valid_file_name( const std::string &file_name );
 
-#endif // CATA_SRC_FILESYSTEM_H
+

--- a/src/filter_utils.h
+++ b/src/filter_utils.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_FILTER_UTILS_H
-#define CATA_SRC_FILTER_UTILS_H
 
 /** Used as a default filter in various functions */
 template<typename T>
@@ -9,4 +7,4 @@ bool return_true( const T & )
     return true;
 }
 
-#endif // CATA_SRC_FILTER_UTILS_H
+

--- a/src/fire.h
+++ b/src/fire.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_FIRE_H
-#define CATA_SRC_FIRE_H
 
 #include "units.h"
 
@@ -56,4 +54,4 @@ struct mat_burn_data {
     float burn = 0.0f;
 };
 
-#endif // CATA_SRC_FIRE_H
+

--- a/src/flag.h
+++ b/src/flag.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_FLAG_H
-#define CATA_SRC_FLAG_H
 
 #include <set>
 #include <string>
@@ -458,4 +456,4 @@ class json_flag
         static void reset();
 };
 
-#endif // CATA_SRC_FLAG_H
+

--- a/src/flag_trait.h
+++ b/src/flag_trait.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_FLAG_TRAIT_H
-#define CATA_SRC_FLAG_TRAIT_H
 
 #include <set>
 #include <string>
@@ -56,4 +54,4 @@ class json_trait_flag
         static void reset();
 };
 
-#endif // CATA_SRC_FLAG_TRAIT_H
+

--- a/src/flat_set.h
+++ b/src/flat_set.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_FLAT_SET_H
-#define CATA_SRC_FLAT_SET_H
 
 #include <algorithm>
 #include <vector>
@@ -218,4 +216,4 @@ class flat_set : private Compare, Data
 
 } // namespace cata
 
-#endif // CATA_SRC_FLAT_SET_H
+

--- a/src/flood_fill.h
+++ b/src/flood_fill.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_FLOOD_FILL_H
-#define CATA_SRC_FLOOD_FILL_H
 
 #include <queue>
 #include <vector>
@@ -52,4 +50,4 @@ std::vector<Point> point_flood_fill_4_connected( const Point &starting_point,
 }
 } // namespace ff
 
-#endif // CATA_SRC_FLOOD_FILL_H
+

--- a/src/fmtlib_core.h
+++ b/src/fmtlib_core.h
@@ -6,8 +6,7 @@
 //
 // For the license information refer to fmtlib_format.h.
 
-#ifndef CATA_SRC_FMTLIB_CORE_H
-#define CATA_SRC_FMTLIB_CORE_H
+#pragma once
 
 #include <cstdio>  // std::FILE
 #include <cstring>
@@ -2367,4 +2366,4 @@ inline void print( const S &format_str, Args && ... args )
 }
 FMT_END_NAMESPACE
 
-#endif  // CATA_SRC_FMTLIB_CORE_H
+

--- a/src/fmtlib_format-inl.h
+++ b/src/fmtlib_format-inl.h
@@ -6,8 +6,7 @@
 //
 // For the license information refer to fmtlib_format.h.
 
-#ifndef CATA_SRC_FMTLIB_FORMAT_INL_H
-#define CATA_SRC_FMTLIB_FORMAT_INL_H
+#pragma once
 
 #include <cassert>
 #include <cctype>
@@ -3057,4 +3056,4 @@ FMT_FUNC void vprint( string_view format_str, format_args args )
 
 FMT_END_NAMESPACE
 
-#endif  // CATA_SRC_FMTLIB_FORMAT_INL_H
+

--- a/src/fmtlib_format.h
+++ b/src/fmtlib_format.h
@@ -31,8 +31,7 @@
  without including the above copyright and permission notices.
  */
 
-#ifndef CATA_SRC_FMTLIB_FORMAT_H
-#define CATA_SRC_FMTLIB_FORMAT_H
+#pragma once
 
 #include <algorithm>
 #include <cerrno>
@@ -4482,4 +4481,4 @@ FMT_END_NAMESPACE
 
 #  define FMT_FUNC
 
-#endif  // CATA_SRC_FMTLIB_FORMAT_H
+

--- a/src/fmtlib_ostream.h
+++ b/src/fmtlib_ostream.h
@@ -6,8 +6,7 @@
 //
 // For the license information refer to fmtlib_format.h.
 
-#ifndef CATA_SRC_FMTLIB_OSTREAM_H
-#define CATA_SRC_FMTLIB_OSTREAM_H
+#pragma once
 
 #include <ostream>
 
@@ -185,4 +184,4 @@ template <typename S, typename... Args,
 }
 FMT_END_NAMESPACE
 
-#endif  // CATA_SRC_FMTLIB_OSTREAM_H
+

--- a/src/fmtlib_printf.h
+++ b/src/fmtlib_printf.h
@@ -6,8 +6,7 @@
 //
 // For the license information refer to fmtlib_format.h.
 
-#ifndef CATA_SRC_FMTLIB_PRINTF_H
-#define CATA_SRC_FMTLIB_PRINTF_H
+#pragma once
 
 #include <algorithm>  // std::max
 #include <limits>     // std::numeric_limits
@@ -822,4 +821,4 @@ inline int fprintf( std::basic_ostream<Char> &os, const S &format_str,
 }
 FMT_END_NAMESPACE
 
-#endif  // CATA_SRC_FMTLIB_PRINTF_H
+

--- a/src/font_loader.h
+++ b/src/font_loader.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_FONT_LOADER_H
-#define CATA_SRC_FONT_LOADER_H
 
 #include <algorithm>
 #include <stdexcept>
@@ -41,4 +39,4 @@ class font_loader
         void load();
 };
 
-#endif // CATA_SRC_FONT_LOADER_H
+

--- a/src/fragment_cloud.h
+++ b/src/fragment_cloud.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_FRAGMENT_CLOUD_H
-#define CATA_SRC_FRAGMENT_CLOUD_H
 
 enum class quadrant;
 
@@ -13,4 +11,4 @@ float accumulate_fragment_cloud( const float &cumulative_obstacle,
                                  const float &current_obstacle,
                                  const int &distance );
 
-#endif // CATA_SRC_FRAGMENT_CLOUD_H
+

--- a/src/fstream_utils.h
+++ b/src/fstream_utils.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_FSTREAM_UTILS_H
-#define CATA_SRC_FSTREAM_UTILS_H
 
 #include <iosfwd>
 #include <string>
@@ -231,4 +229,4 @@ inline void deserialize( T *&obj, const std::string &data )
 }
 /**@}*/
 
-#endif // CATA_SRC_FSTREAM_UTILS_H
+

--- a/src/fungal_effects.h
+++ b/src/fungal_effects.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_FUNGAL_EFFECTS_H
-#define CATA_SRC_FUNGAL_EFFECTS_H
 
 struct tripoint;
 class map;
@@ -27,4 +25,4 @@ class fungal_effects
         void spread_fungus_one_tile( const tripoint &p, int growth );
 };
 
-#endif // CATA_SRC_FUNGAL_EFFECTS_H
+

--- a/src/game.h
+++ b/src/game.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_GAME_H
-#define CATA_SRC_GAME_H
 
 #include <array>
 #include <chrono>
@@ -1096,4 +1094,4 @@ namespace cata_event_dispatch
 void avatar_moves( const avatar &u, const map &m, const tripoint &p );
 } // namespace cata_event_dispatch
 
-#endif // CATA_SRC_GAME_H
+

--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_GAME_CONSTANTS_H
-#define CATA_SRC_GAME_CONSTANTS_H
 
 #include "units.h"
 
@@ -177,4 +175,4 @@ constexpr float morbidly_obese = 40.0f;
 } // namespace character_weight_category
 
 
-#endif // CATA_SRC_GAME_CONSTANTS_H
+

--- a/src/game_info.h
+++ b/src/game_info.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_GAME_INFO_H
-#define CATA_SRC_GAME_INFO_H
 
 #include <optional>
 #include <string>
@@ -27,4 +25,4 @@ auto game_report() -> std::string;
 auto save_file_version() -> std::string;
 } // namespace game_info
 
-#endif // CATA_SRC_GAME_INFO_H
+

--- a/src/game_inventory.h
+++ b/src/game_inventory.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_GAME_INVENTORY_H
-#define CATA_SRC_GAME_INVENTORY_H
 
 #include <functional>
 #include <list>
@@ -117,4 +115,4 @@ item *sterilize_cbm( player &p );
 
 } // namespace game_menus
 
-#endif // CATA_SRC_GAME_INVENTORY_H
+

--- a/src/game_object.h
+++ b/src/game_object.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_GAME_OBJECT_H
-#define CATA_SRC_GAME_OBJECT_H
 
 #include <utility>
 
@@ -63,4 +61,4 @@ class game_object
         virtual std::string debug_name() const = 0;
 };
 
-#endif // CATA_SRC_GAME_OBJECT_H
+

--- a/src/game_ui.h
+++ b/src/game_ui.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_GAME_UI_H
-#define CATA_SRC_GAME_UI_H
 
 namespace game_ui
 {
@@ -15,4 +13,4 @@ void from_map_font_dimension( int &w, int &h );
 void to_overmap_font_dimension( int &w, int &h );
 void reinitialize_framebuffer( bool force_invalidate = false );
 
-#endif // CATA_SRC_GAME_UI_H
+

--- a/src/gamemode.h
+++ b/src/gamemode.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_GAMEMODE_H
-#define CATA_SRC_GAMEMODE_H
 
 #include <memory>
 #include <string>
@@ -34,4 +32,4 @@ struct special_game {
 
 };
 
-#endif // CATA_SRC_GAMEMODE_H
+

--- a/src/gamemode_defense.h
+++ b/src/gamemode_defense.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_GAMEMODE_DEFENSE_H
-#define CATA_SRC_GAMEMODE_DEFENSE_H
 
 #include <string>
 #include <vector>
@@ -130,4 +128,4 @@ struct defense_game : public special_game {
         overmap_special_id defloc_special;
 };
 
-#endif // CATA_SRC_GAMEMODE_DEFENSE_H
+

--- a/src/gamemode_tutorial.h
+++ b/src/gamemode_tutorial.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_GAMEMODE_TUTORIAL_H
-#define CATA_SRC_GAMEMODE_TUTORIAL_H
 
 #include <functional>
 #include <iosfwd>
@@ -71,4 +69,4 @@ struct tutorial_game : public special_game {
         std::map<tut_lesson, bool> tutorials_seen;
 };
 
-#endif // CATA_SRC_GAMEMODE_TUTORIAL_H
+

--- a/src/gates.h
+++ b/src/gates.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_GATES_H
-#define CATA_SRC_GATES_H
 
 #include <string>
 
@@ -35,4 +33,4 @@ void close_door( map &m, Character &who, const tripoint &closep );
 
 } // namespace doors
 
-#endif // CATA_SRC_GATES_H
+

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_GENERIC_FACTORY_H
-#define CATA_SRC_GENERIC_FACTORY_H
 
 #include <algorithm>
 #include <bitset>
@@ -855,4 +853,4 @@ bool one_char_symbol_reader( const JsonObject &jo, const std::string &member_nam
 bool unicode_codepoint_from_symbol_reader( const JsonObject &jo,
         const std::string &member_name, uint32_t &member, bool );
 
-#endif // CATA_SRC_GENERIC_FACTORY_H
+

--- a/src/generic_readers.h
+++ b/src/generic_readers.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_GENERIC_READERS_H
-#define CATA_SRC_GENERIC_READERS_H
 
 #include <map>
 #include <vector>
@@ -469,4 +467,4 @@ inline bool legacy_volume_reader( const JsonObject &jo, const std::string &membe
     return true;
 }
 
-#endif // CATA_SRC_GENERIC_READERS_H
+

--- a/src/get_version.h
+++ b/src/get_version.h
@@ -1,5 +1,3 @@
 #pragma once
-#ifndef CATA_SRC_GET_VERSION_H
-#define CATA_SRC_GET_VERSION_H
 const char *getVersionString();
-#endif // CATA_SRC_GET_VERSION_H
+

--- a/src/gun_mode.h
+++ b/src/gun_mode.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_GUN_MODE_H
-#define CATA_SRC_GUN_MODE_H
 
 #include <set>
 #include <string>
@@ -61,4 +59,4 @@ class gun_mode
         }
 };
 
-#endif // CATA_SRC_GUN_MODE_H
+

--- a/src/handle_liquid.h
+++ b/src/handle_liquid.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_HANDLE_LIQUID_H
-#define CATA_SRC_HANDLE_LIQUID_H
 
 #include "item_stack.h"
 #include "map.h"
@@ -76,4 +74,4 @@ bool handle_liquid( tripoint pos, int radius = 0 );
 bool handle_liquid( vehicle *veh, int part_id, int radius = 0 );
 } // namespace liquid_handler
 
-#endif // CATA_SRC_HANDLE_LIQUID_H
+

--- a/src/harvest.h
+++ b/src/harvest.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_HARVEST_H
-#define CATA_SRC_HARVEST_H
 
 #include <list>
 #include <map>
@@ -93,4 +91,4 @@ class harvest_list
         void finalize();
 };
 
-#endif // CATA_SRC_HARVEST_H
+

--- a/src/hash_utils.h
+++ b/src/hash_utils.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_HASH_UTILS_H
-#define CATA_SRC_HASH_UTILS_H
 
 #include <cstdint>
 #include <functional>
@@ -119,4 +117,4 @@ inline std::size_t hash64( std::uint64_t val )
 
 } // namespace cata
 
-#endif // CATA_SRC_HASH_UTILS_H
+

--- a/src/help.h
+++ b/src/help.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_HELP_H
-#define CATA_SRC_HELP_H
 
 #include <map>
 #include <string>
@@ -34,4 +32,4 @@ help &get_help();
 
 std::string get_hint();
 
-#endif // CATA_SRC_HELP_H
+

--- a/src/iexamine.h
+++ b/src/iexamine.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_IEXAMINE_H
-#define CATA_SRC_IEXAMINE_H
 
 #include <list>
 #include <optional>
@@ -144,4 +142,4 @@ void practice_survival_while_foraging( player *p );
 using iexamine_function = void ( * )( player &, const tripoint & );
 iexamine_function iexamine_function_from_string( const std::string &function_name );
 
-#endif // CATA_SRC_IEXAMINE_H
+

--- a/src/ime.h
+++ b/src/ime.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_IME_H
-#define CATA_SRC_IME_H
 
 /**
  * Enable or disable IME for text/keyboard input
@@ -26,4 +24,4 @@ class ime_sentry
         bool previously_enabled;
 };
 
-#endif // CATA_SRC_IME_H
+

--- a/src/init.h
+++ b/src/init.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_INIT_H
-#define CATA_SRC_INIT_H
 
 #include <functional>
 #include <list>
@@ -221,4 +219,4 @@ bool check_mods_for_errors( loading_ui &ui, const std::vector<mod_id> &opts );
 
 } // namespace init
 
-#endif // CATA_SRC_INIT_H
+

--- a/src/input.h
+++ b/src/input.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_INPUT_H
-#define CATA_SRC_INPUT_H
 
 #include <algorithm>
 #include <cstddef>
@@ -771,4 +769,4 @@ bool gamepad_available();
 // rotate a delta direction clockwise
 void rotate_direction_cw( int &dx, int &dy );
 
-#endif // CATA_SRC_INPUT_H
+

--- a/src/int_id.h
+++ b/src/int_id.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_INT_ID_H
-#define CATA_SRC_INT_ID_H
 
 #include <functional>
 #include <string>
@@ -127,4 +125,4 @@ struct hash< int_id<T> > {
 };
 } // namespace std
 
-#endif // CATA_SRC_INT_ID_H
+

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_INVENTORY_H
-#define CATA_SRC_INVENTORY_H
 
 #include <array>
 #include <bitset>
@@ -405,4 +403,4 @@ class location_inventory : public location_visitable<location_inventory>
         const inventory &as_inventory() const;
 };
 
-#endif // CATA_SRC_INVENTORY_H
+

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_INVENTORY_UI_H
-#define CATA_SRC_INVENTORY_UI_H
 
 #include <cassert>
 #include <climits>
@@ -723,4 +721,4 @@ class inventory_drop_selector : public inventory_multiselector
         excluded_stacks dropping;
 };
 
-#endif // CATA_SRC_INVENTORY_UI_H
+

--- a/src/io_tags.h
+++ b/src/io_tags.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_IO_TAGS_H
-#define CATA_SRC_IO_TAGS_H
 
 namespace io
 {
@@ -28,4 +26,4 @@ struct object_archive_tag {
 
 } // namespace io
 
-#endif // CATA_SRC_IO_TAGS_H
+

--- a/src/item.h
+++ b/src/item.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ITEM_H
-#define CATA_SRC_ITEM_H
 
 #include <climits>
 #include <cstdint>
@@ -2656,4 +2654,4 @@ struct cable_connection_data {
     }
 };
 
-#endif // CATA_SRC_ITEM_H
+

--- a/src/item_action.h
+++ b/src/item_action.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ITEM_ACTION_H
-#define CATA_SRC_ITEM_ACTION_H
 
 #include <map>
 #include <string>
@@ -59,4 +57,4 @@ class item_action_generator
         void reset();
 };
 
-#endif // CATA_SRC_ITEM_ACTION_H
+

--- a/src/item_category.h
+++ b/src/item_category.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ITEM_CATEGORY_H
-#define CATA_SRC_ITEM_CATEGORY_H
 
 #include <optional>
 #include <string>
@@ -81,5 +79,5 @@ class item_category
         void load( const JsonObject &jo, const std::string & );
 };
 
-#endif // CATA_SRC_ITEM_CATEGORY_H
+
 

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ITEM_CONTENTS_H
-#define CATA_SRC_ITEM_CONTENTS_H
 
 #include <cstddef>
 #include <functional>
@@ -116,4 +114,4 @@ class item_contents
         location_vector<item> items;
 };
 
-#endif // CATA_SRC_ITEM_CONTENTS_H
+

--- a/src/item_factory.h
+++ b/src/item_factory.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ITEM_FACTORY_H
-#define CATA_SRC_ITEM_FACTORY_H
 
 #include <functional>
 #include <list>
@@ -381,4 +379,4 @@ class Item_factory
         std::set<std::string> repair_actions;
 };
 
-#endif // CATA_SRC_ITEM_FACTORY_H
+

--- a/src/item_functions.h
+++ b/src/item_functions.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ITEM_FUNCTIONS_H
-#define CATA_SRC_ITEM_FUNCTIONS_H
 
 #include "units.h"
 
@@ -18,4 +16,4 @@ int shots_remaining( const Character &who, const item &it );
 
 } // namespace item_funcs
 
-#endif // CATA_SRC_ITEM_FUNCTIONS_H
+

--- a/src/item_group.h
+++ b/src/item_group.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ITEM_GROUP_H
-#define CATA_SRC_ITEM_GROUP_H
 
 #include <memory>
 #include <optional>
@@ -328,4 +326,4 @@ class Item_group : public Item_spawn_data
         prop_list items;
 };
 
-#endif // CATA_SRC_ITEM_GROUP_H
+

--- a/src/item_handling_util.h
+++ b/src/item_handling_util.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ITEM_HANDLING_UTIL_H
-#define CATA_SRC_ITEM_HANDLING_UTIL_H
 
 #include <list>
 
@@ -25,4 +23,4 @@ using iuse_locations = std::vector<iuse_location>;
 using drop_location = iuse_location;
 using drop_locations = std::vector<drop_location>;
 
-#endif // CATA_SRC_ITEM_HANDLING_UTIL_H
+

--- a/src/item_search.h
+++ b/src/item_search.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ITEM_SEARCH_H
-#define CATA_SRC_ITEM_SEARCH_H
 
 #include <cstddef>
 #include <algorithm>
@@ -96,4 +94,4 @@ std::function<bool( const item & )> item_filter_from_string( const std::string &
  */
 std::function<bool( const item & )> basic_item_filter( std::string filter );
 
-#endif // CATA_SRC_ITEM_SEARCH_H
+

--- a/src/item_stack.h
+++ b/src/item_stack.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ITEM_STACK_H
-#define CATA_SRC_ITEM_STACK_H
 
 #include <cstddef>
 
@@ -72,4 +70,4 @@ class item_stack
         const item *stacks_with( const item &it ) const;
 };
 
-#endif // CATA_SRC_ITEM_STACK_H
+

--- a/src/iteminfo_format_utils.h
+++ b/src/iteminfo_format_utils.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ITEMINFO_FORMAT_UTILS_H
-#define CATA_SRC_ITEMINFO_FORMAT_UTILS_H
 
 #include "item.h"
 
@@ -9,5 +7,5 @@
  */
 void insert_separation_line( std::vector<iteminfo> &info );
 
-#endif // CATA_SRC_ITEMINFO_FORMAT_UTILS_H
+
 

--- a/src/iteminfo_query.h
+++ b/src/iteminfo_query.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ITEMINFO_QUERY_H
-#define CATA_SRC_ITEMINFO_QUERY_H
 
 #include <cstddef>
 #include <bitset>
@@ -244,4 +242,4 @@ class iteminfo_query
         static const iteminfo_query no_conditions;
 };
 
-#endif // CATA_SRC_ITEMINFO_QUERY_H
+

--- a/src/itype.h
+++ b/src/itype.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ITYPE_H
-#define CATA_SRC_ITYPE_H
 
 #include <array>
 #include <iosfwd>
@@ -1097,4 +1095,4 @@ struct itype {
         bool is_seed() const;
 };
 
-#endif // CATA_SRC_ITYPE_H
+

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_IUSE_H
-#define CATA_SRC_IUSE_H
 
 #include <memory>
 #include <string>
@@ -311,4 +309,4 @@ struct use_function {
         void dump_info( const item &, std::vector<iteminfo> & ) const;
 };
 
-#endif // CATA_SRC_IUSE_H
+

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_IUSE_ACTOR_H
-#define CATA_SRC_IUSE_ACTOR_H
 
 #include <climits>
 #include <map>
@@ -1273,4 +1271,4 @@ class heat_food_actor : public iuse_actor
         ret_val<bool> can_use( const Character &, const item &, bool, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
-#endif // CATA_SRC_IUSE_ACTOR_H
+

--- a/src/iuse_software.h
+++ b/src/iuse_software.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_IUSE_SOFTWARE_H
-#define CATA_SRC_IUSE_SOFTWARE_H
 
 #include <map>
 #include <string>
@@ -9,4 +7,4 @@ bool play_videogame( const std::string &function_name,
                      std::string &end_message,
                      int &score );
 
-#endif // CATA_SRC_IUSE_SOFTWARE_H
+

--- a/src/iuse_software_kitten.h
+++ b/src/iuse_software_kitten.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_IUSE_SOFTWARE_KITTEN_H
-#define CATA_SRC_IUSE_SOFTWARE_KITTEN_H
 
 #include <string>
 
@@ -58,4 +56,4 @@ class robot_finds_kitten
         bool end_animation_last_input_left_or_up = false;
 };
 
-#endif // CATA_SRC_IUSE_SOFTWARE_KITTEN_H
+

--- a/src/iuse_software_lightson.h
+++ b/src/iuse_software_lightson.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_IUSE_SOFTWARE_LIGHTSON_H
-#define CATA_SRC_IUSE_SOFTWARE_LIGHTSON_H
 
 #include <vector>
 
@@ -36,4 +34,4 @@ class lightson_game
         lightson_game() = default;
 };
 
-#endif // CATA_SRC_IUSE_SOFTWARE_LIGHTSON_H
+

--- a/src/iuse_software_minesweeper.h
+++ b/src/iuse_software_minesweeper.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_IUSE_SOFTWARE_MINESWEEPER_H
-#define CATA_SRC_IUSE_SOFTWARE_MINESWEEPER_H
 
 #include <map>
 
@@ -38,4 +36,4 @@ class minesweeper_game
         minesweeper_game();
 };
 
-#endif // CATA_SRC_IUSE_SOFTWARE_MINESWEEPER_H
+

--- a/src/iuse_software_snake.h
+++ b/src/iuse_software_snake.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_IUSE_SOFTWARE_SNAKE_H
-#define CATA_SRC_IUSE_SOFTWARE_SNAKE_H
 
 namespace catacurses
 {
@@ -17,4 +15,4 @@ class snake_game
         int start_game();
 };
 
-#endif // CATA_SRC_IUSE_SOFTWARE_SNAKE_H
+

--- a/src/iuse_software_sokoban.h
+++ b/src/iuse_software_sokoban.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_IUSE_SOFTWARE_SOKOBAN_H
-#define CATA_SRC_IUSE_SOFTWARE_SOKOBAN_H
 
 #include <cstddef>
 #include <iosfwd>
@@ -55,4 +53,4 @@ class sokoban_game
         sokoban_game();
 };
 
-#endif // CATA_SRC_IUSE_SOFTWARE_SOKOBAN_H
+

--- a/src/json.h
+++ b/src/json.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_JSON_H
-#define CATA_SRC_JSON_H
 
 #include <array>
 #include <bitset>
@@ -1548,4 +1546,4 @@ void deserialize( std::optional<T> &obj, JsonIn &jsin )
     }
 }
 
-#endif // CATA_SRC_JSON_H
+

--- a/src/json_export.h
+++ b/src/json_export.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_JSON_EXPORT_H
-#define CATA_SRC_JSON_EXPORT_H
 
 #include "json.h"
 
@@ -12,4 +10,4 @@ auto vehicle( JsonOut &json, const vehicle &v ) -> void;
 
 } // namespace json_export
 
-#endif // CATA_SRC_JSON_EXPORT_H
+

--- a/src/json_source_location.h
+++ b/src/json_source_location.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_JSON_SOURCE_LOCATION_H
-#define CATA_SRC_JSON_SOURCE_LOCATION_H
 
 #include <string>
 
@@ -18,4 +16,4 @@ void throw_error_at_json_loc( const json_source_location &loc, const std::string
 /** Show warning at given JSON location. */
 void show_warning_at_json_loc( const json_source_location &loc, const std::string &message );
 
-#endif // CATA_SRC_JSON_SOURCE_LOCATION_H
+

--- a/src/kill_tracker.h
+++ b/src/kill_tracker.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_KILL_TRACKER_H
-#define CATA_SRC_KILL_TRACKER_H
 
 #include <map>
 #include <string>
@@ -59,4 +57,4 @@ class kill_tracker : public event_subscriber
         std::vector<std::string> npc_kills;    // names of NPCs the player killed
 };
 
-#endif // CATA_SRC_KILL_TRACKER_H
+

--- a/src/language.h
+++ b/src/language.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_LANGUAGE_H
-#define CATA_SRC_LANGUAGE_H
 
 #include <string>
 #include <vector>
@@ -136,4 +134,4 @@ void load_mod_catalogues();
 void unload_mod_catalogues();
 } // namespace l10n_data
 
-#endif // CATA_SRC_LANGUAGE_H
+

--- a/src/legacy_pathfinding.h
+++ b/src/legacy_pathfinding.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_PATHFINDING_H
-#define CATA_SRC_PATHFINDING_H
 
 #include "game_constants.h"
 
@@ -72,5 +70,3 @@ struct pathfinding_settings {
           avoid_sharp( as ) {}
     pathfinding_settings &operator = ( const pathfinding_settings & ) = default;
 };
-
-#endif // CATA_SRC_PATHFINDING_H

--- a/src/lightmap.h
+++ b/src/lightmap.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_LIGHTMAP_H
-#define CATA_SRC_LIGHTMAP_H
 
 #include <cmath>
 #include <ostream>
@@ -79,4 +77,4 @@ enum vision_adjustment {
     VISION_ADJUST_HIDDEN
 };
 
-#endif // CATA_SRC_LIGHTMAP_H
+

--- a/src/line.h
+++ b/src/line.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_LINE_H
-#define CATA_SRC_LINE_H
 
 #include <cmath>
 #include <functional>
@@ -275,4 +273,4 @@ void calc_ray_end( units::angle, int range, const tripoint &p, tripoint &out );
  */
 units::angle coord_to_angle( const tripoint &a, const tripoint &b );
 
-#endif // CATA_SRC_LINE_H
+

--- a/src/live_view.h
+++ b/src/live_view.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_LIVE_VIEW_H
-#define CATA_SRC_LIVE_VIEW_H
 
 #include <memory>
 
@@ -27,4 +25,4 @@ class live_view
         std::unique_ptr<ui_adaptor> ui;
 };
 
-#endif // CATA_SRC_LIVE_VIEW_H
+

--- a/src/loading_ui.h
+++ b/src/loading_ui.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_LOADING_UI_H
-#define CATA_SRC_LOADING_UI_H
 
 #include <memory>
 #include <string>
@@ -40,4 +38,4 @@ class loading_ui
         void show();
 };
 
-#endif // CATA_SRC_LOADING_UI_H
+

--- a/src/location_ptr.h
+++ b/src/location_ptr.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_LOCATION_PTR_H
-#define CATA_SRC_LOCATION_PTR_H
 
 #include <memory>
 
@@ -61,4 +59,4 @@ class location_ptr
         location<T> *get_loc_hack() const;
 };
 
-#endif // CATA_SRC_LOCATION_PTR_H
+

--- a/src/location_vector.h
+++ b/src/location_vector.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_LOCATION_VECTOR_H
-#define CATA_SRC_LOCATION_VECTOR_H
 
 #include <vector>
 #include <functional>
@@ -273,4 +271,4 @@ class location_vector
         void on_destroy();
 };
 
-#endif // CATA_SRC_LOCATION_VECTOR_H
+

--- a/src/locations.h
+++ b/src/locations.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_LOCATIONS_H
-#define CATA_SRC_LOCATIONS_H
 
 #include "point.h"
 #include "type_id.h"
@@ -234,4 +232,4 @@ class fake_item_location : public item_location
         std::string describe( const Character *ch, const item *it ) const override;
 };
 
-#endif // CATA_SRC_LOCATIONS_H
+

--- a/src/lru_cache.h
+++ b/src/lru_cache.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_LRU_CACHE_H
-#define CATA_SRC_LRU_CACHE_H
 
 #include <list>
 #include <unordered_map>
@@ -26,4 +24,4 @@ class lru_cache
         std::unordered_map<Key, typename std::list<Pair>::iterator> map;
 };
 
-#endif // CATA_SRC_LRU_CACHE_H
+


### PR DESCRIPTION
## Purpose of change (The Why)

Header guards are ugly and overly complex, pragma is well-supported and much simpler

Split up into 2 PRs because otherwise clang tidy is too slow to finish within the time limit.

## Describe the solution (The How)

Replace header guards with `#pragma once`

## Describe alternatives you've considered

- Leave it be

## Testing

It built when it wasn't split in twain, it should again

## Additional context

If splitting it in half still doesn't let clang-tidy work, I am very opposed to having to split this up into fourths.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

