### PR TITLE
style: Replace header guards with pragma, M-Z (Pragmatization 2/2)

### DIFF
--- a/src/magic.h
+++ b/src/magic.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MAGIC_H
-#define CATA_SRC_MAGIC_H
 
 #include <functional>
 #include <map>
@@ -658,4 +656,4 @@ struct area_expander {
     void sort_descending();
 };
 
-#endif // CATA_SRC_MAGIC_H
+

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MAGIC_ENCHANTMENT_H
-#define CATA_SRC_MAGIC_ENCHANTMENT_H
 
 #include <map>
 #include <optional>
@@ -178,4 +176,4 @@ class enchantment
                                      const fake_spell &sp ) const;
 };
 
-#endif // CATA_SRC_MAGIC_ENCHANTMENT_H
+

--- a/src/magic_spell_effect_helpers.h
+++ b/src/magic_spell_effect_helpers.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MAGIC_SPELL_EFFECT_HELPERS_H
-#define CATA_SRC_MAGIC_SPELL_EFFECT_HELPERS_H
 
 #include <functional>
 #include <set>
@@ -16,4 +14,4 @@ std::set<tripoint> calculate_spell_effect_area( const spell &sp, const tripoint 
         &
         aoe_func, const Creature &caster, bool ignore_walls = false );
 
-#endif // CATA_SRC_MAGIC_SPELL_EFFECT_HELPERS_H
+

--- a/src/magic_teleporter_list.h
+++ b/src/magic_teleporter_list.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MAGIC_TELEPORTER_LIST_H
-#define CATA_SRC_MAGIC_TELEPORTER_LIST_H
 
 #include <map>
 #include <optional>
@@ -39,4 +37,4 @@ class teleporter_list
         void deserialize( JsonIn &jsin );
 };
 
-#endif // CATA_SRC_MAGIC_TELEPORTER_LIST_H
+

--- a/src/magic_ter_furn_transform.h
+++ b/src/magic_ter_furn_transform.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MAGIC_TER_FURN_TRANSFORM_H
-#define CATA_SRC_MAGIC_TER_FURN_TRANSFORM_H
 
 #include <map>
 #include <optional>
@@ -84,4 +82,4 @@ class ter_furn_transform
         bool is_valid() const;
 };
 
-#endif // CATA_SRC_MAGIC_TER_FURN_TRANSFORM_H
+

--- a/src/main_menu.h
+++ b/src/main_menu.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MAIN_MENU_H
-#define CATA_SRC_MAIN_MENU_H
 
 #include <cstddef>
 #include <string>
@@ -117,5 +115,5 @@ class main_menu
         std::string halloween_graves();
 };
 
-#endif // CATA_SRC_MAIN_MENU_H
+
 

--- a/src/make_static.h
+++ b/src/make_static.h
@@ -1,5 +1,4 @@
-#ifndef CATA_SRC_MAKE_STATIC_H
-#define CATA_SRC_MAKE_STATIC_H
+#pragma once
 
 /**
  *  The purpose of this macro is to provide a concise syntax for
@@ -29,4 +28,4 @@
         return _cached_expr; \
     })())
 
-#endif // CATA_SRC_MAKE_STATIC_H
+

--- a/src/map.h
+++ b/src/map.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MAP_H
-#define CATA_SRC_MAP_H
 
 #include <array>
 #include <bitset>
@@ -2101,4 +2099,4 @@ class fake_map : public tinymap
                   int fake_map_z );
         ~fake_map() override;
 };
-#endif // CATA_SRC_MAP_H
+

--- a/src/map_extras.h
+++ b/src/map_extras.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MAP_EXTRAS_H
-#define CATA_SRC_MAP_EXTRAS_H
 
 #include <cstdint>
 #include <string>
@@ -83,4 +81,4 @@ const generic_factory<map_extra> &mapExtraFactory();
 
 } // namespace MapExtras
 
-#endif // CATA_SRC_MAP_EXTRAS_H
+

--- a/src/map_functions.h
+++ b/src/map_functions.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MAP_FUNCTIONS_H
-#define CATA_SRC_MAP_FUNCTIONS_H
 
 #include <optional>
 
@@ -21,4 +19,4 @@ void migo_nerve_cage_removal( map &m, const tripoint &p, bool spawn_damaged );
 
 } // namespace map_funcs
 
-#endif // CATA_SRC_MAP_FUNCTIONS_H
+

--- a/src/map_item_stack.h
+++ b/src/map_item_stack.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MAP_ITEM_STACK_H
-#define CATA_SRC_MAP_ITEM_STACK_H
 
 #include <string>
 #include <vector>
@@ -48,4 +46,4 @@ int list_filter_high_priority( std::vector<map_item_stack> &stack, const std::st
 int list_filter_low_priority( std::vector<map_item_stack> &stack, int start,
                               const std::string &priorities );
 
-#endif // CATA_SRC_MAP_ITEM_STACK_H
+

--- a/src/map_iterator.h
+++ b/src/map_iterator.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MAP_ITERATOR_H
-#define CATA_SRC_MAP_ITERATOR_H
 
 #include <cstddef>
 
@@ -130,4 +128,4 @@ inline tripoint_range<Tripoint> points_in_radius( const Tripoint &center, const 
     return tripoint_range<Tripoint>( center - offset, center + offset );
 }
 
-#endif // CATA_SRC_MAP_ITERATOR_H
+

--- a/src/map_memory.h
+++ b/src/map_memory.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MAP_MEMORY_H
-#define CATA_SRC_MAP_MEMORY_H
 
 #include <map>
 #include <string>
@@ -204,4 +202,4 @@ class map_memory
         void clear_cache();
 };
 
-#endif // CATA_SRC_MAP_MEMORY_H
+

--- a/src/map_selector.h
+++ b/src/map_selector.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MAP_SELECTOR_H
-#define CATA_SRC_MAP_SELECTOR_H
 
 #include <vector>
 
@@ -74,4 +72,4 @@ class map_selector : public location_visitable<map_selector>
         std::vector<value_type> data;
 };
 
-#endif // CATA_SRC_MAP_SELECTOR_H
+

--- a/src/mapbuffer.h
+++ b/src/mapbuffer.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MAPBUFFER_H
-#define CATA_SRC_MAPBUFFER_H
 
 #include <list>
 #include <map>
@@ -86,4 +84,4 @@ class mapbuffer
 
 extern mapbuffer MAPBUFFER;
 
-#endif // CATA_SRC_MAPBUFFER_H
+

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MAPDATA_H
-#define CATA_SRC_MAPDATA_H
 
 #include <array>
 #include <bitset>
@@ -812,4 +810,4 @@ extern furn_id f_null,
 // consistency checking of terlist & furnlist.
 void check_furniture_and_terrain();
 
-#endif // CATA_SRC_MAPDATA_H
+

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MAPGEN_H
-#define CATA_SRC_MAPGEN_H
 
 #include <cstddef>
 #include <memory>
@@ -562,4 +560,4 @@ void circle( map *m, const ter_id &type, point, int rad );
 void circle_furn( map *m, const furn_id &type, point, int rad );
 void add_corpse( map *m, point );
 
-#endif // CATA_SRC_MAPGEN_H
+

--- a/src/mapgen_functions.h
+++ b/src/mapgen_functions.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MAPGEN_FUNCTIONS_H
-#define CATA_SRC_MAPGEN_FUNCTIONS_H
 
 #include <functional>
 #include <map>
@@ -93,4 +91,4 @@ bool has_update_id( const mapgen_id &id );
 
 } // namespace mapgen
 
-#endif // CATA_SRC_MAPGEN_FUNCTIONS_H
+

--- a/src/mapgen_parameter.h
+++ b/src/mapgen_parameter.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MAPGEN_PARAMETER_H
-#define CATA_SRC_MAPGEN_PARAMETER_H
 
 #include "cata_variant.h"
 #include "memory_fast.h"
@@ -68,4 +66,4 @@ struct mapgen_parameters {
                           mapgen_parameter_scope up_to_scope = mapgen_parameter_scope::last );
 };
 
-#endif // CATA_SRC_MAPGEN_PARAMETER_H
+

--- a/src/mapgendata.h
+++ b/src/mapgendata.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MAPGENDATA_H
-#define CATA_SRC_MAPGENDATA_H
 
 #include <unordered_map>
 
@@ -200,4 +198,4 @@ class mapgendata
         }
 };
 
-#endif // CATA_SRC_MAPGENDATA_H
+

--- a/src/mapgenformat.h
+++ b/src/mapgenformat.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MAPGENFORMAT_H
-#define CATA_SRC_MAPGENFORMAT_H
 
 #include <cstddef>
 #include <string>
@@ -85,4 +83,4 @@ inline format_effect<furn_id> furn_bind( const char ( &characters )[N], Args... 
 
 } //END NAMESPACE mapf
 
-#endif // CATA_SRC_MAPGENFORMAT_H
+

--- a/src/mapsharing.h
+++ b/src/mapsharing.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MAPSHARING_H
-#define CATA_SRC_MAPSHARING_H
 
 #include <set>
 #include <string>
@@ -39,4 +37,4 @@ void addDebugger( const std::string &name );
 void setDefaults();
 } // namespace MAP_SHARING
 
-#endif // CATA_SRC_MAPSHARING_H
+

--- a/src/martialarts.h
+++ b/src/martialarts.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MARTIALARTS_H
-#define CATA_SRC_MARTIALARTS_H
 
 #include <cstddef>
 #include <set>
@@ -337,4 +335,4 @@ std::vector<matype_id> autolearn_martialart_types();
 /** Returns true if the character can learn the entered martial art */
 bool can_autolearn_martial_art( const Character &who, const matype_id &ma_id );
 
-#endif // CATA_SRC_MARTIALARTS_H
+

--- a/src/material.h
+++ b/src/material.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MATERIAL_H
-#define CATA_SRC_MATERIAL_H
 
 #include <cstddef>
 #include <map>
@@ -132,4 +130,4 @@ std::set<material_id> get_rotting();
 
 } // namespace materials
 
-#endif // CATA_SRC_MATERIAL_H
+

--- a/src/math_defines.h
+++ b/src/math_defines.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MATH_DEFINES_H
-#define CATA_SRC_MATH_DEFINES_H
 
 // On Visual Studio math.h only provides the defines (M_PI, etc.) if
 // _USE_MATH_DEFINES is defined before including it.
@@ -29,4 +27,4 @@
 #define M_SQRT2 1.41421356237309504880
 #endif
 
-#endif // CATA_SRC_MATH_DEFINES_H
+

--- a/src/matrix_math.h
+++ b/src/matrix_math.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MATRIX_MATH_H
-#define CATA_SRC_MATRIX_MATH_H
 
 #include <array>
 #include <cmath>
@@ -49,4 +47,4 @@ matrix_3d rotation_z_axis( units::angle angle );
 
 } // namespace matrices
 
-#endif // CATA_SRC_MATRIX_MATH_H
+

--- a/src/mattack_actors.h
+++ b/src/mattack_actors.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MATTACK_ACTORS_H
-#define CATA_SRC_MATTACK_ACTORS_H
 
 #include <climits>
 #include <map>
@@ -200,4 +198,4 @@ class gun_actor : public mattack_actor
         std::unique_ptr<mattack_actor> clone() const override;
 };
 
-#endif // CATA_SRC_MATTACK_ACTORS_H
+

--- a/src/mattack_common.h
+++ b/src/mattack_common.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MATTACK_COMMON_H
-#define CATA_SRC_MATTACK_COMMON_H
 
 #include <memory>
 #include <string>
@@ -58,4 +56,4 @@ struct mtype_special_attack {
         }
 };
 
-#endif // CATA_SRC_MATTACK_COMMON_H
+

--- a/src/melee.h
+++ b/src/melee.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MELEE_H
-#define CATA_SRC_MELEE_H
 
 class Character;
 class Creature;
@@ -67,4 +65,4 @@ const attack_statblock &pick_attack( const Character &c, const item &weapon,
 
 } // namespace melee
 
-#endif // CATA_SRC_MELEE_H
+

--- a/src/memorial_logger.h
+++ b/src/memorial_logger.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MEMORIAL_LOGGER_H
-#define CATA_SRC_MEMORIAL_LOGGER_H
 
 #include <iosfwd>
 #include <string>
@@ -48,4 +46,4 @@ class memorial_logger : public event_subscriber
         std::vector<std::string> log;
 };
 
-#endif // CATA_SRC_MEMORIAL_LOGGER_H
+

--- a/src/memory_fast.h
+++ b/src/memory_fast.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MEMORY_FAST_H
-#define CATA_SRC_MEMORY_FAST_H
 
 #include <memory>
 
@@ -22,4 +20,4 @@ template<typename T, typename... Args> shared_ptr_fast<T> make_shared_fast(
 }
 #endif
 
-#endif // CATA_SRC_MEMORY_FAST_H
+

--- a/src/messages.h
+++ b/src/messages.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MESSAGES_H
-#define CATA_SRC_MESSAGES_H
 
 #include <cstddef>
 #include <string>
@@ -72,4 +70,4 @@ inline void add_msg( const game_message_params &params, const char *const msg, A
     return add_msg( params, string_format( msg, std::forward<Args>( args )... ) );
 }
 
-#endif // CATA_SRC_MESSAGES_H
+

--- a/src/mission.h
+++ b/src/mission.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MISSION_H
-#define CATA_SRC_MISSION_H
 
 #include <functional>
 #include <map>
@@ -476,4 +474,4 @@ struct enum_traits<mission::mission_status> {
     static constexpr mission::mission_status last = mission::mission_status::num_mission_status;
 };
 
-#endif // CATA_SRC_MISSION_H
+

--- a/src/mod_manager.h
+++ b/src/mod_manager.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MOD_MANAGER_H
-#define CATA_SRC_MOD_MANAGER_H
 
 #include <cstddef>
 #include <map>
@@ -222,4 +220,4 @@ class mod_ui
         bool can_shift_down( size_t selection, const std::vector<mod_id> &active_list );
 };
 
-#endif // CATA_SRC_MOD_MANAGER_H
+

--- a/src/mod_tileset.h
+++ b/src/mod_tileset.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MOD_TILESET_H
-#define CATA_SRC_MOD_TILESET_H
 
 #include <string>
 #include <vector>
@@ -45,4 +43,4 @@ class mod_tileset
         std::vector<std::string> compatibility;
 };
 
-#endif // CATA_SRC_MOD_TILESET_H
+

--- a/src/mod_tracker.h
+++ b/src/mod_tracker.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MOD_TRACKER_H
-#define CATA_SRC_MOD_TRACKER_H
 
 #include <string>
 
@@ -49,4 +47,4 @@ requires has_src_member<T>::value {
     def.src.emplace_back( def.id, mod_id( src ) );
 }
 
-#endif // CATA_SRC_MOD_TRACKER_H
+

--- a/src/monattack.h
+++ b/src/monattack.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MONATTACK_H
-#define CATA_SRC_MONATTACK_H
 
 class monster;
 class Creature;
@@ -136,4 +134,4 @@ void flame( monster *z, Creature *target );
 bool dodge_check( monster *z, Creature *target );
 } //namespace mattack
 
-#endif // CATA_SRC_MONATTACK_H
+

--- a/src/mondeath.h
+++ b/src/mondeath.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MONDEATH_H
-#define CATA_SRC_MONDEATH_H
 
 class monster;
 
@@ -87,4 +85,4 @@ void gameover( monster &z );
 
 void make_mon_corpse( monster &z, int damageLvl );
 
-#endif // CATA_SRC_MONDEATH_H
+

--- a/src/mondefense.h
+++ b/src/mondefense.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MONDEFENSE_H
-#define CATA_SRC_MONDEFENSE_H
 
 class monster;
 class Creature;
@@ -22,4 +20,4 @@ void revenge_aggro( monster &m, Creature *source, const dealt_projectile_attack 
 void none( monster &, Creature *, const dealt_projectile_attack * );
 } //namespace mdefense
 
-#endif // CATA_SRC_MONDEFENSE_H
+

--- a/src/monexamine.h
+++ b/src/monexamine.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MONEXAMINE_H
-#define CATA_SRC_MONEXAMINE_H
 
 class monster;
 
@@ -43,4 +41,4 @@ void deactivate_pet( monster &z );
 */
 void milk_source( monster &source_mon );
 } // namespace monexamine
-#endif // CATA_SRC_MONEXAMINE_H
+

--- a/src/monfaction.h
+++ b/src/monfaction.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MONFACTION_H
-#define CATA_SRC_MONFACTION_H
 
 #include <unordered_map>
 
@@ -47,4 +45,4 @@ class monfaction
         LUA_TYPE_OPS( monfaction, id );
 };
 
-#endif // CATA_SRC_MONFACTION_H
+

--- a/src/mongroup.h
+++ b/src/mongroup.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MONGROUP_H
-#define CATA_SRC_MONGROUP_H
 
 #include <map>
 #include <set>
@@ -194,4 +192,4 @@ class MonsterGroupManager
         static t_string_set monster_categories_whitelist;
 };
 
-#endif // CATA_SRC_MONGROUP_H
+

--- a/src/monster.h
+++ b/src/monster.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MONSTER_H
-#define CATA_SRC_MONSTER_H
 
 #include <bitset>
 #include <climits>
@@ -652,4 +650,4 @@ class monster : public Creature, public location_visitable<monster>
         void process_one_effect( effect &it, bool is_new ) override;
 };
 
-#endif // CATA_SRC_MONSTER_H
+

--- a/src/monster_oracle.h
+++ b/src/monster_oracle.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MONSTER_ORACLE_H
-#define CATA_SRC_MONSTER_ORACLE_H
 
 #include "behavior.h"
 #include "behavior_oracle.h"
@@ -27,4 +25,4 @@ class monster_oracle_t : public oracle_t
 };
 
 } // namespace behavior
-#endif // CATA_SRC_MONSTER_ORACLE_H
+

--- a/src/monstergenerator.h
+++ b/src/monstergenerator.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MONSTERGENERATOR_H
-#define CATA_SRC_MONSTERGENERATOR_H
 
 #include <map>
 #include <memory>
@@ -118,4 +116,4 @@ class MonsterGenerator
 void load_monster_adjustment( const JsonObject &jsobj );
 void reset_monster_adjustment();
 
-#endif // CATA_SRC_MONSTERGENERATOR_H
+

--- a/src/morale.h
+++ b/src/morale.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MORALE_H
-#define CATA_SRC_MORALE_H
 
 #include <functional>
 #include <map>
@@ -285,4 +283,4 @@ class player_morale
         int perceived_pain;
 };
 
-#endif // CATA_SRC_MORALE_H
+

--- a/src/morale_types.h
+++ b/src/morale_types.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MORALE_TYPES_H
-#define CATA_SRC_MORALE_TYPES_H
 
 #include <string>
 
@@ -117,4 +115,4 @@ extern const morale_type MORALE_TREE_COMMUNION;
 extern const morale_type MORALE_ACCOMPLISHMENT;
 extern const morale_type MORALE_FAILURE;
 
-#endif // CATA_SRC_MORALE_TYPES_H
+

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MTYPE_H
-#define CATA_SRC_MTYPE_H
 
 #include <map>
 #include <optional>
@@ -450,4 +448,4 @@ struct mtype {
 
 mon_effect_data load_mon_effect_data( const JsonObject &e );
 
-#endif // CATA_SRC_MTYPE_H
+

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MUTATION_H
-#define CATA_SRC_MUTATION_H
 
 #include <map>
 #include <memory>
@@ -528,4 +526,4 @@ mutagen_attempt mutagen_common_checks( Character &guy, const item &it, bool stro
 
 void test_crossing_threshold( Character &guy, const mutation_category_trait &m_category );
 
-#endif // CATA_SRC_MUTATION_H
+

--- a/src/mutation_data.h
+++ b/src/mutation_data.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MUTATION_DATA_H
-#define CATA_SRC_MUTATION_DATA_H
 
 #include <string>
 #include <vector>
@@ -26,4 +24,4 @@ std::string get_random_for_category( const mutation_category_id &cat, int streng
 
 } // namespace dreams
 
-#endif // CATA_SRC_MUTATION_DATA_H
+

--- a/src/mutation_ui.h
+++ b/src/mutation_ui.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_MUTATION_UI_H
-#define CATA_SRC_MUTATION_UI_H
 
 #include "type_id.h"
 
@@ -25,4 +23,4 @@ mutations_ui_result show_mutations_ui_internal( Character &who );
 
 void show_mutations_ui( Character &who );
 
-#endif // CATA_SRC_MUTATION_UI_H
+

--- a/src/name.h
+++ b/src/name.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_NAME_H
-#define CATA_SRC_NAME_H
 
 #include <string>
 
@@ -41,4 +39,4 @@ inline nameFlags operator&( nameFlags l, nameFlags r )
     return static_cast<nameFlags>( static_cast<unsigned>( l ) & static_cast<unsigned>( r ) );
 }
 
-#endif // CATA_SRC_NAME_H
+

--- a/src/newcharacter.h
+++ b/src/newcharacter.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_NEWCHARACTER_H
-#define CATA_SRC_NEWCHARACTER_H
 
 #include <string>
 
@@ -56,4 +54,4 @@ bool has_higher_trait( const Character &ch, const trait_id &t );
 bool has_same_type_trait( const Character &ch, const trait_id &t );
 } // namespace newcharacter
 
-#endif // CATA_SRC_NEWCHARACTER_H
+

--- a/src/npc.h
+++ b/src/npc.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_NPC_H
-#define CATA_SRC_NPC_H
 
 #include <algorithm>
 #include <array>
@@ -1410,4 +1408,4 @@ static constexpr int density_search_radius = 120;
 double spawn_chance_in_hour( int current_npc_count, double density );
 } // namespace npc_overmap
 
-#endif // CATA_SRC_NPC_H
+

--- a/src/npc_class.h
+++ b/src/npc_class.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_NPC_CLASS_H
-#define CATA_SRC_NPC_CLASS_H
 
 #include <functional>
 #include <map>
@@ -129,4 +127,4 @@ extern npc_class_id NC_BARTENDER;
 extern npc_class_id NC_JUNK_SHOPKEEP;
 extern npc_class_id NC_HALLU;
 
-#endif // CATA_SRC_NPC_CLASS_H
+

--- a/src/npc_favor.h
+++ b/src/npc_favor.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_NPC_FAVOR_H
-#define CATA_SRC_NPC_FAVOR_H
 
 #include <string>
 
@@ -35,4 +33,4 @@ struct npc_favor {
     void deserialize( JsonIn &jsin );
 };
 
-#endif // CATA_SRC_NPC_FAVOR_H
+

--- a/src/npctalk.h
+++ b/src/npctalk.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_NPCTALK_H
-#define CATA_SRC_NPCTALK_H
 
 #include "type_id.h"
 
@@ -93,4 +91,4 @@ time_duration calc_skill_training_time( const npc &p, const skill_id &skill );
 int calc_skill_training_cost( const npc &p, const skill_id &skill );
 time_duration calc_ma_style_training_time( const npc &, const matype_id & /* id */ );
 int calc_ma_style_training_cost( const npc &p, const matype_id & /* id */ );
-#endif // CATA_SRC_NPCTALK_H
+

--- a/src/npctrade.h
+++ b/src/npctrade.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_NPCTRADE_H
-#define CATA_SRC_NPCTRADE_H
 
 #include <cstddef>
 #include <vector>
@@ -95,4 +93,4 @@ std::vector<item_pricing> init_selling( npc &p );
 std::vector<item_pricing> init_buying( player &buyer, player &seller, bool is_npc );
 } // namespace npc_trading
 
-#endif // CATA_SRC_NPCTRADE_H
+

--- a/src/numeric_interval.h
+++ b/src/numeric_interval.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_NUMERIC_INTERVAL_H
-#define CATA_SRC_NUMERIC_INTERVAL_H
 
 #include <limits>
 #include <type_traits>
@@ -48,4 +46,4 @@ struct numeric_interval {
     }
 };
 
-#endif // CATA_SRC_NUMERIC_INTERVAL_H
+

--- a/src/om_direction.h
+++ b/src/om_direction.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_OM_DIRECTION_H
-#define CATA_SRC_OM_DIRECTION_H
 
 #include <cstdint>
 #include <climits>
@@ -115,4 +113,4 @@ struct enum_traits<om_direction::type> {
     static constexpr om_direction::type last = om_direction::type::last;
 };
 
-#endif // CATA_SRC_OM_DIRECTION_H
+

--- a/src/omdata.h
+++ b/src/omdata.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_OMDATA_H
-#define CATA_SRC_OMDATA_H
 
 #include <climits>
 #include <cstddef>
@@ -335,4 +333,4 @@ const std::vector<overmap_land_use_code> &get_all();
 
 } // namespace overmap_land_use_codes
 
-#endif // CATA_SRC_OMDATA_H
+

--- a/src/options.h
+++ b/src/options.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_OPTIONS_H
-#define CATA_SRC_OPTIONS_H
 
 #include <functional>
 #include <map>
@@ -371,4 +369,4 @@ inline T get_option( const std::string &name )
     return get_options().get_option( name ).value_as<T>();
 }
 
-#endif // CATA_SRC_OPTIONS_H
+

--- a/src/output.h
+++ b/src/output.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_OUTPUT_H
-#define CATA_SRC_OUTPUT_H
 
 #include <algorithm>
 #include <cassert>
@@ -1012,4 +1010,4 @@ std::string colorize_symbols( const std::string &str, F color_of )
     return res;
 }
 
-#endif // CATA_SRC_OUTPUT_H
+

--- a/src/overlay_ordering.h
+++ b/src/overlay_ordering.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_OVERLAY_ORDERING_H
-#define CATA_SRC_OVERLAY_ORDERING_H
 
 #include <map>
 #include <string>
@@ -16,4 +14,4 @@ void load_overlay_ordering_into_array( const JsonObject &jsobj,
 int get_overlay_order_of_mutation( const std::string &mutation_id_string );
 void reset_overlay_ordering();
 
-#endif // CATA_SRC_OVERLAY_ORDERING_H
+

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_OVERMAP_H
-#define CATA_SRC_OVERMAP_H
 
 #include <algorithm>
 #include <array>
@@ -559,4 +557,4 @@ const std::string &oter_get_rotation_string( const oter_id &oter );
  * Determine whether provided tile belongs to overmap connection.
  */
 bool belongs_to_connection( const overmap_connection_id &id, const oter_id &oter );
-#endif // CATA_SRC_OVERMAP_H
+

--- a/src/overmap_connection.h
+++ b/src/overmap_connection.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_OVERMAP_CONNECTION_H
-#define CATA_SRC_OVERMAP_CONNECTION_H
 
 #include <list>
 #include <vector>
@@ -103,4 +101,4 @@ overmap_connection_id guess_for( const oter_id &oter );
 
 } // namespace overmap_connections
 
-#endif // CATA_SRC_OVERMAP_CONNECTION_H
+

--- a/src/overmap_location.h
+++ b/src/overmap_location.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_OVERMAP_LOCATION_H
-#define CATA_SRC_OVERMAP_LOCATION_H
 
 #include <string>
 #include <vector>
@@ -40,4 +38,4 @@ void finalize();
 
 } // namespace overmap_locations
 
-#endif // CATA_SRC_OVERMAP_LOCATION_H
+

--- a/src/overmap_noise.h
+++ b/src/overmap_noise.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_OVERMAP_NOISE_H
-#define CATA_SRC_OVERMAP_NOISE_H
 
 #include "coordinates.h"
 #include "game_constants.h"
@@ -80,4 +78,4 @@ class om_noise_layer_lake : public om_noise_layer
 
 } // namespace om_noise
 
-#endif // CATA_SRC_OVERMAP_NOISE_H
+

--- a/src/overmap_special.h
+++ b/src/overmap_special.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_OVERMAP_SPECIAL_H
-#define CATA_SRC_OVERMAP_SPECIAL_H
 
 #include <climits>
 #include <cstddef>
@@ -254,4 +252,4 @@ class overmap_special_batch
         point_abs_om origin_overmap;
 };
 
-#endif // CATA_SRC_OVERMAP_SPECIAL_H
+

--- a/src/overmap_types.h
+++ b/src/overmap_types.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_OVERMAP_TYPES_H
-#define CATA_SRC_OVERMAP_TYPES_H
 
 #include "calendar.h"
 
@@ -16,4 +14,4 @@ class scent_trace
         int initial_strength; // Original strength, doesn't weaken, it's just adjusted by age.
 };
 
-#endif // CATA_SRC_OVERMAP_TYPES_H
+

--- a/src/overmap_ui.h
+++ b/src/overmap_ui.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_OVERMAP_UI_H
-#define CATA_SRC_OVERMAP_UI_H
 
 #include "coordinates.h"
 #include "type_id.h"
@@ -107,4 +105,4 @@ auto fmt_omt_coords( const tripoint_abs_omt &coord ) -> std::string;
 weather_type_id get_weather_at_point( const point_abs_omt &pos );
 std::tuple<char, nc_color, size_t> get_note_display_info( const std::string &note );
 } // namespace overmap_ui
-#endif // CATA_SRC_OVERMAP_UI_H
+

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_OVERMAPBUFFER_H
-#define CATA_SRC_OVERMAPBUFFER_H
 
 #include <array>
 #include <functional>
@@ -627,4 +625,4 @@ class overmapbuffer
 
 extern overmapbuffer overmap_buffer;
 
-#endif // CATA_SRC_OVERMAPBUFFER_H
+

--- a/src/panels.h
+++ b/src/panels.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_PANELS_H
-#define CATA_SRC_PANELS_H
 
 #include <functional>
 #include <map>
@@ -99,4 +97,4 @@ class panel_manager
 
 };
 
-#endif // CATA_SRC_PANELS_H
+

--- a/src/panels_utility.h
+++ b/src/panels_utility.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_PANELS_UTILITY_H
-#define CATA_SRC_PANELS_UTILITY_H
 
 #include <string>
 #include "color.h"
@@ -13,4 +11,4 @@ std::string value_trimmed( int value, int maximum = 100 );
 
 nc_color focus_color( int focus );
 
-#endif // CATA_SRC_PANELS_UTILITY_H
+

--- a/src/path_display.h
+++ b/src/path_display.h
@@ -1,5 +1,4 @@
-#ifndef CATA_SRC_PATH_DISPLAY_H
-#define CATA_SRC_PATH_DISPLAY_H
+#pragma once
 
 #include <string>
 
@@ -8,4 +7,4 @@ auto user_directory() -> std::string;
 auto defaults_directory() -> std::string;
 auto config_directory() -> std::string;
 
-#endif // CATA_SRC_PATH_DISPLAY_H
+

--- a/src/path_info.h
+++ b/src/path_info.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_PATH_INFO_H
-#define CATA_SRC_PATH_INFO_H
 
 #include <string>
 
@@ -74,4 +72,4 @@ void set_motd( const std::string &motd );
 
 } // namespace PATH_INFO
 
-#endif // CATA_SRC_PATH_INFO_H
+

--- a/src/pathfinding.h
+++ b/src/pathfinding.h
@@ -1,5 +1,4 @@
-#ifndef CATA_SRC_PATHFINDING_DIJIKSTRA_H
-#define CATA_SRC_PATHFINDING_DIJIKSTRA_H
+#pragma once
 
 #include <array>
 #include <cstring>
@@ -338,4 +337,4 @@ class Pathfinding
         //   such as change in terrain
         static void mark_dirty_z_cache();
 };
-#endif // CATA_SRC_PATHFINDING_DIJIKSTRA_H
+

--- a/src/pickup.h
+++ b/src/pickup.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_PICKUP_H
-#define CATA_SRC_PICKUP_H
 
 #include <vector>
 
@@ -50,4 +48,4 @@ int cost_to_move_item( const Character &who, const item &it );
 detached_ptr<item> handle_spillable_contents( Character &c, detached_ptr<item> &&it, map &m );
 } // namespace pickup
 
-#endif // CATA_SRC_PICKUP_H
+

--- a/src/pickup_token.h
+++ b/src/pickup_token.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_PICKUP_TOKEN_H
-#define CATA_SRC_PICKUP_TOKEN_H
 
 #include <list>
 #include <optional>
@@ -61,4 +59,4 @@ std::vector<std::list<item_stack::iterator>> flatten( const std::vector<stacked_
 
 } // namespace pickup
 
-#endif // CATA_SRC_PICKUP_TOKEN_H
+

--- a/src/pimpl.h
+++ b/src/pimpl.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_PIMPL_H
-#define CATA_SRC_PIMPL_H
 
 #include <memory>
 #include <type_traits>
@@ -75,4 +73,4 @@ class pimpl : private std::unique_ptr<T>
         }
 };
 
-#endif // CATA_SRC_PIMPL_H
+

--- a/src/pixel_minimap.h
+++ b/src/pixel_minimap.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_PIXEL_MINIMAP_H
-#define CATA_SRC_PIXEL_MINIMAP_H
 
 #include <map>
 #include <memory>
@@ -95,4 +93,4 @@ class pixel_minimap
         std::map<tripoint, submap_cache> cache;
 };
 
-#endif // CATA_SRC_PIXEL_MINIMAP_H
+

--- a/src/pixel_minimap_projectors.h
+++ b/src/pixel_minimap_projectors.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_PIXEL_MINIMAP_PROJECTORS_H
-#define CATA_SRC_PIXEL_MINIMAP_PROJECTORS_H
 
 #include "point.h"
 #include "sdl_wrappers.h"
@@ -53,4 +51,4 @@ class pixel_minimap_iso_projector : public pixel_minimap_projector
         point tile_size;
 };
 
-#endif // CATA_SRC_PIXEL_MINIMAP_PROJECTORS_H
+

--- a/src/platform_win.h
+++ b/src/platform_win.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_PLATFORM_WIN_H
-#define CATA_SRC_PLATFORM_WIN_H
 
 #if defined(_WIN32)
 #   if !defined(WIN32_LEAN_AND_MEAN)
@@ -26,4 +24,4 @@
 HWND getWindowHandle();
 #endif
 
-#endif // CATA_SRC_PLATFORM_WIN_H
+

--- a/src/player.h
+++ b/src/player.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_PLAYER_H
-#define CATA_SRC_PLAYER_H
 
 #include <climits>
 #include <functional>
@@ -282,4 +280,4 @@ class player : public Character
         void load( const JsonObject &data );
 };
 
-#endif // CATA_SRC_PLAYER_H
+

--- a/src/player_activity.h
+++ b/src/player_activity.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_PLAYER_ACTIVITY_H
-#define CATA_SRC_PLAYER_ACTIVITY_H
 
 #include <climits>
 #include <memory>
@@ -349,4 +347,4 @@ class player_activity
         void inherit_distractions( const player_activity & );
 };
 
-#endif // CATA_SRC_PLAYER_ACTIVITY_H
+

--- a/src/player_activity_ptr.h
+++ b/src/player_activity_ptr.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_PLAYER_ACTIVITY_PTR_H
-#define CATA_SRC_PLAYER_ACTIVITY_PTR_H
 
 #include <memory>
 
@@ -46,4 +44,4 @@ class activity_ptr
         void deserialize( JsonIn &jsin );
 };
 
-#endif // CATA_SRC_PLAYER_ACTIVITY_PTR_H
+

--- a/src/pldata.h
+++ b/src/pldata.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_PLDATA_H
-#define CATA_SRC_PLDATA_H
 
 #include "calendar.h"
 #include "enum_conversions.h"
@@ -64,4 +62,4 @@ inline social_modifiers operator+( social_modifiers lhs, const social_modifiers 
     return lhs;
 }
 
-#endif // CATA_SRC_PLDATA_H
+

--- a/src/point.h
+++ b/src/point.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_POINT_H
-#define CATA_SRC_POINT_H
 
 // The CATA_NO_STL macro is used by the cata clang-tidy plugin tests so they
 // can include this header when compiling with -nostdinc++
@@ -564,4 +562,4 @@ static const std::array<tripoint, 8> eight_horizontal_neighbors = { {
 
 #endif // CATA_NO_STL
 
-#endif // CATA_SRC_POINT_H
+

--- a/src/point_float.h
+++ b/src/point_float.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_POINT_FLOAT_H
-#define CATA_SRC_POINT_FLOAT_H
 
 #include "point_traits.h"
 
@@ -112,4 +110,4 @@ struct rl_vec3d {
     }
 };
 
-#endif // CATA_SRC_POINT_FLOAT_H
+

--- a/src/point_rotate.h
+++ b/src/point_rotate.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_POINT_ROTATE_H
-#define CATA_SRC_POINT_ROTATE_H
 
 #include "point.h"
 #include "coordinates.h"
@@ -23,4 +21,4 @@ auto rotate_point_sm( const tripoint &p, const tripoint &orig, int turns ) -> tr
 
 auto get_rot_turns( const tripoint_abs_omt &here, const tripoint_abs_omt &there ) -> int;
 
-#endif // CATA_SRC_POINT_ROTATE_H
+

--- a/src/point_traits.h
+++ b/src/point_traits.h
@@ -1,5 +1,4 @@
-#ifndef CATA_SRC_POINT_TRAITS_H
-#define CATA_SRC_POINT_TRAITS_H
+#pragma once
 
 #include <type_traits>
 
@@ -104,4 +103,4 @@ struct point_traits <
     }
 };
 
-#endif // CATA_SRC_POINT_TRAITS_H
+

--- a/src/poly_serialized.h
+++ b/src/poly_serialized.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_POLY_SERIALIZED_H
-#define CATA_SRC_POLY_SERIALIZED_H
 
 #include <memory>
 
@@ -65,4 +63,4 @@ poly_serialized<T> make_poly_serialized( Args &&...args )
 
 } // namespace cata
 
-#endif // CATA_SRC_POLY_SERIALIZED_H
+

--- a/src/popup.h
+++ b/src/popup.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_POPUP_H
-#define CATA_SRC_POPUP_H
 
 #include <chrono>
 #include <cstddef>
@@ -332,4 +330,4 @@ class throbber_popup : private query_popup
         std::chrono::steady_clock::time_point last_update;
 };
 
-#endif // CATA_SRC_POPUP_H
+

--- a/src/posix_time.h
+++ b/src/posix_time.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_POSIX_TIME_H
-#define CATA_SRC_POSIX_TIME_H
 
 // Compatibility header.  On POSIX, just include <ctime>.  On Windows, provide
 // our own nanosleep implementation.
@@ -48,4 +46,4 @@ nanosleep( const struct timespec *requested_delay,
            struct timespec *remaining_delay );
 
 #endif
-#endif // CATA_SRC_POSIX_TIME_H
+

--- a/src/profession.h
+++ b/src/profession.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_PROFESSION_H
-#define CATA_SRC_PROFESSION_H
 
 #include <list>
 #include <map>
@@ -123,4 +121,4 @@ class profession
         std::set<trait_id> get_forbidden_traits() const;
 };
 
-#endif // CATA_SRC_PROFESSION_H
+

--- a/src/profile.h
+++ b/src/profile.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_PROFILE_H
-#define CATA_SRC_PROFILE_H
 
 #if defined(USE_TRACY)
 #   include "tracy/Tracy.hpp"
@@ -113,4 +111,4 @@
 
 #endif
 
-#endif // CATA_SRC_PROFILE_H
+

--- a/src/projectile.h
+++ b/src/projectile.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_PROJECTILE_H
-#define CATA_SRC_PROJECTILE_H
 
 #include <memory>
 #include <set>
@@ -83,4 +81,4 @@ void apply_ammo_effects( const tripoint &p, const std::set<std::string> &effects
 int max_aoe_size( const std::set<ammo_effect_str_id> &tags );
 int max_aoe_size( const std::set<std::string> &tags );
 
-#endif // CATA_SRC_PROJECTILE_H
+

--- a/src/ranged.h
+++ b/src/ranged.h
@@ -1,5 +1,4 @@
-#ifndef CATA_SRC_RANGED_H
-#define CATA_SRC_RANGED_H
+#pragma once
 
 #include <map>
 #include <optional>
@@ -207,4 +206,4 @@ auto throw_item( Character &who, const tripoint &target,
 
 } // namespace ranged
 
-#endif // CATA_SRC_RANGED_H
+

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_RECIPE_H
-#define CATA_SRC_RECIPE_H
 
 #include <cstddef>
 #include <functional>
@@ -224,4 +222,4 @@ class recipe
 
 };
 
-#endif // CATA_SRC_RECIPE_H
+

--- a/src/recipe_dictionary.h
+++ b/src/recipe_dictionary.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_RECIPE_DICTIONARY_H
-#define CATA_SRC_RECIPE_DICTIONARY_H
 
 #include <cstddef>
 #include <algorithm>
@@ -188,4 +186,4 @@ class recipe_subset
 void serialize( const recipe_subset &value, JsonOut &jsout );
 void deserialize( recipe_subset &value, JsonIn &jsin );
 
-#endif // CATA_SRC_RECIPE_DICTIONARY_H
+

--- a/src/recipe_groups.h
+++ b/src/recipe_groups.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_RECIPE_GROUPS_H
-#define CATA_SRC_RECIPE_GROUPS_H
 
 #include <map>
 #include <string>
@@ -22,4 +20,4 @@ std::map<recipe_id, translation> get_recipes_by_id( const std::string &id,
         const std::string &om_terrain_id = "ANY" );
 } // namespace recipe_group
 
-#endif // CATA_SRC_RECIPE_GROUPS_H
+

--- a/src/rect_range.h
+++ b/src/rect_range.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_RECT_RANGE_H
-#define CATA_SRC_RECT_RANGE_H
 
 #include "point.h"
 
@@ -60,4 +58,4 @@ class rect_range
         }
 };
 
-#endif // CATA_SRC_RECT_RANGE_H
+

--- a/src/regen.h
+++ b/src/regen.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_REGEN_H
-#define CATA_SRC_REGEN_H
 
 #include "type_id.h"
 
@@ -15,4 +13,4 @@ class Character;
 /// TODO: merge into `Character::heal`?
 auto heal_adjusted( Character &c, const bodypart_id &bp, const int heal ) -> int;
 
-#endif // CATA_SRC_REGEN_H
+

--- a/src/regional_settings.h
+++ b/src/regional_settings.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_REGIONAL_SETTINGS_H
-#define CATA_SRC_REGIONAL_SETTINGS_H
 
 #include <map>
 #include <memory>
@@ -255,4 +253,4 @@ void reset_region_settings();
 void load_region_overlay( const JsonObject &jo );
 void apply_region_overlay( const JsonObject &jo, regional_settings &region );
 
-#endif // CATA_SRC_REGIONAL_SETTINGS_H
+

--- a/src/relic.h
+++ b/src/relic.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_RELIC_H
-#define CATA_SRC_RELIC_H
 
 #include <string>
 #include <vector>
@@ -148,4 +146,4 @@ void process_recharge( item &itm, Character *carrier );
 
 } // namespace relic_funcs
 
-#endif // CATA_SRC_RELIC_H
+

--- a/src/requirements.h
+++ b/src/requirements.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_REQUIREMENTS_H
-#define CATA_SRC_REQUIREMENTS_H
 
 #include <list>
 #include <map>
@@ -468,4 +466,4 @@ class deduped_requirement_data
         std::vector<requirement_data> alternatives_;
 };
 
-#endif // CATA_SRC_REQUIREMENTS_H
+

--- a/src/ret_val.h
+++ b/src/ret_val.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_RET_VAL_H
-#define CATA_SRC_RET_VAL_H
 
 #include <string>
 #include <type_traits>
@@ -98,4 +96,4 @@ struct ret_val<bool>::default_success : public std::integral_constant<bool, true
 template<>
 struct ret_val<bool>::default_failure : public std::integral_constant<bool, false> {};
 
-#endif // CATA_SRC_RET_VAL_H
+

--- a/src/rng.h
+++ b/src/rng.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_RNG_H
-#define CATA_SRC_RNG_H
 
 #include <array>
 #include <functional>
@@ -202,4 +200,4 @@ std::optional<tripoint> random_point( const tripoint_range<tripoint> &range,
 std::optional<tripoint> random_point( const map &m,
                                       const std::function<bool( const tripoint & )> &predicate );
 
-#endif // CATA_SRC_RNG_H
+

--- a/src/rot.h
+++ b/src/rot.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ROT_H
-#define CATA_SRC_ROT_H
 
 enum class temperature_flag : int;
 
@@ -15,4 +13,4 @@ auto temperature_flag_for_location( const map &m, const item &loc ) -> temperatu
 
 } // namespace rot
 
-#endif // CATA_SRC_ROT_H
+

--- a/src/rotatable_symbols.h
+++ b/src/rotatable_symbols.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_ROTATABLE_SYMBOLS_H
-#define CATA_SRC_ROTATABLE_SYMBOLS_H
 
 #include <cstdint>
 #include <string>
@@ -21,4 +19,4 @@ uint32_t get( const uint32_t &symbol, int n );
 
 } // namespace rotatable_symbols
 
-#endif // CATA_SRC_ROTATABLE_SYMBOLS_H
+

--- a/src/runtime_handlers.h
+++ b/src/runtime_handlers.h
@@ -1,8 +1,6 @@
 #pragma once
-#ifndef CATA_SRC_RUNTIME_HANDLERS_H
-#define CATA_SRC_RUNTIME_HANDLERS_H
 
 [[ noreturn ]]
 void exit_handler( int status );
 
-#endif // CATA_SRC_RUNTIME_HANDLERS_H
+

--- a/src/safe_reference.h
+++ b/src/safe_reference.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_SAFE_REFERENCE_H
-#define CATA_SRC_SAFE_REFERENCE_H
 
 /**
  *
@@ -559,4 +557,4 @@ void serialize( const safe_reference<T> &, JsonOut & );
 
 void cleanup_references();
 
-#endif // CATA_SRC_SAFE_REFERENCE_H
+

--- a/src/safemode_ui.h
+++ b/src/safemode_ui.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_SAFEMODE_UI_H
-#define CATA_SRC_SAFEMODE_UI_H
 
 #include <string>
 #include <unordered_map>
@@ -114,4 +112,4 @@ class safemode
 
 safemode &get_safemode();
 
-#endif // CATA_SRC_SAFEMODE_UI_H
+

--- a/src/scenario.h
+++ b/src/scenario.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_SCENARIO_H
-#define CATA_SRC_SCENARIO_H
 
 #include <set>
 #include <string>
@@ -133,4 +131,4 @@ void reset_scenarios_blacklist();
 const scenario *get_scenario();
 void set_scenario( const scenario *new_scenario );
 
-#endif // CATA_SRC_SCENARIO_H
+

--- a/src/scent_block.h
+++ b/src/scent_block.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_SCENT_BLOCK_H
-#define CATA_SRC_SCENT_BLOCK_H
 
 #include <algorithm>
 #include <array>
@@ -42,4 +40,4 @@ struct scent_block {
     void apply_slime( const tripoint &p, int intensity );
 };
 
-#endif // CATA_SRC_SCENT_BLOCK_H
+

--- a/src/scent_map.h
+++ b/src/scent_map.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_SCENT_MAP_H
-#define CATA_SRC_SCENT_MAP_H
 
 #include <array>
 #include <optional>
@@ -85,4 +83,4 @@ class scent_map
         }
 };
 
-#endif // CATA_SRC_SCENT_MAP_H
+

--- a/src/scores_ui.h
+++ b/src/scores_ui.h
@@ -1,5 +1,4 @@
-#ifndef CATA_SRC_SCORES_UI_H
-#define CATA_SRC_SCORES_UI_H
+#pragma once
 
 class achievements_tracker;
 class kill_tracker;
@@ -11,4 +10,4 @@ void show_scores_ui( const achievements_tracker &achievements, stats_tracker &,
 /** Display kills in a scrollable window */
 void show_kills( kill_tracker & );
 
-#endif // CATA_SRC_SCORES_UI_H
+

--- a/src/sdl_font.h
+++ b/src/sdl_font.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_SDL_FONT_H
-#define CATA_SRC_SDL_FONT_H
 
 #if defined(TILES)
 
@@ -171,4 +169,4 @@ class FontFallbackList : public Font
 
 #endif // TILES
 
-#endif // CATA_SRC_SDL_FONT_H
+

--- a/src/sdl_geometry.h
+++ b/src/sdl_geometry.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_SDL_GEOMETRY_H
-#define CATA_SRC_SDL_GEOMETRY_H
 
 #if defined(TILES)
 #include <memory>
@@ -55,4 +53,4 @@ class ColorModulatedGeometryRenderer: public DefaultGeometryRenderer
 
 #endif // TILES
 
-#endif // CATA_SRC_SDL_GEOMETRY_H
+

--- a/src/sdl_utils.h
+++ b/src/sdl_utils.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_SDL_UTILS_H
-#define CATA_SRC_SDL_UTILS_H
 
 #include <algorithm>
 #include <cmath>
@@ -67,4 +65,4 @@ SDL_Rect fit_rect_inside( const SDL_Rect &inner, const SDL_Rect &outer );
 std::vector<SDL_Color> color_linear_interpolate( const SDL_Color &start_color,
         const SDL_Color &end_color, unsigned additional_steps );
 
-#endif // CATA_SRC_SDL_UTILS_H
+

--- a/src/sdl_wrappers.h
+++ b/src/sdl_wrappers.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_SDL_WRAPPERS_H
-#define CATA_SRC_SDL_WRAPPERS_H
 
 #if defined(TILES)
 
@@ -144,4 +142,4 @@ inline bool operator!=( const SDL_Rect &lhs, const SDL_Rect &rhs )
 
 #endif // if defined(TILES)
 
-#endif // CATA_SRC_SDL_WRAPPERS_H
+

--- a/src/sdlsound.h
+++ b/src/sdlsound.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_SDLSOUND_H
-#define CATA_SRC_SDLSOUND_H
 
 #include <string>
 #if defined(SDL_SOUND)
@@ -30,4 +28,4 @@ inline void load_soundset() { }
 
 #endif
 
-#endif // CATA_SRC_SDLSOUND_H
+

--- a/src/sdltiles.h
+++ b/src/sdltiles.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_SDLTILES_H
-#define CATA_SRC_SDLTILES_H
 
 #include <array>
 #if defined(TILES)
@@ -46,4 +44,4 @@ const SDL_Renderer_Ptr &get_sdl_renderer();
 
 #endif // TILES
 
-#endif // CATA_SRC_SDLTILES_H
+

--- a/src/sets_intersect.h
+++ b/src/sets_intersect.h
@@ -1,5 +1,4 @@
-#ifndef CATA_SRC_SETS_INTERSECT_H
-#define CATA_SRC_SETS_INTERSECT_H
+#pragma once
 
 namespace cata
 {
@@ -26,4 +25,3 @@ bool sets_intersect( const SetL &l, const SetR &r )
 
 } // namespace cata
 
-#endif // CATA_SRC_SETS_INTERSECT_H

--- a/src/shadowcasting.h
+++ b/src/shadowcasting.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_SHADOWCASTING_H
-#define CATA_SRC_SHADOWCASTING_H
 
 #include <algorithm>
 #include <array>
@@ -144,4 +142,4 @@ void cast_zlight(
     const array_of_grids_of<const diagonal_blocks> &blocked_caches,
     const tripoint &origin, int offset_distance, T numerator );
 
-#endif // CATA_SRC_SHADOWCASTING_H
+

--- a/src/shape.h
+++ b/src/shape.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_SHAPE_H
-#define CATA_SRC_SHAPE_H
 
 #include <map>
 #include <memory>
@@ -61,4 +59,4 @@ class shape_factory
         std::shared_ptr<shape_factory_impl> impl;
 };
 
-#endif // CATA_SRC_SHAPE_H
+

--- a/src/shape_impl.h
+++ b/src/shape_impl.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_SHAPE_IMPL_H
-#define CATA_SRC_SHAPE_IMPL_H
 
 #include <algorithm>
 #include <cmath>
@@ -322,4 +320,4 @@ class cone_factory : public shape_factory_impl
         }
 };
 
-#endif // CATA_SRC_SHAPE_IMPL_H
+

--- a/src/simple_pathfinding.h
+++ b/src/simple_pathfinding.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_SIMPLE_PATHFINDING_H
-#define CATA_SRC_SIMPLE_PATHFINDING_H
 
 #include <functional>
 #include <optional>
@@ -132,4 +130,4 @@ simple_path<tripoint_abs_omt> find_overmap_path( const tripoint_abs_omt &source,
 
 } // namespace pf
 
-#endif // CATA_SRC_SIMPLE_PATHFINDING_H
+

--- a/src/simplexnoise.h
+++ b/src/simplexnoise.h
@@ -16,8 +16,7 @@
  *
  */
 
-#ifndef CATA_SRC_SIMPLEXNOISE_H
-#define CATA_SRC_SIMPLEXNOISE_H
+#pragma once
 
 /* 2D, 3D and 4D Simplex Noise functions return 'random' values in (-1, 1).
 
@@ -181,4 +180,4 @@ static const int simplex[64][4] = {
     {2, 1, 0, 3}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {3, 1, 0, 2}, {0, 0, 0, 0}, {3, 2, 0, 1}, {3, 2, 1, 0}
 };
 
-#endif // CATA_SRC_SIMPLEXNOISE_H
+

--- a/src/skill.h
+++ b/src/skill.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_SKILL_H
-#define CATA_SRC_SKILL_H
 
 #include <functional>
 #include <map>
@@ -253,4 +251,4 @@ class SkillDisplayType
 
 double price_adjustment( int );
 
-#endif // CATA_SRC_SKILL_H
+

--- a/src/skill_boost.h
+++ b/src/skill_boost.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_SKILL_BOOST_H
-#define CATA_SRC_SKILL_BOOST_H
 
 #include <optional>
 #include <string>
@@ -38,4 +36,4 @@ class skill_boost
         void load( const JsonObject &jo, const std::string &src );
 };
 
-#endif // CATA_SRC_SKILL_BOOST_H
+

--- a/src/sounds.h
+++ b/src/sounds.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_SOUNDS_H
-#define CATA_SRC_SOUNDS_H
 
 #include <string>
 #include <utility>
@@ -171,4 +169,4 @@ struct enum_traits<sfx::channel> {
     static constexpr auto last = sfx::channel::MAX_CHANNEL;
 };
 
-#endif // CATA_SRC_SOUNDS_H
+

--- a/src/speech.h
+++ b/src/speech.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_SPEECH_H
-#define CATA_SRC_SPEECH_H
 
 #include "translations.h"
 
@@ -17,4 +15,4 @@ void load_speech( const JsonObject &jo );
 void reset_speech();
 const SpeechBubble &get_speech( const std::string &label );
 
-#endif // CATA_SRC_SPEECH_H
+

--- a/src/start_location.h
+++ b/src/start_location.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_START_LOCATION_H
-#define CATA_SRC_START_LOCATION_H
 
 #include <cstddef>
 #include <set>
@@ -89,4 +87,4 @@ const std::vector<start_location> &get_all();
 
 } // namespace start_locations
 
-#endif // CATA_SRC_START_LOCATION_H
+

--- a/src/stats_tracker.h
+++ b/src/stats_tracker.h
@@ -1,5 +1,4 @@
-#ifndef CATA_SRC_STATS_TRACKER_H
-#define CATA_SRC_STATS_TRACKER_H
+#pragma once
 
 #include <memory>
 #include <set>
@@ -194,4 +193,4 @@ class stats_tracker : public event_subscriber
         std::unordered_set<string_id<score>> initial_scores;
 };
 
-#endif // CATA_SRC_STATS_TRACKER_H
+

--- a/src/stomach.h
+++ b/src/stomach.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_STOMACH_H
-#define CATA_SRC_STOMACH_H
 
 #include <map>
 
@@ -113,4 +111,4 @@ class stomach_contents
 
 };
 
-#endif // CATA_SRC_STOMACH_H
+

--- a/src/string_editor_window.h
+++ b/src/string_editor_window.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_STRING_EDITOR_WINDOW_H
-#define CATA_SRC_STRING_EDITOR_WINDOW_H
 
 #include <string>
 #include <vector>
@@ -71,4 +69,4 @@ class string_editor_window
         /*returns line and position in folded text for position in text*/
         point get_line_and_position( const int position, const bool zero_x );
 };
-#endif // CATA_SRC_STRING_EDITOR_WINDOW_H
+

--- a/src/string_formatter.h
+++ b/src/string_formatter.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_STRING_FORMATTER_H
-#define CATA_SRC_STRING_FORMATTER_H
 
 #include <cstddef>
 #include <optional>
@@ -463,4 +461,4 @@ inline void cata_printf( std::string_view format, Args &&...args )
 
 /**@}*/
 
-#endif // CATA_SRC_STRING_FORMATTER_H
+

--- a/src/string_id.h
+++ b/src/string_id.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_STRING_ID_H
-#define CATA_SRC_STRING_ID_H
 
 #include <cstdint>
 #include <string>
@@ -387,4 +385,4 @@ struct lexicographic {
     }
 };
 
-#endif // CATA_SRC_STRING_ID_H
+

--- a/src/string_id_utils.h
+++ b/src/string_id_utils.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_STRING_ID_UTILS_H
-#define CATA_SRC_STRING_ID_UTILS_H
 
 #include "string_id.h"
 #include <algorithm>
@@ -44,4 +42,4 @@ requires std::is_same_v<El, string_id<typename El::value_type>> {
     return ret;
 }
 
-#endif // CATA_SRC_STRING_ID_UTILS_H
+

--- a/src/string_input_popup.h
+++ b/src/string_input_popup.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_STRING_INPUT_POPUP_H
-#define CATA_SRC_STRING_INPUT_POPUP_H
 
 #include <cstddef>
 #include <cstdint>
@@ -285,4 +283,4 @@ class string_input_popup // NOLINT(cata-xy)
         std::map<long, std::function<bool()>> callbacks;
 };
 
-#endif // CATA_SRC_STRING_INPUT_POPUP_H
+

--- a/src/string_utils.h
+++ b/src/string_utils.h
@@ -1,6 +1,4 @@
 ﻿#pragma once
-#ifndef CATA_SRC_STRING_UTILS_H
-#define CATA_SRC_STRING_UTILS_H
 
 #include <string>
 #include <vector>
@@ -131,4 +129,4 @@ std::string &capitalize_letter( std::string &str, size_t n = 0 );
  */
 std::string trim_whitespaces( const std::string &str );
 
-#endif // CATA_SRC_STRING_UTILS_H
+

--- a/src/submap.h
+++ b/src/submap.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_SUBMAP_H
-#define CATA_SRC_SUBMAP_H
 
 #include <cstddef>
 #include <cstdint>
@@ -332,4 +330,4 @@ struct maptile {
         }
 };
 
-#endif // CATA_SRC_SUBMAP_H
+

--- a/src/teleport.h
+++ b/src/teleport.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_TELEPORT_H
-#define CATA_SRC_TELEPORT_H
 
 class Creature;
 
@@ -14,4 +12,4 @@ bool teleport( Creature &critter, int min_distance = 2, int max_distance = 12,
                bool add_teleglow = true );
 } // namespace teleport
 
-#endif // CATA_SRC_TELEPORT_H
+

--- a/src/text_snippets.h
+++ b/src/text_snippets.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_TEXT_SNIPPETS_H
-#define CATA_SRC_TEXT_SNIPPETS_H
 
 #include <map>
 #include <optional>
@@ -117,4 +115,4 @@ extern snippet_library SNIPPET;
 /** Get random pre-translated tip of the day for the main menu. */
 std::string get_random_tip_of_the_day();
 
-#endif // CATA_SRC_TEXT_SNIPPETS_H
+

--- a/src/text_style_check.h
+++ b/src/text_style_check.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_TEXT_STYLE_CHECK_H
-#define CATA_SRC_TEXT_STYLE_CHECK_H
 
 // This is used in both the game itself and the clang-tidy check,
 // so only system headers should be included here.
@@ -199,4 +197,4 @@ void text_style_check( Iter beg, Iter end,
     }
 }
 
-#endif // CATA_SRC_TEXT_STYLE_CHECK_H
+

--- a/src/tileray.h
+++ b/src/tileray.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_TILERAY_H
-#define CATA_SRC_TILERAY_H
 
 #include "point.h"
 #include "units_angle.h"
@@ -64,4 +62,4 @@ class tileray
         int get_steps() const;  // how many steps we advanced
 };
 
-#endif // CATA_SRC_TILERAY_H
+

--- a/src/timed_event.h
+++ b/src/timed_event.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_TIMED_EVENT_H
-#define CATA_SRC_TIMED_EVENT_H
 
 #include <list>
 
@@ -67,4 +65,4 @@ class timed_event_manager
         void process();
 };
 
-#endif // CATA_SRC_TIMED_EVENT_H
+

--- a/src/to_string_id.h
+++ b/src/to_string_id.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_TO_STRING_ID_H
-#define CATA_SRC_TO_STRING_ID_H
 
 template<typename T>
 class string_id;
@@ -21,4 +19,4 @@ struct to_string_id<int_id<T>> {
 template<typename Id>
 using to_string_id_t = typename to_string_id<Id>::type;
 
-#endif // CATA_SRC_TO_STRING_ID_H
+

--- a/src/trait_group.h
+++ b/src/trait_group.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_TRAIT_GROUP_H
-#define CATA_SRC_TRAIT_GROUP_H
 
 #include <memory>
 #include <string>
@@ -201,4 +199,4 @@ class Trait_group_distribution : public Trait_group
         void add_entry( std::unique_ptr<Trait_creation_data> ptr ) override;
 };
 
-#endif // CATA_SRC_TRAIT_GROUP_H
+

--- a/src/translations.h
+++ b/src/translations.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_TRANSLATIONS_H
-#define CATA_SRC_TRANSLATIONS_H
 
 #include <map>
 #include <ostream>
@@ -348,4 +346,4 @@ struct localized_comparator {
 
 constexpr localized_comparator localized_compare{};
 
-#endif // CATA_SRC_TRANSLATIONS_H
+

--- a/src/trap.h
+++ b/src/trap.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_TRAP_H
-#define CATA_SRC_TRAP_H
 
 #include <cstddef>
 #include <functional>
@@ -313,4 +311,4 @@ tr_shadow,
 tr_drain,
 tr_snake;
 
-#endif // CATA_SRC_TRAP_H
+

--- a/src/type_id.h
+++ b/src/type_id.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_TYPE_ID_H
-#define CATA_SRC_TYPE_ID_H
 
 #include "int_id.h"
 #include "string_id.h"
@@ -224,4 +222,4 @@ class json_trait_flag;
 using trait_flag_id = int_id<json_trait_flag>;
 using trait_flag_str_id = string_id<json_trait_flag>;
 
-#endif // CATA_SRC_TYPE_ID_H
+

--- a/src/type_id_implement.h
+++ b/src/type_id_implement.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_TYPE_ID_IMPLEMENT_H
-#define CATA_SRC_TYPE_ID_IMPLEMENT_H
 
 /**
  * Macros with boilerplate code for implementing string_id<T> and int_id<T>
@@ -61,4 +59,4 @@
     IMPLEMENT_INT_STRING_ID_CONVERSIONS( T, factory )           \
 
 
-#endif // CATA_SRC_TYPE_ID_IMPLEMENT_H
+

--- a/src/ui.h
+++ b/src/ui.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_UI_H
-#define CATA_SRC_UI_H
 
 #include <initializer_list>
 #include <map>
@@ -438,4 +436,4 @@ class pointmenu_cb : public uilist_callback
         void select( uilist *menu ) override;
 };
 
-#endif // CATA_SRC_UI_H
+

--- a/src/ui_manager.h
+++ b/src/ui_manager.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_UI_MANAGER_H
-#define CATA_SRC_UI_MANAGER_H
 
 #include <functional>
 
@@ -279,4 +277,4 @@ void redraw_invalidated();
 void screen_resized();
 } // namespace ui_manager
 
-#endif // CATA_SRC_UI_MANAGER_H
+

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_UISTATE_H
-#define CATA_SRC_UISTATE_H
 
 #include <list>
 #include <map>
@@ -170,4 +168,4 @@ class uistatedata
 };
 extern uistatedata uistate;
 
-#endif // CATA_SRC_UISTATE_H
+

--- a/src/units.h
+++ b/src/units.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_UNITS_H
-#define CATA_SRC_UNITS_H
 
 #include <limits>
 #include <ostream>
@@ -115,4 +113,4 @@ static const std::vector<std::pair<std::string, probability>> probability_units 
 };
 } // namespace units
 
-#endif // CATA_SRC_UNITS_H
+

--- a/src/units_angle.h
+++ b/src/units_angle.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_UNITS_ANGLE_H
-#define CATA_SRC_UNITS_ANGLE_H
 
 #include <algorithm>
 
@@ -111,4 +109,4 @@ constexpr units::angle operator"" _arcmin( const unsigned long long v )
     return units::from_arcmin( v );
 }
 
-#endif // CATA_SRC_UNITS_ANGLE_H
+

--- a/src/units_def.h
+++ b/src/units_def.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_UNITS_DEF_H
-#define CATA_SRC_UNITS_DEF_H
 
 #include <compare>
 #include <type_traits>
@@ -297,4 +295,4 @@ inline auto operator%=( quantity<lvt, ut> &lhs, const quantity<rvt, ut> &rhs )
 /**@}*/
 } // namespace units
 
-#endif // CATA_SRC_UNITS_DEF_H
+

--- a/src/units_energy.h
+++ b/src/units_energy.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_UNITS_ENERGY_H
-#define CATA_SRC_UNITS_ENERGY_H
 
 #include <algorithm>
 
@@ -73,4 +71,3 @@ constexpr units::quantity<double, units::energy_in_joule_tag> operator"" _kJ(
 }
 
 
-#endif // CATA_SRC_UNITS_ENERGY_H

--- a/src/units_mass.h
+++ b/src/units_mass.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_UNITS_MASS_H
-#define CATA_SRC_UNITS_MASS_H
 
 #include <cstdint>
 #include <algorithm>
@@ -131,4 +129,4 @@ constexpr units::quantity<double, units::mass_in_milligram_tag> operator"" _newt
 
 
 
-#endif // CATA_SRC_UNITS_MASS_H
+

--- a/src/units_money.h
+++ b/src/units_money.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_UNITS_MONEY_H
-#define CATA_SRC_UNITS_MONEY_H
 
 #include <algorithm>
 
@@ -94,4 +92,3 @@ constexpr units::quantity<double, units::money_in_cent_tag> operator"" _kUSD(
 }
 
 
-#endif // CATA_SRC_UNITS_MONEY_H

--- a/src/units_probability.h
+++ b/src/units_probability.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_UNITS_PROBABILITY_H
-#define CATA_SRC_UNITS_PROBABILITY_H
 
 #include "units_def.h"
 
@@ -64,4 +62,4 @@ constexpr units::probability operator"" _pct( const long double v )
 }
 
 
-#endif // CATA_SRC_UNITS_PROBABILITY_H
+

--- a/src/units_serde.h
+++ b/src/units_serde.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_UNITS_SERDE_H
-#define CATA_SRC_UNITS_SERDE_H
 
 /**
  * Measurement units (de-)serialization.
@@ -114,4 +112,4 @@ void dump_to_json_string( T t, JsonOut &jsout,
     jsout.write( str );
 }
 
-#endif // CATA_SRC_UNITS_SERDE_H
+

--- a/src/units_temperature.h
+++ b/src/units_temperature.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_UNITS_TEMPERATURE_H
-#define CATA_SRC_UNITS_TEMPERATURE_H
 
 #include <algorithm>
 
@@ -158,4 +156,4 @@ constexpr units::temperature operator"" _f( const unsigned long long v )
     return units::from_fahrenheit<int>( v );
 }
 
-#endif // CATA_SRC_UNITS_TEMPERATURE_H
+

--- a/src/units_utility.h
+++ b/src/units_utility.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_UNITS_UTILITY_H
-#define CATA_SRC_UNITS_UTILITY_H
 
 #include "units.h"
 
@@ -115,4 +113,4 @@ double convert_volume( int volume );
  */
 double convert_volume( int volume, int *out_scale );
 
-#endif // CATA_SRC_UNITS_UTILITY_H
+

--- a/src/units_volume.h
+++ b/src/units_volume.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_UNITS_VOLUME_H
-#define CATA_SRC_UNITS_VOLUME_H
 
 #include <algorithm>
 
@@ -76,4 +74,3 @@ constexpr units::quantity<double, units::volume_in_milliliter_tag> operator"" _l
 }
 
 
-#endif // CATA_SRC_UNITS_VOLUME_H

--- a/src/url_utility.h
+++ b/src/url_utility.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_URL_UTILITY_H
-#define CATA_SRC_URL_UTILITY_H
 
 #include <string>
 
@@ -25,4 +23,4 @@ void open_url( const std::string &url );
  */
 std::string encode_url( const std::string &text );
 
-#endif // CATA_SRC_URL_UTILITY_H
+

--- a/src/value_ptr.h
+++ b/src/value_ptr.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_VALUE_PTR_H
-#define CATA_SRC_VALUE_PTR_H
 
 #include <memory>
 
@@ -61,4 +59,4 @@ bool value_ptr_equals( const value_ptr<T> &lhs, const value_ptr<T> &rhs )
 
 } // namespace cata
 
-#endif // CATA_SRC_VALUE_PTR_H
+

--- a/src/veh_interact.h
+++ b/src/veh_interact.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_VEH_INTERACT_H
-#define CATA_SRC_VEH_INTERACT_H
 
 #include <cstddef>
 #include <functional>
@@ -268,4 +266,4 @@ class veh_interact
         bool can_self_jack();
 };
 
-#endif // CATA_SRC_VEH_INTERACT_H
+

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_VEH_TYPE_H
-#define CATA_SRC_VEH_TYPE_H
 
 #include <array>
 #include <bitset>
@@ -401,4 +399,4 @@ struct vehicle_prototype {
     static std::vector<vproto_id> get_all();
 };
 
-#endif // CATA_SRC_VEH_TYPE_H
+

--- a/src/veh_utils.h
+++ b/src/veh_utils.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_VEH_UTILS_H
-#define CATA_SRC_VEH_UTILS_H
 
 #include "type_id.h"
 
@@ -27,4 +25,4 @@ vehicle_part &most_repairable_part( vehicle &veh, Character &who_arg,
 bool repair_part( vehicle &veh, vehicle_part &pt, Character &who );
 } // namespace veh_utils
 
-#endif // CATA_SRC_VEH_UTILS_H
+

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_VEHICLE_H
-#define CATA_SRC_VEHICLE_H
 
 #include <array>
 #include <climits>
@@ -1785,4 +1783,4 @@ namespace rot
 temperature_flag temperature_flag_for_part( const vehicle &veh, size_t part );
 } // namespace rot
 
-#endif // CATA_SRC_VEHICLE_H
+

--- a/src/vehicle_group.h
+++ b/src/vehicle_group.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_VEHICLE_GROUP_H
-#define CATA_SRC_VEHICLE_GROUP_H
 
 #include <memory>
 #include <optional>
@@ -187,4 +185,4 @@ class VehicleSpawn
         static FunctionMap builtin_functions;
 };
 
-#endif // CATA_SRC_VEHICLE_GROUP_H
+

--- a/src/vehicle_move.h
+++ b/src/vehicle_move.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_VEHICLE_MOVE_H
-#define CATA_SRC_VEHICLE_MOVE_H
 
 #include "units_angle.h"
 #include "point.h"
@@ -30,4 +28,4 @@ bool is_on_rails( const map &m, const vehicle &veh );
 
 } // namespace vehicle_movement
 
-#endif // CATA_SRC_VEHICLE_MOVE_H
+

--- a/src/vehicle_part.h
+++ b/src/vehicle_part.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#ifndef CATA_SRC_VEHICLE_PART_H
-#define CATA_SRC_VEHICLE_PART_H
+#pragma once
 
 #include <stack>
 #include <set>
@@ -339,4 +338,4 @@ struct vehicle_part {
         std::vector<detached_ptr<item>> pieces_for_broken_part() const;
 };
 
-#endif // CATA_SRC_VEHICLE_PART_H
+

--- a/src/vehicle_selector.h
+++ b/src/vehicle_selector.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_VEHICLE_SELECTOR_H
-#define CATA_SRC_VEHICLE_SELECTOR_H
 
 #include <vector>
 #include <iosfwd>
@@ -94,4 +92,4 @@ class vehicle_selector : public location_visitable<vehicle_selector>
         std::vector<value_type> data;
 };
 
-#endif // CATA_SRC_VEHICLE_SELECTOR_H
+

--- a/src/visitable.h
+++ b/src/visitable.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_VISITABLE_H
-#define CATA_SRC_VISITABLE_H
 
 #include <climits>
 #include <functional>
@@ -158,4 +156,4 @@ class location_visitable : public visitable<T>
         detached_ptr<item> remove_item( item &it );
 };
 
-#endif // CATA_SRC_VISITABLE_H
+

--- a/src/vitamin.h
+++ b/src/vitamin.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_VITAMIN_H
-#define CATA_SRC_VITAMIN_H
 
 #include <map>
 #include <set>
@@ -110,4 +108,4 @@ class vitamin
         std::set<std::string> flags_;
 };
 
-#endif // CATA_SRC_VITAMIN_H
+

--- a/src/vpart_position.h
+++ b/src/vpart_position.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_VPART_POSITION_H
-#define CATA_SRC_VPART_POSITION_H
 
 #include <cstddef>
 #include <functional>
@@ -158,4 +156,4 @@ inline vehicle *veh_pointer_or_null( const optional_vpart_position &p )
     return p ? &p->vehicle() : nullptr;
 }
 
-#endif // CATA_SRC_VPART_POSITION_H
+

--- a/src/vpart_range.h
+++ b/src/vpart_range.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_VPART_RANGE_H
-#define CATA_SRC_VPART_RANGE_H
 
 #include <cassert>
 #include <functional>
@@ -169,4 +167,4 @@ class vehicle_part_with_feature_range : public
         bool matches( size_t part ) const;
 };
 
-#endif // CATA_SRC_VPART_RANGE_H
+

--- a/src/wcwidth.h
+++ b/src/wcwidth.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_WCWIDTH_H
-#define CATA_SRC_WCWIDTH_H
 
 #include <cstdint>
 
@@ -8,4 +6,4 @@
  */
 int mk_wcwidth( uint32_t ucs );
 
-#endif // CATA_SRC_WCWIDTH_H
+

--- a/src/weather.h
+++ b/src/weather.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_WEATHER_H
-#define CATA_SRC_WEATHER_H
 
 #include "calendar.h"
 #include "color.h"
@@ -230,4 +228,4 @@ class weather_manager
 
 weather_manager &get_weather();
 
-#endif // CATA_SRC_WEATHER_H
+

--- a/src/weather_gen.h
+++ b/src/weather_gen.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_WEATHER_GEN_H
-#define CATA_SRC_WEATHER_GEN_H
 
 #include <string>
 
@@ -79,4 +77,4 @@ class weather_generator
         static weather_generator load( const JsonObject &jo );
 };
 
-#endif // CATA_SRC_WEATHER_GEN_H
+

--- a/src/weather_type.h
+++ b/src/weather_type.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_WEATHER_TYPE_H
-#define CATA_SRC_WEATHER_TYPE_H
 
 #include <climits>
 #include <string>
@@ -144,4 +142,4 @@ void load( const JsonObject &jo, const std::string &src );
 /** Checks all loaded from JSON are valid */
 void check_consistency();
 } // namespace weather_types
-#endif // CATA_SRC_WEATHER_TYPE_H
+

--- a/src/weighted_list.h
+++ b/src/weighted_list.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_WEIGHTED_LIST_H
-#define CATA_SRC_WEIGHTED_LIST_H
 
 #include "json.h"
 #include "rng.h"
@@ -288,4 +286,4 @@ void load_weighted_list( const JsonValue &jsv, weighted_list<W, T> &list, W defa
     }
 }
 
-#endif // CATA_SRC_WEIGHTED_LIST_H
+

--- a/src/world.h
+++ b/src/world.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_WORLD_H
-#define CATA_SRC_WORLD_H
 
 #include <functional>
 #include <string>
@@ -182,4 +180,4 @@ class world
         sqlite3 *get_player_db();
 };
 
-#endif // CATA_SRC_WORLD_H
+

--- a/src/worldfactory.h
+++ b/src/worldfactory.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef CATA_SRC_WORLDFACTORY_H
-#define CATA_SRC_WORLDFACTORY_H
 
 #include <cstddef>
 #include <functional>
@@ -123,4 +121,4 @@ void load_external_option( const JsonObject &jo );
 
 extern std::unique_ptr<worldfactory> world_generator;
 
-#endif // CATA_SRC_WORLDFACTORY_H
+


### PR DESCRIPTION
## Purpose of change (The Why)

Same as #6318 

## Describe the solution (The How)

#6318 but for the other half

## Describe alternatives you've considered

- Implode

## Testing

If it doesn't work because I split it apart, I give up

## Additional context

Why does clang tidy have to be so slow

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.