### PR TITLE
fix: fix monster infighting

### DIFF
--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -867,17 +867,6 @@ void monster::move()
         remove_effect( effect_harnessed );
     }
 
-    // A measure to prevent zombies endlessly pathing towards the same goal ineffectively which is already occupied by other zombies
-    //   sharing the same goal, preventing "balling up behavior"
-    if( !this->is_wandering() ) {
-        monster *maybe_friend = g->critter_at<monster>( this->goal );
-        if( maybe_friend != nullptr && maybe_friend->goal == this->goal && this->sees( this->goal ) ) {
-            // Give up on that target and fast-wander off instead
-            this->unset_dest();
-            wandf += 10;
-        }
-    }
-
     // Set attitude to attitude to our current target
     monster_attitude current_attitude = attitude( nullptr );
     if( !is_wandering() ) {


### PR DESCRIPTION
## Purpose of change (The Why)
fixes #6324 
While not having monsters blob up is usually a good thing it's not useful for monster infighting.
<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
Removing the entire conditional solves the issue. I'm not sure how much of an issue monster balling actually is. Monster ball prevention should probably be handled at the planning phase not the moving phase of monster actions.

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
Add a mon v mon hostility check so that if a mon it doesn't like is in the goal location it considers it the same as an NPC / Player and willingly ball up around it.

## Testing
Setup:
1. New world, new character
2. Build the thunderdome (submap or larger sized concrete walled area)
3. Equip player with the architect's cube for clairvoyance effect
4. Spawn a `zombie nurse` and `nurse bot` at the 1/4 and 3/4 partitions of the Thunderdome

Tests:
| Test              | Result                   |
|-------------------|--------------------------|
| Prior + Legacy PF | Z. Nurse Flees           |
| Prior + New PF    | Z. Nurse Flees           |
| PR + Legacy PF    | Z. Nurse kills Nurse Bot |
| PR + New PF       | Z. Nurse kills Nurse Bot |

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
