### PR TITLE
feat(balance): spawn 1d3 stacks for grenade ammo, more food in supply crates, fix ammobelt spawns

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/map_extras.json
+++ b/data/json/itemgroups/Locations_MapExtras/map_extras.json
@@ -163,10 +163,18 @@
     "type": "item_group",
     "subtype": "distribution",
     "id": "map_extra_supplydrop",
-    "//": "40% food and drugs (with an extra nudge towards basic first aid supplies), 20% assorted accessories/wearables, 20% explosives (weighted a bit towards standard frag grenades), 20% magazines and ammo",
+    "//": "40% food and drugs (favoring more basic first aid), 20% assorted accessories/wearables, 20% explosives (weighted a bit towards standard frag grenades), 20% magazines and ammo",
+    "//2": "Ammo spawns are 25% STANAGs, 25% pistol mags plus shotshells, 30% non-standard rifle magazines, and 20% ammo belts",
     "ammo": 100,
     "entries": [
-      { "distribution": [ { "group": "mil_food", "prob": 80 }, { "group": "drugs_soldier", "prob": 20 } ], "prob": 40 },
+      {
+        "distribution": [
+          { "group": "mil_food_nodrugs", "prob": 40, "count": [ 1, 2 ] },
+          { "group": "mil_food", "prob": 40 },
+          { "group": "drugs_soldier", "prob": 20 }
+        ],
+        "prob": 40
+      },
       {
         "distribution": [
           { "group": "mil_accessories", "prob": 50 },
@@ -190,17 +198,22 @@
           { "group": "nested_m1911_mag", "prob": 5, "count": [ 1, 2 ] },
           { "group": "on_hand_shot", "prob": 10, "count": [ 2, 3 ] },
           { "group": "nested_stanag_mag", "prob": 25, "count": [ 1, 2 ] },
-          { "group": "nested_mp5_mag", "prob": 5, "count": [ 1, 2 ] },
-          { "group": "nested_stanag_mag_300", "prob": 5, "count": [ 1, 2 ] },
-          { "group": "nested_hk417_13_mag", "prob": 5, "count": [ 1, 2 ] },
-          { "group": "nested_m14_mag", "prob": 5, "count": [ 1, 2 ] },
-          { "group": "nested_scar_h_mag", "prob": 5, "count": [ 1, 2 ] },
-          { "item": "m107a1mag", "ammo-group": "on_hand_50", "prob": 5, "count": [ 1, 2 ] },
-          { "item": "tac50mag", "ammo-group": "on_hand_50", "prob": 5, "count": [ 1, 2 ] },
-          { "item": "m2010mag", "ammo-group": "on_hand_300", "prob": 5, "count": [ 1, 2 ] },
-          { "item": "belt223", "ammo-group": "on_hand_223", "charges": 5, "prob": 25 },
-          { "item": "belt308", "ammo-group": "on_hand_308", "charges": 3, "prob": 40 },
-          { "item": "belt50", "ammo-group": "on_hand_50", "charges": 2, "prob": 20 }
+          {
+            "distribution": [
+              { "group": "nested_mp5_mag", "prob": 5, "count": [ 1, 2 ] },
+              { "group": "nested_stanag_mag_300", "prob": 5, "count": [ 1, 2 ] },
+              { "group": "nested_hk417_13_mag", "prob": 5, "count": [ 1, 2 ] },
+              { "group": "nested_m14_mag", "prob": 5, "count": [ 1, 2 ] },
+              { "group": "nested_scar_h_mag", "prob": 5, "count": [ 1, 2 ] },
+              { "item": "m107a1mag", "ammo-group": "on_hand_50", "prob": 5, "count": [ 1, 2 ] },
+              { "item": "tac50mag", "ammo-group": "on_hand_50", "prob": 5, "count": [ 1, 2 ] },
+              { "item": "m2010mag", "ammo-group": "on_hand_300", "prob": 5, "count": [ 1, 2 ] }
+            ],
+            "prob": 30
+          },
+          { "item": "belt223", "ammo-group": "on_hand_223", "prob": 10 },
+          { "item": "belt308", "ammo-group": "on_hand_308", "prob": 5 },
+          { "item": "belt50", "ammo-group": "on_hand_50", "prob": 5 }
         ],
         "prob": 20
       }

--- a/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
@@ -439,11 +439,11 @@
     "//": "Factory specification grenade launcher ammo intended for military use",
     "subtype": "distribution",
     "entries": [
-      { "item": "40x53mm_m1001", "prob": 10, "charges": [ 1, 50 ] },
-      { "item": "40x46mm_m433", "prob": 120, "charges": [ 1, 50 ] },
-      { "item": "40x53mm_m430a1", "prob": 75, "charges": [ 1, 50 ] },
-      { "item": "40x46mm_m576", "prob": 15, "charges": [ 1, 50 ] },
-      { "item": "40x46mm_m651", "prob": 20, "charges": [ 1, 50 ] }
+      { "item": "40x53mm_m1001", "prob": 10, "count": [ 1, 3 ] },
+      { "item": "40x46mm_m433", "prob": 120, "count": [ 1, 3 ] },
+      { "item": "40x53mm_m430a1", "prob": 75, "count": [ 1, 3 ] },
+      { "item": "40x46mm_m576", "prob": 15, "count": [ 1, 3 ] },
+      { "item": "40x46mm_m651", "prob": 20, "count": [ 1, 3 ] }
     ]
   },
   {


### PR DESCRIPTION
## Purpose of change (The Why)

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

This tackles some problems with supply crates, following up on https://github.com/cataclysmbnteam/Cataclysm-BN/pull/6223

## Describe the solution (The How)

<!-- e.g nerfs monster A -->

1. Adjusted the food and drug spawns a bit, with the `mil_food` spawn broken up in half, half that previous weight spawning the same "military food plus sometimes drugs including top-tier stuff" while the other half spawns just the food but more of it (1d2).
2. Fixed ammo belts to not use their intended weights as charge amount, making them more rare but actually spawn with the intended default amount of ammo when they do show up.
3. Tweaked `ammo_launcher_grenade` again, shifting away from the previous 1-50 spawn in favor of 1d3 stacks of default ammocount (so, 6-24 for ), making spawns more consistent. Basically the start of retweaking https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4784 into a given number of stacks of ammo instead of an amount that could be anything from a single bullet to an absurd amount of them, which I'll do for the other ammo spawns in a separate PR.
4. Misc: Tweaked it so the misc rifle mags are grouped in their own lil sub-distribution so that a bit more of the total weight of mag spawns can be granted to ammo belts (from an intended 10 weight to 20).

## Describe alternatives you've considered

Screaming.

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled test build.
3. Spawned in a supply drop and popped up the crates, belts that spawn show up loaded and 40mm prefers to spawn in smaller, more consistent batches.

Example:
![image](https://github.com/user-attachments/assets/8850c95d-1c73-466c-b692-682d57921bb5)

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [X] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [X] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [X] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [X] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
