### PR TITLE
feat: Make the Pride Flags mod default

### DIFF
--- a/data/mods/default.json
+++ b/data/mods/default.json
@@ -5,5 +5,6 @@
   "No_Rail_Stations",
   "no_reviving_zombies",
   "limit_fungal_growth",
-  "udp_redux"
+  "udp_redux",
+  "pride_flags"
 ]


### PR DESCRIPTION
## Purpose of change (The Why)

We realized that this seems like a very popular mod to enable anyway, and even if you feel like it's bloat you can just disable it like you would the no-revival mod (which I would argue is a far more intrusive mod than this to have on by default anyway). 

## Describe the solution (The How)

- Adds `pride_flags` to the default mods json file

## Describe alternatives you've considered

- Straight up make it vanilla

**I** certainly wouldn't object or mind it, but for now it seems a fair compromise to make it a default mod instead to satisfy those who have bloat concerns.

## Testing

It does indeed automatically enable it in the world creation screen
![image](https://github.com/user-attachments/assets/341e5e34-149d-43a1-a005-123346d58b96)

## Additional context

Also, I'm not opposed whatsoever to the mod's scope expanding beyond just pride flags to all sorts of other pride-related and adjacent items. Or to additional (good quality) flag PRs.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

