### PR TITLE
refactor: Allow up to 50 million max alternatives for recipes

### DIFF
--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -1512,7 +1512,7 @@ deduped_requirement_data::deduped_requirement_data( const requirement_data &in,
         // sanity check to prevent things getting too far out of control.
         // The worst case in the core game currently is chainmail_suit_faraday
         // with 63 alternatives.
-        static constexpr size_t max_alternatives = 100;
+        static constexpr size_t max_alternatives = 50000000;
         if( alternatives_.size() + pending.size() > max_alternatives ) {
             debugmsg( "Construction of deduped_requirement_data generated too many alternatives.  "
                       "The recipe %s should be simplified.  See the Recipe section in "


### PR DESCRIPTION
## Purpose of change (The Why)

I want to condense all recipes for sandwiches, soups, salads, stews, pies, and so on down into a single recipe for each. A single pie recipe that accepts 4 entries of any valid food, so you can make a chicken pot pie with meat carrot peas and corn without making a new JSON recipe. We can remove A LOT of recipes while adding A LOT via this method of a single "Super" recipe

I got smacked by a JSON error that only allows 100 alternatives. THIS STILL WORKS it just errors.

![image](https://github.com/user-attachments/assets/99ec7c03-cb44-4c36-88da-a797a4393775)
![image](https://github.com/user-attachments/assets/e0e87720-3561-46c8-b294-ef81c0b0c05f)


## Describe the solution (The How)

Sets the limit to 50 million until we investigate how necessary a limit even is. This recipe doesn't dent my load times or performance, but just in case Oren can take a look.

## Describe alternatives you've considered

Make someone code a dynamic food system.

## Testing

It loaded without a JSON error popping up. For testing I havent included a recipe inside the game, I wouldn't want to affect mobile users as the game will still try to load the recipe even if its only debug.

![image](https://github.com/user-attachments/assets/9cf6202a-eb6e-47e4-8660-a0f579d55a2b)

Try these:

```json
{
    "id": "SUPERPIE",
    "type": "COMESTIBLE",
    "comestible_type": "FOOD",
    "name": { "str": "SUPER DUPER pie" },
    "description": "How?.",
    "weight": "1 g",
    "volume": "1 ml",
    "price": "2 USD",
    "price_postapoc": "2 USD",
    "healthy": 69,
    "fun": -4,
    "quench": -1,
    "material": [ "junk" ],
    "symbol": "%",
    "color": "green",
    "calories": 500,
    "vitamins": [ [ "calcium", 10 ], [ "iron", 10 ], [ "vitA", 5 ], [ "vitB", 5 ], [ "vitC", 5 ] ]
  },
{
    "type": "recipe",
    "result": "SUPERPIE",
    "category": "CC_FOOD",
    "subcategory": "CSC_FOOD_VEGGI",
    "skill_used": "cooking",
    "difficulty": 4,
    "time": "30 m",
    "autolearn": true,
    "qualities": [ { "id": "COOK", "level": 2 }, { "id": "CONTAIN", "level": 1 } ],
    "tools": [ [ [ "surface_heat", 10, "LIST" ] ] ],
    "components": [ 
      [ [ "flour", 30 ] ], 
      [ [ "veggy_any", 8, "LIST" ], [ "sweet_fruit_like", 8, "LIST" ], [ "meat_red", 8, "LIST" ] ], 
      [ [ "veggy_any", 8, "LIST" ], [ "sweet_fruit_like", 8, "LIST" ], [ "meat_red", 8, "LIST" ] ], 
      [ [ "veggy_any", 8, "LIST" ], [ "sweet_fruit_like", 8, "LIST" ], [ "meat_red", 8, "LIST" ] ], 
      [ [ "veggy_any", 8, "LIST" ], [ "sweet_fruit_like", 8, "LIST" ], [ "meat_red", 8, "LIST" ] ], 
      [ [ "water", 1 ], [ "water_clean", 1 ] ] 
    ]
  },
  ```

## Additional context

VINTAGE STORY

## Checklist

### Mandatory

- [ ] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [ ] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.