### PR TITLE
chore: Add latest stable to metainfo releases section

### DIFF
--- a/data/XDG/org.cataclysmbn.CataclysmBN.metainfo.xml
+++ b/data/XDG/org.cataclysmbn.CataclysmBN.metainfo.xml
@@ -48,6 +48,22 @@
         <content_attribute id="language-discrimination">intense</content_attribute>
     </content_rating>
     <releases>
+        <release version="0.7.1" date="2025-03-18">
+            <url type="details">https://github.com/cataclysmbnteam/Cataclysm-BN/releases/tag/v0.7.1</url>
+            <description>
+                <p>Notable Changes</p>
+                <ul>
+                    <li>Obsoleted No Hope and Generic Guns</li>
+                    <li>Stamina affects dodge rating and melee damage instead of movecost</li>
+                    <li>Audited basic-tier blacksmithing</li>
+                    <li>JSONized activity movecost and modifiers</li>
+                    <li>More bionics cancel out bad traits</li>
+                    <li>Fixed some accidental cannibalism nutrients in food</li>
+                    <li>Prevent item shortcuts in the inventory resetting</li>
+                    <li>Rest of the changes can be found in the github repo</li>
+                </ul>
+            </description>
+        </release>
         <release version="0.7" date="2025-01-18">
             <url type="details">https://github.com/cataclysmbnteam/Cataclysm-BN/releases/tag/v0.7.0</url>
             <description>


### PR DESCRIPTION
## Purpose of change (The Why)

We gotta keep this up to date whenever we release a new stable now

## Describe the solution (The How)

Adds the newest stable and a few notable changes to the metainfo

## Describe alternatives you've considered

- Not create the stable in the first place

## Testing

Testing not done in this repo, would if anything be done downstream with the flatpak itself

## Additional context

0.7.1 is mostly for flatpak anyway because 0.7 was getting a little stale and old.

I promise, these PRs will get infinitely less frequent once we actually have the flatpak fully set up.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

