### PR TITLE
fix: migrate `22_cb` to `22_cphp`

### DIFF
--- a/data/json/obsoletion/migration.json
+++ b/data/json/obsoletion/migration.json
@@ -883,5 +883,10 @@
     "id": "endochitin",
     "type": "MIGRATION",
     "replace": "chitin_piece"
+  },
+  {
+    "id": "22_cb",
+    "type": "MIGRATION",
+    "replace": "22_cphp"
   }
 ]


### PR DESCRIPTION
## Purpose of change (The Why)

#6346 made it so that `22_cb` ammunition no longer existed and removed them from itemgroups, but did not define a migration for it, meaning any games with them would have them poof out of existence rather than convert into appropriate ammunition.

## Describe the solution (The How)

Define a migration for it.

## Describe alternatives you've considered

## Testing

- Add back the `22_cb` ammunition entry to obsoletion, create a game, spawn in the ammunition and save. Then remove the `22_cb` entry
  - [x] No crash on load and it converts appropriately to `22_cphp`

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.