### PR TITLE
build: resolve some build warnings

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2027,7 +2027,7 @@ void throw_activity_actor::serialize( JsonOut &jsout ) const
 
 std::unique_ptr<activity_actor> throw_activity_actor::deserialize( JsonIn &jsin )
 {
-    std::unique_ptr<throw_activity_actor> actor;
+    std::unique_ptr<throw_activity_actor> actor( new throw_activity_actor() );
 
     JsonObject data = jsin.get_object();
 

--- a/src/damage.cpp
+++ b/src/damage.cpp
@@ -53,6 +53,7 @@ const std::string damage_unit::get_name() const
         case NUM_DT:
             return std::to_string( NUM_DT );
     }
+    return std::to_string( NUM_DT );
 }
 
 damage_instance::damage_instance() = default;

--- a/src/game_info.cpp
+++ b/src/game_info.cpp
@@ -383,6 +383,7 @@ auto game_info::save_file_version() -> std::string
         case save_format::V2_COMPRESSED_SQLITE3:
             return "V2 (compressed with sqlite 3)";
     }
+    return "No save format";
 }
 
 auto game_info::mods_loaded() -> std::string

--- a/src/game_info.cpp
+++ b/src/game_info.cpp
@@ -75,7 +75,7 @@ static auto shell_exec( const std::string &command ) -> std::string
     std::string output;
     struct file_closer_deleter {
         void operator()( FILE *f ) const {
-            (void)pclose( f );
+            ( void )pclose( f );
         }
     };
     try {

--- a/src/game_info.cpp
+++ b/src/game_info.cpp
@@ -73,8 +73,13 @@ static auto shell_exec( const std::string &command ) -> std::string
 {
     std::vector<char> buffer( 512 );
     std::string output;
+    struct file_closer_deleter {
+        void operator()( FILE *f ) const {
+            (void)pclose( f );
+        }
+    };
     try {
-        std::unique_ptr<FILE, decltype( &pclose )> pipe( popen( command.c_str(), "r" ), pclose );
+        std::unique_ptr<FILE, file_closer_deleter> pipe( popen( command.c_str(), "r" ) );
         if( pipe ) {
             while( fgets( buffer.data(), buffer.size(), pipe.get() ) != nullptr ) {
                 output += buffer.data();


### PR DESCRIPTION
## Purpose of change (The Why)
Was mildly annoyed seeing the build warnings whenever I would rebuild the project. This is not an exhaustive sweep of warnings, just ones I encountered very recently. And one bug fix.

<!-- e.g resolves #1234 / monster A is too OP despite being an early-game mob -->

## Describe the solution (The How)
in `throw_activity_actor::deserialize` fix bug where we attempt to use an uninitialized (nullptr) unique_ptr. This threw up three warnings about likely accessing something at address zero because `actor == nullptr`.
in `damage_unit::get_name` fixed warning about flow control reaching the end of a non-void function. Added a default return despite probably being unreachable.
in `game_info::save_file_version` we have another flow control warning. It *should* be unreachable, but add a default return string there as well.
in `shell_exec` the compiler was getting mad about ignoring the attributes for `pclose` so made a deleter struct for it instead of storing the `pclose` function pointer directly.

<!-- e.g nerfs monster A -->

## Describe alternatives you've considered
For `damage_unit::get_name` and `game_info::save_file_version` could probably have used `cata::unreachable();` from `cata_unreachable.h` to tell the compiler, and the reader, that getting to the end of the function normally is undefined behavior.

## Testing
Compiles without the warnings I intended to remove. No playtesting necessary as there are no logical changes easily visible other than `throw_activity_actor::deserialize` and that one's kind of a no-brainer. Previously it would have, or should have, crashed with a SIGSEGV. Now it's actually allocating memory to store and return the activity actor so it won't unless there are issues at the OS allocator level.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

## Additional context
There is another warning in `loslib.c`
```cpp
#define lua_tmpnam(b,e)		{ e = (tmpnam(b) == NULL); }
```
it does not like the use of `tmpnam` here and the warning suggests using `mkstemp` instead but `mkstemp` is not standard so it's better to not use it than to use it and get MORE warnings / errors down the road.

More warning obliteration PRs will come in the future as I get annoyed by them.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

<!--
please remove sections irrelevant to this PR.

### Optional

- [ ] This PR ports commits from DDA or other cataclysm forks.
  - [ ] I have attributed original authors in the commit messages adding [`Co-Authored-By`](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in the commit message.
  - [ ] I have linked the URL of original PR(s) in the description.
- [ ] This is a C++ PR that modifies JSON loading or behavior.
  - [ ] I have documented the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
  - [ ] New localizable fields need to be added to the `lang/bn_extract_json_strings.sh` script if it does not support them yet.
  - [ ] If applicable, add checks on game load that would validate the loaded data.
  - [ ] If it modifies format of save files, please add migration from the old format.
- [ ] This is a PR that modifies build process or code organization.
  - [ ] Please document the changes in the appropriate location in the `doc/` folder.
  - [ ] If documentation for this feature or process does not exist, please write it.
  - [ ] If the change alters versions of software required to build or work with the game, please document it.
- [ ] This is a PR that removes JSON entities.
  - [ ] The removed JSON entities have new entries in `data/json/obsoletion/` folder or use some other migration process for existing saves.
-->
