### PR TITLE
chore: use double quotes for clangd auto includes

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+Style:
+  QuotedHeaders: "src/.*"

--- a/.gitignore
+++ b/.gitignore
@@ -172,7 +172,6 @@ cataclysm.a
 
 # clang tooling
 compile_commands.json
-.clangd
 
 # IDA database
 Cataclysm.i64


### PR DESCRIPTION
## Purpose of change (The Why)

prevents auto-includes in `src/` from annoyingly using angled brackets, which
1. doesn't follow relative imports convention
2. breaks some builds

## Describe the solution (The How)

see: https://clangd.llvm.org/config#quotedheaders

## Describe alternatives you've considered

weep menacingly

## Testing

[스크린캐스트_20250416_223151.webm](https://github.com/user-attachments/assets/fbadcdec-d3ce-4187-8a72-0198ab796c30)

## Additional context

https://discord.com/channels/830879262763909202/830916451517857894/1361944361553887352

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [ ] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [ ] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
