### PR TITLE
fix: Fridgetanks work now

### DIFF
--- a/data/json/items/vehicle/utilities.json
+++ b/data/json/items/vehicle/utilities.json
@@ -207,13 +207,16 @@
     "copy-from": "washing_machine"
   },
   {
-    "type": "GENERIC",
+    "type": "CONTAINER",
     "copy-from": "washing_machine",
     "id": "fridgetank",
     "name": { "str": "refrigerated tank" },
     "description": "A 60L refrigerated tank for keeping liquids cool.  Provides some insulation from outside weather.",
     "volume": "60 L",
-    "weight": "48 kg"
+    "weight": "48 kg",
+    "contains": "60 L",
+    "seals": true,
+    "watertight": true
   },
   {
     "type": "GENERIC",

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -470,6 +470,14 @@ void vehicle_part::process_contents( const tripoint &pos, const bool e_heater )
         if( e_heater ) {
             flag = temperature_flag::TEMP_HEATER;
         }
+
+        const vpart_info vpinfo = info();
+        if( enabled && vpinfo.has_flag( VPFLAG_FRIDGE ) ) {
+            flag = temperature_flag::TEMP_FRIDGE;
+        } else if( enabled && vpinfo.has_flag( VPFLAG_FREEZER ) ) {
+            flag = temperature_flag::TEMP_FREEZER;
+        }
+
         base = item::process( base.release(), nullptr, pos, false, flag );
     }
 }


### PR DESCRIPTION
## Purpose of change (The Why)

Got pinged by @RoyalFox2140 about fridgetanks not working. Was surprised when I looked at the code and realized it'd _never_ functioned as a container to begin with. What the fuck?

## Describe the solution (The How)

Gives fridgetank base items container values so that it is actually considered a container for fluids.

Updates the temp considerations in `vehicle::process_contents()` so that it takes into account fridge and freezer stats.
- Code is shit as always, see additional context.

## Describe alternatives you've considered

## Testing

- Spawn 4 gallon jugs of milk, create a vehicle with a storage tank, a fridge tank, a cargo hold, batteries and an electronics control.
  - Fill each of the tanks with a gallon of milk each, then leave a gallon jug on the floor and one in the cargo bay.
  - [x] The storage tank, floor and cargo bay gallon jugs should all spoil in roughly 2 days time, but the fridgetank should still be relatively fresh. **I'm still waiting on a compile to test this.**

## Additional context

The methods used to process items in vehicles is inefficient, as fluids in fluidtanks are not added to the active processing queue for reasons that are currently beyond me. This means that the processing queue needs to handle them separately as seen in `map::process_items_in_vehicle` where fluidtanks need to be separately processed by `vehicle::process_contents`

Fixing this seems a bit involved, and I've already tried the easy solutions to no avail. Leaving this to someone else.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.