### PR TITLE
fix: Hackers don't jam batteries into their UPS devices

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -2175,11 +2175,7 @@
     "skills": [ { "level": 4, "name": "computer" } ],
     "items": {
       "both": {
-        "items": [ "pants", "tshirt_text", "socks", "sneakers", "mbag", "smart_phone", "caffeine" ],
-        "entries": [
-          { "item": "light_plus_battery_cell", "ammo-item": "battery", "charges": 150, "container-item": "portable_game" },
-          { "item": "medium_battery_cell", "ammo-item": "battery", "charges": 500, "container-item": "laptop" }
-        ]
+        "items": [ "pants", "tshirt_text", "socks", "sneakers", "mbag", "smart_phone", "caffeine", "laptop", "portable_game" ]
       },
       "male": [ "briefs" ],
       "female": [ "panties" ]


### PR DESCRIPTION
## Purpose of change (The Why)

PR https://github.com/cataclysmbnteam/Cataclysm-BN/pull/550 made it so a hacker spawns with a battery in their laptop and game system. 

I don't know how, I don't know why, at some point both items became UPS compatible non-unloadable non-reloadable devices. I don't know if they were added erroneously in 550, or if we never updated professions AFTER such a UPS conversion PR. Why investigate whose at fault?

## Describe the solution (The How)

Removes the batteries that were forcibly jammed in there.

## Describe alternatives you've considered

:(

## Testing

:(

## Additional context
Why do I always run into these problems?
:(

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.