### PR TITLE
fix: remove checks forbiding value to be same as default or inherited

### DIFF
--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -13,17 +13,12 @@ void report_strict_violation( const JsonObject &jo, const std::string &message,
 }
 
 
-bool assign( const JsonObject &jo, const std::string &name, bool &val, bool strict )
+bool assign( const JsonObject &jo, const std::string &name, bool &val, bool )
 {
     bool out;
 
     if( !jo.read( name, out ) ) {
         return false;
-    }
-
-    if( strict && out == val ) {
-        report_strict_violation( jo, "cannot assign explicit value the same as default or inherited value",
-                                 name );
     }
 
     val = out;
@@ -32,7 +27,7 @@ bool assign( const JsonObject &jo, const std::string &name, bool &val, bool stri
 }
 
 bool assign( const JsonObject &jo, const std::string &name, units::volume &val,
-             bool strict,
+             bool,
              const units::volume lo,
              const units::volume hi )
 {
@@ -82,7 +77,6 @@ bool assign( const JsonObject &jo, const std::string &name, units::volume &val,
         if( !parse( err, tmp ) ) {
             err.throw_error( "invalid relative value specified", name );
         }
-        strict = false;
         out = val + tmp;
 
     } else if( proportional.has_member( name ) ) {
@@ -91,7 +85,6 @@ bool assign( const JsonObject &jo, const std::string &name, units::volume &val,
         if( !err.read( name, scalar ) || scalar <= 0 || scalar == 1 ) {
             err.throw_error( "multiplier must be a positive number other than 1", name );
         }
-        strict = false;
         out = val * scalar;
 
     } else if( !parse( jo, out ) ) {
@@ -102,11 +95,6 @@ bool assign( const JsonObject &jo, const std::string &name, units::volume &val,
         err.throw_error( "value outside supported range", name );
     }
 
-    if( strict && out == val ) {
-        report_strict_violation( err, "cannot assign explicit value the same as default or inherited value",
-                                 name );
-    }
-
     val = out;
 
     return true;
@@ -115,7 +103,7 @@ bool assign( const JsonObject &jo, const std::string &name, units::volume &val,
 bool assign( const JsonObject &jo,
              const std::string &name,
              units::mass &val,
-             bool strict,
+             bool,
              const units::mass lo,
              const units::mass hi )
 {
@@ -152,7 +140,6 @@ bool assign( const JsonObject &jo,
         if( !parse( err, tmp ) ) {
             err.throw_error( "invalid relative value specified", name );
         }
-        strict = false;
         out = val + tmp;
 
     } else if( proportional.has_member( name ) ) {
@@ -162,7 +149,6 @@ bool assign( const JsonObject &jo,
             err.throw_error( "multiplier must be a positive number other than 1",
                              name );
         }
-        strict = false;
         out = val * scalar;
 
     } else if( !parse( jo, out ) ) {
@@ -173,13 +159,6 @@ bool assign( const JsonObject &jo,
         err.throw_error( "value outside supported range", name );
     }
 
-    if( strict && out == val ) {
-        report_strict_violation( err,
-                                 "cannot assign explicit value the same as "
-                                 "default or inherited value",
-                                 name );
-    }
-
     val = out;
 
     return true;
@@ -188,7 +167,7 @@ bool assign( const JsonObject &jo,
 bool assign( const JsonObject &jo,
              const std::string &name,
              units::money &val,
-             bool strict,
+             bool,
              const units::money lo,
              const units::money hi )
 {
@@ -225,7 +204,6 @@ bool assign( const JsonObject &jo,
         if( !parse( err, tmp ) ) {
             err.throw_error( "invalid relative value specified", name );
         }
-        strict = false;
         out = val + tmp;
 
     } else if( proportional.has_member( name ) ) {
@@ -235,7 +213,6 @@ bool assign( const JsonObject &jo,
             err.throw_error( "multiplier must be a positive number other than 1",
                              name );
         }
-        strict = false;
         out = val * scalar;
 
     } else if( !parse( jo, out ) ) {
@@ -246,13 +223,6 @@ bool assign( const JsonObject &jo,
         err.throw_error( "value outside supported range", name );
     }
 
-    if( strict && out == val ) {
-        report_strict_violation( err,
-                                 "cannot assign explicit value the same as "
-                                 "default or inherited value",
-                                 name );
-    }
-
     val = out;
 
     return true;
@@ -261,7 +231,7 @@ bool assign( const JsonObject &jo,
 bool assign( const JsonObject &jo,
              const std::string &name,
              units::energy &val,
-             bool strict,
+             bool,
              const units::energy lo,
              const units::energy hi )
 {
@@ -303,7 +273,6 @@ bool assign( const JsonObject &jo,
         if( !parse( err, tmp ) ) {
             err.throw_error( "invalid relative value specified", name );
         }
-        strict = false;
         out = val + tmp;
 
     } else if( proportional.has_member( name ) ) {
@@ -313,7 +282,6 @@ bool assign( const JsonObject &jo,
             err.throw_error( "multiplier must be a positive number other than 1",
                              name );
         }
-        strict = false;
         out = val * scalar;
 
     } else if( !parse( jo, out ) ) {
@@ -322,13 +290,6 @@ bool assign( const JsonObject &jo,
 
     if( out < lo || out > hi ) {
         err.throw_error( "value outside supported range", name );
-    }
-
-    if( strict && out == val ) {
-        report_strict_violation( err,
-                                 "cannot assign explicit value the same as "
-                                 "default or inherited value",
-                                 name );
     }
 
     val = out;
@@ -412,7 +373,7 @@ bool assign( const JsonObject &jo,
 bool assign( const JsonObject &jo,
              const std::string &name,
              nc_color &val,
-             const bool strict )
+             const bool )
 {
     if( !jo.has_member( name ) ) {
         return false;
@@ -421,12 +382,7 @@ bool assign( const JsonObject &jo,
     if( out == c_unset ) {
         jo.throw_error( "invalid color name", name );
     }
-    if( strict && out == val ) {
-        report_strict_violation( jo,
-                                 "cannot assign explicit value the same as "
-                                 "default or inherited value",
-                                 name );
-    }
+
     val = out;
     return true;
 }

--- a/src/assign.h
+++ b/src/assign.h
@@ -43,7 +43,7 @@ void report_strict_violation( const JsonObject &jo, const std::string &message,
                               const std::string &name );
 
 template <Arithmetic T>
-bool assign( const JsonObject &jo, const std::string &name, T &val, bool strict = false,
+bool assign( const JsonObject &jo, const std::string &name, T &val, bool = false,
              T lo = std::numeric_limits<T>::lowest(), T hi = std::numeric_limits<T>::max() )
 {
     T out;
@@ -61,7 +61,6 @@ bool assign( const JsonObject &jo, const std::string &name, T &val, bool strict 
     // such as +10% are well-formed independent of whether they affect base value
     if( relative.read( name, out ) ) {
         err = relative;
-        strict = false;
         out += val;
 
     } else if( proportional.read( name, scalar ) ) {
@@ -69,7 +68,6 @@ bool assign( const JsonObject &jo, const std::string &name, T &val, bool strict 
         if( scalar <= 0 || scalar == 1 ) {
             err.throw_error( "multiplier must be a positive number other than 1", name );
         }
-        strict = false;
         out = val * scalar;
 
     } else if( !jo.read( name, out ) ) {
@@ -78,11 +76,6 @@ bool assign( const JsonObject &jo, const std::string &name, T &val, bool strict 
 
     if( out < lo || out > hi ) {
         err.throw_error( "value outside supported range", name );
-    }
-
-    if( strict && out == val ) {
-        report_strict_violation( err, "cannot assign explicit value the same as default or inherited value",
-                                 name );
     }
 
     val = out;
@@ -96,7 +89,7 @@ bool assign( const JsonObject &jo, const std::string &name, bool &val, bool stri
 
 template <Arithmetic T>
 bool assign( const JsonObject &jo, const std::string &name, std::pair<T, T> &val,
-             bool strict = false, T lo = std::numeric_limits<T>::lowest(), T hi = std::numeric_limits<T>::max() )
+             bool = false, T lo = std::numeric_limits<T>::lowest(), T hi = std::numeric_limits<T>::max() )
 {
     std::pair<T, T> out;
 
@@ -120,11 +113,6 @@ bool assign( const JsonObject &jo, const std::string &name, std::pair<T, T> &val
         jo.throw_error( "value outside supported range", name );
     }
 
-    if( strict && out == val ) {
-        report_strict_violation( jo, "cannot assign explicit value the same as default or inherited value",
-                                 name );
-    }
-
     val = out;
 
     return true;
@@ -133,17 +121,12 @@ bool assign( const JsonObject &jo, const std::string &name, std::pair<T, T> &val
 // Note: is_optional excludes any types based on std::optional, which is
 // handled below in a separate function.
 template < typename T>
-bool assign( const JsonObject &jo, const std::string &name, T &val, bool strict = false )
+bool assign( const JsonObject &jo, const std::string &name, T &val, bool = false )
 requires( std::is_class_v<T> && !is_optional<T>::value ) //*NOPAD*
 {
     T out;
     if( !jo.read( name, out ) ) {
         return false;
-    }
-
-    if( strict && out == val ) {
-        report_strict_violation( jo, "cannot assign explicit value the same as default or inherited value",
-                                 name );
     }
 
     val = out;
@@ -379,7 +362,7 @@ requires( !units::quantity_details<ut>::common_zero_point::value )
 
 template<typename T, typename F>
 inline bool assign_unit_common( const JsonObject &jo, const std::string &name, T &val, F parse,
-                                bool strict, const T lo, const T hi )
+                                bool, const T lo, const T hi )
 {
     T out;
 
@@ -399,7 +382,6 @@ inline bool assign_unit_common( const JsonObject &jo, const std::string &name, T
         if( !parse( err, tmp ) ) {
             err.throw_error( "invalid relative value specified", name );
         }
-        strict = false;
         out = val + tmp;
 
     } else if( proportional.has_member( name ) ) {
@@ -408,7 +390,6 @@ inline bool assign_unit_common( const JsonObject &jo, const std::string &name, T
         if( !err.read( name, scalar ) || scalar <= 0 || scalar == 1 ) {
             err.throw_error( "multiplier must be a positive number other than 1", name );
         }
-        strict = false;
         out = mult_unit( err, name, val, scalar );
 
     } else if( !parse( jo, out ) ) {
@@ -417,11 +398,6 @@ inline bool assign_unit_common( const JsonObject &jo, const std::string &name, T
 
     if( out < lo || out > hi ) {
         err.throw_error( "value outside supported range", name );
-    }
-
-    if( strict && out == val ) {
-        report_strict_violation( err, "cannot assign explicit value the same as default or inherited value",
-                                 name );
     }
 
     val = out;
@@ -477,7 +453,7 @@ requires std::is_same_v<std::decay_t<T>, time_duration> {
 template<typename T>
 inline typename
 std::enable_if<std::is_same<typename std::decay<T>::type, time_duration>::value, bool>::type assign(
-    const JsonObject &jo, const std::string &name, T &val, bool strict, const T &factor )
+    const JsonObject &jo, const std::string &name, T &val, bool, const T &factor )
 {
     T out{};
     double scalar;
@@ -494,7 +470,6 @@ std::enable_if<std::is_same<typename std::decay<T>::type, time_duration>::value,
     // such as +10% are well-formed independent of whether they affect base value
     if( read_with_factor( relative, name, out, factor ) ) {
         err = relative;
-        strict = false;
         out = out + val;
 
     } else if( proportional.read( name, scalar ) ) {
@@ -502,16 +477,10 @@ std::enable_if<std::is_same<typename std::decay<T>::type, time_duration>::value,
         if( scalar <= 0 || scalar == 1 ) {
             err.throw_error( "multiplier must be a positive number other than 1", name );
         }
-        strict = false;
         out = val * scalar;
 
     } else if( !read_with_factor( jo, name, out, factor ) ) {
         return false;
-    }
-
-    if( strict && out == val ) {
-        report_strict_violation( err, "cannot assign explicit value the same as default or inherited value",
-                                 name );
     }
 
     val = out;


### PR DESCRIPTION
## Purpose of change (The Why)

![image](https://github.com/user-attachments/assets/23e6f1ce-b7a6-4d6c-82e8-155e601a7e87)

this is the worst linting rule i've ever seen, it has zero pros and causes numerous headaches like #6373

## Describe the solution (The How)

remove the check.

## Describe alternatives you've considered

remove `strict` field for `assign` functions as well, but this is more involved, and we might want to use the `strict` parameter for other validation such as #3112

## Testing

loaded commit before #6373, no errors were generated.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
