### PR TITLE
feat(mods/MagicalNights): Allow misc repairkits to repair demon chitin and dragon bone

### DIFF
--- a/data/mods/MagicalNights/items/tools.json
+++ b/data/mods/MagicalNights/items/tools.json
@@ -98,20 +98,7 @@
     "use_action": {
       "type": "repair_item",
       "item_action_type": "repair_fabric",
-      "materials": [
-        "cotton",
-        "leather",
-        "nylon",
-        "wool",
-        "fur",
-        "faux_fur",
-        "nomex",
-        "kevlar",
-        "gutskin",
-        "scute",
-        "demon_chitin",
-        "black_dragon_hide"
-      ],
+      "materials": [ "cotton", "leather", "nylon", "wool", "fur", "faux_fur", "nomex", "kevlar", "gutskin", "scute", "black_dragon_hide" ],
       "skill": "tailor",
       "tool_quality": 0,
       "cost_scaling": 0.1,
@@ -139,8 +126,7 @@
           "neoprene",
           "gutskin",
           "scute",
-          "black_dragon_hide",
-          "demon_chitin"
+          "black_dragon_hide"
         ],
         "skill": "tailor",
         "tool_quality": 1,
@@ -159,10 +145,11 @@
           "nomex",
           "kevlar",
           "neoprene",
-          "gutskin",
           "scute",
+          "gutskin",
           "plastic",
-          "kevlar_rigid"
+          "kevlar_rigid",
+          "black_dragon_hide"
         ],
         "skill": "tailor",
         "clothing_mods": [
@@ -178,6 +165,66 @@
           "demonchitin_padded",
           "blackdragon_coated"
         ]
+      }
+    ]
+  },
+  {
+    "id": "misc_repairkit",
+    "name": "misc repair kit",
+    "copy-from": "misc_repairkit",
+    "type": "TOOL",
+    "use_action": [
+      {
+        "type": "repair_item",
+        "item_action_type": "repair_metal",
+        "materials": [
+          "acidchitin",
+          "bone",
+          "bone_heavy",
+          "chitin",
+          "paper",
+          "dry_plant",
+          "cardboard",
+          "wood",
+          "kevlar_rigid",
+          "scute",
+          "demon_chitin",
+          "dragon_bone"
+        ],
+        "skill": "fabrication",
+        "tool_quality": 5,
+        "cost_scaling": 0.1,
+        "move_cost": 1000
+      }
+    ]
+  },
+  {
+    "id": "misc_repairkit_makeshift",
+    "name": "makeshift repair kit",
+    "copy-from": "misc_repairkit_makeshift",
+    "type": "TOOL",
+    "use_action": [
+      {
+        "type": "repair_item",
+        "item_action_type": "repair_metal",
+        "materials": [
+          "acidchitin",
+          "bone",
+          "bone_heavy",
+          "chitin",
+          "paper",
+          "dry_plant",
+          "cardboard",
+          "wood",
+          "kevlar_rigid",
+          "scute",
+          "demon_chitin",
+          "dragon_bone"
+        ],
+        "skill": "fabrication",
+        "tool_quality": 4,
+        "cost_scaling": 0.1,
+        "move_cost": 2000
       }
     ]
   }


### PR DESCRIPTION
## Purpose of change (The Why)

Dragon bone should be able to be repaired if it's so good.

## Describe the solution (The How)

- Adds dragon bone to what misc repairkits can repair
- Also swaps demon chitin from the sewing/tailoring kits to the misc repair kits to better align with normal chitin

## Describe alternatives you've considered

- Put it in sewing for some reason
- Put it on forges / soldering irons despite bones not being metal

## Testing

I loaded in, can confirm it lets you (attempt to) repair the relevant materials with a misc repair kit.

## Additional context

As reported by Phoenix

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

