### PR TITLE
feat: Allow for casting spells to be blocked by mutations

### DIFF
--- a/data/json/debug_spells.json
+++ b/data/json/debug_spells.json
@@ -230,5 +230,23 @@
     "energy_source": "MANA",
     "min_duration": 400,
     "max_duration": 400
+  },
+  {
+    "id": "debug_antirat_cheese",
+    "type": "SPELL",
+    "name": "Debug Anti-rat Cheese Spawning",
+    "description": "You summon some cheese, but not if you're a rat.",
+    "message": "Passed the anti-rat test",
+    "blocker_mutations": [ "THRESH_RAT", "CLAWS_RAT" ],
+    "valid_targets": [ "self" ],
+    "effect": "spawn_item",
+    "effect_str": "cheese",
+    "min_range": 1,
+    "max_range": 1,
+    "base_casting_time": 100,
+    "base_energy_cost": 100,
+    "energy_source": "MANA",
+    "min_duration": 400,
+    "max_duration": 400
   }
 ]

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1469,11 +1469,11 @@ static void cast_spell()
     spell &sp = *u.magic->get_spells()[spell_index];
 
     std::set<trait_id> blockers = sp.get_blocker_muts();
-    if (blockers.size()) {
-        for (trait_id blocker : blockers) {
-            if (u.has_trait(blocker)) {
+    if( blockers.size() ) {
+        for( trait_id blocker : blockers ) {
+            if( u.has_trait( blocker ) ) {
                 add_msg( game_message_params{ m_bad, gmf_bypass_cooldown },
-                    _( "Your %s mutation prevents you from casting this spell!" ), blocker->name() );
+                         _( "Your %s mutation prevents you from casting this spell!" ), blocker->name() );
                 return;
             }
         }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1468,6 +1468,17 @@ static void cast_spell()
 
     spell &sp = *u.magic->get_spells()[spell_index];
 
+    std::set<trait_id> blockers = sp.get_blocker_muts();
+    if (blockers.size()) {
+        for (trait_id blocker : blockers) {
+            if (u.has_trait(blocker)) {
+                add_msg( game_message_params{ m_bad, gmf_bypass_cooldown },
+                    _( "Your %s mutation prevents you from casting this spell!" ), blocker->name() );
+                return;
+            }
+        }
+    }
+
     if( u.is_armed() && !sp.has_flag( spell_flag::NO_HANDS ) &&
         !u.primary_weapon().has_flag( flag_MAGIC_FOCUS ) && u.primary_weapon().is_two_handed( u ) ) {
         add_msg( game_message_params{ m_bad, gmf_bypass_cooldown },

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -266,7 +266,7 @@ void spell_type::load( const JsonObject &jo, const std::string & )
     const auto trigger_reader = enum_flags_reader<valid_target> { "valid_targets" };
     mandatory( jo, was_loaded, "valid_targets", valid_targets, trigger_reader );
 
-    optional(jo, was_loaded, "blocker_mutations", blocker_mutations, auto_flags_reader<trait_id>{} );
+    optional( jo, was_loaded, "blocker_mutations", blocker_mutations, auto_flags_reader<trait_id> {} );
 
     if( jo.has_array( "extra_effects" ) ) {
         for( JsonObject fake_spell_obj : jo.get_array( "extra_effects" ) ) {
@@ -1106,7 +1106,8 @@ int spell::get_max_level() const
     return type->max_level;
 }
 
-std::set<trait_id> spell::get_blocker_muts() const {
+std::set<trait_id> spell::get_blocker_muts() const
+{
     return type->blocker_mutations;
 }
 
@@ -1705,17 +1706,17 @@ static std::string enumerate_spell_data( const spell &sp )
     return enumerate_as_string( spell_data );
 }
 
-static std::string enumerate_traits (const std::set<trait_id> st) {
+static std::string enumerate_traits( const std::set<trait_id> st )
+{
     std::vector<std::string> str_vector;
-    if (st.size()){
-        for (trait_id trait : st) {
-            str_vector.push_back(trait->name());
+    if( st.size() ) {
+        for( trait_id trait : st ) {
+            str_vector.push_back( trait->name() );
         }
+    } else {
+        str_vector.push_back( "None" );
     }
-    else {
-        str_vector.push_back("None");
-    }
-    return enumerate_as_string(str_vector);
+    return enumerate_as_string( str_vector );
 }
 
 
@@ -1749,7 +1750,7 @@ void spellcasting_callback::draw_spell_info( const spell &sp, const uilist *menu
     }
 
     line += fold_and_print( w_menu, point( h_col1, line++ ), info_width, gray, string_format( "%s: %s",
-                        _( "Blocker mutations"), enumerate_traits(sp.get_blocker_muts())));
+                            _( "Blocker mutations" ), enumerate_traits( sp.get_blocker_muts() ) ) );
 
     print_colored_text( w_menu, point( h_col1, line ), gray, gray,
                         string_format( "%s: %d %s", _( "Spell Level" ), sp.get_level(),

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -48,6 +48,7 @@
 #include "string_formatter.h"
 #include "string_id.h"
 #include "translations.h"
+#include "type_id.h"
 #include "ui.h"
 #include "units.h"
 
@@ -264,6 +265,8 @@ void spell_type::load( const JsonObject &jo, const std::string & )
 
     const auto trigger_reader = enum_flags_reader<valid_target> { "valid_targets" };
     mandatory( jo, was_loaded, "valid_targets", valid_targets, trigger_reader );
+
+    optional(jo, was_loaded, "blocker_mutations", blocker_mutations, auto_flags_reader<trait_id>{} );
 
     if( jo.has_array( "extra_effects" ) ) {
         for( JsonObject fake_spell_obj : jo.get_array( "extra_effects" ) ) {
@@ -1103,6 +1106,10 @@ int spell::get_max_level() const
     return type->max_level;
 }
 
+std::set<trait_id> spell::get_blocker_muts() const {
+    return type->blocker_mutations;
+}
+
 // helper function to calculate xp needed to be at a certain level
 // pulled out as a helper function to make it easier to either be used in the future
 // or easier to tweak the formula
@@ -1698,6 +1705,20 @@ static std::string enumerate_spell_data( const spell &sp )
     return enumerate_as_string( spell_data );
 }
 
+static std::string enumerate_traits (const std::set<trait_id> st) {
+    std::vector<std::string> str_vector;
+    if (st.size()){
+        for (trait_id trait : st) {
+            str_vector.push_back(trait->name());
+        }
+    }
+    else {
+        str_vector.push_back("None");
+    }
+    return enumerate_as_string(str_vector);
+}
+
+
 void spellcasting_callback::draw_spell_info( const spell &sp, const uilist *menu )
 {
     const int h_offset = menu->w_width - menu->pad_right + 1;
@@ -1726,6 +1747,9 @@ void spellcasting_callback::draw_spell_info( const spell &sp, const uilist *menu
     if( line <= win_height / 3 ) {
         line++;
     }
+
+    line += fold_and_print( w_menu, point( h_col1, line++ ), info_width, gray, string_format( "%s: %s",
+                        _( "Blocker mutations"), enumerate_traits(sp.get_blocker_muts())));
 
     print_colored_text( w_menu, point( h_col1, line ), gray, gray,
                         string_format( "%s: %d %s", _( "Spell Level" ), sp.get_level(),

--- a/src/magic.h
+++ b/src/magic.h
@@ -154,6 +154,9 @@ class spell_type
         translation sound_description;
         skill_id skill;
 
+        // Mutations that block the spell from being cast
+        std::set<trait_id> blocker_mutations;
+
         requirement_id spell_components;
 
         sounds::sound_t sound_type = sounds::sound_t::_LAST;
@@ -361,6 +364,8 @@ class spell
         bool is_max_level() const;
         // what is the max level of the spell
         int get_max_level() const;
+        // what are the blocker mutations
+        std::set<trait_id> get_blocker_muts() const;
 
         // what is the intensity of the field the spell generates ( 0 if no field )
         int field_intensity() const;


### PR DESCRIPTION
## Purpose of change (The Why)

RoyalFox requested it.
Also, it seems helpful in general as a feature, much like my previous change to allow martial arts to require mutations. I may find a usage for it at some point in MN, and it might be nice for anyone else doing traditional methods of learning spells (i.e. not the Arcana way where everything's tied to mutations anyway and thus it's easier cancelled out by the traditional mutation incompatibilities)

## Describe the solution (The How)

- Adds a new optional `"blocker_mutations"` field to spells that takes an array of mutation ids to block casting the spell for having.
- Adds the c++ required to do so
- Prevents you from casting if you have a mutation the spell doesn't like, prints out a message informing you which one is blocking
- Print the blocker mutations in the spellbook UI
- Add a debug spell for testing purposes

## Describe alternatives you've considered

- Make Royal do it clunkily via spell classes

## Testing

- I compiled it
-  I loaded in
-  I tested normal spells to make sure it didn't crash
-  I tested the spell with a blocker with no blocking mutations
-  I tried it with the first blocking mutation
- I tried it with both blocking mutations
- I tried it with the second blocking mutation

## Additional context

Not adding it to docs yet to save scarf merge-conflict headache while he works on the docs revamp

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

- [x] This is a C++ PR that modifies JSON loading or behavior.
  - [x] If documentation for this feature does not exist, please write it or at least note its lack in PR description.
