### PR TITLE
feat(mods/MagicalNights,balance): Change wizard tower metal doors to the non-locked variety

### DIFF
--- a/data/mods/MagicalNights/worldgen/wizard-towers.json
+++ b/data/mods/MagicalNights/worldgen/wizard-towers.json
@@ -87,7 +87,7 @@
       "#": "t_rock_wall",
       "|": "t_wall_w",
       ":": "t_railing",
-      "M": "t_door_metal_locked",
+      "M": "t_door_metal_c",
       "+": "t_door_c",
       "=": "t_door_locked",
       "w": "t_window_domestic",


### PR DESCRIPTION
## Purpose of change (The Why)

Nobody likes the doors being locked like this.

## Describe the solution (The How)

Use the simply closed variety instead

## Describe alternatives you've considered

- Improve teleportation and make that mandatory instead
- Add a computer for no good reason
- Use pickable doors
- Supply a pickaxe right there

## Testing

Loaded in, confirmed it worked correctly

## Additional context

Simple PR I know *someone* has been waiting on.

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
