### PR TITLE
fix: don't overwhelm stores with antibiotics

### DIFF
--- a/data/json/itemgroups/Drugs_Tobacco_Alcohol/drugs.json
+++ b/data/json/itemgroups/Drugs_Tobacco_Alcohol/drugs.json
@@ -54,6 +54,17 @@
     ]
   },
   {
+    "id": "drugs_vending",
+    "type": "item_group",
+    "//": "Drugs that weren't bought during the panic",
+    "items": [
+      { "group": "drugs_heal_simple", "prob": 100 },
+      { "group": "drugs_misc", "prob": 100 },
+      { "item": "tramadol", "prob": 10 },
+      { "item": "codeine", "prob": 5 }
+    ]
+  },
+  {
     "id": "drugs_rare",
     "type": "item_group",
     "//": "Rare and/or valuable drugs excluding painkillers",

--- a/data/json/itemgroups/vending_machines.json
+++ b/data/json/itemgroups/vending_machines.json
@@ -129,6 +129,6 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "vending_medicine",
-    "entries": [ { "group": "drugs_pharmacy", "count-min": 10, "count-max": 20 } ]
+    "entries": [ { "group": "drugs_vending", "count-min": 10, "count-max": 20 } ]
   }
 ]


### PR DESCRIPTION
## Purpose of change (The Why)

PR https://github.com/cataclysmbnteam/Cataclysm-BN/pull/5316 Absolutely smashed a lot of balance with how many antibiotics can spawn in grocery stores, this dials it back.

## Describe the solution (The How)

New item group just for medical vendors, focused on OTC stuff with some tramadol and codeine that wasn't looted but is rare.

## Describe alternatives you've considered

REDACTED

## Testing
Loads in my current save file.
![image](https://github.com/user-attachments/assets/bb3b25cf-8004-4a20-9213-b13f37f0ffed)


## Additional context
:(

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I fed the tree instead of running the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later