### PR TITLE
ci: pull translations daily

### DIFF
--- a/.github/workflows/pull-translations.yml
+++ b/.github/workflows/pull-translations.yml
@@ -3,7 +3,7 @@ name: "Pull translations from Transifex"
 on:
   workflow_dispatch:
   schedule:
-    - cron: "42 1 * * 6"
+    - cron: "0 21 * * *"
 
 jobs:
   pull-translations:


### PR DESCRIPTION
## Purpose of change (The Why)

because why not?
faster translation updates are always good.

## Describe the solution (The How)

pull daily instead of weekly

## Testing

<https://crontab.guru/#0_21_*_*_*>

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
