### PR TITLE
chore: add git blame ignore-revs-file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# https://github.com/cataclysmbnteam/Cataclysm-BN/pull/6062
+b3810924fd4c4d74e9ad8212ea7bb035d416e53b
+
+# https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3819
+f3d7db35815b0128e557cd9fa7ed2388936a02c5


### PR DESCRIPTION

## Purpose of change (The Why)

makes blame feature more helpful by not showing meaningless formatting changes

## Describe the solution (The How)

add the file. unfortunately, you need to manually enable the feature by running

```sh
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

## Describe alternatives you've considered

crave

## Additional context

see:
- https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-fileltfilegt
- https://gist.github.com/kateinoigakukun/b0bc920e587851bfffa98b9e279175f2

## Checklist

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/en/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/en/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/en/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/en/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.
